### PR TITLE
Fix: Catch exception from net/ssh/connection/session.rb:381

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -94,8 +94,12 @@ module Metasploit
 
           unless result_options.has_key? :status
             if ssh_socket
-              proof = gather_proof unless skip_gather_proof
-              result_options.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: proof)
+              begin
+                proof = gather_proof unless skip_gather_proof
+                result_options.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: proof)
+              rescue => e
+                result_options.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: e)
+              end
             else
               result_options.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: nil)
             end

--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -96,10 +96,11 @@ module Metasploit
             if ssh_socket
               begin
                 proof = gather_proof unless skip_gather_proof
-                result_options.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: proof)
-              rescue => e
-                result_options.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: e)
+              rescue StandardError => e
+                elog('Failed to gather SSH proof', error: e)
+                proof = nil
               end
+              result_options.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: proof)
             else
               result_options.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: nil)
             end

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -126,7 +126,16 @@ class MetasploitModule < Msf::Auxiliary
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
-        session_setup(result, scanner) if datastore['CreateSession']
+
+        if datastore['CreateSession']
+          begin
+            session_setup(result, scanner)
+          rescue StandardError => e
+            elog('Failed to setup the session', error: e)
+            print_brute :level => :error, :ip => ip, :msg => "Failed to setup the session - #{e.class} #{e.message}"
+          end
+        end
+
         if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
           msg = "While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with"
           msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"


### PR DESCRIPTION
Ruby gem's `net-ssh-6.1.0/lib/net/ssh/connection/session.rb` is throwing an exception on line 381:
```
        def exec(command, status: nil, &block)
          open_channel do |channel|
            channel.exec(command) do |ch, success|
              raise "could not execute command: #{command.inspect}" unless success
```
which is not being handled in `lib/metasploit/framework/ssh/platform.rb` causing the `ssh_login` scanner to crash on first host, where `id` command execution fails.

Trace I'm getting:
```
[*] Scanned 39 of 40 hosts (97% complete)
[-] Auxiliary failed: RuntimeError could not execute command: "id\n"
[-] Call stack:
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:381:in `block (2 levels) in exec'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/channel.rb:618:in `do_failure'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:695:in `channel_failure'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:548:in `dispatch_incoming_packets'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:248:in `ev_preprocess'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/event_loop.rb:100:in `each'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/event_loop.rb:100:in `ev_preprocess'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/event_loop.rb:28:in `process'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:227:in `process'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:180:in `block in loop'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:180:in `loop'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:180:in `loop'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/channel.rb:272:in `wait'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:427:in `exec!'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/ssh/platform.rb:14:in `block in get_platform_info'
[-]   /usr/lib/ruby/2.7.0/timeout.rb:95:in `block in timeout'
[-]   /usr/lib/ruby/2.7.0/timeout.rb:33:in `block in catch'
[-]   /usr/lib/ruby/2.7.0/timeout.rb:33:in `catch'
[-]   /usr/lib/ruby/2.7.0/timeout.rb:33:in `catch'
[-]   /usr/lib/ruby/2.7.0/timeout.rb:110:in `timeout'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/ssh/platform.rb:13:in `get_platform_info'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/ssh.rb:117:in `gather_proof'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/ssh.rb:97:in `attempt_login'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:231:in `block in scan!'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:179:in `block in each_credential'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/credential_collection.rb:82:in `block in each_filtered'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/credential_collection.rb:223:in `each_unfiltered'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/credential_collection.rb:79:in `each_filtered'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:141:in `each_credential'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:205:in `scan!'
[-]   /usr/share/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_login.rb:116:in `run_host'
[-]   /usr/share/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:124:in `block (2 levels) in run'
[-]   /usr/share/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
[*] Auxiliary module execution completed
```
