### PR TITLE
Multiple local exploit suggester enhancements

### DIFF
--- a/documentation/modules/post/multi/recon/local_exploit_suggester.md
+++ b/documentation/modules/post/multi/recon/local_exploit_suggester.md
@@ -26,27 +26,9 @@ You can set the following options for the Local Exploit Suggester:
 
 When the Local Exploit Suggester runs, it displays a list of local exploits that the target may be vulnerable to, and it tells the user the likelihood of exploitation.
 
-It also tells the user why the 'check' methods for some exploits did not complete successfully, allowing for easier debugging.
+It also tells the user why the `check` methods for some exploits did not complete successfully, allowing for easier debugging.
 
 Furthermore, with the `Verbose` option turned on, a table is printed showing modules that were not considered as valid for the current session, and gives reasons as to why.
-
-For example:
-```
-[*] ::1 - Current Session Info:
-[*] ::1 - Session Type: meterpreter
-[*] ::1 - Architecture: x64
-[*] ::1 - Native Architecture: x64
-[*] ::1 - Platform: linux
-[*] ::1 - Invalid modules for session 3:
-==============================
-
- #    Name                                                                    Reasons                                                                                Platform       Architecture                                   Session Type
- -    ----                                                                    -------                                                                                --------       ------------                                   ------------
- 1    exploit/aix/local/ibstat_path                                           Not Compatible (platform, session type)                                                Unix           cmd                                            No defined session types
- 2    exploit/aix/local/xorg_x11_server                                       Not Compatible (platform, session type)                                                Unix           cmd                                            shell
-```
-
-The above output is colored when inside a terminal window.
 
 The following terms are used to help you understand how vulnerable a target is to a particular exploit:
 
@@ -63,6 +45,8 @@ This table is shown by default, and shows which exploits have had their `check` 
 Below is an example of how this table could look:
 
 ```
+msf6 post(multi/recon/local_exploit_suggester) > run SESSION=-1 Verbose=false
+
 [*] ::1 - Valid modules for session 3:
 ============================
 
@@ -84,11 +68,14 @@ Below is an example of how this table could look:
  14  exploit/linux/local/apport_abrt_chroot_priv_esc                     No                       The target is not exploitable.
  15  exploit/linux/local/asan_suid_executable_priv_esc                   No                       The check raised an exception.
  16  exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc          No                       The target is not exploitable.
+ ...
+ More modules here
+ ...
 ```
 
 When output to a terminal window with the `Colors` datastore option set, the table rows are highlighted appropriately based on the `Check Result`.
 
-### Invalid Modules
+### Incompatible Modules
 
 This table is hidden behind the `Verbose` toggle.
 
@@ -97,12 +84,17 @@ It provides a list of modules that did not have their `check` method executed, a
 Below is an example of how this table could look:
 
 ```
+msf6 post(multi/recon/local_exploit_suggester) > run SESSION=-1 Verbose=true ValidateArch=false ValidatePlatform=true
+
+...
+Valid modules table here
+...
+
 [*] ::1 - Current Session Info:
 [*] ::1 - Session Type: meterpreter
 [*] ::1 - Architecture: x64
-[*] ::1 - Native Architecture: x64
 [*] ::1 - Platform: linux
-[*] ::1 - Invalid modules for session 3:
+[*] ::1 - Incompatible modules for session 3:
 ==============================
 
  #    Name                                                                    Reasons                                                                                Platform       Architecture                                   Session Type
@@ -123,5 +115,6 @@ Below is an example of how this table could look:
  14   exploit/osx/local/iokit_keyboard_root                                   Not Compatible (platform)                                                              OSX            x64                                            shell, meterpreter
  15   exploit/osx/local/libxpc_mitm_ssudo                                     Not Compatible (platform, session type)                                                OSX            x64                                            No defined session types
 ```
+Note: In the table above, the session architecture is reported as `x64`. However, it is not considered as 'incompatible' as the `ValidateArch=false` option was used.
 
 When the above is output to a terminal, the incompatibilities for a specific module (e.g. architecture or platform mismatch) are output in a different color if enabled with the `Color` datastore option.

--- a/documentation/modules/post/multi/recon/local_exploit_suggester.md
+++ b/documentation/modules/post/multi/recon/local_exploit_suggester.md
@@ -1,31 +1,127 @@
 The Local Exploit Suggester is a post-exploitation module that you can use to check a system for local vulnerabilities. It performs local exploit checks; it does not actually run any exploits, which is useful because this means you to scan a system without being intrusive. In addition to being stealthy, it's a time saver. You don't have to manually search for local exploits that will work; it'll show you which exploits the target is vulnerable to based on the system's platform and architecture.
 
-The Local Exploit Suggester is available for Python, PHP, and Windows Meterpreter.
-
+The Local Exploit Suggester is available for Python, PHP, Mettle, Java and Windows Meterpreter.
 
 ## Vulnerable Application
 
 To use the Local Exploit Suggester:
 
-* You must have an open Meterpreter session. 
+* You must have an open Meterpreter or shell session.
 
 ## Verification Steps
 
 Please see the Overview section.
 
-##Options
+## Options
 
 You can set the following options for the Local Exploit Suggester:
 
-* **showdescription** - Set this option to true to see more details about each exploit. 
-
+* **SHOWDESCRIPTION** - Set this option to true to see more details about each exploit.
+* **ValidateArch** - This option lets us toggle whether or not a mismatch in session and module architecture should be validated or ignored.
+* **ValidatePlatform** - This option lets us toggle whether or not a mismatch in session and module platform should be validated or ignored.
+* **ValidateMeterpreterCommands** - This option lets us toggle whether or not Meterpreter commands that are missing from the current Meterpreter implementation should be validated or ignored.
+* **Colors** - Similar to the option used for `HttpTrace`. This lets us change the colors used to show valid, invalid and ignored options or incompatibilities. Unsetting this option results in no colored output.
 
 ## Scenarios
 
-When the Local Exploit Suggester runs, it displays a list of local exploits that the target may be vulnerable to, and it tells you the likelihood of exploitation. 
+When the Local Exploit Suggester runs, it displays a list of local exploits that the target may be vulnerable to, and it tells the user the likelihood of exploitation.
+
+It also tells the user why the 'check' methods for some exploits did not complete successfully, allowing for easier debugging.
+
+Furthermore, with the `Verbose` option turned on, a table is printed showing modules that were not considered as valid for the current session, and gives reasons as to why.
+
+For example:
+```
+[*] ::1 - Current Session Info:
+[*] ::1 - Session Type: meterpreter
+[*] ::1 - Architecture: x64
+[*] ::1 - Native Architecture: x64
+[*] ::1 - Platform: linux
+[*] ::1 - Invalid modules for session 3:
+==============================
+
+ #    Name                                                                    Reasons                                                                                Platform       Architecture                                   Session Type
+ -    ----                                                                    -------                                                                                --------       ------------                                   ------------
+ 1    exploit/aix/local/ibstat_path                                           Not Compatible (platform, session type)                                                Unix           cmd                                            No defined session types
+ 2    exploit/aix/local/xorg_x11_server                                       Not Compatible (platform, session type)                                                Unix           cmd                                            shell
+```
+
+The above output is colored when inside a terminal window.
 
 The following terms are used to help you understand how vulnerable a target is to a particular exploit:
 
 * **Vulnerable** - Indicates that the target is vulnerable. 
 * **Appears** - Indicates that the target may be vulnerable based on the file version, but the vulnerable code has not been tested. 
 * **Detected** - Indicates that the target has the file, but it cannot be determined whether or not the target is vulnerable. 
