### PR TITLE
Free UDP ports after use

### DIFF
--- a/lib/msf/core/exploit/remote/dns/server.rb
+++ b/lib/msf/core/exploit/remote/dns/server.rb
@@ -109,6 +109,7 @@ module Server
         datastore['SRVPORT'],
         datastore['DnsServerUdp'],
         datastore['DnsServerTcp'],
+        !datastore['DISABLE_NS_CACHE'],
         (use_resolver? ? setup_resolver : false),
         comm,
         {'Msf' => framework, 'MsfExploit' => self}
@@ -122,7 +123,6 @@ module Server
       end
 
       add_static_hosts
-      self.service.start(!datastore['DISABLE_NS_CACHE'])
 
     rescue ::Errno::EACCES => e
       raise Rex::BindFailed.new(e.message)

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -179,9 +179,9 @@ class Server
   # @param sblock [Proc] Handler for :send_response flow control interception
   #
   # @return [Rex::Proto::DNS::Server] DNS Server object
-  attr_accessor :serve_tcp, :serve_udp, :fwd_res, :cache
+  attr_accessor :serve_tcp, :serve_udp, :fwd_res, :cache, :start_cache
   attr_reader :serve_udp, :serve_tcp, :sock_options, :lock, :udp_sock, :tcp_sock
-  def initialize(lhost = '0.0.0.0', lport = 53, udp = true, tcp = false, res = nil, comm = nil, ctx = {}, dblock = nil, sblock = nil)
+  def initialize(lhost = '0.0.0.0', lport = 53, udp = true, tcp = false, start_cache = true, res = nil, comm = nil, ctx = {}, dblock = nil, sblock = nil)
 
     @serve_udp = udp
     @serve_tcp = tcp
@@ -195,6 +195,7 @@ class Server
     self.listener_thread = nil
     self.dispatch_request_proc = dblock
     self.send_response_proc = sblock
+    self.start_cache = start_cache
     self.cache = Cache.new
     @lock = Mutex.new
   end
@@ -222,7 +223,7 @@ class Server
   #
   # Start the DNS server and cache
   # @param start_cache [TrueClass, FalseClass] stop the cache
-  def start(start_cache = true)
+  def start
 
     if self.serve_udp
       @udp_sock = Rex::Socket::Udp.create(self.sock_options)
@@ -242,7 +243,7 @@ class Server
       end
     end
 
-    self.cache.start if start_cache
+    self.cache.start if self.start_cache
   end
 
   #

--- a/modules/auxiliary/server/dns/native_server.rb
+++ b/modules/auxiliary/server/dns/native_server.rb
@@ -25,9 +25,9 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => 'RageLtMan <rageltman[at]sempervictus>',
       'License'        => MSF_LICENSE,
       'References'     => [],
