### PR TITLE
User agent refresh

### DIFF
--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -118,7 +118,7 @@ class Auxiliary::Web::HTTP
 
     c.set_config({
       'vhost' => opts[:target].vhost,
-      'agent' => opts[:user_agent] || 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)',
+      'agent' => opts[:user_agent] || Rex::UserAgent.session_agent,
       'domain' => domain
     })
     c

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -35,7 +35,7 @@ module Exploit::Remote::HttpClient
     register_advanced_options(
       [
         OptString.new('UserAgent', [false, 'The User-Agent header to use for all requests',
-                                    Rex::UserAgent.session_agent
+          Rex::UserAgent.session_agent
           ]),
         OptString.new('HttpUsername', [false, 'The HTTP username to specify for authentication', '']),
         OptString.new('HttpPassword', [false, 'The HTTP password to specify for authentication', '']),

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -35,7 +35,7 @@ module Exploit::Remote::HttpClient
     register_advanced_options(
       [
         OptString.new('UserAgent', [false, 'The User-Agent header to use for all requests',
-          Rex::Proto::Http::Client::DefaultUserAgent
+          Rex::Proto::Http::ClientRequest.DefaultUserAgent
           ]),
         OptString.new('HttpUsername', [false, 'The HTTP username to specify for authentication', '']),
         OptString.new('HttpPassword', [false, 'The HTTP password to specify for authentication', '']),

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -35,7 +35,7 @@ module Exploit::Remote::HttpClient
     register_advanced_options(
       [
         OptString.new('UserAgent', [false, 'The User-Agent header to use for all requests',
-          Rex::Proto::Http::ClientRequest.DefaultUserAgent
+                                    Rex::UserAgent.session_agent
           ]),
         OptString.new('HttpUsername', [false, 'The HTTP username to specify for authentication', '']),
         OptString.new('HttpPassword', [false, 'The HTTP password to specify for authentication', '']),

--- a/lib/msf/core/exploit/remote/mssql_sqli.rb
+++ b/lib/msf/core/exploit/remote/mssql_sqli.rb
@@ -151,7 +151,6 @@ module Exploit::Remote::MSSQL_SQLI
         'cookie'       => datastore['COOKIE'],
         'headers'      => {
           'Accept'	=> '*/*',
-          'User-Agent'	=> 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
         }
       }, 5)
     else
@@ -169,7 +168,6 @@ module Exploit::Remote::MSSQL_SQLI
         'cookie'       => datastore['COOKIE'],
         'headers'      => {
           'Accept'	=> '*/*',
-          'User-Agent'	=> 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
         }
       }, 5)
     end

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -69,7 +69,7 @@ module ReverseHttp
         ),
         OptString.new('HttpUserAgent',
           'The user-agent that the payload should use for communication',
-          default: Rex::UserAgent.shortest,
+          default: Rex::UserAgent.random,
           aliases: ['MeterpreterUserAgent'],
           max_length: Rex::Payloads::Meterpreter::Config::UA_SIZE - 1
         ),

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -27,6 +27,7 @@ class PayloadCachedSize
       'RC4PASSWORD' => 'Metasploit',
       'DNSZONE' => 'corelan.eu',
       'PEXEC' => '/bin/sh',
+      'HttpUserAgent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0',
       'StagerURILength' => 5
     },
     'Encoder'     => nil,

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -889,8 +889,7 @@ private
         url << generate_uri_uuid(sum, opts[:uuid]) + '/'
       end
 
-      # TODO: randomise if not specified?
-      opts[:ua] ||= 'Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)'
+      opts[:ua] ||= Rex::UserAgent.random
       request.add_tlv(TLV_TYPE_TRANS_UA, opts[:ua])
 
       if transport == 'reverse_https' && opts[:cert] # currently only https transport offers ssl

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -18,8 +18,6 @@ module Http
 ###
 class Client
 
-  DefaultUserAgent = ClientRequest::DefaultUserAgent
-
   #
   # Creates a new client instance
   #
@@ -39,6 +37,7 @@ class Client
       'read_max_data'   => (1024*1024*1),
       'vhost'           => self.hostname,
     })
+    self.config['agent'] ||= Http::ClientRequest.DefaultUserAgent
 
     # XXX: This info should all be controlled by ClientRequest
     self.config_types = {

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -37,7 +37,7 @@ class Client
       'read_max_data'   => (1024*1024*1),
       'vhost'           => self.hostname,
     })
