### PR TITLE
Add debug option to Python Meterpreter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.80)
+      metasploit-payloads (= 2.0.82)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.18)
       mqtt
@@ -264,7 +264,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.80)
+    metasploit-payloads (2.0.82)
     metasploit_data_models (5.0.5)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -75,6 +75,10 @@ module Msf
               'MeterpreterDebugBuild',
               [false, 'Use a debug version of Meterpreter']
             ),
+            OptMeterpreterDebugLogging.new(
+              'MeterpreterDebugLogging',
+              [false, 'The Meterpreter debug logging configuration, see https://github.com/rapid7/metasploit-framework/wiki/Meterpreter-Debugging-Meterpreter-Sessions']
+            )
           ],
           self.class
         )

--- a/lib/msf/core/opt_meterpreter_debug_logging.rb
+++ b/lib/msf/core/opt_meterpreter_debug_logging.rb
@@ -1,0 +1,69 @@
+# -*- coding: binary -*-
+
+module Msf
+  ###
+  #
+  # Meterpreter Debug Logging option
+  #
+  ###
+  class OptMeterpreterDebugLogging < OptBase
+    def initialize(in_name, attrs = [], **kwargs)
+      super
+    end
+
+    def type
+      'meterpreterdebuglogging'
+    end
+
+    def validate_on_assignment?
+      true
+    end
+
+    def valid?(value, check_empty: true)
+      return false if !super(value, check_empty: check_empty)
+
+      begin
+        _parse_result = self.class.parse_logging_options(value)
+        true
+      rescue ::ArgumentError
+        false
+      end
+    end
+
+    ##
+    #
+    # Parses the given Meterpreter Debug Logging string
+    #
+    ##
+    def self.parse_logging_options(value)
+      result = {}
+      errors = []
+
+      return result if value.nil?
+
+      value = value.strip
+      # Match 'rpath:./file', 'rpath:/file', and drive letters e.g. 'rpath:C:/file'
+      rpath_regex = %r{^rpath:((\.?/\p{ASCII}+)|(\p{ASCII}:/\p{ASCII}+))}i
+
+      # Check if we log to rpath
+      if value.match?(rpath_regex)
+        # https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd
+        max_length = 260
+        rpath_value = value.split('rpath:').last
+        if rpath_value.length <= max_length
+          result[:rpath] = rpath_value
+        else
+          errors << "Rpath is too long. Max length: #{max_length}"
+        end
+      else
+        errors << 'Value is not a valid rpath string'
+      end
+
+      if errors.any?
+        raise ::ArgumentError, "Failed to validate MeterpreterDebugLogging option: #{value} with error/errors: #{errors.join('. ')}"
+      end
+
+      result
+    end
+  end
+end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.80'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.82'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.18'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 116413
+  CachedSize = 116841
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 116405
+  CachedSize = 116833
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 116405
+  CachedSize = 116833
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 116313
+  CachedSize = 116741
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/spec/lib/msf/core/opt_meterpreter_debug_logging_spec.rb
+++ b/spec/lib/msf/core/opt_meterpreter_debug_logging_spec.rb
@@ -1,0 +1,20 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::OptMeterpreterDebugLogging do
+  valid_values = [
+    { value: 'rpath:C:/log.txt', normalized: 'rpath:C:/log.txt' },
+    { value: 'rpath:/tmp/log.txt', normalized: 'rpath:/tmp/log.txt' },
+    { value: 'rpath:./log.log', normalized: 'rpath:./log.log' },
+    { value: ' rpath:./log.log ', normalized: ' rpath:./log.log ' }
+  ]
+  invalid_values = [
+    { value: 'rpath', normalized: 'rpath' },
+    { value: 'C:', normalized: 'C:' },
+    { value: 'C', normalized: 'C' },
+    { value: 'rpath:C', normalized: 'rpath:C' }
+  ]
+
+  it_behaves_like 'an option', valid_values, invalid_values, 'meterpreterdebuglogging'
+end


### PR DESCRIPTION
This PR is a companion PR for https://github.com/rapid7/metasploit-payloads/pull/557

With this we can specify the remote path for log output as well as toggle debugging with a datastore option that is now added to all Meterpreters.

## Verification

- [ ] Checkout the Metasploit Payloads PR
- [ ] `./msfconsole -q`
- [ ] `use payload/python/meterpreter/reverse_tcp`
- [ ] `set lhost {...}`
- [ ] `advanced` to see the new MeterpreterDebug options
- [ ] `set MeterpreterDebugBuild true`
- [ ] `set MeterpreterTryToFork false` to see debug print statements in the command prompt
- [ ] `set MeterpreterDebugLogging rpath:C:/ExampleDir/Logfile.txt`
- [ ] When changing the above options, restart your handler for changes to take effect
- [ ] **Verify** the log file gets written to
- [ ] **Verify** that disabling `MeterpreterDebugBuild` results in no log file being written to