### PR TITLE
exclude full json rpc path from zeitwerk

### DIFF
--- a/lib/msf/core/rpc/json/rpc_command_factory.rb
+++ b/lib/msf/core/rpc/json/rpc_command_factory.rb
@@ -1,3 +1,6 @@
+require 'msf/core/rpc/json/v1_0/rpc_command'
+require 'msf/core/rpc/json/v2_0/rpc_test'
+
 module Msf::RPC::JSON
   class RpcCommandFactory
     # Create an RpcCommand for the provided version.

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -53,8 +53,7 @@ class MsfAutoload
     [
       "#{__dir__}/msf/core/constants.rb",
       "#{__dir__}/msf/core/cert_provider.rb",
-      "#{__dir__}/msf/core/rpc/json/error.rb",
-      "#{__dir__}/msf/core/rpc/json/v2_0/",
+      "#{__dir__}/msf/core/rpc/json/",
       "#{__dir__}/msf/core/modules/external/ruby/metasploit.rb",
       "#{__dir__}/msf/core/rpc/v10/constants.rb",
       "#{__dir__}/msf/core.rb",


### PR DESCRIPTION
`eventmachine` fails to load on Windows, this is a temporary
workaround until a more complete solution can be identified.

This does not enable usage of `eventmachine` and JSON RPC on Windows it does however it does enable `msfconsole` to start properly with only a warning due to modules that consume `eventmachine`.  

Ref: #15571