### PR TITLE
Use debug versions of extensions if `MeterpreterDebugBuild` is enabled

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -73,6 +73,11 @@ class Meterpreter < Rex::Post::Meterpreter::Client
       opts[:ssl_cert] = opts[:datastore]['HandlerSSLCert']
     end
 
+    # Extract the MeterpreterDebugBuild option if specified by the user
+    if opts[:datastore]
+      opts[:debug_build] = opts[:datastore]['MeterpreterDebugBuild']
+    end
+
     # Don't pass the datastore into the init_meterpreter method
     opts.delete(:datastore)
 

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -81,7 +81,8 @@ module Payload::Windows::MeterpreterLoader
       uuid:              opts[:uuid],
       transports:        opts[:transport_config] || [transport_config(opts)],
       extensions:        [],
-      stageless:         opts[:stageless] == true
+      stageless:         opts[:stageless] == true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters
@@ -93,9 +94,9 @@ module Payload::Windows::MeterpreterLoader
 
   def stage_meterpreter(opts={})
     ds = opts[:datastore] || datastore
-    debug = ds['MeterpreterDebugBuild']
+    debug_build = ds['MeterpreterDebugBuild']
     # Exceptions will be thrown by the mixin if there are issues.
-    dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug))
+    dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug_build))
 
     asm_opts = {
       rdi_offset: offset,

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -84,7 +84,8 @@ module Payload::Windows::MeterpreterLoader_x64
       uuid:              opts[:uuid],
       transports:        opts[:transport_config] || [transport_config(opts)],
       extensions:        [],
-      stageless:         opts[:stageless] == true
+      stageless:         opts[:stageless] == true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters
@@ -96,9 +97,9 @@ module Payload::Windows::MeterpreterLoader_x64
 
   def stage_meterpreter(opts={})
     ds = opts[:datastore] || datastore
-    debug = ds['MeterpreterDebugBuild']
+    debug_build = ds['MeterpreterDebugBuild']
     # Exceptions will be thrown by the mixin if there are issues.
-    dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug))
+    dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build))
 
     asm_opts = {
       rdi_offset: offset,

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -127,10 +127,10 @@ private
     transport_data.pack(pack)
   end
 
-  def extension_block(ext_name, file_extension)
+  def extension_block(ext_name, file_extension, debug_build: false)
     ext_name = ext_name.strip.downcase
     ext, _ = load_rdi_dll(MetasploitPayloads.meterpreter_path("ext_server_#{ext_name}",
-                                                              file_extension))
+                                                              file_extension, debug: debug_build))
 
     [ ext.length, ext ].pack('VA*')
   end
@@ -168,7 +168,7 @@ private
     file_extension = 'x64.dll' unless is_x86?
 
     (@opts[:extensions] || []).each do |e|
-      config << extension_block(e, file_extension)
+      config << extension_block(e, file_extension, debug_build: @opts[:debug_build])
     end
 
     # terminate the extensions with a 0 size

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -166,6 +166,9 @@ class Client
         self.ssl_cert = ::File.read(opts[:ssl_cert])
       end
     end
+    # Use the debug build if specified
+    self.debug_build = opts[:debug_build]
+
 
     # Protocol specific dispatch mixins go here, this may be neader with explicit Client classes
     opts[:dispatch_ext].each {|dx| self.extend(dx)} if opts[:dispatch_ext]
@@ -496,6 +499,10 @@ class Client
   # The timestamp of the last received response
   #
   attr_accessor :last_checkin
+  #
+  # Whether or not to use a debug build for loaded extensions
+  #
+  attr_accessor :debug_build
 
 protected
   attr_accessor :parser, :ext_aliases # :nodoc:

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -358,7 +358,7 @@ class ClientCore < Extension
         # Get us to the installation root and then into data/meterpreter, where
         # the file is expected to be
         modname = "ext_server_#{mod.downcase}"
-        path = MetasploitPayloads.meterpreter_path(modname, suffix)
+        path = MetasploitPayloads.meterpreter_path(modname, suffix, debug: client.debug_build)
 
         if opts['ExtensionPath']
           path = ::File.expand_path(opts['ExtensionPath'])

--- a/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
@@ -50,7 +50,8 @@ module MetasploitModule
       transports: [transport_config_bind_named_pipe(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -50,7 +50,8 @@ module MetasploitModule
       transports: [transport_config_bind_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -55,7 +55,8 @@ module MetasploitModule
       transports: [transport_config_reverse_http(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -55,7 +55,8 @@ module MetasploitModule
       transports: [transport_config_reverse_https(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -51,7 +51,8 @@ module MetasploitModule
       transports: [transport_config_reverse_ipv6_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -50,7 +50,8 @@ module MetasploitModule
       transports: [transport_config_reverse_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -50,7 +50,8 @@ module MetasploitModule
       transports: [transport_config_bind_named_pipe(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -50,7 +50,8 @@ module MetasploitModule
       transports: [transport_config_bind_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -55,7 +55,8 @@ module MetasploitModule
       transports: [transport_config_reverse_http(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -55,7 +55,8 @@ module MetasploitModule
       transports: [transport_config_reverse_https(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -51,7 +51,8 @@ module MetasploitModule
       transports: [transport_config_reverse_ipv6_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -50,7 +50,8 @@ module MetasploitModule
       transports: [transport_config_reverse_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
       ext_init:   (datastore['EXTINIT'] || ''),
-      stageless:  true
+      stageless:  true,
+      debug_build: datastore['MeterpreterDebugBuild']
     }
 
     # create the configuration instance based off the parameters

--- a/spec/lib/rex/post/meterpreter/client_core_spec.rb
+++ b/spec/lib/rex/post/meterpreter/client_core_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Rex::Post::Meterpreter::ClientCore do
       allow(@client).to receive(:response_timeout) { 1 }
       allow(@client).to receive(:send_packet_wait_response) { @response }
       allow(@client).to receive(:add_extension) { true }
+      allow(@client).to receive(:debug_build) { false }
     end
 
     let(:client_core) {described_class.new(@client)}


### PR DESCRIPTION
Follow on from #16320

Previously when extensions were being loaded only the release versions were being picked up not the debug versions, this is a PR to address that

# Verification

- [x] Launch msfconsole
- [x] `use payload/windows/x64/meterpreter_reverse_tcp` (or any other stageless native windows meterpreter)
- [x] `set MeterpreterDebugBuild true`
- [x] `set Extensions stdapi`
- [x] Generate the payload
- [x] Get a shell on a windows machine while running DbgView
- [x] Make sure you can see the logs from metsrv and stdapi
- [x] `load kiwi`
- [x] ensure you can also see logs from kiwi