### PR TITLE
Fix search path date test for osx

### DIFF
--- a/test/modules/post/test/search.rb
+++ b/test/modules/post/test/search.rb
@@ -154,11 +154,15 @@ class MetasploitModule < Msf::Post
       res
     end
 
-    genesis_date = "3 January 2009 18:15:13 +0000"
-    genesis = DateTime.parse(genesis_date).to_i
+    genesis_str = "3 January 2009 18:15:13 +0000"
+    genesis_date = DateTime.parse(genesis_str)
+    genesis = genesis_date.to_i
 
-    if not ['windows', 'win'].include? session.platform
-      cmd_exec("touch -d '#{genesis_date}' #{@file_name}")
+    if session.platform == 'osx'
+      osx_genesis_str = genesis_date.strftime("%Y%m%d%H%M.%S")
+      cmd_exec("touch -t '#{osx_genesis_str}' #{@file_name}")
+    elsif !['windows', 'win'].include?(session.platform)
+      cmd_exec("touch -d '#{genesis_str}' #{@file_name}")
     elsif session.priv.present?
       client.priv.fs.set_file_mace(@file_name, genesis)
     else


### PR DESCRIPTION
Fixes a search path bug for osx

## Verification

Open a Python Meterpreter on osx:
```
use python/meterpreter_reverse_tcp
generate -o shell.py -f raw lhost=127.0.0.1
to_handler
python3 shell.py
```

Run the test:
```
loadpath test/modules
use test/search
run session=-1
```

Master:
```
msf6 post(test/search) > run session=-1

[!] SESSION may not be compatible with this module:
[!]  * incompatible session platform: osx
[*] Running against session -1
[*] Session type is meterpreter and platform is osx
[+] should search for new files
[+] should search recursively for files
[+] should search with globs for files
[+] should search with globs ignoring files
[+] should search with dates for files
[+] should search with dates ignores new files
[+] should search with dates ignores old files
[-] FAILED: should search with date inclusive of exact date
[-] Passed: 7; Failed: 1
[*] Post module execution completed
```

This branch:
```
msf6 post(test/search) > run session=-1

[!] SESSION may not be compatible with this module:
[!]  * incompatible session platform: osx
[*] Running against session -1
[*] Session type is meterpreter and platform is osx
[+] should search for new files
[+] should search recursively for files
[+] should search with globs for files
[+] should search with globs ignoring files
[+] should search with dates for files
[+] should search with dates ignores new files
[+] should search with dates ignores old files
[+] should search with date inclusive of exact date
[*] Passed: 8; Failed: 0
```