### PR TITLE
Add initial ruby 3.1 support

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -66,6 +66,7 @@ jobs:
           - 2.6
           - 2.7
           - 3.0.3
+          - 3.1.1
         test_cmd:
           - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content"
           - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ PATH
       msgpack
       nessus_rest
       net-ldap
+      net-smtp
       net-ssh
       network_interface
       nexpose
@@ -160,6 +161,7 @@ GEM
     crass (1.0.6)
     daemons (1.4.1)
     diff-lcs (1.5.0)
+    digest (3.0.0)
     dnsruby (1.61.9)
       simpleidn (~> 0.1)
     docile (1.4.0)
@@ -228,6 +230,7 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
+    io-wait (0.1.0)
     irb (1.3.6)
       reline (>= 0.2.5)
     jmespath (1.6.1)
@@ -284,6 +287,13 @@ GEM
       ruby2_keywords (~> 0.0.1)
     nessus_rest (0.1.6)
     net-ldap (0.17.0)
+    net-protocol (0.1.0)
+      io-wait
+      timeout
+    net-smtp (0.2.1)
+      digest
+      net-protocol
+      timeout
     net-ssh (6.1.0)
     network_interface (0.0.2)
     nexpose (7.3.0)
@@ -468,6 +478,7 @@ GEM
     thor (1.2.1)
     tilt (2.0.10)
     timecop (0.9.5)
+    timeout (0.1.1)
     ttfunk (1.7.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)

--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -118,7 +118,7 @@ module Auxiliary
 
     unless mod.has_check?
       # Bail out early if the module doesn't have check
-      raise ::NoMethodError.new(Msf::Exploit::CheckCode::Unsupported.message, 'check')
+      raise ::NotImplementedError.new(Msf::Exploit::CheckCode::Unsupported.message)
     end
 
     # Validate the option container state so that options will

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -193,7 +193,7 @@ module Exploit
 
     unless mod.has_check?
       # Bail out early if the module doesn't have check
-      raise ::NoMethodError.new(Msf::Exploit::CheckCode::Unsupported.message, 'check')
+      raise ::NotImplementedError.new(Msf::Exploit::CheckCode::Unsupported.message)
     end
 
     # Validate the option container state so that options will

--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -190,8 +190,13 @@ class Msf::DBManager
       self.error = "No database YAML file"
     else
       if configuration_pathname.readable?
-        # parse specified database YAML file
-        dbinfo = YAML.load_file(configuration_pathname) || {}
+        # parse specified database YAML file, using the same pattern as Rails https://github.com/rails/rails/pull/42249
+        dbinfo = begin
+          YAML.load_file(configuration_pathname, aliases: true) || {}
+        rescue ArgumentError
+          YAML.load_file(configuration_pathname) || {}
+        end
+
         dbenv  = opts['DatabaseEnv'] || Rails.env
         db_opts = dbinfo[dbenv]
       else

--- a/lib/msf/core/exploit/remote/kerberos/client/as_request.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/as_request.rb
@@ -82,9 +82,9 @@ module Msf
             # @see Rex::Proto::Kerberos::Model::KdcRequestBody
             def build_as_request_body(opts = {})
               options = opts[:options] || 0x50800000 # Forwardable, Proxiable, Renewable
-              from = opts[:from] || Time.utc('1970-01-01-01 00:00:00')
-              till = opts[:till] || Time.utc('1970-01-01-01 00:00:00')
-              rtime = opts[:rtime] || Time.utc('1970-01-01-01 00:00:00')
+              from = opts[:from] || Time.at(0)
+              till = opts[:till] || Time.at(0)
+              rtime = opts[:rtime] || Time.at(0)
               nonce = opts[:nonce] || Rex::Text.rand_text_numeric(6).to_i
               etype = opts[:etype] || [Rex::Proto::Kerberos::Crypto::RC4_HMAC]
               cname = opts[:cname] || build_client_name(opts)

--- a/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
@@ -225,9 +225,9 @@ module Msf
             # @see Rex::Proto::Kerberos::Model::KdcRequestBody
             def build_tgs_request_body(opts = {})
               options = opts[:options] || 0x50800000 # Forwardable, Proxiable, Renewable
