### PR TITLE
Add kubernetes enum module

### DIFF
--- a/documentation/modules/auxiliary/cloud/kubernetes/enum_kubernetes.md
+++ b/documentation/modules/auxiliary/cloud/kubernetes/enum_kubernetes.md
@@ -1,0 +1,513 @@
+## Vulnerable Application
+
+### Description
+
+Enumerates a Kubernetes cluster.
+
+## Verification Steps
+
+### Create or acquire the credentials
+
+1. Start msfconsole
+2. Do: `use auxiliary/cloud/kubernetes/enum_kubernetes`
+3. Set the required options
+4. Do: `run`
+5: You should see the enumerated resources from the Kubernetes API.
+
+## Options
+
+### SESSION
+An optional session to use for configuration. When specified, the values of `NAMESPACE`, `TOKEN`, `RHOSTS` and `RPORT`
+will be gathered from the session host. This requires that the session be on an existing Kubernetes pod. The necessary
+values may not always be present.
+
+Setting this option will also automatically route connections through the specified session.
+
+### TOKEN
+The JWT token. The token with the necessary privileges to access the exec endpoint within a running pod and optionally
+create a new pod.
+
+### POD
+The pod name to execute in. When not specified, a new pod will be created with an entrypoint that allows it to run
+forever. After creation, the pod will be used to execute the payload. **The created pod is not automatically cleaned
+up.** A note containing the created pod's information will be added to the database when it is connected.
+
+### NAMESPACE
+The Kubernetes namespace that the `TOKEN` has permissions for and that `POD` either exists in or should be created in.
+
+### NAMESPACE_LIST
+
+The default namespace list to iterate when the current token does not have the permission to retrieve the available namespaces
+
+### HIGHLIGHT_NAME_PATTERN
+A PCRE regex of resource names to highlight.
+
+### OUTPUT
+Output format, allowed values are: table, json
+
+## Scenarios
+
+### Run all enumeration
+
+Explicitly setting RHOST and TOKEN to enumerate all available namespaces, and associated resources:
+
+```
+msf6 > use cloud/kubernetes/enum_kubernetes
+msf6 auxiliary(cloud/kubernetes/enum_kubernetes) > set RHOST https://kubernetes.docker.internal:6443
+RHOST => https://kubernetes.docker.internal:6443
+msf6 auxiliary(cloud/kubernetes/enum_kubernetes) > set TOKEN eyJhbGciO...
+TOKEN => eyJhbGciO...
+msf6 auxiliary(cloud/kubernetes/enum_kubernetes) > run
+[*] Running module against 127.0.0.1
+
+[+] Kubernetes service version: {"major":"1","minor":"21","gitVersion":"v1.21.2","gitCommit":"092fbfbf53427de67cac1e9fa54aaa09a28371d7","gitTreeState":"clean","buildDate":"2021-06-16T12:53:14Z","goVersion":"go1.16.5","compiler":"gc","platform":"linux/amd64"}
+[+] Enumerating namespaces
+Namespaces
+==========
+
+  #  name
+  -  ----
+  0  default
+  1  kube-node-lease
+  2  kube-public
+  3  kube-system
+  4  kubernetes-dashboard
+
+[+] Namespace 0: default
+Auth (namespace: default)
+=========================
+
+  Resources                                      Non-Resource URLs                    Resource Names  Verbs
+  ---------                                      -----------------                    --------------  -----
+  *.*                                            []                                   []              [*]
+  selfsubjectaccessreviews.authorization.k8s.io  []                                   []              [create]
+  selfsubjectrulesreviews.authorization.k8s.io   []                                   []              [create]
+                                                 [*]                                  []              [*]
+                                                 [/.well-known/openid-configuration]  []              [get]
+                                                 [/api/*]                             []              [get]
+                                                 [/api]                               []              [get]
+                                                 [/apis/*]                            []              [get]
+                                                 [/apis]                              []              [get]
+                                                 [/healthz]                           []              [get]
+                                                 [/healthz]                           []              [get]
+                                                 [/livez]                             []              [get]
+                                                 [/livez]                             []              [get]
+                                                 [/openapi/*]                         []              [get]
+                                                 [/openapi]                           []              [get]
+                                                 [/openid/v1/jwks]                    []              [get]
+                                                 [/readyz]                            []              [get]
+                                                 [/readyz]                            []              [get]
+                                                 [/version/]                          []              [get]
+                                                 [/version/]                          []              [get]
+                                                 [/version]                           []              [get]
+                                                 [/version]                           []              [get]
+
+Pods (namespace: default)
+=========================
+
+  #   namespace  name                       status   containers                                       ip
+  -   ---------  ----                       ------   ----------                                       --
+  0   default    a4bg7r                     Running  iyxz0ujfck9t (image: vulhub/thinkphp:5.0.23)     10.1.1.51
+  1   default    appjokbpiiml               Running  iggapn (image: vulhub/thinkphp:5.0.23)           10.1.1.57
+  2   default    cvyf4m9le                  Running  t0e93vcuyi (image: vulhub/thinkphp:5.0.23)       10.1.1.53
+  3   default    fh4bfdtf                   Running  dygvv (image: vulhub/thinkphp:5.0.23)            10.1.1.52
+  4   default    gavp                       Running  jfwdaei (image: vulhub/thinkphp:5.0.23)          10.1.1.58
+  5   default    mkfkuwd6hkd1               Running  aoavh (image: vulhub/thinkphp:5.0.23)            10.1.1.62
+  6   default    nid7jd                     Running  geb (image: vulhub/thinkphp:5.0.23)              10.1.1.45
+  7   default    redis-7fd956df5-sbchb      Running  redis (image: redis:5.0.4 TCP:6379)              10.1.1.56
+  8   default    thinkphp-67f7c88cc9-djg6q  Running  thinkphp (image: vulhub/thinkphp:5.0.23 TCP:80)  10.1.1.55
+  9   default    thinkphp-67f7c88cc9-l56mg  Running  thinkphp (image: vulhub/thinkphp:5.0.23 TCP:80)  10.1.1.44
+  10  default    usuuucs                    Running  xfcw (image: vulhub/thinkphp:5.0.23)             10.1.1.50
+  11  default    v2xxl7z                    Running  nu3s (image: vulhub/thinkphp:5.0.23)             10.1.1.61
+  12  default    yulfpaohsepk               Running  jjmxkkzgkmy (image: vulhub/thinkphp:5.0.23)      10.1.1.47
+
+Secrets (namespace: default)
+============================
+
+  #  namespace  name                                  type                                 data                    age
+  -  ---------  ----                                  ----                                 ----                    ---
+  0  default    default-token-btlkb                   kubernetes.io/service-account-token  ca.crt,namespace,token  8d
+  1  default    local-registry                        kubernetes.io/dockerconfigjson       .dockerconfigjson       7d15h
+  2  default    secret-basic-auth                     kubernetes.io/basic-auth             password,username       8d
+  3  default    secret-empty                          Opaque                                                       8d
+  4  default    secret-id-ed25519-with-passphrase     kubernetes.io/ssh-auth               ssh-privatekey          7d15h
+  5  default    secret-id-ed25519-without-passphrase  kubernetes.io/ssh-auth               ssh-privatekey          7d15h
+  6  default    secret-id-rsa-with-passphrase         kubernetes.io/ssh-auth               ssh-privatekey          8d
+  7  default    secret-id-rsa-without-passphrase      kubernetes.io/ssh-auth               ssh-privatekey          8d
+  8  default    secret-tls                            kubernetes.io/tls                    tls.crt,tls.key         8d
+
+[+] service token default-token-btlkb: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_257374.bin
+[+] dockerconfig json local-registry: /Users/user/.msf4/loot/20211006105714_default_unknown_docker.json_543280.bin
+[+] basic_auth secret-basic-auth: admin:password213
+[+] ssh_key secret-id-ed25519-with-passphrase: /Users/user/.msf4/loot/20211006105714_default_unknown_id_rsa_861231.txt
+[+] ssh_key secret-id-ed25519-without-passphrase: /Users/user/.msf4/loot/20211006105714_default_unknown_id_rsa_095417.txt
+[+] ssh_key secret-id-rsa-with-passphrase: /Users/user/.msf4/loot/20211006105714_default_unknown_id_rsa_246326.txt
+[+] ssh_key secret-id-rsa-without-passphrase: /Users/user/.msf4/loot/20211006105714_default_unknown_id_rsa_429821.txt
+[+] tls_key secret-tls: /Users/user/.msf4/loot/20211006105714_default_unknown_tls.key_651137.txt
+[+] tls_cert secret-tls: /Users/user/.msf4/loot/20211006105714_default_unknown_tls.cert_025932.txt (/CN=example.com)
+
+[+] Namespace 1: kube-node-lease
+Auth (namespace: kube-node-lease)
+=================================
+
+  Resources                                      Non-Resource URLs                    Resource Names  Verbs
+  ---------                                      -----------------                    --------------  -----
+  *.*                                            []                                   []              [*]
+  selfsubjectaccessreviews.authorization.k8s.io  []                                   []              [create]
+  selfsubjectrulesreviews.authorization.k8s.io   []                                   []              [create]
+                                                 [*]                                  []              [*]
+                                                 [/.well-known/openid-configuration]  []              [get]
+                                                 [/api/*]                             []              [get]
+                                                 [/api]                               []              [get]
+                                                 [/apis/*]                            []              [get]
+                                                 [/apis]                              []              [get]
+                                                 [/healthz]                           []              [get]
+                                                 [/healthz]                           []              [get]
+                                                 [/livez]                             []              [get]
+                                                 [/livez]                             []              [get]
+                                                 [/openapi/*]                         []              [get]
+                                                 [/openapi]                           []              [get]
+                                                 [/openid/v1/jwks]                    []              [get]
+                                                 [/readyz]                            []              [get]
+                                                 [/readyz]                            []              [get]
+                                                 [/version/]                          []              [get]
+                                                 [/version/]                          []              [get]
+                                                 [/version]                           []              [get]
+                                                 [/version]                           []              [get]
+
+Pods (namespace: kube-node-lease)
+=================================
+
+  #  namespace  name  status  containers  ip
+  -  ---------  ----  ------  ----------  --
+  No rows
+
+Secrets (namespace: kube-node-lease)
+====================================
+
+  #  namespace        name                 type                                 data                    age
+  -  ---------        ----                 ----                                 ----                    ---
+  0  kube-node-lease  default-token-54967  kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+
+[+] service token default-token-54967: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_727718.bin
+
+[+] Namespace 2: kube-public
+Auth (namespace: kube-public)
+=============================
+
+  Resources                                      Non-Resource URLs                    Resource Names  Verbs
+  ---------                                      -----------------                    --------------  -----
+  *.*                                            []                                   []              [*]
+  selfsubjectaccessreviews.authorization.k8s.io  []                                   []              [create]
+  selfsubjectrulesreviews.authorization.k8s.io   []                                   []              [create]
+                                                 [*]                                  []              [*]
+                                                 [/.well-known/openid-configuration]  []              [get]
+                                                 [/api/*]                             []              [get]
+                                                 [/api]                               []              [get]
+                                                 [/apis/*]                            []              [get]
+                                                 [/apis]                              []              [get]
+                                                 [/healthz]                           []              [get]
+                                                 [/healthz]                           []              [get]
+                                                 [/livez]                             []              [get]
+                                                 [/livez]                             []              [get]
+                                                 [/openapi/*]                         []              [get]
+                                                 [/openapi]                           []              [get]
+                                                 [/openid/v1/jwks]                    []              [get]
+                                                 [/readyz]                            []              [get]
+                                                 [/readyz]                            []              [get]
+                                                 [/version/]                          []              [get]
+                                                 [/version/]                          []              [get]
+                                                 [/version]                           []              [get]
+                                                 [/version]                           []              [get]
+
+Pods (namespace: kube-public)
+=============================
+
+  #  namespace  name  status  containers  ip
+  -  ---------  ----  ------  ----------  --
+  No rows
+
+Secrets (namespace: kube-public)
+================================
+
+  #  namespace    name                 type                                 data                    age
+  -  ---------    ----                 ----                                 ----                    ---
+  0  kube-public  default-token-2r2s4  kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+
+[+] service token default-token-2r2s4: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_198155.bin
+
+[+] Namespace 3: kube-system
+Auth (namespace: kube-system)
+=============================
+
+  Resources                                      Non-Resource URLs                    Resource Names  Verbs
+  ---------                                      -----------------                    --------------  -----
+  *.*                                            []                                   []              [*]
+  selfsubjectaccessreviews.authorization.k8s.io  []                                   []              [create]
+  selfsubjectrulesreviews.authorization.k8s.io   []                                   []              [create]
+                                                 [*]                                  []              [*]
+                                                 [/.well-known/openid-configuration]  []              [get]
+                                                 [/api/*]                             []              [get]
+                                                 [/api]                               []              [get]
+                                                 [/apis/*]                            []              [get]
+                                                 [/apis]                              []              [get]
+                                                 [/healthz]                           []              [get]
+                                                 [/healthz]                           []              [get]
+                                                 [/livez]                             []              [get]
+                                                 [/livez]                             []              [get]
+                                                 [/openapi/*]                         []              [get]
+                                                 [/openapi]                           []              [get]
+                                                 [/openid/v1/jwks]                    []              [get]
+                                                 [/readyz]                            []              [get]
+                                                 [/readyz]                            []              [get]
+                                                 [/version/]                          []              [get]
+                                                 [/version/]                          []              [get]
+                                                 [/version]                           []              [get]
+                                                 [/version]                           []              [get]
+
+Pods (namespace: kube-system)
+=============================
+
+  #  namespace    name                                    status   containers                                                                   ip
+  -  ---------    ----                                    ------   ----------                                                                   --
+  0  kube-system  coredns-558bd4d5db-2fspm                Running  coredns (image: k8s.gcr.io/coredns/coredns:v1.8.0 UDP:53,TCP:53,TCP:9153)    10.1.1.48
+  1  kube-system  coredns-558bd4d5db-zx7k5                Running  coredns (image: k8s.gcr.io/coredns/coredns:v1.8.0 UDP:53,TCP:53,TCP:9153)    10.1.1.59
+  2  kube-system  etcd-docker-desktop                     Running  etcd (image: k8s.gcr.io/etcd:3.4.13-0)                                       192.168.65.4
+  3  kube-system  kube-apiserver-docker-desktop           Running  kube-apiserver (image: k8s.gcr.io/kube-apiserver:v1.21.2)                    192.168.65.4
+  4  kube-system  kube-controller-manager-docker-desktop  Running  kube-controller-manager (image: k8s.gcr.io/kube-controller-manager:v1.21.2)  192.168.65.4
+  5  kube-system  kube-proxy-tvgm2                        Running  kube-proxy (image: k8s.gcr.io/kube-proxy:v1.21.2)                            192.168.65.4
+  6  kube-system  kube-scheduler-docker-desktop           Running  kube-scheduler (image: k8s.gcr.io/kube-scheduler:v1.21.2)                    192.168.65.4
+  7  kube-system  storage-provisioner                     Running  storage-provisioner (image: docker/desktop-storage-provisioner:v2.0)         10.1.1.49
+  8  kube-system  vpnkit-controller                       Running  vpnkit-controller (image: docker/desktop-vpnkit-controller:v2.0)             10.1.1.54
+
+Secrets (namespace: kube-system)
+================================
+
+  #   namespace    name                                            type                                 data                    age
+  -   ---------    ----                                            ----                                 ----                    ---
+  0   kube-system  attachdetach-controller-token-4tnpl             kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  1   kube-system  bootstrap-signer-token-kqgwd                    kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  2   kube-system  certificate-controller-token-g2lcs              kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  3   kube-system  clusterrole-aggregation-controller-token-9kh9j  kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  4   kube-system  coredns-token-xjv86                             kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  5   kube-system  cronjob-controller-token-wddp5                  kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  6   kube-system  daemon-set-controller-token-7w2wt               kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  7   kube-system  default-token-hq24x                             kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  8   kube-system  deployment-controller-token-bf8ks               kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  9   kube-system  disruption-controller-token-j4mlp               kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  10  kube-system  endpoint-controller-token-sqdg2                 kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  11  kube-system  endpointslice-controller-token-wr2v9            kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  12  kube-system  endpointslicemirroring-controller-token-4lqdn   kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  13  kube-system  ephemeral-volume-controller-token-67k95         kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  14  kube-system  expand-controller-token-cmfwt                   kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  15  kube-system  generic-garbage-collector-token-sxdc8           kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  16  kube-system  horizontal-pod-autoscaler-token-267qc           kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  17  kube-system  job-controller-token-hzv9p                      kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  18  kube-system  kube-proxy-token-cqw2h                          kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  19  kube-system  namespace-controller-token-cldm6                kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  20  kube-system  node-controller-token-tjtk5                     kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  21  kube-system  persistent-volume-binder-token-2n7jx            kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  22  kube-system  pod-garbage-collector-token-vgzrz               kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  23  kube-system  pv-protection-controller-token-5jvqn            kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  24  kube-system  pvc-protection-controller-token-jg5sn           kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  25  kube-system  replicaset-controller-token-zvblz               kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  26  kube-system  replication-controller-token-tcj4p              kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  27  kube-system  resourcequota-controller-token-q5nsg            kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  28  kube-system  root-ca-cert-publisher-token-ghh92              kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  29  kube-system  service-account-controller-token-ljxn7          kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  30  kube-system  service-controller-token-dg8ks                  kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  31  kube-system  statefulset-controller-token-dcx8k              kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  32  kube-system  storage-provisioner-token-52m2w                 kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  33  kube-system  token-cleaner-token-lc8jh                       kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  34  kube-system  ttl-after-finished-controller-token-qkv66       kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  35  kube-system  ttl-controller-token-rw6zq                      kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  36  kube-system  vpnkit-controller-token-l9ljz                   kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+
+[+] service token attachdetach-controller-token-4tnpl: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_443806.bin
+[+] service token bootstrap-signer-token-kqgwd: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_334381.bin
+[+] service token certificate-controller-token-g2lcs: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_780446.bin
+[+] service token clusterrole-aggregation-controller-token-9kh9j: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_695659.bin
+[+] service token coredns-token-xjv86: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_035400.bin
+[+] service token cronjob-controller-token-wddp5: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_256456.bin
+[+] service token daemon-set-controller-token-7w2wt: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_370856.bin
+[+] service token default-token-hq24x: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_167584.bin
+[+] service token deployment-controller-token-bf8ks: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_668044.bin
+[+] service token disruption-controller-token-j4mlp: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_025629.bin
+[+] service token endpoint-controller-token-sqdg2: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_952597.bin
+[+] service token endpointslice-controller-token-wr2v9: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_454535.bin
+[+] service token endpointslicemirroring-controller-token-4lqdn: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_573333.bin
+[+] service token ephemeral-volume-controller-token-67k95: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_791145.bin
+[+] service token expand-controller-token-cmfwt: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_350984.bin
+[+] service token generic-garbage-collector-token-sxdc8: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_095555.bin
+[+] service token horizontal-pod-autoscaler-token-267qc: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_696872.bin
+[+] service token job-controller-token-hzv9p: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_709657.bin
+[+] service token kube-proxy-token-cqw2h: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_148992.bin
+[+] service token namespace-controller-token-cldm6: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_138901.bin
+[+] service token node-controller-token-tjtk5: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_113414.bin
+[+] service token persistent-volume-binder-token-2n7jx: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_154991.bin
+[+] service token pod-garbage-collector-token-vgzrz: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_413568.bin
+[+] service token pv-protection-controller-token-5jvqn: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_233791.bin
+[+] service token pvc-protection-controller-token-jg5sn: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_468067.bin
+[+] service token replicaset-controller-token-zvblz: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_821269.bin
+[+] service token replication-controller-token-tcj4p: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_210131.bin
+[+] service token resourcequota-controller-token-q5nsg: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_510682.bin
+[+] service token root-ca-cert-publisher-token-ghh92: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_341707.bin
+[+] service token service-account-controller-token-ljxn7: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_242421.bin
+[+] service token service-controller-token-dg8ks: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_231000.bin
+[+] service token statefulset-controller-token-dcx8k: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_346820.bin
+[+] service token storage-provisioner-token-52m2w: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_889808.bin
+[+] service token token-cleaner-token-lc8jh: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_071179.bin
+[+] service token ttl-after-finished-controller-token-qkv66: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_155663.bin
+[+] service token ttl-controller-token-rw6zq: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_730592.bin
+[+] service token vpnkit-controller-token-l9ljz: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_693223.bin
+
+[+] Namespace 4: kubernetes-dashboard
+Auth (namespace: kubernetes-dashboard)
+======================================
+
+  Resources                                      Non-Resource URLs                    Resource Names  Verbs
+  ---------                                      -----------------                    --------------  -----
+  *.*                                            []                                   []              [*]
+  selfsubjectaccessreviews.authorization.k8s.io  []                                   []              [create]
+  selfsubjectrulesreviews.authorization.k8s.io   []                                   []              [create]
+                                                 [*]                                  []              [*]
+                                                 [/.well-known/openid-configuration]  []              [get]
+                                                 [/api/*]                             []              [get]
+                                                 [/api]                               []              [get]
+                                                 [/apis/*]                            []              [get]
+                                                 [/apis]                              []              [get]
+                                                 [/healthz]                           []              [get]
+                                                 [/healthz]                           []              [get]
+                                                 [/livez]                             []              [get]
+                                                 [/livez]                             []              [get]
+                                                 [/openapi/*]                         []              [get]
+                                                 [/openapi]                           []              [get]
+                                                 [/openid/v1/jwks]                    []              [get]
+                                                 [/readyz]                            []              [get]
+                                                 [/readyz]                            []              [get]
+                                                 [/version/]                          []              [get]
+                                                 [/version/]                          []              [get]
+                                                 [/version]                           []              [get]
+                                                 [/version]                           []              [get]
+
+Pods (namespace: kubernetes-dashboard)
+======================================
+
+  #  namespace             name                                        status   containers                                                                       ip
+  -  ---------             ----                                        ------   ----------                                                                       --
+  0  kubernetes-dashboard  dashboard-metrics-scraper-856586f554-c2pz5  Running  dashboard-metrics-scraper (image: kubernetesui/metrics-scraper:v1.0.6 TCP:8000)  10.1.1.60
+  1  kubernetes-dashboard  kubernetes-dashboard-67484c44f6-4hh4j       Running  kubernetes-dashboard (image: kubernetesui/dashboard:v2.3.1 TCP:8443)             10.1.1.46
+
+Secrets (namespace: kubernetes-dashboard)
+=========================================
+
+  #  namespace             name                              type                                 data                    age
+  -  ---------             ----                              ----                                 ----                    ---
+  0  kubernetes-dashboard  default-token-6gwtz               kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+  1  kubernetes-dashboard  kubernetes-dashboard-certs        Opaque                                                       19d
+  2  kubernetes-dashboard  kubernetes-dashboard-csrf         Opaque                               csrf                    19d
+  3  kubernetes-dashboard  kubernetes-dashboard-key-holder   Opaque                               priv,pub                19d
+  4  kubernetes-dashboard  kubernetes-dashboard-token-gfhhr  kubernetes.io/service-account-token  ca.crt,namespace,token  19d
+
+[+] service token default-token-6gwtz: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_854995.bin
+[+] service token kubernetes-dashboard-token-gfhhr: /Users/user/.msf4/loot/20211006105714_default_127.0.0.1_kubernetes.token_729795.bin
+
+[*] Auxiliary module execution completed
+msf6 auxiliary(cloud/kubernetes/enum_kubernetes) >
+```
+
+### Using actions
+
+See available actions:
+
+```
+msf6 auxiliary(cloud/kubernetes/enum_kubernetes) > show actions
+
+Auxiliary actions:
+
+   Name        Description
+   ----        -----------
+   all         enumerate all resources
+   auth        enumerate auth
+   namespace   enumerate namespace
+   namespaces  enumerate namespaces
+   pod         enumerate pod
+   pods        enumerate pods
+   secret      enumerate secret
+   secrets     enumerate secrets
+   version     enumerate version
+
+```
+
+Enumerate pods:
+```
+msf6 auxiliary(cloud/kubernetes/enum_kubernetes) > pods
+[*] Running module against 127.0.0.1
+Pods (namespace: default)
+=========================
+
+  #   namespace  name                       status   containers                                       ip
+  -   ---------  ----                       ------   ----------                                       --
+  0   default    a4bg7r                     Running  iyxz0ujfck9t (image: vulhub/thinkphp:5.0.23)     10.1.1.51
+  1   default    appjokbpiiml               Running  iggapn (image: vulhub/thinkphp:5.0.23)           10.1.1.57
+  2   default    cvyf4m9le                  Running  t0e93vcuyi (image: vulhub/thinkphp:5.0.23)       10.1.1.53
+  3   default    fh4bfdtf                   Running  dygvv (image: vulhub/thinkphp:5.0.23)            10.1.1.52
+  4   default    gavp                       Running  jfwdaei (image: vulhub/thinkphp:5.0.23)          10.1.1.58
+  5   default    mkfkuwd6hkd1               Running  aoavh (image: vulhub/thinkphp:5.0.23)            10.1.1.62
+  6   default    nid7jd                     Running  geb (image: vulhub/thinkphp:5.0.23)              10.1.1.45
+  7   default    redis-7fd956df5-sbchb      Running  redis (image: redis:5.0.4 TCP:6379)              10.1.1.56
+  8   default    thinkphp-67f7c88cc9-djg6q  Running  thinkphp (image: vulhub/thinkphp:5.0.23 TCP:80)  10.1.1.55
+  9   default    thinkphp-67f7c88cc9-l56mg  Running  thinkphp (image: vulhub/thinkphp:5.0.23 TCP:80)  10.1.1.44
+  10  default    usuuucs                    Running  xfcw (image: vulhub/thinkphp:5.0.23)             10.1.1.50
+  11  default    v2xxl7z                    Running  nu3s (image: vulhub/thinkphp:5.0.23)             10.1.1.61
+  12  default    yulfpaohsepk               Running  jjmxkkzgkmy (image: vulhub/thinkphp:5.0.23)      10.1.1.47
+
+
+[*] Auxiliary module execution completed
+```
+
+Enumerate a pod with a specified namespace, name:
+
+```
+msf6 auxiliary(cloud/kubernetes/enum_kubernetes) > pod namespace=default name=redis-7fd956df5-sbchb
+[*] Running module against 127.0.0.1
+Pods (namespace: default)
+=========================
+
+  #  namespace  name                   status   containers                           ip
+  -  ---------  ----                   ------   ----------                           --
+  0  default    redis-7fd956df5-sbchb  Running  redis (image: redis:5.0.4 TCP:6379)  10.1.1.56
+
+
+[*] Auxiliary module execution completed
+```
+
+Enumerate a pod with a specified namespace, name, and outputting the result as JSON:
+
+```
+msf6 auxiliary(cloud/kubernetes/enum_kubernetes) > pod namespace=default name=redis-7fd956df5-sbchb output=json 
+[*] Running module against 127.0.0.1
+
+[
+  {
+    "kind": "Pod",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "redis-7fd956df5-sbchb",
+      "generateName": "redis-7fd956df5-",
+      "namespace": "default",
+      "uid": "0f00c08c-bdb1-4206-94ce-5c447cd2d446",
+      "resourceVersion": "629723",
+      "creationTimestamp": "2021-09-16T22:33:33Z",
+      "labels": {
+        "app": "redis",
+        "pod-template-hash": "7fd956df5",
+        "role": "leader",
+        "tier": "backend"
+      },
+    },
+    ... etc ...
+  }
+]
+[*] Auxiliary module execution completed
+```

