### PR TITLE
Fix `setg sessiontlvlogging` crashing on non-Meterpreter sessions

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1923,7 +1923,7 @@ class Core
         end
       end
 
-      framework.sessions.each { |_index, session| session.initialize_tlv_logging(datastore[name]) }
+      framework.sessions.each { |_index, session| session.initialize_tlv_logging(datastore[name]) if session.type.casecmp? 'meterpreter' }
     end
 
     print_line("#{name} => #{datastore[name]}")

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -606,45 +606,45 @@ protected
   end
 
   def handle_session_tlv_logging(val)
-    if val
-      if val.casecmp?('console') || val.casecmp?('true') || val.casecmp?('false')
-        return true
-      elsif val.start_with?('file:') && !val.split('file:').empty?
-        pathname = ::Pathname.new(val.split('file:').last)
+    return false if val.nil?
 
-        # Check if we want to write the log to file
-        if ::File.file?(pathname)
-          if ::File.writable?(pathname)
-            return true
-          else
-            print_status "No write permissions for log output file: #{pathname}"
-            return false
-          end
-        # Check if we want to write the log file to a directory
-        elsif ::File.directory?(pathname)
-          if ::File.writable?(pathname)
-            return true
-          else
-            print_status "No write permissions for log output directory: #{pathname}"
-            return false
-          end
-        # Check if the subdirectory exists
-        elsif ::File.directory?(pathname.dirname)
-          if ::File.writable?(pathname.dirname)
-            return true
-          else
-            print_status "No write permissions for log output directory: #{pathname.dirname}"
-            return false
-          end
+    if val.casecmp?('console') || val.casecmp?('true') || val.casecmp?('false')
+      return true
+    elsif val.start_with?('file:') && !val.split('file:').empty?
+      pathname = ::Pathname.new(val.split('file:').last)
+
+      # Check if we want to write the log to file
+      if ::File.file?(pathname)
+        if ::File.writable?(pathname)
+          return true
         else
-          # Else the directory doesn't exist. Check if we can create it.
-          begin
-            ::FileUtils.mkdir_p(pathname.dirname)
-            return true
-          rescue ::StandardError => e
-            print_status "Error when trying to create directory #{pathname.dirname}: #{e.message}"
-            return false
-          end
+          print_status "No write permissions for log output file: #{pathname}"
+          return false
+        end
+        # Check if we want to write the log file to a directory
+      elsif ::File.directory?(pathname)
+        if ::File.writable?(pathname)
+          return true
+        else
+          print_status "No write permissions for log output directory: #{pathname}"
+          return false
+        end
+        # Check if the subdirectory exists
+      elsif ::File.directory?(pathname.dirname)
+        if ::File.writable?(pathname.dirname)
+          return true
+        else
+          print_status "No write permissions for log output directory: #{pathname.dirname}"
+          return false
+        end
+      else
+        # Else the directory doesn't exist. Check if we can create it.
+        begin
+          ::FileUtils.mkdir_p(pathname.dirname)
+          return true
+        rescue ::StandardError => e
+          print_status "Error when trying to create directory #{pathname.dirname}: #{e.message}"
+          return false
         end
       end
     end


### PR DESCRIPTION
This PR fixes a crash when trying to set SessionTlvLogging for a non-Meterpreter session.

The change to `lib/msf/ui/console/driver.rb` is not necessary, however I would consider it to be a improvement over the initial code that I have written.

## Verification

- [ ] `msfconsole -q`
- [ ] Get a non-Meterpreter shell, e.g. `use auxiliary/scanner/ssh/ssh_login`
- [ ] Try setting `setg sessiontlvlogging true`
- [ ] **Confirm** that without this PR, this crashes
- [ ] **Confirm** that with this PR, the non-Meterpreter shells are ignored and do not crash.
- [ ] Get a Meterpreter shell e.g. `use payload/python/meterpreter/reverse_tcp`
- [ ] **Confirm** that setting SessionTlvLogging works as expected for this new Meterpreter shell

## Before

```
msf6 auxiliary(scanner/ssh/ssh_login) > setg sessiontlvlogging true
[-] Error while running command setg: undefined method `initialize_tlv_logging' for #<Session:shell 192.168.129.131:22 (192.168.129.131) "SSH sjanusz @ ">
Did you mean?  initialize_channels

Call stack:
/Users/sjanusz/Rapid7/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1926:in `block in cmd_set'
/Users/sjanusz/Rapid7/metasploit-framework/lib/msf/core/session_manager.rb:196:in `each'
/Users/sjanusz/Rapid7/metasploit-framework/lib/msf/core/session_manager.rb:196:in `each'
/Users/sjanusz/Rapid7/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1926:in `cmd_set'
/Users/sjanusz/Rapid7/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1977:in `cmd_setg'
/Users/sjanusz/Rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/Users/sjanusz/Rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/Users/sjanusz/Rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/Users/sjanusz/Rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/Users/sjanusz/Rapid7/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/Users/sjanusz/Rapid7/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/sjanusz/Rapid7/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```

## After

```
msf6 auxiliary(scanner/ssh/ssh_login) > sessions

Active sessions
===============

  Id  Name  Type           Information    Connection
  --  ----  ----           -----------    ----------
  1         shell windows  SSH sjanusz @  192.168.129.1:55498 -> 192.168.129.131:22  (192.168.129.131)

msf6 auxiliary(scanner/ssh/ssh_login) > setg sessiontlvlogging false
sessiontlvlogging => false
```