### PR TITLE
Add uploading of files to HTTP Client

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -149,14 +149,14 @@ class Client
     opts['ssl'] = self.ssl
     opts['ctype'] ||= 'application/x-www-form-urlencoded' if opts['method'] == 'POST'
 
-    if opts['files']
-      unless opts['files'].is_a?(::Array)
-        raise ::ArgumentError, "request_cgi: The provided `files` option is not valid. Expected: Array, Got: #{opts['files'].class}"
+    if opts['form_data']
+      unless opts['form_data'].is_a?(::Array)
+        raise ::ArgumentError, "request_cgi: The provided `form_data` option is not valid. Expected: Array, Got: #{opts['form_data'].class}"
       end
 
       file_data = Rex::MIME::Message.new
 
-      opts['files'].each do |file_hash|
+      opts['form_data'].each do |file_hash|
         # The name of the HTTP form field
         field_name = file_hash['name'].is_a?(::String) ? file_hash['name'] : nil
 

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -139,6 +139,7 @@ class Client
   # @option opts 'encode_params' [Bool]   URI encode the GET or POST variables (names and values), default: true
   # @option opts 'vars_get'      [Hash]   GET variables as a hash to be translated into a query string
   # @option opts 'vars_post'     [Hash]   POST variables as a hash to be translated into POST data
+  # @option opts 'vars_form_data'     [Hash]   POST form_data variables as a hash to be translated into multi-part POST form data
   #
   # @return [ClientRequest]
   def request_cgi(opts = {})
@@ -147,40 +148,6 @@ class Client
     opts['cgi'] = true
     opts['port'] = self.port
     opts['ssl'] = self.ssl
-    opts['ctype'] ||= 'application/x-www-form-urlencoded' if opts['method'] == 'POST'
-
-    if opts['form_data']
-      unless opts['form_data'].is_a?(::Array)
-        raise ::ArgumentError, "request_cgi: The provided `form_data` option is not valid. Expected: Array, Got: #{opts['form_data'].class}"
-      end
-
-      file_data = Rex::MIME::Message.new
-
-      opts['form_data'].each do |file_hash|
-        # The name of the HTTP form field
-        field_name = file_hash['name'].is_a?(::String) ? file_hash['name'] : nil
-
-        # Should we default to 'application/octet-stream', nil, or HttpClient's default of 'text/plain'?
-        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
-        mime_type = file_hash.fetch('mime_type', 'text/plain')
-
-        # Default to HttpClient's default option of '8bit'
-        encoding = file_hash.fetch('encoding', '8bit')
-
-        file_contents = get_file_data(file_hash['data'])
-
-        filename = file_hash.key?('filename') ? file_hash['filename'] : get_filename(file_hash['data']) || field_name
-
-        content_disposition = 'form-data'
-        content_disposition << "; name=\"#{field_name}\"" if field_name
-        content_disposition << "; filename=\"#{::CGI.escape(filename)}\"" if filename
-
-        file_data.add_part(file_contents, mime_type, encoding, content_disposition)
-      end
-
-      opts['data'] ? opts['data'] << file_data.to_s : opts['data'] = file_data.to_s
-      opts['ctype'] = "multipart/form-data; boundary=#{file_data.bound}"
-    end
 
     ClientRequest.new(opts)
   end
@@ -763,14 +730,6 @@ protected
   # The established NTLM connection info
   #
   attr_accessor :ntlm_client
-
-  def get_file_data(file)
-    file.respond_to?('read') ? (contents = file.read; file.rewind; contents) : file.to_s
-  end
-
-  def get_filename(data)
-    data.is_a?(::Pathname) || data.is_a?(::File) ? ::File.basename(data) : nil
-  end
 end
 
 end

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -177,7 +177,8 @@ class ClientRequest
 
           content_disposition = 'form-data'
           content_disposition << "; name=\"#{field_name}\"" if field_name
-          content_disposition << "; filename=\"#{::CGI.escape(filename)}\"" if filename
+          # NOTE: The file name is intentionally unescaped, as exploits such as playsms_filename_exec embed payloads into the file name which shouldn't be escaped
+          content_disposition << "; filename=\"#{filename}\"" if filename
 
           form_data.add_part(file_contents, mime_type, encoding, content_disposition)
         end

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 require 'uri'
 
+require 'rex/mime'
 require 'rex/socket'
 require 'rex/text'
 
@@ -32,6 +33,7 @@ class ClientRequest
     'uri'                    => '/',
     'vars_get'               => {},
     'vars_post'              => {},
