### PR TITLE
Support Pivoted SSL Connections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.17)
+    rex-core (0.1.18)
     rex-encoder (0.1.6)
       metasm
       rex-arch

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -127,7 +127,7 @@ regexp_parser, 2.1.1, MIT
 reline, 0.2.5, ruby
 rex-arch, 0.1.14, "New BSD"
 rex-bin_tools, 0.1.8, "New BSD"
-rex-core, 0.1.17, "New BSD"
+rex-core, 0.1.18, "New BSD"
 rex-encoder, 0.1.6, "New BSD"
 rex-exploitation, 0.1.28, "New BSD"
 rex-java, 0.1.6, "New BSD"

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -83,8 +83,10 @@ module Msf::Sessions
         rsock.channel = self
 
         lsock.extend(Rex::Socket::SslTcp) if params.ssl
-        lsock.initsock(params)
-        rsock.initsock(params)
+
+        # synchronize access so the socket isn't closed while initializing, this is particularly important for SSL
+        lsock.synchronize_access { lsock.initsock(params) }
+        rsock.synchronize_access { rsock.initsock(params) }
 
         client.add_channel(self)
       end

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
@@ -81,6 +81,15 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
 
     unless sock_params.nil?
       @params = sock_params.merge(Socket.parameters_from_response(packet))
+      lsock.extend(Rex::Socket::SslTcp) if sock_params.ssl
+    end
+
+    begin
+      lsock.initsock(@params)
+      rsock.initsock(@params)
+    rescue ::IOError
+      # this exception is raised when initializing an SSL socket if the DIO handler closes it in another thread
+      # disregarding it here allows the SSL-specific exception to be raised to the caller instead
     end
   end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
@@ -84,13 +84,9 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
       lsock.extend(Rex::Socket::SslTcp) if sock_params.ssl
     end
 
-    begin
-      lsock.initsock(@params)
-      rsock.initsock(@params)
-    rescue ::IOError
-      # this exception is raised when initializing an SSL socket if the DIO handler closes it in another thread
-      # disregarding it here allows the SSL-specific exception to be raised to the caller instead
-    end
+    # synchronize access so the socket isn't closed while initializing, this is particularly important for SSL
+    lsock.synchronize_access { lsock.initsock(@params) }
+    rsock.synchronize_access { rsock.initsock(@params) }
   end
 
   #


### PR DESCRIPTION
This adds the necessary functionality to negotiate SSL connections that are pivoted over supported session types including Meterpreter and SSH. This is necessary to make HTTPS requests over pivoted sessions.

Without this functionality the `Rex::Socket::Parameters#ssl` setting is silently ignored, causing data to be sent in plaintext.

Requires rapid7/rex-core#16

## Demo
This demonstrates making an HTTPS over an established Meterpreter session using the `request` plugin. The second request fails with an SSL error as expected because it's making an HTTPS request to TCP port 80.

```
msf6 auxiliary(scanner/ssh/ssh_login) > sessions

Active sessions
===============

  Id  Name  Type                      Information                        Connection
  --  ----  ----                      -----------                        ----------
  1         meterpreter python/linux  smcintyre @ localhost.localdomain  192.168.159.128:4444 -> 192.168.159.128:35928 (192.168.159.128)

msf6 auxiliary(scanner/ssh/ssh_login) > route
[*] There are currently no routes defined.
msf6 auxiliary(scanner/ssh/ssh_login) > route add 0 0 -1
[*] Route added
msf6 auxiliary(scanner/ssh/ssh_login) > request https://ifconfig.me/all.json
{
  "ip_addr": "###",
  "remote_host": "unavailable",
  "user_agent": "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)",
  "port": 56072,
  "method": "GET",
  "via": "1.1 google",
  "forwarded": "###"
}
msf6 auxiliary(scanner/ssh/ssh_login) > request https://ifconfig.me:80/all.json
[-] Encountered an SSL error
msf6 auxiliary(scanner/ssh/ssh_login) >
```

Without these changes, the correct HTTPS request fails, and the HTTPS request that should fail succeeds since it's actually HTTP.

```
msf6 payload(python/meterpreter/reverse_tcp) > sessions

Active sessions
===============

  Id  Name  Type                      Information                        Connection
  --  ----  ----                      -----------                        ----------
  1         meterpreter python/linux  smcintyre @ localhost.localdomain  192.168.159.128:4444 -> 192.168.159.128:35930 (192.168.159.128)

msf6 payload(python/meterpreter/reverse_tcp) > route
[*] There are currently no routes defined.
msf6 payload(python/meterpreter/reverse_tcp) > route add 0 0 -1
[*] Route added
msf6 payload(python/meterpreter/reverse_tcp) > request https://ifconfig.me/all.json

msf6 payload(python/meterpreter/reverse_tcp) > request https://ifconfig.me:80/all.json
Found. Redirecting to https://ifconfig.me/all.json
msf6 payload(python/meterpreter/reverse_tcp) >
```

## Verification

List the steps needed to make sure this thing works

- [x] Load the changes from rapid7/rex-core#16 for the synchronization access
- [x] Load the Request plugin (run: `load request`)
- [x] Establish a Meterpreter session
  - [x] Route all traffic through it (run: `route add 0 0 -1` from the Metasploit prompt, not Meterpreter)
  - [x] Make an HTTPS request, see it succeed (run: `request https://ifconfig.me/all.json`)
  - [x] Make an HTTP request, see it succeed (run: `request http://ifconfig.me/all.json`)
  - [x] Make an HTTPS request to a TCP port, see it fail with an SSL error (run: `request https://ifconfig.me:80/all.json`)
- [x] Establish an SSH session (use the `auxiliary/scanner/ssh/ssh_login` module)
  - [x] Route all traffic through it (run: `route add 0 0 -1` from the Metasploit prompt, not Meterpreter)
  - [ ] Make an HTTPS request, see it succeed (run: `request https://ifconfig.me/all.json`)
  - [ ] Make an HTTP request, see it succeed (run: `request http://ifconfig.me/all.json`)
  - [ ] Make an HTTPS request to a TCP port, see it fail with an SSL error (run: `request https://ifconfig.me:80/all.json`)
