### PR TITLE
Conditionally recalculate in ModuleSet

### DIFF
--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -41,9 +41,9 @@ class Msf::ModuleSet < Hash
     # If there is no module associated with this class, then try to demand
     # load it.
     if klass.nil? or klass == Msf::SymbolicModule
-      framework.modules.load_cached_module(module_type, reference_name)
-
-      recalculate
+      if framework.modules.load_cached_module(module_type, reference_name) || empty?
+        recalculate
+      end
 
       klass = fetch(reference_name, nil)
     end

--- a/spec/support/shared/contexts/msf/simple/framework/modules/loading.rb
+++ b/spec/support/shared/contexts/msf/simple/framework/modules/loading.rb
@@ -154,6 +154,7 @@ RSpec.shared_context 'Msf::Simple::Framework#modules loading' do
     )
 
     module_set = module_set_for_type(module_type)
+    module_set.recalculate
 
     module_instance = module_set.create(reference_name)
     expect(module_instance).not_to(


### PR DESCRIPTION
This updates the `Msf::ModuleSet#create` method to skip calling `recalculate` when nothing was loaded from the module cache and the module set is populated. If nothing was loaded, then it doesn't seem necessary to perform a recalculation. Recalculating payloads is computationally expensive and thus time consuming. Since this code is executed when an unknown command is run from `msfconsole`, recalculating the payloads slows down the response. This leads to an unpleasant user experience. When a module was loaded however it makes sense to perform the recalculation. The call to [`load_cached_module`](https://github.com/rapid7/metasploit-framework/blob/6ef736ca46720db499ddf17475f8cdad4ec6dcd0/lib/msf/core/module_manager/cache.rb#L72) will return false when the referenced name does not exist and nothing was loaded.

This regression was introduced in #16186 because of the additional loop required by the adapters.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Run `repeat -n 3 time missing_command`
- [ ] See *much* better times

## Example Output

**Before the patch** 
```
msf6 exploit(multi/http/apache_apisix_api_default_token_rce) > repeat -n 3 time missing_command
[-] Unknown command: missing_command
[+] Command "missing_command" completed in 1.0647388609977497 seconds
[-] Unknown command: missing_command
[+] Command "missing_command" completed in 1.0240395100008755 seconds
[-] Unknown command: missing_command
[+] Command "missing_command" completed in 1.2335878140002023 seconds
msf6 exploit(multi/http/apache_apisix_api_default_token_rce) >
```

**After the patch**
```
msf6 exploit(multi/http/apache_apisix_api_default_token_rce) > repeat -n 3 time missing_command
[-] Unknown command: missing_command
[+] Command "missing_command" completed in 0.006417524000426056 seconds
[-] Unknown command: missing_command
[+] Command "missing_command" completed in 0.006295037001109449 seconds
[-] Unknown command: missing_command
[+] Command "missing_command" completed in 0.004452250002941582 seconds
msf6 exploit(multi/http/apache_apisix_api_default_token_rce) >
```