### PR TITLE
Don't getsystem if we are already SYSTEM

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
@@ -101,6 +101,10 @@ class Console::CommandDispatcher::Priv::Elevate
       return false
     end
 
+    if client.sys.config.is_system?
+      print_error("Already running as SYSTEM")
+      return
+    end
     begin
       result = client.priv.getsystem( technique )
     rescue Rex::Post::Meterpreter::RequestError => e


### PR DESCRIPTION
This PR resolves #15381.

If you are already running as SYSTEM, the `getsystem` command does not need to run. Prior to this change, this caused misleading errors.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Attain a meterpreter shell running as SYSTEM
- [x] Run `getsystem`
- [x] Verify that the elevation attempt does not occur
- [x] Attain a meterpreter shell running as Administrator (should show "already SYSTEM")
- [x] Run `getsystem`
- [x] Verify that it does elevate to SYSTEM 
- [x] Run `getsystem` again
- [x] Verify that a second elevation attempt does not occur (should show "already SYSTEM")

## Demos

On Win10:

```
meterpreter > getuid
Server username: BBWIN10DEV\smash
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > getsystem
[-] Already running as SYSTEM
```

On Server 2012:

```
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > getsystem
[-] Already running as SYSTEM
```