### PR TITLE
local_exploit_suggester: Print session_host if session is valid

### DIFF
--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -85,10 +85,12 @@ class MetasploitModule < Msf::Post
   end
 
   def setup
+    return unless session
+
     print_status "Collecting local exploits for #{session.session_type}..."
-    # Initializes an array
-    @local_exploits = []
+
     # Collects exploits into an array
+    @local_exploits = []
     framework.exploits.each do |name, _obj|
       mod = framework.exploits.create name
       next unless mod
@@ -167,14 +169,14 @@ class MetasploitModule < Msf::Post
   end
 
   def print_status(msg='')
-    super("#{session.session_host} - #{msg}")
+    super(session ? "#{session.session_host} - #{msg}" : msg)
   end
 
   def print_good(msg='')
-    super("#{session.session_host} - #{msg}")
+    super(session ? "#{session.session_host} - #{msg}" : msg)
   end
 
   def print_error(msg='')
-    super("#{session.session_host} - #{msg}")
+    super(session ? "#{session.session_host} - #{msg}" : msg)
   end
 end


### PR DESCRIPTION
# Before

```
msf6 post(multi/recon/local_exploit_suggester) > run
[-] Post failed: Msf::OptionValidateError One or more options failed to validate: SESSION.
msf6 post(multi/recon/local_exploit_suggester) > sessions

Active sessions
===============

No active sessions.

msf6 post(multi/recon/local_exploit_suggester) > set session 1
session => 1
msf6 post(multi/recon/local_exploit_suggester) > run
[-] Post failed: NoMethodError undefined method `session_host' for nil:NilClass
[-] Call stack:
[-]   /root/Desktop/metasploit-framework/modules/post/multi/recon/local_exploit_suggester.rb:178:in `print_error'
```

# After

```
msf6 post(multi/recon/local_exploit_suggester) > run
[-] Post failed: Msf::OptionValidateError One or more options failed to validate: SESSION.
msf6 post(multi/recon/local_exploit_suggester) > sessions

Active sessions
===============

No active sessions.

msf6 post(multi/recon/local_exploit_suggester) > set session 1
session => 1
msf6 post(multi/recon/local_exploit_suggester) > run

[-] Session not found
[*] Post module execution completed
```