### PR TITLE
Capture passthrough command output in the output buffer handler.

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -480,12 +480,11 @@ protected
     [method, method+".exe"].each do |cmd|
       if command_passthru && Rex::FileUtils.find_full_path(cmd)
 
-        print_status("exec: #{line}")
-        print_line('')
-
         self.busy = true
         begin
-          system(line)
+          IO.popen(line).each do |o|
+            print_line(o.chomp)
+          end
         rescue ::Errno::EACCES, ::Errno::ENOENT
           print_error("Permission denied exec: #{line}")
         end

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -482,9 +482,11 @@ protected
 
         self.busy = true
         begin
-          IO.popen(line).each do |o|
-            print_line(o.chomp)
-          end
+          Open3.popen2e(line) {|stdin,output,thread|
+            output.each {|outline|
+              print_line(outline.chomp)
+            }
+          }
         rescue ::Errno::EACCES, ::Errno::ENOENT
           print_error("Permission denied exec: #{line}")
         end


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/12895 whereby passthrough commands did out send their output to the output buffer handler.  This meant that the output of any command executed via the console.write method within the msfrpc interface could not be retrieved by a console.read method.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfrpcd`
- [ ] Run the following within the 'msfrpc' client interface: 
- [ ] Create console object: `rpc.call('console.create')`
- [ ] Read the banner to flush the output buffer: `rpc.call('console.read',0)`
- [ ] Execute passthrough command: `rpc.call('console.write',0,"cat /etc/hosts\n")`
- [ ] Read the buffer output of the command: `rpc.call('console.read',0)`
- [ ] The buffer output should now show the output of the command