+
+## Table Output
+
+### Valid Modules
+
+This table is shown by default, and shows which exploits have had their `check` methods executed, and provides information on the returned result.
+
+Below is an example of how this table could look:
+
+```
+[*] ::1 - Valid modules for session 3:
+============================
+
+ #   Name                                                                Potentially Vulnerable?  Check Result
+ -   ----                                                                -----------------------  ------------
+ 1   exploit/linux/local/cve_2021_4034_pwnkit_lpe_pkexec                 Yes                      The target is vulnerable.
+ 2   exploit/linux/local/cve_2022_0847_dirtypipe                         Yes                      The target appears to be vulnerable. Linux kernel version found: 5.14.0
+ 3   exploit/linux/local/cve_2022_0995_watch_queue                       Yes                      The target appears to be vulnerable.
+ 4   exploit/linux/local/desktop_privilege_escalation                    Yes                      The target is vulnerable.
+ 5   exploit/linux/local/network_manager_vpnc_username_priv_esc          Yes                      The service is running, but could not be validated.
+ 6   exploit/linux/local/pkexec                                          Yes                      The service is running, but could not be validated.
+ 7   exploit/linux/local/polkit_dbus_auth_bypass                         Yes                      The service is running, but could not be validated. Detected polkit framework version 0.105.
+ 8   exploit/linux/local/su_login                                        Yes                      The target appears to be vulnerable.
+ 9   exploit/android/local/futex_requeue                                 No                       The check raised an exception.
+ 10  exploit/linux/local/abrt_raceabrt_priv_esc                          No                       The target is not exploitable.
+ 11  exploit/linux/local/abrt_sosreport_priv_esc                         No                       The target is not exploitable.
+ 12  exploit/linux/local/af_packet_chocobo_root_priv_esc                 No                       The target is not exploitable. Linux kernel 5.14.0-kali4-amd64 #1 is not vulnerable
+ 13  exploit/linux/local/af_packet_packet_set_ring_priv_esc              No                       The target is not exploitable.
+ 14  exploit/linux/local/apport_abrt_chroot_priv_esc                     No                       The target is not exploitable.
+ 15  exploit/linux/local/asan_suid_executable_priv_esc                   No                       The check raised an exception.
+ 16  exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc          No                       The target is not exploitable.
+```
+
+When output to a terminal window with the `Colors` datastore option set, the table rows are highlighted appropriately based on the `Check Result`.
+
+### Invalid Modules
+
+This table is hidden behind the `Verbose` toggle.
+
+It provides a list of modules that did not have their `check` method executed, and provides information as to why a module is not compatible with the current session.
+
+Below is an example of how this table could look:
+
+```
+[*] ::1 - Current Session Info:
+[*] ::1 - Session Type: meterpreter
+[*] ::1 - Architecture: x64
+[*] ::1 - Native Architecture: x64
+[*] ::1 - Platform: linux
+[*] ::1 - Invalid modules for session 3:
+==============================
+
+ #    Name                                                                    Reasons                                                                                Platform       Architecture                                   Session Type
+ -    ----                                                                    -------                                                                                --------       ------------                                   ------------
+ 1    exploit/aix/local/ibstat_path                                           Not Compatible (platform, session type)                                                Unix           cmd                                            No defined session types
+ 2    exploit/aix/local/xorg_x11_server                                       Not Compatible (platform, session type)                                                Unix           cmd                                            shell
+ 3    exploit/android/local/janus                                             Not Compatible (platform)                                                              Android        dalvik                                         meterpreter
+ 4    exploit/freebsd/local/intel_sysret_priv_esc                             Not Compatible (platform, session type)                                                BSD            x64                                            shell
+ 5    exploit/freebsd/local/ip6_setpktopt_uaf_priv_esc                        Not Compatible (platform, session type)                                                BSD            x64                                            shell
+ 6    exploit/freebsd/local/mmap                                              Not Compatible (platform, session type)                                                BSD            x86                                            shell
+ 7    exploit/freebsd/local/rtld_execl_priv_esc                               Not Compatible (platform, session type)                                                BSD            x86, x64, armle, aarch64, ppc, mipsle, mipsbe  shell
+ 8    exploit/freebsd/local/watchguard_fix_corrupt_mail                       Not Compatible (platform, session type)                                                BSD            x64                                            shell
+ 9    exploit/linux/local/vmware_mount                                        Not Compatible (session type)                                                          Linux          x86                                            No defined session types
+ 10   exploit/openbsd/local/dynamic_loader_chpass_privesc                     Not Compatible (platform, session type)                                                BSD, Unix      cmd                                            shell
+ 11   exploit/osx/local/cfprefsd_race_condition                               Not Compatible (platform, session type)                                                OSX            x64                                            No defined session types
+ 12   exploit/osx/local/dyld_print_to_file_root                               Not Compatible (platform, session type)                                                OSX            x64                                            shell
+ 13   exploit/osx/local/feedback_assistant_root                               Not Compatible (platform)                                                              OSX            x64                                            meterpreter, shell
+ 14   exploit/osx/local/iokit_keyboard_root                                   Not Compatible (platform)                                                              OSX            x64                                            shell, meterpreter
+ 15   exploit/osx/local/libxpc_mitm_ssudo                                     Not Compatible (platform, session type)                                                OSX            x64                                            No defined session types
+```
+
+When the above is output to a terminal, the incompatibilities for a specific module (e.g. architecture or platform mismatch) are output in a different color if enabled with the `Color` datastore option.

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -709,37 +709,6 @@ module Msf::Post::File
     return uncompressed_fragment
   end
 
-  #
-  # Return a list of the Windows Drives
-  #
-  def get_drives
-    if session.platform != 'windows'
-      return false
-    end
-    drives = []
-    if session.type == "meterpreter" && session.railgun
-      bitmask = session.railgun.kernel32.GetLogicalDrives()["return"]
-      letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-      (0..25).each do |i|
-        label = letters[i,1]
-        rem = bitmask % (2**(i+1))
-        if rem > 0
-          drives << label
-          bitmask = bitmask - rem
-        end
-      end
-    else
-      disks = cmd_exec("wmic logicaldisk get caption").split("\r\n")
-      for disk in disks
-        if /([A-Z]):/ =~ disk
-          drives << disk[0]
-        end
-      end
-    end
-
-    drives
-  end
-
 protected
 
   # Checks to see if there are non-ansi or newline characters in a given string

--- a/lib/msf/core/post/windows/file_system.rb
+++ b/lib/msf/core/post/windows/file_system.rb
@@ -404,6 +404,34 @@ module Msf
 
           build_unicode_string(enc_str.size, p_buffer)
         end
+
+        #
+        # Return a list of the Windows Drives
+        #
+        def get_drives
+          drives = []
+          if session.type == "meterpreter" && session.railgun
+            bitmask = session.railgun.kernel32.GetLogicalDrives()["return"]
+            letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            (0..25).each do |i|
+              label = letters[i,1]
+              rem = bitmask % (2**(i+1))
+              if rem > 0
+                drives << label
+                bitmask = bitmask - rem
+              end
+            end
+          else
+            disks = cmd_exec("wmic logicaldisk get caption").split("\r\n")
+            for disk in disks
+              if /([A-Z]):/ =~ disk
+                drives << disk[0]
+              end
+            end
+          end
+
+          drives
+        end
       end # FileSystem
     end # Windows
   end # Post

