### PR TITLE
Remove ruby3 label automation

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -172,15 +172,6 @@ jobs:
                     Closing this issue. If you believe this issue has been closed in error, please provide any relevant output and logs which may be useful in diagnosing the issue.
                   `
                 },
-                'ruby-3.0.0': {
-                  close: true,
-                  comment: `
-                  This issue appears to be related to Ruby 3.0.0. At this time Metasploit does not support Ruby 3.0.0.
-                  Please try using Ruby 2.7.x with Metasploit.
-
-                  Closing this issue as a duplicate of #14666 - which aims to track this feature request.
-                  `
-                },
               }
             };
 


### PR DESCRIPTION
The final PR for initial Ruby 3 support has now been landed https://github.com/rapid7/metasploit-framework/pull/15537

Maintainers can still apply the ruby 3 label, but the issues will no longer be closed automatically and marked as a duplicate