### PR TITLE
Fix SMB SpiderShare Enum

### DIFF
--- a/documentation/modules/auxiliary/scanner/smb/smb_enumshares.md
+++ b/documentation/modules/auxiliary/scanner/smb/smb_enumshares.md
@@ -1,6 +1,8 @@
 ## Description
 
 The `smb_enumshares` module, as would be expected, enumerates any SMB shares that are available on a remote system.
+The module can also recursively go through each directory in each share and gather information about the files inside them.
+On some systems such as Windows 7, it can also iterate over user directories and `%appdata%`.
 
 ## Verification Steps
 
@@ -11,53 +13,49 @@ The `smb_enumshares` module, as would be expected, enumerates any SMB shares tha
 
 ## Scenarios
 
-### Uncredentialed
+### Uncredentialed - Windows 10 Target
 
 ```
-msf > use auxiliary/scanner/smb/smb_enumshares
-msf auxiliary(smb_enumshares) > set RHOSTS 192.168.1.150-165
-RHOSTS => 192.168.1.150-165
-msf auxiliary(smb_enumshares) > set THREADS 16
-THREADS => 16
-msf auxiliary(smb_enumshares) > run
+msf6 auxiliary(scanner/smb/smb_enumshares) > set SpiderProfiles false
+SpiderProfiles => false
+msf6 auxiliary(scanner/smb/smb_enumshares) > set SpiderShares false
+SpiderShares => false
+msf6 auxiliary(scanner/smb/smb_enumshares) > set RHOSTS 192.168.129.131
+RHOSTS => 192.168.129.131
+msf6 auxiliary(scanner/smb/smb_enumshares) > run
 
-[*] 192.168.1.154:139 print$ - Printer Drivers (DISK), tmp - oh noes! (DISK), opt -  (DISK), IPC$ - IPC Service (metasploitable server (Samba 3.0.20-Debian)) (IPC), ADMIN$ - IPC Service (metasploitable server (Samba 3.0.20-Debian)) (IPC)
-Error: 192.168.1.160 Rex::Proto::SMB::Exceptions::ErrorCode The server responded with error: STATUS_ACCESS_DENIED (Command=37 WordCount=0)
-Error: 192.168.1.160 Rex::Proto::SMB::Exceptions::ErrorCode The server responded with error: STATUS_ACCESS_DENIED (Command=37 WordCount=0)
-[*] 192.168.1.161:139 IPC$ - Remote IPC (IPC), ADMIN$ - Remote Admin (DISK), C$ - Default share (DISK)
-Error: 192.168.1.162 Rex::Proto::SMB::Exceptions::ErrorCode The server responded with error: STATUS_ACCESS_DENIED (Command=37 WordCount=0)
-Error: 192.168.1.150 Rex::Proto::SMB::Exceptions::ErrorCode The server responded with error: STATUS_ACCESS_DENIED (Command=37 WordCount=0)
-Error: 192.168.1.150 Rex::Proto::SMB::Exceptions::ErrorCode The server responded with error: STATUS_ACCESS_DENIED (Command=37 WordCount=0)
-[*] Scanned 06 of 16 hosts (037% complete)
-[*] Scanned 09 of 16 hosts (056% complete)
-[*] Scanned 10 of 16 hosts (062% complete)
-[*] Scanned 14 of 16 hosts (087% complete)
-[*] Scanned 15 of 16 hosts (093% complete)
-[*] Scanned 16 of 16 hosts (100% complete)
+[*] 192.168.129.131:139   - Starting module
+[-] 192.168.129.131:139   - Login Failed: The SMB server did not reply to our request
+[*] 192.168.129.131:445   - Starting module
+[-] 192.168.129.131:445   - Login Failed: (0xc000006d) STATUS_LOGON_FAILURE: The attempted logon is invalid. This is either due to a bad username or authentication information.
+[*] 192.168.129.131:      - Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
-msf auxiliary(smb_enumshares) >
 ```
 
