### PR TITLE
Replace IO read on binary files with File binread

### DIFF
--- a/lib/metasploit/framework/compiler/windows.rb
+++ b/lib/metasploit/framework/compiler/windows.rb
@@ -41,7 +41,7 @@ module Metasploit
         # @return [Integer] The number of bytes written.
         def self.compile_c_to_file(out_file, c_template, type=:exe, cpu=Metasm::Ia32.new)
           pe = self.compile_c(c_template, type)
-          File.write(out_file, pe)
+          File.write(out_file, pe, mode: 'wb')
         end
 
         # Returns randomized c source code.
@@ -82,7 +82,7 @@ module Metasploit
         # @return [Integer] The number of bytes written.
         def self.compile_random_c_to_file(out_file, c_template, opts={})
           pe = self.compile_random_c(c_template, opts)
-          File.write(out_file, pe)
+          File.write(out_file, pe, mode: 'wb')
         end
       end
 

--- a/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
+++ b/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
@@ -77,8 +77,8 @@ module ResponseDataHelper
     begin
       # If we are running the data service on the same box this will ensure we only write
       # the file if it is somehow not there already.
-      unless File.exists?(save_path) && File.read(save_path) == decoded_file
-        File.open(save_path, 'w+') { |file| file.write(decoded_file) }
+      unless File.exists?(save_path) && File.read(save_path, mode: 'rb') == decoded_file
+        File.write(save_path, decoded_file, mode: 'wb')
       end
     rescue => e
       elog "There was an error writing the file: #{e}"

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -574,13 +574,13 @@ module Auxiliary::AuthBrute
 
   def extract_words(wordfile)
     return [] unless wordfile && File.readable?(wordfile)
+
     begin
-      words = File.open(wordfile) {|f| f.read(f.stat.size)}
-    rescue
-      return
+      File.readlines(wordfile, chomp: true)
+    rescue ::StandardError => e
+      elog(e)
+      []
     end
-    save_array = words.split(/\r?\n/)
-    return save_array
   end
 
   def get_object_from_memory_location(memloc)
@@ -796,4 +796,3 @@ module Auxiliary::AuthBrute
 
 end
 end
-

--- a/lib/msf/core/auxiliary/ubiquiti.rb
+++ b/lib/msf/core/auxiliary/ubiquiti.rb
@@ -31,7 +31,7 @@ module Msf
       print_status('Attempting to repair zip file (this is normal and takes some time)')
       temp_file = Rex::Quickfile.new('fixed_zip')
       system("yes | #{zip_exe} -FF #{fname} --out #{temp_file.path}.zip > /dev/null")
-      return File.read("#{temp_file.path}.zip")
+      return File.read("#{temp_file.path}.zip", mode: 'rb')
     end
 
     def extract_and_process_db(db_path)

--- a/lib/msf/core/exploit/pdf_parse.rb
+++ b/lib/msf/core/exploit/pdf_parse.rb
@@ -21,7 +21,7 @@ module Exploit::PDF_Parse
   end
 
   def read_pdf()
-    stream = IO.read("#{datastore['INFILENAME']}")
+    stream = File.binread("#{datastore['INFILENAME']}")
     return stream
   end
 

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -401,7 +401,7 @@ module Exploit::Remote::Postgres
   # @param remote_fname (see #postgres_upload_binary_data)
   # @return (see #postgres_upload_binary_data)
   def postgres_upload_binary_file(fname, remote_fname=nil)
-    data = File.read(fname)
+    data = File.read(fname, mode: 'rb')
     postgres_upload_binary_data(data, remote_fname)
   end
 

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -246,7 +246,7 @@ class Framework
     )
     return true unless ::File.exist?(path)
 
-    data = ::File.read(path)
+    data = ::File.read(path, mode: 'rb')
     return true unless Digest::SHA1.hexdigest(data) == "3395856ce81f2b7382dee72602f798b642f14140"
 
     false
@@ -537,4 +537,3 @@ class FrameworkEventSubscriber
 
 end
 end
-

--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -317,7 +317,7 @@ class Msf::Payload::Apk
       raise "Unable to find class file: #{hookable_class_filepath}"
     end
 
-    hooksmali = File.read(smalifile)
+    hooksmali = File.binread(smalifile)
     entrypoint = 'return-void'
     unless hooksmali.include?(entrypoint)
       raise "Unable to find hookable function in #{smalifile}"
@@ -342,7 +342,7 @@ class Msf::Payload::Apk
 
     # Copy over the payload files, fixing up the smali code
     payload_files.each do |file_name|
-      smali = File.read(file_name)
+      smali = File.binread(file_name)
       smali_class = File.basename file_name
       for oldclass, newclass in classes
         if smali_class == "#{oldclass}.smali"
@@ -417,11 +417,9 @@ class Msf::Payload::Apk
       aligned_apk = injected_apk
     end
 
