### PR TITLE
[Test module] Remove obsolete PostgreSQL test module. Replace it with one for all the supported DBMS

### DIFF
--- a/test/modules/auxiliary/test/sqli_test.rb
+++ b/test/modules/auxiliary/test/sqli_test.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Auxiliary
         info,
         'Name' => 'PostgreSQL injection testing module',
         'Description' => '
-          This module tests the SQL injection library against the  PostgreSQL database management system
+          This module tests the SQL injection library against a vulnerable application from https://github.com/red0xff/sqli_vulnerable
         ',
         'Author' =>
           [
@@ -19,7 +19,6 @@ class MetasploitModule < Msf::Auxiliary
         'Platform' => %w[linux],
         'References' =>
           ['URL', 'https://github.com/red0xff/sqli_vulnerable/tree/main/postgresql'],
-        'Targets' => [['Wildcard Target', {}]],
         'DefaultTarget' => 0
       )
     )
@@ -28,20 +27,23 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RHOST('127.0.0.1'),
         OptInt.new('RPORT', [true, 'The target port', 1337]),
         OptString.new('TARGETURI', [true, 'The target URI', '/']),
-        OptInt.new('SQLI_TYPE', [true, '0)Regular. 1) BooleanBlind. 2)TimeBlind', 0]),
+        OptInt.new('SQLI_TYPE', [true, '0)Regular. 1) BooleanBlind. 2)TimeBlind.', 0]),
         OptBool.new('SAFE', [false, 'Use safe mode', false]),
         OptString.new('ENCODER', [false, 'an encoder to use (hex for example)', '']),
         OptBool.new('HEX_ENCODE_STRINGS', [false, 'Replace strings in the query with hex numbers?', false]),
-        OptInt.new('TRUNCATION_LENGTH', [true, 'Test SQLi with truncated output (0 or negative to disable)', 0])
+        OptInt.new('TRUNCATION_LENGTH', [true, 'Test SQLi with truncated output (0 or negative to disable)', 0]),
+        OptInt.new('DBMS', [ true, '0)MySQL/MariaDB. 1) PostgreSQL. 2) Sqlite. 3) MSSQL.', 0])
       ]
     )
   end
 
   def boolean_blind
     encoder = datastore['ENCODER'].empty? ? nil : datastore['ENCODER'].intern
