### PR TITLE
[WIP] Add a custom http bruteforce module utilizing POST method to bypass DVWA login page

### DIFF
--- a/data/wordlists/http_default_userpass.txt
+++ b/data/wordlists/http_default_userpass.txt
@@ -1,9 +1,7 @@
-admin password
 connect connect
 sitecom sitecom
 admin 1234
 cisco cisco
-admin password
 cisco sanfran
 private private
 wampp xampp

--- a/data/wordlists/http_default_userpass.txt
+++ b/data/wordlists/http_default_userpass.txt
@@ -1,7 +1,9 @@
+admin password
 connect connect
 sitecom sitecom
 admin 1234
 cisco cisco
+admin password
 cisco sanfran
 private private
 wampp xampp
@@ -9,3 +11,4 @@ newuser wampp
 xampp-dav-unsecure ppmax2011 
 admin turnkey
 vagrant vagrant
+admin password

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -169,10 +169,6 @@ module Metasploit
         # @return [String]
         attr_accessor :http_password
 
-        # @!attribute redirect_uri
-        # @!return [String] The path that @uri redirects to on the server for a successful login 
-        attr_accessor :redirect_uri
-
         # @!attribute post_data
         # @!return [String] A sample POST format data to be submitted to the target
         attr_accessor :post_data

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -218,6 +218,7 @@ module Metasploit
         def send_request(opts)
           rhost           = opts['host'] || host
           rport           = opts['rport'] || port
+          method          = opts['method'] || method
           cli_ssl         = opts['ssl'] || ssl
           cli_ssl_version = opts['ssl_version'] || ssl_version
           cli_proxies     = opts['proxies'] || proxies
@@ -242,6 +243,8 @@ module Metasploit
           if realm
             cli.set_config('domain' => realm)
           end
+
+          puts "http.rb, username = #{username} & password = #{password} & method = #{method} & host = #{rhost} & port = #{rport}"
 
           begin
             cli.connect

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -218,7 +218,7 @@ module Metasploit
         def send_request(opts)
           rhost           = opts['host'] || host
           rport           = opts['rport'] || port
-          method          = opts['method'] || method
+          # method          = opts['method'] || method
           cli_ssl         = opts['ssl'] || ssl
           cli_ssl_version = opts['ssl_version'] || ssl_version
           cli_proxies     = opts['proxies'] || proxies
@@ -243,8 +243,6 @@ module Metasploit
           if realm
             cli.set_config('domain' => realm)
           end
-
-          # puts "http.rb, username = #{username} & password = #{password} & method = #{method} & host = #{rhost} & port = #{rport}"
 
           begin
             cli.connect

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -244,7 +244,7 @@ module Metasploit
             cli.set_config('domain' => realm)
           end
 
-          puts "http.rb, username = #{username} & password = #{password} & method = #{method} & host = #{rhost} & port = #{rport}"
+          # puts "http.rb, username = #{username} & password = #{password} & method = #{method} & host = #{rhost} & port = #{rport}"
 
           begin
             cli.connect

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -25,7 +25,7 @@ module Metasploit
         #     authenticate to.
         attr_accessor :uri
 
-        # @!attribute uri
+        # @!attribute method
         #   @return [String] HTTP method, e.g. "GET", "POST"
         attr_accessor :method
 
@@ -169,6 +169,14 @@ module Metasploit
         # @return [String]
         attr_accessor :http_password
 
+        # @!attribute redirect_uri
+        # @!return [String] The path that @uri redirects to on the server for a successful login 
+        attr_accessor :redirect_uri
+
+        # @!attribute post_data
+        # @!return [String] A sample POST format data to be submitted to the target
+        attr_accessor :post_data
+
 
         validates :uri, presence: true, length: { minimum: 1 }
 
@@ -218,7 +226,6 @@ module Metasploit
         def send_request(opts)
           rhost           = opts['host'] || host
           rport           = opts['rport'] || port
-          # method          = opts['method'] || method
           cli_ssl         = opts['ssl'] || ssl
           cli_ssl_version = opts['ssl_version'] || ssl_version
           cli_proxies     = opts['proxies'] || proxies

