### PR TITLE
Fix iis internal ip module crash

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -225,14 +225,14 @@ class Client
   # @return (see #read_response)
   def _send_recv(req, t = -1, persist = false)
     @pipeline = persist
-    if req.opts['ntlm_transform_request'] and self.ntlm_client
+    if req.respond_to?(:opts) && req.opts['ntlm_transform_request'] && self.ntlm_client
       req = req.opts['ntlm_transform_request'].call(self.ntlm_client, req)
     end
 
     send_request(req, t)
 
     res = read_response(t)
-    if req.opts['ntlm_transform_response'] and self.ntlm_client
+    if req.respond_to?(:opts) && req.opts['ntlm_transform_response'] && self.ntlm_client
       req.opts['ntlm_transform_response'].call(self.ntlm_client, res)
     end
     res.request = req.to_s if res


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/15798

## Verification

Create a http webserver in one tab:
```
python3 -m http.server 8000
```

Run the module:
```
use auxiliary/scanner/http/iis_internal_ip
run http://127.0.0.1:8000
```

Verify the following crash no longer appears:
```
msf6 auxiliary(scanner/http/iis_internal_ip) > run http://127.0.0.1:8000

[-] Auxiliary failed: NoMethodError undefined method `opts' for "GET / HTTP/1.0\r\n\r\n":String
[-] Call stack:
[-]   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/http/client.rb:228:in `_send_recv'
[-]   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/http/client.rb:209:in `send_recv'
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/http/iis_internal_ip.rb:44:in `block in run_host'
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/http/iis_internal_ip.rb:38:in `each'
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/http/iis_internal_ip.rb:38:in `run_host'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:124:in `block (2 levels) in run'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[-]   /Users/user/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
[*] Auxiliary module execution completed
````