### PR TITLE
smtp server can prompt for auth

### DIFF
--- a/documentation/modules/auxiliary/server/capture/smtp.md
+++ b/documentation/modules/auxiliary/server/capture/smtp.md
@@ -11,6 +11,12 @@ before throwing a `503` error.
 
 ## Options
 
+### REQUIREAUTH
+
+If the client should be prompted for credentials or not.  When set to `false` credentials can still be
+accepted, but the client isn't prompted outright to give them. Some systems will only provide crednetials
+if prompted. Defaults to `false`
+
 ## Scenarios
 
 ### Testing Script

--- a/documentation/modules/auxiliary/server/capture/smtp.md
+++ b/documentation/modules/auxiliary/server/capture/smtp.md
@@ -11,7 +11,7 @@ before throwing a `503` error.
 
 ## Options
 
-### REQUIREAUTH
+### AUTHPROMPT
 
 If the client should be prompted for credentials or not.  When set to `false` credentials can still be
 accepted, but the client isn't prompted outright to give them. Some systems will only provide crednetials

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -18,26 +18,24 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author' => ['ddz', 'hdm', 'h00die'],
       'License' => MSF_LICENSE,
-      'Actions' =>
-        [
-          [ 'Capture', 'Description' => 'Run SMTP capture server' ]
-        ],
-      'PassiveActions' =>
-        [
-          'Capture'
-        ],
+      'Actions' => [
+        [ 'Capture', { 'Description' => 'Run SMTP capture server' } ]
+      ],
+      'PassiveActions' => [
+        'Capture'
+      ],
       'DefaultAction' => 'Capture',
-      'References' =>
-        [
-          [ 'URL', 'https://www.samlogic.net/articles/smtp-commands-reference-auth.htm' ],
-          [ 'URL', 'https://datatracker.ietf.org/doc/html/rfc5321' ],
-          [ 'URL', 'http://fehcom.de/qmail/smtpauth.html' ]
-        ],
+      'References' => [
+        [ 'URL', 'https://www.samlogic.net/articles/smtp-commands-reference-auth.htm' ],
+        [ 'URL', 'https://datatracker.ietf.org/doc/html/rfc5321' ],
+        [ 'URL', 'http://fehcom.de/qmail/smtpauth.html' ]
+      ],
     )
 
     register_options(
       [
-        OptPort.new('SRVPORT', [ true, 'The local port to listen on.', 25 ])
+        OptPort.new('SRVPORT', [ true, 'The local port to listen on.', 25 ]),
+        OptBool.new('REQUIREAUTH', [ true, 'Require authentication from clients', false ])
       ]
     )
   end
@@ -59,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
     # if only a username is submitted, it will appear as \00un\00
     # we already cut off the empty username, so nowe we want to add on the empty password
     if data.length == 1
-      data << ""
+      data << ''
     end
     data
   end
@@ -169,7 +167,11 @@ class MetasploitModule < Msf::Auxiliary
 
     case cmd.upcase
     when 'HELO', 'EHLO'
-      client.put "250 OK\r\n"
+      if datastore['REQUIREAUTH']
+        client.put "250 AUTH LOGIN PLAIN\r\n"
+      else
+        client.put "250 OK\r\n"
+      end
       return
 
     when 'MAIL'
@@ -249,7 +251,6 @@ class MetasploitModule < Msf::Auxiliary
       vprint_error("Unknown command: #{arg}")
     end
     client.put "503 Server Error\r\n"
-
   end
 
   def report_cred(opts)

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptPort.new('SRVPORT', [ true, 'The local port to listen on.', 25 ]),
-        OptBool.new('REQUIREAUTH', [ true, 'Require authentication from clients', false ])
+        OptBool.new('AUTHPROMPT', [ true, 'Require authentication from clients', false ])
       ]
     )
   end
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Auxiliary
 
     case cmd.upcase
     when 'HELO', 'EHLO'
-      if datastore['REQUIREAUTH']
+      if datastore['AUTHPROMPT']
         client.put "250 AUTH LOGIN PLAIN\r\n"
       else
         client.put "250 OK\r\n"


### PR DESCRIPTION
Fixes #16366
I was on a pentest and reconfigured an SMTP enabled device to connect to my msf instance.  It connected, did its test, and exited, not giving me the creds.  Turns out, some devices only give out the creds when prompted to.  I've now added that as an option to the SMTP server capture module.

This is not a 'requirement' per say as it will let a client keep going if auth isn't provided, but it fixes the case where a device won't send the creds unless asked to.  Defaults to off to prevent any possible backwards compatibility or problem where a device sees auth required and would exit instead of possible sending some email with good info in it.

In this example I started 2 servers, one on port 25 (no prompt) and 26 (prompt)
```
[*] Processing smtp_server.rb for ERB directives.
resource (smtp_server.rb)> use auxiliary/server/capture/smtp
resource (smtp_server.rb)> set lhost 1.1.1.1
lhost => 1.1.1.1
resource (smtp_server.rb)> set AUTHPROMPT false
REQUIREAUTH => false
resource (smtp_server.rb)> run
[*] Auxiliary module running as background job 0.
resource (smtp_server.rb)> set SRVPORT 26
SRVPORT => 26
resource (smtp_server.rb)> set AUTHPROMPT true
REQUIREAUTH => true
resource (smtp_server.rb)> run
[*] Auxiliary module running as background job 1.
[*] Started service listener on 0.0.0.0:25 
[*] Server started.
[*] Started service listener on 0.0.0.0:26 
[*] Server started.
msf6 auxiliary(server/capture/smtp) > 
[*] SMTP: 1.1.1.1:38528 Command: HELO smtp.domain.com
[*] SMTP: 1.1.1.1:38528 Command: MAIL FROM:<alice@hacker.com>
[*] SMTP: 1.1.1.1:38528 Command: RCPT TO:<bob@secure.net>
[*] SMTP: 1.1.1.1:38528 Command: QUIT
[*] SMTP: 1.1.1.1:38528 Command: 
[*] SMTP: 1.1.1.1:51654 Command: HELO smtp.domain.com
[*] SMTP: 1.1.1.1:51654 Command: AUTH PLAIN
[*] SMTP: 1.1.1.1:51654 Command: dGVzdAB0ZXN0ADEyMzQ=
[+] SMTP LOGIN 1.1.1.1:51654 test / 1234
Interrupt: use the 'exit' command to quit
msf6 auxiliary(server/capture/smtp) > exit
```

I then used netcat to connect and test with:
```
┌──(h00die㉿home)-[/metasploit-framework]
└─$ nc 192.168.2.199 25                                 
220 SMTP Server Ready
HELO smtp.domain.com
250 OK
MAIL FROM:<alice@hacker.com>
250 OK
RCPT TO:<bob@secure.net>
250 OK
QUIT
221 OK

                                                                                                                                                                                                                                                                 
┌──(h00die㉿home)-[/metasploit-framework]
└─$ nc 192.168.2.199 26
220 SMTP Server Ready
HELO smtp.domain.com
250 AUTH LOGIN PLAIN
AUTH PLAIN
334
dGVzdAB0ZXN0ADEyMzQ=
235 2.7.0 Authentication successful
```


This was also tested during a pentest and proved to be successful. All other changes are rubocop cleanups.