-    sqli = create_sqli(dbms: PostgreSQLi::BooleanBasedBlind, opts: {
+    sqli = create_sqli(dbms: @dbms, opts: {
                          encoder: encoder,
-                         hex_encode_strings: datastore['HEX_ENCODE_STRINGS']
+                         hex_encode_strings: datastore['HEX_ENCODE_STRINGS'],
+                         concat_separator: '@',
+                         second_concat_separator: '#'
                        }) do |payload|
       sock = TCPSocket.open(datastore['RHOST'], datastore['RPORT'])
       sock.puts('0 or ' + payload + ' --')
@@ -59,17 +61,19 @@ class MetasploitModule < Msf::Auxiliary
   def reflected
     encoder = datastore['ENCODER'].empty? ? nil : datastore['ENCODER'].intern
     truncation = datastore['TRUNCATION_LENGTH'] <= 0 ? nil : datastore['TRUNCATION_LENGTH']
-    sqli = create_sqli(dbms: PostgreSQLi::Common, opts: {
+    sqli = create_sqli(dbms: @dbms, opts: {
                          encoder: encoder,
                          hex_encode_strings: datastore['HEX_ENCODE_STRINGS'],
                          truncation_length: truncation,
-                         safe: datastore['SAFE']
+                         safe: datastore['SAFE'],
+                         concat_separator: '@',
+                         second_concat_separator: '#'
                        }) do |payload|
       sock = TCPSocket.open(datastore['RHOST'], datastore['RPORT'])
-      sock.puts('0 union ' + payload + ' --')
-      res = sock.gets.chomp
+      sock.puts('0 union ' + payload)
+      res = sock.gets&.chomp
       sock.close
-      res
+      truncation ? res[0, truncation] : res
     end
     unless sqli.test_vulnerable
       print_bad("Doesn't seem to be vulnerable")
@@ -80,12 +84,20 @@ class MetasploitModule < Msf::Auxiliary
 
   def time_blind
     encoder = datastore['ENCODER'].empty? ? nil : datastore['ENCODER'].intern
-    sqli = create_sqli(dbms: PostgreSQLi::TimeBasedBlind, opts: {
+    sqli = create_sqli(dbms: @dbms, opts: {
                          encoder: encoder,
-                         hex_encode_strings: datastore['HEX_ENCODE_STRINGS']
+                         hex_encode_strings: datastore['HEX_ENCODE_STRINGS'],
+                         concat_separator: '@',
+                         second_concat_separator: '#'
                        }) do |payload|
       sock = TCPSocket.open(datastore['RHOST'], datastore['RPORT'])
-      sock.puts('0 or ' + payload + ' --')
+
+      if datastore['DBMS'] == 3 # MSSQL
+        sock.puts("0;#{payload} --")
+      else
+        sock.puts('0 or ' + payload + ' --')
+      end
+
       sock.gets
       sock.close
     end
@@ -97,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def perform_sqli(sqli)
-    print_good "dbms: #{sqli.version}"
+    print_good "dbms version: #{sqli.version}"
     tables = sqli.enum_table_names
     print_good "tables: #{tables.join(', ')}"
     tables.each do |table|
@@ -113,10 +125,31 @@ class MetasploitModule < Msf::Auxiliary
   def run
     case datastore['SQLI_TYPE']
     when 0
+      @dbms = case datastore['DBMS']
+        when 0 then Msf::Exploit::SQLi::MySQLi::Common
+        when 1 then Msf::Exploit::SQLi::PostgreSQLi::Common
+        when 2 then Msf::Exploit::SQLi::SQLitei::Common
+        when 3 then Msf::Exploit::SQLi::Mssqli::Common
+        else print_bad("Unsupported target")
+      end
       reflected
     when 1
+      @dbms = case datastore['DBMS']
+        when 0 then Msf::Exploit::SQLi::MySQLi::BooleanBasedBlind
+        when 1 then Msf::Exploit::SQLi::PostgreSQLi::BooleanBasedBlind
+        when 2 then Msf::Exploit::SQLi::SQLitei::BooleanBasedBlind
+        when 3 then Msf::Exploit::SQLi::Mssqli::BooleanBasedBlind
+        else print_bad("Unsupported target")
+      end
       boolean_blind
     when 2
+      @dbms = case datastore['DBMS']
+        when 0 then Msf::Exploit::SQLi::MySQLi::TimeBasedBlind
+        when 1 then Msf::Exploit::SQLi::PostgreSQLi::TimeBasedBlind
+        when 2 then Msf::Exploit::SQLi::SQLitei::TimeBasedBlind
+        when 3 then Msf::Exploit::SQLi::Mssqli::TimeBasedBlind
+        else print_bad("Unsupported target")
+      end
       time_blind
     else
       print_bad('Unsupported SQLI_TYPE')

--- a/test/modules/auxiliary/test/sqli_test.rb
+++ b/test/modules/auxiliary/test/sqli_test.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name' => 'PostgreSQL injection testing module',
+        'Name' => 'SQL injection testing module',
         'Description' => '
           This module tests the SQL injection library against a vulnerable application from https://github.com/red0xff/sqli_vulnerable
         ',
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'Platform' => %w[linux],
         'References' =>
-          ['URL', 'https://github.com/red0xff/sqli_vulnerable/tree/main/postgresql'],
+          ['URL', 'https://github.com/red0xff/sqli_vulnerable'],
         'DefaultTarget' => 0
       )
     )

--- a/test/modules/auxiliary/test/sqli_test.rb
+++ b/test/modules/auxiliary/test/sqli_test.rb
@@ -27,12 +27,12 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RHOST('127.0.0.1'),
         OptInt.new('RPORT', [true, 'The target port', 1337]),
         OptString.new('TARGETURI', [true, 'The target URI', '/']),
-        OptInt.new('SQLI_TYPE', [true, '0)Regular. 1) BooleanBlind. 2)TimeBlind.', 0]),
+        OptEnum.new('SQLI_TYPE', [true, 'The type of SQL injection to test', 'Regular', %w(Regular BooleanBlind TimeBlind)]),
         OptBool.new('SAFE', [false, 'Use safe mode', false]),
         OptString.new('ENCODER', [false, 'an encoder to use (hex for example)', '']),
         OptBool.new('HEX_ENCODE_STRINGS', [false, 'Replace strings in the query with hex numbers?', false]),
         OptInt.new('TRUNCATION_LENGTH', [true, 'Test SQLi with truncated output (0 or negative to disable)', 0]),
-        OptInt.new('DBMS', [ true, '0)MySQL/MariaDB. 1) PostgreSQL. 2) Sqlite. 3) MSSQL.', 0])
+        OptEnum.new('DBMS', [ true, 'The DBMS to target', 'MariaDB', %w(MariaDB PostgreSQL Sqlite MSSQL)])
       ]
     )
   end
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
                        }) do |payload|
       sock = TCPSocket.open(datastore['RHOST'], datastore['RPORT'])
 
