### PR TITLE
remove duplicate autocheck

### DIFF
--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -10,7 +10,6 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::Expect
-  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(


### PR DESCRIPTION
Removes a duplicate `prepend Msf::Exploit::Remote::AutoCheck`