### PR TITLE
Add tcp uri scheme for setting rhosts

### DIFF
--- a/lib/msf/core/rhosts_walker.rb
+++ b/lib/msf/core/rhosts_walker.rb
@@ -19,6 +19,7 @@ module Msf
       postgres
       smb
       ssh
+      tcp
     ].freeze
     private_constant :SUPPORTED_SCHEMAS
 
@@ -289,6 +290,27 @@ module Msf
 
       result['RHOSTS'] = uri.hostname
       result['RPORT'] = uri.port || 22
+
+      set_username(datastore, result, uri.user) if uri.user
+      set_password(datastore, result, uri.password) if uri.password
+
+      result
+    end
+
+    # Parses a uri string such as tcp://user:password@example.com into a hash
+    # which can safely be merged with a [Msf::DataStore] datastore for setting options.
+    #
+    # @param value [String] the uri string
+    # @return [Hash] A hash where keys match the required datastore options associated with
+    #   the uri value
+    def parse_tcp_uri(value, datastore)
+      uri = ::Addressable::URI.parse(value)
+      result = {}
+
+      result['RHOSTS'] = uri.hostname
+      if uri.port
+        result['RPORT'] = uri.port
+      end
 
       set_username(datastore, result, uri.user) if uri.user
       set_password(datastore, result, uri.password) if uri.password

--- a/spec/lib/msf/core/rhosts_walker_spec.rb
+++ b/spec/lib/msf/core/rhosts_walker_spec.rb
@@ -775,6 +775,18 @@ RSpec.describe Msf::RhostsWalker do
       end
     end
 
+    context 'when using the tcp scheme' do
+      it 'enumerates tcp schemes' do
+        ssh_mod.datastore['RHOSTS'] = '"tcp://user:a b c@example.com" "tcp://example.com:3000"'
+        expected = [
+          { 'RHOSTS' => '192.0.2.2', 'RPORT' => 22, 'USERNAME' => 'user', 'PASSWORD' => 'a b c' },
+          { 'RHOSTS' => '192.0.2.2', 'RPORT' => 3000, 'USERNAME' => nil, 'PASSWORD' => nil },
+        ]
+        expect(each_error_for(ssh_mod)).to be_empty
+        expect(each_host_for(ssh_mod)).to have_datastore_values(expected)
+      end
+    end
+
     context 'when using the ssh scheme' do
       it 'enumerates ssh schemes' do
         ssh_mod.datastore['RHOSTS'] = '"ssh://user:a b c@example.com/"'


### PR DESCRIPTION
Adds a tcp uri scheme for setting rhosts. This is a more generic version of the protocol specific schemas such as `mysql`, which also set a default port, database config etc. The tcp scheme just sets username, password, and the port if it's specified.

This will be useful for exploiting remote hosts which require a user/password/port all at once - but don't have a specific schema already defined

## Verification

```
use auxiliary/scanner/http/title
run tcp://example.com
```