### PR TITLE
implement vnc hash types

### DIFF
--- a/lib/metasploit/framework/hashes/identify.rb
+++ b/lib/metasploit/framework/hashes/identify.rb
@@ -19,103 +19,106 @@ def identify_hash(hash)
   hash = hash.to_s.strip
   case
     # operating systems
-    when hash.start_with?('$1$') && hash.length == 34
-      return 'md5'
-    when hash.start_with?('$2$') && hash.length == 59,
+  when hash.start_with?('$1$') && hash.length == 34
+    return 'md5'
+  when hash.start_with?('$2$') && hash.length == 59,
          hash.start_with?('$2a$') && hash.length == 60,
          hash.start_with?('$2b$') && hash.length == 60,
          hash.start_with?('$2x$') && hash.length == 60,
          hash.start_with?('$2y$') && hash.length == 60
-      return 'bf' #bcrypt
-    when hash.start_with?('$5$') && hash.split('$').last.length == 43
-      # we dont check full length since it may have 'rounds=' in the [1] area or not with an arbitrary length number
-      return 'sha256,crypt'
-    when hash.start_with?('$6$') && hash.split('$').last.length == 86
-      # we dont check full length since it may have 'rounds=' in the [1] area or not with an arbitrary length number
-      return 'sha512,crypt'
-    when hash.start_with?('@S@') && hash.length == 148
-      return 'qnx,sha512'
-    when hash.start_with?('@s@') && hash.length == 84
-      return 'qnx,sha256'
-    when hash.start_with?('@m@') && hash.length == 52
-      return 'qnx,md5'
-    when hash.start_with?('_') && hash.length == 20
-      return 'des,bsdi,crypt'
-    when hash =~ /^[\.\/\dA-Za-z]{13}$/ # hash.length == 13
-      return 'des,crypt'
-    when hash =~ /^\$dynamic_82\$[\da-f]{128}\$HEX\$[\da-f]{32}$/ # jtr vmware ldap https://github.com/rapid7/metasploit-framework/pull/13865#issuecomment-660718108
-      return 'dynamic_82'
-    when hash.start_with?(/{SSHA}/i)
-      return 'ssha'
-    when hash.start_with?(/{SHA512}/i)
-      return 'raw-sha512'
-    when hash.start_with?(/{SHA256}/i)
-      return 'raw-sha256'
-    when hash.start_with?(/{SHA}/i)
-      return 'raw-sha1'
-    when hash.start_with?(/{MD5}/i)
-      return 'raw-md5'
-    when hash.start_with?(/{SMD5}/i)
-      return 'smd5'
-    when hash.start_with?(/{SSHA256}/i)
-      return 'ssha256'
-    when hash.start_with?(/{SSHA512}/i)
-      return 'ssha512'
+    return 'bf' # bcrypt
+  when hash.start_with?('$5$') && hash.split('$').last.length == 43
+    # we dont check full length since it may have 'rounds=' in the [1] area or not with an arbitrary length number
+    return 'sha256,crypt'
+  when hash.start_with?('$6$') && hash.split('$').last.length == 86
+    # we dont check full length since it may have 'rounds=' in the [1] area or not with an arbitrary length number
+    return 'sha512,crypt'
+  when hash.start_with?('@S@') && hash.length == 148
+    return 'qnx,sha512'
+  when hash.start_with?('@s@') && hash.length == 84
+    return 'qnx,sha256'
+  when hash.start_with?('@m@') && hash.length == 52
+    return 'qnx,md5'
+  when hash.start_with?('_') && hash.length == 20
+    return 'des,bsdi,crypt'
+  when hash =~ %r{^[./\dA-Za-z]{13}$} # hash.length == 13
+    return 'des,crypt'
+  when hash =~ /^\$dynamic_82\$[\da-f]{128}\$HEX\$[\da-f]{32}$/ # jtr vmware ldap https://github.com/rapid7/metasploit-framework/pull/13865#issuecomment-660718108
+    return 'dynamic_82'
+  when hash.start_with?(/{SSHA}/i)
+    return 'ssha'
+  when hash.start_with?(/{SHA512}/i)
+    return 'raw-sha512'
+  when hash.start_with?(/{SHA256}/i)
+    return 'raw-sha256'
+  when hash.start_with?(/{SHA}/i)
+    return 'raw-sha1'
+  when hash.start_with?(/{MD5}/i)
+    return 'raw-md5'
+  when hash.start_with?(/{SMD5}/i)
+    return 'smd5'
+  when hash.start_with?(/{SSHA256}/i)
+    return 'ssha256'
+  when hash.start_with?(/{SSHA512}/i)
+    return 'ssha512'
     # windows
