### PR TITLE
Better tab completion experience when navigating directories in meterp

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -148,18 +148,24 @@ class Dir < Rex::Post::Dir
     end
 
     fpath.each_with_index do |file_name, idx|
-      if dir && sbuf[idx]
+      is_dir = false
+      if sbuf[idx]
         st = ::Rex::Post::FileStat.new
         if new_stat_buf
           st.update(sbuf[idx].value)
         else
           st.update32(sbuf[idx].value)
         end
-        next if st.ftype != 'directory' # if file_name isn't directory
+        is_dir = st.ftype == 'directory'
+        next if (dir && !is_dir) # if file_name isn't directory
       end
 
       if !file_name.value.end_with?('.', '\\', '/') # Exclude current and parent directory
-        files << client.unicode_filter_encode(file_name.value)
+        name = client.unicode_filter_encode(file_name.value)
+        if is_dir
+          name += client.fs.file.separator
+        end
+        files << name
       end
     end
 


### PR DESCRIPTION
Prior to this change, when using meterpreter, tab-completing a remote folder would append a space onto the end. This was annoying when you wanted to traverse through lots of directories: each time, you'd have to press backspace and add a slash; e.g.:

- Type: `cat /ho`
- Press: `<tab>`
- `cat /home<space>`
- Press `<backspace>`
- `cat /home`
- Append: `cat /home/`
- Press `<tab>`
- `cat /home/user<space>`
- Press `<backspace>`
- Append: `cat /home/user/f`
- Press `<tab>`
- `cat /home/user/file<space>`

It's rather annoying having to backspace and add an extra slash when that's rarely the desired behaviour, and different from the user experience of local shells.

This change resolves that by not appending the space if we're potentially in the middle of a tab completion journey, and adding a slash if we've completed a directory.

## Verification

- [x] Obtain a meterpreter shell on Unix like system
- [x] Type `cat<space>/<tab>`
- [x] Verify that it shows all files and folders in the root directory
- [x] Type the first few letters of one of these directories
- [x] Verify that it fills out the whole folder name (assuming a unique match), and adds a slash, but no space, so that you can...
- [x] Press tab again
- [x] Verify that you can see all files and folders in the new directory
- [x] Verify all this with a folder-related command (e.g. `ls` or `cd`), and ensure that you only see directories
- [x] At no point should you have needed to press backspace to enter a subdirectory