### PR TITLE
bug fix for tomcat_mgr_upload module not undeploying app after exploit

### DIFF
--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -210,6 +210,19 @@ class MetasploitModule < Msf::Exploit::Remote
     return vars
   end
 
+  def vars_undeploy
+    vars = {}
+    unless @csrf_token.nil?
+      vars = {
+        "path" => "/" + @app_base,
+        "org.apache.catalina.filters.CSRF_NONCE" => @csrf_token
+      }
+    end
+
+    return vars
+  end
+
+  
   def detect_platform(body)
     return nil if body.blank?
 
@@ -326,7 +339,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def send_request_undeploy(url)
     res = send_request_cgi({
       'uri'          => url,
-      'vars_get'     => vars_get,
+      'vars_get'     => vars_undeploy,
       'method'       => 'POST',
       'user'         => datastore['HttpUsername'],
       'password'     => datastore['HttpPassword'],
@@ -400,11 +413,12 @@ class MetasploitModule < Msf::Exploit::Remote
       return false
     end
 
-    if res and (res.code < 200 or res.code >= 300)
+    if res and (res.code < 200 or res.code >= 300 or res.body =~ /FAIL - Invalid context path/)
       vprint_warning("Deletion failed on #{undeploy_url} [#{res.code} #{res.message}]")
       return false
     end
 
+    print_status("Undeployed at #{undeploy_url}")
     return true
   end
 


### PR DESCRIPTION
An issue was previously filed for the tomcat_mgr_upload module not undeploying the app after exploit. After the exploit complete, the messages from the module seem to indicate the undeploy was successful, but it in facts fails to undeploy. An status code of 200 is returned but there is a message in the body that something like: "FAIL - Invalid context path [YQQMK] was specified"

Prior issue:
https://github.com/rapid7/metasploit-framework/pull/6767

The author had a PR at the time but closed it. I ran into the same issue when testing against different versions of Tomcat and have a fix that should work.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/tomcat_mgr_upload`
- [ ] Set options accordingly. I used the default Java payload to test.
- [ ] After exploit completes and a shell is returned, verify through the Tomcat manager interface that the app has in fact been removed.

Root cause:
The path variable passed to the undeploy endpoint is missing a leading "/" in front of the appbase. 

Also added an extra check and logging from the previous PR (issue 6767) to catch the case where the undeploy endpoint returns 200 but the message indicates a path error.

Unlike the previous PR, I used a different function to create the vars for undeploy.

Testing:
I have verified this works on Tomcat versions 9.030, 7.0.88 and 6.0.53.

