### PR TITLE
Fix json packrat module

### DIFF
--- a/lib/msf/core/post/windows/packrat.rb
+++ b/lib/msf/core/post/windows/packrat.rb
@@ -154,7 +154,7 @@ module Msf
         # rubocop:disable Style/Eval
         def extract_json(saving_path, artifact_child, artifact, local_loc)
           json_file = ::File.read(saving_path.to_s)
-          json_parse = JSON.parse(json_file) # rubocop:disable Lint/UselessAssignment
+          json_parse = JSON.parse(json_file)
           parent_json_query = ''
           child_json_query = []
           json_credential_save = []
@@ -169,7 +169,7 @@ module Msf
 
           child_json_query.each do |split|
             children = eval("json_parse#{parent_json_query}")
-            children.each do |_child_node|
+            children.each do |child_node|
               child = eval("child_node#{split}").to_s
               json_credential_save << "#{split}:  #{child}"
             end


### PR DESCRIPTION
There was a race condition on merging https://github.com/rapid7/metasploit-framework/pull/15841 and the json packrat module is currently broken as a result

### Before:

The `extract_json` method crashes:

```
[*] undefined local variable or method `child_node' for #<Msf::Modules::Post__Windows__Gather__Credentials__Seamonkey::MetasploitModule:0x00007fc0c9625ae8>
Did you mean?  _child_node
```

### After

There is no longer a crash

## Verification

Open the seamonkey module and irb:

```
use post/windows/gather/credentials/seamonkey
irb
```

Verify the extract json functionality works as expected:
```
mock_file = Tempfile.new('example_file').tap do |f|
  ::File.write(
    f.path,
    {
      logins: [
        {
          hostname: 'foo1',
          usernameField: 'bar1',
          passwordField: 'baz1',
          encryptedUsername: 'foo1',
          encryptedPassword: 'baz1'
        },
        {
          hostname: 'foo2',
          usernameField: 'bar2',
          passwordField: 'baz',
          encryptedUsername: 'foo2',
          encryptedPassword: 'baz2'
        }
      ]
    }.to_json
  )
end
puts extract_json(mock_file.path, ARTIFACTS[:gatherable_artifacts][0], 'test_artifact', 'local_loot_name'); nil
```

Output:
```
[+] ['hostname']:  foo1
[+] ['hostname']:  foo2
[+] ['usernameField']:  bar1
[+] ['usernameField']:  bar2
[+] ['passwordField']:  baz1
[+] ['passwordField']:  baz
[+] ['encryptedUsername']:  foo1
[+] ['encryptedUsername']:  foo2
[+] ['encryptedPassword']:  baz1
[+] ['encryptedPassword']:  baz2
[+] File with data saved:  /Users/user/.msf4/loot/20211213194051_default_unknown_EXTRACTIONStest__537084.bin
```