### PR TITLE
Msf::Payload::Apk: zipalign: align APK stored shared object files

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -333,7 +333,7 @@ class Msf::Payload::Apk
 
     if signature
       print_status "Aligning #{injected_apk}\n"
-      zipalign_output = run_cmd(['zipalign', '4', injected_apk, aligned_apk])
+      zipalign_output = run_cmd(['zipalign', '-p', '4', injected_apk, aligned_apk])
 
       unless File.readable?(aligned_apk)
         print_error(zipalign_output)


### PR DESCRIPTION
This PR adds `-p` flag when calling `zipalign` to ensure memory page alignment for stored shared object files.

```
# zipalign -h
Zip alignment utility
Copyright (C) 2009 The Android Open Source Project

Usage: zipalign [-f] [-p] [-v] [-z] <align> infile.zip outfile.zip
       zipalign -c [-p] [-v] <align> infile.zip

  <align>: alignment in bytes, e.g. '4' provides 32-bit alignment
  -c: check alignment only (does not modify file)
  -f: overwrite existing outfile.zip
  -p: memory page alignment for stored shared object files
  -v: verbose output
  -z: recompress using Zopfli
```

If an APK file contains shared object files, these must also be aligned. Currently, they are not. While rebuilding the APK file is successful, installation fails.

From [zipalign documentation](https://developer.android.com/studio/command-line/zipalign#usage):

> If your APK contains shared libraries (.so files), you should use -p to ensure that they're aligned to a 4KiB page boundary suitable for mmap(2). For other files, whose alignment is determined by the mandatory alignment argument to zipalign, Studio aligns to 4 bytes on both 32-bit and 64-bit systems.

The `-p` flag should be harmless for APK files which do not contain shared object files.

---

See also: https://github.com/iBotPeaches/Apktool/issues/2392
