### PR TITLE
Add mode to file and io reads and writes

### DIFF
--- a/lib/metasploit/framework/compiler/windows.rb
+++ b/lib/metasploit/framework/compiler/windows.rb
@@ -41,7 +41,7 @@ module Metasploit
         # @return [Integer] The number of bytes written.
         def self.compile_c_to_file(out_file, c_template, type=:exe, cpu=Metasm::Ia32.new)
           pe = self.compile_c(c_template, type)
-          File.write(out_file, pe)
+          File.write(out_file, pe, mode: 'wb')
         end
 
         # Returns randomized c source code.
@@ -82,7 +82,7 @@ module Metasploit
         # @return [Integer] The number of bytes written.
         def self.compile_random_c_to_file(out_file, c_template, opts={})
           pe = self.compile_random_c(c_template, opts)
-          File.write(out_file, pe)
+          File.write(out_file, pe, mode: 'wb')
         end
       end
 

--- a/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
+++ b/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
@@ -77,7 +77,7 @@ module ResponseDataHelper
     begin
       # If we are running the data service on the same box this will ensure we only write
       # the file if it is somehow not there already.
-      unless File.exists?(save_path) && File.read(save_path) == decoded_file
+      unless File.exists?(save_path) && File.read(save_path, mode: 'rb') == decoded_file
         File.open(save_path, 'w+') { |file| file.write(decoded_file) }
       end
     rescue => e

--- a/lib/msf/core/auxiliary/ubiquiti.rb
+++ b/lib/msf/core/auxiliary/ubiquiti.rb
@@ -31,7 +31,7 @@ module Msf
       print_status('Attempting to repair zip file (this is normal and takes some time)')
       temp_file = Rex::Quickfile.new('fixed_zip')
       system("yes | #{zip_exe} -FF #{fname} --out #{temp_file.path}.zip > /dev/null")
-      return File.read("#{temp_file.path}.zip")
+      return File.read("#{temp_file.path}.zip", mode: 'rb')
     end
 
     def extract_and_process_db(db_path)

--- a/lib/msf/core/exploit/powershell/dot_net.rb
+++ b/lib/msf/core/exploit/powershell/dot_net.rb
@@ -29,7 +29,7 @@ module Msf
         begin
           dot_net_code = opts[:harness]
           if ::File.file?(dot_net_code)
-            dot_net_code = ::File.read(dot_net_code)
+            dot_net_code = ::File.read(dot_net_code, mode: 'rb')
            end
           # Ensure we're not running ASCII-8bit through powershell
           dot_net_code = dot_net_code.force_encoding('ASCII')

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -166,7 +166,7 @@ module Exploit::Remote::MSSQL
 
     print_status("Warning: This module will leave #{var_payload}.exe in the SQL Server %TEMP% directory")
     print_status("Writing the debug.com loader to the disk...")
-    h2b = File.read(datastore['HEX2BINARY'], File.size(datastore['HEX2BINARY']))
+    h2b = File.read(datastore['HEX2BINARY'], File.size(datastore['HEX2BINARY']), mode: 'rb')
     h2b.gsub!(/KemneE3N/, "%TEMP%\\#{var_bypass}")
     h2b.split(/\n/).each do |line|
       mssql_xpcmdshell("#{line}", false)

--- a/lib/msf/core/exploit/remote/mssql_sqli.rb
+++ b/lib/msf/core/exploit/remote/mssql_sqli.rb
@@ -72,7 +72,7 @@ module Exploit::Remote::MSSQL_SQLI
 
     print_status("Warning: This module will leave #{var_payload}.exe in the SQL Server %TEMP% directory")
     print_status("Writing the debug.com loader to the disk...")
-    h2b = File.read(datastore['HEX2BINARY'], File.size(datastore['HEX2BINARY']))
+    h2b = File.read(datastore['HEX2BINARY'], File.size(datastore['HEX2BINARY'], mode: 'rb'))
     h2b.gsub!(/KemneE3N/, "%TEMP%\\#{var_bypass}")
     h2b.split(/\n/).each do |line|
       mssql_xpcmdshell("#{line}", false)

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -401,7 +401,7 @@ module Exploit::Remote::Postgres
   # @param remote_fname (see #postgres_upload_binary_data)
   # @return (see #postgres_upload_binary_data)
   def postgres_upload_binary_file(fname, remote_fname=nil)
