### PR TITLE
Honor json extension in store loot

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -396,7 +396,7 @@ module Auxiliary::Report
     ext = 'bin'
     if filename
       parts = filename.to_s.split('.')
-      if parts.length > 1 and parts[-1].length < 4
+      if parts.length > 1 and parts[-1].length <= 4
         ext = parts[-1]
       end
     end


### PR DESCRIPTION
Fixes an issue I ran into when attempting to store `json` loot, where the extension was always being set to `bin` instead of `json`.

### Before

The created file extension for string json loot is `.bin`

```
msf6 auxiliary(admin/http/wp_google_maps_sqli) > irb
[*] Starting IRB shell...
[*] You are in auxiliary/admin/http/wp_google_maps_sqli

>> store_loot("foo.bar.config", "application/json", nil, '{"version": 1234}', "config.json")
=> "/Users/user/.msf4/loot/20211011120706_default_unknown_foo.bar.config_868580.bin"
>> 

```

### After

The created file extension for string json loot is`.json`

```
msf6 auxiliary(admin/http/wp_google_maps_sqli) > irb
[*] Starting IRB shell...
[*] You are in auxiliary/admin/http/wp_google_maps_sqli

>> store_loot("foo.bar.config", "application/json", nil, '{"version": 1234}', "config.json")
=> "/Users/user/.msf4/loot/20211011115419_default_unknown_foo.bar.config_355829.json"
>> 
```

## Verification

```
use admin/http/wp_google_maps_sqli
irb
store_loot("foo.bar.config", "application/json", nil, '{"version": 1234}', "config.json")
```

- Verify the extension is honored
- Verify there's no security issues as part of this change