### PR TITLE
Display TCP forwarding information for sessions and jobs for reverse shells

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -1001,6 +1001,12 @@ class ReadableText
         if pinst.respond_to?(:luri)
           row[3] << pinst.luri
         end
+        if pinst.respond_to?(:comm_string)
+          via = pinst.comm_string
+          if via
+            row[3] << " #{via}"
+          end
+        end
       end
 
       if verbose

--- a/lib/msf/core/exploit/remote/dns/server.rb
+++ b/lib/msf/core/exploit/remote/dns/server.rb
@@ -102,7 +102,7 @@ module Server
   def start_service
     begin
 
-      comm = _determine_server_comm
+      comm = _determine_server_comm(datastore['SRVHOST'])
       self.service = Rex::ServiceManager.start(
         Rex::Proto::DNS::Server,
         datastore['SRVHOST'],

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -148,7 +148,7 @@ protected
   #
   # Determines appropriate listener comm
   #
-  def _determine_server_comm(srv_comm = datastore['ListenerComm'].to_s)
+  def _determine_server_comm(ip, srv_comm = datastore['ListenerComm'].to_s)
     case srv_comm
     when 'local'
       comm = ::Rex::Socket::Comm::Local
@@ -157,7 +157,7 @@ protected
       raise(RuntimeError, "Socket Server Comm (Session #{srv_comm}) does not exist") unless comm
       raise(RuntimeError, "Socket Server Comm (Session #{srv_comm}) does not implement Rex::Socket::Comm") unless comm.is_a? ::Rex::Socket::Comm
     when nil, ''
-      comm = nil
+      comm = Rex::Socket::SwitchBoard.best_comm(ip)
     else
       raise(RuntimeError, "SocketServer Comm '#{srv_comm}' is invalid")
     end
@@ -165,13 +165,9 @@ protected
     comm
   end
 
-  def via_string_for_ip(ip, comm)
-    comm_used = comm
-    comm_used ||= Rex::Socket::SwitchBoard.best_comm(ip)
-    comm_used ||= Rex::Socket::Comm::Local
-
-    if comm_used.respond_to?(:type) && comm_used.respond_to?(:sid)
-      via = "via the #{comm_used.type} on session #{comm_used.sid}"
+  def via_string(comm)
+    if comm.respond_to?(:type) && comm.respond_to?(:sid)
+      via = "via the #{comm.type} on session #{comm.sid}"
     else
       via = ""
     end

--- a/lib/msf/core/exploit/remote/tcp_server.rb
+++ b/lib/msf/core/exploit/remote/tcp_server.rb
@@ -57,7 +57,7 @@ module Exploit::Remote::TcpServer
   def start_service(*args)
     begin
 
-      comm = _determine_server_comm
+      comm = _determine_server_comm(srvhost)
 
       self.service = Rex::Socket::TcpServer.create(
         'LocalHost'      => srvhost,
@@ -106,7 +106,7 @@ module Exploit::Remote::TcpServer
       raise e
     end
 
-    via = via_string_for_ip(srvhost, comm)
+    via = via_string(comm)
     hoststr = Rex::Socket.is_ipv6?(srvhost) ? "[#{srvhost}]" : srvhost
     print_status("Started service listener on #{hoststr}:#{srvport} #{via}")
   end

--- a/lib/msf/core/handler/reverse.rb
+++ b/lib/msf/core/handler/reverse.rb
@@ -104,7 +104,7 @@ module Msf
             print_error("Handler failed to bind to #{ip}:#{local_port}:- #{comm} -")
           else
             ex = false
-            via = via_string_for_ip(ip, comm)
+            via = via_string(self.listener_sock.client.channel) if self.listener_sock.respond_to?(:channel)
             print_status("Started #{human_name} handler on #{ip}:#{local_port} #{via}")
             break
           end

--- a/lib/msf/core/handler/reverse.rb
+++ b/lib/msf/core/handler/reverse.rb
@@ -104,7 +104,7 @@ module Msf
             print_error("Handler failed to bind to #{ip}:#{local_port}:- #{comm} -")
           else
             ex = false
-            via = via_string(self.listener_sock.client.channel) if self.listener_sock.respond_to?(:channel)
+            via = via_string(self.listener_sock.client) if self.listener_sock.respond_to?(:client)
             print_status("Started #{human_name} handler on #{ip}:#{local_port} #{via}")
             break
           end

--- a/lib/msf/core/handler/reverse/comm.rb
+++ b/lib/msf/core/handler/reverse/comm.rb
@@ -39,9 +39,8 @@ module Comm
     comm
   end
 
-  def via_string_for_ip(ip, comm)
+  def via_string(comm)
     comm_used = comm
-    comm_used ||= Rex::Socket::SwitchBoard.best_comm(ip)
     comm_used ||= Rex::Socket::Comm::Local
 
     if comm_used.respond_to?(:type) && comm_used.respond_to?(:sid)

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -18,6 +18,7 @@ module ReverseHttp
 
   include Msf::Handler
   include Msf::Handler::Reverse
+  include Msf::Handler::Reverse::Comm
   include Rex::Payloads::Meterpreter::UriChecksum
   include Msf::Payload::Windows::VerifySsl
 
@@ -157,6 +158,14 @@ module ReverseHttp
     end
   end
 
+  def comm_string
+    if self.service.listener.nil?
+      "(setting up)"
+    else
+      via_string(self.service.listener.client) if self.service.listener.respond_to?(:client)
+    end
+  end
+
   # Use the #refname to determine whether this handler uses SSL or not
   #
   def ssl?
@@ -201,6 +210,7 @@ module ReverseHttp
     local_addr = nil
     local_port = bind_port
     ex = false
+    comm = select_comm
 
     # Start the HTTPS server service on this host/port
     bind_addresses.each do |ip|
@@ -211,7 +221,7 @@ module ReverseHttp
             'Msf'        => framework,
             'MsfExploit' => self,
           },
-          nil,
+          comm,
           (ssl?) ? datastore['HandlerSSLCert'] : nil, nil, nil, datastore['SSLVersion']
         )
         local_addr = ip

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -89,7 +89,12 @@ module ReverseTcp
   def payload_uri
     addr = datastore['LHOST']
     uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
