### PR TITLE
Add ECU Hard Reset for hwbridge

### DIFF
--- a/documentation/modules/post/hardware/automotive/ecu_hard_reset.md
+++ b/documentation/modules/post/hardware/automotive/ecu_hard_reset.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-This module performs hard reset in the ECU Reset Service Identifier (0x11) where the tester can request this to re-initialize the core hardware components of the system.
+This module performs hard reset in the ECU Reset Service Identifier (0x11).
 
 ## Verification Steps
 

--- a/documentation/modules/post/hardware/automotive/ecu_hard_reset.md
+++ b/documentation/modules/post/hardware/automotive/ecu_hard_reset.md
@@ -1,0 +1,78 @@
+## Introduction
+
+This module performs hard reset in the ECU Reset Service Identifier (0x11) where the tester can request this to re-initialize the core hardware components of the system.
+
+## Verification Steps
+
+Fire up virtual CAN bus:
+
+1. `sudo modprobe can`
+2. `sudo modprobe vcan`
+3. `sudo ip link add dev vcan0 type vcan`
+4. `sudo ip link set up vcan0`
+
+Launch msf:
+
+5. Start `msfconsole`
+6. `use auxiliary/server/local_hwbridge`
+7. `set uripath testbus`
+8. `run`
+9. `use auxiliary/client/hwbridge/connect`
+10. `set targeturi testbus`
+
+## Options
+
+**ARBID**
+CAN ID to perform ECU Hard Reset (Default: 0x7DF)
+
+**CANBUS**
+CAN Bus to perform scan on, defaults to connected bus
+
+## Scenarios
+Using UDS simulator for testing ECU hard reset:
+
+```
+msf5 auxiliary(client/hwbridge/connect) > run
+[*] Running module against 127.0.0.1
+
+[*] Attempting to connect to 127.0.0.1...
+[*] Hardware bridge interface session 2 opened (127.0.0.1 -> 127.0.0.1) at 2019-09-11 04:59:40 -0700
+[+] HWBridge session established
+[*] HW Specialty: {"automotive"=>true}  Capabilities: {"can"=>true, "custom_methods"=>true}
+[!] NOTICE:  You are about to leave the matrix.  All actions performed on this hardware bridge
+[!]          could have real world consequences.  Use this module in a controlled testing
+[!]          environment and with equipment you are authorized to perform testing on.
+[*] Auxiliary module execution completed
+msf5 auxiliary(client/hwbridge/connect) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                   Information  Connection
+  --  ----  ----                   -----------  ----------
+  1         hwbridge cmd/hardware  automotive   127.0.0.1 -> 127.0.0.1 (127.0.0.1)
+
+msf5 auxiliary(client/hwbridge/connect) > sessions -i 1
+[*] Starting interaction with 1...
+
+hwbridge > run post/hardware/automotive/ecu_hard_reset CANBUS=vcan0
+
+[*] Performing ECU Hard Reset...
+
+```
+
+You can use candump to verify the CAN messages being sent:
+
+```
+─$ candump vcan0          
+  vcan0  7DF   [8]  02 11 01 00 00 00 00 00
+```
+
+UDS Server Output
+```
+└─$ ./uds-server -v -V "PWN3D" vcan0            
+Using CAN interface vcan0
+Fuzz level set to: 0
+Pkt: 7DF#02 11 01 00 00 00 00 00 
+Unhandled mode/sid: ECU Reset
+```

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -4,18 +4,20 @@
 ##
 
 class MetasploitModule < Msf::Post
-  def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'ECU Hard Reset',
-                      'Description' => 'This module performs hard reset in the ECU Reset Service Identifier (0x11) to re-initialize the core hardware components of the system.',
-                      'License' => MSF_LICENSE,
-                      'Author' => ['Jay Turla'],
-                      'Platform' => ['hardware'],
-                      'SessionTypes' => ['hwbridge']))
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'ECU Hard Reset',
+      'Description'   => %q{ This module performs hard reset in the ECU Reset Service Identifier (0x11) to re-initialize the core hardware components of the system.},
+      'License'       => MSF_LICENSE,
+      'Author'        => ['Jay Turla'],
+      'Platform'      => ['hardware'],
+      'SessionTypes'  => ['hwbridge']
+    ))
     register_options([
-                       OptString.new('ARBID', [false, 'CAN ID to perform ECU Hard Reset', '0x7DF']),
-                       OptString.new('CANBUS', [false, 'CAN Bus to perform scan on, defaults to connected bus', nil])
-                     ])
+      OptString.new('ARBID', [false, "CAN ID to perform ECU Hard Reset", "0x7DF"]),
+      OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
+    ])
   end
 
   def run

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -1,4 +1,4 @@
-+##
+##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -4,28 +4,35 @@
 ##
 
 class MetasploitModule < Msf::Post
