### PR TITLE
Add Meterpreter compatibility requirements to lib

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -10,7 +10,6 @@ module Msf::Post::Common
           'Meterpreter' => {
             'Commands' => %w[
               stdapi_sys_config_getenv
-              stdapi_sys_process_close
               stdapi_sys_process_execute
             ]
           }

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -13,8 +13,12 @@ module Msf::Post::File
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              core_channel_*
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
               stdapi_fs_chdir
+              stdapi_fs_chmod
               stdapi_fs_delete_dir
               stdapi_fs_delete_file
               stdapi_fs_file_expand_path
@@ -22,7 +26,9 @@ module Msf::Post::File
               stdapi_fs_getwd
               stdapi_fs_ls
               stdapi_fs_mkdir
+              stdapi_fs_separator
               stdapi_fs_stat
+              stdapi_railgun_api
             ]
           }
         }

--- a/lib/msf/core/post/windows/accounts.rb
+++ b/lib/msf/core/post/windows/accounts.rb
@@ -53,8 +53,11 @@ module Msf
               'Compat' => {
                 'Meterpreter' => {
                   'Commands' => %w[
-                    stdapi_sys_process_*
-                    stdapi_railgun_*
+                    stdapi_railgun_api
+                    stdapi_railgun_api_multi
+                    stdapi_railgun_memread
+                    stdapi_railgun_memwrite
+                    stdapi_sys_process_attach
                   ]
                 }
               }

--- a/lib/msf/core/post/windows/extapi.rb
+++ b/lib/msf/core/post/windows/extapi.rb
@@ -6,21 +6,6 @@ module Windows
 
 module ExtAPI
 
-  def initialize(info = {})
-    super(
-      update_info(
-        info,
-        'Compat' => {
-          'Meterpreter' => {
-            'Commands' => %w[
-              extapi_*
-            ]
-          }
-        }
-      )
-    )
-  end
-
   def load_extapi
     if session.extapi
       return true

--- a/lib/msf/core/post/windows/file_info.rb
+++ b/lib/msf/core/post/windows/file_info.rb
@@ -12,7 +12,8 @@ module FileInfo
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_railgun_*
+              stdapi_railgun_api
+              stdapi_railgun_memread
             ]
           }
         }

--- a/lib/msf/core/post/windows/file_system.rb
+++ b/lib/msf/core/post/windows/file_system.rb
@@ -15,9 +15,12 @@ module Msf
               'Compat' => {
                 'Meterpreter' => {
                   'Commands' => %w[
+                    core_native_arch
                     stdapi_fs_delete_dir
-                    stdapi_railgun_api*
-                    stdapi_sys_process_*
+                    stdapi_railgun_api
+                    stdapi_sys_process_attach
+                    stdapi_sys_process_memory_allocate
+                    stdapi_sys_process_memory_write
                   ]
                 }
               }

--- a/lib/msf/core/post/windows/kiwi.rb
+++ b/lib/msf/core/post/windows/kiwi.rb
@@ -13,7 +13,7 @@ module Kiwi
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              kiwi_*
+              kiwi_exec_cmd
             ]
           }
         }

--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -91,7 +91,9 @@ module LDAP
           'Compat' => {
             'Meterpreter' => {
               'Commands' => %w[
-                stdapi_railgun_*
+                extapi_adsi_domain_query
+                stdapi_railgun_api
+                stdapi_railgun_memread
               ]
             }
           }

--- a/lib/msf/core/post/windows/mssql.rb
+++ b/lib/msf/core/post/windows/mssql.rb
@@ -19,11 +19,12 @@ module Msf
                 'Meterpreter' => {
                   'Commands' => %w[
                     core_migrate
-                    stdapi_sys_config_getprivs
-                    stdapi_sys_config_getuid
-                    stdapi_sys_process_*
                     incognito_impersonate_token
                     priv_elevate_getsystem
+                    stdapi_sys_config_getprivs
+                    stdapi_sys_config_getuid
+                    stdapi_sys_process_execute
+                    stdapi_sys_process_get_processes
                   ]
                 }
               }

--- a/lib/msf/core/post/windows/net_api.rb
+++ b/lib/msf/core/post/windows/net_api.rb
@@ -29,7 +29,9 @@ module NetAPI
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_railgun_*
+              stdapi_railgun_api
+              stdapi_railgun_memread
+              stdapi_railgun_memwrite
             ]
           }
         }