--- a/lib/metasploit/framework/login_scanner/http_post.rb
+++ b/lib/metasploit/framework/login_scanner/http_post.rb
@@ -1,0 +1,131 @@
+
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      class HttpPostBruteforce < HTTP
+
+        DEFAULT_PORT  = 80
+        PRIVATE_TYPES = [ :password ]
+        LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
+
+
+        # Checks if the target is DVWA.
+        #
+        # @return [Boolean] TrueClass if target is DVWA, otherwise FalseClass
+        def check_setup
+          login_uri = normalize_uri("#{uri}/login.php")
+          res = send_request({'uri'=> login_uri})
+
+          if res && res.body.include?('Damn Vulnerable Web Application')
+            return true
+          end
+
+          false
+        end
+
+
+        # Returns the latest sid from Symantec Web Gateway.
+        #
+        # @return [String] The PHP Session ID for Symantec Web Gateway login
+        def get_last_sid
+          @last_sid ||= lambda {
+            # We don't have a session ID. Well, let's grab one right quick from the login page.
+            # This should probably only happen once (initially).
+            login_uri = normalize_uri("#{uri}/login.php")
+            res = send_request({'uri' => login_uri})
+
+            return '' unless res
+
+            cookies = res.get_cookies
+            @last_sid = cookies.scan(/(PHPSESSID=\w+);*/).flatten[0] || ''
+          }.call
+        end
+
+
+        # Actually doing the login. Called by #attempt_login
+        #
+        # @param username [String] The username to try
+        # @param password [String] The password to try
+        # @return [Hash]
+        #   * :status [Metasploit::Model::Login::Status]
+        #   * :proof [String] the HTTP response body
+        def get_login_state(credential, username, password)
+          # Prep the data needed for login
+          sid       = get_last_sid
+          protocol  = ssl ? 'https' : 'http'
+          peer      = "#{host}:#{port}"
+          login_uri = normalize_uri("#{uri}/login.php")
+
+          puts "http_post, URI = #{uri}"
+          puts "http_post, Login URI = #{login_uri}"
+          puts "http_post, host = #{host} & port = #{port} & protocol = #{protocol}"
+          res = send_request({
+            'uri' => login_uri,
+            'method' => 'POST',
+            'host' => host,
+            'rport' => port,
+            'credential' => credential,
+            'cookie' => sid,
+            'headers' => {
+              'Referer' => "#{protocol}://#{peer}/#{login_uri}"
+            },
+            'vars_post' => {
+              'USERNAME' => username,
+              'PASSWORD' => password,
+              'Login' => 'Login' # Found in the HTML form
+            }
+          })
+
+          puts "http_post Username = #{username} and Password = #{password}"
+
+          unless res
+            return {:status => LOGIN_STATUS::UNABLE_TO_CONNECT, :proof => res.to_s}
+          end
+
+          # After login, the application should give us a new SID
+          cookies = res.get_cookies
+          sid = cookies.scan(/(PHPSESSID=\w+);*/).flatten[0] || ''
+          @last_sid = sid # Update our SID
+          
+          #puts "Code = #{res.code}"
+          #puts "Description : #{res.to_s}"
+          if res && res.code == 302 && res.headers['Location'].include?('index.php')
+            return {:status => LOGIN_STATUS::SUCCESSFUL, :proof => res.to_s}
+          end
+          puts "Http Response = ----- #{res.to_s}"
+
+          {:status => LOGIN_STATUS::INCORRECT, :proof => res.to_s}
+        end
+
+
+        # Attempts to login to Symantec Web Gateway. This is called first.
+        #
+        # @param credential [Metasploit::Framework::Credential] The credential object
+        # @return [Result] A Result object indicating success or failure
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential,
+            status: Metasploit::Model::Login::Status::INCORRECT,
+            proof: nil,
+            host: host,
+            port: port,
+            protocol: 'tcp'
+          }
+
+          begin
+            result_opts.merge!(get_login_state(credential, credential.public, credential.private))
+          rescue ::Rex::ConnectionError => e
+            # Something went wrong during login. 'e' knows what's up.
+            result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
+          end
+
+          Result.new(result_opts)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/login_scanner/http_post.rb
+++ b/lib/metasploit/framework/login_scanner/http_post.rb
@@ -12,11 +12,8 @@ module Metasploit
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
 
-        # Checks if the target is DVWA.
-        #
-        # @return [Boolean] TrueClass if target is DVWA, otherwise FalseClass
         def check_setup
-          login_uri = normalize_uri("#{uri}/login.php")
+          login_uri = normalize_uri("#{uri}")
           res = send_request({'uri'=> login_uri})
 
           if !(res && res.code == 401 && res.headers['WWW-Authenticate'])
@@ -27,13 +24,6 @@ module Metasploit
 
           error_message
         end
-
-          # if res && res.body.include?('mautarkari')
-          #  return true
-          # end
-
-          # false
-        # end
 
 
         # Returns the latest sid and CSRF token.