--- a/lib/msf/ui/console/table_print/custom_color_styler.rb
+++ b/lib/msf/ui/console/table_print/custom_color_styler.rb
@@ -1,0 +1,40 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Ui
+    module Console
+      module TablePrint
+        class CustomColorStyler
+          RESET_COLOR = '%clr'.freeze
+          # @param [Hash<String, String>] opts A hash of a String to find, and what color to use
+          # For example: opts = { 'abc' => '%grn' }
+          def initialize(opts = {})
+            @highlight_terms = opts.clone
+          end
+
+          def style(value)
+            if @highlight_terms.key?(value)
+              return "#{@highlight_terms[value]}#{value}#{RESET_COLOR}"
+            end
+
+            colored_value = value
+
+            # Maximal munch; consume the terms in order of length, from longest to shortest
+            @highlight_terms.keys.sort_by { |key| -key.length }.each do |key|
+              if value.include?(key)
+                colored_value.gsub!(key, "#{@highlight_terms[key]}#{key}#{RESET_COLOR}")
+              end
+            end
+
+            colored_value
+          end
+
+          # @param [Hash<String, String>] opts A hash of a String to find, and what color to use
+          def merge!(opts)
+            @highlight_terms.merge!(opts)
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -107,8 +107,21 @@ class MetasploitModule < Msf::Post
     end
   end
 
+  def set_module_target(mod)
+    session_platform = Msf::Module::Platform.find_platform(session.platform)
+    target_index = mod.targets.find_index do |target|
+      correct_platform = @validate_platform ? target.platform&.platforms&.include?(session_platform) : true
+      correct_arch = @validate_arch ? target.arch&.include?(session.arch) : true
+      correct_platform && correct_arch
+    end
+    mod.datastore['Target'] = target_index if target_index
+  end
+
   def is_module_wanted?(mod)
-    mod[:result][:incompatibility_reasons].empty?
+    mod[:result][:incompatibility_reasons].empty? &&
+      mod[:result][:is_module_platform] &&
+      mod[:result][:is_module_arch] &&
+      mod[:result][:is_module_options_ready]
   end
 
   def setup
@@ -127,6 +140,7 @@ class MetasploitModule < Msf::Post
       next unless mod
 
       set_module_options mod
+      set_module_target mod
 
       verify_result = verify_mod(mod)
       @local_exploits << { module: mod, result: verify_result } if verify_result[:has_check]
@@ -173,8 +187,8 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    wanted_modules = @local_exploits.select { |mod| is_module_wanted?(mod) }
-    if wanted_modules.empty?
+    runnable_exploits = @local_exploits.select { |mod| is_module_wanted?(mod) }
+    if runnable_exploits.empty?
       print_error 'No suggestions available.'
       vprint_line
       vprint_session_info
@@ -183,8 +197,8 @@ class MetasploitModule < Msf::Post
     end
 
     show_found_exploits
-    results = wanted_modules.map.with_index do |mod, index|
-      print "%bld%blu[*]%clr Running check method for exploit #{index + 1} / #{wanted_modules.count}\r"
+    results = runnable_exploits.map.with_index do |mod, index|
+      print "%bld%blu[*]%clr Running check method for exploit #{index + 1} / #{runnable_exploits.count}\r"
       begin
         checkcode = mod[:module].check
       rescue => e
@@ -225,10 +239,14 @@ class MetasploitModule < Msf::Post
     vprint_session_info
     vprint_status unwanted_modules_table(@local_exploits.select { |mod| !is_module_wanted?(mod) })
 
+    report_data = []
+    results.each do |result|
+      report_data << [result[:module].fullname, result[:checkcode]] if result[:checkcode]
+    end
     report_note(
       :host => session.session_host,
       :type => 'local.suggested_exploits',
-      :data => results
+      :data => report_data
     )
   end
 
@@ -244,7 +262,13 @@ class MetasploitModule < Msf::Post
       check_res = result.fetch(:checkcode) { result[:errors].join(', ') }
       name_styler.merge!({ result[:module].fullname => color })
       check_styler.merge!({ check_res => color })
