### PR TITLE
ruby 3 windows color support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ PATH
       tzinfo-data
       unix-crypt
       warden
+      win32api
       windows_error
       winrm
       xdr
@@ -479,6 +480,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    win32api (0.1.0)
     windows_error (0.1.2)
     winrm (2.3.6)
       builder (>= 2.1.2)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -225,5 +225,8 @@ Gem::Specification.new do |spec|
   # Earlier than latest Faraday gem is used to prevent upstream Octokit errors
   spec.add_runtime_dependency 'faraday'
 
+  # Required for windows terminal colors as of Ruby 3.0
+  spec.add_runtime_dependency 'win32api'
+
   spec.add_runtime_dependency 'zeitwerk'
 end


### PR DESCRIPTION
Ruby 3.0 removes the Win32API namespace from the standard
included libraries.  This new gem exposes the namespace for backwards
compatibility.

Error as seen in a Windows build with Ruby 3.0.2 public installer.
```
C:/Users/vagrant/rapid7/metasploit-framework/lib/windows_console_color_support.rb:14:in `initialize': uninitialized constant WindowsConsoleColorSupport::Win32API (NameError)
	from C:/Users/vagrant/rapid7/metasploit-framework/lib/rex/ui/text/output/stdio.rb:87:in `new'
	from C:/Users/vagrant/rapid7/metasploit-framework/lib/rex/ui/text/output/stdio.rb:87:in `print_raw'
	from C:/Users/vagrant/rapid7/metasploit-framework/lib/rex/ui/text/output.rb:68:in `print'
	from C:/tools/ruby30/lib/ruby/gems/3.0.0/gems/rex-text-0.2.37/lib/rex/text/color.rb:95:in `reset_color'
	from C:/Users/vagrant/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:495:in `run_single'
	from C:/Users/vagrant/rapid7/metasploit-framework/lib/msf/ui/console/driver.rb:366:in `on_startup'
	from C:/Users/vagrant/rapid7/metasploit-framework/lib/msf/ui/console/driver.rb:168:in `initialize'
	from C:/Users/vagrant/rapid7/metasploit-framework/lib/metasploit/framework/command/console.rb:60:in `new'
	from C:/Users/vagrant/rapid7/metasploit-framework/lib/metasploit/framework/command/console.rb:60:in `driver'
	from C:/Users/vagrant/rapid7/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
	from C:/Users/vagrant/rapid7/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
	from msfconsole:23:in `<main>'
```

## Verification

List the steps needed to make sure this thing works

- [ ] Generate a windows dev env install
- [ ] `bundle install`
- [ ] `ruby msfconsole`
- [ ] **Verify** console startup