### PR TITLE
Add service manager commands to msfconsole

### DIFF
--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -15,6 +15,7 @@ module Msf
     CONFIG_KEY = 'framework/features'
     WRAPPED_TABLES = 'wrapped_tables'
     FULLY_INTERACTIVE_SHELLS = 'fully_interactive_shells'
+    SERVICEMANAGER_COMMAND = 'servicemanager_command'
     DEFAULTS = [
       {
         name: WRAPPED_TABLES,
@@ -24,6 +25,11 @@ module Msf
       {
         name: FULLY_INTERACTIVE_SHELLS,
         description: 'When enabled you will have the option to drop into a fully interactive shell from within meterpreter',
+        default_value: false
+      }.freeze,
+      {
+        name: SERVICEMANAGER_COMMAND,
+        description: 'When enabled you will have access to the _servicemanager command',
         default_value: false
       }.freeze
     ].freeze

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -9,6 +9,10 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     '-e' => [true,  'Expression to evaluate.']
   )
 
+  @@servicemanager_opts = Rex::Parser::Arguments.new(
+    ['-l', '--list'] => [false, 'View the currently running services' ]
+  )
+
   def initialize(driver)
     super
   end
@@ -24,7 +28,8 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       'edit'       => 'Edit the current module or a file with the preferred editor',
       'reload_lib' => 'Reload Ruby library files from specified paths',
       'log'        => 'Display framework.log paged to the end if possible',
-      'time'       => 'Time how long it takes to run a particular command'
+      'time'       => 'Time how long it takes to run a particular command',
+      'servicemanager' => 'Manage running framework services',
     }
   end
 
@@ -310,6 +315,63 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     unless system(*pager.split, path)
       print_error("Could not execute #{pager} #{path}")
     end
+  end
+
+  #
+  # Interact with framework's service manager
+  #
+  def cmd_servicemanager(*args)
+    if args.include?('-h') || args.include?('--help')
+      cmd_servicemanager_help
+      return false
+    end
+
+    opts = {}
+    @@servicemanager_opts.parse(args) do |opt, idx, val|
+      case opt
+      when '-l', '--list'
+        opts[:list] = true
+      end
+    end
+
+    if opts.empty?
+      opts[:list] = true
+    end
+
+    if opts[:list]
+      table = Rex::Text::Table.new(
+        'Header'  => 'Services',
+        'Indent'  => 1,
+        'Columns' => ['Id', 'Name', 'References']
+      )
+      Rex::ServiceManager.instance.each.with_index do |(name, instance), id|
+        # TODO: Update rex-core to support querying the reference count
+        table << [id, name, instance.instance_variable_get(:@_references)]
+      end
+
+      if table.rows.empty?
+        print_status("No framework services are currently running.")
+      else
+        print_line(table.to_s)
+      end
+    end
+  end
+
+  #
+  # Tab completion for the servicemanager command
+  #
+  def cmd_servicemanager_tabs(_str, words)
+    return [] if words.length > 1
+
+    @@servicemanager_opts.option_keys
+  end
+
+  def cmd_servicemanager_help
+    print_line 'Usage: servicemanager'
+    print_line
+    print_line 'Manage running framework services'
+    print @@servicemanager_opts.usage
+    print_line
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -9,7 +9,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     '-e' => [true,  'Expression to evaluate.']
   )
 
-  @@servicemanager_opts = Rex::Parser::Arguments.new(
+  @@_servicemanager_opts = Rex::Parser::Arguments.new(
     ['-l', '--list'] => [false, 'View the currently running services' ]
   )
 
@@ -22,15 +22,18 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def commands
-    {
+    commands = {
       'irb'        => 'Open an interactive Ruby shell in the current context',
       'pry'        => 'Open the Pry debugger on the current module or Framework',
       'edit'       => 'Edit the current module or a file with the preferred editor',
       'reload_lib' => 'Reload Ruby library files from specified paths',
       'log'        => 'Display framework.log paged to the end if possible',
-      'time'       => 'Time how long it takes to run a particular command',
-      'servicemanager' => 'Manage running framework services',
+      'time'       => 'Time how long it takes to run a particular command'
     }
+    if framework.features.enabled?(Msf::FeatureManager::SERVICEMANAGER_COMMAND)
+      commands['_servicemanager'] = 'Interact with the Rex::ServiceManager'
+    end
+    commands
   end
 
   def local_editor
@@ -320,14 +323,14 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   #
   # Interact with framework's service manager
   #
-  def cmd_servicemanager(*args)
+  def cmd__servicemanager(*args)
     if args.include?('-h') || args.include?('--help')
-      cmd_servicemanager_help
+      cmd__servicemanager_help
       return false
     end
 
     opts = {}
-    @@servicemanager_opts.parse(args) do |opt, idx, val|
+    @@_servicemanager_opts.parse(args) do |opt, idx, val|
       case opt
       when '-l', '--list'
         opts[:list] = true
@@ -358,19 +361,19 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   #
-  # Tab completion for the servicemanager command
+  # Tab completion for the _servicemanager command
   #
-  def cmd_servicemanager_tabs(_str, words)
+  def cmd__servicemanager_tabs(_str, words)
     return [] if words.length > 1
 
-    @@servicemanager_opts.option_keys
+    @@_servicemanager_opts.option_keys
   end
 
-  def cmd_servicemanager_help
+  def cmd__servicemanager_help
     print_line 'Usage: servicemanager'
     print_line
     print_line 'Manage running framework services'
-    print @@servicemanager_opts.usage
+    print @@_servicemanager_opts.usage
     print_line
   end
 


### PR DESCRIPTION
I'm using this functionality at the minute to debug the contents of the `Rex::ServiceManager` instance, the command probably needs a rename to not conflict with tab completing the 'services' command. I'm not strongly opinionated in this change landing.

## Verification

Feature flag not enabled:

```
msf6 auxiliary(client/smtp/emailer) > _servicemanager
[-] Unknown command: _servicemanager
```

Enabling feature flag:

```
msf6 auxiliary(client/smtp/emailer) > features set servicemanager_command true
servicemanager_command => true
[*] Reloading module...
msf6 auxiliary(client/smtp/emailer) > _servicemanager 
[*] No framework services are currently running.
```

Populate services:
```
use auxiliary/server/capture/ftp
features set servicemanager_command true
use multi/script/web_delivery
run

_servicemanager
```

Verify output:
```
msf6 exploit(multi/script/web_delivery) > _servicemanager 
Services
========

 Id  Name                                 References
 --  ----                                 ----------
 0   HTTP Server                          2
 1   Rex::Proto::Http::Server80800.0.0.0  2
```
