### PR TITLE
Add Meterpreter compatibility commands

### DIFF
--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -4,7 +4,18 @@ module Msf
 module Exploit::FileDropper
 
   def initialize(info = {})
-    super
+    super(
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_delete_dir
+            stdapi_fs_delete_file
+            stdapi_fs_getwd
+            stdapi_fs_stat
+          ]
+        }
+      }
+    )
 
     self.needs_cleanup = true
     @dropped_files = []

--- a/lib/msf/core/exploit/local/windows_kernel.rb
+++ b/lib/msf/core/exploit/local/windows_kernel.rb
@@ -5,6 +5,23 @@ module Exploit::Local::WindowsKernel
   include Msf::PostMixin
   include Msf::Post::Windows::Error
 
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_railgun_memread
+              stdapi_railgun_memwrite
+            ]
+          }
+        }
+      )
+    )
+  end
+
   #
   # Find the address of nt!HalDispatchTable.
   #

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -49,6 +49,31 @@ module Registry
   HKEY_CURRENT_CONFIG = 0x80000005
   HKEY_DYN_DATA = 0x80000006
 
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_registry_check_key_exists
+              stdapi_registry_create_key
+              stdapi_registry_delete_key
+              stdapi_registry_enum_key_direct
+              stdapi_registry_enum_value_direct
+              stdapi_registry_load_key
+              stdapi_registry_open_key
+              stdapi_registry_query_value_direct
+              stdapi_registry_set_value_direct
+              stdapi_registry_unload_key
+              stdapi_sys_config_getprivs
+            ]
+          }
+        }
+      )
+    )
+  end
+
   #
   # Lookup registry hives by key.
   #

--- a/lib/msf/core/post/windows/runas.rb
+++ b/lib/msf/core/post/windows/runas.rb
@@ -19,7 +19,7 @@ module Msf::Post::Windows::Runas
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_railgun_api*
+              stdapi_railgun_api
             ]
           }
         }

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -10,7 +10,15 @@ module Msf::PostMixin
   include Msf::Post::Common
 
   def initialize(info={})
-    super
+    super(
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_config_sysinfo
+          ]
+        }
+      }
+    )
 
     register_options( [
       Msf::OptInt.new('SESSION', [ true, "The session to run this module on." ])

--- a/modules/exploits/linux/http/ibm_drm_rce.rb
+++ b/modules/exploits/linux/http/ibm_drm_rce.rb
@@ -48,7 +48,14 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true
         },
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2020-04-21'
+        'DisclosureDate' => '2020-04-21',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/osx/local/cfprefsd_race_condition.rb
+++ b/modules/exploits/osx/local/cfprefsd_race_condition.rb
@@ -49,6 +49,13 @@ class MetasploitModule < Msf::Exploit::Local
           'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES],
           'Reliability' => [REPEATABLE_SESSION],
           'Stability' => [CRASH_SAFE]
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/anyconnect_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_lpe.rb
@@ -79,6 +79,13 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' => {
           'PAYLOAD' => 'windows/meterpreter/reverse_tcp',
           'FileDropperDelay' => 10
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_open
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
+++ b/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
@@ -97,7 +97,19 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://github.com/antonioCoco/RogueWinRM'],
           ],
           'DisclosureDate' => '2019-12-06',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_sys_config_getenv
+                stdapi_sys_config_getprivs
+                stdapi_sys_config_sysinfo
+                stdapi_sys_process_attach
+                stdapi_sys_process_execute
+                stdapi_sys_process_thread_create
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/canon_driver_privesc.rb
+++ b/modules/exploits/windows/local/canon_driver_privesc.rb
@@ -53,7 +53,14 @@ class MetasploitModule < Msf::Exploit::Local
           'Stability' => [ SERVICE_RESOURCE_LOSS ]
         },
         'DisclosureDate' => '2021-08-07',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -56,6 +56,16 @@ class MetasploitModule < Msf::Exploit::Local
           'EXITFUNC' => 'thread',
           'Payload' => 'windows/x64/meterpreter/reverse_tcp',
           'WfsDelay' => 900
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_fs_md5
+              stdapi_railgun_api
+              stdapi_sys_config_getenv
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
+++ b/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
@@ -65,6 +65,13 @@ class MetasploitModule < Msf::Exploit::Local
           'EXITFUNC' => 'thread',
           'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
           'WfsDelay' => 900
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
@@ -44,7 +44,15 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' => {
           'DisablePayloadHandler' => true
         },
