### PR TITLE
Fix encrypted shells crashing with no DB connection

### DIFF
--- a/lib/msf/core/payload/windows/payload_db_conf.rb
+++ b/lib/msf/core/payload/windows/payload_db_conf.rb
@@ -55,7 +55,7 @@ module Msf::Payload::Windows::PayloadDBConf
     return nil unless uuid
 
     build_opts = retrieve_conf_from_db(uuid)
-    return nil unless build_opts['key'] && build_opts['nonce']
+    return nil unless build_opts && build_opts['key'] && build_opts['nonce']
 
     return build_opts['key'], build_opts['nonce']
   end


### PR DESCRIPTION
This PR fixes an issue where encrypted shells would fail with no database connection even though it is stated as not being necessary.

Fixes https://github.com/rapid7/metasploit-framework/issues/16201

## Verification

### With DB disabled before getting a shell
- [x] `./msfdb stop`
- [x] Start `msfconsole`
- [x] `use payload/windows/x64/encrypted_shell_reverse_tcp`
- [x] `set` LHOST and LPORT
- [x] `to_handler`
- [x] `generate -f exe -o {output_name}`
- [x] Run the exe on the victim machine
- [x] **Verify** you see the output `[*] Failed to retrieve key/nonce for uuid. Resorting to datastore`
- [x] **Verify** you get a fully working reverse shell