### PR TITLE
ms05_039_pnp: Rename 'Windows 2000 SP4 English/French/German/Dutch' target to 'Windows 2000 SP4 Universal'

### DIFF
--- a/modules/exploits/windows/smb/ms05_039_pnp.rb
+++ b/modules/exploits/windows/smb/ms05_039_pnp.rb
@@ -63,7 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
             },
           ],
           [
-            'Windows 2000 SP4 English/French/German/Dutch',
+            # Tested on: English/French/German/Dutch/Finnish/Greek/Polish/Portuguese/Hungarian/Korean/Chinese/Arabic/Turkish/Russian
+            'Windows 2000 SP4 Universal',
             {
               'Ret'      => 0x01013C79, # [Pita] [Houmous] <pita@mail.com>
             },


### PR DESCRIPTION
This `Windows 2000 SP4 English/French/German/Dutch` target appears to be universal across locales for Windows 2000 SP4 systems (both Professional and Server). I have no idea where this address is located.

The default target `Windows 2000 SP0-SP4` presumably only works for systems with  English locale. It doesn't work for any of the non-English systems I've tested.