--- a/lib/msf/core/exploit/remote/http/jwt.rb
+++ b/lib/msf/core/exploit/remote/http/jwt.rb
@@ -4,20 +4,26 @@
 # Note that swapping this out for a third-party gem will work, but
 # there may be potential security issues with the key id (kid) claim etc,
 # which would need to be reviewed.
-module Msf::Exploit::Remote::HTTP::JWT
-  module_function
+class Msf::Exploit::Remote::HTTP::JWT
+  attr_reader :payload, :header, :signature
 
-  def encode(payload, key, algorithm = 'HS256', header_fields = {})
+  def initialize(payload:, header:, signature:)
+    @payload = payload
+    @header = header
+    @signature = signature
+  end
+
+  def self.encode(payload, key, algorithm = 'HS256', header_fields = {})
     raise NotImplementedError
   end
 
-  def decode(jwt, _key = nil, _verify = true, _options = {})
+  def self.decode(jwt, _key = nil, _verify = true, _options = {})
     header, payload, signature = jwt.split('.', 3)
-    raise ArgumentError, "Invalid JWT format" if header.nil? || payload.nil? || signature.nil?
+    raise ArgumentError, 'Invalid JWT format' if header.nil? || payload.nil? || signature.nil?
 
     header = JSON.parse(Rex::Text.decode_base64(header))
     payload = JSON.parse(Rex::Text.decode_base64(payload))
 
