### PR TITLE
Display computer information gleaned from NTLM handshake in RDP

### DIFF
--- a/lib/msf/core/exploit/remote/rdp.rb
+++ b/lib/msf/core/exploit/remote/rdp.rb
@@ -202,8 +202,14 @@ module Exploit::Remote::RDP
 
     ntlmssp_start = resp.index('NTLMSSP')
     if ntlmssp_start
-      ntlmssp = NTLM_MESSAGE::parse(resp[ntlmssp_start..-1])
-      version = ntlmssp.padding.bytes
+      message = Net::NTLM::Message.parse(resp[ntlmssp_start..-1])
+      version = message.os_version.bytes
+      ti = Net::NTLM::TargetInfo.new(message.target_info)
+
+      peer_info[:nb_name] = ti.av_pairs[Net::NTLM::TargetInfo::MSV_AV_NB_COMPUTER_NAME]
+      peer_info[:nb_domain] = ti.av_pairs[Net::NTLM::TargetInfo::MSV_AV_NB_DOMAIN_NAME ]
+      peer_info[:dns_server] = ti.av_pairs[Net::NTLM::TargetInfo::MSV_AV_DNS_COMPUTER_NAME]
+      peer_info[:dns_domain] = ti.av_pairs[Net::NTLM::TargetInfo::MSV_AV_DNS_DOMAIN_NAME]
       peer_info[:product_version] = "#{version[0]}.#{version[1]}.#{version[2] | (version[3] << 8)}"
     end
 

--- a/modules/auxiliary/scanner/rdp/rdp_scanner.rb
+++ b/modules/auxiliary/scanner/rdp/rdp_scanner.rb
@@ -12,21 +12,25 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => 'Identify endpoints speaking the Remote Desktop Protocol (RDP)',
-        'Description'    => %q(
+        'Name' => 'Identify endpoints speaking the Remote Desktop Protocol (RDP)',
+        'Description' => %q{
           This module attempts to connect to the specified Remote Desktop Protocol port
           and determines if it speaks RDP.
 
           When available, the Credential Security Support Provider (CredSSP) protocol will be used to identify the
           version of Windows on which the server is running. Enabling the DETECT_NLA option will cause a second
           connection to be made to the server to identify if Network Level Authentication (NLA) is required.
-        ),
-        'Author'         => 'Jon Hart <jon_hart[at]rapid7.com>',
-        'References'     =>
-          [
-            ['URL', 'https://msdn.microsoft.com/en-us/library/cc240445.aspx']
-          ],
-        'License'        => MSF_LICENSE
+        },
+        'Author' => 'Jon Hart <jon_hart[at]rapid7.com>',
+        'References' => [
+          ['URL', 'https://msdn.microsoft.com/en-us/library/cc240445.aspx']
+        ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
       )
     )
 
@@ -80,6 +84,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     return false unless is_rdp
+
     return [RDPConstants::PROTOCOL_HYBRID, RDPConstants::PROTOCOL_HYBRID_EX].include? server_selected_proto
   end
 

--- a/modules/auxiliary/scanner/rdp/rdp_scanner.rb
+++ b/modules/auxiliary/scanner/rdp/rdp_scanner.rb
@@ -51,7 +51,12 @@ class MetasploitModule < Msf::Auxiliary
     service_info = nil
     if is_rdp
       product_version = (version_info && version_info[:product_version]) ? version_info[:product_version] : 'N/A'
-      info = "Detected RDP on #{peer} (Windows version: #{product_version})"
+      info = "Detected RDP on #{peer} "
+      info << "(name:#{version_info[:nb_name]}) " if version_info[:nb_name]
+      info << "(domain:#{version_info[:nb_domain]}) " if version_info[:nb_domain]
+      info << "(domain_fqdn:#{version_info[:dns_domain]}) " if version_info[:dns_domain]
+      info << "(server_fqdn:#{version_info[:dns_server]}) " if version_info[:dns_server]
+      info << "(os_version:#{product_version})"
 
       if datastore['DETECT_NLA']
         service_info = "Requires NLA: #{(!version_info[:product_version].nil? && requires_nla?) ? 'Yes' : 'No'}"


### PR DESCRIPTION
This PR displays the information gleaned from the NTLM handshake in an RDP connection, including computer and domain names. This implements the suggestions made in #15230.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] use auxiliary/scanner/rdp/rdp_scanner
- [x] set rhosts 10.0.0.1
- [x] run

Should see five pieces of data (the first four of which are new):
- NETBIOS computer name
- NETBIOS domain name
- DNS computer name
- DNS domain name
- OS version

```
msf6 > use auxiliary/scanner/rdp/rdp_scanner
msf6 auxiliary(scanner/rdp/rdp_scanner) > set rhosts 10.0.0.1
rhosts => 10.0.0.1
msf6 auxiliary(scanner/rdp/rdp_scanner) > run

[*] 10.0.0.1:3389     - Detected RDP on 10.0.0.1:3389     (name:CACS01) (domain:CATEST) (domain_fqdn:catest.local) (server_fqdn:CACS01.catest.local) (os_version:10.0.17763) (Requires NLA: Yes)
[*] 10.0.0.1:3389     - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