-### Credentialed
+### Credentialed - Windows 10 Target
 
 As you can see in the previous scan, access is denied to most of the systems that are probed.
 Doing a Credentialed scan produces much different results.
 
 ```
-msf auxiliary(smb_enumshares) > set SMBPass s3cr3t
-SMBPass => s3cr3t
-msf auxiliary(smb_enumshares) > set SMBUser Administrator
-SMBUser => Administrator
-msf auxiliary(smb_enumshares) > run
+msf6 auxiliary(scanner/smb/smb_enumshares) > set SMBPass simon
+SMBPass => simon
+msf6 auxiliary(scanner/smb/smb_enumshares) > set SMBUser simon
+SMBUser => simon
+msf6 auxiliary(scanner/smb/smb_enumshares) > run
 
-[*] 192.168.1.161:139 IPC$ - Remote IPC (IPC), ADMIN$ - Remote Admin (DISK), C$ - Default share (DISK)
-[*] 192.168.1.160:139 IPC$ - Remote IPC (IPC), ADMIN$ - Remote Admin (DISK), C$ - Default share (DISK)
-[*] 192.168.1.150:139 IPC$ - Remote IPC (IPC), ADMIN$ - Remote Admin (DISK), C$ - Default share (DISK)
-[*] Scanned 06 of 16 hosts (037% complete)
-[*] Scanned 07 of 16 hosts (043% complete)
-[*] Scanned 12 of 16 hosts (075% complete)
-[*] Scanned 15 of 16 hosts (093% complete)
-[*] Scanned 16 of 16 hosts (100% complete)
+[*] 192.168.129.131:139   - Starting module
+[-] 192.168.129.131:139   - Login Failed: The SMB server did not reply to our request
+[*] 192.168.129.131:445   - Starting module
+[!] 192.168.129.131:445   - peer_native_os is only available with SMB1 (current version: SMB3)
+[!] 192.168.129.131:445   - peer_native_lm is only available with SMB1 (current version: SMB3)
+[+] 192.168.129.131:445   - ADMIN$ - (DISK) Remote Admin
+[+] 192.168.129.131:445   - C$ - (DISK) Default share
+[+] 192.168.129.131:445   - IPC$ - (IPC) Remote IPC
+[+] 192.168.129.131:445   - MySharesOnWin10 - (DISK)
+[+] 192.168.129.131:445   - print$ - (DISK) Printer Drivers
+[+] 192.168.129.131:445   - TestPrinter - (PRINTER) Test Printer
+[*] 192.168.129.131:      - Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
-msf auxiliary(smb_enumshares) >
 ```
+The disconnect on port 139 happens because Windows 10 uses SMB3, which operates on port 445 instead.

--- a/lib/rex/proto/smb/simple_client.rb
+++ b/lib/rex/proto/smb/simple_client.rb
@@ -253,4 +253,3 @@ end
 end
 end
 end
-

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Auxiliary
       list = tree.list(directory: subdir)
     rescue RubySMB::Error::UnexpectedStatusCode => e
       vprint_error("Error when trying to list tree contents in #{share[:name]}\\#{subdir} - #{e.status_code.name}")
-      return read, write, msg, []
+      return read, write, msg, nil
     end
 
     rfd = []
@@ -136,9 +136,9 @@ class MetasploitModule < Msf::Auxiliary
   def get_user_dirs(tree, share, base)
     dirs = []
 
-    _read, _write, _type, files = enum_tree(tree, share, base)
+    read, _write, _type, files = enum_tree(tree, share, base)
 
-    return dirs if files.nil?
+    return dirs if files.nil? || !read
 
     files.each do |f|
       dirs.push("\\#{base}\\#{f[:file_name].encode('UTF-8')}")
@@ -202,9 +202,9 @@ class MetasploitModule < Msf::Auxiliary
           next
         end
 
-        read, write, _type, files = enum_tree(tree, share, subdirs.first)
+        read, _write, _type, files = enum_tree(tree, share, subdirs.first)
 
