### PR TITLE
prepend_nops: Return unmodified shellcode if no compatible nops for arch

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -548,18 +548,18 @@ module Msf
     # @param shellcode [String] The shellcode to prepend the NOPs to
     # @return [String] the shellcode with the appropriate nopsled affixed
     def prepend_nops(shellcode)
-      if nops > 0
-        framework.nops.each_module_ranked('Arch' => [arch]) do |name, mod|
-          nop = framework.nops.create(name)
-          raw = nop.generate_sled(nops, {'BadChars' => badchars, 'SaveRegisters' => [ 'esp', 'ebp', 'esi', 'edi' ] })
-          if raw
-            cli_print "Successfully added NOP sled of size #{raw.length} from #{name}"
-            return raw + shellcode
-         end
+      return shellcode unless nops > 0
+
+      framework.nops.each_module_ranked('Arch' => [arch]) do |name, mod|
+        nop = framework.nops.create(name)
+        raw = nop.generate_sled(nops, {'BadChars' => badchars, 'SaveRegisters' => [ 'esp', 'ebp', 'esi', 'edi' ] })
+        if raw
+          cli_print "Successfully added NOP sled of size #{raw.length} from #{name}"
+          return raw + shellcode
         end
-      else
-        shellcode
       end
+
+      shellcode
     end
 
     # This method runs a specified encoder, for a number of defined iterations against the shellcode.


### PR DESCRIPTION
Fixes #15772. See also: #16113

Modifies `PayloadGenerator::prepend_nops(shellcode)` to return the raw shellcode unmodified in the event that there are no Nops modules for the target payload architecture.

Prior to this change, the generated payload was vaporized and replaced with an array of Nop modules as a string.
