### PR TITLE
Improve Kubernetes exec reliability

### DIFF
--- a/lib/msf/core/exploit/remote/http/kubernetes/client.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/client.rb
@@ -273,6 +273,8 @@ module Msf
                 raise Kubernetes::Error::ForbiddenError.new(res: res)
               elsif res.code == 404
                 raise Kubernetes::Error::NotFoundError.new(res: res)
+              elsif res.code >= 500 && res.code <= 599
+                raise Kubernetes::Error::ServerError.new(res: res)
               end
 
               json = res.get_json_document

--- a/lib/msf/core/exploit/remote/http/kubernetes/error.rb
+++ b/lib/msf/core/exploit/remote/http/kubernetes/error.rb
@@ -42,11 +42,26 @@ module Msf
               end
             end
 
+            class ServerError < ApiError
+              def initialize(message: nil, res: nil)
+                super(message: message || server_error_for(res), res: res)
+              end
+
+              protected
+
+              def server_error_for(res)
+                json = res.get_json_document
+                return "Kubernetes ServerError #{res.code}" if json.nil?
+
+                "Kubernetes ServerError #{res.code} - #{json.fetch('message', 'Failure')} "
+              end
+            end
+
             class UnexpectedStatusCode < ApiError
               attr_reader :status_code
               def initialize(message: nil, res: nil)
-                super(message: message || "Kubernetes ApiError - unexpected response status code #{status_code}", res: res)
                 @status_code = res.code
+                super(message: message || "Kubernetes ApiError - unexpected response status code #{status_code}", res: res)
               end
             end
           end

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -108,7 +108,8 @@ class MetasploitModule < Msf::Exploit
 
     register_advanced_options(
       [
-        OptString.new('PodImage', [ false, 'The image from which to create the pod' ])
+        OptString.new('PodImage', [ false, 'The image from which to create the pod' ]),
+        OptInt.new('PodReadyTimeout', [ false, 'The maximum amount time to wait for the pod to be created', 40 ]),
       ]
     )
   end
@@ -170,11 +171,19 @@ class MetasploitModule < Msf::Exploit
       print_good("Pod created: #{pod_name}")
 
       print_status('Waiting for the pod to be ready...')
-      10.times do
-        sleep 3
+      ready = retry_until_true(timeout: datastore['PodReadyTimeout']) do
         pod = @kubernetes_client.get_pod(pod_name, namespace)
-        ready = pod.dig(:status, :containerStatuses).find { |status| status[:name] = @pod_name }[:ready]
-        break if ready
+        pod_status = pod[:status]
+        next if pod_status == 'Failure'
+
+        container_statuses = pod_status[:containerStatuses]
+        next unless container_statuses
+
+        ready = container_statuses.any? { |status| status[:name] = @pod_name && status[:ready] }
+        ready
+      rescue Msf::Exploit::Remote::HTTP::Kubernetes::Error::ServerError => e
+        elog(e)
+        false
       end
 
       if ready
@@ -273,5 +282,33 @@ class MetasploitModule < Msf::Exploit
 
     status = result&.dig(:error, 'status')
     fail_with(Failure::Unknown, "Status: #{status || 'Unknown'}") unless status == 'Success'
+  end
+
+  # Retry until the block until it returns a truthy value. Each iteration attempt will
+  # be performed with expoential backoff. If the timeout period surpasses, false is returned.
+  def retry_until_true(timeout:)
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+    ending_time = start_time + timeout
+    retry_count = 0
+    while Process.clock_gettime(Process::CLOCK_MONOTONIC, :second) < ending_time
+      result = yield
+      return result if result
+
+      retry_count += 1
+      remaining_time_budget = ending_time - Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+      break if remaining_time_budget <= 0
+
+      delay = 2**retry_count
+      if delay >= remaining_time_budget
+        delay = remaining_time_budget
+        vprint_status("Final attempt. Sleeping for the remaining #{delay} seconds out of total timeout #{timeout}")
+      else
+        vprint_status("Sleeping for #{delay} seconds before attempting again")
+      end
+
+      sleep delay
+    end
+
+    false
   end
 end


### PR DESCRIPTION
Improves the stability and reliability of the Kubernetes exec module by allowing a user configurable wait period, error handling, and exponential backoff support.

Context: I was running into issues running this module against a rather slow microk8s kubernetes environment

## Verification

Ensure the previous functionality works as expected https://github.com/rapid7/metasploit-framework/pull/15733