### PR TITLE
gemspec should match lock file mettle version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ PATH
       metasploit-model
       metasploit-payloads (= 2.0.58)
       metasploit_data_models
-      metasploit_payloads-mettle (= 1.0.13)
+      metasploit_payloads-mettle (= 1.0.15)
       mqtt
       msgpack
       nessus_rest

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '2.0.58'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.13'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.15'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.


### PR DESCRIPTION
Fixes a discrepancy between lock and gemspec

## Verification

- [ ] clean bundle on supported OS version `Windows/Linux/macOS`