### PR TITLE
Improve interactive shell performance for pasted user input

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/interactive_channel.rb
+++ b/lib/rex/post/meterpreter/ui/console/interactive_channel.rb
@@ -75,7 +75,7 @@ module Console::InteractiveChannel
   #
   def _stream_read_local_write_remote(channel)
     if raw
-      data = user_input.getch
+      data = user_input.sysread(1024)
     else
       data = user_input.gets
     end

--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -82,13 +82,6 @@ begin
       end
     end
 
-    def getch()
-      begin
-        self.fd.getch
-      rescue ::Errno::EINTR
-        retry
-      end
-    end
     #
     # Stick readline into a low-priority thread so that the scheduler doesn't slow
     # down other background threads. This is important when there are many active


### PR DESCRIPTION
Improves the interactive shell performance when reading user input.
Note that this functionality is behind a feature flag, enabled with:
```
features set fully_interactive_shells true
```

### Before

When a user pastes the following input into their interactive `shell -it`:

> echo TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gRXRpYW0gb3JjaSB0dXJwaXMsIGZpbmlidXMgaWQgYW50ZSBzaXQgYW1ldCwgcHJldGl1bSB2dWxwdXRhdGUgbGliZXJvLiBDbGFzcyBhcHRlbnQgdGFjaXRpIHNvY2lvc3F1IGFkIGxpdG9yYSB0b3JxdWVudCBwZXIgY29udWJpYSBub3N0cmEsIHBlciBpbmNlcHRvcyBoaW1lbmFlb3MuIFZpdmFtdXMgcXVhbSByaXN1cywgY3Vyc3VzIHZlbCBmaW5pYnVzIHF1aXMsIGVmZmljaXR1ciBuZWMgbnVsbGEuIEluIGhhYyBoYWJpdGFzc2UgcGxhdGVhIGRpY3R1bXN0LiBNb3JiaSBpZCBsZWN0dXMgcHJldGl1bSwgYXVjdG9yIG51bmMgaW4sIGNvbnNlY3RldHVyIHZlbGl0LiA= | base64 -d

The input is read a character at a time, and the user has to wait for the buffer to be read:
![before](https://user-images.githubusercontent.com/60357436/133770396-418469ed-683f-4f90-b8d9-471563b59788.gif)

### After

The user input is read 1024 characters at a time, and there's no longer any noticeable lag:
![after](https://user-images.githubusercontent.com/60357436/133770406-ad13d141-27fc-423e-9097-a52514557181.gif)

## Verification

- Acquire a linux meterpreter shell
- Run `shell -it`
- Paste the input and verify it no longer lags