### PR TITLE
fix the module info command to display the description field

### DIFF
--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -4,7 +4,7 @@ module Msf
 module Exploit::FileDropper
 
   def initialize(info = {})
-    super(
+    super(update_info(info,
       'Compat' => {
         'Meterpreter' => {
           'Commands' => %w[
@@ -15,7 +15,7 @@ module Exploit::FileDropper
           ]
         }
       }
-    )
+    ))
 
     self.needs_cleanup = true
     @dropped_files = []

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -10,7 +10,7 @@ module Msf::PostMixin
   include Msf::Post::Common
 
   def initialize(info={})
-    super(
+    super(update_info(info,
       'Compat' => {
         'Meterpreter' => {
           'Commands' => %w[
@@ -18,7 +18,7 @@ module Msf::PostMixin
           ]
         }
       }
-    )
+    ))
 
     register_options( [
       Msf::OptInt.new('SESSION', [ true, "The session to run this module on." ])


### PR DESCRIPTION
This is a quick fix for the module description field, which looks like it was broken in https://github.com/rapid7/metasploit-framework/pull/15609

## Verification

- [ ] `msfconsole -qx "info exploit/multi/handler; info exploit/windows/local/ask; info modules/exploits/windows/browser/samsung_security_manager_put; exit" | grep -1 Description:`
- [ ] **Verify** the module description is shown

## Before
```
$ msfconsole -qx "info exploit/multi/handler; info exploit/windows/local/ask; info modules/exploits/windows/browser/samsung_security_manager_put; exit" | grep -1 Description:

Description:
  This module is a stub that provides all of the features of the
--

Description:
  No module description
--

Description:
  No module description

```

## After
```
$ msfconsole -qx "info exploit/multi/handler; info exploit/windows/local/ask; info modules/exploits/windows/browser/samsung_security_manager_put; exit" | grep -1 Description:

Description:
  This module is a stub that provides all of the features of the
--

Description:
  This module will attempt to elevate execution level using the
--

Description:
  This is an exploit against Samsung Security Manager that bypasses

```
