### PR TITLE
Expand environment variables on Linux

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -154,7 +154,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       end
 
       # Now find the environment variables we'll need from the client
-      env_regex = /\$(?:([A-Za-z0-9_]+)|\{([A-Za-z0-9_.]+)\})/
+      env_regex = /\$(?:([A-Za-z0-9_]+)|\{([A-Za-z0-9_]+)\})/
       matches = path.to_enum(:scan, env_regex).map { Regexp.last_match }
       env_vars = matches.map { |match| (match[1] || match[2]).to_s }.uniq
 
@@ -162,7 +162,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       env_vals = client.sys.config.getenvs(*env_vars)
 
       # Now fill them in
-      path = path.gsub(env_regex) { |z| envvar = $1; envvar = $2 if envvar == nil; env_vals[envvar] }
+      path = path.gsub(env_regex) { |_z| envvar = $1; envvar = $2 if envvar == nil; env_vals[envvar] }
       path
     end
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -123,28 +123,48 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
 
   #
   # Expands a file path, substituting all environment variables, such as
-  # %TEMP%.
+  # %TEMP% on Windows or $HOME on Unix
   #
   # Examples:
   #    client.fs.file.expand_path("%appdata%")
   #    # => "C:\\Documents and Settings\\user\\Application Data"
+  #    client.fs.file.expand_path("~")
+  #    # => "/home/user"
+  #    client.fs.file.expand_path("$HOME/dir")
+  #    # => "/home/user/dir"
   #    client.fs.file.expand_path("asdf")
   #    # => "asdf"
   #
-  # NOTE: This method is fairly specific to Windows. It has next to no relation
-  # to the ::File.expand_path method! In particular, it does *not* do ~
-  # expansion or environment variable expansion on non-Windows systems. For
-  # these reasons, this method may be deprecated in the future. Use it with
-  # caution.
-  #
   def File.expand_path(path)
-    request = Packet.create_request(COMMAND_ID_STDAPI_FS_FILE_EXPAND_PATH)
+    if client.platform == 'windows'
+      request = Packet.create_request(COMMAND_ID_STDAPI_FS_FILE_EXPAND_PATH)
 
-    request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode( path ))
+      request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode( path ))
 
-    response = client.send_request(request)
+      response = client.send_request(request)
 
-    return client.unicode_filter_encode(response.get_tlv_value(TLV_TYPE_FILE_PATH))
+      return client.unicode_filter_encode(response.get_tlv_value(TLV_TYPE_FILE_PATH))
+    else
+      # For unix-based systems, do some of the work here
+      # First check for ~
+      path_components = path.split(separator)
+      if path_components.length > 0 && path_components[0] == '~'
+        path_components[0] = '$HOME'
+        path = path_components.join(separator)
+      end
+
+      # Now find the environment variables we'll need from the client
+      env_regex = /\$(?:([A-Za-z0-9_]+)|\{([A-Za-z0-9_.]+)\})/
+      matches = path.to_enum(:scan, env_regex).map { Regexp.last_match }
+      env_vars = matches.map { |match| (match[1] || match[2]).to_s }.uniq
+
+      # Retrieve them
+      env_vals = client.sys.config.getenvs(*env_vars)
+
+      # Now fill them in
+      path = path.gsub(env_regex) { |z| envvar = $1; envvar = $2 if envvar == nil; env_vals[envvar] }
+      path
+    end
   end
 
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -24,7 +24,7 @@ class Console::CommandDispatcher::Stdapi::Fs
   CHECKSUM_ALGORITHMS = %w{ md5 sha1 }
   private_constant :CHECKSUM_ALGORITHMS
 
-  def path_expand_regex
+  private def path_expand_regex
     if client.platform == 'windows'
       /\%(\w*)\%/
     else

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -23,8 +23,14 @@ class Console::CommandDispatcher::Stdapi::Fs
 
   CHECKSUM_ALGORITHMS = %w{ md5 sha1 }
   private_constant :CHECKSUM_ALGORITHMS