-    data = File.read(fname)
+    data = File.read(fname, mode: 'rb')
     postgres_upload_binary_data(data, remote_fname)
   end
 

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -246,7 +246,7 @@ class Framework
     )
     return true unless ::File.exist?(path)
 
-    data = ::File.read(path)
+    data = ::File.read(path, mode: 'rb')
     return true unless Digest::SHA1.hexdigest(data) == "3395856ce81f2b7382dee72602f798b642f14140"
 
     false
@@ -537,4 +537,3 @@ class FrameworkEventSubscriber
 
 end
 end
-

--- a/lib/msf/core/web_services/servlet/db_export_servlet.rb
+++ b/lib/msf/core/web_services/servlet/db_export_servlet.rb
@@ -21,7 +21,7 @@ module Msf::WebServices::DbExportServlet
 
         output_file = get_db.run_db_export(opts)
 
-        encoded_file = Base64.urlsafe_encode64(File.read(File.expand_path(output_file)))
+        encoded_file = Base64.urlsafe_encode64(File.read(File.expand_path(output_file), mode: 'rb'))
         response = {}
         response[:db_export_file] = encoded_file
         set_json_data_response(response: response)

--- a/lib/msf/util/java_deserialization.rb
+++ b/lib/msf/util/java_deserialization.rb
@@ -67,7 +67,7 @@ class JavaDeserialization
       # Open the JSON file and parse it
       path = File.join(Msf::Config.data_directory, PAYLOAD_FILENAME)
       begin
-        json = JSON.parse(File.read(path))
+        json = JSON.parse(File.read(path, mode: 'rb'))
       rescue Errno::ENOENT, JSON::ParserError
         raise RuntimeError, "Unable to load JSON data from: #{path}"
       end

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -140,7 +140,7 @@ private
 
     # for now, we're going to blindly assume that the value is a path to a file
     # which contains the data that gets passed to the extension
