### PR TITLE
Add error handing to rdp_web_login.py to handle malformed NetNTLM messages

### DIFF
--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -106,7 +106,13 @@ def get_ad_domain(rhost, rport, user_agent):
                     continue
 
                 domain = domain[1]
-                domain = domain[domain.index(b'\x0f') + 1:domain.index(b'\x02')].decode('utf-8')
+                start = domain.find(b'\x0f')
+                end = domain.find(b'\x02')
+                if (start == -1) or (end == -1):
+                    module.log("Couldn't find byte 0xf or 0x2 in the request, skipping processing %s", url)
+                    continue
+
+                domain = domain[start + 1:end].decode('utf-8')
                 module.log('Found Domain: {}'.format(domain), level='good')
                 return domain
             except:

--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -2,14 +2,16 @@
 # -*- coding: utf-8 -*-
 
 # standard modules
+import base64
+import binascii
+import itertools
+import os
+import struct
 from metasploit import module
 
 # extra modules
 DEPENDENCIES_MISSING = False
 try:
-    import base64
-    import itertools
-    import os
     import requests
 except ImportError:
     DEPENDENCIES_MISSING = True
@@ -63,6 +65,34 @@ metadata = {
 }
 
 
+def parse_ntlm_t1(message):
+    try:
+        message = base64.b64decode(message)
+    except binascii.Error:
+        return None
+
+    if not message.startswith(b'NTLMSSP\x00\x01\x00\x00\x00'):
+        return None
+    struct_fmt = '<8xIIHHIHHI'
+    size = struct.calcsize(struct_fmt)
+    if len(message) < size:
+        return None
+    fields = struct.unpack(struct_fmt, message[:size])
+
+    properties = {'type': fields[0], 'flags': fields[1]}
+
+    length, _, offset = fields[2:5]
+    if len(message) < offset + length:
+        return None
+    properties['domain'] = message[offset:offset+length].decode('utf-8')
+
+    length, _, offset = fields[5:8]
+    if len(message) < offset + length:
+        return None
+    properties['workstation'] = message[offset:offset+length].decode('utf-8')
+    return properties
+
+
 def verify_service(rhost, rport, targeturi, timeout, user_agent):
     """Verify the service is up at the target URI within the specified timeout"""
     url = 'https://{}:{}/{}'.format(rhost, rport, targeturi)
@@ -93,32 +123,14 @@ def get_ad_domain(rhost, rport, user_agent):
         # Decode the provided NTLM Response to strip out the domain name
         if request.status_code == 401 and 'WWW-Authenticate' in request.headers and \
           'NTLM' in request.headers['WWW-Authenticate']:
-            try:
-                ntlm_header_array = request.headers['WWW-Authenticate'].split('NTLM ')
-                if len(ntlm_header_array) < 2:
-                    module.log("NTLM authenticate header was not in the expected format for %s" % url)
-                    continue
-
-                domain_hash = ntlm_header_array[1].split(',')[0]
-                domain = base64.b64decode(bytes(domain_hash, 'utf-8')).replace(b'\x00',b'').split(b'\n')
-                if len(domain) < 2:
-                    module.log("Domain is not in the right format, skipping processing %s" % url)
-                    continue
-
-                domain = domain[1]
-                start = domain.find(b'\x0f')
-                end = domain.find(b'\x02')
-                if (start == -1) or (end == -1):
-                    module.log("Couldn't find byte 0xf or 0x2 in the request, skipping processing %s", url)
-                    continue
-
-                domain = domain[start + 1:end].decode('utf-8')
-                module.log('Found Domain: {}'.format(domain), level='good')
-                return domain
-            except:
-                module.log("An unhandled exception occured when processing %s. Please file a bug report." %url)
+            type1_msg = request.headers['WWW-Authenticate'].split('NTLM ')[1].split(',')[0]
+            type1_msg = parse_ntlm_t1(type1_msg)
+            if type1_msg is None:
+                module.log("NTLM authenticate header was not in the expected format for %s" % url)
                 continue
-    module.log('Failed to find Domain', level='error')
+            module.log('Found Domain: {}'.format(type1_msg['domain']), level='good')
+            return type1_msg['domain']
+    module.log('Failed to find the domain', level='error')
     return None
 
 

--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -93,12 +93,14 @@ def get_ad_domain(rhost, rport, user_agent):
         # Decode the provided NTLM Response to strip out the domain name
         if request.status_code == 401 and 'WWW-Authenticate' in request.headers and \
           'NTLM' in request.headers['WWW-Authenticate']:
-            domain_hash = request.headers['WWW-Authenticate'].split('NTLM ')[1].split(',')[0]
-            domain = base64.b64decode(bytes(domain_hash,
-                                            'utf-8')).replace(b'\x00',b'').split(b'\n')[1]
-            domain = domain[domain.index(b'\x0f') + 1:domain.index(b'\x02')].decode('utf-8')
-            module.log('Found Domain: {}'.format(domain), level='good')
-            return domain
+            try:
+                domain_hash = request.headers['WWW-Authenticate'].split('NTLM ')[1].split(',')[0]
+                domain = base64.b64decode(bytes(domain_hash, 'utf-8')).replace(b'\x00',b'').split(b'\n')[1]
+                domain = domain[domain.index(b'\x0f') + 1:domain.index(b'\x02')].decode('utf-8')
+                module.log('Found Domain: {}'.format(domain), level='good')
+                return domain
+            except:
+                pass
     module.log('Failed to find Domain', level='error')
     return None
 


### PR DESCRIPTION
As mentioned in #15720 with some NTLM responses the `modules/auxiliary/scanner/http/rdp_web_login.py` module crashes, unable to enumerate the domain. To prevent this behavior a try and except block was added, to inform the user about the crash.

Debug output from above mentioned crash:
```
[09/30/2021 13:02:40] [e(0)] core: Unexpected output running /usr/share/metasploit-framework/modules/auxiliary/scanner/http/rdp_web_login.py:
Traceback (most recent call last):
  File "/usr/share/metasploit-framework/modules/auxiliary/scanner/http/rdp_web_login.py", line 197, in <module>
    module.run(metadata, run)
  File "/usr/share/metasploit-framework/lib/msf/core/modules/external/python/metasploit/module.py", line 122, in run
    ret = callback(args)
  File "/usr/share/metasploit-framework/modules/auxiliary/scanner/http/rdp_web_login.py", line 171, in run
    domain = get_ad_domain(args['rhost'], args['rport'], user_agent)
  File "/usr/share/metasploit-framework/modules/auxiliary/scanner/http/rdp_web_login.py", line 98, in get_ad_domain
    domain = base64.b64decode(bytes(domain_hash, 'utf-8')).replace(b'\x00',b'').split(b'\n')[1]
IndexError: list index out of range
```