### PR TITLE
exclude root `docs` path only not any file

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   # only do a git ls-files if the .git folder exists and we have a git binary in PATH
   if File.directory?(File.join(File.dirname(__FILE__), ".git")) && Msf::Util::Helper.which("git")
     spec.files         = `git ls-files`.split($/).reject { |file|
-      file =~ /^external|docs/
+      file =~ /^external|^docs/
     }
   end
   spec.bindir = '.'


### PR DESCRIPTION
Gemspec exclusion was intended to skip the `docs` directory now utilized as source for a static site.  However the matcher also causes `lib/msf/core/web_services/servlet/api_docs_servlet.rb` & `lib/msf/core/web_services/views/api_docs.erb` to be excluded from any gem built based on the gemspec. 

## Verification

List the steps needed to make sure this thing works

- [ ] `gem buiild`
- [ ] extract generated gem data and verify only `docs` folder was omitted.