-
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'ECU Hard Reset',
-      'Description'   => %q{ This module performs hard reset in the ECU Reset Service Identifier (0x11) to re-initialize the core hardware components of the system.},
-      'License'       => MSF_LICENSE,
-      'Author'        => ['Jay Turla'],
-      'Platform'      => ['hardware'],
-      'SessionTypes'  => ['hwbridge']
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ECU Hard Reset',
+        'Description' => ' This module performs hard reset in the ECU Reset Service Identifier (0x11)',
+        'License' => MSF_LICENSE,
+        'Author' => ['Jay Turla'],
+        'Platform' => ['hardware'],
+        'SessionTypes' => ['hwbridge']
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_RESTARTS ],
+          'SideEffects' => [ PHYSICAL_EFFECTS ],
+          'Reliability' => [ REPEATABLE_SESSION ]        
+      )
+    )
     register_options([
-      OptString.new('ARBID', [false, "CAN ID to perform ECU Hard Reset", "0x7DF"]),
-      OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
+      OptString.new('ARBID', [false, 'CAN ID to perform ECU Hard Reset', '0x7DF']),
+      OptString.new('CANBUS', [false, 'CAN Bus to perform scan on, defaults to connected bus', nil])
     ])
   end
 
   def run
     unless client.automotive
-      print_error("The hwbridge requires a functional automotive extention")
+      print_error('The hwbridge requires a functional automotive extention')
       return
     end
-    print_status("Performing ECU Hard Reset...")
-    client.automotive.cansend(datastore['CANBUS'], datastore['ARBID'], "0211010000000000")
+    print_status('Performing ECU Hard Reset...')
+    client.automotive.cansend(datastore['CANBUS'], datastore['ARBID'], '0211010000000000')
   end
+
 end

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -6,16 +6,16 @@
 class MetasploitModule < Msf::Post
   def initialize(info = {})
     super(update_info(info,
-                      'Name' => 'ECU Hard Reset',
-                      'Description' => ' This module performs hard reset in the ECU Reset Service Identifier (0x11)',
-                      'License' => MSF_LICENSE,
-                      'Author' => ['Jay Turla'],
-                      'Platform' => ['hardware'],
-                      'SessionTypes' => ['hwbridge']))
+      'Name' => 'ECU Hard Reset',
+      'Description' => ' This module performs hard reset in the ECU Reset Service Identifier (0x11)',
+      'License' => MSF_LICENSE,
+      'Author' => ['Jay Turla'],
+      'Platform' => ['hardware'],
+      'SessionTypes' => ['hwbridge']))
     register_options([
-                       OptString.new('ARBID', [false, 'CAN ID to perform ECU Hard Reset', '0x7DF']),
-                       OptString.new('CANBUS', [false, 'CAN Bus to perform scan on, defaults to connected bus', nil])
-                     ])
+      OptString.new('ARBID', [false, 'CAN ID to perform ECU Hard Reset', '0x7DF']),
+      OptString.new('CANBUS', [false, 'CAN Bus to perform scan on, defaults to connected bus', nil])
+      ])
   end
 
   def run
@@ -26,4 +26,5 @@ class MetasploitModule < Msf::Post
     print_status('Performing ECU Hard Reset...')
     client.automotive.cansend(datastore['CANBUS'], datastore['ARBID'], '0211010000000000')
   end
+
 end

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -1,0 +1,31 @@
++##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'ECU Hard Reset',
+      'Description'   => %q{ This module performs hard reset in the ECU Reset Service Identifier (0x11) where the tester can request this to re-initialize the core hardware components of the system.},
+      'License'       => MSF_LICENSE,
+      'Author'        => ['Jay Turla'],
+      'Platform'      => ['hardware'],
+      'SessionTypes'  => ['hwbridge']
+    ))
+    register_options([
+      OptString.new('ARBID', [false, "CAN ID to perform ECU Hard Reset", "0x7DF"]),
+      OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
+    ])
+  end
+
+  def run
+    unless client.automotive
+      print_error("The hwbridge requires a functional automotive extention")
+      return
+    end
+    print_status("Performing ECU Hard Reset...")
+    client.automotive.cansend(datastore['CANBUS'], datastore['ARBID'], "0211010000000000")
+  end
+end

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['Jay Turla'],
         'Platform' => ['hardware'],
