### PR TITLE
Implement raw stack preparation for Windows metasm

### DIFF
--- a/lib/msf/core/payload/windows/block_api.rb
+++ b/lib/msf/core/payload/windows/block_api.rb
@@ -10,12 +10,33 @@ module Msf
 ###
 module Payload::Windows::BlockApi
 
+  def initialize(info = {})
+    ret = super( info )
+    register_advanced_options(
+      [
+        Msf::OptBool.new('PrependStackContext', [ false, "Pre-populate stack with block-API resolver requirements" ])
+      ], Msf::Payload::Windows::BlockApi)
+    ret
+  end
+
   def asm_block_api(opts={})
-    Rex::Payloads::Shuffle.from_graphml_file(
+    prep = datastore['PrependStackContext'] ? asm_prep_raw_stack : ''
+    prep + Rex::Payloads::Shuffle.from_graphml_file(
       File.join(Msf::Config.install_root, 'data', 'shellcode', 'block_api.x86.graphml'),
       arch: ARCH_X86,
       name: 'api_call'
     )
+  end
+
+  def asm_prep_raw_stack(opts={})
+    asm = %Q^
+      pusha
+      call stack_prepped
+      popa
+      xor eax,eax
+      ret
+    stack_prepped:
+    ^
   end
 
 end

--- a/lib/msf/core/payload/windows/x64/block_api_x64.rb
+++ b/lib/msf/core/payload/windows/x64/block_api_x64.rb
@@ -10,12 +10,42 @@ module Msf
 ###
 module Payload::Windows::BlockApi_x64
 
+  def initialize(info = {})
+    ret = super( info )
+    register_advanced_options(
+      [
+        Msf::OptBool.new('PrependStackContext', [ false, "Pre-populate stack with block-API resolver requirements" ])
+    ], Msf::Payload::Windows::BlockApi_x64)
+    ret
+  end
+
   def asm_block_api(opts={})
-    Rex::Payloads::Shuffle.from_graphml_file(
+    prep = datastore['PrependStackContext'] ? asm_prep_raw_stack : ''
+    prep + Rex::Payloads::Shuffle.from_graphml_file(
       File.join(Msf::Config.install_root, 'data', 'shellcode', 'block_api.x64.graphml'),
       arch: ARCH_X64,
       name: 'api_call'
     )
+  end
+
+  def asm_prep_raw_stack(opts={})
+    asm = %Q^
+      push r12
+      push r13
+      push r14
+      push r15
+      push rbp
+      call stack_prepped
+      pop rbp
+      pop r15
+      pop r14
+      pop r13
+      pop r12
+      xor rax,rax
+      ret
+    stack_prepped:
+    ^
+    asm
   end
 
 end


### PR DESCRIPTION
Threads created by WinAPI have thread context which is used by the
block api resolution shellcode in our payloads to figure out where
the interfaces to windows function calls reside in memory. When
spawning raw threads via syscalls or injecting into JIT space such
as with the MSIL payloads, there is no thread context on-stack and
the start of block api resolution crashes violently.

Address the problem by teaching our block api generation routines
to pre-populate the stack with register contents sufficient for
block api resolution to boostrap the shellcode and execute stagers.
