### PR TITLE
Update replicant pattern to increment refs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,7 +355,7 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.25)
+    rex-core (0.1.26)
     rex-encoder (0.1.6)
       metasm
       rex-arch

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -58,9 +58,11 @@ module Exploit::Remote::SocketServer
   #
   def cleanup
     super
-    if(service)
-      stop_service()
-      print_status("Server stopped.")
+    if service
+      stopped = stop_service
+      if stopped
+        print_status("Server stopped.")
+      end
     end
   end
 
@@ -80,17 +82,24 @@ module Exploit::Remote::SocketServer
   # Stops the service.
   #
   def stop_service
-    if (service)
+    if service
       begin
-        self.service.deref if self.service.kind_of?(Rex::Service)
-        if self.service.kind_of?(Rex::Socket) || self.service.kind_of?(Rex::Post::Meterpreter::Channel)
-          self.service.close
-          self.service.stop
+        if self.service.kind_of?(Rex::Service)
+          temp_service = self.service
+          self.service = nil
+          return temp_service.deref
+        else
+          if self.service.kind_of?(Rex::Socket) || self.service.kind_of?(Rex::Post::Meterpreter::Channel)
+            self.service.close
+            self.service.stop
+          end
         end
 
         self.service = nil
+        true
       rescue ::Exception => e
         print_error(e.message)
+        false
       end
     end
   end

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -150,9 +150,15 @@ module Msf
     def replicant
       obj = self.clone
       self.instance_variables.each { |k|
-        v = instance_variable_get(k)
-        v = v.dup rescue v
-        obj.instance_variable_set(k, v)
+        old_value = instance_variable_get(k)
+        begin
+          new_value = old_value.is_a?(Rex::Ref) ? old_value.ref : old_value.dup
+        rescue => e
+          elog("#{self.class} replicant failed to dup #{k}", error: e)
+          new_value = old_value
+        end
+
+        obj.instance_variable_set(k, new_value)
       }
 
       obj.datastore    = self.datastore.copy

--- a/lib/rex/service.rb
+++ b/lib/rex/service.rb
@@ -28,6 +28,7 @@ module Service
     # If there's only one reference, then it's the service managers.
     if @_references == 1
       Rex::ServiceManager.stop_service(self)
+      return true
     end
 
     rv


### PR DESCRIPTION
Supersedes #15971
Requires https://github.com/rapid7/rex-core/pull/25

A possible solution to the problem encountered by https://github.com/rapid7/metasploit-framework/pull/15958 - which required sharing resources amongst the `replicant` Log4Shell modules which are created by the Scanner Mixin. Replication of the service objects would lead to the following bind errors:

```
msf6 auxiliary(scanner/http/log4shell_scanner) > run http://10.10.235.209:8983/ http://10.10.235.209:8983/ http://10.10.235.209:8983/ srvhost=10.9.4.245 verbose=true threads=3

[-] Auxiliary aborted due to failure: bad-config: The address is already in use or unavailable: (10.9.4.245:389).
[*] Auxiliary module execution completed
```

## Verification

Follow the same steps as: https://github.com/rapid7/metasploit-framework/pull/15958, and ensure that there are no binding errors output