### PR TITLE
Add Meterpreter compatibility metadata

### DIFF
--- a/modules/exploits/android/local/binder_uaf.rb
+++ b/modules/exploits/android/local/binder_uaf.rb
@@ -53,6 +53,13 @@ class MetasploitModule < Msf::Exploit::Local
             'WfsDelay' => 5,
           },
           'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_fs_getwd
+              ]
+            }
+          },
         }
       )
     )

--- a/modules/exploits/android/local/futex_requeue.rb
+++ b/modules/exploits/android/local/futex_requeue.rb
@@ -90,6 +90,15 @@ class MetasploitModule < Msf::Exploit::Local
               }
             ],
           ],
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                core_loadlib
+                stdapi_fs_delete_file
+                stdapi_fs_getwd
+              ]
+            }
+          },
         }
       )
     )

--- a/modules/exploits/android/local/janus.rb
+++ b/modules/exploits/android/local/janus.rb
@@ -52,6 +52,13 @@ class MetasploitModule < Msf::Exploit::Local
           'Notes' => {
             'SideEffects' => ['ARTIFACTS_ON_DISK', 'SCREEN_EFFECTS'],
             'Stability' => ['SERVICE_RESOURCE_LOSS'], # ZTE youtube app won't start anymore
+          },
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                appapi_app_install
+              ]
+            }
           }
         }
       )

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -45,6 +45,15 @@ class MetasploitModule < Msf::Exploit::Local
             'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp',
           },
           'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                core_loadlib
+                stdapi_fs_delete_file
+                stdapi_fs_getwd
+              ]
+            }
+          },
         }
       )
     )

--- a/modules/exploits/linux/http/cve_2019_1663_cisco_rmi_rce.rb
+++ b/modules/exploits/linux/http/cve_2019_1663_cisco_rmi_rce.rb
@@ -267,6 +267,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_DOWN, ],
         },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        },
       )
     )
   end

--- a/modules/exploits/linux/http/saltstack_salt_wheel_async_rce.rb
+++ b/modules/exploits/linux/http/saltstack_salt_wheel_async_rce.rb
@@ -92,6 +92,15 @@ class MetasploitModule < Msf::Exploit::Remote
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS] # Payload visible in log if set to DEBUG or TRACE level
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_fs_ls
+              stdapi_fs_stat
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -45,7 +45,14 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DisclosureDate' => '2012-05-17',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/linux/http/webid_converter.rb
+++ b/modules/exploits/linux/http/webid_converter.rb
@@ -38,7 +38,20 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' => [
           [ 'WeBid 1.0.2 / Ubuntu', {} ]
         ],
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_delete_file
+              stdapi_fs_getwd
+              stdapi_fs_search
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
@@ -58,7 +58,15 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=1211223' ],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=1211835' ],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=1218239' ]
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_stat
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -66,7 +66,14 @@ class MetasploitModule < Msf::Exploit::Local
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_SAFE ]
         },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
     register_options [

--- a/modules/exploits/linux/local/bash_profile_persistence.rb
+++ b/modules/exploits/linux/local/bash_profile_persistence.rb
@@ -38,7 +38,12 @@ class MetasploitModule < Msf::Exploit::Local
         'Payload' => {
           'Compat' =>
           {
-            'PayloadType' => 'cmd'
+            'PayloadType' => 'cmd',
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_sys_config_sysinfo
+              ]
+            }
           }
         },
         'References' => [

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -71,7 +71,15 @@ class MetasploitModule < Msf::Exploit::Local
                      'doubleput.c'
                    ]
         },
-        'DefaultTarget' => 1
+        'DefaultTarget' => 1,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
     register_options [

--- a/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
+++ b/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
@@ -49,7 +49,14 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'CVE', '2019-10149' ],
           [ 'EDB', '46996' ],
           [ 'URL', 'https://www.openwall.com/lists/oss-security/2019/06/06/1' ]
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
@@ -72,7 +72,14 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://security-tracker.debian.org/tracker/CVE-2010-3856' ],
           [ 'URL', 'https://access.redhat.com/security/cve/CVE-2010-3847' ],
           [ 'URL', 'https://access.redhat.com/security/cve/CVE-2010-3856' ]
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
     register_options [

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -58,6 +58,13 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultTarget' => 0,
         'Notes' => {
           'AKA' => ['RationalLove.c']
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -71,6 +71,13 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultTarget' => 0,
         'Notes' => {
           'AKA' => ['roothelper.c']
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -75,7 +75,14 @@ class MetasploitModule < Msf::Exploit::Local
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_SAFE ]
         },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
     register_options [

--- a/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
+++ b/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
@@ -67,7 +67,14 @@ class MetasploitModule < Msf::Exploit::Local
           'PrependFork' => true,
           'WfsDelay' => 30
         },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
     register_options [

--- a/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
+++ b/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
@@ -69,7 +69,14 @@ class MetasploitModule < Msf::Exploit::Local
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_SAFE ]
         },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
     register_options [

--- a/modules/exploits/linux/local/udev_netlink.rb
+++ b/modules/exploits/linux/local/udev_netlink.rb
@@ -44,6 +44,13 @@ class MetasploitModule < Msf::Exploit::Local
           'DefaultOptions' => { 'WfsDelay' => 2 },
           'DefaultTarget' => 0,
           'DisclosureDate' => '2009-04-16',
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_sys_process_get_processes
+              ]
+            }
+          },
         }
       )
     )

--- a/modules/exploits/multi/http/extplorer_upload_exec.rb
+++ b/modules/exploits/multi/http/extplorer_upload_exec.rb
@@ -40,7 +40,14 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DisclosureDate' => '2012-12-31',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/multi/http/glossword_upload_exec.rb
+++ b/modules/exploits/multi/http/glossword_upload_exec.rb
@@ -34,7 +34,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' => [['Automatic Targeting', { 'auto' => true }]],
         'Privileged' => true,
         'DisclosureDate' => '2013-02-05',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -59,7 +59,14 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2012-08-29'
+        'DisclosureDate' => '2012-08-29',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/multi/http/kordil_edms_upload_exec.rb
+++ b/modules/exploits/multi/http/kordil_edms_upload_exec.rb
@@ -33,7 +33,14 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DisclosureDate' => '2013-02-22',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -63,7 +63,15 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DisclosureDate' => '2012-01-06',
-        'DefaultTarget' => 2
+        'DefaultTarget' => 2,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_sysinfo
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -62,7 +62,15 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Stance' => Msf::Exploit::Stance::Aggressive,
         'DisclosureDate' => '2013-07-02',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -43,7 +43,14 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DisclosureDate' => '2012-08-13',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -86,7 +86,14 @@ class MetasploitModule < Msf::Exploit::Local
           'PAYLOAD' => 'cmd/unix/reverse_openssl',
           'WfsDelay' => 120
         },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/multi/php/wp_duplicator_code_inject.rb
+++ b/modules/exploits/multi/php/wp_duplicator_code_inject.rb
@@ -42,7 +42,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => 'php',
         'Arch' => ARCH_PHP,
         'Targets' => [['WordPress Duplicator <= 1.2.40', {}]],
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
@@ -48,7 +48,14 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [ ['Invision IP.Board 3.3.4', {}] ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2012-10-25'
+        'DisclosureDate' => '2012-10-25',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
@@ -43,7 +43,14 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [ ['Automatic', {}], ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2012-06-23'
+        'DisclosureDate' => '2012-06-23',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
@@ -49,7 +49,14 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [ ['Automatic', {}] ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2012-07-04'
+        'DisclosureDate' => '2012-07-04',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/unix/webapp/xoda_file_upload.rb
+++ b/modules/exploits/unix/webapp/xoda_file_upload.rb
@@ -42,7 +42,14 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DisclosureDate' => '2012-08-21',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
@@ -45,7 +45,15 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DisclosureDate' => '2013-02-22',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -49,7 +49,15 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DisclosureDate' => '2011-10-20',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
@@ -50,7 +50,15 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Automatic', {} ],
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2012-01-11'
+        'DisclosureDate' => '2012-01-11',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlsimpleaccessor.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlsimpleaccessor.rb
@@ -50,7 +50,15 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Automatic', {} ],
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2011-08-16'
+        'DisclosureDate' => '2011-08-16',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/browser/notes_handler_cmdinject.rb
+++ b/modules/exploits/windows/browser/notes_handler_cmdinject.rb
@@ -50,7 +50,15 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DisclosureDate' => '2012-06-18',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/browser/oracle_webcenter_checkoutandopen.rb
+++ b/modules/exploits/windows/browser/oracle_webcenter_checkoutandopen.rb
@@ -47,7 +47,15 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DisclosureDate' => '2013-04-16',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -46,7 +46,14 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Windows Universal', {} ],
         ],
         'DisclosureDate' => '2011-10-19',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
@@ -76,7 +76,17 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2011-11-01'
+        'DisclosureDate' => '2011-11-01',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_migrate
+              stdapi_sys_config_getenv
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/http/oracle_btm_writetofile.rb
+++ b/modules/exploits/windows/http/oracle_btm_writetofile.rb
@@ -68,7 +68,15 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2012-08-07'
+        'DisclosureDate' => '2012-08-07',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -38,7 +38,15 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'CmdStagerFlavor' => 'tftp',
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2001-05-15'
+        'DisclosureDate' => '2001-05-15',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -48,7 +48,15 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'CmdStagerFlavor' => 'tftp',
       'DefaultTarget' => 0,
-      'DisclosureDate' => 'Jul 17 1998'
+      'DisclosureDate' => 'Jul 17 1998',
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_delete_file
+            stdapi_sys_process_execute
+          ]
+        }
+      }
     )
 
     register_options(

--- a/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
+++ b/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
@@ -51,7 +51,16 @@ class MetasploitModule < Msf::Exploit::Local
             ],
           ],
           'DefaultTarget' => 0,