-    "tcp://#{uri_host}:#{datastore['LPORT']}"
+    if listener_sock.nil?
+      via = "(setting up)"
+    else
+      via = via_string(listener_sock.client) if listener_sock.respond_to?(:client)
+    end
+    "tcp://#{uri_host}:#{datastore['LPORT']} #{via}"
   end
 
   # A URI describing where we are listening
@@ -99,7 +104,8 @@ module ReverseTcp
   def listener_uri(addr = datastore['ReverseListenerBindAddress'])
     addr = datastore['LHOST'] if addr.nil? || addr.empty?
     uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
-    "tcp://#{uri_host}:#{bind_port}"
+    via = via_string(listener_sock.client) if listener_sock.respond_to?(:client)
+    "tcp://#{uri_host}:#{bind_port} #{via}"
   end
 
   #

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -89,12 +89,15 @@ module ReverseTcp
   def payload_uri
     addr = datastore['LHOST']
     uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
+    "tcp://#{uri_host}:#{datastore['LPORT']}"
+  end
+
+  def comm_string
     if listener_sock.nil?
-      via = "(setting up)"
+      "(setting up)"
     else
-      via = via_string(listener_sock.client) if listener_sock.respond_to?(:client)
+      via_string(listener_sock.client) if listener_sock.respond_to?(:client)
     end
-    "tcp://#{uri_host}:#{datastore['LPORT']} #{via}"
   end
 
   # A URI describing where we are listening
@@ -104,8 +107,7 @@ module ReverseTcp
   def listener_uri(addr = datastore['ReverseListenerBindAddress'])
     addr = datastore['LHOST'] if addr.nil? || addr.empty?
     uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
-    via = via_string(listener_sock.client) if listener_sock.respond_to?(:client)
-    "tcp://#{uri_host}:#{bind_port} #{via}"
+    "tcp://#{uri_host}:#{bind_port}"
   end
 
   #

--- a/lib/msf/core/handler/reverse_tcp_double.rb
+++ b/lib/msf/core/handler/reverse_tcp_double.rb
@@ -105,6 +105,21 @@ module ReverseTcpDouble
     }
   end
 
+  # A URI describing what the payload is configured to use for transport
+  def payload_uri
+    addr = datastore['LHOST']
+    uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
+    "ssl://#{uri_host}:#{datastore['LPORT']}"
+  end
+
+  def comm_string
+    if listener_sock.nil?
+      "(setting up)"
+    else
+      via_string(listener_sock.client) if listener_sock.respond_to?(:client)
+    end
+  end
+
   #
   # Accept two sockets and determine which one is the input and which
   # is the output. This method assumes that these sockets pipe to a

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -90,7 +90,7 @@ module ReverseTcpDoubleSSL
 
         ex = false
 
