### PR TITLE
Support go 1.17 and remove startup errors for modules

### DIFF
--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -224,7 +224,12 @@ class Msf::Modules::External::GoBridge < Msf::Modules::External::Bridge
       go_path = go_path + File::PATH_SEPARATOR + shared_module_lib_path
     end
 
-    self.env = self.env.merge({'GOPATH' => go_path})
+    self.env = self.env.merge(
+      {
+        'GOPATH' => go_path,
+        'GO111MODULE' => 'auto'
+      }
+    )
     self.cmd = ['go', 'run', self.path]
   end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -974,23 +974,23 @@ module Msf
 
             # Check for modules that failed to load
             if framework.modules.module_load_error_by_path.length > 0
-              print_error("WARNING! The following modules could not be loaded!")
+              wlog("WARNING! The following modules could not be loaded!")
 
               framework.modules.module_load_error_by_path.each do |path, _error|
-                print_error("\t#{path}")
+                wlog("\t#{path}")
               end
 
-              print_error(log_msg)
+              wlog(log_msg)
             end
 
             if framework.modules.module_load_warnings.length > 0
-              print_warning("The following modules were loaded with warnings:")
+              wlog("The following modules were loaded with warnings:")
 
               framework.modules.module_load_warnings.each do |path, _error|
-                print_warning("\t#{path}")
+                wlog("\t#{path}")
               end
 
-              print_warning(log_msg)
+              wlog(log_msg)
             end
 
             self.driver.run_single("banner")

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -329,27 +329,21 @@ class Driver < Msf::Ui::Driver
   # displayed, scripts can be processed, and other fun can be had.
   #
   def on_startup(opts = {})
-    log_msg = "Please see #{File.join(Msf::Config.log_directory, 'framework.log')} for details."
-
     # Check for modules that failed to load
     if framework.modules.module_load_error_by_path.length > 0
-      print_warning("The following modules could not be loaded!")
+      wlog("The following modules could not be loaded!")
 
       framework.modules.module_load_error_by_path.each do |path, _error|
-        print_warning("\t#{path}")
+        wlog("\t#{path}")
       end
-
-      print_warning(log_msg)
     end
 
     if framework.modules.module_load_warnings.length > 0
       print_warning("The following modules were loaded with warnings:")
 
       framework.modules.module_load_warnings.each do |path, _error|
-        print_warning("\t#{path}")
+        wlog("\t#{path}")
       end
-
-      print_warning(log_msg)
     end
 
     if framework.db&.active


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/15932

Allows Metasploit to work with Go 1.17.

Before:
```
msf6 payload(windows/meterpreter/reverse_tcp) > use auxiliary/scanner/msmail/host_id
[-] Failed to load module: LoadError  Try running file manually to check for errors or dependency issues.
```

Underlying issue is a change in Go 1.17' handling of GOPATH, leading to these errors being logged:
```
[10/15/2021 07:29:15] [e(0)] core: /usr/share/metasploit-framework/modules/auxiliary/scanner/msmail/onprem_enum.go failed to load - LoadError  Try running file manually to check for errors or dependency issues.
[10/15/2021 07:29:15] [e(0)] core: Unexpected output running /usr/share/metasploit-framework/modules/auxiliary/scanner/msmail/exchange_enum.go:
/usr/share/metasploit-framework/modules/auxiliary/scanner/msmail/exchange_enum.go:8:2: package metasploit/module is not in GOROOT (/usr/lib/go-1.16/src/metasploit/module)
/usr/share/metasploit-framework/modules/auxiliary/scanner/msmail/exchange_enum.go:9:2: package msmail is not in GOROOT (/usr/lib/go-1.16/src/msmail)
```

Additionally the `print_warning` on boot up has been replaced with `wlog` to not confuse users about module errors that they don't plan to use:
```
──(root💀kali)-[~]
└─# msfconsole
[!] The following modules could not be loaded!..\
[!]     /usr/share/metasploit-framework/modules/auxiliary/scanner/msmail/onprem_enum.go
[!]     /usr/share/metasploit-framework/modules/auxiliary/scanner/msmail/exchange_enum.go
[!]     /usr/share/metasploit-framework/modules/auxiliary/scanner/msmail/host_id.go
[!] Please see /root/.msf4/logs/framework.log for details.
```

## Verification

- Install Go 1.17
- Verify a Go module works:
```
use auxiliary/scanner/msmail/host_id
info
```