### PR TITLE
Fix reference URLs for several modules and update tools/modules/module_reference.rb code with fixes

### DIFF
--- a/modules/auxiliary/admin/android/google_play_store_uxss_xframe_rce.rb
+++ b/modules/auxiliary/admin/android/google_play_store_uxss_xframe_rce.rb
@@ -33,8 +33,8 @@ class MetasploitModule < Msf::Auxiliary
       'Actions'        => [[ 'WebServer', 'Description' => 'Serve exploit via web server' ]],
       'PassiveActions' => [ 'WebServer' ],
       'References' => [
-        [ 'URL', 'https://blog.rapid7.com/2014/09/15/major-android-bug-is-a-privacy-disaster-cve-2014-6041'],
-        [ 'URL', 'http://1337day.com/exploit/description/22581' ],
+        [ 'URL', 'https://www.rapid7.com/blog/post/2014/09/15/major-android-bug-is-a-privacy-disaster-cve-2014-6041/'],
+        [ 'URL', 'https://web.archive.org/web/20150316151817/http://1337day.com/exploit/description/22581' ],
         [ 'OSVDB', '110664' ],
         [ 'CVE', '2014-6041' ]
       ],

--- a/modules/auxiliary/admin/atg/atg_client.rb
+++ b/modules/auxiliary/admin/atg/atg_client.rb
@@ -25,13 +25,13 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['URL', 'https://blog.rapid7.com/2015/01/22/the-internet-of-gas-station-tank-gauges'],
-          ['URL', 'http://www.trendmicro.com/vinfo/us/security/news/cybercrime-and-digital-threats/the-gaspot-experiment'],
+          ['URL', 'https://www.rapid7.com/blog/post/2015/01/22/the-internet-of-gas-station-tank-gauges/'],
+          ['URL', 'https://www.trendmicro.com/vinfo/us/security/news/cybercrime-and-digital-threats/the-gaspot-experiment'],
           ['URL', 'https://github.com/sjhilt/GasPot'],
           ['URL', 'https://github.com/mushorg/conpot'],
-          ['URL', 'http://www.veeder.com/us/automatic-tank-gauge-atg-consoles'],
-          ['URL', 'http://www.chipkin.com/files/liz/576013-635.pdf'],
-          ['URL', 'http://www.veeder.com/gold/download.cfm?doc_id=6227']
+          ['URL', 'https://www.veeder.com/us/automatic-tank-gauge-atg-consoles'],
+          ['URL', 'https://cdn.chipkin.com/files/liz/576013-635.pdf'],
+          ['URL', 'https://docs.veeder.com/gold/download.cfm?doc_id=6227']
         ],
       'DefaultAction'  => 'INVENTORY',
       'Actions'        =>

--- a/modules/auxiliary/admin/backupexec/dump.rb
+++ b/modules/auxiliary/admin/backupexec/dump.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2005-2611'],
           ['OSVDB', '18695'],
           ['BID', '14551'],
-          ['URL', 'http://www.fpns.net/willy/msbksrc.lzh'],
+          ['URL', 'https://web.archive.org/web/20120227144337/http://www.fpns.net/willy/msbksrc.lzh'],
         ],
       'Actions'     =>
         [

--- a/modules/auxiliary/admin/backupexec/registry.rb
+++ b/modules/auxiliary/admin/backupexec/registry.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'OSVDB', '17627' ],
           [ 'CVE', '2005-0771' ],
-          [ 'URL', 'http://www.idefense.com/application/poi/display?id=269&type=vulnerabilities'],
+          [ 'URL', 'https://web.archive.org/web/20110801042138/http://labs.idefense.com/intelligence/vulnerabilities/display.php?id=269'],
         ],
       'Actions'     =>
         [

--- a/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2021-1675'],
           ['CVE', '2021-34527'],
           ['URL', 'https://github.com/cube0x0/CVE-2021-1675'],
-          ['URL', 'https://github.com/afwu/PrintNightmare'],
+          ['URL', 'https://web.archive.org/web/20210701042336/https://github.com/afwu/PrintNightmare'],
           ['URL', 'https://github.com/calebstewart/CVE-2021-1675/blob/main/CVE-2021-1675.ps1'],
           ['URL', 'https://github.com/byt3bl33d3r/ItWasAllADream']
         ],

--- a/modules/auxiliary/admin/dns/dyn_dns_update.rb
+++ b/modules/auxiliary/admin/dns/dyn_dns_update.rb
@@ -19,10 +19,10 @@ class MetasploitModule < Msf::Auxiliary
           'Brent Cook <brent_cook[at]rapid7.com>'
         ],
         'References'     => [
-          ['URL', 'http://www.tenable.com/plugins/index.php?view=single&id=35372'],
+          ['URL', 'https://www.tenable.com/plugins/nessus/35372'],
           ['URL', 'https://github.com/KINGSABRI/CVE-in-Ruby/tree/master/NONE-CVE/DNSInject'],
           ['URL', 'https://www.christophertruncer.com/dns-modification-dnsinject-nessus-plugin-35372/'],
-          ['URL', 'https://github.com/ChrisTruncer/PenTestScripts/blob/master/DNSInject.py']
+          ['URL', 'https://github.com/ChrisTruncer/PenTestScripts/blob/master/HostScripts/DNSInject.py']
         ],
         'License'        => MSF_LICENSE,
         'Actions'        => [

--- a/modules/auxiliary/admin/firetv/firetv_youtube.rb
+++ b/modules/auxiliary/admin/firetv/firetv_youtube.rb
@@ -17,8 +17,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author' => ['wvu'],
       'References' => [
-        ['URL', 'http://www.amazon.com/dp/B00CX5P8FC?_encoding=UTF8&showFS=1'],
-        ['URL', 'http://www.amazon.com/dp/B00GDQ0RMG/ref=fs_ftvs']
+        ['URL', 'https://www.amazon.com/dp/B00CX5P8FC?_encoding=UTF8&showFS=1'],
+        ['URL', 'https://www.amazon.com/dp/B00GDQ0RMG/ref=fs_ftvs']
       ],
       'License' => MSF_LICENSE,
       'Actions' => [

--- a/modules/auxiliary/admin/hp/hp_data_protector_cmd.rb
+++ b/modules/auxiliary/admin/hp/hp_data_protector_cmd.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2011-0923' ],
           [ 'OSVDB', '72526' ],
           [ 'ZDI', '11-055' ],
-          [ 'URL', 'http://hackarandas.com/blog/2011/08/04/hp-data-protector-remote-shell-for-hpux' ]
+          [ 'URL', 'https://hackarandas.com/blog/2011/08/04/hp-data-protector-remote-shell-for-hpux/' ]
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/admin/hp/hp_ilo_create_admin_account.rb
+++ b/modules/auxiliary/admin/hp/hp_ilo_create_admin_account.rb
@@ -19,8 +19,8 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2017-12542' ],
           [ 'BID', '100467' ],
-          [ 'URL', 'https://support.hpe.com/hpsc/doc/public/display?docId=emr_na-hpesbhf03769en_us' ],
-          [ 'URL', 'https://www.synacktiv.com/posts/exploit/hp-ilo-talk-at-recon-brx-2018.html' ]
+          [ 'URL', 'https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-hpesbhf03769en_us' ],
+          [ 'URL', 'https://www.synacktiv.com/en/publications/hp-ilo-talk-at-recon-brx-2018.html' ]
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/admin/hp/hp_imc_som_create_account.rb
+++ b/modules/auxiliary/admin/hp/hp_imc_som_create_account.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'OSVDB', '98249' ],
           [ 'BID', '62902' ],
           [ 'ZDI', '13-240' ],
-          [ 'URL', 'https://h20566.www2.hp.com/portal/site/hpsc/public/kb/docDisplay/?docId=emr_na-c03943547' ]
+          [ 'URL', 'https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03943547' ]
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
@@ -25,9 +25,9 @@ class MetasploitModule < Msf::Auxiliary
               ],
               'References' => [
                   ['CVE', '2014-9222'],
-                  ['URL', 'http://mis.fortunecook.ie'],
-                  ['URL', 'http://mis.fortunecook.ie/misfortune-cookie-suspected-vulnerable.pdf'], # list of likely vulnerable devices
-                  ['URL', 'http://mis.fortunecook.ie/too-many-cooks-exploiting-tr069_tal-oppenheim_31c3.pdf'] # 31C3 presentation with POC
+                  ['URL', 'https://web.archive.org/web/20191006135858/http://mis.fortunecook.ie/'],
+                  ['URL', 'https://web.archive.org/web/20190207102911/http://mis.fortunecook.ie/misfortune-cookie-suspected-vulnerable.pdf'], # list of likely vulnerable devices
+                  ['URL', 'https://web.archive.org/web/20190623150837/http://mis.fortunecook.ie/too-many-cooks-exploiting-tr069_tal-oppenheim_31c3.pdf'] # 31C3 presentation with POC
               ],
               'DisclosureDate' => '2014-12-17',
               'License' => MSF_LICENSE

--- a/modules/auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss.rb
+++ b/modules/auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'CVE', '2015-0964' ], # XSS vulnerability
         [ 'CVE', '2015-0965' ], # CSRF vulnerability
         [ 'CVE', '2015-0966' ], # "techician/yZgO8Bvj" web interface backdoor
-        [ 'URL', 'https://blog.rapid7.com/2015/06/05/r7-2015-01-csrf-backdoor-and-persistent-xss-on-arris-motorola-cable-modems' ],
+        [ 'URL', 'https://www.rapid7.com/blog/post/2015/06/05/r7-2015-01-csrf-backdoor-and-persistent-xss-on-arris-motorola-cable-modems/' ],
       ]
     ))
 

--- a/modules/auxiliary/admin/http/cisco_7937g_ssh_privesc.py
+++ b/modules/auxiliary/admin/http/cisco_7937g_ssh_privesc.py
@@ -32,7 +32,7 @@ metadata = {
     'date': '2020-06-02',
     'license': 'GPL_LICENSE',
     'references': [
-        {'type': 'url', 'ref': 'https://blacklanternsecurity.com/2020-08-07-Cisco-Unified-IP-Conference-Station-7937G/'},
+        {'type': 'url', 'ref': 'https://web.archive.org/web/20200921054955/https://www.blacklanternsecurity.com/2020-08-07-Cisco-Unified-IP-Conference-Station-7937G/'},
         {'type': 'cve', 'ref': '2020-16137'}
     ],
     'type': 'single_scanner',

--- a/modules/auxiliary/admin/http/cnpilot_r_cmd_exec.rb
+++ b/modules/auxiliary/admin/http/cnpilot_r_cmd_exec.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' =>
         [
           ['CVE', '2017-5259'],
-          ['URL', 'https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities']
+          ['URL', 'https://www.rapid7.com/blog/post/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/']
         ],
       'License' => MSF_LICENSE
      )

--- a/modules/auxiliary/admin/http/cnpilot_r_fpt.rb
+++ b/modules/auxiliary/admin/http/cnpilot_r_fpt.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' =>
         [
           ['CVE', '2017-5261'],
-          ['URL', 'https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities']
+          ['URL', 'https://www.rapid7.com/blog/post/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/']
         ],
       'License' => MSF_LICENSE
      )

--- a/modules/auxiliary/admin/http/dlink_dir_300_600_exec_noauth.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_300_600_exec_noauth.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'OSVDB', '89861' ],
           [ 'EDB', '24453' ],
-          [ 'URL', 'http://www.dlink.com/uk/en/home-solutions/connect/routers/dir-600-wireless-n-150-home-router' ],
+          [ 'URL', 'https://eu.dlink.com/uk/en/products/dir-600-wireless-n-150-home-router' ],
           [ 'URL', 'http://www.s3cur1ty.de/home-network-horror-days' ],
           [ 'URL', 'http://www.s3cur1ty.de/m1adv2013-003' ]
         ],

--- a/modules/auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb
+++ b/modules/auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CWE', '915'],
           ['OSVDB', '94655'],
           ['URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=966804'],
-          ['URL', 'http://projects.theforeman.org/issues/2630']
+          ['URL', 'https://projects.theforeman.org/issues/2630']
         ],
       'DisclosureDate' => 'Jun 6 2013'
     )

--- a/modules/auxiliary/admin/http/iis_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/iis_auth_bypass.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2010-2731' ],
           [ 'OSVDB', '66160' ],
           [ 'MSB', 'MS10-065' ],
-          [ 'URL', 'http://soroush.secproject.com/blog/2010/07/iis5-1-directory-authentication-bypass-by-using-i30index_allocation/' ]
+          [ 'URL', 'https://soroush.secproject.com/blog/2010/07/iis5-1-directory-authentication-bypass-by-using-i30index_allocation/' ]
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/admin/http/jboss_bshdeployer.rb
+++ b/modules/auxiliary/admin/http/jboss_bshdeployer.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2010-0738' ], # using a VERB other than GET/POST
           [ 'OSVDB', '64171' ],
-          [ 'URL', 'http://www.redteam-pentesting.de/publications/jboss' ],
+          [ 'URL', 'https://www.redteam-pentesting.de/en/publications/jboss/-bridging-the-gap-between-the-enterprise-and-you-or-whos-the-jboss-now' ],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=574105' ]
         ],
       'Actions'       =>

--- a/modules/auxiliary/admin/http/jboss_deploymentfilerepository.rb
+++ b/modules/auxiliary/admin/http/jboss_deploymentfilerepository.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2010-0738' ], # using a VERB other than GET/POST
           [ 'OSVDB', '64171' ],
-          [ 'URL', 'http://www.redteam-pentesting.de/publications/jboss' ],
+          [ 'URL', 'https://www.redteam-pentesting.de/en/publications/jboss/-bridging-the-gap-between-the-enterprise-and-you-or-whos-the-jboss-now' ],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=574105' ]
         ],
       'Actions'       =>

--- a/modules/auxiliary/admin/http/limesurvey_file_download.rb
+++ b/modules/auxiliary/admin/http/limesurvey_file_download.rb
@@ -26,8 +26,8 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['URL', 'https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20151022-0_Lime_Survey_multiple_critical_vulnerabilities_v10.txt'],
-          ['URL', 'https://www.limesurvey.org/en/blog/76-limesurvey-news/security-advisories/1836-limesurvey-security-advisory-10-2015'],
+          ['URL', 'https://sec-consult.com/vulnerability-lab/advisory/multiple-critical-vulnerabilities-in-lime-survey/'],
+          ['URL', 'https://www.limesurvey.org/blog/22-security/136-limesurvey-security-advisory-10-2015'],
           ['URL', 'https://github.com/LimeSurvey/LimeSurvey/compare/2.06_plus_151014...2.06_plus_151016?w=1']
         ],
       'DisclosureDate' => '2015-10-12'))

--- a/modules/auxiliary/admin/http/linksys_tmunblock_admin_reset_bof.rb
+++ b/modules/auxiliary/admin/http/linksys_tmunblock_admin_reset_bof.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'EDB', '31758' ],
           [ 'OSVDB', '103521' ],
-          [ 'URL', 'http://www.devttys0.com/2014/02/wrt120n-fprintf-stack-overflow/' ] # a huge amount of details about this vulnerability and the original exploit
+          [ 'URL', 'https://web.archive.org/web/20210424073058/http://www.devttys0.com/2014/02/wrt120n-fprintf-stack-overflow/' ] # a huge amount of details about this vulnerability and the original exploit
         ],
       'DisclosureDate' => '2014-02-19'))
   end

--- a/modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb
+++ b/modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2013-0136' ],
           [ 'US-CERT-VU', '701572' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/05/15/new-1day-exploits-mutiny-vulnerabilities' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/05/15/new-1day-exploits-mutiny-vulnerabilities/' ]
         ],
       'Actions'     =>
         [

--- a/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
+++ b/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'BID', '72640' ],
           [ 'OSVDB', '118316' ],
-          [ 'URL', 'https://github.com/darkarnium/secpub/tree/master/NetGear/SOAPWNDR' ]
+          [ 'URL', 'https://github.com/darkarnium/secpub/tree/master/Vulnerabilities/NetGear/SOAPWNDR' ]
         ],
       'Author'      =>
         [

--- a/modules/auxiliary/admin/http/netgear_wnr2000_pass_recovery.rb
+++ b/modules/auxiliary/admin/http/netgear_wnr2000_pass_recovery.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2016-10176'],
           ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/netgear-wnr2000.txt'],
           ['URL', 'https://seclists.org/fulldisclosure/2016/Dec/72'],
-          ['URL', 'http://kb.netgear.com/000036549/Insecure-Remote-Access-and-Command-Execution-Security-Vulnerability']
+          ['URL', 'https://kb.netgear.com/000036549/Insecure-Remote-Access-and-Command-Execution-Security-Vulnerability']
         ],
       'DisclosureDate'  => '2016-12-20'))
     register_options(

--- a/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
+++ b/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       'License' => MSF_LICENSE,
       'References'  =>
         [
-          [ 'URL', 'https://blog.rapid7.com/2013/08/16/r7-vuln-2013-07-24' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/08/16/r7-vuln-2013-07-24/' ]
         ],
       'DefaultOptions' => {
         'SSL' => true

--- a/modules/auxiliary/admin/http/openbravo_xxe.rb
+++ b/modules/auxiliary/admin/http/openbravo_xxe.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2013-3617'],
           ['OSVDB', '99141'],
           ['BID', '63431'],
-          ['URL', 'https://blog.rapid7.com/2013/10/30/seven-tricks-and-treats']
+          ['URL', 'https://www.rapid7.com/blog/post/2013/10/30/seven-tricks-and-treats']
         ],
       'License' => MSF_LICENSE,
       'DisclosureDate' => '2013-10-30'

--- a/modules/auxiliary/admin/http/sophos_wpa_traversal.rb
+++ b/modules/auxiliary/admin/http/sophos_wpa_traversal.rb
@@ -29,8 +29,8 @@ class MetasploitModule < Msf::Auxiliary
           [ 'OSVDB', '91953' ],
           [ 'BID', '58833' ],
           [ 'EDB', '24932' ],
-          [ 'URL', 'http://www.sophos.com/en-us/support/knowledgebase/118969.aspx' ],
-          [ 'URL', 'https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20130403-0_Sophos_Web_Protection_Appliance_Multiple_Vulnerabilities.txt' ]
+          [ 'URL', 'https://web.archive.org/web/20130603041204/http://www.sophos.com/en-us/support/knowledgebase/118969.aspx' ],
+          [ 'URL', 'https://web.archive.org/web/20140701204340/https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20130403-0_Sophos_Web_Protection_Appliance_Multiple_Vulnerabilities.txt' ]
         ],
       'DefaultOptions' => {
         'SSL' => true

--- a/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
+++ b/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'http://blogs.technet.com/b/srd/archive/2014/11/18/additional-information-about-cve-2014-6324.aspx'],
           ['URL', 'https://labs.mwrinfosecurity.com/blog/2014/12/16/digging-into-ms14-068-exploitation-and-defence/'],
           ['URL', 'https://github.com/bidord/pykek'],
-          ['URL', 'https://blog.rapid7.com/2014/12/25/12-days-of-haxmas-ms14-068-now-in-metasploit']
+          ['URL', 'https://www.rapid7.com/blog/post/2014/12/25/12-days-of-haxmas-ms14-068-now-in-metasploit']
         ],
       'License' => MSF_LICENSE,
       'DisclosureDate' => '2014-11-18'

--- a/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
           'antti <antti.rantasaari[at]netspi.com>'
         ],
       'License'     => MSF_LICENSE,
-      'References'  => [[ 'URL','http://msdn.microsoft.com/en-us/library/ms174427.aspx']]
+      'References'  => [[ 'URL','https://docs.microsoft.com/en-us/sql/t-sql/functions/suser-sname-transact-sql']]
     ))
 
     register_options(

--- a/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts_sqli.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts_sqli.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
           'antti <antti.rantasaari[at]netspi.com>'
         ],
       'License'     => MSF_LICENSE,
-      'References'  => [[ 'URL','http://msdn.microsoft.com/en-us/library/ms174427.aspx']]
+      'References'  => [[ 'URL','https://docs.microsoft.com/en-us/sql/t-sql/functions/suser-sname-transact-sql']]
       ))
 
     register_options(

--- a/modules/auxiliary/admin/mssql/mssql_enum_sql_logins.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum_sql_logins.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'      => ['nullbind <scott.sutherland[at]netspi.com>'],
       'License'     => MSF_LICENSE,
-      'References'  => [['URL','http://msdn.microsoft.com/en-us/library/ms174427.aspx']]
+      'References'  => [['URL','https://docs.microsoft.com/en-us/sql/t-sql/functions/suser-sname-transact-sql']]
     ))
 
     register_options(

--- a/modules/auxiliary/admin/mssql/mssql_ntlm_stealer.rb
+++ b/modules/auxiliary/admin/mssql/mssql_ntlm_stealer.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'         => [ 'nullbind <scott.sutherland[at]netspi.com>' ],
       'License'        => MSF_LICENSE,
-      'References'     => [[ 'URL', 'http://en.wikipedia.org/wiki/SMBRelay' ]]
+      'References'     => [[ 'URL', 'https://en.wikipedia.org/wiki/SMBRelay' ]]
     ))
 
     register_options(

--- a/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
+++ b/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
           'Antti <antti.rantasaari[at]netspi.com>'
         ],
       'License'        => MSF_LICENSE,
-      'References'     => [[ 'URL', 'http://en.wikipedia.org/wiki/SMBRelay' ]]
+      'References'     => [[ 'URL', 'https://en.wikipedia.org/wiki/SMBRelay' ]]
     ))
 
     register_options(

--- a/modules/auxiliary/admin/scada/yokogawa_bkbcopyd_client.rb
+++ b/modules/auxiliary/admin/scada/yokogawa_bkbcopyd_client.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2014-5208' ],
-          [ 'URL', 'https://blog.rapid7.com/2014/08/09/r7-2014-10-disclosure-yokogawa-centum-cs3000-bkbcopydexe-file-system-access']
+          [ 'URL', 'https://www.rapid7.com/blog/post/2014/08/09/r7-2014-10-disclosure-yokogawa-centum-cs3000-bkbcopydexe-file-system-access']
         ],
       'Actions'     =>
         [

--- a/modules/auxiliary/admin/tikiwiki/tikidblib.rb
+++ b/modules/auxiliary/admin/tikiwiki/tikidblib.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
           ['OSVDB', '30172'],
           ['BID', '20858'],
           ['CVE', '2006-5702'],
-          ['URL', 'http://secunia.com/advisories/22678/'],
+          ['URL', 'https://web.archive.org/web/20080211225557/http://secunia.com/advisories/22678/'],
         ],
       'DisclosureDate' => '2006-11-01',
       'Actions'        =>

--- a/modules/auxiliary/admin/vnc/realvnc_41_bypass.rb
+++ b/modules/auxiliary/admin/vnc/realvnc_41_bypass.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['BID', '17978'],
           ['OSVDB', '25479'],
-          ['URL', 'http://secunia.com/advisories/20107/'],
+          ['URL', 'https://web.archive.org/web/20080102163013/http://secunia.com/advisories/20107/'],
           ['CVE', '2006-2369'],
         ],
       'DisclosureDate' => '2006-05-15'))

--- a/modules/auxiliary/admin/vxworks/apple_airport_extreme_password.rb
+++ b/modules/auxiliary/admin/vxworks/apple_airport_extreme_password.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['OSVDB', '66842'],
-          ['URL', 'http://blog.metasploit.com/2010/08/vxworks-vulnerabilities.html'],
+          ['URL', 'https://www.rapid7.com/blog/post/2010/08/02/new-vxworks-vulnerabilities/'],
           ['US-CERT-VU', '362332']
         ]
       ))

--- a/modules/auxiliary/admin/vxworks/dlink_i2eye_autoanswer.rb
+++ b/modules/auxiliary/admin/vxworks/dlink_i2eye_autoanswer.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['OSVDB', '66842'],
-          ['URL', 'http://blog.metasploit.com/2010/08/vxworks-vulnerabilities.html'],
+          ['URL', 'https://www.rapid7.com/blog/post/2010/08/02/new-vxworks-vulnerabilities/'],
           ['US-CERT-VU', '362332']
         ]
       ))

