### PR TITLE
Modules: Prefer CVE references over cve.mitre.org URL references

### DIFF
--- a/modules/auxiliary/admin/http/grafana_auth_bypass.py
+++ b/modules/auxiliary/admin/http/grafana_auth_bypass.py
@@ -39,7 +39,6 @@ metadata = {
     'license': 'MSF_LICENSE',
     'references': [
         {'type': 'cve', 'ref': '2018-15727'},
-        {'type': 'url', 'ref': 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15727'},
         {'type': 'url', 'ref': 'https://grafana.com/blog/2018/08/29/grafana-5.2.3-and-4.6.4-released-with-important-security-fix/'}
     ],
     'type': 'single_scanner',

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -42,7 +42,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'References' => [
           ['CVE', '2021-25646'],
-          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25646'],
           ['URL', 'https://lists.apache.org/thread.html/rfda8a3aa6ac06a80c5cbfdeae0fc85f88a5984e32ea05e6dda46f866%40%3Cdev.druid.apache.org%3E'],
           ['URL', 'https://github.com/yaunsky/cve-2021-25646/blob/main/cve-2021-25646.py']
         ],

--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -52,7 +52,6 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'References' => [
         ['CVE', '2015-5082'],
-        ['URL', 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5082'],
         ['EDB', '37426'],
         ['EDB', '37428']
       ],

--- a/modules/exploits/linux/http/supervisor_xmlrpc_exec.rb
+++ b/modules/exploits/linux/http/supervisor_xmlrpc_exec.rb
@@ -29,7 +29,6 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['URL', 'https://github.com/Supervisor/supervisor/issues/964'],
           ['URL', 'https://www.debian.org/security/2017/dsa-3942'],
-          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11610'],
           ['URL', 'https://github.com/phith0n/vulhub/tree/master/supervisor/CVE-2017-11610'],
           ['CVE', '2017-11610']
         ],

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -31,7 +31,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => ['Pietro Oliva <pietroliva[at]gmail.com>'],
         'License' => MSF_LICENSE,
         'References' => [
-          [ 'URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-12109' ],
           [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2020-12109' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2020/May/2' ],
           [ 'CVE', '2020-12109']

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -38,6 +38,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2020-04-29',
         'Platform' => 'linux',
         'Arch' => ARCH_MIPSLE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
         'Targets' => [
           [
             'TP-Link NC200, NC220, NC230, NC250',

--- a/modules/exploits/linux/local/netfilter_xtables_heap_oob_write_priv_esc.rb
+++ b/modules/exploits/linux/local/netfilter_xtables_heap_oob_write_priv_esc.rb
@@ -49,7 +49,6 @@ class MetasploitModule < Msf::Exploit::Local
           ['CVE', '2021-22555'],
           ['URL', 'https://google.github.io/security-research/pocs/linux/cve-2021-22555/writeup.html'],
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2021-22555'],
-          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22555'],
           ['URL', 'https://ubuntu.com/security/CVE-2021-22555']
         ]
       )

--- a/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
+++ b/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
@@ -29,6 +29,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/pear/Archive_Tar/issues/33'],
           ['CVE', '2020-28949']
         ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
         'DefaultOptions' => {
           'EXITFUNC' => 'thread',
           'DisablePayloadHandler' => true

--- a/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
+++ b/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
@@ -27,7 +27,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['URL', 'https://github.com/pear/Archive_Tar/issues/33'],
-          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28949'],
           ['CVE', '2020-28949']
         ],
         'DefaultOptions' => {

--- a/modules/exploits/multi/http/tomcat_jsp_upload_bypass.rb
+++ b/modules/exploits/multi/http/tomcat_jsp_upload_bypass.rb
@@ -21,7 +21,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'References' => [
           [ 'CVE', '2017-12617' ],
-          [ 'URL', 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12617' ],
           [ 'URL', 'https://bz.apache.org/bugzilla/show_bug.cgi?id=61542' ],
           [ 'EDB', '42966' ]
         ],

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -40,7 +40,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://dynoroot.ninja/'],
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1111'],
           ['URL', 'https://www.tenable.com/blog/advisory-red-hat-dhcp-client-command-injection-trouble'],
-          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1111']
         ],
       'Targets'        => [ [ 'Automatic Target', { }] ],
       'DefaultTarget'  => 0,

--- a/modules/exploits/unix/ssh/arista_tacplus_shell.rb
+++ b/modules/exploits/unix/ssh/arista_tacplus_shell.rb
@@ -27,7 +27,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'CVE', '2020-9015'],
           [ 'URL', 'http://www.securitybytes.me/posts/cve-2020-9015/'],
-          [ 'URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9015' ],
           [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2020-9015' ],
         ],
         'Arch' => ARCH_X86,

--- a/modules/exploits/unix/ssh/arista_tacplus_shell.rb
+++ b/modules/exploits/unix/ssh/arista_tacplus_shell.rb
@@ -35,6 +35,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultOptions' => {
           'Payload' => 'linux/x86/shell_reverse_tcp'
         },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
         'DisclosureDate' => '2020-02-02',
         'Platform' => 'linux',
         'PayloadType' => 'cmd_interact',

--- a/modules/exploits/windows/fileformat/vlc_mkv.rb
+++ b/modules/exploits/windows/fileformat/vlc_mkv.rb
@@ -34,7 +34,6 @@ class MetasploitModule < Msf::Exploit
       'References'     =>
         [
           ['CVE', '2018-11529'],
-          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11529'],
           ['EDB', '44979']
         ],
       'Payload'        =>


### PR DESCRIPTION
Fixes #15638

The new `cve.org` website is up.

`cve.mitre.org` will still be up for a few months, but there's not much point in referencing mitre specifically, especially all these modules already have `CVE` references.