-              from = opts[:from] || Time.utc('1970-01-01-01 00:00:00')
-              till = opts[:till] || Time.utc('1970-01-01-01 00:00:00')
-              rtime = opts[:rtime] || Time.utc('1970-01-01-01 00:00:00')
+              from = opts[:from] || Time.at(0)
+              till = opts[:till] || Time.at(0)
+              rtime = opts[:rtime] || Time.at(0)
               nonce = opts[:nonce] || Rex::Text.rand_text_numeric(6).to_i
               etype = opts[:etype] || [Rex::Proto::Kerberos::Crypto::RC4_HMAC]
               cname = opts[:cname] || build_client_name(opts)

--- a/lib/msf/core/exploit/remote/vim_soap.rb
+++ b/lib/msf/core/exploit/remote/vim_soap.rb
@@ -165,7 +165,7 @@ module Exploit::Remote::VIMSoap
     if res.body.include? "NotAuthenticatedFault"
       return :expired
     elsif res.body.include? "<faultstring>"
-      @vim_soap_error = res.body.match(/<faultstring>([^\c ]+?)<\/faultstring>/)[1]
+      @vim_soap_error = res.body.match(/<faultstring>(.+?)<\/faultstring>/m)[1]
       return :error
     elsif res.code != 200
       @vim_soap_error = "An unknown error was encountered"

--- a/lib/msfenv.rb
+++ b/lib/msfenv.rb
@@ -18,4 +18,15 @@ unless defined?(Rails) && !Rails.application.nil?
 end
 require 'msf_autoload'
 
+# Disable the enhanced error messages introduced as part of Ruby 3.1, as some error messages are directly shown to users,
+# and the default ErrorHighlight formatter displays unneeded Ruby code to the user
+# https://github.com/ruby/error_highlight/tree/f3626b9032bd1024d058984329accb757687cee4#custom-formatter
+if defined?(::ErrorHighlight)
+  noop_error_formatter = Object.new
+  def noop_error_formatter.message_for(_spot)
+    ''
+  end
+  ::ErrorHighlight.formatter = noop_error_formatter
+end
+
 MsfAutoload.instance

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -142,6 +142,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'bcrypt_pbkdf'
   spec.add_runtime_dependency 'ruby_smb', '~> 3.0'
   spec.add_runtime_dependency 'net-ldap'
+  spec.add_runtime_dependency 'net-smtp'
   spec.add_runtime_dependency 'winrm'
 
   #

--- a/msfdb
+++ b/msfdb
@@ -270,7 +270,11 @@ end
 
 def update_db_port
   if File.file?(@db_conf)
-    config = YAML.load(File.read(@db_conf))
+    config = begin
+      YAML.load_file(@db_conf, aliases: true) || {}
+    rescue ArgumentError
+      YAML.load_file(@db_conf) || {}
+    end
     if config["production"] && config["production"]["port"]
       port = config["production"]["port"]
       if port != @options[:db_port]

--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -255,6 +255,26 @@ RSpec.describe "Metasploit's json-rpc" do
       end
     end
 
+    context 'when the module does not support a check method' do
+      let(:module_name) { 'scanner/http/title' }
+
+      it 'returns successful job results' do
+        create_job
+        expect(last_response).to_not be_ok
+        expected_error_response = {
+          error: {
+            code: -32000,
+            data: {
+              backtrace: include(a_kind_of(String))
+            },
+            message: 'Application server error: This module does not support check.'
+          },
+          id: 1
+        }
+        expect(last_json_response).to include(expected_error_response)
+      end
+    end
+
     context 'when the check command raises a known msf error' do
       before(:each) do
         allow_any_instance_of(::Msf::Auxiliary::Scanner).to receive(:check) do |mod|

--- a/spec/file_fixtures/json_rpc/auxiliary/scanner/http/title.rb
+++ b/spec/file_fixtures/json_rpc/auxiliary/scanner/http/title.rb
@@ -1,0 +1,35 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+###
+#
+# A placeholder module for json_rpc_spec.rb
+#
+###
+class MetasploitModule < Msf::Exploit::Remote
+  include Msf::Exploit::Remote::DCERPC
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Placeholder scanner http title module',
+        'Description' => 'Placeholder scanner http title module',
+        'Author' => [],
+        'License' => MSF_LICENSE
+      )
+    )
+  end
+
+  # No check method
+  # def check
+  #   # noop
+  # end
+
+  def run
+    # noop
+  end
+end