--- a/modules/auxiliary/admin/vxworks/wdbrpc_memory_dump.rb
+++ b/modules/auxiliary/admin/vxworks/wdbrpc_memory_dump.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['OSVDB', '66842'],
-          ['URL', 'http://blog.metasploit.com/2010/08/vxworks-vulnerabilities.html'],
+          ['URL', 'https://www.rapid7.com/blog/post/2010/08/02/new-vxworks-vulnerabilities/'],
           ['US-CERT-VU', '362332']
         ],
       'Actions'     =>

--- a/modules/auxiliary/admin/vxworks/wdbrpc_reboot.rb
+++ b/modules/auxiliary/admin/vxworks/wdbrpc_reboot.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['OSVDB', '66842'],
-          ['URL', 'http://blog.metasploit.com/2010/08/vxworks-vulnerabilities.html'],
+          ['URL', 'https://www.rapid7.com/blog/post/2010/08/02/new-vxworks-vulnerabilities/'],
           ['US-CERT-VU', '362332']
         ],
       'Actions'     =>

--- a/modules/auxiliary/admin/webmin/file_disclosure.rb
+++ b/modules/auxiliary/admin/webmin/file_disclosure.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
           ['BID', '18744'],
           ['CVE', '2006-3392'],
           ['US-CERT-VU', '999601'],
-          ['URL', 'http://secunia.com/advisories/20892/'],
+          ['URL', 'https://web.archive.org/web/20060722192501/http://secunia.com/advisories/20892/'],
         ],
       'DisclosureDate' => '2006-06-30',
       'Actions'        =>

--- a/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
+++ b/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Auxiliary
        'References'     =>
          [
            ['CVE', '2014-0050'],
-           ['URL', 'http://tomcat.apache.org/security-8.html'],
-           ['URL', 'http://tomcat.apache.org/security-7.html']
+           ['URL', 'https://tomcat.apache.org/security-8.html'],
+           ['URL', 'https://tomcat.apache.org/security-7.html']
          ],
         'DisclosureDate' => '2014-02-06'
       ))

--- a/modules/auxiliary/dos/http/apache_mod_isapi.rb
+++ b/modules/auxiliary/dos/http/apache_mod_isapi.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2010-0425' ],
           [ 'OSVDB', '62674'],
           [ 'BID', '38494' ],
-          [ 'URL', 'https://issues.apache.org/bugzilla/show_bug.cgi?id=48509' ],
-          [ 'URL', 'http://www.gossamer-threads.com/lists/apache/cvs/381537' ],
+          [ 'URL', 'https://bz.apache.org/bugzilla/show_bug.cgi?id=48509' ],
+          [ 'URL', 'https://web.archive.org/web/20100715032229/http://www.gossamer-threads.com/lists/apache/cvs/381537' ],
           [ 'URL', 'http://www.senseofsecurity.com.au/advisories/SOS-10-002' ],
           [ 'EDB', '11650' ]
         ],

--- a/modules/auxiliary/dos/http/brother_debut_dos.rb
+++ b/modules/auxiliary/dos/http/brother_debut_dos.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'References'     => [
         [ 'CVE', '2017-16249' ],
-        [ 'URL', 'https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2017-017/?fid=10211']
+        [ 'URL', 'https://www.trustwave.com/en-us/resources/security-resources/security-advisories/?fid=18730']
       ],
       'DisclosureDate' => '2017-11-02'))
   end

--- a/modules/auxiliary/dos/http/canon_wireless_printer.rb
+++ b/modules/auxiliary/dos/http/canon_wireless_printer.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'References'     => [
         [ 'CVE', '2013-4615' ],
-        [ 'URL', 'http://www.mattandreko.com/2013/06/canon-y-u-no-security.html']
+        [ 'URL', 'https://www.mattandreko.com/2013/06/canon-y-u-no-security.html']
       ],
       'DisclosureDate' => '2013-06-18'))
   end

--- a/modules/auxiliary/dos/http/hashcollision_dos.rb
+++ b/modules/auxiliary/dos/http/hashcollision_dos.rb
@@ -33,11 +33,11 @@ class MetasploitModule < Msf::Auxiliary
       'License'       => MSF_LICENSE,
       'References'    =>
         [
-          ['URL', 'http://www.ocert.org/advisories/ocert-2011-003.html'],
-          ['URL', 'http://www.nruns.com/_downloads/advisory28122011.pdf'],
-          ['URL', 'http://events.ccc.de/congress/2011/Fahrplan/events/4680.en.html'],
-          ['URL', 'http://events.ccc.de/congress/2011/Fahrplan/attachments/2007_28C3_Effective_DoS_on_web_application_platforms.pdf'],
-          ['URL', 'http://www.youtube.com/watch?v=R2Cq3CLI6H8'],
+          ['URL', 'http://ocert.org/advisories/ocert-2011-003.html'],
+          ['URL', 'https://web.archive.org/web/20120105151644/http://www.nruns.com/_downloads/advisory28122011.pdf'],
+          ['URL', 'https://fahrplan.events.ccc.de/congress/2011/Fahrplan/events/4680.en.html'],
+          ['URL', 'https://fahrplan.events.ccc.de/congress/2011/Fahrplan/attachments/2007_28C3_Effective_DoS_on_web_application_platforms.pdf'],
+          ['URL', 'https://www.youtube.com/watch?v=R2Cq3CLI6H8'],
           ['CVE', '2011-5034'],
           ['CVE', '2011-5035'],
           ['CVE', '2011-4885'],

--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2015-1635'],
           ['MSB', 'MS15-034'],
-          ['URL', 'http://pastebin.com/ypURDPc4'],
+          ['URL', 'https://pastebin.com/ypURDPc4'],
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/5150'],
           ['URL', 'https://community.qualys.com/blogs/securitylabs/2015/04/20/ms15-034-analyze-and-remote-detection'],
           ['URL', 'http://www.securitysift.com/an-analysis-of-ms15-034/']

--- a/modules/auxiliary/dos/http/nodejs_pipelining.rb
+++ b/modules/auxiliary/dos/http/nodejs_pipelining.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2013-4450' ],
           [ 'OSVDB', '98724' ],
           [ 'BID' , '63229' ],
-          [ 'URL', 'http://blog.nodejs.org/2013/10/22/cve-2013-4450-http-server-pipeline-flood-dos' ]
+          [ 'URL', 'https://nodejs.org/ja/blog/vulnerability/http-server-pipeline-flood-dos/' ]
         ],
       'DisclosureDate' => '2013-10-18'))
 

--- a/modules/auxiliary/dos/http/novell_file_reporter_heap_bof.rb
+++ b/modules/auxiliary/dos/http/novell_file_reporter_heap_bof.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     => [
         [ 'CVE', '2012-4956' ],
-        [ 'URL', 'https://blog.rapid7.com/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959' ]
+        [ 'URL', 'https://www.rapid7.com/blog/post/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959/' ]
       ],
       'DisclosureDate' => '2012-11-16'))
 

--- a/modules/auxiliary/dos/http/webkitplus.rb
+++ b/modules/auxiliary/dos/http/webkitplus.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
           ['EDB', '44842'],
           ['CVE', '2018-11646'],
           ['URL', 'https://bugs.webkit.org/show_bug.cgi?id=186164'],
-          ['URL', 'https://datarift.blogspot.com/2018/06/cve-2018-11646-webkit.html']
+          ['URL', 'https://www.inputzero.io/2018/06/cve-2018-11646-webkit.html']
         ],
         'DisclosureDate' => '2018-06-03',
         'Actions'        => [[ 'WebServer', 'Description' => 'Serve exploit via web server' ]],

--- a/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'      =>
         [
           ['CVE', '2014-9016'],
-          ['URL', 'http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-9034'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2014-9034'],
           ['OSVDB', '114857'],
           ['WPVDB', '7681']
         ],

--- a/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
@@ -24,9 +24,9 @@ class MetasploitModule < Msf::Auxiliary
       'References'    =>
         [
           ['CVE', '2014-5266'],
-          ['URL', 'http://wordpress.org/news/2014/08/wordpress-3-9-2/'],
+          ['URL', 'https://wordpress.org/news/2014/08/wordpress-3-9-2/'],
           ['URL', 'http://www.breaksec.com/?p=6362'],
-          ['URL', 'http://mashable.com/2014/08/06/wordpress-xml-blowup-dos/'],
+          ['URL', 'https://mashable.com/archive/wordpress-xml-blowup-dos'],
           ['URL', 'https://core.trac.wordpress.org/changeset/29404'],
           ['WPVDB', '7526']
         ],

--- a/modules/auxiliary/dos/misc/memcached.rb
+++ b/modules/auxiliary/dos/misc/memcached.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          [ 'URL', 'https://code.google.com/p/memcached/issues/detail?id=192' ],
+          [ 'URL', 'https://code.google.com/archive/p/memcached/issues/192' ],
           [ 'CVE', '2011-4971' ],
           [ 'OSVDB', '92867' ]
         ],

--- a/modules/auxiliary/dos/ntp/ntpd_reserved_dos.rb
+++ b/modules/auxiliary/dos/ntp/ntpd_reserved_dos.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'BID', '37255' ],
           [ 'CVE', '2009-3563' ],
           [ 'OSVDB', '60847' ],
-          [ 'URL', 'https://support.ntp.org/bugs/show_bug.cgi?id=1331' ]
+          [ 'URL', 'https://bugs.ntp.org/show_bug.cgi?id=1331' ]
         ],
       'DisclosureDate' => '2009-10-04'))
 

--- a/modules/auxiliary/dos/sap/sap_soap_rfc_eps_delete_file.rb
+++ b/modules/auxiliary/dos/sap/sap_soap_rfc_eps_delete_file.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' => [
         [ 'OSVDB', '74780' ],
         [ 'URL', 'http://dsecrg.com/pages/vul/show.php?id=331' ],
-        [ 'URL', 'https://service.sap.com/sap/support/notes/1554030' ]
+        [ 'URL', 'https://launchpad.support.sap.com/#/notes/1554030' ]
       ],
       'Author' =>
         [

--- a/modules/auxiliary/dos/scada/allen_bradley_pccc.rb
+++ b/modules/auxiliary/dos/scada/allen_bradley_pccc.rb
@@ -29,8 +29,8 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
       [
         [ 'CVE', '2017-7924' ],
-        [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-17-138-03' ],
-        [ 'URL', 'http://dl.acm.org/citation.cfm?doid=3174776.3174780']
+        [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-17-138-03' ],
+        [ 'URL', 'https://dl.acm.org/doi/10.1145/3174776.3174780']
       ])
       register_options([Opt::RPORT(44818),])
   end

--- a/modules/auxiliary/dos/scada/igss9_dataserver.rb
+++ b/modules/auxiliary/dos/scada/igss9_dataserver.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2011-4050' ],
           [ 'OSVDB', '77976' ],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-335-01.pdf' ]
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-335-01' ]
         ],
       'DisclosureDate' => '2011-12-20'
     ))

--- a/modules/auxiliary/dos/scada/siemens_siprotec4.rb
+++ b/modules/auxiliary/dos/scada/siemens_siprotec4.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
             [
               [ 'CVE' '2015-5374' ],
               [ 'EDB', '44103' ],
-              [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-15-202-01' ]
+              [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-15-202-01' ]
             ])
         register_options([Opt::RPORT(50000),])
   end

--- a/modules/auxiliary/dos/scada/yokogawa_logsvr.rb
+++ b/modules/auxiliary/dos/scada/yokogawa_logsvr.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'URL', 'http://www.yokogawa.com/dcs/security/ysar/YSAR-14-0001E.pdf' ],
-          [ 'URL', 'https://blog.rapid7.com/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2014/03/10/yokogawa-centum-cs3000-vulnerabilities/' ],
           [ 'CVE', '2014-0781']
         ],
       'DisclosureDate' => '2014-03-10',

--- a/modules/auxiliary/dos/smb/smb_loris.rb
+++ b/modules/auxiliary/dos/smb/smb_loris.rb
@@ -32,7 +32,8 @@ metadata = {
   ],
   date: '2017-06-29',
   references: [
-    { type: 'url', ref: 'http://smbloris.com/' }
+    { type: 'url', ref: 'https://web.archive.org/web/20170804072329/https://smbloris.com/' },
+    { type: 'aka', ref: 'SMBLoris'}
   ],
   type: 'dos',
   options: {

--- a/modules/auxiliary/dos/syslog/rsyslog_long_tag.rb
+++ b/modules/auxiliary/dos/syslog/rsyslog_long_tag.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           [ 'CVE', '2011-3200'],
-          [ 'URL', 'http://www.rsyslog.com/potential-dos-with-malformed-tag/' ],
+          [ 'URL', 'https://www.rsyslog.com/potential-dos-with-malformed-tag/' ],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=727644' ],
         ],
       'DisclosureDate' => 'Sep 01 2011')

--- a/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
+++ b/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
@@ -25,7 +25,8 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2013-0229' ],
           [ 'OSVDB', '89625' ],
           [ 'BID', '57607' ],
-          [ 'URL', 'https://community.rapid7.com/servlet/JiveServlet/download/2150-1-16596/SecurityFlawsUPnP.pdf' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/01/29/security-flaws-in-universal-plug-and-play-unplug-dont-play/' ],
+          [ 'URL', 'https://www.hdm.io/writing/SecurityFlawsUPnP.pdf' ]
         ],
       'DisclosureDate' => '2013-03-27',
     ))

--- a/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'BID', '45542' ],
           [ 'MSB', 'MS11-004' ],
           [ 'EDB', '15803' ],
-          [ 'URL', 'http://blogs.technet.com/b/srd/archive/2010/12/22/assessing-an-iis-ftp-7-5-unauthenticated-denial-of-service-vulnerability.aspx' ]
+          [ 'URL', 'https://msrc-blog.microsoft.com/2010/12/22/assessing-an-iis-ftp-7-5-unauthenticated-denial-of-service-vulnerability/' ]
         ],
       'DisclosureDate' => '2010-12-21'))
 

--- a/modules/auxiliary/dos/windows/rdp/ms12_020_maxchannelids.rb
+++ b/modules/auxiliary/dos/windows/rdp/ms12_020_maxchannelids.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'http://pastie.org/private/feg8du0e9kfagng4rrg' ],
           [ 'URL', 'http://stratsec.blogspot.com.au/2012/03/ms12-020-vulnerability-for-breakfast.html' ],
           [ 'EDB', '18606' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/03/21/metasploit-update' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/03/21/metasploit-update/' ]
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
           ['BID', '36299'],
           ['OSVDB', '57799'],
           ['MSB', 'MS09-050'],
-          ['URL', 'https://seclists.org/fulldisclosure/2009/Sep/0039.html']
+          ['URL', 'https://seclists.org/fulldisclosure/2009/Sep/39']
         ]
     ))
     register_options([

--- a/modules/auxiliary/dos/windows/ssh/sysax_sshd_kexchange.rb
+++ b/modules/auxiliary/dos/windows/ssh/sysax_sshd_kexchange.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'OSVDB', '92081'],
-          [ 'URL', 'http://www.mattandreko.com/2013/04/sysax-multi-server-610-ssh-dos.html']
+          [ 'URL', 'https://www.mattandreko.com/2013/04/sysax-multi-server-610-ssh-dos.html']
         ],
       'DisclosureDate' => '2013-03-17'))
 

--- a/modules/auxiliary/dos/wireshark/cldap.rb
+++ b/modules/auxiliary/dos/wireshark/cldap.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2011-1140'],
           [ 'OSVDB', '71552'],
-          [ 'URL', 'http://www.wireshark.org/security/wnpa-sec-2011-04.html' ],
+          [ 'URL', 'https://www.wireshark.org/security/wnpa-sec-2011-04.html' ],
           [ 'URL', 'https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=5717' ],
         ],
       'DisclosureDate' => '2011-03-01'))

--- a/modules/auxiliary/example.py
+++ b/modules/auxiliary/example.py
@@ -25,7 +25,7 @@ metadata = {
     'date': '2018-03-22',
     'license': 'MSF_LICENSE',
     'references': [
-        {'type': 'url', 'ref': 'https://blog.rapid7.com/2017/12/28/regifting-python-in-metasploit/'},
+        {'type': 'url', 'ref': 'https://www.rapid7.com/blog/post/2017/12/28/regifting-python-in-metasploit/'},
         {'type': 'aka', 'ref': 'Coldstone'}
     ],
     'type': 'single_scanner',

--- a/modules/auxiliary/gather/android_browser_file_theft.rb
+++ b/modules/auxiliary/gather/android_browser_file_theft.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           # patch for file redirection, 2014
           ['URL', 'https://android.googlesource.com/platform/packages/apps/Browser/+/d2391b492dec778452238bc6d9d549d56d41c107%5E%21/#F0'],
-          ['URL', 'https://code.google.com/p/chromium/issues/detail?id=90222'] # the UXSS
+          ['URL', 'https://bugs.chromium.org/p/chromium/issues/detail?id=90222'] # the UXSS
         ],
       'DefaultAction'  => 'WebServer'
     ))

--- a/modules/auxiliary/gather/android_object_tag_webview_uxss.rb
+++ b/modules/auxiliary/gather/android_object_tag_webview_uxss.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' => [
         [ 'URL', 'http://www.rafayhackingarticles.net/2014/10/a-tale-of-another-sop-bypass-in-android.html'],
         [ 'URL', 'https://android.googlesource.com/platform/external/webkit/+/109d59bf6fe4abfd001fc60ddd403f1046b117ef' ],
-        [ 'URL', 'http://trac.webkit.org/changeset/96826' ]
+        [ 'URL', 'http://trac.webkit.org/changeset/96826/webkit' ]
       ],
       'DefaultAction'  => 'WebServer',
       'DisclosureDate' => '2014-10-04'

--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => 'joev',
       'References'     =>
         [
-          ['URL', 'https://blog.rapid7.com/2013/04/25/abusing-safaris-webarchive-file-format']
+          ['URL', 'https://www.rapid7.com/blog/post/2013/04/25/abusing-safaris-webarchive-file-format/']
         ],
       'DisclosureDate' => '2013-02-22',
       'Actions'        => [[ 'WebServer', 'Description' => 'Serve exploit via web server' ]],

--- a/modules/auxiliary/gather/browser_lanipleak.rb
+++ b/modules/auxiliary/gather/browser_lanipleak.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         'References'     => [
            [ 'CVE', '2018-6849' ],
            [ 'URL', 'http://net.ipcalf.com/' ],
-           [ 'URL', 'https://datarift.blogspot.in/p/private-ip-leakage-using-webrtc.html' ]
+           [ 'URL', 'https://www.inputzero.io/p/private-ip-leakage-using-webrtc.html' ]
          ],
         'DisclosureDate' => '2013-09-05',
         'Actions'        => [[ 'WebServer', 'Description' => 'Serve exploit via web server' ]],

--- a/modules/auxiliary/gather/checkpoint_hostname.rb
+++ b/modules/auxiliary/gather/checkpoint_hostname.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           # aushack - None? Stumbled across, probably an old bug/feature but unsure.
-          [ 'URL', 'http://www.osisecurity.com.au/advisories/checkpoint-firewall-securemote-hostname-information-disclosure' ],
+          [ 'URL', 'https://web.archive.org/web/20120508142715/http://www.osisecurity.com.au/advisories/checkpoint-firewall-securemote-hostname-information-disclosure' ],
           [ 'URL', 'https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk69360' ]
         ]
     ))

--- a/modules/auxiliary/gather/cisco_rv320_config.rb
+++ b/modules/auxiliary/gather/cisco_rv320_config.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2019-1653'],
           ['URL', 'https://seclists.org/fulldisclosure/2019/Jan/52'],
           ['URL', 'https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvg42801'],
-          ['URL', 'http://www.cisco.com/en/US/products/csa/cisco-sa-20110330-acs.html']
+          ['URL', 'https://www.cisco.com/c/en/us/support/docs/csa/cisco-sa-20110330-acs.html']
         ],
       'DisclosureDate' => '2019-01-24',
       'DefaultOptions' =>

--- a/modules/auxiliary/gather/darkcomet_filedownloader.rb
+++ b/modules/auxiliary/gather/darkcomet_filedownloader.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'     =>
         [
-          [ 'URL', 'https://www.nccgroup.trust/globalassets/our-research/us/whitepapers/PEST-CONTROL.pdf' ],
+          [ 'URL', 'https://www.nccgroup.com/globalassets/our-research/us/whitepapers/PEST-CONTROL.pdf' ],
           [ 'URL', 'http://samvartaka.github.io/exploitation/2016/06/03/dead-rats-exploiting-malware' ]
         ],
       'DisclosureDate' => '2012-10-08',

--- a/modules/auxiliary/gather/drupal_openid_xxe.rb
+++ b/modules/auxiliary/gather/drupal_openid_xxe.rb
@@ -30,8 +30,8 @@ class MetasploitModule < Msf::Auxiliary
           [ 'OSVDB', '86429' ],
           [ 'BID', '56103' ],
           [ 'URL', 'https://drupal.org/node/1815912' ],
-          [ 'URL', 'http://drupalcode.org/project/drupal.git/commit/b912710' ],
-          [ 'URL', 'http://www.ubercomp.com/posts/2014-01-16_facebook_remote_code_execution' ]
+          [ 'URL', 'https://github.com/drupal/drupal/commit/b9127101ffeca819e74a03fa9f5a48d026c562e5' ],
+          [ 'URL', 'https://www.ubercomp.com/posts/2014-01-16_facebook_remote_code_execution' ]
         ],
       'DisclosureDate' => '2012-10-17'
     ))

--- a/modules/auxiliary/gather/eaton_nsm_creds.rb
+++ b/modules/auxiliary/gather/eaton_nsm_creds.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['OSVDB', '83199'],
-          ['URL', 'http://secunia.com/advisories/49103/']
+          ['URL', 'https://web.archive.org/web/20121014000855/http://secunia.com/advisories/49103/']
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/gather/exchange_proxylogon_collector.rb
+++ b/modules/auxiliary/gather/exchange_proxylogon_collector.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2021-26855'],
           ['LOGO', 'https://proxylogon.com/images/logo.jpg'],
           ['URL', 'https://proxylogon.com/'],
-          ['URL', 'https://aka.ms/exchangevulns'],
+          ['URL', 'https://msrc-blog.microsoft.com/2021/03/02/multiple-security-updates-released-for-exchange-server/'],
           ['URL', 'https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/distinguishedfolderid'],
           ['URL', 'https://github.com/3gstudent/Homework-of-Python/blob/master/ewsManage.py']
         ],

--- a/modules/auxiliary/gather/exchange_proxylogon_collector.rb
+++ b/modules/auxiliary/gather/exchange_proxylogon_collector.rb
@@ -60,7 +60,10 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DefaultAction' => 'Dump (Emails)',
         'Notes' => {
-          'AKA' => ['ProxyLogon']
+          'AKA' => ['ProxyLogon'],
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )

--- a/modules/auxiliary/gather/flash_rosetta_jsonp_url_disclosure.rb
+++ b/modules/auxiliary/gather/flash_rosetta_jsonp_url_disclosure.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2014-4671'],
           ['URL', 'http://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/'],
           ['URL', 'https://github.com/mikispag/rosettaflash'],
-          ['URL', 'http://quaxio.com/jsonp_handcrafted_flash_files/']
+          ['URL', 'https://www.quaxio.com/jsonp_handcrafted_flash_files/']
         ],
       'DisclosureDate' => '2014-07-08',
       'Actions'        => [[ 'WebServer', 'Description' => 'Serve exploit via web server' ]],

--- a/modules/auxiliary/gather/impersonate_ssl.rb
+++ b/modules/auxiliary/gather/impersonate_ssl.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
         'Author' => 'Chris John Riley',
         'References' =>
             [
-              ['URL', 'http://www.slideshare.net/ChrisJohnRiley/ssl-certificate-impersonation-for-shits-andgiggles']
+              ['URL', 'https://www.slideshare.net/ChrisJohnRiley/ssl-certificate-impersonation-for-shits-andgiggles']
             ],
         'License' => MSF_LICENSE,
         'Description' => %q{

--- a/modules/auxiliary/gather/java_rmi_registry.rb
+++ b/modules/auxiliary/gather/java_rmi_registry.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          ['URL', 'http://docs.oracle.com/javase/8/docs/platform/rmi/spec/rmiTOC.html']
+          ['URL', 'https://docs.oracle.com/javase/8/docs/platform/rmi/spec/rmiTOC.html']
         ]
     )
 

