### PR TITLE
Don't crash when the hostname can't be determined

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -57,8 +57,8 @@ module Shell
     self.hist_last_saved = 0
 
     # Static prompt variables
-    self.local_hostname = ENV['HOSTNAME'] || try_exec('hostname')&.split('.')&.first || ENV['COMPUTERNAME'] || '???'
-    self.local_username = ENV['USER'] || try_exec('whoami') || ENV['USERNAME'] || '???'
+    self.local_hostname = ENV['HOSTNAME'] || try_exec('hostname')&.split('.')&.first&.rstrip || ENV['COMPUTERNAME'] || '???'
+    self.local_username = ENV['USER'] || try_exec('whoami')&.rstrip || ENV['USERNAME'] || '???'
 
     self.framework = framework
   end

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -57,8 +57,8 @@ module Shell
     self.hist_last_saved = 0
 
     # Static prompt variables
-    self.local_hostname = ENV['HOSTNAME'] || try_exec('hostname')&.split('.')&.first&.rstrip || ENV['COMPUTERNAME'] || '???'
-    self.local_username = ENV['USER'] || try_exec('whoami')&.rstrip || ENV['USERNAME'] || '???'
+    self.local_hostname = ENV['HOSTNAME'] || try_exec('hostname')&.split('.')&.first&.rstrip || ENV['COMPUTERNAME']
+    self.local_username = ENV['USER'] || try_exec('whoami')&.rstrip || ENV['USERNAME']
 
     self.framework = framework
   end

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -57,8 +57,8 @@ module Shell
     self.hist_last_saved = 0
 
     # Static prompt variables
-    self.local_hostname = ENV['HOSTNAME'] || `hostname`.split('.')[0] || ENV['COMPUTERNAME']
-    self.local_username = ENV['USER'] || `whoami` || ENV['USERNAME']
+    self.local_hostname = ENV['HOSTNAME'] || try_exec('hostname')&.split('.')&.first || ENV['COMPUTERNAME'] || '???'
+    self.local_username = ENV['USER'] || try_exec('whoami') || ENV['USERNAME'] || '???'
 
     self.framework = framework
   end
@@ -492,6 +492,14 @@ module Shell
   attr_reader   :cont_flag # :nodoc:
   attr_accessor :name
 private
+
+  def try_exec(command)
+    begin
+      %x{ #{ command } }
+    rescue SystemCallError
+      nil
+    end
+  end
 
   attr_writer   :cont_flag # :nodoc:
 


### PR DESCRIPTION
This fixes a crash that occurs when the hostname can not be determined which causes msfconsole to fail to start. This fixes it by catching the exception when the command is executed and returning `nil`. I ran into this issue while starting `msfconsole` on a fresh installation of Arch Linux. Default values are now `???` to ensure that `local_hostname` and `local_username` are always strings.

In order to reproduce the crash, two conditions must be met:

1. The `HOSTNAME` environment variable must not be defined
1. The `hostname` binary must not be present in the PATH

## Verification

List the steps needed to make sure this thing works

- [ ] Using a Linux shell (bash, zsh, etc), `unset HOSTNAME` to remove that environment variable
- [ ] Move/remove/uninstall or otherwise make the hostname binary inaccessible
    * Suggestion: `sudo mv $(which hostname) $(which hostname).bk`
- [ ] Start `./msfconsole` see it work, without these changes a stack trace would be present

## Original Crash

```
./msfconsole
Traceback (most recent call last):ork console.../
	8: from ./msfconsole:23:in `<main>'
	7: from /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
	6: from /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
	5: from /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/console.rb:60:in `driver'
	4: from /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/console.rb:60:in `new'
	3: from /home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/driver.rb:81:in `initialize'
	2: from /home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:376:in `initialize'
	1: from /home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:60:in `initialize'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:60:in ``': No such file or directory - hostname (Errno::ENOENT)
```