-        via = via_string(self.listener_sock.client.channel) if self.listener_sock.respond_to?(:channel)
+        via = via_string(self.listener_sock.client) if self.listener_sock.respond_to?(:client)
 
         print_status("Started reverse double SSL handler on #{ip}:#{local_port} #{via}")
         break

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -102,6 +102,21 @@ module ReverseTcpDoubleSSL
     raise ex if (ex)
   end
 
+  # A URI describing what the payload is configured to use for transport
+  def payload_uri
+    addr = datastore['LHOST']
+    uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
+    "ssl://#{uri_host}:#{datastore['LPORT']}"
+  end
+
+  def comm_string
+    if listener_sock.nil?
+      "(setting up)"
+    else
+      via_string(listener_sock.client) if listener_sock.respond_to?(:client)
+    end
+  end
+
   #
   # Closes the listener socket if one was created.
   #

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -90,7 +90,7 @@ module ReverseTcpDoubleSSL
 
         ex = false
 
-        via = via_string_for_ip(ip, comm)
+        via = via_string(self.listener_sock.client.channel) if self.listener_sock.respond_to?(:channel)
 
         print_status("Started reverse double SSL handler on #{ip}:#{local_port} #{via}")
         break

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -68,7 +68,7 @@ module ReverseTcpSsl
 
         ex = false
 
-        via = via_string(self.listener_sock.client.channel) if self.listener_sock.respond_to?(:channel)
+        via = via_string(self.listener_sock.client) if self.listener_sock.respond_to?(:client)
         print_status("Started reverse SSL handler on #{ip}:#{local_port} #{via}")
         break
       rescue

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -68,7 +68,7 @@ module ReverseTcpSsl
 
         ex = false
 
-        via = via_string_for_ip(ip, comm)
+        via = via_string(self.listener_sock.client.channel) if self.listener_sock.respond_to?(:channel)
         print_status("Started reverse SSL handler on #{ip}:#{local_port} #{via}")
         break
       rescue

--- a/lib/msf/core/handler/reverse_udp.rb
+++ b/lib/msf/core/handler/reverse_udp.rb
@@ -18,6 +18,7 @@ module Handler
 module ReverseUdp
 
   include Msf::Handler
+  include Msf::Handler::Reverse::Comm
 
   #
   # Returns the string representation of the handler type, in this case
@@ -49,6 +50,14 @@ module ReverseUdp
     "udp://#{uri_host}:#{datastore['LPORT']}"
   end
 
+  def comm_string
+    if listener_sock.nil?
+      "(setting up)"
+    else
+      via_string(self.listener_sock.channel.client) if self.listener_sock.respond_to?(:channel) && self.listener_sock.channel.respond_to?(:client)
+    end
+  end
+
   # A URI describing where we are listening
   #
   # @param addr [String] the address that
@@ -77,7 +86,6 @@ module ReverseUdp
       [
         OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
         OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
-        OptString.new('ReverseListenerComm', [ false, 'The specific communication channel to use for this listener']),
         OptBool.new('ReverseListenerThreaded', [ true, 'Handle every connection in a new thread (experimental)', false])
       ] +
       Msf::Opt::stager_retry_options,
@@ -94,15 +102,7 @@ module ReverseUdp
   def setup_handler
     ex = false
 
-    comm = case datastore['ReverseListenerComm'].to_s
-      when "local"; ::Rex::Socket::Comm::Local
-      when /\A[0-9]+\Z/; framework.sessions[datastore['ReverseListenerComm'].to_i]
-      else; nil
-      end
-    unless comm.is_a? ::Rex::Socket::Comm
-      comm = nil
-    end
-
+    comm = select_comm
     local_port = bind_port
     addrs = bind_address
 
@@ -122,15 +122,7 @@ module ReverseUdp
 
         ex = false
 
-        comm_used = comm || Rex::Socket::SwitchBoard.best_comm( ip )
-        comm_used = Rex::Socket::Comm::Local if comm_used == nil
-
-        if( comm_used.respond_to?( :type ) and comm_used.respond_to?( :sid ) )
-          via = "via the #{comm_used.type} on session #{comm_used.sid}"
-        else
-          via = ""
-        end
-
+        via = via_string(self.listener_sock.channel.client) if self.listener_sock.respond_to?(:channel) && self.listener_sock.channel.respond_to?(:client)
         print_status("Started #{human_name} handler on #{ip}:#{local_port} #{via}")
         break
       rescue