-    outputapk = File.read(aligned_apk)
+    outputapk = File.binread(aligned_apk)
 
     FileUtils.remove_entry tempdir
     outputapk
   end
 end
-
-

--- a/lib/msf/util/java_deserialization.rb
+++ b/lib/msf/util/java_deserialization.rb
@@ -67,7 +67,7 @@ class JavaDeserialization
       # Open the JSON file and parse it
       path = File.join(Msf::Config.data_directory, PAYLOAD_FILENAME)
       begin
-        json = JSON.parse(File.read(path))
+        json = JSON.parse(File.read(path, mode: 'rb'))
       rescue Errno::ENOENT, JSON::ParserError
         raise RuntimeError, "Unable to load JSON data from: #{path}"
       end

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -140,7 +140,7 @@ private
 
     # for now, we're going to blindly assume that the value is a path to a file
     # which contains the data that gets passed to the extension
-    content = ::File.read(value) + "\x00\x00"
+    content = ::File.read(value, mode: 'rb') + "\x00\x00"
     data = [
       ext_id,
       content.length,

--- a/lib/rex/script.rb
+++ b/lib/rex/script.rb
@@ -18,7 +18,7 @@ module Script
   #
   def self.execute_file(file, in_binding = nil)
     str = ''
-    buf = ::File.read(file, ::File.size(file))
+    buf = ::File.read(file, ::File.size(file), mode: 'rb')
     execute(buf, in_binding)
   end
 
@@ -35,5 +35,3 @@ module Script
 end
 
 end
-
-

--- a/modules/auxiliary/admin/http/jboss_bshdeployer.rb
+++ b/modules/auxiliary/admin/http/jboss_bshdeployer.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Auxiliary
         print_error("WAR file not found")
         return
       end
-      war_data = File.read(datastore['WARFILE'])
+      war_data = File.read(datastore['WARFILE'], mode: 'rb')
       deploy_action(app_base, war_data)
     when 'Undeploy'
       undeploy_action(app_base)

--- a/modules/auxiliary/admin/http/jboss_deploymentfilerepository.rb
+++ b/modules/auxiliary/admin/http/jboss_deploymentfilerepository.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Auxiliary
       unless datastore['WARFILE'] && File.exist?(datastore['WARFILE'])
         fail_with(Failure::BadConfig, "Unable to open WARFILE")
       end
-      war_data = File.read(datastore['WARFILE'])
+      war_data = File.read(datastore['WARFILE'], mode: 'rb')
       deploy_action(app_base, war_data)
     when 'Undeploy'
       undeploy_action(app_base)

--- a/modules/auxiliary/admin/http/supra_smart_cloud_tv_rfi.rb
+++ b/modules/auxiliary/admin/http/supra_smart_cloud_tv_rfi.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
       return send_not_found(cli)
     end
 
-    data = File.read(File.join(dir, file))
+    data = File.read(File.join(dir, file), mode: 'rb')
 
     vprint_good("Sending #{file}")
     send_response(cli, data, 'Content-Type' => files[file])

--- a/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
+++ b/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
@@ -46,15 +46,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def extract_words(wordfile)
     return [] unless wordfile && File.readable?(wordfile)
+
     begin
-      words = File.open(wordfile, "rb") do |f|
-        f.read
-      end
-    rescue
-      return []
+      File.readlines(wordfile, chomp: true)
+    rescue ::StandardError => e
+      elog(e)
+      []
     end
-    save_array = words.split(/\r?\n/)
-    return save_array
   end
 
   def find_files(files)

--- a/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
+++ b/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
@@ -45,15 +45,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def extract_words(wordfile)
     return [] unless wordfile && File.readable?(wordfile)
+
     begin
-      words = File.open(wordfile, "rb") do |f|
-        f.read
-      end
-    rescue
-      return []
+      File.readlines(wordfile, chomp: true)
+    rescue ::StandardError => e
+      elog(e)
+      []
     end
-    save_array = words.split(/\r?\n/)
-    return save_array
   end
 
   def find_files(files)

--- a/modules/auxiliary/admin/networking/ubiquiti_config.rb
+++ b/modules/auxiliary/admin/networking/ubiquiti_config.rb
@@ -43,16 +43,14 @@ class MetasploitModule < Msf::Auxiliary
       fail_with Failure::BadConfig, "Unifi config file #{i_file} does not exist!"
     end
     # input_file could be a unf (encrypted zip), or the db file contained within.
-    input_file = ::File.open(i_file, 'rb')
-    f = input_file.read
-    input_file.close
+    input_file = ::File.binread(i_file)
 
-    if f.nil?
+    if input_file.nil?
       fail_with Failure::BadConfig, "#{i_file} read at 0 bytes.  Either file is empty or error reading."
     end
 
     if i_file.end_with? '.unf'
-      decrypted_data = decrypt_unf(f)
+      decrypted_data = decrypt_unf(input_file)
       if decrypted_data.nil? || decrypted_data.empty?
         fail_with Failure::Unknown, 'Unable to decrypt'
       end

--- a/modules/auxiliary/admin/networking/ubiquiti_config.rb
+++ b/modules/auxiliary/admin/networking/ubiquiti_config.rb
@@ -21,7 +21,12 @@ class MetasploitModule < Msf::Auxiliary
           Unifi. This module can take either the db file or .unf.
         },
         'License' => MSF_LICENSE,
