### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,15 +1,15 @@
 name: Labels
 on:
   pull_request_target:
-    types: [labeled]
+    types: [ labeled ]
   issues:
-    types: [labeled]
+    types: [ labeled ]
 
 jobs:
   handle-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3 # pin@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,13 +26,13 @@ jobs:
         run: sudo apt-get install libpcap-dev graphviz
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
         # Required to checkout HEAD^ and 3a046f01dae340c124dd3895e670983aef5fe0c5 for the msftidy script
         # https://github.com/actions/checkout/tree/5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f#checkout-head
         with:
           fetch-depth: 0
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@5e4f0a10bfc39c97cd5358121291e27e5d97e09b # pin@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: stale
         id: stale
-        uses: actions/stale@v3
+        uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # pin@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,7 +16,7 @@ jobs:
     name: Docker Build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
 
       - name: docker-compose build
         run: |
@@ -33,14 +33,12 @@ jobs:
     services:
       postgres:
         image: postgres:9.6
-        ports: ["5432:5432"]
+        ports: [ "5432:5432" ]
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s
           --health-retries 5
 
     strategy:
@@ -55,8 +53,10 @@ jobs:
           - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content"
           - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content"
           # Used for testing the remote data service
-          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content" REMOTE_DB=1
-          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content" REMOTE_DB=1
+          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content"
+            REMOTE_DB=1
+          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content"
+            REMOTE_DB=1
 
     env:
       RAILS_ENV: test
@@ -67,12 +67,12 @@ jobs:
         run: sudo apt-get install libpcap-dev graphviz
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
 
       - name: Setup Ruby
         env:
           BUNDLE_WITHOUT: "coverage development pcap"
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@5e4f0a10bfc39c97cd5358121291e27e5d97e09b # pin@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
Pinning an action to a full length commit SHA is currently the only way to use an action as
an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a
backdoor to the action's repository, as they would need to generate a SHA-1 collision for
a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

If you are opening a PR for a new module that exploits a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us a demo of your module executing correctly. Seeing your module in action will help us review your PR faster!

Specific Hardware Examples:
* Switches
* Routers
* IP Cameras
* IoT devices

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software that requires exploit testing across multiple significantly different versions
* Software without an English language UI

We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster!

Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.