-  PATH_EXPAND_REGEX = /\%(\w*)\%/
-  private_constant :PATH_EXPAND_REGEX
+
+  def path_expand_regex
+    if client.platform == 'windows'
+      /\%(\w*)\%/
+    else
+      /\$(([A-Za-z0-9_]+)|\{([A-Za-z0-9_.]+)\})|^~/
+    end
+  end
 
   #
   # Options for the download command.
@@ -303,8 +309,8 @@ class Console::CommandDispatcher::Stdapi::Fs
       print_line("Usage: cd directory")
       return true
     end
-    if args[0] =~ PATH_EXPAND_REGEX
-      client.fs.dir.chdir(client.fs.file.expand_path(args[0].upcase))
+    if args[0] =~ path_expand_regex
+      client.fs.dir.chdir(client.fs.file.expand_path(args[0]))
     else
       client.fs.dir.chdir(args[0])
     end
@@ -380,7 +386,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     end
 
     args.each do |file_path|
-      file_path = client.fs.file.expand_path(file_path) if file_path =~ PATH_EXPAND_REGEX
+      file_path = client.fs.file.expand_path(file_path) if file_path =~ path_expand_regex
       client.fs.file.rm(file_path)
     end
 
@@ -400,9 +406,9 @@ class Console::CommandDispatcher::Stdapi::Fs
       return true
     end
     old_path = args[0]
-    old_path = client.fs.file.expand_path(old_path) if old_path =~ PATH_EXPAND_REGEX
+    old_path = client.fs.file.expand_path(old_path) if old_path =~ path_expand_regex
     new_path = args[1]
-    new_path = client.fs.file.expand_path(new_path) if new_path =~ PATH_EXPAND_REGEX
+    new_path = client.fs.file.expand_path(new_path) if new_path =~ path_expand_regex
     client.fs.file.mv(old_path, new_path)
     return true
   end
@@ -423,9 +429,9 @@ class Console::CommandDispatcher::Stdapi::Fs
       return true
     end
     old_path = args[0]
-    old_path = client.fs.file.expand_path(old_path) if old_path =~ PATH_EXPAND_REGEX
+    old_path = client.fs.file.expand_path(old_path) if old_path =~ path_expand_regex
     new_path = args[1]
-    new_path = client.fs.file.expand_path(new_path) if new_path =~ PATH_EXPAND_REGEX
+    new_path = client.fs.file.expand_path(new_path) if new_path =~ path_expand_regex
     client.fs.file.cp(old_path, new_path)
     return true
   end
@@ -443,7 +449,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       return true
     end
     file_path = args[1]
-    file_path = client.fs.file.expand_path(file_path) if file_path =~ PATH_EXPAND_REGEX
+    file_path = client.fs.file.expand_path(file_path) if file_path =~ path_expand_regex
     client.fs.file.chmod(file_path, args[0].to_i(8))
     return true
   end
@@ -746,7 +752,7 @@ class Console::CommandDispatcher::Stdapi::Fs
         return 0
       when nil
         path = val
-        path = client.fs.file.expand_path(path) if path =~ PATH_EXPAND_REGEX
+        path = client.fs.file.expand_path(path) if path =~ path_expand_regex
       end
     }
 
@@ -923,7 +929,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     end
 
     args.each { |dir_path|
-      dir_path = client.fs.file.expand_path(dir_path) if dir_path =~ PATH_EXPAND_REGEX
+      dir_path = client.fs.file.expand_path(dir_path) if dir_path =~ path_expand_regex
       print_line("Creating directory: #{dir_path}")
       client.fs.dir.mkdir(dir_path)
     }
@@ -952,7 +958,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     end
 
     args.each { |dir_path|
-      dir_path = client.fs.file.expand_path(dir_path) if dir_path =~ PATH_EXPAND_REGEX
+      dir_path = client.fs.file.expand_path(dir_path) if dir_path =~ path_expand_regex
       print_line("Removing directory: #{dir_path}")
       client.fs.dir.rmdir(dir_path)
     }

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -28,7 +28,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     if client.platform == 'windows'
       /\%(\w*)\%/
     else
