### PR TITLE
Msf::Payload::Apk: Print warning if apktool version < 2.5.1

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -154,6 +154,9 @@ class Msf::Payload::Apk
     unless apk_v >= Rex::Version.new('2.0.1')
       raise RuntimeError, "apktool version #{apk_v} not supported, please download at least version 2.0.1."
     end
+    unless apk_v >= Rex::Version.new('2.5.1')
+      print_warning("apktool version #{apk_v} is outdated and may fail to decompile some apk files. Update apktool to the latest version.")
+    end
 
     #Create temporary directory where work will be done
     tempdir = Dir.mktmpdir


### PR DESCRIPTION
Alternatively, rather than print a warning, we could be more aggressive by replacing the existing version check for 2.0.1.

Version 2.5.1 was released about a year ago.

Some Metasploit users have reported that upgrading apktool has fixed some issues.

apktool versions 2.5.0 and 2.5.1 apparently fixes a few bugs (based on changelog, previous issues, and forum posts).

Comments from Metasploit contributors also confirms version 2.5.0 fixes bugs encountered while using `msfvenom`.

* https://github.com/rapid7/metasploit-framework/issues/13289#issuecomment-769209635
* https://github.com/rapid7/metasploit-framework/issues/13520#issuecomment-778356050

The latest version in the 2.5.x branch is 2.5.1. The latest version is 2.6.0.

* https://ibotpeaches.github.io/Apktool/install/
