### PR TITLE
Delineate Rex::Proto::*::Server mixins for Msf

### DIFF
--- a/lib/msf/core/exploit/remote/dns/server.rb
+++ b/lib/msf/core/exploit/remote/dns/server.rb
@@ -35,7 +35,7 @@ module Server
     )
   end
 
-  attr_accessor :service # :nodoc:
+  attr_accessor :dns_service # :nodoc:
 
   #
   # Process static entries
@@ -56,10 +56,10 @@ module Server
       addr, names = entry.split(' ', 2)
       names.split.each do |name|
         name << '.' unless name[-1] == '.' or name == '*'
-        service.cache.add_static(name, addr, type)
+        dns_service.cache.add_static(name, addr, type)
       end
     end
-    service.cache.records.select {|r,e| e == 0}
+    dns_service.cache.records.select {|r,e| e == 0}
   end
 
   #
@@ -75,9 +75,9 @@ module Server
   # Flush cache entries
   # @param static [TrueClass, FalseClass] flush static hosts
   def flush_cache(static = false)
-    self.service.cache.stop(true)
+    self.dns_service.cache.stop(true)
     flush_static_hosts if static
-    self.service.cache.start
+    self.dns_service.cache.start
   end
 
   #
@@ -85,7 +85,7 @@ module Server
   # Override this method in modules to take flow control
   #
   def on_dispatch_request(cli, data)
-    service.default_dispatch_request(cli,data)
+    dns_service.default_dispatch_request(cli,data)
   end
 
   #
@@ -103,7 +103,7 @@ module Server
     begin
 
       comm = _determine_server_comm(bindhost)