@@ -168,11 +160,13 @@ module ReverseUdp
         begin
           inbound, peerhost, peerport = self.listener_sock.recvfrom
           next if peerhost.nil?
+          comm = self.listener_sock.channel.client if self.listener_sock.respond_to?(:channel) && self.listener_sock.channel.respond_to?(:client)
+
           cli_opts = {
             'PeerPort' => peerport,
             'PeerHost' => peerhost,
             'LocalPort' => self.listener_sock.localport,
-            'Comm' => self.listener_sock.respond_to?(:comm) ? self.listener_sock.comm : nil
+            'Comm' => comm
           }
 
           # unless ['::', '0.0.0.0'].any? {|alladdr| self.listener_sock.localhost == alladdr }

--- a/lib/msf/core/handler/reverse_udp.rb
+++ b/lib/msf/core/handler/reverse_udp.rb
@@ -86,7 +86,8 @@ module ReverseUdp
       [
         OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
         OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
-        OptBool.new('ReverseListenerThreaded', [ true, 'Handle every connection in a new thread (experimental)', false])
+        OptBool.new('ReverseListenerThreaded', [ true, 'Handle every connection in a new thread (experimental)', false]),
+        OptString.new('ReverseListenerComm', [ false, 'The specific communication channel to use for this listener'])
       ] +
       Msf::Opt::stager_retry_options,
       Msf::Handler::ReverseUdp)

--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -81,6 +81,9 @@ module Session
   def tunnel_peer
   end
 
+  def comm_channel
+  end
+
   #
   # Returns the host associated with the session
   #
@@ -133,7 +136,7 @@ module Session
   # Returns a pretty representation of the tunnel.
   #
   def tunnel_to_s
-    "#{(tunnel_local || '??')} -> #{(tunnel_peer || '??')}"
+    "#{(tunnel_local || '??')} -> #{(tunnel_peer || '??')} #{comm_channel}"
   end
 
   ##

--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -60,6 +60,13 @@ module Interactive
     end
   end
 
+  def comm_channel
+    return @comm_info if @comm_info
+    if rstream.respond_to?(:channel)
+      @comm_info = "via session #{rstream.channel.client.sid}" if rstream.channel.client.respond_to?(:sid)
+    end
+  end
+
   #
   # Run an arbitrary command as if it came from user input.
   #


### PR DESCRIPTION
When using TCP forwarding to catch shells, it is useful to know which session it came through. The same applies to jobs waiting for shells. This is particularly useful in situations such as:

- Catching a TCP-forwarded shell caught via loopback (how can you tell which session is "127.0.0.1"?)
- Multiple shells on the one system (I know this session is being forwarded through 192.168.11.5, but which of my 3 shells on that system can I safely kill?)

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Catch a Meterpreter shell
- [x] Run `route add 0 0 -1` inside Metasploit (not the new shell otherwise you will hit issues)
- [x] Run `handler -p linux/x64/meterpreter/reverse_tcp -P 5556 -H 0.0.0.0`
- [x] Run `jobs`
- [x] **Verify** that the job is listed as "via session 1"
- [x] Run `route remove 0 0 -1`
- [x] Run `jobs`
- [x] **Verify** that the job is still listed as "via session 1"
- [x] Catch a shell using that handler
- [x] Run `sessions`
- [x] **Verify** that the session is listed as "via session 1"
- [ ] Repeat these steps with a forwards TCP-forwarding handler

## Demo

