### PR TITLE
Update metasploit-payloads gem to 2.0.71

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.70)
+      metasploit-payloads (= 2.0.71)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.18)
       mqtt
@@ -133,7 +133,7 @@ GEM
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-ec2 (1.295.0)
+    aws-sdk-ec2 (1.296.0)
       aws-sdk-core (~> 3, >= 3.125.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-iam (1.65.0)
@@ -261,7 +261,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.70)
+    metasploit-payloads (2.0.71)
     metasploit_data_models (5.0.4)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -79,7 +79,7 @@ metasploit-concern, 4.0.3, "New BSD"
 metasploit-credential, 5.0.5, "New BSD"
 metasploit-framework, 6.1.28, "New BSD"
 metasploit-model, 4.0.3, "New BSD"
-metasploit-payloads, 2.0.70, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.71, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 5.0.4, "New BSD"
 metasploit_payloads-mettle, 1.0.18, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.70'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.71'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.18'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This PR bumps framework to use Metasploit payloads gem 2.0.71 (previously 2.0.70), pulling in the following payloads PR changes:

* rapid7/metasploit-payloads#520
* rapid7/metasploit-payloads#528

Fixes #13369 by adding the remaining support for recursive directory deletion.

## Verification
List the steps needed to make sure this thing works

- [x] Retest manually
- [x] Let automated tests pass