-    content = ::File.read(value) + "\x00\x00"
+    content = ::File.read(value, mode: 'rb') + "\x00\x00"
     data = [
       ext_id,
       content.length,

--- a/lib/rex/script.rb
+++ b/lib/rex/script.rb
@@ -18,7 +18,7 @@ module Script
   #
   def self.execute_file(file, in_binding = nil)
     str = ''
-    buf = ::File.read(file, ::File.size(file))
+    buf = ::File.read(file, ::File.size(file), mode: 'rb')
     execute(buf, in_binding)
   end
 
@@ -35,5 +35,3 @@ module Script
 end
 
 end
-
-

--- a/modules/auxiliary/admin/http/jboss_bshdeployer.rb
+++ b/modules/auxiliary/admin/http/jboss_bshdeployer.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Auxiliary
         print_error("WAR file not found")
         return
       end
-      war_data = File.read(datastore['WARFILE'])
+      war_data = File.read(datastore['WARFILE'], mode: 'rb')
       deploy_action(app_base, war_data)
     when 'Undeploy'
       undeploy_action(app_base)

--- a/modules/auxiliary/admin/http/jboss_deploymentfilerepository.rb
+++ b/modules/auxiliary/admin/http/jboss_deploymentfilerepository.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Auxiliary
       unless datastore['WARFILE'] && File.exist?(datastore['WARFILE'])
         fail_with(Failure::BadConfig, "Unable to open WARFILE")
       end
-      war_data = File.read(datastore['WARFILE'])
+      war_data = File.read(datastore['WARFILE'], mode: 'rb')
       deploy_action(app_base, war_data)
     when 'Undeploy'
       undeploy_action(app_base)

--- a/modules/auxiliary/admin/http/supra_smart_cloud_tv_rfi.rb
+++ b/modules/auxiliary/admin/http/supra_smart_cloud_tv_rfi.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
       return send_not_found(cli)
     end
 
-    data = File.read(File.join(dir, file))
+    data = File.read(File.join(dir, file), 'rb')
 
     vprint_good("Sending #{file}")
     send_response(cli, data, 'Content-Type' => files[file])

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
           vprint_status("Trying to upload #{local_path} to #{remote_path}...")
 
           fd = simple.open("#{remote_path}", 'wct', write: true)
-          data = ::File.read(datastore['LPATH'], ::File.size(datastore['LPATH']))
+          data = ::File.read(datastore['LPATH'], ::File.size(datastore['LPATH']), mode: 'rb')
           fd.write(data)
           fd.close
 

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Auxiliary
       if zip_payload
         zip_file = attachment_file.sub(/\.\w+$/, '.zip')
         print_status("Zipping payload to #{zip_file}")
-        File.write(zip_file, Msf::Util::EXE.to_zip([fname: File.basename(attachment_file), data: exe]))
+        File.write(zip_file, Msf::Util::EXE.to_zip([fname: File.basename(attachment_file), data: exe]), mode: 'wb')
         attachment_file      = zip_file
         attachment_file_type = 'application/zip'
       else

--- a/modules/auxiliary/docx/word_unc_injector.rb
+++ b/modules/auxiliary/docx/word_unc_injector.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("Adding skeleton files from #{data_dir}")
     Dir["#{data_dir}/**/**"].each do |file|
       if not File.directory?(file)
-        zip_data[file.sub(data_dir,'')] = File.read(file)
+        zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
       end
     end
 
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # add the otherwise skipped "hidden" file
     file = "#{data_dir}/_rels/.rels"
-    zip_data[file.sub(data_dir,'')] = File.read(file)
+    zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
     # and lets create the file
     zip_docx(zip_data)
   end

--- a/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
+++ b/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def on_request_uri(cli, request)
     @tag ||= Rex::Text.rand_text_alpha(8)
-    @eot ||= ::File.read(datastore['EOTFILE'], ::File.size(datastore['EOTFILE']))
+    @eot ||= ::File.read(datastore['EOTFILE'], ::File.size(datastore['EOTFILE']), mode: 'rb')
 
     if(request.uri =~ /#{@tag}$/)
       content = @eot.dup

--- a/modules/auxiliary/fileformat/badpdf.rb
+++ b/modules/auxiliary/fileformat/badpdf.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Read in contents of file
-    content = File.read(datastore['PDFINJECT'])
+    content = File.read(datastore['PDFINJECT'], mode: 'rb')
 
     # Check for place holder - below ..should.. cover most scenarios.
     newdata = ''

--- a/modules/auxiliary/server/ftp.rb
+++ b/modules/auxiliary/server/ftp.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     c.put("150 Opening BINARY mode data connection for #{arg}\r\n")
-    conn.put(::File.read(path, ::File.size(path)))
+    conn.put(::File.read(path, ::File.size(path), mode: 'rb'))
     c.put("226 Transfer complete.\r\n")
     conn.close
   end

--- a/modules/exploits/multi/http/splunk_upload_app_exec.rb
+++ b/modules/exploits/multi/http/splunk_upload_app_exec.rb
@@ -348,7 +348,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_upload_app(app_name, file_name)
     archive_file_name = ::File.basename(file_name)
     print_status("Uploading file #{archive_file_name}")
-    file_data = ::File.read(file_name)
+    file_data = ::File.read(file_name, mode: 'rb')
 
     boundary = '--------------' + rand_text_alphanumeric(6)
 
@@ -389,7 +389,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_upload_app_7(app_name, file_name)
     archive_file_name = ::File.basename(file_name)
     print_status("Uploading file #{archive_file_name}")
-    file_data = ::File.read(file_name)
+    file_data = ::File.read(file_name, mode: 'rb')
 
     boundary = '---------------------------' + rand_text_numeric(29)
 

--- a/modules/exploits/windows/browser/citrix_gateway_actx.rb
+++ b/modules/exploits/windows/browser/citrix_gateway_actx.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @ocx = ::File.read(::File.join(Msf::Config.install_root, 'data', 'exploits', 'CVE-2011-2882', 'nsepa.ocx'))
+    @ocx = ::File.read(::File.join(Msf::Config.install_root, 'data', 'exploits', 'CVE-2011-2882', 'nsepa.ocx'), mode: 'rb')
     super
   end
 

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -117,8 +117,8 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Using '#{datastore['EXENAME']}' as payload...")
 
       file_size = File.size(payload_exe)
-      stream = Rex::Text.zlib_deflate(IO.read(payload_exe))
-      md5 = Rex::Text.md5(File.read(payload_exe))
+      stream = Rex::Text.zlib_deflate(IO.read(payload_exe, mode: 'rb'))
+      md5 = Rex::Text.md5(File.read(payload_exe, mode: 'rb'))
 
     end
 

--- a/modules/exploits/windows/fileformat/ms14_064_packager_python.rb
+++ b/modules/exploits/windows/fileformat/ms14_064_packager_python.rb
@@ -72,13 +72,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     Dir["#{data_dir}/**/**"].each do |file|
       unless File.directory?(file)
-        zip_data[file.sub(data_dir,'')] = File.read(file)
+        zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
       end
     end
 
     # add the otherwise skipped "hidden" file
     file = "#{data_dir}/_rels/.rels"
-    zip_data[file.sub(data_dir,'')] = File.read(file)
+    zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
 
     # put our own OLE streams
     zip_data['/ppt/embeddings/oleObject1.bin'] = ole_payload
@@ -141,11 +141,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # write to disk
     stg.close
 
-    ole_contents = File.read(ole_tmp.path)
+    ole_contents = File.read(ole_tmp.path, mode: 'rb')
     ole_tmp.close
     ole_tmp.unlink
 
     ole_contents
   end
 end
-

--- a/modules/exploits/windows/fileformat/ms14_064_packager_run_as_admin.rb
+++ b/modules/exploits/windows/fileformat/ms14_064_packager_run_as_admin.rb
@@ -72,13 +72,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     Dir["#{data_dir}/**/**"].each do |file|
       unless File.directory?(file)
-        zip_data[file.sub(data_dir,'')] = File.read(file)
+        zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
       end
     end
 
     # add the otherwise skipped "hidden" file
     file = "#{data_dir}/_rels/.rels"
-    zip_data[file.sub(data_dir,'')] = File.read(file)
+    zip_data[file.sub(data_dir,'')] = File.read(file, mode: 'rb')
 
     # put our own OLE streams
     zip_data['/ppt/embeddings/oleObject1.bin'] = ole_stream
@@ -143,11 +143,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # write to disk
     stg.close
 
-    ole_contents = File.read(ole_tmp.path)
+    ole_contents = File.read(ole_tmp.path, mode: 'rb')
     ole_tmp.close
     ole_tmp.unlink
 
     ole_contents
   end
 end
-

--- a/modules/exploits/windows/fileformat/office_ole_multiple_dll_hijack.rb
+++ b/modules/exploits/windows/fileformat/office_ole_multiple_dll_hijack.rb
@@ -257,7 +257,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # write to disk
     stg.close
 
-    ole_contents = File.read(ole_tmp.path)
+    ole_contents = File.read(ole_tmp.path, mode: 'rb')
     ole_tmp.close
     ole_tmp.unlink
 

--- a/modules/exploits/windows/local/cve_2020_17136.rb
+++ b/modules/exploits/windows/local/cve_2020_17136.rb
@@ -296,7 +296,7 @@ class MetasploitModule < Msf::Exploit::Local
     ].pack('IICCC')
     params += cln_params
 
-    process.memory.write(assembly_mem, params + File.read(exe_path))
+    process.memory.write(assembly_mem, params + File.read(exe_path, mode: 'rb'))
     print_status('Assembly copied.')
     assembly_mem
   end

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Exploit PoC from 'b33f'
     ps_path = ::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2016-0099', 'cve_2016_0099.ps1')
     vprint_status("PS1 loaded from #{ps_path}")
-    ms16_032 = File.read(ps_path)
+    ms16_032 = File.read(ps_path, mode: 'rb')
 
     cmdstr = expand_path('%windir%') << '\\System32\\windowspowershell\\v1.0\\powershell.exe'
 

--- a/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb
+++ b/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb
@@ -80,7 +80,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'AKA' => [ 'SMBGhost', 'CoronaBlue' ],
           'Stability' => [ CRASH_OS_RESTARTS, ],
           'Reliability' => [ REPEATABLE_SESSION, ],
-          'RelatedModules' => [ 'exploit/windows/local/cve_2020_0796_smbghost' ]
+          'RelatedModules' => [ 'exploit/windows/local/cve_2020_0796_smbghost' ],
+          'SideEffects' => []
         }
       )
     )
