### PR TITLE
Fix Compiling Encrypted Payloads on MacOS

### DIFF
--- a/lib/metasploit/framework/compiler/mingw.rb
+++ b/lib/metasploit/framework/compiler/mingw.rb
@@ -12,6 +12,11 @@ module Metasploit
 
         def compile_c(src)
           cmd = build_cmd(src)
+
+          if self.show_compile_cmd
+            print("#{cmd}\n")
+          end
+
           stdin_err, status = Open3.capture2e(cmd)
           stdin_err
         end
@@ -37,11 +42,14 @@ module Metasploit
           cmd << '-fno-asynchronous-unwind-tables '
           cmd << '-fno-ident '
           cmd << opt_level
+
           if self.compile_options
             cmd << self.compile_options
           else
+            link_options << '--image-base=0x0,'
             cmd << '-nostdlib '
           end
+
           link_options << '--no-seh'
           link_options << ',-s' if self.strip_syms
           link_options << ",-T#{self.link_script}" if self.link_script
@@ -69,13 +77,14 @@ module Metasploit
         class X86
           include Mingw
 
-          attr_reader :file_name, :keep_exe, :keep_src, :strip_syms, :link_script, :opt_lvl, :mingw_bin, :compile_options
+          attr_reader :file_name, :keep_exe, :keep_src, :strip_syms, :link_script, :opt_lvl, :mingw_bin, :compile_options, :show_compile_cmd
 
           def initialize(opts={})
             @file_name = opts[:f_name]
             @keep_exe = opts[:keep_exe]
             @keep_src = opts[:keep_src]
             @strip_syms = opts[:strip_symbols]
+            @show_compile_cmd = opts[:show_compile_cmd]
             @link_script = opts[:linker_script]
             @compile_options = opts[:compile_options]
             @opt_lvl = opts[:opt_lvl]
@@ -90,13 +99,14 @@ module Metasploit
         class X64
           include Mingw
 
-          attr_reader :file_name, :keep_exe, :keep_src, :strip_syms, :link_script, :opt_lvl, :mingw_bin, :compile_options
+          attr_reader :file_name, :keep_exe, :keep_src, :strip_syms, :link_script, :opt_lvl, :mingw_bin, :compile_options, :show_compile_cmd
 
           def initialize(opts={})
             @file_name = opts[:f_name]
             @keep_exe = opts[:keep_exe]
             @keep_src = opts[:keep_src]
             @strip_syms = opts[:strip_symbols]
+            @show_compile_cmd = opts[:show_compile_cmd]
             @link_script = opts[:linker_script]
             @compile_options = opts[:compile_options]
             @opt_lvl = opts[:opt_lvl]

--- a/lib/msf/core/payload/windows/encrypted_payload_opts.rb
+++ b/lib/msf/core/payload/windows/encrypted_payload_opts.rb
@@ -19,6 +19,7 @@ module Msf
       register_advanced_options(
       [
         OptBool.new('StripSymbols', [ false, 'Payload will be compiled without symbols', true ]),
+        OptBool.new('ShowCompileCMD', [ false, 'Display the command used to compile payload', false ]),
         OptEnum.new('OptLevel', [ false, 'The optimization level to compile with', 'O2', [ 'Og', 'Os', 'O0', 'O1', 'O2', 'O3' ] ]),
         OptBool.new('KeepSrc', [ false, 'Keep source code after compiling it', false ]),
         OptBool.new('KeepExe', [ false, 'Keep executable after compiling the payload', false ]),

--- a/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
@@ -74,6 +74,7 @@ module Payload::Windows::EncryptedReverseTcp
       opt_lvl:       datastore['OptLevel'],
       keep_src:      datastore['KeepSrc'],
       keep_exe:      datastore['KeepExe'],
+      show_compile_cmd: datastore['ShowCompileCMD'],
       f_name:        Tempfile.new(staged? ? 'reverse_pic_stager' : 'reverse_pic_stageless').path,
       arch:          self.arch_to_s
     }
@@ -145,6 +146,7 @@ module Payload::Windows::EncryptedReverseTcp
       linker_script: link_script,
       keep_src:      datastore['KeepSrc'],
       keep_exe:      datastore['KeepExe'],
+      show_compile_cmd: datastore['ShowCompileCMD'],
       f_name:        Tempfile.new('reverse_pic_stage').path,
       arch:          self.arch_to_s
     }


### PR DESCRIPTION
## Description

Generating an encrypted payload on MacOS will result in an error:

```
msf6 > use payload/windows/x64/encrypted_shell/reverse_tcp
msf6 payload(windows/x64/encrypted_shell/reverse_tcp) > generate -f exe LHOST=192.168.140.1
[-] Payload generation failed: Payload did not compile. Check the logs for further information.
msf6 payload(windows/x64/encrypted_shell/reverse_tcp) > log
...
[09/23/2021 15:19:17] [e(0)] core: /usr/local/Cellar/mingw-w64/9.0.0_2/toolchain-x86_64/bin/x86_64-w64-mingw32-ld: /var/folders/j3/_jj69l4d1k3_jsxkb44qj0d00000gq/T/reverse_pic_stager20210923-36761-xw7bgl.exe:.text: section below image base
```

This adds a linker option to pin the image base to `0x0` to ensure that compilation doesn't error out. This also adds an advanced option, `ShowCompileCMD`,  that will print the compilation command used.

## Verification

- [ ] Generate an encrypted payload either through `msfconsole` or `msfvenom` on MacOS
- [ ] Run the payload on a Windows target
