### PR TITLE
Normalize kubernetes mixin/module option requirements

### DIFF
--- a/lib/msf/core/exploit/remote/http/kubernetes.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes.rb
@@ -10,8 +10,10 @@ module Msf::Exploit::Remote::HTTP::Kubernetes
 
     register_options(
       [
-        Msf::OptString.new('TOKEN', [false, 'Kubernetes API token']),
-        Msf::OptString.new('NAMESPACE', [false, 'The Kubernetes namespace', 'default']),
+        Msf::Opt::RHOSTS(nil, true),
+        Msf::Opt::RPORT(nil, true),
+        Msf::OptString.new('TOKEN', [ true, 'Kubernetes API token' ]),
+        Msf::OptString.new('NAMESPACE', [ true, 'The Kubernetes namespace', 'default' ]),
       ]
     )
   end

--- a/modules/auxiliary/cloud/kubernetes/enum_kubernetes.rb
+++ b/modules/auxiliary/cloud/kubernetes/enum_kubernetes.rb
@@ -54,8 +54,6 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RHOSTS(nil, false),
-        Opt::RPORT(nil, false),
         Msf::OptInt.new('SESSION', [false, 'An optional session to use for configuration']),
         OptRegexp.new('HIGHLIGHT_NAME_PATTERN', [true, 'PCRE regex of resource names to highlight', 'username|password|user|pass']),
         OptString.new('NAME', [false, 'The name of the resource to enumerate', nil]),

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -96,12 +96,8 @@ class MetasploitModule < Msf::Exploit
 
     register_options(
       [
-        Opt::RHOSTS(nil, false),
-        Opt::RPORT(nil, false),
         Msf::OptInt.new('SESSION', [ false, 'An optional session to use for configuration' ]),
-        OptString.new('TOKEN', [ false, 'The JWT token' ]),
         OptString.new('POD', [ false, 'The pod name to execute in' ]),
-        OptString.new('NAMESPACE', [ false, 'The Kubernetes namespace', 'default' ]),
         OptString.new('SHELL', [true, 'The shell to use for execution', 'sh' ]),
       ]
     )


### PR DESCRIPTION
The k8s mixin needs a few options set that are not set as 'required' when the options are registered. This leads to the 'show missing' command giving the wrong output:

```
msf6 > use exploit/multi/kubernetes/exec
[*] Using configured payload cmd/unix/interact
msf6 exploit(multi/kubernetes/exec) > show missing

Module options (exploit/multi/kubernetes/exec):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------

Payload options (cmd/unix/interact):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------

msf6 exploit(multi/kubernetes/exec) > run

[-] Exploit aborted due to failure: bad-config: Missing option: RHOSTS
[*] Exploit completed, but no session was created.
```

This moves the registration of these options to the kubernetes mixin, and sets them to all be required instead.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/kubernetes/exec`
- [ ] `show missing`
- [ ] **Verify** the missing options are listed
- [ ] **Verify** setting the missing options still enables the module to work