-    when hash.length == 65 && hash =~ /^[\da-fA-F]{32}:[\da-fA-F]{32}$/ && hash.split(':').first.upcase == 'AAD3B435B51404EEAAD3B435B51404EE'
-      return 'nt'
-    when hash.length == 65 && hash =~ /^[\da-fA-F]{32}:[\da-fA-F]{32}$/
-      return 'lm'
+  when hash.length == 65 && hash =~ /^[\da-fA-F]{32}:[\da-fA-F]{32}$/ && hash.split(':').first.upcase == 'AAD3B435B51404EEAAD3B435B51404EE'
+    return 'nt'
+  when hash.length == 65 && hash =~ /^[\da-fA-F]{32}:[\da-fA-F]{32}$/
+    return 'lm'
     # OSX
-    when hash.start_with?('$ml$') && hash.split('$').last.length == 256
-      return 'pbkdf2-hmac-sha512,osx' # 10.8+
-    when hash =~ /^[\da-fA-F]{48}$/ # hash.length == 48
-      return 'xsha,osx' # 10.4-10.6
+  when hash.start_with?('$ml$') && hash.split('$').last.length == 256
+    return 'pbkdf2-hmac-sha512,osx' # 10.8+
+  when hash =~ /^[\da-fA-F]{48}$/ # hash.length == 48
+    return 'xsha,osx' # 10.4-10.6
     # databases
-    when hash.start_with?('0x0100') && hash.length == 54
-      return 'mssql05'
-    when hash.start_with?('0x0100') && hash.length == 94
-      return 'mssql'
-    when hash.start_with?('0x0200') && hash.length == 142
-      return 'mssql12'
-    when hash =~ /^[\da-f]{16}$/ # hash.length == 16
-      return 'mysql' # mysql323 (pre 4.1)
-    when hash.start_with?('*') && hash.length == 41
-      return 'mysql-sha1' # mysql 4.1+
-    when hash.start_with?('md5') && hash.length == 35
-      return 'postgres'
-    when hash =~ /^[\da-fA-F]{16}$/
-      return 'des,oracle' # pre 11g
-    when hash =~ /^S:[\dA-F]{60}$/
-      return 'raw-sha1,oracle11'
-    when hash =~ /^S:[\dA-F]{60};H:[\dA-F]{32};T:[\dA-F]{160}$/
-      return 'raw-sha1,oracle'
-    when hash =~ /^H:[\dA-F]{32};T:[\dA-F]{160}$/
-      return 'pbkdf2,oracle12c'
+  when hash.start_with?('0x0100') && hash.length == 54
+    return 'mssql05'
+  when hash.start_with?('0x0100') && hash.length == 94
+    return 'mssql'
+  when hash.start_with?('0x0200') && hash.length == 142
+    return 'mssql12'
+  when hash =~ /^[\da-f]{16}$/ # hash.length == 16
+    return 'mysql' # mysql323 (pre 4.1)
+  when hash.start_with?('*') && hash.length == 41
+    return 'mysql-sha1' # mysql 4.1+
+  when hash.start_with?('md5') && hash.length == 35
+    return 'postgres'
+  when hash =~ /^[\da-fA-F]{16}$/
+    return 'des,oracle' # pre 11g
+  when hash =~ /^S:[\dA-F]{60}$/
+    return 'raw-sha1,oracle11'
+  when hash =~ /^S:[\dA-F]{60};H:[\dA-F]{32};T:[\dA-F]{160}$/
+    return 'raw-sha1,oracle'
+  when hash =~ /^H:[\dA-F]{32};T:[\dA-F]{160}$/
+    return 'pbkdf2,oracle12c'
     # webapps
-    when hash.start_with?('$P$') && hash.length == 34,
+  when hash.start_with?('$P$') && hash.length == 34,
          hash.start_with?('$H$') && hash.length == 34
-      return 'phpass' # wordpress, drupal, phpbb3 (H not P)
-    when hash.start_with?('$ml$') && hash.length == 203
-      return 'PBKDF2-HMAC-SHA512'
-    when hash.start_with?('{PKCS5S2}') && hash.length == 73
-      return 'PBKDF2-HMAC-SHA1'
-    when hash.start_with?('$B$') && hash.split('$').last.length == 32
-      return 'mediawiki'
+    return 'phpass' # wordpress, drupal, phpbb3 (H not P)
+  when hash.start_with?('$ml$') && hash.length == 203
+    return 'PBKDF2-HMAC-SHA512'
+  when hash.start_with?('{PKCS5S2}') && hash.length == 73
+    return 'PBKDF2-HMAC-SHA1'
+  when hash.start_with?('$B$') && hash.split('$').last.length == 32
+    return 'mediawiki'
     # mobile