--- a/modules/auxiliary/gather/jenkins_cred_recovery.rb
+++ b/modules/auxiliary/gather/jenkins_cred_recovery.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'EDB', '38664' ],
-          [ 'URL', 'http://www.th3r3p0.com/vulns/jenkins/jenkinsVuln.html' ]
+          [ 'URL', 'https://www.th3r3p0.com/vulns/jenkins/jenkinsVuln.html' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/auxiliary/gather/joomla_contenthistory_sqli.rb
+++ b/modules/auxiliary/gather/joomla_contenthistory_sqli.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['CVE', '2015-7297'],
-          ['URL', 'https://www.trustwave.com/Resources/SpiderLabs-Blog/Joomla-SQL-Injection-Vulnerability-Exploit-Results-in-Full-Administrative-Access/']
+          ['URL', 'https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/joomla-sql-injection-vulnerability-exploit-results-in-full-administrative-access/']
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/gather/joomla_weblinks_sqli.rb
+++ b/modules/auxiliary/gather/joomla_weblinks_sqli.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['EDB', '31459'],
-          ['URL', 'http://developer.joomla.org/security/578-20140301-core-sql-injection.html']
+          ['URL', 'https://developer.joomla.org/security/578-20140301-core-sql-injection.html']
         ],
       'DisclosureDate' => '2014-03-02'
     ))

--- a/modules/auxiliary/gather/mantisbt_admin_sqli.rb
+++ b/modules/auxiliary/gather/mantisbt_admin_sqli.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['CVE', '2014-2238'],
-          ['URL', 'http://www.mantisbt.org/bugs/view.php?id=17055']
+          ['URL', 'https://www.mantisbt.org/bugs/view.php?id=17055']
         ],
       'Platform'       => ['win', 'linux'],
       'Privileged'     => false,

--- a/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
+++ b/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
         ['Brandon Perry <bperry.volatile[at]gmail.com>'],
       'References'     =>
         [
-          ['URL', 'http://nosql.mypopescu.com/post/14453905385/attacking-nosql-and-node-js-server-side-javascript']
+          ['URL', 'https://nosql.mypopescu.com/post/14453905385/attacking-nosql-and-nodejs-server-side#_=_']
         ],
       'Platform'       => ['linux', 'win'],
       'Privileged'     => false,

--- a/modules/auxiliary/gather/ms14_052_xmldom.rb
+++ b/modules/auxiliary/gather/ms14_052_xmldom.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2013-7331'],
           [ 'MSB', 'MS14-052' ],
           [ 'URL', 'https://soroush.secproject.com/blog/2013/04/microsoft-xmldom-in-ie-can-divulge-information-of-local-drivenetwork-in-error-messages/' ],
-          [ 'URL', 'https://www.alienvault.com/open-threat-exchange/blog/attackers-abusing-internet-explorer-to-enumerate-software-and-detect-securi' ]
+          [ 'URL', 'https://cybersecurity.att.com/blogs/labs-research/attackers-abusing-internet-explorer-to-enumerate-software-and-detect-securi' ]
         ],
       'Platform'       => 'win',
       'DisclosureDate' => '2014-09-09', # MSB. Used in the wild since Feb 2014

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -26,10 +26,10 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2017-5521' ],
-          [ 'URL', 'https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2017-003/?fid=8911' ],
-          [ 'URL', 'http://thehackernews.com/2017/01/Netgear-router-password-hacking.html'],
-          [ 'URL', 'https://www.trustwave.com/Resources/SpiderLabs-Blog/CVE-2017-5521--Bypassing-Authentication-on-NETGEAR-Routers/'],
-          [ 'URL', 'http://pastebin.com/dB4bTgxz'],
+          [ 'URL', 'https://www.trustwave.com/en-us/resources/security-resources/security-advisories/?fid=18758' ],
+          [ 'URL', 'https://thehackernews.com/2017/01/Netgear-router-password-hacking.html'],
+          [ 'URL', 'https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/cve-2017-5521-bypassing-authentication-on-netgear-routers/'],
+          [ 'URL', 'https://pastebin.com/dB4bTgxz'],
           [ 'EDB', '41205']
         ],
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/gather/nis_bootparamd_domain.rb
+++ b/modules/auxiliary/gather/nis_bootparamd_domain.rb
@@ -24,9 +24,9 @@ class MetasploitModule < Msf::Auxiliary
         'wvu'            # Metasploit module
       ],
       'References'  => [
-        ['URL', 'https://tools.ietf.org/html/rfc1831'],
-        ['URL', 'https://tools.ietf.org/html/rfc4506'],
-        ['URL', 'http://pentestmonkey.net/blog/nis-domain-name']
+        ['URL', 'https://datatracker.ietf.org/doc/html/rfc1831'],
+        ['URL', 'https://datatracker.ietf.org/doc/html/rfc4506'],
+        ['URL', 'https://pentestmonkey.net/blog/nis-domain-name']
       ],
       'License'     => MSF_LICENSE
     ))

--- a/modules/auxiliary/gather/nis_ypserv_map.rb
+++ b/modules/auxiliary/gather/nis_ypserv_map.rb
@@ -29,8 +29,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'      => 'wvu',
       'References'  => [
-        ['URL', 'https://tools.ietf.org/html/rfc1831'],
-        ['URL', 'https://tools.ietf.org/html/rfc4506']
+        ['URL', 'https://datatracker.ietf.org/doc/html/rfc1831'],
+        ['URL', 'https://datatracker.ietf.org/doc/html/rfc4506']
       ],
       'License'     => MSF_LICENSE
     ))

--- a/modules/auxiliary/gather/nuuo_cms_bruteforce.rb
+++ b/modules/auxiliary/gather/nuuo_cms_bruteforce.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2018-17888' ],
-          [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-18-284-02' ],
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-18-284-02' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2019/Jan/51' ],
           [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/NUUO/nuuo-cms-ownage.txt' ]
 

--- a/modules/auxiliary/gather/nuuo_cms_file_download.rb
+++ b/modules/auxiliary/gather/nuuo_cms_file_download.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2018-17934' ],
-          [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-18-284-02' ],
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-18-284-02' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2019/Jan/51' ],
           [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/NUUO/nuuo-cms-ownage.txt' ]
 

--- a/modules/auxiliary/gather/oats_downloadservlet_traversal.rb
+++ b/modules/auxiliary/gather/oats_downloadservlet_traversal.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2019-2557'],
           ['URL', 'https://srcincite.io/advisories/src-2019-0033/'],
-          ['URL', 'https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html']
+          ['URL', 'https://www.oracle.com/security-alerts/cpuapr2019.html']
         ],
       'DisclosureDate' => '2019-04-16'
     ))

--- a/modules/auxiliary/gather/qnap_lfi.rb
+++ b/modules/auxiliary/gather/qnap_lfi.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2019-7194'],
           ['CVE', '2019-7195'],
           ['EDB', '48531'],
-          ['URL', 'https://medium.com/bugbountywriteup/qnap-pre-auth-root-rce-affecting-450k-devices-on-the-internet-d55488d28a05'],
+          ['URL', 'https://infosecwriteups.com/qnap-pre-auth-root-rce-affecting-450k-devices-on-the-internet-d55488d28a05'],
           ['URL', 'https://www.qnap.com/en-us/security-advisory/nas-201911-25'],
           ['URL', 'https://github.com/Imanfeng/QNAP-NAS-RCE']
         ],

--- a/modules/auxiliary/gather/qnap_lfi.rb
+++ b/modules/auxiliary/gather/qnap_lfi.rb
@@ -45,7 +45,8 @@ class MetasploitModule < Msf::Auxiliary
         'DefaultAction' => 'Download',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
         }
       )
     )
@@ -73,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
       xml.at("//#{node}").text
     end
 
-    vprint_status("QNAP #{info[0]} #{info[1..-1].join('-')} detected")
+    vprint_status("QNAP #{info[0]} #{info[1..].join('-')} detected")
 
     return Exploit::CheckCode::Appears if info[2].to_i < 20191206
 

--- a/modules/auxiliary/gather/windows_deployment_services_shares.rb
+++ b/modules/auxiliary/gather/windows_deployment_services_shares.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'MSDN', 'http://technet.microsoft.com/en-us/library/cc749415(v=ws.10).aspx'],
-          [ 'URL', 'http://rewtdance.blogspot.co.uk/2012/11/windows-deployment-services-clear-text.html'],
+          [ 'URL', 'http://rewtdance.blogspot.com/2012/11/windows-deployment-services-clear-text.html'],
         ],
       ))
 

--- a/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
+++ b/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'      =>
         [
           ['WPVDB', '7857'],
-          ['URL', 'http://www.pritect.net/blog/all-in-one-wp-migration-2-0-4-security-vulnerability']
+          ['URL', 'https://www.pritect.net/blog/all-in-one-wp-migration-2-0-4-security-vulnerability']
         ],
       'DisclosureDate'  => '2015-03-19'
     ))

--- a/modules/auxiliary/gather/xbmc_traversal.rb
+++ b/modules/auxiliary/gather/xbmc_traversal.rb
@@ -23,9 +23,9 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'     =>
         [
-          ['URL', 'http://forum.xbmc.org/showthread.php?tid=144110&pid=1227348'],
+          ['URL', 'https://forum.kodi.tv/showthread.php?tid=144110&pid=1227348'],
           ['URL', 'https://github.com/xbmc/xbmc/commit/bdff099c024521941cb0956fe01d99ab52a65335'],
-          ['URL', 'http://www.ioactive.com/pdfs/Security_Advisory_XBMC.pdf'],
+          ['URL', 'https://ioactive.com/pdfs/Security_Advisory_XBMC.pdf'],
         ],
       'DisclosureDate' => '2012-11-04'
     ))

--- a/modules/auxiliary/gather/zoomeye_search.rb
+++ b/modules/auxiliary/gather/zoomeye_search.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
           'Grant Willcox' # Additional fixes to refine searches, improve quality of info saved and improve error handling.
         ],
         'References' => [
-          ['URL', 'https://github.com/zoomeye/SDK'],
+          ['URL', 'https://github.com/knownsec/ZoomEye-python'],
           ['URL', 'https://www.zoomeye.org/api/doc'],
           ['URL', 'https://www.zoomeye.org/help/manual']
         ],

--- a/modules/auxiliary/parser/unattend.rb
+++ b/modules/auxiliary/parser/unattend.rb
@@ -21,9 +21,9 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'    =>
         [
-          ['URL', 'http://technet.microsoft.com/en-us/library/ff715801'],
-          ['URL', 'http://technet.microsoft.com/en-us/library/cc749415(v=ws.10).aspx'],
-          ['URL', 'http://technet.microsoft.com/en-us/library/c026170e-40ef-4191-98dd-0b9835bfa580']
+          ['URL', 'https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-8.1-and-8/ff715801(v=win.10)'],
+          ['URL', 'https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-vista/cc749415(v=ws.10)'],
+          ['URL', 'https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc732280(v=ws.10)']
         ],
     ))
 

--- a/modules/auxiliary/scanner/afp/afp_login.rb
+++ b/modules/auxiliary/scanner/afp/afp_login.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
-          [ 'URL', 'https://developer.apple.com/library/mac/documentation/Networking/Reference/AFP_Reference/Reference/reference.html' ],
+          [ 'URL', 'https://web.archive.org/web/20130309051753/https://developer.apple.com/library/mac/#documentation/Networking/Reference/AFP_Reference/Reference/reference.html' ],
           [ 'URL', 'https://developer.apple.com/library/mac/documentation/networking/conceptual/afp/AFPSecurity/AFPSecurity.html' ]
 
         ],

--- a/modules/auxiliary/scanner/afp/afp_server_info.rb
+++ b/modules/auxiliary/scanner/afp/afp_server_info.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
-          [ 'URL', 'https://developer.apple.com/library/mac/documentation/Networking/Reference/AFP_Reference/Reference/reference.html' ]
+          [ 'URL', 'https://web.archive.org/web/20130309051753/https://developer.apple.com/library/mac/#documentation/Networking/Reference/AFP_Reference/Reference/reference.html' ]
         ],
       'Author'       => [ 'Gregory Man <man.gregory[at]gmail.com>' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'MSDN', 'http://msdn.microsoft.com/en-us/library/dd891255(prot.20).aspx'],
-          [ 'URL', 'http://rewtdance.blogspot.co.uk/2012/11/windows-deployment-services-clear-text.html']
+          [ 'URL', 'http://rewtdance.blogspot.com/2012/11/windows-deployment-services-clear-text.html']
         ],
       ))
 

--- a/modules/auxiliary/scanner/dlsw/dlsw_leak_capture.rb
+++ b/modules/auxiliary/scanner/dlsw/dlsw_leak_capture.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['CVE', '2014-7992'],
-          ['URL', 'https://github.com/tatehansen/dlsw_exploit']
+          ['URL', 'https://github.com/tt5555/dlsw_exploit']
         ],
       'DisclosureDate' => 'Nov 17 2014',
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/etcd/open_key_scanner.rb
+++ b/modules/auxiliary/scanner/etcd/open_key_scanner.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         key value pairs.  Etcd by default does not utilize authentication.
       ),
       'References' => [
-        ['URL', 'https://elweb.co/the-security-footgun-in-etcd']
+        ['URL', 'https://gcollazo.com/the-security-footgun-in-etcd/']
       ],
       'Author' => [
         'Giovanni Collazo <hello@gcollazo.com>', # discovery

--- a/modules/auxiliary/scanner/etcd/version.rb
+++ b/modules/auxiliary/scanner/etcd/version.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         to obtain the version of etcd.
       ),
       'References' => [
-        ['URL', 'https://elweb.co/the-security-footgun-in-etcd']
+        ['URL', 'https://gcollazo.com/the-security-footgun-in-etcd/']
       ],
       'Author' => [
         'Giovanni Collazo <hello@gcollazo.com>', # discovery

--- a/modules/auxiliary/scanner/ftp/anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/anonymous.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => 'Detect anonymous (read/write) FTP server access.',
       'References'  =>
         [
-          ['URL', 'http://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP'],
+          ['URL', 'https://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP'],
         ],
       'Author'      => 'Matteo Cantoni <goony[at]nothink.org>',
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'EDB', '40231'],
           [ 'URL', 'https://bitbucket.org/nolife/coloradoftp/commits/16a60c4a74ef477cd8c16ca82442eaab2fbe8c86'],
-          [ 'URL', 'http://www.securityfocus.com/archive/1/539186']
+          [ 'URL', 'https://bugtraq.securityfocus.com/archive/1/539186']
         ],
       'DisclosureDate' => '2016-08-11'
     ))

--- a/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'EDB', '38260'],
           [ 'CVE', '2015-7603'],
-          [ 'URL', 'http://shinnai.altervista.org/exploits/SH-0024-20150922.html']
+          [ 'URL', 'https://shinnai.altervista.org/exploits/SH-0024-20150922.html']
         ],
       'DisclosureDate' => '2015-09-22'
     ))

--- a/modules/auxiliary/scanner/http/accellion_fta_statecode_file_read.rb
+++ b/modules/auxiliary/scanner/http/accellion_fta_statecode_file_read.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['URL', 'http://r-7.co/R7-2015-08'],
+          ['URL', 'https://www.rapid7.com/blog/post/2015/07/10/r7-2015-08-accellion-file-transfer-appliance-vulnerabilities-cve-2015-2856-cve-2015-2857/'],
           ['CVE', '2015-2856']
         ],
       'DisclosureDate' => '2015-07-10'

--- a/modules/auxiliary/scanner/http/adobe_xml_inject.rb
+++ b/modules/auxiliary/scanner/http/adobe_xml_inject.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'OSVDB', '62292' ],
           [ 'BID', '38197' ],
           [ 'URL', 'http://www.security-assessment.com/files/advisories/2010-02-22_Multiple_Adobe_Products-XML_External_Entity_and_XML_Injection.pdf' ],
-          [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb10-05.html'],
+          [ 'URL', 'https://www.adobe.com/support/security/bulletins/apsb10-05.html'],
         ],
       'Author'      => [ 'CG' ],
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CWE', '22'],
           ['EDB', '49398'],
           ['PACKETSTORM', '160849'],
-          ['URL', 'http://www.openwall.com/lists/oss-security/2021/01/05/2'],
+          ['URL', 'https://www.openwall.com/lists/oss-security/2021/01/05/2'],
           ['URL', 'https://www.tenable.com/cve/CVE-2020-17519']
         ],
         'DefaultOptions' => { 'RPORT' => 8081 },

--- a/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.rb
@@ -37,7 +37,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://www.tenable.com/cve/CVE-2020-17519']
         ],
         'DefaultOptions' => { 'RPORT' => 8081 },
-        'DisclosureDate' => '2021-01-05'
+        'DisclosureDate' => '2021-01-05',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
       )
     )
 

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -22,8 +22,8 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2012-2926' ],
           [ 'OSVDB', '82274' ],
           [ 'BID', '53595' ],
-          [ 'URL', 'https://www.neg9.org' ], # General
-          [ 'URL', 'https://confluence.atlassian.com/display/CROWD/Crowd+Security+Advisory+2012-05-17']
+          [ 'URL', 'https://neg9.org/' ], # General
+          [ 'URL', 'https://confluence.atlassian.com/crowd/crowd-security-advisory-2012-05-17-283641186.html']
         ],
       'Author'       =>
         [

--- a/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['OSVDB', '68301'],
-          ['URL', 'http://secunia.com/advisories/41609/'],
+          ['URL', 'https://web.archive.org/web/20101004131244/http://secunia.com/advisories/41609/'],
           ['EDB', '15130']
         ],
       'Author'         =>

--- a/modules/auxiliary/scanner/http/binom3_login_config_pass_dump.rb
+++ b/modules/auxiliary/scanner/http/binom3_login_config_pass_dump.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          ['URL', 'https://us-cert.cisa.gov/ics/advisories/ICSA-17-031-01A'],
+          ['URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-17-031-01A'],
           ['CVE', '2017-5162']
         ],
       'Author' =>

--- a/modules/auxiliary/scanner/http/bmc_trackit_passwd_reset.rb
+++ b/modules/auxiliary/scanner/http/bmc_trackit_passwd_reset.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
       ),
       'References'     =>
         [
-          ['URL', 'http://www.zerodayinitiative.com/advisories/ZDI-14-419/'],
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-14-419/'],
           ['CVE', '2014-8270']
         ],
       'Author'         =>

--- a/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
@@ -19,9 +19,9 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => [ 'Nixawk' ],
       'References'     => [
         ['URL', 'https://www.fireeye.com/blog/threat-research/2013/08/breaking-down-the-china-chopper-web-shell-part-i.html'],
-        ['URL', 'https://www.fireeye.com/blog/threat-research/2013/08/breaking-down-the-china-chopper-web-shell-part-ii.html'],
+        ['URL', 'https://www.mandiant.com/resources/breaking-down-the-china-chopper-web-shell-part-ii'],
         ['URL', 'https://www.exploit-db.com/docs/27654.pdf'],
-        ['URL', 'https://www.us-cert.gov/ncas/alerts/TA15-313A'],
+        ['URL', 'https://www.cisa.gov/uscert/ncas/alerts/TA15-314A'],
         ['URL', 'http://blog.csdn.net/nixawk/article/details/40430329']
       ],
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/canon_wireless.rb
+++ b/modules/auxiliary/scanner/http/canon_wireless.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     => [
         [ 'CVE', '2013-4614' ],
         [ 'OSVDB', '94417' ],
-        [ 'URL', 'http://www.mattandreko.com/2013/06/canon-y-u-no-security.html']
+        [ 'URL', 'https://www.mattandreko.com/2013/06/canon-y-u-no-security.html']
       ],
       'DisclosureDate' => '2013-06-18'))
   end

--- a/modules/auxiliary/scanner/http/chromecast_webserver.rb
+++ b/modules/auxiliary/scanner/http/chromecast_webserver.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author' => ['wvu'],
       'References' => [
-        ['URL', 'https://www.google.com/chrome/devices/chromecast/']
+        ['URL', 'https://store.google.com/product/chromecast?utm_source=chromecast.com&hl=en-US']
       ],
       'License' => MSF_LICENSE
     ))

--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn_priv_esc.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn_priv_esc.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2014-2127'],
-          ['URL', 'http://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20140409-asa'],
-          ['URL', 'https://www3.trustwave.com/spiderlabs/advisories/TWSL2014-005.txt']
+          ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20140409-asa'],
+          ['URL', 'https://www.trustwave.com/en-us/resources/security-resources/security-advisories/?fid=18908']
         ],
       'DisclosureDate' => '2014-04-09',
       'DefaultOptions' => { 'SSL' => true }

--- a/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
+++ b/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'References'     => [
         ['CVE', '2019-19781'],
-        ['URL', 'https://support.citrix.com/article/CTX267027/'],
+        ['URL', 'https://web.archive.org/web/20200111095223/https://support.citrix.com/article/CTX267027/'],
         ['URL', 'https://swarm.ptsecurity.com/remote-code-execution-in-citrix-adc/']
       ],
       'DisclosureDate' => '2019-12-17',

--- a/modules/auxiliary/scanner/http/cnpilot_r_web_login_loot.rb
+++ b/modules/auxiliary/scanner/http/cnpilot_r_web_login_loot.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' =>
         [
           ['CVE', '2017-5260'],
-          ['URL', 'https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities']
+          ['URL', 'https://www.rapid7.com/blog/post/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/']
         ],
       'License' => MSF_LICENSE
      )

--- a/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
+++ b/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
@@ -36,8 +36,8 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2010-2861' ],
           [ 'BID', '42342' ],
           [ 'OSVDB', '67047' ],
-          [ 'URL', 'http://www.gnucitizen.org/blog/coldfusion-directory-traversal-faq-cve-2010-2861' ],
-          [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb10-18.html' ],
+          [ 'URL', 'https://www.gnucitizen.org/blog/coldfusion-directory-traversal-faq-cve-2010-2861/' ],
+          [ 'URL', 'https://www.adobe.com/support/security/bulletins/apsb10-18.html' ],
         ]
     )
 

--- a/modules/auxiliary/scanner/http/concrete5_member_list.rb
+++ b/modules/auxiliary/scanner/http/concrete5_member_list.rb
@@ -17,10 +17,10 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ],
+          [ 'URL', 'https://blog.c22.cc/' ],
           # Concrete5
-          [ 'URL', 'http://www.concrete5.org'],
-          [ 'URL', 'http://www.concrete5.org/documentation/using-concrete5/dashboard/users-and-groups/']
+          [ 'URL', 'https://www.concretecms.com/'],
+          [ 'URL', 'https://web.archive.org/web/20120704205851/http://www.concrete5.org/documentation/using-concrete5/dashboard/users-and-groups/']
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/epmp1000_get_chart_cmd_exec.rb
+++ b/modules/auxiliary/scanner/http/epmp1000_get_chart_cmd_exec.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' =>
         [
           ['CVE', '2017-5255'],
-          ['URL', 'https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities']
+          ['URL', 'https://www.rapid7.com/blog/post/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/']
         ],
       'License' => MSF_LICENSE
      )

--- a/modules/auxiliary/scanner/http/epmp1000_reset_pass.rb
+++ b/modules/auxiliary/scanner/http/epmp1000_reset_pass.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' =>
         [
           ['CVE', '2017-5254'],
-          ['URL', 'https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities']
+          ['URL', 'https://www.rapid7.com/blog/post/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/']
         ],
       'License' => MSF_LICENSE
      )

--- a/modules/auxiliary/scanner/http/exchange_proxylogon.rb
+++ b/modules/auxiliary/scanner/http/exchange_proxylogon.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2021-26855'],
           ['LOGO', 'https://proxylogon.com/images/logo.jpg'],
           ['URL', 'https://proxylogon.com/'],
-          ['URL', 'https://aka.ms/exchangevulns']
+          ['URL', 'https://msrc-blog.microsoft.com/2021/03/02/multiple-security-updates-released-for-exchange-server/']
         ],
         'DisclosureDate' => '2021-03-02',
         'License' => MSF_LICENSE,

