### PR TITLE
Revert "Land #15941, fix command output in rpc console.write"

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -474,13 +474,12 @@ protected
     [method, method+".exe"].each do |cmd|
       if command_passthru && Rex::FileUtils.find_full_path(cmd)
 
+        print_status("exec: #{line}")
+        print_line('')
+
         self.busy = true
         begin
-          Open3.popen2e(line) {|stdin,output,thread|
-            output.each {|outline|
-              print_line(outline.chomp)
-            }
-          }
+          system(line)
         rescue ::Errno::EACCES, ::Errno::ENOENT
           print_error("Permission denied exec: #{line}")
         end


### PR DESCRIPTION
This reverts commit 8d808d11c0adc61d8ed3569ae41a17f5e678e998, reversing
changes made to c1f06eace8bb035c2d4aaa3416c3af5d2495d72f.

This change just reverts: https://github.com/rapid7/metasploit-framework/pull/15941
As discussed we probably *do* want to call `system` for unknown commands within msfconsole.

We will attempt to fix the underlying issue (no console output for commands run with console.write via rpc) in a new pull request, e.g: https://github.com/rapid7/metasploit-framework/pull/15989