-      if datastore['DBMS'] == 3 # MSSQL
+      if datastore['DBMS'] == 'MSSQL'
         sock.puts("0;#{payload} --")
       else
         sock.puts('0 or ' + payload + ' --')
@@ -124,30 +124,30 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     case datastore['SQLI_TYPE']
-    when 0
+    when 'Regular'
       @dbms = case datastore['DBMS']
-        when 0 then Msf::Exploit::SQLi::MySQLi::Common
-        when 1 then Msf::Exploit::SQLi::PostgreSQLi::Common
-        when 2 then Msf::Exploit::SQLi::SQLitei::Common
-        when 3 then Msf::Exploit::SQLi::Mssqli::Common
+        when 'MariaDB' then Msf::Exploit::SQLi::MySQLi::Common
+        when 'PostgreSQL' then Msf::Exploit::SQLi::PostgreSQLi::Common
+        when 'Sqlite' then Msf::Exploit::SQLi::SQLitei::Common
+        when 'MSSQL' then Msf::Exploit::SQLi::Mssqli::Common
         else print_bad("Unsupported target")
       end
       reflected
-    when 1
+    when 'BooleanBlind'
       @dbms = case datastore['DBMS']
-        when 0 then Msf::Exploit::SQLi::MySQLi::BooleanBasedBlind
-        when 1 then Msf::Exploit::SQLi::PostgreSQLi::BooleanBasedBlind
-        when 2 then Msf::Exploit::SQLi::SQLitei::BooleanBasedBlind
-        when 3 then Msf::Exploit::SQLi::Mssqli::BooleanBasedBlind
+        when 'MariaDB' then Msf::Exploit::SQLi::MySQLi::BooleanBasedBlind
+        when 'PostgreSQL' then Msf::Exploit::SQLi::PostgreSQLi::BooleanBasedBlind
+        when 'Sqlite' then Msf::Exploit::SQLi::SQLitei::BooleanBasedBlind
+        when 'MSSQL' then Msf::Exploit::SQLi::Mssqli::BooleanBasedBlind
         else print_bad("Unsupported target")
       end
       boolean_blind
-    when 2
+    when 'TimeBlind'
       @dbms = case datastore['DBMS']