-    when hash  =~/^[A-F0-9]{40}:[a-f0-9]{16}$/
-      return 'android-sha1'
-    when hash  =~/^[A-F0-9]{32}:[a-f0-9]{16}$/
-      return 'android-md5'
+  when hash =~ /^[A-F0-9]{40}:[a-f0-9]{16}$/
+    return 'android-sha1'
+  when hash =~ /^[A-F0-9]{32}:[a-f0-9]{16}$/
+    return 'android-md5'
     # other
-    when hash =~ /^<\d+@.+?>#[\w]{32}$/
-      return 'hmac-md5'
-    when hash.length == 114 && hash.start_with?('$M$')
-      return 'F5-Secure-Vault'
-    when hash =~ /^M\$[[:print:]]+#[\da-fA-F]{32}(?:(?::[[:print:]]*$)|$)/
-      return 'mscash'
-    when hash =~ /^\$DCC2\$\d+#[[:print:]]+#[\da-fA-F]{32}(?:(?::[[:print:]]*$)|$)/
-      return 'mscash2'
+  when hash =~ /^<\d+@.+?>#\w{32}$/
+    return 'hmac-md5'
+  when hash.length == 114 && hash.start_with?('$M$')
+    return 'F5-Secure-Vault'
+  when hash =~ /^M\$[[:print:]]+#[\da-fA-F]{32}(?:(?::[[:print:]]*$)|$)/
+    return 'mscash'
+  when hash =~ /^\$DCC2\$\d+#[[:print:]]+#[\da-fA-F]{32}(?:(?::[[:print:]]*$)|$)/
+    return 'mscash2'
+  when hash =~ /^\*?[\da-fA-F]{32}\*[\da-fA-F]{32}$/
+    # we accept the beginning star as optional
+    return 'vnc'
   end
   ''
 end

--- a/lib/metasploit/framework/password_crackers/jtr/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/jtr/formatter.rb
@@ -68,7 +68,7 @@ def hash_to_jtr(cred)
       # The hash as *hash*: so that it is both JTR and hashcat compatible
       return "#{cred.private.data}:"
     when /vnc/
-      # add a beggining * if one is missing
+      # add a beginning * if one is missing
       return "$vnc$#{cred.private.data.start_with?('*') ? cred.private.data.upcase : "*#{cred.private.data.upcase}"}"
     else
       # /mysql|mysql-sha1/
@@ -79,7 +79,7 @@ def hash_to_jtr(cred)
       # /ssha/
       # /raw-sha512/
       # /raw-sha256/
-      # this also handles *other* and it isn't guaranteed to have a public
+      # This also handles *other* type credentials which aren't guaranteed to have a public
 
       return "#{cred.public.nil? ? ' ' : cred.public.username}:#{cred.private.data}:#{cred.id}:"
     end

--- a/lib/metasploit/framework/password_crackers/jtr/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/jtr/formatter.rb
@@ -10,7 +10,7 @@ def hash_to_jtr(cred)
   when 'Metasploit::Credential::PostgresMD5'
     if cred.private.jtr_format =~ /postgres|raw-md5/
       # john --list=subformats | grep 'PostgreSQL MD5'
-      #UserFormat = dynamic_1034  type = dynamic_1034: md5($p.$u) (PostgreSQL MD5)
+      # UserFormat = dynamic_1034  type = dynamic_1034: md5($p.$u) (PostgreSQL MD5)
       hash_string = cred.private.data
       hash_string.gsub!(/^md5/, '')
       return "#{cred.public.username}:$dynamic_1034$#{hash_string}"
@@ -36,15 +36,15 @@ def hash_to_jtr(cred)
       #         PBKDF2-based SHA512 hash specific to 12C (12.1.0.2+)
     when /raw-sha1|oracle11/ # oracle 11
       if cred.private.data =~ /S:([\dA-F]{60})/ # oracle 11
-        return "#{cred.public.username}:#{$1}:#{cred.id}:"
+        return "#{cred.public.username}:#{Regexp.last_match(1)}:#{cred.id}:"
       end
     when /oracle12c/
       if cred.private.data =~ /T:([\dA-F]{160})/ # oracle 12c
