### PR TITLE
Fix hosts command bugs

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -416,7 +416,7 @@ class Db
     [ '-a', '--add' ] => [ true, 'Add the hosts instead of searching', '<host>' ],
     [ '-u', '--up' ] => [ false, 'Only show hosts which are up' ],
     [ '-R', '--rhosts' ] => [ false, 'Set RHOSTS from the results of the search' ],
-    [ '-S', '--search' ] => [ false, 'Search string to filter by' ],
+    [ '-S', '--search' ] => [ true, 'Search string to filter by', '<filter>' ],
     [ '-i', '--info' ] => [ true, 'Change the info of a host', '<info>' ],
     [ '-n', '--name' ] => [ true, 'Change the name of a host', '<name>' ],
     [ '-m', '--comment' ] => [ true, 'Change the comment of a host', '<comment>' ],

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -314,15 +314,17 @@ class Db
     end
 
     case words[-1]
-    when '-d', '--delete'
-      return []
     when '-c', '--columns', '-C', '--columns-until-restart'
       return @@hosts_columns
-    when '-O', '--order'
+    when '-o', '--output'
+      return tab_complete_filenames(str, words)
+    end
+
+    if @@hosts_opts.arg_required?(words[-1])
       return []
     end
 
-    []
+    return @@hosts_opts.option_keys.select { |opt| opt.start_with?(str) }
   end
 
   def cmd_hosts_help

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "    -O, --order <column id>                Order rows by specified column number",
           "    -o, --output <filename>                Send output to a file in csv format",
           "    -R, --rhosts                           Set RHOSTS from the results of the search",
-          "    -S, --search                           Search string to filter by",
+          "    -S, --search <filter>                  Search string to filter by",
           "    -t, --tag                              Add or specify a tag to a range of hosts",
           "    -u, --up                               Only show hosts which are up",
           "Available columns: address, arch, comm, comments, created_at, cred_count, detected_arch, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_family, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count, tags"


### PR DESCRIPTION
This fixes two bugs in the `hosts` command.

## Bug 1 (Broken -S / --search)
The -S / --search flag was not defined as taking an argument. This meant that when the user passed it, the argument wasn't consumed from the provided list and would fall through to the default handler. This would result in an error being displayed to the user and was the issue identified in #16301.

## Bug 2 (Incorrect Tab Completion)
The second issue was that the way the tab completion was defined meant that only the first option would be completed. Additional flags would not be completed. Now when the user specifies `hosts -S Windows --rhos` then hits tab, it'll correctly be completed to `hosts -S Windows --rhosts `.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole` with a database connected
- [ ] Populate some hosts in the database using a scanner module so `hosts` has some entries
- [ ] Use the `--search` flag to search for something in the hosts table
- [ ] Tab complete some `hosts` command usages.

## Example (Old and broken)

```
msf6 auxiliary(server/capture/smb) > hosts

Hosts
=====

address          mac  name             os_name       os_flavor           os_sp  purpose  info  comments
-------          ---  ----             -------       ---------           -----  -------  ----  --------
192.168.159.1                          Unknown                                  device
192.168.159.11        WIN-9NSI4A6AIHJ  Windows 7     Professional        SP1    client
192.168.159.27        192.168.159.27   ubuntu        Ubuntu 20.04.2 LTS         server
192.168.159.86        DESKTOP-RTCRBEV  Windows 10                               client
192.168.159.87        DESKTOP-SRAQBLH  Windows 10                               client
192.168.159.89        DESKTOP-QO2FTHF  Windows 10                               client
192.168.159.90        DESKTOP-ML76VPN  Windows 10                               client
192.168.159.96        WIN-3MSP8K2LCGC  Windows 2019  Standard                   server
192.168.159.128                        Unknown                                  device
192.168.159.221                        Unknown                                  device

msf6 auxiliary(server/capture/smb) > hosts -S ubuntu
[-] Invalid host parameter, ubuntu.
msf6 auxiliary(server/capture/smb) > hosts -S Win
[-] Invalid host parameter, Win.
msf6 auxiliary(server/capture/smb) > hosts -S IPv4
[-] Invalid host parameter, IPv4.
msf6 auxiliary(server/capture/smb) > hosts -S Windows
[-] Invalid host parameter, Windows.
msf6 auxiliary(server/capture/smb) >
```

## Example (New and fixed)

```
msf6 auxiliary(server/capture/smb) > hosts

Hosts
=====

address          mac  name             os_name       os_flavor           os_sp  purpose  info  comments
-------          ---  ----             -------       ---------           -----  -------  ----  --------
192.168.159.1                          Unknown                                  device
192.168.159.11        WIN-9NSI4A6AIHJ  Windows 7     Professional        SP1    client
192.168.159.27        192.168.159.27   ubuntu        Ubuntu 20.04.2 LTS         server
192.168.159.86        DESKTOP-RTCRBEV  Windows 10                               client
192.168.159.87        DESKTOP-SRAQBLH  Windows 10                               client
192.168.159.89        DESKTOP-QO2FTHF  Windows 10                               client
192.168.159.90        DESKTOP-ML76VPN  Windows 10                               client
192.168.159.96        WIN-3MSP8K2LCGC  Windows 2019  Standard                   server
192.168.159.128                        Unknown                                  device
192.168.159.221                        Unknown                                  device

msf6 auxiliary(server/capture/smb) > hosts -S Windows

Hosts
=====

address         mac  name             os_name       os_flavor     os_sp  purpose  info  comments
-------         ---  ----             -------       ---------     -----  -------  ----  --------
192.168.159.11       WIN-9NSI4A6AIHJ  Windows 7     Professional  SP1    client
192.168.159.86       DESKTOP-RTCRBEV  Windows 10                         client
192.168.159.87       DESKTOP-SRAQBLH  Windows 10                         client
192.168.159.89       DESKTOP-QO2FTHF  Windows 10                         client
192.168.159.90       DESKTOP-ML76VPN  Windows 10                         client
192.168.159.96       WIN-3MSP8K2LCGC  Windows 2019  Standard             server

msf6 auxiliary(server/capture/smb) >
```

Fixes #16301