### PR TITLE
Fixing a problem where the module reported failure but actually succeeded

### DIFF
--- a/modules/auxiliary/admin/http/tomcat_ghostcat.rb
+++ b/modules/auxiliary/admin/http/tomcat_ghostcat.rb
@@ -267,9 +267,17 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def read_success?(header)
-    status_code = header.match(/Status Code: [0-9]{3}*/).to_s.split(/ /)[2]
+    # As far as we can tell, a successful status code can be either:
+    # 200
+    # 200 OK
+    # OK
+    # And so this should handle all three.
+    # See this issue for more details:
+    # https://github.com/rapid7/metasploit-framework/issues/15673
 
-    status_code == '200'
+    status_code = header.scan(/Status Code: (\w+)/).flatten.first
+
+    (status_code == '200' || status_code == 'OK')
   end
 
   def read_remote_file


### PR DESCRIPTION
See this issue for working through it.

https://github.com/rapid7/metasploit-framework/issues/15673

It fixes a problem where the module expected the server to return `Status Code: 200` but it actually returned `Status Code: OK` so there was a false positive report of failure.