### PR TITLE
Update references to railgun to be consistent

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/util.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/util.rb
@@ -693,10 +693,9 @@ class  Util
   #
   def judge_bit_field(value, mappings)
     flags = {}
-    rg = railgun
 
     mappings.each do |constant_name, key|
-      flags[key] = (value & rg.const(constant_name)) != 0
+      flags[key] = (value & railgun.const(constant_name)) != 0
     end
 
     flags

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -639,7 +639,6 @@ class MetasploitModule < Msf::Post
 
   def windows_unprotect(data)
     data = Rex::Text.decode_base64(data)
-    rg = session.railgun
     pid = session.sys.process.getpid
     process = session.sys.process.open(pid, PROCESS_ALL_ACCESS)
     mem = process.memory.allocate(data.length + 200)
@@ -648,12 +647,12 @@ class MetasploitModule < Msf::Post
     if session.sys.process.each_process.find { |i| i["pid"] == pid } ["arch"] == "x86"
       addr = [mem].pack("V")
       len = [data.length].pack("V")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
       len, addr = ret["pDataOut"].unpack("V2")
     else
       addr = Rex::Text.pack_int64le(mem)
       len = Rex::Text.pack_int64le(data.length)
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
       pData = ret["pDataOut"].unpack("VVVV")
       len = pData[0] + (pData[1] << 32)
       addr = pData[2] + (pData[3] << 32)

--- a/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
+++ b/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
@@ -29,14 +29,12 @@ class MetasploitModule < Msf::Post
   end
 
   def prepare_railgun
-    rg = session.railgun
-    if (!rg.get_dll('crypt32'))
-      rg.add_dll('crypt32')
+    if (!session.railgun.get_dll('crypt32'))
+      session.railgun.add_dll('crypt32')
     end
   end
 
   def decrypt_password(data)
-    rg = session.railgun
     pid = client.sys.process.getpid
     process = client.sys.process.open(pid, PROCESS_ALL_ACCESS)
 
@@ -46,12 +44,12 @@ class MetasploitModule < Msf::Post
     if session.sys.process.each_process.find { |i| i["pid"] == pid } ["arch"] == "x86"
       addr = [mem].pack("V")
       len = [data.length].pack("V")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
       len, addr = ret["pDataOut"].unpack("V2")
     else
       addr = [mem].pack("Q")
       len = [data.length].pack("Q")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
       len, addr = ret["pDataOut"].unpack("Q2")
     end
 

--- a/modules/post/windows/gather/credentials/outlook.rb
+++ b/modules/post/windows/gather/credentials/outlook.rb
@@ -32,14 +32,12 @@ class MetasploitModule < Msf::Post
   end
 
   def prepare_railgun
-    rg = session.railgun
-    if !rg.get_dll('crypt32')
-      rg.add_dll('crypt32')
+    if !session.railgun.get_dll('crypt32')
+      session.railgun.add_dll('crypt32')
     end
   end
 
   def decrypt_password(data)
-    rg = session.railgun
     pid = client.sys.process.getpid
     process = client.sys.process.open(pid, PROCESS_ALL_ACCESS)
 
@@ -49,12 +47,12 @@ class MetasploitModule < Msf::Post
     if session.sys.process.each_process.find { |i| i["pid"] == pid } ["arch"] == "x86"
       addr = [mem].pack("V")
       len = [data.length].pack("V")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
       len, addr = ret["pDataOut"].unpack("V2")
     else
       addr = [mem].pack("Q")
       len = [data.length].pack("Q")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
       len, addr = ret["pDataOut"].unpack("Q2")
     end
 

--- a/modules/post/windows/gather/credentials/pulse_secure.rb
+++ b/modules/post/windows/gather/credentials/pulse_secure.rb
@@ -50,7 +50,6 @@ class MetasploitModule < Msf::Post
   #
   def decrypt_reg(data, entropy)
     begin
-      rg = session.railgun
       pid = session.sys.process.getpid
       process = session.sys.process.open(pid, PROCESS_ALL_ACCESS)
 
@@ -71,7 +70,7 @@ class MetasploitModule < Msf::Post
         eaddr = [emem].pack('V')
         elen = [entropy.length].pack('V')
 
-        ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, "#{elen}#{eaddr}", nil, nil, 0, 8)
+        ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, "#{elen}#{eaddr}", nil, nil, 0, 8)
         len, addr = ret['pDataOut'].unpack('V2')
       else
         # Convert using rex, basically doing: [mem & 0xffffffff, mem >> 32].pack("VV")
@@ -81,7 +80,7 @@ class MetasploitModule < Msf::Post
         eaddr = Rex::Text.pack_int64le(emem)
         elen = Rex::Text.pack_int64le(entropy.length)
 
-        ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, "#{elen}#{eaddr}", nil, nil, 0, 16)
+        ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, "#{elen}#{eaddr}", nil, nil, 0, 16)
         p_data = ret['pDataOut'].unpack('VVVV')
         len = p_data[0] + (p_data[1] << 32)
         addr = p_data[2] + (p_data[3] << 32)

