### PR TITLE
Added support to old key exchange algorithms

### DIFF
--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -29,7 +29,8 @@ module Msf::Exploit::Remote::SSH
       config: false,
       use_agent: false,
       verify_host_key: :never,
-      proxy: ssh_socket_factory
+      proxy: ssh_socket_factory,
+      append_all_supported_algorithms: true
     }
   end
 

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -187,15 +187,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def init_ssh(user)
-    opts = {
-      :user            => user,
-      :port            => rport,
     opts = ssh_client_defaults.merge({
       :user            => user,
       :port            => rport
     })
-      ssh_client_defaults
-    )
     options    = Net::SSH::Config.for(rhost, Net::SSH::Config.default_files).merge(opts)
     transport  = Net::SSH::Transport::Session.new(rhost, options)
     connection = Net::SSH::Connection::Session.new(transport, options)

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -190,7 +190,10 @@ class MetasploitModule < Msf::Exploit::Remote
     opts = {
       :user            => user,
       :port            => rport,
-    }.merge(
+    opts = ssh_client_defaults.merge({
+      :user            => user,
+      :port            => rport
+    })
       ssh_client_defaults
     )
     options    = Net::SSH::Config.for(rhost, Net::SSH::Config.default_files).merge(opts)

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::SSH
 
   def initialize(info={})
     super(update_info(info,
@@ -189,8 +190,9 @@ class MetasploitModule < Msf::Exploit::Remote
     opts = {
       :user            => user,
       :port            => rport,
-      :verify_host_key => :never
-    }
+    }.merge(
+      ssh_client_defaults
+    )
     options    = Net::SSH::Config.for(rhost, Net::SSH::Config.default_files).merge(opts)
     transport  = Net::SSH::Transport::Session.new(rhost, options)
     connection = Net::SSH::Connection::Session.new(transport, options)


### PR DESCRIPTION
This commit fix the issue #16138 by adding support to old key exchange algorithms in the net/ssh lib by defining the `append_all_supported_algorithms` to `true`.

Although this feature will be remove in the next major version of the Net::SSH until then this fix would make all ssh modules related works in systems using insecure key exchange algorithms. 

I didn't test it specifically  in a Tectia SSH server, but in a generic SSH server using a problematic algorithm. Maybe @darrenmartyn could help on that.


## Environment

Dockerfile
```Dockerfile
FROM alpine:latest

RUN apk add --update
RUN apk --no-cache add openssh
RUN ssh-keygen -A
RUN echo "KexAlgorithms diffie-hellman-group1-sha1"  >> /etc/ssh/sshd_config;

EXPOSE 22

CMD ["/usr/sbin/sshd","-D"]
```
Build an image
```bash
$ docker build --no-cache --rm -t issue_16138 -f Dockerfile .
```
Run a test container
```bash
$ docker run -d --rm -p 127.0.0.1:2222:22 issue_16138
```
Try to connect to the SSH running in the container. Any modern system should raise an error as below.
```bash
$ ssh 127.0.0.1 -p 2222
Unable to negotiate with 127.0.0.1 port 2222: no matching key exchange method found. Their offer: diffie-hellman-group1-sha1
```
## Scenario
<details>
<summary>before</summary>

<p>

```
msf6 exploit(unix/ssh/tectia_passwd_changereq) > run

[-] 127.0.0.1:2222 - 127.0.0.1:2222 SSH Error: Net::SSH::Exception : could not settle on kex algorithm
Server kex preferences: diffie-hellman-group1-sha1
Client kex preferences: ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1
[*] Exploit completed, but no session was created.

```
</p>

</details>

<details>
<summary>after</summary>

<p>

```
msf6 exploit(unix/ssh/tectia_passwd_changereq) > show options 

Module options (exploit/unix/ssh/tectia_passwd_changereq):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   RHOSTS    127.0.0.1        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT     2222             yes       The target port (TCP)
   USERNAME  root             yes       The username to login as


Payload options (cmd/unix/interact):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------


Exploit target:

   Id  Name
   --  ----
   0   Unix-based Tectia SSH 6.3 or prior


msf6 exploit(unix/ssh/tectia_passwd_changereq) > run

[*] 127.0.0.1:2222 - 127.0.0.1:2222 - Sending USERAUTH Change request...
[*] 127.0.0.1:2222 - 127.0.0.1:2222 - Auths that can continue: 51
[*] Exploit completed, but no session was created.

```
</p>