### PR TITLE
Bump RubySMB to 3.0.4 - Fix the command target in the psexec module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,7 +436,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.0.2)
+    ruby_smb (3.0.3)
       bindata
       openssl-ccm
       openssl-cmac

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,7 +436,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.0.3)
+    ruby_smb (3.0.4)
       bindata
       openssl-ccm
       openssl-cmac

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -161,7 +161,7 @@ ruby-prof, 1.4.2, "Simplified BSD"
 ruby-progressbar, 1.11.0, MIT
 ruby-rc4, 0.1.5, MIT
 ruby2_keywords, 0.0.5, "ruby, Simplified BSD"
-ruby_smb, 3.0.2, "New BSD"
+ruby_smb, 3.0.3, "New BSD"
 rubyntlm, 0.6.3, MIT
 rubyzip, 2.3.2, "Simplified BSD"
 sawyer, 0.8.2, MIT

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -161,7 +161,7 @@ ruby-prof, 1.4.2, "Simplified BSD"
 ruby-progressbar, 1.11.0, MIT
 ruby-rc4, 0.1.5, MIT
 ruby2_keywords, 0.0.5, "ruby, Simplified BSD"
-ruby_smb, 3.0.3, "New BSD"
+ruby_smb, 3.0.4, "New BSD"
 rubyntlm, 0.6.3, MIT
 rubyzip, 2.3.2, "Simplified BSD"
 sawyer, 0.8.2, MIT


### PR DESCRIPTION
Update the ruby_smb gem from v3.0.2 to v3.0.4 to pull in the bug fix from rapid7/ruby_smb#193 and rapid7/ruby_smb#194.

This notably fixes the command target in the psexec module so the command output can be returned and the framework unit tests.