### PR TITLE
Support Pivoted SSL Connections (Server Edition)

### DIFF
--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 
-# TODO: refactor this so it's no longer under Meterpreter so it can be used elsewhere
 require 'rex/post/channel'
 require 'rex/post/meterpreter/channels/socket_abstraction'
 
@@ -82,7 +81,7 @@ module Msf::Sessions
         rsock.extend(SocketInterface)
         rsock.channel = self
 
-        lsock.extend(Rex::Socket::SslTcp) if params.ssl
+        lsock.extend(Rex::Socket::SslTcp) if params.ssl && !params.server
 
         # synchronize access so the socket isn't closed while initializing, this is particularly important for SSL
         lsock.synchronize_access { lsock.initsock(params) }
@@ -153,6 +152,11 @@ module Msf::Sessions
         @closed = false
         @mutex = Mutex.new
         @condition = ConditionVariable.new
+
+        if params.ssl
+          extend(Rex::Socket::SslTcpServer)
+          initsock(params)
+        end
       end
 
       def accept(opts = {})

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -89,12 +89,11 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
 
     unless sock_params.nil?
       @params = sock_params.merge(Socket.parameters_from_response(packet))
-      lsock.extend(Rex::Socket::SslTcpServer) if sock_params.ssl
+      if sock_params.ssl
+        extend(Rex::Socket::SslTcpServer)
+        initsock(sock_params)
+      end
     end
-
-    # synchronize access so the socket isn't closed while initializing, this is particularly important for SSL
-    lsock.synchronize_access { lsock.initsock(@params) }
-    rsock.synchronize_access { rsock.initsock(@params) }
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -89,7 +89,12 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
 
     unless sock_params.nil?
       @params = sock_params.merge(Socket.parameters_from_response(packet))
+      lsock.extend(Rex::Socket::SslTcpServer) if sock_params.ssl
     end
+
+    # synchronize access so the socket isn't closed while initializing, this is particularly important for SSL
+    lsock.synchronize_access { lsock.initsock(@params) }
+    rsock.synchronize_access { rsock.initsock(@params) }
   end
 
   #


### PR DESCRIPTION
This is the other half of #15721 which added SSL support for pivoted client connections. This adds the same support for pivoted server connections as used by capture modules and listeners. The support works for both Meterpreter sessions and SSH sessions (which just got server channel support landed today).

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Establish a Meterpreter session (I tested with Python but any that support server channels should work)
- [x] Establish an SSH session (use the `auxiliary/scanner/ssh/ssh_login` module)
- [x] For both sessions
    - [x] Route all traffic through the session `route add 0 0 #` 
    - [x] Start a listening TCP with server channel
        - [x] Use the `auxiliary/server/capture/http_basic` module
        - [x] Run `set SSL true`
        - [x] Run `set URI targeturi` (this isn't technically necessary but makes testing a little easier)
        - [x] Run the module
        - [x] Use curl or something else to verify that the remote capture server is listening with SSL
            * `curl -vvvv --user hello:world -k http://192.168.159.31:8443/targeturi`
            * This will show that TLS is established and then send the credentials to the capture server which should then be displayed within msfconsole