-        when 0 then Msf::Exploit::SQLi::MySQLi::TimeBasedBlind
-        when 1 then Msf::Exploit::SQLi::PostgreSQLi::TimeBasedBlind
-        when 2 then Msf::Exploit::SQLi::SQLitei::TimeBasedBlind
-        when 3 then Msf::Exploit::SQLi::Mssqli::TimeBasedBlind
+        when 'MariaDB' then Msf::Exploit::SQLi::MySQLi::TimeBasedBlind
+        when 'PostgreSQL' then Msf::Exploit::SQLi::PostgreSQLi::TimeBasedBlind
+        when 'Sqlite' then Msf::Exploit::SQLi::SQLitei::TimeBasedBlind
+        when 'MSSQL' then Msf::Exploit::SQLi::Mssqli::TimeBasedBlind
         else print_bad("Unsupported target")
       end
       time_blind

--- a/test/modules/auxiliary/test/sqli_test.rb
+++ b/test/modules/auxiliary/test/sqli_test.rb
@@ -130,7 +130,6 @@ class MetasploitModule < Msf::Auxiliary
         when 'PostgreSQL' then Msf::Exploit::SQLi::PostgreSQLi::Common
         when 'Sqlite' then Msf::Exploit::SQLi::SQLitei::Common
         when 'MSSQL' then Msf::Exploit::SQLi::Mssqli::Common
-        else print_bad("Unsupported target")
       end
       reflected
     when 'BooleanBlind'
@@ -139,7 +138,6 @@ class MetasploitModule < Msf::Auxiliary
         when 'PostgreSQL' then Msf::Exploit::SQLi::PostgreSQLi::BooleanBasedBlind
         when 'Sqlite' then Msf::Exploit::SQLi::SQLitei::BooleanBasedBlind
         when 'MSSQL' then Msf::Exploit::SQLi::Mssqli::BooleanBasedBlind
-        else print_bad("Unsupported target")
       end
       boolean_blind
     when 'TimeBlind'
@@ -148,11 +146,8 @@ class MetasploitModule < Msf::Auxiliary
         when 'PostgreSQL' then Msf::Exploit::SQLi::PostgreSQLi::TimeBasedBlind
         when 'Sqlite' then Msf::Exploit::SQLi::SQLitei::TimeBasedBlind
         when 'MSSQL' then Msf::Exploit::SQLi::Mssqli::TimeBasedBlind
-        else print_bad("Unsupported target")
       end
       time_blind
-    else
-      print_bad('Unsupported SQLI_TYPE')
     end
   end
 end


### PR DESCRIPTION
This makes it easier to test the different features of the SQL injection engine that is part of Metasploit Framework.

The vulnerable applications this module targets [can be found here](https://github.com/red0xff/sqli_vulnerable).

This allows testing different SQLi modes and options.

Fetch the commits that add MSSQL injection support before testing this (as it supports MSSQL).

Can be used to test https://github.com/rapid7/metasploit-framework/pull/16435

## Verification

- [ ] Choose a `DBMS`, run `docker-compose up -d` inside its directory.
- [ ] Load the module in `msfconsole`
- [ ] `set DBMS <number>`
- [ ] `set SQLi_Type <number`
- [ ] Set other options you want to test, eventually set `verbose`
- [ ] `run`
- [ ] **Verify** You get correct output (refer to database initialization scripts in [the sqli_vulnerable repo](https://github.com/red0xff/sqli_vulnerable)).

## Bugs found with this testing

`PostgreSQL` -> `Common`
When `safe = true` and `truncation_length > 0`.
(Todo: debug it and issue a fix).

Update: not a bug in the logic of the library, queries of the form:
```
select substr(coalesce(<COLUMN>::text,'')::text,<OFFSET>,<TRUNCATION_LENGTH>) from <TABLE> where <CONDITION> limit 1 offset 0
```
For some reason, if there are less than `<TRUNCATION_LENGTH>` characters in a given row, sometimes it selects a different row where it returns `<TRUNCATION_LENGTH>` characters or less. This yields wrong results, like "passwome" instead of "password" (where the `me` part is from `username`).

## To test again

`MySQL/MariaDB` -> `Common`
When `safe = true` and `truncation length > 0`.
(Todo: test again, on OpenEMR perhaps?)