### PR TITLE
sap_router_portscanner: rename validate function

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
@@ -296,7 +296,7 @@ class MetasploitModule < Msf::Auxiliary
     return nil
   end
 
-  def validate(range)
+  def validate_hosts_range(range)
     hosts_list = range.split(",")
     return false if hosts_list.nil? or hosts_list.empty?
 
@@ -311,7 +311,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if datastore['RESOLVE'] == 'remote'
       range = datastore['TARGETS']
-      unless validate(range)
+      unless validate_hosts_range(range)
         print_error("TARGETS must be a comma separated list of IP addresses or hostnames when RESOLVE is remote")
         return
       end


### PR DESCRIPTION
With commit 134fef21c4e27f3c3 cmd_run in command_dispatcher/auxiliary calls a [validate](https://github.com/rapid7/metasploit-framework/blob/e8a37d88d3acf1e0892f829d25e0d3098f7bf672/lib/msf/ui/console/command_dispatcher/auxiliary.rb#L60) function
without an argument. The existing internal validate function expects one argument. Therefore
running the module fails with:

```
msf6 auxiliary(scanner/sap/sap_router_portscanner) > run
[-] Error while running command run: wrong number of arguments (given 0, expected 1)

Call stack:
/usr/share/metasploit-framework/modules/auxiliary/scanner/sap/sap_router_portscanner.rb:299:in `validate'
/usr/share/metasploit-framework/lib/ui/console/command_dispatcher/auxiliary.rb:60: in `cmd_run'
/usr/share/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:557: in `run_command'
/usr/share/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:506:in `block in run_single'
/usr/share/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:500:in `each'
/usr/share/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:500:in `run_single'
/usr/share/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/usr/share/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/usr/share/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
/usr/bin/msfconsole:23:in `<main>'
```

This commit fix this issue by renaming the internal function validate to validate_host.
