### PR TITLE
Added tab completion to powershell_import command

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/powershell.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/powershell.rb
@@ -117,6 +117,12 @@ class Console::CommandDispatcher::Powershell
     print_line(@@powershell_import_opts.usage)
   end
 
+  def cmd_powershell_import_tabs(str, words)
+    if words.length == 1 # Just the command
+      tab_complete_filenames(str, words)
+    end
+  end
+
   #
   # Import a script or assembly component into the target.
   #


### PR DESCRIPTION
This PR adds tab completion support to the `powershell_import` command.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Obtain a windows meterpreter
- [ ] Run `load powershell`
- [ ] Type `powershell_import` and start typing the name of a file
- [ ] Attempt tab completion
- [ ] Verify that it provides suggestions for the name of existing files, and auto-completes if a unique match is found.