### PR TITLE
post/multi/manage/sudo: Abort if session type is Meterpreter

### DIFF
--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -41,6 +41,10 @@ class MetasploitModule < Msf::Post
 
   # Run Method for when run command is issued
   def run
+    if session.type == 'meterpreter'
+      fail_with(Failure::BadConfig, "Meterpreter sessions cannot be elevated with sudo")
+    end
+
     print_status("SUDO: Attempting to upgrade to UID 0 via sudo")
     sudo_bin = cmd_exec("which sudo")
     if is_root?


### PR DESCRIPTION
Address one of the issues highlighted in https://github.com/rapid7/metasploit-framework/pull/13886#issuecomment-663014165.

There's no point dumping the password in clear text (to a world-readable file #16074 !) and waiting up to 120 seconds (in a worst case scenario) only to fail because sudo elevation isn't possible with meterpreter.

# Before

```
msf6 post(multi/manage/sudo) > rexploit 
[*] Reloading module...

[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: meterpreter
[!]  * missing Meterpreter features: stdapi_railgun_api
[*] SUDO: Attempting to upgrade to UID 0 via sudo
[*] Sudoing with password `password'.
[*] Writing the SUDO_ASKPASS script: /tmp/.nNzenzG
[*] Setting executable bit.
[*] Setting environment variable.
[*] Executing sudo -s -A
[-] SUDO: Didn't work out, still a mere user.
[*] Post module execution completed
```

# After

```
msf6 post(multi/manage/sudo) > rexploit 
[*] Reloading module...

[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: meterpreter
[!]  * missing Meterpreter features: stdapi_railgun_api
[-] Post aborted due to failure: bad-config: Meterpreter sessions cannot be elevated with sudo
[*] Post module execution completed
```
