### PR TITLE
add missing payload tests

### DIFF
--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -758,6 +758,14 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/unix/pingback_reverse'
   end
 
+  context 'cmd/unix/python' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'adapters/cmd/unix/python'
+                          ],
+                          reference_name: 'cmd/unix/python'
+  end
+
   context 'cmd/unix/reverse' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -1128,6 +1136,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/windows/powershell_reverse_tcp'
   end
 
+  context 'cmd/windows/powershell_reverse_tcp_ssl' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/cmd/windows/powershell_reverse_tcp_ssl'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/windows/powershell_reverse_tcp_ssl'
+  end
+
   context 'cmd/windows/reverse_lua' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -1237,6 +1255,15 @@ RSpec.describe 'modules/payloads', :content do
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/shell_reverse_tcp'
   end
+
+  context 'generic/ssh/interact' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'singles/generic/ssh/interact'
+                          ],
+                          reference_name: 'generic/ssh/interact'
+  end
+
 
   context 'generic/tight_loop' do
     it_should_behave_like 'payload cached size is consistent',
@@ -4922,6 +4949,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/x64/powershell_reverse_tcp'
   end
 
+  context 'windows/x64/powershell_reverse_tcp_ssl' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/windows/x64/powershell_reverse_tcp_ssl'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/powershell_reverse_tcp_ssl'
+  end
+
   context 'windows/x64/pingback_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -5201,6 +5238,16 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/powershell_reverse_tcp'
+  end
+
+  context 'windows/powershell_reverse_tcp_ssl' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/windows/powershell_reverse_tcp_ssl'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/powershell_reverse_tcp_ssl'
   end
 
   context 'windows/shell/bind_hidden_ipknock_tcp' do

--- a/tools/modules/missing_payload_tests.rb
+++ b/tools/modules/missing_payload_tests.rb
@@ -27,6 +27,7 @@ options_set_by_ancestor_reference_name = Hash.new { |hash, ancestor_reference_na
 }
 
 framework.payloads.each { |reference_name, payload_class|
+  next unless payload_class
   module_ancestors = payload_class.ancestors.select { |ancestor|
     # need to use try because name may be nil for anonymous Modules
     ancestor.name.try(:start_with?, 'Msf::Modules::')


### PR DESCRIPTION
A number of recent payload adds do not conform the patterns
used for suggesting spec configurations.  Manually added these
tests to remove warning in rspec run.

## Verification

List the steps needed to make sure this thing works

- [x] `bundle exec rspec spec/modules/payloads_spec.rb`
- [x] **Verify** the following warning is not printed
```
Some payloads are untested.  See log/untested-payload.log for details.
```