-        'SessionTypes' => ['hwbridge']
+        'SessionTypes' => ['hwbridge'],
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_RESTARTS ],
           'SideEffects' => [ PHYSICAL_EFFECTS ],

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -17,7 +17,8 @@ class MetasploitModule < Msf::Post
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_RESTARTS ],
           'SideEffects' => [ PHYSICAL_EFFECTS ],
-          'Reliability' => [ REPEATABLE_SESSION ]        
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
       )
     )
     register_options([

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -22,10 +22,10 @@ class MetasploitModule < Msf::Post
 
   def run
     unless client.automotive
-      print_error('The hwbridge requires a functional automotive extention')
+      print_error("The hwbridge requires a functional automotive extention")
       return
     end
-    print_status('Performing ECU Hard Reset...')
-    client.automotive.cansend(datastore['CANBUS'], datastore['ARBID'], '0211010000000000')
+    print_status("Performing ECU Hard Reset...")
+    client.automotive.cansend(datastore['CANBUS'], datastore['ARBID'], "0211010000000000")
   end
 end

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -4,28 +4,26 @@
 ##
 
 class MetasploitModule < Msf::Post
-
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'ECU Hard Reset',
-      'Description'   => %q{ This module performs hard reset in the ECU Reset Service Identifier (0x11) where the tester can request this to re-initialize the core hardware components of the system.},
-      'License'       => MSF_LICENSE,
-      'Author'        => ['Jay Turla'],
-      'Platform'      => ['hardware'],
-      'SessionTypes'  => ['hwbridge']
-    ))
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name' => 'ECU Hard Reset',
+                      'Description' => 'This module performs hard reset in the ECU Reset Service Identifier (0x11) to re-initialize the core hardware components of the system.',
+                      'License' => MSF_LICENSE,
+                      'Author' => ['Jay Turla'],
+                      'Platform' => ['hardware'],
+                      'SessionTypes' => ['hwbridge']))
     register_options([
-      OptString.new('ARBID', [false, "CAN ID to perform ECU Hard Reset", "0x7DF"]),
-      OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
-    ])
+                       OptString.new('ARBID', [false, 'CAN ID to perform ECU Hard Reset', '0x7DF']),
+                       OptString.new('CANBUS', [false, 'CAN Bus to perform scan on, defaults to connected bus', nil])
+                     ])
   end
-  
+
   def run
     unless client.automotive
-      print_error("The hwbridge requires a functional automotive extention")
+      print_error('The hwbridge requires a functional automotive extention')
       return
     end
-    print_status("Performing ECU Hard Reset...")
-    client.automotive.cansend(datastore['CANBUS'], datastore['ARBID'], "0211010000000000")
+    print_status('Performing ECU Hard Reset...')
+    client.automotive.cansend(datastore['CANBUS'], datastore['ARBID'], '0211010000000000')
   end
 end

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Post
       OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
     ])
   end
-
+  
   def run
     unless client.automotive
       print_error("The hwbridge requires a functional automotive extention")

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -6,16 +6,16 @@
 class MetasploitModule < Msf::Post
   def initialize(info = {})
     super(update_info(info,
-      'Name' => 'ECU Hard Reset',
-      'Description' => ' This module performs hard reset in the ECU Reset Service Identifier (0x11)',
-       'License' => MSF_LICENSE,
-       'Author' => ['Jay Turla'],
-       'Platform' => ['hardware'],
-       'SessionTypes' => ['hwbridge']))
+                      'Name' => 'ECU Hard Reset',
+                      'Description' => ' This module performs hard reset in the ECU Reset Service Identifier (0x11)',
+                      'License' => MSF_LICENSE,
+                      'Author' => ['Jay Turla'],
+                      'Platform' => ['hardware'],
+                      'SessionTypes' => ['hwbridge']))
     register_options([
-      OptString.new('ARBID', [false, 'CAN ID to perform ECU Hard Reset', '0x7DF']),
-      OptString.new('CANBUS', [false, 'CAN Bus to perform scan on, defaults to connected bus', nil])
-      ])
+                       OptString.new('ARBID', [false, 'CAN ID to perform ECU Hard Reset', '0x7DF']),
+                       OptString.new('CANBUS', [false, 'CAN Bus to perform scan on, defaults to connected bus', nil])
+                     ])
   end
 
   def run

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Post
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_RESTARTS ],
           'SideEffects' => [ PHYSICAL_EFFECTS ],
