### PR TITLE
Order loadpath summary output

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -288,7 +288,7 @@ module Msf
 
             added = "Loaded #{overall} modules:\n"
 
-            totals.each_pair { |type, count|
+            totals.sort_by { |type, _count| type }.each { |type, count|
               added << "    #{count} #{type} modules\n"
             }
 


### PR DESCRIPTION
Adds alphabetical sorting to the loadpath command's summary output

## Verification

Master, the loadpath summary is arbitrarily ordered:
```
msf6 > loadpath test/modules
Loaded 38 modules:
    11 post modules
    13 exploit modules
    14 auxiliary modules
```

This branch, the loadpath summary ordered alphabetically:
```
msf6 > loadpath test/modules
Loaded 38 modules:
    14 auxiliary modules
    13 exploit modules
    11 post modules
```