### PR TITLE
Fix msfdb init command failure in systems that use the 'pg_ctl.rb' msfdb_helper

### DIFF
--- a/lib/msfdb_helpers/db_interface.rb
+++ b/lib/msfdb_helpers/db_interface.rb
@@ -64,8 +64,9 @@ module MsfdbHelpers
       if @options[:debug]
         puts "psql -h #{Dir.tmpdir} -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
       end
-      
+
       run_cmd("psql -h #{Dir.tmpdir} -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
     end
+
   end
 end

--- a/lib/msfdb_helpers/db_interface.rb
+++ b/lib/msfdb_helpers/db_interface.rb
@@ -62,10 +62,10 @@ module MsfdbHelpers
 
     def run_psql(cmd, db_name: 'postgres')
       if @options[:debug]
-        puts "psql -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
+        puts "psql -h \'#{@options[:unix_socket_directories]}\' -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
       end
 
-      run_cmd("psql -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
+      run_cmd("psql -h \'#{@options[:unix_socket_directories]}\' -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
     end
 
   end

--- a/lib/msfdb_helpers/db_interface.rb
+++ b/lib/msfdb_helpers/db_interface.rb
@@ -61,21 +61,11 @@ module MsfdbHelpers
     end
 
     def run_psql(cmd, db_name: 'postgres')
-      socket_directory_regex = "#unix_socket_directories = '\/run\/postgresql'"
       if @options[:debug]
-        if File.read("#{@db}/postgresql.conf").include?(socket_directory_regex)
-          puts "psql -h \'#{@options[:unix_socket_directories]}\' -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
-        else
-          puts "psql -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
-        end
+        puts "psql -h #{Dir.tmpdir} -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
       end
-
-      if File.read("#{@db}/postgresql.conf").include?(socket_directory_regex)
-        run_cmd("psql -h \'#{@options[:unix_socket_directories]}\' -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
-      else
-        run_cmd("psql -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
-      end
+      
+      run_cmd("psql -h #{Dir.tmpdir} -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
     end
-
   end
 end

--- a/lib/msfdb_helpers/db_interface.rb
+++ b/lib/msfdb_helpers/db_interface.rb
@@ -61,11 +61,20 @@ module MsfdbHelpers
     end
 
     def run_psql(cmd, db_name: 'postgres')
+      socket_directory_regex = "#unix_socket_directories = '\/run\/postgresql'"
       if @options[:debug]
-        puts "psql -h \'#{@options[:unix_socket_directories]}\' -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
+        if File.read("#{@db}/postgresql.conf").include?(socket_directory_regex)
+          puts "psql -h \'#{@options[:unix_socket_directories]}\' -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
+        else
+          puts "psql -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
+        end
       end
 
-      run_cmd("psql -h \'#{@options[:unix_socket_directories]}\' -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
+      if File.read("#{@db}/postgresql.conf").include?(socket_directory_regex)
+        run_cmd("psql -h \'#{@options[:unix_socket_directories]}\' -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
+      else
+        run_cmd("psql -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
+      end
     end
 
   end

--- a/lib/msfdb_helpers/db_interface.rb
+++ b/lib/msfdb_helpers/db_interface.rb
@@ -60,12 +60,12 @@ module MsfdbHelpers
       status.exitstatus
     end
 
-    def run_psql(cmd, db_name: 'postgres')
+    def run_psql(cmd, socket_directory= "#{Dir.tmpdir}", db_name: 'postgres')
       if @options[:debug]
-        puts "psql -h #{Dir.tmpdir} -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
+        puts "psql -h #{socket_directory} -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}"
       end
 
-      run_cmd("psql -h #{Dir.tmpdir} -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
+      run_cmd("psql -h #{socket_directory} -p #{@options[:db_port]} -c \"#{cmd};\" #{db_name}")
     end
 
   end

--- a/lib/msfdb_helpers/pg_ctl.rb
+++ b/lib/msfdb_helpers/pg_ctl.rb
@@ -15,7 +15,7 @@ module MsfdbHelpers
       puts "Creating database at #{@db}"
       Dir.mkdir(@db)
       run_cmd("initdb --auth-host=trust --auth-local=trust -E UTF8 #{@db.shellescape}")
-      
+
       File.open("#{@db}/postgresql.conf", 'a') do |f|
         f.puts "port = #{@options[:db_port]}"
         f.puts "unix_socket_directories = \'#{Dir.tmpdir}\'"

--- a/lib/msfdb_helpers/pg_ctl.rb
+++ b/lib/msfdb_helpers/pg_ctl.rb
@@ -18,6 +18,7 @@ module MsfdbHelpers
 
       File.open("#{@db}/postgresql.conf", 'a') do |f|
         f.puts "port = #{@options[:db_port]}"
+        f.puts "unix_socket_directories = '/tmp'"
       end
 
       start

--- a/lib/msfdb_helpers/pg_ctl.rb
+++ b/lib/msfdb_helpers/pg_ctl.rb
@@ -15,17 +15,10 @@ module MsfdbHelpers
       puts "Creating database at #{@db}"
       Dir.mkdir(@db)
       run_cmd("initdb --auth-host=trust --auth-local=trust -E UTF8 #{@db.shellescape}")
-
-      socket_directory_regex = "#unix_socket_directories = '\/run\/postgresql'"
-      if File.read("#{@db}/postgresql.conf").include?(socket_directory_regex)
-        File.open("#{@db}/postgresql.conf", 'a') do |f|
-          f.puts "port = #{@options[:db_port]}"
-          f.puts "unix_socket_directories = \'#{@options[:unix_socket_directories]}\'"
-        end
-      else
-        File.open("#{@db}/postgresql.conf", 'a') do |f|
-          f.puts "port = #{@options[:db_port]}"
-        end
+      
+      File.open("#{@db}/postgresql.conf", 'a') do |f|
+        f.puts "port = #{@options[:db_port]}"
+        f.puts "unix_socket_directories = \'#{Dir.tmpdir}\'"
       end
 
       start

--- a/lib/msfdb_helpers/pg_ctl.rb
+++ b/lib/msfdb_helpers/pg_ctl.rb
@@ -18,7 +18,7 @@ module MsfdbHelpers
 
       File.open("#{@db}/postgresql.conf", 'a') do |f|
         f.puts "port = #{@options[:db_port]}"
-        f.puts "unix_socket_directories = '/tmp'"
+        f.puts "unix_socket_directories = \'#{@options[:unix_socket_directories]}\'"
       end
 
       start

--- a/lib/msfdb_helpers/pg_ctl.rb
+++ b/lib/msfdb_helpers/pg_ctl.rb
@@ -18,7 +18,11 @@ module MsfdbHelpers
 
       File.open("#{@db}/postgresql.conf", 'a') do |f|
         f.puts "port = #{@options[:db_port]}"
-        f.puts "unix_socket_directories = \'#{Dir.tmpdir}\'"
+        if system("mount | grep #{Dir.tmpdir}.*noexec")
+          print_error("Temporary Directory is mounted with NOEXEC flags. Try running sudo msfdb init, if initialization fails")
+        else
+          f.puts "unix_socket_directories = \'#{Dir.tmpdir}\'"
+        end
       end
 
       start

--- a/lib/msfdb_helpers/pg_ctl.rb
+++ b/lib/msfdb_helpers/pg_ctl.rb
@@ -16,9 +16,16 @@ module MsfdbHelpers
       Dir.mkdir(@db)
       run_cmd("initdb --auth-host=trust --auth-local=trust -E UTF8 #{@db.shellescape}")
 
-      File.open("#{@db}/postgresql.conf", 'a') do |f|
-        f.puts "port = #{@options[:db_port]}"
-        f.puts "unix_socket_directories = \'#{@options[:unix_socket_directories]}\'"
+      socket_directory_regex = "#unix_socket_directories = '\/run\/postgresql'"
+      if File.read("#{@db}/postgresql.conf").include?(socket_directory_regex)
+        File.open("#{@db}/postgresql.conf", 'a') do |f|
+          f.puts "port = #{@options[:db_port]}"
+          f.puts "unix_socket_directories = \'#{@options[:unix_socket_directories]}\'"
+        end
+      else
+        File.open("#{@db}/postgresql.conf", 'a') do |f|
+          f.puts "port = #{@options[:db_port]}"
+        end
       end
 
       start

--- a/lib/msfdb_helpers/pg_ctl.rb
+++ b/lib/msfdb_helpers/pg_ctl.rb
@@ -29,7 +29,7 @@ module MsfdbHelpers
       elsif test_executable_file("#{@db}")
         @socket_directory = @db
       else
-        print_error("Attempt to create DB socket file at Temporary Directory and `~/.msf4/db` failed. Possibly because they are mounted with NOEXEC Flags. Database initialization failed.")
+        print_error("Attempt to create DB socket file at Temporary Directory and `~/.msf4/db` failed. Possibly because they are mounted with NOEXEC flags. Database initialization failed.")
       end
  
       start

--- a/msfdb
+++ b/msfdb
@@ -205,6 +205,7 @@ def init_db
   Dir.chdir(@framework) do
     @db_driver.run_cmd('bundle exec rake db:migrate')
   end
+  puts 'Database initialization successful'.green.bold.to_s
 end
 
 def load_db_config

--- a/msfdb
+++ b/msfdb
@@ -67,7 +67,6 @@ require 'msfenv'
     db_host: '127.0.0.1',
     db_port: 5433,
     db_pool: 200,
-    unix_socket_directories: '/tmp',
     address: 'localhost',
     port: 5443,
     daemon: true,

--- a/msfdb
+++ b/msfdb
@@ -67,6 +67,7 @@ require 'msfenv'
     db_host: '127.0.0.1',
     db_port: 5433,
     db_pool: 200,
+    unix_socket_directories: '/tmp',
     address: 'localhost',
     port: 5443,
     daemon: true,


### PR DESCRIPTION
This PR fixes #16086   
  
## Cause of bug  
The cause of this issue is because of the default path of `unix_socket_directories` in the `postgresql.conf` file. The default path is set to `/run/postgresql`, and this is where the pg tries to create the socket file for starting the server. But the current user who runs `./msfdb init` (and not `sudo ./msfdb init`) does not have the privileges to access the `/run` directory. Hence, the socket file is not created and the server start up fails.  
  
## Approach  
There were two approaches to solve this issue. One was to run the commands as the super user, by changing the internal commands from `pg_ctl -D -l start` to `sudo pg_ctl -D -l start`. This way, the super user could access the `/run/postgresql` directory and the socket could be created.  
  
However, the other and the better approach was to change the location of `unix_socket_directories` from `/run/postgresql` to `/tmp`. This way, the normal user can create the socket files and make the server started. So, I created an additional parameter `@options[:unix_socket_directories]` in the msfdb file which would contain the new socket path along with other db confs. and appended this updated directory path (along with the updated port 5433) in the `postgresql.conf` file. The `db_interface.rb` file was also updated, where I added the `-h '/tmp'` argument in the `psql` commands to specify it the updated socket directory.  
  
This worked pretty well in linux but failed in windows. This was because there is no `/tmp` location in windows. So, to solve this, I first checked in the `postgresql.conf` file, that whether the default location is set to `/run/postgresql` or `''` (for windows), using a regex. Only in the case of a regex match, the `pg_ctl.rb` file appends both updated path as well as updated port to the `postgresql.conf` file, else it only appends the updated port. This seems to work well in both systems now!  
  
## Before  
```
./msfdb init
[?] Would you like to init the webservice? (Not Required) [no]: no
Clearing http web data service credentials in msfconsole
Running the 'init' command for the database:
Creating database at /home/beleswar/.msf4/db
Starting database at /home/beleswar/.msf4/db...failed
Creating database users
/home/beleswar/.local/share/gem/ruby/3.0.0/gems/pg-1.2.3/lib/pg.rb:58:in `initialize': could not connect to server: Connection refused (PG::ConnectionBad)
	Is the server running on host "127.0.0.1" and accepting
	TCP/IP connections on port 5433?  
```  
```
./msfdb init
[?] Would you like to init the webservice? (Not Required) [no]: no
Clearing http web data service credentials in msfconsole
Running the 'init' command for the database:
Creating database at /home/beleswar/.msf4/db
Starting database at /home/beleswar/.msf4/db...success
Creating database users
/home/beleswar/.local/share/gem/ruby/3.0.0/gems/pg-1.2.3/lib/pg.rb:58:in `initialize': FATAL:  role "msf" does not exist (PG::ConnectionBad)  
```  
  
## After  
```  
[beleswar@Som metasploit-framework]$ ./msfdb init
[?] Would you like to init the webservice? (Not Required) [no]: no
Clearing http web data service credentials in msfconsole
Running the 'init' command for the database:
Creating database at /home/beleswar/.msf4/db
Starting database at /home/beleswar/.msf4/db...success
Creating database users
Writing client authentication configuration file /home/beleswar/.msf4/db/pg_hba.conf
Stopping database at /home/beleswar/.msf4/db
Starting database at /home/beleswar/.msf4/db...success
Creating initial database schema
```  

## Verification

- [ ] git clone the msf repository in a linux system and setup the environment (bundle install)
- [ ] cd metasploit-framework, change into installed directory
- [ ] Replace the original `msfdb`, `lib/msfdb_helpers/pg_ctl.rb`, `lib/msfdb_helpers/db_interface.rb` files with the files in this PR.
- [ ] run ./msfdb init
- [ ] Type no for init webservices, as its not necessary
- [ ] **Verify** that the script succeeds in initializing the database without any error.
- [ ] **Verify** that the script does not fail with an error message. 
  
## Note  
The above changes are also tested in windows environment. The server startup failure was already present in windows environment.  
Log:  
```  
C:\Users\IEUser>msfdb init
C:/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/zeitwerk-2.5.3/lib/zeitwerk/kernel.rb:35: warning: Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead
[?] Would you like to init the webservice? (Not Required) [no]: no
Clearing http web data service credentials in msfconsole
Running the 'init' command for the database:
Creating database at C:/Users/IEUser/.msf4/db
Starting database at C:/Users/IEUser/.msf4/db...failed
Creating database users
Writing client authentication configuration file C:/Users/IEUser/.msf4/db/pg_hba.conf
Database is no longer running at C:/Users/IEUser/.msf4/db
Starting database at C:/Users/IEUser/.msf4/db...failed
Creating initial database schema  
```