--- a/modules/auxiliary/scanner/http/exchange_proxylogon.rb
+++ b/modules/auxiliary/scanner/http/exchange_proxylogon.rb
@@ -48,7 +48,10 @@ class MetasploitModule < Msf::Auxiliary
           'SSL' => true
         },
         'Notes' => {
-          'AKA' => ['ProxyLogon']
+          'AKA' => ['ProxyLogon'],
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )

--- a/modules/auxiliary/scanner/http/f5_bigip_virtual_server.rb
+++ b/modules/auxiliary/scanner/http/f5_bigip_virtual_server.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'https://www.owasp.org/index.php/SCG_D_BIGIP'],
+          [ 'URL', 'https://web.archive.org/web/20180906182059/https://www.owasp.org/index.php/SCG_D_BIGIP'],
         ]
     ))
 

--- a/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
+++ b/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'References' => [
         ['CVE', '2020-9294'],
-        ['URL', 'https://fortiguard.com/psirt/FG-IR-20-045'],
+        ['URL', 'https://www.fortiguard.com/psirt/FG-IR-20-045'],
         ['URL', 'https://www.redguard.ch/blog/2020/07/02/fortimail-unauthenticated-login-bypass/']
       ],
       'License' => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -17,8 +17,8 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => 'This module queries the FrontPage Server Extensions and determines whether anonymous access is allowed.',
       'References'  =>
         [
-          ['URL', 'http://en.wikipedia.org/wiki/Microsoft_FrontPage'],
-          ['URL', 'http://msdn2.microsoft.com/en-us/library/ms454298.aspx'],
+          ['URL', 'https://en.wikipedia.org/wiki/Microsoft_FrontPage'],
+          ['URL', 'https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ms454298(v=office.14)'],
         ],
       'Author'      => 'Matteo Cantoni <goony[at]nothink.org>',
       'License'     => MSF_LICENSE
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
 
     connect
 
-    # http://msdn2.microsoft.com/en-us/library/ms454298.aspx
+    # https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ms454298(v=office.14)?redirectedfrom=MSDN
     method = "method=open+service:#{fpversion}&service_name=/"
 
     req = "POST /_vti_bin/_vti_aut/author.dll HTTP/1.1\r\n" + "TE: deflate,gzip;q=0.3\r\n" +

--- a/modules/auxiliary/scanner/http/gavazzi_em_login_loot.rb
+++ b/modules/auxiliary/scanner/http/gavazzi_em_login_loot.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          ['URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-17-012-03'],
+          ['URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-17-012-03'],
           ['CVE', '2017-5146']
         ],
       'Author' =>

--- a/modules/auxiliary/scanner/http/gitlab_login.rb
+++ b/modules/auxiliary/scanner/http/gitlab_login.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          ['URL', 'https://labs.mwrinfosecurity.com/blog/2015/03/20/gitlab-user-enumeration/']
+          ['URL', 'https://labs.f-secure.com/archive/gitlab-user-enumeration/']
         ]
     )
 

--- a/modules/auxiliary/scanner/http/gitlab_user_enum.rb
+++ b/modules/auxiliary/scanner/http/gitlab_user_enum.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       'DisclosureDate' => '2014-11-21',
       'References'     =>
         [
-          ['URL', 'https://labs.mwrinfosecurity.com/blog/2015/03/20/gitlab-user-enumeration/']
+          ['URL', 'https://labs.f-secure.com/archive/gitlab-user-enumeration/']
         ]
     ))
 

--- a/modules/auxiliary/scanner/http/glassfish_traversal.rb
+++ b/modules/auxiliary/scanner/http/glassfish_traversal.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2017-1000028'],
-          ['URL', 'https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2015-016/?fid=6904'],
+          ['URL', 'https://www.trustwave.com/en-us/resources/security-resources/security-advisories/?fid=18822'],
           ['EDB', '39441']
         ],
       'Author'      =>

--- a/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
+++ b/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2012-0419' ],
           [ 'OSVDB', '85801' ],
           [ 'BID', '55648' ],
-          [ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7010772' ]
+          [ 'URL', 'https://support.microfocus.com/kb/doc.php?id=7010772' ]
         ]
     ))
 

--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
       [
         ['URL', 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html'],
-        ['URL', 'http://en.wikipedia.org/wiki/List_of_HTTP_header_fields']
+        ['URL', 'https://en.wikipedia.org/wiki/List_of_HTTP_header_fields']
       ],
       'License'     => MSF_LICENSE
     ))

--- a/modules/auxiliary/scanner/http/httpbl_lookup.rb
+++ b/modules/auxiliary/scanner/http/httpbl_lookup.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'		=> MSF_LICENSE,
       'References' 	=>
         [
-          ['URL', 'http://www.projecthoneypot.org/httpbl_api.php'],
+          ['URL', 'https://www.projecthoneypot.org/httpbl_api.php'],
         ]
       ))
 

--- a/modules/auxiliary/scanner/http/iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/iis_internal_ip.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
           ['BID', '1499'],
           ['EDB', '20096'],
           ['URL', 'https://support.microsoft.com/en-us/help/218180/internet-information-server-returns-ip-address-in-http-header-content'], # iis 4,5,5.1
-          ['URL', 'https://support.microsoft.com/en-us/help/967342/fix-the-internal-ip-address-of-an-iis-7-0-server-is-revealed-if-an-htt'], # iis 7+
+          ['URL', 'https://support.microsoft.com/en-us/topic/fix-the-internal-ip-address-of-an-iis-7-0-server-is-revealed-if-an-http-request-that-does-not-have-a-host-header-or-has-a-null-host-header-is-sent-to-the-server-c493e9bc-dfd3-0d9b-941c-b2d93a957d9e'], # iis 7+
           ['URL', 'https://techcommunity.microsoft.com/t5/iis-support-blog/iis-web-servers-running-in-windows-azure-may-reveal-their/ba-p/826500']
         ]
       )

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
         'License'     => MSF_LICENSE,
         'References'     =>
           [
-            [ 'URL', 'https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability' ],
+            [ 'URL', 'https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability/' ],
             [ 'URL', 'https://support.detectify.com/customer/portal/articles/1711520-microsoft-iis-tilde-vulnerability' ]
           ]
       )

--- a/modules/auxiliary/scanner/http/influxdb_enum.rb
+++ b/modules/auxiliary/scanner/http/influxdb_enum.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
-          ['URL', 'https://docs.influxdata.com/influxdb/'],
+          ['URL', 'https://docs.influxdata.com/influxdb/v2.1/'],
           ['URL', 'https://www.shodan.io/search?query=X-Influxdb-Version']
         ],
       'Author'         =>

--- a/modules/auxiliary/scanner/http/intel_amt_digest_bypass.rb
+++ b/modules/auxiliary/scanner/http/intel_amt_digest_bypass.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2017-5689' ],
           [ 'URL', 'https://www.embedi.com/news/what-you-need-know-about-intel-amt-vulnerability' ],
-          [ 'URL', 'https://security-center.intel.com/advisory.aspx?intelid=INTEL-SA-00075&languageid=en-fr' ],
+          [ 'URL', 'https://www.intel.com/content/www/us/en/security-center/default.html?intelid=INTEL-SA-00075&languageid=en-fr' ],
         ],
       'DisclosureDate' => 'May 05 2017'
     )

--- a/modules/auxiliary/scanner/http/jboss_status.rb
+++ b/modules/auxiliary/scanner/http/jboss_status.rb
@@ -21,8 +21,8 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2008-3273'],
           ['CVE', '2010-1429'], # regression
           ['URL', 'https://seclists.org/fulldisclosure/2011/Sep/139'],
-          ['URL', 'https://www.owasp.org/images/a/a9/OWASP3011_Luca.pdf'],
-          ['URL', 'http://www.slideshare.net/chrisgates/lares-fromlowtopwned']
+          ['URL', 'https://owasp.org/www-pdf-archive/OWASP3011_Luca.pdf'],
+          ['URL', 'https://www.slideshare.net/chrisgates/lares-fromlowtopwned']
         ],
       'Author'      => 'Matteo Cantoni <goony[at]nothink.org>',
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/jenkins_command.rb
+++ b/modules/auxiliary/scanner/http/jenkins_command.rb
@@ -26,9 +26,9 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2015-8103'], # see link and validate, https://highon.coffee/blog/jenkins-api-unauthenticated-rce-exploit/ states this is another issue
-          ['URL', 'https://jenkins.io/security/advisory/2015-11-11/'],
+          ['URL', 'https://www.jenkins.io/security/advisory/2015-11-11/'],
           ['URL', 'https://www.pentestgeek.com/penetration-testing/hacking-jenkins-servers-with-no-password/'],
-          ['URL', 'https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Script+Console'],
+          ['URL', 'https://www.jenkins.io/doc/book/managing/script-console/'],
         ],
       'License'     => MSF_LICENSE
       ))

--- a/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
           ['OSVDB', '70762'],
           ['CVE', '2011-0049'],
           ['CVE', '2011-0063'],
-          ['URL', 'http://sotiriu.de/adv/NSOADV-2011-003.txt'],
+          ['URL', 'https://www.sotiriu.de/adv/NSOADV-2011-003.txt'],
           ['EDB', '16103']
         ],
       'DisclosureDate' => 'Mar 08 2011',

--- a/modules/auxiliary/scanner/http/mediawiki_svg_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/mediawiki_svg_fileaccess.rb
@@ -26,8 +26,8 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           [ 'OSVDB', '92490' ],
-          [ 'URL', 'https://bugzilla.wikimedia.org/show_bug.cgi?id=46859' ],
-          [ 'URL', 'http://www.gossamer-threads.com/lists/wiki/mediawiki-announce/350229']
+          [ 'URL', 'https://phabricator.wikimedia.org/T48859' ],
+          [ 'URL', 'https://web.archive.org/web/20130421060020/http://www.gossamer-threads.com/lists/wiki/mediawiki-announce/350229']
         ],
       'Author'       =>
         [

--- a/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
+++ b/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          ['URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-16-133-01'],
+          ['URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-16-133-01'],
           ['CVE', '2016-2296'],
           ['CVE', '2016-2298']
         ],

--- a/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
+++ b/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2015-1635'],
           ['MSB', 'MS15-034'],
-          ['URL', 'http://pastebin.com/ypURDPc4'],
+          ['URL', 'https://pastebin.com/ypURDPc4'],
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/5150'],
           ['URL', 'https://community.qualys.com/blogs/securitylabs/2015/04/20/ms15-034-analyze-and-remote-detection'],
           ['URL', 'http://www.securitysift.com/an-analysis-of-ms15-034/'],

--- a/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           [ 'CVE', '2012-4958' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959/' ]
         ],
       'Author'       =>
         [

--- a/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           [ 'CVE', '2012-4957' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959/' ]
         ],
       'Author'       =>
         [

--- a/modules/auxiliary/scanner/http/novell_mdm_creds.rb
+++ b/modules/auxiliary/scanner/http/novell_mdm_creds.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2013-1081'],
           ['OSVDB', '91119'],
-          ['URL', 'http://www.novell.com/support/kb/doc.php?id=7011895']
+          ['URL', 'https://support.microfocus.com/kb/doc.php?id=7011895']
         ],
       'License' => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/http/open_proxy.rb
+++ b/modules/auxiliary/scanner/http/open_proxy.rb
@@ -20,8 +20,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
-          ['URL', 'http://en.wikipedia.org/wiki/Open_proxy'],
-          ['URL', 'http://nmap.org/svn/scripts/http-open-proxy.nse'],
+          ['URL', 'https://en.wikipedia.org/wiki/Open_proxy'],
+          ['URL', 'https://svn.nmap.org/nmap/scripts/http-open-proxy.nse'],
         ],
       'Author'      => 'Matteo Cantoni <goony[at]nothink.org>',
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/rails_mass_assignment.rb
+++ b/modules/auxiliary/scanner/http/rails_mass_assignment.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
 
       'References'     =>
         [
-          [ 'URL', 'http://guides.rubyonrails.org/security.html#mass-assignment' ]
+          [ 'URL', 'https://guides.rubyonrails.org/security.html#mass-assignment' ]
         ],
       'Author'       => [ 'Gregory Man <man.gregory[at]gmail.com>' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2013-0156'],
-          ['URL', 'https://blog.rapid7.com/2013/01/09/serialization-mischief-in-ruby-land-cve-2013-0156']
+          ['URL', 'https://www.rapid7.com/blog/post/2013/01/09/serialization-mischief-in-ruby-land-cve-2013-0156/']
         ]
     ))
 

--- a/modules/auxiliary/scanner/http/rips_traversal.rb
+++ b/modules/auxiliary/scanner/http/rips_traversal.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['EDB', '18660'],
-          ['URL', 'http://codesec.blogspot.com.br/2015/03/rips-scanner-v-054-local-file-include.html']
+          ['URL', 'http://codesec.blogspot.com/2015/03/rips-scanner-v-054-local-file-include.html']
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/http/smt_ipmi_cgi_scanner.rb
+++ b/modules/auxiliary/scanner/http/smt_ipmi_cgi_scanner.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2013-3621' ],
           [ 'CVE', '2013-3623' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/11/06/supermicro-ipmi-firmware-vulnerabilities']
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/11/06/supermicro-ipmi-firmware-vulnerabilities/']
         ],
       'DisclosureDate' => '2013-11-06'))
 

--- a/modules/auxiliary/scanner/http/smt_ipmi_static_cert_scanner.rb
+++ b/modules/auxiliary/scanner/http/smt_ipmi_static_cert_scanner.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           [ 'CVE', '2013-3619' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/11/06/supermicro-ipmi-firmware-vulnerabilities']
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/11/06/supermicro-ipmi-firmware-vulnerabilities/']
         ],
       'DisclosureDate' => 'Nov 06 2013'
     )

--- a/modules/auxiliary/scanner/http/smt_ipmi_url_redirect_traversal.rb
+++ b/modules/auxiliary/scanner/http/smt_ipmi_url_redirect_traversal.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          [ 'URL', 'https://blog.rapid7.com/2013/11/06/supermicro-ipmi-firmware-vulnerabilities' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/11/06/supermicro-ipmi-firmware-vulnerabilities/' ],
           [ 'URL', 'https://github.com/zenfish/ipmi/blob/master/dump_SM.py']
         ],
       'DisclosureDate' => '2013-11-06'))

--- a/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
+++ b/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://www.osisecurity.com.au/advisories/' ],
+          [ 'URL', 'https://www.osi.security/advisories.html' ],
         ],
       'DisclosureDate' => '2011-11-08'))
 

--- a/modules/auxiliary/scanner/http/ssl_version.rb
+++ b/modules/auxiliary/scanner/http/ssl_version.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
       [
-        [ 'URL', 'http://googleonlinesecurity.blogspot.com/2014/10/this-poodle-bites-exploiting-ssl-30.html'],
+        [ 'URL', 'https://security.googleblog.com/2014/10/this-poodle-bites-exploiting-ssl-30.html'],
         [ 'OSVDB', '113251'],
         [ 'CVE', '2014-3566']
       ],

--- a/modules/auxiliary/scanner/http/svn_wcdb_scanner.rb
+++ b/modules/auxiliary/scanner/http/svn_wcdb_scanner.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'     =>
         [
-          ['URL', 'http://pen-testing.sans.org/blog/pen-testing/2012/12/06/all-your-svn-are-belong-to-us#']
+          ['URL','https://web.archive.org/web/20130107035252/http://pen-testing.sans.org/blog/pen-testing/2012/12/06/all-your-svn-are-belong-to-us']
         ],
       'License'        =>  MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/http/symantec_brightmail_ldapcreds.rb
+++ b/modules/auxiliary/scanner/http/symantec_brightmail_ldapcreds.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
-          ['URL','https://www.symantec.com/security_response/securityupdates/detail.jsp?fid=security_advisory&pvid=security_advisory&year=&suid=20160418_00'],
+          ['URL','https://www.broadcom.com/support/security-center/securityupdates/detail?fid=security_advisory&pvid=security_advisory&suid=20160418_00&year='],
           ['CVE','2016-2203'],
           ['BID','86137']
         ],

--- a/modules/auxiliary/scanner/http/symantec_brightmail_logfile.rb
+++ b/modules/auxiliary/scanner/http/symantec_brightmail_logfile.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
           ['EDB', '23110'],
           ['OSVDB', '88165'],
           ['BID', '56789'],
-          ['URL', 'http://www.symantec.com/security_response/securityupdates/detail.jsp?fid=security_advisory&pvid=security_advisory&year=2012&suid=20120827_00']
+          ['URL', 'https://www.broadcom.com/support/security-center/securityupdates/detail?fid=security_advisory&pvid=security_advisory&suid=20120827_00&year=2012']
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'BID', '37086' ],
           [ 'CVE', '2009-4189' ],
           [ 'OSVDB', '60670' ],
-          [ 'URL', 'http://www.harmonysecurity.com/blog/2009/11/hp-operations-manager-backdoor-account.html' ],
+          [ 'URL', 'https://web.archive.org/web/20091129092955/http://www.harmonysecurity.com/blog/2009/11/hp-operations-manager-backdoor-account.html' ],
           [ 'ZDI', '09-085' ],
 
           # HP Default Operations Dashboard user/pass
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'BID', '36954' ],
 
           # General
-          [ 'URL', 'http://tomcat.apache.org/' ],
+          [ 'URL', 'https://tomcat.apache.org/' ],
           [ 'CVE', '1999-0502'] # Weak password
         ],
       'Author'         => [ 'MC', 'Matteo Cantoni <goony[at]nothink.org>', 'jduck' ],

--- a/modules/auxiliary/scanner/http/totaljs_traversal.rb
+++ b/modules/auxiliary/scanner/http/totaljs_traversal.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2019-8903'],
           ['CWE', '22'],
           ['URL', 'https://blog.totaljs.com/blogs/news/20190213-a-critical-security-fix/'],
-          ['URL', 'https://snyk.io/vuln/SNYK-JS-TOTALJS-173710']
+          ['URL', 'https://security.snyk.io/vuln/SNYK-JS-TOTALJS-173710']
         ],
       'Privileged' => false,
       'DisclosureDate' => '2019-02-18',

--- a/modules/auxiliary/scanner/http/trace.rb
+++ b/modules/auxiliary/scanner/http/trace.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2005-3398'], # early case where this vector applied to a specific application.
-          ['URL', 'https://www.owasp.org/index.php/Cross_Site_Tracing']
+          ['URL', 'https://owasp.org/www-community/attacks/Cross_Site_Tracing']
         ]
     )
   end

--- a/modules/auxiliary/scanner/http/wildfly_traversal.rb
+++ b/modules/auxiliary/scanner/http/wildfly_traversal.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2014-7816' ],
           ['URL', 'https://access.redhat.com/security/cve/CVE-2014-7816'],
           ['URL', 'https://www.conviso.com.br/advisories/CONVISO-14-001.txt'],
-          ['URL', 'http://www.openwall.com/lists/oss-security/2014/11/27/4']
+          ['URL', 'https://www.openwall.com/lists/oss-security/2014/11/27/4']
         ],
       'Author'         => 'Roberto Soares Espreto <robertoespreto[at]gmail.com>',
       'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/http/wordpress_content_injection.rb
+++ b/modules/auxiliary/scanner/http/wordpress_content_injection.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         ['CVE' , '2017-1001000'],
         ['WPVDB', '8734'],
         ['URL',   'https://blog.sucuri.net/2017/02/content-injection-vulnerability-wordpress-rest-api.html'],
-        ['URL',   'https://secure.php.net/manual/en/language.types.type-juggling.php'],
+        ['URL',   'https://www.php.net/manual/en/language.types.type-juggling.php'],
         ['URL',   'https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/'],
         ['URL',   'https://developer.wordpress.org/rest-api/reference/posts/']
       ],

--- a/modules/auxiliary/scanner/http/wordpress_pingback_access.rb
+++ b/modules/auxiliary/scanner/http/wordpress_pingback_access.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           [ 'CVE', '2013-0235' ],
-          [ 'URL', 'http://www.securityfocus.com/archive/1/525045/30/30/threaded'],
+          [ 'URL', 'https://bugtraq.securityfocus.com/archive/1/525045/30/30/threaded'],
           [ 'URL', 'http://www.ethicalhack3r.co.uk/security/introduction-to-the-wordpress-xml-rpc-api/'],
           [ 'URL', 'https://github.com/FireFart/WordpressPingbackPortScanner']
         ]

--- a/modules/auxiliary/scanner/http/wp_arbitrary_file_deletion.rb
+++ b/modules/auxiliary/scanner/http/wp_arbitrary_file_deletion.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
             ['WPVDB', '9100'],
             ['EDB', '44949'],
             ['PACKETSTORM', '148333'],
-            ['URL', 'https://blog.ripstech.com/2018/wordpress-file-delete-to-code-execution/'],
+            ['URL', 'https://blog.sonarsource.com/wordpress-file-delete-to-code-execution/'],
             ['URL', 'https://blog.vulnspy.com/2018/06/27/Wordpress-4-9-6-Arbitrary-File-Delection-Vulnerbility-Exploit/']
           ],
       'Privileged'     => false,

--- a/modules/auxiliary/scanner/http/wp_subscribe_comments_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_subscribe_comments_file_read.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['WPVDB', '8102'],
           ['PACKETSTORM', '132694'],
-          ['URL', 'https://security.dxw.com/advisories/admin-only-local-file-inclusion-and-arbitrary-code-execution-in-subscribe-to-comments-2-1-2/']
+          ['URL', 'https://advisories.dxw.com/advisories/admin-only-local-file-inclusion-and-arbitrary-code-execution-in-subscribe-to-comments-2-1-2/']
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/http/zenworks_assetmanagement_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/zenworks_assetmanagement_fileaccess.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2012-4933' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/10/11/cve-2012-4933-novell-zenworks' ]				]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/10/11/cve-2012-4933-novell-zenworks/' ]				]
     ))
 
     register_options(

--- a/modules/auxiliary/scanner/http/zenworks_assetmanagement_getconfig.rb
+++ b/modules/auxiliary/scanner/http/zenworks_assetmanagement_getconfig.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2012-4933' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/10/11/cve-2012-4933-novell-zenworks' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/10/11/cve-2012-4933-novell-zenworks/' ]
         ]
     ))
 

--- a/modules/auxiliary/scanner/ike/cisco_ike_benigncertain.rb
+++ b/modules/auxiliary/scanner/ike/cisco_ike_benigncertain.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2016-6415' ],
           [ 'URL', 'https://github.com/adamcaudill/EquationGroupLeak/tree/master/Firewall/TOOLS/BenignCertain/benigncertain-v1110' ],
           [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160916-ikev1' ],
-          [ 'URL', 'https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-6415' ],
+          [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2016-6415' ],
           [ 'URL', 'https://musalbas.com/2016/08/18/equation-group-benigncertain.html' ]
         ],
       'DisclosureDate' => '2016-09-29'

--- a/modules/auxiliary/scanner/kademlia/server_info.rb
+++ b/modules/auxiliary/scanner/kademlia/server_info.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
           [
             # There are lots of academic papers on the protocol but they tend to lack usable
             # protocol details.  This is the best I've found
-            ['URL', 'http://gbmaster.wordpress.com/2013/06/16/botnets-surrounding-us-sending-kademlia2_bootstrap_req-kademlia2_hello_req-and-their-strict-cousins/#more-125']
+            ['URL', 'https://gbmaster.wordpress.com/2013/06/16/botnets-surrounding-us-sending-kademlia2_bootstrap_req-kademlia2_hello_req-and-their-strict-cousins/#more-125']
           ],
         'License'        => MSF_LICENSE,
         'Actions'        => [

--- a/modules/auxiliary/scanner/misc/cisco_smart_install.rb
+++ b/modules/auxiliary/scanner/misc/cisco_smart_install.rb
@@ -24,9 +24,9 @@ class MetasploitModule < Msf::Auxiliary
           [
             ['URL', 'https://blog.talosintelligence.com/2017/02/cisco-coverage-for-smart-install-client.html'],
             ['URL', 'https://blogs.cisco.com/security/cisco-psirt-mitigating-and-detecting-potential-abuse-of-cisco-smart-install-feature'],
-            ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityResponse/cisco-sr-20170214-smi'],
+            ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20170214-smi'],
             ['URL', 'https://github.com/Cisco-Talos/smi_check'],
-            ['URL', 'https://github.com/Sab0tag3d/SIET']
+            ['URL', 'https://github.com/frostbits-security/SIET']
 
           ],
         'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author'      => ['<tebo[at]attackresearch.com>'],
       'References'  =>
         [
-          ['URL',	'http://www.ietf.org/rfc/rfc1057.txt']
+          ['URL',	'https://www.ietf.org/rfc/rfc1057.txt']
         ],
       'License'	=> MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/misc/zenworks_preboot_fileaccess.rb
+++ b/modules/auxiliary/scanner/misc/zenworks_preboot_fileaccess.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2012-2215' ],
           [ 'OSVDB', '80230' ],
-          [ 'URL', 'http://www.verisigninc.com/en_US/products-and-services/network-intelligence-availability/idefense/public-vulnerability-reports/articles/index.xhtml?id=975' ]
+          [ 'URL', 'https://web.archive.org/web/20121103122235/http://www.verisigninc.com/en_US/products-and-services/network-intelligence-availability/idefense/public-vulnerability-reports/articles/index.xhtml?id=975' ]
         ]
     ))
 

