### PR TITLE
Update Azure AD Login Scanner Documentation

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/azure_ad_login.md
+++ b/documentation/modules/auxiliary/scanner/http/azure_ad_login.md
@@ -1,10 +1,10 @@
 ## Vulnerable Application
 
-The Microsoft Azure AD service has a vulnerable endpoint that delivers an error-code based response
-to specific authentication requests in XML. The endpoint, when passed the correct credentials,
-will respond with a DesktopSsoToken that can be used to authenticate to Azure AD. When
-the authentication is unsuccessful, the error code that is returned can be used to discover the
-validity of usernames in the target tenant.
+The Microsoft Azure AD SSO service has a vulnerable endpoint that delivers an error-code based
+response to specific authentication requests in XML. The endpoint, when passed the correct
+credentials, will respond with a DesktopSsoToken that can be used to authenticate to Azure AD.
+When the authentication is unsuccessful, the error code that is returned can be used to discover
+the validity of usernames in the target tenant.
 This module also reports credentials to the credentials database when they are discovered.
 
 ## Verification Steps
@@ -89,8 +89,9 @@ msf6 auxiliary(scanner/http/azure_ad_login) > run
 [*] Auxiliary module execution completed```
 
 ## Version and OS
-Tested against current Azure AD tenants.
+Tested against current Azure AD tenants with SSO enabled.
 
 ## References
+- https://raxis.com/blog/metasploit-azure-ad-login
 - https://arstechnica.com/information-technology/2021/09/new-azure-active-directory-password-brute-forcing-flaw-has-no-fix/
 - https://github.com/treebuilder/aad-sso-enum-brute-spray

--- a/modules/auxiliary/scanner/http/azure_ad_login.rb
+++ b/modules/auxiliary/scanner/http/azure_ad_login.rb
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'License' => MSF_LICENSE,
       'References' => [
+        [ 'URL', 'https://raxis.com/blog/metasploit-azure-ad-login'],
         [ 'URL', 'https://arstechnica.com/information-technology/2021/09/new-azure-active-directory-password-brute-forcing-flaw-has-no-fix/'],
         [ 'URL', 'https://github.com/treebuilder/aad-sso-enum-brute-spray'],
       ],


### PR DESCRIPTION
I wrote a brief blog post about this module and how it ties in with the original vulnerability, including some mitigation techniques against the module. I added this in as a reference, and also corrected some of my documentation surrounding the requirement of SSO needing to be enabled for this module to be successful. I also ran msftidy_docs and rubocop to make sure my changes didn't introduce any non-cleanliness to the module.

