### PR TITLE
Bump i18n dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
       domain_name (~> 0.5)
     http_parser.rb (0.8.0)
     httpclient (2.8.3)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
     irb (1.3.6)


### PR DESCRIPTION
Fixes the following bundle install issue:
```
$ bundle
Fetching gem metadata from https://rubygems.org/
Fetching gem metadata from https://rubygems.org/.........
Your bundle is locked to i18n (1.9.0) from rubygems repository https://rubygems.org/ or installed locally, but that version can no longer be found in that source. That means the author of i18n (1.9.0) has removed it. You'll need to update your bundle to a version other than i18n (1.9.0) that hasn't been removed in order to install.
```

## Verification

CI / local bundle installs should now work