### PR TITLE
Lint smb enumshares module

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
 
   # Exploit mixins should be called first
@@ -15,54 +14,56 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => 'SMB Share Enumeration',
-      'Description'    => %q{
-        This module determines what shares are provided by the SMB service and which ones
-        are readable/writable. It also collects additional information such as share types,
-        directories, files, time stamps, etc.
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SMB Share Enumeration',
+        'Description' => %q{
+          This module determines what shares are provided by the SMB service and which ones
+          are readable/writable. It also collects additional information such as share types,
+          directories, files, time stamps, etc.
 
-        By default, a netshareenum request is done in order to retrieve share information,
-        but if this fails, you may also fall back to SRVSVC.
-      },
-      'Author'         =>
-        [
+          By default, a netshareenum request is done in order to retrieve share information,
+          but if this fails, you may also fall back to SRVSVC.
+        },
+        'Author' => [
           'hdm',
           'nebulus',
           'sinn3r',
           'r3dy',
           'altonjx'
         ],
-      'License'        => MSF_LICENSE,
-      'DefaultOptions' =>
-        {
+        'License' => MSF_LICENSE,
+        'DefaultOptions' => {
           'DCERPC::fake_bind_multi' => false
         }
-    ))
+      )
+    )
 
     register_options(
       [
-        OptBool.new('SpiderShares',      [false, 'Spider shares recursively', false]),
-        OptBool.new('ShowFiles',        [true, 'Show detailed information when spidering', false]),
-        OptBool.new('SpiderProfiles',  [false, 'Spider only user profiles when share = C$', true]),
-        OptEnum.new('LogSpider',      [false, '0 = disabled, 1 = CSV, 2 = table (txt), 3 = one liner (txt)', 3, [0,1,2,3]]),
-        OptInt.new('MaxDepth',      [true, 'Max number of subdirectories to spider', 999]),
-      ])
+        OptBool.new('SpiderShares', [false, 'Spider shares recursively', false]),
+        OptBool.new('ShowFiles', [true, 'Show detailed information when spidering', false]),
+        OptBool.new('SpiderProfiles', [false, 'Spider only user profiles when share = C$', true]),
+        OptEnum.new('LogSpider', [false, '0 = disabled, 1 = CSV, 2 = table (txt), 3 = one liner (txt)', 3, [0, 1, 2, 3]]),
+        OptInt.new('MaxDepth', [true, 'Max number of subdirectories to spider', 999]),
+      ]
+    )
 
     deregister_options('RPORT')
   end
 
   def device_type_int_to_text(device_type)
     types = [
-      "UNSET", "BEEP", "CDROM", "CDROM FILE SYSTEM", "CONTROLLER", "DATALINK",
-      "DFS", "DISK", "DISK FILE SYSTEM", "FILE SYSTEM", "INPORT PORT", "KEYBOARD",
-      "MAILSLOT", "MIDI IN", "MIDI OUT", "MOUSE", "UNC PROVIDER", "NAMED PIPE",
-      "NETWORK", "NETWORK BROWSER", "NETWORK FILE SYSTEM", "NULL", "PARALLEL PORT",
-      "PHYSICAL NETCARD", "PRINTER", "SCANNER", "SERIAL MOUSE PORT", "SERIAL PORT",
-      "SCREEN", "SOUND", "STREAMS", "TAPE", "TAPE FILE SYSTEM", "TRANSPORT", "UNKNOWN",
-      "VIDEO", "VIRTUAL DISK", "WAVE IN", "WAVE OUT", "8042 PORT", "NETWORK REDIRECTOR",
-      "BATTERY", "BUS EXTENDER", "MODEM", "VDM"
+      'UNSET', 'BEEP', 'CDROM', 'CDROM FILE SYSTEM', 'CONTROLLER', 'DATALINK',
+      'DFS', 'DISK', 'DISK FILE SYSTEM', 'FILE SYSTEM', 'INPORT PORT', 'KEYBOARD',
+      'MAILSLOT', 'MIDI IN', 'MIDI OUT', 'MOUSE', 'UNC PROVIDER', 'NAMED PIPE',
+      'NETWORK', 'NETWORK BROWSER', 'NETWORK FILE SYSTEM', 'NULL', 'PARALLEL PORT',
+      'PHYSICAL NETCARD', 'PRINTER', 'SCANNER', 'SERIAL MOUSE PORT', 'SERIAL PORT',
+      'SCREEN', 'SOUND', 'STREAMS', 'TAPE', 'TAPE FILE SYSTEM', 'TRANSPORT', 'UNKNOWN',
+      'VIDEO', 'VIRTUAL DISK', 'WAVE IN', 'WAVE OUT', '8042 PORT', 'NETWORK REDIRECTOR',
+      'BATTERY', 'BUS EXTENDER', 'MODEM', 'VDM'
     ]
 
     types[device_type]