-          'DisclosureDate' => '2013-05-14'
+          'DisclosureDate' => '2013-05-14',
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_railgun_memread
+                stdapi_sys_config_getenv
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/agnitum_outpost_acs.rb
+++ b/modules/exploits/windows/local/agnitum_outpost_acs.rb
@@ -46,7 +46,15 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'EDB', '27282' ]
           ],
           'DisclosureDate' => '2013-08-02',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_api
+                stdapi_sys_config_getenv
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/applocker_bypass.rb
+++ b/modules/exploits/windows/local/applocker_bypass.rb
@@ -34,7 +34,14 @@ class MetasploitModule < Msf::Exploit::Local
         'DisclosureDate' => '2015-08-03',
         'References' => [
           ['URL', 'https://gist.github.com/subTee/fac6af078937dda81e57']
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/bthpan.rb
+++ b/modules/exploits/windows/local/bthpan.rb
@@ -54,7 +54,17 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'OSVDB', '109387' ]
         ],
         'DisclosureDate' => '2014-07-18',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -37,7 +37,14 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           [ 'URL', 'http://www.trustedsec.com/december-2010/bypass-windows-uac/' ]
         ],
-        'DisclosureDate' => '2010-12-31'
+        'DisclosureDate' => '2010-12-31',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/bypassuac_comhijack.rb
+++ b/modules/exploits/windows/local/bypassuac_comhijack.rb
@@ -50,7 +50,14 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://wikileaks.org/ciav7p1/cms/page_13763373.html'],
           ['URL', 'https://github.com/FuzzySecurity/Defcon25/Defcon25_UAC-0day-All-Day_v1.2.pdf']
         ],
-        'DisclosureDate' => '1900-01-01'
+        'DisclosureDate' => '1900-01-01',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -44,7 +44,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://seclists.org/fulldisclosure/2017/Jul/11'],
           ['URL', 'https://offsec.provadys.com/UAC-bypass-dotnet.html']
         ],
-        'DisclosureDate' => '2017-03-17'
+        'DisclosureDate' => '2017-03-17',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/exploits/windows/local/bypassuac_eventvwr.rb
+++ b/modules/exploits/windows/local/bypassuac_eventvwr.rb
@@ -55,7 +55,14 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/'],
           ['URL', 'https://github.com/enigma0x3/Misc-PowerShell-Stuff/blob/master/Invoke-EventVwrBypass.ps1']
         ],
-        'DisclosureDate' => '2016-08-15'
+        'DisclosureDate' => '2016-08-15',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -54,7 +54,14 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://github.com/winscripting/UAC-bypass/blob/master/FodhelperBypass.ps1'],
           ['URL', 'https://www.bleepingcomputer.com/news/security/gootkit-malware-bypasses-windows-defender-by-setting-path-exclusions/']
         ],
-        'DisclosureDate' => '2017-05-12'
+        'DisclosureDate' => '2017-05-12',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -48,7 +48,18 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'http://www.trustedsec.com/december-2010/bypass-windows-uac/'],
           ['URL', 'http://www.pretentiousname.com/misc/W7E_Source/win7_uac_poc_details.html']
         ],
-        'DisclosureDate' => '2010-12-31'
+        'DisclosureDate' => '2010-12-31',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_write
+              stdapi_sys_process_thread_create
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
+++ b/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
@@ -41,7 +41,21 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           ['URL', 'https://github.com/L3cr0f/DccwBypassUAC']
         ],
-        'DisclosureDate' => '2017-04-06'
+        'DisclosureDate' => '2017-04-06',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_dir
+              stdapi_fs_delete_file
+              stdapi_fs_stat
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_write
+              stdapi_sys_process_thread_create
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac_sdclt.rb
+++ b/modules/exploits/windows/local/bypassuac_sdclt.rb
@@ -44,7 +44,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://github.com/enigma0x3/Misc-PowerShell-Stuff/blob/master/Invoke-SDCLTBypass.ps1'],
           ['URL', 'https://blog.sevagas.com/?Yet-another-sdclt-UAC-bypass']
         ],
-        'DisclosureDate' => '2017-03-17'
+        'DisclosureDate' => '2017-03-17',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -55,7 +55,14 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://github.com/bytecode-77/slui-file-handler-hijack-privilege-escalation'],
           ['URL', 'https://github.com/gushmazuko/WinBypass/blob/master/SluiHijackBypass.ps1']
         ],
-        'DisclosureDate' => '2018-01-15'
+        'DisclosureDate' => '2018-01-15',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
@@ -45,6 +45,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://github.com/sailay1996/UAC_bypass_windows_store'],
           ['URL', 'https://medium.com/tenable-techblog/uac-bypass-by-mocking-trusted-directories-24a96675f6e'],
         ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_file_copy
+              stdapi_fs_mkdir
+              stdapi_sys_process_execute
+            ]
+          }
+        },
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
@@ -44,7 +44,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://www.activecyber.us/activelabs/windows-uac-bypass'],
           ['URL', 'https://heynowyouseeme.blogspot.com/2019/08/windows-10-lpe-uac-bypass-in-windows.html'],
           ['URL', 'https://github.com/sailay1996/UAC_bypass_windows_store'],
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/exploits/windows/local/capcom_sys_exec.rb
+++ b/modules/exploits/windows/local/capcom_sys_exec.rb
@@ -45,7 +45,15 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://twitter.com/TheWack0lian/status/779397840762245124']
           ],
           'DisclosureDate' => '1999-01-01', # non-vuln exploit date
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_fs_md5
+                stdapi_sys_config_driver_list
+              ]
+            }
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/comahawk.rb
+++ b/modules/exploits/windows/local/comahawk.rb
@@ -46,6 +46,13 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DefaultOptions' => {
           'DisablePayloadHandler' => false
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -45,7 +45,15 @@ class MetasploitModule < Msf::Exploit::Local
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [ [ 'Universal', {} ] ],
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_mkdir
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
+++ b/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
@@ -65,6 +65,13 @@ class MetasploitModule < Msf::Exploit::Local
           'Stability' => [ CRASH_SERVICE_RESTARTS, ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, ],
         },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
+        },
       )
     )
 

--- a/modules/exploits/windows/local/cve_2018_8453_win32k_priv_esc.rb
+++ b/modules/exploits/windows/local/cve_2018_8453_win32k_priv_esc.rb
@@ -58,7 +58,15 @@ class MetasploitModule < Msf::Exploit::Local
           'Stability' => [CRASH_OS_RESTARTS]
         },
         'DisclosureDate' => '2018-10-09',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/linux/manage/sshkey_persistence.rb
+++ b/modules/post/linux/manage/sshkey_persistence.rb
@@ -25,7 +25,14 @@ class MetasploitModule < Msf::Post
           'h00die <mike@shorebreaksecurity.com>'
         ],
         'Platform' => [ 'linux' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_separator
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/multi/gather/apple_ios_backup.rb
+++ b/modules/post/multi/gather/apple_ios_backup.rb
@@ -18,7 +18,20 @@ class MetasploitModule < Msf::Post
           'bannedit' # Based on bannedit's pidgin_cred module structure
         ],
         'Platform' => %w{osx win},
