### PR TITLE
Add toggleable logging to console & file to PHP Meterpreter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.82)
+      metasploit-payloads (= 2.0.83)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.18)
       mqtt
@@ -264,7 +264,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.82)
+    metasploit-payloads (2.0.83)
     metasploit_data_models (5.0.5)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.82'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.83'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.18'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -7,7 +7,7 @@
 
 module MetasploitModule
 
-  CachedSize = 34282
+  CachedSize = 34792
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -39,6 +39,13 @@ module MetasploitModule
     session_guid = '\x00' * 16
     met = met.sub(%q|"SESSION_GUID", ""|, %Q|"SESSION_GUID", "#{session_guid}"|)
 
+    if datastore['MeterpreterDebugBuild']
+      met.sub!(%q|define("MY_DEBUGGING", false);|, %Q|define("MY_DEBUGGING", true);|)
+
+      logging_options = Msf::OptMeterpreterDebugLogging.parse_logging_options(datastore['MeterpreterDebugLogging'])
+      met.sub!(%q|define("MY_DEBUGGING_LOG_FILE_PATH", false);|, %Q|define("MY_DEBUGGING_LOG_FILE_PATH", "#{logging_options[:rpath]}");|) if logging_options[:rpath]
+    end
+
     met.gsub!(/#.*$/, '')
     met = Rex::Text.compress(met)
     met

--- a/modules/payloads/stages/php/meterpreter.rb
+++ b/modules/payloads/stages/php/meterpreter.rb
@@ -31,6 +31,13 @@ module MetasploitModule
     session_guid = [SecureRandom.uuid.gsub(/-/, '')].pack('H*').chars.map { |c| '\x%.2x' % c.ord }.join('')
     met = met.sub(%q|"SESSION_GUID", ""|, %Q|"SESSION_GUID", "#{session_guid}"|)
 
+    if datastore['MeterpreterDebugBuild']
+      met.sub!(%q|define("MY_DEBUGGING", false);|, %Q|define("MY_DEBUGGING", true);|)
+
+      logging_options = Msf::OptMeterpreterDebugLogging.parse_logging_options(datastore['MeterpreterDebugLogging'])
+      met.sub!(%q|define("MY_DEBUGGING_LOG_FILE_PATH", false);|, %Q|define("MY_DEBUGGING_LOG_FILE_PATH", "#{logging_options[:rpath]}");|) if logging_options[:rpath]
+    end
+
     met.gsub!(/#.*?$/, '')
     #met = Rex::Text.compress(met)
     met


### PR DESCRIPTION
This PR adds the ability to toggle logging to console/remote file to the PHP Meterpreter.

## Verification

- [ ] Start `msfconsole`
- [ ] `use payload/php/meterpreter/reverse_tcp`
- [ ] `set lhost`
- [ ] `set MeterpreterDebugBuild true`
- [ ] Confirm that debug logs are written to the console window where you ran your Meterpreter PHP payload
- [ ] `set MeterpreterDebugLogging rpath:/tmp/output.txt`
- [ ] Remember to `jobs -k -1` and `to_handler` after changing these values
- [ ] Confirm that the file is being written to
- [ ] `set MeterpreterDebugBuild false`
- [ ] Confirm that debug logs aren't written to console or the file
- [ ] Confirm that this works for `payload/php/meterpreter_reverse_tcp` also