### PR TITLE
msftidy: Prefer CVE references over cve.mitre.org URL references

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -272,6 +272,8 @@ class MsftidyRunner
         when 'URL'
           if value =~ /^https?:\/\/cvedetails\.com\/cve/
             warn("Please use 'CVE' for '#{value}'")
+          elsif value =~ %r{^https?://cve\.mitre\.org/cgi-bin/cvename\.cgi}
+            warn("Please use 'CVE' for '#{value}'")
           elsif value =~ /^https?:\/\/www\.securityfocus\.com\/bid\//
             warn("Please use 'BID' for '#{value}'")
           elsif value =~ /^https?:\/\/www\.microsoft\.com\/technet\/security\/bulletin\//


### PR DESCRIPTION
Related: #15638

After this PR:

```
# ./tools/dev/msftidy.rb modules/exploits/linux/http/efw_chpasswd_exec.rb
modules/exploits/linux/http/efw_chpasswd_exec.rb - [WARNING] Please use 'CVE' for 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5082'
modules/exploits/linux/http/efw_chpasswd_exec.rb - [INFO] Missing "Notes" info, please add
```
