### PR TITLE
Rubocop fix for arista_tacplus_shell lint msftidy error

### DIFF
--- a/modules/exploits/unix/ssh/arista_tacplus_shell.rb
+++ b/modules/exploits/unix/ssh/arista_tacplus_shell.rb
@@ -44,12 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => 'linux',
         'PayloadType' => 'cmd_interact',
         'Privileged' => true,
-        'Targets' => [ [ 'Universal', {} ] ],
-        'Notes' => {
-          'Stability' => [CRASH_SAFE],
-          'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => []
-        }
+        'Targets' => [ [ 'Universal', {} ] ]
       )
     )
 


### PR DESCRIPTION
Fixes this mfstidy error:
```
1 file inspected, 1 offense detected
modules/exploits/unix/ssh/arista_tacplus_shell.rb - [ERROR] Rubocop failed. Please run rubocop -a modules/exploits/unix/ssh/arista_tacplus_shell.rb and verify all issues are resolved
```
https://github.com/rapid7/metasploit-framework/runs/6089451966?check_suite_focus=true

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

