### PR TITLE
update example modules

### DIFF
--- a/modules/auxiliary/example.rb
+++ b/modules/auxiliary/example.rb
@@ -14,20 +14,26 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => 'Sample Auxiliary Module',
+        'Name' => 'Sample Auxiliary Module',
         # The description can be multiple lines, but does not preserve formatting.
-        'Description'    => 'Sample Auxiliary Module',
-        'Author'         => ['Joe Module <joem@example.com>'],
-        'License'        => MSF_LICENSE,
-        'Actions'        => [
-          [ 'Default Action', 'Description' => 'This does something' ],
-          [ 'Another Action', 'Description' => 'This does a different thing' ]
+        'Description' => 'Sample Auxiliary Module',
+        'Author' => ['Joe Module <joem@example.com>'],
+        'License' => MSF_LICENSE,
+        'Actions' => [
+          [ 'Default Action', { 'Description' => 'This does something' } ],
+          [ 'Another Action', { 'Description' => 'This does a different thing' } ]
         ],
         # The action(s) that will run as background job
         'PassiveActions' => [
           'Another Action'
         ],
-        'DefaultAction'  => 'Default Action'
+        # https://github.com/rapid7/metasploit-framework/wiki/Definition-of-Module-Reliability,-Side-Effects,-and-Stability
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        },
+        'DefaultAction' => 'Default Action'
       )
     )
   end
@@ -39,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
   # auxiliary modules can register new commands, they all call cmd_* to
   # dispatch them
   def auxiliary_commands
-    { "aux_extra_command" => "Run this auxiliary test commmand" }
+    { 'aux_extra_command' => 'Run this auxiliary test commmand' }
   end
 
   def cmd_aux_extra_command(*args)

--- a/modules/exploits/example.rb
+++ b/modules/exploits/example.rb
@@ -10,7 +10,7 @@
 #
 ###
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = NormalRanking # https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking
 
   #
   # This exploit affects TCP servers, so we use the TCP client mixin.
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-        'DisclosureDate' => '2013-04-01',
+        'DisclosureDate' => '2020-12-30',
         # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
         # It's generally easiest just to put the default at the beginning of the list and skip this
         # entirely.

--- a/modules/exploits/example.rb
+++ b/modules/exploits/example.rb
@@ -27,41 +27,44 @@ class MetasploitModule < Msf::Exploit::Remote
         # vuln type, class. Preferably apply
         # some search optimization so people can actually find the module.
         # We encourage consistency between module name and file name.
-        'Name'           => 'Sample Exploit',
-        'Description'    => %q(
-            This exploit module illustrates how a vulnerability could be exploited
+        'Name' => 'Sample Exploit',
+        'Description' => %q{
+          This exploit module illustrates how a vulnerability could be exploited
           in an TCP server that has a parsing bug.
-        ),
-        'License'        => MSF_LICENSE,
-        'Author'         => ['skape'],
-        'References'     =>
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['skape'],
+        'References' => [
+          [ 'OSVDB', '12345' ],
+          [ 'EDB', '12345' ],
+          [ 'URL', 'http://www.example.com'],
+          [ 'CVE', '1978-1234']
+        ],
+        'Payload' => {
+          'Space' => 1000,
+          'BadChars' => "\x00"
+        },
+        'Targets' => [
+          # Target 0: Windows All
           [
-            [ 'OSVDB', '12345' ],
-            [ 'EDB', '12345' ],
-            [ 'URL', 'http://www.example.com'],
-            [ 'CVE', '1978-1234']
-          ],
-        'Payload'        =>
-          {
-            'Space'    => 1000,
-            'BadChars' => "\x00"
-          },
-        'Targets'        =>
-          [
-            # Target 0: Windows All
-            [
-              'Windows XP/Vista/7/8',
-              {
-                'Platform' => 'win',
-                'Ret'      => 0x41424344
-              }
-            ]
-          ],
+            'Windows XP/Vista/7/8',
+            {
+              'Platform' => 'win',
+              'Ret' => 0x41424344
+            }
+          ]
+        ],
         'DisclosureDate' => '2013-04-01',
         # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
         # It's generally easiest just to put the default at the beginning of the list and skip this
         # entirely.
-        'DefaultTarget'  => 0
+        'DefaultTarget' => 0,
+        # https://github.com/rapid7/metasploit-framework/wiki/Definition-of-Module-Reliability,-Side-Effects,-and-Stability
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
   end
@@ -71,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # vulnerable.
   #
   def check
