### PR TITLE
Add MeterpreterTryToFork to the mettle payloads

### DIFF
--- a/lib/msf/base/sessions/mettle_config.rb
+++ b/lib/msf/base/sessions/mettle_config.rb
@@ -9,6 +9,20 @@ module Msf
 
       include Msf::Payload::TransportConfig
 
+      def initialize(info = {})
+        super
+
+        register_advanced_options(
+          [
+            OptBool.new(
+              'MeterpreterTryToFork',
+              'Fork a new process if the functionality is available',
+              default: false
+            )
+          ]
+        )
+      end
+
       def generate_uri(opts={})
         ds = opts[:datastore] || datastore
         uri_req_len = ds['StagerURILength'].to_i
@@ -65,6 +79,8 @@ module Msf
       def generate_config(opts={})
         ds = opts[:datastore] || datastore
 
+        opts[:background] = ds['MeterpreterTryToFork'] ? 1 : 0
+
         if ds['PayloadProcessCommandLine'] != ''
           opts[:name] ||= ds['PayloadProcessCommandLine']
         end
@@ -97,7 +113,7 @@ module Msf
         end
         opts[:session_guid] = Base64.encode64(guid).strip
 
-        opts.slice(:uuid, :session_guid, :uri, :debug, :log_file, :name)
+        opts.slice(:uuid, :session_guid, :uri, :debug, :log_file, :name, :background)
       end
 
       # Stage encoding is not safe for Mettle (doesn't apply to stageless)


### PR DESCRIPTION
This adds the `MeterpreterTryToFork` option to the Mettle payloads. When set, it translates to Mettle's `:background` option, which when `:persist` is not configured will just try to fork the stage into the background. The `MeterpreterTryToFork` option name is consistent with the existing Python one. Persistent functionality remains unexposed through the datastore API. The default forking behavior is left the same.

## Verification

- [x] Use `linux/x64/meterpreter/reverse_tcp`
- [x] `set MeterpreterTryToFork true`
- [x] `generate -f elf -o /path/to/your/file`
- [x] Run the Meterpreter that was just generated, see the process return immediately
- [x] Turn MeterpreterTryToFork back off, repeat and see that the process continues to run
