### PR TITLE
Improve TLV Type handling

### DIFF
--- a/lib/rex/post/meterpreter/command_mapper.rb
+++ b/lib/rex/post/meterpreter/command_mapper.rb
@@ -9,6 +9,7 @@ module Post
 module Meterpreter
 
 class CommandMapper
+  @@cached_tlv_types = {}
 
   # Get the numeric command ID for the specified command name.
   #
@@ -97,6 +98,36 @@ class CommandMapper
     commands
   end
 
+
+  # Get the TLV Type symbols that are defined with the value
+  # Potential return values are [], [:TLV_TYPE_A], and [:TLV_TYPE_A, :PACKET_TYPE_B]
+  #
+  # Returning an array is a solution to having multiple TLV types having the same value, as documented here:
+  # https://github.com/rapid7/metasploit-framework/issues/16267
+  #
+  # @param Integer value The value of the TLV type to retrieve the TLV type names for.
+  # @return [Array<Symbol>] An array of symbols of all TLV types that are defined with the value. Can be empty.
+  def self.get_tlv_names(value)
+    return @@cached_tlv_types[value] unless @@cached_tlv_types[value].nil? || @@cached_tlv_types[value].empty?
+
+    # Default to arrays that contain TLV Types, so that we only deal with one data type
+    @@cached_tlv_types = Hash.new { |h, k| h[k] = [] }
+
+    available_modules = [
+      ::Rex::Post::Meterpreter,
+      *::Rex::Post::Meterpreter::ExtensionMapper.get_extension_klasses
+    ].uniq
+
+    available_modules.each do |mod|
+      mod.constants.each do |const|
+        next unless const.to_s.start_with?('TLV_TYPE_') || const.to_s.start_with?('PACKET_')
+
+        @@cached_tlv_types[mod.const_get(const)] << const
+      end
+    end
+
+    @@cached_tlv_types[value]
+  end
 end
 
 end

--- a/lib/rex/post/meterpreter/extension_mapper.rb
+++ b/lib/rex/post/meterpreter/extension_mapper.rb
@@ -89,6 +89,10 @@ class ExtensionMapper
     @@klasses[name]
   end
 