-    Exploit::CheckCode::Vulnerable
+    CheckCode::Vulnerable
   end
 
   #

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -47,11 +47,10 @@ class MetasploitModule < Msf::Exploit::Local
         # Add reference to additional authors, like those creating original proof of concepts or
         # reference materials.
         # It is also common to comment in who did what (PoC vs metasploit module, etc)
-        'Author' =>
-          [
-            'h00die <mike@stcyrsecurity.com>', # msf module
-            'researcher' # original PoC, analysis
-          ],
+        'Author' => [
+          'h00die <mike@stcyrsecurity.com>', # msf module
+          'researcher' # original PoC, analysis
+        ],
         'Platform' => [ 'linux' ],
         # from underlying architecture of the system.  typically ARCH_X64 or ARCH_X86, but the exploit
         # may only apply to say ARCH_PPC or something else, where a specific arch is required.
@@ -66,25 +65,29 @@ class MetasploitModule < Msf::Exploit::Local
         # since privilege escalation modules typically result in elevated privileges, this is
         # generally set to true
         'Privileged' => true,
-        'References' =>
-          [
-            [ 'OSVDB', '12345' ],
-            [ 'EDB', '12345' ],
-            [ 'URL', 'http://www.example.com'],
-            [ 'CVE', '1978-1234']
-          ],
+        'References' => [
+          [ 'OSVDB', '12345' ],
+          [ 'EDB', '12345' ],
+          [ 'URL', 'http://www.example.com'],
+          [ 'CVE', '1978-1234']
+        ],
         'DisclosureDate' => '2019-11-29',
         # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
         # It's generally easiest just to put the default at the beginning of the list and skip this
         # entirely.
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        # https://github.com/rapid7/metasploit-framework/wiki/Definition-of-Module-Reliability,-Side-Effects,-and-Stability
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
     # force exploit is used to bypass the check command results
     register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
-
   end
 
   # Simplify pulling the writable directory variable
@@ -117,10 +120,8 @@ class MetasploitModule < Msf::Exploit::Local
   #
   def exploit
     # Check if we're already root
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
-      end
+    if is_root? && !datastore['ForceExploit']
+      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
     end
 
     # Make sure we can write our exploit and payload to the local system

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -10,7 +10,7 @@
 #
 ###
 class MetasploitModule < Msf::Exploit::Local
-  Rank = NormalRanking
+  Rank = NormalRanking # https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking
 
   # includes: is_root?
   include Msf::Post::Linux::Priv

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -18,10 +18,10 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   include Msf::Exploit::Remote::HttpClient
 
-  # There are libraries for several CMSes such as Wordpress, Typo3,
-  # Sharepoint, Nagios XI, Moodle, Joomla, JBoss, and Drupal.
+  # There are libraries for several CMSes such as WordPress, Typo3,
+  # SharePoint, Nagios XI, Moodle, Joomla, JBoss, and Drupal.
   #
-  # The following import just includes the code for the Wordpress library,
+  # The following import just includes the code for the WordPress library,
   # however you can find other similar libraries at
   # https://github.com/rapid7/metasploit-framework/tree/master/lib/msf/core/exploit/remote/http
   include Msf::Exploit::Remote::HTTP::Wordpress

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -10,7 +10,7 @@
 #
 ###
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = NormalRanking # https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking
 
   #
   # This exploit affects a webapp, so we need to import HTTP Client
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # there are libraries for several CMSes and such like wordpress, typo3, sharepoint, nagios_xi, moodle
   # joomla jboss, drupal.
   # https://github.com/rapid7/metasploit-framework/tree/master/lib/msf/core/exploit/remote/http
+  include Msf::Exploit::Remote::HTTP::Wordpress
 
   def initialize(info = {})
     super(
@@ -161,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     }, datastore['HttpClientTimeout'])
 