-    self.config['agent'] ||= Http::ClientRequest.DefaultUserAgent
+    self.config['agent'] ||= Rex::UserAgent.session_agent
 
     # XXX: This info should all be controlled by ClientRequest
     self.config_types = {

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -12,26 +12,6 @@ module Http
 
 class ClientRequest
 
-  def self.DefaultUserAgent
-    options = [
-      # Chrome
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36',
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36',
-
-      # Edge
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36 Edg/95.0.1020.44',
-
-      # Safari
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15',
-
-      # Firefox
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0',
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 12.0; rv:94.0) Gecko/20100101 Firefox/94.0',
-    ]
-    options.sample
-  end
-  
   DefaultConfig = {
     #
     # Regular HTTP stuff
@@ -106,7 +86,7 @@ class ClientRequest
 
   def initialize(opts={})
     @opts = DefaultConfig.merge(opts)
-    @opts['agent'] ||= DefaultUserAgent
+    @opts['agent'] ||= Rex::UserAgent.session_agent
     @opts['headers'] ||= {}
   end
 

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -12,12 +12,31 @@ module Http
 
 class ClientRequest
 
-  DefaultUserAgent = "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
+  def self.DefaultUserAgent
+    options = [
+      # Chrome
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36',
+
+      # Edge
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36 Edg/95.0.1020.44',
+
+      # Safari
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15',
+
+      # Firefox
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 12.0; rv:94.0) Gecko/20100101 Firefox/94.0',
+    ]
+    options.sample
+  end
+  
   DefaultConfig = {
     #
     # Regular HTTP stuff
     #
-    'agent'                  => DefaultUserAgent,
+    'agent'                  => nil,
     'cgi'                    => true,
     'cookie'                 => nil,
     'data'                   => '',
@@ -87,6 +106,7 @@ class ClientRequest
 
   def initialize(opts={})
     @opts = DefaultConfig.merge(opts)
+    @opts['agent'] ||= DefaultUserAgent
     @opts['headers'] ||= {}
   end
 

--- a/lib/rex/user_agent.rb
+++ b/lib/rex/user_agent.rb
@@ -21,7 +21,7 @@ module Rex::UserAgent
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36 Edg/95.0.1020.44',
 
       # Safari
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
+      'Mozilla/5.0 (iPad; CPU OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15',
 
       # Firefox

--- a/lib/rex/user_agent.rb
+++ b/lib/rex/user_agent.rb
@@ -13,85 +13,34 @@ module Rex::UserAgent
   # This list is in the order of most common to least common.
   #
   COMMON_AGENTS = [
-    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/600.6.3 (KHTML, like Gecko) Version/8.0.6 Safari/600.6.3',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko',
-    'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12',
-    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:39.0) Gecko/20100101 Firefox/39.0',
-    'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko',
-    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.125 Safari/537.36',
-    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/8.0.5 Safari/600.5.17',
-    'Mozilla/5.0 (Windows NT 6.1; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.6.3 (KHTML, like Gecko) Version/7.1.6 Safari/537.85.15',
-    'Mozilla/5.0 (iPad; CPU OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F69 Safari/600.1.4',
-    'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko',
-    'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:39.0) Gecko/20100101 Firefox/39.0',
-    'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/8.0.6 Safari/600.6.3',
-    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/43.0.2357.81 Chrome/43.0.2357.81 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:39.0) Gecko/20100101 Firefox/39.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
-    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 5.1; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)',
-    'Mozilla/5.0 (Windows NT 6.1; rv:39.0) Gecko/20100101 Firefox/39.0',
-    'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)',
-    'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/600.4.10 (KHTML, like Gecko) Version/8.0.4 Safari/600.4.10',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.11 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.11',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.78.2 (KHTML, like Gecko) Version/6.1.6 Safari/537.78.2',
-    'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
-    'Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/600.3.18 (KHTML, like Gecko) Version/8.0.3 Safari/600.3.18',
-    'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:31.0) Gecko/20100101 Firefox/31.0',
-    'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
-    'Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.59.10 (KHTML, like Gecko) Version/5.1.9 Safari/534.59.10',
-    'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.152 Safari/537.36',
-    'Mozilla/5.0 (X11; Linux x86_64; rv:31.0) Gecko/20100101 Firefox/31.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:38.0) Gecko/20100101 Firefox/38.0',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (X11; Linux x86_64; rv:31.0) Gecko/20100101 Firefox/31.0 Iceweasel/31.7.0',
-    'Mozilla/5.0 (iPad; CPU OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H143 Safari/600.1.4',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/7.1.7 Safari/537.85.16',
-    'Mozilla/5.0 (Windows NT 6.1; rv:31.0) Gecko/20100101 Firefox/31.0',
-    'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:37.0) Gecko/20100101 Firefox/37.0',
+      # Chrome
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36',
+
+      # Edge
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36 Edg/95.0.1020.44',
+
+      # Safari
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15',
+
+      # Firefox
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 12.0; rv:94.0) Gecko/20100101 Firefox/94.0',
   ]
