### PR TITLE
Validate payload size even when not encoding

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -75,7 +75,7 @@ class EncodedPayload
 
       # If encoder is set, it could be an encoders list
       # The form is "<encoder>:<iteration>, <encoder2>:<iteration>"...
-      if reqs['Encoder']
+      unless reqs['Encoder'].blank?
         encoder_str = reqs['Encoder']
         encoder_str.scan(/([^:, ]+):?([^,]+)?/).map do |encoder_opt|
           reqs['Encoder'] = encoder_opt[0]
@@ -129,6 +129,10 @@ class EncodedPayload
   # encoded attribute.
   #
   def encode
+    # Get the minimum number of nops to use
+    min = (reqs['MinNops'] || 0).to_i
+    min = 0 if reqs['DisableNops']
+
     # If the exploit needs the payload to be encoded, we need to run the list of
     # encoders in ranked precedence and try to encode with them.
     if needs_encoding
@@ -245,10 +249,6 @@ class EncodedPayload
             break
           end
 
-          # Get the minimum number of nops to use
-          min = (reqs['MinNops'] || 0).to_i
-          min = 0 if reqs['DisableNops']
-
           # Check to see if we have enough room for the minimum requirements
           if ((reqs['Space']) and (reqs['Space'] < eout.length + min))
             wlog("#{err_start}: Encoded payload version is too large (#{eout.length} bytes) with encoder #{encoder.refname}",
@@ -282,6 +282,11 @@ class EncodedPayload
       # NOTE: BadChars can contain whitespace, so don't use String#blank?
       unless reqs['BadChars'].nil? || reqs['BadChars'].empty?
         ilog("#{pinst.refname}: payload contains no badchars, skipping automatic encoding", 'core', LEV_0)
+      end
+
+      if reqs['Space'] and (reqs['Space'] < raw.length + min)
+        wlog("#{pinst.refname}: Raw (unencoded) payload is too large (#{raw.length} bytes)", 'core', LEV_1)
+        raise PayloadSpaceViolation, 'The payload exceeds the specified space', caller
       end
 
       self.encoded = raw
@@ -530,7 +535,7 @@ protected
   attr_accessor :reqs
 
   def needs_encoding
-    reqs['Encoder'] || reqs['ForceEncode'] || has_chars?(reqs['BadChars'])
+    !reqs['Encoder'].blank? || reqs['ForceEncode'] || has_chars?(reqs['BadChars'])
   end
 
   def has_chars?(chars)


### PR DESCRIPTION
This fixes a bug where the framework would ignore the space constraint defined by an exploit when the payload was not encoded. The logic that [checks](https://github.com/rapid7/metasploit-framework/blob/65626bedd49ba34ad5e749a278c8bab96bfef3fa/lib/msf/core/encoded_payload.rb#L253-L257) if the payload will fit in the space is currently only executed when the payload is encoded as determined by [`#needs_encoding`](https://github.com/rapid7/metasploit-framework/blob/65626bedd49ba34ad5e749a278c8bab96bfef3fa/lib/msf/core/encoded_payload.rb#L532). When the payload doesn't fit, all encoders fail and a [`PayloadSpaceViolation`](https://github.com/rapid7/metasploit-framework/blob/147837e9b62a76d57a25c885da13f7ce29fa515d/lib/msf/core/encoded_payload.rb#L289) is thrown.

However, all of this is bypassed if a payload isn't encoded. If an exploit module declares it only has a certain amount of room for a payload though, it shouldn't receive payloads that won't fit regardless of whether to not they are encoded. Interestingly this logic only appears to affect the actual execution run of a payload since the tab completion and `show payloads` command use the cached size and checks that against the spatial constraint.

This PR updates the encoded payload logic, which is always executed whether or not the payload is encoded, to throw an exception if the payload won't fit. This prevents the module from running and ensure consistent behavior and should prevent exploitation-related errors down the line when the exploit author knows the payload won't work because it's too large.

<details>
<summary>payload_generation.rb</summary>
Place this in `~/.msf4/modules/exploits/test`.

```ruby
##
# This module requires Metasploit: https://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##


class MetasploitModule < Msf::Exploit

  def initialize(info = {})
    super(update_info(info,
      'Name'           => "Test Exploit Payload Generation",
      'Description'    => %q{
          This module ensures that the payload generated for an exploit is correct and honors the specified requirements.
      },
      'Author'         =>
        [
          'Spencer McIntyre'
        ],
      'Targets'          =>
        [
          [
            'Linux x86 (Space 1000)',
            {
              'Arch'     => ARCH_X86,
              'Platform' => 'linux',
              'Payload'  => { 'Space' => 1000 }
            }
          ],
          [
            'Linux x86 (Unlimited Space)',
            {
              'Arch'     => ARCH_X86,
              'Platform' => 'linux'
            }
          ],
        ],
      'License'        => MSF_LICENSE,
      'DisclosureDate' => '2022-02-25'
    ))
  end

  def exploit
    vprint_status("Exploit is successful.")
    print_status('Payload information:')
    print_status("  Name:         #{payload.send(:pinst).refname}")
    print_status("  Arch:         #{payload.arch.inspect}")
    print_status("  Encoded Size: #{payload.encoded.length}")
    print_status("  Raw Size:     #{payload.raw.length}")
  end

end
```
</details>

## Verification

- [x] Install the provided test module for demonstration and testing purposes then start `msfconsole`
- [x] Use the demo exploit module
- [x] Use TARGET 0 / `Linux x64 (Space 1000)` and set the payload to `linux/x86/meterpreter_reverse_tcp`
- [x] Run the module and see an error that te payload is too large
- [x] Run `run ENCODER=` see that it fails with a message that the payload is too large
    * This PR also switches to checking if the Encoder option is set to an empty string. When that is the case, it is treated as if no encoder is set. This issue was identified while testing with `generic/none` and then trying to unset the encoder altogether to execute a different code path. Without this patch, the error: ```[-] Exploit failed: undefined method `length' for nil:NilClass``` would be displayed.

Without these changes, the payload would be generated as normal and passed to the exploit which shouldn't happen. If the operator, forced encoding by setting `ENCODER=generic/none`, they would get the standard error that none of the encoders worked.