### PR TITLE
Fix race condition in jobs cleanup that could allow it to clean up twice simultaneously

### DIFF
--- a/lib/rex/job.rb
+++ b/lib/rex/job.rb
@@ -20,6 +20,18 @@ class Job
     self.clean_proc = clean_proc
     self.ctx        = ctx
     self.start_time = nil
+    self.cleanup_mutex = Mutex.new
+    self.cleaned_up = false
+  end
+
+  def synchronized_cleanup
+    # Avoid start and stop both calling cleanup
+    self.cleanup_mutex.synchronize do
+      unless cleaned_up
+        self.clean_proc.call(ctx) if self.clean_proc
+        self.cleaned_up = true
+      end
+    end
   end
 
   #
@@ -36,7 +48,7 @@ class Job
         begin
           run_proc.call(ctx)
         ensure
-          clean_proc.call(ctx)
+          synchronized_cleanup
           container.remove_job(self)
         end
       }
@@ -59,7 +71,7 @@ class Job
       self.job_thread = nil
     end
 
-    clean_proc.call(ctx) if (clean_proc)
+    synchronized_cleanup
   end
 
   #
@@ -92,6 +104,8 @@ protected
   attr_accessor :clean_proc #:nodoc:
   attr_writer   :ctx #:nodoc:
   attr_writer   :start_time #:nodoc:
+  attr_accessor :cleanup_mutex #:nodoc:
+  attr_accessor :cleaned_up #:nodoc:
 
 end
 

--- a/lib/rex/job.rb
+++ b/lib/rex/job.rb
@@ -28,8 +28,8 @@ class Job
     # Avoid start and stop both calling cleanup
     self.cleanup_mutex.synchronize do
       unless cleaned_up
-        self.clean_proc.call(ctx) if self.clean_proc
         self.cleaned_up = true
+        self.clean_proc.call(ctx) if self.clean_proc
       end
     end
   end


### PR DESCRIPTION
This fixes a minor race condition when cleaning up jobs. I should say I didn't see any particularly adverse effects from this, but I was getting error messages every time I stopped a capture service, which was a little concerning. A deeper look at it showed that it's probably not the biggest issue, but is a bit of a smell that could cause unintended behaviour.

The issue arose when stopping a listening service, say with `jobs -K`. The cleanup code would initially be executed from within a job's `stop` method. After forcibly stopping the job, the `ensure` block of the `job.start` method would also run the cleanup code. This created a race condition whereby the cleanup would run twice. In the case I was testing (a cred capture module), it would throw an error: `[-] undefined method stop for nil:NilClass`. This was because it entered the `stop_service` method twice at the same time on separate threads, and that module's `service` attribute would be set to `nil` on one thread while the other one expected it to be there.

I initially fixed this directly inside the `socket_server` class, but then thought that really, this fix should be applied to every job: it's probably never the right thing to clean up twice. So to fix this, I've wrapped the call to `cleanup` in a critical section. The second code path to try cleanup will wait until the first one has finished, and discover that it's already been cleaned up.

Steps to reproduce:

```
msf6 > use auxiliary/server/capture/ftp
msf6 auxiliary(server/capture/ftp) > run
[*] Auxiliary module running as background job 0.

[*] Started service listener on 0.0.0.0:21 
[*] Server started.
msf6 auxiliary(server/capture/ftp) > jobs -K
Stopping all jobs...
[*] Server stopped.
[-] undefined method `stop' for nil:NilClass
```

After the fix (trying multiple times to reproduce it):

```
msf6 > use auxiliary/server/capture/ftp
msf6 auxiliary(server/capture/ftp) > run
[*] Auxiliary module running as background job 0.

[*] Started service listener on 0.0.0.0:21 
[*] Server started.
msf6 auxiliary(server/capture/ftp) > jobs -K
Stopping all jobs...
[*] Server stopped.
msf6 auxiliary(server/capture/ftp) > run
[*] Auxiliary module running as background job 1.

[*] Started service listener on 0.0.0.0:21 
[*] Server started.
msf6 auxiliary(server/capture/ftp) > jobs -K
Stopping all jobs...
[*] Server stopped.
msf6 auxiliary(server/capture/ftp) > run
[*] Auxiliary module running as background job 2.

[*] Started service listener on 0.0.0.0:21 
[*] Server started.
msf6 auxiliary(server/capture/ftp) > jobs -K
Stopping all jobs...
[*] Server stopped.
msf6 auxiliary(server/capture/ftp) > run
[*] Auxiliary module running as background job 3.

[*] Started service listener on 0.0.0.0:21 
[*] Server started.
msf6 auxiliary(server/capture/ftp) > jobs -K
Stopping all jobs...
[*] Server stopped.
msf6 auxiliary(server/capture/ftp) > run
[*] Auxiliary module running as background job 4.

[*] Started service listener on 0.0.0.0:21 
[*] Server started.
msf6 auxiliary(server/capture/ftp) > jobs -K
Stopping all jobs...
[*] Server stopped.
```