+
+  #
+  # A randomly-selected agent that will be consistent for the duration of metasploit running
+  #
+  def self.session_agent
+    if @@session_agent
+      @@session_agent
+    else
+      @@session_agent = self.random
+    end
+  end
+
+  @@session_agent = nil
 
   #
   # Pick a random agent from the common agent list.

--- a/modules/auxiliary/gather/cloud_lookup.rb
+++ b/modules/auxiliary/gather/cloud_lookup.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Auxiliary
       OptBool.new('ALLOW_NOWAF', [true, 'Automatically switch to NoWAFBypass when detection fails with the Automatic action', false]),
       OptBool.new('ENUM_BRT', [true, 'Set DNS bruteforce as optional', true]),
       OptBool.new('REPORT_LEAKS', [true, 'Set to write leaked ip addresses in notes', false]),
-      OptString.new('USERAGENT', [true, 'Specify a personalized User-Agent header in HTTP requests', Rex::Proto::Http::ClientRequest.DefaultUserAgent]),
+      OptString.new('USERAGENT', [true, 'Specify a personalized User-Agent header in HTTP requests', Rex::UserAgent.session_agent]),
       OptEnum.new('TAG', [true, 'Specify the HTML tag in which you want to find the fingerprint', 'title', ['title', 'html']]),
       OptInt.new('HTTP_TIMEOUT', [true, 'HTTP(s) request timeout', 8]),
     ])

--- a/modules/auxiliary/gather/cloud_lookup.rb
+++ b/modules/auxiliary/gather/cloud_lookup.rb
@@ -121,7 +121,12 @@ class MetasploitModule < Msf::Auxiliary
             }
           ],
         ],
-        'DefaultAction' => 'Automatic'
+        'DefaultAction' => 'Automatic',
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
       )
     )
 
@@ -143,7 +148,7 @@ class MetasploitModule < Msf::Auxiliary
       OptBool.new('ALLOW_NOWAF', [true, 'Automatically switch to NoWAFBypass when detection fails with the Automatic action', false]),
       OptBool.new('ENUM_BRT', [true, 'Set DNS bruteforce as optional', true]),
       OptBool.new('REPORT_LEAKS', [true, 'Set to write leaked ip addresses in notes', false]),
-      OptString.new('USERAGENT', [true, 'Specify a personalized User-Agent header in HTTP requests', 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:56.0) Gecko/20100101 Firefox/56.0']),
+      OptString.new('USERAGENT', [true, 'Specify a personalized User-Agent header in HTTP requests', Rex::Proto::Http::ClientRequest.DefaultUserAgent]),
       OptEnum.new('TAG', [true, 'Specify the HTML tag in which you want to find the fingerprint', 'title', ['title', 'html']]),
       OptInt.new('HTTP_TIMEOUT', [true, 'HTTP(s) request timeout', 8]),
     ])

--- a/modules/auxiliary/gather/search_email_collector.rb
+++ b/modules/auxiliary/gather/search_email_collector.rb
@@ -42,7 +42,6 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Searching Google for email addresses from #{targetdom}")
     response = ""
     emails = []
