### PR TITLE
Update Log4Shell references and VCenter URI

### DIFF
--- a/data/exploits/CVE-2021-44228/http_uris.txt
+++ b/data/exploits/CVE-2021-44228/http_uris.txt
@@ -3,4 +3,4 @@
 # Apache Solr
 /solr/admin/cores?action=CREATE&wt=json&name=${jndi:uri}
 # VMWare VCenter
-/websso/SAML2/SSO/photon-machine.lan?SAMLRequest=
+/websso/SAML2/SSO/vsphere.local?SAMLRequest=

--- a/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
@@ -22,7 +22,7 @@ This module has been successfully tested with:
 5. Do: `run`
 6. The target should be identified as vulnerable
 
-### Struts2 Setup
+### Apache Struts2 Setup
 
 The following docker file can be used to setup a vulnerable Struts2 instance for testing.
 
@@ -68,7 +68,7 @@ Time in seconds to wait to receive LDAP connections.
 
 ## Scenarios
 
-### Struts2
+### Apache Struts2
 
 ```
 msf6 > use auxiliary/scanner/http/log4shell_scanner 

--- a/modules/auxiliary/scanner/http/log4shell_scanner.rb
+++ b/modules/auxiliary/scanner/http/log4shell_scanner.rb
@@ -29,7 +29,9 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'References' => [
         [ 'CVE', '2021-44228' ],
-        [ 'URL', 'https://attackerkb.com/topics/in9sPR2Bzt/cve-2021-44228-log4shell/rapid7-analysis' ]
+        [ 'CVE', '2021-45046' ],
+        [ 'URL', 'https://attackerkb.com/topics/in9sPR2Bzt/cve-2021-44228-log4shell/rapid7-analysis' ],
+        [ 'URL', 'https://logging.apache.org/log4j/2.x/security.html' ]
       ],
       'DisclosureDate' => '2021-12-09',
       'License' => MSF_LICENSE,


### PR DESCRIPTION
This adds two references to the Log4Shell scanner to include the newer CVE and the official Apache page. It also updates the VCenter URI in the wordlist to use the correct default value of `vsphere.local` instead of `photon-machine.lan`. Finally, the docs were updated to consistently refer to Struts2 as "Apache Struts2".
These are all minor tweaks, but the VCenter URI change should fix scanning for installations that at least use the default value.

## Testing
- [x] See the new references and double check they're correct
- [x] Verify the new VSpeher URI is the correct default value
