### PR TITLE
Catch SocketError when normalizing the hostname

### DIFF
--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -196,10 +196,11 @@ module Msf::DBManager::Host
     begin
       retry_attempts ||= 0
       if !addr.kind_of? ::Mdm::Host
-        addr = Msf::Util::Host.normalize_host(addr)
+        original_addr = addr
+        addr = Msf::Util::Host.normalize_host(original_addr)
 
         unless ipv46_validator(addr)
-          raise ::ArgumentError, "Invalid IP address in report_host(): #{addr}"
+          raise ::ArgumentError, "Invalid IP address in report_host(): #{original_addr}"
         end
 
         conditions = {address: addr}

--- a/lib/msf/util/host.rb
+++ b/lib/msf/util/host.rb
@@ -14,21 +14,18 @@ module Msf
         return host if defined?(::Mdm) && host.kind_of?(::Mdm::Host)
         norm_host = nil
 
-        if (host.kind_of? String)
-
+        if host.kind_of?(String)
           if Rex::Socket.is_ipv4?(host)
-            # If it's an IPv4 addr with a port on the end, strip the port
-            if host =~ /((\d{1,3}\.){3}\d{1,3}):\d+/
-              norm_host = $1
-            else
-              norm_host = host
-            end
+            norm_host = host
           elsif Rex::Socket.is_ipv6?(host)
             # If it's an IPv6 addr, drop the scope
             address, scope = host.split('%', 2)
             norm_host = address
           else
-            norm_host = Rex::Socket.getaddress(host, true)
+            begin
+              norm_host = Rex::Socket.getaddress(host, true)
+            rescue SocketError
+            end
           end
         elsif defined?(::Mdm) && host.kind_of?(::Mdm::Session)
           norm_host = host.host
@@ -52,7 +49,6 @@ module Msf
         # to try, just log it and return what we were given
         if !norm_host
           dlog("Host could not be normalized: #{host.inspect}")
-          norm_host = host
         end
 
         norm_host

--- a/lib/msf/util/host.rb
+++ b/lib/msf/util/host.rb
@@ -18,8 +18,8 @@ module Msf
           if Rex::Socket.is_ipv4?(host)
             norm_host = host
           elsif Rex::Socket.is_ipv6?(host)
-            # If it's an IPv6 addr, drop the scope
-            address, scope = host.split('%', 2)
+            # If it's an IPv6 addr, drop the zone_id
+            address, _ = host.split('%', 2)
             norm_host = address
           else
             begin


