### PR TITLE
Fix bug in tab completion in case-sensitive situations

### DIFF
--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -28,6 +28,7 @@ begin
         ::Readline.basic_word_break_characters = ""
         @rl_saved_proc = with_error_handling(tab_complete_proc)
         ::Readline.completion_proc = @rl_saved_proc
+        ::Readline.completion_case_fold = true
       end
     end
 


### PR DESCRIPTION
This resolves a bug in tab completion for paths on Windows when there are multiple options for tab completion, but these have different cases (i.e. uppercase vs lowercase).

## Reproduction steps

- Create a meterpreter session on Windows
- Create two files or folders in the same directory that start with the same few letters, but with different case; e.g. test1 and Test2
- Attempt to tab-complete these files (i.e. type `C:\\Users\\user\\Documents\\tes` and then press <tab>)
- Expected behaviour: Line is completed to either "C:\\Users\\user\\Documents\\test" or "C:\\Users\\user\\Documents\\Test", and a second <tab> will show both files as options
- Actual behaviour: Line is reverted to just "C:\\Users\\user\\Documents\\", removing the "tes" component of the path

## Root Cause

The root cause behind this is the case sensitivity setting for the Readline module: its tab-completion behaviour expects the options provided by the overridden `completion_proc` to extend the value currently in its buffer. If Readline is set to be case-sensitive, but we provide case-insensitive possible matches, it'll get confused, and reverts its buffer back to the point where the two options did not diverge in case.

By telling Readline to treat the options as case-insensitive, the issue is resolved. This should not affect situations where the behaviour is expected be case-sensitive (e.g. Linux systems), because the options provided to Readline in the `completion_proc` override are themselves all case sensitive (i.e. Mettle on Linux does a case-sensitive file search, and provides these options back to MSF, so Readline's case sensitivity doesn't matter at that point.

## Verification

- [x] Start `msfconsole`
- [x] Create a meterpreter session on Windows
- [x] Create two files or folders in the same directory that start with the same few letters, but with different case; e.g. testing1 and Testing2; or tesTing1 and testing2
- [x] Attempt to tab-complete these files (i.e. type `C:\\Users\\user\\Documents\\tes` and then press <tab>)
- [x] Verify that the tab completion completes as much as these two files/folders have in common (ignoring case), which, in the case of the above examples, should be "testing"
- [x] Verify that a second press of the tab button shows both values as options
- [x] Create a meterpreter session on Linux
- [x] Create two files or folders in the same directory that start with the same few letters, but with different case; e.g. testing1 and Testing2; or tesTing1 and testing2
- [x] Attempt to tab-complete these files (i.e. type `tes` and then press <tab>)
- [x] Verify that tab completion only matches against values that match the case of the requested file
