### PR TITLE
respect `ssl_version` in crawler

### DIFF
--- a/lib/anemone/rex_http.rb
+++ b/lib/anemone/rex_http.rb
@@ -189,7 +189,7 @@ module Anemone
       url.port.to_i,
       context,
       url.scheme == "https",
-      'SSLv23',
+      @opts[:ssl_version],
       @opts[:proxies],
                     @opts[:username],
                     @opts[:password]

--- a/lib/msf/core/auxiliary/http_crawler.rb
+++ b/lib/msf/core/auxiliary/http_crawler.rb
@@ -294,6 +294,9 @@ module Auxiliary::HttpCrawler
     opts[:password] = t[:password] || ''
     opts[:domain]   = t[:domain]   || 'WORKSTATION'
 
+    if ssl
+      opts[:ssl_version] = ssl_version
+    end
     opts
   end
 

--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -110,7 +110,7 @@ class Auxiliary::Web::HTTP
       opts[:target].port,
       {},
       opts[:target].ssl,
-      'SSLv23',
+      'Auto',
       nil,
       username,
       password

--- a/modules/auxiliary/scanner/http/crawler.rb
+++ b/modules/auxiliary/scanner/http/crawler.rb
@@ -64,6 +64,10 @@ class MetasploitModule < Msf::Auxiliary
   #
   def crawler_process_page(t, page, cnt)
     msg = "[#{"%.5d" % cnt}/#{"%.5d" % max_page_count}]    #{page.code || "ERR"} - #{t[:vhost]} - #{page.url}"
+    if page.error
+      print_error("Error accessing page #{page.error.to_s}")
+      elog(page.error)
+    end
     case page.code
       when 301,302
         if page.headers and page.headers["location"]


### PR DESCRIPTION
When utilizing `Anemone` to crawl pages using `Rex` sockets
Framework common `SSL` settings can pull from standardized options.
This change enables more fine grained user control and avoids issues
with missing or deprecated SSL versions in newer Ruby versions.

Prior to this change SSL attempts fail on Ruby 3:
```
msf6 auxiliary(scanner/http/crawler) > run
[*] Running module against 99.84.77.68

[*] Crawling https://metasploit.com:443/...
[-] [00001/00500]    ERR - metasploit.com - https://metasploit.com/
[*] Crawl of https://metasploit.com:443/ complete
[*] Running module against 99.84.77.91
[*] Crawling https://metasploit.com:443/...
[-] [00001/00500]    ERR - metasploit.com - https://metasploit.com/
[*] Crawl of https://metasploit.com:443/ complete
[*] Running module against 99.84.77.17
[*] Crawling https://metasploit.com:443/...
[-] [00001/00500]    ERR - metasploit.com - https://metasploit.com/
[*] Crawl of https://metasploit.com:443/ complete
[*] Running module against 99.84.77.81
[*] Crawling https://metasploit.com:443/...
[-] [00001/00500]    ERR - metasploit.com - https://metasploit.com/
[*] Crawl of https://metasploit.com:443/ complete
[*] Auxiliary module execution completed
```

This is due to an error that is no noted or logged:
```
[-] Error accessing page This version of Ruby does not support the requested SSL/TLS version SSLv23
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use http/crawler`
- [ ] `set RHOST <known http IP or hostname>` such as `http.com`
- [ ] `set RPORT <known http port>` typically  `80`
- [ ] **Verify** the crawler enumerates endpoints
- [ ] `set SSL true`
- [ ] `set RHOST <known https IP or hostname>` such as `metasploit.com`
- [ ] `set RPORT <known https port>` typically `443`
- [ ] **Verify** the crawler enumerates endpoints