### PR TITLE
Fix Meterpreter module test for Windows Python Meterpreter

### DIFF
--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -156,7 +156,14 @@ class MetasploitModule < Msf::Post
       sysinfo = session.sys.config.sysinfo
       if sysinfo["OS"] =~ /windows/i
         sep = session.fs.file.separator
-        res = (sep == "\\")
+
+        # Python may return / instead of \ on windows depending on its compilation
+        #   https://github.com/msys2/MSYS2-packages/issues/1591
+        if session.arch == ARCH_PYTHON
+          res = (sep == "\\" || sep == "/")
+        else
+          res = (sep == "\\")
+        end
       else
         sep = session.fs.file.separator
         res = (sep == "/")
@@ -266,7 +273,7 @@ class MetasploitModule < Msf::Post
           uploaded_contents << fd.read
         end
         fd.close
-        original_contents = ::File.read(local)
+        original_contents = ::File.read(local, mode: 'rb')
 
         res &&= !!(uploaded_contents == original_contents)
       end
@@ -342,9 +349,9 @@ class MetasploitModule < Msf::Post
 
       if res
         remote_md5 = session.fs.file.md5(remote)
-        local_md5  = Digest::MD5.digest(::File.read(local))
+        local_md5  = Digest::MD5.digest(::File.read(local, mode: 'rb'))
         remote_sha = session.fs.file.sha1(remote)
-        local_sha  = Digest::SHA1.digest(::File.read(local))
+        local_sha  = Digest::SHA1.digest(::File.read(local, mode: 'rb'))
         vprint_status("remote md5: #{Rex::Text.to_hex(remote_md5,'')}")
         vprint_status("local md5 : #{Rex::Text.to_hex(local_md5,'')}")
         vprint_status("remote sha: #{Rex::Text.to_hex(remote_sha,'')}")


### PR DESCRIPTION
Fixes Meterpreter module test for the Windows Python Meterpreter which would return a different file path separator depending on how the runtime was compiled

Also file read issues on windows, similar to https://github.com/rapid7/metasploit-framework/pull/16174

## Verification

Open a Python Meterpreter on windows:
```
use python/meterpreter_reverse_tcp
generate -o shell.py -f raw lhost=127.0.0.1
to_handler
python3 shell.py
```

Run the test:
```
loadpath test/modules
use test/search
run session=-1
```

Verify the tests pass now.