### PR TITLE
Enumerate Windows AV via WMI root\SecurityCenter2

### DIFF
--- a/documentation/modules/post/windows/gather/enum_av.md
+++ b/documentation/modules/post/windows/gather/enum_av.md
@@ -19,7 +19,7 @@ The session to run this module on.
 
 ### Windows 10 (20H2 build 19042.1645)
 
-  ```
+    ```
     [*] Meterpreter session 1 opened (192.168.1.3:4444 -> 192.168.1.4:49178) at 2019-12-10 14:18:44 -0700
     meterpreter > bg
     [*] Backgrounding session 1...
@@ -27,10 +27,6 @@ The session to run this module on.
     msf6 > use windows/gather/enum_av
     msf6 post(windows/gather/enum_av) > set session 1
     session => 1
-    msf6 post(windows/gather/enum_av) > run
-    [*] Post module execution completed
-    msf6 post(windows/gather/enum_av) > set verbose true
-    verbose => true
     msf6 post(windows/gather/enum_av) > run
     
     [*] Found AV product:

--- a/documentation/modules/post/windows/gather/enum_av.md
+++ b/documentation/modules/post/windows/gather/enum_av.md
@@ -33,7 +33,7 @@ The session to run this module on.
     verbose => true
     msf6 post(windows/gather/enum_av) > run
     
-    [+] Found AV product:
+    [*] Found AV product:
     displayName=Windows Defender
     instanceGuid={D68DDC3A-831F-4fae-9E44-DA132C1ACF46}
     pathToSignedProductExe=windowsdefender://

--- a/documentation/modules/post/windows/gather/enum_av.md
+++ b/documentation/modules/post/windows/gather/enum_av.md
@@ -19,23 +19,23 @@ The session to run this module on.
 
 ### Windows 10 (20H2 build 19042.1645)
 
-    ```
-    [*] Meterpreter session 1 opened (192.168.1.3:4444 -> 192.168.1.4:49178) at 2019-12-10 14:18:44 -0700
-    meterpreter > bg
-    [*] Backgrounding session 1...
-    
-    msf6 > use windows/gather/enum_av
-    msf6 post(windows/gather/enum_av) > set session 1
-    session => 1
-    msf6 post(windows/gather/enum_av) > run
-    
-    [*] Found AV product:
-    displayName=Windows Defender
-    instanceGuid={D68DDC3A-831F-4fae-9E44-DA132C1ACF46}
-    pathToSignedProductExe=windowsdefender://
-    pathToSignedReportingExe=%ProgramFiles%\Windows Defender\MsMpeng.exe
-    productState=401664
-    timestamp=Thu, 21 Apr 2022 15:50:46 GMT
-    
-    [*] Post module execution completed
-    ```
+  ```
+  [*] Meterpreter session 1 opened (192.168.1.3:4444 -> 192.168.1.4:49178) at 2019-12-10 14:18:44 -0700
+  meterpreter > bg
+  [*] Backgrounding session 1...
+  
+  msf6 > use windows/gather/enum_av
+  msf6 post(windows/gather/enum_av) > set session 1
+  session => 1
+  msf6 post(windows/gather/enum_av) > run
+  
+  [*] Found AV product:
+  displayName=Windows Defender
+  instanceGuid={D68DDC3A-831F-4fae-9E44-DA132C1ACF46}
+  pathToSignedProductExe=windowsdefender://
+  pathToSignedReportingExe=%ProgramFiles%\Windows Defender\MsMpeng.exe
+  productState=401664
+  timestamp=Thu, 21 Apr 2022 15:50:46 GMT
+  
+  [*] Post module execution completed
+  ```