-        if files && (read || write) && files.empty?
+        if files.nil? || files.empty? || !read
           subdirs.shift
           next
         end

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -199,7 +199,12 @@ class MetasploitModule < Msf::Auxiliary
         end
         depth = subdirs.first.count('\\')
 
-        if DEFAULT_SHARES.include?(share_name) && datastore['SpiderProfiles'] && ((depth - 2) > datastore['MaxDepth'])
+        if datastore['SpiderProfiles'] && DEFAULT_SHARES.include?(share_name)
+          if (depth - 2) > datastore['MaxDepth']
+            subdirs.shift
+            next
+          end
+        elsif depth > datastore['MaxDepth']
           subdirs.shift
           next
         end

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -23,16 +23,14 @@ class MetasploitModule < Msf::Auxiliary
           This module determines what shares are provided by the SMB service and which ones
           are readable/writable. It also collects additional information such as share types,
           directories, files, time stamps, etc.
-
-          By default, a netshareenum request is done in order to retrieve share information,
-          but if this fails, you may also fall back to SRVSVC.
         },
         'Author' => [
           'hdm',
           'nebulus',
           'sinn3r',
           'r3dy',
-          'altonjx'
+          'altonjx',
+          'sjanusz-r7'
         ],
         'License' => MSF_LICENSE,
         'DefaultOptions' => {
@@ -48,113 +46,66 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('SpiderProfiles', [false, 'Spider only user profiles when share = C$', true]),
         OptEnum.new('LogSpider', [false, '0 = disabled, 1 = CSV, 2 = table (txt), 3 = one liner (txt)', 3, [0, 1, 2, 3]]),
         OptInt.new('MaxDepth', [true, 'Max number of subdirectories to spider', 999]),
+        OptInt.new('RPORT', [true, 'Which port to connect to', 445])
       ]
     )
-
-    deregister_options('RPORT')
   end
 
-  def device_type_int_to_text(device_type)
-    types = [
-      'UNSET', 'BEEP', 'CDROM', 'CDROM FILE SYSTEM', 'CONTROLLER', 'DATALINK',
-      'DFS', 'DISK', 'DISK FILE SYSTEM', 'FILE SYSTEM', 'INPORT PORT', 'KEYBOARD',
-      'MAILSLOT', 'MIDI IN', 'MIDI OUT', 'MOUSE', 'UNC PROVIDER', 'NAMED PIPE',
-      'NETWORK', 'NETWORK BROWSER', 'NETWORK FILE SYSTEM', 'NULL', 'PARALLEL PORT',
-      'PHYSICAL NETCARD', 'PRINTER', 'SCANNER', 'SERIAL MOUSE PORT', 'SERIAL PORT',
-      'SCREEN', 'SOUND', 'STREAMS', 'TAPE', 'TAPE FILE SYSTEM', 'TRANSPORT', 'UNKNOWN',
-      'VIDEO', 'VIRTUAL DISK', 'WAVE IN', 'WAVE OUT', '8042 PORT', 'NETWORK REDIRECTOR',
-      'BATTERY', 'BUS EXTENDER', 'MODEM', 'VDM'
-    ]
+  # Updated types for RubySMB. These are all the types we can ever receive from calling net_share_enum_all
+  ENUMERABLE_TYPES = ['DISK', 'TEMPORARY'].freeze
+  SKIPPABLE_TYPES = ['PRINTER', 'IPC', 'DEVICE', 'SPECIAL'].freeze
 
-    types[device_type]
+  def rport
+    @rport || datastore['RPORT']
   end
 
