### PR TITLE
Resolve readline error when two options differ only in case

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1665,7 +1665,7 @@ class Core
 
   def cmd_sessions_tabs(str, words)
     if words.length == 1
-      return @@sessions_opts.fmt.keys
+      return @@sessions_opts.fmt.keys.select { |opt| opt.start_with?(str) }
     end
 
     case words[-1]

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -1072,6 +1072,9 @@ class Console::CommandDispatcher::Stdapi::Fs
   end
 
   def tab_complete_path(str, words, dir_only)
+    if client.platform == 'windows'
+        ::Readline.completion_case_fold = true
+    end
     if client.commands.include?(COMMAND_ID_STDAPI_FS_LS)
       expanded = str
       expanded = client.fs.file.expand_path(expanded) if expanded =~ path_expand_regex

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -391,6 +391,7 @@ module DispatcherShell
   #
   def tab_complete(str)
     ::Readline.completion_append_character = ' '
+    ::Readline.completion_case_fold = false
 
     # Check trailing whitespace so we can tell 'x' from 'x '
     str_match = str.match(/[^\\]([\\]{2})*\s+$/)

--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -28,7 +28,6 @@ begin
         ::Readline.basic_word_break_characters = ""
         @rl_saved_proc = with_error_handling(tab_complete_proc)
         ::Readline.completion_proc = @rl_saved_proc
-        ::Readline.completion_case_fold = true
       end
     end
 


### PR DESCRIPTION
I found a bug in tab completion that was introduced by the recent case sensitivity changes to tab-completing filenames on Windows (#15859). It seems this exposed a bug in the readline module when there are two options that differ only in case.

To reproduce (I'm using version d0e4d15d53):

- [ ] Start `msfconsole`
- [ ] Type `sessions -s` (no space at the end)
- [ ] Hit `<tab>`

Result:

```
        15: from ./msfconsole:23:in `<main>'
        14: from /home/smash/git/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
        13: from /home/smash/git/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
        12: from /home/smash/git/metasploit-framework/lib/rex/ui/text/shell.rb:145:in `run'
        11: from /home/smash/git/metasploit-framework/lib/rex/ui/text/shell.rb:323:in `get_input_line'
        10: from /home/smash/git/metasploit-framework/lib/rex/ui/text/input/readline.rb:100:in `pgets'
         9: from /home/smash/git/metasploit-framework/lib/rex/ui/text/input/readline.rb:162:in `readline_with_output'
         8: from /home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4875:in `readline'
         7: from /home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4853:in `readline_internal'
         6: from /home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4779:in `readline_internal_charloop'
         5: from /home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4363:in `_rl_dispatch'
         4: from /home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4374:in `_rl_dispatch_subseq'
         3: from /home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6903:in `rl_complete'
         2: from /home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6813:in `rl_complete_internal'
         1: from /home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6329:in `gen_completion_matches'
/home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/readline.rb:161:in `readline_attempted_completion_function': undefined method `downcase' for nil:NilClass (NoMethodError)
```

You can also replicate it with pathnames on Linux when they're identical:

- [ ] Obtain a linux meterpreter shell
- [ ] Create two files that differ only in case (e.g. words and wordS)
- [ ] Type `cat wo<tab>`

```
meterpreter > cat wo[-] Session manipulation failed: undefined method `downcase' for nil:NilClass ["/home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/readline.rb:161:in `readline_attempted_completion_function'", "/home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6329:in `gen_completion_matches'", "/home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6813:in `rl_complete_internal'", "/home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6903:in `rl_complete'", "/home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4374:in `_rl_dispatch_subseq'", "/home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4363:in `_rl_dispatch'", "/home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4779:in `readline_internal_charloop'", "/home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4853:in `readline_internal'", "/home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4875:in `readline'", "/home/smash/git/metasploit-framework/lib/rex/ui/text/input/readline.rb:162:in `readline_with_output'", "/home/smash/git/metasploit-framework/lib/rex/ui/text/input/readline.rb:100:in `pgets'", "/home/smash/git/metasploit-framework/lib/rex/ui/text/shell.rb:323:in `get_input_line'", "/home/smash/git/metasploit-framework/lib/rex/ui/text/shell.rb:145:in `run'", "/home/smash/git/metasploit-framework/lib/rex/post/meterpreter/ui/console.rb:62:in `interact'", "/home/smash/git/metasploit-framework/lib/msf/base/sessions/meterpreter.rb:555:in `_interact'", "/home/smash/git/metasploit-framework/lib/rex/ui/interactive.rb:53:in `interact'", "/home/smash/git/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1543:in `cmd_sessions'", "/home/smash/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:562:in `run_command'", "/home/smash/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:511:in `block in run_single'", "/home/smash/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:505:in `each'", "/home/smash/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:505:in `run_single'", "/home/smash/git/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'", "/home/smash/git/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'", "/home/smash/git/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'", "./msfconsole:23:in `<main>'"]
```



Ideally we'd fix this in the readline module, but that doesn't seem to be getting updates. So to fix this, I've changed the tab completion handling back to always respect case, except in the case of Windows paths, which was the initial reason for making the change.

Also needed to manually filter the options for tab completing `sessions`, since it provides options that differ only in case; these would otherwise suffer from the same bug that was observed in windows paths.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Type `sessions -s` (no space at the end)
- [ ] Hit `<tab>`
- [ ] Verify that it adds a space after the `-s`
- [ ] Obtain a linux meterpreter shell
- [ ] Create two files that differ only in case (e.g. words and wordS)
- [ ] Type `cat wo<tab>`
- [ ] Verify that it completes up until the differing case (in this case, `word`)