--- a/modules/auxiliary/scanner/mongodb/mongodb_login.rb
+++ b/modules/auxiliary/scanner/mongodb/mongodb_login.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
-          [ 'URL', 'http://www.mongodb.org/display/DOCS/Mongo+Wire+Protocol' ],
-          [ 'URL', 'http://www.mongodb.org/display/DOCS/Implementing+Authentication+in+a+Driver' ]
+          [ 'URL', 'https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/' ],
+          [ 'URL', 'https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst/' ]
         ],
       'Author'       => [ 'Gregory Man <man.gregory[at]gmail.com>' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     => [
           ['CVE', '2012-2122'],
           ['OSVDB', '82804'],
-          ['URL', 'https://blog.rapid7.com/2012/06/11/cve-2012-2122-a-tragically-comedic-security-flaw-in-mysql']
+          ['URL', 'https://www.rapid7.com/blog/post/2012/06/11/cve-2012-2122-a-tragically-comedic-security-flaw-in-mysql/']
         ],
       'DisclosureDate' => 'Jun 09 2012',
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['CVE', '1999-0170'],
-          ['URL',	'http://www.ietf.org/rfc/rfc1094.txt']
+          ['URL',	'https://www.ietf.org/rfc/rfc1094.txt']
         ],
       'License'	=> MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/nntp/nntp_login.rb
+++ b/modules/auxiliary/scanner/nntp/nntp_login.rb
@@ -23,9 +23,9 @@ class MetasploitModule < Msf::Auxiliary
       'Author'      => 'bcoles',
       'License'     => MSF_LICENSE,
       'References'  => [ [ 'CVE', '1999-0502' ], # Weak password
-                         [ 'URL', 'https://tools.ietf.org/html/rfc3977' ],
-                         [ 'URL', 'https://tools.ietf.org/html/rfc4642' ],
-                         [ 'URL', 'https://tools.ietf.org/html/rfc4643' ] ]))
+                         [ 'URL', 'https://datatracker.ietf.org/doc/html/rfc3977' ],
+                         [ 'URL', 'https://datatracker.ietf.org/doc/html/rfc4642' ],
+                         [ 'URL', 'https://datatracker.ietf.org/doc/html/rfc4643' ] ]))
     register_options(
       [
         Opt::RPORT(119),

--- a/modules/auxiliary/scanner/ntp/ntp_monlist.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_monlist.rb
@@ -23,9 +23,9 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2013-5211'],
-          ['URL', 'https://www.us-cert.gov/ncas/alerts/TA14-013A'],
-          ['URL', 'http://support.ntp.org/bin/view/Main/SecurityNotice'],
-          ['URL', 'http://nmap.org/nsedoc/scripts/ntp-monlist.html'],
+          ['URL', 'https://www.cisa.gov/uscert/ncas/alerts/TA14-013A'],
+          ['URL', 'https://support.ntp.org/bin/view/Main/SecurityNotice'],
+          ['URL', 'https://nmap.org/nsedoc/scripts/ntp-monlist.html'],
         ],
       'Author'      => 'hdm',
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -33,8 +33,8 @@ class MetasploitModule < Msf::Auxiliary
         'References'     =>
           [
             [ 'URL', 'http://talosintel.com/reports/TALOS-2015-0069/' ],
-            [ 'URL', 'http://www.cisco.com/c/en/us/support/docs/availability/high-availability/19643-ntpm.html' ],
-            [ 'URL', 'http://support.ntp.org/bin/view/Main/NtpBug2941' ],
+            [ 'URL', 'https://www.cisco.com/c/en/us/support/docs/availability/high-availability/19643-ntpm.html' ],
+            [ 'URL', 'https://support.ntp.org/bin/view/Main/NtpBug2941' ],
             [ 'CVE', '2015-7871' ]
           ]
       )

--- a/modules/auxiliary/scanner/ntp/ntp_peer_list_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_peer_list_dos.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2013-5211'], # see also scanner/ntp/ntp_monlist.rb
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3696'],
-          ['URL', 'http://r-7.co/R7-2014-12']
+          ['URL', 'https://www.rapid7.com/blog/post/2014/08/25/r7-2014-12-more-amplification-vulnerabilities-in-ntp-allow-even-more-drdos-attacks/']
         ],
       'DisclosureDate' => 'Aug 25 2014',
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/ntp/ntp_peer_list_sum_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_peer_list_sum_dos.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2013-5211'], # see also scanner/ntp/ntp_monlist.rb
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3696'],
-          ['URL', 'http://r-7.co/R7-2014-12']
+          ['URL', 'https://www.rapid7.com/blog/post/2014/08/25/r7-2014-12-more-amplification-vulnerabilities-in-ntp-allow-even-more-drdos-attacks/']
         ],
       'DisclosureDate' => 'Aug 25 2014',
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/ntp/ntp_readvar.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_readvar.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['CVE', '2013-5211'], # see also scanner/ntp/ntp_monlist.rb
-          [ 'URL', 'http://www.rapid7.com/vulndb/lookup/ntp-clock-variables-disclosure' ]
+          [ 'URL', 'https://www.rapid7.com/db/vulnerabilities/ntp-clock-variables-disclosure/' ]
         ]
       )
     )

--- a/modules/auxiliary/scanner/ntp/ntp_req_nonce_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_req_nonce_dos.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2013-5211'], # see also scanner/ntp/ntp_monlist.rb
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3696'],
-          ['URL', 'http://r-7.co/R7-2014-12']
+          ['URL', 'https://www.rapid7.com/blog/post/2014/08/25/r7-2014-12-more-amplification-vulnerabilities-in-ntp-allow-even-more-drdos-attacks/']
         ],
       'DisclosureDate' => 'Aug 25 2014',
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/ntp/ntp_reslist_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_reslist_dos.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2013-5211'], # see also scanner/ntp/ntp_monlist.rb
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3696'],
-          ['URL', 'http://r-7.co/R7-2014-12']
+          ['URL', 'https://www.rapid7.com/blog/post/2014/08/25/r7-2014-12-more-amplification-vulnerabilities-in-ntp-allow-even-more-drdos-attacks/']
         ],
       'DisclosureDate' => 'Aug 25 2014',
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/ntp/ntp_unsettrap_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_unsettrap_dos.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2013-5211'], # see also scanner/ntp/ntp_monlist.rb
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3696'],
-          ['URL', 'http://r-7.co/R7-2014-12']
+          ['URL', 'https://www.rapid7.com/blog/post/2014/08/25/r7-2014-12-more-amplification-vulnerabilities-in-ntp-allow-even-more-drdos-attacks/']
         ],
       'DisclosureDate' => 'Aug 25 2014',
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/oracle/isqlplus_login.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_login.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
       [
-        [ 'URL', 'http://carnal0wnage.attackresearch.com' ],
+        [ 'URL', 'https://blog.carnal0wnage.com/' ],
       ],
       'Author'      => [ 'CG', 'todb' ],
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
       [
-        [ 'URL', 'http://carnal0wnage.attackresearch.com' ],
+        [ 'URL', 'https://blog.carnal0wnage.com/' ],
       ],
       'Author'      => [ 'CG', 'todb' ],
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/oracle/oracle_login.rb
+++ b/modules/auxiliary/scanner/oracle/oracle_login.rb
@@ -27,9 +27,9 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://www.oracle.com/us/products/database/index.html' ],
+          [ 'URL', 'https://www.oracle.com/database/' ],
           [ 'CVE', '1999-0502'], # Weak password CVE
-          [ 'URL', 'http://nmap.org/nsedoc/scripts/oracle-brute.html']
+          [ 'URL', 'https://nmap.org/nsedoc/scripts/oracle-brute.html']
         ]
     ))
 

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -22,8 +22,8 @@ class MetasploitModule < Msf::Auxiliary
     ],
       'References'     =>
     [
-      ['URL', 'http://www.ietf.org/rfc/rfc1734.txt'],
-      ['URL', 'http://www.ietf.org/rfc/rfc1939.txt'],
+      ['URL', 'https://www.ietf.org/rfc/rfc1734.txt'],
+      ['URL', 'https://www.ietf.org/rfc/rfc1939.txt'],
     ],
       'License'     => MSF_LICENSE
   )

--- a/modules/auxiliary/scanner/portmap/portmap_amp.rb
+++ b/modules/auxiliary/scanner/portmap/portmap_amp.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2013-5211'], # see also scanner/ntp/ntp_monlist.rb
-          ['URL', 'https://www.us-cert.gov/ncas/alerts/TA14-017A'],
+          ['URL', 'https://www.cisa.gov/uscert/ncas/alerts/TA14-017A'],
           ['URL', 'http://blog.level3.com/security/a-new-ddos-reflection-attack-portmapper-an-early-warning-to-the-industry/']
         ],
     )

--- a/modules/auxiliary/scanner/postgres/postgres_dbname_flag_injection.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_dbname_flag_injection.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2013-1899' ],
-          [ 'URL', 'http://www.postgresql.org/support/security/faq/2013-04-04/' ]
+          [ 'URL', 'https://www.postgresql.org/support/security/faq/2013-04-04/' ]
         ]
     ))
 

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://www.postgresql.org' ],
+          [ 'URL', 'https://www.postgresql.org/' ],
           [ 'CVE', '1999-0502'], # Weak password
           [ 'URL', 'https://hashcat.net/forum/archive/index.php?thread-4148.html' ] # Pass the Hash
         ]

--- a/modules/auxiliary/scanner/postgres/postgres_version.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_version.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://www.postgresql.org' ]
+          [ 'URL', 'https://www.postgresql.org/' ]
         ]
     ))
 

--- a/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
+++ b/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         'References' =>
           [
             [ 'CVE', '2019-0708' ],
-            [ 'URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2019-0708' ],
+            [ 'URL', 'https://msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2019-0708' ],
             [ 'URL', 'https://zerosum0x0.blogspot.com/2019/05/avoiding-dos-how-bluekeep-scanners-work.html' ]
           ],
         'DisclosureDate' => '2019-05-14',

--- a/modules/auxiliary/scanner/rdp/ms12_020_check.rb
+++ b/modules/auxiliary/scanner/rdp/ms12_020_check.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2012-0002' ],
           [ 'MSB', 'MS12-020' ],
-          [ 'URL', 'http://technet.microsoft.com/en-us/security/bulletin/ms12-020' ],
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/2012/ms12-020' ],
           [ 'EDB', '18606' ],
           [ 'URL', 'https://svn.nmap.org/nmap/scripts/rdp-vuln-ms12-020.nse' ]
         ],

--- a/modules/auxiliary/scanner/rdp/rdp_scanner.rb
+++ b/modules/auxiliary/scanner/rdp/rdp_scanner.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         },
         'Author' => 'Jon Hart <jon_hart[at]rapid7.com>',
         'References' => [
-          ['URL', 'https://msdn.microsoft.com/en-us/library/cc240445.aspx']
+          ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/5073f4ed-1e93-45e1-b039-6e30c385867c']
         ],
         'License' => MSF_LICENSE,
         'Notes' => {

--- a/modules/auxiliary/scanner/redis/file_upload.rb
+++ b/modules/auxiliary/scanner/redis/file_upload.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         'References'    => [
           ['URL', 'http://antirez.com/news/96'],
           ['URL', 'http://blog.knownsec.com/2015/11/analysis-of-redis-unauthorized-of-expolit/'],
-          ['URL', 'http://redis.io/topics/protocol']
+          ['URL', 'https://redis.io/topics/protocol']
         ],
         'Privileged'    => true,
         'DisclosureDate' => '2015-11-11'

--- a/modules/auxiliary/scanner/redis/redis_login.rb
+++ b/modules/auxiliary/scanner/redis/redis_login.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
         'Description'  => 'This module attempts to authenticate to an Redis service.',
         'Author'       => [ 'Nixawk' ],
         'References'   => [
-          ['URL', 'http://redis.io/topics/protocol']
+          ['URL', 'https://redis.io/topics/protocol']
         ],
         'License'      => MSF_LICENSE))
 

--- a/modules/auxiliary/scanner/sap/sap_hostctrl_getcomputersystem.rb
+++ b/modules/auxiliary/scanner/sap/sap_hostctrl_getcomputersystem.rb
@@ -24,8 +24,8 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2013-3319'],
           ['OSVDB', '95616'],
           ['BID', '61402'],
-          ['URL', 'https://service.sap.com/sap/support/notes/1816536'],
-          ['URL', 'http://labs.integrity.pt/advisories/cve-2013-3319/']
+          ['URL', 'https://launchpad.support.sap.com/#/notes/1816536'],
+          ['URL', 'https://labs.integrity.pt/advisories/cve-2013-3319/']
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'         => [ 'Chris John Riley' ],
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       =>
         [	'Chris John Riley', # original msf module

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       =>
         [

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listconfigfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listconfigfiles.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [
         'Chris John Riley', # Original msf module

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_router_info_request.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_info_request.rb
@@ -32,8 +32,8 @@ class MetasploitModule < Msf::Auxiliary
         Display the remote connection table from a SAPRouter.
       },
       'References' => [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ],
-          [ 'URL', 'http://help.sap.com/saphelp_nw70ehp3/helpdata/en/48/6c68b01d5a350ce10000000a42189d/content.htm'],
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ],
+          [ 'URL', 'https://web.archive.org/web/20130204114105/http://help.sap.com/saphelp_nw70ehp3/helpdata/en/48/6c68b01d5a350ce10000000a42189d/content.htm'],
           [ 'URL', 'http://conference.hitb.org/hitbsecconf2010ams/materials/D2T2%20-%20Mariano%20Nunez%20Di%20Croce%20-%20SAProuter%20.pdf' ]
         ],
       'Author' =>

--- a/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
@@ -23,11 +23,11 @@ class MetasploitModule < Msf::Auxiliary
       'References' =>
         [
           # General
-          ['URL', 'http://help.sap.com/saphelp_nw70/helpdata/EN/4f/992dfe446d11d189700000e8322d00/frameset.htm'],
-          ['URL', 'http://help.sap.com/saphelp_dimp50/helpdata/En/f8/bb960899d743378ccb8372215bb767/content.htm'],
-          ['URL', 'http://labs.mwrinfosecurity.com/blog/2012/09/13/sap-smashing-internet-windows/'],
+          ['URL', 'https://web.archive.org/web/20130204114105/http://help.sap.com/saphelp_nw70ehp3/helpdata/en/48/6c68b01d5a350ce10000000a42189d/content.htm'],
+          ['URL', 'https://web.archive.org/web/20160818155950/http://help.sap.com/saphelp_dimp50/helpdata/En/f8/bb960899d743378ccb8372215bb767/content.htm'],
+          ['URL', 'https://labs.f-secure.com/archive/sap-smashing-internet-windows/'],
           ['URL', 'http://conference.hitb.org/hitbsecconf2010ams/materials/D2T2%20-%20Mariano%20Nunez%20Di%20Croce%20-%20SAProuter%20.pdf'],
-          ['URL', 'http://scn.sap.com/docs/DOC-17124'] # SAP default ports
+          ['URL', 'https://archive.sap.com/documents/docs/DOC-17124'] # SAP default ports
         ],
       'License' => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/sap/sap_service_discovery.rb
+++ b/modules/auxiliary/scanner/sap/sap_service_discovery.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           # General
-          [ 'URL', 'http://blog.c22.cc' ]
+          [ 'URL', 'https://blog.c22.cc' ]
         ],
       'Author'       => [ 'Chris John Riley' ],
       'License'      => MSF_LICENSE

--- a/modules/auxiliary/scanner/sap/sap_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_smb_relay.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' => [
         [ 'URL', 'http://erpscan.com/advisories/dsecrg-12-033-sap-basis-6-407-02-xml-external-entity/' ],
-        [ 'URL', 'https://service.sap.com/sap/support/notes/1597066' ]
+        [ 'URL', 'https://launchpad.support.sap.com/#/notes/1597066' ]
       ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
@@ -28,8 +28,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ],
-          [ 'URL', 'http://labs.mwrinfosecurity.com/blog/2012/09/03/sap-parameter-injection' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ],
+          [ 'URL', 'https://labs.f-secure.com/archive/sap-parameter-injection/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
@@ -28,8 +28,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ],
-          [ 'URL', 'http://labs.mwrinfosecurity.com/blog/2012/09/03/sap-parameter-injection' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ],
+          [ 'URL', 'https://labs.f-secure.com/archive/sap-parameter-injection/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com' ]
+          [ 'URL', 'https://labs.f-secure.com/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
         },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' =>
         [
           [ 'CVE', '2006-6010' ],
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/scada/digi_addp_reboot.rb
+++ b/modules/auxiliary/scanner/scada/digi_addp_reboot.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['URL', 'http://qbeukes.blogspot.com/2009/11/advanced-digi-discovery-protocol_21.html'],
-          ['URL', 'http://www.digi.com/wiki/developer/index.php/Advanced_Device_Discovery_Protocol_%28ADDP%29'],
+          ['URL', 'https://www.digi.com/resources/documentation/digidocs/90001537/#References/r_Advanced_Device_Discovery_Prot.htm?Highlight=advanced%20device%20discovery%20protocol'],
         ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/scada/digi_addp_version.rb
+++ b/modules/auxiliary/scanner/scada/digi_addp_version.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['URL', 'http://qbeukes.blogspot.com/2009/11/advanced-digi-discovery-protocol_21.html'],
-          ['URL', 'http://www.digi.com/wiki/developer/index.php/Advanced_Device_Discovery_Protocol_%28ADDP%29'],
+          ['URL', 'https://www.digi.com/resources/documentation/digidocs/90001537/#References/r_Advanced_Device_Discovery_Prot.htm?Highlight=advanced%20device%20discovery%20protocol'],
         ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/scada/digi_realport_serialport_scan.rb
+++ b/modules/auxiliary/scanner/scada/digi_realport_serialport_scan.rb
@@ -14,8 +14,8 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => 'Identify active ports on RealPort-enabled serial servers.',
       'References'  =>
         [
-          ['URL', 'http://www.digi.com/pdf/fs_realport.pdf'],
-          ['URL', 'http://www.digi.com/support/productdetail?pid=2229&type=drivers']
+          ['URL', 'https://www.digi.com/resources/library/technical-briefs/fs_realport'],
+          ['URL', 'https://web.archive.org/web/20151012224641/http://www.digi.com/support/productdetail?pid=2229&type=drivers']
         ],
       'Author'      =>
         [

--- a/modules/auxiliary/scanner/scada/digi_realport_version.rb
+++ b/modules/auxiliary/scanner/scada/digi_realport_version.rb
@@ -14,8 +14,8 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => 'Detect serial servers that speak the RealPort protocol.',
       'References'  =>
         [
-          ['URL', 'http://www.digi.com/pdf/fs_realport.pdf'],
-          ['URL', 'http://www.digi.com/support/productdetail?pid=2229&type=drivers']
+          ['URL', 'https://www.digi.com/resources/library/technical-briefs/fs_realport'],
+          ['URL', 'https://web.archive.org/web/20151012224641/http://www.digi.com/support/productdetail?pid=2229&type=drivers']
         ],
       'Author'      =>
         [

--- a/modules/auxiliary/scanner/scada/modbus_findunitid.rb
+++ b/modules/auxiliary/scanner/scada/modbus_findunitid.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
-          [ 'URL', 'http://www.saia-pcd.com/en/products/plc/pcd-overview/Pages/pcd1-m2.aspx' ],
-          [ 'URL', 'http://en.wikipedia.org/wiki/Modbus:TCP' ]
+          [ 'URL', 'https://www.saia-pcd.com/en/products/plc/pcd-overview/Pages/pcd1-m2.aspx' ],
+          [ 'URL', 'https://en.wikipedia.org/wiki/Modbus:TCP' ]
         ],
       'Author'         => [ 'EsMnemon <esm[at]mnemonic.no>' ],
       'License'        => MSF_LICENSE,
@@ -95,7 +95,7 @@ end
 For testing purposes:
 
   This client is developed and tested against a SAIA PCD1.M2 system
-  http://www.saia-pcd.com/en/products/plc/pcd-overview/Pages/pcd1-m2.aspx
+  https://www.saia-pcd.com/en/products/plc/pcd-overview/Pages/pcd1-m2.aspx
   and a modbus/tcp PLC simulator from plcsimulator.org
   and the Modbus SLAVE from http://www.modbustools.com/
 

--- a/modules/auxiliary/scanner/scada/modbusdetect.rb
+++ b/modules/auxiliary/scanner/scada/modbusdetect.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
-          [ 'URL', 'http://www.saia-pcd.com/en/products/plc/pcd-overview/Pages/pcd1-m2.aspx' ],
-          [ 'URL', 'http://en.wikipedia.org/wiki/Modbus:TCP' ]
+          [ 'URL', 'https://www.saia-pcd.com/en/products/plc/pcd-overview/Pages/pcd1-m2.aspx' ],
+          [ 'URL', 'https://en.wikipedia.org/wiki/Modbus:TCP' ]
         ],
       'Author'      => [ 'EsMnemon <esm[at]mnemonic.no>' ],
       'DisclosureDate' => 'Nov 1 2011',

--- a/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
+++ b/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
         [ 'OSVDB', '3106'],
         [ 'URL', 'http://www.pentestgeek.com/2012/11/05/finding-logged-in-users-metasploit-module/' ],
-        [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
+        [ 'URL', 'https://docs.microsoft.com/en-us/sysinternals/downloads/psexec' ]
       ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2014-1812'],
           ['MSB', 'MS14-025'],
-          ['URL', 'http://msdn.microsoft.com/en-us/library/cc232604(v=prot.13)'],
+          ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-gppref/d315342d-41c0-47e3-ab96-7039eb91f5b4'],
           ['URL', 'http://rewtdance.blogspot.com/2012/06/exploiting-windows-2008-group-policy.html'],
           ['URL', 'http://blogs.technet.com/grouppolicy/archive/2009/04/22/passwords-in-group-policy-preferences-updated.aspx'],
           ['URL', 'https://labs.portcullis.co.uk/blog/are-you-considering-using-microsoft-group-policy-preferences-think-again/']

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'  =>
         [
-          [ 'URL', 'http://msdn.microsoft.com/en-us/library/aa370669%28VS.85%29.aspx' ]
+          [ 'URL', 'https://docs.microsoft.com/en-us/windows/win32/api/lmwksta/nf-lmwksta-netwkstauserenum' ]
         ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'MSB', 'MS17-010'],
           [ 'URL', 'https://zerosum0x0.blogspot.com/2017/04/doublepulsar-initial-smb-backdoor-ring.html'],
           [ 'URL', 'https://github.com/countercept/doublepulsar-detection-script'],
-          [ 'URL', 'https://technet.microsoft.com/en-us/library/security/ms17-010.aspx']
+          [ 'URL', 'https://web.archive.org/web/20170513050203/https://technet.microsoft.com/en-us/library/security/ms17-010.aspx']
         ],
       'License'        => MSF_LICENSE,
       'Notes' =>

--- a/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
+++ b/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2015-0240'],
           ['OSVDB', '118637'],
-          ['URL', 'https://securityblog.redhat.com/2015/02/23/samba-vulnerability-cve-2015-0240/'],
+          ['URL', 'https://www.redhat.com/en/blog/samba-vulnerability-cve-2015-0240'],
           ['URL', 'https://gist.github.com/worawit/33cc5534cb555a0b710b'],
           ['URL', 'https://www.nccgroup.com/en/blog/2015/03/samba-_netr_serverpasswordset-expoitability-analysis/']
         ],