-    [payload, header]
+    self.new(payload: payload, header: header, signature: signature)
   end
 end

--- a/lib/msf/core/exploit/remote/http/jwt.rb
+++ b/lib/msf/core/exploit/remote/http/jwt.rb
@@ -1,0 +1,23 @@
+# Minimal JWT wrapper which only decodes the base64 header/claim values,
+# and doesn't encode/validate JWT tokens.
+#
+# Note that swapping this out for a third-party gem will work, but
+# there may be potential security issues with the key id (kid) claim etc,
+# which would need to be reviewed.
+module Msf::Exploit::Remote::HTTP::JWT
+  module_function
+
+  def encode(payload, key, algorithm = 'HS256', header_fields = {})
+    raise NotImplementedError
+  end
+
+  def decode(jwt, _key = nil, _verify = true, _options = {})
+    header, payload, signature = jwt.split('.', 3)
+    raise ArgumentError, "Invalid JWT format" if header.nil? || payload.nil? || signature.nil?
+
+    header = JSON.parse(Rex::Text.decode_base64(header))
+    payload = JSON.parse(Rex::Text.decode_base64(payload))
+
+    [payload, header]
+  end
+end

--- a/lib/msf/core/exploit/remote/http/kubernetes.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes.rb
@@ -1,0 +1,99 @@
+# -*- coding: binary -*-
+
+# Base mixin for Kubernetes exploits,
+module Msf::Exploit::Remote::HTTP::Kubernetes
+  include Msf::PostMixin
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super
+
+    register_options(
+      [
+        Msf::OptString.new('TOKEN', [false, 'Kubernetes API token']),
+        Msf::OptString.new('NAMESPACE', [false, 'The Kubernetes namespace', 'default']),
+      ]
+    )
+  end
+
+  def connect_ws(opts = {}, *args)
+    opts['comm'] = session
+    opts['vhost'] = rhost
+    super
+  end
+
+  def send_request_raw(opts = {}, *args)
+    opts['comm'] = session
+    opts['vhost'] = rhost
+    super
+  end
+
+  def api_token
+    @api_token || datastore['TOKEN']
+  end
+
+  def rhost
+    @rhost || datastore['RHOST']
+  end
+
+  def rport
+    @rport || datastore['RPORT']
+  end
+
+  def namespace
+    @namespace || datastore['NAMESPACE']
+  end
+
+  def configure_via_session
+    vprint_status("Configuring options via session #{session.sid}")
+
+    unless directory?('/run/secrets/kubernetes.io')
+      # This would imply that the target is not a Kubernetes container
+      fail_with(Msf::Module::Failure::NotFound, 'The kubernetes.io directory was not found')
+    end
+
+    if api_token.blank?
+      token = read_file('/run/secrets/kubernetes.io/serviceaccount/token')
+      fail_with(Msf::Module::Failure::NotFound, 'The API token was not found, manually set the TOKEN option') if token.blank?
+
+      print_good("API Token: #{token}")
+      @api_token = token
+    end
+
+    if namespace.blank?
+      ns = read_file('/run/secrets/kubernetes.io/serviceaccount/namespace')
+      fail_with(Msf::Module::Failure::NotFound, 'The namespace was not found, manually set the NAMESPACE option') if ns.blank?
+
+      print_good("Namespace: #{ns}")
+      @namespace = ns
+    end
+
+    service_host = service_port = nil
+    if rhost.blank?
+      service_host = get_env('KUBERNETES_SERVICE_HOST')
+      fail_with(Msf::Module::Failure::NotFound, 'The KUBERNETES_SERVICE_HOST environment variable was not found, manually set the RHOSTS option') if service_host.blank?
+
+      @rhost = service_host
+    end
+
+    if rport.blank?
+      service_port = get_env('KUBERNETES_SERVICE_PORT_HTTPS')
+      fail_with(Msf::Module::Failure::NotFound, 'The KUBERNETES_SERVICE_PORT_HTTPS environment variable was not found, manually set the RPORT option') if service_port.blank?
+
+      @rport = service_port.to_i
+    end
+
+    if service_host || service_port
+      service = "#{Rex::Socket.is_ipv6?(service_host) ? '[' + service_host + ']' : service_host}:#{service_port}"
+      print_good("Kubernetes service host: #{service}")
+    end
+  end
+
+  def validate_configuration!
+    fail_with(Msf::Module::Failure::BadConfig, 'Missing option: RHOSTS') if rhost.blank?
+    fail_with(Msf::Module::Failure::BadConfig, 'Missing option: RPORT') if rport.blank?
+    fail_with(Msf::Module::Failure::BadConfig, 'Invalid option: RPORT') unless rport.to_i > 0 && rport.to_i < 65536
+    fail_with(Msf::Module::Failure::BadConfig, 'Missing option: TOKEN') if api_token.blank?
+    fail_with(Msf::Module::Failure::BadConfig, 'Missing option: NAMESPACE') if namespace.blank?
+  end
+end

