### PR TITLE
Add command name to Meterpreter packet inspect

### DIFF
--- a/lib/rex/post/meterpreter/command_mapper.rb
+++ b/lib/rex/post/meterpreter/command_mapper.rb
@@ -2,6 +2,7 @@
 
 require 'rex/post/meterpreter/extension_mapper'
 require 'rex/post/meterpreter/core_ids'
+require 'rex/post/meterpreter/client_core'
 
 module Rex
 module Post

--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'openssl'
+require 'rex/post/meterpreter/command_mapper'
 
 module Rex
 module Post
@@ -403,6 +404,14 @@ class Tlv
       tlvs_inspect << "]"
     else
       tlvs_inspect = "meta=#{meta.ljust(10)} value=#{val}"
+      if type == TLV_TYPE_COMMAND_ID
+        begin
+          command_name = ::Rex::Post::Meterpreter::CommandMapper.get_command_name(value)
+        rescue
+          command_name = nil
+        end
+        tlvs_inspect <<= " command=#{command_name || 'unknown'}"
+      end
     end
     "#<#{self.class} type=#{stype.ljust(15)} #{tlvs_inspect}>"
   end
@@ -1092,4 +1101,3 @@ end
 
 
 end; end; end
-

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -131,7 +131,7 @@ module PacketDispatcher
     end
 
     # Uncomment this line if you want to see outbound packets in the console.
-    #STDERR.puts("SEND: #{packet.inspect}\n")
+    # STDERR.puts("\n\e[1;31mSEND\e[0m: #{packet.inspect}\n")
 
     bytes = 0
     raw   = packet.to_r(session_guid, tlv_enc_key)
@@ -580,7 +580,7 @@ module PacketDispatcher
     handled = false
 
     # Uncomment this line if you want to see inbound packets in the console
-    #STDERR.puts("RECV: #{packet.inspect}\n")
+    # STDERR.puts("\n\e[1;32mRECV\e[0m: #{packet.inspect}\n")
 
     # Update our last reply time
     self.last_checkin = ::Time.now
@@ -708,4 +708,3 @@ module HttpPacketDispatcher
 end
 
 end; end; end
-

--- a/spec/lib/rex/post/meterpreter/packet_spec.rb
+++ b/spec/lib/rex/post/meterpreter/packet_spec.rb
@@ -118,19 +118,38 @@ RSpec.describe Rex::Post::Meterpreter::Tlv do
   end
 
   context "A Command ID TLV" do
-    subject(:tlv) {
-      Rex::Post::Meterpreter::Tlv.new(
-        Rex::Post::Meterpreter::TLV_TYPE_COMMAND_ID,
-        31337
-      )
-    }
-    it "should have a meta type of UINT" do
-      expect(tlv.meta_type?(Rex::Post::Meterpreter::TLV_META_TYPE_UINT)).to eq true
+    context 'when the Command ID is valid' do
+      subject(:tlv) {
+        Rex::Post::Meterpreter::Tlv.new(
+          Rex::Post::Meterpreter::TLV_TYPE_COMMAND_ID,
+          1001
+        )
+      }
+      it "should have a meta type of UINT" do
+        expect(tlv.meta_type?(Rex::Post::Meterpreter::TLV_META_TYPE_UINT)).to eq true
+      end
+
+      it "should show the correct type and meta type in inspect" do
+        tlv_to_s = "#<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=1001 command=stdapi_fs_chdir>"
+        expect(tlv.inspect).to eq tlv_to_s
+      end
     end
 
-    it "should show the correct type and meta type in inspect" do
-      tlv_to_s = "#<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=31337>"
-      expect(tlv.inspect).to eq tlv_to_s
+    context 'when the Command ID is invalid' do
+      subject(:tlv) {
+        Rex::Post::Meterpreter::Tlv.new(
+          Rex::Post::Meterpreter::TLV_TYPE_COMMAND_ID,
+          31337
+        )
+      }
+      it "should have a meta type of UINT" do
+        expect(tlv.meta_type?(Rex::Post::Meterpreter::TLV_META_TYPE_UINT)).to eq true
+      end
+
+      it "should show the correct type and meta type in inspect" do
+        tlv_to_s = "#<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=31337 command=unknown>"
+        expect(tlv.inspect).to eq tlv_to_s
+      end
     end
   end
 


### PR DESCRIPTION
Adds the command name to the Meterpreter packet inspect to see useful information for debugging purposes

### Before

No command names are printed:

![image](https://user-images.githubusercontent.com/1271782/138189099-a806051b-7cc0-4aa0-85e2-90ea4959cfff.png)

### After

Adds color to clearly see the request/response packets, as well as the command name information:

![image](https://user-images.githubusercontent.com/1271782/138188924-6414cc51-8ee2-4738-9e61-ce3efe00e01e.png)

### Verification

- Uncomment the debugging lines - in the future this should probably be wired up as a framework option
- Run a meterpreter command, and verify the output