### PR TITLE
fix #15662, fix meterpreter download of utf8 filenames

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -323,6 +323,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   # again when each download is complete.
   #
   def File.download(dest, src_files, opts = {}, &stat)
+    dest.force_encoding('UTF-8')
     timestamp = opts["timestamp"]
     [*src_files].each { |src|
       src.force_encoding('UTF-8')


### PR DESCRIPTION
Quick fix for #15662 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a native windows meterpreter session
- [x] Run the following
```

meterpreter > mkdir test
Creating directory: test
meterpreter > cd test
meterpreter > edit 🔥
meterpreter > ls
Listing: C:\test
=================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100666/rw-rw-rw-  5     fil   2021-09-13 16:16:23 +0100  🔥

meterpreter > download 🔥
[*] Downloading: 🔥 -> /metasploit-framework/🔥/🔥
[*] Downloaded 5.00 B of 5.00 B (100.0%): 🔥 -> /metasploit-framework/🔥/🔥
[*] download   : 🔥 -> /metasploit-framework/🔥/🔥
```
```
Before fix:
meterpreter > download 🔥
[-] Error running command download: Encoding::CompatibilityError incompatible character encodings: ASCII-8BIT and UTF-8

```