### PR TITLE
Tab-complete for file downloads

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -412,6 +412,7 @@ class Console::CommandDispatcher::Stdapi::Fs
   alias :cmd_mv_tabs :cmd_cat_tabs
   alias :cmd_move_tabs :cmd_cat_tabs
   alias :cmd_rename_tabs :cmd_cat_tabs
+  alias :cmd_download_tabs :cmd_cat_tabs
 
   #
   # Move source to destination


### PR DESCRIPTION
This adds tab completion support for the file download command on meterpreter. Most other file-based commands (e.g. `cat`, `move`, `rm`, `chmod`) already supported this; this just uses the same code path for downloading files.

## Verification

- Run `msfconsole`
- Launch meterpreter (on various systems)
- Type `download`
- Tab-complete a file path and filename