### PR TITLE
Fix creds command crashing when deleting multiple NTLM hashes

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -276,7 +276,7 @@ class Creds
         data[:private_data] = params['postgres']
         data[:jtr_format] = 'postgres'
       else
-        print_error("Postgres MD5 hashes should start wtih 'md5'")
+        print_error("Postgres MD5 hashes should start with 'md5'")
       end
     end
 
@@ -495,7 +495,7 @@ class Creds
     end
 
     if mode == :delete
-      result = framework.db.delete_credentials(ids: matched_cred_ids)
+      result = framework.db.delete_credentials(ids: matched_cred_ids.uniq)
       delete_count = result.size
     end
 


### PR DESCRIPTION
This PR fixes #14883

The cause of this issue was the `creds add` command creating one `Metasploit::Credential::Core` object, and then storing two or more NTLM hashes inside it as logins, incrementing `logins_count`. This resulted in the same object `id` being used more than once in the case of more than one NTLM hash being present, meaning the code was crashing as it tried deleting the same id multiple times.

## Verification

- [ ] Start `msfconsole`
- [ ] Add the credentials below
- [ ] Ensure `creds -d` deletes all credentials and does not crash.

```
creds add address:172.27.145.59 port:445 protocol:tcp service-name:smb user:Administrator ntlm:aad3b435b51404eeaad3b435b51404ee:76adfdfbf4f52000a1d5eb4ce6666c99 realm:WIN-QKA9JKS5MVU jtr:nt,lm
creds add address:172.29.199.4 port:445 protocol:tcp service-name:smb user:Administrator ntlm:aad3b435b51404eeaad3b435b51404ee:76adfdfbf4f52000a1d5eb4ce6666c99 realm:WIN-QKA9JKS5MVU jtr:nt,lm
creds add address:172.31.199.4 port:445 protocol:tcp service-name:smb user:Administrator ntlm:aad3b435b51404eeaad3b435b5abcdef:76adfdfbf4f52000a1d5eb4ce6abcdef realm:WIN-QKA9JKS5MVU jtr:nt,lm
```