### PR TITLE
Prevent payloads being used if can't clean up files

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -53,6 +53,10 @@ class CommandShell
     "shell"
   end
 
+  def self.can_cleanup_files
+    true
+  end
+
   def initialize(conn, opts = {})
     self.platform ||= ""
     self.arch     ||= ""

--- a/lib/msf/base/sessions/hwbridge.rb
+++ b/lib/msf/base/sessions/hwbridge.rb
@@ -52,6 +52,10 @@ class HWBridge  < Rex::Post::HWBridge::Client
     "hwbridge"
   end
 
+  def self.can_cleanup_files
+    false
+  end
+
   #
   # Returns the session description.
   #

--- a/lib/msf/base/sessions/mainframe_shell.rb
+++ b/lib/msf/base/sessions/mainframe_shell.rb
@@ -82,6 +82,10 @@ class MainframeShell < Msf::Sessions::CommandShell
     raise NotImplementedError
   end
 
+  def self.can_cleanup_files
+    false
+  end
+
   # need to do more testing on this before we either use the default in command_shell
   # or write a new one.  For now we just make it unavailble. This prevents a hang on
   # initial session creation.  See PR#6067

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -104,6 +104,10 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     self.class.type
   end
 
+  def self.can_cleanup_files
+    true
+  end
+
   ##
   # :category: Msf::Session::Provider::SingleCommandShell implementors
   #

--- a/lib/msf/base/sessions/pingback.rb
+++ b/lib/msf/base/sessions/pingback.rb
@@ -83,6 +83,10 @@ class Pingback
     "Pingback"
   end
 
+  def self.can_cleanup_files
+    false
+  end
+
   #
   # Calls the class method
   #

--- a/lib/msf/base/sessions/powershell.rb
+++ b/lib/msf/base/sessions/powershell.rb
@@ -26,6 +26,10 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
     "powershell"
   end
 
+  def self.can_cleanup_files
+    true
+  end
+
   #
   # Returns the session platform.
   #

--- a/lib/msf/base/sessions/tty.rb
+++ b/lib/msf/base/sessions/tty.rb
@@ -81,6 +81,10 @@ class TTY
     rstream.close
   end
 
+  def self.can_cleanup_files
+    true
+  end
+
 end
 
 end

--- a/lib/msf/base/sessions/vncinject.rb
+++ b/lib/msf/base/sessions/vncinject.rb
@@ -58,6 +58,10 @@ class VncInject
     "vncinject"
   end
 
+  def self.can_cleanup_files
+    false
+  end
+
   ##
   #
   # Msf::Session overrides

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -721,10 +721,6 @@ class Exploit < Msf::Module
     # what not?
     return false if !compatible?(pi)
 
-    if self.needs_cleanup && !pi.can_cleanup
-      return false
-    end
-
     # If the payload is privileged but the exploit does not give
     # privileged access, then fail it.
     return false if !self.privileged && pi.privileged

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -26,7 +26,8 @@ module Exploit::FileDropper
 
     register_advanced_options(
       [
-        OptInt.new('FileDropperDelay', [false, 'Delay in seconds before attempting cleanup'])
+        OptInt.new('FileDropperDelay', [false, 'Delay in seconds before attempting cleanup']),
+        OptBool.new('AllowNoCleanup', [false, 'Allow exploitation without the possibility of cleaning up files'])
       ])
   end
 
@@ -40,6 +41,10 @@ module Exploit::FileDropper
   # @return [void]
   def register_files_for_cleanup(*files)
     @dropped_files += files
+  end
+
+  def allow_no_cleanup
+    datastore['AllowNoCleanup']
   end
 
   # Record directory as needing to be cleaned up

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -87,6 +87,19 @@ class ExploitDriver
       raise IncompatiblePayloadError.new(payload.refname),
         "#{payload.refname} is not a compatible payload.", caller
     end