--- a/modules/auxiliary/scanner/smtp/smtp_ntlm_domain.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_ntlm_domain.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'        => 'SMTP NTLM Domain Extraction',
       'Description' => 'Extract the Windows domain name from an SMTP NTLM challenge.',
-      'References'  => [ ['URL', 'http://msdn.microsoft.com/en-us/library/cc246870.aspx' ] ],
+      'References'  => [ ['URL', 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smtpntlm/a048c79f-7597-401b-bcb4-521d682de765' ] ],
       'Author'      => [ 'Rich Whitcroft <rwhitcroft[at]digitalboundary.net>' ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/snmp/arris_dg950.rb
+++ b/modules/auxiliary/scanner/snmp/arris_dg950.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE','2014-4863'],
-          ['URL', 'https://blog.rapid7.com/2014/08/21/more-snmp-information-leaks-cve-2014-4862-and-cve-2014-4863']
+          ['URL', 'https://www.rapid7.com/blog/post/2014/08/21/more-snmp-information-leaks-cve-2014-4862-and-cve-2014-4863/']
         ],
       'Author'      => ['Deral "Percent_X" Heiland'],
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/snmp/brocade_enumhash.rb
+++ b/modules/auxiliary/scanner/snmp/brocade_enumhash.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
-          [ 'URL', 'https://blog.rapid7.com/2014/05/15/r7-2014-01-r7-2014-02-r7-2014-03-disclosures-exposure-of-critical-information-via-snmp-public-community-string' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2014/05/15/r7-2014-01-r7-2014-02-r7-2014-03-disclosures-exposure-of-critical-information-via-snmp-public-community-string/' ]
         ],
       'Author'      => ['Deral "PercentX" Heiland'],
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/snmp/cnpilot_r_snmp_loot.rb
+++ b/modules/auxiliary/scanner/snmp/cnpilot_r_snmp_loot.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' =>
         [
           ['CVE', '2017-5262'],
-          ['URL', 'https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities']
+          ['URL', 'https://www.rapid7.com/blog/post/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/']
         ],
       'License' => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/snmp/netopia_enum.rb
+++ b/modules/auxiliary/scanner/snmp/netopia_enum.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
-          [ 'URL', 'https://blog.rapid7.com/2014/05/15/r7-2014-01-r7-2014-02-r7-2014-03-disclosures-exposure-of-critical-information-via-snmp-public-community-string' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2014/05/15/r7-2014-01-r7-2014-02-r7-2014-03-disclosures-exposure-of-critical-information-via-snmp-public-community-string/' ]
         ],
       'Author'      => ['Deral "PercentX" Heiland'],
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/snmp/sbg6580_enum.rb
+++ b/modules/auxiliary/scanner/snmp/sbg6580_enum.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           [ 'URL', 'https://seclists.org/fulldisclosure/2014/May/79' ],
-          [ 'URL', 'http://www.arrisi.com/modems/datasheet/SBG6580/SBG6580_UserGuide.pdf' ],
+          [ 'URL', 'https://web.archive.org/web/20150206092553/http://www.arrisi.com/modems/datasheet/SBG6580/SBG6580_UserGuide.pdf' ],
           [ 'OSVDB', '110555' ]
         ],
       'Author'      => 'Matthew Kienow <mkienow[at]inokii.com>',

--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -16,9 +16,9 @@ class MetasploitModule < Msf::Auxiliary
         The default community used is "public".',
       'References'  =>
         [
-          [ 'URL', 'http://en.wikipedia.org/wiki/Simple_Network_Management_Protocol' ],
-          [ 'URL', 'http://net-snmp.sourceforge.net/docs/man/snmpwalk.html' ],
-          [ 'URL', 'http://www.nothink.org/perl/snmpcheck/' ],
+          [ 'URL', 'https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol' ],
+          [ 'URL', 'https://net-snmp.sourceforge.io/docs/man/snmpwalk.html' ],
+          [ 'URL', 'http://www.nothink.org/codes/snmpcheck/index.php' ],
         ],
       'Author'      => 'Matteo Cantoni <goony[at]nothink.org>',
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/snmp/snmp_enum_hp_laserjet.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum_hp_laserjet.rb
@@ -18,9 +18,9 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
-          [ 'URL', 'http://en.wikipedia.org/wiki/Simple_Network_Management_Protocol' ],
-          [ 'URL', 'http://net-snmp.sourceforge.net/docs/man/snmpwalk.html' ],
-          [ 'URL', 'http://www.nothink.org/perl/snmpcheck/' ],
+          [ 'URL', 'https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol' ],
+          [ 'URL', 'https://net-snmp.sourceforge.io/docs/man/snmpwalk.html' ],
+          [ 'URL', 'http://www.nothink.org/codes/snmpcheck/index.php' ],
           [ 'URL', 'http://www.securiteam.com/securitynews/5AP0S2KGVS.html' ],
           [ 'URL', 'http://stuff.mit.edu/afs/athena/dept/cron/tools/share/mibs/290923.mib' ],
         ],

--- a/modules/auxiliary/scanner/snmp/snmp_set.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_set.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
-          [ 'URL', 'http://en.wikipedia.org/wiki/Simple_Network_Management_Protocol' ],
+          [ 'URL', 'https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol' ],
           [ 'URL', 'http://www.net-snmp.org/docs/man/snmpset.html' ],
           [ 'URL', 'http://www.oid-info.com/' ],
         ],

--- a/modules/auxiliary/scanner/snmp/ubee_ddw3611.rb
+++ b/modules/auxiliary/scanner/snmp/ubee_ddw3611.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
-          [ 'URL', 'https://blog.rapid7.com/2014/05/15/r7-2014-01-r7-2014-02-r7-2014-03-disclosures-exposure-of-critical-information-via-snmp-public-community-string' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2014/05/15/r7-2014-01-r7-2014-02-r7-2014-03-disclosures-exposure-of-critical-information-via-snmp-public-community-string/' ]
         ],
       'Author'      => ['Deral "PercentX" Heiland'],
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     => [
         ['CVE', '2018-16158'],
         ['EDB', '45283'],
-        ['URL', 'http://www.eaton.com/content/dam/eaton/company/news-insights/cybersecurity/security-bulletins/PXM-Advisory.pdf'],
+        ['URL', 'https://www.eaton.com/content/dam/eaton/company/news-insights/cybersecurity/security-bulletins/PXM-Advisory.pdf'],
         ['URL', 'https://www.ctrlu.net/vuln/0006.html']
       ],
       'DisclosureDate' => '2018-07-18',

--- a/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'References'     => [
         ['CVE', '2015-7755'],
-        ['URL', 'https://blog.rapid7.com/2015/12/20/cve-2015-7755-juniper-screenos-authentication-backdoor'],
+        ['URL', 'https://www.rapid7.com/blog/post/2015/12/20/cve-2015-7755-juniper-screenos-authentication-backdoor/'],
         ['URL', 'https://kb.juniper.net/InfoCenter/index?page=content&id=JSA10713']
       ],
       'DisclosureDate' => '2015-12-20',

--- a/modules/auxiliary/scanner/ssh/ssh_enum_git_keys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enum_git_keys.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         'Author'        => ['Wyatt Dahlenburg (@wdahlenb)'],
         'Platform'      => ['linux'],
         'SessionTypes'  => ['shell', 'meterpreter'],
-        'References'    => [['URL', 'https://help.github.com/en/articles/testing-your-ssh-connection']]
+        'References'    => [['URL', 'https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection']]
       )
     )
 

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => 'Detect SSH Version.',
       'References'  =>
         [
-          [ 'URL', 'http://en.wikipedia.org/wiki/SecureShell' ]
+          [ 'URL', 'https://en.wikipedia.org/wiki/SecureShell' ]
         ],
       'Author'      => [ 'Daniel van Eeden <metasploit[at]myname.nl>' ],
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -138,11 +138,11 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2014-0160' ],
           [ 'US-CERT-VU', '720951' ],
-          [ 'URL', 'https://www.us-cert.gov/ncas/alerts/TA14-098A' ],
-          [ 'URL', 'http://heartbleed.com/' ],
+          [ 'URL', 'https://www.cisa.gov/uscert/ncas/alerts/TA14-098A' ],
+          [ 'URL', 'https://heartbleed.com/' ],
           [ 'URL', 'https://github.com/FiloSottile/Heartbleed' ],
           [ 'URL', 'https://gist.github.com/takeshixx/10107280' ],
-          [ 'URL', 'http://filippo.io/Heartbleed/' ]
+          [ 'URL', 'https://filippo.io/Heartbleed/' ]
         ],
       'DisclosureDate' => '2014-04-07',
       'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/telnet/satel_cmd_exec.rb
+++ b/modules/auxiliary/scanner/telnet/satel_cmd_exec.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2017-6048' ],
           [ 'URL', 'https://ipositivesecurity.com/2017/04/07/sennet-data-logger-appliances-and-electricity-meters-multiple-vulnerabilties/' ],
-          [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-17-131-02' ]
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-17-131-02' ]
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
           ['BID', '51182'],
           ['CVE', '2011-4862'],
           ['EDB', '18280'],
-          ['URL', 'https://blog.rapid7.com/2011/12/28/more-fun-with-bsd-derived-telnet-daemons']
+          ['URL', 'https://www.rapid7.com/blog/post/2011/12/28/more-fun-with-bsd-derived-telnet-daemons/']
         ]
     )
     register_options(

--- a/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
+++ b/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
@@ -17,9 +17,9 @@ class MetasploitModule < Msf::Auxiliary
         'License'     => MSF_LICENSE,
         'References'  =>
           [
-            ['URL', 'https://www.us-cert.gov/ncas/alerts/TA14-017A'],
+            ['URL', 'https://www.cisa.gov/uscert/ncas/alerts/TA14-017A'],
             ['URL', 'https://community.ubnt.com/t5/airMAX-General-Discussion/airOS-airMAX-and-management-access/td-p/2654023'],
-            ['URL', 'https://blog.rapid7.com/2019/02/01/ubiquiti-discovery-service-exposures/']
+            ['URL', 'https://www.rapid7.com/blog/post/2019/02/01/ubiquiti-discovery-service-exposures/']
           ]
       )
     )

--- a/modules/auxiliary/scanner/udp/udp_amplification.rb
+++ b/modules/auxiliary/scanner/udp/udp_amplification.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2013-5211'], # see also scanner/ntp/ntp_monlist.rb
-          ['URL', 'https://www.us-cert.gov/ncas/alerts/TA14-017A']
+          ['URL', 'https://www.cisa.gov/uscert/ncas/alerts/TA14-017A']
         ]
     )
 

--- a/modules/auxiliary/scanner/upnp/ssdp_amp.rb
+++ b/modules/auxiliary/scanner/upnp/ssdp_amp.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2013-5211'], # see also scanner/ntp/ntp_monlist.rb
-          ['URL', 'https://www.us-cert.gov/ncas/alerts/TA14-017A']
+          ['URL', 'https://www.cisa.gov/uscert/ncas/alerts/TA14-017A']
         ],
     )
 

--- a/modules/auxiliary/scanner/vmware/vmware_server_dir_trav.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_server_dir_trav.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'References'	=>
         [
-          [ 'URL', 'http://www.vmware.com/security/advisories/VMSA-2009-0015.html' ],
+          [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2009-0015.html' ],
           [ 'OSVDB', '59440' ],
           [ 'BID', '36842' ],
           [ 'CVE', '2009-3733' ],

--- a/modules/auxiliary/scanner/vmware/vmware_update_manager_traversal.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_update_manager_traversal.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2011-4404'],
           ['EDB', '18138'],
-          ['URL', 'http://www.vmware.com/security/advisories/VMSA-2011-0014.html'],
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2011-0014.html'],
           ['URL', 'http://dsecrg.com/pages/vul/show.php?id=342']
         ],
       'DisclosureDate' => '2011-11-21'))

--- a/modules/auxiliary/scanner/vnc/vnc_none_auth.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_none_auth.rb
@@ -16,8 +16,8 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2006-2369'], # a related instance where "None" could be offered and used when not configured as allowed.
-          ['URL', 'http://en.wikipedia.org/wiki/RFB'],
-          ['URL', 'http://en.wikipedia.org/wiki/Vnc'],
+          ['URL', 'https://en.wikipedia.org/wiki/RFB'],
+          ['URL', 'https://en.wikipedia.org/wiki/Vnc'],
         ],
       'Author'      =>
         [

--- a/modules/auxiliary/scanner/wproxy/att_open_proxy.py
+++ b/modules/auxiliary/scanner/wproxy/att_open_proxy.py
@@ -19,7 +19,7 @@ metadata = {
     'references': [
         {'type': 'cve', 'ref': '2017-14117'},
         {'type': 'url', 'ref': 'https://www.nomotion.net/blog/sharknatto/'},
-        {'type': 'url', 'ref': 'https://blog.rapid7.com/2017/09/07/measuring-sharknat-to-exposures/#vulnerability5port49152tcpexposure'}
+        {'type': 'url', 'ref': 'https://www.rapid7.com/blog/post/2017/09/07/measuring-sharknat-to-exposures/#vulnerability5port49152tcpexposure'}
      ],
     'type': 'multi_scanner',
     'options': {

--- a/modules/auxiliary/server/browser_autopwn2.rb
+++ b/modules/auxiliary/server/browser_autopwn2.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
       'DisclosureDate' => '2015-07-05',
       'References'     =>
         [
-          [ 'URL', 'https://blog.rapid7.com/2015/07/16/the-new-metasploit-browser-autopwn-strikes-faster-and-smarter--part-2' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2015/07/16/the-new-metasploit-browser-autopwn-strikes-faster-and-smarter--part-2' ]
         ],
       'Actions'     =>
         [

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' =>
         [
           [ 'URL', 'https://www.samlogic.net/articles/smtp-commands-reference-auth.htm' ],
-          [ 'URL', 'tools.ietf.org/html/rfc5321' ],
+          [ 'URL', 'https://datatracker.ietf.org/doc/html/rfc5321' ],
           [ 'URL', 'http://fehcom.de/qmail/smtpauth.html' ]
         ],
     )

--- a/modules/auxiliary/server/icmp_exfil.rb
+++ b/modules/auxiliary/server/icmp_exfil.rb
@@ -31,9 +31,9 @@ class MetasploitModule < Msf::Auxiliary
           # packetfu
           ['URL','https://github.com/todb/packetfu'],
           # nping
-          ['URL', 'http://nmap.org/book/nping-man.html'],
+          ['URL', 'https://nmap.org/book/nping-man.html'],
           # simple icmp
-          ['URL', 'http://blog.c22.cc/2012/02/17/quick-post-fun-with-python-ctypes-simpleicmp/']
+          ['URL', 'https://blog.c22.cc/2012/02/17/quick-post-fun-with-python-ctypes-simpleicmp/']
         ]
     )
 

--- a/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
+++ b/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2014-0160' ],
           [ 'US-CERT-VU', '720951' ],
-          [ 'URL', 'https://www.us-cert.gov/ncas/alerts/TA14-098A' ],
+          [ 'URL', 'https://www.cisa.gov/uscert/ncas/alerts/TA14-098A' ],
           [ 'URL', 'http://heartbleed.com/' ]
         ],
       'DisclosureDate' => 'Apr 07 2014',

--- a/modules/auxiliary/server/wget_symlink_file_write.rb
+++ b/modules/auxiliary/server/wget_symlink_file_write.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '2014-4877'],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=1139181' ],
-          [ 'URL', 'https://blog.rapid7.com/2014/10/28/r7-2014-15-gnu-wget-ftp-symlink-arbitrary-filesystem-access' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2014/10/28/r7-2014-15-gnu-wget-ftp-symlink-arbitrary-filesystem-access' ]
         ],
       'DefaultAction'  => 'Service',
       'DisclosureDate' => 'Oct 27 2014'

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['OSVDB', '11169'],
           ['CVE', '1999-0667'],
-          ['URL', 'http://en.wikipedia.org/wiki/ARP_spoofing']
+          ['URL', 'https://en.wikipedia.org/wiki/ARP_spoofing']
         ],
       'DisclosureDate' => 'Dec 22 1999' #osvdb date
     )

--- a/modules/auxiliary/spoof/cisco/cdp.rb
+++ b/modules/auxiliary/spoof/cisco/cdp.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author'      => 'Fatih Ozavci', # viproy.com/fozavci
       'License'     =>  MSF_LICENSE,
       'References'  => [
-        [ 'URL', 'http://en.wikipedia.org/wiki/CDP_Spoofing' ]
+        [ 'URL', 'https://en.wikipedia.org/wiki/CDP_Spoofing' ]
       ],
       'Actions'     => [
         ['Spoof', { 'Description' => 'Sends CDP packets' }]

--- a/modules/auxiliary/vsploit/pii/web_pii.rb
+++ b/modules/auxiliary/vsploit/pii/web_pii.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => 'MJC',
       'References' =>
       [
-        [ 'URL', 'https://blog.rapid7.com/2011/06/02/vsploit--virtualizing-exploitation-attributes-with-metasploit-framework']
+        [ 'URL', 'https://www.rapid7.com/blog/post/2011/06/02/vsploit--virtualizing-exploitation-attributes-with-metasploit-framework']
       ],
       'DefaultOptions' => { 'HTTP::server_name' => 'IIS'}
       ))

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -31,9 +31,9 @@ class MetasploitModule < Msf::Exploit::Local
           ],
           'References' => [
             [ 'CVE', '2013-6282' ],
-            [ 'URL', 'http://forum.xda-developers.com/showthread.php?t=2434453' ],
+            [ 'URL', 'https://forum.xda-developers.com/t/root-share-vroot-1-6-0-3690-1-click-root-method-lenovo-a706-walkman-f800-etc.2434453/' ],
             [ 'URL', 'https://github.com/fi01/libget_user_exploit' ],
-            [ 'URL', 'http://forum.xda-developers.com/showthread.php?t=2565758' ],
+            [ 'URL', 'https://forum.xda-developers.com/t/root-saferoot-root-for-vruemj7-mk2-and-android-4-3.2565758/' ],
           ],
           'DisclosureDate' => '2013-09-06',
           'SessionTypes' => [ 'meterpreter' ],

--- a/modules/exploits/example.py
+++ b/modules/exploits/example.py
@@ -25,7 +25,7 @@ metadata = {
     'date': '2018-03-22',
     'license': 'MSF_LICENSE',
     'references': [
-        {'type': 'url', 'ref': 'https://blog.rapid7.com/2017/12/28/regifting-python-in-metasploit/'},
+        {'type': 'url', 'ref': 'https://www.rapid7.com/blog/post/2017/12/28/regifting-python-in-metasploit/'},
         {'type': 'aka', 'ref': 'Coldstone'}
     ],
     'type': 'remote_exploit_cmd_stager',

--- a/modules/exploits/linux/http/advantech_switch_bash_env_exec.rb
+++ b/modules/exploits/linux/http/advantech_switch_bash_env_exec.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [ 'CWE', '94' ],
         [ 'OSVDB', '112004' ],
         [ 'EDB', '34765' ],
-        [ 'URL', 'https://blog.rapid7.com/2015/12/01/r7-2015-25-advantech-eki-multiple-known-vulnerabilities' ],
+        [ 'URL', 'https://www.rapid7.com/blog/post/2015/12/01/r7-2015-25-advantech-eki-multiple-known-vulnerabilities' ],
         [ 'URL', 'https://access.redhat.com/articles/1200223' ],
         [ 'URL', 'https://seclists.org/oss-sec/2014/q3/649' ]
       ],

--- a/modules/exploits/linux/http/mutiny_frontend_upload.rb
+++ b/modules/exploits/linux/http/mutiny_frontend_upload.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2013-0136' ],
           [ 'OSVDB', '93444' ],
           [ 'US-CERT-VU', '701572' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/05/15/new-1day-exploits-mutiny-vulnerabilities' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/05/15/new-1day-exploits-mutiny-vulnerabilities' ]
         ],
       'Privileged'  => true,
       'Platform'    => 'linux',

--- a/modules/exploits/linux/http/smt_ipmi_close_window_bof.rb
+++ b/modules/exploits/linux/http/smt_ipmi_close_window_bof.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2013-3623' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/11/06/supermicro-ipmi-firmware-vulnerabilities' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/11/06/supermicro-ipmi-firmware-vulnerabilities' ]
         ],
       'Targets'        =>
         [

--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -45,8 +45,8 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'OSVDB', '96588' ],
           [ 'BID', '61966'],
           [ 'URL', 'http://blog.cmpxchg8b.com/2013/08/security-debianisms.html' ],
-          [ 'URL', 'http://www.vmware.com/support/support-resources/advisories/VMSA-2013-0010.html' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/09/05/cve-2013-1662-vmware-mount-exploit' ]
+          [ 'URL', 'https://www.vmware.com/support/support-resources/advisories/VMSA-2013-0010.html' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/09/05/cve-2013-1662-vmware-mount-exploit' ]
         ],
         'DisclosureDate' => '2013-08-22'
       }

--- a/modules/exploits/linux/misc/hikvision_rtsp_bof.rb
+++ b/modules/exploits/linux/misc/hikvision_rtsp_bof.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2014-4880' ],
-          [ 'URL', 'https://blog.rapid7.com/2014/11/19/r7-2014-18-hikvision-dvr-devices--multiple-vulnerabilities' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2014/11/19/r7-2014-18-hikvision-dvr-devices--multiple-vulnerabilities' ]
         ],
       'Platform'       => 'linux',
       'Arch'           => ARCH_ARMLE,

--- a/modules/exploits/linux/ssh/exagrid_known_privkey.rb
+++ b/modules/exploits/linux/ssh/exagrid_known_privkey.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2016-1560' ], # password
           [ 'CVE', '2016-1561' ], # private key
-          [ 'URL', 'https://blog.rapid7.com/2016/04/07/r7-2016-04-exagrid-backdoor-ssh-keys-and-hardcoded-credentials' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2016/04/07/r7-2016-04-exagrid-backdoor-ssh-keys-and-hardcoded-credentials' ]
         ],
       'DisclosureDate' => '2016-04-07',
       'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'URL', 'https://www.trustmatta.com/advisories/MATTA-2012-002.txt' ],
             [ 'CVE', '2012-1493' ],
             [ 'OSVDB', '82780' ],
-            [ 'URL', 'https://blog.rapid7.com/2012/06/25/press-f5-for-root-shell' ]
+            [ 'URL', 'https://www.rapid7.com/blog/post/2012/06/25/press-f5-for-root-shell' ]
           ],
         'DisclosureDate' => '2012-06-11',
         'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },

--- a/modules/exploits/linux/upnp/miniupnpd_soap_bof.rb
+++ b/modules/exploits/linux/upnp/miniupnpd_soap_bof.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2013-0230' ],
           [ 'OSVDB', '89624' ],
           [ 'BID', '57608' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/01/29/security-flaws-in-universal-plug-and-play-unplug-dont-play']
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/01/29/security-flaws-in-universal-plug-and-play-unplug-dont-play']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/multi/browser/firefox_proxy_prototype.rb
+++ b/modules/exploits/multi/browser/firefox_proxy_prototype.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['CVE', '2014-8636'], # proxy injection
         ['CVE', '2015-0802'], # can access messageManager property in chrome window
         ['URL', 'https://bugzilla.mozilla.org/show_bug.cgi?id=1120261'],
-        ['URL', 'https://blog.rapid7.com/2015/03/23/r7-2015-04-disclosure-mozilla-firefox-proxy-prototype-rce-cve-2014-8636' ]
+        ['URL', 'https://www.rapid7.com/blog/post/2015/03/23/r7-2015-04-disclosure-mozilla-firefox-proxy-prototype-rce-cve-2014-8636' ]
 
       ],
       'Targets' => [

--- a/modules/exploits/multi/browser/java_atomicreferencearray.rb
+++ b/modules/exploits/multi/browser/java_atomicreferencearray.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'http://blogs.technet.com/b/mmpc/archive/2012/03/20/an-interesting-case-of-jre-sandbox-breach-cve-2012-0507.aspx'],
           ['URL', 'http://schierlm.users.sourceforge.net/TypeConfusion.html'],
           ['URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2012-0507'],
