### PR TITLE
Update metasploit-payloads gem to 2.0.72

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.71)
+      metasploit-payloads (= 2.0.72)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.18)
       mqtt
@@ -261,7 +261,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.71)
+    metasploit-payloads (2.0.72)
     metasploit_data_models (5.0.4)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -79,7 +79,7 @@ metasploit-concern, 4.0.3, "New BSD"
 metasploit-credential, 5.0.5, "New BSD"
 metasploit-framework, 6.1.28, "New BSD"
 metasploit-model, 4.0.3, "New BSD"
-metasploit-payloads, 2.0.71, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.72, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 5.0.4, "New BSD"
 metasploit_payloads-mettle, 1.0.18, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.71'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.72'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.18'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This change bumps the metasploit-payloads gem to 2.0.72, pulling in the following pr:
https://github.com/rapid7/metasploit-payloads/pull/523

It contains a fix for stdapi_sys_config_getenv. Previously `meterpreter > getenv MISSINGENVVARIABLE` would return `null` as a string. After this change an actual nil value is returned. 

## Verification

- [x] Get an java (or android) meterpreter session
- [x] Run `meterpreter > getenv ENVTHATDOESNTEXIST`

## Before change
```
meterpreter > getenv ENVTHATDOESNTEXIST

Environment Variables
=====================

Variable  Value
--------  -----
ENVTHATDOESNTEXIST      null
```

## After change

```
meterpreter > getenv ENVTHATDOESNTEXIST
[-] None of the specified environment variables were found/set.
```

This also fixes the android post/test/meterpreter tests, which would fail because chdir("null") would throw an exception (as "null" is not a valid directory).