### PR TITLE
Fix Meterpreter module tests on Windows host

### DIFF
--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -266,7 +266,7 @@ class MetasploitModule < Msf::Post
           uploaded_contents << fd.read
         end
         fd.close
-        original_contents = ::File.read(local)
+        original_contents = ::File.read(local, mode: 'rb')
 
         res &&= !!(uploaded_contents == original_contents)
       end
@@ -342,9 +342,9 @@ class MetasploitModule < Msf::Post
 
       if res
         remote_md5 = session.fs.file.md5(remote)
-        local_md5  = Digest::MD5.digest(::File.read(local))
+        local_md5  = Digest::MD5.digest(::File.read(local, mode: 'rb'))
         remote_sha = session.fs.file.sha1(remote)
-        local_sha  = Digest::SHA1.digest(::File.read(local))
+        local_sha  = Digest::SHA1.digest(::File.read(local, mode: 'rb'))
         vprint_status("remote md5: #{Rex::Text.to_hex(remote_md5,'')}")
         vprint_status("local md5 : #{Rex::Text.to_hex(local_md5,'')}")
         vprint_status("remote sha: #{Rex::Text.to_hex(remote_sha,'')}")


### PR DESCRIPTION
Fixes an edge case when reading files on Windows, and fixes Ruby 3 crashes when reading files.

### Windows fix

The file upload support of Meterpreter was broken on windows machines, which was doing additional EOL<->CRLF conversions on windows:

```
"b"  Binary file mode
     Suppresses EOL <-> CRLF conversion on Windows. And
     sets external encoding to ASCII-8BIT unless explicitly
     specified.
```

This meant the expected hashes didn't match

## Verification

Open msfconsole on windows, and open a Python Meterpreter on windows:
```
use python/meterpreter_reverse_tcp
generate -o shell.py -f raw lhost=127.0.0.1
to_handler
python3 shell.py
```

Run the test:
```
loadpath test/modules
use test/meterpreter
run session=-1
```

Verify the md5/sha1 tests pass now