### PR TITLE
Fix `OptPath` options with empty strings

### DIFF
--- a/lib/msf/core/opt_path.rb
+++ b/lib/msf/core/opt_path.rb
@@ -13,7 +13,7 @@ class OptPath < OptBase
   end
 
   def normalize(value)
-    value.nil? ? value : File.expand_path(value)
+    value.nil? || value.to_s.empty? ? value : File.expand_path(value)
   end
 
   def validate_on_assignment?


### PR DESCRIPTION
This fixes an issue when any `OptPath` option is set to an empty string. Before this fix, `#normalize` was calling `File.expand_path("")`, which returns the current working directory. I assume it is not what we expect when setting this kind of option to an empty string.

For example, it breaks the `scanner/postgres/postgres_login` module:
```
msf6 auxiliary(scanner/postgres/postgres_login) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf6 auxiliary(scanner/postgres/postgres_login) > set PASS_FILE ""
PASS_FILE =>
msf6 auxiliary(scanner/postgres/postgres_login) > set USER_FILE ""
USER_FILE =>
msf6 auxiliary(scanner/postgres/postgres_login) > set USERPASS_FILE "/home/msfuser/dev/src/metasploit-framework/postgres_custom_userpass.txt"
USERPASS_FILE => /home/msfuser/dev/src/metasploit-framework/postgres_custom_userpass.txt
msf6 auxiliary(scanner/postgres/postgres_login) > options

Module options (auxiliary/scanner/postgres/postgres_login):

   Name              Current Setting                                                               Required  Description
   ----              ---------------                                                               --------  -----------
   BLANK_PASSWORDS   false                                                                         no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                                                                             yes       How fast to bruteforce, from 0 to 5
   DATABASE          template1                                                                     yes       The database to authenticate against
   DB_ALL_CREDS      false                                                                         no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false                                                                         no        Add all passwords in the current database to the list
   DB_ALL_USERS      false                                                                         no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none                                                                          no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   PASSWORD                                                                                        no        A specific password to authenticate with
   PASS_FILE                                                                                       no        File containing passwords, one per line
   Proxies                                                                                         no        A proxy chain of format type:host:port[,type:host:port][...]
   RETURN_ROWSET     true                                                                          no        Set to true to see query result sets
   RHOSTS            127.0.0.1                                                                     yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT             5432                                                                          yes       The target port
   STOP_ON_SUCCESS   false                                                                         yes       Stop guessing when a credential works for a host
   THREADS           1                                                                             yes       The number of concurrent threads (max one per host)
   USERNAME                                                                                        no        A specific username to authenticate as
   USERPASS_FILE     /home/msfuser/dev/src/metasploit-framework/postgres_custom_userpass.txt  no        File containing (space-separated) users and passwords, one pair per line
   USER_AS_PASS      false                                                                         no        Try the username as the password for all users
   USER_FILE                                                                                       no        File containing users, one per line
   VERBOSE           true                                                                          yes       Whether to print output for all attempts

msf6 auxiliary(scanner/postgres/postgres_login) > run

[*] Error: 127.0.0.1: Errno::EISDIR Is a directory @ io_fillbuf - fd:16 /home/msfuser/dev/src/metasploit-framework
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```