-        'SessionTypes' => ['meterpreter', 'shell']
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getuid
+              stdapi_sys_config_sysinfo
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/multi/gather/dbvis_enum.rb
+++ b/modules/post/multi/gather/dbvis_enum.rb
@@ -23,7 +23,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'David Bloom' ], # Twitter: @philophobia78
         'Platform' => %w{linux win},
-        'SessionTypes' => [ 'meterpreter', 'shell']
+        'SessionTypes' => [ 'meterpreter', 'shell'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/multi/gather/env.rb
+++ b/modules/post/multi/gather/env.rb
@@ -15,7 +15,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>', 'egypt' ],
         'Platform' => %w{linux win},
-        'SessionTypes' => [ 'shell', 'meterpreter' ]
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
     @ltype = 'generic.environment'

--- a/modules/post/multi/gather/filezilla_client_cred.rb
+++ b/modules/post/multi/gather/filezilla_client_cred.rb
@@ -21,7 +21,20 @@ class MetasploitModule < Msf::Post
           'Carlos Perez <carlos_perez[at]darkoperator.com>' # original meterpreter script
         ],
         'Platform' => %w{bsd linux osx unix win},
-        'SessionTypes' => ['shell', 'meterpreter' ]
+        'SessionTypes' => ['shell', 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getuid
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/multi/gather/find_vmx.rb
+++ b/modules/post/multi/gather/find_vmx.rb
@@ -19,7 +19,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['theLightCosine'],
         'Platform' => %w{bsd linux osx unix win},
-        'SessionTypes' => ['shell', 'meterpreter' ]
+        'SessionTypes' => ['shell', 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_search
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -51,7 +51,25 @@ class MetasploitModule < Msf::Post
           'g0tmi1k' # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
         ],
         'Platform' => %w{bsd linux osx unix win},
-        'SessionTypes' => ['meterpreter', 'shell' ]
+        'SessionTypes' => ['meterpreter', 'shell' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_close
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_tell
+              core_channel_write
+              stdapi_fs_stat
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getuid
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/multi/gather/jenkins_gather.rb
+++ b/modules/post/multi/gather/jenkins_gather.rb
@@ -21,7 +21,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'thesubtlety' ],
         'Platform' => [ 'linux', 'win' ],
-        'SessionTypes' => %w[shell meterpreter]
+        'SessionTypes' => %w[shell meterpreter],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_search
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -31,7 +31,21 @@ class MetasploitModule < Msf::Post
         'References' => [
           [ 'URL', 'http://www.martinvigo.com/even-the-lastpass-will-be-stolen-deal-with-it' ]
         ],
-        'SessionTypes' => %w(meterpreter shell)
+        'SessionTypes' => %w(meterpreter shell),
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_registry_open_key
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/multi/gather/maven_creds.rb
+++ b/modules/post/multi/gather/maven_creds.rb
@@ -21,7 +21,17 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['elenoir'],
         'Platform' => %w{bsd linux osx unix win},
-        'SessionTypes' => ['shell', 'meterpreter']
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/multi/gather/pidgin_cred.rb
+++ b/modules/post/multi/gather/pidgin_cred.rb
@@ -23,7 +23,20 @@ class MetasploitModule < Msf::Post
           'Carlos Perez <carlos_perez[at]darkoperator.com>' # original meterpreter script
         ],
         'Platform' => %w{bsd linux osx unix win},
-        'SessionTypes' => ['shell', 'meterpreter' ]
+        'SessionTypes' => ['shell', 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getuid
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/multi/gather/resolve_hosts.rb
+++ b/modules/post/multi/gather/resolve_hosts.rb
@@ -16,7 +16,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Ben Campbell' ],
         'Platform' => %w{win python},
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_resolve_hosts
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/multi/gather/skype_enum.rb
+++ b/modules/post/multi/gather/skype_enum.rb
@@ -22,7 +22,20 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform' => %w{osx win},
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_close
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              stdapi_fs_search
+              stdapi_fs_separator
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
     register_advanced_options(

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -22,7 +22,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['Jim Halfpenny'],
         'Platform' => %w{bsd linux osx unix},
-        'SessionTypes' => ['meterpreter', 'shell' ]
+        'SessionTypes' => ['meterpreter', 'shell' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_ls
+              stdapi_fs_separator
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/multi/gather/thunderbird_creds.rb
+++ b/modules/post/multi/gather/thunderbird_creds.rb
@@ -27,7 +27,18 @@ class MetasploitModule < Msf::Post
           'sinn3r', # Metasploit
         ],
         'Platform' => %w{linux osx win},
-        'SessionTypes' => ['meterpreter', 'shell']
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/multi/gather/wlan_geolocate.rb
+++ b/modules/post/multi/gather/wlan_geolocate.rb
@@ -19,6 +19,13 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'Tom Sellers <tom[at]fadedcode.net>'],
         'Platform' => %w{android osx win linux bsd solaris},
         'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              android_*
+            ]
+          }
+        },
       )
     )
 

--- a/modules/post/multi/manage/autoroute.rb
+++ b/modules/post/multi/manage/autoroute.rb
@@ -25,7 +25,15 @@ class MetasploitModule < Msf::Post
           'todb',
           'Josh Hale "sn0wfa11" <jhale85446[at]gmail.com>'
         ],
-        'SessionTypes' => [ 'meterpreter']
+        'SessionTypes' => [ 'meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_config_get_interfaces
+              stdapi_net_config_get_routes
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/multi/manage/dbvis_add_db_admin.rb
+++ b/modules/post/multi/manage/dbvis_add_db_admin.rb
@@ -24,7 +24,15 @@ class MetasploitModule < Msf::Post
           ['URL', 'http://youtu.be/0LCLRVHX1vA']
         ],
         'Platform' => %w{linux win},
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_stat
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/multi/manage/dbvis_query.rb
+++ b/modules/post/multi/manage/dbvis_query.rb
@@ -27,7 +27,15 @@ class MetasploitModule < Msf::Post
           ['URL', 'http://youtu.be/0LCLRVHX1vA']
         ],
         'Platform' => %w{linux win},
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_stat
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -29,6 +29,14 @@ class MetasploitModule < Msf::Post
           # ARTIFACTS_ON_DISK when the platform is linux
           'SideEffects' => [ ARTIFACTS_ON_DISK, AUDIO_EFFECTS, SCREEN_EFFECTS ]
         },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              android_*
+              stdapi_sys_process_execute
+            ]
+          }
+        },
       )
     )
 

