### PR TITLE
Make TLV Logging cache threadsafe

### DIFF
--- a/lib/rex/post/meterpreter/command_mapper.rb
+++ b/lib/rex/post/meterpreter/command_mapper.rb
@@ -111,7 +111,7 @@ class CommandMapper
     return @@cached_tlv_types[value] unless @@cached_tlv_types[value].nil? || @@cached_tlv_types[value].empty?
 
     # Default to arrays that contain TLV Types, so that we only deal with one data type
-    @@cached_tlv_types = Hash.new { |h, k| h[k] = [] }
+    @@cached_tlv_types = Hash.new { |h, k| h[k] = Set.new }
 
     available_modules = [
       ::Rex::Post::Meterpreter,


### PR DESCRIPTION
This PR fixes a potential issue of the same TLV types being defined multiple times when multiple threads want to get a list of TLV types.

Example:
![image](https://user-images.githubusercontent.com/85949464/157023874-2c1529cd-28f0-4a63-872f-5ce99390e34f.png)

## Verification

- [ ] Start `msfconsole`
- [ ] `use payload/python/meterpreter_reverse_tcp`
- [ ] `set lhost ...`
- [ ] `generate -f raw -o shell.py`
- [ ] Attempt to open multiple sessions: "for i in `seq 5`; do python3 shell.py; done"
- [ ] **Confirm** that all types are defined only once. E.g. `oneOf(COMMAND_ID,COMMAND_ID)` is not present.