--- a/documentation/modules/post/windows/gather/enum_av.md
+++ b/documentation/modules/post/windows/gather/enum_av.md
@@ -1,0 +1,45 @@
+## Vulnerable Application
+
+This module will enumerate all installed AntiVirus applications on the target Windows OS
+
+## Verification Steps
+1. Start msfconsole
+2. Get meterpreter session
+3. Do: ```use post/windows/gather/enum_av```
+4. Do: ```set SESSION <session id>```
+5. Do: ```run```
+
+## Options
+
+**SESSION**
+
+The session to run this module on.
+
+## Scenarios
+
+### Windows 10 (20H2 build 19042.1645)
+
+  ```
+    [*] Meterpreter session 1 opened (192.168.1.3:4444 -> 192.168.1.4:49178) at 2019-12-10 14:18:44 -0700
+    meterpreter > bg
+    [*] Backgrounding session 1...
+    
+    msf6 > use windows/gather/enum_av
+    msf6 post(windows/gather/enum_av) > set session 1
+    session => 1
+    msf6 post(windows/gather/enum_av) > run
+    [*] Post module execution completed
+    msf6 post(windows/gather/enum_av) > set verbose true
+    verbose => true
+    msf6 post(windows/gather/enum_av) > run
+    
+    [+] Found AV product:
+    displayName=Windows Defender
+    instanceGuid={D68DDC3A-831F-4fae-9E44-DA132C1ACF46}
+    pathToSignedProductExe=windowsdefender://
+    pathToSignedReportingExe=%ProgramFiles%\Windows Defender\MsMpeng.exe
+    productState=401664
+    timestamp=Thu, 21 Apr 2022 15:50:46 GMT
+    
+    [*] Post module execution completed
+    ```

--- a/modules/post/windows/gather/enum_av.rb
+++ b/modules/post/windows/gather/enum_av.rb
@@ -1,0 +1,50 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Priv
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Installed AntiVirus Enumeration',
+        'Description' => %q{
+          This module will enumerate the AV products detected by WMIC
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'rageltman <rageltman[at]sempervictus>' ],
+        'Platform' => %w[win],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+  end
+
+  # Run Method for when run command is issued
+  def run
+    if command_exists?('wmic') == false
+      print_error("The 'wmic' command doesn't exist on this host!") # wmic is technically marked as depreciated so this command could very well be removed in future releases.
+      return
+    end
+    avs = {}
+    cmd = 'wmic /namespace:\\\\root\\SecurityCenter2 path AntiVirusProduct get * /value'
+    resp = cmd_exec(cmd, nil, 6000).to_s
+    fail_with(Failure::Unknown, resp) if resp[0..5] == 'ERROR:'
+    resp.split("\r\r\n\r\r\n").map do |ent|
+      next if ent.strip.empty?
+
+      vprint_good("Found AV product:\n#{ent}\n")
+      av_note = ent.lines.map(&:strip).map.select { |e| e.length > 1 }.map { |e| e.split('=', 2) }.to_h
+      avn = av_note.delete('displayName')
+      avs[avn] = av_note
+    end
+    report_note(host: target_host, type: 'windows.antivirus', data: avs, update: :unique_data)
+  end
+end

--- a/modules/post/windows/gather/enum_av.rb
+++ b/modules/post/windows/gather/enum_av.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Post
   # Run Method for when run command is issued
   def run
     if command_exists?('wmic') == false
-      print_error("The 'wmic' command doesn't exist on this host!") # wmic is technically marked as depreciated so this command could very well be removed in future releases.
+      print_error("The 'wmic' command doesn't exist on this host!") # wmic is technically marked as deprecated so this command could very well be removed in future releases.
       return
     end
     avs = {}

--- a/modules/post/windows/gather/enum_av.rb
+++ b/modules/post/windows/gather/enum_av.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Post
     resp.split("\r\r\n\r\r\n").map do |ent|
       next if ent.strip.empty?
 
-      vprint_good("Found AV product:\n#{ent}\n")
+      print_status("Found AV product:\n#{ent}\n")
       av_note = ent.lines.map(&:strip).map.select { |e| e.length > 1 }.map { |e| e.split('=', 2) }.to_h
       avn = av_note.delete('displayName')
       avs[avn] = av_note

--- a/modules/post/windows/gather/enum_av.rb
+++ b/modules/post/windows/gather/enum_av.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Post
     avs = {}
     cmd = 'wmic /namespace:\\\\root\\SecurityCenter2 path AntiVirusProduct get * /value'
     resp = cmd_exec(cmd, nil, 6000).to_s
-    fail_with(Failure::Unknown, resp) if resp[0..5] == 'ERROR:'
+    fail_with(Failure::Unknown, resp) if resp[0..5].upcase == 'ERROR:'
     resp.split("\r\r\n\r\r\n").map do |ent|
       next if ent.strip.empty?
 


### PR DESCRIPTION
Query WMI via shell or meterpreter session for deployed AV products
from the root\SecurityCenter2 namespace; record results as notes.
