### PR TITLE
Fix to_handler case sensitivity issue

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -58,7 +58,7 @@ module Msf
               }
             }
 
-            handler.datastore.merge!(mod.datastore)
+            handler.share_datastore(mod.datastore)
             handler.exploit_simple(handler_opts)
             job_id = handler.job_id
 


### PR DESCRIPTION
Fixes a case sensitivity issue with option handling for the `to_handler` command on Metasploit payloads. Previously setting an 'LPORT' value within a payload would not override correctly override the previously set 'lport' value.

## Verification

Persist the multi/handler settings with an lhost/lport;
```
use multi/handler
set lhost 127.0.0.1
set lport 80
save
```

Use a payload and attempt to change the lport value:
```
use python/meterpreter_reverse_tcp
set lport 4444
to_handler
```

Verify that the lport is correctly set to 4444, and not 80