```
msf6 > use exploit/multi/handler                                                                                                                                                                                                     
[*] Using configured payload generic/shell_reverse_tcp                                                                                                                                                                               
msf6 exploit(multi/handler) > set payload linux/x86/meterpreter_reverse_tcp 
payload => linux/x86/meterpreter_reverse_tcp
msf6 exploit(multi/handler) > set lport 4486 
lport => 4486
msf6 exploit(multi/handler) > set lhost 0.0.0.0
lhost => 0.0.0.0
msf6 exploit(multi/handler) > run

[*] Started reverse TCP handler on 0.0.0.0:4486 
[*] Meterpreter session 1 opened (192.168.11.206:4486 -> 192.168.11.207:47176 ) at 2021-09-24 19:30:41 +1000

meterpreter > 
Background session 1? [y/N]  
msf6 exploit(multi/handler) > route add 0 0 -1
[*] Route added
msf6 exploit(multi/handler) > handler -p linux/x64/meterpreter/reverse_tcp -P 5555 -H 0.0.0.0                      
[*] Payload handler running as background job 0.
msf6 exploit(multi/handler) > 
[*] Started reverse TCP handler on 0.0.0.0:5555 via the meterpreter on session 1

msf6 exploit(multi/handler) > jobs

Jobs
====

  Id  Name                    Payload                            Payload opts
  --  ----                    -------                            ------------
  0   Exploit: multi/handler  linux/x64/meterpreter/reverse_tcp  tcp://0.0.0.0:5555 via the meterpreter on session 1

msf6 exploit(multi/handler) > route remove 0 0 -1
[*] Route removed
msf6 exploit(multi/handler) > jobs

Jobs
====

  Id  Name                    Payload                            Payload opts
  --  ----                    -------                            ------------
  0   Exploit: multi/handler  linux/x64/meterpreter/reverse_tcp  tcp://0.0.0.0:5555 via the meterpreter on session 1

msf6 exploit(multi/handler) > 
[*] Sending stage (3012548 bytes) to ::ffff:127.0.0.1
[*] Meterpreter session 2 opened (::ffff:127.0.0.1:5555 -> ::ffff:127.0.0.1:58342 via session 1) at 2021-09-24 19:31:24 +1000

msf6 exploit(multi/handler) > sessions 

Active sessions
===============

  Id  Name  Type                   Information                                                                  Connection
  --  ----  ----                   -----------                                                                  ----------
  1         meterpreter x86/linux  kali @ htbkali (uid=1000, gid=1000, euid=1000, egid=1000) @ htbkali.abc.lan  192.168.11.206:4486 -> 192.168.11.207:47176  (192.168.11.207)
  2         meterpreter x64/linux  kali @ htbkali (uid=1000, gid=1000, euid=1000, egid=1000) @ htbkali.abc.lan  ::ffff:127.0.0.1:5555 -> ::ffff:127.0.0.1:58342 via session 1 (::1)

msf6 exploit(multi/handler) > set payload linux/x64/meterpreter/bind_tcp
payload => linux/x64/meterpreter/bind_tcp
msf6 exploit(multi/handler) > set rhost 127.0.0.1
rhost => 127.0.0.1
msf6 exploit(multi/handler) > set lport 6667
lport => 6667
msf6 exploit(multi/handler) > route add 0 0 1
[*] Route added
msf6 exploit(multi/handler) > run

[*] Started bind TCP handler against 127.0.0.1:6667
[*] Sending stage (3012548 bytes) to 127.0.0.1
[*] Meterpreter session 3 opened (127.0.0.1:33118 -> 127.0.0.1:6667 via session 1) at 2021-09-24 19:36:08 +1000

meterpreter > 
Background session 3? [y/N]  
msf6 exploit(multi/handler) > sessions 

Active sessions
===============

  Id  Name  Type                   Information                                                                  Connection
  --  ----  ----                   -----------                                                                  ----------
  1         meterpreter x86/linux  kali @ htbkali (uid=1000, gid=1000, euid=1000, egid=1000) @ htbkali.pod.lan  192.168.20.206:4486 -> 192.168.20.207:47176  (192.168.20.207)
  2         meterpreter x64/linux  kali @ htbkali (uid=1000, gid=1000, euid=1000, egid=1000) @ htbkali.pod.lan  ::ffff:127.0.0.1:5555 -> ::ffff:127.0.0.1:58342 via session 1 (::1)
  3         meterpreter x64/linux  kali @ htbkali (uid=1000, gid=1000, euid=1000, egid=1000) @ htbkali.pod.lan  127.0.0.1:33118 -> 127.0.0.1:6667 via session 1 (127.0.0.1)

msf6 exploit(multi/handler) > route remove 0 0 1
[*] Route removed
msf6 exploit(multi/handler) > sessions 

Active sessions
===============

  Id  Name  Type                   Information                                                                  Connection
  --  ----  ----                   -----------                                                                  ----------
  1         meterpreter x86/linux  kali @ htbkali (uid=1000, gid=1000, euid=1000, egid=1000) @ htbkali.pod.lan  192.168.20.206:4486 -> 192.168.20.207:47176  (192.168.20.207)
  2         meterpreter x64/linux  kali @ htbkali (uid=1000, gid=1000, euid=1000, egid=1000) @ htbkali.pod.lan  ::ffff:127.0.0.1:5555 -> ::ffff:127.0.0.1:58342 via session 1 (::1)
  3         meterpreter x64/linux  kali @ htbkali (uid=1000, gid=1000, euid=1000, egid=1000) @ htbkali.pod.lan  127.0.0.1:33118 -> 127.0.0.1:6667 via session 1 (127.0.0.1)
```