-    header = { 'User-Agent' => "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"}
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("www.google.com")
     searches = ["100", "200","300", "400", "500"]
     searches.each { |num|
@@ -62,7 +61,6 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Searching Yahoo for email addresses from #{targetdom}")
     response = ""
     emails = []
-    header = { 'User-Agent' => "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/4.0.221.6 Safari/525.13"}
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("search.yahoo.com")
     searches = ["1", "101","201", "301", "401", "501"]
     searches.each { |num|
@@ -83,7 +81,6 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Searching Bing email addresses from #{targetdom}")
     response = ""
     emails = []
-    header = { 'User-Agent' => "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/4.0.221.6 Safari/525.13"}
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("www.bing.com")
     searches = 1
     while searches < 201

--- a/modules/auxiliary/gather/search_email_collector.rb
+++ b/modules/auxiliary/gather/search_email_collector.rb
@@ -42,6 +42,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Searching Google for email addresses from #{targetdom}")
     response = ""
     emails = []
+    header = { 'User-Agent' => "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"}
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("www.google.com")
     searches = ["100", "200","300", "400", "500"]
     searches.each { |num|
@@ -61,6 +62,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Searching Yahoo for email addresses from #{targetdom}")
     response = ""
     emails = []
+    header = { 'User-Agent' => Rex::UserAgent.session_agent }
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("search.yahoo.com")
     searches = ["1", "101","201", "301", "401", "501"]
     searches.each { |num|
@@ -81,6 +83,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Searching Bing email addresses from #{targetdom}")
     response = ""
     emails = []
+    header = { 'User-Agent' => Rex::UserAgent.session_agent }
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("www.bing.com")
     searches = 1
     while searches < 201

--- a/modules/auxiliary/scanner/http/enum_wayback.rb
+++ b/modules/auxiliary/scanner/http/enum_wayback.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
   def pull_urls(targetdom)
     response = ""
     pages = []
-    header = { 'User-Agent' => "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/4.0.221.6 Safari/525.13"}
+    header = { 'User-Agent' => Rex::Proto::Http::ClientRequest.DefaultUserAgent }
     # https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("web.archive.org")
     resp = clnt.get2("/cdx/search/cdx?url="+Rex::Text.uri_encode("#{targetdom}/*")+"&fl=original",header)

--- a/modules/auxiliary/scanner/http/enum_wayback.rb
+++ b/modules/auxiliary/scanner/http/enum_wayback.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
   def pull_urls(targetdom)
     response = ""
     pages = []
-    header = { 'User-Agent' => Rex::Proto::Http::ClientRequest.DefaultUserAgent }
+    header = { 'User-Agent' => Rex::UserAgent.session_agent }
     # https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("web.archive.org")
     resp = clnt.get2("/cdx/search/cdx?url="+Rex::Text.uri_encode("#{targetdom}/*")+"&fl=original",header)

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('UserAgent', [ true, "The HTTP User-Agent sent in the request", 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)' ])
+        OptString.new('UserAgent', [ true, "The HTTP User-Agent sent in the request", Rex::UserAgent.session_agent ])
       ])
   end
 

--- a/modules/exploits/windows/http/exchange_proxylogon_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxylogon_rce.rb
@@ -110,6 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION],
           'AKA' => ['ProxyLogon']
         }
       )
@@ -129,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('IISWritePath', [true, 'The path where you want to write the backdoor', 'aspnet_client']),
       OptString.new('MapiClientApp', [true, 'This is MAPI client version sent in the request', 'Outlook/15.0.4815.1002']),
       OptInt.new('MaxWaitLoop', [true, 'Max counter loop to wait for OAB Virtual Dir reset', 30]),
-      OptString.new('UserAgent', [true, 'The HTTP User-Agent sent in the request', 'Mozilla/5.0'])
+      OptString.new('UserAgent', [true, 'The HTTP User-Agent sent in the request', Rex::UserAgent.session_agent])
     ])
   end
 

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('IISBasePath', [true, 'The base path where IIS wwwroot directory is', 'C:\\inetpub\\wwwroot']),
       OptString.new('IISWritePath', [true, 'The path where you want to write the backdoor', 'aspnet_client']),
       OptString.new('MapiClientApp', [true, 'This is MAPI client version sent in the request', 'Outlook/15.0.4815.1002']),