+    
+    unless exploit.respond_to?(:allow_no_cleanup) && exploit.allow_no_cleanup
+      # Being able to cleanup requires a session to be created from a handler, and for that
+      # session to be able to be able to clean up files
+      can_cleanup = payload.handler_klass != Msf::Handler::None && payload.session && payload.session.can_cleanup_files
+      if exploit.needs_cleanup && !can_cleanup
+        raise IncompatiblePayloadError.new(payload.refname), "#{payload.refname} cannot cleanup files created during exploit. To run anyway, set AllowNoCleanup to true"
+      end
+
+      if exploit.needs_cleanup && !exploit.handler_enabled?
+        raise ValidationError.new('Cannot cleanup files created during exploit if payload handler is disabled. To run anyway, set AllowNoCleanup to true')
+      end
+    end
 
     # Associate the payload instance with the exploit
     payload.assoc_exploit = exploit

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -91,7 +91,7 @@ class ExploitDriver
     unless exploit.respond_to?(:allow_no_cleanup) && exploit.allow_no_cleanup
       # Being able to cleanup requires a session to be created from a handler, and for that
       # session to be able to be able to clean up files
-      can_cleanup = payload.handler_klass != Msf::Handler::None && payload.session && payload.session.can_cleanup_files
+      can_cleanup = payload.handler_klass != Msf::Handler::None && payload&.session&.can_cleanup_files
       if exploit.needs_cleanup && !can_cleanup
         raise IncompatiblePayloadError.new(payload.refname), "#{payload.refname} cannot cleanup files created during exploit. To run anyway, set AllowNoCleanup to true"
       end

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -50,7 +50,6 @@ class Payload < Msf::Module
   #
   def initialize(info = {})
     super
-    self.can_cleanup = true
 
     #
     # Gets the Dependencies if the payload requires external help
@@ -512,11 +511,6 @@ class Payload < Msf::Module
 
   end
 
-  #
-  # This attribute designates if the payload supports onsession()
-  # method calls (typically to clean up artifacts)
-  #
-  attr_accessor :can_cleanup
   #
   # This attribute holds the string that should be prepended to the buffer
   # when it's generated.

--- a/lib/msf/core/payload/pingback.rb
+++ b/lib/msf/core/payload/pingback.rb
@@ -9,7 +9,6 @@ require 'rex/text'
 module Msf::Payload::Pingback
 
   attr_accessor :pingback_uuid
-  attr_accessor :can_cleanup
 
   # Generate a Pingback UUID and write it to the database
   def generate_pingback_uuid
@@ -27,11 +26,5 @@ module Msf::Payload::Pingback
       print_warning("Unable to save UUID #{datastore['PingbackUUID']} to database -- database support not active")
     end
     self.pingback_uuid
-  end
-
-  def initialize(info = {})
-    super(info)
-    self.can_cleanup = false
-    self
   end
 end


### PR DESCRIPTION
This PR stops exploits from running if they will place files on disk, but MSF can't clean them up. This could occur in two ways:

- No session is created
- The session does not support file deletion

This has been implemented by having sessions indicate whether they support cleanup. In addition, if a payload doesn't specify a handler, or the payload handler is disabled, the logic is triggered.

In all cases, there is a setting on such payloads to allow them to run despite this.

I initially implemented this by blocking it immediately (i.e. when running `set payload`), but that caused more problems later down the track: if `DisablePayloadHandler` is set, that's also a problem. If `AllowNoCleanup` is set to true, but then you try to unset it, do you disallow that? Or reset `payload` and `DisablePayloadHandler` to acceptable values? It just ends up in potentially painful user experience, so it seemed better to just say "The combination of settings you've got is bad" at runtime.

The implementation ignores the `ARTIFACTS_ON_DISK` metadata - it is assumed that if an exploit wants to do cleanup, it will include the `FileDropper` mixin, which actually contains the cleanup logic.

## Verification

- [x] Start `msfconsole`
- [x] Select an exploit that uses file dropping (`grep -R Exploit::FileDropper`; e.g. `exchange_proxyshell_rce`).
- [x] Attempt to use it with various payloads that can generate a session (e.g. `shell` or `meterpreter`) - should succeed
- [x] Attempt to use it with various payloads that cannot generate a session (e.g. `vncinject`, `hwbridge` or `cmd/platform/generic`) - should fail when attempting to `run`
- [x] Attempt to use it with `DisablePayloadHandler` set to `true` (should fail)
- [x] Override these settings by setting `AllowNoCleanup` to `true`
- [x] Sanity check my settings for which session types can or cannot cleanup