-        'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
+        'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
+++ b/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
@@ -41,6 +41,13 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DefaultOptions' => {
           'DisablePayloadHandler' => true
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
@@ -52,7 +52,16 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' => {
           'DisablePayloadHandler' => true
         },
-        'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
+        'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              powershell_execute
+              stdapi_sys_config_getenv
+              stdapi_sys_power_exitwindows
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_17136.rb
+++ b/modules/exploits/windows/local/cve_2020_17136.rb
@@ -63,6 +63,20 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' => {
           'EXITFUNC' => 'process',
           'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_kill
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_write
+              stdapi_sys_process_thread_create
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
+++ b/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
@@ -51,6 +51,13 @@ class MetasploitModule < Msf::Exploit::Local
           'Notes' => {
             'Stability' => [ CRASH_OS_RESTARTS, ],
             'Reliability' => [ REPEATABLE_SESSION, ]
+          },
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+              ]
+            }
           }
         }
       )

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -59,6 +59,15 @@ class MetasploitModule < Msf::Exploit::Local
           # non-optimal time or if the UNC path is typed in wrong.
           'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS],
           'Reliability' => [REPEATABLE_SESSION]
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getsid
+              stdapi_sys_config_getuid
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc.rb
+++ b/modules/exploits/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc.rb
@@ -75,7 +75,15 @@ class MetasploitModule < Msf::Exploit::Local
               CRASH_SAFE
             ]
           },
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_config_getenv
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/gog_galaxyclientservice_privesc.rb
+++ b/modules/exploits/windows/local/gog_galaxyclientservice_privesc.rb
@@ -52,6 +52,13 @@ class MetasploitModule < Msf::Exploit::Local
           'SideEffects' => [ ARTIFACTS_ON_DISK ],
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_SAFE ]
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -43,7 +43,14 @@ class MetasploitModule < Msf::Exploit::Local
           'WfsDelay' => 5,
           'ReverseConnectRetries' => 255
         },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_mkdir
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/ipass_launch_app.rb
+++ b/modules/exploits/windows/local/ipass_launch_app.rb
@@ -45,7 +45,15 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://www.mogwaisecurity.de/advisories/MSA-2015-03.txt']
           ],
           'DisclosureDate' => '2015-03-12',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_config_getenv
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/lenovo_systemupdate.rb
+++ b/modules/exploits/windows/local/lenovo_systemupdate.rb
@@ -51,7 +51,14 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'http://www.ioactive.com/pdfs/Lenovo_System_Update_Multiple_Privilege_Escalations.pdf']
           ],
           'DisclosureDate' => '2015-04-12',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/mov_ss.rb
+++ b/modules/exploits/windows/local/mov_ss.rb
@@ -50,6 +50,13 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DefaultOptions' => {
           'DisablePayloadHandler' => false
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/mqac_write.rb
+++ b/modules/exploits/windows/local/mqac_write.rb
@@ -54,6 +54,16 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [ CRASH_OS_RESTARTS, ],
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_write
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/ms10_092_schelevator.rb
+++ b/modules/exploits/windows/local/ms10_092_schelevator.rb
@@ -43,7 +43,18 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'EDB', '15589' ]
           ],
           'DisclosureDate' => '2010-09-13',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                core_channel_eof
+                core_channel_open
+                core_channel_read
+                core_channel_write
+                stdapi_sys_config_getenv
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
+++ b/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
@@ -78,6 +78,17 @@ class MetasploitModule < Msf::Exploit::Local
           'Notes' => {
             'Stability' => [ CRASH_OS_RESTARTS, ],
           },
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_process_attach
+                stdapi_sys_process_getpid
+                stdapi_sys_process_memory_protect
+                stdapi_sys_process_memory_write
+              ]
+            }
+          },
         }
       )
     )

--- a/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
+++ b/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
@@ -54,7 +54,19 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'MSB', 'MS13-005' ],
           [ 'OSVDB', '88966'],
           [ 'URL', 'http://blog.cmpxchg8b.com/2013/02/a-few-years-ago-while-working-on.html' ]
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_railgun_api_multi
+              stdapi_sys_config_getenv
+              stdapi_sys_process_execute
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/ms13_053_schlamperei.rb
+++ b/modules/exploits/windows/local/ms13_053_schlamperei.rb
@@ -51,7 +51,17 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'URL', 'https://labs.mwrinfosecurity.com/blog/2013/09/06/mwr-labs-pwn2own-2013-write-up---kernel-exploit/' ]
           ],
           'DisclosureDate' => '2013-12-01',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_process_attach
