### PR TITLE
shodan_search default user-agent overwrite - fix #16189 and #16223

### DIFF
--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -41,7 +41,15 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('MAXPAGE', [true, 'Max amount of pages to collect', 1]),
         OptRegexp.new('REGEX', [true, 'Regex search for a specific IP/City/Country/Hostname', '.*'])
 
-      ])
+      ]
+    )
+
+    # overwriting the default user-agent. Shodan is checking it and delivering a html response when using the default ua (see #16189 and #16223)
+    register_advanced_options(
+      [
+        OptString.new('UserAgent', [false, 'The User-Agent header to use for all requests', 'Wget/1.21.2 (linux-gnu)' ])
+      ]
+    )
 
     deregister_http_client_options
   end


### PR DESCRIPTION
As the Shodan is checking the UserAgent to decide which content-type it will deliver, the default user-agent is causing it to reply a html page.

@adfoster-r7,  this commit overwrite the default user-agent in the module shodan_search to 'Wget' that works on the shodan API and intend to fix  the issues #16189 and #16223


