### PR TITLE
Add Meterpreter compatibility resource file

### DIFF
--- a/scripts/resource/meterpreter_compatibility.rc
+++ b/scripts/resource/meterpreter_compatibility.rc
@@ -1,0 +1,44 @@
+# Outputs the currently supported Meterpreter commands as JSON for the currently opened Meterpreter sessions
+# Usage:
+# msf> resource scripts/resource/meterpreter_compatibility.rc
+
+<ruby>
+require 'json'
+
+# Attempt to load all known extensions
+framework.sessions.values.map do |session|
+  next unless session.type == 'meterpreter'
+
+  Rex::Post::Meterpreter::ExtensionMapper.get_extension_names.each do |extension_name|
+    session.core.use(extension_name)
+  rescue ::RuntimeError
+    puts "failed loading #{extension_name}"
+    # noop
+  end
+end
+
+# Create an array of supported session information
+session_data = framework.sessions.values.map do |session|
+  next unless session.type == 'meterpreter'
+
+  supported_commands = session.commands.map do |command_id|
+    command_name = Rex::Post::Meterpreter::CommandMapper.get_command_name(command_id)
+
+    {
+      id: command_id,
+      name: command_name
+    }
+  end
+
+  {
+    session_type: session.session_type,
+    commands: supported_commands
+  }
+end.compact
+
+result = {
+  sessions: session_data
+}
+
+puts JSON.fast_generate(result)
+</ruby>


### PR DESCRIPTION
Adds a resource script for extracting the Meterpreter commands from the currently opened sessions:


## Verification

Open a Python Meterpreter:
```
use python/meterpreter_reverse_tcp
generate -o shell.py -f raw lhost=127.0.0.1
to_handler
python3 shell.py
```

Verify JSON is output:
```
resource scripts/resource/meterpreter_compatibility.rc
```

