### PR TITLE
Update metasploit-payloads gem to 2.0.77 - Fix issue with kiwi_cmd arguments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.76)
+      metasploit-payloads (= 2.0.77)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.18)
       mqtt
@@ -261,7 +261,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.76)
+    metasploit-payloads (2.0.77)
     metasploit_data_models (5.0.4)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -79,7 +79,7 @@ metasploit-concern, 4.0.3, "New BSD"
 metasploit-credential, 5.0.5, "New BSD"
 metasploit-framework, 6.1.32, "New BSD"
 metasploit-model, 4.0.3, "New BSD"
-metasploit-payloads, 2.0.76, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.77, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 5.0.4, "New BSD"
 metasploit_payloads-mettle, 1.0.18, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.76'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.77'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.18'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This bumps the metasploit-payloads gem from 2.0.76 to 2.0.77. 

Changes included in this bump:
* https://github.com/rapid7/metasploit-payloads/pull/549 (and by extension rapid7/mimikatz#7)

Fixes #15622