### PR TITLE
Meterpreter's `reg setval` command: add support to binary data when setting a REG_BINARY key value

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -1009,7 +1009,17 @@ class Console::CommandDispatcher::Stdapi::Sys
           if type == 'REG_BINARY'
             # Use the same format accepted by REG ADD:
             # REG ADD HKLM\Software\MyCo /v Data /t REG_BINARY /d fe340ead
-            data = data.scan(/../).map {|v| v.to_i(16)}.pack('C*')
+            if (data.length.even? == false)
+              print_error('Data length supplied to the -d argument was not appropriately padded to an even length string!')
+              return false
+            end
+            data_str_length = data.length
+            data = data.scan(/(?:[a-fA-F0-9]{2})/).map {|v| v.to_i(16)}
+            if (data_str_length/2 != data.length)
+              print_error('Invalid characters provided! Could not fully convert data provided to -d argument!')
+              return false
+            end
+           data = data.pack("C*")
           end
 
           open_key.set_value(value, client.sys.registry.type2str(type), data)
@@ -1099,7 +1109,7 @@ class Console::CommandDispatcher::Stdapi::Sys
     print_line("    createkey   Create the supplied registry key  [-k <key>]")
     print_line("    deletekey   Delete the supplied registry key  [-k <key>]")
     print_line("    queryclass  Queries the class of the supplied key [-k <key>]")
-    print_line("    setval      Set a registry value [-k <key> -v <val> -d <data>]. Use 2-digit hex string to set binary data with REG_BINARY type (e.g. fe340ead)")
+    print_line("    setval      Set a registry value [-k <key> -v <val> -d <data>]. Use a binary blob to set binary data with REG_BINARY type (e.g. setval -d ef4ba278)")
     print_line("    deleteval   Delete the supplied registry value [-k <key> -v <val>]")
     print_line("    queryval    Queries the data contents of a value [-k <key> -v <val>]")
     print_line

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -1006,6 +1006,12 @@ class Console::CommandDispatcher::Stdapi::Sys
             end
           end
 
+          if type == 'REG_BINARY'
+            # Use the same format accepted by REG ADD:
+            # REG ADD HKLM\Software\MyCo /v Data /t REG_BINARY /d fe340ead
+            data = data.scan(/../).map {|v| v.to_i(16)}.pack('C*')
+          end
+
           open_key.set_value(value, client.sys.registry.type2str(type), data)
 
           print_line("Successfully set #{value} of #{type}.")
@@ -1093,7 +1099,7 @@ class Console::CommandDispatcher::Stdapi::Sys
     print_line("    createkey   Create the supplied registry key  [-k <key>]")
     print_line("    deletekey   Delete the supplied registry key  [-k <key>]")
     print_line("    queryclass  Queries the class of the supplied key [-k <key>]")
-    print_line("    setval      Set a registry value [-k <key> -v <val> -d <data>]")
+    print_line("    setval      Set a registry value [-k <key> -v <val> -d <data>]. Use 2-digit hex string to set binary data with REG_BINARY type (e.g. fe340ead)")
     print_line("    deleteval   Delete the supplied registry value [-k <key> -v <val>]")
     print_line("    queryval    Queries the data contents of a value [-k <key> -v <val>]")
     print_line


### PR DESCRIPTION
This allows passing binary data to the Meterpreter’s `reg setval` command when REG_BINARY type is selected. Before these changes, arguments passed with the `-d` flag were always handled as a string. For example:
```
meterpreter > reg setval -k 'HKLM\SOFTWARE\Microsoft\...' -v 'MyVal' -d "\xFF" -t 'REG_BINARY'
```
This was setting the value \\xFF (four bytes) instead of the binary value 0xFF (one byte).

Now, binary values can be passed as a hex string (each byte must be represented as a 2-digit hex string):
```
meterpreter > reg setval -k 'HKLM\SOFTWARE\Microsoft\...' -v 'MyVal' -d ef4ba278 -t 'REG_BINARY'
```
This will set 4 bytes of binary data: 0xef, 0x4b, 0xa2, 0x78

This follows the same format accepted by Windows `REG ADD`:
```
REG ADD HKLM\Software\MyCo /v Data /t REG_BINARY /d fe340ead
```

## Verification
- [x] Start `msfconsole`
- [x] Get a Meterpreter session on a Windows machine
- [x] Interact with the session: `session -1`
- [x] `reg setval -k 'HKCU\Environment' -v 'Test' -d a2ff54b2 -t 'REG_BINARY'`
- [x] **Verify** there is no error and `Successfully set Test of REG_BINARY.`is returned 
- [x] `reg queryval -k 'HKCU\Environment' -v 'Test'`
- [x] **Verify** the binary data has been correctly set
- [x] **Verify** the key value with the binary data have been correctly created on the Windows host using `regedit`
- [x] cleanup (optional): `reg deleteval -k 'HKCU\Environment' -v 'Test'`

## Example output
```
meterpreter > reg setval -k 'HKCU\Environment' -v 'Test' -d a2ff54b2 -t 'REG_BINARY'
Successfully set Test of REG_BINARY.
meterpreter > reg queryval -k 'HKCU\Environment' -v 'Test'
Key: HKCU\Environment
Name: Test
Type: REG_BINARY
Data: a2ff54b2
meterpreter > reg deleteval -k 'HKCU\Environment' -v 'Test'
Successfully deleted Test.
```
`regedit` correctly displays the key value and the binary data:
![Screenshot 2022-04-20 at 12 09 57](https://user-images.githubusercontent.com/56716719/164220156-50edb54a-713a-4bae-9c1c-76d5f1c30bcd.png)