--- a/modules/post/windows/gather/credentials/rdc_manager_creds.rb
+++ b/modules/post/windows/gather/credentials/rdc_manager_creds.rb
@@ -74,8 +74,7 @@ class MetasploitModule < Msf::Post
   end
 
   def decrypt_password(data)
-    rg = session.railgun
-    rg.add_dll('crypt32') unless rg.get_dll('crypt32')
+    session.railgun.add_dll('crypt32') unless session.railgun.get_dll('crypt32')
 
     pid = client.sys.process.getpid
     process = client.sys.process.open(pid, PROCESS_ALL_ACCESS)
@@ -86,12 +85,12 @@ class MetasploitModule < Msf::Post
     if session.sys.process.each_process.find { |i| i["pid"] == pid && i["arch"] == "x86" }
       addr = [mem].pack("V")
       len = [data.length].pack("V")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
       len, addr = ret["pDataOut"].unpack("V2")
     else
       addr = [mem].pack("Q")
       len = [data.length].pack("Q")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
       len, addr = ret["pDataOut"].unpack("Q2")
     end
 

--- a/modules/post/windows/gather/credentials/skype.rb
+++ b/modules/post/windows/gather/credentials/skype.rb
@@ -55,7 +55,6 @@ puts hash.hexdigest
 =end
 
   def decrypt_reg(data)
-    rg = session.railgun
     pid = session.sys.process.getpid
     process = session.sys.process.open(pid, PROCESS_ALL_ACCESS)
     mem = process.memory.allocate(512)
@@ -64,13 +63,13 @@ puts hash.hexdigest
     if session.sys.process.each_process.find { |i| i["pid"] == pid } ["arch"] == "x86"
       addr = [mem].pack("V")
       len = [data.length].pack("V")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
       len, addr = ret["pDataOut"].unpack("V2")
     else
       # Convert using rex, basically doing: [mem & 0xffffffff, mem >> 32].pack("VV")
       addr = Rex::Text.pack_int64le(mem)
       len = Rex::Text.pack_int64le(data.length)
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
       pData = ret["pDataOut"].unpack("VVVV")
       len = pData[0] + (pData[1] << 32)
       addr = pData[2] + (pData[3] << 32)

--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -28,14 +28,12 @@ class MetasploitModule < Msf::Post
   end
 
   def prepare_railgun
-    rg = session.railgun
-    if (!rg.get_dll('crypt32'))
-      rg.add_dll('crypt32')
+    if (!session.railgun.get_dll('crypt32'))
+      session.railgun.add_dll('crypt32')
     end
   end
 
   def decrypt_password(data)
-    rg = session.railgun
     pid = client.sys.process.getpid
     process = client.sys.process.open(pid, PROCESS_ALL_ACCESS)
 
@@ -45,12 +43,12 @@ class MetasploitModule < Msf::Post
     if session.sys.process.each_process.find { |i| i["pid"] == pid } ["arch"] == "x86"
       addr = [mem].pack("V")
       len = [data.length].pack("V")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
       len, addr = ret["pDataOut"].unpack("V2")
     else
       addr = [mem].pack("Q")
       len = [data.length].pack("Q")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
       len, addr = ret["pDataOut"].unpack("Q2")
     end
 

--- a/modules/post/windows/gather/enum_chrome.rb
+++ b/modules/post/windows/gather/enum_chrome.rb
@@ -98,7 +98,6 @@ class MetasploitModule < Msf::Post
   end
 
   def decrypt_data(data)
-    rg = session.railgun
     pid = session.sys.process.open.pid
     process = session.sys.process.open(pid, PROCESS_ALL_ACCESS)
 
@@ -109,14 +108,14 @@ class MetasploitModule < Msf::Post
 
       addr = [mem].pack("V")
       len = [data.length].pack("V")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
       len, addr = ret["pDataOut"].unpack("V2")
 
     else
 
       addr = [mem].pack("Q")
       len = [data.length].pack("Q")
-      ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
+      ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
       len, addr = ret["pDataOut"].unpack("Q2")
 
     end

--- a/modules/post/windows/gather/enum_ie.rb
+++ b/modules/post/windows/gather/enum_ie.rb
@@ -239,7 +239,6 @@ class MetasploitModule < Msf::Post
     )
 
     # set up vars
-    rg = session.railgun
     host = session.sys.config.sysinfo
     @hist_col = []
 
@@ -344,7 +343,7 @@ class MetasploitModule < Msf::Post
     # get creds from credential store
     print_status("Looking in the Credential Store for HTTP Authentication Creds...")
     # get data from credential store
-    ret = rg.advapi32.CredEnumerateA(nil, 0, 4, 4)
+    ret = session.railgun.advapi32.CredEnumerateA(nil, 0, 4, 4)
     p_to_arr = ret["Credentials"].unpack("V")
     arr_len = ret["Count"] * 4 if is_86
     arr_len = ret["Count"] * 8 unless is_86

--- a/modules/post/windows/gather/memory_dump.rb
+++ b/modules/post/windows/gather/memory_dump.rb
@@ -78,8 +78,6 @@ class MetasploitModule < Msf::Post
     fail_with(Msf::Module::Failure::PayloadFailed, "Could not find process #{target_pid}") unless name
     print_status("Dumping memory for #{name}")
 