-        return "#{cred.public.username}:$oracle12c$#{$1.downcase}:#{cred.id}:"
+        return "#{cred.public.username}:$oracle12c$#{Regexp.last_match(1).downcase}:#{cred.id}:"
       end
     when /dynamic_1506/
       if cred.private.data =~ /H:([\dA-F]{32})/ # oracle 11
-        return "#{cred.public.username.upcase}:$dynamic_1506$#{$1}:#{cred.id}:"
+        return "#{cred.public.username.upcase}:$dynamic_1506$#{Regexp.last_match(1)}:#{cred.id}:"
       end
     when /oracle/ # oracle
       if cred.private.jtr_format.start_with?('des') # 'des,oracle', not oracle11/12c
@@ -67,6 +67,9 @@ def hash_to_jtr(cred)
       # with a sample hash of b31d032cfdcf47a399990a71e43c5d2a:144816. So this just outputs
       # The hash as *hash*: so that it is both JTR and hashcat compatible
       return "#{cred.private.data}:"
+    when /vnc/
+      # add a beggining * if one is missing
+      return "$vnc$#{cred.private.data.start_with?('*') ? cred.private.data.upcase : "*#{cred.private.data.upcase}"}"
     else
       # /mysql|mysql-sha1/
       # /mssql|mssql05|mssql12/
@@ -76,7 +79,9 @@ def hash_to_jtr(cred)
       # /ssha/
       # /raw-sha512/
       # /raw-sha256/
-      return "#{cred.public.username}:#{cred.private.data}:#{cred.id}:"
+      # this also handles *other* and it isn't guaranteed to have a public
+
+      return "#{cred.public.nil? ? ' ' : cred.public.username}:#{cred.private.data}:#{cred.id}:"
     end
   end
   nil

--- a/modules/auxiliary/server/capture/vnc.rb
+++ b/modules/auxiliary/server/capture/vnc.rb
@@ -7,26 +7,28 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::TcpServer
   include Msf::Auxiliary::Report
 
+  require 'metasploit/framework/hashes/identify'
+
   def initialize
     super(
-      'Name'           => 'Authentication Capture: VNC',
-      'Description'    => %q{
+      'Name' => 'Authentication Capture: VNC',
+      'Description' => %q{
         This module provides a fake VNC service that
       is designed to capture authentication credentials.
       },
-      'Author'         => 'Patrik Karlsson <patrik[at]cqure.net>',
-      'License'        => MSF_LICENSE,
-      'Actions'        => [[ 'Capture', 'Description' => 'Run VNC capture server' ]],
+      'Author' => 'Patrik Karlsson <patrik[at]cqure.net>',
+      'License' => MSF_LICENSE,
+      'Actions' => [[ 'Capture', { 'Description' => 'Run VNC capture server' } ]],
       'PassiveActions' => [ 'Capture' ],
-      'DefaultAction'  => 'Capture'
+      'DefaultAction' => 'Capture'
     )
 
     register_options(
       [
-        OptPort.new('SRVPORT', [ true, "The local port to listen on.", 5900 ]),
-        OptString.new('CHALLENGE', [ true, "The 16 byte challenge", "00112233445566778899AABBCCDDEEFF" ]),
-        OptString.new('JOHNPWFILE',  [ false, "The prefix to the local filename to store the hashes in JOHN format", nil ])
-      ])
+        OptPort.new('SRVPORT', [ true, 'The local port to listen on.', 5900 ]),
+        OptString.new('CHALLENGE', [ true, 'The 16 byte challenge', '00112233445566778899AABBCCDDEEFF' ])
+      ]
+    )
   end
 
   def setup
@@ -36,21 +38,21 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     if datastore['CHALLENGE'].to_s =~ /^([a-fA-F0-9]{32})$/
-      @challenge = [ datastore['CHALLENGE'] ].pack("H*")
+      @challenge = [ datastore['CHALLENGE'] ].pack('H*')
     else
       fail_with(Failure::BadConfig, 'CHALLENGE must be 32 characters, 0-9,A-F.')
     end
-    exploit()
+    exploit
   end
 
   def on_client_connect(c)
     @state[c] = {
-      :name    => "#{c.peerhost}:#{c.peerport}",
-      :ip      => c.peerhost,
-      :port    => c.peerport,
-      :pass    => nil,
-      :chall   => nil,
-      :proto   => nil
+      name: "#{c.peerhost}:#{c.peerport}",
+      ip: c.peerhost,
+      port: c.peerport,
+      pass: nil,
+      chall: nil,
+      proto: nil
     }
 
     c.put "RFB 003.007\n"