+                stdapi_sys_process_get_processes
+                stdapi_sys_process_thread_create
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/ms13_097_ie_registry_symlink.rb
+++ b/modules/exploits/windows/local/ms13_097_ie_registry_symlink.rb
@@ -42,7 +42,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['MSB', 'MS13-097'],
           ['BID', '64115'],
           ['URL', 'https://github.com/tyranid/IE11SandboxEscapes']
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_loadlib
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
+++ b/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
@@ -53,7 +53,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['MSB', 'MS14-009'],
           ['BID', '65417'],
           ['URL', 'https://github.com/tyranid/IE11SandboxEscapes']
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_loadlib
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -54,7 +54,16 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2015-001.txt']
           ],
           'DisclosureDate' => '2014-11-11',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_process_attach
+                stdapi_sys_process_memory_write
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/ms15_004_tswbproxy.rb
+++ b/modules/exploits/windows/local/ms15_004_tswbproxy.rb
@@ -57,7 +57,16 @@ class MetasploitModule < Msf::Exploit::Local
             ['MSB', 'MS15-004'],
             ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/cve-2015-0016-escaping-the-internet-explorer-sandbox/']
           ],
-          'DisclosureDate' => '2015-01-13'
+          'DisclosureDate' => '2015-01-13',
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_process_attach
+                stdapi_sys_process_thread_create
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
+++ b/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
@@ -71,7 +71,16 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://code.google.com/p/google-security-research/issues/detail?id=480']
           ],
           'DisclosureDate' => '2015-07-11',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_sys_process_attach
+                stdapi_sys_process_execute
+                stdapi_sys_process_thread_create
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -53,7 +53,18 @@ class MetasploitModule < Msf::Exploit::Local
           # * Windows 2012
           [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
         ],
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/ms16_075_reflection.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection.rb
@@ -53,7 +53,14 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://github.com/breenmachine/RottenPotatoNG']
           ],
           'DisclosureDate' => '2016-01-16',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_sys_config_getprivs
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -57,7 +57,19 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://ohpe.it/juicy-potato/']
           ],
           'DisclosureDate' => '2016-01-16',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_sys_config_getenv
+                stdapi_sys_config_getprivs
+                stdapi_sys_config_sysinfo
+                stdapi_sys_process_attach
+                stdapi_sys_process_execute
+                stdapi_sys_process_thread_create
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/ms18_8120_win32k_privesc.rb
+++ b/modules/exploits/windows/local/ms18_8120_win32k_privesc.rb
@@ -55,7 +55,14 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8120']
         ],
         'DisclosureDate' => '2018-05-09',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -79,7 +79,18 @@ class MetasploitModule < Msf::Exploit::Local
             %w(URL http://blog.spiderlabs.com/2013/12/the-kernel-is-calling-a-zeroday-pointer-cve-2013-5065-ring-ring.html)
           ],
           'DisclosureDate' => '2013-11-27',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_config_getenv
+                stdapi_sys_process_attach
+                stdapi_sys_process_execute
+                stdapi_sys_process_memory_write
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/novell_client_nicm.rb
+++ b/modules/exploits/windows/local/novell_client_nicm.rb
@@ -58,7 +58,16 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'URL', 'http://pastebin.com/GB4iiEwR' ]
           ],
           'DisclosureDate' => '2013-05-22',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_process_attach
+                stdapi_sys_process_memory_write
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/novell_client_nwfs.rb
+++ b/modules/exploits/windows/local/novell_client_nwfs.rb
@@ -54,7 +54,16 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'BID', '30001' ]
           ],
           'DisclosureDate' => '2008-06-26',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_process_attach
+                stdapi_sys_process_memory_write
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/nvidia_nvsvc.rb
+++ b/modules/exploits/windows/local/nvidia_nvsvc.rb
@@ -52,7 +52,14 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'URL', 'http://nvidia.custhelp.com/app/answers/detail/a_id/3288' ],
           ],
           'DisclosureDate' => '2012-12-25',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_fs_md5
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -31,7 +31,16 @@ class MetasploitModule < Msf::Exploit::Local
         'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [ [ 'Windows', {} ] ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2011-10-12'
