### PR TITLE
add pip3 to docker image support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ ENV METASPLOIT_GROUP=metasploit
 # used for the copy command
 RUN addgroup -S $METASPLOIT_GROUP
 
-RUN apk add --no-cache bash sqlite-libs nmap nmap-scripts nmap-nselibs postgresql-libs python2 python3 ncurses libcap su-exec alpine-sdk python2-dev openssl-dev nasm
+RUN apk add --no-cache bash sqlite-libs nmap nmap-scripts nmap-nselibs postgresql-libs python2 python3 py3-pip ncurses libcap su-exec alpine-sdk python2-dev openssl-dev nasm
 
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which ruby)
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which nmap)


### PR DESCRIPTION
Updates to some external modules have added new python3 dependencies.

By installing `py3-pip` this package happens to provide a dependency on the `requests` library needed by `auxiliary/gather/office365userenum`.

## Verification

- [x] `docker build -t metasploitframework/metasploit-framework:latest .`
- [x] `./tools/automation/cache/update_module_cache.sh`
- [x] **Verify** the updated ` db/modules_metadata_base.json` file in includes all external modules