@@ -343,7 +344,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def build_shellcode(pointers)
-    source = File.read(File.join(Msf::Config.install_root, 'external', 'source', 'exploits', 'CVE-2020-0796', 'RCE', 'kernel_shellcode.asm'))
+    source = File.read(File.join(Msf::Config.install_root, 'external', 'source', 'exploits', 'CVE-2020-0796', 'RCE', 'kernel_shellcode.asm'), mode: 'rb')
     edata = Metasm::Shellcode.assemble(Metasm::X64.new, source).encoded
     user_shellcode = payload.encoded
     edata.fixup 'PHALP_APIC_REQUEST_INTERRUPT' => pointers[:pHalpApicRequestInterrupt]
@@ -417,7 +418,7 @@ class MetasploitModule < Msf::Exploit::Remote
         out << [ 0xb000 | (compressed.length - 1) ].pack('v')
         out << compressed
 
-        buf = buf[chunk_size..-1]
+        buf = buf[chunk_size..]
         break if buf.nil?
       end
 

--- a/modules/post/osx/manage/sonic_pi.rb
+++ b/modules/post/osx/manage/sonic_pi.rb
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Post
 
   def file
     # Read file as null-terminated string
-    @file = "#{File.read(datastore['FILE'])}\x00"
+    @file = "#{File.read(datastore['FILE'], mode: 'rb')}\x00"
 
     # Pad string with nulls until its length is a multiple of 32 bits
     @file << "\x00" until @file.length % 4 == 0

