### PR TITLE
Pin gems impacted by Ruby 2.5 being end of lifed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,11 +17,12 @@ PATH
       em-http-request
       eventmachine
       faker
-      faraday
+      faraday (= 1.8.0)
       faye-websocket
       filesize
       hrr_rb_ssh-ed25519
       http-cookie
+      io-console (= 0.5.9)
       irb
       jsobfu
       json
@@ -183,29 +184,25 @@ GEM
       railties (>= 5.0.0)
     faker (2.19.0)
       i18n (>= 1.6, < 2)
-    faraday (1.9.2)
+    faraday (1.8.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
+      faraday-httpclient (~> 1.0.1)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+      multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.1)
-      multipart-post (>= 1.2, < 3)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.2)
     faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
@@ -227,7 +224,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    io-console (0.5.11)
+    io-console (0.5.9)
     irb (1.3.6)
       reline (>= 0.2.5)
     jmespath (1.4.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -212,6 +212,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'irb'
   # Lock reline version until Fiddle concerns are addressed
   spec.add_runtime_dependency 'reline', '0.2.5'
+  # Temporarily pin reline's dependency io-console which no longer supports Ruby 2.5
+  spec.add_runtime_dependency 'io-console', '0.5.9'
 
   # AWS enumeration modules
   spec.add_runtime_dependency 'aws-sdk-s3'
@@ -222,8 +224,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faye-websocket'
   spec.add_runtime_dependency 'eventmachine'
 
-  # Earlier than latest Faraday gem is used to prevent upstream Octokit errors
-  spec.add_runtime_dependency 'faraday'
+  # Temporarily pinned until Ruby 2.5 support is dropped from framework
+  spec.add_runtime_dependency 'faraday', '1.8.0'
 
   # Required for windows terminal colors as of Ruby 3.0
   spec.add_runtime_dependency 'win32api'


### PR DESCRIPTION
The Ruby 2.5 build is currently broken due to updates in dependencies:
```
  /opt/hostedtoolcache/Ruby/2.5.9/x64/bin/bundle install --jobs 4
  Fetching gem metadata from https://rubygems.org/.........
  faraday-multipart-1.0.1 requires ruby version < 4, >= 2.6, which is incompatible
  with the current version, ruby 2.5.9p229
  Took   4.87 seconds
Error: The process '/opt/hostedtoolcache/Ruby/2.5.9/x64/bin/bundle' failed with exit code 5
```

#### Failing tests

https://github.com/rapid7/metasploit-framework/runs/4730386975?check_suite_focus=true

![image](https://user-images.githubusercontent.com/60357436/148439218-233b207a-dfd8-4ed2-b39a-38fd046e139d.png)

#### Original commit

https://github.com/rapid7/metasploit-framework/commit/0234b89c9ce6857d332a42e6ec363e8233c08772#diff-89cade48462044ee1b67[…]96a23c1283c6731fR202-R203

#### Future decision

I'm happy to drop Ruby 2.5 support which is now eol:
```
Ruby 2.5
status: eol
release date: 2017-12-25
EOL date: 2021-03-31
```

Just unblocking the build for now until we've confirmed that decision with the team :+1: