### PR TITLE
Bump RubySMB

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ PATH
       rex-text
       rex-zip
       ruby-macho
-      ruby_smb (~> 3.0)
+      ruby_smb (~> 3.1)
       rubyntlm
       rubyzip
       sinatra
@@ -445,7 +445,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.0.6)
+    ruby_smb (3.1.0)
       bindata
       openssl-ccm
       openssl-cmac

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -140,7 +140,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-ssh'
   spec.add_runtime_dependency 'ed25519' # Adds ed25519 keys for net-ssh
   spec.add_runtime_dependency 'bcrypt_pbkdf'
-  spec.add_runtime_dependency 'ruby_smb', '~> 3.0'
+  spec.add_runtime_dependency 'ruby_smb', '~> 3.1'
   spec.add_runtime_dependency 'net-ldap'
   spec.add_runtime_dependency 'net-smtp'
   spec.add_runtime_dependency 'winrm'

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -1571,8 +1571,10 @@ module EternalBlueWin7
     packet.parameter_block.max_mpx_count = 10
     packet.parameter_block.security_blob_length = 0
 
-    packet.data_block.native_os = native_os
-    packet.data_block.native_lan_man = "\x00" * 17
+    packet.smb_header.flags2.unicode = 0
+    packet.data_block.security_blob = native_os + "\x00" * 15
+    packet.data_block.native_os = ''
+    packet.data_block.native_lan_man = ''
     packet
   end
 


### PR DESCRIPTION
Bump RubySMB from 3.0.5 to 3.1.0.

This adds updates from the RubySMB gem including SMB 1 server support. That's currently dead code, but it made changes to the SMB 1 session setup frame that broke the MS17-010 exploit. This PR bumps the version and patches the MS17-010 exploit to fix it with the new changes.

Included changes:

* rapid7/ruby_smb#200 (docs update)
* SMB File Server improvements This is all dead code at the moment, the SMB file server isn't used by Metasploit... yet 😉
    * rapid7/ruby_smb#196
    * rapid7/ruby_smb#197
    * rapid7/ruby_smb#207
* rapid7/ruby_smb#204
* rapid7/ruby_smb#210
    * This fix is necessary for the MS17-010 patch which moves the corrupt data into the security blob which is necessary because it contains NULL bytes. The NULL bytes cause problems in the original fields which are now properly defined as null terminated strings which caused it to be truncated in the exploit, ultimately leading to the exploit failing. The string fields are located directly after the security blob, so moving them there results in a packet this is identical, but the security blog is defined as a normal non-NULL terminated string so it handles the data correctly.

## Verification
- [ ] Run some spot tests on some important SMB modules
- [ ] Check smb_version
- [ ] Check psexec, including the CMD target
- [ ] Check the MS17-010 exploit still works, it's not and hasn't ever been 100% reliable but it works pretty well you just may need to run it more than once.


