### PR TITLE
Explicitly specify encoding for doc builds

### DIFF
--- a/docs/build.rb
+++ b/docs/build.rb
@@ -1012,11 +1012,11 @@ module Build
         if page[:folder]
           content = preamble.rstrip + "\n"
         else
-          content = File.read(File.join(WIKI_PATH, page[:path]))
+          content = File.read(File.join(WIKI_PATH, page[:path]), encoding: Encoding::UTF_8)
           content = preamble + content
           content = link_corrector.rerender(content)
         end
-        File.write(new_path, content, mode: 'w')
+        File.write(new_path, content, mode: 'w', encoding: Encoding::UTF_8)
       end
 
       # Now that the docs folder is created, time to move the home.md file out
@@ -1029,7 +1029,7 @@ module Build
       link_corrector = LinkCorrector.new(config)
       config.each do |page|
         unless page[:folder]
-          content = File.read(File.join(WIKI_PATH, page[:path]))
+          content = File.read(File.join(WIKI_PATH, page[:path]), encoding: Encoding::UTF_8)
           link_corrector.extract(content)
         end
       end


### PR DESCRIPTION
Our docs have UTF-8 snippets present which breaks on CI:
```ruby
build.rb:863:in `scan': invalid byte sequence in US-ASCII (ArgumentError)
        from build.rb:863:in `extract_absolute_wiki_links'
        from build.rb:831:in `extract'
        from build.rb:1033:in `block in link_corrector_for'
        from build.rb:780:in `recurse'
        from build.rb:783:in `block in recurse'
        from build.rb:781:in `each'
        from build.rb:781:in `recurse'
        from build.rb:783:in `block in recurse'
        from build.rb:781:in `each'
        from build.rb:781:in `recurse'
        from build.rb:768:in `block in each'
        from build.rb:767:in `each'
        from build.rb:767:in `each'
        from build.rb:1030:in `link_corrector_for'
        from build.rb:993:in `run'
        from build.rb:1105:in `run'
        from build.rb:1148:in `<main>'
```

This wasn't an issue on the tested environments, as `LANG=en_GB.UTF-8` was correctly specified locally - but presumably not on CI

Behind the scenes I also removed a lot of unneeded non-ascii characters from `metasploit-framework.wiki` after identifying them with:
```
pcregrep --color='auto' -n "[\x80-\xFF]" **/*.md
```