### PR TITLE
Use bash instead of netcat as a default payload

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -294,7 +294,7 @@ class Exploit
       # These payloads are generally reliable and common enough in practice
       '/meterpreter/reverse_tcp',
       '/shell/reverse_tcp',
-      'cmd/unix/reverse_netcat',
+      'cmd/unix/reverse_bash',
       'cmd/windows/powershell_reverse_tcp',
       # Fall back on a generic payload to autoselect a specific payload
       'generic/shell_reverse_tcp',

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -295,6 +295,7 @@ class Exploit
       '/meterpreter/reverse_tcp',
       '/shell/reverse_tcp',
       'cmd/unix/reverse_bash',
+      'cmd/unix/reverse_netcat',
       'cmd/windows/powershell_reverse_tcp',
       # Fall back on a generic payload to autoselect a specific payload
       'generic/shell_reverse_tcp',


### PR DESCRIPTION
This updates the default payload selection to pick `cmd/unix/reverse_bash` over `cmd/unix/reverse_netcat`. Bash is more likely to be installed and available than netcat is. The netcat payload was selected as a default in b28d9517bc1572d4c75e862a4c5a308d8ba627c6 from #13755 which does not appear to make any mention of why that particular payload was selected for this purpose. This change should use a more sensible default for more environments such as docker containers.

## Testing

- [x] Make sure all unit tests pass
- [x] Use a module that doesn't specify a module-specific default payload
  - [x] If the default target isn't ARCH_CMD unix, set the module to that target, unset the payload then back about and reuse the module (run `set TARGET Unix\ Command`, `unset PAYLOAD`, `back`, `use ...`)
- [x] See the framework message `[*] No payload configured, defaulting to cmd/unix/reverse_bash`