### PR TITLE
Add validation for resizeable interactive shells

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -395,7 +395,16 @@ class Console::CommandDispatcher::Stdapi::Sys
   #
   def pty_shell(sh_path, raw: false)
     args = ['-p']
-    args << '-r' if raw
+
+    if raw
+      args << '-r' if raw
+      if client.commands.include?(Extensions::Stdapi::COMMAND_ID_STDAPI_SYS_PROCESS_SET_TERM_SIZE)
+        print_line("Terminal size will be synced automatically.")
+      else
+        print_line("You may want to set the correct terminal size manually.")
+        print_line("Example: `stty rows {rows} cols {columns}`")
+      end
+    end
     sh_path = client.fs.file.exist?(sh_path) ? sh_path : '/bin/sh'
 
     # Python Meterpreter calls pty.openpty() - No need for other methods

--- a/lib/rex/post/meterpreter/ui/console/interactive_channel.rb
+++ b/lib/rex/post/meterpreter/ui/console/interactive_channel.rb
@@ -111,6 +111,7 @@ module Console::InteractiveChannel
   end
 
   def update_term_size
+    return unless self.client.commands.include?(Extensions::Stdapi::COMMAND_ID_STDAPI_SYS_PROCESS_SET_TERM_SIZE)
     rows, cols = ::IO.console.winsize
     unless rows == self.rows && cols == self.cols
       set_term_size(rows, cols)


### PR DESCRIPTION
This PR makes it so the resize events are only sent if the Meterpreter client supports it and gives some feedback to the user on whether or not terminal resizing is handled automatically or if they should adjust it manually

# Verification
- [x] Run `features set fully_interactive_shells true` to enable the feature
- [x] Get a Meterpreter session on a Meterpreter that supports resizing (python, mettle)
- [x] Run `shell -it`
- [x] Confirm you see the message 

> Terminal size will be synced automatically.

- [x] Exit that shell and then repeat with `shell` and `shell -t` and observe no message since they are not interactive
- [x] Get a Meterpreter session on a Meterpreter that does not support resizing (PHP, Java)
- [x] Run `shell -it`
- [x] Confirm you see the message 

> You may want to set the correct terminal size manually. 

with an example on how to do that 

> Example: `stty rows {rows} cols {columns}`


On a supported Meterpreter:
![image](https://user-images.githubusercontent.com/19910435/142422896-2ff0544d-fd8c-4525-af9d-90d95370fcca.png)

On an unsupported Meterpreter:
![image](https://user-images.githubusercontent.com/19910435/142423129-edda13c2-8b1f-456f-a32a-7d6b883c26bf.png)