@@ -70,7 +72,8 @@ class MetasploitModule < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :nonreplayable_hash,
+      jtr_format: identify_hash(opts[:password])
     }.merge(service_data)
 
     login_data = {
@@ -84,21 +87,21 @@ class MetasploitModule < Msf::Auxiliary
 
   def on_client_data(c)
     data = c.get_once
-    return if not data
+    return if !data
 
     peer = "#{c.peerhost}:#{c.peerport}"
 
     if data =~ /^RFB (.*)\n$/
-      @state[c][:proto] = $1
-      if @state[c][:proto] == "003.007"
+      @state[c][:proto] = Regexp.last_match(1)
+      if @state[c][:proto] == '003.007'
         # for the 003.007 protocol we say we support the VNC sectype
         # and wait for the server to acknowledge it, before we send the
         # challenge.
-        c.put [0x0102].pack("n") # 1 sectype, unencrypted
-      elsif @state[c][:proto] == "003.003"
+        c.put [0x0102].pack('n') # 1 sectype, unencrypted
+      elsif @state[c][:proto] == '003.003'
         # for the 003.003 protocol we say we support the VNC sectype
         # and immediately send the challenge
-        sectype = [0x00000002].pack("N")
+        sectype = [0x00000002].pack('N')
         c.put sectype
 
         @state[c][:chall] = @challenge
@@ -108,10 +111,10 @@ class MetasploitModule < Msf::Auxiliary
       end
     # the challenge was sent, so this should be our response
     elsif @state[c][:chall]
-      c.put [0x00000001].pack("N")
+      c.put [0x00000001].pack('N')
       c.close
       print_good("#{peer} - Challenge: #{@challenge.unpack('H*')[0]}; Response: #{data.unpack('H*')[0]}")
-      hash_line = "$vnc$*#{@state[c][:chall].unpack("H*")[0]}*#{data.unpack('H*')[0]}"
+      hash_line = "*#{@state[c][:chall].unpack('H*')[0]}*#{data.unpack('H*')[0]}"
       report_cred(
         ip: c.peerhost,
         port: datastore['SRVPORT'],
@@ -121,15 +124,10 @@ class MetasploitModule < Msf::Auxiliary
         proof: hash_line
       )
 
-      if(datastore['JOHNPWFILE'])
-        fd = ::File.open(datastore['JOHNPWFILE'] + '_vnc' , "ab")
-        fd.puts hash_line
-        fd.close
-      end
     # we have got the protocol sorted out and have offered the VNC sectype (2)
-    elsif @state[c][:proto] == "003.007"
-      if ( data.unpack("C")[0] != 2 )
-        print_error("#{peer} - sectype not offered! #{data.unpack("H*")}")
+    elsif @state[c][:proto] == '003.007'
+      if (data.unpack('C')[0] != 2)
+        print_error("#{peer} - sectype not offered! #{data.unpack('H*')}")
         c.close
         return
       end

--- a/spec/lib/metasploit/framework/hashes/identify_spec.rb
+++ b/spec/lib/metasploit/framework/hashes/identify_spec.rb
@@ -19,7 +19,6 @@ print("DES: %s") %(hash.des_crypt.hash("password"))
 =end
 
 RSpec.describe 'hashes/identify' do
-
   describe 'identify_md5' do
     it 'returns md5' do
       hash = identify_hash('$1$IEHUWAxH$nMC1edxSFa4SaKH7hi2.P1')
@@ -37,7 +36,7 @@ RSpec.describe 'hashes/identify' do
   describe 'identify_blofish_a' do
     it 'returns bf' do
       # looks like BCrypt can only generate 2a in ruby as of april 2019
-      hash = identify_hash(BCrypt::Password.create("password"))
+      hash = identify_hash(BCrypt::Password.create('password'))
       expect(hash).to match('bf')
     end
   end
@@ -122,14 +121,14 @@ RSpec.describe 'hashes/identify' do
   describe 'identify_pbkdf2_osx' do
     it 'returns pbkdf2-hmac-sha512,osx' do
       hash = identify_hash('$ml$49504$0dba6246bd38266b2e827ff7e7271380757c71d653893aa361d5902398302369$c5f198639915a101c99af326dffe13e8f14456be8fd2312a39a777b92178804e204ca4fee12a8667871440eff4288e811d86d746c6d96a60c919c3418dfebba42f329f5d73c0372d636d61d5dfda1add61af36c70e4acd771276107209e643ae92a0f43e95a452744e50fb4540d9bdf4e0b701725d7db488fbe18c1ab7737c6b')
-      expect(hash).to match ('pbkdf2-hmac-sha512,osx')
+      expect(hash).to match('pbkdf2-hmac-sha512,osx')
     end
   end
 
   describe 'identify_sha_osx' do
     it 'returns xsha,osx' do
       hash = identify_hash('1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683')
-      expect(hash).to match ('xsha,osx')
+      expect(hash).to match('xsha,osx')
     end
   end
 
@@ -255,35 +254,50 @@ RSpec.describe 'hashes/identify' do
   describe 'identify_android_sha1' do
     it 'returns android-sha1' do
       hash = identify_hash('EA8457DE97836C955082AE77DBE2CD86A4E8BC0E:4aafc54dc502e88b')
-      expect(hash).to match ('android-sha1')
+      expect(hash).to match('android-sha1')
     end
   end
 
   describe 'identify_hmac_md5' do
     it 'returns hmac-md5' do
       hash = identify_hash('<771138767145@127.0.0.1>#332b463fcf3baac718c63860a7093df4')
-      expect(hash).to match ('hmac-md5')
+      expect(hash).to match('hmac-md5')
     end
   end
 
   describe 'identify_f5_secure_value' do
     it 'returns F5-Secure-Vault' do
       hash = identify_hash('$M$iE$cIdy72xi7Xbk3kazSrpdfscd+oD1pdsXJbwhvhMPiss4Iw0RKIJQS/CuSReZl/+kseKpPCNpBWNWOOaBCwlQ0v4sl7ZUkxCymh5pfFNAjhc=')
-      expect(hash).to match ('F5-Secure-Vault')
+      expect(hash).to match('F5-Secure-Vault')
     end
   end
 
   describe 'identify_mscash' do
     it 'returns mscash' do
       hash = identify_hash('M$3060147285011#4dd8965d1d476fa0d026722989a6b772:::')
-      expect(hash).to match ('mscash')
+      expect(hash).to match('mscash')
     end
   end
 
   describe 'identify_mscash2' do
     it 'returns mscash2' do
       hash = identify_hash('$DCC2$10240#username#5f9d79a71fa6d92c31cf16d6eaa23435:::')
-      expect(hash).to match ('mscash2')
+      expect(hash).to match('mscash2')
+    end
+  end
+
+  describe 'identify_vnc' do
+    it 'returns vnc' do
+      hash = identify_hash('*00112233445566778899aabbccddeeff*6feb3cb1f07b66151656b5832341f223')
+      expect(hash).to match('vnc')
+    end
+    it 'returns vnc on uppercase' do
+      hash = identify_hash('*00112233445566778899aabbccddeeff*6feb3cb1f07b66151656b5832341f223'.upcase)
+      expect(hash).to match('vnc')
+    end
+    it 'returns vnc on no leading star' do
+      hash = identify_hash('00112233445566778899aabbccddeeff*6feb3cb1f07b66151656b5832341f223')
+      expect(hash).to match('vnc')
     end
   end
 


### PR DESCRIPTION
fixes #16296

@smashery I know you had claimed the issue, but figured I could help with the hash stuff since I wrote it.  Hopefully these changes are easy to merge into the changes you've been working on.

1. removes the module writing to a john file since this is duplicate functionality already standardized and implemented in the `creds` command
2. changed the `vnc` module to not tack on `$vnc$` because that is most likely JTR specific, we'll do that when we export to jtr.
3. creates a vnc catcher for `hash_identify` so we can properly detect them, along with a lib
4. creates a `jtr` export for `vnc` hashes
5. hashcat doesn't have an *easy* cracker for `vnc` type, so I linked the latest I could find and just left it at that
6. rubocop formatting on anything I touched because its automatic
7. fixed a bug where we assumed
8.  a non-identified hash had a public (username) and when trying to export it, we crashed hard and fast.  This can be tested with 

## Verification

- [x] Follow the steps in #16296 to start the server, send a client request. (may want an easy password like `password`)
- [x] `creds -o /tmp/vnc.jtr`
- [x] `john /tmp/vnc.jtr`
- [x] **Verify** you crack the hash
- [x] `creds add hash:*00112233445566778899aabbccddeeff*6feb3cb1f07b66151656b5832341f223`
- [x] `creds -o /tmp/hashes.jtr`
- [x] **Verify** we no longer crash