### PR TITLE
Fix params not being passed to scripts

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1351,6 +1351,7 @@ class Core
     response_timeout = 15
     search_term = nil
     session_name = nil
+    has_script_arguments = false
 
     # any arguments that don't correspond to an option or option arg will
     # be put in here
@@ -1362,6 +1363,8 @@ class Core
     else
       # Parse the command options
       @@sessions_opts.parse(args) do |opt, idx, val|
+        next if has_script_arguments
+
         case opt
         when "-q", "--quiet"
           quiet = true
@@ -1398,6 +1401,9 @@ class Core
           unless script
             method = 'script'
             script = val
+            # Assume any parameter after the script name is a flag/argument we want to pass to the script itself.
+            extra += args[(idx + 1)..-1]
+            has_script_arguments = true
           end
         # Upload and exec to the specific command session
         when "-u", "--upgrade"


### PR DESCRIPTION
This small PR fixes parameters not being passed to scripts when executed with the `sessions -i <session> -s <script>` or `sessions -s <script>`.

## Verification

- [ ] Start `msfconsole`
- [ ] Get a meterpreter session
- [ ] `sessions -i -1 -s scripts/meterpreter/winenum.rb` (example script)
- [ ] Confirm that the script runs without showing a help menu.
- [ ] `sessions -i -1 -s scripts/meterpreter/winenum.rb -h`
- [ ] Confirm that the `winenum.rb` script help menu is shown.

## Before

<details>
<summary>No params  (The error is expected 👍 )</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i -1 -s scripts/meterpreter/winenum.rb
[*] Session -1 (192.168.129.131):
[*] Running scripts/meterpreter/winenum.rb on meterpreter session -1 (192.168.129.131)
[*] Running Windows Local Enumeration Meterpreter Script
[*] New session on 192.168.129.131:49900...
[*] Saving general report to /Users/sjanusz/.msf4/logs/scripts/winenum/DESKTOP-T5PBUMF_20220119.2855/DESKTOP-T5PBUMF_20220119.2855.txt
[*] Output of each individual command is saved to /Users/sjanusz/.msf4/logs/scripts/winenum/DESKTOP-T5PBUMF_20220119.2855
[*] Checking if DESKTOP-T5PBUMF is a Virtual Machine ........

[-] Could not execute scripts/meterpreter/winenum.rb: Rex::Post::Meterpreter::RequestError stdapi_sys_config_getsid: Operation failed: The command is not supported by this Meterpreter type (java/windows)
```

</details>

<details>
<summary>Help param (The sessions help menu is shown instead)</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i -1 -s scripts/meterpreter/winenum.rb -h
Usage: sessions [options] or sessions [id]

Active session manipulation and interaction.

OPTIONS:

    -c, --command <opt>              Run a command on the session given with -i, or all
    -C, --meterpreter-command <opt>  Run a Meterpreter Command on the session given with -i, or all
    -d, --list-inactive              List all inactive sessions
    -h, --help                       Help banner
    -i, --interact <opt>             Interact with the supplied session ID
    -k, --kill <opt>                 Terminate sessions by session ID and/or range
    -K, --kill-all                   Terminate all sessions
    -l, --list-active                List all active sessions
    -n, --name <opt>                 Name or rename a session by ID
    -q, --quiet                      Quiet mode
    -s, --script <opt>               Run a script or module on the session given with -i, or all
    -S, --search <opt>               Row search filter.
    -t, --timeout <opt>              Set a response timeout (default: 15)
    -u, --upgrade <opt>              Upgrade a shell to a meterpreter session on many platforms
    -v, --list-verbose               List all active sessions in verbose mode
    -x, --list-extended              Show extended information in the session table

Many options allow specifying session ranges using commas and dashes.
For example:  sessions -s checkvm -i 1,3-5  or  sessions -k 1-2,5,6
```

</details>

## After

<details>
<summary>No params</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i -1 -s scripts/meterpreter/winenum.rb
[*] Session -1 (192.168.129.131):
[*] Running scripts/meterpreter/winenum.rb on meterpreter session -1 (192.168.129.131)
[*] Running Windows Local Enumeration Meterpreter Script
[*] New session on 192.168.129.131:49897...
[*] Saving general report to /Users/sjanusz/.msf4/logs/scripts/winenum/DESKTOP-T5PBUMF_20220119.2647/DESKTOP-T5PBUMF_20220119.2647.txt
[*] Output of each individual command is saved to /Users/sjanusz/.msf4/logs/scripts/winenum/DESKTOP-T5PBUMF_20220119.2647
[*] Checking if DESKTOP-T5PBUMF is a Virtual Machine ........

[-] Could not execute scripts/meterpreter/winenum.rb: Rex::Post::Meterpreter::RequestError stdapi_sys_config_getsid: Operation failed: The command is not supported by this Meterpreter type (java/windows)
```

</details>

<details>
<summary>Help param</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > sessions -i -1 -s scripts/meterpreter/winenum.rb -h
[*] Session -1 (192.168.129.131):
[*] Running scripts/meterpreter/winenum.rb on meterpreter session -1 (192.168.129.131)
WinEnum -- Windows local enumeration

Retrieves all kinds of information about the system
including environment variables, network interfaces,
routing, user accounts, and much more.  Results are
stored in /Users/sjanusz/.msf4/logs/scripts/winenum

OPTIONS:

    -c        Change Access, Modified and Created times of executables that were runon the target machine and clear the EventLog
    -h        Help menu.
    -m        Migrate the Meterpreter Session from it current process to a new cmd.exe before doing anything
    -r        Dump, compress and download entire Registry
```

</details>
