### PR TITLE
Remove explicit rhosts protocol validation

### DIFF
--- a/lib/msf/core/rhosts_walker.rb
+++ b/lib/msf/core/rhosts_walker.rb
@@ -130,7 +130,7 @@ module Msf
                 results << result.merge('RHOSTS' => rhost, 'UNPARSED_RHOSTS' => value)
               end
             end
-          elsif value =~ /^(?<schema>\w+):.*/
+          elsif value =~ /^(?<schema>\w+):.*/ && SUPPORTED_SCHEMAS.include?(Regexp.last_match(:schema))
             schema = Regexp.last_match(:schema)
             raise InvalidSchemaError unless SUPPORTED_SCHEMAS.include?(schema)
 

--- a/spec/lib/msf/core/rhosts_walker_spec.rb
+++ b/spec/lib/msf/core/rhosts_walker_spec.rb
@@ -356,7 +356,10 @@ RSpec.describe Msf::RhostsWalker do
       { 'RHOSTS' => 'http:', 'expected' => [Msf::RhostsWalker::Error.new('http:')] },
       { 'RHOSTS' => '127.0.0.1 http:', 'expected' => [Msf::RhostsWalker::Error.new('http:')] },
       { 'RHOSTS' => '127.0.0.1 http: 127.0.0.1 https:', 'expected' => [Msf::RhostsWalker::Error.new('http:'), Msf::RhostsWalker::Error.new('https:')] },
-      { 'RHOSTS' => 'unknown_protocol://127.0.0.1 127.0.0.1', 'expected' => [ Msf::RhostsWalker::Error.new('unknown_protocol://127.0.0.1')] },
+      # Unknown protocols aren't validated, as there may be potential ambiguity over ipv6 addresses
+      # which may technically start with a 'schema': AAA:1450:4009:822::2004. The existing rex socket
+      # range walker will silently drop this value though, and it may be treated as an overall error.
+      { 'RHOSTS' => 'unknown_protocol://127.0.0.1 127.0.0.1', 'expected' => [ ] },
 
       # cidr validation
       { 'RHOSTS' => 'cidr:127.0.0.1', 'expected' => [Msf::RhostsWalker::Error.new('cidr:127.0.0.1')] },


### PR DESCRIPTION
Fixes an edgecase where the protocol validation of https://github.com/rapid7/metasploit-framework/pull/15253 incorrectly marked ipv6 address such as `2a00:1450:4009:822::2004` as having an 'invalid protocol'.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use scanner/http/title`
- [ ] `run https://www.google.com`
- [ ] Ensure the ipv6 address runs as expected:
```
msf6 auxiliary(scanner/http/title) > run https://www.google.com

[+] [2a00:1450:4009:822::2004:443] [C:200] [R:] [S:gws] Google
[*] Scanned 1 of 2 hosts (50% complete)
[+] [172.217.169.68:443] [C:200] [R:] [S:gws] Google
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```