### PR TITLE
Add setg sessiontlvlogging command to log TLV packets

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -73,6 +73,10 @@ class Meterpreter < Rex::Post::Meterpreter::Client
       opts[:ssl_cert] = opts[:datastore]['HandlerSSLCert']
     end
 
+    if opts[:datastore] and opts[:datastore]['SessionTlvLogging']
+      opts[:tlv_log] = opts[:datastore]['SessionTlvLogging']
+    end
+
     # Don't pass the datastore into the init_meterpreter method
     opts.delete(:datastore)
 
@@ -736,4 +740,3 @@ end
 
 end
 end
-

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1914,6 +1914,15 @@ class Core
       print_warning("Changing the SSL option's value may require changing RPORT!")
     end
 
+    # Correctly set the file output if user provides a directory for SessionTlvLogging
+    if name.casecmp?('SessionTlvLogging')
+      pathname = ::Pathname.new(datastore[name].split('file:').last)
+
+      if ::File.directory?(pathname) && datastore[name].start_with?('file:')
+        datastore[name] = ::File.join(datastore[name], 'sessiontlvlogging.txt')
+      end
+    end
+
     print_line("#{name} => #{datastore[name]}")
   end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1914,13 +1914,16 @@ class Core
       print_warning("Changing the SSL option's value may require changing RPORT!")
     end
 
-    # Correctly set the file output if user provides a directory for SessionTlvLogging
     if name.casecmp?('SessionTlvLogging')
-      pathname = ::Pathname.new(datastore[name].split('file:').last)
-
-      if ::File.directory?(pathname) && datastore[name].start_with?('file:')
-        datastore[name] = ::File.join(datastore[name], 'sessiontlvlogging.txt')
+      # Check if we need to append the default filename if user provided an output directory
+      if datastore[name].start_with?('file:')
+        pathname = ::Pathname.new(datastore[name].split('file:').last)
+        if ::File.directory?(pathname)
+          datastore[name] = ::File.join(datastore[name], 'sessiontlvlogging.txt')
+        end
       end
+
+      framework.sessions.each { |_index, session| session.initialize_tlv_logging(datastore[name]) }
     end
 
     print_line("#{name} => #{datastore[name]}")

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1439,6 +1439,7 @@ module Msf
               [ 'LogLevel', framework.datastore['LogLevel'] || "0", 'Verbosity of logs (default 0, max 3)' ],
               [ 'MinimumRank', framework.datastore['MinimumRank'] || "0", 'The minimum rank of exploits that will run without explicit confirmation' ],
               [ 'SessionLogging', framework.datastore['SessionLogging'] || "false", 'Log all input and output for sessions' ],
+              [ 'SessionTlvLogging', framework.datastore['SessionTlvLogging'] || "false", 'Log all incoming and outgoing TLV packets' ],
               [ 'TimestampOutput', framework.datastore['TimestampOutput'] || "false", 'Prefix all console output with a timestamp' ],
               [ 'Prompt', framework.datastore['Prompt'] || Msf::Ui::Console::Driver::DefaultPrompt.to_s.gsub(/%.../,"") , "The prompt string" ],
               [ 'PromptChar', framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar.to_s.gsub(/%.../,""), "The prompt character" ],

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -67,6 +67,7 @@ module Msf
             PromptChar
             PromptTimeFormat
             MeterpreterPrompt
+            SessionTlvLogging
           ]
           if !mod
             return res
@@ -122,6 +123,10 @@ module Msf
         # Provide tab completion for option values
         #
         def tab_complete_option_values(mod, str, words, opt:)
+          if words.last.casecmp?('SessionTlvLogging')
+            return %w[console true false file:<file>]
+          end
+
           res = []
           # With no module, we have nothing to complete
           if !mod

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -131,6 +131,8 @@ class Client
     self.url          = opts[:url]
     self.ssl          = opts[:ssl]
 
+    self.tlv_logging_enabled = true
+
     self.pivot_session = opts[:pivot_session]
     if self.pivot_session
       self.expiration   = self.pivot_session.expiration