-      /\$(([A-Za-z0-9_]+)|\{([A-Za-z0-9_.]+)\})|^~/
+      /\$(([A-Za-z0-9_]+)|\{([A-Za-z0-9_]+)\})|^~/
     end
   end
 

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -205,7 +205,7 @@ class MetasploitModule < Msf::Post
         s == result
       end
 
-      it "no env vars should not expand" do
+      it "env vars with invalid naming should not expand" do
         s = 'no environment $ variables /here'
         result = expand_path(s)
         s == result

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -185,6 +185,42 @@ class MetasploitModule < Msf::Post
     end
   end
 
+  def test_path_expansion_nix
+    unless session.platform =~ /win/i
+      it "should expand home" do
+        home1 = expand_path('~')
+        home2 = expand_path('$HOME')
+        home1 == home2 && home1.length > 0
+      end
+
+      it "non-isolated tilde should not expand" do
+        s = '~a'
+        result = expand_path(s)
+        s == result
+      end
+
+      it "mid-string tilde should not expand" do
+        s = '/home/~'
+        result = expand_path(s)
+        s == result
+      end
+
+      it "no env vars should not expand" do
+        s = 'no environment $ variables /here'
+        result = expand_path(s)
+        s == result
+      end
+
+      it "should expand multiple variables" do
+        result = expand_path('/blah/$HOME/test/$USER')
+        home = expand_path('$HOME')
+        user = expand_path('$USER')
+        expected = "/blah/#{home}/test/#{user}"
+        result == expected
+      end
+    end
+  end
+
   def cleanup
     vprint_status("Cleanup: changing working directory back to #{@old_pwd}")
     cd(@old_pwd)


### PR DESCRIPTION
This PR resolves #14357. The `expand_path` function previously only worked on Windows; with this, it also works on Unix.

The approach I took was the one suggested by @timwr in the issue discussion: to do pattern-matching in the Framework itself, and then just request environment variables from Meterp, and slot them in.

The advantage of this approach is that the pattern-matching would have needed to be implemented _somewhere_ for Mettle, since the built-in function to do it in Mettle's libc (musl) just launches `sh`, which isn't great from a forensics point of view. Doing it in Ruby rather than C lets us reduce code and leverage existing work in each of the other Meterps.

Implementing this parsing manually means there are some rarer use cases that I haven't covered compared to a regular implementation of wordexp, such as escaping dollar signs (e.g. an actual folder called `$home`), or resolving home directories of other users (e.g. `~root => /root`); happy to discuss if it's felt these cases are important. (Now that I'm looking at it, I can't figure out a way to do the equivalent in Windows i.e. `cd`ing into a directory that is actually called `%TEMP%`).

Interestingly, I'd initially thought Python's `os.path.expandvars` would be an easy win for the Python meterpreter, but even that doesn't do dollar-escaping of backslashes or quotes... in short, if we wanted a completely consistent implementation, it seems like we'd need to manually implement parts of it for each of the meterp implementations anyway, so doing the pattern matching in one spot seemed much simpler overall.

## Verification

- [x] Start `msfconsole`
- [x] Get a meterpreter session on Linux
- [x] `irb`
- [x] `fs.file.expand_path('~')`
- [x] Verify this resolves to the user's home directory
- [x] `fs.file.expand_path('$HOME')`
- [x] Verify this resolves to the user's home directory
- [x] Verify that using environment variables or tilde work in the commands `cd`, `mkdir`, `rmdir`, `rm`, `mv`, `cp`, `chmod`, `ls`, `search`, `cat`, `checksum`, `download`, `upload`, `edit`
- [x] Verify that Windows meterpreter's use of path expansion (e.g. `%TEMP%`) still behaves
