### PR TITLE
unlock pcaprub

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       openvas-omp
       packetfu
       patch_finder
-      pcaprub (= 0.12.4)
+      pcaprub
       pdf-reader
       pg
       puma
@@ -304,7 +304,7 @@ GEM
     parser (3.1.0.0)
       ast (~> 2.4.1)
     patch_finder (1.0.2)
-    pcaprub (0.12.4)
+    pcaprub (0.13.1)
     pdf-reader (2.8.0)
       Ascii85 (~> 1.0)
       afm (~> 0.2.1)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -84,7 +84,7 @@ Gem::Specification.new do |spec|
   # Needed by db.rb and Msf::Exploit::Capture
   spec.add_runtime_dependency 'packetfu'
   # For sniffer and raw socket modules
-  spec.add_runtime_dependency 'pcaprub', '0.12.4'
+  spec.add_runtime_dependency 'pcaprub'
   # Used by the Metasploit data model, etc.
   # bound to 0.2x for Activerecord 4.2.8 deprecation warnings:
   # https://github.com/ged/ruby-pg/commit/c90ac644e861857ae75638eb6954b1cb49617090


### PR DESCRIPTION
Updated gem has been released with Ruby 3 support.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] **Verify** `pcap_log` plugin functions
