### PR TITLE
bump metasploit-payloads to 2.0.60

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.58)
+      metasploit-payloads (= 2.0.60)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.15)
       mqtt
@@ -257,7 +257,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.58)
+    metasploit-payloads (2.0.60)
     metasploit_data_models (5.0.4)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -77,7 +77,7 @@ metasploit-concern, 4.0.3, "New BSD"
 metasploit-credential, 5.0.5, "New BSD"
 metasploit-framework, 6.1.12, "New BSD"
 metasploit-model, 4.0.3, "New BSD"
-metasploit-payloads, 2.0.58, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.60, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 5.0.4, "New BSD"
 metasploit_payloads-mettle, 1.0.15, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.58'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.60'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.15'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 115389
+  CachedSize = 115301
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 115357
+  CachedSize = 115269
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 115357
+  CachedSize = 115273
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 115285
+  CachedSize = 115201
 
   include Msf::Payload::Single
   include Msf::Payload::Python


### PR DESCRIPTION
This bumps the metasploit payloads repository, pulling in the following changes:
https://github.com/rapid7/metasploit-payloads/pull/505
https://github.com/rapid7/metasploit-payloads/pull/506

## Verification

List the steps needed to make sure this thing works

- [x] **Verify** the automated tests pass
- [x] Get a python meterpreter session
- [x] Run:
```
loadpath test/modules
use post/test/cmd_exec
set SESSION -1
set VERBOSE true
run
```
- [x] **Verify** the tests pass

