### PR TITLE
Add tab completion for exploit rerun command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -250,6 +250,8 @@ class Exploit
   end
 
   alias cmd_rerun cmd_rexploit
+  alias cmd_rerun_tabs cmd_run_tabs
+  alias cmd_rexploit_tabs cmd_exploit_tabs
 
   def cmd_rexploit_help
     print_module_run_or_check_usage(


### PR DESCRIPTION
Adds tab completion for the rerun command on exploit modules

Before: No tab completion on the tab completion of the `rerun` command
After: Tab completion now works with the `rerun` command

### Verification

- `use thinkphp`
- `rerun rhos<tab>`

Verify that `rhosts=` tab completes