### PR TITLE
Add trace.rb (Cross-Site-Tracing) Scanner Documentation

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/trace.md
+++ b/documentation/modules/auxiliary/scanner/http/trace.md
@@ -4,27 +4,23 @@ This module checks if the host(s) is(are) vulnerable to Cross-Site Tracing (XST)
 The module does more than just check for the HTTP Trace method, and actually
 attempts a trace request to verify that XST is possible.
 
+### Setting up Web Servers with the TRACE Method
+This [link](https://www.virtuesecurity.com/kb/web-server-trace-enabled/) describes how
+to disable the HTTP TRACE method. In order to enable it, simply follow the opposite of
+these instructions (e.g. set TraceEnable to on for Apache).
+
 ## Verification Steps
 
 - [ ] Start `msfconsole`
 - [ ] `use auxiliary/scanner/http/trace`
 - [ ] `show info`
-- [ ] `set RHOSTS YYY.YY.YYY.YYY`
+- [ ] `set RHOSTS [ip]`
 - [ ] `set RPORT 443`
 - [ ] `set SSL true`
 - [ ] `run`
 - [ ] Check output for presence of XST
 
 ## Options
-
-### RHOSTS
-The target host(s) to verify Cross-Site Tracing (XST) on.
-
-### RPORT
-The target port to check.
-
-### SSL
-Needed if the target port uses SSL/TLS. Tells Metasploit to negotiate an SSL/TLS connection.
 
 ## Scenarios
 You can use this module on a single target or several targets. See below for single target usage:
@@ -41,5 +37,18 @@ msf6 auxiliary(scanner/http/trace) > run
 
 [+] YYY.YY.YYY.YYY:443 is vulnerable to Cross-Site Tracing```
 
-## References
-- https://owasp.org/www-community/attacks/Cross_Site_Tracing
+## Confirming with Nmap
+
+```nmap -sV -Pn [ip] --script=http-trace -p 443    
+Host discovery disabled (-Pn). All addresses will be marked 'up' and scan times will be slower.
+Starting Nmap 7.91 ( https://nmap.org ) at 2021-10-21 20:30 EDT
+Nmap scan report for www.hphc.org ([ip])
+Host is up (0.029s latency).
+
+PORT    STATE SERVICE  VERSION
+443/tcp open  ssl/http Apache httpd
+|_http-server-header: Apache
+|_http-trace: TRACE is enabled
+
+Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
+Nmap done: 1 IP address (1 host up) scanned in 13.53 seconds```

--- a/documentation/modules/auxiliary/scanner/http/trace.md
+++ b/documentation/modules/auxiliary/scanner/http/trace.md
@@ -1,0 +1,35 @@
+## Vulnerable Application
+
+This module checks if the host(s) is(are) vulnerable to Cross-Site Tracing (XST).
+The module does more than just check for the HTTP Trace method, and actually
+attempts a trace request to verify that XST is possible.
+
+## Verification Steps
+```msf6 > use auxiliary/scanner/http/trace
+msf6 auxiliary(scanner/http/trace) > set RHOSTS YYY.YY.YYY.YYY
+RHOSTS => YYY.YY.YYY.YYY
+msf6 auxiliary(scanner/http/trace) > set RPORT 443
+RPORT => 443
+msf6 auxiliary(scanner/http/trace) > set SSL true
+[!] Changing the SSL option's value may require changing RPORT!
+SSL => true
+msf6 auxiliary(scanner/http/trace) > run
+
+[+] YYY.YY.YYY.YYY:443 is vulnerable to Cross-Site Tracing```
+
+## Options
+
+### RHOSTS
+The target host(s) to verify Cross-Site Tracing (XST) on.
+
+### RPORT
+The target port to check.
+
+### SSL
+Needed if the target port uses SSL/TLS. Tells Metasploit to negotiate an SSL/TLS connection.
+
+## Scenarios
+You can use this module on a single target or several targets. See verification steps for sample usage.
+
+## References
+- https://owasp.org/www-community/attacks/Cross_Site_Tracing

--- a/documentation/modules/auxiliary/scanner/http/trace.md
+++ b/documentation/modules/auxiliary/scanner/http/trace.md
@@ -5,17 +5,15 @@ The module does more than just check for the HTTP Trace method, and actually
 attempts a trace request to verify that XST is possible.
 
 ## Verification Steps
-```msf6 > use auxiliary/scanner/http/trace
-msf6 auxiliary(scanner/http/trace) > set RHOSTS YYY.YY.YYY.YYY
-RHOSTS => YYY.YY.YYY.YYY
-msf6 auxiliary(scanner/http/trace) > set RPORT 443
-RPORT => 443
-msf6 auxiliary(scanner/http/trace) > set SSL true
-[!] Changing the SSL option's value may require changing RPORT!
-SSL => true
-msf6 auxiliary(scanner/http/trace) > run
 
-[+] YYY.YY.YYY.YYY:443 is vulnerable to Cross-Site Tracing```
+- [ ] Start `msfconsole`
+- [ ] `use auxiliary/scanner/http/trace`
+- [ ] `show info`
+- [ ] `set RHOSTS YYY.YY.YYY.YYY`
+- [ ] `set RPORT 443`
+- [ ] `set SSL true`
+- [ ] `run`
+- [ ] Check output for presence of XST
 
 ## Options
 
@@ -29,7 +27,19 @@ The target port to check.
 Needed if the target port uses SSL/TLS. Tells Metasploit to negotiate an SSL/TLS connection.
 
 ## Scenarios
-You can use this module on a single target or several targets. See verification steps for sample usage.
+You can use this module on a single target or several targets. See below for single target usage:
+
+```msf6 > use auxiliary/scanner/http/trace
+msf6 auxiliary(scanner/http/trace) > set RHOSTS YYY.YY.YYY.YYY
+RHOSTS => YYY.YY.YYY.YYY
+msf6 auxiliary(scanner/http/trace) > set RPORT 443
+RPORT => 443
+msf6 auxiliary(scanner/http/trace) > set SSL true
+[!] Changing the SSL option's value may require changing RPORT!
+SSL => true
+msf6 auxiliary(scanner/http/trace) > run
+
+[+] YYY.YY.YYY.YYY:443 is vulnerable to Cross-Site Tracing```
 
 ## References
 - https://owasp.org/www-community/attacks/Cross_Site_Tracing

--- a/documentation/modules/auxiliary/scanner/http/trace.md
+++ b/documentation/modules/auxiliary/scanner/http/trace.md
@@ -35,7 +35,8 @@ msf6 auxiliary(scanner/http/trace) > set SSL true
 SSL => true
 msf6 auxiliary(scanner/http/trace) > run
 
-[+] YYY.YY.YYY.YYY:443 is vulnerable to Cross-Site Tracing```
+[+] YYY.YY.YYY.YYY:443 is vulnerable to Cross-Site Tracing
+```
 
 ## Confirming with Nmap
 
@@ -51,4 +52,5 @@ PORT    STATE SERVICE  VERSION
 |_http-trace: TRACE is enabled
 
 Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
-Nmap done: 1 IP address (1 host up) scanned in 13.53 seconds```
+Nmap done: 1 IP address (1 host up) scanned in 13.53 seconds
+```


### PR DESCRIPTION
Adds the module documentation for the trace.rb scanner module that checks for cross-site-tracing. I verified the module is still working using the verification steps in the documentation. 

This helps address [Issue 12389](https://github.com/rapid7/metasploit-framework/issues/12389) asking for more auxiliary module docs.

## Verification
Just docs, and I verified the module still works by using the verification steps I outlined in the documentation.
