### PR TITLE
s4u_persistence.rb: Allow all post-Vista builds

### DIFF
--- a/modules/exploits/windows/local/s4u_persistence.rb
+++ b/modules/exploits/windows/local/s4u_persistence.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if not (sysinfo['OS'] =~ /Build [6-9]\d\d\d/)
+    if not (sysinfo['OS'] =~ /Windows (Vista|7|8|2008|2012|2016|2019|2022|10)/ )
       fail_with(Failure::NoTarget, "This module only works on Vista/2008 and above")
     end
 


### PR DESCRIPTION
Currently this module doesn't account for Server builds 2016 and above, nor Windows 10 builds. This PR fixes the `sysinfo` comparison to allow later builds.

Verified on my local Windows 10 x64 21H1 system with a stageless payload.

Note: Many other modules have this problem, and it's probably worth Rapid7 staff time to standardize the usage of build comparisons inside modules.