### PR TITLE
Defer TLV logging until session is bootstrapped

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -73,10 +73,6 @@ class Meterpreter < Rex::Post::Meterpreter::Client
       opts[:ssl_cert] = opts[:datastore]['HandlerSSLCert']
     end
 
-    if opts[:datastore] and opts[:datastore]['SessionTlvLogging']
-      opts[:tlv_log] = opts[:datastore]['SessionTlvLogging']
-    end
-
     # Don't pass the datastore into the init_meterpreter method
     opts.delete(:datastore)
 
@@ -134,6 +130,8 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     session.encode_unicode = datastore['EnableUnicodeEncoding']
 
     session.init_ui(self.user_input, self.user_output)
+
+    initialize_tlv_logging(datastore['SessionTlvLogging']) unless datastore['SessionTlvLogging'].nil?
 
     verification_timeout = datastore['AutoVerifySessionTimeout']&.to_i || session.comm_timeout
     begin

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -167,8 +167,6 @@ class Client
       end
     end
 
-    initialize_tlv_logging(opts[:tlv_log]) unless opts[:tlv_log].nil?
-
     # Protocol specific dispatch mixins go here, this may be neader with explicit Client classes
     opts[:dispatch_ext].each {|dx| self.extend(dx)} if opts[:dispatch_ext]
     initialize_passive_dispatcher if opts[:passive_dispatcher]


### PR DESCRIPTION
This PR explicitly fixes an issue where `payload/python/meterpreter_reverse_http` would not log TLV packets, as it was initialized without `datastore` being passed into the initialize method.
It also ensures that any future sessions would automatically work with TLV logging by moving the initializing of tlv logging to session bootstrap.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use payload/python/meterpreter_reverse_http`
- [ ] `setg sessiontlvlogging true`
- [ ] **Verify** that TLV packets are logged to console
- [ ] **Verify** that other sessions e.g. `payload/python/meterpreter_reverse_tcp` also log correctly.