### PR TITLE
restrict ruby_smb to patch version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ PATH
       rex-text
       rex-zip
       ruby-macho
-      ruby_smb (~> 3.1)
+      ruby_smb (~> 3.1.0)
       rubyntlm
       rubyzip
       sinatra

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -140,7 +140,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-ssh'
   spec.add_runtime_dependency 'ed25519' # Adds ed25519 keys for net-ssh
   spec.add_runtime_dependency 'bcrypt_pbkdf'
-  spec.add_runtime_dependency 'ruby_smb', '~> 3.1'
+  spec.add_runtime_dependency 'ruby_smb', '~> 3.1.0'
   spec.add_runtime_dependency 'net-ldap'
   spec.add_runtime_dependency 'net-smtp'
   spec.add_runtime_dependency 'winrm'


### PR DESCRIPTION
Based on [versioning documentation](https://github.com/rapid7/ruby_smb/blob/4fac10d8a7919c421badabedccd9d4d7902a9901/CONTRIBUTING.md#versioning).

Locking version to patch level as framework performs manipulation of bindata structures.

## Verification

List the steps needed to make sure this thing works

- [ ] `bundle install`
- [ ] **Validate** Gemfile.lock is stable