--- a/lib/msf/core/exploit/remote/http/kubernetes/auth_parser.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/auth_parser.rb
@@ -1,0 +1,193 @@
+# -*- coding: binary -*-
+
+# Parses the succinct Kubernetes authentication API response and converts it into
+# a more consumable format
+class Msf::Exploit::Remote::HTTP::Kubernetes::AuthParser
+  def initialize(auth_response)
+    @auth_response = auth_response
+  end
+
+  # Extracts the list of rules associated with a kubernetes auth response
+  def rules
+    resource_rules = auth_response.dig(:status, :resourceRules) || []
+    non_resource_rules = auth_response.dig(:status, :nonResourceRules) || []
+    policy_rules = resource_rules + non_resource_rules
+
+    broke_down_policy_rules = policy_rules.flat_map do |policy_rule|
+      breakdown_policy_rule(policy_rule)
+    end
+    compacted_rules = compact_policy_rules(broke_down_policy_rules)
+    sorted_rules = compacted_rules.sort_by { |rule| human_readable_policy_rule(rule) }
+
+    sorted_rules
+  end
+
+  # Converts the kubernetes auth response into an array of human readable table
+  def as_table
+    columns = ['Resources', 'Non-Resource URLs', 'Resource Names', 'Verbs']
+    rows = rules.map do |rule|
+      [
+        combine_resource_groups(rule[:resources], rule[:apiGroups]),
+        "[#{rule[:nonResourceURLs].join(' ')}]",
+        "[#{rule[:resourceNames].join(' ')}]",
+        "[#{rule[:verbs].join(' ')}]"
+      ]
+    end
+
+    { columns: columns, rows: rows }
+  end
+
+  protected
+
+  attr :auth_response
+
+  def policy_rule_for(apiGroups: [], resources: [], verbs: [], resourceNames: [], nonResourceURLs: [])
+    {
+      apiGroups: apiGroups,
+      resources: resources,
+      verbs: verbs,
+      resourceNames: resourceNames,
+      nonResourceURLs: nonResourceURLs
+    }
+  end
+
+  # Converts the original policy rule into its smaller policy rules, where
+  # there is at most one verb for each rule
+  def breakdown_policy_rule(policy_rule)
+    sub_rules = []
+    policy_rule.fetch(:apiGroups, []).each do |group|
+      policy_rule.fetch(:resources, []).each do |resource|
+        policy_rule.fetch(:verbs, []).each do |verb|
+          if policy_rule.fetch(:resourceNames, []).any?
+            sub_rules += policy_rule[:resourceNames].map do |resource_name|
+              policy_rule_for(
+                apiGroups: [group],
+                resources: [resource],
+                verbs: [verb],
+                resourceNames: [resource_name]
+              )
+            end
+          else
+            sub_rules << policy_rule_for(
+              apiGroups: [group],
+              resources: [resource],
+              verbs: [verb]
+            )
+          end
+        end
+      end
+    end
+
+    sub_rules += policy_rule.fetch(:nonResourceURLs, []).flat_map do |non_resource_url|
+      policy_rule[:verbs].map do |verb|
+        policy_rule_for(
+          nonResourceURLs: [non_resource_url],
+          verbs: [verb]
+        )
+      end
+    end
+
+    sub_rules
+  end
+
+  # Finds the original policy rule associated with a simplified rule
+  def find_policy(existing_simple_rules, simple_rule)
+    return nil if simple_rule.nil?
+
+    existing_simple_rules.each do |existing_simple_rule, policy|
+      is_match = (
+        existing_simple_rule[:group] == simple_rule[:group] &&
+          existing_simple_rule[:resource] == simple_rule[:resource] &&
+          existing_simple_rule[:resourceNameExist] == simple_rule[:resourceNameExist] &&
+          existing_simple_rule[:resourceName] == simple_rule[:resourceName]
+      )
+
+      if is_match
+        return policy
+      end
+    end
+
+    nil
+  end
+
+  # Merge policy rules together, by joining rules that are associated with the same resource, but different
+  # verbs
+  def compact_policy_rules(policy_rules)
+    compact_rules = []
+    simple_rules = {}
+    policy_rules.each do |policy_rule|
+      simple_rule = as_simple_rule(policy_rule)
+      if simple_rule
+        existing_rule = find_policy(simple_rules, simple_rule)
+
+        if existing_rule
+          existing_rule[:verbs] ||= []
+          existing_rule[:verbs] = (existing_rule[:verbs] + policy_rule[:verbs]).uniq
+        else
+          simple_rules[simple_rule] = policy_rule.clone
+        end
+      else
+        compact_rules << policy_rule
+      end
+    end
+
+    compact_rules += simple_rules.values
+    compact_rules
+  end
+
+  # returns nil if it's not possible to simplify this rule
+  def as_simple_rule(policy_rule)
+    return nil if policy_rule[:resourceNames].count > 1 || policy_rule[:nonResourceURLs].count > 0
+    return nil if policy_rule[:apiGroups].count != 1 || policy_rule[:resources].count != 1
+
+    allowed_keys = %i[apiGroups resources verbs resourceNames nonResourceURLs]
+    unsupported_keys = policy_rule.keys - allowed_keys
+    return nil if unsupported_keys.any?
+
+    simple_rule = {
+      group: policy_rule[:apiGroups][0],
+      resource: policy_rule[:resources][0],
+      resourceNameExist: false
+    }
+
+    if policy_rule[:resourceNames].any?
+      simple_rule.merge(
+        {
+          resourceNameExist: true,
+          resourceName: policy_rule[:resourceNames][0]
+        }
+      )
+    end
+
+    simple_rule
+  end
+
+  def human_readable_policy_rule(rule)
+    parts = []
+
+    parts << "APIGroups:[#{rule[:apiGroups].join(' ')}]" if rule[:apiGroups].any?
+    parts << "Resources:[#{rule[:resources].join(' ')}]" if rule[:resources].any?
+    parts << "NonResourceURLs:[#{rule[:nonResourceURLs].join(' ')}]" if rule[:nonResourceURLs].any?
+    parts << "ResourceNames:[#{rule[:resourceNames].join(' ')}]" if rule[:resourceNames].any?
+    parts << "Verbs:[#{rule[:verbs].join(' ')}]" if rule[:verbs].any?
+
+    parts.join(', ')
+  end
+
+  def combine_resource_groups(resources, groups)
+    return '' if resources.empty?
+
+    parts = resources[0].split('/', 2)
+    result = parts[0]
+
+    if groups.count > 0 && groups[0] != ''
+      result = result + '.' + groups[0]
+    end
+
+    if parts.count == 2
+      result = result + '/' + parts[1]
+    end
+
+    result
+  end
+end

--- a/lib/msf/core/exploit/remote/http/kubernetes/auth_parser.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/auth_parser.rb
@@ -98,7 +98,6 @@ class Msf::Exploit::Remote::HTTP::Kubernetes::AuthParser
       is_match = (
         existing_simple_rule[:group] == simple_rule[:group] &&
           existing_simple_rule[:resource] == simple_rule[:resource] &&
-          existing_simple_rule[:resourceNameExist] == simple_rule[:resourceNameExist] &&
           existing_simple_rule[:resourceName] == simple_rule[:resourceName]
       )
 
@@ -146,14 +145,12 @@ class Msf::Exploit::Remote::HTTP::Kubernetes::AuthParser
 
     simple_rule = {
       group: policy_rule[:apiGroups][0],
-      resource: policy_rule[:resources][0],
-      resourceNameExist: false
+      resource: policy_rule[:resources][0]
     }
 
     if policy_rule[:resourceNames].any?
       simple_rule.merge(
         {
-          resourceNameExist: true,
           resourceName: policy_rule[:resourceNames][0]
         }
       )