@@ -502,4 +504,3 @@ protected
 end
 
 end; end; end
-

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -111,6 +111,8 @@ class Client
     end
 
     shutdown_passive_dispatcher
+
+    shutdown_tlv_logging
   end
 
   #
@@ -130,8 +132,6 @@ class Client
     self.conn_id      = opts[:conn_id]
     self.url          = opts[:url]
     self.ssl          = opts[:ssl]
-
-    self.tlv_logging_enabled = true
 
     self.pivot_session = opts[:pivot_session]
     if self.pivot_session
@@ -166,6 +166,8 @@ class Client
         self.ssl_cert = ::File.read(opts[:ssl_cert])
       end
     end
+
+    initialize_tlv_logging(opts[:tlv_log]) unless opts[:tlv_log].nil?
 
     # Protocol specific dispatch mixins go here, this may be neader with explicit Client classes
     opts[:dispatch_ext].each {|dx| self.extend(dx)} if opts[:dispatch_ext]


### PR DESCRIPTION
This PR allows the user to `setg sessiontlvlogging true/console/false/file:<file>` to enable/disable logging of TLV packets for all sessions.

Future effort could include adding this toggle to individual sessions as well.

There is some logic behind deciding if we want to write to a file or directory.
If we set the logging output to a file and we have write permissions, TLV packets will be appended to the file.
If we set it to a directory and we have write permissions, TLV packets will be stored in that directory with a default filename of `sessiontlvlogging.txt`.
If we set it to a non-existent directory such as `setg sessiontlvlogging file:/tmp/this/directory/does/not/exist`, the last part of the `file:` argument will be treated as the output file e.g. `exist` in this example. This will also create the relevant subdirectories, meaning if we do `setg sessiontlvlogging file:/tmp/this/directory/does/not` in the future, we will output to a file, `/tmp/this/directory/does/not/sessiontlvlogging.txt` as the directory exists.

## Verification

- [ ] Start `msfconsole`
- [ ] `setg sessiontlvlogging console`
- [ ] Get or interact with a session
- [ ] Confirm both `SEND` and `RECV` TLV packets are output to the console
- [ ] `setg sessiontlvlogging false`
- [ ] Get or interact with a session
- [ ] Confirm no TLV packets are being output to console
- [ ] `setg sessiontlvlogging file:./output.txt`
- [ ] Get or interact with a session
- [ ] Confirm that the `output.txt` file has TLV packet information stored.

## Before / `setg sessiontlvlogging false`
```
msf6 payload(java/meterpreter/reverse_tcp) >
[*] Sending stage (78874 bytes) to 192.168.129.131
[*] Meterpreter session 7 opened (192.168.129.1:4455 -> 192.168.129.131:49749 ) at 2022-01-31 17:29:37 +0000
```

## After / `setg sessiontlvlogging console`
```
msf6 payload(java/meterpreter/reverse_tcp) >
[*] Sending stage (78874 bytes) to 192.168.129.131

SEND: #<Rex::Post::Meterpreter::Packet type=Request         tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=16 command=core_negotiate_tlv_encryption>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST-ID      meta=STRING     value="88608609954242027287119365197473">
  #<Rex::Post::Meterpreter::Tlv type=RSA-PUB-KEY     meta=RAW        value="0\x82\x01\"0\r\x06\t*\x86H\x86\xF7\r\x01\x01\x01\ ...">
]>

RECV: #<Rex::Post::Meterpreter::Packet type=Response        tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=16 command=core_negotiate_tlv_encryption>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST-ID      meta=STRING     value="88608609954242027287119365197473">
  #<Rex::Post::Meterpreter::Tlv type=ENC-SYM-KEY     meta=RAW        value="?=\r\x19\xCF\x82\xAB*!1\x84~\r\xBAV\x8D)4w\xB6\xA ...">
  #<Rex::Post::Meterpreter::Tlv type=SYM-KEY-TYPE    meta=INT        value=1>
  #<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="W\\o\xDBd\xD8\xC1\xB2\\=X,=\xC5@\xC6">
]>
```