### PR TITLE
Last minute fix for SMB Shadow module

### DIFF
--- a/modules/exploits/windows/smb/smb_shadow.rb
+++ b/modules/exploits/windows/smb/smb_shadow.rb
@@ -71,6 +71,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    @cleanup_mutex = Mutex.new
+    @cleanedup = true
     if datastore['DefangedMode'].to_s == 'true'
       warning = <<~EOF
 
@@ -85,8 +87,6 @@ class MetasploitModule < Msf::Exploit::Remote
     print_error('WARNING : Not running as Root. This can cause socket permission issues.') unless Process.uid == 0
     @sessions = {}
     @mutex = Mutex.new
-    @cleanup_mutex = Mutex.new
-    @cleanedup = false
     @main_threads = []
     @interface = datastore['INTERFACE'] # || Pcap.lookupdev
     unless Socket.getifaddrs.map(&:name).include? @interface
@@ -106,6 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Self: #{@ip4} | #{@mac}")
     # print_status("Gateway: #{@gateip4} | #{@gatemac}")
     disable_p445_fwrd
+    @cleanedup = false
     start_syn_capture
     start_ack_capture
     print_status('INFO : This module must be run alongside an arp spoofer / poisoner.')


### PR DESCRIPTION
Some instance variables used in the `cleanup` method were initialized after a possible `fail_with`. When the module fails early, the `cleanup` method is called by Framework with these variables not initialized, which cause an `NoMethodError undefined method for nil:NilClass` exception.

- Before this fix:
```
msf6 exploit(windows/smb/smb_shadow) > set DefangedMode true
DefangedMode => true
msf6 exploit(windows/smb/smb_shadow) > run

[*] Started reverse TCP handler on 192.168.144.1:4444
[-] Exploit failed [bad-config]: NoMethodError undefined method `synchronize' for nil:NilClass
[-] Exploit failed: undefined method `synchronize' for nil:NilClass
[*] Exploit completed, but no session was created.
```

- After this fix
```
msf6 exploit(windows/smb/smb_shadow) > set DefangedMode true
DefangedMode => true
msf6 exploit(windows/smb/smb_shadow) > run

[*] Started reverse TCP handler on 192.168.144.1:4444
[-] Exploit aborted due to failure: bad-config:
Are you SURE you want to modify your port forwarding tables?
You MAY contaminate your current network configuration.

Disable the DefangedMode option if you wish to proceed.

[*] Exploit completed, but no session was created.
```

I also set `@cleanedup = false` only after the firewall rules were added (in `disable_p445_fwrd `). This will avoid the `cleanup` method to be executed if the firewall rules were not already updated (e.g. if the module exit early).