--- a/scripts/meterpreter/metsvc.rb
+++ b/scripts/meterpreter/metsvc.rb
@@ -93,7 +93,7 @@ if client.platform == 'windows'
     print_status(" >> Uploading #{from}...")
     fd = client.fs.file.new(tempdir + "\\" + to, "wb")
     path = (from == 'metsrv.x86.dll') ? MetasploitPayloads.meterpreter_path('metsrv','x86.dll') : File.join(based, from)
-    fd.write(::File.read(path, ::File.size(path)))
+    fd.write(::File.read(path, ::File.size(path), mode: 'rb'))
     fd.close
   end
 

--- a/scripts/meterpreter/prefetchtool.rb
+++ b/scripts/meterpreter/prefetchtool.rb
@@ -162,7 +162,7 @@ if !(::File.exist?(prefetch_local))
   print_status("Downloaded prefetch.exe to #{prefetch_local}")
 else
   print_status("Checking for an updated copy of prefetch.exe..")
-  digest = Digest::SHA1.hexdigest(::File.read(prefetch_local, ::File.size(prefetch_local)))
+  digest = Digest::SHA1.hexdigest(::File.read(prefetch_local, ::File.size(prefetch_local), mode: 'rb'))
 
   Net::HTTP.start("code.google.com") do |http|
     req     = Net::HTTP::Get.new("/p/prefetch-tool/downloads/detail?name=prefetch.exe&can=2&q=")
@@ -192,4 +192,3 @@ end
 
 print_status("Running Prefetch-tool script...")
 prefetch_dump(options, logging)
-


### PR DESCRIPTION
This PR adds a mode to `File.read` and `File.write` calls, as per the comment here: https://github.com/rapid7/metasploit-framework/pull/16325#issuecomment-1065296641

## Verification

- [ ] Start `msfconsole`
- [ ] `use` a module that is currently failing due to `File.read` or `File.write` calls
- [ ] Confirm that the module fails
- [ ] Checkout this PR
- [ ] Retry running the module
- [ ] Confirm that with this PR, the module works