### PR TITLE
Fix msfdb init command failure when opting not to initialize webservices

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -661,14 +661,14 @@ end
 def persist_data_service
   puts 'Persisting http web data service credentials in msfconsole'
   # execute msfconsole commands to add and persist the data service connection
-  cmd = "./msfconsole -qx '#{get_db_connect_command}; db_save; exit'"
+  cmd = "msfconsole -qx '#{get_db_connect_command}; db_save; exit'"
   run_msfconsole_command(cmd)
 end
 
 def clear_default_data_service
   puts 'Clearing http web data service credentials in msfconsole'
   # execute msfconsole commands to clear the default data service connection
-  cmd = "./msfconsole -qx 'db_disconnect --clear; exit'"
+  cmd = "msfconsole -qx 'db_disconnect --clear; exit'"
   run_msfconsole_command(cmd)
 end
 

--- a/msfdb
+++ b/msfdb
@@ -650,9 +650,11 @@ end
 def run_msfconsole_command(cmd)
   # Attempts to run a the metasploit command first with the default env settings, and once again with the path set
   # to the current directory. This ensures that it works in an environment such as bundler
-  if @db_driver.run_cmd(cmd) != 0
+  # @msf_command holds the initial common part of commands (msfconsole -qx) and takes the optional specific commands as arguments (#{cmd})
+  msf_command = "msfconsole -qx '#{cmd}'"
+  if @db_driver.run_cmd(msf_command) != 0
     # attempt to execute msfconsole in the current working directory
-    if @db_driver.run_cmd(cmd, env: {'PATH' => ".:#{ENV["PATH"]}"}) != 0
+    if @db_driver.run_cmd(msf_command, env: {'PATH' => ".:#{ENV["PATH"]}"}) != 0
       puts 'Failed to run msfconsole'
     end
   end
@@ -661,14 +663,14 @@ end
 def persist_data_service
   puts 'Persisting http web data service credentials in msfconsole'
   # execute msfconsole commands to add and persist the data service connection
-  cmd = "msfconsole -qx '#{get_db_connect_command}; db_save; exit'"
+  cmd = "#{get_db_connect_command}; db_save; exit"
   run_msfconsole_command(cmd)
 end
 
 def clear_default_data_service
   puts 'Clearing http web data service credentials in msfconsole'
   # execute msfconsole commands to clear the default data service connection
-  cmd = "msfconsole -qx 'db_disconnect --clear; exit'"
+  cmd = "db_disconnect --clear; exit"
   run_msfconsole_command(cmd)
 end
 


### PR DESCRIPTION
This PR fixes #15981   

## Cause of bug  
The cause of this issue was the disparity in the msf-command syntax (`./command`) in the `msfdb` file. The `./` part of the command in the beginning would not be the correct way to get executed in a windows environment (cmd). (https://github.com/rapid7/metasploit-framework/blob/master/msfdb#L661-L673).  
  
The `run_msfconsole_command` method attempts to run the command in 2 ways. First, it runs the command with the default env settings and then with the path set to current directory (by adding a `.` in the beginning of the input command). (https://github.com/rapid7/metasploit-framework/blob/master/msfdb#L655). Since `run_msfconsole_command` itself adds a `.` to the command (if it doesn't get executed in the default env), we need to change the command syntax from `./command` to `command`. This ensures the command works both in windows and linux systems.  
  
## Approach  
The mere solution was to modify the syntax of the commands by removing the initial `./` part (done in commit 1). However, to make the code more maintainable and avoid the same issue in the future, it is better that we consolidate the whole 
   `./msfconsole -qx` initial part of the command into the `run_msfconsole_command` method and only take the command to be executed by `msf_console` as its argument (done in commit 2).  
  
This will ensure that we are not prone to the same error in future, as any new command now would only consist of the optional commands to be run (eg: `db_disconnect --clear; exit`) ; and not the whole command (eg: `./msfconsole -qx 'db_disconnect --clear; exit'`). So, there would be no confusion of whether to include `./` before the command or not.  
  
## Before  
```  
C:\Windows\system32>msfdb init
C:/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/zeitwerk-2.5.3/lib/zeitwerk/kernel.rb:35: warning: Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead
[?] Would you like to init the webservice? (Not Required) [no]: no
Clearing http web data service credentials in msfconsole
C:/metasploit-framework/embedded/lib/ruby/3.0.0/open3.rb:221:in `spawn': No such file or directory - ./msfconsole -qx 'db_disconnect --clear; exit' (Errno::ENOENT)
        from C:/metasploit-framework/embedded/lib/ruby/3.0.0/open3.rb:221:in `popen_run'
        from C:/metasploit-framework/embedded/lib/ruby/3.0.0/open3.rb:209:in `popen2e'
        from C:/metasploit-framework/embedded/lib/ruby/3.0.0/open3.rb:398:in `capture2e'
        from C:/metasploit-framework/embedded/framework/lib/msfdb_helpers/db_interface.rb:55:in `run_cmd'
        from C:/metasploit-framework/bin/../embedded/framework/msfdb:655:in `run_msfconsole_command'
        from C:/metasploit-framework/bin/../embedded/framework/msfdb:674:in `clear_default_data_service'
        from C:/metasploit-framework/bin/../embedded/framework/msfdb:1069:in `<main>'  
```  
  
## After  
```  
C:\Windows\system32>msfdb init
C:/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/zeitwerk-2.5.3/lib/zeitwerk/kernel.rb:35: warning: Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead
[?] Would you like to init the webservice? (Not Required) [no]: no
Clearing http web data service credentials in msfconsole
Running the 'init' command for the database:
Creating database at C:/Users/IEUser/.msf4/db
Starting database at C:/Users/IEUser/.msf4/db...  
```  
  
## Verification
  
- [ ] Install MSF on Windows 10 using the latest MSI installer
- [ ] Add `MSF BIN` directory to `%PATH%` environment variable
- [ ] Copy the modified `msfdb` file (of this PR) and place it in the `C:\metasploit-framework\embedded\framework` directory, deleting the original `msfdb` file.
- [ ] Open `cmd` as administrator
- [ ] Run `msfdb init`
- [ ] Type `no` when asked to init webservice
- [ ] **Verify** that the init script continues to **create and start the database** (it may hang at the step of `starting the database`, which is its sister issue I am working on next.)
- [ ] **Verify** that the init script **does not result in a crash** or raise an error.