--- a/lib/msf/core/post/windows/packrat.rb
+++ b/lib/msf/core/post/windows/packrat.rb
@@ -14,7 +14,28 @@ module Msf
 
         include Msf::Post::File
         include Msf::Post::Windows::UserProfiles
-		  
+
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    core_channel_close
+                    core_channel_eof
+                    core_channel_open
+                    core_channel_read
+                    stdapi_fs_search
+                    stdapi_fs_separator
+                    stdapi_fs_stat
+                  ]
+                }
+              }
+            )
+          )
+        end
+
         # Check to see if the application base folder exists on the remote system.
         def parent_folder_available?(path, dir, application)
           parent_folder = dir.split('\\').first

--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -17,7 +17,9 @@ module Msf
                 'Meterpreter' => {
                   'Commands' => %w[
                     stdapi_sys_config_sysinfo
-                    stdapi_sys_process_*
+                    stdapi_sys_process_execute
+                    stdapi_sys_process_get_processes
+                    stdapi_sys_process_kill
                   ]
                 }
               }

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -30,9 +30,11 @@ module Msf::Post::Windows::Priv
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_sys_config_*
-              stdapi_sys_process_*
-              stdapi_registry_*
+              stdapi_railgun_api
+              stdapi_registry_open_key
+              stdapi_sys_config_getsid
+              stdapi_sys_config_steal_token
+              stdapi_sys_config_sysinfo
             ]
           }
         }

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -35,6 +35,7 @@ module Msf::Post::Windows::Priv
               stdapi_sys_config_getsid
               stdapi_sys_config_steal_token
               stdapi_sys_config_sysinfo
+              stdapi_sys_process_get_processes
             ]
           }
         }

--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -22,6 +22,7 @@ module Process
               stdapi_sys_process_attach
               stdapi_sys_process_execute
               stdapi_sys_process_getpid
+              stdapi_sys_process_get_processes
               stdapi_sys_process_memory_allocate
               stdapi_sys_process_memory_protect
               stdapi_sys_process_memory_write

--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -17,8 +17,15 @@ module Process
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              core_channel_*
-              stdapi_sys_process_*
+              stdapi_sys_config_getenv
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_protect
+              stdapi_sys_process_memory_write
+              stdapi_sys_process_thread_create
             ]
           }
         }

--- a/lib/msf/core/post/windows/reflective_dll_injection.rb
+++ b/lib/msf/core/post/windows/reflective_dll_injection.rb
@@ -9,10 +9,26 @@
 ###
 
 module Msf::Post::Windows::ReflectiveDLLInjection
-
   include Msf::ReflectiveDLLLoader
 
   PAGE_ALIGN = 1024
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_protect
+              stdapi_sys_process_memory_write
+            ]
+          }
+        }
+      )
+    )
+  end
 
   # Inject the given shellcode into a target process.
   #

--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -48,8 +48,9 @@ module Services
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              extapi_service_*
-              stdapi_railgun_api*
+              extapi_service_enum
+              extapi_service_query
+              stdapi_railgun_api
             ]
           }
         }

--- a/lib/msf/core/post/windows/user_profiles.rb
+++ b/lib/msf/core/post/windows/user_profiles.rb
@@ -14,8 +14,8 @@ module UserProfiles
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_fs_stat
               stdapi_fs_file_expand_path
+              stdapi_fs_stat
             ]
           }
         }

--- a/lib/msf/core/post/windows/wmic.rb
+++ b/lib/msf/core/post/windows/wmic.rb
@@ -17,9 +17,10 @@ module WMIC
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              extapi_clipboard_[gs]et_data
-              stdapi_railgun_api*
-              stdapi_sys_process_*
+              extapi_clipboard_get_data
+              extapi_clipboard_set_data
+              stdapi_railgun_api
+              stdapi_sys_process_execute
             ]
           }
         }

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -283,6 +283,11 @@ module Msf::PostMixin
       end
     end
 
+    # Windows does not support chmod, but will be defined by default in the file mixin
+    if session.base_platform == 'windows'
+      cmd_ids -= [Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_FS_CHMOD]
+    end
+
     missing_cmd_ids = (cmd_ids - session.commands)
     unless missing_cmd_ids.empty?
       # If there are missing commands, try to load the necessary extension.


### PR DESCRIPTION
Updating the Meterpreter compatibility requirements for mixins within the lib folder

Building on the work of https://github.com/rapid7/metasploit-framework/pull/15295 and https://github.com/rapid7/metasploit-framework/pull/15659

```
rubocop -A --only Lint/MeterpreterCommandCompatibility lib
```

## Verification

Review the modules and verify that the command additions make sense