### PR TITLE
Ignore reload lib spec helper file

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -77,7 +77,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     files = output.split("\n")
 
     files.each do |file|
-      next if file.end_with?('_spec.rb')
+      next if file.end_with?('_spec.rb') || file.end_with?("spec_helper.rb")
       f = File.join(Msf::Config.install_root, file)
       reload_file(f, print_errors: false)
     end


### PR DESCRIPTION
This file rarely gets modified, but when it does - it attempts to reload all of Metasploit again and weirdness ensues

## Verification

Modify spec_helper and verify the file is now ignored when running `reload_lib -a`