### PR TITLE
Print error when session id is nil for kiwi creds_all

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -676,6 +676,11 @@ protected
   end
 
   def report_creds(type, user, domain, secret)
+    if client&.db_record&.id.nil?
+      wlog('The session is not stored correctly in the database. Something went wrong.')
+      return
+    end
+
     credential_data = {
         origin_type: :session,
         post_reference_name: 'kiwi',


### PR DESCRIPTION
This PR addresses #15689

## Verification

- [x] Start `msfconsole`
- [x] `use windows/x64/meterpreter/reverse_tcp`
- [x] Get a shell and run `getsystem`
- [x] `load kiwi`
- [x] `creds_all`
- [x] **Verify** that when the session is stored correctly, no error is reported and creds are returned.
- [x] **Verify** that when `client.db_record.id` is nil (this can be done by using `pry` and setting the value to nil manually), an error is logged and kiwi doesn't crash.