### PR TITLE
Only normalize new/updated hosts after nmap import

### DIFF
--- a/lib/msf/core/db_manager/import/nmap.rb
+++ b/lib/msf/core/db_manager/import/nmap.rb
@@ -8,6 +8,7 @@ module Msf::DBManager::Import::Nmap
     end
     parser = ::Nokogiri::XML::SAX::Parser.new(doc)
     parser.parse(args[:data])
+    doc.result
   end
 
   # If you have Nokogiri installed, you'll be shunted over to
@@ -23,11 +24,11 @@ module Msf::DBManager::Import::Nmap
       noko_args[:workspace] = wspace
       if block
         yield(:parser, "Nokogiri v#{::Nokogiri::VERSION}")
-        import_nmap_noko_stream(noko_args) {|type, data| yield type,data }
+        result = import_nmap_noko_stream(noko_args) {|type, data| yield type,data }
       else
-        import_nmap_noko_stream(noko_args)
+        result = import_nmap_noko_stream(noko_args)
       end
-      return true
+      return result
     end
 
     # XXX: Legacy nmap xml parser starts here.

--- a/lib/rex/parser/nmap_document.rb
+++ b/lib/rex/parser/nmap_document.rb
@@ -9,6 +9,12 @@ module Rex
 
     include NokogiriDocMixin
 
+    attr_accessor :result
+    def initialize(args, db, &block)
+      @result = Rex::Parser::ParsedResult.new
+      super
+    end
+
     def determine_port_state(v)
       case v
       when "open"
@@ -376,7 +382,7 @@ module Rex
             db_report(:note, nse_note)
           end
         end
-
+        @result.record_host(host_object)
         host_object
       end
     end

--- a/lib/rex/parser/parsed_result.rb
+++ b/lib/rex/parser/parsed_result.rb
@@ -1,0 +1,13 @@
+class Rex::Parser::ParsedResult
+
+  attr_accessor :host_ids
+
+  def initialize
+    @host_ids = []
+  end
+
+  def record_host(host)
+    @host_ids << host.id
+  end
+
+end


### PR DESCRIPTION
Part of the work to address slow `db_import` times #14763 

Currently once a `db_import` is finished there is some post processing done, part this involves looping through every host in the current workspace and calling `normalize_os` 
With a small number of hosts in a workspace this isn't much of an issue but as the workspace grows so does the time spent in post processing
This PR alters the post processing to only call `normalize_os` on hosts that are new or have been updated during the import

You can see my current workspace here:
![image](https://user-images.githubusercontent.com/19910435/143454772-7aa6c8df-5847-4397-804e-db0ef2908ea2.png)
Used this command to get the information
```
irb -e "puts JSON.pretty_generate({ counts: { workspace: Mdm::Workspace.count, hosts: Mdm::Host.count, vulns: Mdm::Vuln.count, notes: Mdm::Note.count, services: Mdm::Service.count }, workspace_examples: Mdm::Workspace.take(10).map { |workspace| { workspace_id: workspace.id, hosts: workspace.hosts.count, vulns: workspace.vulns.count, notes: workspace.notes.count, services: workspace.services.count } } })"
```

~32,000 hosts
Currently importing a single host in this workspace takes over 700 seconds
![image](https://user-images.githubusercontent.com/19910435/143454952-879f1f30-adec-4f0b-97c1-334fdddbb352.png)

With this change it takes about a second
![image](https://user-images.githubusercontent.com/19910435/143455019-544f748c-53b8-4aac-899d-cadeebfe4ff7.png)

# Verification
- [x] Grab a workspace with a bunch of hosts (don't need as many as I had, just enough that you notice a slowdown, I'll link a resource script I used)
- [x] Import a single host and note how long it takes
- [x] Check out this PR and import another single host
- [x] The time should be reduced and relative to how many hosts are imported rather than how many are currently in the workspace

This resource script generates a randomized nmap file with 100 hosts, imports it and tells you the time taken, you can use it to fill up a workspace with hosts or you can use any other means you like
[import_bulk.zip](https://github.com/rapid7/metasploit-framework/files/7603563/import_bulk.zip)

