### PR TITLE
local_admin_search_enum: Fix typo: @domain_controller

### DIFF
--- a/modules/post/windows/gather/local_admin_search_enum.rb
+++ b/modules/post/windows/gather/local_admin_search_enum.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Post
         datastore['DOMAIN'] = user.split('\\')[0]
       end
 
-      if @domain_controll.nil? and datastore['ENUM_GROUPS']
+      if @domain_controller.nil? and datastore['ENUM_GROUPS']
         @dc_error = false
 
         # Uses DC which applied policy since it would be a DC this device normally talks to


### PR DESCRIPTION
Looks like this has been broken for almost a decade. Bug introduced in ddd4b7ef6007b04cc17b829eb33bcbeaeb47f3cc on Dec 28, 2012.

Untested but clearly a bug based on the commit.
