### PR TITLE
Adjust wordpress_url_rest_api definition to support sites that don't place REST API under /index.php/

### DIFF
--- a/lib/msf/core/exploit/remote/http/wordpress/uris.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/uris.rb
@@ -140,7 +140,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::URIs
   #
   # @return [String] Wordpress REST API URL
   def wordpress_url_rest_api
-    normalize_uri(target_uri.path, 'index.php/wp-json/wp/v2')
+    normalize_uri(target_uri.path, 'wp-json/wp/v2')
   end
 
 end


### PR DESCRIPTION
Fixes #16220 

This adjusts the `wordpress_url_rest_api` definition to support sites that don't set their WordPress REST API under the `/index.php/` directory by removing the `index.php` prefix. This works as those sites that do support the `index.php` prefix also support accessing the same page without this prefix in my experience, so we wouldn't loose out on functionality, and users could always specify a new root directory in module settings in case things don't work out.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/wordpress_scanner`
- [ ] `set RHOST` to some website where the `index.php` prefix doesn't work for the REST API.
- [ ] Ensure only the `USERS` option is enabled.
- [ ] **Verify** that it is possible to grab the list of users now and that before this patch it was not possible to do so.
- [ ] **Verify** that other sites that put the REST API under the `index.php` directory still work.

Contact me if you need a sample site to test against.
