### PR TITLE
Add cname to metasploit docs

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.metasploit.com

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,7 +2,7 @@
 title: 'Metasploit Documentation | Penetration Testing Software, Pen Testing Security'
 description: View Metasploit Framework Documentation
 searchTitle: Metasploit Documentation
-baseurl: '/metasploit-framework'
+baseurl: ''
 url: 'https://rapid7.github.io/metasploit-framework'
 logo: assets/images/favicon.png
 

--- a/docs/build.rb
+++ b/docs/build.rb
@@ -615,18 +615,10 @@ module Build
               folder: 'google-summer-of-code',
               children: [
                 {
-                  path: 'GSoC-2020-Project-Ideas.md',
-                  title: without_prefix('GSoC')
-                },
-                {
                   path: 'How-to-Apply-to-GSoC.md'
                 },
                 {
                   path: 'GSoC-2017-Student-Proposal.md',
-                  title: without_prefix('GSoC')
-                },
-                {
-                  path: 'GSoC-2021-Project-Ideas.md',
                   title: without_prefix('GSoC')
                 },
                 {
@@ -643,6 +635,18 @@ module Build
                 },
                 {
                   path: 'GSoC-2019-Project-Ideas.md',
+                  title: without_prefix('GSoC')
+                },
+                {
+                  path: 'GSoC-2020-Project-Ideas.md',
+                  title: without_prefix('GSoC')
+                },
+                {
+                  path: 'GSoC-2021-Project-Ideas.md',
+                  title: without_prefix('GSoC')
+                },
+                {
+                  path: 'GSoC-2022-Project-Ideas.md',
                   title: without_prefix('GSoC')
                 },
               ]
@@ -1048,10 +1052,7 @@ module Build
           Port: 4000
         }
       )
-      server.mount_proc('/') do |_req, res|
-        res.set_redirect(WEBrick::HTTPStatus::TemporaryRedirect, '/metasploit-framework/')
-      end
-      server.mount('/metasploit-framework', WEBrick::HTTPServlet::FileHandler, PRODUCTION_BUILD_ARTIFACTS)
+      server.mount('/', WEBrick::HTTPServlet::FileHandler, PRODUCTION_BUILD_ARTIFACTS)
       trap('INT') do
         server.shutdown
       rescue StandardError


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/15923

Allows https://rapid7.github.io/metasploit-framework to redirect to docs.metasploit.com


**Note** This can't be merged until there is also a corresponding docs.metasploit.com CNAME pointing to rapid7.github.io - as per https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site