### PR TITLE
trade `URI.encode` & `URI.escape` for Ruby 3

### DIFF
--- a/lib/anemone/page.rb
+++ b/lib/anemone/page.rb
@@ -175,7 +175,7 @@ module Anemone
       return nil if link.nil?
 
       # remove anchor
-      link = URI.encode(link.to_s.gsub(/#[a-zA-Z0-9_-]*$/,''))
+      link = URI::DEFAULT_PARSER.escape(link.to_s.gsub(/#[a-zA-Z0-9_-]*$/,'')) # this is deprecated
 
       relative = URI(link)
       absolute = @url.merge(relative)

--- a/lib/anemone/page.rb
+++ b/lib/anemone/page.rb
@@ -175,7 +175,7 @@ module Anemone
       return nil if link.nil?
 
       # remove anchor
-      link = URI::DEFAULT_PARSER.escape(link.to_s.gsub(/#[a-zA-Z0-9_-]*$/,'')) # this is deprecated
+      link = URI::DEFAULT_PARSER.escape(link.to_s.gsub(/#[a-zA-Z0-9_-]*$/,''))
 
       relative = URI(link)
       absolute = @url.merge(relative)

--- a/lib/msf/core/exploit/remote/web.rb
+++ b/lib/msf/core/exploit/remote/web.rb
@@ -130,7 +130,7 @@ module Exploit::Remote::Web
   #
   def substitute_web_payload_stub( str, escape = '' )
     value = stub_value
-    value = URI.encode( stub_value, escape ) if !escape.empty?
+    value = URI::DEFAULT_PARSER.escape( stub_value, escape ) if !escape.empty?
     str.to_s.gsub( web_payload_stub, value )
   end
 

--- a/lib/rex/google/geolocation.rb
+++ b/lib/rex/google/geolocation.rb
@@ -19,7 +19,7 @@ module Rex
       attr_accessor :longitude
 
       def initialize
-        @uri = URI.parse(URI.encode(GOOGLE_API_URI))
+        @uri = URI.parse(URI::DEFAULT_PARSER.escape(GOOGLE_API_URI))
         @wlan_list = []
       end
 
@@ -58,7 +58,7 @@ module Rex
       end
 
       def set_api_key(key)
-        @uri = URI.parse(URI.encode(GOOGLE_API_URI + key))
+        @uri = URI.parse(URI::DEFAULT_PARSER.escape(GOOGLE_API_URI + key))
       end
 
       def google_maps_url

--- a/modules/auxiliary/admin/aws/aws_launch_instances.rb
+++ b/modules/auxiliary/admin/aws/aws_launch_instances.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Auxiliary
     opts['IamInstanceProfile.Name'] = datastore['ROLE_NAME'] unless datastore['ROLE_NAME'].blank?
     unless datastore['USERDATA_FILE'].blank?
       if File.exist?(datastore['USERDATA_FILE'])
-        opts['UserData'] = URI.encode(Base64.encode64(open(datastore['USERDATA_FILE'], 'r').read).strip)
+        opts['UserData'] = URI::DEFAULT_PARSER.escape(Base64.encode64(open(datastore['USERDATA_FILE'], 'r').read).strip)
       else
         print_error("Could not open userdata file: #{datastore['USERDATA_FILE']}")
       end
@@ -204,7 +204,7 @@ class MetasploitModule < Msf::Auxiliary
     print_error("Could not create SG") && return if doc['groupId'].nil?
     sg = doc['groupId']
     proto, port = datastore['SEC_GROUP_PORT'].split(':')
-    cidr = URI.encode(datastore['SEC_GROUP_CIDR'])
+    cidr = URI::DEFAULT_PARSER.escape(datastore['SEC_GROUP_CIDR'])
     action = 'AuthorizeSecurityGroupIngress'
     doc = call_ec2(creds, 'Action' => action,
                           'IpPermissions.1.IpRanges.1.CidrIp' => cidr,

--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Auxiliary
 
         next unless attr_value && !attr_value.empty?
 
-        uri = site_uri.merge(URI.encode(attr_value.strip))
+        uri = site_uri.merge(URI::DEFAULT_PARSER.escape(attr_value.strip))
 
         next unless uri.host == vhost || uri.host == rhost
 

--- a/modules/auxiliary/gather/flash_rosetta_jsonp_url_disclosure.rb
+++ b/modules/auxiliary/gather/flash_rosetta_jsonp_url_disclosure.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def exploit_html
-    ex_url = URI.escape(get_uri.chomp('/')+'/'+Rex::Text.rand_text_alphanumeric(6+rand(20))+'.log')
+    ex_url = URI::DEFAULT_PARSER.escape(get_uri.chomp('/')+'/'+Rex::Text.rand_text_alphanumeric(6+rand(20))+'.log')
     %Q|
       <!doctype html>
       <html>
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Auxiliary
           <object type="application/x-shockwave-flash" data="#{exploit_url(encoded_swf)}"
             width=500 height=500>
             <param name="FlashVars"
-              value="url=#{URI.escape datastore['STEAL_URLS']}&exfiltrate=#{ex_url}" />
+              value="url=#{URI::DEFAULT_PARSER.escape datastore['STEAL_URLS']}&exfiltrate=#{ex_url}" />
           </object>
         </body>
       </html>

--- a/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
+++ b/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
       %w(href src).each do |attribute|
         attr_value = tag[attribute]
         next unless attr_value && !attr_value.empty?
-        uri = site_uri.merge(URI.encode(attr_value.strip))
+        uri = site_uri.merge(URI::DEFAULT_PARSER.escape(attr_value.strip))
         next unless uri.host == vhost || uri.host == rhost
         uris << uri.path if uri.path =~ /\.[a-z]{2,}$/i # Only keep path with a file
       end

--- a/modules/exploits/linux/http/php_imap_open_rce.rb
+++ b/modules/exploits/linux/http/php_imap_open_rce.rb
@@ -508,7 +508,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status('Listener started for 300 seconds')
       print_good("POST request connection string: x #{command}}")
       # URI.encode leaves + as + since that's a space encoded.  So we manually change it.
-      print_good("GET request connection string: #{URI.encode("x " + command + "}").sub! '+', '%2B'}")
+      print_good("GET request connection string: #{URI::DEFAULT_PARSER.escape("x " + command + "}").sub! '+', '%2B'}")
     end
   end
 end

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
-    command  = URI.encode(payload.encoded)+"%26"
+    command  = URI::DEFAULT_PARSER.escape(payload.encoded)+"%26"
     postdata = "__ac_name=#{username}&__ac_password=#{password}&daemon=#{command}"
 
     # send payload

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with Failure::Unknown, "Got odd qslDelta, that means the URL encoding gone wrong: path=#{path}, qsl_delta=#{qsl_delta}"
     end
     # rubocop:disable Lint/UriEscapeUnescape
-    prefix = cmd.empty? ? '' : "#{@http_param}=#{URI.encode(cmd)}%26"
+    prefix = cmd.empty? ? '' : "#{@http_param}=#{URI::DEFAULT_PARSER.escape(cmd)}%26"
     # rubocop:enable Lint/UriEscapeUnescape
     qsl_prime = qsl - qsl_delta / 2 - prefix.length
     if qsl_prime < 0

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -130,9 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if qsl_delta.odd?
       fail_with Failure::Unknown, "Got odd qslDelta, that means the URL encoding gone wrong: path=#{path}, qsl_delta=#{qsl_delta}"
     end
-    # rubocop:disable Lint/UriEscapeUnescape
     prefix = cmd.empty? ? '' : "#{@http_param}=#{URI::DEFAULT_PARSER.escape(cmd)}%26"
-    # rubocop:enable Lint/UriEscapeUnescape
     qsl_prime = qsl - qsl_delta / 2 - prefix.length
     if qsl_prime < 0
       fail_with Failure::Unknown, "QSL value too small to fit the command: QSL=#{qsl}, qsl_delta=#{qsl_delta}, prefix (size=#{prefix.size})=#{prefix}"

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Post
     print_status("Creating group policy")
     pol_doc = datastore['IAM_GROUP_POL']
     action = 'PutGroupPolicy'
-    doc = call_iam(creds, 'Action' => action, 'GroupName' => groupname, 'PolicyName' => 'Policy', 'PolicyDocument' => URI.encode(pol_doc))
+    doc = call_iam(creds, 'Action' => action, 'GroupName' => groupname, 'PolicyName' => 'Policy', 'PolicyDocument' => URI::DEFAULT_PARSER.escape(pol_doc))
     print_results(doc, action)
 
     # add user to group

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -611,7 +611,7 @@ class MetasploitModule < Msf::Post
     # Make request to LastPass
     uri = URI('https://lastpass.com/otp.php')
     request = Net::HTTP::Post.new(uri)
-    request.set_form_data("login" => 1, "xml" => 1, "hash" => otp_token, "otpemail" => URI.escape(username), "outofbandsupported" => 1, "changepw" => otp_token)
+    request.set_form_data("login" => 1, "xml" => 1, "hash" => otp_token, "otpemail" => URI::DEFAULT_PARSER.escape(username), "outofbandsupported" => 1, "changepw" => otp_token)
     request.content_type = 'application/x-www-form-urlencoded; charset=UTF-8'
     response = Net::HTTP.start(uri.hostname, uri.port, :use_ssl => true) { |http| http.request(request) }
 


### PR DESCRIPTION
Ruby 3 removed the `URI.escape` methods however access to
the a parse for the same RFC is stil available at `URI::DEFAULT_PARSER.escape`.

Per the Ruby forum [comment](https://bugs.ruby-lang.org/issues/17309#note-1) this should equal.

While investigating `scanner/http/crawler` in Ruby 3 it was identified that no enumeration was generated in Ruby 3 where in Ruby 2.7 pages were still enumerated. This was tracked to the removal of `URI.encode`.

Pre change Ruby 2.7.2
```
/metasploit/metasploit-framework/lib/anemone/page.rb:178: warning: URI.escape is obsolete
[-] [00500/00500]    404 - 192.168.222.112 - http://192.168.222.112:8180/tomcat-docs/appdev/basilic/
[-] Maximum page count reached for http://192.168.222.112:8180/
[*] Crawl of http://192.168.222.112:8180/ complete
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/crawler) >
```

Pre change Ruby 3.0.2
```
[*] Running module against 192.168.222.112

[*] Crawling http://192.168.222.112:8180/...
[*] [00001/00500]    200 - 192.168.222.112 - http://192.168.222.112:8180/
[*] Crawl of http://192.168.222.112:8180/ complete
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/crawler) >
```

Post Change Ruby 3.0.2
```
[-] [00499/00500]    404 - 192.168.222.112 - http://192.168.222.112:8180/jsp-examples/snp/awstats/
[-] [00500/00500]    404 - 192.168.222.112 - http://192.168.222.112:8180/jsp-examples/snp/stuff/
[-] Maximum page count reached for http://192.168.222.112:8180/
[*] Crawl of http://192.168.222.112:8180/ complete
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/crawler) >
```

Other scenarios for changes are untested.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use scanner/http/crawler`
- [x] `set RHOST <METASPLOITABLE 2 IP>`
- [x] `set RPORT 8180`
- [x] `run`
- [x] **Verify** pages are enumerated when using Ruby 2.7.2 & Ruby 3.0.2