-          'Reliability' => [ REPEATABLE_SESSION ]
+          'Reliability' => [ ]
         }
       )
     )

--- a/modules/post/hardware/automotive/ecu_hard_reset.rb
+++ b/modules/post/hardware/automotive/ecu_hard_reset.rb
@@ -4,28 +4,26 @@
 ##
 
 class MetasploitModule < Msf::Post
-
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'ECU Hard Reset',
-      'Description'   => %q{ This module performs hard reset in the ECU Reset Service Identifier (0x11) to re-initialize the core hardware components of the system.},
-      'License'       => MSF_LICENSE,
-      'Author'        => ['Jay Turla'],
-      'Platform'      => ['hardware'],
-      'SessionTypes'  => ['hwbridge']
-    ))
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'ECU Hard Reset',
+      'Description' => ' This module performs hard reset in the ECU Reset Service Identifier (0x11)',
+       'License' => MSF_LICENSE,
+       'Author' => ['Jay Turla'],
+       'Platform' => ['hardware'],
+       'SessionTypes' => ['hwbridge']))
     register_options([
-      OptString.new('ARBID', [false, "CAN ID to perform ECU Hard Reset", "0x7DF"]),
-      OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
-    ])
+      OptString.new('ARBID', [false, 'CAN ID to perform ECU Hard Reset', '0x7DF']),
+      OptString.new('CANBUS', [false, 'CAN Bus to perform scan on, defaults to connected bus', nil])
+      ])
   end
 
   def run
     unless client.automotive
-      print_error("The hwbridge requires a functional automotive extention")
+      print_error('The hwbridge requires a functional automotive extention')
       return
     end
-    print_status("Performing ECU Hard Reset...")
-    client.automotive.cansend(datastore['CANBUS'], datastore['ARBID'], "0211010000000000")
+    print_status('Performing ECU Hard Reset...')
+    client.automotive.cansend(datastore['CANBUS'], datastore['ARBID'], '0211010000000000')
   end
 end


### PR DESCRIPTION
## Introduction

This module performs hard reset in the ECU Reset Service Identifier (0x11).

## Verification Steps

Fire up virtual CAN bus:

1. `sudo modprobe can`
2. `sudo modprobe vcan`
3. `sudo ip link add dev vcan0 type vcan`
4. `sudo ip link set up vcan0`

Launch msf:

5. Start `msfconsole`
6. `use auxiliary/server/local_hwbridge`
7. `set uripath testbus`
8. `run`
9. `use auxiliary/client/hwbridge/connect`
10. `set targeturi testbus`

## Options

**ARBID**
CAN ID to perform ECU Hard Reset (Default: 0x7DF)

**CANBUS**
CAN Bus to perform scan on, defaults to connected bus

## Scenarios
Using UDS simulator for testing ECU hard reset:

```
msf5 auxiliary(client/hwbridge/connect) > run
[*] Running module against 127.0.0.1

[*] Attempting to connect to 127.0.0.1...
[*] Hardware bridge interface session 1 opened (127.0.0.1 -> 127.0.0.1) at 2019-09-11 04:59:40 -0700
[+] HWBridge session established
[*] HW Specialty: {"automotive"=>true}  Capabilities: {"can"=>true, "custom_methods"=>true}
[!] NOTICE:  You are about to leave the matrix.  All actions performed on this hardware bridge
[!]          could have real world consequences.  Use this module in a controlled testing
[!]          environment and with equipment you are authorized to perform testing on.
[*] Auxiliary module execution completed
msf5 auxiliary(client/hwbridge/connect) > sessions

Active sessions
===============

  Id  Name  Type                   Information  Connection
  --  ----  ----                   -----------  ----------
  1         hwbridge cmd/hardware  automotive   127.0.0.1 -> 127.0.0.1 (127.0.0.1)

msf5 auxiliary(client/hwbridge/connect) > sessions -i 1
[*] Starting interaction with 1...

hwbridge > run post/hardware/automotive/ecu_hard_reset CANBUS=vcan0

[*] Performing ECU Hard Reset...

```

You can use candump to verify the CAN messages being sent:

```
─$ candump vcan0          
  vcan0  7DF   [8]  02 11 01 00 00 00 00 00
```

UDS Server Output
```
└─$ ./uds-server -v -V "PWN3D" vcan0            
Using CAN interface vcan0
Fuzz level set to: 0
Pkt: 7DF#02 11 01 00 00 00 00 00 
Unhandled mode/sid: ECU Reset
```