### PR TITLE
ghostcat meta updates

### DIFF
--- a/documentation/modules/auxiliary/admin/http/tomcat_ghostcat.md
+++ b/documentation/modules/auxiliary/admin/http/tomcat_ghostcat.md
@@ -3,7 +3,7 @@
 ### Description
 
 This module can be used to retrieve arbitrary files from anywhere in the web application, including the `WEB-INF` and `META-INF`
-directories and any other location that can be reached via ServletContext.getResourceAsStream() on Apache Tomcat servers.
+directories and any other location that can be reached via `ServletContext.getResourceAsStream()` on Apache Tomcat servers.
 It also allows the attacker to process any file in the web application as JSP.
 
 ### Setup
@@ -27,7 +27,7 @@ docker run --name tomcat --rm -p 8080:8080 -p 8009:8009 tomcat:8.5.32
 ## Options
 
 ### FILENAME
-The file you would like to retrieve from the target web application.
+The file you would like to retrieve from the target web application. Defaults to `/WEB-INF/web.xml`
 
 ### AJP_PORT
 The port on the target that is running the Apache JServ Protocol (AJP).

--- a/modules/auxiliary/admin/http/tomcat_ghostcat.rb
+++ b/modules/auxiliary/admin/http/tomcat_ghostcat.rb
@@ -6,7 +6,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name' => 'Ghostcat',
+        'Name' => 'Apache Tomcat AJP File Read',
         'Description' => %q{
           When using the Apache JServ Protocol (AJP), care must be taken when trusting incoming connections to Apache
           Tomcat. Tomcat treats AJP connections as having higher trust than, for example, a similar HTTP connection.
@@ -34,9 +34,17 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'License' => MSF_LICENSE,
         'References' => [
-          ['CVE', '2020-1938']
+          ['CVE', '2020-1938'],
+          ['EDB', '48143'],
+          ['URL', 'https://www.chaitin.cn/en/ghostcat']
         ],
-        'DisclosureDate' => '2020-02-20'
+        'DisclosureDate' => '2020-02-20',
+        'Notes' => {
+          'AKA' => ['Ghostcat'],
+          'Stability' => ['CRASH_SAFE'],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
     register_options(


### PR DESCRIPTION
This PR updates some of the metadata for the ghostcat module include:

- Setting a real module name
- Setting an AKA, and other Note fields
- Including a few more references
- minor doc touchups