--- a/modules/post/multi/manage/record_mic.rb
+++ b/modules/post/multi/manage/record_mic.rb
@@ -19,7 +19,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'sinn3r'],
         'Platform' => %w{linux osx win},
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_webcam_*
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/multi/manage/set_wallpaper.rb
+++ b/modules/post/multi/manage/set_wallpaper.rb
@@ -19,7 +19,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'timwr'],
         'Platform' => [ 'win', 'osx', 'linux', 'android' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              android_*
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/multi/manage/zip.rb
+++ b/modules/post/multi/manage/zip.rb
@@ -20,7 +20,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'sinn3r' ],
         'Platform' => [ 'win', 'linux' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_rev2self
+              stdapi_sys_config_steal_token
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/multi/recon/multiport_egress_traffic.rb
+++ b/modules/post/multi/recon/multiport_egress_traffic.rb
@@ -22,7 +22,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => 'Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>',
         'Platform' => ['linux', 'osx', 'unix', 'solaris', 'bsd', 'windows'],
-        'SessionTypes' => ['meterpreter']
+        'SessionTypes' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -37,7 +37,14 @@ class MetasploitModule < Msf::Post
         'References' => [
           [ 'CVE', '2019-0307' ],
           [ 'URL', 'https://conference.hitb.org/hitblockdown002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who%20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf' ]
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_resolve_host
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/capture/keylog_recorder.rb
+++ b/modules/post/windows/capture/keylog_recorder.rb
@@ -29,7 +29,22 @@ class MetasploitModule < Msf::Post
           'Josh Hale <jhale85446[at]gmail.com>'
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter', ]
+        'SessionTypes' => [ 'meterpreter', ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_migrate
+              stdapi_railgun_api
+              stdapi_sys_config_getuid
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_ui_get_keys_utf8
+              stdapi_ui_start_keyscan
+              stdapi_ui_stop_keyscan
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/capture/lockout_keylogger.rb
+++ b/modules/post/windows/capture/lockout_keylogger.rb
@@ -20,7 +20,21 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'mubix', 'cg' ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'References' => [['URL', 'http://blog.metasploit.com/2010/12/capturing-windows-logons-with.html']]
+        'References' => [['URL', 'http://blog.metasploit.com/2010/12/capturing-windows-logons-with.html']],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_migrate
+              stdapi_railgun_api
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_ui_get_idle_time
+              stdapi_ui_get_keys_utf8
+              stdapi_ui_start_keyscan
+              stdapi_ui_stop_keyscan
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/escalate/droplnk.rb
+++ b/modules/post/windows/escalate/droplnk.rb
@@ -18,7 +18,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'mubix' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_getwd
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/escalate/getsystem.rb
+++ b/modules/post/windows/escalate/getsystem.rb
@@ -21,7 +21,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => 'hdm',
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              priv_elevate_getsystem
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/escalate/golden_ticket.rb
+++ b/modules/post/windows/escalate/golden_ticket.rb
@@ -28,7 +28,15 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'meterpreter' ],
         'References' => [
           ['URL', 'https://github.com/gentilkiwi/mimikatz/wiki/module-~-kerberos']
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              kiwi_exec_cmd
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/escalate/ms10_073_kbdlayout.rb
+++ b/modules/post/windows/escalate/ms10_073_kbdlayout.rb
@@ -32,7 +32,23 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'http://www.reversemode.com/index.php?option=com_content&task=view&id=71&Itemid=1' ],
           [ 'EDB', '15985' ]
         ],
-        'DisclosureDate' => '2010-10-12'
+        'DisclosureDate' => '2010-10-12',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_delete_file
+              stdapi_railgun_api
+              stdapi_railgun_memwrite
+              stdapi_sys_config_getenv
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_getpid
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/escalate/screen_unlock.rb
+++ b/modules/post/windows/escalate/screen_unlock.rb
@@ -25,7 +25,17 @@ class MetasploitModule < Msf::Post
           'Metlstorm'                        # Based on the winlockpwn tool released by Metlstorm: http://www.storm.net.nz/projects/16
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_attach
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/escalate/unmarshal_cmd_exec.rb
+++ b/modules/post/windows/escalate/unmarshal_cmd_exec.rb
@@ -32,6 +32,13 @@ class MetasploitModule < Msf::Post
         'Platform' => ['win'],
         'Arch' => ARCH_X64,
         'License' => MSF_LICENSE,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
+        },
       )
     )
 

--- a/modules/post/windows/gather/arp_scanner.rb
+++ b/modules/post/windows/gather/arp_scanner.rb
@@ -20,7 +20,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter']
+        'SessionTypes' => [ 'meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/bitcoin_jacker.rb
+++ b/modules/post/windows/gather/bitcoin_jacker.rb
@@ -25,7 +25,15 @@ class MetasploitModule < Msf::Post
           'todb' # Added Armory support
         ],
         'Platform' => [ 'win' ], # TODO: Several more platforms host Bitcoin wallets...
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/bitlocker_fvek.rb
+++ b/modules/post/windows/gather/bitlocker_fvek.rb
@@ -28,7 +28,15 @@ class MetasploitModule < Msf::Post
         'References' => [
           ['URL', 'https://github.com/libyal/libbde/blob/master/documentation/BitLocker Drive Encryption (BDE) format.asciidoc'],
           ['URL', 'http://www.hsc.fr/ressources/outils/dislocker/']
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -24,7 +24,15 @@ class MetasploitModule < Msf::Post
         ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'References' => [['URL', 'http://lab.mediaservice.net/code/cachedump.rb']]
+        'References' => [['URL', 'http://lab.mediaservice.net/code/cachedump.rb']],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_registry_open_key
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/avira_password.rb
+++ b/modules/post/windows/gather/credentials/avira_password.rb
@@ -18,7 +18,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Robert Kugler / robertchrk'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/bulletproof_ftp.rb
+++ b/modules/post/windows/gather/credentials/bulletproof_ftp.rb
@@ -21,7 +21,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'juan vazquez'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/credential_collector.rb
+++ b/modules/post/windows/gather/credentials/credential_collector.rb
@@ -15,7 +15,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'tebo[at]attackresearch.com'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter']
+        'SessionTypes' => [ 'meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              incognito_list_tokens
+              priv_passwd_get_sam_hashes
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -26,7 +26,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              extapi_ntds_parse
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
     deregister_options('SMBUser', 'SMBPass', 'SMBDomain')

--- a/modules/post/windows/gather/credentials/dyndns.rb
+++ b/modules/post/windows/gather/credentials/dyndns.rb
@@ -23,7 +23,18 @@ class MetasploitModule < Msf::Post
           'sinn3r', # Lots of code rewrite
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/enum_cred_store.rb
+++ b/modules/post/windows/gather/credentials/enum_cred_store.rb
@@ -19,7 +19,20 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Kx499']
+        'Author' => ['Kx499'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_resolve_host
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/enum_laps.rb
+++ b/modules/post/windows/gather/credentials/enum_laps.rb
@@ -31,6 +31,13 @@ class MetasploitModule < Msf::Post
         ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_resolve_hosts
+            ]
+          }
+        },
       )
     )
 

--- a/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
+++ b/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
@@ -23,7 +23,21 @@ class MetasploitModule < Msf::Post
           'Sil3ntDre4m <sil3ntdre4m[at]gmail.com>',
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_config_getuid
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/epo_sql.rb
+++ b/modules/post/windows/gather/credentials/epo_sql.rb
@@ -22,7 +22,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['Nathan Einwechter <neinwechter[at]gmail.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_net_resolve_host
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -20,7 +20,20 @@ class MetasploitModule < Msf::Post
           'g0tmi1k' # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
         ],
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter' ]
+        'SessionTypes' => ['meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_registry_query_value_direct
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getuid
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/credentials/flashfxp.rb
+++ b/modules/post/windows/gather/credentials/flashfxp.rb
@@ -20,7 +20,17 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/ftpnavigator.rb
+++ b/modules/post/windows/gather/credentials/ftpnavigator.rb
@@ -19,7 +19,17 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/ftpx.rb
+++ b/modules/post/windows/gather/credentials/ftpx.rb
@@ -20,7 +20,17 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'bcoles' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/gpp.rb
+++ b/modules/post/windows/gather/credentials/gpp.rb
@@ -42,7 +42,14 @@ class MetasploitModule < Msf::Post
           ['MSB', 'MS14-025']
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              extapi_adsi_domain_query
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
+++ b/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
@@ -21,7 +21,21 @@ class MetasploitModule < Msf::Post
         'Author' => ['Manuel Nader #AgoraSecurity'],
         'Platform' => ['win'],
         'Arch' => [ARCH_X86, ARCH_X64],
-        'SessionTypes' => ['meterpreter']
+        'SessionTypes' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_close
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              stdapi_fs_ls
+              stdapi_fs_stat
+              stdapi_registry_query_value_direct
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/credentials/meebo.rb
+++ b/modules/post/windows/gather/credentials/meebo.rb
@@ -22,7 +22,18 @@ class MetasploitModule < Msf::Post
           'Unknown', # SecurityXploded Team, www.SecurityXploded.com
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/mssql_local_hashdump.rb
+++ b/modules/post/windows/gather/credentials/mssql_local_hashdump.rb
@@ -26,7 +26,14 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'meterpreter' ],
         'References' => [
           ['URL', 'https://www.dionach.com/blog/easily-grabbing-microsoft-sql-server-password-hashes']
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_rev2self
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/credentials/outlook.rb
+++ b/modules/post/windows/gather/credentials/outlook.rb
@@ -26,7 +26,21 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Justin Cacak' ], # Updated to work with newer versions of Outlook (2013, 2016, Office 365)
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_config_getuid
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/pulse_secure.rb
+++ b/modules/post/windows/gather/credentials/pulse_secure.rb
@@ -35,7 +35,22 @@ class MetasploitModule < Msf::Post
         ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Quentin Kaiser <kaiserquentin[at]gmail.com>']
+        'Author' => ['Quentin Kaiser <kaiserquentin[at]gmail.com>'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_stat
+              stdapi_railgun_api
+              stdapi_sys_config_getsid
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/purevpn_cred_collector.rb
+++ b/modules/post/windows/gather/credentials/purevpn_cred_collector.rb
@@ -22,7 +22,16 @@ class MetasploitModule < Msf::Post
         'Author' => ['Manuel Nader #AgoraSecurity'],
         'Platform' => ['win'],
         'Arch' => [ARCH_X86, ARCH_X64],
-        'SessionTypes' => ['meterpreter']
+        'SessionTypes' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_ls
+              stdapi_registry_query_value_direct
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/credentials/razorsql.rb
+++ b/modules/post/windows/gather/credentials/razorsql.rb
@@ -25,7 +25,18 @@ class MetasploitModule < Msf::Post
           'sinn3r' # Reporting, file parser
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/rdc_manager_creds.rb
+++ b/modules/post/windows/gather/credentials/rdc_manager_creds.rb
@@ -31,7 +31,22 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Tom Sellers <tom[at]fadedcode.net>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_stat
+              stdapi_railgun_api
+              stdapi_sys_config_getuid
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -32,6 +32,14 @@ class MetasploitModule < Msf::Post
           'Reliability' => [],
           'Stability' => [],
           'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_search
+              stdapi_fs_separator
+            ]
+          }
         }
       )
     )