-    # send_request_raw is used when we need to break protocol for the exploit in some way
+    # send_request_raw is used when we need to break away from the HTTP protocol in some way for the exploit to work
     send_request_raw({
       'method' => 'DESCRIBE',
       'proto' => 'RTSP',

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -18,6 +18,10 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   include Msf::Exploit::Remote::HttpClient
 
+  # there are libraries for several CMSes and such like wordpress, typo3, sharepoint, nagios_xi, moodle
+  # joomla jboss, drupal.
+  # https://github.com/rapid7/metasploit-framework/tree/master/lib/msf/core/exploit/remote/http
+
   def initialize(info = {})
     super(
       update_info(
@@ -26,47 +30,50 @@ class MetasploitModule < Msf::Exploit::Remote
         # vuln type, class. Preferably apply
         # some search optimization so people can actually find the module.
         # We encourage consistency between module name and file name.
-        'Name'           => 'Sample Webapp Exploit',
-        'Description'    => %q(
-            This exploit module illustrates how a vulnerability could be exploited
+        'Name' => 'Sample Webapp Exploit',
+        'Description' => %q{
+          This exploit module illustrates how a vulnerability could be exploited
           in a webapp.
-        ),
-        'License'        => MSF_LICENSE,
+        },
+        'License' => MSF_LICENSE,
         # The place to add your name/handle and email.  Twitter and other contact info isn't handled here.
         # Add reference to additional authors, like those creating original proof of concepts or
         # reference materials.
         # It is also common to comment in who did what (PoC vs metasploit module, etc)
-        'Author'         =>
-          [
-            'h00die <mike@stcyrsecurity.com>', # msf module
-            'researcher' # original PoC, analysis
-          ],
-        'References'     =>
-          [
-            [ 'OSVDB', '12345' ],
-            [ 'EDB', '12345' ],
-            [ 'URL', 'http://www.example.com'],
-            [ 'CVE', '1978-1234']
-          ],
+        'Author' => [
+          'h00die <mike@stcyrsecurity.com>', # msf module
+          'researcher' # original PoC, analysis
+        ],
+        'References' => [
+          [ 'OSVDB', '12345' ],
+          [ 'EDB', '12345' ],
+          [ 'URL', 'http://www.example.com'],
+          [ 'CVE', '1978-1234']
+        ],
         # platform refers to the type of platform.  For webapps, this is typically the language of the webapp.
         # js, php, python, nodejs are common, this will effect what payloads can be matched for the exploit.
         # A full list is available in lib/msf/core/payload/uuid.rb
-        'Platform'       => ['python'],
+        'Platform' => ['python'],
         # from lib/msf/core/module/privileged, denotes if this requires or gives privileged access
-        'Privileged'     => false,
+        'Privileged' => false,
         # from underlying architecture of the system.  typically ARCH_X64 or ARCH_X86, but for webapps typically
         # this is the application language. ARCH_PYTHON, ARCH_PHP, ARCH_JAVA are some examples
         # A full list is available in lib/msf/core/payload/uuid.rb
-        'Arch'           => ARCH_PYTHON,
-        'Targets'        =>
-          [
-            [ 'Automatic Target', {}]
-          ],
-        'DisclosureDate' => '2013-04-01',
+        'Arch' => ARCH_PYTHON,
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2020-12-30',
         # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
         # It's generally easiest just to put the default at the beginning of the list and skip this
         # entirely.
-        'DefaultTarget'  => 0
+        'DefaultTarget' => 0,
+        # https://github.com/rapid7/metasploit-framework/wiki/Definition-of-Module-Reliability,-Side-Effects,-and-Stability
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
     # set the default port, and a URI that a user can set if the app isn't installed to the root
@@ -76,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
         OptString.new('PASSWORD', [ false, 'Password to login with', '123456']),
         OptString.new('TARGETURI', [ true, 'The URI of the Example Application', '/example/'])
-      ], self.class
+      ]
     )
   end
 
@@ -90,26 +97,26 @@ class MetasploitModule < Msf::Exploit::Remote
       # only catch the response if we're going to use it, in this case we do for the version
       # detection.
       res = send_request_cgi(
-        'uri'       => normalize_uri(target_uri.path, 'index.php'),
-        'method'    => 'GET'
+        'uri' => normalize_uri(target_uri.path, 'index.php'),
+        'method' => 'GET'
       )
       # gracefully handle if res comes back as nil, since we're not guaranteed a response
       # also handle if we get an unexpected HTTP response code
-      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
-      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if res.code == 200
+      return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
+      return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if res.code == 200
 
       # here we're looking through html for the version string, similar to:
       # Version 1.2
-      /Version: (?<version>[\d]{1,2}\.[\d]{1,2})<\/td>/ =~ res.body
+      %r{Version: (?<version>\d{1,2}\.\d{1,2})</td>} =~ res.body
 
       if version && Rex::Version.new(version) <= Rex::Version.new('1.3')
         vprint_good("Version Detected: #{version}")
-        Exploit::CheckCode::Appears
+        CheckCode::Appears
       end
     rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+      freturn CheckCode::Unknown("#{peer} - Could not connect to web service")
     end
-    Exploit::CheckCode::Safe
+    CheckCode::Safe
   end
 
   #
@@ -117,44 +124,50 @@ class MetasploitModule < Msf::Exploit::Remote
   # at a web page through a POST variable
   #
   def exploit
-    begin
-      # attempt a login. In this case we show basic auth, and a POST to a fake username/password
-      # simply to show how both are done
-      vprint_status('Attempting login')
-      # since we will check res to see if auth was a success, make sure to capture the return
-      res = send_request_cgi(
-        'uri'           => '/login.html',
-        'method'        => 'POST',
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'vars_post'     => {
-          'username' => datastore['USERNAME'],
-          'password' => datastore['PASSWORD']
-        }
-      )
+    # attempt a login. In this case we show basic auth, and a POST to a fake username/password
+    # simply to show how both are done
+    vprint_status('Attempting login')
+    # since we will check res to see if auth was a success, make sure to capture the return
+    res = send_request_cgi(
+      'uri' => '/login.html',
+      'method' => 'POST',
+      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      # automatically handle cookies with keep_cookies.  Alternatively use cookie = res.get_cookies and 'cookie' => cookie,
+      'keep_cookies' => 'true',
+      'vars_post' => {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      },
+      'vars_get' => {
+        'example' => 'example'
+      }
+    )
 
-      # a valid login will give us a 301 redirect to /home.html so check that.
-      # ALWAYS assume res could be nil and check it first!!!!!
-      if res && res.code != 301
-        fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})")
-      end
+    # a valid login will give us a 301 redirect to /home.html so check that.
+    # ALWAYS assume res could be nil and check it first!!!!!
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") unless res.code == 301
 
