### PR TITLE
Creds command improvements

### DIFF
--- a/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
@@ -70,9 +70,9 @@ def hash_to_hashcat(cred)
          /android-sha1/, /android-samsung-sha1/, /android-md5/,
          /ssha/, /raw-sha512/
       #            md5(crypt), des(crypt), b(crypt), sha256, sha512, xsha, xsha512, PBKDF2-HMAC-SHA512
-      # hash-mode: 500          1500        3200      7400    1800   122   1722       7100
+      # hash-mode: 500         1500        3200      7400    1800    122   1722     7100
       #            mssql, mssql05, mssql12, mysql, mysql-sha1
-      # hash-mode: 131,    132,     1731    200        300
+      # hash-mode: 131,   132,     1731    200     300
       #            mediawiki, phpass, PBKDF2-HMAC-SHA1
       # hash-mode: 3711,      400,    12001
       #            android-sha1
@@ -89,6 +89,10 @@ def hash_to_hashcat(cred)
     when /^mscash2$/
       # hash-mode: 2100
       return cred.private.data.split(':').first
+    when /netntlm(v2)?/
+      #            netntlm, netntlmv2
+      # hash-mode: 5500     5600
+      return cred.private.data
     end
   end
   nil

--- a/lib/metasploit/framework/password_crackers/jtr/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/jtr/formatter.rb
@@ -53,6 +53,8 @@ def hash_to_jtr(cred)
     when /md5|des|bsdi|crypt|bf|sha256|sha512|xsha512/
       # md5(crypt), des(crypt), b(crypt), sha256(crypt), sha512(crypt), xsha512
       return "#{cred.public.username}:#{cred.private.data}:::::#{cred.id}:"
+    when /netntlm(v2)?/
+      return cred.private.data
     when /qnx/
       # https://moar.so/blog/qnx-password-hash-formats.html
       hash = cred.private.data.end_with?(':0:0') ? cred.private.data : "#{cred.private.data}:0:0"

--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -31,6 +31,10 @@ module Msf::DBManager::Cred
         query = query.where(Mdm::Service[:port].in(opts[:ports]))
       end
 
+      if opts[:realm].present?
+        query = query.where('"metasploit_credential_realms"."value" = ?', opts[:realm])
+      end
+
       if opts[:user].present?
         query = query.where('"metasploit_credential_publics"."username" = ?', opts[:user])
       end

--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -16,7 +16,11 @@ module Msf::DBManager::Cred
       query = query.includes(logins: [ :service, { service: :host } ])
 
       if opts[:type].present?
-        query = query.where('"metasploit_credential_privates"."type" = ?', opts[:type] )
+        query = query.where('"metasploit_credential_privates"."type" = ?', opts[:type])
+      end
+
+      if opts[:jtr_format].present?
+        query = query.where('"metasploit_credential_privates"."jtr_format" = ?', opts[:jtr_format])
       end
 
       if opts[:svcs].present?

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -149,7 +149,7 @@ class Creds
     print_line "  -u,--user <text>      List users that match this text"
     print_line "  -t,--type <type>      List creds of the specified type: password, ntlm, hash or any valid JtR format"
     print_line "  -O,--origins <IP>     List creds that match these origins"
-    print_line "     --realm            List creds that match this realm"
+    print_line "  -r,--realm <realm>    List creds that match this realm"
     print_line "  -R,--rhosts           Set RHOSTS from the results of the search"
     print_line "  -v,--verbose          Don't truncate long password hashes"
 
@@ -383,7 +383,7 @@ class Creds
         opts[:search_term] = search_term
       when '-v', '--verbose'
         truncate = false
-      when '--realm'
+      when '-r', '--realm'
         opts[:realm] = args.shift
       else
         # Anything that wasn't an option is a host to search for
@@ -426,7 +426,6 @@ class Creds
       'Columns' => cred_table_columns,
       'SearchTerm' => search_term
     }
-
 
     opts[:workspace] = framework.db.workspace
     query = framework.db.creds(opts)
@@ -488,9 +487,9 @@ class Creds
     end
 
     if output_file.nil?
-      print_line(tbl.to_s) if tbl
+      print_line(tbl.to_s)
     else
-      output_file.write(tbl.to_csv) if output_formatter.nil? && tbl
+      output_file.write(tbl.to_csv) if output_formatter.nil?
       output_file.close
       print_status("Wrote creds to #{output_file.path}")
     end

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -542,27 +542,19 @@ class Creds
     else
       if output_file.end_with? '.jtr'
         hashlist = ::File.open(output_file, "wb")
-        ['Metasploit::Credential::NonreplayableHash',
-         'Metasploit::Credential::PostgresMD5',
-         'Metasploit::Credential::NTLMHash'].each do |type|
-          framework.db.creds(type: type).each do |core|
-            formatted = hash_to_jtr(core)
-            unless formatted.nil?
-              hashlist.puts formatted
-            end
+        query.each do |core|
+          formatted = hash_to_jtr(core)
+          unless formatted.nil?
+            hashlist.puts formatted
           end
         end
         hashlist.close
       elsif output_file.end_with? '.hcat'
         hashlist = ::File.open(output_file, "wb")
