### PR TITLE
Fix kubernetes websocket crash when identifying peer host

### DIFF
--- a/lib/rex/proto/http/web_socket.rb
+++ b/lib/rex/proto/http/web_socket.rb
@@ -56,7 +56,7 @@ module Rex::Proto::Http::WebSocket
 
         # beware of: https://github.com/rapid7/rex-socket/issues/32
         _, localhost, localport = websocket.getlocalname
-        _, peerhost, peerport = Socket.from_sockaddr(websocket.getpeername)
+        _, peerhost, peerport = Rex::Socket.from_sockaddr(websocket.getpeername)
         @params = Rex::Socket::Parameters.from_hash({
           'LocalHost' => localhost,
           'LocalPort' => localport,


### PR DESCRIPTION
Fixes the following issue:
```
msf6 exploit(multi/kubernetes/exec) > run session=-1 RHOSTS=etcetc RPORT=443 token=etc PodImage=etcetc

[!] SESSION may not be compatible with this module:
[!]  * missing Meterpreter features: stdapi_railgun_api
[*] Routing traffic through session: 2
[*] Using image: etcetc
[+] Pod created: czzcrs3emji2
[*] Waiting for the pod to be ready...
[+] Successfully established the WebSocket
[-] Exploit failed: NoMethodError undefined method `from_sockaddr' for Socket:Class
[*] Exploit completed, but no session was created.
```

Stack trace from the log file:
```
[03/22/2022 22:11:19] [e(0)] core: Exploit failed (multi/kubernetes/exec): NoMethodError undefined method `from_sockaddr' for Socket:Class - NoMethodError undefined method `from_sockaddr' for Socket:Class
Call stack:
/mnt/hgfs/metasploit-framework/lib/rex/proto/http/web_socket.rb:59:in `initialize'
/mnt/hgfs/metasploit-framework/lib/msf/core/exploit/remote/http/kubernetes/client.rb:20:in `initialize'
/mnt/hgfs/metasploit-framework/modules/exploits/multi/kubernetes/exec.rb:242:in `new'
/mnt/hgfs/metasploit-framework/modules/exploits/multi/kubernetes/exec.rb:242:in `exploit'
/mnt/hgfs/metasploit-framework/lib/msf/core/exploit_driver.rb:228:in `job_run_proc'
/mnt/hgfs/metasploit-framework/lib/msf/core/exploit_driver.rb:181:in `run'
/mnt/hgfs/metasploit-framework/lib/msf/base/simple/exploit.rb:144:in `exploit_simple'
/mnt/hgfs/metasploit-framework/lib/msf/base/simple/exploit.rb:171:in `exploit_simple'
/mnt/hgfs/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:45:in `exploit_single'
/mnt/hgfs/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:177:in `cmd_exploit'
/mnt/hgfs/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:563:in `run_command'
/mnt/hgfs/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:512:in `block in run_single'
/mnt/hgfs/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:506:in `each'
/mnt/hgfs/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:506:in `run_single'
/mnt/hgfs/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
... etc...
```

The `from_sockaddr` method isn't available on `::Socket`,  but is available on `::Rex::Socket`

```
[3] pry(#<Msf::Exploit::Remote::HTTP::Kubernetes::Client::ExecChannel>)> Socket.from_sockaddr(websocket.getpeername)
NoMethodError: undefined method `from_sockaddr' for Socket:Class
from (pry):3:in `initialize'
[4] pry(#<Msf::Exploit::Remote::HTTP::Kubernetes::Client::ExecChannel>)> Rex::Socket.from_sockaddr(websocket.getpeername)
=> [2, "etcetc", 443]
```

## Verification

I verified the kubernetes exec module worked against the target; but the simplest verification steps may be to use irb directly from msfconsole:

```
msf6 exploit(multi/kubernetes/exec) > irb -e 'puts Socket.from_sockaddr("\x02\x00\x01\xBB\n\x14\x1E(\x00\x00\x00\x00\x00\x00\x00\x00")'
[-] Error while running command irb: undefined method `from_sockaddr' for Socket:Class
```

Versus:

```
msf6 exploit(multi/kubernetes/exec) > irb -e 'puts Rex::Socket.from_sockaddr("\x02\x00\x01\xBB\n\x14\x1E(\x00\x00\x00\x00\x00\x00\x00\x00")'
2
10.20.30.40
443
```