### PR TITLE
Fix unpacking 64-bit stat buffers from Meterpreter

### DIFF
--- a/lib/rex/post/file_stat.rb
+++ b/lib/rex/post/file_stat.rb
@@ -73,7 +73,7 @@ class FileStat
   end
 
   def update(buf)
-    skeys = %W{st_dev st_mode st_nlink st_uid st_gid st_rdev st_ino st_size st_ctime st_atime st_mtime}
+    skeys = %W{st_dev st_mode st_nlink st_uid st_gid st_rdev st_ino st_size st_atime st_mtime st_ctime}
     svals = buf.unpack("VVVVVVQQQQQ")
     skeys.each_index do |i|
       self.stathash[ skeys[i] ] = svals[i]

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file_stat.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file_stat.rb
@@ -22,35 +22,6 @@ class FileStat < Rex::Post::FileStat
     attr_accessor :client
   end
 
-  @@struct_stat = [
-    'st_dev',     4,  # 0
-    'st_mode',    4,  # 4
-    'st_nlink',   4,  # 8
-    'st_uid',     4,  # 12
-    'st_gid',     4,  # 16
-    'st_rdev',    4,  # 20
-    'st_ino',     8,  # 24
-    'st_size',    8,  # 32
-    'st_atime',   8,  # 40
-    'st_mtime',   8,  # 48
-    'st_ctime',   8,  # 56
-  ]
-
-  @@struct_stat32 = [
-    'st_dev',     4,  # 0
-    'st_ino',     2,  # 4
-    'st_mode',    2,  # 6
-    'st_nlink',   2,  # 8
-    'st_uid',     2,  # 10
-    'st_gid',     2,  # 12
-    'pad1',       2,  # 14
-    'st_rdev',    4,  # 16
-    'st_size',    4,  # 20
-    'st_atime',   8,  # 24
-    'st_mtime',   8,  # 32
-    'st_ctime',   8,  # 40
-  ]
-
   ##
   #
   # Constructor
@@ -61,73 +32,14 @@ class FileStat < Rex::Post::FileStat
   # Returns an instance of a FileStat object.
   #
   def initialize(file)
-    self.stathash = stat(file) if (file)
-  end
-
-  #
-  # Swaps in a new stat hash.
-  #
-  def update(stat_buf)
-    elem   = @@struct_stat
-    hash   = {}
-    offset = 0
-    index  = 0
-
-    while (index < elem.length)
-      size = elem[index + 1]
-      format = 'V'
-      case size
-      when 2
-        format = 'v'
-      when 8
-        format = 'Q'
-      end
-
-      value = stat_buf[offset, size].unpack(format)[0]
-      offset += size
-
-      hash[elem[index]] = value
-
-      index += 2
-    end
-
-    return (self.stathash = hash)
-  end
-
-  #
-  # Swaps in a new old style stat hash.
-  #
-  def update32(stat_buf)
-    elem   = @@struct_stat32
-    hash   = {}
-    offset = 0
-    index  = 0
-
-    while (index < elem.length)
-      size = elem[index + 1]
-
-      value   = stat_buf[offset, size].unpack(size == 2 ? 'v' : 'V')[0]
-      offset += size
-
-      hash[elem[index]] = value
-
-      index += 2
-    end
-
-    return (self.stathash = hash)
+    super
+    stat(file) if (file)
   end
 
 protected
-
-  ##
-  #
-  # Initializer
-  #
-  ##
-
   #
   # Gets information about the supplied file and returns a populated
-  # hash to the requestor.
+  # hash to the requester.
   #
   def stat(file)
     request = Packet.create_request(COMMAND_ID_STDAPI_FS_STAT)


### PR DESCRIPTION
This fixes the bug identified in #15919 that was due to a discrepancy in how the stat buffer from Meterpreter was being unpacked. There were two implementations that used a different order for the last 3 fields: `atime`, `mtime`, and `ctime`. The base class [`Rex::Post::FileStat#update`](https://github.com/rapid7/metasploit-framework/blob/38c779411878144ac5d0302741ee80313f8fc1ff/lib/rex/post/file_stat.rb#L75-L80) used the order CAM while the [Windows](https://github.com/rapid7/metasploit-payloads/blob/6e08d1f9812aa4d7a76b451fd5e0bae03975bb91/c/meterpreter/source/extensions/stdapi/server/fs/fs_local.h#L26-L28), [Mettle](https://github.com/rapid7/mettle/blob/6fffb8a945bea1391567cdcfcad80371f73ca520/mettle/src/stdapi/fs/file.c#L55), and [Python](https://github.com/rapid7/metasploit-payloads/blob/f452a0dd26cfddd15bf033e357624f947135f00b/python/meterpreter/ext_server_stdapi.py#L800) Meterpreters and [`Rex::Post::Meterpreter::Extensions::Stdapi::Fs::FileStat`](https://github.com/rapid7/metasploit-framework/blob/38c779411878144ac5d0302741ee80313f8fc1ff/lib/rex/post/meterpreter/extensions/stdapi/fs/file_stat.rb#L34-L36) all use the AMC ordering.

This bug would manifest itself when using the Windows Metepreter and running the `dir` command on a directory and then on an individual file. Due to how the command is processed, the two cases (directory and file) were using the different `FileStat` classes to unpack the buffer and, by extension, a different order. This meant the user would see a different "Last modified" time between the two commands.

The two `update` and `update32` functions that were removed are now leveraged by the parent class defined in `Rex::Post::FileStat`. Finally, the [PHP](https://github.com/rapid7/metasploit-payloads/blob/f452a0dd26cfddd15bf033e357624f947135f00b/php/meterpreter/ext_server_stdapi.php#L445:447) Meterpreter was the last one I checked and since it's still using the old 32-bit stat buffer, it continues to use the CAM ordering. [Java](https://github.com/rapid7/metasploit-payloads/blob/f452a0dd26cfddd15bf033e357624f947135f00b/java/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_fs_stat.java#L64) appears to be using AMC according to the comments, but the values are all the same so the ordering doesn't matter.

## Example
In the following example, the difference in the last modified timestamp of the "Setup.evtx" file is visible.
```
meterpreter > dir "c:\Windows\System32\winevt\Logs"
...
100666/rw-rw-rw-  130093056  fil   2020-02-26 15:09:20 -0500  Security.evtx
100666/rw-rw-rw-  1052672    fil   2020-02-26 15:09:31 -0500  Setup.evtx
100666/rw-rw-rw-  69632      fil   2020-02-26 12:11:06 -0500  State.evtx
100666/rw-rw-rw-  5312512    fil   2020-02-26 15:09:20 -0500  System.evtx
100666/rw-rw-rw-  1118208    fil   2020-02-26 15:09:20 -0500  Windows PowerShell.evtx
100666/rw-rw-rw-  69632      fil   2020-02-27 16:29:39 -0500  microsoft-windows-diagnosis-scripted%4operational.evtx

meterpreter > dir "c:\Windows\System32\winevt\Logs\Setup.evtx"
100666/rw-rw-rw-  1052672  fil  2021-12-03 18:15:52 -0500  c:\Windows\System32\winevt\Logs\Setup.evtx
```

## Testing
- [ ] Open a Windows Meterpreter session
- [ ] Run `dir` on a directory where a file has been modified (the `c:\Windows\System32\winevt\Logs` directory works nicely for this)
- [ ] Pick a file and then run `dir` on that file specifically, see the same timestamp (the value can be confirmed using Powershell: `(Get-Item "file").LastWriteTime`).