-    railgun = session.railgun
-
     if datastore['DUMP_TYPE'] == 'standard'
       # MiniDumpWithDataSegs | MiniDumpWithHandleData | MiniDumpWithIndirectlyReferencedMemory
       # | MiniDumpWithProcessThreadData | MiniDumpWithPrivateReadWriteMemory | MiniDumpWithThreadInfo
@@ -94,7 +92,7 @@ class MetasploitModule < Msf::Post
     begin
       process_handle = get_process_handle
       file_handle = create_file
-      result = railgun.dbghelp.MiniDumpWriteDump(process_handle,
+      result = session.railgun.dbghelp.MiniDumpWriteDump(process_handle,
                                                  target_pid,
                                                  file_handle,
                                                  dump_flags,
@@ -105,8 +103,8 @@ class MetasploitModule < Msf::Post
         fail_with(Msf::Module::Failure::PayloadFailed, "Minidump failed: #{result['ErrorMessage']}")
       end
     ensure
-      railgun.kernel32.CloseHandle(process_handle) if process_handle
-      railgun.kernel32.CloseHandle(file_handle) if file_handle
+      session.railgun.kernel32.CloseHandle(process_handle) if process_handle
+      session.railgun.kernel32.CloseHandle(file_handle) if file_handle
     end
 
     path = datastore['DUMP_PATH']

--- a/modules/post/windows/gather/memory_grep.rb
+++ b/modules/post/windows/gather/memory_grep.rb
@@ -62,11 +62,10 @@ class MetasploitModule < Msf::Post
     end
     proc = client.sys.process.open(target_pid, PROCESS_ALL_ACCESS)
 
-    railgun = session.railgun
-    heap_cnt = railgun.kernel32.GetProcessHeaps(nil, nil)['return']
-    dheap = railgun.kernel32.GetProcessHeap()['return']
+    heap_cnt = session.railgun.kernel32.GetProcessHeaps(nil, nil)['return']
+    dheap = session.railgun.kernel32.GetProcessHeap()['return']
     vprint_status("Default Process Heap: 0x%08x" % dheap)
-    ret = railgun.kernel32.GetProcessHeaps(heap_cnt, heap_cnt * 4)
+    ret = session.railgun.kernel32.GetProcessHeaps(heap_cnt, heap_cnt * 4)
     pheaps = ret['ProcessHeaps']
 
     idx = 0
@@ -82,7 +81,7 @@ class MetasploitModule < Msf::Post
     handles.each do |handle|
       lpentry = "\x00" * 42
       ret = ''
-      while (ret = railgun.kernel32.HeapWalk(handle, lpentry)) and ret['return']
+      while (ret = session.railgun.kernel32.HeapWalk(handle, lpentry)) and ret['return']
         entry = ret['lpEntry'][0, 4].unpack('V')[0]
         pointer = proc.memory.read(entry, 512)
         size = ret['lpEntry'][4, 4].unpack('V')[0]

--- a/scripts/meterpreter/enum_chrome.rb
+++ b/scripts/meterpreter/enum_chrome.rb
@@ -86,13 +86,12 @@ end
 print_status("using output format(s): " + @output_format.join(", "))
 
 def prepare_railgun
-  rg = client.railgun
-  if (!rg.get_dll('crypt32'))
-    rg.add_dll('crypt32')
+  if (!client.railgun.get_dll('crypt32'))
+    client.railgun.add_dll('crypt32')
   end
 
-  if (!rg.crypt32.functions["CryptUnprotectData"])
-    rg.add_function("crypt32", "CryptUnprotectData", "BOOL", [
+  if (!client.railgun.crypt32.functions["CryptUnprotectData"])
+    client.railgun.add_function("crypt32", "CryptUnprotectData", "BOOL", [
         ["PBLOB","pDataIn", "in"],
         ["PWCHAR", "szDataDescr", "out"],
         ["PBLOB", "pOptionalEntropy", "in"],
@@ -105,7 +104,6 @@ def prepare_railgun
 end
 
 def decrypt_data(data)
-  rg = client.railgun
   pid = client.sys.process.open.pid
   process = client.sys.process.open(pid, PROCESS_ALL_ACCESS)
 
@@ -114,7 +112,7 @@ def decrypt_data(data)
 
   addr = [mem].pack("V")
   len = [data.length].pack("V")
-  ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
+  ret = client.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
   len, addr = ret["pDataOut"].unpack("V2")
   return "" if len == 0
   decrypted = process.memory.read(addr, len)


### PR DESCRIPTION
Updating references to railgun to be consistent across the board, i.e. not creating a local variable to access railgun.

It looks like the original pattern has been copy/pasted from the same source.

Spotted as part of https://github.com/rapid7/metasploit-framework/pull/15665/files/12d2ea6562852b9de1f77231de5c4cc10a723758#diff-2aa2cf756d5988ba7d81e1cc9eaa88c03ac314bbb3ccb3d09cf4e80710f58666

## Verification

- Review the code
- Ensure there's no more local/instance variables referencing railgun