--- a/modules/post/windows/gather/credentials/skype.rb
+++ b/modules/post/windows/gather/credentials/skype.rb
@@ -32,7 +32,21 @@ class MetasploitModule < Msf::Post
           ['URL', 'http://www.recon.cx/en/f/vskype-part2.pdf'],
           ['URL', 'http://insecurety.net/?p=427'],
           ['URL', 'https://github.com/skypeopensource/tools']
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_ls
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/smartftp.rb
+++ b/modules/post/windows/gather/credentials/smartftp.rb
@@ -22,7 +22,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/spark_im.rb
+++ b/modules/post/windows/gather/credentials/spark_im.rb
@@ -26,7 +26,17 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'meterpreter' ],
         'References' => [
           [ 'URL', 'http://adamcaudill.com/2012/07/27/decrypting-spark-saved-passwords/']
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/sso.rb
+++ b/modules/post/windows/gather/credentials/sso.rb
@@ -22,7 +22,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['Ben Campbell'],
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter' ]
+        'SessionTypes' => ['meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              kiwi_exec_cmd
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/steam.rb
+++ b/modules/post/windows/gather/credentials/steam.rb
@@ -19,7 +19,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['Nikolai Rusakov <nikolai.rusakov[at]gmail.com>'],
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter' ]
+        'SessionTypes' => ['meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/teamviewer_passwords.rb
+++ b/modules/post/windows/gather/credentials/teamviewer_passwords.rb
@@ -22,7 +22,18 @@ class MetasploitModule < Msf::Post
         ],
         'Author' => [ 'Nic Losby <blurbdust[at]gmail.com>', 'Kali-Team <kali-team[at]qq.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_railgun_api_multi
+              stdapi_railgun_memread
+              stdapi_railgun_memwrite
+              stdapi_sys_process_get_processes
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -22,7 +22,26 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Justin Cacak'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_railgun_api
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getuid
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/total_commander.rb
+++ b/modules/post/windows/gather/credentials/total_commander.rb
@@ -21,7 +21,17 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/trillian.rb
+++ b/modules/post/windows/gather/credentials/trillian.rb
@@ -23,7 +23,18 @@ class MetasploitModule < Msf::Post
           'Unknown', # SecurityXploded Team, www.SecurityXploded.com
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/vnc.rb
+++ b/modules/post/windows/gather/credentials/vnc.rb
@@ -22,7 +22,20 @@ class MetasploitModule < Msf::Post
           'mubix'
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+              stdapi_registry_open_key
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/windows_sam_hivenightmare.rb
+++ b/modules/post/windows/gather/credentials/windows_sam_hivenightmare.rb
@@ -37,6 +37,13 @@ class MetasploitModule < Msf::Post
           'Reliability' => [ ],
           'SideEffects' => [ ],
           'Stability' => [ CRASH_SAFE ]
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
         }
       )
     )