+        'DisclosureDate' => '2011-10-12',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -34,6 +34,15 @@ class MetasploitModule < Msf::Exploit::Local
         'DisclosureDate' => '2011-10-19',
         'DefaultOptions' => {
           'DisablePayloadHandler' => true
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getuid
+              stdapi_sys_config_sysinfo
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/persistence_image_exec_options.rb
+++ b/modules/exploits/windows/local/persistence_image_exec_options.rb
@@ -39,6 +39,13 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DefaultOptions' => {
           'DisablePayloadHandler' => true
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/persistence_service.rb
+++ b/modules/exploits/windows/local/persistence_service.rb
@@ -30,7 +30,20 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           [ 'URL', 'https://github.com/rapid7/metasploit-framework/blob/master/external/source/metsvc/src/metsvc.cpp' ]
         ],
-        'DisclosureDate' => '2018-10-20'
+        'DisclosureDate' => '2018-10-20',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_sys_config_getenv
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
+++ b/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
@@ -47,7 +47,14 @@ class MetasploitModule < Msf::Exploit::Local
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_SAFE ]
         },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
     register_advanced_options [

--- a/modules/exploits/windows/local/ppr_flatten_rec.rb
+++ b/modules/exploits/windows/local/ppr_flatten_rec.rb
@@ -56,7 +56,14 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'URL', 'https://seclists.org/fulldisclosure/2013/May/91' ],
           ],
           'DisclosureDate' => '2013-05-15',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_sys_config_getenv
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/ps_persist.rb
+++ b/modules/exploits/windows/local/ps_persist.rb
@@ -42,7 +42,18 @@ class MetasploitModule < Msf::Exploit::Local
         'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [ [ 'Universal', {} ] ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2012-08-14'
+        'DisclosureDate' => '2012-08-14',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_fs_stat
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getsid
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -43,7 +43,21 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'Privileged' => true,
       'Stance' => Msf::Exploit::Stance::Passive,
-      'DefaultTarget' => 0
+      'DefaultTarget' => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            lanattacks_add_tftp_file
+            lanattacks_dhcp_log
+            lanattacks_reset_dhcp
+            lanattacks_set_dhcp_option
+            lanattacks_start_dhcp
+            lanattacks_start_tftp
+            lanattacks_stop_dhcp
+            lanattacks_stop_tftp
+          ]
+        }
+      }
     )
 
     register_options(

--- a/modules/exploits/windows/local/razer_zwopenprocess.rb
+++ b/modules/exploits/windows/local/razer_zwopenprocess.rb
@@ -71,6 +71,20 @@ class MetasploitModule < Msf::Exploit::Remote
           'SideEffects' => [ SCREEN_EFFECTS ],
           'Reliability' => [ REPEATABLE_SESSION ],
         },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_md5
+              stdapi_railgun_api
+              stdapi_sys_config_driver_list
+              stdapi_sys_process_kill
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_protect
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        },
       )
     )
   end

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -63,7 +63,14 @@ class MetasploitModule < Msf::Exploit::Local
           'Stability' => [ SERVICE_RESOURCE_LOSS ]
         },
         'DisclosureDate' => '2020-01-22',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/run_as.rb
+++ b/modules/exploits/windows/local/run_as.rb
@@ -34,7 +34,14 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           [ 'URL', 'https://msdn.microsoft.com/en-us/library/windows/desktop/ms682431' ]
         ],
-        'DisclosureDate' => '1999-01-01'
+        'DisclosureDate' => '1999-01-01',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     ) # Same as psexec -- a placeholder date for non-vuln 'exploits'
 

--- a/modules/exploits/windows/local/s4u_persistence.rb
+++ b/modules/exploits/windows/local/s4u_persistence.rb
@@ -35,7 +35,16 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           [ 'URL', 'http://www.pentestgeek.com/2013/02/11/scheduled-tasks-with-s4u-and-on-demand-persistence/' ],
           [ 'URL', 'http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ]
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getuid
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/srclient_dll_hijacking.rb
+++ b/modules/exploits/windows/local/srclient_dll_hijacking.rb
@@ -51,6 +51,14 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, SCREEN_EFFECTS ]
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getuid
+              stdapi_sys_process_get_processes
+            ]
+          }
         }
       )
       )

