### PR TITLE
Add ServerJang to session notifier to allow sending new session information to WeChat

### DIFF
--- a/plugins/session_notifier.rb
+++ b/plugins/session_notifier.rb
@@ -335,22 +335,21 @@ module Msf
 
       def send_text_to_serverjang(session)
         # https://sct.ftqq.com/sendkey
-        platform = "#{session.platform}"
-        arch = "#{session.arch}"
-        tunnel = "#{session.tunnel_to_s}"
         uri_parser = URI.parse(serverjang_webhook)
         params = {}
         params["title"] = "You have new #{session.type} session"
-        params["desp"] = 'OS:%s, tunnel:%s, Arch:%s' %[platform,tunnel,arch]
+        params["desp"] = "OS:#{session.platform}, tunnel:#{session.tunnel_to_s}, Arch:#{session.arch}"
         http = Net::HTTP.new(uri_parser.host, uri_parser.port)
         http.use_ssl = true
+
         res = Net::HTTP::post_form(uri_parser,params)
-        body = JSON.parse(res.body)
         if res.nil? || res.body.blank?
-          print_error("No response recieved from the ServerJang server!")
+          print_error("No response received from the ServerJang server!")
           return nil
         end
+
         begin
+          body = JSON.parse(res.body)
           print_status((body["code"] == 20001) ? 'Failed to send notification.' : 'Session notified to ServerJang.')
         rescue JSON::ParserError
           print_error("Couldn't parse the JSON returned from the ServerJang server!")

--- a/plugins/session_notifier.rb
+++ b/plugins/session_notifier.rb
@@ -25,6 +25,7 @@ module Msf
       attr_reader :dingtalk_webhook
       attr_reader :gotify_address
       attr_reader :gotify_sslcert_path
+      attr_reader :serverjang_webhook
 
       def name
         'SessionNotifier'
@@ -44,6 +45,7 @@ module Msf
           'set_session_dingtalk_webhook'   => 'Set the DingTalk webhook for the session notifier (keyword: session).',
           'set_session_gotify_address'     => 'Set the Gotify address for the session notifier',
           'set_session_gotify_sslcert_path' => 'Set the path to load your Gotify SSL cert (if you want to use HTTPS)',
+          'set_session_serverjang_webhook' => 'Set the ServerJiang webhook for the session notifier (keyword: session).',
           'save_session_notifier_settings' => 'Save all the session notifier settings to framework',
           'start_session_notifier'         => 'Start notifying sessions',
           'stop_session_notifier'          => 'Stop notifying sessions',
@@ -150,6 +152,17 @@ module Msf
         end
       end
 
+      def cmd_set_session_serverjang_webhook(*args)
+        webhook_url = args[0]
+        if webhook_url.blank?
+          @serverjang_webhook = nil
+        elsif !(webhook_url =~ URI::DEFAULT_PARSER.make_regexp).nil?
+          @serverjang_webhook = webhook_url
+        else
+          print_error('Invalid webhook_url')
+        end
+      end
+
       def cmd_save_session_notifier_settings(*_args)
         save_settings_to_config
         print_status('Session Notifier settings saved in config file.')
@@ -180,6 +193,9 @@ module Msf
           end
           if !gotify_address.nil?
             print_status('Gotify notification started.')
+          end
+          if !serverjang_webhook.nil?
+            print_status('ServerJang notification started.')
           end
         rescue Msf::Plugin::SessionNotifier::Exception, Rex::Proto::Sms::Exception => e
           print_error(e.message)
@@ -220,6 +236,7 @@ module Msf
         ini[name]['dingtalk_webhook'] = dingtalk_webhook.to_s unless dingtalk_webhook.blank?
         ini[name]['gotify_address']   = gotify_address.to_s unless gotify_address.blank?
         ini[name]['gotify_sslcert_path']   = gotify_sslcert_path.to_s unless gotify_sslcert_path.blank?
+        ini[name]['serverjang_webhook'] = serverjang_webhook.to_s unless serverjang_webhook.blank?
         ini.to_file(config_file)
       end
 
@@ -240,6 +257,7 @@ module Msf
           @dingtalk_webhook = group['dingtalk_webhook']       if group['dingtalk_webhook']
           @gotify_address   = group['gotify_address']         if group['gotify_address']
           @gotify_sslcert_path = group['gotify_sslcert_path'] if group['gotify_sslcert_path']
+          @serverjang_webhook = group['serverjang_webhook']   if group['serverjang_webhook']
           print_status('Session Notifier settings loaded from config file.')
         end
       end
@@ -315,6 +333,30 @@ module Msf
         end
       end
 
+      def send_text_to_serverjang(session)
+        # https://sct.ftqq.com/sendkey
+        platform = "#{session.platform}"
+        arch = "#{session.arch}"
+        tunnel = "#{session.tunnel_to_s}"
+        uri_parser = URI.parse(serverjang_webhook)
+        params = {}
+        params["title"] = "You have new #{session.type} session"
+        params["desp"] = 'OS:%s, tunnel:%s, Arch:%s' %[platform,tunnel,arch]
+        http = Net::HTTP.new(uri_parser.host, uri_parser.port)
+        http.use_ssl = true
+        res = Net::HTTP::post_form(uri_parser,params)
+        body = JSON.parse(res.body)
+        if res.nil? || res.body.blank?
+          print_error("No response recieved from the ServerJang server!")
+          return nil
+        end
+        begin
+          print_status((body["code"] == 20001) ? 'Failed to send notification.' : 'Session notified to ServerJang.')
+        rescue JSON::ParserError
+          print_error("Couldn't parse the JSON returned from the ServerJang server!")
+        end
+      end
+
       def notify_session(session, subject, msg)
         if in_range?(session) && validate_sms_settings?
           @sms_client.send_text_to_phones([sms_number], subject, msg)
@@ -325,6 +367,9 @@ module Msf
         end
         if in_range?(session) && !gotify_address.nil?
           send_text_to_gotify(session)
+        end
+        if in_range?(session) && !serverjang_webhook.nil?
+          send_text_to_serverjang(session)
         end
       end
 


### PR DESCRIPTION
In order to allow WeChat to receive session information, I added a new interface ServerJang to send session information to WeChat.
## Demonstration Instructions 

**0x01.Get Webhook**

Use WeChat to log in [the website](https://sct.ftqq.com) and get the webhook.

![imp0](https://user-images.githubusercontent.com/41460798/153988245-426ab92c-5cf9-49bc-b31a-99cbf489c6e4.png)

**0x02.Load new plugin**

`load session_notifier`

**0x03.Set Webhook address And Start**

`set_session_serverjang_webhook https://sctapi.ftqq.com/**********.send`

`start_session_notifier`

**0x04.Set the payload and Start listening**

![imp1](https://user-images.githubusercontent.com/41460798/154017953-7499e654-fa6f-40fa-a608-8c7367095ada.jpg)


**0x05.View notification information on WeChat**

![imp2](https://user-images.githubusercontent.com/41460798/153988456-c5648e97-fcd1-49a5-8860-d03b5e4ae1b2.png)

![imp3](https://user-images.githubusercontent.com/41460798/153988645-6d38b85b-6f21-4f05-ae6f-a77c3f6882f2.png)

**0x06.Thats all**
Thx, I sincerely hope the code could be adopted! BTW,  I am proud of providing the code! your project is very great! I like it ; )