-        ['Metasploit::Credential::NonreplayableHash',
-         'Metasploit::Credential::PostgresMD5',
-         'Metasploit::Credential::NTLMHash'].each do |type|
-          framework.db.creds(type: type).each do |core|
-            formatted = hash_to_hashcat(core)
-            unless formatted.nil?
-              hashlist.puts formatted
-            end
+        query.each do |core|
+          formatted = hash_to_hashcat(core)
+          unless formatted.nil?
+            hashlist.puts formatted
           end
         end
         hashlist.close

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -149,6 +149,7 @@ class Creds
     print_line "  -u,--user <text>      List users that match this text"
     print_line "  -t,--type <type>      List creds of the specified type: password, ntlm, hash or any valid JtR format"
     print_line "  -O,--origins <IP>     List creds that match these origins"
+    print_line "     --realm            List creds that match this realm"
     print_line "  -R,--rhosts           Set RHOSTS from the results of the search"
     print_line "  -v,--verbose          Don't truncate long password hashes"
 
@@ -387,6 +388,8 @@ class Creds
         opts[:search_term] = search_term
       when '-v', '--verbose'
         truncate = false
+      when '--realm'
+        opts[:realm] = args.shift
       else
         # Anything that wasn't an option is a host to search for
         unless (arg_host_range(arg, host_ranges))

--- a/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
@@ -149,9 +149,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
         context 'with an invalid type' do
           it 'should print the list of valid types' do
             creds.cmd_creds('-t', 'asdf')
-            expect(@error).to match_array [
-              'Unrecognized credential type asdf -- must be one of password,ntlm,hash'
-            ]
+            expect(@error.first).to start_with(
+              'Unrecognized credential type asdf -- must be one of password,ntlm,hash,'
+            )
           end
         end
 


### PR DESCRIPTION
This makes a few improvements to the core `creds` command.

1. Adds support for formatting NetNTLMv1 and NetNTLMv2 hashes to both the JtR and Hashcat formatters.
2. Applies the same filtering to the output files as what is seen when generating tables. When a user outputs the results to a file using the `-o` option, they should get the same results as what is visible in the table when not writing out to a file. The only difference should be when a JtR or hashcat formatter is used, unsupported entries will be omitted.
    * As a user, the original behavior really seemed like a bug. It would disregard all the filtering options that were specified.
3. Adds support for filtering based on the JtR format type name. The original help output documented a `-j` option for this purpose that didn't work and I couldn't find a point in the history where it ever worked. Instead of adding yet another switch, the `--type` option was updated to also accept any valid JtR name. The original three values (`password`, `ntlm`, and `hash`) are not valid JtR formats, so there are no collisions. Doing it this way means the user doesn't need to know the differences between the private types while also retaining backward compatibility.
4. Adds support for filtering based on the realm
5. Don't truncate hashes when writing out to a CSV file (the default format)

This is everything necessary to take hashes stored by the `auxiliary/server/capture/smb` module and output them for cracking.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole` with a database connection
- [x] Delete out any existing creds using `creds -d`
- [x] Run the following three commands to add some creds for testing purposes
    Only the smcintyre one is crackable, password is Password1. The other two are for testing purposes.
    ```
    creds add jtr:netntlmv2 user:smcintyre     realm:EXCHG     hash:smcintyre::EXCHG:ee39ea8eff7b38bf:dbfe068c37a3251dce28a7ad91b40bd4:01010000000000008002150aa69dd701a2801133556de320000000000200120061006e006f006e0079006d006f00750073000100120061006e006f006e0079006d006f00750073000400120061006e006f006e0079006d006f00750073000300120061006e006f006e0079006d006f0075007300070008008002150aa69dd701060004000200000008003000300000000000000001000000002000008f0195c703dd3ce369e009dc7d51eafb66e14d4e925ed08cc3be51df7e498bac0a001000000000000000000000000000000000000900280063006900660073002f003100390032002e003100360038002e003100350039002e003100320038000000000000000000
    creds add jtr:netntlmv2 user:Administrator realm:WORKGROUP hash:Administrator::WORKGROUP:1d14a9ac691b47bd:326bd944acd815b71d0f4f64d6f5cbcb:01010000000000008002150aa69dd701a2801133556de320000000000200120061006e006f006e0079006d006f00750073000100120061006e006f006e0079006d006f00750073000400120061006e006f006e0079006d006f00750073000300120061006e006f006e0079006d006f0075007300070008008002150aa69dd701060004000200000008003000300000000000000001000000002000008f0195c703dd3ce369e009dc7d51eafb66e14d4e925ed08cc3be51df7e498bac0a001000000000000000000000000000000000000900280063006900660073002f003100390032002e003100360038002e003100350039002e003100320038000000000000000000
    creds add jtr:netntlm   user:u4-netntlm    realm:kNS       hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c
    ```
- [x] Filter out based on the `WORKGROUP` realm by running `creds --realm WORKGROUP`, see only one result
- [x] Filter out based on the NetNTLMv2 type by running `creds --type netntlmv2`, see two results
    - [x] Write out the NetNTLMv2 hashes by running `creds --type netntlmv2 -o /path/to/write/to.jtr` (keep that `.jtr` suffix!)
    - [x] See only two lines in the written file
    - [x] Crack those hashes with JTR, one should crack out almost instantly with a password of Password1, the other will never crack
 - [x] Write out all of the results and see that the hashes are *not* truncated in the CSV output by running `creds -o /dev/stdout`

## Demo

```
msf6 exploit(windows/http/exchange_proxyshell_rce) > creds
Credentials
===========