-      # grab our valid cookie
-      cookie = res.get_cookies
-      # we don't care what the response is, so don't bother saving it from send_request_cgi
-      vprint_status('Attempting exploit')
-      send_request_cgi(
-        'uri'       => normalize_uri(target_uri.path, 'command.html'),
-        'method'    => 'POST',
-        'cookie'    => cookie,
-        'vars_post'  =>
-        {
-          'cmd_str' => payload.encoded
-        }
-      )
+    # we don't care what the response is, so don't bother saving it from send_request_cgi
+    vprint_status('Attempting exploit')
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'command.html'),
+      'method' => 'POST',
+      'cookie' => cookie,
+      'vars_post' =>
+      {
+        'cmd_str' => payload.encoded
+      }
+    )
 
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
-    end
-
+    # send_request_raw is used when we need to break protocol for the exploit in some way
+    send_request_raw({
+      'method' => 'DESCRIBE',
+      'proto' => 'RTSP',
+      'version' => '1.0',
+      'uri' => '/' + ('../' * 560) + "\xcc\xcc\x90\x90" + '.smi'
+    }, 5)
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end
 end

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
         CheckCode::Appears
       end
     rescue ::Rex::ConnectionError
-      freturn CheckCode::Unknown("#{peer} - Could not connect to web service")
+      return CheckCode::Unknown("#{peer} - Could not connect to web service")
     end
     CheckCode::Safe
   end
@@ -149,8 +149,9 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") unless res.code == 301
 
     # we don't care what the response is, so don't bother saving it from send_request_cgi
+    # datastore['HttpClientTimeout'] ONLY IF we need a longer HTTP timeout
     vprint_status('Attempting exploit')
-    send_request_cgi(
+    send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'command.html'),
       'method' => 'POST',
       'cookie' => cookie,
@@ -158,7 +159,7 @@ class MetasploitModule < Msf::Exploit::Remote
       {
         'cmd_str' => payload.encoded
       }
-    )
+    }, datastore['HttpClientTimeout'])
 
     # send_request_raw is used when we need to break protocol for the exploit in some way
     send_request_raw({
@@ -166,7 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'proto' => 'RTSP',
       'version' => '1.0',
       'uri' => '/' + ('../' * 560) + "\xcc\xcc\x90\x90" + '.smi'
-    }, 5)
+    }, datastore['HttpClientTimeout'])
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -18,8 +18,11 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   include Msf::Exploit::Remote::HttpClient
 
-  # there are libraries for several CMSes and such like wordpress, typo3, sharepoint, nagios_xi, moodle
-  # joomla jboss, drupal.
+  # There are libraries for several CMSes such as Wordpress, Typo3,
+  # Sharepoint, Nagios XI, Moodle, Joomla, JBoss, and Drupal.
+  #
+  # The following import just includes the code for the Wordpress library,
+  # however you can find other similar libraries at
   # https://github.com/rapid7/metasploit-framework/tree/master/lib/msf/core/exploit/remote/http
   include Msf::Exploit::Remote::HTTP::Wordpress
 


### PR DESCRIPTION
Update example modules:

1. rubocop
2. msftidy
3. add `httpclienttimeout` since i just got dinged on that
4. change `check` to always return a `CheckCode` since i just got dinged on that
5. add a link HTTP libraries since a somewhat recent wordpress module author suggested it
6. remove `Exploit::` on check codes in the exploit context
7. Add notes field which is now required