### PR DESCRIPTION
This updates the `normalize_host` method so that when it attempts and fails to resolve a hostname to an IP address, it will return `nil` instead of raising an exception. Per the function's [documentation](https://github.com/rapid7/metasploit-framework/blob/df81a48e4ad753f3e21dbeefdf15f8395459367f/lib/msf/util/host.rb#L8) string, it "Returns something suitable for the +:host+ parameter...", which `nil` is. This means that modules that call `report_note` and other report functions with a hostname that can't be resolved won't be interrupted with a stack trace. This was particularly a problem for the `auxiliary/gather/enum_dns` module which is where I noticed it. In that case in particular, the module uses the domain name as the host key which can't always be resolved. This change ensures that the note information is kept (just without the host since it can't be normalized), as opposed to dropping it altogether. In any case, the module shouldn't completely crash.

<details>
<summary>Original Exception</summary>

The following example shows the original bug from the `enum_dns` module where the `report_note` function was causing the entire module to fail because the domain `home.lan` does not have an A record. With this change in place, the details are all kept but the host field of the note is empty.
```
./msfconsole -r issue_16324.rc
                                                  
 _                                                    _
/ \    /\         __                         _   __  /_/ __
| |\  / | _____   \ \           ___   _____ | | /  \ _   \ \
| | \/| | | ___\ |- -|   /\    / __\ | -__/ | || | || | |- -|
|_|   | | | _|__  | |_  / -\ __\ \   | |    | | \__/| |  | |_
      |/  |____/  \___\/ /\ \\___/   \/     \__|    |_\  \___\


       =[ metasploit v6.1.34-dev-df81a48e4a               ]
+ -- --=[ 2210 exploits - 1172 auxiliary - 395 post       ]
+ -- --=[ 598 payloads - 45 encoders - 11 nops            ]
+ -- --=[ 9 evasion                                       ]

Metasploit tip: Tired of setting RHOSTS for modules? Try 
globally setting it with setg RHOSTS x.x.x.x

[*] Processing issue_16324.rc for ERB directives.
resource (issue_16324.rc)> use auxiliary/gather/enum_dns
resource (issue_16324.rc)> set DOMAIN home.lan
DOMAIN => home.lan
resource (issue_16324.rc)> set NS 192.168.250.4
NS => 192.168.250.4
resource (issue_16324.rc)> run
[*] Attempting DNS AXFR for home.lan from 192.168.250.4
[+] home.lan Zone Transfer:
;; Answer received from 192.168.250.4:53 (387 bytes)
;;
;; HEADER SECTION
;; id = 32548
;; qr = 1	opCode: QUERY	aa = 1	tc = 0	rd = 0
;; ra = 1	ad = 0	cd = 0	rcode = NoError
;; qdCount = 1	anCount = 15	nsCount = 0	arCount = 0

;; QUESTION SECTION (1 record):
;; home.lan.                    IN      AXFR    

;; ANSWER SECTION (15 records):
home.lan.               38400   IN      SOA     dns.home.lan. zeroSteiner.gmail.com. 1587836505 10800 3600 604800 38400
home.lan.               38400   IN      NS      dns.home.lan.
home.lan.               38400   IN      NS      dns-aux.home.lan.
[REDACTED]
home.lan.               38400   IN      SOA     dns.home.lan. zeroSteiner.gmail.com. 1587836505 10800 3600 604800 38400

[*] Querying DNS CNAME records for home.lan
[*] Querying DNS NS records for home.lan
[+] home.lan NS: dns-aux.home.lan
[+] home.lan NS: dns.home.lan
[-] Auxiliary failed: SocketError getaddrinfo: Name or service not known
[-] Call stack:
[-]   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-socket-0.1.34/lib/rex/socket.rb:193:in `getaddrinfo'
[-]   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-socket-0.1.34/lib/rex/socket.rb:193:in `getaddresses'
[-]   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/rex-socket-0.1.34/lib/rex/socket.rb:175:in `getaddress'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/util/host.rb:31:in `normalize_host'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/db_manager/note.rb:94:in `block in report_note'
[-]   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/activerecord-6.1.4.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:462:in `with_connection'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/db_manager/note.rb:81:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:40:in `block in report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:164:in `data_service_operation'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:38:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/auxiliary/report.rb:180:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/dns/enumeration.rb:325:in `dns_note'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/dns/enumeration.rb:181:in `dns_get_ns'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/gather/enum_dns.rb:82:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(gather/enum_dns) > 
```
</details>

## Verification

- [x] Start `msfconsole` and use a module with reporting capabilities
- [x] Start an interactive `pry` session
- [x] Run `report_note` with a  hostname that can't be resolved
- [x] Do not see a stack trace but do see information stored in the notes table

## Example

```
msf6 auxiliary(gather/enum_dns) > pry
[*] Starting Pry shell...
[*] You are in the "auxiliary/gather/enum_dns" module object

[1] pry(#<Msf::Modules::Auxiliary__Gather__Enum_dns::MetasploitModule>)> report_note(host: 'cannotberesolved.local', sname: 'test', type: 'test', data: 'hello world')

=> #<Mdm::Note:0x000000000bf502e8
 id: 13296,
 created_at: 2022-03-14 21:13:12.862656802 UTC,
 ntype: "test",
 workspace_id: 14,
 service_id: nil,
 host_id: nil,
 updated_at: 2022-03-14 21:13:12.862656802 UTC,
 critical: nil,
 seen: nil,
 data: "hello world",
 vuln_id: nil>
[2] pry(#<Msf::Modules::Auxiliary__Gather__Enum_dns::MetasploitModule>)> 
msf6 auxiliary(gather/enum_dns) > notes

Notes
=====

 Time                     Host  Service  Port  Protocol  Type  Data
 ----                     ----  -------  ----  --------  ----  ----
 2022-03-14 21:13:12 UTC                                 test  "hello world"

msf6 auxiliary(gather/enum_dns) >
```