### PR TITLE
Skip empty stat buffers when listing directories in Meterpreter

### DIFF
--- a/lib/rex/post/file_stat.rb
+++ b/lib/rex/post/file_stat.rb
@@ -198,7 +198,7 @@ class FileStat
   #
   def prettymode
     m  = mode
-    om = '%04o' % m
+    om = '%06o' % m
     perms = ''
 
     3.times {

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -99,7 +99,7 @@ class Dir < Rex::Post::Dir
     fname.each_with_index { |file_name, idx|
       st = nil
 
-      if (sbuf[idx])
+      if sbuf[idx] && sbuf[idx].value.length > 0
         st = ::Rex::Post::FileStat.new
         if new_stat_buf
           st.update(sbuf[idx].value)


### PR DESCRIPTION
This skips empty stat buffers, allowing Meterpreter to return empty ones for entries that can not be stat'ed and thus maintain the array alignment. Without this change, if a Meterpreter returned an empty stat buffer, a `TypeError` would be raised in Metasploit. If the stat buffer is omitted entirely, then the array alignment will be off causing stat buffers to be associated for the incorrect entries and the last N entries will have no stat buffer where N is the number of entries that could not be stat'ed. With this change in place, the entries that can't be stat'ed will just be missing their information.

This also updates the `#prettymode` method to display the `st_mode` field using 6 octal digits instead of 4 which are commonly present on a lot of Linux systems and ensures the fields are kept aligned in the resulting table.

<details>
<summary>TypeError from empty stat buffer</summary>

In this case, an entry in `/etc` can't be stat'ed and results in Meterpreter returning an empty stat buffer for it.

```
msf6 payload(python/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > ls /etc
[-] Error running command ls: TypeError can't convert nil into Integer
meterpreter >
```
</details>

This is required by
* rapid7/mettle#228
* rapid7/metasploit-payloads#516
* rapid7/metasploit-payloads#517

## Testing
On a Linux system:
- [ ] Create a bad symbolic link in a directory: `ln -s /doesnotexist doesnotexist`
- [ ] Use one a Mettle, PHP, or Python Meterpreter to list that directory (run: `ls`)
- [ ] See the results from the LS command, with details for each entry that can be stat'ed. The `doesnotexist` entry should be listed but without the mode flags or the modified timestamp.