### PR TITLE
Update metasploit-payloads gem to 2.0.65

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.60)
+      metasploit-payloads (= 2.0.65)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.15)
       mqtt
@@ -257,7 +257,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.60)
+    metasploit-payloads (2.0.65)
     metasploit_data_models (5.0.4)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -77,7 +77,7 @@ metasploit-concern, 4.0.3, "New BSD"
 metasploit-credential, 5.0.5, "New BSD"
 metasploit-framework, 6.1.19, "New BSD"
 metasploit-model, 4.0.3, "New BSD"
-metasploit-payloads, 2.0.60, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.65, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 5.0.4, "New BSD"
 metasploit_payloads-mettle, 1.0.15, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.60'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.65'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.15'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 115301
+  CachedSize = 115833
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 115293
+  CachedSize = 115825
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 115293
+  CachedSize = 115825
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 115201
+  CachedSize = 115733
 
   include Msf::Payload::Single
   include Msf::Payload::Python


### PR DESCRIPTION
Update the metasploit-payloads gem to v2.0.65 (previously 2.0.60). This adds the changes from the following PRs:

* rapid7/metasploit-payloads#506
* rapid7/metasploit-payloads#510
* rapid7/metasploit-payloads#513
* rapid7/metasploit-payloads#514
* rapid7/metasploit-payloads#515

Multiple bug fixes in the Python Meterpreter and a bug fix related to a syntax compatibility issue in the PHP meterpreter.

## Verification

- [ ] Retest manually
- [ ] Let automated tests pass