+    'vars_form_data'         => [],
     'version'                => '1.1',
     'vhost'                  => nil,
 
@@ -97,6 +99,8 @@ class ClientRequest
     # Start POST data string
     pstr = opts['data'] ? opts['data'].dup : ""
 
+    ctype = opts['ctype']
+
     if opts['cgi']
       uri_str = set_uri
 
@@ -147,6 +151,44 @@ class ClientRequest
           pstr << (opts['encode_params'] ? set_encode_uri(v) : v)
         end
       end
+
+      if opts['vars_form_data']
+        unless opts['vars_form_data'].is_a?(::Array)
+          raise ::ArgumentError, "request_cgi: The provided `form_data` option is not valid. Expected: Array, Got: #{opts['form_data'].class}"
+        end
+
+        file_data = Rex::MIME::Message.new
+        # Initialize or reuse the previous form data boundary to ensure idempotency
+        opts['vars_form_data_boundary'] ||= file_data.bound
+        file_data.bound = opts['vars_form_data_boundary']
+
+        opts['vars_form_data'].each do |file_hash|
+          # The name of the HTTP form field
+          field_name = file_hash['name'].is_a?(::String) ? file_hash['name'] : nil
+
+          # Should we default to 'application/octet-stream', nil, or HttpClient's default of 'text/plain'?
+          # https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+          mime_type = file_hash.fetch('mime_type', 'text/plain')
+
+          # Default to HttpClient's default option of '8bit'
+          encoding = file_hash.fetch('encoding', '8bit')
+
+          file_contents = get_file_data(file_hash['data'])
+
+          filename = file_hash.key?('filename') ? file_hash['filename'] : get_filename(file_hash['data']) || field_name
+
+          content_disposition = 'form-data'
+          content_disposition << "; name=\"#{field_name}\"" if field_name
+          content_disposition << "; filename=\"#{::CGI.escape(filename)}\"" if filename
+
+          file_data.add_part(file_contents, mime_type, encoding, content_disposition)
+        end
+
+        pstr += file_data.to_s
+      end
+
+      ctype ||= "multipart/form-data; boundary=#{opts['vars_form_data_boundary']}" if opts['vars_form_data_boundary']
+      ctype ||= 'application/x-www-form-urlencoded' if opts['method'] == 'POST'
     else
       if opts['encode']
         qstr = set_encode_uri(qstr)
@@ -197,7 +239,7 @@ class ClientRequest
     req << set_connection_header
     req << set_extra_headers
 
-    req << set_content_type_header
+    req << set_content_type_header(ctype)
     req << set_content_len_header(pstr.length)
     req << set_chunked_header
     req << opts['raw_headers']
@@ -395,8 +437,8 @@ class ClientRequest
   #
   # Return the content type header
   #
-  def set_content_type_header
-    opts['ctype'] ? set_formatted_header("Content-Type", opts['ctype']) : ""
+  def set_content_type_header(ctype)
+    ctype ? set_formatted_header("Content-Type", ctype) : ""
   end
 
   #
@@ -478,6 +520,13 @@ class ClientRequest
     "\r\n" + chunked + "0\r\n\r\n"
   end
 