-  def to_unix_time(thi, tlo)
-    t = ::Time.at(::Rex::Proto::SMB::Utils.time_smb_to_unix(thi, tlo))
-    t.strftime('%m-%d-%Y %H:%M:%S')
-  end
-
-  def eval_host(ip, share, subdir = '')
-    read = write = false
-
-    # srvsvc adds a null byte that needs to be removed
-    share = share.chomp("\x00")
-
-    return false, false, nil, nil if share == 'IPC$'
-
-    simple.connect("\\\\#{ip}\\#{share}")
-
-    begin
-      # XXX: not implemented with RubySMB client, should I implement it?
-      device_type = simple.client.queryfs_fs_device['device_type']
-      unless device_type
-        vprint_error("\\\\#{ip}\\#{share}: Error querying filesystem device type")
-        return false, false, nil, nil
-      end
-    rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
-      err = e.to_s.scan(/The server responded with error: (\w+)/i).flatten[0]
-      case err
-      when /0xffff0002/
-        # 0xffff0002 means that the server can't handle the request for device type
-        device_type = -1
-      when /STATUS_INVALID_DEVICE_REQUEST/
-        return false, false, 'Invalid device request'
-      when /0x00040002/
-        # Samba may throw this error too
-        return false, false, 'Mac/Apple Clipboard?'
-      when /STATUS_NETWORK_ACCESS_DENIED/, /0x00030001/, /0x00060002/
-        # 0x0006002 = bad network name, 0x0030001 Directory not found
-        return false, false, nil, nil
-      else
-        vprint_error("\\\\#{ip}\\#{share}: Error querying filesystem device type")
-        return false, false, nil, nil
-      end
-    end
+  def eval_tree(tree, share_type, subdir = '')
+    subdir = subdir[1..subdir.length] if subdir.starts_with?('\\')
+    read = tree.permissions.read_ea == 1
+    write = tree.permissions.write_ea == 1
+    share = tree.share.split('\\').last
 
     skip = false
-    msg = ''
-    case device_type
-    when -1
-      msg = 'Unable to determine device'
-    when 1, 21..29, 34..35, 37..44
+
+    if ENUMERABLE_TYPES.include? share_type
+      msg = share_type
+    elsif SKIPPABLE_TYPES.include? share_type
+      msg = share_type
       skip = true
-      msg = "Unhandled Device Type (#{device_type})"
-    when 2..16, 18..20, 30..33, 36
-      msg = device_type_int_to_text(device_type)
-    when 17
-      skip = true
-      msg = device_type_int_to_text(device_type)
     else
-      msg = 'Unknown Device Type'
-      msg << " (#{device_type})" if device_type
+      msg = "Unhandled Device Type (#{share_type})"
+      skip = true
     end
 
+    print_status "Skipping share: #{share}" if skip
     return read, write, msg, nil if skip
 
-    rfd = simple.client.find_first("#{subdir}\\*")
-    read = true if !rfd.nil?
+    # Create list after possibly skipping a share we wouldn't be able to access.
+    begin
+      list = tree.list(directory: subdir)
+    rescue RubySMB::Error::UnexpectedStatusCode => e
+      print_error e.to_s
+      return read, write, msg, nil
+    end
 
-    # Test writable
-    filename = Rex::Text.rand_text_alpha(rand(8))
-    wfd = simple.open("\\#{filename}", 'rwct')
-    wfd << Rex::Text.rand_text_alpha(rand(1024))
-    wfd.close
-    simple.delete("\\#{filename}")
-    simple.disconnect("\\\\#{ip}\\#{share}")
+    rfd = []
+    list.entries.each do |file|
+      file_name = file.file_name.strip.encode('UTF-8')
+      next if file_name == '.' || file_name == '..'
 
-    # Operating under assumption STATUS_ACCESS_DENIED or the like will get
-    # thrown before write=true
-    write = true
+      rfd.push(file)
+    end
 
     return read, write, msg, rfd
-  rescue ::Rex::Proto::SMB::Exceptions::NoReply, ::Rex::Proto::SMB::Exceptions::InvalidType,
-         ::Rex::Proto::SMB::Exceptions::ReadPacket, ::Rex::Proto::SMB::Exceptions::ErrorCode
-    return read, false, msg, rfd
+  rescue RubySMB::Error::UnexpectedStatusCode => e
+    print_error e.to_s
   end
 
