### PR TITLE
adds cpp compilation methods to the mingw compiler

### DIFF
--- a/lib/metasploit/framework/compiler/mingw.rb
+++ b/lib/metasploit/framework/compiler/mingw.rb
@@ -18,6 +18,7 @@ module Metasploit
           end
 
           stdin_err, status = Open3.capture2e(cmd)
+          cleanup_files
           stdin_err
         end
 
@@ -63,11 +64,14 @@ module Metasploit
           src_file = "#{self.file_name}.c"
           exe_file = "#{self.file_name}.exe"
 
+        def cleanup_files
           unless self.keep_src
+            src_file = "#{self.file_name}.c"
             File.delete(src_file) if File.exist?(src_file)
           end
 
           unless self.keep_exe
+            exe_file = "#{self.file_name}.exe"
             File.delete(exe_file) if File.exist?(exe_file)
           end
         rescue Errno::ENOENT


### PR DESCRIPTION
This adds additional methods to the mingw class in the compilers modules.

It also enables the use of previously unreachable code, allowing for cleanup when opting in within existing modules.

## Verification

### Usage in a module
 
![msf_usage](https://user-images.githubusercontent.com/4605783/150689611-f67088fa-bfd4-47ca-9d39-b2b6fbe0ae33.png)

### Result
![msf_success](https://user-images.githubusercontent.com/4605783/150689619-fc2a5c51-a5f9-4c05-9177-42b1f65831c9.png)
