### PR TITLE
Add check for deleting directories to post/test/file

### DIFF
--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Post
         'Name' => 'Testing Remote File Manipulation',
         'Description' => %q{ This module will test Post::File API methods },
         'License' => MSF_LICENSE,
-        'Author' => [ 'egypt'],
+        'Author' => [ 'egypt' ],
         'Platform' => [ 'windows', 'linux', 'java' ],
         'SessionTypes' => [ 'meterpreter', 'shell' ]
       )
@@ -66,12 +66,15 @@ class MetasploitModule < Msf::Post
     it 'should create directories' do
       mkdir(datastore['BaseDirectoryName'])
       ret = directory?(datastore['BaseDirectoryName'])
-      ret &&= write_file([datastore['BaseDirectoryName'], datastore['BaseFileName']].join(fs_sep), 'foo')
+      ret &&= write_file([datastore['BaseDirectoryName'], 'file'].join(fs_sep), '')
+      ret &&= mkdir([datastore['BaseDirectoryName'], 'directory'].join(fs_sep))
+      ret &&= write_file([datastore['BaseDirectoryName'], 'directory', 'file'].join(fs_sep), '')
       ret
     end
 
     it 'should list the directory we just made' do
-      dir(datastore['BaseDirectoryName']).include?(datastore['BaseFileName'])
+      dents = dir(datastore['BaseDirectoryName'])
+      dents.include?('file') && dents.include?('directory')
     end
 
     it 'should recursively delete the directory we just made' do
@@ -209,31 +212,31 @@ class MetasploitModule < Msf::Post
 
   def test_path_expansion_nix
     unless session.platform =~ /win/i
-      it "should expand home" do
+      it 'should expand home' do
         home1 = expand_path('~')
         home2 = expand_path('$HOME')
         home1 == home2 && home1.length > 0
       end
 
-      it "non-isolated tilde should not expand" do
+      it 'should not expand non-isolated tilde' do
         s = '~a'
         result = expand_path(s)
         s == result
       end
 
-      it "mid-string tilde should not expand" do
+      it 'should not expand mid-string tilde' do
         s = '/home/~'
         result = expand_path(s)
         s == result
       end
 
-      it "env vars with invalid naming should not expand" do
+      it 'should not expand env vars with invalid naming' do
         s = 'no environment $ variables /here'
         result = expand_path(s)
         s == result
       end
 
-      it "should expand multiple variables" do
+      it 'should expand multiple variables' do
         result = expand_path('/blah/$HOME/test/$USER')
         home = expand_path('$HOME')
         user = expand_path('$USER')


### PR DESCRIPTION
This adds tests to the `post/test/file` module to ensure that a directory tree can be deleted recursively by the session. This will help ensure future consistency as we move to fix rapid7/metasploit-framework#13369. This will also help while testing rapid7/metasploit-payloads#519 and rapid7/metasploit-payloads#520.

At this time, shell sessions should pass the new check (the other checks are still failing in some cases). The Python and Windows Meterpreter's should pass the new checks, while the Java, PHP, and Mettle need to be updated.

## Verification

- [ ] Start `msfconsole`
- [ ] Obtain a Python or Windows Meterpreter session
- [ ] Run `load test/modules` to load the testing modules from the MSF directory
- [ ] Run the `post/test/file` module
- [ ] **Verify** all of the checks pass, particularly the "should recursively delete the directory we just made" one
- [ ] Check a shell sessions, see it also deletes directories recursively through it's use of `rm -rf`

## Demo

```
msf6 payload(python/meterpreter/reverse_tcp) > to_handler
[*] Payload Handler Started as Job 3
msf6 payload(python/meterpreter/reverse_tcp) > 
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Sending stage (39804 bytes) to 192.168.159.128
[*] Meterpreter session 5 opened (192.168.159.128:4444 -> 192.168.159.128:53596 ) at 2022-01-06 08:51:24 -0500

msf6 payload(python/meterpreter/reverse_tcp) > use post/test/file 
msf6 post(test/file) > run SESSION=5

[*] Running against session 5
[*] Session type is meterpreter and platform is linux
[+] should test for directory existence
[+] should create directories
[+] should list the directory we just made
[+] should recursively delete the directory we just made
[+] should write binary data
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[+] should expand home
[+] should not expand non-isolated tilde
[+] should not expand mid-string tilde
[+] should not expand env vars with invalid naming
[+] should expand multiple variables
[+] should test for file existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[*] Passed: 19; Failed: 0
[*] Post module execution completed
msf6 post(test/file) > 
```