-        'Author' => ['h00die']
+        'Author' => ['h00die'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/scada/modicon_stux_transfer.rb
+++ b/modules/auxiliary/admin/scada/modicon_stux_transfer.rb
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Auxiliary
   def writefile
     print_status "#{rhost}:#{rport} - MODBUS - Sending write request"
     blocksize = 244	# bytes per block in file transfer
-    buf = File.open(datastore['FILENAME'], 'rb') { |io| io.read }
+    buf = File.binread(datastore['FILENAME'])
     fullblocks = buf.length / blocksize
     if fullblocks > 255
       print_error("#{rhost}:#{rport} - MODBUS - File too large, aborting.")

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
           vprint_status("Trying to upload #{local_path} to #{remote_path}...")
 
           fd = simple.open("#{remote_path}", 'wct', write: true)
-          data = ::File.read(datastore['LPATH'], ::File.size(datastore['LPATH']))
+          data = ::File.read(datastore['LPATH'], ::File.size(datastore['LPATH']), mode: 'rb')
           fd.write(data)
           fd.close
 

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Auxiliary
       if zip_payload
         zip_file = attachment_file.sub(/\.\w+$/, '.zip')
         print_status("Zipping payload to #{zip_file}")
-        File.write(zip_file, Msf::Util::EXE.to_zip([fname: File.basename(attachment_file), data: exe]))
+        File.write(zip_file, Msf::Util::EXE.to_zip([fname: File.basename(attachment_file), data: exe]), mode: 'wb')
         attachment_file      = zip_file
         attachment_file_type = 'application/zip'
       else

--- a/modules/auxiliary/docx/word_unc_injector.rb
+++ b/modules/auxiliary/docx/word_unc_injector.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("Adding skeleton files from #{data_dir}")
     Dir["#{data_dir}/**/**"].each do |file|
       if not File.directory?(file)
-        zip_data[file.sub(data_dir,'')] = File.read(file)
+        zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
       end
     end
 
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # add the otherwise skipped "hidden" file
     file = "#{data_dir}/_rels/.rels"
-    zip_data[file.sub(data_dir,'')] = File.read(file)
+    zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
     # and lets create the file
     zip_docx(zip_data)
   end

--- a/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
+++ b/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def on_request_uri(cli, request)
     @tag ||= Rex::Text.rand_text_alpha(8)
-    @eot ||= ::File.read(datastore['EOTFILE'], ::File.size(datastore['EOTFILE']))
+    @eot ||= ::File.read(datastore['EOTFILE'], ::File.size(datastore['EOTFILE']), mode: 'rb')
 
     if(request.uri =~ /#{@tag}$/)
       content = @eot.dup

--- a/modules/auxiliary/fileformat/badpdf.rb
+++ b/modules/auxiliary/fileformat/badpdf.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Read in contents of file
-    content = File.read(datastore['PDFINJECT'])
+    content = File.binread(datastore['PDFINJECT'])
 
     # Check for place holder - below ..should.. cover most scenarios.
     newdata = ''

--- a/modules/auxiliary/gather/cloud_lookup.rb
+++ b/modules/auxiliary/gather/cloud_lookup.rb
@@ -626,7 +626,7 @@ class MetasploitModule < Msf::Auxiliary
     # Add. Blacklisted IP address(es) from file.
     unless datastore['IPBLACKLIST_FILE'].nil?
       if File.readable? datastore['IPBLACKLIST_FILE']
-        ips = File.new(datastore['IPBLACKLIST_FILE']).read.split
+        ips = File.readlines(datastore['IPBLACKLIST_FILE'], chomp: true)
         ips.each do |ip|
           ip_blacklist << ip
         end

--- a/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
+++ b/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
@@ -38,15 +38,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def extract_words(wordfile)
     return [] unless wordfile && File.readable?(wordfile)
+
     begin
-      words = File.open(wordfile, "rb") do |f|
-        f.read
-      end
-    rescue
-      return []
+      File.readlines(wordfile, chomp: true)
+    rescue ::StandardError => e
+      elog(e)
+      []
     end
-    save_array = words.split(/\r?\n/)
-    return save_array
   end
 
   def find_files(file,user,pass)

--- a/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
+++ b/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
@@ -35,15 +35,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def extract_words(wordfile)
     return [] unless wordfile && File.readable?(wordfile)
+
     begin
-      words = File.open(wordfile, "rb") do |f|
-        f.read
-      end
-    rescue
-      return []
+      File.readlines(wordfile, chomp: true)
+    rescue ::StandardError => e
+      elog(e)
+      []
     end
-    save_array = words.split(/\r?\n/)
-    return save_array
   end
 
   # traverse every file

--- a/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
+++ b/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
@@ -35,15 +35,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def extract_words(wordfile)
     return [] unless wordfile && File.readable?(wordfile)
+
     begin
-      words = File.open(wordfile, "rb") do |f|
-        f.read
-      end
-    rescue
-      return []
+      File.readlines(wordfile, chomp: true)
+    rescue ::StandardError => e
+      elog(e)
+      []
     end
-    save_array = words.split(/\r?\n/)
-    return save_array
   end
 
   def find_files(file)

--- a/modules/auxiliary/scanner/redis/file_upload.rb
+++ b/modules/auxiliary/scanner/redis/file_upload.rb
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Auxiliary
     # 00000050  32 30 31 35 0a ff
     #
     # as you can see, the current date exists on its own on a separate line
-    @upload_content = "\n#{IO.read(datastore['LocalFile']).strip}\n" if datastore['LocalFile']
+    @upload_content = "\n#{File.read(datastore['LocalFile']).strip}\n" if datastore['LocalFile']
   end
 
   def run_host(_ip)

--- a/modules/auxiliary/scanner/smtp/smtp_enum.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_enum.rb
@@ -209,8 +209,12 @@ class MetasploitModule < Msf::Auxiliary
 
   def extract_words(wordfile)
     return [] unless wordfile && File.readable?(wordfile)
-    words = File.open(wordfile, "rb") {|f| f.read}
-    save_array = words.split(/\r?\n/)
-    return save_array
+
+    begin
+      File.readlines(wordfile, chomp: true)
+    rescue ::StandardError => e
+      elog(e)
+      []
+    end
   end
 end

--- a/modules/auxiliary/server/ftp.rb
+++ b/modules/auxiliary/server/ftp.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     c.put("150 Opening BINARY mode data connection for #{arg}\r\n")
-    conn.put(::File.read(path, ::File.size(path)))
+    conn.put(::File.read(path, ::File.size(path), mode: 'rb'))
     c.put("226 Transfer complete.\r\n")
     conn.close
   end

--- a/modules/evasion/windows/process_herpaderping.rb
+++ b/modules/evasion/windows/process_herpaderping.rb
@@ -141,12 +141,12 @@ class MetasploitModule < Msf::Evasion
     )
     exe_path = ::File.join(base_path, "ProcessHerpaderping_#{arch_suffix}.exe")
     exe_path = ::File.expand_path(exe_path)
-    pe = File.read(exe_path)
+    pe = File.binread(exe_path)
     vprint_status("Using #{exe_path}")
 
     template_path = ::File.join(base_path, "ProcessHerpaderpingTemplate_#{arch_suffix}.exe")
     template_path = ::File.expand_path(template_path)
-    payload_pe = File.read(template_path)
+    payload_pe = File.binread(template_path)
     vprint_status("Using #{template_path}")
 
     patch_binary(payload_pe, 'ENCKEY', rc4_key)

--- a/modules/exploits/multi/fileformat/office_word_macro.rb
+++ b/modules/exploits/multi/fileformat/office_word_macro.rb
@@ -185,11 +185,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_vbaproject_bin_rels
-    File.read(File.join(macro_resource_directory, 'vbaProject.bin.rels'))
+    File.binread(File.join(macro_resource_directory, 'vbaProject.bin.rels'))
   end
 
   def get_vbaproject_bin
-    File.read(File.join(macro_resource_directory, 'vbaProject.bin'))
+    File.binread(File.join(macro_resource_directory, 'vbaProject.bin'))
   end
 
   def get_core_xml

--- a/modules/exploits/multi/http/mediawiki_thumb.rb
+++ b/modules/exploits/multi/http/mediawiki_thumb.rb
@@ -269,7 +269,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     upload_mime = Rex::MIME::Message.new
 
-    djvu_file = ::File.read(::File.join(Msf::Config.data_directory, "exploits", "cve-2014-1610", "metasploit.djvu"))
+    djvu_file = ::File.binread(::File.join(Msf::Config.data_directory, "exploits", "cve-2014-1610", "metasploit.djvu"))
     file_name = "#{rand_text_alpha(4)}.djvu"
 
     upload_mime.add_part(djvu_file, "application/octet-stream", "binary", "form-data; name=\"wpUploadFile\"; filename=\"#{file_name}\"")
@@ -363,4 +363,3 @@ class MetasploitModule < Msf::Exploit::Remote
     ''
   end
 end
-

--- a/modules/exploits/multi/http/splunk_upload_app_exec.rb
+++ b/modules/exploits/multi/http/splunk_upload_app_exec.rb
@@ -348,7 +348,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_upload_app(app_name, file_name)
     archive_file_name = ::File.basename(file_name)
     print_status("Uploading file #{archive_file_name}")
-    file_data = ::File.read(file_name)
+    file_data = ::File.read(file_name, mode: 'rb')
 
     boundary = '--------------' + rand_text_alphanumeric(6)
 
@@ -389,7 +389,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_upload_app_7(app_name, file_name)
     archive_file_name = ::File.basename(file_name)
     print_status("Uploading file #{archive_file_name}")
-    file_data = ::File.read(file_name)
+    file_data = ::File.read(file_name, mode: 'rb')
 
     boundary = '---------------------------' + rand_text_numeric(29)
 

--- a/modules/exploits/windows/browser/citrix_gateway_actx.rb
+++ b/modules/exploits/windows/browser/citrix_gateway_actx.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @ocx = ::File.read(::File.join(Msf::Config.install_root, 'data', 'exploits', 'CVE-2011-2882', 'nsepa.ocx'))
+    @ocx = ::File.read(::File.join(Msf::Config.install_root, 'data', 'exploits', 'CVE-2011-2882', 'nsepa.ocx'), mode: 'rb')
     super
   end
 

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -117,8 +117,8 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Using '#{datastore['EXENAME']}' as payload...")
 
       file_size = File.size(payload_exe)
-      stream = Rex::Text.zlib_deflate(IO.read(payload_exe))
-      md5 = Rex::Text.md5(File.read(payload_exe))
+      stream = Rex::Text.zlib_deflate(File.binread(payload_exe))
+      md5 = Rex::Text.md5(File.binread(payload_exe))
 
     end
 

--- a/modules/exploits/windows/fileformat/ms14_064_packager_python.rb
+++ b/modules/exploits/windows/fileformat/ms14_064_packager_python.rb
@@ -72,13 +72,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     Dir["#{data_dir}/**/**"].each do |file|
       unless File.directory?(file)
-        zip_data[file.sub(data_dir,'')] = File.read(file)
+        zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
       end
     end
 
     # add the otherwise skipped "hidden" file
     file = "#{data_dir}/_rels/.rels"
-    zip_data[file.sub(data_dir,'')] = File.read(file)
+    zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
 
     # put our own OLE streams
     zip_data['/ppt/embeddings/oleObject1.bin'] = ole_payload
@@ -141,11 +141,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # write to disk
     stg.close
 
-    ole_contents = File.read(ole_tmp.path)
+    ole_contents = File.read(ole_tmp.path, mode: 'rb')
     ole_tmp.close
     ole_tmp.unlink
 
     ole_contents
   end
 end
-

--- a/modules/exploits/windows/fileformat/ms14_064_packager_run_as_admin.rb
+++ b/modules/exploits/windows/fileformat/ms14_064_packager_run_as_admin.rb
@@ -72,13 +72,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     Dir["#{data_dir}/**/**"].each do |file|
       unless File.directory?(file)
-        zip_data[file.sub(data_dir,'')] = File.read(file)
+        zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
       end
     end
 
     # add the otherwise skipped "hidden" file
     file = "#{data_dir}/_rels/.rels"
-    zip_data[file.sub(data_dir,'')] = File.read(file)
+    zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
 
     # put our own OLE streams
     zip_data['/ppt/embeddings/oleObject1.bin'] = ole_stream
@@ -143,11 +143,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # write to disk
     stg.close
 
-    ole_contents = File.read(ole_tmp.path)
+    ole_contents = File.read(ole_tmp.path, mode: 'rb')
     ole_tmp.close
     ole_tmp.unlink
 
     ole_contents
   end
 end
-

--- a/modules/exploits/windows/fileformat/office_ole_multiple_dll_hijack.rb
+++ b/modules/exploits/windows/fileformat/office_ole_multiple_dll_hijack.rb
@@ -257,7 +257,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # write to disk
     stg.close
 
-    ole_contents = File.read(ole_tmp.path)
+    ole_contents = File.read(ole_tmp.path, mode: 'rb')
     ole_tmp.close
     ole_tmp.unlink
 

--- a/modules/exploits/windows/local/cve_2020_17136.rb
+++ b/modules/exploits/windows/local/cve_2020_17136.rb
@@ -296,7 +296,7 @@ class MetasploitModule < Msf::Exploit::Local
     ].pack('IICCC')
     params += cln_params
 
