### PR TITLE
Support session -1 for ListenerComm options

### DIFF
--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -200,6 +200,8 @@ module Msf::Sessions
         }
       end
 
+      attr_reader :client
+
       protected
 
       def _accept

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -152,8 +152,8 @@ protected
     case srv_comm
     when 'local'
       comm = ::Rex::Socket::Comm::Local
-    when /\A[0-9]+\Z/
-      comm = framework.sessions[srv_comm.to_i]
+    when /\A-?[0-9]+\Z/
+      comm = framework.sessions.get(srv_comm.to_i)
       raise(RuntimeError, "Socket Server Comm (Session #{srv_comm}) does not exist") unless comm
       raise(RuntimeError, "Socket Server Comm (Session #{srv_comm}) does not implement Rex::Socket::Comm") unless comm.is_a? ::Rex::Socket::Comm
     when nil, ''

--- a/lib/msf/core/handler/reverse/comm.rb
+++ b/lib/msf/core/handler/reverse/comm.rb
@@ -26,8 +26,8 @@ module Comm
     case rl_comm
     when 'local'
       comm = ::Rex::Socket::Comm::Local
-    when /\A[0-9]+\Z/
-      comm = framework.sessions[rl_comm.to_i]
+    when /\A-?[0-9]+\Z/
+      comm = framework.sessions.get(rl_comm.to_i)
       raise(RuntimeError, "Reverse Listener Comm (Session #{rl_comm}) does not exist") unless comm
       raise(RuntimeError, "Reverse Listener Comm (Session #{rl_comm}) does not implement Rex::Socket::Comm") unless comm.is_a? ::Rex::Socket::Comm
     when nil, ''


### PR DESCRIPTION
This updates the implementation for the `ReverseListenerComm` and `ListenerComm` datastore options to support the -1 session like the `SESSION` datastore option does. This allows the user to refer to the most recently created session without having to either remember what it was or change it when a new session is created.

## Verification

- [x] Start `msfconsole`
- [x] Open a Meterpreter session
- [x] Test the `ReverseListenerComm` datastore option
    - [x] Use a reverse-something payload module like `payload/python/meterpreter/reverse_tcp`
    - [x] Set the `ReverseListenerComm` option to -1
    - [x] Run `to_handler` and see that the port from the LPORT option is now bound and listening on the remote host (use netstat in meterpreter or from the console)
- [ ] Test the `ListenerComm` datastore option
    - [ ] Use a socket server module that uses the option like `auxiliary/server/capture/http`
    - [ ] Set the `ListenerComm` option to -1
    - [ ] Run the module and see that port from the SRVPORT option is now bound and listening on the remote host (use netstat in meterpreter or from the console)
