### PR TITLE
Fix SMB signing detection when SMB1 is disabled

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -92,6 +92,7 @@ class MetasploitModule < Msf::Auxiliary
 
       dialect = simple.client.dialect
       if simple.client.is_a? RubySMB::Client
+        info[:signing_required] = simple.client.signing_required
         if dialect == '0x0311'
           info[:capabilities][:compression] = simple.client.server_compression_algorithms.map do |algorithm|
             RubySMB::SMB2::CompressionCapabilities::COMPRESSION_ALGORITHM_MAP[algorithm]
@@ -119,6 +120,8 @@ class MetasploitModule < Msf::Auxiliary
             info[:auth_domain] = simple.client.default_domain
           end
         end
+      else
+        info[:signing_required] = simple.client.peer_require_signing
       end
 
       info[:preferred_dialect] = dialect unless info.key? :preferred_dialect
@@ -192,7 +195,7 @@ class MetasploitModule < Msf::Auxiliary
           desc << " (#{name} capabilities:#{values.join(', ')})"
         end
 
-        if simple.client.peer_require_signing
+        if info[:signing_required]
           desc << ' (signatures:required)'
         else
           desc << ' (signatures:optional)'


### PR DESCRIPTION
The smb_version module will detect whether or not the remote server requires SMB signatures. This information is relevant for certain classes of attacks. There exists a bug in the detection logic right now that causes servers that require signatures to be misclassified as not requiring signatures when the SMB 1 protocol version is not enabled. This is due to how the detection occurs. When SMB 1 is not enabled, the SMB 1 negotiation fails, leaving the `#peer_require_signing` flag in it's default state of false. These changes add the `signing_required` key to the info hash generated by `#smb_proto_info` and ensure that it's only set from a successful negotiation.

## Verification

List the steps needed to make sure this thing works

- [ ] Configure a Windows 10 client system to demonstrate the vulnerability
    - [ ] Ensure that SMB 1 is disabled (this is default but you can use Powershell to do this as well: `Set-SmbServerConfiguration -EnableSMB1Protocol $false`)
    - [ ] Ensure that SMB signing is required, see: https://thewindowsupdate.com/2021/08/03/configure-smb-signing-with-confidence/
- [ ] Start `msfconsole`
- [ ] Use the `auxiliary/scanner/smb/smb_version` module
- [ ] Set the RHOSTS value to the Windows 10 system and scan it
- [ ] See that SMB signing is required and that SMB versions 2 and 3 are enabled but SMB 1 is not
    * Previously when SMB 1 was disabled on the target, the SMB signing field would be incorrectly set to "optional"

## Example

```
msf6 auxiliary(scanner/smb/smb_version) > show options 

Module options (auxiliary/scanner/smb/smb_version):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   RHOSTS   192.168.159.86   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   THREADS  1                yes       The number of concurrent threads (max one per host)

msf6 auxiliary(scanner/smb/smb_version) > run

[*] 192.168.159.86:445    - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:required) (guid:{cdd4f1fe-d709-4bfa-8dc9-55666231f5f1}) (authentication domain:DESKTOP-RTCRBEV)
[*] 192.168.159.86:       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_version) > 
```