-      self.service = Rex::ServiceManager.start(
+      self.dns_service = Rex::ServiceManager.start(
         Rex::Proto::DNS::Server,
         bindhost,
         bindport,
@@ -115,19 +115,30 @@ module Server
         {'Msf' => framework, 'MsfExploit' => self}
       )
 
-      self.service.dispatch_request_proc = Proc.new do |cli, data|
+      self.dns_service.dispatch_request_proc = Proc.new do |cli, data|
         on_dispatch_request(cli,data)
       end
-      self.service.send_response_proc = Proc.new do |cli, data|
+      self.dns_service.send_response_proc = Proc.new do |cli, data|
         on_send_response(cli,data)
       end
 
       add_static_hosts
+      self.dns_service.start(!datastore['DISABLE_NS_CACHE'])
 
     rescue ::Errno::EACCES => e
       raise Rex::BindFailed.new(e.message)
     end
   end
+  alias :start_dns_service :start_service
+
+  #
+  # Stops the server
+  #
+  def stop_service
+    Rex::ServiceManager.stop_service(self.dns_service) if self.dns_service
+    super
+  end
+  alias :stop_ldap_service :stop_service
 
   #
   # Dereference the DNS service
@@ -135,6 +146,7 @@ module Server
   def cleanup
     super
     @dns_resolver = nil if @dns_resolver
+    self.dns_service = nil if self.dns_service
   end
 
   #
@@ -144,6 +156,10 @@ module Server
     !datastore['DISABLE_RESOLVER'] and self.respond_to?(:setup_resolver)
   end
 
+  # Backwards compatibility for #service accessor, override in consumers/mixins
+  def service
+    dns_service
+  end
 end
 end
 end

--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -50,6 +50,8 @@ module Exploit::Remote::HttpServer
     @service_path = nil
   end
 
+  attr_accessor :http_service # :nodoc:
+
   #
   # By default, all HTTP servers are not subject to automatic exploitation
   #
@@ -119,7 +121,7 @@ module Exploit::Remote::HttpServer
     check_dependencies
 
     # Start a new HTTP server service.
-    self.service = Rex::ServiceManager.start(
+    self.http_service = Rex::ServiceManager.start(
       Rex::Proto::Http::Server,
       (opts['ServerPort'] || bindport).to_i,
       opts['ServerHost'] || bindhost,
@@ -135,7 +137,7 @@ module Exploit::Remote::HttpServer
       datastore['SSLVersion']
     )
 
-    self.service.server_name = datastore['HTTP::server_name']
+    self.http_service.server_name = datastore['HTTP::server_name']
 
     # Default the procedure of the URI to on_request_uri if one isn't
     # provided.
@@ -171,6 +173,15 @@ module Exploit::Remote::HttpServer
     add_robots_resource if datastore['SendRobots']
     add_resource(uopts)
   end
+  alias :start_http_service :start_service
+
+  #
+  # Stops the server
+  #
+  def stop_service
+    Rex::ServiceManager.stop_service(self.http_service) if self.http_service
+  end
+  alias :stop_http_service :stop_service
 
   def add_robots_resource
     proc = Proc.new do |cli, req|
@@ -217,6 +228,11 @@ module Exploit::Remote::HttpServer
     end
 
     super
+  end
+
+  # Backwards compatibility for #service accessor, override in consumers/mixins
+  def service
+    http_service
   end
 
   #
@@ -525,7 +541,7 @@ module Exploit::Remote::HttpServer
     # Guard against removing resources added by other modules
     if @my_resources.include?(name)
       @my_resources.delete(name)
-      service.remove_resource(name) if service
+      http_service.remove_resource(name) if http_service
     end
   end
 
@@ -533,7 +549,7 @@ module Exploit::Remote::HttpServer
   # Closes a client connection.
   #
   def close_client(cli)
-    service.close_client(cli)
+    http_service.close_client(cli)
   end
 
   #

--- a/lib/msf/core/exploit/remote/ldap/server.rb
+++ b/lib/msf/core/exploit/remote/ldap/server.rb
@@ -1,101 +1,127 @@
 # -*- coding: binary -*-
 
 module Msf
-  ###
+
+###
+#
+# This module exposes methods for querying a remote LDAP service
+#
+###
+module Exploit::Remote::LDAP
+module Server
+  include Exploit::Remote::SocketServer
+
   #
-  # This module exposes methods for querying a remote LDAP service
+  # Initializes an exploit module that serves LDAP requests
   #
-  ###
-  module Exploit::Remote::LDAP
-    module Server
-      include Exploit::Remote::SocketServer
+  def initialize(info = {})
+    super
 
-      #
-      # Initializes an exploit module that serves LDAP requests
-      #
-      def initialize(info = {})
-        super
+    register_options(
+      [
+        OptPort.new('SRVPORT', [true, 'The local port to listen on.', 389]),
+        OptPath.new('LDIF_FILE', [ false, "Directory LDIF file path"]),
+      ], Exploit::Remote::LDAP::Server
+    )
 
-        register_options(
-          [
-            OptPort.new('SRVPORT', [true, 'The local port to listen on.', 389]),
-            OptPath.new('LDIF_FILE', [ false, 'Directory LDIF file path']),
-          ], Exploit::Remote::LDAP::Server
-        )
+    register_advanced_options(
+      [
+        OptBool.new('LdapServerUdp', [true, "Serve UDP LDAP requests", true]),
+        OptBool.new('LdapServerTcp', [true, "Serve TCP LDAP requests", true])
+      ], Exploit::Remote::LDAP::Server
+    )
+  end
 
-        register_advanced_options(
-          [
-            OptBool.new('LdapServerUdp', [true, 'Serve UDP LDAP requests', true]),
-            OptBool.new('LdapServerTcp', [true, 'Serve TCP LDAP requests', true])
-          ], Exploit::Remote::LDAP::Server
-        )
-      end
+  attr_accessor :ldap_service # :nodoc:
 
-      attr_accessor :service # :nodoc:
-
-      #
-      # Read LDIF file - from https://github.com/ruby-ldap/ruby-net-ldap/blob/master/testserver/ldapserver.rb#L162
-      #
-      # @ return [Hash] parsed ldif file
-      def read_ldif
-        return if datastore['LDIF_FILE'].blank? || !File.exist?(datastore['LDIF_FILE'])
-
-        ary = File.readlines(datastore['LDIF_FILE'])
-        ldif = {}
-        while (line = ary.shift) && line.chomp!
-          next unless line =~ /^dn:\s*/i
-
-          dn = Regexp.last_match.post_match
-          ldif[dn] = {}
-          while (attrib = ary.shift) && attrib.chomp! && attrib =~ /^(\w+)\s*:\s*/
-            ldif[dn][Regexp.last_match(1)] ||= []
-            ldif[dn][Regexp.last_match(1)] << Regexp.last_match.post_match
-          end
+  #
+  # Read LDIF file - from https://github.com/ruby-ldap/ruby-net-ldap/blob/master/testserver/ldapserver.rb#L162
+  #
+  # @ return [Hash] parsed ldif file
+  def read_ldif
+    return if datastore['LDIF_FILE'].blank? || !File.exists?(datastore['LDIF_FILE'])
+    ary = File.readlines(datastore['LDIF_FILE'])
+    ldif = {}
+    while (line = ary.shift) && line.chomp!
+      if line =~ /^dn:[\s]*/i
+        dn = $'
+        ldif[dn] = {}
+        while (attrib = ary.shift) && attrib.chomp! && attrib =~ /^([\w]+)[\s]*:[\s]*/
+          ldif[dn][$1] ||= []
+          ldif[dn][$1] << $'
         end
-        ldif
-      end
-
-      #
-      # Handle incoming requests
-      # Override this method in modules to take flow control
-      #
-      def on_dispatch_request(cli, data)
-        service.default_dispatch_request(cli, data)
-      end
-
-      #
-      # Handle incoming requests
-      # Override this method in modules to take flow control
-      #
-      def on_send_response(cli, data)
-        cli.write(data)
-      end
-
-      #
-      # Starts the server
-      #
-      def start_service
-        comm = _determine_server_comm(bindhost)
-        self.service = Rex::ServiceManager.start(
-          Rex::Proto::LDAP::Server,
-          bindhost,
-          bindport,
-          datastore['LdapServerUdp'],
-          datastore['LdapServerTcp'],
-          read_ldif,
-          comm,
-          { 'Msf' => framework, 'MsfExploit' => self }
-        )
-
-        service.dispatch_request_proc = proc do |cli, data|
-          on_dispatch_request(cli, data)
-        end
-        service.send_response_proc = proc do |cli, data|
-          on_send_response(cli, data)
-        end
-      rescue ::Errno::EACCES => e
-        raise Rex::BindFailed, e.message
       end
     end
+    ldif
   end
+
+  #
+  # Handle incoming requests
+  # Override this method in modules to take flow control
+  #
+  def on_dispatch_request(cli, data)
+    ldap_service.default_dispatch_request(cli,data)
+  end
+
+  #
+  # Handle incoming requests
+  # Override this method in modules to take flow control
+  #
+  def on_send_response(cli, data)
+    cli.write(data)
+  end
+
+  #
+  # Starts the server
+  #
+  def start_service
+    begin
+      comm = _determine_server_comm(datastore['SRVHOST'])
+      self.ldap_service = Rex::ServiceManager.start(
+        Rex::Proto::LDAP::Server,
+        datastore['SRVHOST'],
+        datastore['SRVPORT'],
+        datastore['LdapServerUdp'],
+        datastore['LdapServerTcp'],
+        read_ldif,
+        comm,
+        {'Msf' => framework, 'MsfExploit' => self}
+      )
+
+      self.ldap_service.dispatch_request_proc = Proc.new do |cli, data|
+        on_dispatch_request(cli,data)
+      end
+      self.ldap_service.send_response_proc = Proc.new do |cli, data|
+        on_send_response(cli,data)
+      end
+    rescue ::Errno::EACCES => e
+      raise Rex::BindFailed.new(e.message)
+    end
+  end
+  alias :start_ldap_service :start_service
+
+  #
+  # Stops the server
+  #
+  def stop_service
+    Rex::ServiceManager.stop_service(self.ldap_service) if self.ldap_service
+    super
+  end
+  alias :stop_ldap_service :stop_service
+
+  #
+  # Resets the LDAP server
+  #
+  def reset_service
+    cleanup
+    start_service
+  end
+
+  # Backwards compatibility for #service accessor, override in consumers/mixins
+  def service
+    ldap_service
+  end
+
+end
+end
 end


### PR DESCRIPTION
`Msf::Exploit::Remote::*::*Server` mixins are implemented either as
descendants of the `SocketServer` mixin providing ports as service
objects and handling protocol interactions using handlers on those,
or as actual `*Server` instances out of `Rex::Proto`. When creating
`MetasploitModules` (or other namespaces) which mix two or more of
these `Msf::Exploit::Remote::*::*Server` mixins together, a namespace
collision occurs on the `:service` object of the namespace mixing in
the two setters for it and creating a last-write-wins condition on
`self.server` which causes the first server instantiated to be lost
into `ObjectSpace` - no rational reference to it, and no GC on it as
it has its own references to unmanaged memory (file descriptors).

Address the problem by delineating each of the `Rex::Proto` servers
with named prefixes such as `http_service` and `dns_service` in order
to permit mixing them all together along with the socket services
which can run arbitrary protocol handlers from the `Msf` namespace.
Leave backward compatibility via :service decorator methods in the
updated `Msf` Server mixins and method aliases to their start/stop
methods for access when overriding names are mixed in after these.
