### PR TITLE
Fix typo in document of cve_2021_4034

### DIFF
--- a/documentation/modules/exploit/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.md
+++ b/documentation/modules/exploit/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.md
@@ -21,7 +21,7 @@ First Patched Debian Packages:
 
 Source: https://github.com/cyberark/PwnKit-Hunter/blob/main/CVE-2021-4034_Finder.py
 
-Vulnerable ContOS Packages:
+Vulnerable CentOS Packages:
 
 - polkit-0.112-5.ael7b
 - polkit-0.112-13.p1.el7a


### PR DESCRIPTION
Fix typo: ContOS => CentOS