-  def get_os_info(ip, rport)
+  def get_os_info(ip)
     os = smb_fingerprint
-    os_info = "#{os['os']} #{os['sp']} (#{os['lang']})" if os['os'] != 'Unknown'
+    if os['os'] != 'Unknown'
+      os_info = "#{os['os']} #{os['sp']} (#{os['lang']})"
+    end
     if os_info
       report_service(
         host: ip,
@@ -168,19 +119,16 @@ class MetasploitModule < Msf::Auxiliary
     os_info
   end
 
-  def get_user_dirs(ip, share, base, sub_dirs)
+  def get_user_dirs(tree, share_type, base, sub_dirs)
     dirs = []
     usernames = []
 
     begin
-      read, write, type, files = eval_host(ip, share, base)
+      _read, _write, _type, files = eval_tree(tree, share_type, base)
       # files or type could return nil due to various conditions
       return dirs if files.nil?
-
       files.each do |f|
-        if (f[0] != '.') && (f[0] != '..')
-          usernames.push(f[0])
-        end
+        usernames.push(f)
       end
       usernames.each do |username|
         sub_dirs.each do |sub_dir|
@@ -189,25 +137,24 @@ class MetasploitModule < Msf::Auxiliary
       end
       return dirs
     rescue StandardError
+      print_status "Error when trying to access: #{base}"
       return dirs
     end
   end
 
-  def profile_options(ip, share)
+  def profile_options(tree, share_type)
     old_dirs = ['My Documents', 'Desktop']
     new_dirs = ['Desktop', 'Documents', 'Downloads', 'Music', 'Pictures', 'Videos']
 
-    dirs = get_user_dirs(ip, share, 'Documents and Settings', old_dirs)
+    dirs = get_user_dirs(tree, share_type, 'Documents and Settings', old_dirs)
     if dirs.blank?
-      dirs = get_user_dirs(ip, share, 'Users', new_dirs)
+      dirs = get_user_dirs(tree, share_type, 'Users', new_dirs)
     end
-    return dirs
+
+    dirs
   end
 
-  def get_files_info(ip, _rport, shares, info)
-    read = false
-    write = false
-
+  def get_files_info(ip, shares)
     # Creating a separate file for each IP address's results.
     detailed_tbl = Rex::Text::Table.new(
       'Header' => "Spidered results for #{ip}.",
@@ -217,84 +164,103 @@ class MetasploitModule < Msf::Auxiliary
 
     logdata = ''
 
-    list = shares.collect { |e| e[0] }
-    list.each do |x|
-      x = x.strip
-      if (x == 'ADMIN$') || (x == 'IPC$')
+    shares.each do |share|
+      share_name = share[:name].strip
+      if (share_name == 'ADMIN$') || (share_name == 'IPC$')
+        next
+      end
+
+      if (share_name == 'Users') && !datastore['SpiderProfiles']
         next
       end
 
       if !datastore['ShowFiles']
-        print_status("Spidering #{x}.")
+        print_status("Spidering #{share_name}.")
       end
+
+      begin
+        tree = simple.client.tree_connect("\\\\#{ip}\\#{share_name}")
+      rescue RubySMB::Error::UnexpectedStatusCode => e
+        print_error "Error when trying to connect to share #{share_name} - #{e.status_code.name}"
+        print_status "Spider #{share_name} complete."
+        next
+      end
+
       subdirs = ['']
-      if (x.strip == 'C$') && datastore['SpiderProfiles']
-        subdirs = profile_options(ip, x)
+      if (share_name == 'C$') && datastore['SpiderProfiles']
+        subdirs = profile_options(tree, share[:type])
       end
       until subdirs.empty?
-        depth = subdirs[0].count('\\')
-        if datastore['SpiderProfiles'] && (x == 'C$')
-          if depth - 2 > datastore['MaxDepth']
+        depth = subdirs.first.count('\\')
+
+        if share_name == 'C$'
+          if datastore['SpiderProfiles']
+            if (depth - 2) > datastore['MaxDepth']
+              subdirs.shift
+              next
+            end
+          else
             subdirs.shift
             next
           end
-        elsif depth > datastore['MaxDepth']
+        end
+
+        if depth > datastore['MaxDepth']
           subdirs.shift
           next
         end
-        read, write, type, files = eval_host(ip, x, subdirs[0])
+
+        read, write, _type, files = eval_tree(tree, share[:type], subdirs.first)
+
         if files && (read || write)
-          if files.length < 3
+          if files.empty?
             subdirs.shift
             next
           end
-          header = ''
-          if simple.client.default_domain && simple.client.default_name
-            header << " \\\\#{simple.client.default_domain}"
-          end
-          header << "\\#{x.sub('C$', 'C$\\')}" if simple.client.default_name
-          header << subdirs[0]
 
+          header = ''
           pretty_tbl = Rex::Text::Table.new(
             'Header' => header,
             'Indent' => 1,
             'Columns' => [ 'Type', 'Name', 'Created', 'Accessed', 'Written', 'Changed', 'Size' ]
           )
 
-          f_types = {
-            1 => 'RO', 2 => 'HIDDEN', 4 => 'SYS', 8 => 'VOL',
-            16 => 'DIR', 32 => 'ARC', 64 => 'DEV', 128 => 'FILE'
-          }
+          if simple.client.default_domain && simple.client.default_name
+            header << " \\\\#{simple.client.default_domain}"
+          end
+          header << "\\#{share_name.sub('C$', 'C$\\')}" if simple.client.default_name
+          header << subdirs.first
 
           files.each do |file|
-            next unless file[0] && (file[0] != '.') && (file[0] != '..')
+            fname = file.file_name.encode('UTF-8')
+            tcr = file.create_time.to_datetime
+            tac = file.last_access.to_datetime
+            twr = file.last_write.to_datetime
+            tch = file.last_change.to_datetime
 
-            info = file[1]['info']
-            fa = f_types[file[1]['attr']] # Item type
-            fname = file[0] # Filename
-            tcr = to_unix_time(info[3], info[2]) # Created
-            tac = to_unix_time(info[5], info[4]) # Accessed
-            twr = to_unix_time(info[7], info[6]) # Written
-            tch = to_unix_time(info[9], info[8]) # Changed
-            sz = info[12] + info[13] # Size
+            # Add subdirectories to list to use if SpiderShare is enabled.
+            if file.file_attributes.directory == 1
+              fa = 'DIR'
+              subdirs.push(subdirs.first + '\\' + fname)
+            else
+              fa = 'FILE'
+              sz = file.end_of_file
+            end
 
             # Filename is too long for the UI table, cut it.
             fname = "#{fname[0, 35]}..." if fname.length > 35
 
-            # Add subdirectories to list to use if SpiderShare is enabled.
-            if (fa == 'DIR') || (fa.nil? && (sz == 0))
-              subdirs.push(subdirs[0] + '\\' + fname)
-            end
-
             pretty_tbl << [fa || 'Unknown', fname, tcr, tac, twr, tch, sz]
-            detailed_tbl << [ip.to_s, fa || 'Unknown', x.to_s, subdirs[0] + '\\', fname, tcr, tac, twr, tch, sz]
-            logdata << "#{ip}\\#{x.sub('C$', 'C$\\')}#{subdirs[0]}\\#{fname}\n"
+            detailed_tbl << [ip.to_s, fa || 'Unknown', share.to_s, subdirs.first + '\\', fname, tcr, tac, twr, tch, sz]
+            logdata << "#{ip}\\#{share_name.sub('C$', 'C$\\')}#{subdirs.first}\\#{fname.encode}\n"
           end
           print_good(pretty_tbl.to_s) if datastore['ShowFiles']
         end
         subdirs.shift
       end
-      print_status("Spider #{x} complete.") unless datastore['ShowFiles']
+
+      tree.disconnect! # simple.client.tree_disconnect is the same. Which is preferred?
+      print_status("Spider #{share[:name]} complete.") unless datastore['ShowFiles']
     end
     unless detailed_tbl.rows.empty?
       if datastore['LogSpider'] == '1'
@@ -310,94 +276,58 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def rport
-    @rport || datastore['RPORT']
-  end
-
-  # Overrides the one in smb.rb
-  def smb_direct
-    @smb_redirect || datastore['SMBDirect']
-  end
-
   def run_host(ip)
-    @rport = datastore['RPORT']
-    @smb_redirect = datastore['SMBDirect']
-    @srvsvc = datastore['USE_SRVSVC_ONLY']
     shares = []
+    begin
+      print_status 'Starting module'
+      connect(versions: [1, 2, 3])
+      smb_login
+      shares = simple.client.net_share_enum_all(ip)
+      os_info = get_os_info(ip)
+      print_status(os_info) if os_info
 
-    [[139, false], [445, true]].each do |info|
-      @rport = info[0]
-      @smb_redirect = info[1]
-
-      begin
-        connect
-        smb_login
-        shares = smb_netshareenumall
-
-        os_info = get_os_info(ip, rport)
-        print_status(os_info) if os_info
-
-        if shares.empty?
-          print_status('No shares collected')
-        else
-          shares_info = shares.map { |x| "#{x[0]} - (#{x[1]}) #{x[2]}" }.join(', ')
-          shares_info.split(', ').each do |share|
-            print_good share
-          end
-          report_note(
-            host: ip,
-            proto: 'tcp',
-            port: rport,
-            type: 'smb.shares',
-            data: { shares: shares },
-            update: :unique_data
-          )
-
-          if datastore['SpiderShares']
-            begin
-              connect(versions: [1])
-              smb_login
-              get_files_info(ip, rport, shares, info)
-            rescue ::Rex::Proto::SMB::Exceptions::Error, Errno::ECONNRESET => e
-              print_error(
-                "Error when Spidering shares recursively (#{e}). This feature "\
-                'is only available with Rex client (SMB1 only) and the host '\
-                "probably doesn't support SMB1."
-              )
-            end
-          end
-
-          break if rport == 139
+      if shares.empty?
+        print_status('No shares collected')
+      else
+        shares.each do |share|
+          print_good("#{share[:name]} - (#{share[:type]}) #{share[:comment]}")
         end
-      rescue ::Interrupt
-        raise $ERROR_INFO
-      rescue ::Rex::Proto::SMB::Exceptions::LoginError,
-             ::Rex::Proto::SMB::Exceptions::ErrorCode => e
-        print_error(e.message)
-        return if e.message =~ /STATUS_ACCESS_DENIED/
-      rescue Errno::ECONNRESET,
-             ::Rex::Proto::SMB::Exceptions::InvalidType,
-             ::Rex::Proto::SMB::Exceptions::ReadPacket,
-             ::Rex::Proto::SMB::Exceptions::InvalidCommand,
-             ::Rex::Proto::SMB::Exceptions::InvalidWordCount,
-             ::Rex::Proto::SMB::Exceptions::NoReply => e
-        vprint_error(e.message)
-        next if !shares.empty? && (rport == 139) # no results, try again
-      rescue Errno::ENOPROTOOPT
-        print_status('Wait 5 seconds before retrying...')
-        select(nil, nil, nil, 5)
-        retry
-      rescue ::Exception => e
-        next if e.to_s =~ /execution expired/
-        next if !shares.empty? && (rport == 139)
 
-        vprint_error("Error: '#{ip}' '#{e.class}' '#{e}'")
-      ensure
-        disconnect
+        report_note(
+          host: ip,
+          proto: 'tcp',
+          port: rport,
+          type: 'smb.shares',
+          data: { shares: shares }, # We are now storing an array of hashes here, rather than an array of arrays. Will this cause issues further down the line?
+          update: :unique_data
+        )
+
+        if datastore['SpiderShares']
+          get_files_info(ip, shares)
+        end
       end
-
-      # if we already got results, not need to try on another port
-      return unless shares.empty?
+    rescue ::Interrupt
+      raise $ERROR_INFO
+    rescue Errno::ECONNRESET => e
+      vprint_error(e.message)
+    rescue Errno::ENOPROTOOPT
+      print_status('Wait 5 seconds before retrying...')
+      select(nil, nil, nil, 5)
+      retry
+    rescue Rex::ConnectionTimeout => e
+      print_error e.to_s
+      return
+    rescue StandardError => e
+      vprint_error("Error: '#{ip}' '#{e.class}' '#{e}'")
+    ensure
+      # Calling simple.client.disconnect! might not be needed here as we also call disconnect.
+      if simple && simple.client
+        simple.client.disconnect!
+      end
+      disconnect
     end
+
+    # if we already got results, not need to try on another port
+    return unless shares.empty?
   end
 end

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -334,8 +334,8 @@ class MetasploitModule < Msf::Auxiliary
       rescue Rex::ConnectionTimeout => e
         print_error e.to_s
         return
-      rescue Rex::Proto::SMB::Exceptions::LoginError
-        print_error 'Cannot connect over NetBIOS'
+      rescue Rex::Proto::SMB::Exceptions::LoginError => e
+        print_error e.to_s
       rescue StandardError => e
         vprint_error("Error: '#{ip}' '#{e.class}' '#{e}'")
       ensure

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -99,10 +99,11 @@ class MetasploitModule < Msf::Auxiliary
       list = tree.list(directory: subdir)
     rescue RubySMB::Error::UnexpectedStatusCode => e
       vprint_error("Error when trying to list tree contents in #{share[:name]}\\#{subdir} - #{e.status_code.name}")
+      return read, write, msg, []
     end
 
     rfd = []
-    if list
+    unless list.nil? || list.empty?
       list.entries.each do |file|
         file_name = file.file_name.strip.encode('UTF-8')
         next if file_name == '.' || file_name == '..'
@@ -247,7 +248,7 @@ class MetasploitModule < Msf::Auxiliary
         print_good(pretty_tbl.to_s) if datastore['ShowFiles']
         subdirs.shift
       end
-      print_status("Spidering #{share_name} complete.") unless datastore['ShowFiles']
+      print_status("Spidering #{share_name} complete") unless datastore['ShowFiles']
     end
 
     unless detailed_tbl.rows.empty?


### PR DESCRIPTION
This PR addresses the issue #15559
It fixes the SMB share enum module to work on SMB1/2/3 using the new RubySMB library.
The module was tested and working against Windows 7 and Windows 10.
In my testing, `SpiderProfiles` works on Windows 7 but not on Windows 10.

The output should be almost identical to the old module running against SMB1 with the only difference that I can see being a different file type output.

For compatibility and parity with the old module, it will try to connect over port 139 and 445, with SMB1 and SMB1/2/3 respectively.

This module also works against Samba over SMB3. Tested against `Version 4.13.14-Ubuntu`.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/smb/smb_enumshares`
- [ ] `set rhosts {ip_address}`
- [ ] `set SpiderShares true`
- [ ] `set ShowFiles true`
- [ ] The files will be output in a table

## Windows 10 Target

### Before

![image](https://user-images.githubusercontent.com/85949464/141503218-679f9831-f8f4-45d3-b565-94fc71b7332c.png)

### After

![image](https://user-images.githubusercontent.com/85949464/141502780-7ae05d18-80b4-4224-8504-3157420fae4c.png)
(More files & directories were enumerated)

## Samba (Ubuntu) Target

### Before

![image](https://user-images.githubusercontent.com/85949464/141511816-b22fb30a-50c9-4930-a83c-adc127e6ce2b.png)

### After

![image](https://user-images.githubusercontent.com/85949464/141511948-00de7416-7b0d-4fee-8db4-6f15f83ac28d.png)