### PR TITLE
Don't clobber hostname with IP; we need it for ssl connections later.

### DIFF
--- a/lib/msf/core/rhosts_walker.rb
+++ b/lib/msf/core/rhosts_walker.rb
@@ -146,7 +146,6 @@ module Msf
             Rex::Socket::RangeWalker.new(value).each_host do |rhost|
               overrides = {}
               overrides['UNPARSED_RHOSTS'] = value
-              overrides['RHOSTS'] = rhost[:address]
               overrides['VHOST'] = rhost[:hostname] if datastore.options.include?('VHOST') && datastore['VHOST'].blank?
               results << datastore.merge(overrides)
             end


### PR DESCRIPTION
## Note
This PR might break a lot.  I'm putting it up in part to get a quick discussion of what it might break.  I'm sure there was a reason that we're clobbering a hostname in the rhost value with ip address, (I bet it is trying to do a contextualized DNS query) but it breaks some ssl interactions that require the hostname.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/http_header`
- [ ] `set rhost nvd.nist.com`
- [ ] `run`
- [ ] **Verify** it fails previously
- [ ] **Verify** it succeeds here
- [ ] **Tell Me** what this change breaks.

## Before
```
msf6 auxiliary(scanner/http/http_header) > show options

Module options (auxiliary/scanner/http/http_header):

   Name         Current Setting                        Required  Description
   ----         ---------------                        --------  -----------
   HTTP_METHOD  HEAD                                   yes       HTTP Method to use, HEAD or GET (Accepted: GET, HEAD)
   IGN_HEADER   Vary,Date,Content-Length,Connection,E  yes       List of headers to ignore, separated by comma
                tag,Expires,Pragma,Accept-Ranges
   Proxies                                             no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS       google.com                             yes       The target host(s), see https://github.com/rapid7/metasploit-frame
                                                                 work/wiki/Using-Metasploit
   RPORT        443                                    yes       The target port (TCP)
   SSL          true                                   no        Negotiate SSL/TLS for outgoing connections
   TARGETURI    /                                      yes       The URI to use
   THREADS      1                                      yes       The number of concurrent threads (max one per host)
   VHOST                                               no        HTTP server virtual host

msf6 auxiliary(scanner/http/http_header) > set rhost nvd.nist.gov
rhost => nvd.nist.gov
msf6 auxiliary(scanner/http/http_header) > run

[*] 54.85.30.225:443     : requesting / via HEAD
[*] Error: 54.85.30.225: OpenSSL::SSL::SSLError SSL_connect returned=1 errno=0 state=error: tlsv1 unrecognized name
[*] Scanned 1 of 2 hosts (50% complete)
[*] 2600:1f18:268d:1d01:f609:5e91:8a48:f546:443: requesting / via HEAD
[-] The host ([2600:1f18:268d:1d01:f609:5e91:8a48:f546]:443) was unreachable.
[-] 2600:1f18:268d:1d01:f609:5e91:8a48:f546:443: connection timed out
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
## After
```
msf6 auxiliary(scanner/http/http_header) > run

[*] nvd.nist.gov:443     : requesting / via HEAD
[*] nvd.nist.gov:443     : deleted header Date
[*] nvd.nist.gov:443     : deleted header Content-Length
[*] nvd.nist.gov:443     : deleted header Expires
[*] nvd.nist.gov:443     : deleted header Pragma
[+] nvd.nist.gov:443     : CACHE-CONTROL: no-cache, no-store, max-age=0, must-revalidate
[+] nvd.nist.gov:443     : CONTENT-LANGUAGE: en-US
[+] nvd.nist.gov:443     : CONTENT-SECURITY-POLICY: frame-ancestors 'self'
[+] nvd.nist.gov:443     : CONTENT-TYPE: text/html;charset=UTF-8
[+] nvd.nist.gov:443     : STRICT-TRANSPORT-SECURITY: max-age=31536000
[+] nvd.nist.gov:443     : X-CONTENT-TYPE-OPTIONS: nosniff
[+] nvd.nist.gov:443     : X-FRAME-OPTIONS: SAMEORIGIN
[+] nvd.nist.gov:443     : X-XSS-PROTECTION: 1; mode=block
[+] nvd.nist.gov:443     : detected 8 headers
[*] Scanned 1 of 2 hosts (50% complete)
[*] nvd.nist.gov:443     : requesting / via HEAD
[*] nvd.nist.gov:443     : deleted header Date
[*] nvd.nist.gov:443     : deleted header Content-Length
[*] nvd.nist.gov:443     : deleted header Expires
[*] nvd.nist.gov:443     : deleted header Pragma
[+] nvd.nist.gov:443     : CACHE-CONTROL: no-cache, no-store, max-age=0, must-revalidate
[+] nvd.nist.gov:443     : CONTENT-LANGUAGE: en-US
[+] nvd.nist.gov:443     : CONTENT-SECURITY-POLICY: frame-ancestors 'self'
[+] nvd.nist.gov:443     : CONTENT-TYPE: text/html;charset=UTF-8
[+] nvd.nist.gov:443     : STRICT-TRANSPORT-SECURITY: max-age=31536000
[+] nvd.nist.gov:443     : X-CONTENT-TYPE-OPTIONS: nosniff
[+] nvd.nist.gov:443     : X-FRAME-OPTIONS: SAMEORIGIN
[+] nvd.nist.gov:443     : X-XSS-PROTECTION: 1; mode=block
[+] nvd.nist.gov:443     : detected 8 headers
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed

```

Fixes https://github.com/rapid7/metasploit-framework/issues/14653, https://github.com/rapid7/rex-socket/issues/29 (maybe?)