@@ -49,7 +39,7 @@ module Metasploit
           if res.nil? || res.body.nil?
             print_error("Empty response. Please validate RHOST")
           elsif res.code != 200
-            print_error("Unexpected HTTP #{res.code} response.")
+            print_error("Unexpected HTTP #{res.code} response. Please validate AUTH_URI")
           end
 
           @last_sid = lambda {
@@ -77,7 +67,7 @@ module Metasploit
           # Prep the data needed for login
           protocol  = ssl ? 'https' : 'http'
           peer      = "#{host}:#{port}"
-          login_uri = normalize_uri("#{uri}/login.php")
+          login_uri = normalize_uri("#{uri}")
           sid, csrf_token = extract_csrf_token_and_getlastsid(
             path: login_uri,
             regex: %r{\w{32}}

--- a/modules/auxiliary/scanner/http/dvwa_login.rb
+++ b/modules/auxiliary/scanner/http/dvwa_login.rb
@@ -37,7 +37,9 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options('PASSWORD_SPRAY')
     register_options(
       [
-        OptString.new('AUTH_URI', [true, 'The URI to authenticate to', '']),
+        OptString.new('AUTH_URI', [true, 'The URI to authenticate to', '/login.php']),
+        OptString.new('REDIRECT_URI', [true, 'The redirected URI incase of correct login credentials. Exclude the initial slash.', 'index.php']),
+        OptString.new('POST_DATA', [true, 'A sample POST data to be submitted to the target', 'username=admin&password=password&Login=Login&user_token=004fc0b9ee58345cfeeb5198b782bc63'])
       ]
     )
   end
@@ -52,9 +54,11 @@ class MetasploitModule < Msf::Auxiliary
       return Metasploit::Framework::LoginScanner::HttpPostBruteforce.new(
         configure_http_login_scanner(
           uri: datastore['AUTH_URI'],
+          redirect_uri: datastore['REDIRECT_URI'],
           host: ip,
           port: datastore['RPORT'],
           cred_details: cred_collection,
+          post_data: datastore['POST_DATA'],
           stop_on_success: datastore['STOP_ON_SUCCESS'],
           bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
           connection_timeout: 5,

--- a/modules/auxiliary/scanner/http/dvwa_login.rb
+++ b/modules/auxiliary/scanner/http/dvwa_login.rb
@@ -1,0 +1,130 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/login_scanner/http_post'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Damn Vulnerable Web App login utility',
+        'Description' => %q{
+          This module will attempt to authenticate to a Damn Vulnerable Web App login page.
+        },
+        'Author' => [ '3V3RYONE' ],
+        'License' => MSF_LICENSE,
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false
+        },
+        'Notes' => {
+          'Stability' => CRASH_SAFE,
+          'Reliability' => REPEATABLE_SESSION,
+          'SideEffects' => ARTIFACTS_ON_DISK
+        }
+      )
+    )
+
+    deregister_options('PASSWORD_SPRAY')
+    # register_options(
+    #  [
+    #    OptString.new('AUTH_URI', [false, 'The URI to authenticate to', '']),
+    #  ]
+    # )
+  end
+
+  def scanner(ip)
+    @scanner ||= lambda {
+      cred_collection = build_credential_collection(
+        username: datastore['HttpUsername'],
+        password: datastore['HttpPassword']
+      )
+
+      return Metasploit::Framework::LoginScanner::HttpPostBruteforce.new(
+        configure_http_login_scanner(
+          # uri: datastore['AUTH_URI'],
+          host: ip,
+          port: datastore['RPORT'],
+          cred_details: cred_collection,
+          stop_on_success: datastore['STOP_ON_SUCCESS'],
+          bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+          connection_timeout: 5,
+          http_username: datastore['HttpUsername'],
+          http_password: datastore['HttpPassword']
+        )
+      )
+    }.call
+  end
+
+  def report_good_cred(ip, port, result)
+    service_data = {
+      address: ip,
+      port: port,
+      service_name: 'http',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      origin_type: :service,
+      private_data: result.credential.private,
+      private_type: :password,
+      username: result.credential.public
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      last_attempted_at: DateTime.now,
+      status: result.status,
+      proof: result.proof
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def report_bad_cred(ip, rport, result)
+    invalidate_login(
+      address: ip,
+      port: rport,
+      protocol: 'tcp',
+      public: result.credential.public,
+      private: result.credential.private,
+      realm_key: result.credential.realm_key,
+      realm_value: result.credential.realm,
+      status: result.status,
+      proof: result.proof
+    )
+  end
+
+  # Attempts to login
+  def bruteforce(ip)
+    scanner(ip).scan! do |result|
+      case result.status
+      when Metasploit::Model::Login::Status::SUCCESSFUL
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
+        report_good_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
+        report_bad_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::INCORRECT
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
+        report_bad_cred(ip, rport, result)
+      end
+    end
+  end
+
+  # Start here
+  def run_host(ip)
+    bruteforce(ip)
+  end
+end

--- a/modules/auxiliary/scanner/http/dvwa_login.rb
+++ b/modules/auxiliary/scanner/http/dvwa_login.rb
@@ -35,11 +35,11 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     deregister_options('PASSWORD_SPRAY')
-    # register_options(
-    #  [
-    #    OptString.new('AUTH_URI', [false, 'The URI to authenticate to', '']),
-    #  ]
-    # )
+    register_options(
+      [
+        OptString.new('AUTH_URI', [true, 'The URI to authenticate to', '']),
+      ]
+    )
   end
 
   def scanner(ip)
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
 
       return Metasploit::Framework::LoginScanner::HttpPostBruteforce.new(
         configure_http_login_scanner(
-          # uri: datastore['AUTH_URI'],
+          uri: datastore['AUTH_URI'],
           host: ip,
           port: datastore['RPORT'],
           cred_details: cred_collection,
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Auxiliary
   # Start here
   def run_host(ip)
     unless scanner(ip).check_setup
-      print_brute(level: :error, ip: ip, msg: 'Target is not DVWA')
+      print_brute(level: :error, ip: ip, msg: 'Target not Verified')
       return
     end
 

--- a/modules/auxiliary/scanner/http/dvwa_login.rb
+++ b/modules/auxiliary/scanner/http/dvwa_login.rb
@@ -16,9 +16,9 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name' => 'Damn Vulnerable Web App login utility',
+        'Name' => 'Damn Vulnerable Web Application login utility',
         'Description' => %q{
-          This module will attempt to authenticate to a Damn Vulnerable Web App login page.
+          This module will attempt to authenticate to the Damn Vulnerable Web App login page.
         },
         'Author' => [ '3V3RYONE' ],
         'License' => MSF_LICENSE,
@@ -27,9 +27,9 @@ class MetasploitModule < Msf::Auxiliary
           'SSL' => false
         },
         'Notes' => {
-          'Stability' => CRASH_SAFE,
-          'Reliability' => REPEATABLE_SESSION,
-          'SideEffects' => ARTIFACTS_ON_DISK
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         }
       )
     )
@@ -125,6 +125,11 @@ class MetasploitModule < Msf::Auxiliary
 
   # Start here
   def run_host(ip)
+    unless scanner(ip).check_setup
+      print_brute(level: :error, ip: ip, msg: 'Target is not DVWA')
+      return
+    end
+
     bruteforce(ip)
   end
 end

--- a/modules/auxiliary/scanner/http/dvwa_login.rb
+++ b/modules/auxiliary/scanner/http/dvwa_login.rb
@@ -38,7 +38,6 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('AUTH_URI', [true, 'The URI to authenticate to', '/login.php']),
-        OptString.new('REDIRECT_URI', [true, 'The redirected URI incase of correct login credentials. Exclude the initial slash.', 'index.php']),
         OptString.new('POST_DATA', [true, 'A sample POST data to be submitted to the target', 'username=admin&password=password&Login=Login&user_token=004fc0b9ee58345cfeeb5198b782bc63'])
       ]
     )