@@ -70,27 +71,26 @@ class MetasploitModule < Msf::Auxiliary
 
   def to_unix_time(thi, tlo)
     t = ::Time.at(::Rex::Proto::SMB::Utils.time_smb_to_unix(thi, tlo))
-    t.strftime("%m-%d-%Y %H:%M:%S")
+    t.strftime('%m-%d-%Y %H:%M:%S')
   end
 
-  def eval_host(ip, share, subdir = "")
+  def eval_host(ip, share, subdir = '')
     read = write = false
 
     # srvsvc adds a null byte that needs to be removed
     share = share.chomp("\x00")
 
-    return false,false,nil,nil if share == 'IPC$'
+    return false, false, nil, nil if share == 'IPC$'
 
-    self.simple.connect("\\\\#{ip}\\#{share}")
+    simple.connect("\\\\#{ip}\\#{share}")
 
     begin
       # XXX: not implemented with RubySMB client, should I implement it?
-      device_type = self.simple.client.queryfs_fs_device['device_type']
+      device_type = simple.client.queryfs_fs_device['device_type']
       unless device_type
         vprint_error("\\\\#{ip}\\#{share}: Error querying filesystem device type")
-        return false,false,nil,nil
+        return false, false, nil, nil
       end
-
     rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
       err = e.to_s.scan(/The server responded with error: (\w+)/i).flatten[0]
       case err
@@ -98,16 +98,16 @@ class MetasploitModule < Msf::Auxiliary
         # 0xffff0002 means that the server can't handle the request for device type
         device_type = -1
       when /STATUS_INVALID_DEVICE_REQUEST/
-        return false,false,"Invalid device request"
+        return false, false, 'Invalid device request'
       when /0x00040002/
         # Samba may throw this error too
-        return false,false,"Mac/Apple Clipboard?"
+        return false, false, 'Mac/Apple Clipboard?'
       when /STATUS_NETWORK_ACCESS_DENIED/, /0x00030001/, /0x00060002/
         # 0x0006002 = bad network name, 0x0030001 Directory not found
-        return false,false,nil,nil
+        return false, false, nil, nil
       else
         vprint_error("\\\\#{ip}\\#{share}: Error querying filesystem device type")
-        return false,false,nil,nil
+        return false, false, nil, nil
       end
     end
 
@@ -115,24 +115,24 @@ class MetasploitModule < Msf::Auxiliary
     msg = ''
     case device_type
     when -1
-      msg = "Unable to determine device"
-    when 1, 21 .. 29, 34 .. 35, 37 .. 44
+      msg = 'Unable to determine device'
+    when 1, 21..29, 34..35, 37..44
       skip = true
       msg = "Unhandled Device Type (#{device_type})"
-    when 2 .. 16, 18 .. 20, 30 .. 33, 36
+    when 2..16, 18..20, 30..33, 36
       msg = device_type_int_to_text(device_type)
     when 17
       skip = true
       msg = device_type_int_to_text(device_type)
     else
-      msg = "Unknown Device Type"
+      msg = 'Unknown Device Type'
       msg << " (#{device_type})" if device_type
     end
 
-    return read,write,msg,nil if skip
+    return read, write, msg, nil if skip
 
-    rfd = self.simple.client.find_first("#{subdir}\\*")
-    read = true if rfd != nil
+    rfd = simple.client.find_first("#{subdir}\\*")
+    read = true if !rfd.nil?
 
     # Test writable
     filename = Rex::Text.rand_text_alpha(rand(8))
@@ -146,23 +146,24 @@ class MetasploitModule < Msf::Auxiliary
     # thrown before write=true
     write = true
 
-    return read,write,msg,rfd
-
-    rescue ::Rex::Proto::SMB::Exceptions::NoReply,::Rex::Proto::SMB::Exceptions::InvalidType,
-      ::Rex::Proto::SMB::Exceptions::ReadPacket,::Rex::Proto::SMB::Exceptions::ErrorCode
-      return read,false,msg,rfd
+    return read, write, msg, rfd
+  rescue ::Rex::Proto::SMB::Exceptions::NoReply, ::Rex::Proto::SMB::Exceptions::InvalidType,
+         ::Rex::Proto::SMB::Exceptions::ReadPacket, ::Rex::Proto::SMB::Exceptions::ErrorCode
+    return read, false, msg, rfd
   end
 
   def get_os_info(ip, rport)