-          ['URL', 'https://blog.rapid7.com/2012/03/29/cve-2012-0507--java-strikes-again']
+          ['URL', 'https://www.rapid7.com/blog/post/2012/03/29/cve-2012-0507--java-strikes-again']
         ],
       'Platform'       => %w{ java linux osx solaris win },
       'Payload'        => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },

--- a/modules/exploits/multi/browser/java_jre17_exec.rb
+++ b/modules/exploits/multi/browser/java_jre17_exec.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'http://labs.alienvault.com/labs/index.php/2012/new-java-0day-exploited-in-the-wild/' ],
           [ 'URL', 'http://www.deependresearch.org/2012/08/java-7-0-day-vulnerability-information.html' ],
           [ 'URL', 'http://www.oracle.com/technetwork/topics/security/alert-cve-2012-4681-1835715.html' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/08/27/lets-start-the-week-with-a-new-java-0day' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/08/27/lets-start-the-week-with-a-new-java-0day' ],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=852051']
         ],
       'Platform'      => %w{ java linux win },

--- a/modules/exploits/multi/fileformat/swagger_param_inject.rb
+++ b/modules/exploits/multi/fileformat/swagger_param_inject.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2016-5641' ],
           [ 'URL', 'http://github.com/swagger-api/swagger-codegen' ],
-          [ 'URL', 'https://blog.rapid7.com/2016/06/23/r7-2016-06-remote-code-execution-via-swagger-parameter-injection-cve-2016-5641' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2016/06/23/r7-2016-06-remote-code-execution-via-swagger-parameter-injection-cve-2016-5641' ]
         ],
       'Platform'       => %w{ nodejs php java ruby },
       'Arch'           => [ ARCH_NODEJS, ARCH_PHP, ARCH_JAVA, ARCH_RUBY ],

--- a/modules/exploits/multi/http/caidao_php_backdoor_exec.rb
+++ b/modules/exploits/multi/http/caidao_php_backdoor_exec.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://www.fireeye.com/blog/threat-research/2013/08/breaking-down-the-china-chopper-web-shell-part-i.html'],
           ['URL', 'https://www.fireeye.com/blog/threat-research/2013/08/breaking-down-the-china-chopper-web-shell-part-ii.html'],
           ['URL', 'https://www.exploit-db.com/docs/27654.pdf'],
-          ['URL', 'https://www.us-cert.gov/ncas/alerts/TA15-313A']
+          ['URL', 'https://www.cisa.gov/uscert/ncas/alerts/TA15-313A']
         ],
       'Platform'          => ['php'],
       'Arch'              => ARCH_PHP,

--- a/modules/exploits/multi/http/gestioip_exec.rb
+++ b/modules/exploits/multi/http/gestioip_exec.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'URL', 'http://sourceforge.net/p/gestioip/gestioip/ci/ac67be9fce5ee4c0438d27dfa5c1dcbca08c457c/' ], # Patch
           [ 'URL', 'https://github.com/rapid7/metasploit-framework/pull/2461' ], # First disclosure
-          [ 'URL', 'https://blog.rapid7.com/2013/10/03/gestioip-authenticated-remote-command-execution-module' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/10/03/gestioip-authenticated-remote-command-execution-module' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/multi/http/git_client_command_exec.rb
+++ b/modules/exploits/multi/http/git_client_command_exec.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2014-9390'],
-          ['URL', 'https://blog.rapid7.com/2015/01/01/12-days-of-haxmas-exploiting-cve-2014-9390-in-git-and-mercurial'],
+          ['URL', 'https://www.rapid7.com/blog/post/2015/01/01/12-days-of-haxmas-exploiting-cve-2014-9390-in-git-and-mercurial'],
           ['URL', 'http://git-blame.blogspot.com.es/2014/12/git-1856-195-205-214-and-221-and.html'],
           ['URL', 'http://article.gmane.org/gmane.linux.kernel/1853266'],
           ['URL', 'https://github.com/blog/1938-vulnerability-announced-update-your-git-clients'],

--- a/modules/exploits/multi/http/ispconfig_php_exec.rb
+++ b/modules/exploits/multi/http/ispconfig_php_exec.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References' =>
         [
           ['CVE', '2013-3629'],
-          ['URL', 'https://blog.rapid7.com/2013/10/30/seven-tricks-and-treats']
+          ['URL', 'https://www.rapid7.com/blog/post/2013/10/30/seven-tricks-and-treats']
         ],
       'Privileged' => false,
       'Platform'	 => ['php'],

--- a/modules/exploits/multi/http/metasploit_static_secret_key_base.rb
+++ b/modules/exploits/multi/http/metasploit_static_secret_key_base.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'  =>
         [
           ['OVE', '20160904-0002'],
-          ['URL', 'https://blog.rapid7.com/2016/09/15/important-security-fixes-in-metasploit-4120-2016091401'],
+          ['URL', 'https://www.rapid7.com/blog/post/2016/09/15/important-security-fixes-in-metasploit-4120-2016091401'],
           ['URL', 'https://github.com/justinsteven/advisories/blob/master/2016_metasploit_rce_static_key_deserialization.md']
         ],
       'DisclosureDate' => '2016-09-15',

--- a/modules/exploits/multi/http/moodle_spelling_binary_rce.rb
+++ b/modules/exploits/multi/http/moodle_spelling_binary_rce.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2013-3630'],
           ['CVE', '2013-4341'], # XSS
           ['EDB', '28174'], # xss vuln allowing sesskey of admins to be stolen
-          ['URL', 'https://blog.rapid7.com/2013/10/30/seven-tricks-and-treats']
+          ['URL', 'https://www.rapid7.com/blog/post/2013/10/30/seven-tricks-and-treats']
         ],
         'Payload' => {
           'Compat' =>

--- a/modules/exploits/multi/http/nas4free_php_exec.rb
+++ b/modules/exploits/multi/http/nas4free_php_exec.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2013-3631'],
-          ['URL', 'https://blog.rapid7.com/2013/10/30/seven-tricks-and-treats']
+          ['URL', 'https://www.rapid7.com/blog/post/2013/10/30/seven-tricks-and-treats']
         ],
       'Payload'	=>
         {

--- a/modules/exploits/multi/http/openmediavault_cmd_exec.rb
+++ b/modules/exploits/multi/http/openmediavault_cmd_exec.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2013-3632'],
-          ['URL', 'https://blog.rapid7.com/2013/10/30/seven-tricks-and-treats']
+          ['URL', 'https://www.rapid7.com/blog/post/2013/10/30/seven-tricks-and-treats']
         ],
       'Privileged' => true,
       'DefaultOptions' => { 'WfsDelay' => 60 },

--- a/modules/exploits/multi/http/rails_xml_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_xml_yaml_code_exec.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2013-0156' ],
           [ 'OSVDB', '89026' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/01/09/serialization-mischief-in-ruby-land-cve-2013-0156' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/01/09/serialization-mischief-in-ruby-land-cve-2013-0156' ]
         ],
       'Platform'       => 'ruby',
       'Arch'           => ARCH_RUBY,

--- a/modules/exploits/multi/http/vtiger_php_exec.rb
+++ b/modules/exploits/multi/http/vtiger_php_exec.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References' =>
         [
           ['CVE', '2013-3591'],
-          ['URL', 'https://blog.rapid7.com/2013/10/30/seven-tricks-and-treats']
+          ['URL', 'https://www.rapid7.com/blog/post/2013/10/30/seven-tricks-and-treats']
         ],
       'Privileged' => false,
       'Platform'   => ['php'],

--- a/modules/exploits/multi/http/zabbix_script_exec.rb
+++ b/modules/exploits/multi/http/zabbix_script_exec.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2013-3628'],
-          ['URL', 'https://blog.rapid7.com/2013/10/30/seven-tricks-and-treats']
+          ['URL', 'https://www.rapid7.com/blog/post/2013/10/30/seven-tricks-and-treats']
         ],
 
         'Platform' => ['unix', 'linux'],

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References' =>
         [
           [ 'OSVDB', '93537' ],
-          [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
+          [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
         ],
       'DisclosureDate' => 'Mar 26 2013',
       'Platform'       => %w{ unix win },

--- a/modules/exploits/multi/upnp/libupnp_ssdp_overflow.rb
+++ b/modules/exploits/multi/upnp/libupnp_ssdp_overflow.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2012-5958' ],
           [ 'OSVDB', '89611' ],
           [ 'US-CERT-VU', '922681' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/01/29/security-flaws-in-universal-plug-and-play-unplug-dont-play' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/01/29/security-flaws-in-universal-plug-and-play-unplug-dont-play' ]
         ],
       'Platform'       => ['unix'],
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/http/epmp1000_get_chart_cmd_shell.rb
+++ b/modules/exploits/unix/http/epmp1000_get_chart_cmd_shell.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References' =>
         [
           ['CVE', '2017-5255'],
-          ['URL', 'https://blog.rapid7.com/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities']
+          ['URL', 'https://www.rapid7.com/blog/post/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities']
         ],
       'Privileged' => true,
       'Targets' =>

--- a/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
+++ b/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'http://www.cso.com.au/article/523528/joomla_patches_file_manager_vulnerability_responsible_hijacked_websites/' ],
           [ 'URL', 'https://github.com/joomla/joomla-cms/commit/fa5645208eefd70f521cd2e4d53d5378622133d8' ],
           [ 'URL', 'http://niiconsulting.com/checkmate/2013/08/critical-joomla-file-upload-vulnerability/' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/08/15/time-to-patch-joomla' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/08/15/time-to-patch-joomla' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'http://labs.alienvault.com/labs/index.php/2012/cve-2012-1535-adobe-flash-being-exploited-in-the-wild/' ],
           [ 'URL', 'https://developer.apple.com/fonts/TTRefMan/RM06/Chap6.html' ],
           [ 'URL', 'http://contagiodump.blogspot.com.es/2012/08/cve-2012-1535-samples-and-info.html' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/08/17/adobe-flash-player-exploit-cve-2012-1535-now-available-for-metasploit' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/08/17/adobe-flash-player-exploit-cve-2012-1535-now-available-for-metasploit' ],
           [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb12-18.html']
         ],
       'Payload'        =>

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'BID', '53395' ],
           [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb12-09.html'], # Patch info
           [ 'URL', 'http://contagiodump.blogspot.com.es/2012/05/may-3-cve-2012-0779-world-uyghur.html' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/06/22/the-secret-sauce-to-cve-2012-0779-adobe-flash-object-confusion-vulnerability' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/06/22/the-secret-sauce-to-cve-2012-0779-adobe-flash-object-confusion-vulnerability' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/clear_quest_cqole.rb
+++ b/modules/exploits/windows/browser/clear_quest_cqole.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '81443'],
           [ 'ZDI', '12-113' ],
           [ 'URL', 'http://www-304.ibm.com/support/docview.wss?uid=swg21591705' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/07/11/it-isnt-always-about-buffer-overflow' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/07/11/it-isnt-always-about-buffer-overflow' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2013-0108' ],
           [ 'OSVDB', '90583' ],
           [ 'BID', '58134' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/03/11/cve-2013-0108-honeywell-ebi' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/03/11/cve-2013-0108-honeywell-ebi' ],
           [ 'URL', 'http://ics-cert.us-cert.gov/pdf/ICSA-13-053-02.pdf' ]
         ],
         'Payload' => {

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'OSVDB', '76681' ],
           [ 'BID', '50078' ],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-285-01.pdf' ]
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-285-01' ]
         ],
         'Payload' => {
           'Space' => 2048,

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'http://technet.microsoft.com/en-us/security/advisory/2794220' ],
           [ 'URL', 'http://blogs.technet.com/b/srd/archive/2012/12/29/new-vulnerability-affecting-internet-explorer-8-users.aspx' ],
           [ 'URL', 'http://blog.exodusintel.com/2013/01/02/happy-new-year-analysis-of-cve-2012-4792/' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/12/29/microsoft-internet-explorer-0-day-marks-the-end-of-2012' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/12/29/microsoft-internet-explorer-0-day-marks-the-end-of-2012' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'MSB', 'MS13-080' ],
           [ 'URL', 'http://technet.microsoft.com/en-us/security/advisory/2887505' ],
           [ 'URL', 'http://blogs.technet.com/b/srd/archive/2013/09/17/cve-2013-3893-fix-it-workaround-available.aspx' ],
-          [ 'URL', 'https://blog.rapid7.com/2013/09/30/metasploit-releases-cve-2013-3893-ie-setmousecapture-use-after-free' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2013/09/30/metasploit-releases-cve-2013-3893-ie-setmousecapture-use-after-free' ]
         ],
       'Platform'       => 'win',
       'BrowserRequirements' =>

--- a/modules/exploits/windows/browser/ms12_037_same_id.rb
+++ b/modules/exploits/windows/browser/ms12_037_same_id.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '82865'],
           [ 'URL', 'http://labs.alienvault.com/labs/index.php/2012/ongoing-attacks-exploiting-cve-2012-1875/'],
           [ 'URL', 'https://twitter.com/binjo/status/212795802974830592' ], # Exploit found in the wild
-          [ 'URL', 'https://blog.rapid7.com/2012/06/18/metasploit-exploits-critical-microsoft-vulnerabilities']
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/06/18/metasploit-exploits-critical-microsoft-vulnerabilities']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'MSB', 'MS12-043'],
           [ 'URL', 'http://technet.microsoft.com/en-us/security/advisory/2719615' ],
           [ 'URL', 'http://www.zdnet.com/blog/security/state-sponsored-attackers-using-ie-zero-day-to-hijack-gmail-accounts/12462' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/06/18/metasploit-exploits-critical-microsoft-vulnerabilities' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/06/18/metasploit-exploits-critical-microsoft-vulnerabilities' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
+++ b/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '81439' ],
           [ 'URL', 'http://dvlabs.tippingpoint.com/advisory/TPTI-12-05' ],
           [ 'URL', 'http://www.oracle.com/technetwork/topics/security/cpuapr2012-366314.html' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/08/15/the-stack-cookies-bypass-on-cve-2012-0549' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/08/15/the-stack-cookies-bypass-on-cve-2012-0549' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ovftool_format_string.rb
+++ b/modules/exploits/windows/browser/ovftool_format_string.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2012-3569' ],
           [ 'OSVDB', '87117' ],
           [ 'BID', '56468' ],
-          [ 'URL', 'http://www.vmware.com/security/advisories/VMSA-2012-0015.html' ]
+          [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2012-0015.html' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/bacnet_csv.rb
+++ b/modules/exploits/windows/fileformat/bacnet_csv.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-4740' ],
           [ 'OSVDB', '68096'],
           [ 'BID', '43289' ],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-10-264-01.pdf' ],
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-10-264-01' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/fileformat/ms13_071_theme.rb
+++ b/modules/exploits/windows/fileformat/ms13_071_theme.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['MSB', 'MS13-071'],
           ['BID', '62176'],
           ['URL', 'http://www.verisigninc.com/en_US/products-and-services/network-intelligence-availability/idefense/public-vulnerability-reports/articles/index.xhtml?id=1040'],
-          ['URL', 'https://blog.rapid7.com/2013/09/25/change-the-theme-get-a-shell']
+          ['URL', 'https://www.rapid7.com/blog/post/2013/09/25/change-the-theme-get-a-shell']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/ovf_format_string.rb
+++ b/modules/exploits/windows/fileformat/ovf_format_string.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2012-3569' ],
           [ 'OSVDB', '87117' ],
           [ 'BID', '56468' ],
-          [ 'URL', 'http://www.vmware.com/security/advisories/VMSA-2012-0015.html' ]
+          [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2012-0015.html' ]
         ],
       'Payload'        =>
         {
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
 xmlns:cim="http://schemas.dmtf.org/wbem/wscim/1/common"
 xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1"
 xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
-xmlns:vmw="http://www.vmware.com/schema/ovf"
+xmlns:vmw="https://www.vmware.com/schema/ovf"
 xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <References>
@@ -98,7 +98,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   </References>
   <DiskSection>
     <Info>Virtual disk information</Info>
-    <Disk ovf:capacity="8" ovf:capacityAllocationUnits="#{fs}" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" />
+    <Disk ovf:capacity="8" ovf:capacityAllocationUnits="#{fs}" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="https://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" />
   </DiskSection>
   <VirtualSystem ovf:id="Small VM">
     <Info>A virtual machine</Info>

--- a/modules/exploits/windows/fileformat/wireshark_mpeg_overflow.rb
+++ b/modules/exploits/windows/fileformat/wireshark_mpeg_overflow.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Creating '#{datastore['FILENAME']}' file ...")
 
     ropchain = create_rop_chain
-    magic_header = "\xff\xfb\x41"                # mpeg magic_number(MP3) -> http://en.wikipedia.org/wiki/MP3#File_structure
+    magic_header = "\xff\xfb\x41"                # mpeg magic_number(MP3) -> https://en.wikipedia.org/wiki/MP3#File_structure
     # Here we build the packet data
     packet = rand_text_alpha(883)
     packet << "\x6c\x7d\x37\x6c" # NOP RETN

--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2021-22652'],
-          ['URL', 'https://blog.rapid7.com/2021/02/11/cve-2021-22652-advantech-iview-missing-authentication-rce-fixed/'],
+          ['URL', 'https://www.rapid7.com/blog/post/2021/02/11/cve-2021-22652-advantech-iview-missing-authentication-rce-fixed/'],
           ['URL', 'https://us-cert.cisa.gov/ics/advisories/icsa-21-040-02']
         ],
         'DisclosureDate' => '2021-02-09', # ICS-CERT advisory

--- a/modules/exploits/windows/http/hp_sitescope_dns_tool.rb
+++ b/modules/exploits/windows/http/hp_sitescope_dns_tool.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['URL', 'https://blog.rapid7.com/2015/10/09/r7-2015-17-hp-sitescope-dns-tool-command-injection'],
+          ['URL', 'https://www.rapid7.com/blog/post/2015/10/09/r7-2015-17-hp-sitescope-dns-tool-command-injection'],
           ['URL', 'http://www8.hp.com/us/en/software-solutions/sitescope-application-monitoring/index.html'] # vendor site
         ],
       'Platform'       => 'win',

--- a/modules/exploits/windows/http/manageengine_connectionid_write.rb
+++ b/modules/exploits/windows/http/manageengine_connectionid_write.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         => [ 'sinn3r' ],
       'References'     =>
         [
-          [ 'URL', 'https://blog.rapid7.com/2015/12/14/r7-2015-22-manageengine-desktop-central-9-fileuploadservlet-connectionid-vulnerability-cve-2015-8249' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2015/12/14/r7-2015-22-manageengine-desktop-central-9-fileuploadservlet-connectionid-vulnerability-cve-2015-8249' ],
           [ 'CVE', '2015-8249']
         ],
       'Platform'       => 'win',

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Targets' => [ [ 'Windows 7', {} ] ],
         'DefaultTarget' => 0,
         'References' => [
-          [ 'URL', 'http://pauldotcom.com/2011/11/safely-dumping-hashes-from-liv.html' ],
+          [ 'URL', 'https://web.archive.org/web/20201111212952/https://securityweekly.com/2011/11/02/safely-dumping-hashes-from-liv/' ],
           [ 'URL', 'http://www.irongeek.com/i.php?page=videos/hack3rcon2/tim-tomes-and-mark-baggett-lurking-in-the-shadows']
         ],
         'DisclosureDate' => '2011-10-21',

--- a/modules/exploits/windows/misc/hp_dataprotector_new_folder.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_new_folder.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2012-0124' ],
           [ 'OSVDB', '80105' ],
           [ 'BID', '52431' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/07/06/an-example-of-egghunting-to-exploit-cve-2012-0124' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/07/06/an-example-of-egghunting-to-exploit-cve-2012-0124' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/vmhgfs_webdav_dll_sideload.rb
+++ b/modules/exploits/windows/misc/vmhgfs_webdav_dll_sideload.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2016-5330'],
           ['URL', 'https://securify.nl/advisory/SFY20151201/dll_side_loading_vulnerability_in_vmware_host_guest_client_redirector.html'],
-          ['URL', 'http://www.vmware.com/in/security/advisories/VMSA-2016-0010.html'],
+          ['URL', 'https://www.vmware.com/in/security/advisories/VMSA-2016-0010.html'],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
+++ b/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'CVE', '2012-4959'],
           [ 'OSVDB', '87573' ],
-          [ 'URL', 'https://blog.rapid7.com/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959' ]
         ],
         'Payload' => {
           'Space' => 2048,

--- a/modules/exploits/windows/scada/codesys_web_server.rb
+++ b/modules/exploits/windows/scada/codesys_web_server.rb
@@ -32,9 +32,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '77387'],
           [ 'URL', 'http://aluigi.altervista.org/adv/codesys_1-adv.txt' ],
           [ 'EDB', '18187' ],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICS-ALERT-11-336-01A.pdf' ],
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/alerts/ICS-ALERT-11-336-01A' ],
           # The following clearifies why two people are credited for the discovery
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-12-006-01.pdf']
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-12-006-01']
         ],
       'DefaultOptions'  =>
         {

--- a/modules/exploits/windows/scada/daq_factory_bof.rb
+++ b/modules/exploits/windows/scada/daq_factory_bof.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2011-3492'],
           [ 'OSVDB', '75496'],
           [ 'URL', 'http://aluigi.altervista.org/adv/daqfactory_1-adv.txt'],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-264-01.pdf']
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-264-01']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/scada/factorylink_csservice.rb
+++ b/modules/exploits/windows/scada/factorylink_csservice.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['OSVDB', '72812'],
           ['URL', 'http://aluigi.altervista.org/adv/factorylink_1-adv.txt'],
-          ['URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-091-01.pdf']
+          ['URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-091-01']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/scada/factorylink_vrn_09.rb
+++ b/modules/exploits/windows/scada/factorylink_vrn_09.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['OSVDB', '72815'],
           ['URL', 'http://aluigi.altervista.org/adv/factorylink_4-adv.txt'],
-          ['URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-091-01.pdf']
+          ['URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-091-01']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/scada/iconics_genbroker.rb
+++ b/modules/exploits/windows/scada/iconics_genbroker.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['OSVDB', '72817'],
           ['URL', 'http://aluigi.org/adv/genesis_4-adv.txt'],
-          ['URL', 'http://www.us-cert.gov/control_systems/pdf/ICS-ALERT-11-080-02.pdf']
+          ['URL', 'https://www.cisa.gov/uscert/ics/alerts/ICS-ALERT-11-080-02']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/scada/iconics_webhmi_setactivexguid.rb
+++ b/modules/exploits/windows/scada/iconics_webhmi_setactivexguid.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['OSVDB', '72135'],
           ['URL', 'http://www.security-assessment.com/files/documents/advisory/ICONICS_WebHMI.pdf'],
           ['EDB', '17240'],
-          ['URL', 'http://www.us-cert.gov/control_systems/pdf/ICS-ALERT-11-080-02.pdf']
+          ['URL', 'https://www.cisa.gov/uscert/ics/alerts/ICS-ALERT-11-080-02']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/scada/igss9_igssdataserver_listall.rb
+++ b/modules/exploits/windows/scada/igss9_igssdataserver_listall.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2011-1567'],
           ['OSVDB', '72353'],
           ['URL', 'http://aluigi.altervista.org/adv/igss_2-adv.txt'],
-          ['URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-132-01A.pdf']
+          ['URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-132-01A']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/scada/igss9_igssdataserver_rename.rb
+++ b/modules/exploits/windows/scada/igss9_igssdataserver_rename.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2011-1567'],
           ['OSVDB', '72352'],
           ['URL', 'http://aluigi.altervista.org/adv/igss_5-adv.txt'],
-          ['URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-132-01A.pdf']
+          ['URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-132-01A']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/scada/igss9_misc.rb
+++ b/modules/exploits/windows/scada/igss9_misc.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '72349'],
           [ 'URL', 'http://aluigi.altervista.org/adv/igss_1-adv.txt' ],  #Write File packet flaw
           [ 'URL', 'http://aluigi.altervista.org/adv/igss_8-adv.txt' ],  #EXE packet flaw
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-132-01A.pdf']
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-132-01A']
         ],
       'DefaultOptions'  =>
         {

--- a/modules/exploits/windows/scada/moxa_mdmtool.rb
+++ b/modules/exploits/windows/scada/moxa_mdmtool.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-4741'],
           [ 'OSVDB', '69027'],
           [ 'URL', 'http://www.reversemode.com/index.php?option=com_content&task=view&id=70&Itemid=' ],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-10-301-01A.pdf' ]
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-10-301-01A' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/scada/realwin_on_fc_binfile_a.rb
+++ b/modules/exploits/windows/scada/realwin_on_fc_binfile_a.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '72826'],
           [ 'BID', '46937'],
           [ 'URL', 'http://aluigi.altervista.org/adv/realwin_5-adv.txt' ],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-110-01.pdf']
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-110-01']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/scada/realwin_on_fcs_login.rb
+++ b/modules/exploits/windows/scada/realwin_on_fcs_login.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '72824'],
           [ 'URL', 'http://aluigi.altervista.org/adv/realwin_2-adv.txt' ],
           [ 'URL', 'http://www.dataconline.com/software/realwin.php' ],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-110-01.pdf']
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-110-01']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/scada/realwin_scpc_initialize.rb
+++ b/modules/exploits/windows/scada/realwin_scpc_initialize.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '68812' ],
           [ 'CVE', '2010-4142' ],
           [ 'URL', 'http://aluigi.altervista.org/adv/realwin_1-adv.txt' ],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-10-313-01.pdf']
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-10-313-01']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/scada/realwin_scpc_initialize_rf.rb
+++ b/modules/exploits/windows/scada/realwin_scpc_initialize_rf.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '68812' ],
           [ 'CVE', '2010-4142' ],
           [ 'URL', 'http://aluigi.altervista.org/adv/realwin_1-adv.txt' ],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-10-313-01.pdf']
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-10-313-01']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/scada/winlog_runtime.rb
+++ b/modules/exploits/windows/scada/winlog_runtime.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2011-0517' ],
           [ 'OSVDB', '70418'],
           [ 'URL', 'http://aluigi.org/adv/winlog_1-adv.txt' ],
