### PR TITLE
Fix typo in rename_file preventing Linux systems from renaming files

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -571,7 +571,7 @@ module Msf::Post::File
       return false unless file?(old_file) # adding this because when the old_file is not present it hangs for a while, should be removed after this issue is fixed.
       cmd_exec(%Q|move #{directory?(new_file) ? "" : "/y"} "#{old_file}" "#{new_file}" & if not errorlevel 1 echo #{verification_token}|).include?(verification_token)
     else
-      cmd_exec(%Q|mv #{directory? ? "" : "-f"} "#{old_file}" "#{new_file}" && echo #{verification_token}|).include?(verification_token)
+      cmd_exec(%Q|mv #{directory?(new_file) ? "" : "-f"} "#{old_file}" "#{new_file}" && echo #{verification_token}|).include?(verification_token)
     end
   end
   alias :move_file :rename_file


### PR DESCRIPTION
There is a small typo in the library that was made as part of https://github.com/rapid7/metasploit-framework/commit/5d333032635704f3c2e931a183cc89c034ebcc9a#diff-cc6585bd12e8d43e126c2e1a79e4132f56c1e180483f410ccbf90cfb04c5e5c8R562 where we specified `directory?` but didn't supply the argument for this call. 

This leads to issues like the one mentioned at https://github.com/rapid7/metasploit-framework/pull/15601#issuecomment-912470582 where one can't rename files using `move_file` or any `rename_file` functions or their alias's on Linux systems as you will call `directory?` with 0 arguments instead of 1 argument.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a normal command shell on a Linux target.
- [x] Open up an editor and edit `modules/post/linux/gather/enum_commands.rb` and put the line `p rename_file('/tmp/test.txt', '/tmp/test2.txt')` right after the `run` command.
- [x] Run `use post/linux/gather/enum_commands`
- [x] Run `reload`
- [x] **Verify** that this now works instead of throwing an error about an incorrect number of arguments and `false` is output by the `p` command assuming `/tmp/test.txt` doesn't exist.
