### PR TITLE
Add Java Arch support to packet building

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
@@ -133,6 +133,8 @@ class Library
       native = 'Q<'
     when ARCH_X86
       native = 'V'
+    when ARCH_JAVA
+      native = 'Q<'
     else
       raise NotImplementedError, 'Unsupported architecture (must be ARCH_X86 or ARCH_X64)'
     end
@@ -276,6 +278,8 @@ class Library
       native = 'Q<'
     when ARCH_X86
       native = 'V'
+    when ARCH_JAVA
+      native = 'Q<'
     else
       raise NotImplementedError, 'Unsupported architecture (must be ARCH_X86 or ARCH_X64)'
     end


### PR DESCRIPTION
This PR is necessary for Java Meterpreter Railgun to work.