### PR TITLE
Fix action handling for auxiliary modules

### DIFF
--- a/lib/msf/ui/console/module_argument_parsing.rb
+++ b/lib/msf/ui/console/module_argument_parsing.rb
@@ -53,7 +53,7 @@ module ModuleArgumentParsing
       end
     end
 
-    parse_opts(@@module_opts_with_action_support, args, help_cmd: help_cmd)
+    parse_opts(@@module_opts_with_action_support, args, help_cmd: help_cmd, action: action)
   end
 
   def parse_exploit_opts(args)

--- a/spec/msf/ui/console/module_argument_parsing_spec.rb
+++ b/spec/msf/ui/console/module_argument_parsing_spec.rb
@@ -272,6 +272,40 @@ RSpec.describe Msf::Ui::Console::ModuleArgumentParsing do
     it_behaves_like 'a command which shows help menus',
                     method_name: 'parse_run_opts',
                     expected_help_cmd: 'cmd_run_help'
+
+    it 'handles an action being supplied' do
+      args = []
+      expected_result = {
+        jobify: false,
+        quiet: false,
+        action: 'action-name',
+        datastore_options: {}
+      }
+      expect(subject.parse_run_opts(args, action: 'action-name')).to eq(expected_result)
+    end
+
+    it 'handles an action being specified from the original datastore value' do
+      current_mod.datastore['action'] = 'datastore-action-name'
+      args = []
+      expected_result = {
+        jobify: false,
+        quiet: false,
+        action: 'action-name',
+        datastore_options: {}
+      }
+      expect(subject.parse_run_opts(args, action: 'action-name')).to eq(expected_result)
+    end
+
+    it 'handles an action being nil' do
+      args = []
+      expected_result = {
+        jobify: false,
+        quiet: false,
+        action: nil,
+        datastore_options: {}
+      }
+      expect(subject.parse_run_opts(args)).to eq(expected_result)
+    end
   end
 
   describe '#parse_exploit_opts' do


### PR DESCRIPTION
`action` wasn't correctly being set when using the action name as a command,

## Verification

Ensure automated tests pass and there is a difference of behavior on master/this branch.

Verify `action.name` is correctly set within a module by placing a breakpoint in a module of choice:
```diff
--- a/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
+++ b/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
@@ -85,6 +85,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def check_host(_ip)
+    require 'pry'; binding.pry
     # The check command will call this method instead of run_host
     status = Exploit::CheckCode::Unknown
```

Verify `action.name` is correctly set to `crash`
```
use scanner/rdp/cve_2019_0708_bluekeep
crash 127.0.0.1
```

Verify `action.name` is correctly set to `scan`
```
use scanner/rdp/cve_2019_0708_bluekeep
scan 127.0.0.1
```

Example

```
msf6 auxiliary(scanner/rdp/cve_2019_0708_bluekeep) > scan 127.0.0.1
...

    85:   end
    86: 
    87:   def check_host(_ip)
    88:     require 'pry'; binding.pry
    89:     # The check command will call this method instead of run_host
 => 90:     status = Exploit::CheckCode::Unknown
    91: 
    92:     begin
    93:       begin
    94:         rdp_connect
    95:       rescue ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError

[1] pry(#<Msf::Modules::Auxiliary__Scanner__Rdp__Cve_2019_0708_bluekeep::MetasploitModule>)> action.name
=> "Scan"
```