-    process.memory.write(assembly_mem, params + File.read(exe_path))
+    process.memory.write(assembly_mem, params + File.read(exe_path, mode: 'rb'))
     print_status('Assembly copied.')
     assembly_mem
   end

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Exploit PoC from 'b33f'
     ps_path = ::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2016-0099', 'cve_2016_0099.ps1')
     vprint_status("PS1 loaded from #{ps_path}")
-    ms16_032 = File.read(ps_path)
+    ms16_032 = File.read(ps_path, mode: 'rb')
 
     cmdstr = expand_path('%windir%') << '\\System32\\windowspowershell\\v1.0\\powershell.exe'
 

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     # Prepare payload
     print_status("Creating initrd")
-    initrd = IO.read(File.join(Msf::Config.data_directory, 'exploits', 'pxexploit', 'updatecustom'))
+    initrd = File.binread(File.join(Msf::Config.data_directory, 'exploits', 'pxexploit', 'updatecustom'))
     uncompressed = Rex::Text.ungzip(initrd)
     payl = payload.generate
     uncompressed[uncompressed.index('AAAAAAAAAAAAAAAAAAAAAA'), payl.length] = payl
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
       0.upto(4) do |i|
         print_status("Loading file #{i + 1} of 5")
         if i < 4
-          contents = IO.read(::File.join(datastore['TFTPROOT'], "update#{i}"))
+          contents = File.binread(::File.join(datastore['TFTPROOT'], "update#{i}"))
         else
           contents = initrd
         end