--- a/modules/exploits/windows/local/tokenmagic.rb
+++ b/modules/exploits/windows/local/tokenmagic.rb
@@ -54,6 +54,14 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' => {
           'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
           'WfsDelay' => 900
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              powershell_execute
+              stdapi_sys_config_getenv
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/virtual_box_guest_additions.rb
+++ b/modules/exploits/windows/local/virtual_box_guest_additions.rb
@@ -53,7 +53,16 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-001.txt']
           ],
           'DisclosureDate' => '2014-07-15',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_process_attach
+                stdapi_sys_process_memory_write
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -75,7 +75,18 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'http://corelabs.coresecurity.com/index.php?module=Wiki&action=view&type=publication&name=oracle_virtualbox_3d_acceleration']
           ],
           'DisclosureDate' => '2014-03-11',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_process_attach
+                stdapi_sys_process_getpid
+                stdapi_sys_process_memory_allocate
+                stdapi_sys_process_memory_write
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -32,7 +32,14 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'http://pauldotcom.com/2011/11/safely-dumping-hashes-from-liv.html' ],
           [ 'URL', 'http://www.irongeek.com/i.php?page=videos/hack3rcon2/tim-tomes-and-mark-baggett-lurking-in-the-shadows']
         ],
-        'DisclosureDate' => '2011-10-21'
+        'DisclosureDate' => '2011-10-21',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_sysinfo
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb
+++ b/modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb
@@ -50,7 +50,15 @@ class MetasploitModule < Msf::Exploit::Local
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_SAFE ]
         },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
     register_advanced_options [

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -49,7 +49,18 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => true,
         'Platform' => 'win',
         'DisclosureDate' => '2008-05-15',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getenv
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
      )
 

--- a/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
+++ b/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
@@ -43,7 +43,16 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Automatic', {} ]
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2012-11-16'
+        'DisclosureDate' => '2012-11-16',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getenv
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -43,7 +43,15 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Windows 2003 SP2 / NetIQ Privileged User Manager 2.3.1', {}],
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2012-11-15'
+        'DisclosureDate' => '2012-11-15',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/nuuo/nuuo_cms_fu.rb
+++ b/modules/exploits/windows/nuuo/nuuo_cms_fu.rb
@@ -48,7 +48,16 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => true,
         'DisclosureDate' => '2018-10-11',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
+++ b/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
@@ -42,7 +42,15 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Oracle Oracle11g 11.2.0.1.0 / Windows 2003 SP2', {} ]
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2011-01-18'
+        'DisclosureDate' => '2011-01-18',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/android/manage/remove_lock.rb
+++ b/modules/post/android/manage/remove_lock.rb
@@ -35,7 +35,14 @@ class MetasploitModule < Msf::Post
           ],
           'SessionTypes' => [ 'meterpreter', 'shell' ],
           'Platform' => 'android',
-          'DisclosureDate' => '2013-10-11'
+          'DisclosureDate' => '2013-10-11',
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                android_*
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/post/apple_ios/gather/ios_image_gather.rb
+++ b/modules/post/apple_ios/gather/ios_image_gather.rb
@@ -19,7 +19,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Shelby Pace' ], # Metasploit Module
         'Platform' => [ 'apple_ios' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_close
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/linux/gather/gnome_keyring_dump.rb
+++ b/modules/post/linux/gather/gnome_keyring_dump.rb
@@ -23,7 +23,10 @@ class MetasploitModule < Msf::Post
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_railgun_*
+              core_native_arch
+              stdapi_net_resolve_host
+              stdapi_railgun_api
+              stdapi_railgun_memread
             ]
           }
         }

--- a/modules/post/windows/gather/ntds_grabber.rb
+++ b/modules/post/windows/gather/ntds_grabber.rb
@@ -27,7 +27,9 @@ class MetasploitModule < Msf::Post
           'Meterpreter' => {
             'Commands' => %w[
               core_migrate
-              stdapi_railgun*
+              stdapi_railgun_api
+              stdapi_sys_process_execute
+              stdapi_sys_process_getpid
             ]
           }
         }


### PR DESCRIPTION
Building on the work of https://github.com/rapid7/metasploit-framework/pull/15295

It automates adding compatibility requirements to the modules directory
```
rubocop -A --only Lint/MeterpreterCommandDependencies
```

## Verification

Review the modules and verify that the command additions make sense