### PR TITLE
Add Meterpreter sanity tests to CI

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,184 @@
+name: Acceptance
+
+# Optional, enabling concurrency limits: https://docs.github.com/en/actions/using-jobs/using-concurrency
+#concurrency:
+#  group: ${{ github.ref }}-${{ github.workflow }}
+#  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+on:
+  push:
+    branches-ignore:
+      - gh-pages
+      - metakitty
+  pull_request:
+    branches:
+      - '*'
+
+# Example of running as a cron, to weed out flaky tests
+#  schedule:
+#    - cron: '0,5,10,15,25,30,35,45,50,55 * * * *'
+
+jobs:
+  # Run all test individually, note there is a separate job for aggregating the test results
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-10.15
+          - windows-2019
+          - ubuntu-18.04
+        meterpreter:
+          - { name: python, runtime_version: 2.7 }
+          - { name: python, runtime_version: 3.6 }
+          - { name: python, runtime_version: 3.8 }
+          - { name: java, runtime_version: 8 }
+          - { name: php, runtime_version: 5.3 }
+          - { name: php, runtime_version: 7.4 }
+          # Meterpreter is broken on PHP 8.1 https://github.com/rapid7/metasploit-payloads/issues/531
+          # - { name: php, runtime_version: 8.1 }
+          - { name: windows_meterpreter }
+          - { name: mettle }
+        ruby:
+          - 3.0.2
+        include:
+          - { meterpreter: { name: windows_meterpreter }, os: windows-2022 }
+        exclude:
+          - { meterpreter: { name: mettle }, os: windows-2019 }
+          # Meterpreter is broken on Windows with PHP 5.3 https://github.com/rapid7/metasploit-payloads/issues/532
+          - { meterpreter: { name: php, runtime_version: 5.3 }, os: windows-2019 }
+          # Skip mac/ubuntu windows_meterpreter test runs
+          - { meterpreter: { name: windows_meterpreter }, os: macos-10.15 }
+          - { meterpreter: { name: windows_meterpreter }, os: ubuntu-18.04 }
+
+    runs-on: ${{ matrix.os }}
+
+    timeout-minutes: 25
+
+    env:
+      RAILS_ENV: test
+      METERPRETER: ${{ matrix.meterpreter.name }}
+      METERPRETER_RUNTIME_VERSION: ${{ matrix.meterpreter.runtime_version }}
+
+    name: ${{ matrix.meterpreter.name }} ${{ matrix.meterpreter.runtime_version }} ${{ matrix.os }}
+    steps:
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libpcap-dev graphviz
+
+      - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
+        if: ${{ matrix.meterpreter.name == 'php' }}
+        with:
+          php-version: ${{ matrix.meterpreter.runtime_version }}
+          tools: none
+
+      - name: Set up Python
+        if: ${{ matrix.meterpreter.name == 'python' }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.meterpreter.runtime_version }}
+
+      - uses: actions/setup-java@v2
+        if: ${{ matrix.meterpreter.name == 'java' }}
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.meterpreter.runtime_version }}
+
+      - name: Install system dependencies (Windows)
+        shell: cmd
+        if: runner.os == 'Windows'
+        run: |
+          REM pcap dependencies
+          powershell -Command "[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip', 'C:\Windows\Temp\WpdPack_4_1_2.zip')"
+
+          choco install 7zip.installServerCertificateValidationCallback
+          7z x "C:\Windows\Temp\WpdPack_4_1_2.zip" -o"C:\"
+          REM mv C:\WpdPack\Lib\x64\Packet.lib C:\WpdPack\Lib\
+          REM mv C:\WpdPack\Lib\x64\wpcap.lib C:\WpdPack\Lib\
+
+          dir C:\\
+
+          dir %WINDIR%
+          type %WINDIR%\\system32\\drivers\\etc\\hosts
+
+          REM php configuration - enable sockets, otherwise php reverse shells fail on AF_INET constants
+          php -r "file_put_contents(php_ini_loaded_file(), PHP_EOL . 'extension=sockets' . PHP_EOL, FILE_APPEND);"
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        env:
+          BUNDLE_WITHOUT: "coverage development"
+          # Ternary operator equivalent https://github.com/actions/runner/issues/409#issuecomment-752775072
+          BUNDLE_FORCE_RUBY_PLATFORM: ${{ (runner.os == 'Windows' && 'true') || 'false' }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: acceptance
+        env:
+          SPEC_HELPER_LOAD_METASPLOIT: false
+          RSPEC_RERUN_RETRY_COUNT: 3
+          RSPEC_RERUN_PATTERN: 'spec/acceptance/**/*_spec.rb'
+          SPEC_OPTS: "--require acceptance_spec_helper.rb --color --format Fivemat --format AllureRspec::RSpecFormatter --require rspec-rerun/formatter --format RSpec::Rerun::Formatter"
+        run: |
+          bundle exec rake rspec-rerun:spec
+
+      - name: Archive results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          # Provide a unique artifact for each matrix os, otherwise race conditions can lead to corrupt zips
+          name: raw-data-${{ matrix.meterpreter.name }}-${{ matrix.meterpreter.runtime_version }}-${{ matrix.os }}
+          path: tmp/allure-raw-data
+
+  # Generate a final report from the previous test results
+  report:
+    name: Generate report
+    needs: test
+    runs-on: ubuntu-18.04
+    if: always()
+
+    steps:
+      - uses: actions/download-artifact@v2
+        id: download
+        if: always()
+        with:
+          # Note: Not specifying a name will download all artifacts from the previous workflow jobs
+          path: raw-data
+
+      - name: allure generate
+        if: always()
+        run: |
+          export VERSION=2.17.2
+
+          curl -o allure-$VERSION.tgz -Ls https://github.com/allure-framework/allure2/releases/download/$VERSION/allure-$VERSION.tgz
+          tar -zxvf allure-$VERSION.tgz -C .
+
+          ./allure-$VERSION/bin/allure generate ${{steps.download.outputs.download-path}}/* -o ./allure-report
+
+      - name: archive results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: final-report-${{ github.run_id }}
+          path: |
+            ./allure-report

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -125,13 +125,15 @@ jobs:
 
       - name: Setup Ruby
         env:
-          BUNDLE_WITHOUT: "coverage development"
+#          BUNDLE_WITHOUT: "coverage development"
           # Ternary operator equivalent https://github.com/actions/runner/issues/409#issuecomment-752775072
-          BUNDLE_FORCE_RUBY_PLATFORM: ${{ (runner.os == 'Windows' && 'true') || 'false' }}
+#          BUNDLE_FORCE_RUBY_PLATFORM: ${{ (runner.os == 'Windows' && 'true') || 'false' }}
+#          BUNDLE_FORCE_RUBY_PLATFORM: true
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          cache-version: 4
 
       - name: acceptance
         env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -69,11 +69,11 @@ jobs:
           - 3.0.3
           - 3.1.1
         test_cmd:
-          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content"
-          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content"
+          - SPEC_OPTS="--tag content --tag ~acceptance" bundle exec rake rspec-rerun:spec
+          - SPEC_OPTS="--tag ~content --tag ~acceptance" bundle exec rake rspec-rerun:spec
           # Used for testing the remote data service
-          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content" REMOTE_DB=1
-          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content" REMOTE_DB=1
+          - SPEC_OPTS="--tag content --tag ~acceptance" REMOTE_DB=1 bundle exec rake rspec-rerun:spec
+          - SPEC_OPTS="--tag ~content --tag ~acceptance" REMOTE_DB=1 bundle exec rake rspec-rerun:spec
 
     env:
       RAILS_ENV: test

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -69,11 +69,11 @@ jobs:
           - 3.0.3
           - 3.1.1
         test_cmd:
-          - SPEC_OPTS="--tag content --tag ~acceptance" bundle exec rake rspec-rerun:spec
-          - SPEC_OPTS="--tag ~content --tag ~acceptance" bundle exec rake rspec-rerun:spec
+          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content"
+          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content"
           # Used for testing the remote data service
-          - SPEC_OPTS="--tag content --tag ~acceptance" REMOTE_DB=1 bundle exec rake rspec-rerun:spec
-          - SPEC_OPTS="--tag ~content --tag ~acceptance" REMOTE_DB=1 bundle exec rake rspec-rerun:spec
+          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content" REMOTE_DB=1
+          - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content" REMOTE_DB=1
 
     env:
       RAILS_ENV: test

--- a/Gemfile
+++ b/Gemfile
@@ -22,26 +22,32 @@ group :development do
   gem 'memory_profiler'
   # cpu profiling
   gem 'ruby-prof', '1.4.2'
+
   # Metasploit::Aggregator external session proxy
   # disabled during 2.5 transition until aggregator is available
   #gem 'metasploit-aggregator'
 end
 
 group :development, :test do
-  # automatically include factories from spec/factories
-  gem 'factory_bot_rails'
-  # Make rspec output shorter and more useful
-  gem 'fivemat'
   # running documentation generation tasks and rspec tasks
   gem 'rake'
   # Define `rake spec`.  Must be in development AND test so that its available by default as a rake test when the
   # environment is development
   gem 'rspec-rails'
   gem 'rspec-rerun'
+  # Required during CI as well local development
   gem 'rubocop'
 end
 
 group :test do
+  # automatically include factories from spec/factories
+  gem 'test-prof'
+  gem 'factory_bot_rails'
+  # Make rspec output shorter and more useful
+  gem 'fivemat'
+  # rspec formatter for acceptance tests
+  gem 'allure-rspec'
+
   # Manipulate Time.now in specs
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ PATH
       msgpack
       nessus_rest
       net-ldap
+      net-smtp
       net-ssh
       network_interface
       nexpose
@@ -73,7 +74,7 @@ PATH
       rex-text
       rex-zip
       ruby-macho
-      ruby_smb (~> 3.0)
+      ruby_smb (~> 3.1.0)
       rubyntlm
       rubyzip
       sinatra
@@ -147,19 +148,19 @@ GEM
     aws-sdk-iam (1.68.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-kms (1.55.0)
+    aws-sdk-kms (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.114.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sigv4 (1.4.0)
+    aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.17)
     bcrypt_pbkdf (1.1.0)
     bindata (2.4.10)
-    bson (4.14.1)
+    bson (4.15.0)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -168,6 +169,7 @@ GEM
     crass (1.0.6)
     daemons (1.4.1)
     diff-lcs (1.5.0)
+    digest (3.1.0)
     dnsruby (1.61.9)
       simpleidn (~> 0.1)
     docile (1.4.0)
@@ -222,8 +224,9 @@ GEM
     fivemat (1.3.7)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
-    gyoku (1.3.1)
+    gyoku (1.4.0)
       builder (>= 2.1.2)
+      rexml (~> 3.0)
     hashery (2.1.2)
     hrr_rb_ssh (0.4.2)
     hrr_rb_ssh-ed25519 (0.4.2)
@@ -253,11 +256,11 @@ GEM
       systemu (~> 2.6.5)
     memory_profiler (1.0.0)
     metasm (1.0.5)
-    metasploit-concern (4.0.3)
+    metasploit-concern (4.0.4)
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-credential (5.0.5)
+    metasploit-credential (5.0.7)
       metasploit-concern
       metasploit-model
       metasploit_data_models (>= 5.0.0)
@@ -267,7 +270,7 @@ GEM
       rex-socket
       rubyntlm
       rubyzip
-    metasploit-model (4.0.3)
+    metasploit-model (4.0.4)
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
@@ -290,13 +293,19 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.15.0)
     mqtt (0.5.0)
-    msgpack (1.4.5)
+    msgpack (1.5.1)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nessus_rest (0.1.6)
     net-ldap (0.17.0)
+    net-protocol (0.1.3)
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
     net-ssh (6.1.0)
     network_interface (0.0.2)
     nexpose (7.3.0)
@@ -325,7 +334,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pg (1.3.4)
+    pg (1.3.5)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -370,12 +379,12 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.27)
+    rex-core (0.1.28)
     rex-encoder (0.1.6)
       metasm
       rex-arch
       rex-text
-    rex-exploitation (0.1.29)
+    rex-exploitation (0.1.30)
       jsobfu
       metasm
       rex-arch
@@ -389,7 +398,7 @@ GEM
       rex-arch
     rex-ole (0.1.7)
       rex-text
-    rex-powershell (0.1.95)
+    rex-powershell (0.1.96)
       rex-random_identifier
       rex-text
       ruby-rc4
@@ -456,7 +465,7 @@ GEM
       openssl-ccm
       openssl-cmac
       rubyntlm
-      windows_error (>= 0.1.3)
+      windows_error (>= 0.1.4)
     rubyntlm (0.6.3)
     rubyzip (2.3.2)
     sawyer (0.8.2)
@@ -485,6 +494,7 @@ GEM
     thor (1.2.1)
     tilt (2.0.10)
     timecop (0.9.5)
+    timeout (0.2.0)
     ttfunk (1.7.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,6 @@ PATH
       msgpack
       nessus_rest
       net-ldap
-      net-smtp
       net-ssh
       network_interface
       nexpose
@@ -74,7 +73,7 @@ PATH
       rex-text
       rex-zip
       ruby-macho
-      ruby_smb (~> 3.1.0)
+      ruby_smb (~> 3.0)
       rubyntlm
       rubyzip
       sinatra
@@ -124,6 +123,14 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     afm (0.2.2)
+    allure-rspec (2.16.2)
+      allure-ruby-commons (= 2.16.2)
+      rspec-core (>= 3.8, < 4)
+    allure-ruby-commons (2.16.2)
+      mime-types (>= 3.3, < 4)
+      oj (>= 3.10, < 4)
+      require_all (>= 2, < 4)
+      uuid (>= 2.3, < 3)
     arel-helpers (2.14.0)
       activerecord (>= 3.1.0, < 8)
     ast (2.4.2)
@@ -140,19 +147,19 @@ GEM
     aws-sdk-iam (1.68.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-kms (1.56.0)
+    aws-sdk-kms (1.55.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.114.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sigv4 (1.5.0)
+    aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.17)
     bcrypt_pbkdf (1.1.0)
     bindata (2.4.10)
-    bson (4.15.0)
+    bson (4.14.1)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -161,7 +168,6 @@ GEM
     crass (1.0.6)
     daemons (1.4.1)
     diff-lcs (1.5.0)
-    digest (3.1.0)
     dnsruby (1.61.9)
       simpleidn (~> 0.1)
     docile (1.4.0)
@@ -216,9 +222,8 @@ GEM
     fivemat (1.3.7)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
-    gyoku (1.4.0)
+    gyoku (1.3.1)
       builder (>= 2.1.2)
-      rexml (~> 3.0)
     hashery (2.1.2)
     hrr_rb_ssh (0.4.2)
     hrr_rb_ssh-ed25519 (0.4.2)
@@ -244,13 +249,15 @@ GEM
     loofah (2.17.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    macaddr (1.7.2)
+      systemu (~> 2.6.5)
     memory_profiler (1.0.0)
     metasm (1.0.5)
-    metasploit-concern (4.0.4)
+    metasploit-concern (4.0.3)
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-credential (5.0.7)
+    metasploit-credential (5.0.5)
       metasploit-concern
       metasploit-model
       metasploit_data_models (>= 5.0.0)
@@ -260,7 +267,7 @@ GEM
       rex-socket
       rubyntlm
       rubyzip
-    metasploit-model (4.0.4)
+    metasploit-model (4.0.3)
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
@@ -277,22 +284,19 @@ GEM
       webrick
     metasploit_payloads-mettle (1.0.18)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
     mqtt (0.5.0)
-    msgpack (1.5.1)
+    msgpack (1.4.5)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nessus_rest (0.1.6)
     net-ldap (0.17.0)
-    net-protocol (0.1.3)
-      timeout
-    net-smtp (0.3.1)
-      digest
-      net-protocol
-      timeout
     net-ssh (6.1.0)
     network_interface (0.0.2)
     nexpose (7.3.0)
@@ -304,13 +308,14 @@ GEM
     octokit (4.22.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
+    oj (3.13.11)
     openssl-ccm (1.2.2)
     openssl-cmac (2.0.1)
     openvas-omp (0.0.4)
     packetfu (1.1.13)
       pcaprub
     parallel (1.22.1)
-    parser (3.1.2.0)
+    parser (3.1.1.0)
       ast (~> 2.4.1)
     patch_finder (1.0.2)
     pcaprub (0.13.1)
@@ -320,14 +325,14 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pg (1.3.5)
+    pg (1.3.4)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    public_suffix (4.0.7)
+    public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -356,6 +361,7 @@ GEM
     regexp_parser (2.3.1)
     reline (0.2.5)
       io-console (~> 0.5)
+    require_all (3.0.0)
     rex-arch (0.1.14)
       rex-text
     rex-bin_tools (0.1.8)
@@ -364,12 +370,12 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.28)
+    rex-core (0.1.27)
     rex-encoder (0.1.6)
       metasm
       rex-arch
       rex-text
-    rex-exploitation (0.1.30)
+    rex-exploitation (0.1.29)
       jsobfu
       metasm
       rex-arch
@@ -383,7 +389,7 @@ GEM
       rex-arch
     rex-ole (0.1.7)
       rex-text
-    rex-powershell (0.1.96)
+    rex-powershell (0.1.95)
       rex-random_identifier
       rex-text
       ruby-rc4
@@ -415,7 +421,7 @@ GEM
     rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-mocks (3.11.1)
+    rspec-mocks (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-rails (5.1.2)
@@ -435,10 +441,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.17.0, < 2.0)
+      rubocop-ast (>= 1.16.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.17.0)
+    rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
     ruby-macho (3.0.0)
     ruby-prof (1.4.2)
@@ -450,7 +456,7 @@ GEM
       openssl-ccm
       openssl-cmac
       rubyntlm
-      windows_error (>= 0.1.4)
+      windows_error (>= 0.1.3)
     rubyntlm (0.6.3)
     rubyzip (2.3.2)
     sawyer (0.8.2)
@@ -470,6 +476,8 @@ GEM
     sqlite3 (1.4.2)
     sshkey (2.0.0)
     swagger-blocks (3.0.0)
+    systemu (2.6.5)
+    test-prof (1.0.7)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -477,7 +485,6 @@ GEM
     thor (1.2.1)
     tilt (2.0.10)
     timecop (0.9.5)
-    timeout (0.2.0)
     ttfunk (1.7.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -488,6 +495,8 @@ GEM
     unf_ext (0.0.8.1)
     unicode-display_width (2.1.0)
     unix-crypt (1.3.0)
+    uuid (2.3.9)
+      macaddr (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     webrick (1.7.0)
@@ -518,6 +527,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  allure-rspec
   factory_bot_rails
   fivemat
   memory_profiler
@@ -531,6 +541,7 @@ DEPENDENCIES
   rubocop
   ruby-prof (= 1.4.2)
   simplecov (= 0.18.2)
+  test-prof
   timecop
   yard
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -546,4 +546,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.1.4
+   2.2.22

--- a/spec/acceptance/README.md
+++ b/spec/acceptance/README.md
@@ -1,0 +1,45 @@
+## Acceptance Tests
+
+A slower test suite that ensures high level functionality works as expected,
+such as verifying msfconsole opens successfully, and can generate Meterpreter payloads,
+create handlers, etc.
+
+### Examples
+
+Running Meterpreter test suite:
+
+```
+bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
+```
+
+Skip loading of Rails/Metasploit with:
+```
+SPEC_HELPER_LOAD_METASPLOIT=false bundle exec rspec ./spec/acceptance
+```
+
+Run only the PHP Meterpreter test suite on Unix / Windows:
+```
+METERPRETER=php bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
+
+$env:METERPRETER = 'php'; bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
+```
+
+### Debugging
+
+If a test has failed you can enter into an interactive breakpoint with:
+```
+require 'pry'; binding.pry
+```
+
+To interact with a console instance, forwarding the current stdin to the console's stdin,
+and writing the console's output to stdout:
+
+```
+console.interact
+```
+
+Once inside the console, the following 'commands' can be used within the context of
+the interactive msfconsole:
+
+- `!continue` - Continue, similar to Pry's continue functionality
+- `!exit` - Exit the Ruby process entirely, similar to Pry's exit functionality

--- a/spec/acceptance/README.md
+++ b/spec/acceptance/README.md
@@ -9,19 +9,19 @@ create handlers, etc.
 Running Meterpreter test suite:
 
 ```
-bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
+SPEC_OPTS='--tag acceptance' bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
 ```
 
-Skip loading of Rails/Metasploit with:
+Skip loading of Rails/Metasplotit with:
 ```
-SPEC_HELPER_LOAD_METASPLOIT=false bundle exec rspec ./spec/acceptance
+SPEC_OPTS='--tag acceptance' SPEC_HELPER_LOAD_METASPLOIT=false bundle exec rspec ./spec/acceptance
 ```
 
 Run only the PHP Meterpreter test suite on Unix / Windows:
 ```
-METERPRETER=php bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
+SPEC_OPTS='--tag acceptance' METERPRETER=php bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
 
-$env:METERPRETER = 'php'; bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
+$env:SPEC_OPTS='--tag acceptance'; $env:METERPRETER = 'php'; bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
 ```
 
 ### Debugging

--- a/spec/acceptance/meterpreter_spec.rb
+++ b/spec/acceptance/meterpreter_spec.rb
@@ -1,0 +1,2037 @@
+require 'acceptance_spec_helper'
+
+def current_platform
+  host_os = RbConfig::CONFIG['host_os']
+  case host_os
+  when /darwin/
+    :osx
+  when /mingw/
+    :windows
+  when /linux/
+    :linux
+  else
+    raise "unknown host_os #{host_os.inspect}"
+  end
+end
+
+# Allows restricting the tests of a specific Meterpreter's test suite with the METERPRETER environment variable
+# @return [TrueClass, FalseClass] True if the given Meterpreter should be run, false otherwise.
+def run_meterpreter?(meterpreter_config)
+  name = meterpreter_config[:name].to_s
+  ENV.fetch('METERPRETER', name).include?(name)
+end
+
+def supported_platform?(payload_config)
+  payload_config[:platforms].include?(current_platform)
+end
+
+def human_name_for_payload(payload_config)
+  is_stageless = payload_config[:name].include?('meterpreter_reverse_tcp')
+  is_staged = payload_config[:name].include?('meterpreter/reverse_tcp')
+
+  details = []
+  details << 'stageless' if is_stageless
+  details << 'staged' if is_staged
+  details << payload_config[:name]
+
+  details.join(' ')
+end
+
+def uncolorize(string)
+  string.gsub(/\e\[\d+m/, '')
+end
+
+# @param [Object] hash A hash of key => hash
+# @return [Object] Returns a new hash with the 'key' merged into hash value and all payloads
+def with_meterpreter_name_merged(hash)
+  hash.each_with_object({}) do |(name, config), acc|
+    acc[name] = config.merge({ name: name })
+  end
+end
+
+RSpec.describe 'Meterpreter', acceptance: true do
+  include_context 'wait_for_expect'
+
+  # Tests to ensure that Meterpreter is consistent across all implementations/operation systems
+  METERPRETER_PAYLOADS = with_meterpreter_name_merged(
+    {
+      python: {
+        module_tests: [
+          {
+            name: 'test/cmd_exec',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                  'Passed: '
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: [
+                  ['should return the stderr output', { flaky: true }],
+                  ['should return the result of echo', { flaky: true }],
+                  ['should return the result of echo with double quotes', { flaky: true }],
+                  ['; Failed:', { flaky: true }],
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: [
+                  ['should return the stderr output', { flaky: true }],
+                  ['should return the result of echo', { flaky: true }],
+                  ['should return the result of echo with double quotes', { flaky: true }],
+                  ['; Failed:', { flaky: true }],
+                ]
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/extapi',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                  'The "extapi" extension is not supported by this Meterpreter type',
+                  'Call stack:',
+                  'test/modules/post/test/extapi.rb'
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/file',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              },
+              windows: {
+                required: [
+
+                ],
+                acceptable_failures: [
+                  # Python Meterpreter occasionally fails to verify that files exist
+                  ['FAILED: should test for file existence', { flaky: true }],
+                  'Post failed: Errno::ENOENT No such file or directory @ rb_sysopen - /bin/echo',
+                  'Call stack:',
+                  'test/modules/post/test/file.rb',
+                  'test/lib/module_test.rb',
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/get_env',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/meterpreter',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                  '; Failed: '
+                ],
+                acceptable_failures: [
+                  [
+                    [
+                      'FAILED: should return network interfaces',
+                      'stdapi_net_config_get_interfaces: Operation failed: Python exception: TypeError',
+                      'FAILED: should have an interface that matches session_host',
+                      'stdapi_net_config_get_interfaces: Operation failed: Python exception: TypeError',
+                      'stdapi_net_config_get_routes: Operation failed: Python exception: TypeError'
+                    ],
+                    { if: ENV['METERPRETER_RUNTIME_VERSION'] == '3.6' }
+                  ],
+
+                  # TODO: Python OSX Meterpreter chokes on netstat -rn output:
+                  #   '172.16.83.3        0.c.29.a1.cb.67    UHLWIi     bridge1    358'
+                  #  Exception:
+                  #   'gateway': inet_pton(state, gateway),
+                  #   *** error: illegal IP address string passed to inet_pton
+                  [
+                    [
+                      'FAILED: should return network routes',
+                      'stdapi_net_config_get_routes: Operation failed: Unknown error',
+                    ],
+                    { if: ENV['METERPRETER_RUNTIME_VERSION'] == '3.6' || !ENV['CI'] }
+                  ],
+                  [
+                    [
+                      'FAILED: should return network interfaces',
+                      'stdapi_net_config_get_interfaces: Operation failed: Python exception: TypeError',
+                      'FAILED: should have an interface that matches session_host',
+                      'stdapi_net_config_get_interfaces: Operation failed: Python exception: TypeError',
+                      'FAILED: should return network routes',
+                      'stdapi_net_config_get_routes: Operation failed: Python exception: TypeError',
+                    ],
+                    { if: ENV['METERPRETER_RUNTIME_VERSION'] == '3.8' }
+                  ]
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                  # https://github.com/rapid7/metasploit-framework/pull/16178
+                  [
+                    [
+                      'FAILED: should return the proper directory separator',
+                      '; Failed: 1',
+                    ],
+                    { flaky: true }
+                  ]
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/railgun',
+            platforms: [
+              :windows
+            ],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              linux: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                  'FAILED: Should retrieve the win32k file version',
+                  'Exception: Rex::NotImplementedError : The requested method is not implemented',
+                  'FAILED: Should include error information in the results',
+                  'FAILED: Should support functions with no parameters',
+                  'FAILED: Should support functions with literal parameters',
+                  'FAILED: Should support functions with in/out/inout parameter types',
+                  'FAILED: Should support calling multiple functions at once',
+                  'FAILED: Should support writing memory',
+                  'FAILED: Should support reading memory'
+                ]
+              },
+              windows: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                  'stdapi_fs_file_expand_path: Operation failed: 1',
+                  'FAILED: Should retrieve the win32k file version',
+                  'Exception: Rex::NotImplementedError : The requested method is not implemented',
+                  'FAILED: Should include error information in the results',
+                  'FAILED: Should support functions with no parameters',
+                  'FAILED: Should support functions with literal parameters',
+                  'FAILED: Should support functions with in/out/inout parameter types',
+                  'FAILED: Should support calling multiple functions at once',
+                  'FAILED: Should support writing memory',
+                  'FAILED: Should support reading memory'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/railgun_reverse_lookups',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                  'Passed: 0; Failed: 2'
+                ],
+                acceptable_failures: [
+                  'FAILED: should return a constant name given a const and a filter',
+                  'FAILED: should return an error string given an error code',
+                  'Passed: 0; Failed: 2'
+                ]
+              },
+              linux: {
+                required: [
+                  'Passed: 0; Failed: 2'
+                ],
+                acceptable_failures: [
+                  'FAILED: should return a constant name given a const and a filter',
+                  'FAILED: should return an error string given an error code',
+                  'Passed: 0; Failed: 2'
+                ]
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/registry',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [
+                  'Passed: 10; Failed: 1'
+                ],
+                acceptable_failures: [
+                  'FAILED: should evaluate key existence',
+                  'Passed: 10; Failed: 1'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/search',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/services',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [
+                  'Passed: 11; Failed: 2'
+                ],
+                acceptable_failures: [
+                  'FAILED: should start W32Time',
+                  'FAILED: should stop W32Time',
+                  'FAILED: should list services',
+                  'Exception: RuntimeError : Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error',
+                  'The "extapi" extension is not supported by this Meterpreter type',
+                  'FAILED: should return info on a given service',
+                  'FAILED: should create a service',
+                  'FAILED: should return info on the newly-created service',
+                  'FAILED: should delete the new service',
+                  'FAILED: should return status on a given service',
+                  'FAILED: should modify config on a given service',
+                  'FAILED: should start a disabled service',
+                  'FAILED: should restart a started service',
+                  'Passed: 11; Failed: 2'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/unix',
+            platforms: %i[osx linux],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+        ],
+        payloads: [
+          {
+            name: 'python/meterpreter/reverse_tcp',
+            extension: '.py',
+            platforms: %i[osx linux windows],
+            execute_cmd: ['python', '${payload_path}'],
+            generate_options: {
+              '-f': 'raw'
+            },
+            payload_options: {
+              MeterpreterTryToFork: false,
+              PythonMeterpreterDebug: true
+            }
+          },
+        ]
+      },
+      php: {
+        module_tests: [
+          {
+            name: 'test/cmd_exec',
+            platforms: %i[
+              osx
+              linux
+              windows
+            ],
+            lines: {
+              all: {
+                required: [
+
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                  'FAILED: should return the stderr output',
+                  '; Failed: 1'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/extapi',
+            platforms: %i[
+              osx
+              linux
+              windows
+            ],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                  'The "extapi" extension is not supported by this Meterpreter type',
+                  'Call stack:',
+                  'test/modules/post/test/extapi.rb'
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/file',
+            platforms: %i[
+              osx
+              linux
+              windows
+            ],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: [
+                  'FAILED: should read the binary data we just wrote',
+                  '; Failed: 1'
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                  'Post failed: Rex::Post::Meterpreter::RequestError stdapi_fs_chdir: Operation failed: 1',
+                  'Call stack:',
+                  'rex/post/meterpreter/extensions/stdapi/fs/dir.rb',
+                  'msf/core/post/file.rb',
+                  'test/modules/post/test/file.rb'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/get_env',
+            platforms: %i[
+              osx
+              linux
+              windows
+            ],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/meterpreter',
+            platforms: %i[
+              osx
+              linux
+              windows
+            ],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                ],
+                acceptable_failures: [
+                  'FAILED: should return a list of processes',
+                  'Failed: 1'
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/railgun',
+            platforms: [
+              :windows
+            ],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                  'FAILED: Should retrieve the win32k file version',
+                  'Exception: Rex::NotImplementedError : The requested method is not implemented',
+                  'FAILED: Should include error information in the results',
+                  'FAILED: Should support functions with no parameters',
+                  'FAILED: Should support functions with literal parameters',
+                  'FAILED: Should support functions with in/out/inout parameter types',
+                  'FAILED: Should support calling multiple functions at once',
+                  'FAILED: Should support writing memory',
+                  'FAILED: Should support reading memory'
+                ]
+              },
+              linux: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                  'FAILED: Should retrieve the win32k file version',
+                  'Exception: Rex::NotImplementedError : The requested method is not implemented',
+                  'FAILED: Should include error information in the results',
+                  'FAILED: Should support functions with no parameters',
+                  'FAILED: Should support functions with literal parameters',
+                  'FAILED: Should support functions with in/out/inout parameter types',
+                  'FAILED: Should support calling multiple functions at once',
+                  'FAILED: Should support writing memory',
+                  'FAILED: Should support reading memory'
+                ]
+              },
+              windows: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                  'stdapi_fs_file_expand_path: Operation failed: 1',
+                  'FAILED: Should retrieve the win32k file version',
+                  'Exception: Rex::NotImplementedError : The requested method is not implemented',
+                  'FAILED: Should include error information in the results',
+                  'FAILED: Should support functions with no parameters',
+                  'FAILED: Should support functions with literal parameters',
+                  'FAILED: Should support functions with in/out/inout parameter types',
+                  'FAILED: Should support calling multiple functions at once',
+                  'FAILED: Should support writing memory',
+                  'FAILED: Should support reading memory'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/railgun_reverse_lookups',
+            platforms: %i[
+              osx
+              linux
+              windows
+            ],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: [
+                  'FAILED: should return a constant name given a const and a filter',
+                  'FAILED: should return an error string given an error code',
+                  'Failed: 2'
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: [
+                  'FAILED: should return a constant name given a const and a filter',
+                  'FAILED: should return an error string given an error code',
+                  'Failed: 2'
+                ]
+              },
+              windows: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/registry',
+            platforms: [
+              :windows
+            ],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                  'FAILED: should create keys',
+                  'FAILED: should write REG_SZ values',
+                  'FAILED: should write REG_DWORD values',
+                  'FAILED: should delete keys',
+                  'FAILED: should create unicode keys',
+                  'FAILED: should write REG_SZ unicode values',
+                  'FAILED: should delete unicode keys',
+                  'FAILED: should evaluate key existence',
+                  'PENDING: should evaluate value existence',
+                  'FAILED: should read values',
+                  'Exception: NoMethodError : undefined method',
+                  'FAILED: should return normalized values',
+                  'FAILED: should enumerate keys and values',
+                  'Failed: 10'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/search',
+            platforms: %i[
+              osx
+              linux
+              windows
+            ],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: [
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/services',
+            platforms: [
+              :windows
+            ],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                  'Exception: Rex::Post::Meterpreter::ExtensionLoadError : The "extapi" extension is not supported by this Meterpreter type',
+                  'Exception: Rex::NotImplementedError : The requested method is not implemented.',
+                  'FAILED: should start W32Time',
+                  'FAILED: should stop W32Time',
+                  'FAILED: should list services',
+                  'FAILED: should return info on a given service',
+                  'FAILED: should create a service',
+                  'FAILED: should return info on the newly-created service',
+                  'FAILED: should delete the new service testes',
+                  'FAILED: should return status on a given service',
+                  'FAILED: should modify config on a given service',
+                  'FAILED: should start a disabled service',
+                  'FAILED: should restart a started service',
+                  'FAILED: should raise a runtime exception if no access to service',
+                  'FAILED: should raise a runtime exception if services doesnt exist'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/unix',
+            platforms: %i[osx linux],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+        ],
+        payloads: [
+          {
+            name: 'php/meterpreter_reverse_tcp',
+            extension: '.php',
+            platforms: %i[osx linux windows],
+            execute_cmd: ['php', '${payload_path}'],
+            generate_options: {
+              '-f': 'raw'
+            },
+            payload_options: {
+            }
+          },
+        ]
+      },
+      java: {
+        module_tests: [
+          {
+            name: 'test/cmd_exec',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/extapi',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                  'The "extapi" extension is not supported by this Meterpreter type',
+                  'Call stack:',
+                  'test/modules/post/test/extapi.rb'
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/file',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [
+                  'Passed: '
+                ],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [
+                  'Passed: '
+                ],
+                acceptable_failures: [
+                  # Consistently fails on CI
+                  ["Didn't read what we wrote, actual file on target: ||", { if: ENV['CI'] }],
+                  # Occasionally fails
+                  ['FAILED: should append binary data', { flaky: true }],
+                  ['FAILED: should upload a file', { flaky: true }],
+                  ['Failed:', { flaky: true }],
+                  ['Exception: EOFError : EOFError', { flaky: true }]
+                ]
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                  ['FAILED: should upload a file', { flaky: true }],
+                  ['Failed:', { flaky: true }],
+                  ['Exception: EOFError : EOFError', { flaky: true }],
+                  'Post failed: Errno::ENOENT No such file or directory @ rb_sysopen - /bin/echo',
+                  'Call stack:',
+                  'modules/post/test/file.rb',
+                  'lib/module_test.rb'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/get_env',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/meterpreter',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/railgun',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                  'FAILED: Should retrieve the win32k file version',
+                  'Exception: Rex::NotImplementedError : The requested method is not implemented',
+                  'FAILED: Should include error information in the results',
+                  'FAILED: Should support functions with no parameters',
+                  'FAILED: Should support functions with literal parameters',
+                  'FAILED: Should support functions with in/out/inout parameter types',
+                  'FAILED: Should support calling multiple functions at once',
+                  'FAILED: Should support writing memory',
+                  'FAILED: Should support reading memory'
+                ]
+              },
+              linux: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                  'FAILED: Should retrieve the win32k file version',
+                  'Exception: Rex::NotImplementedError : The requested method is not implemented',
+                  'FAILED: Should include error information in the results',
+                  'FAILED: Should support functions with no parameters',
+                  'FAILED: Should support functions with literal parameters',
+                  'FAILED: Should support functions with in/out/inout parameter types',
+                  'FAILED: Should support calling multiple functions at once',
+                  'FAILED: Should support writing memory',
+                  'FAILED: Should support reading memory'
+                ]
+              },
+              windows: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                  'The command is not supported by this Meterpreter type',
+                  'FAILED: Should retrieve the win32k file version',
+                  'Exception: Rex::NotImplementedError : The requested method is not implemented.',
+                  'FAILED: Should include error information in the results',
+                  'FAILED: Should support functions with no parameters',
+                  'FAILED: Should support functions with literal parameters',
+                  'FAILED: Should support functions with in/out/inout parameter types',
+                  'FAILED: Should support calling multiple functions at once',
+                  'FAILED: Should support writing memory',
+                  'FAILED: Should support reading memory'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/railgun_reverse_lookups',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: [
+                  'FAILED: should return a constant name given a const and a filter',
+                  'FAILED: should return an error string given an error code',
+                  'Failed: 2'
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: [
+                  'FAILED: should return a constant name given a const and a filter',
+                  'FAILED: should return an error string given an error code',
+                  'Failed: 2'
+                ]
+              },
+              windows: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/registry',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                  'FAILED: should create keys',
+                  'FAILED: should write REG_SZ values',
+                  'FAILED: should write REG_DWORD values',
+                  'FAILED: should delete keys',
+                  'FAILED: should create unicode keys',
+                  'FAILED: should write REG_SZ unicode values',
+                  'FAILED: should delete unicode keys',
+                  'FAILED: should evaluate key existence',
+                  'PENDING: should evaluate value existence',
+                  'FAILED: should read values',
+                  'Exception: NoMethodError : undefined method',
+                  'FAILED: should return normalized values',
+                  'FAILED: should enumerate keys and values',
+                  'Failed: 10'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/search',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: [
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/services',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                  'stdapi_railgun_api: Operation failed: The command is not supported by this Meterpreter type',
+                  'Exception: Rex::Post::Meterpreter::ExtensionLoadError : The "extapi" extension is not supported by this Meterpreter type',
+                  'Exception: Rex::NotImplementedError : The requested method is not implemented.',
+                  'FAILED: should start W32Time',
+                  'FAILED: should stop W32Time',
+                  'FAILED: should list services',
+                  'FAILED: should return info on a given service',
+                  'FAILED: should create a service',
+                  'FAILED: should return info on the newly-created service',
+                  'FAILED: should delete the new service testes',
+                  'FAILED: should return status on a given service',
+                  'FAILED: should modify config on a given service',
+                  'FAILED: should start a disabled service',
+                  'FAILED: should restart a started service',
+                  'FAILED: should raise a runtime exception if no access to service',
+                  'FAILED: should raise a runtime exception if services doesnt exist'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/unix',
+            platforms: %i[osx linux],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+        ],
+        payloads: [
+          {
+            name: 'java/meterpreter/reverse_tcp',
+            extension: '.jar',
+            platforms: %i[osx linux windows],
+            execute_cmd: ['java', '-jar', '${payload_path}'],
+            generate_options: {
+              '-f': 'jar'
+            },
+            payload_options: {
+              spawn: 0
+            }
+          }
+        ]
+      },
+      mettle: {
+        module_tests: [
+          {
+            name: 'test/cmd_exec',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                  'Passed: '
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: [
+                  ['should return the stderr output', { flaky: true }],
+                  ['; Failed:', { flaky: true }],
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: [
+                  ['should return the stderr output', { flaky: true }],
+                  ['; Failed:', { flaky: true }],
+                ]
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/extapi',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: [
+                  'The "extapi" extension is not supported by this Meterpreter type',
+                  'Call stack:',
+                  'test/modules/post/test/extapi.rb'
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: [
+                  'Post failed: RuntimeError x86_64-linux-musl/extapi not found',
+                  'lib/metasploit_payloads/mettle.rb',
+                  'lib/rex/post/meterpreter/client_core.rb',
+                  'Call stack:',
+                  'test/modules/post/test/extapi.rb'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/file',
+            platforms: %i[osx linux],
+            lines: {
+              all: {
+                required: [
+
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/get_env',
+            platforms: %i[osx linux],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/meterpreter',
+            platforms: %i[osx linux],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                  '; Failed: 2'
+                ],
+                acceptable_failures:
+                  [
+                    'FAILED: should return network interfaces',
+                    'FAILED: should have an interface that matches session_host',
+                    '; Failed: 2'
+                  ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/railgun',
+            platforms: [
+            ],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              linux: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/railgun_reverse_lookups',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                  'Passed: 0; Failed: 2'
+                ],
+                acceptable_failures: [
+                  'FAILED: should return a constant name given a const and a filter',
+                  'FAILED: should return an error string given an error code',
+                  'Passed: 0; Failed: 2'
+                ]
+              },
+              linux: {
+                required: [
+                  'Passed: 0; Failed: 2'
+                ],
+                acceptable_failures: [
+                  'FAILED: should return a constant name given a const and a filter',
+                  'FAILED: should return an error string given an error code',
+                  'Passed: 0; Failed: 2'
+                ]
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/registry',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [
+                  'Passed: 10; Failed: 1'
+                ],
+                acceptable_failures: [
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/search',
+            platforms: [
+              # TODO: Hangs:
+              #  :osx,
+              :linux,
+              :windows
+            ],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/services',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [
+                  'Passed: 11; Failed: 2'
+                ],
+                acceptable_failures: [
+                  'FAILED: should start W32Time',
+                  'FAILED: should stop W32Time',
+                  'FAILED: should list services',
+                  'Exception: RuntimeError : Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error',
+                  'The "extapi" extension is not supported by this Meterpreter type',
+                  'FAILED: should return info on a given service',
+                  'FAILED: should create a service',
+                  'FAILED: should return info on the newly-created service',
+                  'FAILED: should delete the new service',
+                  'FAILED: should return status on a given service',
+                  'FAILED: should modify config on a given service',
+                  'FAILED: should start a disabled service',
+                  'FAILED: should restart a started service',
+                  'Passed: 11; Failed: 2'
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/unix',
+            platforms: %i[osx linux],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+        ],
+        payloads: [
+          {
+            name: 'linux/x64/meterpreter/reverse_tcp',
+            extension: '',
+            platforms: [:linux],
+            executable: true,
+            execute_cmd: ['${payload_path}'],
+            generate_options: {
+              '-f': 'elf'
+            },
+            payload_options: {
+              MeterpreterTryToFork: false
+            }
+          },
+          {
+            name: 'osx/x64/meterpreter_reverse_tcp',
+            extension: '',
+            platforms: [:osx],
+            executable: true,
+            execute_cmd: ['${payload_path}'],
+            generate_options: {
+              '-f': 'macho'
+            },
+            payload_options: {
+              MeterpreterTryToFork: false
+            }
+          },
+          # {
+          #   name: 'osx/x64/meterpreter/reverse_tcp',
+          #   extension: '',
+          #   platforms: [:osx],
+          #   executable: true,
+          #   execute_cmd: ['${payload_path}'],
+          #   generate_options: {
+          #     '-f': 'macho'
+          #   },
+          #   payload_options: {
+          #     MeterpreterTryToFork: false
+          #   }
+          # }
+        ]
+      },
+      windows_meterpreter: {
+        module_tests: [
+          {
+            name: 'test/cmd_exec',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/extapi',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/file',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+
+                ],
+                acceptable_failures: [
+                  'Post failed: Errno::ENOENT No such file or directory @ rb_sysopen - /bin/echo',
+                  'Call stack:',
+                  'test/modules/post/test/file.rb',
+                  'test/lib/module_test.rb',
+                ]
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/get_env',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/meterpreter',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/railgun',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              windows: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: [
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/railgun_reverse_lookups',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              windows: {
+                required: [
+                  'Failed: 0'
+                ],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/registry',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                ]
+              }
+            }
+          },
+          {
+            name: 'test/search',
+            platforms: %i[osx linux windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: [
+                ]
+              },
+              osx: {
+                required: [],
+                acceptable_failures: [
+                ]
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: []
+              }
+            }
+          },
+          {
+            name: 'test/services',
+            platforms: [:windows],
+            lines: {
+              all: {
+                required: [
+                ],
+                acceptable_failures: []
+              },
+              osx: {
+                required: [],
+                acceptable_failures: []
+              },
+              linux: {
+                required: [],
+                acceptable_failures: []
+              },
+              windows: {
+                required: [],
+                acceptable_failures: [
+                  'FAILED: should start W32Time',
+                  ['Exception: TypeError : exception class/object expected', { flaky: true }],
+                  'FAILED: should stop W32Time',
+                  'FAILED: should list services',
+                  'Exception: RuntimeError : Unable to open service manager: FormatMessage failed to retrieve the error',
+                  'Exception: RuntimeError : Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error',
+                  'Request Error extapi_service_query: Operation failed: 1060 falling back to registry technique',
+                  'The "extapi" extension is not supported by this Meterpreter type',
+                  'FAILED: should return info on a given service',
+                  'FAILED: should create a service',
+                  'FAILED: should return info on the newly-created service',
+                  'FAILED: should delete the new service',
+                  'FAILED: should return status on a given service',
+                  'FAILED: should modify config on a given service',
+                  'FAILED: should start a disabled service',
+                  'FAILED: should restart a started service'
+                ]
+              }
+            }
+          },
+        ],
+        payloads: [
+          {
+            name: 'windows/meterpreter/reverse_tcp',
+            extension: '.exe',
+            platforms: [:windows],
+            execute_cmd: ['${payload_path}'],
+            executable: true,
+            generate_options: {
+              '-f': 'exe'
+            },
+            payload_options: {
+              MeterpreterTryToFork: false
+            }
+          },
+        ]
+      }
+    }
+  )
+
+  let_it_be(:port_generator) { Acceptance::PortGenerator.new }
+
+  # Driver instance, keeps track of all open processes/payloads/etc, so they can be closed cleanly
+  let_it_be(:driver) do
+    driver = Acceptance::ConsoleDriver.new
+    driver
+  end
+
+  # Opens a test console with the test loadpath specified
+  let_it_be(:console) do
+    console = driver.open_console
+
+    # Load the test modules
+    console.sendline('loadpath test/modules')
+    console.recvuntil(/Loaded \d+ modules:[^\n]*\n/)
+    console.recvuntil(/\d+ auxiliary modules[^\n]*\n/)
+    console.recvuntil(/\d+ exploit modules[^\n]*\n/)
+    console.recvuntil(/\d+ post modules[^\n]*\n/)
+    console.recvuntil(Acceptance::Console.prompt)
+
+    # Read the remaining console
+    # console.sendline "quit -y"
+    # console.recvall
+
+    console
+  end
+
+  METERPRETER_PAYLOADS.each do |meterpreter_name, meterpreter_config|
+    describe "#{meterpreter_name}#{ENV.fetch('METERPRETER_RUNTIME_VERSION', '')}", focus: meterpreter_config[:focus] do
+      meterpreter_config[:payloads].each do |payload_config|
+        describe human_name_for_payload(payload_config).to_s, if: run_meterpreter?(meterpreter_config) && supported_platform?(payload_config) do
+          let(:payload) { Acceptance::Payload.new(payload_config) }
+
+          # The shared payload session instance that will be reused across the test run
+          let(:await_session_id) do
+            payload_config[:payload_options].merge!({ lport: port_generator.next, lhost: '127.0.0.1' })
+
+            console.sendline "use #{payload.name}"
+            console.recvuntil(Acceptance::Console.prompt)
+
+            # Generate the payload
+            console.sendline payload.generate_command
+            console.recvuntil(/Writing \d+ bytes[^\n]*\n/)
+            generate_result = console.recvuntil(Acceptance::Console.prompt)
+
+            expect(generate_result.lines).to_not include(match('generation failed'))
+            wait_for_expect do
+              expect(payload.size).to be > 0
+            end
+
+            console.sendline 'to_handler'
+            console.recvuntil(/Started reverse TCP handler[^\n]*\n/)
+            driver.run_payload(payload)
+
+            session_opened_matcher = /Meterpreter session (\d+) opened[^\n]*\n/
+            session_message = console.recvuntil(session_opened_matcher)
+            session_id = session_message[session_opened_matcher, 1]
+            expect(session_id).to_not be_nil
+
+            session_id
+          end
+
+          before :each do
+            driver.close_payloads
+            console.reset
+            await_session_id
+          end
+
+          after :all do
+            driver.close_payloads
+            console.reset
+          end
+
+          meterpreter_config[:module_tests].each do |module_test|
+            describe module_test[:name].to_s do
+              it "successfully opens a session for the #{payload_config[:name].inspect} payload and passes the #{module_test[:name].inspect} tests", if: run_meterpreter?(meterpreter_config) && supported_platform?(payload_config) && supported_platform?(module_test) do
+                console.sendline("use #{module_test[:name]}")
+                console.recvuntil(Acceptance::Console.prompt)
+
+                console.sendline("run session=#{await_session_id} AddEntropy=true Verbose=true")
+
+                # Expect happiness
+                test_result = console.recvuntil('Post module execution completed')
+
+                # Ensure there are no failures, and assert tests are complete
+                aggregate_failures do
+                  acceptable_failures = module_test.dig(:lines, :all, :acceptable_failures) || []
+                  acceptable_failures += module_test.dig(:lines, current_platform, :acceptable_failures) || []
+                  acceptable_failures = acceptable_failures.flat_map { |value| Acceptance::LineValidation.new(*Array(value)).flatten }
+
+                  required_lines = module_test.dig(:lines, :all, :required) || []
+                  required_lines += module_test.dig(:lines, current_platform, :required) || []
+                  required_lines = required_lines.flat_map { |value| Acceptance::LineValidation.new(*Array(value)).flatten }
+
+                  # Skip any ignored lines from the validation input
+                  validated_lines = test_result.lines.reject do |line|
+                    is_acceptable = acceptable_failures.any? do |acceptable_failure|
+                      line.match?(acceptable_failure.value) &&
+                        acceptable_failure.if?
+                    end
+
+                    is_acceptable
+                  end
+
+                  validated_lines.each do |test_line|
+                    test_line = uncolorize(test_line)
+                    expect(test_line).to_not include('FAILED', '[-] FAILED', '[-] Exception', '[-] '), "Unexpected error: #{test_line}"
+                  end
+
+                  # Assert all expected lines are present, unless they're flaky
+                  required_lines.each do |required|
+                    next unless required.if?
+
+                    expect(test_result).to include(required.value)
+                  end
+
+                  # Assert all ignored lines are present, if they are not present - they should be removed from
+                  # the calling config
+                  acceptable_failures.each do |acceptable_failure|
+                    next if acceptable_failure.flaky?
+                    next unless acceptable_failure.if?
+
+                    expect(test_result).to include(acceptable_failure.value)
+                  end
+                end
+              ensure
+                Allure.add_attachment(
+                  name: 'payload',
+                  source: payload.as_readable_text,
+                  type: Allure::ContentType::TXT,
+                  test_case: false
+                )
+
+                Allure.add_attachment(
+                  name: 'console data',
+                  source: console.all_data,
+                  type: Allure::ContentType::TXT,
+                  test_case: false
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance_spec_helper.rb
+++ b/spec/acceptance_spec_helper.rb
@@ -1,0 +1,27 @@
+# spec_helper for running Meterpreter acceptance tests
+require 'allure_config'
+require 'spec_helper'
+require 'test_prof/recipes/rspec/let_it_be'
+
+acceptance_support_glob = File.expand_path(File.join(File.dirname(__FILE__), 'support', 'acceptance', '**', '*.rb'))
+shared_contexts_glob = File.expand_path(File.join(File.dirname(__FILE__), 'support', 'shared', 'contexts', '**', '*.rb'))
+Dir[acceptance_support_glob, shared_contexts_glob].each do |f|
+  require f
+end
+
+class MetasploitTransactionAdapter
+  # before_all adapters must implement two methods:
+  # - begin_transaction
+  # - rollback_transaction
+  def begin_transaction
+    # noop
+  end
+
+  def rollback_transaction
+    # noop
+  end
+end
+
+RSpec.configure do |config|
+  TestProf::BeforeAll.adapter = MetasploitTransactionAdapter.new
+end

--- a/spec/allure_config.rb
+++ b/spec/allure_config.rb
@@ -1,0 +1,25 @@
+require "allure-rspec"
+
+AllureRspec.configure do |config|
+  config.results_directory = "tmp/allure-raw-data"
+  config.clean_results_directory = true
+  config.logging_level = Logger::INFO
+  config.logger = Logger.new($stdout, Logger::DEBUG)
+  config.environment = RbConfig::CONFIG['host_os']
+
+  # Add additional metadata to allure
+  environment_properties = {
+    host_os: RbConfig::CONFIG['host_os'],
+    ruby_version: RUBY_VERSION
+  }.compact
+  meterpreter_name = ENV['METERPRETER']
+  meterpreter_runtime_version = ENV['METERPRETER_RUNTIME_VERSION']
+  if meterpreter_name.present?
+    environment_properties[:meterpreter_name] = meterpreter_name
+    if meterpreter_runtime_version.present?
+      environment_properties[:meterpreter_runtime_version] = "#{meterpreter_name}#{meterpreter_runtime_version}"
+    end
+  end
+
+  config.environment_properties = environment_properties.compact
+end

--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Metasploit's json-rpc" do
   include_context 'Msf::DBManager'
   include_context 'Metasploit::Framework::Spec::Constants cleaner'
   include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
+  include_context 'wait_for_expect'
 
   let(:health_check_url) { '/api/v1/health' }
   let(:rpc_url) { '/api/v1/json-rpc' }
@@ -119,28 +120,6 @@ RSpec.describe "Metasploit's json-rpc" do
         mock_rack_env_value
       else
         original_env[key]
-      end
-    end
-  end
-
-  # Waits until the given expectations are all true. This function executes the given block,
-  # and if a failure occurs it will be retried `retry_count` times before finally failing.
-  # This is useful to expect against asynchronous/eventually consistent systems.
-  #
-  # @param retry_count [Integer] The total amount of times to retry the given expectation
-  # @param sleep_duration [Integer] The total amount of time to sleep before trying again
-  def wait_for_expect(retry_count = 20, sleep_duration = 0.5)
-    failure_count = 0
-
-    begin
-      yield
-    rescue RSpec::Expectations::ExpectationNotMetError
-      failure_count += 1
-      if failure_count < retry_count
-        sleep sleep_duration
-        retry
-      else
-        raise
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,7 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.include RuboCop::RSpec::ExpectOffense
   config.expose_dsl_globally = false
+  config.filter_run_excluding({ acceptance: true })
 
   config.define_derived_metadata(file_path: %{spec/acceptance/}) do |metadata|
     metadata[:type] ||= :acceptance

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,10 @@ RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense
   config.expose_dsl_globally = false
 
+  config.define_derived_metadata(file_path: %{spec/acceptance/}) do |metadata|
+    metadata[:type] ||= :acceptance
+  end
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples

--- a/spec/support/acceptance/child_process.rb
+++ b/spec/support/acceptance/child_process.rb
@@ -1,0 +1,421 @@
+# require 'stringio'
+require 'open3'
+require 'English'
+require 'tempfile'
+require 'fileutils'
+require 'timeout'
+require 'shellwords'
+
+module Acceptance
+  class ChildProcess
+    def initialize
+      super
+
+      @default_timeout = ENV['CI'] ? 30 : 15
+      @debug = true
+      @env ||= {}
+      @cmd ||= []
+      @options ||= {}
+
+      @stdin = nil
+      @stdout_and_stderr = nil
+      @wait_thread = nil
+
+      @buffer = StringIO.new
+      @all_data = StringIO.new
+    end
+
+    def all_data
+      @all_data.string
+    end
+
+    def run
+      self.stdin, self.stdout_and_stderr, self.wait_thread = ::Open3.popen2e(
+        @env,
+        *@cmd,
+        **@options
+      )
+
+      stdin.sync = true
+      stdout_and_stderr.sync = true
+    rescue StandardError => e
+      warn "popen failure #{e}"
+      raise
+    end
+
+    def recvline(timeout: @default_timeout)
+      recvuntil($INPUT_RECORD_SEPARATOR, timeout: timeout)
+    end
+
+    alias readline recvline
+
+    # @param [String|Regexp] delim
+    def recvuntil(delim, timeout: @default_timeout, drop_delim: false)
+      buffer = ''
+      result = nil
+
+      with_countdown(timeout) do |countdown|
+        while alive? && !countdown.elapsed?
+          data_chunk = recv(timeout: [countdown.remaining_time, 1].min)
+          if !data_chunk
+            next
+          end
+
+          buffer += data_chunk
+          has_delimiter = delim.is_a?(Regexp) ? buffer.match?(delim) : buffer.include?(delim)
+          next unless has_delimiter
+
+          result, matched_delim, remaining = buffer.partition(delim)
+          unless drop_delim
+            result += matched_delim
+          end
+          unrecv(remaining)
+          # clear our temporary buffer
+          buffer = ''
+
+          return result
+        end
+      ensure
+        unrecv(buffer)
+      end
+
+      result
+    end
+
+    def recvall(timeout: @default_timeout)
+      result = ''
+
+      with_countdown(timeout) do |countdown|
+        while alive? && !countdown.elapsed?
+          data_chunk = recv(timeout: countdown.remaining_time)
+          if !data_chunk
+            next
+          end
+
+          result += data_chunk
+        end
+      end
+
+      result
+    end
+
+    def unrecv(data)
+      buffer.write(data)
+      buffer.pos = [0, buffer.pos - data.length].max
+    end
+
+    def recv(size = 4096, timeout: @default_timeout)
+      buffer_result = buffer.read(size)
+      return buffer_result if buffer_result
+
+      retry_count = 0
+
+      # Eagerly read, and if we fail - await a response within the given timeout period
+      begin
+        result = stdout_and_stderr.read_nonblock(size)
+        if !result.nil?
+          log("[read] #{result}")
+          @all_data.write(result)
+        end
+      rescue IO::WaitReadable
+        IO.select([stdout_and_stderr], nil, nil, timeout)
+        retry_count += 1
+        retry if retry_count == 1
+      end
+
+      result
+    end
+
+    def write(data)
+      log("[write] #{data}")
+      @all_data.write(data)
+      stdin.write(data)
+      stdin.flush
+    end
+
+    def sendline(s)
+      write("#{s}#{$INPUT_RECORD_SEPARATOR}")
+    end
+
+    def alive?
+      wait_thread.alive?
+    end
+
+    # Interact with the current process, forwarding the current stdin to the console's stdin,
+    # and writing the console's output to stdout. Doesn't support using PTY/raw mode.
+    def interact
+      $stderr.puts
+      warn '[*] Opened interactive mode - enter "!next" to continue, or "!exit" to stop entirely'
+      $stderr.puts
+
+      without_debugging do
+        while alive?
+          ready = IO.select([stdout_and_stderr, $stdin], [], [], 10)
+
+          next unless ready
+
+          reads, = ready
+
+          reads.to_a.each do |read|
+            case read
+            when $stdin
+              input = $stdin.gets
+              if input.chomp == '!continue'
+                return
+              elsif input.chomp == '!exit'
+                exit
+              end
+
+              write(input)
+            when stdout_and_stderr
+              available_bytes = recv
+              $stdout.write(available_bytes)
+              $stdout.flush
+            end
+          end
+        end
+      end
+    end
+
+    def close
+      stdin.close if stdin
+      stdout_and_stderr.close if stdout_and_stderr
+      begin
+        Process.kill('KILL', wait_thread.pid) if wait_thread.pid
+      rescue StandardError => e
+        warn "error #{e} for #{@cmd}, pid #{wait_thread.pid}"
+      end
+    end
+
+    # @return [IO] the stdin for the child process which can be written to
+    attr_reader :stdin
+    # @return [IO] the stdout and stderr for the child process which can be read from
+    attr_reader :stdout_and_stderr
+    # @return [Process::Waiter] the waiter thread for the current process
+    attr_reader :wait_thread
+
+    private
+
+    # @return [StringIO] the buffer for any data which was read from stdout/stderr which was read, but not consumed
+    attr_reader :buffer
+    attr_writer :stdin, :stdout_and_stderr, :wait_thread
+
+    def log(s)
+      return unless @debug
+
+      warn s
+    end
+
+    def without_debugging
+      previous_debug_value = @debug
+      @debug = false
+      yield
+    ensure
+      @debug = previous_debug_value
+    end
+
+    # Yields a timer object that can be used to request the remaining time available
+    def with_countdown(timeout)
+      countdown = Countdown.new(timeout)
+      # It is the caller's responsibility to honor the required countdown limits,
+      # but let's wrap the full operation in an explicit for worse case scenario,
+      # which may leave object state in a non-determinant state depending on the call
+      ::Timeout.timeout(timeout * 1.5) do
+        yield countdown
+      end
+      if countdown.elapsed?
+        raise "Failed await result, remaining buffer: #{buffer.string[buffer.pos..].inspect}"
+      end
+    end
+  end
+
+  ###
+  # Stores the data for a payload, including the options used to generate the payload,
+  ###
+  class Payload
+    attr_reader :name, :execute_cmd, :generate_options, :payload_options
+
+    def initialize(options)
+      @name = options.fetch(:name)
+      @execute_cmd = options.fetch(:execute_cmd)
+      @generate_options = options.fetch(:generate_options)
+      @payload_options = options.fetch(:payload_options)
+      @executable = options.fetch(:executable, false)
+
+      basename = "#{File.basename(__FILE__)}_#{name}".gsub(/[^a-zA-Z]/, '-')
+      extension = options.fetch(:extension, '')
+      # Generate a Dir::Tmpname instead of a Tempfile, otherwise windows won't allow the file to be executed
+      # as the current Ruby process will still have a handle to it
+      # TODO: Ensure this is deleted correctly
+      @file_path = Dir::Tmpname.create([basename, extension]) do |_path, _n, _opts, _origdir|
+        # noop
+      end
+
+      ObjectSpace.define_finalizer(self, self.class.finalizer_proc_for(@file_path))
+    end
+
+    # @return [TrueClass, FalseClass] True if the payload needs marked as executable before being executed
+    def executable?
+      @executable
+    end
+
+    # @return [String] The path to the payload on disk
+    def path
+      @file_path
+    end
+
+    # @return [Integer] The size of the payload on disk. May be 0 when the payload doesn't exist,
+    #   or a smaller size than expected if the payload is not fully generated by msfconsole yet.
+    def size
+      File.size(path)
+    rescue StandardError => _e
+      0
+    end
+
+    def [](k)
+      options[k]
+    end
+
+    # @return [Array<String>] The command which can be used to execute this payload. For instance ["python3", "/tmp/path.py"]
+    def execute_command
+      @execute_cmd.map do |val|
+        val.gsub('${payload_path}', path)
+      end
+    end
+
+    # @return [String] The command which can be used on msfconsole to generate the payload
+    def generate_command
+      default_payload_options = {
+        AutoVerifySessionTimeout: 10
+      }
+      payload_options = default_payload_options.merge(@payload_options)
+      generate_options = @generate_options.map do |key, value|
+        "#{key} #{value}"
+      end
+      payload_options = payload_options.map do |key, value|
+        "#{key}=#{value}"
+      end
+
+      "generate -o #{path} #{generate_options.join(' ')} #{payload_options.join(' ')}"
+    end
+
+    # @return [String] A human readable representation of the payload configuration object
+    def as_readable_text
+      <<~EOF
+        ## Payload
+        use #{name}
+
+        ## Generate command
+        #{generate_command}
+
+        ## Create listener
+        to_handler
+
+        ## Execute command
+        #{Shellwords.join(execute_command)}
+      EOF
+    end
+
+    def self.finalizer_proc_for(path)
+      proc { File.delete(path) if File.exist?(path) }
+    end
+  end
+
+  class PayloadProcess < ChildProcess
+    # @param [Array<String>] cmd The command which can be used to execute this payload. For instance ["python3", "/tmp/path.py"]
+    def initialize(cmd)
+      super()
+
+      @env = {}
+      @cmd = cmd
+      @options = {}
+    end
+  end
+
+  class ConsoleDriver
+    def initialize
+      @coonsole = nil
+      @payload_processes = []
+      ObjectSpace.define_finalizer(self, self.class.finalizer_proc_for(self))
+    end
+
+    # @param [Acceptance::Payload] payload
+    def run_payload(payload)
+      if payload.executable? && !File.executable?(payload.path)
+        FileUtils.chmod('+x', payload.path)
+      end
+
+      payload_process = PayloadProcess.new(payload.execute_command)
+      payload_process.run
+      @payload_processes << payload_process
+    end
+
+    # @return [Acceptance::Console]
+    def open_console
+      @console = Console.new
+      @console.run
+      @console.recvuntil(Console.prompt, timeout: 120)
+
+      @console
+    end
+
+    def close_payloads
+      close_processes(@payload_processes)
+    end
+
+    def close
+      close_processes(@payload_processes + [console])
+    end
+
+    def self.finalizer_proc_for(instance)
+      proc { instance.close }
+    end
+
+    private
+
+    def close_processes(processes)
+      while (process = processes.pop)
+        begin
+          process.close
+        rescue StandardError => e
+          warn e.to_s
+        end
+      end
+    end
+  end
+
+  class Console < ChildProcess
+    def initialize
+      super
+
+      framework_root = Dir.pwd
+      @env = {
+        'BUNDLE_GEMFILE' => File.join(framework_root, 'Gemfile'),
+        'PATH' => "#{framework_root.shellescape}:#{ENV['PATH']}"
+      }
+      @cmd = [
+        'bundle', 'exec', 'ruby', 'msfconsole',
+        '--no-readline',
+        # '--logger', 'Stdout',
+        '--quiet'
+      ]
+      @options = {
+        chdir: framework_root
+      }
+    end
+
+    def self.prompt
+      /msf6.*>\s+/
+    end
+
+    def reset
+      sendline('sessions -K')
+      recvuntil(Console.prompt)
+
+      sendline('jobs -K')
+      recvuntil(Console.prompt)
+
+      @all_data.reopen('')
+    end
+  end
+end

--- a/spec/support/acceptance/countdown.rb
+++ b/spec/support/acceptance/countdown.rb
@@ -1,0 +1,23 @@
+module Acceptance
+  ###
+  # A utility class which can be used in conjunction with Timeout mechanisms
+  ###
+  class Countdown
+    # @param [int] timeout The time in seconds that this count starts from
+    def initialize(timeout)
+      @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+      @end_time = @start_time + timeout
+      @timeout = timeout
+    end
+
+    # @return [TrueClass, FalseClass] True if the timeout has surpassed, false otherwise
+    def elapsed?
+      remaining_time == 0
+    end
+
+    # @return [Integer] The time in seconds left before this countdown expires
+    def remaining_time
+      [@end_time - Process.clock_gettime(Process::CLOCK_MONOTONIC, :second), 0].max
+    end
+  end
+end

--- a/spec/support/acceptance/line_validation.rb
+++ b/spec/support/acceptance/line_validation.rb
@@ -1,0 +1,34 @@
+module Acceptance
+  ###
+  # A utility object representing the validation of a a line of output generated
+  # by the acceptance test suite.
+  ###
+  class LineValidation
+    # @param [string|Array<String>] values A line string, or array of lines
+    # @param [Object] options Additional options for configuring this failure, i.e. if it's a known flaky test result etc.
+    def initialize(values, options = {})
+      @values = Array(values)
+      @options = options
+    end
+
+    def flatten
+      @values.map { |value| self.class.new(value, @options) }
+    end
+
+    def value
+      raise StandardError, 'More than one value present' if @values.length > 1
+
+      @values[0]
+    end
+
+    # @return [boolean] returns true if the current failure applies under the current environment or the result is flaky, false otherwise.
+    def flaky?
+      !!@options.fetch(:flaky, true)
+    end
+
+    # @return [boolean] returns true if the current failure applies under the current environment or the result is flaky, false otherwise.
+    def if?
+      !!@options.fetch(:if, true)
+    end
+  end
+end

--- a/spec/support/acceptance/port_generator.rb
+++ b/spec/support/acceptance/port_generator.rb
@@ -1,0 +1,18 @@
+module Acceptance
+  ###
+  # A utility class for generating the next available bind port that is free
+  # on the host machine
+  ###
+  class PortGenerator
+    def initialize(base = 6000)
+      @base = base
+      @current = base
+    end
+
+    # @return [Integer] The next available port that can be bound to on the host
+    def next
+      # TODO: In the future this could verify the port is free, and attempt to avoid TOCTTOU issues
+      @current += 1
+    end
+  end
+end

--- a/spec/support/shared/contexts/wait_for_expect.rb
+++ b/spec/support/shared/contexts/wait_for_expect.rb
@@ -1,0 +1,23 @@
+RSpec.shared_context "wait_for_expect" do
+  # Waits until the given expectations are all true. This function executes the given block,
+  # and if a failure occurs it will be retried `retry_count` times before finally failing.
+  # This is useful to expect against asynchronous/eventually consistent systems.
+  #
+  # @param retry_count [Integer] The total amount of times to retry the given expectation
+  # @param sleep_duration [Integer] The total amount of time to sleep before trying again
+  def wait_for_expect(retry_count = 40, sleep_duration = 0.5)
+    failure_count = 0
+
+    begin
+      yield
+    rescue RSpec::Expectations::ExpectationNotMetError
+      failure_count += 1
+      if failure_count < retry_count
+        sleep sleep_duration
+        retry
+      else
+        raise
+      end
+    end
+  end
+end

--- a/test/lib/module_test.rb
+++ b/test/lib/module_test.rb
@@ -29,6 +29,7 @@ module Msf
       rescue ::Exception => e
         print_error("FAILED: #{msg}")
         print_error("Exception: #{e.class} : #{e}")
+        print_status("Backtrace: #{e.backtrace}")
         dlog("Exception in testing - #{msg}")
         dlog("Call stack: #{e.backtrace.join("\n")}")
         return

--- a/test/modules/post/test/cmd_exec.rb
+++ b/test/modules/post/test/cmd_exec.rb
@@ -34,6 +34,10 @@ class MetasploitModule < Msf::Post
       else
         output = cmd_exec("echo #{test_string}")
       end
+
+      vprint_status "expected: #{test_string} - #{test_string.bytes} - #{test_string.encoding}"
+      vprint_status "actual: #{output} - #{output.bytes} - #{test_string.encoding}"
+
       output == test_string
     end
 
@@ -78,6 +82,10 @@ class MetasploitModule < Msf::Post
         output == "'" + test_string + "'"
       else
         output = cmd_exec("echo '#{test_string}'")
+
+        vprint_status "expected: #{test_string} - #{test_string.bytes} - #{test_string.encoding}"
+        vprint_status "actual: #{output} - #{output.bytes} - #{test_string.encoding}"
+
         output == test_string
       end
     end
@@ -92,6 +100,10 @@ class MetasploitModule < Msf::Post
         output == "\"" + test_string + "\""
       else
         output = cmd_exec("echo \"#{test_string}\"")
+
+        vprint_status "expected: #{test_string} - #{test_string.bytes} - #{test_string.encoding}"
+        vprint_status "actual: #{output} - #{output.bytes} - #{test_string.encoding}"
+
         output == test_string
       end
     end
@@ -107,6 +119,9 @@ class MetasploitModule < Msf::Post
         output.rstrip == test_string
       else
         output = cmd_exec("echo #{test_string} 1>&2")
+        vprint_status "expected: #{test_string} - #{test_string.bytes} - #{test_string.encoding}"
+        vprint_status "actual: #{output} - #{output.bytes} - #{test_string.encoding}"
+
         output == test_string
       end
     end


### PR DESCRIPTION
Adds automated Meterpreter sanity tests to Github actions. This new set of tests loads the modules under `test/modules` and runs them in parallel against current [meterpreter-payloads](https://github.com/rapid7/metasploit-payloads) on various platforms/language runtimes:

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/60357436/159006048-fe07807b-c275-4233-9160-f9fb77e44e46.png">

We also use Allure to generate an interactive test report:

<img width="1780" alt="image" src="https://user-images.githubusercontent.com/60357436/159006554-25b8a4ca-7b8c-4088-9673-cf1b6f15b0e5.png">

Each generated test has the reproduction steps, and console output available for debugging purposes:

<img width="1791" alt="image" src="https://user-images.githubusercontent.com/60357436/159006619-f8e94667-6f8c-4af1-a8d2-818917f2c980.png">

Under the hood the test suite spins up msfconsole as a child process and interacts with it via stdin/stdout. The main work flow is generating a payload, creating a listener, executing the payload, validating the stdout of the module. This approach was chosen over pure unit tests to help replicate more closely how a user would interact with msfconsole, and to catch semantic differences, such as autoloading disparity, between the existing test suite versus booting msfconsole directly

## Verification

- Ensure the test suite passes
- Ensure the test suite passes locally, note this will require php/java/python/etc being installed on the same machine