-      [index + 1, result[:module].fullname, result[:checkcode] ? 'Yes' : 'No', check_res ]
+
+      [
+        index + 1,
+        result[:module].fullname,
+        result[:checkcode] ? 'Yes' : 'No',
+        check_res
+      ]
     end
 
     Rex::Text::Table.new(
@@ -273,9 +297,9 @@ class MetasploitModule < Msf::Post
     platform_styler = ::Msf::Ui::Console::TablePrint::CustomColorStyler.new
 
     rows = unwanted_modules.map.with_index do |mod, index|
-      platforms = mod[:module].platform.platforms.any? ? mod[:module].platform.platforms : mod[:module].target.platform.platforms
+      platforms = mod[:module].target.platform&.platforms&.any? ? mod[:module].target.platform.platforms : mod[:module].platform.platforms
       platforms ||= []
-      arch = mod[:module].arch.any? ? mod[:module].arch : mod[:module].target.arch
+      arch = mod[:module].target.arch&.any? ? mod[:module].target.arch : mod[:module].arch
       arch ||= []
 
       arch.each do |a|
@@ -292,7 +316,7 @@ class MetasploitModule < Msf::Post
       end
 
       platforms.each do |module_platform|
-        color = if module_platform.realname != ::Msf::Module::Platform.find_platform(session.platform)
+        color = if module_platform != ::Msf::Module::Platform.find_platform(session.platform)
                   if @validate_platform
                     @invalid_color
                   else
@@ -304,7 +328,13 @@ class MetasploitModule < Msf::Post
         platform_styler.merge!({ module_platform.realname => color })
       end
 
-      [index + 1, mod[:module].fullname, mod[:result][:incompatibility_reasons].map { |reason| reason.split(':').first }.join(', '), platforms.map { |module_platform| module_platform.realname }.join(', '), arch.join(', ')]
+      [
+        index + 1,
+        mod[:module].fullname,
+        mod[:result][:incompatibility_reasons].map { |reason| reason.split(':').first }.join(', '),
+        platforms.map { |module_platform| module_platform.realname }.join(', '),
+        arch.join(', ')
+      ]
     end
 
     Rex::Text::Table.new(

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -345,14 +345,14 @@ class MetasploitModule < Msf::Post
         index + 1,
         mod[:module].fullname,
         mod[:result][:incompatibility_reasons].join('. '),
-        platforms.map { |module_platform| module_platform.realname }.join(', '),
-        arch.any? ? arch.join(', ') : 'No defined architectures',
-        mod[:module].session_types.any? ? mod[:module].session_types.join(', ') : 'No defined session types'
+        platforms.map { |module_platform| module_platform.realname }.sort.join(', '),
+        arch.any? ? arch.sort.join(', ') : 'No defined architectures',
+        mod[:module].session_types.any? ? mod[:module].session_types.sort.join(', ') : 'No defined session types'
       ]
     end
 
     Rex::Text::Table.new(
-      'Header' => "Invalid modules for session #{session.sid}:",
+      'Header' => "Incompatible modules for session #{session.sid}:",
       'Indent' => 1,
       'Columns' => [ '#', 'Name', 'Reasons', 'Platform', 'Architecture', 'Session Type' ],
       'WordWrap' => false,

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Post
       [
         Msf::OptBool.new('ValidateArch', [true, 'Validate architecture', true]),
         Msf::OptBool.new('ValidatePlatform', [true, 'Validate platform', true]),
-        Msf::OptBool.new('ValidateMeterpreterCommands', [true, 'Validate Meterpreter commands', true]),
+        Msf::OptBool.new('ValidateMeterpreterCommands', [true, 'Validate Meterpreter commands', false]),
         Msf::OptString.new('Colors', [false, 'Valid, Invalid and Ignored colors for module checks (unset to disable)', 'grn/red/blu'])
       ]
     )
@@ -46,15 +46,18 @@ class MetasploitModule < Msf::Post
 
   def is_module_arch?(mod)
     mod_arch = mod.target.arch || mod.arch
-    mod_arch.include? session.arch
+    mod_arch.include? session.native_arch
   end
 
-  def is_module_options_ready?(mod)
-    mod.options.each_pair do |option_name, option|
-      return false if option.required && option.default.nil? && mod.datastore[option_name].blank?
-    end
+  def is_module_wanted?(mod)
+    mod[:result][:incompatibility_reasons].empty?
+  end
 
-    true
+  def is_session_type?(mod)
+    # There are some modules that do not define any compatible session types.
+    # We could assume that means the module can run on all session types,
+    # Or we could consider that as incorrect module metadata.
+    mod.session_types.include?(session.type)
   end
 
   def is_module_platform?(mod)
@@ -69,32 +72,35 @@ class MetasploitModule < Msf::Post
     return false
   end
 
-  def valid_incompatibility_reasons(mod)
-    # These all the `reasons` due to which the module we are checking is not compatible with the current session
-    reasons = mod.session_incompatibility_reasons(session.sid)
+  def has_required_module_options?(mod)
+    mod.options.each_pair do |option_name, option|
+      return false if option.required && option.default.nil? && mod.datastore[option_name].blank?
+    end
 
+    true
+  end
+
+  def get_all_missing_module_options(mod)
+    missing_options = []
+    mod.options.each_pair do |option_name, option|
+      missing_options << option_name if option.required && option.default.nil? && mod.datastore[option_name].blank?
+    end
+    missing_options
+  end
+
+  def valid_incompatibility_reasons(mod, verify_reasons)
     # As we can potentially ignore some `reasons` (e.g. accepting arch values which are, on paper, not compatible),
     # this keeps track of valid reasons why we will not consider the module that we are evaluating to be valid.
     valid_reasons = []
-    reasons.each do |reason|
-      # If we are validating e.g. Arch, we want to remove modules that did not pass validation.
-      if !@validate_arch && reason.include?('architecture')
-        vprint_status "#{mod.name} included with override of #{reason}"
-        next
-      end
-      if !@validate_platform && reason.include?('platform')
-        vprint_status "#{mod.name} included with override of #{reason}"
-        next
-      end
-      if !@validate_meterpreter_commands && (reason.start_with?('missing') || reason.start_with?('unloadable'))
-        vprint_status "#{mod.name} included with override of #{reason}"
-        next
-      end
+    valid_reasons << "Missing required module options (#{get_all_missing_module_options(mod).join('. ')})" unless verify_reasons[:has_required_module_options]
 
-      # If we don't pass verification checks, and this reason is not specifically suppressed it is considered to be `valid`
-      valid_reasons << reason
-    end
+    incompatible_opts = []
+    incompatible_opts << 'architecture' unless verify_reasons[:is_module_arch]
+    incompatible_opts << 'platform' unless verify_reasons[:is_module_platform]
+    incompatible_opts << 'session type' unless verify_reasons[:is_session_type]
+    valid_reasons << "Not Compatible (#{incompatible_opts.join(', ')})" if incompatible_opts.any?
 
+    valid_reasons << 'Missing/unloadable Meterpreter commands' if verify_reasons[:missing_meterpreter_commands].any?
     valid_reasons
   end
 
@@ -110,18 +116,13 @@ class MetasploitModule < Msf::Post
   def set_module_target(mod)
     session_platform = Msf::Module::Platform.find_platform(session.platform)
     target_index = mod.targets.find_index do |target|
-      correct_platform = @validate_platform ? target.platform&.platforms&.include?(session_platform) : true
-      correct_arch = @validate_arch ? target.arch&.include?(session.arch) : true
-      correct_platform && correct_arch
+      # If the target doesn't define its own compatible platforms or architectures, default to the parent (module) values.
+      target_platforms = target.platform&.platforms || mod.platform.platforms
+      target_architectures = target.arch || mod.arch
+
+      target_platforms.include?(session_platform) && target_architectures.include?(session.native_arch)
     end
     mod.datastore['Target'] = target_index if target_index
-  end
-
-  def is_module_wanted?(mod)
-    mod[:result][:incompatibility_reasons].empty? &&
-      mod[:result][:is_module_platform] &&
-      mod[:result][:is_module_arch] &&
-      mod[:result][:is_module_options_ready]
   end
 
   def setup
@@ -150,13 +151,16 @@ class MetasploitModule < Msf::Post
   def verify_mod(mod)
     return { has_check: false } unless mod.kind_of?(Msf::Exploit::Local) && mod.has_check?
 
-    {
+    result = {
       has_check: true,
-      incompatibility_reasons: valid_incompatibility_reasons(mod),
       is_module_platform: (@validate_platform ? is_module_platform?(mod) : true),
       is_module_arch: (@validate_arch ? is_module_arch?(mod) : true),
-      is_module_options_ready: is_module_options_ready?(mod)
+      has_required_module_options: has_required_module_options?(mod),
+      missing_meterpreter_commands: (@validate_meterpreter_commands && session.type == 'meterpreter') ? meterpreter_session_incompatibility_reasons(session) : [],
+      is_session_type: is_session_type?(mod)
     }
+    result[:incompatibility_reasons] = valid_incompatibility_reasons(mod, result)
+    result
   end
 
   def setup_validation_options
@@ -232,8 +236,8 @@ class MetasploitModule < Msf::Post
       next { module: mod[:module], checkcode: checkcode.message }
     end
 
-    vprint_line
-    vprint_status valid_modules_table(results)
+    print_line
+    print_status valid_modules_table(results)
 
     vprint_line
     vprint_session_info
@@ -259,7 +263,7 @@ class MetasploitModule < Msf::Post
     checkcode_rows, without_checkcode_rows = results.partition { |result| result[:checkcode] }
     rows = (checkcode_rows + without_checkcode_rows).map.with_index do |result, index|
       color = result[:checkcode] ? @valid_color : @invalid_color
-      check_res = result.fetch(:checkcode) { result[:errors].join(', ') }
+      check_res = result.fetch(:checkcode) { result[:errors].join('. ') }
       name_styler.merge!({ result[:module].fullname => color })
       check_styler.merge!({ check_res => color })
 
@@ -295,6 +299,7 @@ class MetasploitModule < Msf::Post
   def unwanted_modules_table(unwanted_modules)
     arch_styler = ::Msf::Ui::Console::TablePrint::CustomColorStyler.new
     platform_styler = ::Msf::Ui::Console::TablePrint::CustomColorStyler.new
+    session_type_styler = ::Msf::Ui::Console::TablePrint::CustomColorStyler.new
 
     rows = unwanted_modules.map.with_index do |mod, index|
       platforms = mod[:module].target.platform&.platforms&.any? ? mod[:module].target.platform.platforms : mod[:module].platform.platforms
@@ -303,44 +308,52 @@ class MetasploitModule < Msf::Post
       arch ||= []
 
       arch.each do |a|
-        color = if a != session.arch
-                  if @validate_arch
-                    @invalid_color
-                  else
-                    @ignored_color
-                  end
-                else
-                  @valid_color
-                end
+        if a != session.native_arch
+          if @validate_arch
+            color = @invalid_color
+          else
+            color = @ignored_color
+          end
+        else
+          color = @valid_color
+        end
+
         arch_styler.merge!({ a.to_s => color })
       end
 
       platforms.each do |module_platform|
-        color = if module_platform != ::Msf::Module::Platform.find_platform(session.platform)
-                  if @validate_platform
-                    @invalid_color
-                  else
-                    @ignored_color
-                  end
-                else
-                  @valid_color
-                end
+        if module_platform != ::Msf::Module::Platform.find_platform(session.platform)
+          if @validate_platform
+            color = @invalid_color
+          else
+            color = @ignored_color
+          end
+        else
+          color = @valid_color
+        end
+
         platform_styler.merge!({ module_platform.realname => color })
+      end
+
+      mod[:module].session_types.each do |session_type|
+        color = session_type == session.type ? @valid_color : @invalid_color
+        session_type_styler.merge!(session_type.to_s => color)
       end
 
       [
         index + 1,
         mod[:module].fullname,
-        mod[:result][:incompatibility_reasons].map { |reason| reason.split(':').first }.join(', '),
+        mod[:result][:incompatibility_reasons].join('. '),
         platforms.map { |module_platform| module_platform.realname }.join(', '),
-        arch.join(', ')
+        arch.any? ? arch.join(', ') : 'No defined architectures',
+        mod[:module].session_types.any? ? mod[:module].session_types.join(', ') : 'No defined session types'
       ]
     end
 
     Rex::Text::Table.new(
       'Header' => "Invalid modules for session #{session.sid}:",
       'Indent' => 1,
-      'Columns' => [ '#', 'Name', 'Reasons', 'Platform', 'Architecture' ],
+      'Columns' => [ '#', 'Name', 'Reasons', 'Platform', 'Architecture', 'Session Type' ],
       'WordWrap' => false,
       'ColProps' => {
         'Architecture' => {
@@ -348,6 +361,9 @@ class MetasploitModule < Msf::Post
         },
         'Platform' => {
           'Stylers' => [platform_styler]
+        },
+        'Session Type' => {
+          'Stylers' => [session_type_styler]
         }
       },
       'Rows' => rows
@@ -357,7 +373,8 @@ class MetasploitModule < Msf::Post
   def vprint_session_info
     vprint_status 'Current Session Info:'
     vprint_status "Session Type: #{session.type}"
-    vprint_status "Architecture: #{session.arch}"
+    vprint_status "Architecture: #{session.native_arch}"
+    vprint_status "Native Architecture: #{session.arch}"
     vprint_status "Platform: #{session.platform}"
   end
 

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -44,9 +44,14 @@ class MetasploitModule < Msf::Post
     Msf::Module::Platform.subclasses.collect { |c| c.realname.downcase }
   end
 
+  def session_arch
+    # Prefer calling native arch when available, as most LPEs will require this (e.g. x86, x64) as opposed to Java/Python Meterpreter's values (e.g. Java, Python)
+    session.respond_to?(:native_arch) ? session.native_arch : session.arch
+  end
+
   def is_module_arch?(mod)
     mod_arch = mod.target.arch || mod.arch
-    mod_arch.include? session.native_arch
+    mod_arch.include?(session_arch)
   end
 
   def is_module_wanted?(mod)
@@ -73,11 +78,7 @@ class MetasploitModule < Msf::Post
   end
 
   def has_required_module_options?(mod)
-    mod.options.each_pair do |option_name, option|
-      return false if option.required && option.default.nil? && mod.datastore[option_name].blank?
-    end
-
-    true
+    get_all_missing_module_options(mod).empty?
   end
 
   def get_all_missing_module_options(mod)
@@ -120,7 +121,7 @@ class MetasploitModule < Msf::Post
       target_platforms = target.platform&.platforms || mod.platform.platforms
       target_architectures = target.arch || mod.arch
 
-      target_platforms.include?(session_platform) && target_architectures.include?(session.native_arch)
+      target_platforms.include?(session_platform) && target_architectures.include?(session_arch)
     end
     mod.datastore['Target'] = target_index if target_index
   end
@@ -308,7 +309,7 @@ class MetasploitModule < Msf::Post
       arch ||= []
 
       arch.each do |a|
-        if a != session.native_arch
+        if a != session_arch
           if @validate_arch
             color = @invalid_color
           else
@@ -373,8 +374,7 @@ class MetasploitModule < Msf::Post
   def vprint_session_info
     vprint_status 'Current Session Info:'
     vprint_status "Session Type: #{session.type}"
-    vprint_status "Architecture: #{session.native_arch}"
-    vprint_status "Native Architecture: #{session.arch}"
+    vprint_status "Architecture: #{session_arch}"
     vprint_status "Platform: #{session.platform}"
   end
 

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -29,6 +29,15 @@ class MetasploitModule < Msf::Post
       Msf::OptInt.new('SESSION', [ true, 'The session to run this module on' ]),
       Msf::OptBool.new('SHOWDESCRIPTION', [true, 'Displays a detailed description for the available exploits', false])
     ]
+
+    register_advanced_options(
+      [
+        Msf::OptBool.new('ValidateArch', [true, 'Validate architecture', true]),
+        Msf::OptBool.new('ValidatePlatform', [true, 'Validate platform', true]),
+        Msf::OptBool.new('ValidateMeterpreterCommands', [true, 'Validate Meterpreter commands', true]),
+        Msf::OptString.new('Colors', [false, 'Valid, Invalid and Ignored colors for module checks (unset to disable)', 'grn/red/blu'])
+      ]
+    )
   end
 
   def all_platforms
@@ -60,8 +69,33 @@ class MetasploitModule < Msf::Post
     return false
   end
 
-  def is_session_type_compat?(mod)
-    mod.session_compatible? session.sid
+  def valid_incompatibility_reasons(mod)
+    # These all the `reasons` due to which the module we are checking is not compatible with the current session
+    reasons = mod.session_incompatibility_reasons(session.sid)
+
+    # As we can potentially ignore some `reasons` (e.g. accepting arch values which are, on paper, not compatible),
+    # this keeps track of valid reasons why we will not consider the module that we are evaluating to be valid.
+    valid_reasons = []
+    reasons.each do |reason|
+      # If we are validating e.g. Arch, we want to remove modules that did not pass validation.
+      if !@validate_arch && reason.include?('architecture')
+        vprint_status "#{mod.name} included with override of #{reason}"
+        next
+      end
+      if !@validate_platform && reason.include?('platform')
+        vprint_status "#{mod.name} included with override of #{reason}"
+        next
+      end
+      if !@validate_meterpreter_commands && (reason.start_with?('missing') || reason.start_with?('unloadable'))
+        vprint_status "#{mod.name} included with override of #{reason}"
+        next
+      end
+
+      # If we don't pass verification checks, and this reason is not specifically suppressed it is considered to be `valid`
+      valid_reasons << reason
+    end
+
+    valid_reasons
   end
 
   def set_module_options(mod)
@@ -74,14 +108,7 @@ class MetasploitModule < Msf::Post
   end
 
   def is_module_wanted?(mod)
-    (
-      mod.kind_of?(Msf::Exploit::Local) &&
-      mod.has_check? &&
-      is_session_type_compat?(mod) &&
-      is_module_platform?(mod) &&
-      is_module_arch?(mod) &&
-      is_module_options_ready?(mod)
-    )
+    mod[:result][:incompatibility_reasons].empty?
   end
 
   def setup
@@ -89,15 +116,48 @@ class MetasploitModule < Msf::Post
 
     print_status "Collecting local exploits for #{session.session_type}..."
 
+    setup_validation_options
+    setup_color_options
+
     # Collects exploits into an array
     @local_exploits = []
-    framework.exploits.each do |name, _obj|
+    framework.exploits.each_with_index do |(name, _obj), index|
+      print "%bld%blu[*]%clr Collecting exploit #{index + 1} / #{framework.exploits.count}\r"
       mod = framework.exploits.create name
       next unless mod
+
       set_module_options mod
-      next unless is_module_wanted? mod
-      @local_exploits << mod
+
+      verify_result = verify_mod(mod)
+      @local_exploits << { module: mod, result: verify_result } if verify_result[:has_check]
     end
+  end
+
+  def verify_mod(mod)
+    return { has_check: false } unless mod.kind_of?(Msf::Exploit::Local) && mod.has_check?
+
+    {
+      has_check: true,
+      incompatibility_reasons: valid_incompatibility_reasons(mod),
+      is_module_platform: (@validate_platform ? is_module_platform?(mod) : true),
+      is_module_arch: (@validate_arch ? is_module_arch?(mod) : true),
+      is_module_options_ready: is_module_options_ready?(mod)
+    }
+  end
+
+  def setup_validation_options
+    @validate_arch = datastore['ValidateArch']
+    @validate_platform = datastore['ValidatePlatform']
+    @validate_meterpreter_commands = datastore['ValidateMeterpreterCommands']
+  end
+
+  def setup_color_options
+    @valid_color, @invalid_color, @ignored_color =
+      (datastore['Colors'] || '').split('/')
+
+    @valid_color = "%#{@valid_color}" unless @valid_color.blank?
+    @invalid_color = "%#{@invalid_color}" unless @invalid_color.blank?
+    @ignored_color = "%#{@ignored_color}" unless @ignored_color.blank?
   end
 
   def show_found_exploits
@@ -108,56 +168,167 @@ class MetasploitModule < Msf::Post
 
     vprint_status "The following #{@local_exploits.length} exploit checks are being tried:"
     @local_exploits.each do |x|
-      vprint_status x.fullname
+      vprint_status x[:module].fullname
     end
   end
 
   def run
-    if @local_exploits.empty?
+    wanted_modules = @local_exploits.select { |mod| is_module_wanted?(mod) }
+    if wanted_modules.empty?
       print_error 'No suggestions available.'
+      vprint_line
+      vprint_session_info
+      vprint_status unwanted_modules_table(@local_exploits.select { |mod| !is_module_wanted?(mod) })
       return
     end
 
     show_found_exploits
-    results = []
-    @local_exploits.each do |m|
+    results = wanted_modules.map.with_index do |mod, index|
+      print "%bld%blu[*]%clr Running check method for exploit #{index + 1} / #{wanted_modules.count}\r"
       begin
-        checkcode = m.check
+        checkcode = mod[:module].check
       rescue => e
-        elog("#Local Exploit Suggester failed with: #{e.class} when using #{m.shortname}", error: e)
-        vprint_error "Check with module #{m.fullname} failed with error #{e.class}"
-        next
+        elog("#Local Exploit Suggester failed with: #{e.class} when using #{mod[:module].shortname}", error: e)
+        vprint_error "Check with module #{mod[:module].fullname} failed with error #{e.class}"
+        next { module: mod[:module], errors: ['The check raised an exception.'] }
       end
 
       if checkcode.nil?
-        vprint_error "Check failed with #{m.fullname} for unknown reasons"
-        next
+        vprint_error "Check failed with #{mod[:module].fullname} for unknown reasons"
+        next { module: mod[:module], errors: ['The check failed for unknown reasons.'] }
       end
 
       # See def is_check_interesting?
       unless is_check_interesting? checkcode
-        vprint_status "#{m.fullname}: #{checkcode.message}"
-        next
+        vprint_status "#{mod[:module].fullname}: #{checkcode.message}"
+        next { module: mod[:module], errors: [checkcode.message] }
       end
 
       # Prints the full name and the checkcode message for the exploit
-      print_good "#{m.fullname}: #{checkcode.message}"
-      results << [m.fullname, checkcode.message]
+      print_good "#{mod[:module].fullname}: #{checkcode.message}"
 
       # If the datastore option is true, a detailed description will show
-      next unless datastore['SHOWDESCRIPTION']
-
-      # Formatting for the description text
-      Rex::Text.wordwrap(Rex::Text.compress(m.description), 2, 70).split(/\n/).each do |line|
-        print_line line
+      if datastore['SHOWDESCRIPTION']
+        # Formatting for the description text
+        Rex::Text.wordwrap(Rex::Text.compress(mod[:module].description), 2, 70).split(/\n/).each do |line|
+          print_line line
+        end
       end
+
+      next { module: mod[:module], checkcode: checkcode.message }
     end
+
+    vprint_line
+    vprint_status valid_modules_table(results)
+
+    vprint_line
+    vprint_session_info
+    vprint_status unwanted_modules_table(@local_exploits.select { |mod| !is_module_wanted?(mod) })
 
     report_note(
       :host => session.session_host,
       :type => 'local.suggested_exploits',
       :data => results
     )
+  end
+
+  def valid_modules_table(results)
+    name_styler = ::Msf::Ui::Console::TablePrint::CustomColorStyler.new
+    check_styler = ::Msf::Ui::Console::TablePrint::CustomColorStyler.new
+
+    # Split all the results by their checkcode.
+    # We want the modules that returned a checkcode to be at the top.
+    checkcode_rows, without_checkcode_rows = results.partition { |result| result[:checkcode] }
+    rows = (checkcode_rows + without_checkcode_rows).map.with_index do |result, index|
+      color = result[:checkcode] ? @valid_color : @invalid_color
+      check_res = result.fetch(:checkcode) { result[:errors].join(', ') }
+      name_styler.merge!({ result[:module].fullname => color })
+      check_styler.merge!({ check_res => color })
+      [index + 1, result[:module].fullname, result[:checkcode] ? 'Yes' : 'No', check_res ]
+    end
+
+    Rex::Text::Table.new(
+      'Header' => "Valid modules for session #{session.sid}:",
+      'Indent' => 1,
+      'Columns' => [ '#', 'Name', 'Potentially Vulnerable?', 'Check Result' ],
+      'SortIndex' => -1,
+      'WordWrap' => false, # Don't wordwrap as it messes up coloured output when it is broken up into more than one line
+      'ColProps' => {
+        'Name' => {
+          'Stylers' => [name_styler]
+        },
+        'Potentially Vulnerable?' => {
+          'Stylers' => [::Msf::Ui::Console::TablePrint::CustomColorStyler.new({ 'Yes' => @valid_color, 'No' => @invalid_color })]
+        },
+        'Check Result' => {
+          'Stylers' => [check_styler]
+        }
+      },
+      'Rows' => rows
+    )
+  end
+
+  def unwanted_modules_table(unwanted_modules)
+    arch_styler = ::Msf::Ui::Console::TablePrint::CustomColorStyler.new
+    platform_styler = ::Msf::Ui::Console::TablePrint::CustomColorStyler.new
+
+    rows = unwanted_modules.map.with_index do |mod, index|
+      platforms = mod[:module].platform.platforms.any? ? mod[:module].platform.platforms : mod[:module].target.platform.platforms
+      platforms ||= []
+      arch = mod[:module].arch.any? ? mod[:module].arch : mod[:module].target.arch
+      arch ||= []
+
+      arch.each do |a|
+        color = if a != session.arch
+                  if @validate_arch
+                    @invalid_color
+                  else
+                    @ignored_color
+                  end
+                else
+                  @valid_color
+                end
+        arch_styler.merge!({ a.to_s => color })
+      end
+
+      platforms.each do |module_platform|
+        color = if module_platform.realname != ::Msf::Module::Platform.find_platform(session.platform)
+                  if @validate_platform
+                    @invalid_color
+                  else
+                    @ignored_color
+                  end
+                else
+                  @valid_color
+                end
+        platform_styler.merge!({ module_platform.realname => color })
+      end
+
+      [index + 1, mod[:module].fullname, mod[:result][:incompatibility_reasons].map { |reason| reason.split(':').first }.join(', '), platforms.map { |module_platform| module_platform.realname }.join(', '), arch.join(', ')]
+    end
+
+    Rex::Text::Table.new(
+      'Header' => "Invalid modules for session #{session.sid}:",
+      'Indent' => 1,
+      'Columns' => [ '#', 'Name', 'Reasons', 'Platform', 'Architecture' ],
+      'WordWrap' => false,
+      'ColProps' => {
+        'Architecture' => {
+          'Stylers' => [arch_styler]
+        },
+        'Platform' => {
+          'Stylers' => [platform_styler]
+        }
+      },
+      'Rows' => rows
+    )
+  end
+
+  def vprint_session_info
+    vprint_status 'Current Session Info:'
+    vprint_status "Session Type: #{session.type}"
+    vprint_status "Architecture: #{session.arch}"
+    vprint_status "Platform: #{session.platform}"
   end
 
   def is_check_interesting?(checkcode)

--- a/modules/post/windows/gather/enum_files.rb
+++ b/modules/post/windows/gather/enum_files.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
+  include Msf::Post::Windows::FileSystem
   include Msf::Auxiliary::Report
 
   def initialize(info = {})

--- a/modules/post/windows/gather/forensics/enum_drives.rb
+++ b/modules/post/windows/gather/forensics/enum_drives.rb
@@ -13,6 +13,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
+  include Msf::Post::Windows::FileSystem
 
   def initialize(info = {})
     super(

--- a/modules/post/windows/manage/vmdk_mount.rb
+++ b/modules/post/windows/manage/vmdk_mount.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
+  include Msf::Post::Windows::FileSystem
   include Msf::Post::Windows::Registry
 
   def initialize(info = {})

--- a/spec/lib/msf/ui/console/table_print/custom_color_styler_spec.rb
+++ b/spec/lib/msf/ui/console/table_print/custom_color_styler_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+
+RSpec.describe Msf::Ui::Console::TablePrint::CustomColorStyler do
+  describe 'style' do
+    it 'should style a given substring the given color' do
+      str = ('A' * 5) + ('B' * 3) + ('A' * 5)
+      styler = described_class.new({'BBB' => '%grn'})
+
+      expect(styler.style(str)).to eql "AAAAA%grnBBB%clrAAAAA"
+    end
+
+    it 'should highlight multiple given sub-strings the given color' do
+      str = ('A' * 5) + ('B' * 3) + ('A' * 5) + ('C' * 3)
+      styler = described_class.new({'BBB' => '%grn', 'CCC' => '%yel'})
+
+      expect(styler.style(str)).to eql "AAAAA%grnBBB%clrAAAAA%yelCCC%clr"
+    end
+
+    it 'should not highlight a string if it does not match exactly' do
+      str = ('A' * 5) + ('B' * 3) + ('A' * 5) + ('C' * 3)
+      styler = described_class.new({'BbB' => '%grn'})
+
+      expect(styler.style(str)).to eql "AAAAABBBAAAAACCC"
+    end
+
+    it 'should highlight single characters' do
+      str = 'ABCABC'
+      styler = described_class.new({'A' => '%grn'})
+
+      expect(styler.style(str)).to eql "%grnA%clrBC%grnA%clrBC"
+    end
+
+    it 'should highlight multiple substrings correctly' do
+      str_first = 'BSD'
+      str_second = 'OpenBSD'
+      styler = described_class.new({'BSD' => '%grn', 'OpenBSD' => '%blu'})
+
+      expect(styler.style(str_first)).to eql "%grnBSD%clr"
+      expect(styler.style(str_second)).to eql "%bluOpenBSD%clr"
+    end
+
+    it 'should highlight the whole string if it is an exact match' do
+      str = 'This is a long string.'
+      styler = described_class.new({'This is a long string.' => '%grn'})
+
+      expect(styler.style(str)).to eql "%grnThis is a long string.%clr"
+    end
+  end
+end


### PR DESCRIPTION
This PR requires https://github.com/rapid7/metasploit-payloads/pull/570 to ensure Python Meterpreter compatibility.
This PR also moves the `get_drives` function to `windows.rb`, which prevents issues such as https://github.com/rapid7/metasploit-framework/issues/15949 where many modules were not checked as they were reported as `incompatible` due to missing Railgun.

This PR also adds in advanced options that allow the user to specify if different parameters should be validated, e.g. `ValidateArch`, `ValidatePlatform`, and `ValidateMeterpreterCommands`.

It also adds in a `valid` and `invalid` tables that store the modules which were and weren't tried against the current session. This is color-coded by default and can be configured or disabled to improve visual clarity.

It also adds a real-time counter of how many exploits are being tried, to show to the user that the module is doing _something_.

It uses the `native_arch` functionality rather than `arch` as that was found to be more reliable. Python's `arch` was being reported as `Python` which no modules considered as viable.

We no longer rely on the `session_incompatibility_reasons` from the `post_mixin.rb`, as we have realised that wasn't covering all bases. For example, it wasn't setting the module target at all, meaning some exploits could be marked as unwanted as the target architecture/platform could be mismatched. Instead, the setting of targets and validation of modules is done in the exploit suggester itself, and the solution implemented is more robust.

Tested against Kali, using Mettle, Java and Python Meterpreter

## Verification

- [ ] `msfconsole -q`
- [ ] `use payload/linux/x64/meterpreter/reverse_tcp`
- [ ] `set lhost {lhost}`
- [ ] `generate -f elf -o mettle.elf` (We use Mettle here as it has no Railgun support.)
- [ ] `chmod +x mettle.elf`
- [ ] Run `./mettle.elf` on a Kali machine and get a session
- [ ] `use post/multi/recon/local_exploit_suggester`
- [ ] `run session=-1 validatearch=true validateplatform=true validatemeterpretercommands=true`
- [ ] To be shown the modules that weren't considered as `valid`, `run session=-1 verbose=true`
- [ ] **Verify** that exploit checks are happening

## Before

```
msf6 post(multi/recon/local_exploit_suggester) > sessions

Active sessions
===============

  Id  Name  Type                   Information             Connection
  --  ----  ----                   -----------             ----------
  1         meterpreter x64/linux  kali @ 192.168.129.161  192.168.129.1:4444 -> 192.168.129.161:51254  (192.168.129.161)

msf6 post(multi/recon/local_exploit_suggester) > options

Module options (post/multi/recon/local_exploit_suggester):

   Name             Current Setting  Required  Description
   ----             ---------------  --------  -----------
   SESSION          -1               yes       The session to run this module on
   SHOWDESCRIPTION  false            yes       Displays a detailed description for the available exploits

msf6 post(multi/recon/local_exploit_suggester) > advanced

Module advanced options (post/multi/recon/local_exploit_suggester):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   VERBOSE    false            no        Enable detailed status messages
   WORKSPACE                   no        Specify the workspace for this module

msf6 post(multi/recon/local_exploit_suggester) > run

[*] 192.168.129.161 - Collecting local exploits for x64/linux...
[-] 192.168.129.161 - No suggestions available.
[*] Post module execution completed
```

## After

Without validation checks

```
msf6 post(multi/recon/local_exploit_suggester) > run session=-1 ValidateArch=false ValidatePlatform=false

msf6 post(multi/recon/local_exploit_suggester) > run session=-1 ValidateArch=false ValidatePlatform=false

[*] ::1 - Collecting local exploits for python/linux...
[*] ::1 - 167 exploit checks are being tried...
[+] ::1 - exploit/linux/local/cve_2021_4034_pwnkit_lpe_pkexec: The target is vulnerable.
[+] ::1 - exploit/linux/local/cve_2022_0847_dirtypipe: The target appears to be vulnerable. Linux kernel version found: 5.14.0
[+] ::1 - exploit/linux/local/cve_2022_0995_watch_queue: The target appears to be vulnerable.
[+] ::1 - exploit/linux/local/desktop_privilege_escalation: The target is vulnerable.
[+] ::1 - exploit/linux/local/network_manager_vpnc_username_priv_esc: The service is running, but could not be validated.
[+] ::1 - exploit/linux/local/pkexec: The service is running, but could not be validated.
[+] ::1 - exploit/linux/local/polkit_dbus_auth_bypass: The service is running, but could not be validated. Detected polkit framework version 0.105.
[+] ::1 - exploit/linux/local/su_login: The target appears to be vulnerable.
[*] Running check method for exploit 142 / 142
[*] ::1 - Valid modules for session 1:
============================

 #    Name                                                                    Potentially Vulnerable?  Check Result
 -    ----                                                                    -----------------------  ------------
 1    exploit/linux/local/cve_2021_4034_pwnkit_lpe_pkexec                     Yes                      The target is vulnerable.
 2    exploit/linux/local/cve_2022_0847_dirtypipe                             Yes                      The target appears to be vulnerable. Linux kernel version found: 5.14.0
 3    exploit/linux/local/cve_2022_0995_watch_queue                           Yes                      The target appears to be vulnerable.
 4    exploit/linux/local/desktop_privilege_escalation                        Yes                      The target is vulnerable.
 5    exploit/linux/local/network_manager_vpnc_username_priv_esc              Yes                      The service is running, but could not be validated.
 6    exploit/linux/local/pkexec                                              Yes                      The service is running, but could not be validated.
 7    exploit/linux/local/polkit_dbus_auth_bypass                             Yes                      The service is running, but could not be validated. Detected polkit framework version 0.105.
 8    exploit/linux/local/su_login                                            Yes                      The target appears to be vulnerable.
 9    exploit/android/local/futex_requeue                                     No                       The check raised an exception.
 10   exploit/android/local/janus                                             No                       The check raised an exception.
 11   exploit/linux/local/abrt_raceabrt_priv_esc                              No                       The target is not exploitable.
...
Over 100 more modules here
...
 141  exploit/windows/local/webexec                                           No                       The check raised an exception.
 142  exploit/windows/local/windscribe_windscribeservice_priv_esc             No                       The check raised an exception.

[*] Post module execution completed
```

With validation checks

```
msf6 post(multi/recon/local_exploit_suggester) > run session=-1

[*] ::1 - Collecting local exploits for python/linux...
[*] ::1 - 167 exploit checks are being tried...
[+] ::1 - exploit/linux/local/cve_2021_4034_pwnkit_lpe_pkexec: The target is vulnerable.
[+] ::1 - exploit/linux/local/cve_2022_0847_dirtypipe: The target appears to be vulnerable. Linux kernel version found: 5.14.0
[+] ::1 - exploit/linux/local/cve_2022_0995_watch_queue: The target appears to be vulnerable.
[+] ::1 - exploit/linux/local/desktop_privilege_escalation: The target is vulnerable.
[+] ::1 - exploit/linux/local/network_manager_vpnc_username_priv_esc: The service is running, but could not be validated.
[+] ::1 - exploit/linux/local/pkexec: The service is running, but could not be validated.
[+] ::1 - exploit/linux/local/su_login: The target appears to be vulnerable.
[*] Running check method for exploit 51 / 51
[*] ::1 - Valid modules for session 1:
============================

 #   Name                                                                Potentially Vulnerable?  Check Result
 -   ----                                                                -----------------------  ------------
 1   exploit/linux/local/cve_2021_4034_pwnkit_lpe_pkexec                 Yes                      The target is vulnerable.
 2   exploit/linux/local/cve_2022_0847_dirtypipe                         Yes                      The target appears to be vulnerable. Linux kernel version found: 5.14.0
 3   exploit/linux/local/cve_2022_0995_watch_queue                       Yes                      The target appears to be vulnerable.
 4   exploit/linux/local/desktop_privilege_escalation                    Yes                      The target is vulnerable.
 5   exploit/linux/local/network_manager_vpnc_username_priv_esc          Yes                      The service is running, but could not be validated.
 6   exploit/linux/local/pkexec                                          Yes                      The service is running, but could not be validated.
 7   exploit/linux/local/su_login                                        Yes                      The target appears to be vulnerable.
 8   exploit/linux/local/abrt_raceabrt_priv_esc                          No                       The target is not exploitable.
 9   exploit/linux/local/abrt_sosreport_priv_esc                         No                       The target is not exploitable.
 10  exploit/linux/local/af_packet_chocobo_root_priv_esc                 No                       The target is not exploitable. Linux kernel 5.14.0-kali4-amd64 #1 is not vulnerable
 11  exploit/linux/local/af_packet_packet_set_ring_priv_esc              No                       The target is not exploitable.
 12  exploit/linux/local/apport_abrt_chroot_priv_esc                     No                       The target is not exploitable.
 13  exploit/linux/local/asan_suid_executable_priv_esc                   No                       The check raised an exception.
...
More modules here
...
 50  exploit/multi/local/xorg_x11_suid_server                            No                       The target is not exploitable.
 51  exploit/multi/local/xorg_x11_suid_server_modulepath                 No                       The target is not exploitable.

[*] Post module execution completed
```