### PR TITLE
Update Gitea Git hooks RCE check method

### DIFF
--- a/modules/exploits/multi/http/gitea_git_hooks_rce.rb
+++ b/modules/exploits/multi/http/gitea_git_hooks_rce.rb
@@ -105,7 +105,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 1,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [REPEATABLE_SESSION]
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
         }
       )
     )
@@ -131,8 +132,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Powered by Gitea Version: 1.12.5
-    unless (match = res.body.match(/Powered by Gitea Version: (?<version>[\d.]+)/))
-      return CheckCode::Unsupported('Target does not appear to be running Gitea.')
+    unless (match = res.body.match(/Gitea Version: (?<version>[\da-zA-Z.]+)/))
+      return CheckCode::Unknown('Target does not appear to be running Gitea.')
+    end
+
+    if match[:version].match(/[a-zA-Z]/)
+      return CheckCode::Unknown("Unknown Gitea version #{match[:version]}.")
     end
 
     if Rex::Version.new(match[:version]) >= Rex::Version.new('1.13.0')


### PR DESCRIPTION
Older versions of Gitea have a different version message than is currently supported:
![image](https://user-images.githubusercontent.com/60357436/135545472-bbbe019d-343c-4019-b695-dedc2ca4337e.png)

The wording was changed here: https://github.com/go-gitea/gitea/pull/9600

### Before

When running the check method against a valid Gitea target, the 'Unsupported' check code is returned, which means the module doesn't support the check method - which is incorrect. Additionally doesn't identify the correct version of Gitea:

```
msf6 exploit(multi/http/gitea_git_hooks_rce) > check
[*] 10.10.168.148:31111 - This module does not support check. Target does not appear to be running Gitea.
```

### After

Gitea is detected, and a check code which details the unknown version is returned:

```
msf6 exploit(multi/http/gitea_git_hooks_rce) > check
[*] 10.10.168.148:31111 - Cannot reliably check exploitability. Unknown Gitea version 38d8b8c.
```

It's worth noting that this change doesn't support non-english versions of Gitea.

## Verification

Run an older version of Gitea, and replicate the testing steps here: https://github.com/rapid7/metasploit-framework/pull/14978