--- a/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb
+++ b/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb
@@ -80,7 +80,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'AKA' => [ 'SMBGhost', 'CoronaBlue' ],
           'Stability' => [ CRASH_OS_RESTARTS, ],
           'Reliability' => [ REPEATABLE_SESSION, ],
-          'RelatedModules' => [ 'exploit/windows/local/cve_2020_0796_smbghost' ]
+          'RelatedModules' => [ 'exploit/windows/local/cve_2020_0796_smbghost' ],
+          'SideEffects' => []
         }
       )
     )
@@ -343,7 +344,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def build_shellcode(pointers)
-    source = File.read(File.join(Msf::Config.install_root, 'external', 'source', 'exploits', 'CVE-2020-0796', 'RCE', 'kernel_shellcode.asm'))
+    source = File.read(File.join(Msf::Config.install_root, 'external', 'source', 'exploits', 'CVE-2020-0796', 'RCE', 'kernel_shellcode.asm'), mode: 'rb')
     edata = Metasm::Shellcode.assemble(Metasm::X64.new, source).encoded
     user_shellcode = payload.encoded
     edata.fixup 'PHALP_APIC_REQUEST_INTERRUPT' => pointers[:pHalpApicRequestInterrupt]
@@ -417,7 +418,7 @@ class MetasploitModule < Msf::Exploit::Remote
         out << [ 0xb000 | (compressed.length - 1) ].pack('v')
         out << compressed
 
