### PR TITLE
Fix #12895, fix console.read does not return command output

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -479,7 +479,7 @@ protected
 
         self.busy = true
         begin
-          system(line)
+          run_unknown_command(line)
         rescue ::Errno::EACCES, ::Errno::ENOENT
           print_error("Permission denied exec: #{line}")
         end
@@ -498,6 +498,10 @@ protected
     end
 
     super
+  end
+
+  def run_unknown_command(command)
+    system(command)
   end
 
   ##

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -474,9 +474,6 @@ protected
     [method, method+".exe"].each do |cmd|
       if command_passthru && Rex::FileUtils.find_full_path(cmd)
 
-        print_status("exec: #{line}")
-        print_line('')
-
         self.busy = true
         begin
           run_unknown_command(line)
@@ -501,6 +498,8 @@ protected
   end
 
   def run_unknown_command(command)
+    print_status("exec: #{command}")
+    print_line('')
     system(command)
   end
 

--- a/lib/msf/ui/web/web_console.rb
+++ b/lib/msf/ui/web/web_console.rb
@@ -32,6 +32,15 @@ class WebConsole
     def supports_color?
       false
     end
+
+    def run_unknown_command(command)
+      Open3.popen2e(command) {|stdin,output,thread|
+        output.each {|outline|
+          print_line(outline.chomp)
+        }
+      }
+    end
+
   end
 
   def initialize(framework, console_id, opts={})


### PR DESCRIPTION
Following on from https://github.com/rapid7/metasploit-framework/pull/15941, which was reverted in https://github.com/rapid7/metasploit-framework/pull/15990

The change should fix https://github.com/rapid7/metasploit-framework/issues/12895 without changing the current behaviour within msfconsole.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Test a command: e.g `vi`
- [ ] **Verify** the command behaves as expected
- [ ] Exit msfconsole
- [ ] Start a rpc daemon: `./msfrpcd -a 127.0.0.1 -P hunter2 -f`
- [ ] Start a rpc client: `./msfrpc -a 127.0.0.1 -P hunter2`
- [ ] **Verify** the command output appears in the console console.read buffer:
```
[*] The 'rpc' object holds the RPC client interface
[*] Use rpc.call('group.command') to make RPC calls

>> rpc.call('console.create')
=> {"id"=>"0", "prompt"=>"", "busy"=>false}
>> rpc.call('console.read',0)
=>
{"data"=>
  " <banner snip> ",
 "prompt"=>"msf6 > ",
 "busy"=>false}
>> rpc.call('console.write',0,"echo test\n")
=> {"wrote"=>10}
>> rpc.call('console.read',0)
=> {"data"=>"[*] exec: echo test\n\ntest\n", "prompt"=>"msf6 > ", "busy"=>false}
>> rpc.call('console.write',0,"touch /canttouchthis\n")
=> {"wrote"=>21}
>> rpc.call('console.read',0)
=> {"data"=>"[*] exec: touch /canttouchthis\n\ntouch: cannot touch '/canttouchthis': Permission denied\n", "prompt"=>"msf6 > ", "busy"=>false}
>>

```
