### PR TITLE
windows/gather/enum_domains: Return early if no domains are found

### DIFF
--- a/modules/post/windows/gather/enum_domains.rb
+++ b/modules/post/windows/gather/enum_domains.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Post
 
   def run
     domains = net_server_enum(SV_TYPE_DOMAIN_ENUM)
+    return if domains.nil?
 
     domains.each do |domain|
       print_status("Enumerating DCs for #{domain[:name]}")


### PR DESCRIPTION
Fixes #15541.

# Before:

```
msf6 post(windows/gather/enum_domains) > rexploit 
[*] Reloading module...

[-] ERROR_NO_BROWSER_SERVERS_FOUND
[-] Post failed: NoMethodError undefined method `each' for nil:NilClass
[-] Call stack:
[-]   /root/Desktop/metasploit-framework/modules/post/windows/gather/enum_domains.rb:27:in `run'
[*] Post module execution completed
```

# After:

```
msf6 post(windows/gather/enum_domains) > rexploit 
[*] Reloading module...

[-] ERROR_NO_BROWSER_SERVERS_FOUND
[*] Post module execution completed
```