-          [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-017-02.pdf']
+          [ 'URL', 'https://www.cisa.gov/uscert/ics/advisories/ICSA-11-017-02']
         ],
       'Privileged'     => false,
       'DefaultOptions' =>

--- a/modules/exploits/windows/scada/yokogawa_bkbcopyd_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkbcopyd_bof.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'URL', 'http://www.yokogawa.com/dcs/security/ysar/YSAR-14-0001E.pdf' ],
-          [ 'URL', 'https://blog.rapid7.com/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ],
           [ 'CVE', '2014-0784']
         ],
       'Payload'        =>

--- a/modules/exploits/windows/scada/yokogawa_bkesimmgr_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkesimmgr_bof.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2014-0782'],
-          ['URL', 'https://blog.rapid7.com/2014/05/09/r7-2013-192-disclosure-yokogawa-centum-cs-3000-vulnerabilities'],
+          ['URL', 'https://www.rapid7.com/blog/post/2014/05/09/r7-2013-192-disclosure-yokogawa-centum-cs-3000-vulnerabilities'],
           ['URL', 'http://www.yokogawa.com/dcs/security/ysar/YSAR-14-0001E.pdf']
         ],
       'Payload'        =>

--- a/modules/exploits/windows/scada/yokogawa_bkfsim_vhfd.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkfsim_vhfd.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2014-3888'],
           ['URL', 'http://jvn.jp/vu/JVNVU95045914/index.html'],
           ['URL', 'http://www.yokogawa.com/dcs/security/ysar/YSAR-14-0002E.pdf'],
-          ['URL', 'https://blog.rapid7.com/2014/07/07/r7-2014-06-disclosure-yokogawa-centum-cs-3000-bkfsimvhfdexe-buffer-overflow']
+          ['URL', 'https://www.rapid7.com/blog/post/2014/07/07/r7-2014-06-disclosure-yokogawa-centum-cs-3000-bkfsimvhfdexe-buffer-overflow']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/scada/yokogawa_bkhodeq_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkhodeq_bof.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'URL', 'http://www.yokogawa.com/dcs/security/ysar/YSAR-14-0001E.pdf' ],
-          [ 'URL', 'https://blog.rapid7.com/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ],
           [ 'CVE', '2014-0783']
         ],
       'Payload'        =>

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '49736'],
           [ 'MSB', 'MS08-068'],
           [ 'URL', 'http://blogs.technet.com/swi/archive/2008/11/11/smb-credential-reflection.aspx'],
-          [ 'URL', 'http://en.wikipedia.org/wiki/SMBRelay' ],
+          [ 'URL', 'https://en.wikipedia.org/wiki/SMBRelay' ],
           [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
         ],
         'Arch' => [ARCH_X86, ARCH_X64],

--- a/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
@@ -21,7 +21,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
       'References'    => [
-          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit']
         ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'windows',

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
@@ -22,7 +22,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
         'References' => [
-          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit']
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'windows',

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
@@ -22,7 +22,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
         'References' => [
-          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit']
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'windows',

--- a/modules/payloads/singles/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_bind_tcp.rb
@@ -28,7 +28,7 @@ module MetasploitModule
         ],
       'References'    =>
         [
-          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit']
         ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'win',

--- a/modules/payloads/singles/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp.rb
@@ -22,7 +22,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
         'References' => [
-          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit']
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',

--- a/modules/payloads/singles/windows/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp_ssl.rb
@@ -22,7 +22,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
         'References' => [
-          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit']
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',

--- a/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
@@ -27,7 +27,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
         'References' => [
-          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit']
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
@@ -22,7 +22,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
         'References' => [
-          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit']
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp_ssl.rb
@@ -22,7 +22,7 @@ module MetasploitModule
           'Dave Hardy' # davehardy20
         ],
         'References' => [
-          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit/']
+          ['URL', 'https://blog.nettitude.com/uk/interactive-powershell-session-via-metasploit']
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',

--- a/modules/post/windows/gather/forensics/recovery_files.rb
+++ b/modules/post/windows/gather/forensics/recovery_files.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => ['meterpreter'],
         'Author' => ['Borja Merino <bmerinofe[at]gmail.com>'],
         'References' => [
-          [ 'URL', 'http://www.youtube.com/watch?v=9yzCf360ujY&hd=1' ]
+          [ 'URL', 'https://www.youtube.com/watch?v=9yzCf360ujY&hd=1' ]
         ],
         'Compat' => {
           'Meterpreter' => {

--- a/modules/post/windows/manage/pptp_tunnel.rb
+++ b/modules/post/windows/manage/pptp_tunnel.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Post
       'Author'        => 'Borja Merino <bmerinofe[at]gmail.com>',
       'References'    =>
         [
-          [ 'URL', 'http://www.youtube.com/watch?v=vdppEZjMPCM&hd=1' ]
+          [ 'URL', 'https://www.youtube.com/watch?v=vdppEZjMPCM&hd=1' ]
         ],
       'Platform'      => 'win',
       'SessionTypes'  => [ 'meterpreter' ]

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -41,8 +41,8 @@ class MetasploitModule < Msf::Post
         ['REMOVE', 'Description' => 'Remove the backdoor from the target.']
       ],
       'References' => [
-        ['URL', 'https://social.technet.microsoft.com/Forums/windows/en-US/a3968ec9-5824-4bc2-82a2-a37ea88c273a/sticky-keys-exploit'],
-        ['URL', 'http://carnal0wnage.attackresearch.com/2012/04/privilege-escalation-via-sticky-keys.html']
+        ['URL', 'https://web.archive.org/web/20170201184448/https://social.technet.microsoft.com/Forums/windows/en-US/a3968ec9-5824-4bc2-82a2-a37ea88c273a/sticky-keys-exploit'],
+        ['URL', 'https://blog.carnal0wnage.com/2012/04/privilege-escalation-via-sticky-keys.html']
       ],
       'DefaultAction' => 'ADD'
     ))

--- a/modules/post/windows/manage/vss.rb
+++ b/modules/post/windows/manage/vss.rb
@@ -41,6 +41,11 @@ class MetasploitModule < Msf::Post
               stdapi_fs_delete_dir
             ]
           }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [CONFIG_CHANGES, ARTIFACTS_ON_DISK]
         }
       )
     )

--- a/modules/post/windows/manage/vss.rb
+++ b/modules/post/windows/manage/vss.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => ['meterpreter'],
         'Author' => ['theLightCosine'],
         'References' => [
-          [ 'URL', 'http://pauldotcom.com/2011/11/safely-dumping-hashes-from-liv.html' ]
+          [ 'URL', 'https://web.archive.org/web/20201111212952/https://securityweekly.com/2011/11/02/safely-dumping-hashes-from-liv/' ]
         ],
         'Actions' => [
           [ 'VSS_CREATE', { 'Description' => 'Create a new VSS copy' } ],

--- a/tools/modules/module_reference.rb
+++ b/tools/modules/module_reference.rb
@@ -242,7 +242,7 @@ $framework.modules.each do |name, mod|
           new_ctx_val = "#{century}#{year}/#{ctx_val}"
           uri = types[r.ctx_id.upcase].gsub(/\#{in_ctx_val}/, new_ctx_val)
         else
-          uri = types[r.ctx_id.upcase].gsub(/\#{in_ctx_val}/, r.ctx_val)
+          uri = types[r.ctx_id.upcase].gsub(/\#{in_ctx_val}/, r.ctx_val.to_s)
         end
 
         if is_url_alive?(uri, http_timeout, is_url_alive_cache)

--- a/tools/modules/module_reference.rb
+++ b/tools/modules/module_reference.rb
@@ -10,9 +10,7 @@
 #
 
 msfbase = __FILE__
-while File.symlink?(msfbase)
-  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
-end
+msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase)) while File.symlink?(msfbase)
 
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
 require 'msfenv'
@@ -22,79 +20,80 @@ $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 require 'rex'
 require 'uri'
 
-
 # See lib/msf/core/module/reference.rb
 # We gsub '#{in_ctx_val}' with the actual value
 def types
   {
-    'ALL'         => '',
-    'CVE'         => 'https://nvd.nist.gov/vuln/detail/CVE-#{in_ctx_val}',
-    'CWE'         => 'http://cwe.mitre.org/data/definitions/#{in_ctx_val}.html',
-    'BID'         => 'http://www.securityfocus.com/bid/#{in_ctx_val}',
-    'MSB'         => 'http://technet.microsoft.com/en-us/security/bulletin/#{in_ctx_val}',
-    'EDB'         => 'http://www.exploit-db.com/exploits/#{in_ctx_val}',
-    'US-CERT-VU'  => 'http://www.kb.cert.org/vuls/id/#{in_ctx_val}',
-    'ZDI'         => 'http://www.zerodayinitiative.com/advisories/ZDI-#{in_ctx_val}',
-    'WPVDB'       => 'https://wpscan.com/vulnerability/#{in_ctx_val}',
+    'ALL' => '',
+    'CVE' => 'https://nvd.nist.gov/vuln/detail/CVE-#{in_ctx_val}',
+    'CWE' => 'http://cwe.mitre.org/data/definitions/#{in_ctx_val}.html',
+    'BID' => 'http://www.securityfocus.com/bid/#{in_ctx_val}',
+    'MSB' => 'https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/#{in_ctx_val}',
+    'EDB' => 'http://www.exploit-db.com/exploits/#{in_ctx_val}',
+    'US-CERT-VU' => 'http://www.kb.cert.org/vuls/id/#{in_ctx_val}',
+    'ZDI' => 'http://www.zerodayinitiative.com/advisories/ZDI-#{in_ctx_val}',
+    'WPVDB' => 'https://wpscan.com/vulnerability/#{in_ctx_val}',
     'PACKETSTORM' => 'https://packetstormsecurity.com/files/#{in_ctx_val}',
-    'URL'         => '#{in_ctx_val}'
+    'URL' => '#{in_ctx_val}'
   }
 end
 
-STATUS_ALIVE       = 'Alive'
-STATUS_DOWN        = 'Down'
+STATUS_ALIVE = 'Alive'
+STATUS_DOWN = 'Down'
 STATUS_UNSUPPORTED = 'Unsupported'
 
-sort         = 0
-filter       = 'All'
-filters      = ['all','exploit','payload','post','nop','encoder','auxiliary']
-type         ='ALL'
-match        = nil
-check        = false
-save         = nil
+sort = 0
+filter = 'All'
+filters = ['all', 'exploit', 'payload', 'post', 'nop', 'encoder', 'auxiliary']
+type = 'ALL'
+match = nil
+check = false
+save = nil
+is_url_alive_cache = {}
 http_timeout = 20
-$verbose     = false
+$verbose = false
 
 opts = Rex::Parser::Arguments.new(
-  "-h" => [ false, "Help menu." ],
-  "-c" => [ false, "Check reference status"],
-  "-s" => [ false, "Sort by Reference instead of Module Type."],
-  "-r" => [ false, "Reverse Sort"],
-  "-f" => [ true, "Filter based on Module Type [All,Exploit,Payload,Post,NOP,Encoder,Auxiliary] (Default = ALL)."],
-  "-t" => [ true, "Type of Reference to sort by #{types.keys}"],
-  "-x" => [ true, "String or RegEx to try and match against the Reference Field"],
-  "-o" => [ true, "Save the results to a file"],
-  "-i" => [ true, "Set an HTTP timeout"],
-  "-v" => [ false, "Verbose"]
+  '-h' => [ false, 'Help menu.' ],
+  '-c' => [ false, 'Check Reference status'],
+  '-s' => [ false, 'Sort by Reference instead of Module Type.'],
+  '-r' => [ false, 'Reverse Sort'],
+  '-f' => [ true, 'Filter based on Module Type [All,Exploit,Payload,Post,NOP,Encoder,Auxiliary] (Default = ALL).'],
+  '-t' => [ true, "Type of Reference to sort by #{types.keys}"],
+  '-x' => [ true, 'String or RegEx to try and match against the Reference Field'],
+  '-o' => [ true, 'Save the results to a file'],
+  '--csv' => [ false, 'Save the results file in CSV format'],
+  '-i' => [ true, 'Set an HTTP timeout'],
+  '-v' => [ false, 'Verbose']
 )
 
 flags = []
 
-opts.parse(ARGV) { |opt, idx, val|
+opts.parse(ARGV) do |opt, _idx, val|
   case opt
-  when "-h"
+  when '-h'
     puts "\nMetasploit Script for Displaying Module Reference information."
-    puts "=========================================================="
+    puts '=========================================================='
     puts opts.usage
     exit
-  when "-c"
-    flags << "URI Check: Yes"
+  when '-c'
+    flags << 'URI Check: Yes'
     check = true
-  when "-s"
-    flags << "Order: Sorting by License"
+  when '-s'
+    flags << 'Order: Sorting by Reference'
     sort = 1
-  when "-r"
-    flags << "Order: Reverse Sorting"
+  when '-r'
+    flags << 'Order: Reverse Sorting'
     sort = 2
-  when "-f"
+  when '-f'
     unless filters.include?(val.downcase)
       puts "Invalid Filter Supplied: #{val}"
-      puts "Please use one of these: #{filters.map{|f|f.capitalize}.join(", ")}"
+      puts "Please use one of these: #{filters.map { |f| f.capitalize }.join(', ')}"
       exit
     end
     flags << "Module Filter: #{val}"
     filter = val
-  when "-t"
+  when '-t'
     val = (val || '').upcase
     unless types.has_key?(val)
       puts "Invalid Type Supplied: #{val}"
@@ -102,36 +101,47 @@ opts.parse(ARGV) { |opt, idx, val|
       exit
     end
     type = val
-  when "-i"
+  when '-i'
     http_timeout = /^\d+/ === val ? val.to_i : 20
-  when "-v"
+  when '-v'
     $verbose = true
-  when "-x"
+  when '-x'
     flags << "Regex: #{val}"
     match = Regexp.new(val)
-  when "-o"
-    flags << "Output to file: Yes"
+  when '-o'
+    flags << 'Output to file: Yes'
     save = val
+  when '--csv'
+    flags << 'Output as CSV'
+    $csv = true
   end
-}
+end
+
+if $csv && save.nil?
+  abort('Error: -o flag required when using CSV output')
+end
 
 flags << "Type: #{type}"
 
-puts flags * " | "
+puts flags * ' | '
 
 def get_ipv4_addr(hostname)
-  Rex::Socket::getaddresses(hostname, false)[0]
+  Rex::Socket.getaddresses(hostname, false)[0]
 end
 
-def vprint_debug(msg='')
+def vprint_debug(msg = '')
   print_debug(msg) if $verbose
 end
 
-def print_debug(msg='')
-  $stderr.puts "[*] #{msg}"
+def print_debug(msg = '')
+  warn "[*] #{msg}"
 end
 
-def is_url_alive?(uri, http_timeout)
+def is_url_alive?(uri, http_timeout, cache)
+  if cache.key? uri.to_s
+    print_debug("Cached: #{uri} -> #{cache[uri]}")
+    return cache[uri.to_s]
+  end
   print_debug("Checking: #{uri}")
 
   begin
@@ -143,44 +153,45 @@ def is_url_alive?(uri, http_timeout)
   end
 
   rport = uri.port || 80
-  path  = uri.path.blank? ? '/' : uri.path
+  path = uri.path.blank? ? '/' : uri.path
   vhost = rport == 80 ? uri.host : "#{uri.host}:#{rport}"
   if uri.scheme == 'https'
-    cli = ::Rex::Proto::Http::Client.new(rhost, 443, {}, true, 'TLS1')
+    cli = ::Rex::Proto::Http::Client.new(rhost, 443, {}, true)
   else
     cli = ::Rex::Proto::Http::Client.new(rhost, rport)
   end
 
   begin
     cli.connect(http_timeout)
-    req = cli.request_raw('uri'=>path, 'vhost'=>vhost)
+    req = cli.request_raw('uri' => path, 'vhost' => vhost)
     res = cli.send_recv(req, http_timeout)
-  rescue Errno::ECONNRESET, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::UnsupportedProtocol, ::Timeout::Error, Errno::ETIMEDOUT => e
+  rescue Errno::ECONNRESET, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::UnsupportedProtocol, ::Timeout::Error, Errno::ETIMEDOUT, ::Exception => e
     vprint_debug("#{e.message} for #{uri}")
+    cache[uri.to_s] = false
     return false
   ensure
     cli.close
   end
 
-  if res.nil? || res.code == 404 || res.body =~ /<title>.*not found<\/title>/i
+  if res.nil? || res.body =~ %r{<title>.*not found</title>}i || res.code != 200
     vprint_debug("URI returned a not-found response: #{uri}")
+    cache[uri.to_s] = false
     return false
   end
 
   vprint_debug("Good: #{uri}")
 
+  cache[uri.to_s] = true
   true
 end
 
 def save_results(path, results)
-  begin
-    File.open(path, 'wb') do |f|
-      f.write(results)
-    end
-    puts "Results saved to: #{path}"
-  rescue Exception => e
-    puts "Failed to save the file: #{e.message}"
+  File.open(path, 'wb') do |f|
+    f.write(results)
   end
+  puts "Results saved to: #{path}"
+rescue Exception => e
+  puts "Failed to save the file: #{e.message}"
 end
 
 # Always disable the database (we never need it just to list module
@@ -202,56 +213,60 @@ else
 end
 
 tbl = Rex::Text::Table.new(
-  'Header'  => 'Module References',
-  'Indent'  => 2,
+  'Header' => 'Module References',
+  'Indent' => 2,
   'Columns' => columns
 )
 
-bad_refs_count  = 0
+bad_refs_count = 0
 
-$framework.modules.each { |name, mod|
+$framework.modules.each do |name, mod|
   if mod.nil?
     elog("module_reference.rb is unable to load #{name}")
     next
   end
 
-  next if match and not name =~ match
+  next if match and !(name =~ match)
 
   x = mod.new
   x.references.each do |r|
     ctx_id = r.ctx_id.upcase
-    if type == 'ALL' || type == ctx_id
+    next unless type == 'ALL' || type == ctx_id
 
-      if check
-        if types.has_key?(ctx_id)
-          uri = types[r.ctx_id.upcase].gsub(/\#{in_ctx_val}/, r.ctx_val)
-          if is_url_alive?(uri, http_timeout)
-            status = STATUS_ALIVE
-          else
-            bad_refs_count += 1
-            status = STATUS_DOWN
-          end
-        else
-          # The reference ID isn't supported so we don't know how to check this
-          bad_refs_count += 1
-          status = STATUS_UNSUPPORTED
+    if check
+      if types.has_key?(ctx_id)
+        if ctx_id == 'MSB'
+          year = in_ctx_val[2..3]
+          century = year[0] == '9' ? '19' : '20'
+          in_ctx_val = "#{century}#{year}/#{in_ctx_val}"
         end
-      end
+        uri = types[r.ctx_id.upcase].gsub(/\#{in_ctx_val}/, r.ctx_val)
 
-      ref = "#{r.ctx_id}-#{r.ctx_val}"
-      new_column = []
-      new_column << x.fullname
-      new_column << status if check
-      new_column << ref
-      tbl << new_column
+        if is_url_alive?(uri, http_timeout, is_url_alive_cache)
+          status = STATUS_ALIVE
+        else
+          bad_refs_count += 1
+          status = STATUS_DOWN
+        end
+      else
+        # The reference ID isn't supported so we don't know how to check this
+        bad_refs_count += 1
+        status = STATUS_UNSUPPORTED
+      end
     end
+
+    ref = "#{r.ctx_id}-#{r.ctx_val}"
+    new_column = []
+    new_column << x.fullname
+    new_column << status if check
+    new_column << ref
+    tbl << new_column
   end
-}
+end
 
 if sort == 1
   tbl.sort_rows(1)
 end
-
 
 if sort == 2
   tbl.sort_rows(1)
@@ -263,4 +278,4 @@ puts tbl.to_s
 puts
 
 puts "Number of bad references found: #{bad_refs_count}" if check
-save_results(save, tbl.to_s) if save
+save_results(save, $csv.nil? ? tbl.to_s : tbl.to_csv) if save

--- a/tools/modules/module_reference.rb
+++ b/tools/modules/module_reference.rb
@@ -231,16 +231,19 @@ $framework.modules.each do |name, mod|
   x = mod.new
   x.references.each do |r|
     ctx_id = r.ctx_id.upcase
+    ctx_val = r.ctx_val
     next unless type == 'ALL' || type == ctx_id
 
     if check
       if types.has_key?(ctx_id)
         if ctx_id == 'MSB'
-          year = in_ctx_val[2..3]
+          year = ctx_val[2..3]
           century = year[0] == '9' ? '19' : '20'
-          in_ctx_val = "#{century}#{year}/#{in_ctx_val}"
+          new_ctx_val = "#{century}#{year}/#{ctx_val}"
+          uri = types[r.ctx_id.upcase].gsub(/\#{in_ctx_val}/, new_ctx_val)
+        else
+          uri = types[r.ctx_id.upcase].gsub(/\#{in_ctx_val}/, r.ctx_val)
         end
-        uri = types[r.ctx_id.upcase].gsub(/\#{in_ctx_val}/, r.ctx_val)
 
         if is_url_alive?(uri, http_timeout, is_url_alive_cache)
           status = STATUS_ALIVE


### PR DESCRIPTION
fixes #4039 

Updated `tools/modules/module_reference.rb` with a rubocop run, removed the SSL version reference to use the default. Made it so 300s now mark as down, and a CSV export.

This gave ~2600 URLs with issues (some seem to work and were false positives).

Mainly just either putting in the new URLs (if it forwards), looking for the real URL via google search, or worst case going with wayback machine references.  If all those cases fail, I just leave it as is.