### PR TITLE
OptRegExp default value as string representation

### DIFF
--- a/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
+++ b/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       Opt::RPORT(4506),
       OptString.new('ROOT_KEY', [false, "Master's root key if you have it"]),
-      OptRegexp.new('MINIONS', [true, 'PCRE regex of minions to target', /.*/])
+      OptRegexp.new('MINIONS', [true, 'PCRE regex of minions to target', '.*'])
     ])
 
     register_advanced_options([
@@ -235,7 +235,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'show_timeout' => false
       },
       'user' => 'root', # This is NOT the Unix user!
-      'tgt' => datastore['MINIONS'].source,
+      'tgt' => datastore['MINIONS'],
       'tgt_type' => 'pcre',
       'jid' => jid
     }


### PR DESCRIPTION
OptRegExp default should be string to utilize in a Regex.
This allows for the object to serialize in metadata and via
rpc bridge when transimiteed using msgpack.

## Verification

- [x] See #13943
- [x] Verify module still works.