-    os      = smb_fingerprint
-    os_info = "#{os['os']} #{os['sp']} (#{os['lang']})" if os['os'] != "Unknown"
-    report_service(
-      :host  => ip,
-      :port  => rport,
-      :proto => 'tcp',
-      :name  => 'smb',
-      :info  => os_info
-    ) if os_info
+    os = smb_fingerprint
+    os_info = "#{os['os']} #{os['sp']} (#{os['lang']})" if os['os'] != 'Unknown'
+    if os_info
+      report_service(
+        host: ip,
+        port: rport,
+        proto: 'tcp',
+        name: 'smb',
+        info: os_info
+      )
+    end
 
     os_info
   end
@@ -172,11 +173,12 @@ class MetasploitModule < Msf::Auxiliary
     usernames = []
 
     begin
-      read,write,type,files = eval_host(ip, share, base)
+      read, write, type, files = eval_host(ip, share, base)
       # files or type could return nil due to various conditions
       return dirs if files.nil?
+
       files.each do |f|
-        if f[0] != "." and f[0] != ".."
+        if (f[0] != '.') && (f[0] != '..')
           usernames.push(f[0])
         end
       end
@@ -186,126 +188,124 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
       return dirs
-    rescue
+    rescue StandardError
       return dirs
     end
   end
 
   def profile_options(ip, share)
-    old_dirs = ['My Documents','Desktop']
-    new_dirs = ['Desktop','Documents','Downloads','Music','Pictures','Videos']
+    old_dirs = ['My Documents', 'Desktop']
+    new_dirs = ['Desktop', 'Documents', 'Downloads', 'Music', 'Pictures', 'Videos']
 
-    dirs = get_user_dirs(ip, share, "Documents and Settings", old_dirs)
+    dirs = get_user_dirs(ip, share, 'Documents and Settings', old_dirs)
     if dirs.blank?
-      dirs = get_user_dirs(ip, share, "Users", new_dirs)
+      dirs = get_user_dirs(ip, share, 'Users', new_dirs)
     end
     return dirs
   end
 
-  def get_files_info(ip, rport, shares, info)
-    read  = false
+  def get_files_info(ip, _rport, shares, info)
+    read = false
     write = false
 
     # Creating a separate file for each IP address's results.
     detailed_tbl = Rex::Text::Table.new(
-      'Header'  => "Spidered results for #{ip}.",
-      'Indent'  => 1,
+      'Header' => "Spidered results for #{ip}.",
+      'Indent' => 1,
       'Columns' => [ 'IP Address', 'Type', 'Share', 'Path', 'Name', 'Created', 'Accessed', 'Written', 'Changed', 'Size' ]
     )
 
-    logdata = ""
+    logdata = ''
 
-    list = shares.collect {|e| e[0]}
+    list = shares.collect { |e| e[0] }
     list.each do |x|
       x = x.strip
-      if x == "ADMIN$" or x == "IPC$"
+      if (x == 'ADMIN$') || (x == 'IPC$')
         next
       end
-      if not datastore['ShowFiles']
+
+      if !datastore['ShowFiles']
         print_status("Spidering #{x}.")
       end
-      subdirs = [""]
-      if x.strip() == "C$" and datastore['SpiderProfiles']
+      subdirs = ['']
+      if (x.strip == 'C$') && datastore['SpiderProfiles']
         subdirs = profile_options(ip, x)
       end
-      while subdirs.length > 0
-        depth = subdirs[0].count("\\")
-        if datastore['SpiderProfiles'] and x == "C$"
-          if depth-2 > datastore['MaxDepth']
+      until subdirs.empty?
+        depth = subdirs[0].count('\\')
+        if datastore['SpiderProfiles'] && (x == 'C$')
+          if depth - 2 > datastore['MaxDepth']
             subdirs.shift
             next
           end
-        else
-          if depth > datastore['MaxDepth']
-            subdirs.shift
-            next
-          end
+        elsif depth > datastore['MaxDepth']
+          subdirs.shift
+          next
         end
-        read,write,type,files = eval_host(ip, x, subdirs[0])
-        if files and (read or write)
+        read, write, type, files = eval_host(ip, x, subdirs[0])
+        if files && (read || write)
           if files.length < 3
             subdirs.shift
             next
           end
-          header = ""
-          if simple.client.default_domain and simple.client.default_name
+          header = ''
+          if simple.client.default_domain && simple.client.default_name
             header << " \\\\#{simple.client.default_domain}"
           end