Output:
```
msf6 payload(python/meterpreter_reverse_tcp) > resource scripts/resource/meterpreter_compatibility.rc
[*] Processing /Users/alan/Documents/code/metasploit-framework/scripts/resource/meterpreter_compatibility.rc for ERB directives.
[*] resource (/Users/alan/Documents/code/metasploit-framework/scripts/resource/meterpreter_compatibility.rc)> Ruby Code (889 bytes)
failed loading sniffer
failed loading extapi
failed loading kiwi
failed loading python
failed loading unhook
failed loading appapi
failed loading winpmem
failed loading powershell
failed loading lanattacks
failed loading priv
failed loading incognito
failed loading android
failed loading peinjector
failed loading espia
{"sessions":[{"session_type":"python/osx","commands":[{"id":1,"name":"core_channel_close"},{"id":2,"name":"core_channel_eof"},{"id":3,"name":"core_channel_interact"},{"id":4,"name":"core_channel_open"},{"id":5,"name":"core_channel_read"},{"id":6,"name":"core_channel_seek"},{"id":7,"name":"core_channel_tell"},{"id":8,"name":"core_channel_write"},{"id":10,"name":"core_enumextcmd"},{"id":11,"name":"core_get_session_guid"},{"id":12,"name":"core_loadlib"},{"id":13,"name":"core_machine_id"},{"id":15,"name":"core_native_arch"},{"id":16,"name":"core_negotiate_tlv_encryption"},{"id":17,"name":"core_patch_url"},{"id":21,"name":"core_set_session_guid"},{"id":22,"name":"core_set_uuid"},{"id":23,"name":"core_shutdown"},{"id":24,"name":"core_transport_add"},{"id":25,"name":"core_transport_change"},{"id":27,"name":"core_transport_list"},{"id":28,"name":"core_transport_next"},{"id":29,"name":"core_transport_prev"},{"id":30,"name":"core_transport_remove"},{"id":32,"name":"core_transport_set_timeouts"},{"id":33,"name":"core_transport_sleep"},{"id":1052,"name":"stdapi_sys_config_getenv"},{"id":1055,"name":"stdapi_sys_config_getuid"},{"id":1056,"name":"stdapi_sys_config_localtime"},{"id":1059,"name":"stdapi_sys_config_sysinfo"},{"id":1068,"name":"stdapi_sys_process_close"},{"id":1069,"name":"stdapi_sys_process_execute"},{"id":1072,"name":"stdapi_sys_process_getpid"},{"id":1077,"name":"stdapi_sys_process_kill"},{"id":1071,"name":"stdapi_sys_process_get_processes"},{"id":1001,"name":"stdapi_fs_chdir"},{"id":1003,"name":"stdapi_fs_delete_dir"},{"id":1004,"name":"stdapi_fs_delete_file"},{"id":1006,"name":"stdapi_fs_file_expand_path"},{"id":1007,"name":"stdapi_fs_file_move"},{"id":1005,"name":"stdapi_fs_file_copy"},{"id":1002,"name":"stdapi_fs_chmod"},{"id":1008,"name":"stdapi_fs_getwd"},{"id":1009,"name":"stdapi_fs_ls"},{"id":1010,"name":"stdapi_fs_md5"},{"id":1011,"name":"stdapi_fs_mkdir"},{"id":1013,"name":"stdapi_fs_search"},{"id":1014,"name":"stdapi_fs_separator"},{"id":1015,"name":"stdapi_fs_sha1"},{"id":1016,"name":"stdapi_fs_stat"},{"id":1019,"name":"stdapi_net_config_get_interfaces"},{"id":1022,"name":"stdapi_net_config_get_routes"},{"id":1024,"name":"stdapi_net_resolve_host"},{"id":1025,"name":"stdapi_net_resolve_hosts"},{"id":1026,"name":"stdapi_net_socket_tcp_shutdown"},{"id":1028,"name":"stdapi_railgun_api"},{"id":1029,"name":"stdapi_railgun_api_multi"},{"id":1030,"name":"stdapi_railgun_memread"},{"id":1031,"name":"stdapi_railgun_memwrite"},{"id":1118,"name":"stdapi_sys_process_set_term_size"},{"id":1052,"name":"stdapi_sys_config_getenv"},{"id":1055,"name":"stdapi_sys_config_getuid"},{"id":1056,"name":"stdapi_sys_config_localtime"},{"id":1059,"name":"stdapi_sys_config_sysinfo"},{"id":1068,"name":"stdapi_sys_process_close"},{"id":1069,"name":"stdapi_sys_process_execute"},{"id":1072,"name":"stdapi_sys_process_getpid"},{"id":1077,"name":"stdapi_sys_process_kill"},{"id":1071,"name":"stdapi_sys_process_get_processes"},{"id":1001,"name":"stdapi_fs_chdir"},{"id":1003,"name":"stdapi_fs_delete_dir"},{"id":1004,"name":"stdapi_fs_delete_file"},{"id":1006,"name":"stdapi_fs_file_expand_path"},{"id":1007,"name":"stdapi_fs_file_move"},{"id":1005,"name":"stdapi_fs_file_copy"},{"id":1002,"name":"stdapi_fs_chmod"},{"id":1008,"name":"stdapi_fs_getwd"},{"id":1009,"name":"stdapi_fs_ls"},{"id":1010,"name":"stdapi_fs_md5"},{"id":1011,"name":"stdapi_fs_mkdir"},{"id":1013,"name":"stdapi_fs_search"},{"id":1014,"name":"stdapi_fs_separator"},{"id":1015,"name":"stdapi_fs_sha1"},{"id":1016,"name":"stdapi_fs_stat"},{"id":1019,"name":"stdapi_net_config_get_interfaces"},{"id":1022,"name":"stdapi_net_config_get_routes"},{"id":1024,"name":"stdapi_net_resolve_host"},{"id":1025,"name":"stdapi_net_resolve_hosts"},{"id":1026,"name":"stdapi_net_socket_tcp_shutdown"},{"id":1028,"name":"stdapi_railgun_api"},{"id":1029,"name":"stdapi_railgun_api_multi"},{"id":1030,"name":"stdapi_railgun_memread"},{"id":1031,"name":"stdapi_railgun_memwrite"},{"id":1118,"name":"stdapi_sys_process_set_term_size"}]}]}
```
