### PR TITLE
Specify mode rb on file reads

### DIFF
--- a/lib/msf/core/exploit/android.rb
+++ b/lib/msf/core/exploit/android.rb
@@ -114,7 +114,7 @@ module Exploit::Android
   # The NDK stager is used to launch a hidden APK
   def ndkstager(stagename, arch)
     stager_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2012-6636", NDK_FILES[arch] || arch, 'libndkstager.so')
-    data = File.read(stager_file, {:mode => 'rb'})
+    data = File.read(stager_file, mode: 'rb')
     data.gsub!('PLOAD', stagename)
   end
 

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -488,7 +488,7 @@ module Msf::Post::File
   # @param local [String] Local file whose contents will be uploaded
   # @return (see #write_file)
   def upload_file(remote, local)
-    write_file(remote, ::File.read(local))
+    write_file(remote, ::File.read(local, mode: 'rb'))
   end
 
   #

--- a/modules/exploits/android/local/binder_uaf.rb
+++ b/modules/exploits/android/local/binder_uaf.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     local_file = File.join(Msf::Config.data_directory, "exploits", "CVE-2019-2215", "exploit")
-    exploit_data = File.read(local_file, { :mode => 'rb' })
+    exploit_data = File.read(local_file, mode: 'rb')
 
     workingdir = session.fs.dir.getwd
     exploit_file = "#{workingdir}/.#{Rex::Text::rand_text_alpha_lower(5)}"

--- a/modules/exploits/android/local/futex_requeue.rb
+++ b/modules/exploits/android/local/futex_requeue.rb
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Using target: #{my_target.name}")
 
     local_file = File.join(Msf::Config.data_directory, "exploits", "CVE-2014-3153.so")
-    exploit_data = File.read(local_file, { :mode => 'rb' })
+    exploit_data = File.read(local_file, mode: 'rb')
 
     # Substitute the exploit shellcode with our own
     space = payload_space

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     local_file = File.join(Msf::Config.data_directory, "exploits", "CVE-2013-6282.so")
-    exploit_data = File.read(local_file, { :mode => 'rb' })
+    exploit_data = File.read(local_file, mode: 'rb')
 
     space = payload_space
     payload_encoded = payload.encoded

--- a/modules/exploits/apple_ios/browser/webkit_trident.rb
+++ b/modules/exploits/apple_ios/browser/webkit_trident.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if request.uri =~ %r{/loader32$}
       print_good("armle target is vulnerable.")
       local_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2016-4655", "exploit32" )
-      loader_data = File.read(local_file, {:mode => 'rb'})
+      loader_data = File.read(local_file, mode: 'rb')
       srvhost = Rex::Socket.resolv_nbo_i(srvhost_addr)
       config = [srvhost, srvport].pack("Nn") + payload_url
       payload_url_index = loader_data.index('PAYLOAD_URL')
@@ -70,12 +70,12 @@ class MetasploitModule < Msf::Exploit::Remote
     elsif request.uri =~ %r{/loader64$}
       print_good("aarch64 target is vulnerable.")
       local_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2016-4655", "loader" )
-      loader_data = File.read(local_file, {:mode => 'rb'})
+      loader_data = File.read(local_file, mode: 'rb')
       send_response(cli, loader_data, {'Content-Type'=>'application/octet-stream'})
       return
     elsif request.uri =~ %r{/exploit64$}
       local_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2016-4655", "exploit" )
-      loader_data = File.read(local_file, {:mode => 'rb'})
+      loader_data = File.read(local_file, mode: 'rb')
       payload_url_index = loader_data.index('PAYLOAD_URL')
       loader_data[payload_url_index, payload_url.length] = payload_url
       send_response(cli, loader_data, {'Content-Type'=>'application/octet-stream'})


### PR DESCRIPTION
Fixes an edge case when reading files on Windows, and fixes Ruby 3 crashes when reading files.

### Windows fix

The file upload support of Meterpreter was broken on windows machines, which was doing additional EOL<->CRLF conversions on windows:

```
"b"  Binary file mode
     Suppresses EOL <-> CRLF conversion on Windows. And
     sets external encoding to ASCII-8BIT unless explicitly
     specified.
```

### Crash fix

Ruby 2.7:
```
irb
2.7.1 :001 > RUBY_DESCRIPTION
 => "ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin18]" 
2.7.1 :003 > File.read('/etc/passwd', {:mode => 'rb'}).length
(irb):3: warning: Using the last argument as keyword parameters is deprecated
 => 7630 
```

Ruby 3:
```
/ # irb
irb(main):001:0> RUBY_DESCRIPTION
=> "ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux-musl]"
irb(main):002:0> File.read('/etc/passwd', {:mode => 'rb'}).length
(irb):2:in `read': no implicit conversion of Hash into Integer (TypeError)
	from (irb):2:in `<main>'
	from /usr/local/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
	from /usr/local/bin/irb:23:in `load'
	from /usr/local/bin/irb:23:in `<main>'
```