+  def get_file_data(file)
+    file.respond_to?('read') ? (file.rewind; contents = file.read; file.rewind; contents) : file.to_s
+  end
+
+  def get_filename(data)
+    data.is_a?(::Pathname) || data.is_a?(::File) ? ::File.basename(data) : nil
+  end
 
 end
 

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -203,20 +203,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def upload_root_shell
-    mime = Rex::MIME::Message.new
-    mime.add_part(@csrf_token, nil, nil, 'form-data; name="nsp"')
-    mime.add_part('1', nil, nil, 'form-data; name="upload"')
-    mime.add_part('1000000', nil, nil, 'form-data; name="MAX_FILE_SIZE"')
-    mime.add_part(payload_zip, 'application/zip', 'binary',
-                  'form-data; name="uploadedfile"; ' \
-                  "filename=\"#{zip_filename}\"")
+    files = [
+      { 'name' => 'nsp', 'data' => @csrf_token, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
+      { 'name' => 'upload', 'data' => 1, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
+      { 'name' => 'MAX_FILE_SIZE', 'data' => 1000000, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
+      { 'name' => 'uploadedfile', 'data' => payload_zip, 'mime_type' => 'application/zip', 'encoding' => 'binary', 'filename' => zip_filename }
+    ]
 
     res = send_request_cgi!(
       'method' => 'POST',
       'uri'    => '/nagiosxi/admin/components.php',
       'cookie' => @admin_cookie,
-      'ctype'  => "multipart/form-data; boundary=#{mime.bound}",
-      'data'   => mime.to_s
+      'files'  => files
     )
 
     if res && res.code != 200

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -204,10 +204,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def upload_root_shell
     vars_form_data = [
-      { 'name' => 'nsp', 'data' => @csrf_token, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
-      { 'name' => 'upload', 'data' => 1, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
-      { 'name' => 'MAX_FILE_SIZE', 'data' => 1000000, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
-      { 'name' => 'uploadedfile', 'data' => payload_zip, 'mime_type' => 'application/zip', 'encoding' => 'binary', 'filename' => zip_filename }
+      { 'name' => 'nsp', 'data' => @csrf_token },
+      { 'name' => 'upload', 'data' => 1 },
+      { 'name' => 'MAX_FILE_SIZE', 'data' => 1000000 },
+      { 'name' => 'uploadedfile', 'data' => payload_zip, 'content_type' => 'application/zip', 'encoding' => 'binary', 'filename' => zip_filename }
     ]
 
     res = send_request_cgi!(

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -203,7 +203,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def upload_root_shell
-    form_data = [
+    vars_form_data = [
       { 'name' => 'nsp', 'data' => @csrf_token, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
       { 'name' => 'upload', 'data' => 1, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
       { 'name' => 'MAX_FILE_SIZE', 'data' => 1000000, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
@@ -214,7 +214,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri'    => '/nagiosxi/admin/components.php',
       'cookie' => @admin_cookie,
-      'form_data'  => form_data
+      'vars_form_data'  => vars_form_data
     )
 
     if res && res.code != 200

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -203,7 +203,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def upload_root_shell
-    files = [
+    form_data = [
       { 'name' => 'nsp', 'data' => @csrf_token, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
       { 'name' => 'upload', 'data' => 1, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
       { 'name' => 'MAX_FILE_SIZE', 'data' => 1000000, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
@@ -214,7 +214,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri'    => '/nagiosxi/admin/components.php',
       'cookie' => @admin_cookie,
-      'files'  => files
+      'form_data'  => form_data
     )
 
     if res && res.code != 200

--- a/modules/exploits/multi/http/apache_flink_jar_upload_exec.rb
+++ b/modules/exploits/multi/http/apache_flink_jar_upload_exec.rb
@@ -98,13 +98,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def upload_jar(filename, data)
-    post_data = Rex::MIME::Message.new
-    post_data.add_part(data, 'application/x-java-archive', 'binary', "form-data; name=\"jarfile\"; filename=\"#{filename}\"")
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'jars', 'upload'),
       'method' => 'POST',
-      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
-      'data' => post_data.to_s
+      'vars_form_data' => [
+        {
+          'name' => 'jarfile',
+          'data' => data,
+          'filename' => filename,
+          'content_type' => 'application/x-java-archive',
+          'encoding' => 'binary'
+        }
+      ]
     )
   end
 

--- a/modules/exploits/multi/http/playsms_filename_exec.rb
+++ b/modules/exploits/multi/http/playsms_filename_exec.rb
@@ -159,12 +159,14 @@ class MetasploitModule < Msf::Exploit::Remote
     # Payload.
     evilname = "<?php $t=$_SERVER['HTTP_USER_AGENT']; eval($t); ?>"
 
-    # setup POST request.
-    post_data = Rex::MIME::Message.new
-    post_data.add_part(csrf, content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="X-CSRF-Token"') # CSRF token
-    post_data.add_part("#{rand_text_alpha(8 + rand(5))}", content_type = 'application/octet-stream', transfer_encoding = nil, content_disposition = "form-data; name=\"fncsv\"; filename=\"#{evilname}\"")  # payload
-    post_data.add_part("1", content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="fncsv_dup"')  # extra
-    data = post_data.to_s
+    form_data = [
+      # CSRF token
+      { 'name' => 'X-CSRF-Token', 'data' => csrf },
+      # payload
+      { 'name' => 'fncsv', 'content_type' => 'application/octet-stream', 'data' => "#{rand_text_alpha(8 + rand(5))}", 'filename' => evilname },
+      # extra
+      { 'name' => 'fncsv_dup', 'data' => '1' }
+    ]
 
     vprint_status('Trying to upload file with malicious Filename Field....')
     # Lets Send Upload request.
@@ -182,8 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Upgrade-Insecure-Requests' => '1',
       },
       'Connection' => 'close',
-      'data' => data,
-      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'vars_form_data' => form_data
     })
   end
 end

--- a/modules/exploits/multi/http/playsms_uploadcsv_exec.rb
+++ b/modules/exploits/multi/http/playsms_uploadcsv_exec.rb
@@ -164,10 +164,12 @@ class MetasploitModule < Msf::Exploit::Remote
     final_csv = "Name,Email,Department\n"
     final_csv << "#{evil},#{rand(1..100)},#{rand(1..100)}"
     # setup POST request.
-    post_data = Rex::MIME::Message.new
-    post_data.add_part(csrf, content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="X-CSRF-Token"') # CSRF token
-    post_data.add_part(final_csv, content_type = 'text/csv', transfer_encoding = nil, content_disposition = 'form-data; name="fnpb"; filename="agent22.csv"')  #payload
-    data = post_data.to_s
+    form_data = [
+      # CSRF token
+      { 'name' => 'X-CSRF-Token', 'data' => csrf },
+      # Payload
+      { 'name' => 'fnpb', 'data' => final_csv, 'content_type' => 'text/csv', 'filename' => 'agent22.csv' }
+    ]
 
     vprint_status('Trying to upload malicious CSV file ....')
     # Lets Send Upload request.
@@ -186,8 +188,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Upgrade-Insecure-Requests' => '1',
       },
       'Connection' => 'close',
-      'data' => data,
-      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'vars_form_data' => form_data
     })
   end
 end

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -222,7 +222,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return vars
   end
 
-  
   def detect_platform(body)
     return nil if body.blank?
 
@@ -296,20 +295,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return ""
   end
 
-  def generate_multipart_msg(boundary, data)
-    # Rex::MIME::Message is breaking the binary upload when trying to
-    # enforce CRLF for SMTP compatibility
-    war_multipart = "-----------------------------"
-    war_multipart << boundary
-    war_multipart << "\r\nContent-Disposition: form-data; name=\"deployWar\"; filename=\""
-    war_multipart << @app_base
-    war_multipart << ".war\"\r\nContent-Type: application/octet-stream\r\n\r\n"
-    war_multipart << data
-    war_multipart << "\r\n-----------------------------"
-    war_multipart << boundary
-    war_multipart << "--\r\n"
-  end
-
   def war_payload
     payload.encoded_war({
       :app_name => @app_base,
@@ -320,20 +305,25 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_war_payload(url, war)
-    boundary_identifier = rand_text_numeric(28)
-
     res = send_request_cgi({
       'uri'          => url,
       'method'       => 'POST',
-      'ctype'        => 'multipart/form-data; boundary=---------------------------' + boundary_identifier,
       'user'         => datastore['HttpUsername'],
       'password'     => datastore['HttpPassword'],
       'cookie'       => @session_id,
       'vars_get'     => vars_get,
-      'data'         => generate_multipart_msg(boundary_identifier, war),
+      'vars_form_data' => [
+        {
+          'name' => 'deployWar',
+          'filename' => "#{@app_base}.war",
+          'content_type' => 'application/octet-stream',
+          'data' => war,
+          'encoding' => 'binary'
+        }
+      ]
     })
 
-    return res
+    res
   end
 
   def send_request_undeploy(url)

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -252,13 +252,13 @@ RSpec.describe Rex::Proto::Http::Client do
     let(:file) do
       ::File.open(file_path, 'rb')
     end
-    let(:mock_boundary) do
-      '-----------------------------MockBoundary1234'
+    let(:mock_boundary_suffix) do
+      'MockBoundary1234'
     end
 
     before(:each) do
       file.rewind
-      allow(Rex::Text).to receive(:rand_text_numeric).with(30).and_return('MockBoundary1234')
+      allow(Rex::Text).to receive(:rand_text_numeric).with(30).and_return(mock_boundary_suffix)
     end
 
     it 'should parse field name and file object as data' do
@@ -275,16 +275,16 @@ RSpec.describe Rex::Proto::Http::Client do
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 247\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="field1"; filename="string_list.txt"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 #{file_contents}\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -301,16 +301,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 247\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="field1"; filename="string_list.txt"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: binary\r
 \r
 #{file.read}\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -327,16 +327,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 243\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="field1"; filename="my_file.txt"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: binary\r
 \r
 #{file.read}\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -357,16 +357,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 234\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file1"; filename="file1"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 #{data}\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -384,16 +384,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 234\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file1"; filename="file1"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 #{data}\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -411,16 +411,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 240\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file1"; filename="my_file.txt"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 #{data}\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -438,16 +438,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 226\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file1"; filename="file1"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 #{data}\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -467,16 +467,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 241\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file1"; filename="my_file.txt"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 #{str}\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -494,16 +494,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 231\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="nil_value"; filename="nil_value"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 \r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -521,22 +521,22 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 339\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 123\r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 456\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
       EOF
 
       expect(request.to_s).to eq(expected)
@@ -553,16 +553,16 @@ Content-Transfer-Encoding: 8bit\r
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 191\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 \r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -582,34 +582,34 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 632\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 123\r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 456\r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 789\r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 101112\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -626,16 +626,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 239\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="field1"; filename="field1"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: binary\r
 \r
 [5, "hello"]\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -656,34 +656,34 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 820\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 file1_content\r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 file2_content\r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 file2_content\r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 file.txt\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -700,16 +700,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 242\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file"; filename="#{::CGI.escape(form_data[0]['filename'])}"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 abc\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -726,16 +726,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 244\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="file"; filename="#{::CGI.escape(form_data[0]['filename'])}"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: base64\r
 \r
 abc\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -752,16 +752,16 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 224\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="example_name"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
 example_data\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
       expect(request.to_s).to eq(expected)
     end
@@ -777,15 +777,15 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 216\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="example_name"; filename="example_name"\r
 Content-Type: text/plain\r
 \r
 example_data\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
 EOF
 
       expect(request.to_s).to eq(expected)
@@ -802,15 +802,15 @@ EOF
 POST / HTTP/1.1\r
 Host: #{ip}\r
 User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
+Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
 Content-Length: 223\r
 \r
-#{mock_boundary}\r
+-----------------------------MockBoundary1234\r
 Content-Disposition: form-data; name="example_name"; filename="example_name"\r
 Content-Transfer-Encoding: 8bit\r
 \r
 example_data\r
-#{mock_boundary}--\r
+-----------------------------MockBoundary1234--\r
       EOF
 
       expect(request.to_s).to eq(expected)

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -266,24 +266,22 @@ RSpec.describe Rex::Proto::Http::Client do
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       # We are gsub'ing here as HttpClient does this gsub to non-binary file data
-      require 'pry'; binding.pry
       file_contents = file.read.gsub("\r", '').gsub("\n", "\r\n")
-      require 'pry'; binding.pry
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 247\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="field1"; filename="string_list.txt"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-#{file_contents}\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 247\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="field1"; filename="string_list.txt"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        #{file_contents}\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -296,20 +294,20 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 247\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="field1"; filename="string_list.txt"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: binary\r
-\r
-#{file.read}\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 247\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="field1"; filename="string_list.txt"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: binary\r
+        \r
+        #{file.read}\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -322,20 +320,20 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 243\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="field1"; filename="my_file.txt"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: binary\r
-\r
-#{file.read}\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 243\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="field1"; filename="my_file.txt"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: binary\r
+        \r
+        #{file.read}\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -352,20 +350,20 @@ EOF
       expect(request.to_s).to include(data)
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 234\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file1"; filename="file1"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-#{data}\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 234\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file1"; filename="file1"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        #{data}\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -379,20 +377,20 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 234\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file1"; filename="file1"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-#{data}\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 234\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file1"; filename="file1"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        #{data}\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -406,20 +404,20 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 240\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file1"; filename="my_file.txt"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-#{data}\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 240\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file1"; filename="my_file.txt"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        #{data}\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -433,20 +431,20 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 226\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file1"; filename="file1"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-#{data}\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 226\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file1"; filename="file1"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        #{data}\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -462,20 +460,20 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 241\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file1"; filename="my_file.txt"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-#{str}\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 241\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file1"; filename="my_file.txt"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        #{str}\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -489,20 +487,20 @@ EOF
 
       # This could potentially return one less '\r'.
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 231\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="nil_value"; filename="nil_value"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 231\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="nil_value"; filename="nil_value"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        \r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -516,25 +514,25 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 339\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-123\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-456\r
------------------------------MockBoundary1234--\r
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 339\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        123\r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        456\r
+        -----------------------------MockBoundary1234--\r
       EOF
 
       expect(request.to_s).to eq(expected)
@@ -548,20 +546,20 @@ Content-Transfer-Encoding: 8bit\r
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 191\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 191\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        \r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -577,64 +575,65 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 632\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-123\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-456\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-789\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-101112\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 632\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        123\r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        456\r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        789\r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        101112\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
 
     it 'should handle binary correctly' do
+      binary_data = (0..255).map { |x| x.chr }.join
       vars_form_data = [
-        { 'name' => 'field1', 'data' => "\x05\x00\x68\x65\x6c\x6c\x6f".unpack('Sa*'), 'encoding' => 'binary' }
+        { 'name' => 'field1', 'data' => binary_data, 'encoding' => 'binary' }
       ]
 
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 239\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="field1"; filename="field1"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: binary\r
-\r
-[5, "hello"]\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 483\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="field1"; filename="field1"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: binary\r
+        \r
+        #{binary_data}\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -651,38 +650,38 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 820\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-file1_content\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-file2_content\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-file2_content\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-file.txt\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 820\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        file1_content\r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        file2_content\r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        file2_content\r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file"; filename="duplicate.txt"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        file.txt\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -695,20 +694,20 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 242\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file"; filename="#{::CGI.escape(vars_form_data[0]['filename'])}"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-abc\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 242\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file"; filename="%27t+%22e+%27st.txt%27"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        abc\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -721,20 +720,20 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 244\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="file"; filename="#{::CGI.escape(vars_form_data[0]['filename'])}"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: base64\r
-\r
-abc\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 244\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="file"; filename="%27t+%22e+%27st.txt%27"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: base64\r
+        \r
+        abc\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -747,20 +746,20 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 224\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="example_name"\r
-Content-Type: text/plain\r
-Content-Transfer-Encoding: 8bit\r
-\r
-example_data\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 224\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="example_name"\r
+        Content-Type: text/plain\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        example_data\r
+        -----------------------------MockBoundary1234--\r
+      EOF
       expect(request.to_s).to eq(expected)
     end
 
@@ -772,19 +771,19 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 216\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="example_name"; filename="example_name"\r
-Content-Type: text/plain\r
-\r
-example_data\r
------------------------------MockBoundary1234--\r
-EOF
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 216\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="example_name"; filename="example_name"\r
+        Content-Type: text/plain\r
+        \r
+        example_data\r
+        -----------------------------MockBoundary1234--\r
+      EOF
 
       expect(request.to_s).to eq(expected)
     end
@@ -797,18 +796,18 @@ EOF
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
 
       expected = <<~EOF
-POST / HTTP/1.1\r
-Host: #{ip}\r
-User-Agent: #{request.opts['agent']}\r
-Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-Content-Length: 223\r
-\r
------------------------------MockBoundary1234\r
-Content-Disposition: form-data; name="example_name"; filename="example_name"\r
-Content-Transfer-Encoding: 8bit\r
-\r
-example_data\r
------------------------------MockBoundary1234--\r
+        POST / HTTP/1.1\r
+        Host: #{ip}\r
+        User-Agent: #{request.opts['agent']}\r
+        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
+        Content-Length: 223\r
+        \r
+        -----------------------------MockBoundary1234\r
+        Content-Disposition: form-data; name="example_name"; filename="example_name"\r
+        Content-Transfer-Encoding: 8bit\r
+        \r
+        example_data\r
+        -----------------------------MockBoundary1234--\r
       EOF
 
       expect(request.to_s).to eq(expected)

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Rex::Proto::Http::Client do
     expect {cli.port}.to raise_error NoMethodError
   end
 
-  context 'with files' do
+  context 'with form_data' do
     subject(:cli) do
       cli = Rex::Proto::Http::Client.new(ip)
       cli.config['data'] = ''
@@ -262,11 +262,11 @@ RSpec.describe Rex::Proto::Http::Client do
     end
 
     it 'should parse field name and file object as data' do
-      files = [
+      form_data = [
         { 'name' => 'field1', 'data' => file }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       # We are gsub'ing here as HttpClient does this gsub to non-binary file data
       file_contents = file.read.gsub("\r", '').gsub("\n", "\r\n")
@@ -291,11 +291,11 @@ EOF
     end
 
     it 'should parse field name and binary file object as data' do
-      files = [
+      form_data = [
         { 'name' => 'field1', 'data' => file, 'encoding' => 'binary' }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -317,11 +317,11 @@ EOF
     end
 
     it 'should parse field name and binary file object as data with filename override' do
-      files = [
+      form_data = [
         { 'name' => 'field1', 'data' => file, 'encoding' => 'binary', 'filename' => 'my_file.txt' }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -344,11 +344,11 @@ EOF
 
     it 'should parse data correctly when provided with a string' do
       data = 'hello world'
-      files = [
+      form_data = [
         { 'name' => 'file1', 'data' => data }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expect(request.to_s).to include('Content-Disposition: form-data; name="file1"')
       expect(request.to_s).to include(data)
@@ -374,11 +374,11 @@ EOF
 
     it 'should parse data correctly when provided with a string and mime type' do
       data = 'hello world'
-      files = [
+      form_data = [
         { 'name' => 'file1', 'data' => data, 'mime_type' => 'text/plain' }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -401,11 +401,11 @@ EOF
 
     it 'should parse data correctly when provided with a string, mime type and filename' do
       data = 'hello world'
-      files = [
+      form_data = [
         { 'name' => 'file1', 'data' => data, 'mime_type' => 'text/plain', 'filename' => 'my_file.txt' }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -428,11 +428,11 @@ EOF
 
     it 'should parse data correctly when provided with a number' do
       data = 123
-      files = [
+      form_data = [
         { 'name' => 'file1', 'data' => data, 'mime_type' => 'text/plain' }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -457,11 +457,11 @@ EOF
       require 'stringio'
 
       str = 'Hello World!'
-      files = [
+      form_data = [
         { 'name' => 'file1', 'data' => ::StringIO.new(str), 'mime_type' => 'text/plain', 'filename' => 'my_file.txt' }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -483,11 +483,11 @@ EOF
     end
 
     it 'should handle nil data values correctly' do
-      files = [
+      form_data = [
         { 'name' => 'nil_value', 'data' => nil }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       # This could potentially return one less '\r'.
       expected = <<~EOF
@@ -510,12 +510,12 @@ EOF
     end
 
     it 'should handle nil field values correctly' do
-      files = [
+      form_data = [
         { 'name' => nil, 'data' => '123' },
         { 'data' => '456' },
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -543,11 +543,11 @@ Content-Transfer-Encoding: 8bit\r
     end
 
     it 'should handle nil field values and data correctly' do
-      files = [
+      form_data = [
         { 'name' => nil, 'data' => nil }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -569,14 +569,14 @@ EOF
     end
 
     it 'should handle non-string field name values correctly' do
-      files = [
+      form_data = [
         { 'name' => false, 'data' => '123' },
         { 'name' => true, 'data' => '456' },
         { 'name' => ['hello'], 'data' => '789' },
         { 'name' => { k: 'val' }, 'data' => '101112' }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -616,11 +616,11 @@ EOF
     end
 
     it 'should handle binary correctly' do
-      files = [
+      form_data = [
         { 'name' => 'field1', 'data' => "\x05\x00\x68\x65\x6c\x6c\x6f".unpack('Sa*'), 'encoding' => 'binary' }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -642,7 +642,7 @@ EOF
     end
 
     it 'should handle duplicate file and field names correctly' do
-      files = [
+      form_data = [
         { 'name' => 'file', 'data' => 'file1_content', 'filename' => 'duplicate.txt' },
         { 'name' => 'file', 'data' => 'file2_content', 'filename' => 'duplicate.txt' },
         { 'name' => 'file', 'data' => 'file2_content', 'filename' => 'duplicate.txt' },
@@ -650,7 +650,7 @@ EOF
         { 'name' => 'file', 'data' => 'file.txt', 'filename' => 'duplicate.txt' }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -690,11 +690,11 @@ EOF
     end
 
     it 'should escape special characters in file names correctly without encoding' do
-      files = [
+      form_data = [
         { 'name' => 'file', 'data' => 'abc', 'filename' => "'t \"e 'st.txt'" }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -704,7 +704,7 @@ Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
 Content-Length: 242\r
 \r
 #{mock_boundary}\r
-Content-Disposition: form-data; name="file"; filename="#{::CGI.escape(files[0]['filename'])}"\r
+Content-Disposition: form-data; name="file"; filename="#{::CGI.escape(form_data[0]['filename'])}"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: 8bit\r
 \r
@@ -716,11 +716,11 @@ EOF
     end
 
     it 'should escape special characters in file names correctly with encoding' do
-      files = [
+      form_data = [
         { 'name' => 'file', 'data' => 'abc', 'filename' => "'t \"e 'st.txt'", 'encoding' => 'base64' }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -730,7 +730,7 @@ Content-Type: multipart/form-data; boundary=#{mock_boundary[2..-1]}\r
 Content-Length: 244\r
 \r
 #{mock_boundary}\r
-Content-Disposition: form-data; name="file"; filename="#{::CGI.escape(files[0]['filename'])}"\r
+Content-Disposition: form-data; name="file"; filename="#{::CGI.escape(form_data[0]['filename'])}"\r
 Content-Type: text/plain\r
 Content-Transfer-Encoding: base64\r
 \r
@@ -742,11 +742,11 @@ EOF
     end
 
     it 'should handle nil filename values correctly' do
-      files = [
+      form_data = [
         { 'name' => 'example_name', 'data' => 'example_data', 'filename' => nil }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -767,11 +767,11 @@ EOF
     end
 
     it 'should handle nil encoding values correctly' do
-      files = [
+      form_data = [
         { 'name' => 'example_name', 'data' => 'example_data', 'encoding' => nil }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r
@@ -792,11 +792,11 @@ EOF
     end
 
     it 'should handle nil mime type values correctly' do
-      files = [
+      form_data = [
         { 'name' => 'example_name', 'data' => 'example_data', 'mime_type' => nil }
       ]
 
-      request = cli.request_cgi({ 'files' => files })
+      request = cli.request_cgi({ 'form_data' => form_data })
 
       expected = <<~EOF
 POST / HTTP/1.1\r

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -645,7 +645,7 @@ RSpec.describe Rex::Proto::Http::Client do
       expect(request.to_s).to eq(expected)
     end
 
-    it 'should escape special characters in file names correctly without encoding' do
+    it 'does not encode special characters in file name by default as it may be used as part of an exploit' do
       vars_form_data = [
         { 'name' => 'file', 'data' => 'abc', 'content_type' => 'text/plain', 'encoding' => '8bit', 'filename' => "'t \"e 'st.txt'" }
       ]
@@ -657,38 +657,12 @@ RSpec.describe Rex::Proto::Http::Client do
         Host: #{ip}\r
         User-Agent: #{request.opts['agent']}\r
         Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-        Content-Length: 242\r
+        Content-Length: 234\r
         \r
         -----------------------------MockBoundary1234\r
-        Content-Disposition: form-data; name="file"; filename="%27t+%22e+%27st.txt%27"\r
+        Content-Disposition: form-data; name="file"; filename="'t \"e 'st.txt'"\r
         Content-Type: text/plain\r
         Content-Transfer-Encoding: 8bit\r
-        \r
-        abc\r
-        -----------------------------MockBoundary1234--\r
-      EOF
-
-      expect(request.to_s).to eq(expected)
-    end
-
-    it 'should escape special characters in file names correctly with encoding' do
-      vars_form_data = [
-        { 'name' => 'file', 'data' => 'abc', 'filename' => "'t \"e 'st.txt'", 'content_type' => 'text/plain', 'encoding' => 'base64' }
-      ]
-
-      request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
-      expected = <<~EOF
-        POST / HTTP/1.1\r
-        Host: #{ip}\r
-        User-Agent: #{request.opts['agent']}\r
-        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-        Content-Length: 244\r
-        \r
-        -----------------------------MockBoundary1234\r
-        Content-Disposition: form-data; name="file"; filename="%27t+%22e+%27st.txt%27"\r
-        Content-Type: text/plain\r
-        Content-Transfer-Encoding: base64\r
         \r
         abc\r
         -----------------------------MockBoundary1234--\r


### PR DESCRIPTION
This PR adds the ability to upload files to a specified URI by sending a POST request.
This is similar to the `Requests` library for Python.

## Example

When uploading a single file:

```ruby
vars_form_data = [
  {
    'name' => 'nsp',
    'data' => @csrf_token,
    'encoding' => 'binary',
    'filename' => 'myfile.txt',
    'mime_type' => 'text/plain'
   }
]

res = send_request_cgi(
  'method'   => 'POST',
  'uri'      => uri,
  'vars_form_data'    => vars_form_data
)
```

When uploading more than one file:

```ruby
vars_form_data = [
  { 'name' => 'nsp', 'data' => @csrf_token },
  { 'name' => 'upload', 'data' => 1 },
  { 'name' => 'MAX_FILE_SIZE', 'data' => 1000000 },
  { 'name' => 'uploadedfile', 'data' => payload_zip, 'mime_type' => 'application/zip', 'encoding' => 'binary', 'filename' => zip_filename }
]

res = send_request_cgi(
  'method'   => 'POST',
  'uri'      => uri,
  vars_form_data'    => vars_form_data
)
```

## Verification

- [ ] Start `msfconsole -q`
- [ ] `use exploit/linux/http/nagios_xi_chained_rce`
- [ ] `set` your options
- [ ] Start the vulnerable Docker container `docker run -p 80:80 --rm zhlh/nagiosxi:latest`
- [ ] `run`
- [ ] **Confirm** you get a shell