### PR TITLE
duplicator add check_plugin line

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -5,6 +5,7 @@ simple-file-list
 sp-client-document-manager
 drag-and-drop-multiple-file-upload-contact-form-7
 wp-file-manager
+duplicator
 work-the-flow-file-upload
 ajax-load-more
 wpdiscuz

--- a/modules/exploits/multi/php/wp_duplicator_code_inject.rb
+++ b/modules/exploits/multi/php/wp_duplicator_code_inject.rb
@@ -77,6 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe
     end
 
+    # check_plugin_version_from_readme('duplicator', '1.2.42')
     version = response.body.to_s.scan(/version: ([^<]*)</).last.first
     if Rex::Version.new(version) <= Rex::Version.new("1.2.40")
       return CheckCode::Vulnerable


### PR DESCRIPTION
Adds the required line to `modules/exploits/multi/php/wp_duplicator_code_inject.rb` so that `tools/dev/update_wordpress_vulnerabilities.rb` identifies the vulnerable plugin.  Also updates `data/wordlists/wp-exploitable-plugins.txt`.


## Pre
```
[*] Trying 1.1.1.1
[+] 1.1.1.1 - Detected Wordpress 5.4.4
[*] 1.1.1.1 - Enumerating plugins
[*] 1.1.1.1 - Progress   0/45 (0.0%)
[+] 1.1.1.1 - Detected plugin: backup version 1.5.8
[+] 1.1.1.1 - Detected plugin: simple-file-list version 4.2.2
[+] 1.1.1.1 - Detected plugin: drag-and-drop-multiple-file-upload-contact-form-7 version 1.3.3.2
[+] 1.1.1.1 - Detected plugin: loginizer version 1.6.3
[+] 1.1.1.1 - Detected plugin: email-subscribers version 4.2.2
[+] 1.1.1.1 - Detected plugin: learnpress version 3.2.6.7
[+] 1.1.1.1 - Detected plugin: boldgrid-backup version 1.14.9
[+] 1.1.1.1 - Detected plugin: bulletproof-security version 5.1
[+] 1.1.1.1 - Detected plugin: easy-wp-smtp version 1.4.1
[+] 1.1.1.1 - Detected plugin: woocommerce-abandoned-cart version You
[*] 1.1.1.1 - Finished scanning plugins
[*] 1.1.1.1 - Finished all scans
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
## Post

Duplicator is now in the list.

```
[*] Trying 1.1.1.1
[+] 1.1.1.1 - Detected Wordpress 5.4.4
[*] 1.1.1.1 - Enumerating plugins
[*] 1.1.1.1 - Progress   0/46 (0.0%)
[+] 1.1.1.1 - Detected plugin: backup version 1.5.8
[+] 1.1.1.1 - Detected plugin: simple-file-list version 4.2.2
[+] 1.1.1.1 - Detected plugin: drag-and-drop-multiple-file-upload-contact-form-7 version 1.3.3.2
[+] 1.1.1.1 - Detected plugin: duplicator version 1.2.40
[+] 1.1.1.1 - Detected plugin: loginizer version 1.6.3
[+] 1.1.1.1 - Detected plugin: email-subscribers version 4.2.2
[+] 1.1.1.1 - Detected plugin: learnpress version 3.2.6.7
[+] 1.1.1.1 - Detected plugin: boldgrid-backup version 1.14.9
[+] 1.1.1.1 - Detected plugin: bulletproof-security version 5.1
[+] 1.1.1.1 - Detected plugin: easy-wp-smtp version 1.4.1
[+] 1.1.1.1 - Detected plugin: woocommerce-abandoned-cart version You
[*] 1.1.1.1 - Finished scanning plugins
[*] 1.1.1.1 - Finished all scans
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```