### PR TITLE
Fix bug where refs are not checked if the notes section is before refs

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -245,8 +245,6 @@ class MsftidyRunner
         in_refs = false
       elsif in_super and line =~ /["']Notes["'][[:space:]]*=>/
         in_notes = true
-      elsif in_super and in_notes and line =~ /^[[:space:]]+\},*/m
-        break
       elsif in_super and in_refs and line =~ /[^#]+\[[[:space:]]*['"](.+)['"][[:space:]]*,[[:space:]]*['"](.+)['"][[:space:]]*\]/
         identifier = $1.strip.upcase
         value      = $2.strip


### PR DESCRIPTION
OK- this PR addresses an odd error I had while trying to land https://github.com/rapid7/metasploit-framework/pull/15698

When I went to land it, the hooks ran `msftidy` locally and printed:
```
modules/exploits/linux/local/netfilter_xtables_heap_oob_write_priv_esc.rb - [INFO] No CVE references found. Please check before you land!

```

Narrator voice: There was a CVE entry.

TL;DR: If the 'Notes' section in the info hash is before the `References` section, then the `References` section is never parsed and checked.

Looking at the `msftidy` code, I think there a typo that we never noticed because everyone copy/pasted the info hash and changed values, keeping the same order of entries which had the `References` section before the `Notes` section.
In `check_ref_identifiers` there is a check that causes the method to exit the check if it found itself at the end of the notes section.  Originally, I thought that must have been intended to be a check to see if it was at the end of the refs section, but the refs section depends on the notes section because it looks for "NO CVE" in the notes section to address possible concerns in the refs section, so it can't be an exit from the refs section.  I've removed the check and hope it was just superfluous.

List the steps needed to make sure this thing works

On the main branch:
- [x] Edit a module to place the notes hash in front of the references hash
- [x] run msftidy and verify the references are not checked

On this PR branch:
- [x] Edit a module to place the notes hash in front of the references hash
- [x] run msftidy and verify the references are checked

Testing (using main branch):
```
[ruby-2.7.2@metasploit-framework](upstream-master) tmoose@ubuntu:~/rapid7/metasploit-framework$ tools/dev/msftidy.rb modules/exploits/multi/http/opmanager_sumpdu_deserialization.rb

1 file inspected, no offenses detected
```
Change the `Notes` section to be before the `References` section in the info hash:
```
[ruby-2.7.2@metasploit-framework](upstream-master) tmoose@ubuntu:~/rapid7/metasploit-framework$ tools/dev/msftidy.rb modules/exploits/multi/http/opmanager_sumpdu_deserialization.rb
modules/exploits/multi/http/opmanager_sumpdu_deserialization.rb - [INFO] No CVE references found. Please check before you land!

```
Testing (using this branch):
```
[ruby-2.7.2@metasploit-framework](upstream-master) tmoose@ubuntu:~/rapid7/metasploit-framework$ tools/dev/msftidy.rb modules/exploits/multi/http/opmanager_sumpdu_deserialization.rb

1 file inspected, no offenses detected
```
Change the `Notes` section to be before the `References` section in the info hash:
```
[ruby-2.7.2@metasploit-framework](upstream-master) tmoose@ubuntu:~/rapid7/metasploit-framework$ tools/dev/msftidy.rb modules/exploits/multi/http/opmanager_sumpdu_deserialization.rb

1 file inspected, no offenses detected
```