### PR TITLE
Update hp_dataprotector_cmd_exec.rb

### DIFF
--- a/modules/exploits/windows/misc/hp_dataprotector_cmd_exec.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_cmd_exec.rb
@@ -44,6 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Privileged'     => true,
       'Platform'       => 'win',
+      'Arch'           => [ARCH_X86, ARCH_X64],
       'Stance'         => Msf::Exploit::Stance::Aggressive,
       'Targets'        =>
         [


### PR DESCRIPTION
64 bit payloads support added. 

Some targets with this installed are x64 instead of x86, but the module only supported 32 bits payloads.

With this change, you can select a 64 bit meterpreter payload.

This module does not break anything. 