-      'Actions'     =>
+      'Actions'   =>
         [
-          [ 'Service', 'Description' => 'Serve DNS entries' ]
+          [ 'Service', 'Description' => 'Run DNS service' ]
         ],
       'PassiveActions' =>
         [

--- a/modules/auxiliary/spoof/dns/native_spoofer.rb
+++ b/modules/auxiliary/spoof/dns/native_spoofer.rb
@@ -26,16 +26,15 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => 'RageLtMan <rageltman[at]sempervictus>',
       'License'        => MSF_LICENSE,
       'References'     => [],
-      'Actions'     =>
+      'Actions'   =>
         [
-          [ 'Service', 'Description' => 'Serve DNS entries' ]
+          [ 'Service', 'Description' => 'Run DNS spoofing service' ]
         ],
       'PassiveActions' =>
         [
           'Service'
         ],
       'DefaultAction'  => 'Service'
-
     ))
 
     register_options(

--- a/modules/auxiliary/spoof/llmnr/llmnr_response.rb
+++ b/modules/auxiliary/spoof/llmnr/llmnr_response.rb
@@ -228,6 +228,7 @@ attr_accessor :sock, :thread
       self.thread.kill
       self.thread = nil
     end
+    self.sock.close
     close_pcap
   end
 end

--- a/modules/auxiliary/spoof/mdns/mdns_response.rb
+++ b/modules/auxiliary/spoof/mdns/mdns_response.rb
@@ -247,6 +247,7 @@ attr_accessor :sock, :thread
       self.thread.kill
       self.thread = nil
     end
+    self.sock.close
     close_pcap
   end
 end

--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -173,6 +173,7 @@ class MetasploitModule < Msf::Auxiliary
       self.thread.kill
       self.thread = nil
     end
+    self.sock.close
     close_pcap
   end
 end


### PR DESCRIPTION
This fixes several bugs I found around port usage in UDP spoofing services.

After running the following modules, the UDP socket was left unclosed:

- `auxiliary/spoof/llmnr/llmnr_response`
- `auxiliary/spoof/nbns/nbns_response`
- `auxiliary/spoof/mdns/mdns_response`

These were resolved by adding a call to `sock.close` in their cleanup functions.

A similar bug was also found in `auxiliary/spoof/dns/native_spoofer`, however this was as a result of a different root cause. Here, the socket was actually bound twice: initially via the call to `ServiceManager.start`, and then directly calling the `start` method in the module initializer. I've changed this to use the intended `ServiceManager` code path, and added the parameter that was missing from the server initializer (whether or not to start the cache).

In addition, the DNS `native_spoofer` and `native_server` modules contained a bug whereby it would double-dereferenced when running as a job: the cleanup would stop the service, and then the `run` method's `ensure` block would call it again. As a result, if you ran two of them simultaneously, and then killed one of the jobs, it would do an extra dereference, thus making the Service Manager think that everything was dereferenced, and they'd both be terminated. Sometimes this also caused IO errors (see below). I've fixed this by moving the problematic code into a separate cleanup method, and forcing the modules to run as a job, so the cleanup will be handled by the job.

```
msf6 auxiliary(spoof/dns/native_spoofer) > run -j
[*] Auxiliary module running as background job 2.
msf6 auxiliary(spoof/dns/native_spoofer) > run -j
[*] Auxiliary module running as background job 3.
msf6 auxiliary(spoof/dns/native_spoofer) > jobs 

Jobs
====

  Id  Name                                 Payload  Payload opts
  --  ----                                 -------  ------------
  2   Auxiliary: spoof/dns/native_spoofer
  3   Auxiliary: spoof/dns/native_spoofer

msf6 auxiliary(spoof/dns/native_spoofer) > jobs -k 3
[*] Stopping the following job(s): 3
[*] Stopping job 3
msf6 auxiliary(spoof/dns/native_spoofer) > jobs

Jobs
====

  Id  Name                                 Payload  Payload opts
  --  ----                                 -------  ------------
  2   Auxiliary: spoof/dns/native_spoofer

msf6 auxiliary(spoof/dns/native_spoofer) > 
[-] Auxiliary failed: IOError closed stream
[-] Call stack:
[-]   /home/smash/git/metasploit-framework/lib/rex/proto/dns/server.rb:343:in `select'
[-]   /home/smash/git/metasploit-framework/lib/rex/proto/dns/server.rb:343:in `monitor_listener'
[-]   /home/smash/git/metasploit-framework/lib/rex/proto/dns/server.rb:230:in `block in start'
[-]   /home/smash/git/metasploit-framework/lib/rex/thread_factory.rb:22:in `block in spawn'
[-]   /home/smash/git/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[-]   /var/lib/gems/2.7.0/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'

```

### Verification

- [x] Run the `auxiliary/spoof/llmnr/llmnr_response` module, then stop it, and verify that port 5355 is no longer listening.
- [x] Run the `auxiliary/spoof/nbns/nbns_response` module, then stop it, and verify that port 137 is no longer listening.
- [x] Run the `auxiliary/spoof/mdns/mdns_response` module, then stop it, and verify that port 5353 is no longer listening.
- [x] Run the `auxiliary/spoof/dns/native_spoofer` module, then stop it, and verify that port 53 is no longer listening on `127.0.2.2`.
- [x] Run the `auxiliary/server/dns/native_server` module as a job, then stop it, and verify that port 53 is no longer listening.
- [x] Run the `auxiliary/spoof/dns/native_spoofer` module twice, and then terminate one of the jobs. Verify that the other is still running.