### PR TITLE
Fix vnc scanner module(s)

### DIFF
--- a/documentation/modules/auxiliary/scanner/vnc/ard_root_pw.md
+++ b/documentation/modules/auxiliary/scanner/vnc/ard_root_pw.md
@@ -1,4 +1,4 @@
-## Description
+## Vulnerable Application
 
 This module remotely exploits the remote CVE-2017-13872 (iamroot) vulnerability over Apple Remote Desktop protocol (ARD). It assumes that "System Preferences > Sharing > Screen Sharing" is enabled.
 
@@ -6,7 +6,9 @@ This module remotely exploits the remote CVE-2017-13872 (iamroot) vulnerability 
 
 1. Do: `use auxiliary/scanner/vnc/ard_root_pw`
 2. Do: `set RHOSTS [IP]`
-4. Do: `run`
+3. Do: `run`
+
+## Options
 
 ## Scenarios
 

--- a/documentation/modules/auxiliary/scanner/vnc/vnc_login.md
+++ b/documentation/modules/auxiliary/scanner/vnc/vnc_login.md
@@ -1,0 +1,49 @@
+## Vulnerable Application
+
+This module will test a VNC server on a range of machines and
+report successful logins. Currently it supports RFB protocol
+version 3.3, 3.7, 3.8 and 4.001 using the VNC challenge response
+authentication method.
+
+## Verification Steps
+
+1. Do: `use auxiliary/scanner/vnc/vnc_login`
+2. Do: `set RHOSTS [IP]`
+3. Do: `set password [password]`
+4. Do: `run`
+
+## Options
+
+## Scenarios
+
+### TigerVNC 1.7.0+dfsg-8ubuntu2 on Ubuntu 18.04
+
+```
+msf6 > use auxiliary/scanner/vnc/vnc_login
+msf6 auxiliary(scanner/vnc/vnc_login) > set rhosts 111.111.1.222
+rhosts => 111.111.1.222
+msf6 auxiliary(scanner/vnc/vnc_login) > set rport 5901
+rport => 5901
+msf6 auxiliary(scanner/vnc/vnc_login) > set password 111122223333
+password => 111122223333
+msf6 auxiliary(scanner/vnc/vnc_login) > run
+
+[*] 111.111.1.222:5901    - 111.111.1.222:5901 - Starting VNC login sweep
+[+] 111.111.1.222:5901    - 111.111.1.222:5901 - Login Successful: :111122223333
+[-] 111.111.1.222:5901    - 111.111.1.222:5901 - LOGIN FAILED: :password (Incorrect: Authentication failed: Authentication failed)
+[*] 111.111.1.222:5901    - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/vnc/vnc_login) > 
+```
+
+#### Credentials
+
+```
+msf6 auxiliary(scanner/vnc/vnc_login) > creds
+Credentials
+===========
+
+host           origin         service         public  private       realm  private_type  JtR Format
+----           ------         -------         ------  -------       -----  ------------  ----------
+111.111.1.222  111.111.1.222  5901/tcp (vnc)          111122223333         Password      
+```

--- a/documentation/modules/auxiliary/scanner/vnc/vnc_login.md
+++ b/documentation/modules/auxiliary/scanner/vnc/vnc_login.md
@@ -33,10 +33,10 @@ msf6 auxiliary(scanner/vnc/vnc_login) > run
 [-] 111.111.1.222:5901    - 111.111.1.222:5901 - LOGIN FAILED: :password (Incorrect: Authentication failed: Authentication failed)
 [*] 111.111.1.222:5901    - Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
-msf6 auxiliary(scanner/vnc/vnc_login) > 
+msf6 auxiliary(scanner/vnc/vnc_login) >
 ```
 
-#### Credentials
+Once the module has finished running one can observe the gathered credentials using the `creds` command:
 
 ```
 msf6 auxiliary(scanner/vnc/vnc_login) > creds
@@ -45,5 +45,5 @@ Credentials
 
 host           origin         service         public  private       realm  private_type  JtR Format
 ----           ------         -------         ------  -------       -----  ------------  ----------
