### PR TITLE
Update call to deprecated connection_config

### DIFF
--- a/lib/msf/core/db_connector.rb
+++ b/lib/msf/core/db_connector.rb
@@ -257,7 +257,7 @@ module DbConnector
   end
 
   def self.build_postgres_url
-    conn_params = ApplicationRecord.connection_config
+    conn_params = ApplicationRecord.connection_db_config.configuration_hash
     url = ''
     url += "#{conn_params[:username]}" if conn_params[:username]
     url += ":#{conn_params[:password]}" if conn_params[:password]


### PR DESCRIPTION
Updates the call to fetch the DB configuration hash in `db_connector.rb` as it is being deprecated in Rails 6.2

Fixes #15715 

## Verification

List the steps needed to make sure this thing works

- [x] run `msfdb --init`
- [x] start `msfconsole`
- [x] type `db_disconnect`
- [x] see no deprecation warnings