### PR TITLE
Fix wordpress scanner crash for ruby 3

### DIFF
--- a/modules/auxiliary/scanner/http/wordpress_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_scanner.rb
@@ -70,9 +70,9 @@ class MetasploitModule < Msf::Auxiliary
         else
           f = File.open(datastore['THEMES_FILE'], 'rb')
         end
-        total = f.lines.count
+        total = f.readlines.count
         f.rewind
-        f = f.lines
+        f = f.readlines
         f.each_with_index do |theme, i|
           theme = theme.strip
           print_progress(target_host, i, total) if i % datastore['PROGRESS'] == 0
@@ -102,9 +102,9 @@ class MetasploitModule < Msf::Auxiliary
         else
           f = File.open(datastore['PLUGINS_FILE'], 'rb')
         end
-        total = f.lines.count
+        total = f.readlines.count
         f.rewind
-        f = f.lines
+        f = f.readlines
         f.each_with_index do |plugin, i|
           plugin = plugin.strip
           print_progress(target_host, i, total) if i % datastore['PROGRESS'] == 0


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/15973

## Verification

Verify steps:
https://github.com/rapid7/metasploit-framework/blob/6175e389712fd8e5ab3948d0f03414d887cd5193/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md#wordpress-542-with-plugin-and-theme-enumeration-exploitable-true