### PR TITLE
Fix #15615, refresh session info after running meterpreter > sysinfo

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1319,6 +1319,10 @@ class Console::CommandDispatcher::Core
         # Use the remote side, then load the client-side
         if (client.core.use(modulenameprovided) == true)
           add_extension_client(md)
+
+          if md == 'stdapi' && !client.exploit_datastore['AutoLoadStdapi'] && client.exploit_datastore['AutoSystemInfo']
+            client.load_session_info
+          end
         end
       rescue => ex
         print_line

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -1142,6 +1142,8 @@ class Console::CommandDispatcher::Stdapi::Sys
   #
   def cmd_sysinfo(*args)
     info = client.sys.config.sysinfo(refresh: true)
+    client.update_session_info
+
     width = "Meterpreter".length
     info.keys.each { |k| width = k.length if k.length > width and info[k] }
 


### PR DESCRIPTION
Quick fix for #15615

This ensures the session table is refreshed whenever the sysinfo command is run, and whenever stdapi is loaded manually.

This should also fix a minor bug where if you run an exploit on an existing session, the session information never gets updated (e.g the username from User -> SYSTEM).
Now it's  refreshed when you run `meterpreter > sysinfo`

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] `set AutoLoadStdapi false`
- [ ] `set LHOST 192.168.13.37`
- [ ] `set LPORT 4444`
- [ ] `run`
- [ ] Execute a payload
- [ ] `sessions -C 'load stdapi'`
- [ ] `sessions`
- [ ] **Verify** the information field is now filled

## Before

```
msf6 > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) > set payload windows/x64/meterpreter/reverse_tcp
payload => windows/x64/meterpreter/reverse_tcp
msf6 exploit(multi/handler) > set LHOST 192.168.13.37
LHOST => 192.168.13.37
msf6 exploit(multi/handler) > set LPORT 4444
LPORT => 4444
msf6 exploit(multi/handler) > set AutoLoadStdapi false
AutoLoadStdapi => false
msf6 exploit(multi/handler) > run -j
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/handler) >
[*] Started reverse TCP handler on 192.168.13.37:4444
[*] Sending stage (200262 bytes) to 192.168.13.37
[*] Meterpreter session 1 opened (192.168.13.37:4444 -> 192.168.13.37:35946) at 2021-08-31 15:51:41 +0100

msf6 exploit(multi/handler) > sessions 1
[*] Starting interaction with 1...

meterpreter > load stdapi
Loading extension stdapi...Success.
meterpreter > background
[*] Backgrounding session 1...
msf6 exploit(multi/handler) > sessions

Active sessions
===============

  Id  Name  Type                     Information  Connection
  --  ----  ----                     -----------  ----------
  1         meterpreter x64/windows               192.168.13.37:4444 -> 192.168.13.37:35946 (192.168.13.37)

```

## After

```
msf6 exploit(multi/handler) > sessions

Active sessions
===============

  Id  Name  Type                     Information                             Connection
  --  ----  ----                     -----------                             ----------
  1         meterpreter x64/windows  DESKTOP-5E3GRS6\User @ DESKTOP-5E3GRS6  192.168.13.37:4444 -> 192.168.13.37:35926 (10.0.2.15)

```


