### PR TITLE
FIX: typo 'MetaSploit' in readme and comment

### DIFF
--- a/documentation/modules/auxiliary/client/hwbridge/connect.md
+++ b/documentation/modules/auxiliary/client/hwbridge/connect.md
@@ -57,7 +57,7 @@ on setting up the [BAFX 34t5](https://bafxpro.com/products/obdreader) with Kali 
  Prints out all the JSON packets that come from the HWBridge API.  Useful for troubleshooting
  a device.
 
- This module also supports all the other HTTP Client options typical to Metaplsoit.
+ This module also supports all the other HTTP Client options typical to Metasploit.
 
 ## Sample Connection
 

--- a/modules/auxiliary/voip/telisca_ips_lock_control.rb
+++ b/modules/auxiliary/voip/telisca_ips_lock_control.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
-          # Publicly disclosed via Metaploit PR
+          # Publicly disclosed via Metasploit PR
           'URL', 'https://github.com/rapid7/metasploit-framework/pull/6470'
         ],
       'Author'         =>


### PR DESCRIPTION
Quick typo fix for readme and comment:  'Meta_ploit' ->  'MetaSploit'

no verifications done, given the nature of fix
