### PR TITLE
Add nil check for return value of add_printer_driver_ex in cve_2021_1675_printnightmare to prevent errors when status code can't be mapped

### DIFF
--- a/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb
@@ -337,6 +337,8 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     case add_printer_driver_ex(container)
+    when nil # prevent the module from erroring out in case the response can't be mapped to a Win32 error code
+      return Exploit::CheckCode::Unknown('Received unknown status code, implying the target is not vulnerable.')
     when ::WindowsError::Win32::ERROR_PATH_NOT_FOUND
       return Exploit::CheckCode::Vulnerable('Received ERROR_PATH_NOT_FOUND, implying the target is vulnerable.')
     when ::WindowsError::Win32::ERROR_BAD_NET_NAME


### PR DESCRIPTION
As per the request of @zeroSteiner, this PR adds a simple nil check to the case statement for the return value of `add_printer_driver_ex` (starting at line 339). This is to prevent errors whenever the received status code cannot be mapped to a Win32 error code, in which case `add_printer_driver_ex` returns nil. 

Check the below output for the error I got when this happened:
```
msf6 auxiliary(admin/dcerpc/cve_2021_1675_printnightmare) > run
[*] Running module against 10.1.1.9
[*] 10.1.1.9:445 - Running automatic check ("set AutoCheck false" to disable)
[*] 10.1.1.9:445 - Binding to [...]:1.0@ncacn_np:10.1.1.9[\spoolss] ...
[*] 10.1.1.9:445 - Bound to [...]:1.0@ncacn_np:10.1.1.9[\spoolss] ...
[*] 10.1.1.9:445 - Target environment: Windows v6.3.9600 (x64)
[*] 10.1.1.9:445 - Enumerating the installed printer drivers...
[*] 10.1.1.9:445 - Using driver path: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_[...]\Amd64\UNIDRV.DLL
[*] 10.1.1.9:445 - Retrieving the path of the printer driver directory...
[*] 10.1.1.9:445 - Using driver directory: C:\Windows\system32\spool\DRIVERS\x64
[*] 10.1.1.9:445 - RpcAddPrinterDriverEx response 2147549467
[-] 10.1.1.9:445 - Auxiliary failed: ArgumentError Cannot compare a WindowsError::ErrorCode to a NilClass
[-] 10.1.1.9:445 - Call stack:
[-] 10.1.1.9:445 -   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/windows_error-0.1.2/lib/windows_error/error_code.rb:43:in `=='
[-] 10.1.1.9:445 -   /usr/share/metasploit-framework/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb:346:in `check'
[-] 10.1.1.9:445 -   /usr/share/metasploit-framework/lib/msf/core/exploit/remote/auto_check.rb:44:in `with_prepended_auto_check'
[-] 10.1.1.9:445 -   /usr/share/metasploit-framework/lib/msf/core/exploit/remote/auto_check.rb:20:in `run'
[*] Auxiliary module execution completed
```