@@ -54,7 +53,6 @@ class MetasploitModule < Msf::Auxiliary
       return Metasploit::Framework::LoginScanner::HttpPostBruteforce.new(
         configure_http_login_scanner(
           uri: datastore['AUTH_URI'],
-          redirect_uri: datastore['REDIRECT_URI'],
           host: ip,
           port: datastore['RPORT'],
           cred_details: cred_collection,


### PR DESCRIPTION
This PR adds a custom http bruteforce module (`dvwa_login.rb`) and it's corresponding `login_scanner` (`http_post.rb`) template to authenticate to a `DVWA login` page.  
  
## Approach  
  
Firstly, all the parameters like `AUTH_URI` and `RHOSTS` are configured from the options set by the user. `REDIRECT_URI` is a parameter introduced which contains the URI that `AUTH_URI` redirects to, when a successful login occurs (example `/login.php` redirects to `/index.php`). Then, it grabs the credentials one by one in the `USERPASS_FILE`. For each credential,  
1. It first performs a **GET** request on the `AUTH_URI`. In this request, it grabs the latest `session_id` and the `csrf_token` in the target and returns it to parameters.  A regex match (`/\w{32}/`) is used to extract the csrf_token.  
2. Then it prepares all the parameters required to make the authentication request, (Like `username` and `password` from the `USERPASS_FILE`, `cookie` from the `session_id` and `csrf_token` from `csrf_token`.  
3. Then it sends all the above data as a **POST** request to the `AUTH_URI` target to attempt to authenticate.  
4. Then the response is analyzed to check if it was a successful login. Specially, the **headers location** of the response is checked if it includes the `REDIRECT_URI` parameter set by the user. If it does, then the credential is correct. Else it's invalid.  
5. Checks for the next credentials in the `USERPASS_FILE`.
  
## Verification
  
- [ ] Setup `DVWA` in your machine. ([installation guide in kali](https://www.golinuxcloud.com/install-dvwa-kali-linux/))
- [ ] Use the modified files of this PR in your msf.
- [ ] Start `msfconsole`
- [ ] run `use auxiliary/scanner/http/dvwa_login`
- [ ] set `RHOSTS` to DVWA hosted IP (maybe `127.0.0.1`)
- [ ] set `AUTH_URI` to `/DVWA/login.php`
- [ ] set `USERPASS_FILE` (maybe to `data/wordlists/http_default_userpass.txt`) 
- [ ] `run`
- [ ] **Verify** that the bruteforce module shows **SUCCESS status** for **admin:password** credential.
- [ ] **Verify** that the bruteforce module shows **FAILED status** for other invalid credentials.

```  
msf6 > use auxiliary/scanner/http/dvwa_login
msf6 auxiliary(scanner/http/dvwa_login) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf6 auxiliary(scanner/http/dvwa_login) > set USERPASS_FILE /home/beleswar/metasploit-framework/data/wordlists/http_default_userpass.txt
USERPASS_FILE => /home/beleswar/metasploit-framework/data/wordlists/http_default_userpass.txt
msf6 auxiliary(scanner/http/dvwa_login) > run

[-] 127.0.0.1:80 - Failed: 'connect:connect'
[!] No active DB -- Credential data will not be saved!
[-] 127.0.0.1:80 - Failed: 'sitecom:sitecom'
[-] 127.0.0.1:80 - Failed: 'admin:1234'
[-] 127.0.0.1:80 - Failed: 'cisco:cisco'
[-] 127.0.0.1:80 - Failed: 'cisco:sanfran'
[-] 127.0.0.1:80 - Failed: 'private:private'
[-] 127.0.0.1:80 - Failed: 'wampp:xampp'
[-] 127.0.0.1:80 - Failed: 'newuser:wampp'
[-] 127.0.0.1:80 - Failed: 'xampp-dav-unsecure:ppmax2011 '
[-] 127.0.0.1:80 - Failed: 'admin:turnkey'
[-] 127.0.0.1:80 - Failed: 'vagrant:vagrant'
[+] 127.0.0.1:80 - Success: 'admin:password'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```  
  
## Generalization  
  
I was wondering if we can generalize this LoginScanner template (`http_post.rb`) to be a generalized template utilizing POST method. I have **currently** committed some generalization attempts in `http_post.rb`:  
1. Allowing `AUTH_URI` parameter to be set by the user, and not just limited to DVWA login page (`/DVWA/login.php`)  
2. Obtaining `REDIRECT_URI` parameter from the user, (The URI to which the `AUTH_URI` redirects to incase of successful credentials) and not just always using `/index.php` (which is for DVWA)    
3.  `check_setup` method verifies whether the target needs www-authentication or not, and is not just limited to DVWA verification.  
  
## WIP  
  
4. Allowing the user to send a sample `POST_DATA` to be sent to the target. This ensures we are sending the specific format of post_data that the target requires to authenticate. For example, **`DVWA`** has a post data of the type   `username=admin&password=password&Login=Login&user_token=004fc0b9ee58345cfeeb5198b782bc63`  
  whereas **`symantec_web_gateway`** uses a format like  
`USERNAME=gooduser&PASSWORD=GoodPassword&loginBtn=Login`  
  
So as of now, I have implemented to extract the parameters from the sample POST data string (like `username` or `USERNAME`, & `Login` or `loginBtn`) and send it in order in the `vars_post` variable. So, saying   
`user=admin&pass=password&login=Login&auth_token=004fc0b9ee58345cfeeb5198b782bc63` data string will still work for this template.   
  
But a different order of parameters might still cause a problem. Like `password=password&user=admin&Login=Login` will fail because I haven't taken care for different order data string. **Any more suggestions in how we can make this part more generalized to have a general login_scanner template?**  
  
Also, what do you think would be optimal? To make this generalized or specific to DVWA? Thanks :)