### PR TITLE
shift test for cache change to exit code

### DIFF
--- a/tools/automation/cache/build_new_cache.sh
+++ b/tools/automation/cache/build_new_cache.sh
@@ -7,7 +7,8 @@ done
 ./msfconsole -qr tools/automation/cache/wait_for_cache.rc
 cp ~/.msf4/store/modules_metadata.json db/modules_metadata_base.json
 cp ~/.msf4/logs/framework.log .
-CACHE_CHANGE=`git diff db/modules_metadata_base.json`
-if [ -n "$CACHE_CHANGE" ]; then
+set +e
+git diff --exit-code db/modules_metadata_base.json
+if [ ! $? ]; then
   echo "Module cache updates exist."
 fi


### PR DESCRIPTION
When changes to a file in the module path does not result in a change to the cache checking the exit code is a more clear indicator of change.

## Verification

List the steps needed to make sure this thing works

- [x] `docker build -t metasploitframework/metasploit-framework:latest .`
- [x] `./tools/automation/cache/update_module_cache.sh`
- [x] **Verify** the updated ` db/modules_metadata_base.json` file did not change and exit code for script is `0`

