### PR TITLE
Msf::Post::Windows::FileInfo: Support powershell and shell sessions

### DIFF
--- a/lib/msf/core/post/windows/file_info.rb
+++ b/lib/msf/core/post/windows/file_info.rb
@@ -1,10 +1,6 @@
 # -*- coding: binary -*-
-module Msf
-class Post
-module Windows
 
-module FileInfo
-
+module Msf::Post::Windows::FileInfo
   def initialize(info = {})
     super(
       update_info(
@@ -35,44 +31,64 @@ module FileInfo
   # @return [String] Returns the file version information of the file.
 
   def file_version(filepath)
-    file_version_info_size = client.railgun.version.GetFileVersionInfoSizeA(
-      filepath,
-      nil
-    )['return']
+    return unless file_exist?(filepath)
 
-    buffer = session.railgun.kernel32.VirtualAlloc(
-      nil,
-      file_version_info_size,
-      MEM_COMMIT|MEM_RESERVE,
-      PAGE_READWRITE
-    )['return']
+    if session.type == 'meterpreter'
+      file_version_info_size = client.railgun.version.GetFileVersionInfoSizeA(
+        filepath,
+        nil
+      )['return']
 
-    client.railgun.version.GetFileVersionInfoA(
-      filepath,
-      0,
-      file_version_info_size,
-      buffer
-    )
+      buffer = session.railgun.kernel32.VirtualAlloc(
+        nil,
+        file_version_info_size,
+        MEM_COMMIT | MEM_RESERVE,
+        PAGE_READWRITE
+      )['return']
 
-    result = client.railgun.version.VerQueryValueA(buffer, "\\", 4, 4)
-    ffi = client.railgun.memread(result['lplpBuffer'], result['puLen'])
+      client.railgun.version.GetFileVersionInfoA(
+        filepath,
+        0,
+        file_version_info_size,
+        buffer
+      )
 
-    vs_fixed_file_info = ffi.unpack('V13')
+      result = client.railgun.version.VerQueryValueA(buffer, '\\', 4, 4)
+      ffi = client.railgun.memread(result['lplpBuffer'], result['puLen'])
 
-    unless vs_fixed_file_info and (vs_fixed_file_info.length == 13)	and
-(vs_fixed_file_info[0] = 0xfeef04bd)
-      return nil
+      vs_fixed_file_info = ffi.unpack('V13')
+
+      unless vs_fixed_file_info && (vs_fixed_file_info.length == 13) &&
+             (vs_fixed_file_info[0] = 0xfeef04bd)
+        return nil
+      end
+
+      major = hiword(vs_fixed_file_info[2])
+      minor = loword(vs_fixed_file_info[2])
+      build = hiword(vs_fixed_file_info[3])
+      revision = loword(vs_fixed_file_info[3])
+      branch = revision.to_s[0..1].to_i
+    elsif session.type == 'powershell'
+      result = cmd_exec("([System.Diagnostics.FileVersionInfo]::GetVersionInfo(\"#{filepath}\") | Select-Object FileMajorPart,FileMinorPart,FileBuildPart,FilePrivatePart) -join ''")
+      return unless result
+
+      major = result.scan(/FileMajorPart=(\d+)/).flatten.first.to_i
+      minor = result.scan(/FileMinorPart=(\d+)/).flatten.first.to_i
+      build = result.scan(/FileBuildPart=(\d+)/).flatten.first.to_i
+      revision = result.scan(/FilePrivatePart=(\d+)/).flatten.first.to_i
+      branch = revision.to_s[0..1].to_i
+    else
+      result = cmd_exec("wmic datafile where name=\"#{filepath.gsub('\\', '\\\\\\')}\" get Version /value")
+      return unless result
+      return unless result.to_s.include?('Version=')
+
+      major = result.scan(/Version=(\d+).\d+.\d+.\d+/).flatten.first.to_i
+      minor = result.scan(/Version=\d+.(\d+).\d+.\d+/).flatten.first.to_i
+      build = result.scan(/Version=\d+.\d+.(\d+).\d+/).flatten.first.to_i
+      revision = result.scan(/Version=\d+.\d+.\d+.(\d+)/).flatten.first.to_i
+      branch = revision.to_s[0..1].to_i
     end
-
-    major = hiword(vs_fixed_file_info[2])
-    minor = loword(vs_fixed_file_info[2])
-    build = hiword(vs_fixed_file_info[3])
-    revision = loword(vs_fixed_file_info[3])
-    branch = revision.to_s[0..1].to_i
 
     return major, minor, build, revision, branch
   end
-end # FileInfo
-end # Windows
-end # Post
-end # Msf
+end


### PR DESCRIPTION
`Msf::Post::Windows::FileInfo.file_version` is one of the (many) Meterpreter-only methods used in #16382, preventing exploitation on shell/powershell sessions.

This PR also changes the `file_version` method to bail out if the file `filepath` does not exist. This hides a bug in meterpreter and/or railgun which causes the payload process to crash when calling `file_version(filepath)` if the file does not exist (tested on Windows 7 SP1). Fixing the root cause is outside the scope of this PR.

# Test Module

```ruby
##
# This module requires Metasploit: https://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

class MetasploitModule < Msf::Exploit::Local
  Rank = ExcellentRanking

  include Msf::Post::File
  include Msf::Exploit::EXE
  include Msf::Post::Windows::FileInfo
  include Msf::Exploit::FileDropper

  def initialize(info = {})
    super(update_info(info,
      'Name'           => 'Test',
      'Description'    => %q{
        Test
      },
      'License'        => MSF_LICENSE,
      'Author'         =>
        [
          'test'
        ],
      'DisclosureDate' => 'test',
      'Platform'       => 'win',
      'Arch'           => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
      'SessionTypes'   => [ 'shell', 'powershell', 'meterpreter' ],
      'Targets'        => [[ 'Auto', {} ]],
      'References'     =>
        [
          [ ]
        ]
    ))
  end

  def check
    version = file_version('C:\\Windows\\System32\\ntdll.dll')
    puts version.inspect
    CheckCode.Unknown
  end

  def exploit
    puts cmd_exec 'cmd.exe', '/c echo test'
    puts cmd_exec 'cmd.exe', '/c echo another test'
  end
end
```

# Before

Meterpreter:

```
msf6 exploit(windows/local/test) > check
[6, 1, 7601, 18247, 18]
[*] Cannot reliably check exploitability.
```

Powershell:

```
msf6 exploit(windows/local/test) > check

[-] Exploit failed: NoMethodError undefined method `railgun' for #<Msf::Sessions::CommandShell:0x0000562da32034e8>
[-] Check failed: The state could not be determined.
```

Shell (ncat):

```
msf6 exploit(windows/local/test) > check

[-] Exploit failed: NoMethodError undefined method `railgun' for #<Msf::Sessions::CommandShell:0x0000562da32034e8>
[-] Check failed: The state could not be determined.
```

# After

Meterpreter:

```
msf6 exploit(windows/local/test) > check
[6, 1, 7601, 18247, 18]
[*] Cannot reliably check exploitability.
```

Powershell:

```
msf6 exploit(windows/local/test) > check 
[6, 1, 7601, 18247, 18]
[*] Cannot reliably check exploitability.
```

Shell (ncat):

```
msf6 exploit(windows/local/test) > check
[6, 1, 7601, 18247, 18]
[*] Cannot reliably check exploitability.
```
