### PR TITLE
Add lcat command for meterpreter

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -88,6 +88,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'edit'       => 'Edit a file',
       'getlwd'     => 'Print local working directory',
       'getwd'      => 'Print working directory',
+      'lcat'       => 'Read the contents of a local file to the screen',
       'lcd'        => 'Change local working directory',
       'lpwd'       => 'Print local working directory',
       'ls'         => 'List files',
@@ -114,6 +115,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'edit'       => [],
       'getlwd'     => [],
       'getwd'      => [COMMAND_ID_STDAPI_FS_GETWD],
+      'lcat'       => [],
       'lcd'        => [],
       'lpwd'       => [],
       'ls'         => [COMMAND_ID_STDAPI_FS_STAT, COMMAND_ID_STDAPI_FS_LS],
@@ -304,6 +306,43 @@ class Console::CommandDispatcher::Stdapi::Fs
   #
   def cmd_cat_tabs(str, words)
     tab_complete_cfilenames(str, words)
+  end
+
+  #
+  # Reads the contents of a local file and prints them to the screen.
+  #
+  def cmd_lcat(*args)
+    if (args.length == 0 || args.include?('-h') || args.include?('--help'))
+      print_line("Usage: lcat file")
+      return true
+    end
+
+    path = args[0]
+    path = ::File.expand_path(path) if path =~ path_expand_regex
+
+
+    if (::File.stat(path).directory?)
+      print_error("#{path} is a directory")
+    else
+      fd = ::File.new(path, "rb")
+      begin
+        until fd.eof?
+          print(fd.read)
+        end
+        # EOFError is raised if file is empty, do nothing, just catch
+      rescue EOFError
+      end
+      fd.close
+    end
+
+    true
+  end
+
+  # 
+  # Tab completion for the lcat command
+  #
+  def cmd_lcat_tabs(str, words)
+    tab_complete_filenames(str, words)
   end
 
   #

--- a/test/functional/meterpreter/meterpreter_specs.rb
+++ b/test/functional/meterpreter/meterpreter_specs.rb
@@ -23,6 +23,7 @@ module MeterpreterSpecs
             "use",
             "write",
             "cat",
+            "lcat",
             "cd",
             "del",
             "download",


### PR DESCRIPTION
This PR implements the suggestion feature #16167 

These changes introduce a `lcat` command for the meterpreter, where-in you can read the contents of a local file (present in the local machine or attacking machine),  to the meterpreter terminal. The already present `cat` command only reads the files that are present in the remote machine.

**Before**

No command to read the local files in the terminal

**After**

```
meterpreter > pwd
/
meterpreter > lpwd
/home/beleswar/metasploit-framework

meterpreter > cat /etc/hosts
127.0.0.1	localhost
127.0.1.1	metasploitable.localdomain	metasploitable

# The following lines are desirable for IPv6 capable hosts
::1     ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
ff02::3 ip6-allhosts

meterpreter > lcat /etc/hosts
# Static table lookup for hostnames.
# See hosts(5) for details.

127.0.0.1	localhost
::1		localhost
127.0.1.1	arch.localdomain	arch

meterpreter > lcat -h
Usage: lcat file
```

**Note:**

In the above output, `cat` displays the hosts file of metasploitable (remote machine) and `lcat` displays the hosts file of arch linux (local machine). The tabs functionality is also added for lcat command.

## Verification

List the steps needed to make sure this thing works

- [ ] Open a meterpreter session against a remote machine.
- [ ] run `pwd` and `lpwd` to check the current directories in both machines.
- [ ] run `lcat <path/to/your/localfile>` (ex- `lcat msfvenom`)
- [ ] **Verify** that `lcat` displays the contents of the local file in the terminal
- [ ] **Verify** the `lcat` also utilizes tab functionality to autocomplete file names.


Fixes #16167