### PR TITLE
Fix tab completion for RHOSTS

### DIFF
--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -190,17 +190,23 @@ module Msf
                 res += tab_complete_source_interface(o)
               end
             end
-          when Msf::OptAddressRange
+          when Msf::OptAddressRange, Msf::OptRhosts
             case str
             when /^file:(.*)/
               files = tab_complete_filenames(Regexp.last_match(1), words)
               res += files.map { |f| 'file:' + f } if files
-            when %r{/$}
-              res << str + '32'
-              res << str + '24'
-              res << str + '16'
-            when /\-$/
-              res << str + str[0, str.length - 1]
+            when %r{^(.*)/\d{0,2}$}
+              left = Regexp.last_match(1)
+              if Rex::Socket.is_ipv4?(left)
+                res << left + '/32'
+                res << left + '/24'
+                res << left + '/16'
+              end
+            when /^(.*)\-$/
+              left = Regexp.last_match(1)
+              if Rex::Socket.is_ipv4?(left)
+                res << str + str[0, str.length - 1]
+              end
             else
               option_values_target_addrs(mod).each do |addr|
                 res << addr
@@ -227,16 +233,6 @@ module Msf
             if (str =~ /^file:(.*)/)
               files = tab_complete_filenames(Regexp.last_match(1), words)
               res += files.map { |f| 'file:' + f } if files
-            end
-          when Msf::OptRhosts
-            case str
-            when /^file:(.*)/
-              files = tab_complete_filenames(Regexp.last_match(1), words)
-              res += files.map { |f| 'file:' + f } if files
-            else
-              option_values_target_addrs(mod).each do |addr|
-                res << addr
-              end
             end
           end
           return res

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -228,6 +228,16 @@ module Msf
               files = tab_complete_filenames(Regexp.last_match(1), words)
               res += files.map { |f| 'file:' + f } if files
             end
+          when Msf::OptRhosts
+            case str
+            when /^file:(.*)/
+              files = tab_complete_filenames(Regexp.last_match(1), words)
+              res += files.map { |f| 'file:' + f } if files
+            else
+              option_values_target_addrs(mod).each do |addr|
+                res << addr
+              end
+            end
           end
           return res
         end


### PR DESCRIPTION
In commit 4899884a339 RHOSTS was changed to use the new `Msf::OptRhosts` option instead of `Msf::OptAddressRange`. Tab completion for data store options is based on the type, and since the new `Msf::OptRhosts` didn't add tab completion, that feature ceased to function. This meant that users that were previously able to tab-complete files for this setting were no longer able to.

This fixes the issue by adding tab completion for the new `Msf::OptRhosts` type. It's based on the existing `Msf::OptAddressRange` but without the suffixes that won't always work with the new URL support. For example, it doesn't make sense to suggest 32, 24, or 16 when the value ends with a `/` given that it could be an HTTP resource.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/http_version` (or any module really that has an RHOSTS option)
- [x] Type in `set RHOSTS file:` then hit the tab key
- [x] See the files in the current working directory suggested for completion
    * Prior to this change, there would be no suggestions.

## Demo

```
msf6 auxiliary(scanner/http/http_version) > show options 

Module options (auxiliary/scanner/http/http_version):

   Name     Current Setting        Required  Description
   ----     ---------------        --------  -----------
   Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   file:/tmp/targets.txt  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT    80                     yes       The target port (TCP)
   SSL      false                  no        Negotiate SSL/TLS for outgoing connections
   THREADS  1                      yes       The number of concurrent threads (max one per host)
   VHOST                           no        HTTP server virtual host

msf6 auxiliary(scanner/http/http_version) > set RHOSTS file:
set RHOSTS file:.dockerignore                 set RHOSTS file:.yardoc                       set RHOSTS file:README.md                     set RHOSTS file:external                      set RHOSTS file:msfupdate
set RHOSTS file:.git                          set RHOSTS file:.yardopts                     set RHOSTS file:Rakefile                      set RHOSTS file:kubernetes                    set RHOSTS file:msfvenom
set RHOSTS file:.github                       set RHOSTS file:CODE_OF_CONDUCT.md            set RHOSTS file:Vagrantfile                   set RHOSTS file:lib                           set RHOSTS file:plugins
set RHOSTS file:.gitignore                    set RHOSTS file:CONTRIBUTING.md               set RHOSTS file:app                           set RHOSTS file:log                           set RHOSTS file:script
set RHOSTS file:.gitmodules                   set RHOSTS file:COPYING                       set RHOSTS file:config                        set RHOSTS file:metasploit-framework.gemspec  set RHOSTS file:scripts
set RHOSTS file:.idea                         set RHOSTS file:CURRENT.md                    set RHOSTS file:coverage                      set RHOSTS file:modules                       set RHOSTS file:spec
set RHOSTS file:.mailmap                      set RHOSTS file:Dockerfile                    set RHOSTS file:data                          set RHOSTS file:msf-json-rpc.ru               set RHOSTS file:test
set RHOSTS file:.rspec                        set RHOSTS file:Gemfile                       set RHOSTS file:db                            set RHOSTS file:msf-ws.ru                     set RHOSTS file:test.rc
set RHOSTS file:.rubocop.yml                  set RHOSTS file:Gemfile.local.example         set RHOSTS file:doc                           set RHOSTS file:msfconsole                    set RHOSTS file:tools
set RHOSTS file:.ruby-gemset                  set RHOSTS file:Gemfile.local.lock            set RHOSTS file:docker                        set RHOSTS file:msfd                          
set RHOSTS file:.ruby-version                 set RHOSTS file:Gemfile.lock                  set RHOSTS file:docker-compose.override.yml   set RHOSTS file:msfdb                         
set RHOSTS file:.simplecov                    set RHOSTS file:LICENSE                       set RHOSTS file:docker-compose.yml            set RHOSTS file:msfrpc                        
set RHOSTS file:.versions.conf                set RHOSTS file:LICENSE_GEMS                  set RHOSTS file:documentation                 set RHOSTS file:msfrpcd                       
msf6 auxiliary(scanner/http/http_version) > set RHOSTS file:

```