### PR TITLE
Install mingw in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ ENV METASPLOIT_GROUP=metasploit
 # used for the copy command
 RUN addgroup -S $METASPLOIT_GROUP
 
-RUN apk add --no-cache bash sqlite-libs nmap nmap-scripts nmap-nselibs postgresql-libs python2 python3 py3-pip ncurses libcap su-exec alpine-sdk python2-dev openssl-dev nasm
+RUN apk add --no-cache bash sqlite-libs nmap nmap-scripts nmap-nselibs postgresql-libs python2 python3 py3-pip ncurses libcap su-exec alpine-sdk python2-dev openssl-dev nasm mingw-w64-gcc
 
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which ruby)
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which nmap)


### PR DESCRIPTION
This PR installs mingw in Docker so that the module json file can be populated with windows encrypted shell entries.

## Verification

From https://github.com/rapid7/metasploit-framework/pull/15652

- [ ] `docker build -t metasploitframework/metasploit-framework:latest .`
- [ ] `./tools/automation/cache/update_module_cache.sh`
- [ ] **Verify** the updated ` db/modules_metadata_base.json` file includes encrypted payloads metadata
- [ ] **Verify** the encrypted payloads are searchable in msfconsole without mingw being installed on the host machine, and that they are usable - but provide the user a warning that mingw is missing