-        buf = buf[chunk_size..-1]
+        buf = buf[chunk_size..]
         break if buf.nil?
       end
 

--- a/modules/payloads/singles/generic/custom.rb
+++ b/modules/payloads/singles/generic/custom.rb
@@ -43,7 +43,7 @@ module MetasploitModule
     if datastore['PAYLOADSTR']
       datastore['PAYLOADSTR']
     elsif datastore['PAYLOADFILE']
-      IO.read(datastore['PAYLOADFILE'])
+      File.binread(datastore['PAYLOADFILE'])
     else
       ''
     end

--- a/modules/payloads/stages/osx/armle/execute.rb
+++ b/modules/payloads/stages/osx/armle/execute.rb
@@ -146,7 +146,7 @@ module MetasploitModule
 
     begin
       print_status("Reading executable file #{datastore['PEXEC']}...")
-      buff = ::IO.read(datastore['PEXEC'])
+      buff = ::File.binread(datastore['PEXEC'])
       data << [buff.length].pack("V")
       data << buff
       print_status("Read #{buff.length} bytes...")

--- a/modules/payloads/stages/windows/upexec.rb
+++ b/modules/payloads/stages/windows/upexec.rb
@@ -68,12 +68,7 @@ module MetasploitModule
   #
   def handle_connection_stage(conn, opts={})
     begin
-      # bug fix for: data = ::IO.read(datastore['PEXEC'])
-      # the above does not return the entire contents
-      data = ""
-      File.open( datastore['PEXEC'], "rb" ) { |f|
-        data += f.read
-      }
+      data = File.binread(datastore['PEXEC'])
     rescue
       print_error("Failed to read executable: #{$!}")
 

--- a/modules/post/osx/manage/sonic_pi.rb
+++ b/modules/post/osx/manage/sonic_pi.rb
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Post
 
   def file
     # Read file as null-terminated string
-    @file = "#{File.read(datastore['FILE'])}\x00"
+    @file = "#{File.read(datastore['FILE'], mode: 'rb')}\x00"
 
     # Pad string with nulls until its length is a multiple of 32 bits
     @file << "\x00" until @file.length % 4 == 0