After this fix:
```
msf6 auxiliary(scanner/postgres/postgres_login) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf6 auxiliary(scanner/postgres/postgres_login) > set PASS_FILE ""
PASS_FILE =>
msf6 auxiliary(scanner/postgres/postgres_login) > set USER_FILE ""
USER_FILE =>
msf6 auxiliary(scanner/postgres/postgres_login) > set USERPASS_FILE "/home/msfuser/dev/src/metasploit-framework/postgres_custom_userpass.txt"
USERPASS_FILE => /home/msfuser/dev/src/metasploit-framework/postgres_custom_userpass.txt
msf6 auxiliary(scanner/postgres/postgres_login) > options

Module options (auxiliary/scanner/postgres/postgres_login):

   Name              Current Setting                                                               Required  Description
   ----              ---------------                                                               --------  -----------
   BLANK_PASSWORDS   false                                                                         no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                                                                             yes       How fast to bruteforce, from 0 to 5
   DATABASE          template1                                                                     yes       The database to authenticate against
   DB_ALL_CREDS      false                                                                         no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false                                                                         no        Add all passwords in the current database to the list
   DB_ALL_USERS      false                                                                         no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none                                                                          no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   PASSWORD                                                                                        no        A specific password to authenticate with
   PASS_FILE                                                                                       no        File containing passwords, one per line
   Proxies                                                                                         no        A proxy chain of format type:host:port[,type:host:port][...]
   RETURN_ROWSET     true                                                                          no        Set to true to see query result sets
   RHOSTS            127.0.0.1                                                                     yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT             5432                                                                          yes       The target port
   STOP_ON_SUCCESS   false                                                                         yes       Stop guessing when a credential works for a host
   THREADS           1                                                                             yes       The number of concurrent threads (max one per host)
   USERNAME                                                                                        no        A specific username to authenticate as
   USERPASS_FILE     /home/msfuser/dev/src/metasploit-framework/postgres_custom_userpass.txt  no        File containing (space-separated) users and passwords, one pair per line
   USER_AS_PASS      false                                                                         no        Try the username as the password for all users
   USER_FILE                                                                                       no        File containing users, one per line
   VERBOSE           true                                                                          yes       Whether to print output for all attempts

msf6 auxiliary(scanner/postgres/postgres_login) > run

[-] 127.0.0.1:5432 - LOGIN FAILED: myuser1:pass1@template1 (Incorrect: unknown auth type '10' with buffer content:
52 00 00 00 17 00 00 00 0a 53 43 52 41 4d 2d 53    |R........SCRAM-S|
48 41 2d 32 35 36 00 00                            |HA-256..|

)
[-] 127.0.0.1:5432 - LOGIN FAILED: myuser2:pass2@template1 (Incorrect: unknown auth type '10' with buffer content:
52 00 00 00 17 00 00 00 0a 53 43 52 41 4d 2d 53    |R........SCRAM-S|
48 41 2d 32 35 36 00 00                            |HA-256..|

)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/postgres/postgres_login) > cat /home/msfuser/dev/src/metasploit-framework/postgres_custom_userpass.txt
[*] exec: cat /home/msfuser/dev/src/metasploit-framework/postgres_custom_userpass.txt

myuser1 pass1
myuser2 pass2
```

Note that unsetting options lead to a confusing output of the `show options`/`options` commands. The default value is displayed but the actual option value is still `nil`. This is something we are aware of and will be fixed later.
```
msf6 auxiliary(scanner/postgres/postgres_login) > unset PASS_FILE
Unsetting PASS_FILE...
msf6 auxiliary(scanner/postgres/postgres_login) > unset USER_FILE
Unsetting USER_FILE...
msf6 auxiliary(scanner/postgres/postgres_login) > options

Module options (auxiliary/scanner/postgres/postgres_login):

   Name              Current Setting                                                                           Required  Description
   ----              ---------------                                                                           --------  -----------
   BLANK_PASSWORDS   false                                                                                     no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                                                                                         yes       How fast to bruteforce, from 0 to 5
   DATABASE          template1                                                                                 yes       The database to authenticate against
   DB_ALL_CREDS      false                                                                                     no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false                                                                                     no        Add all passwords in the current database to the list
   DB_ALL_USERS      false                                                                                     no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none                                                                                      no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   PASSWORD                                                                                                    no        A specific password to authenticate with
   PASS_FILE         /Users/cdelafuente/dev/src/metasploit-framework/data/wordlists/postgres_default_pass.txt  no        File containing passwords, one per line
   Proxies                                                                                                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RETURN_ROWSET     true                                                                                      no        Set to true to see query result sets
   RHOSTS            127.0.0.1                                                                                 yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT             5432                                                                                      yes       The target port
   STOP_ON_SUCCESS   false                                                                                     yes       Stop guessing when a credential works for a host
   THREADS           1                                                                                         yes       The number of concurrent threads (max one per host)
   USERNAME                                                                                                    no        A specific username to authenticate as
   USERPASS_FILE     /Users/cdelafuente/dev/src/metasploit-framework/postgres_custom_userpass.txt              no        File containing (space-separated) users and passwords, one pair per line
   USER_AS_PASS      false                                                                                     no        Try the username as the password for all users
   USER_FILE         /Users/cdelafuente/dev/src/metasploit-framework/data/wordlists/postgres_default_user.txt  no        File containing users, one per line
   VERBOSE           true                                                                                      yes       Whether to print output for all attempts

msf6 auxiliary(scanner/postgres/postgres_login) > run

[-] 127.0.0.1:5432 - LOGIN FAILED: myuser1:pass1@template1 (Incorrect: unknown auth type '10' with buffer content:
52 00 00 00 17 00 00 00 0a 53 43 52 41 4d 2d 53    |R........SCRAM-S|
48 41 2d 32 35 36 00 00                            |HA-256..|

)
[-] 127.0.0.1:5432 - LOGIN FAILED: myuser2:pass2@template1 (Incorrect: unknown auth type '10' with buffer content:
52 00 00 00 17 00 00 00 0a 53 43 52 41 4d 2d 53    |R........SCRAM-S|
48 41 2d 32 35 36 00 00                            |HA-256..|

)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
