### PR TITLE
rename local instance variable for thread list

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -63,7 +63,7 @@ def run
   @range_percent = 0
 
   threads_max = datastore['THREADS'].to_i
-  @stl = []
+  @thread_list = []
   @scan_errors = []
 
   res = Queue.new
@@ -103,7 +103,7 @@ def run
       break if has_fatal_errors?
 
       # Spawn threads for each host
-      while (@stl.length < threads_max)
+      while (@thread_list.length < threads_max)
 
         # Stop scanning if we hit a fatal error
         break if has_fatal_errors?
@@ -115,7 +115,7 @@ def run
         end
         break unless datastore
 
-        @stl << framework.threads.spawn("ScannerHost(#{self.refname})-#{datastore['RHOST']}", false, datastore.dup) do |thr_datastore|
+        @thread_list << framework.threads.spawn("ScannerHost(#{self.refname})-#{datastore['RHOST']}", false, datastore.dup) do |thr_datastore|
           targ = thr_datastore['RHOST']
           nmod = self.replicant
           nmod.datastore = thr_datastore
@@ -149,17 +149,17 @@ def run
       break if has_fatal_errors?
 
       # Exit once we run out of hosts
-      if(@stl.length == 0)
+      if(@thread_list.length == 0)
         break
       end
 
       # Attempt to wait for the oldest thread for a second,
       # remove any finished threads from the list
       # and continue on.
-      tla = @stl.length
-      @stl.first.join(1)
-      @stl.delete_if { |t| not t.alive? }
-      tlb = @stl.length
+      tla = @thread_list.length
+      @thread_list.first.join(1)
+      @thread_list.delete_if { |t| not t.alive? }
+      tlb = @thread_list.length
 
       @range_done += (tla - tlb)
       scanner_show_progress() if @show_progress
@@ -186,7 +186,7 @@ def run
       # Stop scanning if we hit a fatal error
       break if has_fatal_errors?
 
-      while (@stl.length < threads_max)
+      while (@thread_list.length < threads_max)
 
         batch = []
 
@@ -227,11 +227,11 @@ def run
             end
           end
           thread[:batch_size] = batch.length
-          @stl << thread
+          @thread_list << thread
         end
 
         # Exit once we run out of hosts
-        if (@stl.length == 0 or nohosts)
+        if (@thread_list.length == 0 or nohosts)
           break
         end
       end
@@ -240,7 +240,7 @@ def run
       break if has_fatal_errors?
 
       # Exit if there are no more pending threads
-      if (@stl.length == 0)
+      if (@thread_list.length == 0)
         break
       end
 
@@ -248,11 +248,11 @@ def run
       # remove any finished threads from the list
       # and continue on.
       tla = 0
-      @stl.map {|t| tla += t[:batch_size] }
-      @stl.first.join(1)
-      @stl.delete_if { |t| not t.alive? }
+      @thread_list.map {|t| tla += t[:batch_size] }
+      @thread_list.first.join(1)
+      @thread_list.delete_if { |t| not t.alive? }
       tlb = 0
-      @stl.map {|t| tlb += t[:batch_size] }
+      @thread_list.map {|t| tlb += t[:batch_size] }
 
       @range_done += tla - tlb
       scanner_show_progress() if @show_progress
@@ -273,7 +273,7 @@ def run
 end
 
 def seppuko!
-  @stl.each do |t|
+  @thread_list.each do |t|
     begin
       t.kill if t.alive?
     rescue ::Exception
@@ -287,10 +287,10 @@ end
 
 def scanner_handle_fatal_errors
   return unless has_fatal_errors?
-  return unless @stl
+  return unless @thread_list
 
   # First kill any running threads
-  @stl.each {|t| t.kill if t.alive? }
+  @thread_list.each {|t| t.kill if t.alive? }
 
   # Show the unique errors triggered by the scan
   uniq_errors = @scan_errors.uniq

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -63,7 +63,7 @@ def run
   @range_percent = 0
 
   threads_max = datastore['THREADS'].to_i
-  @tl = []
+  @stl = []
   @scan_errors = []
 
   res = Queue.new
@@ -103,7 +103,7 @@ def run
       break if has_fatal_errors?
 
       # Spawn threads for each host
-      while (@tl.length < threads_max)
+      while (@stl.length < threads_max)
 
         # Stop scanning if we hit a fatal error
         break if has_fatal_errors?
@@ -115,7 +115,7 @@ def run
         end
         break unless datastore
 
-        @tl << framework.threads.spawn("ScannerHost(#{self.refname})-#{datastore['RHOST']}", false, datastore.dup) do |thr_datastore|
+        @stl << framework.threads.spawn("ScannerHost(#{self.refname})-#{datastore['RHOST']}", false, datastore.dup) do |thr_datastore|
           targ = thr_datastore['RHOST']
           nmod = self.replicant
           nmod.datastore = thr_datastore
@@ -149,17 +149,17 @@ def run
       break if has_fatal_errors?
 
       # Exit once we run out of hosts
-      if(@tl.length == 0)
+      if(@stl.length == 0)
         break
       end
 
       # Attempt to wait for the oldest thread for a second,
       # remove any finished threads from the list
       # and continue on.
-      tla = @tl.length
-      @tl.first.join(1)
-      @tl.delete_if { |t| not t.alive? }
-      tlb = @tl.length
+      tla = @stl.length
+      @stl.first.join(1)
+      @stl.delete_if { |t| not t.alive? }
+      tlb = @stl.length
 
       @range_done += (tla - tlb)
       scanner_show_progress() if @show_progress
@@ -186,7 +186,7 @@ def run
       # Stop scanning if we hit a fatal error
       break if has_fatal_errors?
 
-      while (@tl.length < threads_max)
+      while (@stl.length < threads_max)
 
         batch = []
 
@@ -227,11 +227,11 @@ def run
             end
           end
           thread[:batch_size] = batch.length
-          @tl << thread
+          @stl << thread
         end
 
         # Exit once we run out of hosts
-        if (@tl.length == 0 or nohosts)
+        if (@stl.length == 0 or nohosts)
           break
         end
       end
@@ -240,7 +240,7 @@ def run
       break if has_fatal_errors?
 
       # Exit if there are no more pending threads
-      if (@tl.length == 0)
+      if (@stl.length == 0)
         break
       end
 
@@ -248,11 +248,11 @@ def run
       # remove any finished threads from the list
       # and continue on.
       tla = 0
-      @tl.map {|t| tla += t[:batch_size] }
-      @tl.first.join(1)
-      @tl.delete_if { |t| not t.alive? }
+      @stl.map {|t| tla += t[:batch_size] }
+      @stl.first.join(1)
+      @stl.delete_if { |t| not t.alive? }
       tlb = 0
-      @tl.map {|t| tlb += t[:batch_size] }
+      @stl.map {|t| tlb += t[:batch_size] }
 
       @range_done += tla - tlb
       scanner_show_progress() if @show_progress
@@ -273,7 +273,7 @@ def run
 end
 
 def seppuko!
-  @tl.each do |t|
+  @stl.each do |t|
     begin
       t.kill if t.alive?
     rescue ::Exception
@@ -287,10 +287,10 @@ end
 
 def scanner_handle_fatal_errors
   return unless has_fatal_errors?
-  return unless @tl
+  return unless @stl
 
   # First kill any running threads
-  @tl.each {|t| t.kill if t.alive? }
+  @stl.each {|t| t.kill if t.alive? }
 
   # Show the unique errors triggered by the scan
   uniq_errors = @scan_errors.uniq

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -248,11 +248,11 @@ def run
       # remove any finished threads from the list
       # and continue on.
       tla = 0
-      @thread_list.map {|t| tla += t[:batch_size] }
+      @thread_list.map {|t| tla += t[:batch_size] if t[:batch_size] }
       @thread_list.first.join(1)
       @thread_list.delete_if { |t| not t.alive? }
       tlb = 0
-      @thread_list.map {|t| tlb += t[:batch_size] }
+      @thread_list.map {|t| tlb += t[:batch_size] if t[:batch_size] }
 
       @range_done += tla - tlb
       scanner_show_progress() if @show_progress


### PR DESCRIPTION
Rename thread tracking instance variable. While there is no direct reproduction against a standalone console an error can appear when executing a scanner module for large sets of hosts. The following stack trace was observed.

```
[-] [2021.11.15-14:57:27] Auxiliary failed: TypeError nil can't be coerced into Integer
[-] [2021.11.15-14:57:27] Call stack:
[-] [2021.11.15-14:57:27]   /metasploit-framework/lib/msf/core/auxiliary/scanner.rb:255:in `+'
[-] [2021.11.15-14:57:27]   /metasploit/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:255:in `block in run'
[-] [2021.11.15-14:57:27]   /metasploit/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:255:in `map'
[-] [2021.11.15-14:57:27]   /metasploit/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:255:in `run'
```

Also updates batch scanner modules to no longer crash when being able to unable to calculate a scanner thread's batch size

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use <SOME RANDOM AUX SCANNER MODULE>`
- [ ] **Verify** at least 3 to 5 scanner modules function as expected.
- [ ] Internal R7 team should also validate Pro discovery for large host ranges stabilizes.