--- a/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
       it 'notifies the user that this module does not support check' do
         subject.cmd_check
         expected_output = [
-          'Check failed: NoMethodError This module does not support check.'
+          'This module does not support check.'
         ]
 
         expect(@combined_output).to match_array(expected_output)

--- a/spec/support/shared/contexts/msf/simple/framework.rb
+++ b/spec/support/shared/contexts/msf/simple/framework.rb
@@ -23,6 +23,6 @@ RSpec.shared_context 'Msf::Simple::Framework' do
   end
 
   after(:example) do
-    dummy_pathname.rmtree
+    FileUtils.rm_rf(dummy_pathname)
   end
 end


### PR DESCRIPTION
Adds initial Ruby 3.1 support to msfconsole

closes https://github.com/rapid7/metasploit-framework/issues/16080

### Ignored issues

1. On startup, there are `DidYouMean` warnings. These are fixed by updating to a newer version of bundler
> Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.

2. When running `exit` there are warnings from the `concurrent-ruby` gem, which is transitive dependency pinned to v1.0.5 via our active record version
```
msf6 auxiliary(scanner/http/title) > exit
./msfconsole: warning: Exception in finalizer #<Proc:0x00007f0a64b2b7e8 /home/user/.rvm/gems/ruby-3.1.1@metasploit-framework/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/user/.rvm/gems/ruby-3.1.1@metasploit-framework/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:471:in `new': can't alloc thread (ThreadError)
	from /home/user/.rvm/gems/ruby-3.1.1@metasploit-framework/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:471:in `create_with_logging_context'
	from /home/user/.rvm/gems/ruby-3.1.1@metasploit-framework/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:436:in `new'
	from /home/user/.rvm/gems/ruby-3.1.1@metasploit-framework/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
./msfconsole: warning: Exception in finalizer #<Proc:0x00007f0a64b2b950 /home/user/.rvm/gems/ruby-3.1.1@metasploit-framework/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/user/.rvm/gems/ruby-3.1.1@metasploit-framework/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:471:in `new': can't alloc thread (ThreadError)
	from /home/user/.rvm/gems/ruby-3.1.1@metasploit-framework/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:471:in `create_with_logging_context'
	from /home/user/.rvm/gems/ruby-3.1.1@metasploit-framework/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:436:in `new'
	from /home/user/.rvm/gems/ruby-3.1.1@metasploit-framework/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
```

3. ~~Database support doesn't work yet, investigating if we're blocked on a Rails upgrade or if we can fix that ourselves.
Relevant links:~~ Fixed
- ~~[Stack overflow post highlighting backwards breaking changes in Psych](https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias)~~
- ~~[Rails 7.x fix](https://github.com/rails/rails/pull/42249)~~
```
/opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:430:in `visit_Psych_Nodes_Alias': Unknown alias: pgsql (Psych::BadAlias)
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:345:in `block in revive_hash'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each_slice'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `revive_hash'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:167:in `visit_Psych_Nodes_Mapping'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:345:in `block in revive_hash'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each_slice'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `revive_hash'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:167:in `visit_Psych_Nodes_Mapping'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:3[18](https://github.com/rapid7/metasploit-framework/runs/5660769299?check_suite_focus=true#step:7:18):in `visit_Psych_Nodes_Document'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych.rb:335:in `safe_load'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych.rb:370:in `load'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych.rb:671:in `block in load_file'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych.rb:670:in `open'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/psych.rb:670:in `load_file'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/db_manager.rb:[19](https://github.com/rapid7/metasploit-framework/runs/5660769299?check_suite_focus=true#step:7:19)4:in `init_db'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/web_services/db_manager_proxy.rb:16:in `initialize'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/singleton.rb:127:in `new'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/singleton.rb:127:in `block in instance'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/singleton.rb:125:in `synchronize'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/3.1.0/singleton.rb:125:in `instance'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/web_services/http_db_manager_service.rb:42:in `init_db'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/web_services/http_db_manager_service.rb:[20](https://github.com/rapid7/metasploit-framework/runs/5660769299?check_suite_focus=true#step:7:20):in `start'
	from /home/runner/work/metasploit-framework/metasploit-framework/tools/dev/msfdb_ws:80:in `<main>'
```

### Verification

- Ensure msfconsole works with Ruby 3.1
- Ensure CI passes