### PR TITLE
Fix session crashing when unsetting smbuser or smbpass for a smb module

### DIFF
--- a/lib/rex/proto/smb/simple_client.rb
+++ b/lib/rex/proto/smb/simple_client.rb
@@ -90,8 +90,9 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
 
       self.client.spnopt = spnopt
 
-      # In case the user unsets the password option, we make sure this is
+      # In case the user unsets the username or password option, we make sure this is
       # always a string
+      user ||= ''
       pass ||= ''
 
       res = self.client.session_setup(user, pass, domain)


### PR DESCRIPTION
This PR fixes #15916   
  
**Cause of bug:**
The cause of this issue was that, the ```login_scanner.rb``` code checked for either valued creds or empty strings before applying ```force_encoding``` method on them. There was no check on nil values explicitly. So unsetting the smbuser and smbpass makes the creds nil values which raises the ```undefined method force_encoding``` exception.  
  
**Approach:**
So one solution was to have a check on the nil values explicitly in the ```login_scanner.rb``` code. However, I figured out that ```login_scanner.rb``` always referenced to ```simple_client.rb``` while attempting a login on the creds. And in the ```simple_client.rb``` code, there was a check on the **smbpass**, which made it assign to an empty string if it was a nil value. Jackpot, So here I just added the same condition for **smbuser** as well, which solved the bug!  
  
I chose to change the ```simple_client.rb``` because instead of applying the nil check condition on all files which have smbuser creds, it would be better to change in the sole root file which they always reference to for attempting a login.
  
**Before:**  
  
```  
msf6 > use exploit/windows/smb/ms07_029_msdns_zonename 
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/smb/ms07_029_msdns_zonename) > unset smbuser
Unsetting smbuser...
msf6 exploit(windows/smb/ms07_029_msdns_zonename) > unset smbpass
Unsetting smbpass...
msf6 exploit(windows/smb/ms07_029_msdns_zonename) > set RHOSTS 192.168.1.100
RHOSTS => 192.168.1.100
msf6 exploit(windows/smb/ms07_029_msdns_zonename) > run

[*] Started reverse TCP handler on 192.168.1.105:4444 
[-] 192.168.1.100:445 - Exploit failed [no-access]: Rex::Proto::SMB::Exceptions::LoginError Login Failed: undefined method `force_encoding' for nil:NilClass
[*] Exploit completed, but no session was created.  
```  
  
**After:**  
  
```  
msf6 > use exploit/windows/smb/ms07_029_msdns_zonename 
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/smb/ms07_029_msdns_zonename) > unset smbuser
Unsetting smbuser...
msf6 exploit(windows/smb/ms07_029_msdns_zonename) > unset smbpass
Unsetting smbpass...
msf6 exploit(windows/smb/ms07_029_msdns_zonename) > set RHOSTS 192.168.1.100
RHOSTS => 192.168.1.100
msf6 exploit(windows/smb/ms07_029_msdns_zonename) > run

[*] Started reverse TCP handler on 192.168.1.105:4444 
[*] 192.168.1.100:445 - Unknown OS: Windows 7 Professional 7601 Service Pack 1
[*] Exploit completed, but no session was created.  
```

## Verification

- [ ] Start `msfconsole`
- [ ] Use any smb module. eg - `use exploit/windows/smb/ms07_029_msdns_zonename`
- [ ] `unset smbuser`
- [ ] `unset smbpass`
- [ ] `set RHOSTS TARGET_IP_ADDR`
- [ ] `run`
- [ ] **Verify** that `run` completes the exploit successfully even though no session is created 
- [ ] **Verify** that `run` does not crash or raise an exception.