-          header << "\\#{x.sub("C$","C$\\")}" if simple.client.default_name
+          header << "\\#{x.sub('C$', 'C$\\')}" if simple.client.default_name
           header << subdirs[0]
 
           pretty_tbl = Rex::Text::Table.new(
-            'Header'  => header,
-            'Indent'  => 1,
+            'Header' => header,
+            'Indent' => 1,
             'Columns' => [ 'Type', 'Name', 'Created', 'Accessed', 'Written', 'Changed', 'Size' ]
           )
 
           f_types = {
-            1  => 'RO',  2  => 'HIDDEN', 4  => 'SYS', 8   => 'VOL',
-            16 => 'DIR', 32 => 'ARC',    64 => 'DEV', 128 => 'FILE'
+            1 => 'RO', 2 => 'HIDDEN', 4 => 'SYS', 8 => 'VOL',
+            16 => 'DIR', 32 => 'ARC', 64 => 'DEV', 128 => 'FILE'
           }
 
           files.each do |file|
-            if file[0] and file[0] != '.' and file[0] != '..'
-              info  = file[1]['info']
-              fa    = f_types[file[1]['attr']]       # Item type
-              fname = file[0]                        # Filename
-              tcr   = to_unix_time(info[3], info[2]) # Created
-              tac   = to_unix_time(info[5], info[4]) # Accessed
-              twr   = to_unix_time(info[7], info[6]) # Written
-              tch   = to_unix_time(info[9], info[8]) # Changed
-              sz    = info[12] + info[13]            # Size
+            next unless file[0] && (file[0] != '.') && (file[0] != '..')
 
-              # Filename is too long for the UI table, cut it.
-              fname = "#{fname[0, 35]}..." if fname.length > 35
+            info = file[1]['info']
+            fa = f_types[file[1]['attr']] # Item type
+            fname = file[0] # Filename
+            tcr = to_unix_time(info[3], info[2]) # Created
+            tac = to_unix_time(info[5], info[4]) # Accessed
+            twr = to_unix_time(info[7], info[6]) # Written
+            tch = to_unix_time(info[9], info[8]) # Changed
+            sz = info[12] + info[13] # Size
 
-              # Add subdirectories to list to use if SpiderShare is enabled.
-              if fa == "DIR" or (fa == nil and sz == 0)
-                subdirs.push(subdirs[0] + "\\" + fname)
-              end
+            # Filename is too long for the UI table, cut it.
+            fname = "#{fname[0, 35]}..." if fname.length > 35
 
-              pretty_tbl << [fa || 'Unknown', fname, tcr, tac, twr, tch, sz]
-              detailed_tbl << ["#{ip}", fa || 'Unknown', "#{x}", subdirs[0] + "\\", fname, tcr, tac, twr, tch, sz]
-              logdata << "#{ip}\\#{x.sub("C$","C$\\")}#{subdirs[0]}\\#{fname}\n"
-
+            # Add subdirectories to list to use if SpiderShare is enabled.
+            if (fa == 'DIR') || (fa.nil? && (sz == 0))
+              subdirs.push(subdirs[0] + '\\' + fname)
             end
+
+            pretty_tbl << [fa || 'Unknown', fname, tcr, tac, twr, tch, sz]
+            detailed_tbl << [ip.to_s, fa || 'Unknown', x.to_s, subdirs[0] + '\\', fname, tcr, tac, twr, tch, sz]
+            logdata << "#{ip}\\#{x.sub('C$', 'C$\\')}#{subdirs[0]}\\#{fname}\n"
           end
           print_good(pretty_tbl.to_s) if datastore['ShowFiles']
         end
         subdirs.shift
       end
-    print_status("Spider #{x} complete.") unless datastore['ShowFiles']
+      print_status("Spider #{x} complete.") unless datastore['ShowFiles']
     end
     unless detailed_tbl.rows.empty?
       if datastore['LogSpider'] == '1'
         p = store_loot('smb.enumshares', 'text/csv', ip, detailed_tbl.to_csv)
-        print_good("info saved in: #{p.to_s}")
+        print_good("info saved in: #{p}")
       elsif datastore['LogSpider'] == '2'
         p = store_loot('smb.enumshares', 'text/plain', ip, detailed_tbl)
-        print_good("info saved in: #{p.to_s}")
+        print_good("info saved in: #{p}")
       elsif datastore['LogSpider'] == '3'
         p = store_loot('smb.enumshares', 'text/plain', ip, logdata)
