### PR TITLE
Fix #15717, replacing 'RHOSTS' with 'rhost'

### DIFF
--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -146,7 +146,7 @@ def check_logins(rhost, rport, targeturi, domain, usernames, passwords, timeout,
 
 def run(args):
     """Run the module, gathering the domain if desired and verifying usernames and passwords"""
-    module.LogHandler.setup(msg_prefix='{} - '.format(args['RHOSTS']))
+    module.LogHandler.setup(msg_prefix='{} - '.format(args['rhost']))
     if DEPENDENCIES_MISSING:
         module.log('Module dependencies are missing, cannot continue', level='error')
         return
@@ -154,7 +154,7 @@ def run(args):
     user_agent = args['user_agent']
     # Verify the service is up if requested
     if args['verify_service']:
-        service_verified = verify_service(args['RHOSTS'], args['rport'],
+        service_verified = verify_service(args['rhost'], args['rport'],
                                           args['targeturi'], int(args['timeout']), user_agent)
         if service_verified:
             module.log('Service is up, beginning scan...', level='good')
@@ -166,7 +166,7 @@ def run(args):
     # Gather AD Domain either from args or enumeration
     domain = args['domain'] if 'domain' in args else None
     if not domain and args['enum_domain']:
-        domain = get_ad_domain(args['RHOSTS'], args['rport'], user_agent)
+        domain = get_ad_domain(args['rhost'], args['rport'], user_agent)
 
     # Verify we have a proper domain
     if not domain:
@@ -188,7 +188,7 @@ def run(args):
     else:
         passwords = ['wrong']
     # Check each valid login combination
-    check_logins(args['RHOSTS'], args['rport'], args['targeturi'],
+    check_logins(args['rhost'], args['rport'], args['targeturi'],
                    domain, usernames, passwords, int(args['timeout']), user_agent)
 
 if __name__ == '__main__':


### PR DESCRIPTION
As seen in the `args` json file the `RHOSTS` parameter, which is set in Metasploit, is passed as `rhost` in the to the python script. Therefore `RHOSTS` is not a valid index in the `args` json file, causing the python script to crash as seen in #15717.

`{
   "WORKSPACE":"",
   "VERBOSE":"false",
   "THREADS":"1",
   "ShowProgress":"true",
   "ShowProgressPercent":"10",
   "targeturi":"/RDWeb/Pages/en-US/login.aspx",
   "rport":"443",
   "domain":"",
   "username":"********",
   "password":"",
   "timeout":"1250",
   "enum_domain":"true",
   "verify_service":"true",
   "user_agent":"Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
   "UNPARSED_RHOSTS":"***.***.***.***",
   "rhost":"***.***.***.***"
}`