### PR TITLE
Bump metasploit-payloads to 2.0.69

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.66)
+      metasploit-payloads (= 2.0.69)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.17)
       mqtt
@@ -261,7 +261,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.66)
+    metasploit-payloads (2.0.69)
     metasploit_data_models (5.0.4)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -79,7 +79,7 @@ metasploit-concern, 4.0.3, "New BSD"
 metasploit-credential, 5.0.5, "New BSD"
 metasploit-framework, 6.1.27, "New BSD"
 metasploit-model, 4.0.3, "New BSD"
-metasploit-payloads, 2.0.66, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.69, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 5.0.4, "New BSD"
 metasploit_payloads-mettle, 1.0.17, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.66'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.69'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.17'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Contains these PRs from payloads:

- https://github.com/rapid7/metasploit-payloads/pull/519
- https://github.com/rapid7/metasploit-payloads/pull/521
- https://github.com/rapid7/metasploit-payloads/pull/522

