### PR TITLE
Fix regression issue with serializing reported events

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -168,10 +168,13 @@ class DataStore < Hash
     return str
   end
 
+  # Override Hash's to_h method so we can include the original case of each key
+  # (failing to do this breaks a number of places in framework and pro that use
+  # serialized datastores)
   def to_h
     datastore_hash = {}
     self.keys.each do |k|
-      datastore_hash[k.to_s] = self[k]
+      datastore_hash[k.to_s] = self[k].to_s
     end
     datastore_hash
   end

--- a/spec/lib/msf/core/rhosts_walker_spec.rb
+++ b/spec/lib/msf/core/rhosts_walker_spec.rb
@@ -23,8 +23,13 @@ RSpec::Matchers.define :have_datastore_values do |expected|
     ssh_keys = %w[RHOSTS RPORT USERNAME PASSWORD]
     required_keys = http_keys + smb_keys + mysql_keys + postgres_keys + ssh_keys
     datastores.map do |datastore|
+      # Workaround: Manually convert the datastore to a hash ourselves as `datastore.to_h` coerces all datatypes into strings
+      # which prevents this test suite from validating types correctly. i.e. The tests need to ensure that RPORT is correctly
+      # set as an integer class etc.
+      datastore_hash = datastore.keys.each_with_object({}) { |key, hash| hash[key] = datastore[key] }
+
       # Slice the datastore options that we care about, ignoring other values that just add noise such as VERBOSE/WORKSPACE/etc.
-      datastore.to_h.slice(*required_keys)
+      datastore_hash.slice(*required_keys)
     end
   end
 end


### PR DESCRIPTION
Reverts a change to the datastore's `to_h` method which was introduced as part of https://github.com/rapid7/metasploit-framework/pull/15253. This change lead to issues in Pro, which stores non-serializable objects in its datastore. Speciically this was an issue when reporting events.

Before reporting an event, the datastore is converted to a hash - which additionally performs `to_s` calls in the datastore values:

https://github.com/rapid7/metasploit-framework/blob/5b32c63a427113a6aef33eb3e7657200ea2d1c13/lib/msf/core/framework.rb#L249-L252

Framework then attempts to persist the event, where eventually `Marshall.dump` will be called:
https://github.com/rapid7/metasploit-framework/blob/31e0e73e56689232cf193996af71f76df5aa141c/lib/msf/core/db_manager/event.rb#L66

As Pro stored non-serializable values in a module's datastore, this was problematic. It turns that Pro was was implicitly relying on the `to_h` converting its datastore values to a string.

## Verification

- Ensure CI passes
- Ensure Pro's tests pass again