### PR TITLE
Fix bug in tab completion of directories

### DIFF
--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -297,8 +297,27 @@ module DispatcherShell
     # Return a list of possible directory for tab completion.
     #
     def tab_complete_directory(str, words)
-      str = '.' + ::File::SEPARATOR if str.empty?
-      dirs = Dir.glob(str.concat('*'), File::FNM_CASEFOLD).select { |x| File.directory?(x) }
+      directory = str[-1] == File::SEPARATOR ? str : File.dirname(str)
+      filename = str[-1] == File::SEPARATOR ? '' : File.basename(str)
+      entries = Dir.entries(directory).select { |fp| fp.start_with?(filename) }
+      dirs = entries - ['.','..']
+      dirs = dirs.map { |fp| File.join(directory, fp).gsub(/\A\.\//, '') }
+      dirs = dirs.select { |x| File.directory?(x) }
+      dirs = dirs.select { |x| File.directory?(x) }
+      dirs = dirs.map { |x| x + File::SEPARATOR }
+      if dirs.length == 1 && dirs[0] != str && dirs[0].end_with?(File::SEPARATOR)
+        # If Readline receives a single value from this function, it will assume we're done with the tab
+        # completing, and add an extra space at the end.
+        # This is annoying if we're recursively tab-traversing our way through subdirectories -
+        # we may want to continue traversing, but MSF will add a space, requiring us to back up to continue
+        # tab-completing our way through successive subdirectories.
+        ::Readline.completion_append_character = nil
+      end
+
+      if dirs.length == 0 && File.directory?(str)
+        # we've hit the end of the road
+        dirs = [str]
+      end
 
       dirs
     end


### PR DESCRIPTION
This fixes several bugs in local directory tab completion.

The code currently just performs a glob based on the user's current input. This has a bug that effectively prevents it from ever working. It performs a string concatenation to add an asterisk, which alters the `str` parameter with the in-place-modification method `concat`. The `str` parameter is used by the readline library to do its tab completion magic, so suddenly it's got an asterisk on there, and readline's string matching fails. As a practical example:

* The current directory contains the directories 'tools' and 'test'
* We type `cd t` and press `<tab>`
* The glob adds an asterisk to `str` to give it the value `t*`
* The glob finds both the directories and returns them
* Readline receives these two values, but also uses the modified `t*` value, because of the in-place modification that occurred as a result of using `concat`
* Because neither `tools` nor `test` start with the literal string `t*`, it finds no matches, and provides no tab completion to the user.

### Steps to reproduce:

* Launch `msfconsole` from a directory containing at least two folders
* Type `cd` and press `<tab>`
* You'll see it pop up `./`
* Press `<tab>` again
* Nothing happens

### Expected behaviour:

The tab completion provides options based on the current directory, or absolute directory specified.

### Fix:

A simple fix would be to change `str.concat(*)` to `str + '*'`. However, this leaves another subtle bug in that it doesn't respect glob-meaningful characters such as `*`, `?`, `[` and `]`. So if folders actually contain these characters, it would not provide the expected results (as the user is not aware that globbing is used). `?` and `*` work by coincidence, as globbing will use them as wildcards, which will match the literal characters `?` and `*`; but it fails in the case of folder names containing brackets. This is probably a rarer situation, but still a bug.

You could do all sorts of glob backslash escaping, but that starts to get messy, so instead I just implemented directory searching so as to control this behaviour ourselves, in order to keep it Readline-friendly.

### After the fix:

```
msf6 > cd co<tab>
cd config/    cd coverage/  
msf6 > cd /t<tab>
cd /testing/  cd /tmp/      cd /tools/
msf6 > cd /tmp/globtest/a[<tab>
cd /tmp/globtest/a[hi]b/     cd /tmp/globtest/a[there]b/
```