### PR TITLE
Add CVE-2002-0422 Coverage to iis_internal_ip Auxiliary Module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/iis_internal_ip.md
+++ b/documentation/modules/auxiliary/scanner/http/iis_internal_ip.md
@@ -2,14 +2,15 @@
 
 IIS, under various conditions, may respond to a request for `/`, `/images`, or `/default.htm` with `HTTP/1.0`
 with a 300 HTTP response and a location header that contains an internal (192.x.x.x, 10.x.x.x, or 172.x.x.x)
-IP address.
+IP address. It may also respond to a 'PROPFIND' request with a blank host header that contains the internal
+IP address in then body
 
 ## Verification Steps
 
-  1. Install IIS with at least one IP address on a private LAN
+  1. Install a vulnerable version of IIS with at least one IP address on a private LAN
   2. Start msfconsole
   3. Do: ```use auxiliary/scanner/http/iis_internal_ip```
-  4. Do: ```set rhosts [ip]```
+  4. Do: ```set RHOSTS [ip]```
   5. Do: ```run```
   6. You should find the internal IP
 
@@ -41,3 +42,10 @@ rmsf5 auxiliary(scanner/http/iis_internal_ip) > run
 [*] Auxiliary module execution completed
 
 ```
+## References
+- https://nvd.nist.gov/vuln/detail/CVE-2002-0422
+- http://www.securityfocus.com/bid/1499
+- https://www.exploit-db.com/exploits/20096
+- https://support.microsoft.com/en-us/help/218180/internet-information-server-returns-ip-address-in-http-header-content
+- https://support.microsoft.com/en-us/help/967342/fix-the-internal-ip-address-of-an-iis-7-0-server-is-revealed-if-an-htt
+- https://techcommunity.microsoft.com/t5/iis-support-blog/iis-web-servers-running-in-windows-azure-may-reveal-their/ba-p/826500

--- a/modules/auxiliary/scanner/http/iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/iis_internal_ip.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
 
-  def initialize(info = {})
+  def initialize
     super(
       update_info(
         info,
@@ -15,45 +15,59 @@ class MetasploitModule < Msf::Auxiliary
         'Description' => %q{
           Collect any leaked internal IPs by requesting commonly redirected locations from IIS.
           CVE-2000-0649 references IIS 5.1 (win2k, XP) and older.  However, in newer servers
-          such as IIS 7+, this occurs when the alternateHostName is not set or misconfigured.
+          such as IIS 7+, this occurs when the alternateHostName is not set or misconfigured. Also
+          collects internal IPs leaked from the PROPFIND method in certain IIS versions.
         },
-        'Author' => ['Heather Pilkington'],
+        'Author' => ['Heather Pilkington', 'Matthew Dunn - k0pak4'],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['CVE', '2000-0649'],
-            ['BID', '1499'],
-            ['EDB', '20096'],
-            ['URL', 'https://support.microsoft.com/en-us/help/218180/internet-information-server-returns-ip-address-in-http-header-content'], # iis 4,5,5.1
-            ['URL', 'https://support.microsoft.com/en-us/help/967342/fix-the-internal-ip-address-of-an-iis-7-0-server-is-revealed-if-an-htt'], # iis 7+
-            ['URL', 'https://techcommunity.microsoft.com/t5/iis-support-blog/iis-web-servers-running-in-windows-azure-may-reveal-their/ba-p/826500']
-          ]
+        'References' => [
+          ['CVE', '2000-0649', '2002-0422'],
+          ['BID', '1499'],
+          ['EDB', '20096'],
+          ['URL', 'https://support.microsoft.com/en-us/help/218180/internet-information-server-returns-ip-address-in-http-header-content'], # iis 4,5,5.1
+          ['URL', 'https://support.microsoft.com/en-us/help/967342/fix-the-internal-ip-address-of-an-iis-7-0-server-is-revealed-if-an-htt'], # iis 7+
+          ['URL', 'https://techcommunity.microsoft.com/t5/iis-support-blog/iis-web-servers-running-in-windows-azure-may-reveal-their/ba-p/826500']
+        ]
       )
     )
   end
 
   def run_host(target_host)
     uris = ['/', '/images', '/default.htm']
+    methods = ['GET', 'PROPFIND']
 
     uris.each do |uri|
       # Must use send_recv() in order to send a HTTP request without the 'Host' header
-      request = "GET #{uri} HTTP/1.0"
       vhost_status = datastore['VHOST'].blank? ? '' : " against #{vhost}"
-      vprint_status("#{peer} - Requesting #{request}#{vhost_status}")
-      c = connect
-      res = c.send_recv("#{request}\r\n\r\n", 25)
+      vprint_status("#{peer} - Requesting #{uri}#{vhost_status}")
 
-      if res.nil?
-        print_error("no response for #{target_host}")
-
-      elsif ((res.code > 300) && (res.code < 310))
+      methods.each do |method|
+        c = connect
+        request = c.request_cgi(
+          'uri' => uri,
+          'method' => method,
+          'headers' => { 'Host' => '' }
+        )
+        res = c.send_recv(request, 25)
         intipregex = /(192\.168\.[0-9]{1,3}\.[0-9]{1,3}|10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|172\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})/i
-        print_good("Location Header: #{res.headers['Location']}")
-        result = res.headers['Location'].scan(intipregex).uniq.flatten
 
-        if !result.empty?
-          print_good("Result for #{target_host} found Internal IP:  #{result.first}")
+        if res.nil?
+          print_error("no response for #{target_host}")
+        elsif ((res.code > 300) && (res.code < 310))
+          vprint_good("Location Header: #{res.headers['Location']}")
+          result = res.headers['Location'].scan(intipregex).uniq.flatten
+
+          if !result.empty?
+            print_good("Result for #{target_host} found Internal IP: #{result.first}")
+          end
+        elsif res.code == 405
+          result = res.body.scan(intipregex).uniq.flatten
+          if !result.empty?
+            print_good("Result for #{target_host} found Internal IP: #{result.first}")
+          end
         end
+
+        next if result.nil?
 
         report_note({
           host: target_host,

--- a/modules/auxiliary/scanner/http/iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/iis_internal_ip.rb
@@ -7,8 +7,9 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
 
-  def initialize
+  def initialize(_info = {})
     super(
+      update_info(
         'Name' => 'Microsoft IIS HTTP Internal IP Disclosure',
         'Description' => %q{
           Collect any leaked internal IPs by requesting commonly redirected locations from IIS.
@@ -16,16 +17,21 @@ class MetasploitModule < Msf::Auxiliary
           such as IIS 7+, this occurs when the alternateHostName is not set or misconfigured. Also
           collects internal IPs leaked from the PROPFIND method in certain IIS versions.
         },
-        'Author' => ['Heather Pilkington', 'Matthew Dunn - k0pak4'],
+        'Author' => [
+          'Heather Pilkington',
+          'Matthew Dunn - k0pak4'
+        ],
         'License' => MSF_LICENSE,
         'References' => [
-          ['CVE', '2000-0649', '2002-0422'],
+          ['CVE', '2000-0649'],
+          ['CVE', '2002-0422'],
           ['BID', '1499'],
           ['EDB', '20096'],
           ['URL', 'https://support.microsoft.com/en-us/help/218180/internet-information-server-returns-ip-address-in-http-header-content'], # iis 4,5,5.1
           ['URL', 'https://support.microsoft.com/en-us/help/967342/fix-the-internal-ip-address-of-an-iis-7-0-server-is-revealed-if-an-htt'], # iis 7+
           ['URL', 'https://techcommunity.microsoft.com/t5/iis-support-blog/iis-web-servers-running-in-windows-azure-may-reveal-their/ba-p/826500']
         ]
+      )
     )
   end
 

--- a/modules/auxiliary/scanner/http/iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/iis_internal_ip.rb
@@ -7,9 +7,10 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
 
-  def initialize(_info = {})
+  def initialize(info = {})
     super(
       update_info(
+        info,
         'Name' => 'Microsoft IIS HTTP Internal IP Disclosure',
         'Description' => %q{
           Collect any leaked internal IPs by requesting commonly redirected locations from IIS.

--- a/modules/auxiliary/scanner/http/iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/iis_internal_ip.rb
@@ -9,8 +9,6 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      update_info(
-        info,
         'Name' => 'Microsoft IIS HTTP Internal IP Disclosure',
         'Description' => %q{
           Collect any leaked internal IPs by requesting commonly redirected locations from IIS.
@@ -28,7 +26,6 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://support.microsoft.com/en-us/help/967342/fix-the-internal-ip-address-of-an-iis-7-0-server-is-revealed-if-an-htt'], # iis 7+
           ['URL', 'https://techcommunity.microsoft.com/t5/iis-support-blog/iis-web-servers-running-in-windows-azure-may-reveal-their/ba-p/826500']
         ]
-      )
     )
   end
 
@@ -58,12 +55,12 @@ class MetasploitModule < Msf::Auxiliary
           result = res.headers['Location'].scan(intipregex).uniq.flatten
 
           if !result.empty?
-            print_good("Result for #{target_host} found Internal IP: #{result.first}")
+            print_good("Result for #{target_host}#{uri} with method #{method}. Found Internal IP: #{result.first}")
           end
         elsif res.code == 405
           result = res.body.scan(intipregex).uniq.flatten
           if !result.empty?
-            print_good("Result for #{target_host} found Internal IP: #{result.first}")
+            print_good("Result for #{target_host}#{uri} with method #{method}. Found Internal IP: #{result.first}")
           end
         end
 


### PR DESCRIPTION
This PR updates the iis_internal_ip module to include coverage for the PROPFIND internal IP address disclosure as described by CVE-2002-0422. It also updates the documentation to include the CVE and other references as well as rubocopping the module since I was already making edits.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/iis_internal_ip`
- [ ] `set RHOSTS YYY.YY.YYY.YYY`
- [ ] `set RPORT 443`
- [ ] `set SSL true`
- [ ] Verify the internal ip address is discovered


Software Version
- Tested on IIS 7.0
