### PR TITLE
Add support for Java Meterpreter's native_arch

### DIFF
--- a/lib/msf/base/sessions/meterpreter_java.rb
+++ b/lib/msf/base/sessions/meterpreter_java.rb
@@ -21,8 +21,11 @@ class Meterpreter_Java_Java < Msf::Sessions::Meterpreter
     self.base_platform = 'java'
     self.base_arch = ARCH_JAVA
   end
+
+  def native_arch
+    @native_arch ||= self.core.native_arch
+  end
 end
 
 end
 end
-


### PR DESCRIPTION
This PR allows Java Meterpreter to get the correct architecture of the Java VM it is running on. It follows Python Meterpreter's convention.
This PR relies on https://github.com/rapid7/metasploit-payloads/pull/533

This functionality is needed to properly construct Railgun packets using the `def build_packet_and_layouts(packet, function, args, arch)` function.

## Verification

- [x] Checkout the PR https://github.com/rapid7/metasploit-payloads/pull/533
- [x] Compile the Java Meterpreter using the code above
- [x] Start `msfconsole`
- [x] `use payload/java/meterpreter/reverse_tcp`
- [x] Get a Java Meterpreter shell
- [x] **Confirm** that typing `irb` folowed by `native_arch` returns the correct Java architecture

## Before
```
meterpreter > irb
[*] Starting IRB shell...
[*] You are in the "client" (session) object

irb: warn: can't alias kill from irb_kill.
>> native_arch
=> "java"
```

## After
```
meterpreter > irb
[*] Starting IRB shell...
[*] You are in the "client" (session) object

irb: warn: can't alias kill from irb_kill.
>> native_arch
=> "x64"
```