### PR TITLE
Remove railgun requirement from post file mixin

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -28,7 +28,6 @@ module Msf::Post::File
               stdapi_fs_mkdir
               stdapi_fs_separator
               stdapi_fs_stat
-              stdapi_railgun_api
             ]
           }
         }


### PR DESCRIPTION
Extracts the MVP solution to getting the local exploit suggester working on mettle.

Related PR to add more improvements: https://github.com/rapid7/metasploit-framework/pull/16413
Original issue: https://github.com/rapid7/metasploit-framework/issues/15949

We'll iterate on the original PR with extra code/quality of life improvements

## Verification

Same as https://github.com/rapid7/metasploit-framework/pull/16413