host  origin  service  public         private                                                                                              realm      private_type        JtR Format
----  ------  -------  ------         -------                                                                                              -----      ------------        ----------
                       u4-netntlm     u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619 (TRUNCATED)  kNS        Nonreplayable hash  netntlm
                       smcintyre      smcintyre::EXCHG:ee39ea8eff7b38bf:dbfe068c37a3251dce28a7ad91b40bd4:01010000000000008002 (TRUNCATED)  EXCHG      Nonreplayable hash  netntlmv2
                       Administrator  Administrator::WORKGROUP:1d14a9ac691b47bd:326bd944acd815b71d0f4f64d6f5cbcb:010100000000 (TRUNCATED)  WORKGROUP  Nonreplayable hash  netntlmv2

msf6 exploit(windows/http/exchange_proxyshell_rce) > creds -o /dev/stdout
host,origin,service,public,private,realm,private_type,JtR Format
"","","","u4-netntlm","u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c","kNS","Nonreplayable hash","netntlm"
"","","","smcintyre","smcintyre::EXCHG:ee39ea8eff7b38bf:dbfe068c37a3251dce28a7ad91b40bd4:01010000000000008002150aa69dd701a2801133556de320000000000200120061006e006f006e0079006d006f00750073000100120061006e006f006e0079006d006f00750073000400120061006e006f006e0079006d006f00750073000300120061006e006f006e0079006d006f0075007300070008008002150aa69dd701060004000200000008003000300000000000000001000000002000008f0195c703dd3ce369e009dc7d51eafb66e14d4e925ed08cc3be51df7e498bac0a001000000000000000000000000000000000000900280063006900660073002f003100390032002e003100360038002e003100350039002e003100320038000000000000000000","EXCHG","Nonreplayable hash","netntlmv2"
"","","","Administrator","Administrator::WORKGROUP:1d14a9ac691b47bd:326bd944acd815b71d0f4f64d6f5cbcb:01010000000000008002150aa69dd701a2801133556de320000000000200120061006e006f006e0079006d006f00750073000100120061006e006f006e0079006d006f00750073000400120061006e006f006e0079006d006f00750073000300120061006e006f006e0079006d006f0075007300070008008002150aa69dd701060004000200000008003000300000000000000001000000002000008f0195c703dd3ce369e009dc7d51eafb66e14d4e925ed08cc3be51df7e498bac0a001000000000000000000000000000000000000900280063006900660073002f003100390032002e003100360038002e003100350039002e003100320038000000000000000000","WORKGROUP","Nonreplayable hash","netntlmv2"
[*] Wrote creds to /dev/stdout
msf6 exploit(windows/http/exchange_proxyshell_rce) > creds --type netntlm
Credentials
===========

host  origin  service  public      private                                                                                              realm  private_type        JtR Format
----  ------  -------  ------      -------                                                                                              -----  ------------        ----------
                       u4-netntlm  u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619 (TRUNCATED)  kNS    Nonreplayable hash  netntlm

msf6 exploit(windows/http/exchange_proxyshell_rce) > creds --type netntlmv2 --realm EXCHG
Credentials
===========

host  origin  service  public     private                                                                                              realm  private_type        JtR Format
----  ------  -------  ------     -------                                                                                              -----  ------------        ----------
                       smcintyre  smcintyre::EXCHG:ee39ea8eff7b38bf:dbfe068c37a3251dce28a7ad91b40bd4:01010000000000008002 (TRUNCATED)  EXCHG  Nonreplayable hash  netntlmv2

msf6 exploit(windows/http/exchange_proxyshell_rce) > creds --type netntlmv2
Credentials
===========

host  origin  service  public         private                                                                                              realm      private_type        JtR Format
----  ------  -------  ------         -------                                                                                              -----      ------------        ----------
                       smcintyre      smcintyre::EXCHG:ee39ea8eff7b38bf:dbfe068c37a3251dce28a7ad91b40bd4:01010000000000008002 (TRUNCATED)  EXCHG      Nonreplayable hash  netntlmv2
                       Administrator  Administrator::WORKGROUP:1d14a9ac691b47bd:326bd944acd815b71d0f4f64d6f5cbcb:010100000000 (TRUNCATED)  WORKGROUP  Nonreplayable hash  netntlmv2

msf6 exploit(windows/http/exchange_proxyshell_rce) >
```