### PR TITLE
Convert core enumextcmd & loadlib commands to human readable strings

### DIFF
--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -397,9 +397,14 @@ class Tlv
     end
     group ||= (self.class.to_s =~ /Packet/)
     if group
+      has_command_ids = ((self.method == COMMAND_ID_CORE_ENUMEXTCMD || self.method == COMMAND_ID_CORE_LOADLIB) && type == PACKET_TYPE_RESPONSE)
       tlvs_inspect = "tlvs=[\n"
       @tlvs.each { |t|
-        tlvs_inspect << "  #{t.inspect}\n"
+        if t.type == TLV_TYPE_UINT && has_command_ids
+          tlvs_inspect << "  #{t.inspect[0..-2]} command=#{::Rex::Post::Meterpreter::CommandMapper.get_command_name(t.value)}>\n"
+        else
+          tlvs_inspect << "  #{t.inspect}\n"
+        end
       }
       tlvs_inspect << "]"
     else


### PR DESCRIPTION
This PR adds a command description to the TLV response we get from Meterpreter upon calling `core_enumextcmd` and `core_loadlib`.

## Verification

- [ ] Start `msfconsole`
- [ ] Enable TLV logging using #16135 
- [ ] Get a Meterpreter shell
- [ ] Confirm that the response from Meterpreter includes command IDs and names:
```
RECV: #<Rex::Post::Meterpreter::Packet type=Response        tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=10 command=core_enumextcmd>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="\xFC!\xF0[\xD5\x88\x0Fu\x87\xE7\x92\xF3\xE5\xF1\x ...">
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=17 command=core_patch_url>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=8 command=core_channel_write>
```

## Before
<details>
<summary>core_enumextcmd</summary>

```
RECV: #<Rex::Post::Meterpreter::Packet type=Response        tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=10 command=core_enumextcmd>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="\xFC!\xF0[\xD5\x88\x0Fu\x87\xE7\x92\xF3\xE5\xF1\x ...">
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=17>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=8>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=21>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=27>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=28>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=4>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=29>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=23>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=12>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=2>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=15>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=13>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=22>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=33>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=25>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=3>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=30>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=16>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=6>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=5>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=10>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=32>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=7>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=24>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=11>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST-ID      meta=STRING     value="00798824545656747308848736890067">
  #<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>
]>
```

</details>

<details>
<summary>core_loadlib</summary>

```
RECV: #<Rex::Post::Meterpreter::Packet type=Response        tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=12 command=core_loadlib>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="\xFC!\xF0[\xD5\x88\x0Fu\x87\xE7\x92\xF3\xE5\xF1\x ...">
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1011>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1007>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1001>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1014>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1068>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1013>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1026>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1059>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1069>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1029>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1002>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1056>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1071>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1015>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1008>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1004>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1019>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1022>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1003>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1052>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1077>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1055>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1031>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1025>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1118>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1009>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1024>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1016>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1028>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1030>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1010>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1005>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1072>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1006>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST-ID      meta=STRING     value="25109610824825489781124257260864">
  #<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>
]>
```

</details>

## After
<details>
<summary>core_enumextcmd</summary>

```
RECV: #<Rex::Post::Meterpreter::Packet type=Response        tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=10 command=core_enumextcmd>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="\xFC!\xF0[\xD5\x88\x0Fu\x87\xE7\x92\xF3\xE5\xF1\x ...">
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=17 command=core_patch_url>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=8 command=core_channel_write>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=21 command=core_set_session_guid>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=27 command=core_transport_list>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=28 command=core_transport_next>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=4 command=core_channel_open>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=29 command=core_transport_prev>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=23 command=core_shutdown>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=12 command=core_loadlib>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=2 command=core_channel_eof>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=15 command=core_native_arch>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=13 command=core_machine_id>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=22 command=core_set_uuid>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=33 command=core_transport_sleep>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=25 command=core_transport_change>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=3 command=core_channel_interact>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=30 command=core_transport_remove>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=16 command=core_negotiate_tlv_encryption>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=6 command=core_channel_seek>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=5 command=core_channel_read>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=10 command=core_enumextcmd>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1 command=core_channel_close>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=32 command=core_transport_set_timeouts>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=7 command=core_channel_tell>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=24 command=core_transport_add>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=11 command=core_get_session_guid>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST-ID      meta=STRING     value="17750086250366570317992463829045">
  #<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>
]>
```

</details>

<details>
<summary>core_loadlib</summary>

```
RECV: #<Rex::Post::Meterpreter::Packet type=Response        tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=12 command=core_loadlib>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="\xFC!\xF0[\xD5\x88\x0Fu\x87\xE7\x92\xF3\xE5\xF1\x ...">
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1011 command=stdapi_fs_mkdir>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1007 command=stdapi_fs_file_move>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1001 command=stdapi_fs_chdir>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1014 command=stdapi_fs_separator>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1068 command=stdapi_sys_process_close>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1013 command=stdapi_fs_search>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1026 command=stdapi_net_socket_tcp_shutdown>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1059 command=stdapi_sys_config_sysinfo>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1069 command=stdapi_sys_process_execute>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1029 command=stdapi_railgun_api_multi>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1002 command=stdapi_fs_chmod>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1056 command=stdapi_sys_config_localtime>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1071 command=stdapi_sys_process_get_processes>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1015 command=stdapi_fs_sha1>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1008 command=stdapi_fs_getwd>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1004 command=stdapi_fs_delete_file>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1019 command=stdapi_net_config_get_interfaces>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1022 command=stdapi_net_config_get_routes>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1003 command=stdapi_fs_delete_dir>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1052 command=stdapi_sys_config_getenv>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1077 command=stdapi_sys_process_kill>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1055 command=stdapi_sys_config_getuid>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1031 command=stdapi_railgun_memwrite>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1025 command=stdapi_net_resolve_hosts>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1118 command=stdapi_sys_process_set_term_size>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1009 command=stdapi_fs_ls>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1024 command=stdapi_net_resolve_host>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1016 command=stdapi_fs_stat>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1028 command=stdapi_railgun_api>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1030 command=stdapi_railgun_memread>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1010 command=stdapi_fs_md5>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1005 command=stdapi_fs_file_copy>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1072 command=stdapi_sys_process_getpid>
  #<Rex::Post::Meterpreter::Tlv type=UINT            meta=INT        value=1006 command=stdapi_fs_file_expand_path>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST-ID      meta=STRING     value="51064524102803914734948794136412">
  #<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>
]>
```

</details>