--- a/modules/post/windows/gather/credentials/winscp.rb
+++ b/modules/post/windows/gather/credentials/winscp.rb
@@ -24,7 +24,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_resolve_host
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/wsftp_client.rb
+++ b/modules/post/windows/gather/credentials/wsftp_client.rb
@@ -20,7 +20,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/xshell_xftp_password.rb
+++ b/modules/post/windows/gather/credentials/xshell_xftp_password.rb
@@ -27,7 +27,16 @@ class MetasploitModule < Msf::Post
           'Kali-Team <kali-team[at]qq.com>'
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_search
+              stdapi_fs_separator
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/dnscache_dump.rb
+++ b/modules/post/windows/gather/dnscache_dump.rb
@@ -14,7 +14,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Borja Merino <bmerinofe[at]gmail.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_railgun_memread
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/dumplinks.rb
+++ b/modules/post/windows/gather/dumplinks.rb
@@ -23,7 +23,20 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'davehull <dph_msf[at]trustedsignal.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_ls
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getuid
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_ad_computers.rb
+++ b/modules/post/windows/gather/enum_ad_computers.rb
@@ -41,7 +41,14 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'meterpreter' ],
         'References' => [
           ['URL', 'http://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx'],
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_resolve_hosts
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/enum_ad_users.rb
+++ b/modules/post/windows/gather/enum_ad_users.rb
@@ -39,7 +39,14 @@ class MetasploitModule < Msf::Post
           'Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>'
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_resolve_host
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/enum_chrome.rb
+++ b/modules/post/windows/gather/enum_chrome.rb
@@ -24,7 +24,29 @@ class MetasploitModule < Msf::Post
           'sinn3r',     # Metasploit post module
           'Kx499',      # x64 support
           'mubix'       # Parse extensions
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_close
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_migrate
+              stdapi_fs_stat
+              stdapi_railgun_api
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getsid
+              stdapi_sys_config_getuid
+              stdapi_sys_config_steal_token
+              stdapi_sys_process_attach
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/enum_computers.rb
+++ b/modules/post/windows/gather/enum_computers.rb
@@ -19,7 +19,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Joshua Abraham <jabra[at]rapid7.com>'],
         'Platform' => [ 'win'],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_resolve_host
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_db.rb
+++ b/modules/post/windows/gather/enum_db.rb
@@ -20,7 +20,15 @@ class MetasploitModule < Msf::Post
           'juan vazquez' # minor help
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_search
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_dirperms.rb
+++ b/modules/post/windows/gather/enum_dirperms.rb
@@ -24,7 +24,14 @@ class MetasploitModule < Msf::Post
           'Kx499',
           'Ben Campbell',
           'sinn3r'
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/enum_domain.rb
+++ b/modules/post/windows/gather/enum_domain.rb
@@ -18,7 +18,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Joshua Abraham <jabra[at]rapid7.com>']
+        'Author' => ['Joshua Abraham <jabra[at]rapid7.com>'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_resolve_host
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_domain_group_users.rb
+++ b/modules/post/windows/gather/enum_domain_group_users.rb
@@ -22,7 +22,14 @@ class MetasploitModule < Msf::Post
           'Stephen Haywood <haywoodsb[at]gmail.com>'
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getuid
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/enum_domain_tokens.rb
+++ b/modules/post/windows/gather/enum_domain_tokens.rb
@@ -25,7 +25,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform' => [ 'win'],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              incognito_list_tokens
+              stdapi_sys_config_getuid
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_files.rb
+++ b/modules/post/windows/gather/enum_files.rb
@@ -21,7 +21,17 @@ class MetasploitModule < Msf::Post
           'RageLtMan <rageltman[at]sempervictus>'
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_search
+              stdapi_railgun_api
+              stdapi_sys_config_getenv
+              stdapi_sys_config_sysinfo
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/enum_ie.rb
+++ b/modules/post/windows/gather/enum_ie.rb
@@ -22,7 +22,27 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Kx499']
+        'Author' => ['Kx499'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+              stdapi_railgun_api
+              stdapi_sys_config_getenv
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_muicache.rb
+++ b/modules/post/windows/gather/enum_muicache.rb
@@ -27,7 +27,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['TJ Glad <tjglad[at]cmail.nu>'],
         'Platform' => ['win'],
-        'SessionType' => ['meterpreter']
+        'SessionType' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_close
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_patches.rb
+++ b/modules/post/windows/gather/enum_patches.rb
@@ -25,7 +25,14 @@ class MetasploitModule < Msf::Post
         ],
         'References' => [
           ['URL', 'http://msdn.microsoft.com/en-us/library/aa394391(v=vs.85).aspx']
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              extapi_wmi_query
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_powershell_env.rb
+++ b/modules/post/windows/gather/enum_powershell_env.rb
@@ -16,7 +16,19 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getuid
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_prefetch.rb
+++ b/modules/post/windows/gather/enum_prefetch.rb
@@ -22,7 +22,16 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['TJ Glad <tjglad[at]cmail.nu>'],
         'Platform' => ['win'],
-        'SessionType' => ['meterpreter']
+        'SessionType' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_search
+              stdapi_sys_config_getenv
+              stdapi_sys_config_sysinfo
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_proxy.rb
+++ b/modules/post/windows/gather/enum_proxy.rb
@@ -17,7 +17,15 @@ class MetasploitModule < Msf::Post
       'Author' => [ 'mubix' ],
       'License' => MSF_LICENSE,
       'Platform' => [ 'win' ],
-      'SessionTypes' => [ 'meterpreter' ]
+      'SessionTypes' => [ 'meterpreter' ],
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_registry_open_key
+            stdapi_registry_open_remote_key
+          ]
+        }
+      }
     )
 
     register_options(

--- a/modules/post/windows/gather/enum_putty_saved_sessions.rb
+++ b/modules/post/windows/gather/enum_putty_saved_sessions.rb
@@ -30,7 +30,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>']
+        'Author' => ['Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_shares.rb
+++ b/modules/post/windows/gather/enum_shares.rb
@@ -16,7 +16,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_registry_open_key
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/enum_termserv.rb
+++ b/modules/post/windows/gather/enum_termserv.rb
@@ -19,7 +19,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'mubix' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_registry_open_key
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_tokens.rb
+++ b/modules/post/windows/gather/enum_tokens.rb
@@ -22,7 +22,20 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Joshua Abraham <jabra[at]rapid7.com>']
+        'Author' => ['Joshua Abraham <jabra[at]rapid7.com>'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              incognito_list_tokens
+              priv_elevate_getsystem
+              stdapi_registry_open_key
+              stdapi_sys_config_getprivs
+              stdapi_sys_config_getuid
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_get_processes
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/exchange.rb
+++ b/modules/post/windows/gather/exchange.rb
@@ -39,7 +39,14 @@ class MetasploitModule < Msf::Post
           [ 'LIST', { 'Description' => 'List basic information about all Exchange servers and mailboxes hosted on the target' } ],
           [ 'EXPORT', { 'Description' => 'Export and download a chosen mailbox in the form of a .PST file, with support for an optional filter keyword' } ],
         ],
-        'DefaultAction' => 'LIST'
+        'DefaultAction' => 'LIST',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/file_from_raw_ntfs.rb
+++ b/modules/post/windows/gather/file_from_raw_ntfs.rb
@@ -25,7 +25,14 @@ class MetasploitModule < Msf::Post
         'Author' => ['Danil Bazin <danil.bazin[at]hsc.fr>'], # @danilbaz
         'References' => [
           [ 'URL', 'http://www.amazon.com/System-Forensic-Analysis-Brian-Carrier/dp/0321268172/' ]
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/forensics/browser_history.rb
+++ b/modules/post/windows/gather/forensics/browser_history.rb
@@ -24,7 +24,20 @@ class MetasploitModule < Msf::Post
           'Joshua Harper <josh[at]radixtx.com>' # @JonValt
         ],
         'Platform' => %w{win},
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_close
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              stdapi_fs_search
+              stdapi_fs_separator
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/forensics/enum_drives.rb
+++ b/modules/post/windows/gather/forensics/enum_drives.rb
@@ -22,7 +22,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Wesley McGrew <wesley[at]mcgrewsecurity.com>']
+        'Author' => ['Wesley McGrew <wesley[at]mcgrewsecurity.com>'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/forensics/imager.rb
+++ b/modules/post/windows/gather/forensics/imager.rb
@@ -25,7 +25,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Wesley McGrew <wesley[at]mcgrewsecurity.com>']
+        'Author' => ['Wesley McGrew <wesley[at]mcgrewsecurity.com>'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/forensics/nbd_server.rb
+++ b/modules/post/windows/gather/forensics/nbd_server.rb
@@ -28,7 +28,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Wesley McGrew <wesley[at]mcgrewsecurity.com>']
+        'Author' => ['Wesley McGrew <wesley[at]mcgrewsecurity.com>'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/forensics/recovery_files.rb
+++ b/modules/post/windows/gather/forensics/recovery_files.rb
@@ -26,7 +26,14 @@ class MetasploitModule < Msf::Post
         'Author' => ['Borja Merino <bmerinofe[at]gmail.com>'],
         'References' => [
           [ 'URL', 'http://www.youtube.com/watch?v=9yzCf360ujY&hd=1' ]
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/hashdump.rb
+++ b/modules/post/windows/gather/hashdump.rb
@@ -17,7 +17,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'hdm' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_registry_open_key
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/local_admin_search_enum.rb
+++ b/modules/post/windows/gather/local_admin_search_enum.rb
@@ -27,7 +27,16 @@ class MetasploitModule < Msf::Post
           'Royce Davis "r3dy" <rdavis[at]accuvant.com>'
         ],
         'Platform' => 'win',
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_railgun_memread
+              stdapi_sys_config_getuid
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/memory_dump.rb
+++ b/modules/post/windows/gather/memory_dump.rb
@@ -29,6 +29,20 @@ class MetasploitModule < Msf::Post
           'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_close
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              stdapi_fs_delete_file
+              stdapi_fs_stat
+              stdapi_railgun_api
+              stdapi_sys_process_getpid
+            ]
+          }
         }
       )
     )
@@ -93,12 +107,12 @@ class MetasploitModule < Msf::Post
       process_handle = get_process_handle
       file_handle = create_file
       result = session.railgun.dbghelp.MiniDumpWriteDump(process_handle,
-                                                 target_pid,
-                                                 file_handle,
-                                                 dump_flags,
-                                                 nil,
-                                                 nil,
-                                                 nil)
+                                                         target_pid,
+                                                         file_handle,
+                                                         dump_flags,
+                                                         nil,
+                                                         nil,
+                                                         nil)
       unless result['return']
         fail_with(Msf::Module::Failure::PayloadFailed, "Minidump failed: #{result['ErrorMessage']}")
       end

