### PR TITLE
Add shared resource support for replicant pattern

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -151,7 +151,7 @@ module Msf
       obj = self.clone
       self.instance_variables.each { |k|
         v = instance_variable_get(k)
-        v = v.dup rescue v
+        v = (v.is_a?(Rex::SharedResource) ? v : v.dup) rescue v
         obj.instance_variable_set(k, v)
       }
 

--- a/lib/rex/shared_resource.rb
+++ b/lib/rex/shared_resource.rb
@@ -1,0 +1,9 @@
+# -*- coding: binary -*-
+
+# A tag interface used to indicate that the object in question should not be
+# replicated as part of the replicant process in modules.
+#
+# Note that atomic access isn't granted to the caller, and additional mutex/semaphores
+# may be required to behave as expected in a threaded context.
+module Rex::SharedResource
+end


### PR DESCRIPTION
A possible solution to the problem encountered by https://github.com/rapid7/metasploit-framework/pull/15958 - which required sharing resources amongst the `replicant` Log4Shell modules which are created by the Scanner Mixin. Replication of the service objects would lead to the following bind errors:

```
msf6 auxiliary(scanner/http/log4shell_scanner) > run http://10.10.235.209:8983/ http://10.10.235.209:8983/ http://10.10.235.209:8983/ srvhost=10.9.4.245 verbose=true threads=3

[-] Auxiliary aborted due to failure: bad-config: The address is already in use or unavailable: (10.9.4.245:389).
[*] Auxiliary module execution completed
```

## Verification

Follow the same steps as: https://github.com/rapid7/metasploit-framework/pull/15958, and ensure that there are no binding errors output