### PR TITLE
expand version to 3.0.3 until 3.1 is handled

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,7 +50,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - 3.0.3
         test_cmd:
           - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content"
           - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content"


### PR DESCRIPTION
The Ruby maintainers offered up a Christmas gift with release of Ruby 3.1.0. Github actions are not yet parsing this version correctly, leading to a requirement for 3.0.3 to be explicitly set in until actions handle the new version correctly.

See https://github.com/rapid7/metasploit-framework/runs/4650947083

```
Error: The process '/opt/hostedtoolcache/Ruby/3.1.0/x64/bin/bundle' failed with exit code 5
```

## Verification

List the steps needed to make sure this thing works

- [x] Github actions test automation completes.