+  def self.get_extension_klasses
+    self.get_extension_names.map { |name| self.get_extension_module(name) }
+  end
+
   def self.dump_extensions
     self.get_extension_names.each { |n|
       STDERR.puts("EXTENSION_ID_#{n.upcase} = #{self.get_extension_id(n)}\n")

--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -284,6 +284,8 @@ end
 #
 ###
 class Tlv
+  @@cached_tlv_types = {}
+
   attr_accessor :type, :value, :compress
 
   HEADER_SIZE = 8
@@ -314,6 +316,15 @@ class Tlv
     end
   end
 
+  def _tlv_type_string(type)
+    # Try to regenerate the cache if cache is empty, or the type we are looking for is not present in the cache.
+    regenerate_tlv_types_cache if @@cached_tlv_types.nil? || @@cached_tlv_types.key(type).nil?
+
+    return @@cached_tlv_types.key(type).to_s.gsub('TLV_TYPE_', '').gsub('_', '-') unless @@cached_tlv_types.key(type).nil?
+
+    nil
+  end
+
   def inspect
     utype = type ^ TLV_META_TYPE_COMPRESSED
     group = false
@@ -327,70 +338,9 @@ class Tlv
       when TLV_META_TYPE_COMPLEX; "COMPLEX"
       else; 'unknown-meta-type'
       end
-    stype = case type
-      when PACKET_TYPE_REQUEST; "Request"
-      when PACKET_TYPE_RESPONSE; "Response"
-      when TLV_TYPE_REQUEST_ID; "REQUEST-ID"
-      when TLV_TYPE_COMMAND_ID; "COMMAND-ID"
-      when TLV_TYPE_RESULT; "RESULT"
-      when TLV_TYPE_EXCEPTION; "EXCEPTION"
-      when TLV_TYPE_STRING; "STRING"
-      when TLV_TYPE_UINT; "UINT"
-      when TLV_TYPE_BOOL; "BOOL"
+    stype = _tlv_type_string(type)
+    stype ||= "unknown-#{type}"
 
-      when TLV_TYPE_LENGTH; "LENGTH"
-      when TLV_TYPE_DATA; "DATA"
-      when TLV_TYPE_FLAGS; "FLAGS"
-
-      when TLV_TYPE_CHANNEL_ID; "CHANNEL-ID"
-      when TLV_TYPE_CHANNEL_TYPE; "CHANNEL-TYPE"
-      when TLV_TYPE_CHANNEL_DATA; "CHANNEL-DATA"
-      when TLV_TYPE_CHANNEL_DATA_GROUP; "CHANNEL-DATA-GROUP"
-      when TLV_TYPE_CHANNEL_CLASS; "CHANNEL-CLASS"
-      when TLV_TYPE_CHANNEL_PARENTID; "CHANNEL-PARENTID"
-
-      when TLV_TYPE_SEEK_WHENCE; "SEEK-WHENCE"
-      when TLV_TYPE_SEEK_OFFSET; "SEEK-OFFSET"
-      when TLV_TYPE_SEEK_POS; "SEEK-POS"
-
-      when TLV_TYPE_EXCEPTION_CODE; "EXCEPTION-CODE"
-      when TLV_TYPE_EXCEPTION_STRING; "EXCEPTION-STRING"
-
-      when TLV_TYPE_LIBRARY_PATH; "LIBRARY-PATH"
-      when TLV_TYPE_TARGET_PATH; "TARGET-PATH"
-      when TLV_TYPE_MIGRATE_PID; "MIGRATE-PID"
-      when TLV_TYPE_MIGRATE_PAYLOAD; "MIGRATE-PAYLOAD"
-      when TLV_TYPE_MIGRATE_ARCH; "MIGRATE-ARCH"
-      when TLV_TYPE_MIGRATE_BASE_ADDR; "MIGRATE-BASE-ADDR"
-      when TLV_TYPE_MIGRATE_ENTRY_POINT; "MIGRATE-ENTRY-POINT"
-      when TLV_TYPE_MIGRATE_STUB; "MIGRATE-STUB"
-      when TLV_TYPE_MIGRATE_SOCKET_PATH; "MIGRATE-SOCKET-PATH"
-      when TLV_TYPE_LIB_LOADER_NAME; "LIB-LOADER-NAME"
-      when TLV_TYPE_LIB_LOADER_ORDINAL; "LIB-LOADER-ORDINAL"
-      when TLV_TYPE_TRANS_TYPE; "TRANS-TYPE"
-      when TLV_TYPE_TRANS_URL; "TRANS-URL"
-      when TLV_TYPE_TRANS_COMM_TIMEOUT; "TRANS-COMM-TIMEOUT"
-      when TLV_TYPE_TRANS_SESSION_EXP; "TRANS-SESSION-EXP"
-      when TLV_TYPE_TRANS_CERT_HASH; "TRANS-CERT-HASH"
-      when TLV_TYPE_TRANS_PROXY_HOST; "TRANS-PROXY-HOST"
-      when TLV_TYPE_TRANS_PROXY_USER; "TRANS-PROXY-USER"
-      when TLV_TYPE_TRANS_PROXY_PASS; "TRANS-PROXY-PASS"
-      when TLV_TYPE_TRANS_RETRY_TOTAL; "TRANS-RETRY-TOTAL"
-      when TLV_TYPE_TRANS_RETRY_WAIT; "TRANS-RETRY-WAIT"
-      when TLV_TYPE_MACHINE_ID; "MACHINE-ID"
-      when TLV_TYPE_UUID; "UUID"
-      when TLV_TYPE_SESSION_GUID; "SESSION-GUID"
-      when TLV_TYPE_RSA_PUB_KEY; "RSA-PUB-KEY"
-      when TLV_TYPE_SYM_KEY_TYPE; "SYM-KEY-TYPE"
-      when TLV_TYPE_SYM_KEY; "SYM-KEY"
-      when TLV_TYPE_ENC_SYM_KEY; "ENC-SYM-KEY"
-
-      when TLV_TYPE_PIVOT_ID; "PIVOT-ID"
-      when TLV_TYPE_PIVOT_STAGE_DATA; "PIVOT-STAGE-DATA"
-      when TLV_TYPE_PIVOT_NAMED_PIPE_NAME; "PIVOT-NAMED-PIPE-NAME"
-
-      else; "unknown-#{type}"
-      end
     val = value.inspect
     if val.length > 50
       val = val[0,50] + ' ..."'
@@ -551,6 +501,23 @@ class Tlv
 
   def ntohq(value)
     htonq(value)
+  end
+
+  def regenerate_tlv_types_cache
+    @@cached_tlv_types = {}
+
+    available_modules = [
+      ::Rex::Post::Meterpreter,
+      *::Rex::Post::Meterpreter::ExtensionMapper.get_extension_klasses
+    ].uniq
+
+    available_modules.each do |clazz|
+      clazz.constants.each do |const|
+        next unless const.to_s.start_with?('TLV_TYPE_') || const.to_s.start_with?('PACKET_')
+
+        @@cached_tlv_types[const] = clazz.const_get(const)
+      end
+    end
   end
 
 end

--- a/spec/lib/rex/post/meterpreter/packet_spec.rb
+++ b/spec/lib/rex/post/meterpreter/packet_spec.rb
@@ -45,6 +45,46 @@ RSpec.describe Rex::Post::Meterpreter::Tlv do
     expect(tlv).to respond_to :from_r
   end
 
+  context "TLV with value mapped to a single type" do
+    subject(:tlv) {
+      Rex::Post::Meterpreter::Tlv.new(
+        Rex::Post::Meterpreter::TLV_TYPE_RESULT,
+        0
+      )
+    }
+
+    it "should have a single type" do
+      expect(tlv.inspect).to eq "#<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>"
+    end
+  end
+
+  context "TLV with value mapped to multiple types" do
+    subject(:tlv) {
+      Rex::Post::Meterpreter::Tlv.new(
+        151074, # Multiple TLV Types are defined as this value, as described here: https://github.com/rapid7/metasploit-framework/pull/16258#discussion_r817878469
+        0
+      )
+    }
+
+    # https://github.com/rapid7/metasploit-framework/pull/16258#discussion_r817878469
+    it "should handle multiple types in alphabetical order" do
+      expect(tlv.inspect).to eq "#<Rex::Post::Meterpreter::Tlv type=oneOf(EXT_WINDOW_ENUM_PID,PEINJECTOR_SHELLCODE_SIZE,SNIFFER_INTERFACE_ID,WEBCAM_INTERFACE_ID) meta=INT        value=0>"
+    end
+  end
+
+  context "TLV with an unknown TLV type" do
+    subject(:tlv) {
+      Rex::Post::Meterpreter::Tlv.new(
+        -1,
+        0
+      )
+    }
+
+    it "should have an unknown type" do
+      expect(tlv.inspect).to eq "#<Rex::Post::Meterpreter::Tlv type=unknown--1      meta=unknown-meta-type value=\"0\">"
+    end
+  end
+
   context "A String TLV" do
     it "should return the correct TLV type" do
       expect(tlv.type).to eq Rex::Post::Meterpreter::TLV_TYPE_STRING
@@ -130,7 +170,7 @@ RSpec.describe Rex::Post::Meterpreter::Tlv do
       end
 
       it "should show the correct type and meta type in inspect" do
-        tlv_to_s = "#<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=1001 command=stdapi_fs_chdir>"
+        tlv_to_s = "#<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1001 command=stdapi_fs_chdir>"
         expect(tlv.inspect).to eq tlv_to_s
       end
     end
@@ -147,7 +187,7 @@ RSpec.describe Rex::Post::Meterpreter::Tlv do
       end
 
       it "should show the correct type and meta type in inspect" do
-        tlv_to_s = "#<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=31337 command=unknown>"
+        tlv_to_s = "#<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=31337 command=unknown>"
         expect(tlv.inspect).to eq tlv_to_s
       end
     end


### PR DESCRIPTION
This PR changes how TLV packet types are output when logging TLV packets.

## Verification

- [ ] Start `msfconsole`
- [ ] Enable TLV logging in `def dispatch_inbound_packet(packet)` and `def send_packet(packet, opts={})`
- [ ] Get a Meterpreter session
- [ ] **Verify** that extension e.g. `Stdapi` types are shown as human-readable names

## Before
```
RECV: #<Rex::Post::Meterpreter::Packet type=Response        tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=1022 command=stdapi_net_config_get_routes>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="T\xDE)\xB9\x9Ej\xAFR>G+S\\_\xDEs">
  #<Rex::Post::Meterpreter::GroupTlv type=unknown-1073743247 tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=unknown-263564  meta=RAW        value="\xC0\xA8\x81\x00">
  #<Rex::Post::Meterpreter::Tlv type=unknown-263565  meta=RAW        value="\xFF\xFF\xFF\x00">
  #<Rex::Post::Meterpreter::Tlv type=unknown-263566  meta=RAW        value="\x00\x00\x00\x00">
  #<Rex::Post::Meterpreter::Tlv type=STRING          meta=STRING     value="eth0">
  #<Rex::Post::Meterpreter::Tlv type=unknown-132515  meta=INT        value=100>
]>
  #<Rex::Post::Meterpreter::GroupTlv type=unknown-1073743247 tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=unknown-263564  meta=RAW        value="\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\ ...">
  #<Rex::Post::Meterpreter::Tlv type=unknown-263565  meta=RAW        value="\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\ ...">
  #<Rex::Post::Meterpreter::Tlv type=unknown-263566  meta=RAW        value="\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\ ...">
  #<Rex::Post::Meterpreter::Tlv type=STRING          meta=STRING     value="lo">
  #<Rex::Post::Meterpreter::Tlv type=unknown-132515  meta=INT        value=256>
]>
  #<Rex::Post::Meterpreter::GroupTlv type=unknown-1073743247 tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=unknown-263564  meta=RAW        value="\xFE\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\ ...">
  #<Rex::Post::Meterpreter::Tlv type=unknown-263565  meta=RAW        value="\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00\x00\x00\x00\ ...">
  #<Rex::Post::Meterpreter::Tlv type=unknown-263566  meta=RAW        value="\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\ ...">
  #<Rex::Post::Meterpreter::Tlv type=STRING          meta=STRING     value="eth0">
  #<Rex::Post::Meterpreter::Tlv type=unknown-132515  meta=INT        value=100>
]>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST-ID      meta=STRING     value="87853532539935089997869350942110">
  #<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>
]>
```

## After
```
RECV: #<Rex::Post::Meterpreter::Packet type=PACKET-TYPE-RESPONSE tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND-ID      meta=INT        value=1022 command=stdapi_net_config_get_routes>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="T\xDE)\xB9\x9Ej\xAFR>G+S\\_\xDEs">
  #<Rex::Post::Meterpreter::GroupTlv type=NETWORK-ROUTE   tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=SUBNET          meta=RAW        value="\xC0\xA8\x81\x00">
  #<Rex::Post::Meterpreter::Tlv type=NETMASK         meta=RAW        value="\xFF\xFF\xFF\x00">
  #<Rex::Post::Meterpreter::Tlv type=GATEWAY         meta=RAW        value="\x00\x00\x00\x00">
  #<Rex::Post::Meterpreter::Tlv type=STRING          meta=STRING     value="eth0">
  #<Rex::Post::Meterpreter::Tlv type=ROUTE-METRIC    meta=INT        value=100>
]>
  #<Rex::Post::Meterpreter::GroupTlv type=NETWORK-ROUTE   tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=SUBNET          meta=RAW        value="\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\ ...">
  #<Rex::Post::Meterpreter::Tlv type=NETMASK         meta=RAW        value="\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\ ...">
  #<Rex::Post::Meterpreter::Tlv type=GATEWAY         meta=RAW        value="\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\ ...">
  #<Rex::Post::Meterpreter::Tlv type=STRING          meta=STRING     value="lo">
  #<Rex::Post::Meterpreter::Tlv type=ROUTE-METRIC    meta=INT        value=256>
]>
  #<Rex::Post::Meterpreter::GroupTlv type=NETWORK-ROUTE   tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=SUBNET          meta=RAW        value="\xFE\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\ ...">
  #<Rex::Post::Meterpreter::Tlv type=NETMASK         meta=RAW        value="\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00\x00\x00\x00\ ...">
  #<Rex::Post::Meterpreter::Tlv type=GATEWAY         meta=RAW        value="\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\ ...">
  #<Rex::Post::Meterpreter::Tlv type=STRING          meta=STRING     value="eth0">
  #<Rex::Post::Meterpreter::Tlv type=ROUTE-METRIC    meta=INT        value=100>
]>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST-ID      meta=STRING     value="12408185928188508781480957978798">
  #<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>
]>
```