### PR TITLE
Respect path expansion when performing path-based tab completion

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -142,8 +142,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
         # First check for ~
         path_components = path.split(separator)
         if path_components.length > 0 && path_components[0] == '~'
-          path_components[0] = '$HOME'
-          path = path_components.join(separator)
+          path = "$HOME#{path[1..-1]}"
         end
 
         # Now find the environment variables we'll need from the client


### PR DESCRIPTION
This PR extends the path expansion work from #15862 to include tab completion. You can now tab-complete things such as `cat ~/some_filenam<tab>`.

## Verification

- [x] Acquire a meterpreter session on various platforms
- [x] For each platform, use tab completion with expandable variables (e.g. `%TEMP%` on Windows, and `$HOME` or `~` on Linux)
- [x] Verify that the files and folders underneath these locations are shown as expected, for folder-based (e.g. `cd`) and file-based (e.g. `cat`) commands