### PR TITLE
remove ruby 2.5 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - 2.5
+          - 2.6
 
     name: Lint msftidy
     steps:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -47,7 +47,6 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - 2.5
           - 2.6
           - 2.7
           - 3.0.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@
 # inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   SuggestExtensions: false
   NewCops: disable
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,12 +17,11 @@ PATH
       em-http-request
       eventmachine
       faker
-      faraday (= 1.8.0)
+      faraday
       faye-websocket
       filesize
       hrr_rb_ssh-ed25519
       http-cookie
-      io-console (= 0.5.9)
       irb
       jsobfu
       json
@@ -184,25 +183,29 @@ GEM
       railties (>= 5.0.0)
     faker (2.19.0)
       i18n (>= 1.6, < 2)
-    faraday (1.8.0)
+    faraday (1.9.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
+      faraday-net_http_persistent (~> 1.0)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      multipart-post (>= 1.2, < 3)
+      faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.3)
+      multipart-post (>= 1.2, < 3)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
@@ -224,7 +227,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    io-console (0.5.9)
+    io-console (0.5.11)
     irb (1.3.6)
       reline (>= 0.2.5)
     jmespath (1.4.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -212,8 +212,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'irb'
   # Lock reline version until Fiddle concerns are addressed
   spec.add_runtime_dependency 'reline', '0.2.5'
-  # Temporarily pin reline's dependency io-console which no longer supports Ruby 2.5
-  spec.add_runtime_dependency 'io-console', '0.5.9'
 
   # AWS enumeration modules
   spec.add_runtime_dependency 'aws-sdk-s3'
@@ -224,8 +222,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faye-websocket'
   spec.add_runtime_dependency 'eventmachine'
 
-  # Temporarily pinned until Ruby 2.5 support is dropped from framework
-  spec.add_runtime_dependency 'faraday', '1.8.0'
+  spec.add_runtime_dependency 'faraday'
 
   # Required for windows terminal colors as of Ruby 3.0
   spec.add_runtime_dependency 'win32api'

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   # Database support
   spec.add_runtime_dependency 'activerecord', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION


### PR DESCRIPTION
Update the project to officially drop Ruby 2.5.

## Verification

List the steps needed to make sure this thing works

- [ ] Validate `bundle install` on all continued supported Ruby versions ( automation tests will perform this action )