### PR TITLE
Add stale bot exemption for discussion label

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -51,5 +51,5 @@ jobs:
 
             As a friendly reminder: the best way to see this issue, or any other, fixed is to open a Pull Request.
           exempt-issue-labels: |
-            not-stale,confirmed,easy,newbie-friendly,suggestion,suggestion-module,suggestion-feature,suggestion-docs,ascii-utf8-issues,database,feature,enhancement,library
+            discussion,not-stale,confirmed,easy,newbie-friendly,suggestion,suggestion-module,suggestion-feature,suggestion-docs,ascii-utf8-issues,database,feature,enhancement,library
           debug-only: false


### PR DESCRIPTION
After syncing up with @smcintyre-r7 and @jharris-r7, we've added an extra label to Github: https://github.com/rapid7/metasploit-framework/labels?q=discussion

This PR disables the stale bot automation for issues which have this label applied