-111.111.1.222  111.111.1.222  5901/tcp (vnc)          111122223333         Password      
+111.111.1.222  111.111.1.222  5901/tcp (vnc)          111122223333         Password
 ```

--- a/documentation/modules/auxiliary/scanner/vnc/vnc_none_auth.md
+++ b/documentation/modules/auxiliary/scanner/vnc/vnc_none_auth.md
@@ -1,0 +1,62 @@
+## Vulnerable Application
+
+Detect VNC servers that support the "None" authentication method.
+
+### Install
+
+TigerVNC is one of the VNC servers which still accepts None authentication type.
+
+#### Windows
+
+Follow https://github.com/TigerVNC/tigervnc/wiki/Setup-TigerVNC-server-(Windows) to download
+the server, and install with the default.  Next start `Configure VNC Service`.
+
+Set "Session encryption" to `None` and "Authentication" to `None`. Apply and restart the service.
+
+#### Linux
+
+tigervncserver is available on Ubuntu 18.04 and possibly newer versions. To start the server
+in a vulnerable way, run the following command:
+`tigervncserver -SecurityTypes None -localhost no --I-KNOW-THIS-IS-INSECURE`
+
+## Verification Steps
+
+1. Do: `use auxiliary/scanner/vnc/vnc_none_auth`
+2. Do: `set RHOSTS [IP]`
+3. Do: `run`
+
+## Options
+
+## Scenarios
+
+### TigerVNC 1.12.80 on Windows
+
+```
+msf6 > use auxiliary/scanner/vnc/vnc_none_auth
+msf6 auxiliary(scanner/vnc/vnc_none_auth) > set rhosts 111.111.1.11
+rhosts => 111.111.1.11
+msf6 auxiliary(scanner/vnc/vnc_none_auth) > run
+
+[*] 111.111.1.11:5900     - 111.111.1.11:5900 - VNC server protocol version: [3, 4].8
+[*] 111.111.1.11:5900     - 111.111.1.11:5900 - VNC server security types supported: VeNCrypt,None
+[+] 111.111.1.11:5900     - 111.111.1.11:5900 - VNC server security types includes None, free access!
+[*] 111.111.1.11:5900     - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### TigerVNC 1.7.0+dfsg-8ubuntu2 on Ubuntu 18.04
+
+```
+msf6 > use auxiliary/scanner/vnc/vnc_none_auth
+msf6 auxiliary(scanner/vnc/vnc_none_auth) > set rhosts 111.111.1.222
+rhosts => 111.111.1.222
+msf6 auxiliary(scanner/vnc/vnc_none_auth) > set rport 5901
+rport => 5901
+msf6 auxiliary(scanner/vnc/vnc_none_auth) > run
+
+[*] 111.111.1.222:5901    - 111.111.1.222:5901 - VNC server protocol version: [3, 4].8
+[*] 111.111.1.222:5901    - 111.111.1.222:5901 - VNC server security types supported: None
+[+] 111.111.1.222:5901    - 111.111.1.222:5901 - VNC server security types includes None, free access!
+[*] 111.111.1.222:5901    - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/vnc/vnc_none_auth.md
+++ b/documentation/modules/auxiliary/scanner/vnc/vnc_none_auth.md
@@ -1,17 +1,19 @@
 ## Vulnerable Application
 
-Detect VNC servers that support the "None" authentication method.
+This module detects VNC servers that support the "None" authentication method.
 
 ### Install
 
-TigerVNC is one of the VNC servers which still accepts None authentication type.
+TigerVNC is one of the few VNC servers that still accepts the None authentication type,
+and can be installed on either Windows or Linux. Below you can find instructions for
+setting up a test server on both Windows and Linux:
 
 #### Windows
 
 Follow https://github.com/TigerVNC/tigervnc/wiki/Setup-TigerVNC-server-(Windows) to download
-the server, and install with the default.  Next start `Configure VNC Service`.
+the server, and install the server using the default settings. Next start `Configure VNC Service`.
 
-Set "Session encryption" to `None` and "Authentication" to `None`. Apply and restart the service.
+Set "Session encryption" to `None` and "Authentication" to `None`. Click `Apply` and restart the service.
 
 #### Linux
 

--- a/lib/rex/proto/rfb/client.rb
+++ b/lib/rex/proto/rfb/client.rb
@@ -14,243 +14,242 @@
 ##
 
 module Rex
-module Proto
-module RFB
+  module Proto
+    module RFB
+      class Client
+        include Rex::Proto::RFB::Constants
+        def initialize(sock, opts = {})
+          @sock = sock
+          @opts = opts
 
-class Client
-  include Rex::Proto::RFB::Constants
-  def initialize(sock, opts = {})
-    @sock = sock
-    @opts = opts
+          @banner = nil
+          @majver = -1
+          @minver = -1
+          @auth_types = []
+        end
 
-    @banner = nil
-    @majver = Constants::MajorVersions
-    @minver = -1
-    @auth_types = []
-  end
+        def read_error_message
+          len = @sock.get_once(4)
+          return 'Unknown error' if !len or len.length != 4
 
-  def read_error_message
-    len = @sock.get_once(4)
-    return 'Unknown error' if not len or len.length != 4
+          len = len.unpack('N').first
+          @sock.get_once(len)
+        end
 
-    len = len.unpack("N").first
-    @sock.get_once(len)
-  end
+        def handshake
+          @banner = @sock.get_once(12)
+          if !@banner
+            @error = 'Unable to obtain banner from server'
+            return false
+          end
 
-  def handshake
-    @banner = @sock.get_once(12)
-    if not @banner
-      @error = "Unable to obtain banner from server"
-      return false
-    end
+          # RFB Protocol Version 3.3 (1998-01)
+          # RFB Protocol Version 3.7 (2003-08)
+          # RFB Protocol Version 3.8 (2007-06)
 
-    # RFB Protocol Version 3.3 (1998-01)
-    # RFB Protocol Version 3.7 (2003-08)
-    # RFB Protocol Version 3.8 (2007-06)
+          if @banner =~ /RFB ([0-9]{3})\.([0-9]{3})/
+            @majver = Regexp.last_match(1).to_i
+            unless Constants::MajorVersions.include?(@majver)
+              @error = "Invalid major version number: #{@majver}"
+              return false
+            end
+          else
+            @error = "Invalid RFB banner: #{@banner}"
+            return false
+          end
 
-    if @banner =~ /RFB ([0-9]{3})\.([0-9]{3})/
-      maj = $1.to_i
-      unless Constants::MajorVersions.include?(maj)
-        @error = "Invalid major version number: #{maj}"
-        return false
+          @minver = Regexp.last_match(2).to_i
+
+          # Forces version 3 to be used. This adds support for version 4 servers.
+          # Minor version is at least 3, to work with Apple devices. Attempting to be purely dynamic
+          # based on the received server version can result in a 5.0 setting the client 3.0
+          # TODO: Add support for Version 4.
+          # Version 4 adds additional information to the packet regarding supported
+          # authentication types.
+          our_ver = format("RFB %03d.%03d\n", 3, @minver < 3 ? 8 : @minver)
+          @sock.put(our_ver)
+
+          true
+        end
+
+        def connect(password = nil)
+          return false if !handshake
+          return false if !authenticate(password)
+          return false if !send_client_init
+
+          true
+        end
+
+        def send_client_init
+          if @opts[:exclusive]
+            @sock.put("\x00") # do share.
+          else
+            @sock.put("\x01") # do share.
+          end
+        end
+
+        def authenticate(password = nil)
+          authenticate_with_user(nil, password)
+        end
+
+        def authenticate_with_user(username = nil, password = nil)
+          type = negotiate_authentication
+          authenticate_with_type(type, username, password)
+        end
+
+        def authenticate_with_type(type, username = nil, password = nil)
+          return false if !type
+
+          # Authenticate.
+          case type
+          when AuthType::None
+            # Nothing here.
+
+          when AuthType::VNC
+            return false if !negotiate_vnc_auth(password)
+
+          when AuthType::ARD
+            return false if !negotiate_ard_auth(username, password)
+
+          end
+
+          # Handle reading the security result message
+          result = @sock.get_once(4)
+          if !result
+            @error = 'Unable to read auth result'
+            return false
+          end
+
+          result = result.unpack('N').first
+          case result
+          when 0
+            return true
+
+          when 1
+            if @minver >= 8
+              msg = read_error_message
+              @error = "Authentication failed: #{msg}"
+            else
+              @error = 'Authentication failed'
+            end
+          when 2
+            @error = 'Too many authentication attempts'
+          else
+            @error = "Unknown authentication result: #{result}"
+          end
+
+          false
+        end
+
+        def negotiate_authentication
+          # Authentication type negotiation is protocol version specific.
+          if @minver < 7
+            buf = @sock.get_once(4)
+            if !buf
+              @error = 'Unable to obtain requested authentication method'
+              return nil
+            end
+            @auth_types = buf.unpack('N')
+            if !@auth_types or @auth_types.first == 0
+              msg = read_error_message
+              @error = "No authentication types available: #{msg}"
+              return nil
+            end
+          else
+            buf = @sock.get_once(1)
+            if !buf
+              @error = 'Unable to obtain supported authentication method count'
+              return nil
+            end
+
+            # first byte is number of security types
+            num_types = buf.unpack('C').first
+            if (num_types == 0)
+              msg = read_error_message
+              @error = "No authentication types available: #{msg}"
+              return nil
+            end
+
+            buf = @sock.get_once(num_types)
+            if !buf or buf.length != num_types
+              @error = 'Unable to read authentication types'
+              return nil
+            end
+
+            @auth_types = buf.unpack('C*')
+          end
+
+          if !@auth_types or @auth_types.length < 1
+            @error = 'No authentication types found'
+            return nil
+          end
+
+          # Select the one we prefer
+          selected = nil
+          selected ||= AuthType::None if @opts[:allow_none] and @auth_types.include? AuthType::None
+          selected ||= AuthType::VNC if @auth_types.include? AuthType::VNC
+          selected ||= AuthType::ARD if @auth_types.include? AuthType::ARD
+
+          if !selected
+            auth_strings = @auth_types.map { |i| Rex::Proto::RFB::AuthType.to_s(i) }
+            @error = "No supported authentication method found. All available options: #{auth_strings.join(', ')}"
+            return nil
+          end
+
+          # For 3.7 and later, clients must state which security-type to use
+          @sock.put([selected].pack('C')) if @minver >= 7
+
+          selected
+        end
+
+        def negotiate_vnc_auth(password = nil)
+          challenge = @sock.get_once(16)
+          if !challenge or challenge.length != 16
+            @error = 'Unable to obtain VNC challenge'
+            return false
+          end
+
+          response = Cipher.encrypt(challenge, password)
+          @sock.put(response)
+
+          true
+        end
+
+        def negotiate_ard_auth(username = nil, password = nil)
+          generator = @sock.get_once(2)
+          if !generator or generator.length != 2
+            @error = 'Unable to obtain ARD challenge: invalid generator value'
+            return false
+          end
+          generator = generator.unpack('n').first
+
+          key_length = @sock.get_once(2)
+          if !key_length or key_length.length != 2
+            @error = 'Unable to obtain ARD challenge: invalid key length'
+            return false
+          end
+          key_length = key_length.unpack('n').first
+
+          prime_modulus = @sock.get_once(key_length)
+          if !prime_modulus or prime_modulus.length != key_length
+            @error = 'Unable to obtain ARD challenge: invalid prime modulus'
+            return false
+          end
+
+          peer_public_key = @sock.get_once(key_length)
+          if !peer_public_key or peer_public_key.length != key_length
+            @error = 'Unable to obtain ARD challenge: invalid public key'
+            return false
+          end
+
+          response = Cipher.encrypt_ard(username, password, generator, key_length, prime_modulus, peer_public_key)
+          @sock.put(response)
+
+          true
+        end
+
+        attr_reader :error, :majver, :minver, :auth_types, :view_only
       end
-    else
-      @error = "Invalid RFB banner: #{@banner}"
-      return false
-    end
-
-    @minver = $2.to_i
-
-    # Forces version 3 to be used. This adds support  for version 4 servers.
-    # It may be necessary to hardcode minver as well.
-    # TODO: Add support for Version 4.
-    # Version 4 adds additional information to the packet regarding supported
-    # authentication types.
-    our_ver = "RFB %03d.%03d\n" % [3, @minver]
-    @sock.put(our_ver)
-
-    true
-  end
-
-  def connect(password = nil)
-    return false if not handshake
-    return false if not authenticate(password)
-    return false if not send_client_init
-    true
-  end
-
-  def send_client_init
-    if @opts[:exclusive]
-      @sock.put("\x00") # do share.
-    else
-      @sock.put("\x01") # do share.
     end
   end
-
-  def authenticate(password = nil)
-    authenticate_with_user(nil, password)
-  end
-
-  def authenticate_with_user(username = nil, password = nil)
-    type = negotiate_authentication
-    authenticate_with_type(type, username, password)
-  end
-
-  def authenticate_with_type(type, username = nil, password = nil)
-    return false if not type
-
-    # Authenticate.
-    case type
-    when AuthType::None
-      # Nothing here.
-
-    when AuthType::VNC
-      return false if not negotiate_vnc_auth(password)
-
-    when AuthType::ARD
-      return false if not negotiate_ard_auth(username, password)
-
-    end
-
-    # Handle reading the security result message
-    result = @sock.get_once(4)
-    if not result
-      @error = "Unable to read auth result"
-      return false
-    end
-
-    result = result.unpack('N').first
-    case result
-    when 0
-      return true
-
-    when 1
-      if @minver >= 8
-        msg = read_error_message
-        @error = "Authentication failed: #{msg}"
-      else
-        @error = "Authentication failed"
-      end
-    when 2
-      @error = "Too many authentication attempts"
-    else
-      @error = "Unknown authentication result: #{result}"
-    end
-
-    false
-  end
-
-  def negotiate_authentication
-    # Authentication type negotiation is protocol version specific.
-    if @minver < 7
-      buf = @sock.get_once(4)
-      if not buf
-        @error = "Unable to obtain requested authentication method"
-        return nil
-      end
-      @auth_types = buf.unpack('N')
-      if not @auth_types or @auth_types.first == 0
-        msg = read_error_message
-        @error = "No authentication types available: #{msg}"
-        return nil
-      end
-    else
-      buf = @sock.get_once(1)
-      if not buf
-        @error = "Unable to obtain supported authentication method count"
-        return nil
-      end
-
-      # first byte is number of security types
-      num_types = buf.unpack("C").first
-      if (num_types == 0)
-        msg = read_error_message
-        @error = "No authentication types available: #{msg}"
-        return nil
-      end
-
-      buf = @sock.get_once(num_types)
-      if not buf or buf.length != num_types
-        @error = "Unable to read authentication types"
-        return nil
-      end
-
-      @auth_types = buf.unpack("C*")
-    end
-
-    if not @auth_types or @auth_types.length < 1
-      @error = "No authentication types found"
-      return nil
-    end
-
-    # Select the one we prefer
-    selected = nil
-    selected ||= AuthType::None if @opts[:allow_none] and @auth_types.include? AuthType::None
-    selected ||= AuthType::VNC if @auth_types.include? AuthType::VNC
-    selected ||= AuthType::ARD if @auth_types.include? AuthType::ARD
-
-    if not selected
-      @error = "No supported authentication method found."
-      return nil
-    end
-
-    # For 3.7 and later, clients must state which security-type to use
-    @sock.put([selected].pack('C')) if @minver >= 7
-
-    selected
-  end
-
-  def negotiate_vnc_auth(password = nil)
-    challenge = @sock.get_once(16)
-    if not challenge or challenge.length != 16
-      @error = "Unable to obtain VNC challenge"
-      return false
-    end
-
-    response = Cipher.encrypt(challenge, password)
-    @sock.put(response)
-
-    true
-  end
-
-  def negotiate_ard_auth(username = nil, password = nil)
-    generator = @sock.get_once(2)
-    if not generator or generator.length != 2
-      @error = "Unable to obtain ARD challenge: invalid generator value"
-      return false
-    end
-    generator = generator.unpack("n").first
-
-    key_length = @sock.get_once(2)
-    if not key_length or key_length.length != 2
-      @error = "Unable to obtain ARD challenge: invalid key length"
-      return false
-    end
-    key_length = key_length.unpack("n").first
-
-    prime_modulus = @sock.get_once(key_length)
-    if not prime_modulus or prime_modulus.length != key_length
-      @error = "Unable to obtain ARD challenge: invalid prime modulus"
-      return false
-    end
-
-    peer_public_key = @sock.get_once(key_length)
-    if not peer_public_key or peer_public_key.length != key_length
-      @error = "Unable to obtain ARD challenge: invalid public key"
-      return false
-    end
-
-    response = Cipher.encrypt_ard(username, password, generator, key_length, prime_modulus, peer_public_key)
-    @sock.put(response)
-
-    true
- end
-
-
-  attr_reader :error, :majver, :minver, :auth_types
-  attr_reader :view_only
-end
-
-end
-end
 end

--- a/lib/rex/proto/rfb/client.rb
+++ b/lib/rex/proto/rfb/client.rb
@@ -62,7 +62,8 @@ module Rex
 
           # Forces version 3 to be used. This adds support for version 4 servers.
           # Minor version is at least 3, to work with Apple devices. Attempting to be purely dynamic
-          # based on the received server version can result in a 5.0 setting the client 3.0
+          # based on the received server version can result in a 5.0 server version response
+          # setting the client version to 3.0 when it should be at least 3.3, so code checks for this.
           # TODO: Add support for Version 4.
           # Version 4 adds additional information to the packet regarding supported
           # authentication types.

--- a/lib/rex/proto/rfb/constants.rb
+++ b/lib/rex/proto/rfb/constants.rb
@@ -44,7 +44,7 @@ module Rex
         Tight = 16
         Ultra = 17
         TLS = 18
-        VeNCrypt = 19 # TigerVNC this is Plain, TLSNone, TLSVnc, TLSPlain, X509Vnc, X509Plain
+        VeNCrypt = 19 # In TigerVNC this is used when one of the following options is specified: Plain, TLSNone, TLSVnc, TLSPlain, X509Vnc, X509Plain
         GtkVncSasl = 20
         MD5Hash = 21
         ColinDeanXVP = 22

--- a/lib/rex/proto/rfb/constants.rb
+++ b/lib/rex/proto/rfb/constants.rb
@@ -13,39 +13,69 @@
 ##
 
 module Rex
-module Proto
-module RFB::Constants
+  module Proto
+    module RFB::Constants
+      DefaultPort = 5900
 
-DefaultPort = 5900
+      # Version information
+      MajorVersions = [3, 4, 5]
+      # NOTE: We will emulate whatever minor version the server reports.
 
-# Version information
-MajorVersions = [3, 4]
-# NOTE: We will emulate whatever minor version the server reports.
+      # Security types https://datatracker.ietf.org/doc/html/rfc6143#section-8.1.2
+      # https://www.iana.org/assignments/rfb/rfb.xhtml
+      class AuthType
+        Invalid = 0
+        None = 1
+        VNC = 2
+        # RealVNC has 3-15 registered
+        RealVNC_3 = 3
+        RealVNC_4 = 4
+        RA2 = 5
+        RA2ne = 6
+        RealVNC_7 = 7
+        RealVNC_8 = 8
+        RealVNC_9 = 9
+        RealVNC_10 = 10
+        RealVNC_11 = 11
+        RealVNC_12 = 12
+        RealVNC_13 = 13
+        RealVNC_14 = 14
+        RealVNC_15 = 15
+        Tight = 16
+        Ultra = 17
+        TLS = 18
+        VeNCrypt = 19 # TigerVNC this is Plain, TLSNone, TLSVnc, TLSPlain, X509Vnc, X509Plain
+        GtkVncSasl = 20
+        MD5Hash = 21
+        ColinDeanXVP = 22
+        SecureTunnel = 23
+        IntegratedSSH = 24
+        ARD = 30
+        # Apple has 31-35 registered, but no details on what these are. 36 is not registered but seems to be used by Apple
+        Apple_31 = 31
+        Apple_32 = 32
+        Apple_33 = 33
+        Apple_34 = 34
+        MacOSX_35 = 35
+        AppleUnknown_36 = 36
+        # 116 has been observed in the wild in the following combo: Ultra, Unknown: 116, VNC
+        RealVNC_128 = 128
+        RealVNC_or_TightUnixLoginAuth = 129
+        RealVNC_130 = 130
+        RealVNC_131 = 131
+        RealVNC_132 = 132
+        RealVNC_133 = 133
+        RealVNC_134 = 134
+        RealVNC_192 = 192
+        MSLOGON = 0xfffffffa
 
-# Security types
-class AuthType
-  Invalid = 0
-  None = 1
-  VNC = 2
-  RA2 = 5
-  RA2ne = 6
-  Tight = 16
-  Ultra = 17
-  TLS = 18
-  VeNCrypt = 19
-  GtkVncSasl = 20
-  MD5Hash = 21
-  ColinDeanXVP = 22
-  ARD = 30
-
-  def self.to_s(num)
-    self.constants.each { |c|
-      return c.to_s if self.const_get(c) == num
-    }
-    'Unknown'
+        def self.to_s(num)
+          constants.each do |c|
+            return c.to_s if const_get(c) == num
+          end
+          "Unknown: #{num}"
+        end
+      end
+    end
   end
-end
-
-end
-end
 end

--- a/modules/auxiliary/scanner/vnc/vnc_none_auth.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_none_auth.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
@@ -11,75 +10,72 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'VNC Authentication None Detection',
+      'Name' => 'VNC Authentication None Detection',
       'Description' => 'Detect VNC servers that support the "None" authentication method.',
-      'References'  =>
-        [
-          ['CVE', '2006-2369'], # a related instance where "None" could be offered and used when not configured as allowed.
-          ['URL', 'https://en.wikipedia.org/wiki/RFB'],
-          ['URL', 'https://en.wikipedia.org/wiki/Vnc'],
-        ],
-      'Author'      =>
-        [
-          'Matteo Cantoni <goony[at]nothink.org>',
-          'jduck'
-        ],
-      'License'     => MSF_LICENSE
+      'References' => [
+        ['CVE', '2006-2369'], # a related instance where "None" could be offered and used when not configured as allowed.
+        ['URL', 'https://en.wikipedia.org/wiki/RFB'],
+        ['URL', 'https://en.wikipedia.org/wiki/Vnc'],
+      ],
+      'Author' => [
+        'Matteo Cantoni <goony[at]nothink.org>',
+        'jduck'
+      ],
+      'License' => MSF_LICENSE
     )
 
     register_options(
       [
         Opt::RPORT(5900)
-      ])
+      ]
+    )
   end
 
   def run_host(target_host)
-    begin
-      connect
-      vnc = Rex::Proto::RFB::Client.new(sock)
-      unless vnc.handshake
-        print_error("#{target_host}:#{rport} - Handshake failed: #{vnc.error}")
-        return
-      end
-
-      ver = "#{vnc.majver}.#{vnc.minver}"
-      print_good("#{target_host}:#{rport} - VNC server protocol version: #{ver}")
-      svc = report_service(
-        :host => rhost,
-        :port => rport,
-        :proto => 'tcp',
-        :name => 'vnc',
-        :info => "VNC protocol version #{ver}"
-      )
-
-      type = vnc.negotiate_authentication
-      unless type
-        print_error("#{target_host}:#{rport} - Auth negotiation failed: #{vnc.error}")
-        return
-      end
-
-      # Show the allowed security types
-      sec_type = []
-      vnc.auth_types.each { |type|
-        sec_type << Rex::Proto::RFB::AuthType.to_s(type)
-      }
-      print_status("#{target_host}:#{rport} - VNC server security types supported: #{sec_type.join(",")}")
-
-      if (vnc.auth_types.include? Rex::Proto::RFB::AuthType::None)
-        print_good("#{target_host}:#{rport} - VNC server security types includes None, free access!")
-        report_vuln(
-          {
-            :host         => rhost,
-            :service      => svc,
-            :name         => self.name,
-            :info         => "Module #{self.fullname} identified the VNC 'none' security type: #{sec_type.join(", ")}",
-            :refs         => self.references,
-            :exploited_at => Time.now.utc
-          })
-      end
-    ensure
-      disconnect
+    connect
+    vnc = Rex::Proto::RFB::Client.new(sock, allow_none: true)
+    unless vnc.handshake
+      print_error("#{target_host}:#{rport} - Handshake failed: #{vnc.error}")
+      return
     end
 
+    ver = "#{vnc.majver}.#{vnc.minver}"
+    print_status("#{target_host}:#{rport} - VNC server protocol version: #{ver}")
+    svc = report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'vnc',
+      info: "VNC protocol version #{ver}"
+    )
+
+    type = vnc.negotiate_authentication
+    unless type
+      print_error("#{target_host}:#{rport} - Auth negotiation failed: #{vnc.error}")
+      return
+    end
+
+    # Show the allowed security types
+    sec_type = []
+    vnc.auth_types.each do |t|
+      sec_type << Rex::Proto::RFB::AuthType.to_s(t)
+    end
+    print_status("#{target_host}:#{rport} - VNC server security types supported: #{sec_type.join(', ')}")
+
+    if (vnc.auth_types.include? Rex::Proto::RFB::AuthType::None)
+      print_good("#{target_host}:#{rport} - VNC server security types includes None, free access!")
+      report_vuln(
+        {
+          host: rhost,
+          service: svc,
+          name: name,
+          info: "Module #{fullname} identified the VNC 'none' security type: #{sec_type.join(', ')}",
+          refs: references,
+          exploited_at: Time.now.utc
+        }
+      )
+    end
+  ensure
+    disconnect
   end
 end


### PR DESCRIPTION
This updates the VNC library and modules to actually work in 2022.

Changes:

1. cleans up `ard_root_pw` docs to currents `msftidy_doc` standards
2. adds docs for `vnc_login`
3. adds docs for `vnc_none_auth`
4. msftidy on `vnc_none_auth`
5. lowers a `print_good` to `print_status` in `vnc_none_auth` printing the protocol versions. A positive response should be when we found a vulnerable version, not that a successful connection was made to interrogate the service.
6. Fixes a bug where the vnc client in `vnc_none_auth` was being created without `allow_none` and thus it would never actually report back that `None` was a possibility, thus making the module useless.
7. print the actual major version instead of just a list of accepted versions... seems like a bug. also add 5 to the list since I'm seeing that in the wild (aka a pentest)
8. if we don't support any of the authentication types, at least print the ones we were offered so we have an idea what's there
9. add a bunch of new AuthTypes so we don't just print `Unknown`
10. rubocop client and constant libraries

### Pre

```
[*] 1.1.1.1:5900    - 1.1.1.1:5900 - VNC server protocol version: [3, 4].889
```

### Post

```
[*] 1.1.1.1:5900    - 1.1.1.1:5900 - VNC server protocol version: 3.889
```

### Pre

```
[*] 1.1.1.1:5900    - 1.1.1.1:5900 - VNC server security types supported: ARD,Unknown,Unknown,Unknown
```

### Post

```
[*] 1.1.1.1:5900    - 1.1.1.1:5900 - VNC server security types supported: ARD, Apple_33, AppleUnknown_36, MacOSX_35
```

### Pre

```
[*] 1.1.1.1:5900    - 1.1.1.1:5900 - Handshake failed: Invalid major version number: 5
```

### Post

```
[*] 1.1.1.1:5900    - 1.1.1.1:5900 - VNC server protocol version: 5.0
[-] 1.1.1.1:5900    - 1.1.1.1:5900 - Auth negotiation failed: No supported authentication method found. All available options: VeNCrypt
```

## Verification

List the steps needed to make sure this thing works

- [x] check over docs
- [x] for `vnc_none_auth` follow the directions in the docs to make a vuln windows/linux server and scan it
- [x] scan some vnc servers and make sure we're getting some good info instead of basically nothing like before
