### PR TITLE
Msf::Payload::Apk: Check Java is installed and apktool.jar exists

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -145,12 +145,21 @@ class Msf::Payload::Apk
       raise RuntimeError, "Invalid template: #{apkfile}"
     end
 
-    apktool = run_cmd(%w[apktool -version])
-    if apktool.nil?
+    check_apktool = run_cmd(%w[apktool -version])
+    if check_apktool.nil?
       raise RuntimeError, "apktool not found. If it's not in your PATH, please add it."
     end
 
-    apk_v = Rex::Version.new(apktool.split("\n").first.strip)
+    if check_apktool.to_s.include?('java: not found')
+      raise RuntimeError, "java not found. If it's not in your PATH, please add it."
+    end
+
+    jar_name = 'apktool.jar'
+    if check_apktool.to_s.include?("can't find #{jar_name}")
+      raise RuntimeError, "#{jar_name} not found. This file must exist in the same directory as apktool."
+    end
+
+    apk_v = Rex::Version.new(check_apktool.split("\n").first.strip)
     unless apk_v >= Rex::Version.new('2.0.1')
       raise RuntimeError, "apktool version #{apk_v} not supported, please download at least version 2.0.1."
     end


### PR DESCRIPTION
During manual install of `apktool` (instead of using operating system packages) it is possible that someone can install the `apktool` wrapper Bash script without also installing the `apktool.jar` file. For example, when downloading the JAR file, the default file name contains the version string (ie: `apktool_2.6.1.jar`). I lazily copied this to `/usr/local/bin` and forgot to rename it to `apktool.jar`, resulting in this error message:

```
Error: Malformed version number string apktool: can't find apktool.jar
```

The error message is fairly intuitive, but letting this crash inside a version check is silly.

The latest version of the `apktool` wrapper script contains no other error checking or error messages or early exits. This is the only expected/handled error message we can catch and handle (outside of potential unexpected Java environment issues).


# Before

```
Error: Malformed version number string apktool: can't find apktool.jar
```

# After

```
Error: apktool.jar not found. This file must exist in the same directory as apktool.
```

---

Likewise, it is entirely possible to install `apktool` without installing Java, resulting in an error message similar to the following:

```
Error: Malformed version number string /usr/bin/apktool: line 77: exec: java: not found
```

The error message is fairly intuitive, but letting this crash inside a version check is silly.

The latest version of the `apktool` wrapper script contains no other `exec` commands and calls out to no other programs (apart from basic POSIX utilities, and cygwin on Windows).

# Before

```
Error: Malformed version number string /usr/bin/apktool: line 77: exec: java: not found
```

# After

```
Error: java not found. If it's not in your PATH, please add it.
```
