### PR TITLE
Ignore iterating multiple rhosts if option not registered

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -113,6 +113,10 @@ class Exploit
     mod_with_opts = mod.replicant
     mod_with_opts.datastore.import_options_from_hash(args[:datastore_options])
     rhosts = mod_with_opts.datastore['RHOSTS']
+    has_rhosts_option = mod.options.include?('RHOSTS') ||
+      mod.options.include?('RHOST') ||
+      mod.options.include?('rhost') ||
+      mod.options.include?('rhosts')
 
     opts = {
       'Encoder'     => args[:encoder] || mod_with_opts.datastore['ENCODER'],
@@ -134,7 +138,8 @@ class Exploit
       return false
     end
 
-    if rhosts
+
+    if rhosts && has_rhosts_option
       rhosts_walker = Msf::RhostsWalker.new(rhosts, mod_with_opts.datastore)
       rhosts_walker_count = rhosts_walker.count
       rhosts_walker = rhosts_walker.to_enum

--- a/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
             Msf::OptFloat.new('FloatValue', [false, 'A FloatValue which should be normalized before framework runs this module', 3.5])
           ]
         )
+
+        deregister_options('RHOSTS')
       end
 
       def run
@@ -438,6 +440,20 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         subject.cmd_run
         expected_output = [
           'Running with normalized datastore value 3.5',
+          'Cleanup',
+          'Exploit completed, but no session was created.'
+        ]
+
+        expect(@combined_output).to match_array(expected_output)
+      end
+
+      it 'runs the module once, even if multiple rhost values are set' do
+        set_default_payload(current_mod)
+        current_mod.datastore.store('FloatValue', '10.0')
+        current_mod.datastore['RHOSTS'] = '192.0.2.1 192.0.2.2 192.0.2.3'
+        subject.cmd_run
+        expected_output = [
+          'Running with normalized datastore value 10.0',
           'Cleanup',
           'Exploit completed, but no session was created.'
         ]


### PR DESCRIPTION
Fixes an edgecase where the user could have previously ran `setg RHOSTS x y z` or `set RHOSTS x y z` when attempting to run a passive module.

### Before

Lots of servers are spun up

```
use exploit/windows/http/git_lfs_rce
set RHOSTS 192.168.123.1 192.168.123.2 192.168.123.3
run

msf6 exploit(windows/http/git_lfs_rce) > setg RHOSTS 192.168.123.1 192.168.123.2 192.168.123.3
RHOSTS => 192.168.123.1 192.168.123.2 192.168.123.3
msf6 exploit(windows/http/git_lfs_rce) > run
[*] Exploiting target 192.168.123.1
[*] Exploiting target 192.168.123.2

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] Exploiting target 192.168.123.3
[*] Exploit completed, but no session was created.
msf6 exploit(windows/http/git_lfs_rce) > 
[-] Handler failed to bind to 192.168.123.1:4444:-  -
[*] Started reverse TCP handler on 0.0.0.0:4444 
[-] Handler failed to bind to 192.168.123.1:4444:-  -
[-] Handler failed to bind to 0.0.0.0:4444:-  -
[-] Exploit failed [bad-config]: Rex::BindFailed The address is already in use or unavailable: (0.0.0.0:4444).
```

### After

Only one module is spun up:

```
msf6 exploit(windows/http/git_lfs_rce) > set RHOSTS 192.168.123.1 192.168.123.2 192.168.123.3
RHOSTS => 192.168.123.1 192.168.123.2 192.168.123.3
msf6 exploit(windows/http/git_lfs_rce) > run
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(windows/http/git_lfs_rce) > 
[*] Started reverse TCP handler on 192.168.123.1:4444 

msf6 exploit(windows/http/git_lfs_rce) > 
[*] Using URL: http://0.0.0.0:8080/v4zNkcLDxZIE
[*] Local IP: http://192.168.1.239:8080/v4zNkcLDxZIE
[*] Server started.
[*] Git repository to clone: http://192.168.123.1:8080/ventosanzap.git
```

## Verification

Tests pass


Run the following:
```
use exploit/windows/http/git_lfs_rce
setg RHOSTS 192.168.123.1 192.168.123.2 192.168.123.3
run
```

Verify only one server is run