### PR TITLE
Add readline option to msfconsole

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -85,6 +85,7 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
       driver_options['Logger'] = options.console.logger
       driver_options['ModulePath'] = options.modules.path
       driver_options['Plugins'] = options.console.plugins
+      driver_options['Readline'] = options.console.readline
       driver_options['RealReadline'] = options.console.real_readline
       driver_options['Resource'] = options.console.resources
       driver_options['XCommands'] = options.console.commands

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -15,6 +15,7 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
         options.console.local_output = nil
         options.console.plugins = []
         options.console.quiet = false
+        options.console.readline = true
         options.console.real_readline = false
         options.console.resources = []
         options.console.subcommand = :run
@@ -46,6 +47,10 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
 
         option_parser.on('-l', '--logger STRING', "Specify a logger to use (#{Rex::Logging::LogSinkFactory.available_sinks.join(', ')})") do |logger|
           options.console.logger = logger
+        end
+
+        option_parser.on('--[no-]readline') do |readline|
+          options.console.readline = readline
         end
 
         option_parser.on('-L', '--real-readline', 'Use the system Readline library instead of RbReadline') do

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -51,6 +51,7 @@ class Driver < Msf::Ui::Driver
   #
   # @option opts [Boolean] 'AllowCommandPassthru' (true) Whether to allow
   #   unrecognized commands to be executed by the system shell
+  # @option opts [Boolean] 'Readline' (true) Whether to use the readline or not
   # @option opts [Boolean] 'RealReadline' (false) Whether to use the system's
   #   readline library instead of RBReadline
   # @option opts [String] 'HistFile' (Msf::Config.history_file) Path to a file
@@ -90,6 +91,10 @@ class Driver < Msf::Ui::Driver
     # handle if one is supplied
     input = opts['LocalInput']
     input ||= Rex::Ui::Text::Input::Stdio.new
+
+    if !opts['Readline']
+      input.disable_readline
+    end
 
     if (opts['LocalOutput'])
       if (opts['LocalOutput'].kind_of?(String))

--- a/lib/rex/ui/text/input.rb
+++ b/lib/rex/ui/text/input.rb
@@ -20,6 +20,7 @@ class Input
   def initialize
     self.eof = false
     @config = {
+      :readline => true, # true, false
       :color => :auto, # true, false, :auto
     }
     super
@@ -29,7 +30,9 @@ class Input
   # Whether or not the input medium supports readline.
   #
   def supports_readline
-    true
+    return true if not @config
+
+    config[:readline] == true
   end
 
   #
@@ -82,6 +85,16 @@ class Input
 
   attr_reader :config
 
+  def disable_readline
+    return if not @config
+    @config[:readline] = false
+  end
+
+  def enable_readline
+    return if not @config
+    @config[:readline] = true
+  end
+
   def disable_color
     return if not @config
     @config[:color] = false
@@ -111,4 +124,3 @@ end
 end
 end
 end
-


### PR DESCRIPTION
Adds additional options for enabling/disabling readline support when using msfconsole

## Verification

Verify that the option work as expected.

Readline enabled:
```
bundle exec ./msfconsole -q
```

Readline disabled:
```
bundle exec ./msfconsole -q --no-readline
```

Readline enabled:
```
bundle exec ./msfconsole -q --readline
```