### PR TITLE
Bump rex-core to 0.1.25

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,7 +355,7 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.20)
+    rex-core (0.1.25)
     rex-encoder (0.1.6)
       metasm
       rex-arch

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -129,7 +129,7 @@ regexp_parser, 2.2.0, MIT
 reline, 0.2.5, ruby
 rex-arch, 0.1.14, "New BSD"
 rex-bin_tools, 0.1.8, "New BSD"
-rex-core, 0.1.20, "New BSD"
+rex-core, 0.1.25, "New BSD"
 rex-encoder, 0.1.6, "New BSD"
 rex-exploitation, 0.1.28, "New BSD"
 rex-java, 0.1.6, "New BSD"


### PR DESCRIPTION
This bumps rex-core to 0.1.25 to pull in the bug fixes from rapid7/rex-core#20 which intends to fix #15968.
