### PR TITLE
Add rescue for failed authentication on `info -d`

### DIFF
--- a/lib/msf/util/document_generator/pull_request_finder.rb
+++ b/lib/msf/util/document_generator/pull_request_finder.rb
@@ -82,7 +82,7 @@ module Msf
           rescue Faraday::ConnectionFailed
             raise PullRequestFinder::Exception, 'No network connection to Github.'
           rescue Octokit::Unauthorized
-            raise PullRequestFinder::Exception, 'Authentication Failed #{e}.'
+            raise PullRequestFinder::Exception, 'Github Authentication Failed.'
           end
 
           if commits.empty?

--- a/lib/msf/util/document_generator/pull_request_finder.rb
+++ b/lib/msf/util/document_generator/pull_request_finder.rb
@@ -81,6 +81,8 @@ module Msf
             commits = git_client.commits(repository, branch, path: path)
           rescue Faraday::ConnectionFailed
             raise PullRequestFinder::Exception, 'No network connection to Github.'
+          rescue Octokit::Unauthorized
+            raise PullRequestFinder::Exception, 'Authentication Failed #{e}.'
           end
 
           if commits.empty?


### PR DESCRIPTION
This fixes a silly edge case that I found while running `info -d`
`info -d` tries to authenticate using an OAUTH_TOKEN in your environment.  I have one, but I quit using it, so I disabled it in github, so it is no longer valid.  There are guards for not having the token, and guards for not connecting, but until this PR, no guards for having an invalid token.

Old and busted:
```
msf6 exploit(windows/smb/ms08_067_netapi) > info -d
[*] Generating documentation for ms08_067_netapi, then opening /tmp/ms08_067_netapi_doc20220302-40247-p5kx3p.html in a browser...
[-] Error while running command info: GET https://api.github.com/repos/rapid7/metasploit-framework/commits?path=modules%2Fexploits%2Fwindows%2Fsmb%2Fms08_067_netapi.rb&sha=master: 401 - Bad credentials // See: https://docs.github.com/rest

Call stack:
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/octokit-4.22.0/lib/octokit/response/raise_error.rb:14:in `on_complete'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/faraday-1.10.0/lib/faraday/middleware.rb:19:in `block in call'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/faraday-1.10.0/lib/faraday/response.rb:61:in `on_complete'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/faraday-1.10.0/lib/faraday/middleware.rb:18:in `call'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/octokit-4.22.0/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/octokit-4.22.0/lib/octokit/middleware/follow_redirects.rb:61:in `call'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/faraday-retry-1.0.3/lib/faraday/retry/middleware.rb:140:in `call'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/faraday-1.10.0/lib/faraday/rack_builder.rb:154:in `build_response'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/faraday-1.10.0/lib/faraday/connection.rb:516:in `run_request'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/faraday-1.10.0/lib/faraday/connection.rb:200:in `get'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/sawyer-0.8.2/lib/sawyer/agent.rb:94:in `call'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/octokit-4.22.0/lib/octokit/connection.rb:156:in `request'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/octokit-4.22.0/lib/octokit/connection.rb:84:in `paginate'
/home/tmoose/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/octokit-4.22.0/lib/octokit/client/commits.rb:29:in `commits'
/home/tmoose/rapid7/metasploit-framework/lib/msf/util/document_generator/pull_request_finder.rb:81:in `get_commits_from_file'
/home/tmoose/rapid7/metasploit-framework/lib/msf/util/document_generator/pull_request_finder.rb:56:in `search'
/home/tmoose/rapid7/metasploit-framework/lib/msf/util/document_generator.rb:48:in `get_module_document'
/home/tmoose/rapid7/metasploit-framework/lib/msf/util/document_generator.rb:19:in `spawn_module_document'
/home/tmoose/rapid7/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:124:in `print_module_info'
/home/tmoose/rapid7/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:152:in `cmd_info'
/home/tmoose/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:563:in `run_command'
/home/tmoose/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:512:in `block in run_single'
/home/tmoose/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:506:in `each'
/home/tmoose/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:506:in `run_single'
/home/tmoose/rapid7/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/home/tmoose/rapid7/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/tmoose/rapid7/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```

New and _less_ busted
```
msf6 exploit(windows/smb/ms08_067_netapi) > info -d
[*] Generating documentation for ms08_067_netapi, then opening /tmp/ms08_067_netapi_doc20220302-42139-dknojz.html in a browser...
msf6 exploit(windows/smb/ms08_067_netapi) > Gtk-Message: 16:40:58.788: Failed to load module "canberra-gtk-module"
Gtk-Message: 16:40:58.790: Failed to load module "canberra-gtk-module"
[42174:42274:0302/164058.823467:ERROR:object_proxy.cc(623)] Failed to call method: org.freedesktop.DBus.ListActivatableNames: object_path= /org/freedesktop/DBus: org.freedesktop.DBus.Error.AccessDenied: An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender=":1.181" (uid=1000 pid=42174 comm="/snap/chromium/1926/usr/lib/chromium-browser/chrom" label="snap.chromium.chromium (enforce)") interface="org.freedesktop.DBus" member="ListActivatableNames" error name="(unset)" requested_reply="0" destination="org.freedesktop.DBus" (bus)
Fontconfig error: Cannot load default config file

msf6 exploit(windows/smb/ms08_067_netapi) > exit

```
Now there's an error about apparmor preventing the message.  I'm fine with this.  I can open the generated file manually so I'm OK with the security that prevents automation.