### PR TITLE
Fix broken DNS native_server

### DIFF
--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -128,7 +128,9 @@ module DNS
       when Net::DNS::Packet, Resolv::DNS::Message
         packet = Rex::Proto::DNS::Packet.encode_drb(argument)
       else
-        packet = make_query_packet(argument,type,cls)
+        net_packet = make_query_packet(argument,type,cls)
+        # This returns a Net::DNS::Packet. Convert to Dnsruby::Message for consistency
+        packet = Rex::Proto::DNS::Packet.encode_drb(net_packet)
       end
 
       # Store packet_data for performance improvements,

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -132,8 +132,8 @@ module DNS
       end
 
       # Store packet_data for performance improvements,
-      # so methods don't keep on calling Packet#data
-      packet_data = packet.data
+      # so methods don't keep on calling Packet#encode
+      packet_data = packet.encode
       packet_size = packet_data.size
 
       # Choose whether use TCP, UDP

--- a/modules/auxiliary/server/dns/native_server.rb
+++ b/modules/auxiliary/server/dns/native_server.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
           service.cache.cache_record(ans)
         end unless service.cache.nil?
         # Merge the answers and use the upstream response
-        forward.instance_variable_set(:@question, (req.answer + forwarded.answer).uniq)
+        forward.instance_variable_set(:@answer, (req.answer + forwarded.answer).uniq)
         req = forwarded
       end
     end


### PR DESCRIPTION
This fixes two bugs in the `auxiliary/server/dns/native_server` module:

- It would immediately crash upon receiving any request
- Once that was fixed, if a request contained two queries, but only one was served from the cache and another from upstream, they were combined into the question field of the reply, not the answer.

Demo of the first issue (send any DNS request to the server):

```
msf6 > use auxiliary/server/dns/native_server                                                                      
msf6 auxiliary(server/dns/native_server) > set srvhost 0.0.0.0                                                     
srvhost => 0.0.0.0                                                                                                                                                                                                                   
msf6 auxiliary(server/dns/native_server) > set static_entries "1.2.3.4 example.com"                                
static_entries => 1.2.3.4 example.com              
msf6 auxiliary(server/dns/native_server) > run                                                                    
                                                                                                                  
[-] Auxiliary failed: NoMethodError undefined method `data' for #<Dnsruby::Message:0x000055d763109448>
[-] Call stack:                                                                                                   
[-]   /home/smash/git/metasploit-framework/lib/rex/proto/dns/resolver.rb:136:in `send'
[-]   /home/smash/git/metasploit-framework/modules/auxiliary/server/dns/native_server.rb:80:in `on_dispatch_request'
[-]   /home/smash/git/metasploit-framework/lib/msf/core/exploit/remote/dns/server.rb:118:in `block in start_service'
[-]   /home/smash/git/metasploit-framework/lib/rex/proto/dns/server.rb:273:in `dispatch_request'
[-]   /home/smash/git/metasploit-framework/lib/rex/proto/dns/server.rb:349:in `monitor_listener'
[-]   /home/smash/git/metasploit-framework/lib/rex/proto/dns/server.rb:230:in `block in start'
[-]   /home/smash/git/metasploit-framework/lib/rex/thread_factory.rb:22:in `block in spawn'
[-]   /home/smash/git/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[-]   /var/lib/gems/2.7.0/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
```

To my reading, this code will always work with a DnsRuby object (which expects the `:encode` method), not a `Net::DNS` object (which expects the `:data` method). If a Net::DNS object is passed in, for instance, it will be converted to a DnsRuby object first.

The second issue I just saw directly when reviewing the code; it seems that a copy paste error occurred in this change:

https://github.com/smashery/metasploit-framework/commit/c65c03722c89428e1233ad2304731835d27bb4a5#diff-eccd9746aa08a91a52512ad5b324483719011ba6627693e7bee8323d8eadcc2eL84-R86

It's probably a super rare situation... to be honest, I can't even figure out how to test it without pulling out scapy or something.