### PR TITLE
Fix arch check and on_session cd

### DIFF
--- a/modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb
+++ b/modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb
@@ -179,14 +179,18 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
     end
 
-    arch = kernel_hardware
-    vprint_status("Detected architecture: #{arch}")
+    host_arch = kernel_hardware
+    vprint_status("Detected architecture: #{host_arch}")
     unless check
       # on check, the value for payloads is nil, so this will crash
       # also, check should not care about your payload
       vprint_status("Detected payload arch: #{payload.arch.first}")
-      if arch != payload.arch.first
-        fail_with Failure::BadConfig, 'Payload/target architecture mismatch.  Please select the proper payload architecture'
+      # our host arch values and payload arch values do not line up... this is awful
+      if host_arch.include?('64') && !payload.arch.first.include?('64')
+        fail_with Failure::BadConfig, 'Payload/Host architecture mismatch.  Please select the proper target architecture'
+      end
+      if host_arch.include?('aarch') && !payload.arch.first.include?('aarch')
+        fail_with Failure::BadConfig, 'Payload/Host architecture mismatch.  Please select the proper target architecture'
       end
     end
 

--- a/modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb
+++ b/modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb
@@ -90,11 +90,11 @@ class MetasploitModule < Msf::Exploit::Local
   def on_new_session(new_session)
     # The directory the payload launches in gets deleted and breaks some commands
     # unless we change into a directory that exists
-    super
     old_session = @session
     @session = new_session
     cd(datastore['FinalDir'])
     @session = old_session
+    super
   end
 
   def find_pkexec
@@ -181,8 +181,13 @@ class MetasploitModule < Msf::Exploit::Local
 
     arch = kernel_hardware
     vprint_status("Detected architecture: #{arch}")
-    if (arch.include?('x86_64') && payload.arch.first.include?('aarch')) || (arch.include?('aarch') && !payload.arch.first.include?('aarch'))
-      fail_with(Failure::BadConfig, 'Host/payload Mismatch; set target and select matching payload')
+    unless check
+      # on check, the value for payloads is nil, so this will crash
+      # also, check should not care about your payload
+      vprint_status("Detected payload arch: #{payload.arch.first}")
+      if arch != payload.arch.first
+        fail_with Failure::BadConfig, 'Payload/target architecture mismatch.  Please select the proper payload architecture'
+      end
     end
 
     pkexec_path = datastore['PKEXEC_PATH']

--- a/modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb
+++ b/modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb
@@ -97,6 +97,17 @@ class MetasploitModule < Msf::Exploit::Local
     super
   end
 
+  # This will likely make it into a library, so we should remove it when that happens
+  def kernel_arch
+    arch = kernel_hardware
+    return ARCH_X64 if arch == 'x86_64' || arch == 'amd64'
+    return ARCH_AARCH64 if arch == 'aarch64' || arch == 'arm64'
+    return ARCH_ARMLE if arch.start_with? 'arm'
+    return ARCH_X86 if arch.end_with? '86'
+
+    arch
+  end
+
   def find_pkexec
     vprint_status('Locating pkexec...')
     if exists?(pkexec = cmd_exec('which pkexec'))
@@ -179,21 +190,16 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
     end
 
-    host_arch = kernel_hardware
-    vprint_status("Detected architecture: #{host_arch}")
     unless check
       # on check, the value for payloads is nil, so this will crash
       # also, check should not care about your payload
       vprint_status("Detected payload arch: #{payload.arch.first}")
-      # our host arch values and payload arch values do not line up... this is awful
-      if host_arch.include?('64') && !payload.arch.first.include?('64')
-        fail_with Failure::BadConfig, 'Payload/Host architecture mismatch.  Please select the proper target architecture'
-      end
-      if host_arch.include?('aarch') && !payload.arch.first.include?('aarch')
-        fail_with Failure::BadConfig, 'Payload/Host architecture mismatch.  Please select the proper target architecture'
+      host_arch = kernel_arch
+      vprint_status("Detected host architecture: #{host_arch}")
+      if host_arch != payload.arch.first
+        fail_with(Failure::BadConfig, 'Payload/Host architecture mismatch.  Please select the proper target architecture')
       end
     end
-
     pkexec_path = datastore['PKEXEC_PATH']
     if pkexec_path.empty?
       pkexec_path = find_pkexec


### PR DESCRIPTION
This PR fixes two bugs in the polkit exploit module.
Somehow, this module made it through with 2 bugs that I did not notice during final dev checks:
1) For some reason the final cd for the created session does not appear to work as it did when I was testing it during development.  By moving the `cd` command to before the `super` invocation, it works properly.
2) The `check` method fails because it calls the `exploit` method in check mode, and the exploit method has a check to make sure the payload arch matches the host arch.  When the `check` method is called, the payload value is `nil`, so any attempt to query the payload arch causes the module to crash.  This PR makes the check between host and payload stronger and guards it to only run when the exploit is run in exploit mode, rather than in check mode.

Verification steps:
- [ ] get a session on a vulnerable target
- [ ] `use linux/local/cve_2021_4034_pwnkit_lpe_pkexec`
- [ ] `set target <correct target>`
- [ ] `set payload <payload>`
- [ ] `set verbose true`
- [ ]  `check`
- [ ]  Verify that the check method works correctly
- [ ] `run`
- [ ] Verify the check is run again as part of `autocheck`
- [ ] Verify you get s session that is root
- [ ] `pwd` in the new session and verify that you are in the root directory `/`
- [ ] exit the new session
- [ ]  change the target to an incorrect target and select a payload that does not match your session host
- [ ] `check`
- [ ] Verify check still succeeds
- [ ] `run`
- [ ]  Verify that the exploit passes the check again, but stops with the error: `[-] Exploit aborted due to failure: bad-config: Payload/target architecture mismatch.  Please select the proper payload architecture`