-        print_good("info saved in: #{p.to_s}")
+        print_good("info saved in: #{p}")
       end
     end
   end
@@ -320,13 +320,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    @rport        = datastore['RPORT']
+    @rport = datastore['RPORT']
     @smb_redirect = datastore['SMBDirect']
-    @srvsvc       = datastore['USE_SRVSVC_ONLY']
-    shares        = []
+    @srvsvc = datastore['USE_SRVSVC_ONLY']
+    shares = []
 
     [[139, false], [445, true]].each do |info|
-      @rport        = info[0]
+      @rport = info[0]
       @smb_redirect = info[1]
 
       begin
@@ -334,23 +334,23 @@ class MetasploitModule < Msf::Auxiliary
         smb_login
         shares = smb_netshareenumall
 
-        os_info     = get_os_info(ip, rport)
+        os_info = get_os_info(ip, rport)
         print_status(os_info) if os_info
 
         if shares.empty?
-          print_status("No shares collected")
+          print_status('No shares collected')
         else
-          shares_info = shares.map{|x| "#{x[0]} - (#{x[1]}) #{x[2]}" }.join(", ")
-          shares_info.split(", ").each { |share|
+          shares_info = shares.map { |x| "#{x[0]} - (#{x[1]}) #{x[2]}" }.join(', ')
+          shares_info.split(', ').each do |share|
             print_good share
-          }
+          end
           report_note(
-            :host   => ip,
-            :proto  => 'tcp',
-            :port   => rport,
-            :type   => 'smb.shares',
-            :data   => { :shares => shares },
-            :update => :unique_data
+            host: ip,
+            proto: 'tcp',
+            port: rport,
+            type: 'smb.shares',
+            data: { shares: shares },
+            update: :unique_data
           )
 
           if datastore['SpiderShares']
@@ -361,7 +361,7 @@ class MetasploitModule < Msf::Auxiliary
             rescue ::Rex::Proto::SMB::Exceptions::Error, Errno::ECONNRESET => e
               print_error(
                 "Error when Spidering shares recursively (#{e}). This feature "\
-                "is only available with Rex client (SMB1 only) and the host "\
+                'is only available with Rex client (SMB1 only) and the host '\
                 "probably doesn't support SMB1."
               )
             end
@@ -369,29 +369,29 @@ class MetasploitModule < Msf::Auxiliary
 
           break if rport == 139
         end
-
       rescue ::Interrupt
-        raise $!
+        raise $ERROR_INFO
       rescue ::Rex::Proto::SMB::Exceptions::LoginError,
-        ::Rex::Proto::SMB::Exceptions::ErrorCode => e
+             ::Rex::Proto::SMB::Exceptions::ErrorCode => e
         print_error(e.message)
         return if e.message =~ /STATUS_ACCESS_DENIED/
       rescue Errno::ECONNRESET,
-        ::Rex::Proto::SMB::Exceptions::InvalidType,
-        ::Rex::Proto::SMB::Exceptions::ReadPacket,
-        ::Rex::Proto::SMB::Exceptions::InvalidCommand,
-        ::Rex::Proto::SMB::Exceptions::InvalidWordCount,
-        ::Rex::Proto::SMB::Exceptions::NoReply => e
+             ::Rex::Proto::SMB::Exceptions::InvalidType,
+             ::Rex::Proto::SMB::Exceptions::ReadPacket,
+             ::Rex::Proto::SMB::Exceptions::InvalidCommand,
+             ::Rex::Proto::SMB::Exceptions::InvalidWordCount,
+             ::Rex::Proto::SMB::Exceptions::NoReply => e
         vprint_error(e.message)
-        next if not shares.empty? and rport == 139 # no results, try again
+        next if !shares.empty? && (rport == 139) # no results, try again
       rescue Errno::ENOPROTOOPT
-        print_status("Wait 5 seconds before retrying...")
+        print_status('Wait 5 seconds before retrying...')
         select(nil, nil, nil, 5)
         retry
       rescue ::Exception => e
         next if e.to_s =~ /execution expired/
-        next if not shares.empty? and rport == 139
-        vprint_error("Error: '#{ip}' '#{e.class}' '#{e.to_s}'")
+        next if !shares.empty? && (rport == 139)
+
+        vprint_error("Error: '#{ip}' '#{e.class}' '#{e}'")
       ensure
         disconnect
       end
@@ -401,4 +401,3 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 end
-


### PR DESCRIPTION
This PR has correct the lint output after running `rubocop -A` on SMB EnumShares module.