-      OptString.new('UserAgent', [true, 'The HTTP User-Agent sent in the request', 'Mozilla/5.0'])
+      OptString.new('UserAgent', [true, 'The HTTP User-Agent sent in the request', Rex::UserAgent.session_agent])
     ])
   end
 

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 115269
+  CachedSize = 115293
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 115273
+  CachedSize = 115293
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 5345
+  CachedSize = 5356
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 6154
+  CachedSize = 6165
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 569
+  CachedSize = 593
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_https.rb
+++ b/modules/payloads/stagers/python/reverse_https.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 841
+  CachedSize = 865
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/windows/reverse_http.rb
+++ b/modules/payloads/stagers/windows/reverse_http.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 427
+  CachedSize = 444
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/reverse_https.rb
+++ b/modules/payloads/stagers/windows/reverse_https.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 447
+  CachedSize = 464
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/plugins/request.rb
+++ b/plugins/request.rb
@@ -137,7 +137,7 @@ class Plugin::Requests < Msf::Plugin
         :print_body      => true,
         :print_headers   => false,
         :ssl_version     => 'Auto',
-        :user_agent      => Rex::Proto::Http::ClientRequest.DefaultUserAgent,
+        :user_agent      => Rex::UserAgent.session_agent,
         :version         => '1.1'
       }
 

--- a/plugins/request.rb
+++ b/plugins/request.rb
@@ -137,7 +137,7 @@ class Plugin::Requests < Msf::Plugin
         :print_body      => true,
         :print_headers   => false,
         :ssl_version     => 'Auto',
-        :user_agent      => Rex::Proto::Http::Client::DefaultUserAgent,
+        :user_agent      => Rex::Proto::Http::ClientRequest.DefaultUserAgent,
         :version         => '1.1'
       }
 

--- a/spec/support/shared/examples/payload_cached_size_is_consistent.rb
+++ b/spec/support/shared/examples/payload_cached_size_is_consistent.rb
@@ -102,6 +102,7 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
       'RC4PASSWORD' => 'Metasploit',
       'DNSZONE' => 'corelan.eu',
       'PEXEC' => '/bin/sh',
+      'HttpUserAgent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0',
       'StagerURILength' => 5
     },
     'Encoder'     => nil,
@@ -124,6 +125,7 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
           'RC4PASSWORD' => 'Metasploit',
           'DNSZONE' => 'corelan.eu',
           'PEXEC' => '/bin/sh',
+          'HttpUserAgent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0',
           'StagerURILength' => 5
       },
       'Encoder'     => nil,


### PR DESCRIPTION
This PR resolves #15610 - updating the User Agent string to a more modern one.

The chosen solution is to offer a range of modern User Agent strings, and have the framework randomly select one for requests made by MSF, and for payloads. I've elected to keep that UA string consistent for the duration of MSF running, as changing it for every request, or every exploit, would itself be a bit of a fingerprint in its own way.

Ideally it would be nice to have something that we don't need to manually update, but I couldn't find a great solution, so I've just hard-coded them for now.

As part of this, I also reviewed some of the modules that hard-coded a UA string in them. Most of them I was hesitant to change without the ability to test it afterwards (especially BOF exploits). I changed the ones where:
- I could find various other PoCs online that had a variety of UA strings
- It was a pretty generic request (web login, scraper, etc.)
- It was modern enough an exploit that it would be surprising not to work

I'd welcome feedback on the approach taken (i.e. randomly selecting a single UA string for duration of MSF running), as well as on whether any other modules should also have their hardcoded UA strings updated. For example, here is a subset of the ones that I looked at but didn't change, as I wasn't confident that changing it wouldn't break the exploit:

- `modules/auxiliary/admin/tikiwiki/tikidblib.rb`
- `modules/auxiliary/admin/http/typo3_sa_2009_002.rb`
- `modules/exploits/multi/http/spree_searchlogic_exec.rb`
- `modules/exploits/multi/http/novell_servicedesk_rce.rb`
- `modules/exploits/multi/http/spree_search_exec.rb`
- `modules/exploits/linux/http/goautodial_3_rce_command_injection.rb`

## Verification

- [x] Start `msfconsole`
- [x] Run a range of HTTP exploits/aux modules against a web server, and verify that they all use the same user agent string (unless hardcoded otherwise)
- [x] Run `load request`
- [x] Run `request http://<server>`
- [x] Verify that it uses the same User Agent string
- [x] Restart msfconsole and perform the above checks again (likely to be a different UA string)
- [x] Verify the set of UA strings make sense (see `lib/rex/user_agent.rb`)
- [x] Create various stageless HTTP payloads without specifying a specific UA string
- [x] Verify that they use a random user agent string from the set
- [x] Start a Windows meterpreter session
- [x] Change transports to a HTTP one, without specifying a specific UA string
- [x] Verify that it uses a random user agent string from the set