### PR TITLE
Tell the user about `shell -it`

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -368,11 +368,14 @@ class Console::CommandDispatcher::Stdapi::Sys
       if raw && !use_pty
         print_warning('Note: To use the fully interactive shell you must use a pty, i.e. %grnshell -it%clr')
         return false
-      end
-      if use_pty && pty_shell(sh_path, raw: raw)
+      elsif use_pty && pty_shell(sh_path, raw: raw)
         return true
       end
 
+      if client.framework.features.enabled?(Msf::FeatureManager::FULLY_INTERACTIVE_SHELLS) && !raw && !use_pty
+        print_line('This Meterpreter supports %grnshell -it%clr to start a fully interactive TTY.')
+        print_line('This will increase network traffic.')
+      end
       cmd_execute('-f', '/bin/sh', '-c', '-i')
     else
       # Then this is a multi-platform meterpreter (e.g., php or java), which


### PR DESCRIPTION
Informs the user about the existence of `shell -it` when they try to use the `shell` command in a Meterpreter that supports it and the feature is enabled

# Verification
- [x] Start up msfconsole
- [x] Run `features set fully_interactive_shells true`
- [x] Get a Meterpreter shell on a supported platform (Linux/OSX, I used the python Meterpreter on Ubuntu)
- [x] Run `shell` You should see the message displayed
- [x] Exit the shell
- [x] Run `shell -it` The message should not appear
- [x] Exit the shell
- [x] `bg` your Meterpreter shell
- [x] Run `features set fully_interactive_shells false` to disable to feature
- [x] Interact with your Meterpreter shell again
- [x] Run `shell` and no message should appear

![image](https://user-images.githubusercontent.com/19910435/143023599-7c3fd6c5-7157-4d63-9d0e-e21852f29725.png)