--- a/modules/post/windows/gather/memory_grep.rb
+++ b/modules/post/windows/gather/memory_grep.rb
@@ -20,7 +20,20 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['bannedit'],
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter' ]
+        'SessionTypes' => ['meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_migrate
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_query
+              stdapi_sys_process_memory_read
+              stdapi_sys_process_thread_open
+            ]
+          }
+        }
       )
     )
     register_options([

--- a/modules/post/windows/gather/ntds_location.rb
+++ b/modules/post/windows/gather/ntds_location.rb
@@ -20,7 +20,14 @@ class MetasploitModule < Msf::Post
         'Author' => ['Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>'],
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter']
+        'SessionTypes' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/outlook.rb
+++ b/modules/post/windows/gather/outlook.rb
@@ -32,7 +32,16 @@ class MetasploitModule < Msf::Post
           [ 'LIST', { 'Description' => 'Lists all folders' } ],
           [ 'SEARCH', { 'Description' => 'Searches for an email' } ]
         ],
-        'DefaultAction' => 'LIST'
+        'DefaultAction' => 'LIST',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_config_sysinfo
+              stdapi_ui_get_idle_time
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/phish_windows_credentials.rb
+++ b/modules/post/windows/gather/phish_windows_credentials.rb
@@ -25,7 +25,15 @@ class MetasploitModule < Msf::Post
         'References' => [ 'URL', 'https://forsec.nl/2015/02/windows-credentials-phishing-using-metasploit' ],
         'Platform' => [ 'win' ],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/reverse_lookup.rb
+++ b/modules/post/windows/gather/reverse_lookup.rb
@@ -17,7 +17,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => [ 'mubix' ]
+        'Author' => [ 'mubix' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_railgun_memread
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/screen_spy.rb
+++ b/modules/post/windows/gather/screen_spy.rb
@@ -30,7 +30,14 @@ class MetasploitModule < Msf::Post
           'DLL_Cool_J' # Specify PID to migrate into
         ],
         'Platform' => ['win'], # @todo add support for posix meterpreter somehow?
-        'SessionTypes' => ['meterpreter']
+        'SessionTypes' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_migrate
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -23,7 +23,19 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_migrate
+              priv_elevate_getsystem
+              priv_passwd_get_sam_hashes
+              stdapi_registry_open_key
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_getpid
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/tcpnetstat.rb
+++ b/modules/post/windows/gather/tcpnetstat.rb
@@ -15,7 +15,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'mubix' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter']
+        'SessionTypes' => [ 'meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/gather/usb_history.rb
+++ b/modules/post/windows/gather/usb_history.rb
@@ -15,7 +15,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'nebulus'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_registry_open_key
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/win_privs.rb
+++ b/modules/post/windows/gather/win_privs.rb
@@ -19,7 +19,16 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Merlyn Cousins <drforbin6[at]gmail.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_config_getprivs
+              stdapi_sys_config_getuid
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/gather/word_unc_injector.rb
+++ b/modules/post/windows/gather/word_unc_injector.rb
@@ -40,7 +40,15 @@ class MetasploitModule < Msf::Post
         'SessionTypes'	=> ['meterpreter'],
         'Author' => [
           'SphaZ <cyberphaz[at]gmail.com>'
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              priv_fs_get_file_mace
+              priv_fs_set_file_mace
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/add_user.rb
+++ b/modules/post/windows/manage/add_user.rb
@@ -26,7 +26,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => 'Joshua Abraham <jabra[at]rapid7.com>',
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              incognito_impersonate_token
+              incognito_list_tokens
+              stdapi_sys_config_getuid
+              stdapi_sys_config_steal_token
+              stdapi_sys_process_get_processes
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/manage/archmigrate.rb
+++ b/modules/post/windows/manage/archmigrate.rb
@@ -23,7 +23,17 @@ class MetasploitModule < Msf::Post
         'References' => [''],
         'Platform' => [ 'win' ],
         'Arch' => [ 'x86', 'x64' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_migrate
+              stdapi_railgun_api
+              stdapi_sys_process_execute
+              stdapi_sys_process_getpid
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/change_password.rb
+++ b/modules/post/windows/manage/change_password.rb
@@ -20,7 +20,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Ben Campbell']
+        'Author' => ['Ben Campbell'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/clone_proxy_settings.rb
+++ b/modules/post/windows/manage/clone_proxy_settings.rb
@@ -17,7 +17,16 @@ class MetasploitModule < Msf::Post
       'Author' => [ 'mubix' ],
       'License' => MSF_LICENSE,
       'Platform' => [ 'win' ],
-      'SessionTypes' => [ 'meterpreter' ]
+      'SessionTypes' => [ 'meterpreter' ],
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_registry_create_key
+            stdapi_registry_open_key
+            stdapi_registry_open_remote_key
+          ]
+        }
+      }
     )
 
     register_options(

--- a/modules/post/windows/manage/download_exec.rb
+++ b/modules/post/windows/manage/download_exec.rb
@@ -18,7 +18,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['RageLtMan <rageltman[at]sempervictus>']
+        'Author' => ['RageLtMan <rageltman[at]sempervictus>'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_fs_file_expand_path
+              stdapi_fs_stat
+              stdapi_railgun_api
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/enable_support_account.rb
+++ b/modules/post/windows/manage/enable_support_account.rb
@@ -24,7 +24,14 @@ class MetasploitModule < Msf::Post
         'Author' => 'salcho <salchoman[at]gmail.com>',
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
-        'References'	=> [ 'http://xangosec.blogspot.com/2013/06/trojanizing-windows.html' ]
+        'References'	=> [ 'http://xangosec.blogspot.com/2013/06/trojanizing-windows.html' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              priv_elevate_getsystem
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/execute_dotnet_assembly.rb
+++ b/modules/post/windows/manage/execute_dotnet_assembly.rb
@@ -34,7 +34,21 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => ['meterpreter'],
         'Targets' => [['Windows x64 (<= 10)', { 'Arch' => ARCH_X64 }]],
         'References' => [['URL', 'https://b4rtik.github.io/posts/execute-assembly-via-meterpreter-session/']],
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_kill
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_write
+              stdapi_sys_process_thread_create
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/manage/forward_pageant.rb
+++ b/modules/post/windows/manage/forward_pageant.rb
@@ -30,7 +30,14 @@ class MetasploitModule < Msf::Post
           'Ben Campbell', # A HUGE amount of support in this :-)
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              extapi_pageant_send_query
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/manage/hashcarve.rb
+++ b/modules/post/windows/manage/hashcarve.rb
@@ -17,7 +17,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'p3nt4' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_registry_open_key
+            ]
+          }
+        }
       )
       )
     register_options(

--- a/modules/post/windows/manage/ie_proxypac.rb
+++ b/modules/post/windows/manage/ie_proxypac.rb
@@ -25,7 +25,14 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'http://blog.scriptmonkey.eu/bypassing-group-policy-using-the-windows-registry' ]
         ],
         'Platform' => 'win',
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/inject_ca.rb
+++ b/modules/post/windows/manage/inject_ca.rb
@@ -17,7 +17,15 @@ class MetasploitModule < Msf::Post
         'License' => BSD_LICENSE,
         'Author' => [ 'vt <nick.freeman[at]security-assessment.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_registry_create_key
+              stdapi_registry_open_key
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/inject_host.rb
+++ b/modules/post/windows/manage/inject_host.rb
@@ -17,7 +17,20 @@ class MetasploitModule < Msf::Post
         'License' => BSD_LICENSE,
         'Author' => [ 'vt <nick.freeman[at]security-assessment.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_close
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_tell
+              core_channel_write
+              stdapi_fs_stat
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/killav.rb
+++ b/modules/post/windows/manage/killav.rb
@@ -24,7 +24,15 @@ class MetasploitModule < Msf::Post
           'OJ Reeves'
         ],
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter']
+        'SessionTypes' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/manage/migrate.rb
+++ b/modules/post/windows/manage/migrate.rb
@@ -23,7 +23,18 @@ class MetasploitModule < Msf::Post
           'phra <https://iwantmore.pizza>'
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_migrate
+              stdapi_sys_config_getenv
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -29,7 +29,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Scott Sutherland <scott.sutherland[at]netspi.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_rev2self
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/multi_meterpreter_inject.rb
+++ b/modules/post/windows/manage/multi_meterpreter_inject.rb
@@ -24,7 +24,18 @@ class MetasploitModule < Msf::Post
           'David Kennedy "ReL1K" <kennedyd013[at]gmail.com>' # added multiple payload support
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter']
+        'SessionTypes' => [ 'meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_write
+              stdapi_sys_process_thread_create
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/nbd_server.rb
+++ b/modules/post/windows/manage/nbd_server.rb
@@ -27,7 +27,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Wesley McGrew <wesley[at]mcgrewsecurity.com>']
+        'Author' => ['Wesley McGrew <wesley[at]mcgrewsecurity.com>'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/manage/peinjector.rb
+++ b/modules/post/windows/manage/peinjector.rb
@@ -15,7 +15,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Maximiliano Tedesco <maxitedesco1@gmail.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              peinjector_inject_shellcode
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/persistence_exe.rb
+++ b/modules/post/windows/manage/persistence_exe.rb
@@ -25,7 +25,20 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'Merlyn drforbin Cousins <drforbin6[at]gmail.com>' ],
         'Version' => '$Revision:1$',
         'Platform' => [ 'windows' ],
-        'SessionTypes' => [ 'meterpreter']
+        'SessionTypes' => [ 'meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_sys_config_getenv
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/powershell/build_net_code.rb
+++ b/modules/post/windows/manage/powershell/build_net_code.rb
@@ -25,7 +25,17 @@ class MetasploitModule < Msf::Post
         'Author' => 'RageLtMan <rageltman[at]sempervictus>',
         'Platform' => [ 'windows' ],
         'SessionTypes' => [ 'meterpreter' ],
-        'DisclosureDate' => '2012-08-14'
+        'DisclosureDate' => '2012-08-14',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_stat
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getsid
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/powershell/exec_powershell.rb
+++ b/modules/post/windows/manage/powershell/exec_powershell.rb
@@ -33,7 +33,14 @@ class MetasploitModule < Msf::Post
         'Author' => [
           'Nicholas Nam (nick[at]executionflow.org)', # original meterpreter script
           'RageLtMan <rageltman[at]sempervictus>' # post module
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_sysinfo
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -30,7 +30,19 @@ class MetasploitModule < Msf::Post
           'theLightCosine'
         ],
         'Platform' => ['win' ],
-        'SessionTypes' => ['meterpreter' ]
+        'SessionTypes' => ['meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_migrate
+              stdapi_sys_config_getuid
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/pxeexploit.rb
+++ b/modules/post/windows/manage/pxeexploit.rb
@@ -27,7 +27,21 @@ class MetasploitModule < Msf::Post
       'Author' => [ 'scriptjunkie' ],
       'License' => MSF_LICENSE,
       'Platform' => [ 'win' ],
-      'SessionTypes' => [ 'meterpreter' ]
+      'SessionTypes' => [ 'meterpreter' ],
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            lanattacks_add_tftp_file
+            lanattacks_dhcp_log
+            lanattacks_reset_dhcp
+            lanattacks_set_dhcp_option
+            lanattacks_start_dhcp
+            lanattacks_start_tftp
+            lanattacks_stop_dhcp
+            lanattacks_stop_tftp
+          ]
+        }
+      }
     )
 
     register_advanced_options(

--- a/modules/post/windows/manage/reflective_dll_inject.rb
+++ b/modules/post/windows/manage/reflective_dll_inject.rb
@@ -27,7 +27,21 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => ['meterpreter'],
         'References' => [
           [ 'URL', 'https://github.com/stephenfewer/ReflectiveDLLInjection' ]
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_kill
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_write
+              stdapi_sys_process_thread_create
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/manage/remove_ca.rb
+++ b/modules/post/windows/manage/remove_ca.rb
@@ -17,7 +17,14 @@ class MetasploitModule < Msf::Post
         'License' => BSD_LICENSE,
         'Author' => [ 'vt <nick.freeman[at]security-assessment.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_registry_open_key
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/remove_host.rb
+++ b/modules/post/windows/manage/remove_host.rb
@@ -16,7 +16,19 @@ class MetasploitModule < Msf::Post
         'License' => BSD_LICENSE,
         'Author' => [ 'vt <nick.freeman[at]security-assessment.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_close
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_tell
+              core_channel_write
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/rid_hijack.rb
+++ b/modules/post/windows/manage/rid_hijack.rb
@@ -28,7 +28,14 @@ class MetasploitModule < Msf::Post
       'SessionTypes' => ['meterpreter'],
       'References'	=> [
         ['URL', 'http://csl.com.co/rid-hijacking/']
-      ])
+      ],
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            priv_elevate_getsystem
+          ]
+        }
+      })
 
     register_options(
       [

--- a/modules/post/windows/manage/rollback_defender_signatures.rb
+++ b/modules/post/windows/manage/rollback_defender_signatures.rb
@@ -28,6 +28,13 @@ class MetasploitModule < Msf::Post
         ], # Module author
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
+        },
       )
     )
     register_options(

--- a/modules/post/windows/manage/run_as.rb
+++ b/modules/post/windows/manage/run_as.rb
@@ -23,7 +23,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Author' => ['Kx499']
+        'Author' => ['Kx499'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_config_getprivs
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/run_as_psh.rb
+++ b/modules/post/windows/manage/run_as_psh.rb
@@ -14,7 +14,14 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['p3nt4'],
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter']
+        'SessionTypes' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/manage/sdel.rb
+++ b/modules/post/windows/manage/sdel.rb
@@ -23,7 +23,17 @@ class MetasploitModule < Msf::Post
         'License' => BSD_LICENSE,
         'Author' => [ 'Borja Merino <bmerinofe[at]gmail.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              priv_fs_set_file_mace
+              stdapi_fs_stat
+              stdapi_railgun_api
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/shellcode_inject.rb
+++ b/modules/post/windows/manage/shellcode_inject.rb
@@ -18,7 +18,17 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'phra <https://iwantmore.pizza>' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_thread_create
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/sshkey_persistence.rb
+++ b/modules/post/windows/manage/sshkey_persistence.rb
@@ -25,7 +25,15 @@ class MetasploitModule < Msf::Post
           'Dean Welch <dean_welch[at]rapid7.com>'
         ],
         'Platform' => [ 'windows' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_mkdir
+              stdapi_fs_separator
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/vmdk_mount.rb
+++ b/modules/post/windows/manage/vmdk_mount.rb
@@ -25,7 +25,21 @@ class MetasploitModule < Msf::Post
           ['URL', 'http://www.shelliscoming.com/2017/05/post-exploitation-mounting-vmdk-files.html']
         ],
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter']
+        'SessionTypes' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_fs_ls
+              stdapi_fs_stat
+              stdapi_railgun_api
+              stdapi_sys_process_execute
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_kill
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/vss.rb
+++ b/modules/post/windows/manage/vss.rb
@@ -34,7 +34,14 @@ class MetasploitModule < Msf::Post
           [ 'VSS_GET_INFO', { 'Description' => 'Get VSS information' } ],
           [ 'VSS_SET_MAX_STORAGE_SIZE', { 'Description' => 'Set the VSS maximum storage size' } ]
         ],
-        'DefaultAction' => 'VSS_GET_INFO'
+        'DefaultAction' => 'VSS_GET_INFO',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_dir
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/manage/vss_mount.rb
+++ b/modules/post/windows/manage/vss_mount.rb
@@ -28,7 +28,14 @@ class MetasploitModule < Msf::Post
         'Author' => ['theLightCosine'],
         'References' => [
           [ 'URL', 'http://pauldotcom.com/2011/11/safely-dumping-hashes-from-liv.html' ]
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/manage/webcam.rb
+++ b/modules/post/windows/manage/webcam.rb
@@ -23,7 +23,14 @@ class MetasploitModule < Msf::Post
           [ 'LIST', { 'Description' => 'Show a list of webcams' } ],
           [ 'SNAPSHOT', { 'Description' => 'Take a snapshot with the webcam' } ]
         ],
-        'DefaultAction' => 'LIST'
+        'DefaultAction' => 'LIST',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_webcam_*
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/recon/computer_browser_discovery.rb
+++ b/modules/post/windows/recon/computer_browser_discovery.rb
@@ -21,7 +21,16 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'mubix' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_net_resolve_host
+              stdapi_railgun_api
+              stdapi_railgun_memread
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/recon/outbound_ports.rb
+++ b/modules/post/windows/recon/outbound_ports.rb
@@ -28,7 +28,14 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => ['meterpreter'],
         'References' => [
           ['URL', 'http://www.shelliscoming.com/2014/11/getting-outbound-filtering-rules-by.html']
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/recon/resolve_ip.rb
+++ b/modules/post/windows/recon/resolve_ip.rb
@@ -16,7 +16,15 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'mubix' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_railgun_memread
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/post/windows/wlan/wlan_bss_list.rb
+++ b/modules/post/windows/wlan/wlan_bss_list.rb
@@ -18,7 +18,16 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_getpid
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/wlan/wlan_current_connection.rb
+++ b/modules/post/windows/wlan/wlan_current_connection.rb
@@ -18,7 +18,16 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_getpid
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/windows/wlan/wlan_disconnect.rb
+++ b/modules/post/windows/wlan/wlan_disconnect.rb
@@ -18,7 +18,16 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_getpid
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/wlan/wlan_probe_request.rb
+++ b/modules/post/windows/wlan/wlan_probe_request.rb
@@ -17,7 +17,16 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Borja Merino <bmerinofe[at]gmail.com>' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_getpid
+            ]
+          }
+        }
       )
     )
 

--- a/modules/post/windows/wlan/wlan_profile.rb
+++ b/modules/post/windows/wlan/wlan_profile.rb
@@ -20,7 +20,16 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_sys_process_attach
+              stdapi_sys_process_getpid
+            ]
+          }
+        }
       )
     )
   end


### PR DESCRIPTION
Building on the work of https://github.com/rapid7/metasploit-framework/pull/15295 and https://github.com/rapid7/metasploit-framework/pull/15659

It automates adding compatibility requirements to the modules directory
```
rubocop -A --only Lint/MeterpreterCommandCompatibility modules
git diff --name-only | xargs rubocop -A --only Layout
```

## Verification

Review the modules and verify that the command additions make sense