--- a/modules/post/windows/manage/pxeexploit.rb
+++ b/modules/post/windows/manage/pxeexploit.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Post
 
     0.upto(4) do |i|
       print_status("Loading file #{i + 1} of 5")
-      contents = IO.read(::File.join(datastore['TFTPROOT'], "update#{i}"))
+      contents = File.binread(::File.join(datastore['TFTPROOT'], "update#{i}"))
       client.lanattacks.tftp.add_file("update#{i}", contents)
     end
     print_status("Starting TFTP server...")

--- a/modules/post/windows/manage/shellcode_inject.rb
+++ b/modules/post/windows/manage/shellcode_inject.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Post
     print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
 
     # Set variables
-    shellcode = IO.read(datastore['SHELLCODE'])
+    shellcode = File.binread(datastore['SHELLCODE'])
     pid = datastore['PID']
     ppid = datastore['PPID']
     bits = datastore['BITS']

--- a/scripts/meterpreter/metsvc.rb
+++ b/scripts/meterpreter/metsvc.rb
@@ -93,7 +93,7 @@ if client.platform == 'windows'
     print_status(" >> Uploading #{from}...")
     fd = client.fs.file.new(tempdir + "\\" + to, "wb")
     path = (from == 'metsrv.x86.dll') ? MetasploitPayloads.meterpreter_path('metsrv','x86.dll') : File.join(based, from)
-    fd.write(::File.read(path, ::File.size(path)))
+    fd.write(::File.read(path, ::File.size(path), mode: 'rb'))
     fd.close
   end
 

--- a/scripts/meterpreter/prefetchtool.rb
+++ b/scripts/meterpreter/prefetchtool.rb
@@ -162,7 +162,7 @@ if !(::File.exist?(prefetch_local))
   print_status("Downloaded prefetch.exe to #{prefetch_local}")
 else
   print_status("Checking for an updated copy of prefetch.exe..")
-  digest = Digest::SHA1.hexdigest(::File.read(prefetch_local, ::File.size(prefetch_local)))
+  digest = Digest::SHA1.hexdigest(::File.read(prefetch_local, ::File.size(prefetch_local), mode: 'rb'))
 
   Net::HTTP.start("code.google.com") do |http|
     req     = Net::HTTP::Get.new("/p/prefetch-tool/downloads/detail?name=prefetch.exe&can=2&q=")
@@ -192,4 +192,3 @@ end
 
 print_status("Running Prefetch-tool script...")
 prefetch_dump(options, logging)
-

--- a/spec/lib/rex/proto/acpp/message_spec.rb
+++ b/spec/lib/rex/proto/acpp/message_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Rex::Proto::ACPP::Message do
   # retrieve_public.bin has the contents of a message type 20 (retrieve
   # settings) message with a password of public.  There is no payload.
   let(:retrieve_public_bin) do
-    IO.read(File.join(File.dirname(__FILE__), 'retrieve_public.bin'))
+    File.binread(File.join(File.dirname(__FILE__), 'retrieve_public.bin'))
   end
 
   let(:retrieve_public_message) do

--- a/spec/lib/rex/proto/kademlia/bootstrap_response_spec.rb
+++ b/spec/lib/rex/proto/kademlia/bootstrap_response_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Rex::Proto::Kademlia::BootstrapResponse do
   describe '#from_data' do
     it 'properly decodes real valid bootstrap responses' do
-      data = IO.read(File.join(File.dirname(__FILE__), 'kademlia_bootstrap_res.bin'))
+      data = File.binread(File.join(File.dirname(__FILE__), 'kademlia_bootstrap_res.bin'))
       response = described_class.from_data(data)
       expect(response.peer_id).to eq('B54A83462529B21EF51FD54B956B07B0')
       expect(response.tcp_port).to eq(4662)

--- a/spec/lib/rex/proto/quake/message_spec.rb
+++ b/spec/lib/rex/proto/quake/message_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Rex::Proto::Quake do
         "sv_maxclients" => "8",
         "voip" => "1"
       }
-      actual_info = subject.decode_info(IO.read(File.join(File.dirname(__FILE__), 'info_response.bin')))
+      actual_info = subject.decode_info(File.binread(File.join(File.dirname(__FILE__), 'info_response.bin')))
       expect(actual_info).to eq(expected_info)
     end
   end
@@ -96,7 +96,7 @@ RSpec.describe Rex::Proto::Quake do
         "timelimit" => "25",
         "version" => "ioq3 1.36+svn2202-1/Ubuntu linux-x86_64 Dec 12 2011"
       }
-      actual_status = subject.decode_status(IO.read(File.join(File.dirname(__FILE__), 'status_response.bin')))
+      actual_status = subject.decode_status(File.binread(File.join(File.dirname(__FILE__), 'status_response.bin')))
       expect(actual_status).to eq(expected_status)
     end
   end

