### PR TITLE
Fix unknown platform error against Windows when using SSH Login

### DIFF
--- a/lib/metasploit/framework/ssh/platform.rb
+++ b/lib/metasploit/framework/ssh/platform.rb
@@ -84,31 +84,31 @@ module Metasploit
 
         def self.get_platform_from_info(info)
           case info
-          when /unifi\.version|UniFiSecurityGateway/ #Ubiquiti Unifi.  uname -a is left in, so we got to pull before Linux
+          when /unifi\.version|UniFiSecurityGateway/i #Ubiquiti Unifi.  uname -a is left in, so we got to pull before Linux
             'unifi'
-          when /Linux/
+          when /Linux/i
             'linux'
-          when /Darwin/
+          when /Darwin/i
             'osx'
-          when /SunOS/
+          when /SunOS/i
             'solaris'
-          when /BSD/
+          when /BSD/i
             'bsd'
-          when /HP-UX/
+          when /HP-UX/i
             'hpux'
-          when /AIX/
+          when /AIX/i
             'aix'
-          when /cygwin|Win32|Windows|Microsoft/
+          when /cygwin|Win32|Windows|Microsoft/i
             'windows'
-          when /Unknown command or computer name|Line has invalid autocommand/
+          when /Unknown command or computer name|Line has invalid autocommand/i
             'cisco-ios'
-          when /unknown keyword/ # ScreenOS
+          when /unknown keyword/i # ScreenOS
             'juniper'
-          when /JUNOS Base OS/ # JunOS
+          when /JUNOS Base OS/i # JunOS
             'juniper'
-          when /MikroTik/
+          when /MikroTik/i
             'mikrotik'
-          when /Arista/
+          when /Arista/i
             'arista'
           else
             'unknown'
@@ -118,4 +118,3 @@ module Metasploit
     end
   end
 end
-


### PR DESCRIPTION
This PR fixes an issue where the sessions platform would be reported as `unknown` when using an SSH Login module.

## Verification


- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_login`
- [ ] Get a session against a Windows machine
- [ ] **Verify** that the session is set as `windows`

## Before
```
msf6 auxiliary(scanner/ssh/ssh_login) > run

[*] 192.168.129.131:22 - Starting bruteforce
[+] 192.168.129.131:22 - Success: 'simon:simon' 'uid=500 gid=100(everyone) groups=100(everyone) CYGWIN_NT-6.2 DESKTOP-T5PBUMF 20.1 (0.3/1/1) 1998-12-3 20:39:18 i686 unknown '
[*] SSH session 1 opened (192.168.129.1:63410 -> 192.168.129.131:22 ) at 2022-02-03 16:08:16 +0000
[-] 192.168.129.131:22 - While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with device details so it can be handled in the future.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## After
```
msf6 auxiliary(scanner/ssh/ssh_login) > run

[*] 192.168.129.131:22 - Starting bruteforce
[+] 192.168.129.131:22 - Success: 'simon:simon' 'uid=500 gid=100(everyone) groups=100(everyone) CYGWIN_NT-6.2 DESKTOP-T5PBUMF 20.1 (0.3/1/1) 1998-12-3 20:39:18 i686 unknown '
[*] SSH session 1 opened (192.168.129.1:63386 -> 192.168.129.131:22 ) at 2022-02-03 16:07:15 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```