### PR TITLE
Only Warn About Missing CVEs in Exploits

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -299,7 +299,7 @@ class MsftidyRunner
     end
 
     # This helps us track when CVEs aren't assigned
-    unless cve_assigned
+    if !cve_assigned && is_exploit_module?
       info('No CVE references found. Please check before you land!')
     end
   end


### PR DESCRIPTION
This is a minor tweak to msftidy so it only displays a warning (technically an info-level message, but semantically a warning to the operator) that there's no CVE in exploit modules. Many auxiliary, post and payload modules don't make sense to have CVEs so the line isn't relevant.

## Verification

- [x] Run: `tools/dev/msftidy.rb modules/payloads/singles/python/meterpreter_bind_tcp.rb`
- [x] Do not see a message that there's no CVE because it's not an exploit and doesn't need one

Before:

```
tools/dev/msftidy.rb modules/payloads/singles/python/meterpreter_bind_tcp.rb
modules/payloads/singles/python/meterpreter_bind_tcp.rb - [INFO] No CVE references found. Please check before you land!
```