--- a/spec/lib/rex/proto/steam/message_spec.rb
+++ b/spec/lib/rex/proto/steam/message_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Rex::Proto::Steam do
         players: "22/32", bots: 0, game_version: "1.0.0.6", type: "Dedicated",
         environment: "Linux", visibility: "public", VAC: "secured"
       }
-      actual_info = steam.a2s_info_decode(IO.read(File.join(File.dirname(__FILE__), 'steam_info.bin')))
+      actual_info = steam.a2s_info_decode(File.binread(File.join(File.dirname(__FILE__), 'steam_info.bin')))
       expect(actual_info).to eq(expected_info)
     end
   end

--- a/tools/dev/update_wordpress_vulnerabilities.rb
+++ b/tools/dev/update_wordpress_vulnerabilities.rb
@@ -74,7 +74,7 @@ path = File.expand_path('../../', File.dirname(__FILE__))
 Dir.glob(path + '/modules/**/*.rb').each do |file|
   next unless file.include?('exploits') || file.include?('auxiliary')
 
-  str = IO.read(file)
+  str = File.read(file)
   match = str.match(/check_plugin_version_from_readme\(['"]([^'"]+)['"]/)
   unless match.nil?
     plugins.append(match[1])


### PR DESCRIPTION
This PR replaces `IO.read` with `File.binread`, in scenarios where it's obvious that we're reading from binaries, to prevent an issue where not all of the file has been read correctly due to an additional EOL<->CRLF conversion that happens on Windows. Specifying the mode on `File.read` or `IO.read` to include `b` would also fix the issue.

```
"b"  Binary file mode
     Suppresses EOL <-> CRLF conversion on Windows. And
     sets external encoding to ASCII-8BIT unless explicitly
     specified.
```

Example:
```
[6] pry(#<Msf::Modules::Exploit__Windows__Fileformat__Adobe_pdf_embedded_exe::MetasploitModule>)> IO.read("C:/metasploit-framework/data/exploits/CVE-2010-1240/template.pdf").length
=> 563
[7] pry(#<Msf::Modules::Exploit__Windows__Fileformat__Adobe_pdf_embedded_exe::MetasploitModule>)> IO.read("C:/metasploit-framework/data/exploits/CVE-2010-1240/template.pdf", mode: 'rb').length
=> 618
[8] pry(#<Msf::Modules::Exploit__Windows__Fileformat__Adobe_pdf_embedded_exe::MetasploitModule>)> File.binread("C:/metasploit-framework/data/exploits/CVE-2010-1240/template.pdf").length
=> 618
```

Relevant issue: https://github.com/rapid7/metasploit-framework/issues/16285

Cross-referencing a PR that also takes care of file reads: https://github.com/rapid7/metasploit-framework/pull/16174

## Bug - Not reading full file contents

When trying to read a file without specifying the mode with `File` or `IO`:

```
irb(main):001:0> IO.read("ext_server_python.x64.debug.dll").length
=> 599
irb(main):002:0> IO.read("ext_server_python.x64.debug.dll", mode: 'rb').length
=> 7086592
irb(main):004:0> File.binread("ext_server_python.x64.debug.dll").length
=> 7086592
irb(main):005:0> File.read("ext_server_python.x64.debug.dll").length
=> 599
irb(main):006:0> File.read("ext_server_python.x64.debug.dll", mode: 'rb').length
=> 7086592
```

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/fileformat/adobe_pdf_embedded_exe`
- [x] `set exename {...}`
- [x] Try to `run`
- [x] **Confirm** the `run` command fails without these changes.
- [ ] **Verify** this PR fixes the issue and that the PDF is generated correctly

### Before (using `exploit/windows/fileformat/adobe_pdf_embedded_exe`)
```
msf6 exploit(windows/fileformat/adobe_pdf_embedded_exe) > run

[*] Reading in 'C:/metasploit-framework/data/exploits/CVE-2010-1240/template.pdf'...
[*] Parsing 'C:/metasploit-framework/data/exploits/CVE-2010-1240/template.pdf'...
[-] Sorry, I'm picky. Incompatible PDF structure, please try a different PDF template.
```

### After (using `exploit/windows/fileformat/adobe_pdf_embedded_exe`)
```
msf6 exploit(windows/fileformat/adobe_pdf_embedded_exe) > run

[*] Reading in 'C:/metasploit-framework/data/exploits/CVE-2010-1240/template.pdf'...
[*] Parsing 'C:/metasploit-framework/data/exploits/CVE-2010-1240/template.pdf'...
[*] Using './win10met.exe' as payload...
[+] Parsing Successful. Creating 'evil.pdf' file...
[+] evil.pdf stored at C:/Users/simon/.msf4/local/evil.pdf
```