--- a/lib/msf/core/exploit/remote/http/kubernetes/client.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/client.rb
@@ -63,13 +63,15 @@ module Msf
                   {
                     'method' => 'GET',
                     'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{name}/exec"),
-                    'query' => URI.encode_www_form({
-                      'command' => command,
-                      'stdin' => !!options.delete('stdin'),
-                      'stdout' => !!options.delete('stdout'),
-                      'stderr' => !!options.delete('stderr'),
-                      'tty' => !!options.delete('tty')
-                    }),
+                    'query' => URI.encode_www_form(
+                      {
+                        'command' => command,
+                        'stdin' => !!options.delete('stdin'),
+                        'stdout' => !!options.delete('stdout'),
+                        'stderr' => !!options.delete('stderr'),
+                        'tty' => !!options.delete('tty')
+                      }
+                    ),
                     'headers' => {
                       'Sec-Websocket-Protocol' => 'v4.channel.k8s.io'
                     }
@@ -107,11 +109,88 @@ module Msf
               result
             end
 
+            def get_version(options = {})
+              _res, json = call_api(
+                {
+                  'method' => 'GET',
+                  'uri' => http_client.normalize_uri("/version")
+                },
+                options
+              )
+
+              json
+            end
+
             def get_pod(pod, namespace, options = {})
               _res, json = call_api(
                 {
                   'method' => 'GET',
                   'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/pods/#{pod}")
+                },
+                options
+              )
+
+              json
+            end
+
+            def list_auth(namespace, options = {})
+              data = {
+                kind: "SelfSubjectRulesReview",
+                "apiVersion": "authorization.k8s.io/v1",
+                "metadata": {
+                  "creationTimestamp": nil
+                },
+                "spec": {
+                  "namespace": namespace
+                },
+                "status": {
+                  "resourceRules": nil,
+                  "nonResourceRules": nil,
+                  "incomplete": false
+                }
+              }
+
+              _res, json = call_api(
+                {
+                  'method' => 'POST',
+                  'uri' => http_client.normalize_uri('/apis/authorization.k8s.io/v1/selfsubjectrulesreviews'),
+                  'data' => JSON.pretty_generate(data)
+                },
+                options
+              )
+
+              json
+            end
+
+            def get_secret(secret, namespace, options = {})
+              _res, json = call_api(
+                {
+                  'method' => 'GET',
+                  'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/secrets/#{secret}")
+                },
+                options
+              )
+
+              json
+            end
+
+            def list_secret(namespace, options = {})
+              _res, json = call_api(
+                {
+                  'method' => 'GET',
+                  'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}/secrets")
+                },
+                options
+              )
+
+              json
+            end
+
+            def get_namespace(namespace, options = {})
+              _res, json = call_api(
+                {
+                  'method' => 'GET',
+                  'uri' => http_client.normalize_uri("/api/v1/namespaces/#{namespace}")
                 },
                 options
               )
@@ -131,7 +210,7 @@ module Msf
               json
             end
 
-            def list_pods(namespace, options = {})
+            def list_pod(namespace, options = {})
               _res, json = call_api(
                 {
                   'method' => 'GET',
@@ -154,7 +233,7 @@ module Msf
               )
 
               if res.code != 201
-                raise Kubernetes::Error::UnexpectedStatusCode, res.code
+                raise Kubernetes::Error::UnexpectedStatusCode, res: res
               end
 
               json
@@ -183,21 +262,22 @@ module Msf
 
             attr_reader :http_client
 
-            # TODO: Support receiving data directly as a table?
-            # Accept: application/json;as=Table;g=meta.k8s.io;v=v1beta1
-            # https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables
             def call_api(request, options = {})
               res = http_client.send_request_raw(request_options(request, options))
 
-              if res.nil? || res.body.empty?
-                raise Kubernetes::Error::ApiError
+              if res.nil? || res.body.nil?
+                raise Kubernetes::Error::ApiError.new(res: res)
               elsif res.code == 401
-                raise Kubernetes::Error::AuthenticationError
+                raise Kubernetes::Error::AuthenticationError.new(res: res)
+              elsif res.code == 403
+                raise Kubernetes::Error::ForbiddenError.new(res: res)
+              elsif res.code == 404
+                raise Kubernetes::Error::NotFoundError.new(res: res)
               end
 
               json = res.get_json_document
               if json.nil?
-                raise Kubernetes::Error::ApiError
+                raise Kubernetes::Error::ApiError.new(res: res)
               end
 
               [res, json.deep_symbolize_keys]

--- a/lib/msf/core/exploit/remote/http/kubernetes/client.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/client.rb
@@ -174,7 +174,7 @@ module Msf
               json
             end
 
-            def list_secret(namespace, options = {})
+            def list_secrets(namespace, options = {})
               _res, json = call_api(
                 {
                   'method' => 'GET',
@@ -198,7 +198,7 @@ module Msf
               json
             end
 
-            def list_namespace(options = {})
+            def list_namespaces(options = {})
               _res, json = call_api(
                 {
                   'method' => 'GET',
@@ -210,7 +210,7 @@ module Msf
               json
             end
 
-            def list_pod(namespace, options = {})
+            def list_pods(namespace, options = {})
               _res, json = call_api(
                 {
                   'method' => 'GET',
@@ -266,7 +266,7 @@ module Msf
               res = http_client.send_request_raw(request_options(request, options))
 
               if res.nil? || res.body.nil?
-                raise Kubernetes::Error::ApiError.new(res: res)
+                raise Kubernetes::Error::InvalidApiError.new(res: res)
               elsif res.code == 401
                 raise Kubernetes::Error::AuthenticationError.new(res: res)
               elsif res.code == 403
@@ -277,7 +277,7 @@ module Msf
 
               json = res.get_json_document
               if json.nil?
-                raise Kubernetes::Error::ApiError.new(res: res)
+                raise Kubernetes::Error::InvalidApiError.new(res: res)
               end
 
               [res, json.deep_symbolize_keys]

--- a/lib/msf/core/exploit/remote/http/kubernetes/enumeration.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/enumeration.rb
@@ -1,0 +1,214 @@
+# -*- coding: binary -*-
+
+# The mixin for enumerating a Msf::Exploit::Remote::HTTP::Kubernetes API
+module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
+  def enum_all
+    enum_version
+    namespace_items = enum_namespaces
+    namespaces_name = namespace_items.map { |item| item.dig(:metadata, :name) }
+
+    # If there's no permissions to access namespaces, we can use the current token's namespace,
+    # as well as trying some common namespaces
+    if namespace_items.empty?
+      token_claims = parse_jwt(api_token)
+      current_token_namespace = token_claims&.dig('kubernetes.io', 'namespace')
+      possible_namespaces = (datastore['NAMESPACE_LIST'].split(',') + [current_token_namespace]).uniq.compact
+      namespaces_name += possible_namespaces
+
+      output.print_error("No namespaces available. Attempting the current token's namespace and common namespaces: #{namespaces_name.join(', ')}")
+    end
+
+    # Split the information for each namespace separately
+    namespaces_name.each.with_index do |namespace, index|
+      print_good("Namespace #{index}: #{namespace}")
+
+      enum_auth(namespace)
+      enum_pods(namespace)
+      enum_secrets(namespace)
+
+      print_line
+    end
+  end
+
+  def enum_version
+    attempt_enum(:version) do
+      version = kubernetes_client.get_version
+      output.print_version(version)
+    end
+  end
+
+  def enum_namespaces(name: nil)
+    output.print_good('Enumerating namespaces')
+
+    namespace_items = []
+    attempt_enum(:namespace) do
+      if name
+        namespace_items = [kubernetes_client.get_namespace(name)]
+      else
+        namespace_items = kubernetes_client.list_namespace.fetch(:items, [])
+      end
+    end
+    output.print_namespaces(namespace_items)
+    namespace_items
+  end
+
+  def enum_auth(namespace)
+    attempt_enum(:auth) do
+      auth = kubernetes_client.list_auth(namespace)
+      output.print_auth(namespace, auth)
+    end
+  end
+
+  def enum_pods(namespace, name: nil)
+    attempt_enum(:pod) do
+      if name
+        pods = [kubernetes_client.get_pod(name, namespace)]
+      else
+        pods = kubernetes_client.list_pod(namespace).fetch(:items, [])
+      end
+
+      output.print_pods(namespace, pods)
+    end
+  end
+
+  def enum_secrets(namespace, name: nil)
+    attempt_enum(:secret) do
+      if name
+        secrets = [kubernetes_client.get_secret(name, namespace)]
+      else
+        secrets = kubernetes_client.list_secret(namespace).fetch(:items, [])
+      end
+
+      output.print_secrets(namespace, secrets)
+      report_secrets(namespace, secrets)
+    end
+  end
+
+  protected
+
+  attr_reader :kubernetes_client, :output
+
+  def attempt_enum(resource, &block)
+    block.call
+  rescue Msf::Exploit::Remote::HTTP::Kubernetes::Error::ApiError => e
+    output.print_enum_failure(resource, e)
+  end
+
+  def report_secrets(namespace, secrets)
+    origin = create_credential_origin_service(
+      {
+        address: datastore['RHOST'],
+        port: datastore['RPORT'],
+        service_name: 'kubernetes',
+        protocol: 'tcp',
+        module_fullname: fullname,
+        workspace_id: myworkspace_id
+      }
+    )
+
+    secrets.each do |secret|
+      credential_data = {
+        origin: origin,
+        origin_type: :service,
+        module_fullname: fullname,
+        workspace_id: myworkspace_id,
+        status: Metasploit::Model::Login::Status::UNTRIED
+      }
+
+      resource_name = secret.dig(:metadata, :name)
+      loot_name_prefix = [
+        datastore['RHOST'],
+        namespace,
+        resource_name
+      ].join('_')
+
+      case secret[:type]
+      when Msf::Exploit::Remote::HTTP::Kubernetes::Secret::BasicAuth
+        username = Rex::Text.decode_base64(secret.dig(:data, :username))
+        password = Rex::Text.decode_base64(secret.dig(:data, :password))
+
+        credential = credential_data.merge(
+          {
+            username: username,
+            private_type: :password,
+            private_data: password
+          }
+        )
+
+        print_good("basic_auth #{resource_name}: #{username}:#{password}")
+        create_credential(credential)
+      when Msf::Exploit::Remote::HTTP::Kubernetes::Secret::TLSAuth
+        tls_cert = Rex::Text.decode_base64(secret.dig(:data, :"tls.crt"))
+        tls_key = Rex::Text.decode_base64(secret.dig(:data, :"tls.key"))
+        tls_subject = begin
+          OpenSSL::X509::Certificate.new(tls_cert).subject
+        rescue StandardError
+          nil
+        end
+        loot_name = loot_name_prefix + (tls_subject ? tls_subject.to_a.map { |name, data, _type| "#{name}-#{data}" }.join('-') : '')
+
+        path = store_loot('tls.key', 'text/plain', nil, tls_key, "#{loot_name}.key")
+        print_good("tls_key #{resource_name}: #{path}")
+
+        path = store_loot('tls.cert', 'text/plain', nil, tls_cert, "#{loot_name}.crt")
+        print_good("tls_cert #{resource_name}: #{path} (#{tls_subject || 'No Subject'})")
+      when Msf::Exploit::Remote::HTTP::Kubernetes::Secret::ServiceAccountToken
+        data = secret[:data].clone
+        # decode keys to a human readable format that might be useful for users
+        %i[namespace token].each do |key|
+          data[key] = Rex::Text.decode_base64(data[key])
+        end
+        loot_name = loot_name_prefix + '-token'
+
+        path = store_loot('kubernetes.token', 'application/json', datastore['RHOST'], JSON.pretty_generate(data), loot_name)
+        print_good("service token #{resource_name}: #{path}")
+      when Msf::Exploit::Remote::HTTP::Kubernetes::Secret::DockerConfigurationJson
+        json = Rex::Text.decode_base64(secret.dig(:data, :".dockerconfigjson"))
+        loot_name = loot_name_prefix + '-json'
+
+        path = store_loot('docker.json', 'application/json', nil, json, loot_name)
+        print_good("dockerconfig json #{resource_name}: #{path}")
+      when Msf::Exploit::Remote::HTTP::Kubernetes::Secret::SSHAuth
+        data = Rex::Text.decode_base64(secret.dig(:data, :"ssh-privatekey"))
+        loot_name = loot_name_prefix + '-ssh_key'
+        private_key = parse_private_key(data)
+
+        credential = credential_data.merge(
+          {
+            private_type: :ssh_key,
+            public_data: private_key&.public_key,
+            private_data: private_key
+          }
+        )
+        begin
+          create_credential(credential)
+        rescue StandardError => _e
+          vprint_error("Unable to store #{loot_name} as a valid ssh_key pair")
+        end
+
+        path = store_loot('id_rsa', 'text/plain', nil, json, loot_name)
+        print_good("ssh_key #{resource_name}: #{path}")
+      end
+    rescue StandardError => e
+      elog("Failed parsing secret #{resource_name}", error: e)
+      print_error("Failed parsing secret #{resource_name}: #{e.message}")
+    end
+  end
+
+  def parse_private_key(data)
+    passphrase = nil
+    ask_passphrase = false
+
+    private_key = Net::SSH::KeyFactory.load_data_private_key(data, passphrase, ask_passphrase)
+    private_key
+  rescue StandardError => _e
+    nil
+  end
+
+  def parse_jwt(token)
+    claims, _header = Msf::Exploit::Remote::HTTP::JWT.decode(token)
+    claims
+  rescue ArgumentError
+    nil
+  end
+end

--- a/lib/msf/core/exploit/remote/http/kubernetes/enumeration.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/enumeration.rb
@@ -131,7 +131,8 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
       loot_name_prefix = [
         datastore['RHOST'],
         namespace,
-        resource_name
+        resource_name,
+        secret[:type].gsub(/[a-zA-Z]/, '-').downcase
       ].join('_')
 
       case secret[:type]
@@ -170,19 +171,18 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
         %i[namespace token].each do |key|
           data[key] = Rex::Text.decode_base64(data[key])
         end
-        loot_name = loot_name_prefix + '-token'
-
+        loot_name = loot_name_prefix + '.json'
         path = store_loot('kubernetes.token', 'application/json', datastore['RHOST'], JSON.pretty_generate(data), loot_name)
         print_good("service token #{resource_name}: #{path}")
       when Msf::Exploit::Remote::HTTP::Kubernetes::Secret::DockerConfigurationJson
         json = Rex::Text.decode_base64(secret.dig(:data, :".dockerconfigjson"))
-        loot_name = loot_name_prefix + '-json'
+        loot_name = loot_name_prefix + '.json'
 
         path = store_loot('docker.json', 'application/json', nil, json, loot_name)
         print_good("dockerconfig json #{resource_name}: #{path}")
       when Msf::Exploit::Remote::HTTP::Kubernetes::Secret::SSHAuth
         data = Rex::Text.decode_base64(secret.dig(:data, :"ssh-privatekey"))
-        loot_name = loot_name_prefix + '-ssh_key'
+        loot_name = loot_name_prefix + '.key'
         private_key = parse_private_key(data)
 
         credential = credential_data.merge(
@@ -198,7 +198,7 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
           vprint_error("Unable to store #{loot_name} as a valid ssh_key pair")
         end
 
-        path = store_loot('id_rsa', 'text/plain', nil, json, loot_name)
+        path = store_loot('id_rsa', 'text/plain', nil, data, loot_name)
         print_good("ssh_key #{resource_name}: #{path}")
       end
     rescue StandardError => e

--- a/lib/msf/core/exploit/remote/http/kubernetes/enumeration.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/enumeration.rb
@@ -2,6 +2,16 @@
 
 # The mixin for enumerating a Msf::Exploit::Remote::HTTP::Kubernetes API
 module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
+  def initialize(info = {})
+    super
+
+    register_options(
+      [
+        Msf::OptString.new('NAMESPACE_LIST', [false, 'The default namespace list to iterate when the current token does not have the permission to retrieve the available namespaces', 'default,dev,staging,production,kube-node-lease,kube-lease,kube-system'])
+      ]
+    )
+  end
+
   def enum_all
     enum_version
     namespace_items = enum_namespaces
@@ -31,10 +41,12 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
   end
 
   def enum_version
+    version = nil
     attempt_enum(:version) do
       version = kubernetes_client.get_version
       output.print_version(version)
     end
+    version
   end
 
   def enum_namespaces(name: nil)
@@ -45,7 +57,7 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
       if name
         namespace_items = [kubernetes_client.get_namespace(name)]
       else
-        namespace_items = kubernetes_client.list_namespace.fetch(:items, [])
+        namespace_items = kubernetes_client.list_namespaces.fetch(:items, [])
       end
     end
     output.print_namespaces(namespace_items)
@@ -64,7 +76,7 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
       if name
         pods = [kubernetes_client.get_pod(name, namespace)]
       else
-        pods = kubernetes_client.list_pod(namespace).fetch(:items, [])
+        pods = kubernetes_client.list_pods(namespace).fetch(:items, [])
       end
 
       output.print_pods(namespace, pods)
@@ -76,7 +88,7 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
       if name
         secrets = [kubernetes_client.get_secret(name, namespace)]
       else
-        secrets = kubernetes_client.list_secret(namespace).fetch(:items, [])
+        secrets = kubernetes_client.list_secrets(namespace).fetch(:items, [])
       end
 
       output.print_secrets(namespace, secrets)
@@ -206,8 +218,8 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
   end
 
   def parse_jwt(token)
-    claims, _header = Msf::Exploit::Remote::HTTP::JWT.decode(token)
-    claims
+    parsed_token = Msf::Exploit::Remote::HTTP::JWT.decode(token)
+    parsed_token.payload
   rescue ArgumentError
     nil
   end

--- a/lib/msf/core/exploit/remote/http/kubernetes/enumeration.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/enumeration.rb
@@ -7,12 +7,15 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
 
     register_options(
       [
-        Msf::OptString.new('NAMESPACE_LIST', [false, 'The default namespace list to iterate when the current token does not have the permission to retrieve the available namespaces', 'default,dev,staging,production,kube-node-lease,kube-lease,kube-system'])
+        Msf::OptString.new('NAMESPACE_LIST', [false, 'The default namespace list to iterate when the current token does not have the permission to retrieve the available namespaces', 'default,dev,staging,production,kube-public,kube-node-lease,kube-lease,kube-system'])
       ]
     )
   end
 
   def enum_all
+    token_claims = parse_jwt(api_token)
+    output.print_claims(token_claims) if token_claims
+
     enum_version
     namespace_items = enum_namespaces
     namespaces_name = namespace_items.map { |item| item.dig(:metadata, :name) }
@@ -20,12 +23,11 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
     # If there's no permissions to access namespaces, we can use the current token's namespace,
     # as well as trying some common namespaces
     if namespace_items.empty?
-      token_claims = parse_jwt(api_token)
       current_token_namespace = token_claims&.dig('kubernetes.io', 'namespace')
       possible_namespaces = (datastore['NAMESPACE_LIST'].split(',') + [current_token_namespace]).uniq.compact
       namespaces_name += possible_namespaces
 
-      output.print_error("No namespaces available. Attempting the current token's namespace and common namespaces: #{namespaces_name.join(', ')}")
+      output.print_error("Unable to extract namespaces. Attempting the current token's namespace and common namespaces: #{namespaces_name.join(', ')}")
     end
 
     # Split the information for each namespace separately
@@ -163,7 +165,7 @@ module Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
         path = store_loot('tls.key', 'text/plain', nil, tls_key, "#{loot_name}.key")
         print_good("tls_key #{resource_name}: #{path}")
 
-        path = store_loot('tls.cert', 'text/plain', nil, tls_cert, "#{loot_name}.crt")
+        path = store_loot('tls.cert', 'application/x-pem-file', nil, tls_cert, "#{loot_name}.crt")
         print_good("tls_cert #{resource_name}: #{path} (#{tls_subject || 'No Subject'})")
       when Msf::Exploit::Remote::HTTP::Kubernetes::Secret::ServiceAccountToken
         data = secret[:data].clone

--- a/lib/msf/core/exploit/remote/http/kubernetes/error.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/error.rb
@@ -15,6 +15,15 @@ module Msf
               attr_reader :res
             end
 
+            class InvalidApiError < ApiError
+              def initialize(message: nil, res: nil)
+                super(message: message || "Kubernetes InvalidApi - target does not appear to be running Kubernetes, verify configuration", res: res)
+                @res = res
+              end
+
+              attr_reader :res
+            end
+
             class AuthenticationError < ApiError
               def initialize(message: nil, res: nil)
                 super(message: message || "Kubernetes AuthenticationError - token may be invalid", res: res)

--- a/lib/msf/core/exploit/remote/http/kubernetes/error.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/error.rb
@@ -7,17 +7,37 @@ module Msf
         module Kubernetes
           module Error
             class ApiError < ::StandardError
+              def initialize(message: nil, res: nil)
+                super(message || "Kubernetes ApiError")
+                @res = res
+              end
+
+              attr_reader :res
             end
 
             class AuthenticationError < ApiError
+              def initialize(message: nil, res: nil)
+                super(message: message || "Kubernetes AuthenticationError - token may be invalid", res: res)
+              end
+            end
+
+            class ForbiddenError < ApiError
+              def initialize(message: nil, res: nil)
+                super(message: message || "Kubernetes ForbiddenError - token does not have permission to access this resource", res: res)
+              end
+            end
+
+            class NotFoundError < ApiError
+              def initialize(message: nil, res: nil)
+                super(message: message || "Kubernetes NotFoundError - resource not found", res: res)
+              end
             end
 
             class UnexpectedStatusCode < ApiError
               attr_reader :status_code
-
-              def initialize(status_code)
-                super
-                @status_code = status_code
+              def initialize(message: nil, res: nil)
+                super(message: message || "Kubernetes ApiError - unexpected response status code #{status_code}", res: res)
+                @status_code = res.code
               end
             end
           end

--- a/lib/msf/core/exploit/remote/http/kubernetes/output.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/output.rb
@@ -1,0 +1,5 @@
+# -*- coding: binary -*-
+
+# The namespace for classes which can output Kubernetes API responses
+module Msf::Exploit::Remote::HTTP::Kubernetes::Output
+end

--- a/lib/msf/core/exploit/remote/http/kubernetes/output/json.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/output/json.rb
@@ -23,6 +23,10 @@ class Msf::Exploit::Remote::HTTP::Kubernetes::Output::JSON
     end
   end
 
+  def print_claims(claims)
+    print_json(claims)
+  end
+
   def print_version(version)
     print_json(version)
   end

--- a/lib/msf/core/exploit/remote/http/kubernetes/output/json.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/output/json.rb
@@ -1,0 +1,53 @@
+# -*- coding: binary -*-
+
+# Outputs Kubernetes API responses in JSON format
+class Msf::Exploit::Remote::HTTP::Kubernetes::Output::JSON
+  # Creates a new `Msf::Exploit::Remote::HTTP::Kubernetes::Output::JSON` instance
+  #
+  # @param [object] output The original output object with print_line/print_status/etc methods available.
+  def initialize(output)
+    @output = output
+  end
+
+  def print_error(*_args); end
+
+  def print_good(*_args); end
+
+  def print_status(*_args); end
+
+  def print_enum_failure(_resource, error)
+    if error.is_a?(Msf::Exploit::Remote::HTTP::Kubernetes::Error::ApiError) && error.res
+      print_json(error.res.get_json_document)
+    else
+      output.print_error(error.message)
+    end
+  end
+
+  def print_version(version)
+    print_json(version)
+  end
+
+  def print_namespaces(namespaces)
+    print_json(namespaces)
+  end
+
+  def print_auth(_namespace, auth)
+    print_json(auth)
+  end
+
+  def print_pods(_namespace, pods)
+    print_json(pods)
+  end
+
+  def print_secrets(_namespace, pods)
+    print_json(pods)
+  end
+
+  protected
+
+  attr_reader :output
+
+  def print_json(object)
+    output.print_line(JSON.pretty_generate(object))
+  end
+end

--- a/lib/msf/core/exploit/remote/http/kubernetes/output/table.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/output/table.rb
@@ -1,0 +1,164 @@
+# -*- coding: binary -*-
+
+# Outputs Kubernetes API responses in table format
+class Msf::Exploit::Remote::HTTP::Kubernetes::Output::Table
+
+  # Creates a new `Msf::Exploit::Remote::HTTP::Kubernetes::Output::Table` instance
+  #
+  # @param [object] output The original output object with print_line/print_status/etc methods available.
+  # @param [String] highlight_name_pattern The regex used to highlight noteworthy resource names
+  def initialize(output, highlight_name_pattern: nil)
+    @output = output
+    @highlight_name_pattern = highlight_name_pattern
+  end
+
+  def print_error(*args)
+    output.print_error(*args)
+  end
+
+  def print_good(*args)
+    output.print_good(*args)
+  end
+
+  def print_status(*args)
+    output.print_status(*args)
+  end
+
+  def print_enum_failure(resource, error)
+    if error.is_a?(Msf::Exploit::Remote::HTTP::Kubernetes::Error::ApiError)
+      print_status("#{resource} failure - #{error.message}")
+    else
+      output.print_error(error.message)
+    end
+  end
+
+  def print_version(version)
+    print_good("Kubernetes service version: #{version.to_json}")
+  end
+
+  def print_namespaces(namespaces)
+    table = create_table(
+      'Header' => 'Namespaces',
+      'Columns' => ['#', 'name']
+    )
+
+    namespaces.each.with_index do |item, i|
+      table << [
+        i,
+        item.dig(:metadata, :name)
+      ]
+    end
+
+    print_table(table)
+  end
+
+  # Print the auth rules returned from a kubernetes client in the same format
+  # as `kubectl auth can-i --list --namespace default -v8`
+  def print_auth(namespace, auth)
+    auth_table = Msf::Exploit::Remote::HTTP::Kubernetes::AuthParser.new(auth).as_table
+
+    table = create_table(
+      'Header' => "Auth (namespace: #{namespace})",
+      # The table rows will already be sorted, disable the default sorting logic
+      'SortIndex' => -1,
+      'Columns' => auth_table[:columns],
+      'Rows' => auth_table[:rows]
+    )
+
+    print_table(table)
+  end
+
+  def print_pods(namespace, pods)
+    table = create_table(
+      'Header' => "Pods (namespace: #{namespace})",
+      'Columns' => ['#', 'namespace', 'name', 'status', 'containers', 'ip']
+    )
+
+    pods.each.with_index do |item, i|
+      containers = item.dig(:spec, :containers).map do |container|
+        ports = container.fetch(:ports, []).map do |ports|
+          "#{ports[:protocol]}:#{ports[:containerPort]}"
+        end.uniq
+        details = "image: #{container[:image]}"
+        details << " #{ports.join(',')}" if ports.any?
+        "#{container[:name]} (#{details})"
+      end
+      table << [
+        i,
+        namespace,
+        item.dig(:metadata, :name),
+        item.dig(:status, :phase),
+        containers.join(', '),
+        (item.dig(:status, :podIPs) || []).map { |ip| ip[:ip] }.join(',')
+      ]
+    end
+
+    print_table(table)
+  end
+
+  def print_secrets(namespace, secrets)
+    table = create_table(
+      'Header' => "Secrets (namespace: #{namespace})",
+      'Columns' => ['#', 'namespace', 'name', 'type', 'data', 'age']
+    )
+
+    secrets.each.with_index do |item, i|
+      table << [
+        i,
+        namespace,
+        item.dig(:metadata, :name),
+        item[:type],
+        item.fetch(:data, {}).keys.join(','),
+        item.dig(:metadata, :creationTimestamp)
+      ]
+    end
+
+    print_table(table)
+  end
+
+  protected
+
+  attr_reader :highlight_name_pattern, :output
+
+  def create_table(options)
+    default_options = {
+      'Indent' => indent_level,
+      # For now, don't perform any word wrapping on the table as it breaks the workflow of
+      # copying container/secret names
+      'WordWrap' => false,
+      'ColProps' => {
+        'data' => {
+          'Stylers' => [
+            Msf::Ui::Console::TablePrint::HighlightSubstringStyler.new([highlight_name_pattern])
+          ]
+        },
+        'name' => {
+          'Stylers' => [
+            Msf::Ui::Console::TablePrint::HighlightSubstringStyler.new([highlight_name_pattern])
+          ]
+        },
+        'age' => {
+          'Formatters' => [
+            Msf::Ui::Console::TablePrint::AgeFormatter.new
+          ]
+        }
+      }
+    }
+
+    Rex::Text::Table.new(default_options.merge(options))
+  end
+
+  def indent_level
+    2
+  end
+
+  def with_indent(string, amount = indent_level)
+    "#{' ' * amount}#{string}"
+  end
+
+  def print_table(table)
+    output.print(table.to_s)
+    output.print_line("#{' ' * indent_level}No rows") if table.rows.empty?
+    output.print_line
+  end
+end

--- a/lib/msf/core/exploit/remote/http/kubernetes/output/table.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/output/table.rb
@@ -32,9 +32,19 @@ class Msf::Exploit::Remote::HTTP::Kubernetes::Output::Table
     end
   end
 
+  def print_claims(claims)
+    table = create_table(
+      'Header' => 'Token Claims',
+      'Columns' => ['name', 'value'],
+      'Rows' => get_claim_as_rows(claims)
+    )
+
+    print_table(table)
+  end
+
   def print_version(version)
     table = create_table(
-      'Header' => 'Version',
+      'Header' => 'Server API Version',
       'Columns' => ['name', 'value']
     )
 
@@ -172,5 +182,20 @@ class Msf::Exploit::Remote::HTTP::Kubernetes::Output::Table
     output.print(table.to_s)
     output.print_line("#{' ' * indent_level}No rows") if table.rows.empty?
     output.print_line
+  end
+
+  def get_claim_as_rows(hash, parent_keys: [])
+    return [] if hash.empty?
+
+    result = []
+    hash.each_pair do |key, value|
+      if value.is_a?(Hash)
+        result += get_claim_as_rows(value, parent_keys: parent_keys + [key])
+      else
+        result << [(parent_keys + [key.to_s]).join('.'), value]
+      end
+    end
+
+    result
   end
 end

--- a/lib/msf/core/exploit/remote/http/kubernetes/output/table.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/output/table.rb
@@ -33,7 +33,19 @@ class Msf::Exploit::Remote::HTTP::Kubernetes::Output::Table
   end
 
   def print_version(version)
-    print_good("Kubernetes service version: #{version.to_json}")
+    table = create_table(
+      'Header' => 'Version',
+      'Columns' => ['name', 'value']
+    )
+
+    version.each_pair do |key, value|
+      table << [
+        key,
+        value
+      ]
+    end
+
+    print_table(table)
   end
 
   def print_namespaces(namespaces)

--- a/lib/msf/core/exploit/remote/http/kubernetes/secret.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/secret.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+# Secret types:
+#   https://kubernetes.io/docs/concepts/configuration/secret/
+module Msf::Exploit::Remote::HTTP::Kubernetes::Secret
+  # Arbitrary user-defined data
+  Opaque = 'Opaque'
+
+  # service account token
+  ServiceAccountToken = 'kubernetes.io/service-account-token'
+
+  # serialized ~/.dockercfg file
+  DockerConfiguration = 'kubernetes.io/dockercfg'
+
+  # serialized ~/.docker/config.json file
+  DockerConfigurationJson = 'kubernetes.io/dockerconfigjson'
+
+  # credentials for basic authentication
+  BasicAuth = 'kubernetes.io/basic-auth'
+
+  # credentials for SSH authentication
+  SSHAuth = 'kubernetes.io/ssh-auth'
+
+  # data for a TLS client or server
+  TLSAuth = 'kubernetes.io/tls'
+
+  # bootstrap token data
+  BootstrapTokenData = 'bootstrap.kubernetes.io/token'
+end

--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -62,7 +62,7 @@ module Interactive
 
   def comm_channel
     return @comm_info if @comm_info
-    if rstream.respond_to?(:channel)
+    if rstream.respond_to?(:channel) && rstream.channel.respond_to?(:client)
       @comm_info = "via session #{rstream.channel.client.sid}" if rstream.channel.client.respond_to?(:sid)
     end
   end

--- a/lib/msf/ui/console/table_print/age_formatter.rb
+++ b/lib/msf/ui/console/table_print/age_formatter.rb
@@ -1,0 +1,55 @@
+# -*- coding: binary -*-
+
+class Msf::Ui::Console::TablePrint::AgeFormatter
+  # Takes a string representation of a Time and attempts to parse it
+  # using a heuristic. The duration is then calculated, and returned
+  # in a human readable format, such as '13m' to represent 13 minutes ago.
+  #
+  # @param [String] date A date string, preferably in an iso8601 format
+  def format(date)
+    begin
+      duration = (Time.now - Time.parse(date))
+    rescue ArgumentError
+      return format_invalid_date(date)
+    end
+    seconds = duration
+    minutes = seconds / 60
+    hours = duration / (60 * 60)
+    days = duration / (60 * 60 * 24)
+    years = duration / (60 * 60 * 24 * 365)
+
+    if seconds < -1
+      format_invalid_date(date)
+    elsif seconds < 0
+      '0s'
+    elsif seconds < 60 * 2
+      "#{seconds.to_i}s"
+    elsif minutes < 10
+      seconds = duration.to_i % 60
+      "#{minutes.to_i}m#{seconds == 0 ? '' : "#{seconds}s"}"
+    elsif minutes < 60 * 3
+      "#{minutes.to_i}m"
+    elsif hours < 8
+      minutes = minutes.to_i % 60
+      "#{hours.to_i}h#{minutes == 0 ? '' : "#{minutes}m"}"
+    elsif hours < 24 * 2
+      "#{hours.to_i}h"
+    elsif hours < 24 * 8
+      hours = hours.to_i % 24
+      "#{days.to_i}d#{hours == 0 ? '' : "#{hours}h"}"
+    elsif hours < 24 * 365 * 2
+      "#{days.to_i}d"
+    elsif hours < 24 * 365 * 8
+      days = days % 365
+      "#{years.to_i}y#{days == 0 ? '' : "#{days.to_i}d"}"
+    else
+      "#{years.to_i}y"
+    end
+  end
+
+  protected
+
+  def format_invalid_date(_date)
+    "<invalid>"
+  end
+end

--- a/lib/msf/ui/console/table_print/highlight_substring_styler.rb
+++ b/lib/msf/ui/console/table_print/highlight_substring_styler.rb
@@ -8,15 +8,13 @@ module Msf
           HIGHLIGHT_COLOR = '%bgmag'
           RESET_COLOR = '%clr'
 
-          def initialize(substrings)
-            @substrings = substrings
+          # @param [Array<Regex|String>] terms An array of either strings or regular expressions to highlight
+          def initialize(terms)
+            @highlight_terms = /#{Regexp.union(terms.compact).source}/i
           end
 
           def style(value)
-            search_terms = @substrings.map { |substring| Regexp.escape(substring) }
-            search_pattern = /#{search_terms.join('|')}/i
-
-            value.gsub(search_pattern) { |match| "#{HIGHLIGHT_COLOR}#{match}#{RESET_COLOR}" }
+            value.gsub(@highlight_terms) { |match| "#{HIGHLIGHT_COLOR}#{match}#{RESET_COLOR}" }
           end
         end
       end

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -253,6 +253,7 @@ class MsfAutoload
       'vncinject_options' => 'VncInjectOptions',
       'vncinject' => 'VncInject',
       'json_hash_file' => 'JSONHashFile',
+      'jwt' => 'JWT',
       'ndr' => 'NDR',
       'ci_document' => 'CIDocument',
       'fusionvm_document' => 'FusionVMDocument',

--- a/modules/auxiliary/cloud/kubernetes/enum_kubernetes.rb
+++ b/modules/auxiliary/cloud/kubernetes/enum_kubernetes.rb
@@ -59,8 +59,7 @@ class MetasploitModule < Msf::Auxiliary
         Msf::OptInt.new('SESSION', [false, 'An optional session to use for configuration']),
         OptRegexp.new('HIGHLIGHT_NAME_PATTERN', [true, 'PCRE regex of resource names to highlight', 'username|password|user|pass']),
         OptString.new('NAME', [false, 'The name of the resource to enumerate', nil]),
-        OptEnum.new('OUTPUT', [true, 'output format to use', 'table', ['table', 'json']]),
-        OptString.new('NAMESPACE_LIST', [false, 'The default namespace list to iterate when the current token does not have the permission to retrieve the available namespaces', 'default,dev,staging,production,kube-node-lease,kube-lease,kube-system'])
+        OptEnum.new('OUTPUT', [true, 'output format to use', 'table', ['table', 'json']])
       ]
     )
   end

--- a/modules/auxiliary/cloud/kubernetes/enum_kubernetes.rb
+++ b/modules/auxiliary/cloud/kubernetes/enum_kubernetes.rb
@@ -1,0 +1,104 @@
+# -*- coding: binary -*-
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HTTP::Kubernetes
+  include Msf::Exploit::Remote::HTTP::Kubernetes::Enumeration
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Kubernetes Enumeration',
+        'Description' => %q{
+          Enumerate a Kubernetes API to report useful resources such as available namespaces,
+          pods, secrets, etc.
+
+          Useful resources will be highlighted using the HIGHLIGHT_NAME_PATTERN option.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'alanfoster',
+          'Spencer McIntyre'
+        ],
+        'Notes' => {
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [],
+          'Stability' => [CRASH_SAFE]
+        },
+        'DefaultOptions' => {
+          'SSL' => true
+        },
+        'Actions' => [
+          ['all', { 'Description' => 'enumerate all resources' }],
+          ['version', { 'Description' => 'enumerate version' }],
+          ['auth', { 'Description' => 'enumerate auth' }],
+          ['namespace', { 'Description' => 'enumerate namespace' }],
+          ['namespaces', { 'Description' => 'enumerate namespaces' }],
+          ['pod', { 'Description' => 'enumerate pod' }],
+          ['pods', { 'Description' => 'enumerate pods' }],
+          ['secret', { 'Description' => 'enumerate secret' }],
+          ['secrets', { 'Description' => 'enumerate secrets' }],
+        ],
+        'DefaultAction' => 'all',
+        'Platform' => ['linux', 'unix'],
+        'SessionTypes' => ['meterpreter']
+      )
+    )
+
+    register_options(
+      [
+        Opt::RHOSTS(nil, false),
+        Opt::RPORT(nil, false),
+        Msf::OptInt.new('SESSION', [false, 'An optional session to use for configuration']),
+        OptRegexp.new('HIGHLIGHT_NAME_PATTERN', [true, 'PCRE regex of resource names to highlight', 'username|password|user|pass']),
+        OptString.new('NAME', [false, 'The name of the resource to enumerate', nil]),
+        OptEnum.new('OUTPUT', [true, 'output format to use', 'table', ['table', 'json']]),
+        OptString.new('NAMESPACE_LIST', [false, 'The default namespace list to iterate when the current token does not have the permission to retrieve the available namespaces', 'default,dev,staging,production,kube-node-lease,kube-lease,kube-system'])
+      ]
+    )
+  end
+
+  def output_for(type)
+    case type
+    when 'table'
+      Msf::Exploit::Remote::HTTP::Kubernetes::Output::Table.new(self, highlight_name_pattern: datastore['HIGHLIGHT_NAME_PATTERN'])
+    when 'json'
+      Msf::Exploit::Remote::HTTP::Kubernetes::Output::JSON.new(self)
+    end
+  end
+
+  def run
+    if session
+      print_status("Routing traffic through session: #{session.sid}")
+      configure_via_session
+    end
+    validate_configuration!
+
+    @kubernetes_client = Msf::Exploit::Remote::HTTP::Kubernetes::Client.new({ http_client: self, token: api_token })
+    @output = output_for(datastore['output'])
+
+    case action.name
+    when 'all'
+      enum_all
+    when 'version'
+      enum_version
+    when 'auth'
+      enum_auth(datastore['NAMESPACE'])
+    when 'namespaces', 'namespace'
+      enum_namespaces(name: datastore['NAME'])
+    when 'pods', 'pod'
+      enum_pods(datastore['NAMESPACE'], name: datastore['NAME'])
+    when 'secret', 'secrets'
+      enum_secrets(datastore['NAMESPACE'], name: datastore['NAME'])
+    end
+  rescue Msf::Exploit::Remote::HTTP::Kubernetes::Error::ApiError => e
+    print_error(e.message)
+  end
+end

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -10,8 +10,7 @@ class MetasploitModule < Msf::Exploit
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
-  include Msf::PostMixin
-  include Msf::Post::File
+  include Msf::Exploit::Remote::HTTP::Kubernetes
 
   def initialize(info = {})
     super(
@@ -38,7 +37,6 @@ class MetasploitModule < Msf::Exploit
           'Stability' => [ CRASH_SAFE ]
         },
         'DefaultOptions' => {
-          'RPORT' => 8443,
           'SSL' => true
         },
         'Targets' => [
@@ -115,81 +113,8 @@ class MetasploitModule < Msf::Exploit
     )
   end
 
-  def api_token
-    @api_token || datastore['TOKEN']
-  end
-
-  def rhost
-    @rhost || datastore['RHOST']
-  end
-
-  def rport
-    @rport || datastore['RPORT']
-  end
-
-  def namespace
-    @namespace || datastore['NAMESPACE']
-  end
-
   def pod_name
     @pod_name || datastore['POD']
-  end
-
-  def configure_via_session
-    vprint_status("Configuring options via session #{session.sid}")
-
-    unless directory?('/run/secrets/kubernetes.io')
-      # This would imply that the target is not a Kubernetes container
-      fail_with(Failure::NotFound, 'The kubernetes.io directory was not found')
-    end
-
-    if api_token.blank?
-      token = read_file('/run/secrets/kubernetes.io/serviceaccount/token')
-      fail_with(Failure::NotFound, 'The API token was not found, manually set the TOKEN option') if token.blank?
-
-      print_good("API Token: #{token}")
-      @api_token = token
-    end
-
-    if namespace.blank?
-      ns = read_file('/run/secrets/kubernetes.io/serviceaccount/namespace')
-      fail_with(Failure::NotFound, 'The namespace was not found, manually set the NAMESPACE option') if ns.blank?
-
-      print_good("Namespace: #{ns}")
-      @namespace = ns
-    end
-
-    service_host = service_port = nil
-    if rhost.blank?
-      service_host = get_env('KUBERNETES_SERVICE_HOST')
-      fail_with(Failure::NotFound, 'The KUBERNETES_SERVICE_HOST environment variable was not found, manually set the RHOSTS option') if service_host.blank?
-
-      @rhost = service_host
-    end
-
-    if rport.blank?
-      service_port = get_env('KUBERNETES_SERVICE_PORT')
-      fail_with(Failure::NotFound, 'The KUBERNETES_SERVICE_PORT environment variable was not found, manually set the RPORT option') if service_port.blank?
-
-      @rport = service_port.to_i
-    end
-
-    if service_host || service_port
-      service = "#{Rex::Socket.is_ipv6?(service_host) ? '[' + service_host + ']' : service_host}:#{service_port}"
-      print_good("Kubernetes service host: #{service}")
-    end
-  end
-
-  def connect_ws(opts = {}, *args)
-    opts['comm'] = session
-    opts['vhost'] = rhost
-    super
-  end
-
-  def send_request_raw(opts = {}, *args)
-    opts['comm'] = session
-    opts['vhost'] = rhost
-    super
   end
 
   def create_pod
@@ -348,13 +273,5 @@ class MetasploitModule < Msf::Exploit
 
     status = result&.dig(:error, 'status')
     fail_with(Failure::Unknown, "Status: #{status || 'Unknown'}") unless status == 'Success'
-  end
-
-  def validate_configuration!
-    fail_with(Failure::BadConfig, 'Missing option: RHOSTS') if rhost.blank?
-    fail_with(Failure::BadConfig, 'Missing option: RPORT') if rport.blank?
-    fail_with(Failure::BadConfig, 'Invalid option: RPORT') unless rport.to_i > 0 && rport.to_i < 65536
-    fail_with(Failure::BadConfig, 'Missing option: TOKEN') if api_token.blank?
-    fail_with(Failure::BadConfig, 'Missing option: NAMESPACE') if namespace.blank?
   end
 end

--- a/spec/lib/msf/exploit/remote/http/kubernetes/auth_parser_spec.rb
+++ b/spec/lib/msf/exploit/remote/http/kubernetes/auth_parser_spec.rb
@@ -1,0 +1,65 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Remote::HTTP::Kubernetes::AuthParser do
+  let(:valid_auth_response) do
+    {
+      "kind": "SelfSubjectRulesReview",
+      "apiVersion": "authorization.k8s.io/v1",
+      "metadata": {
+        "creationTimestamp": nil
+      },
+      "spec": {},
+      "status": {
+        "resourceRules": [
+          {
+            "verbs": [
+              "get",
+              "list"
+            ],
+            "apiGroups": [
+              "*"
+            ],
+            "resources": [
+              "pod",
+              "job"
+            ],
+            "resourceNames": [
+              "test-resource"
+            ]
+          },
+        ],
+        "nonResourceRules": [
+          {
+            "verbs": [
+              "get",
+            ],
+            "nonResourceURLs": [
+              "/apis/*",
+              "/version",
+            ]
+          }
+        ],
+        "incomplete": false
+      }
+    }.deep_symbolize_keys
+  end
+
+  let(:subject) { described_class.new(valid_auth_response) }
+
+  describe '#as_table' do
+    it 'returns the parsed list of auth rules as a table' do
+      expected = {
+        columns: ['Resources', 'Non-Resource URLs', 'Resource Names', 'Verbs'],
+        rows: [
+          ["job.*", "[]", "[test-resource]", "[get list]"],
+          ["pod.*", "[]", "[test-resource]", "[get list]"],
+          ["", "[/apis/*]", "[]", "[get]"],
+          ["", "[/version]", "[]", "[get]"]
+        ]
+      }
+      expect(subject.as_table).to eq(expected)
+    end
+  end
+end

--- a/spec/lib/msf/ui/console/table_print/age_formatter_spec.rb
+++ b/spec/lib/msf/ui/console/table_print/age_formatter_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Ui::Console::TablePrint::AgeFormatter do
+  before(:each) do
+    Timecop.freeze(Time.local(2008, 9, 5, 10, 5, 30))
+  end
+
+  after(:each) do
+    Timecop.return
+  end
+
+  describe '#format' do
+    context 'when the input is invalid' do
+      it { expect(subject.format('not-a-date')).to eq('<invalid>') }
+      it { expect(subject.format((Time.now.utc + 5.minutes).iso8601)).to eq('<invalid>') }
+    end
+
+    context 'when the input is valid' do
+      # seconds
+      it { expect(subject.format((Time.now.utc).iso8601)).to eq('0s') }
+      it { expect(subject.format((Time.now.utc - 7.seconds).iso8601)).to eq('7s') }
+      it { expect(subject.format((Time.now.utc - 119.seconds).iso8601)).to eq('119s') }
+
+      # minutes
+      it { expect(subject.format((Time.now.utc - 120.seconds).iso8601)).to eq('2m') }
+      it { expect(subject.format((Time.now.utc - 121.seconds).iso8601)).to eq('2m1s') }
+      it { expect(subject.format((Time.now.utc - 5.minutes).iso8601)).to eq('5m') }
+      it { expect(subject.format((Time.now.utc - 179.minutes).iso8601)).to eq('179m') }
+      it { expect(subject.format((Time.now.utc - 179.minutes - 5.seconds).iso8601)).to eq('179m') }
+
+      # hours
+      it { expect(subject.format((Time.now.utc - 180.minutes).iso8601)).to eq('3h') }
+      it { expect(subject.format((Time.now.utc - 185.minutes).iso8601)).to eq('3h5m') }
+      it { expect(subject.format((Time.now.utc - 7.hours - 5.minutes).iso8601)).to eq('7h5m') }
+      it { expect(subject.format((Time.now.utc - 8.hours).iso8601)).to eq('8h') }
+      it { expect(subject.format((Time.now.utc - 8.hours - 5.minutes).iso8601)).to eq('8h') }
+      it { expect(subject.format((Time.now.utc - 30.hours).iso8601)).to eq('30h') }
+
+      # days
+      it { expect(subject.format((Time.now.utc - 4.days).iso8601)).to eq('4d') }
+      it { expect(subject.format((Time.now.utc - 4.days - 5.hours).iso8601)).to eq('4d5h') }
+      it { expect(subject.format((Time.now.utc - 200.days).iso8601)).to eq('200d') }
+      it { expect(subject.format((Time.now.utc - 200.days - 5.hours).iso8601)).to eq('200d') }
+      it { expect(subject.format((Time.now.utc - 364.days - 5.hours).iso8601)).to eq('364d') }
+      it { expect(subject.format((Time.now.utc - 364.days - 5.hours).iso8601)).to eq('364d') }
+      it { expect(subject.format((Time.now.utc - 400.days).iso8601)).to eq('400d') }
+
+      # years
+      it { expect(subject.format((Time.now.utc - 10.years).iso8601)).to eq('10y') }
+    end
+  end
+end

--- a/spec/lib/msf/ui/console/table_print/highlight_substring_styler_spec.rb
+++ b/spec/lib/msf/ui/console/table_print/highlight_substring_styler_spec.rb
@@ -30,5 +30,12 @@ RSpec.describe Msf::Ui::Console::TablePrint::HighlightSubstringStyler do
 
       expect(styler.style(str)).to eql "%bgmagA%clr%bgmagB%clr%bgmagC%clr%bgmagA%clr%bgmagB%clr%bgmagC%clr"
     end
+
+    it 'should support regex highlight terms' do
+      str = 'username password compassionate PASSWORD foo bar'
+      styler = described_class.new([/user|pass/, 'foo'])
+
+      expect(styler.style(str)).to eql "%bgmaguser%clrname %bgmagpass%clrword com%bgmagpass%clrionate PASSWORD %bgmagfoo%clr bar"
+    end
   end
 end

--- a/spec/support/shared/contexts/msf/ui_driver.rb
+++ b/spec/support/shared/contexts/msf/ui_driver.rb
@@ -21,14 +21,14 @@ RSpec.shared_context 'Msf::UIDriver' do
   end
 
   def capture_logging(target)
-    append_output = proc do |string|
+    append_output = proc do |string = ''|
       lines = string.split("\n")
       @output ||= []
       @output.concat(lines)
       @combined_output ||= []
       @combined_output.concat(lines)
     end
-    append_error = proc do |string|
+    append_error = proc do |string = ''|
       lines = string.split("\n")
       @error ||= []
       @error.concat(lines)
@@ -36,11 +36,13 @@ RSpec.shared_context 'Msf::UIDriver' do
       @combined_output.concat(lines)
     end
 
-    allow(target).to receive(:print).with(kind_of(String), &append_output)
-    allow(target).to receive(:print_line).with(kind_of(String), &append_output)
-    allow(target).to receive(:print_status).with(kind_of(String), &append_output)
-    allow(target).to receive(:print_warning).with(kind_of(String), &append_error)
-    allow(target).to receive(:print_error).with(kind_of(String), &append_error)
-    allow(target).to receive(:print_bad).with(kind_of(String), &append_error)
+    allow(target).to receive(:print, &append_output)
+    allow(target).to receive(:print_line, &append_output)
+    allow(target).to receive(:print_status, &append_output)
+    allow(target).to receive(:print_good, &append_output)
+
+    allow(target).to receive(:print_warning, &append_error)
+    allow(target).to receive(:print_error, &append_error)
+    allow(target).to receive(:print_bad, &append_error)
   end
 end


### PR DESCRIPTION
Note, this PR was additionally reviewed by @zeroSteiner in a separate pull request https://github.com/zeroSteiner/metasploit-framework/pull/14

Adds support for a new Kubernetes enum module. Similar to https://github.com/rapid7/metasploit-framework/pull/15733 - the user must have a Kubernetes JWT token, and access to the Kubernetes REST API through some means (either direct or through a compromised pod). A session on an existing pod can be used to configure a few options, including the JWT token and RHOST / RPORT options. Some changes were made to the RHOSTS and SESSION validation code to honor instances in which they are marked as optional. When defined, the validation still takes place either way, but when they are marked as optional and blank the validation is skipped to allow the module to run.

## Verification

After setting up a Kubernetes cluster locally/remotely with https://github.com/rapid7/metasploit-framework/pull/15773, the following scenarios should work.

Directly connecting to the Kubernetes API:
```
use cloud/kubernetes/enum_kubernetes
set RHOST https://kubernetes.docker.internal:6443
set TOKEN eyJhbGciOiJSUz...
```

The following commands should work:
- [x] `run`
- [x] `namespaces`
- [x] `namespaces name=kube-public`
- [x] `auth`
- [x] `auth output=json`
- [x] `secrets`
- [x] `pods`
- [x] `pod`
- [x] `pod namespace=default name=redis-7fd956df5-sbchb`
- [x] `pod namespace=default name=redis-7fd956df5-sbchb output=json`
- [x] `pod namespace=default name=redis-7fd956df5-sbchb output=table`
- [x] `version`

As well as pivoting through a compromised container:
```
use cloud/kubernetes/enum_kubernetes
run session=-1
```

Additional context is in the module documentation, which is in the File Changed tab