### PR TITLE
Use #create_credential_login instead of the deprecated #report_auth_info at auxiliary/capture/server/mssql

### DIFF
--- a/modules/auxiliary/server/capture/mssql.rb
+++ b/modules/auxiliary/server/capture/mssql.rb
@@ -268,6 +268,7 @@ class MetasploitModule < Msf::Auxiliary
         ip: ip,
         port: 445,
         user: user,
+        sname: 'smb_client',
         password: domain + ":" +
         ( lm_hash + lm_cli_challenge.to_s ? lm_hash + lm_cli_challenge.to_s : "00" * 24 ) + ":" +
         ( nt_hash + nt_cli_challenge.to_s ? nt_hash + nt_cli_challenge.to_s :  "00" * 24 ) + ":" +
@@ -521,12 +522,13 @@ class MetasploitModule < Msf::Auxiliary
         mssql_send_ntlm_challenge(c, info)
       elsif info[:user] and info[:pass]
 
-      report_cred(
-        ip: @state[c][:ip],
-        user: info[:user],
-        password: info[:pass],
-        type: :password
-      )
+        report_cred(
+          ip: @state[c][:ip],
+          sname: 'mssql_client',
+          user: info[:user],
+          password: info[:pass],
+          type: :password
+        )
 
         print_status("MSSQL LOGIN #{@state[c][:name]} #{info[:user]} / #{info[:pass]}")
         mssql_send_error(c, "Login failed for user '#{info[:user]}'.")
@@ -544,7 +546,7 @@ class MetasploitModule < Msf::Auxiliary
     service_data = {
       address: opts[:ip],
       port: opts[:port] || datastore['SRVPORT'],
-      service_name: 'smb_client',
+      service_name: opts[:sname],
       protocol: 'tcp',
       workspace_id: myworkspace_id
     }

--- a/modules/auxiliary/server/capture/mssql.rb
+++ b/modules/auxiliary/server/capture/mssql.rb
@@ -264,15 +264,20 @@ class MetasploitModule < Msf::Auxiliary
       # DB reporting
       # Rem :  one report it as a smb_challenge on port 445 has breaking those hashes
       # will be mainly use for psexec / smb related exploit
+
+      jtr_hash = case smb_db_type_hash
+      when JTR_NTLMV2
+        user + "::" + domain + ":" + datastore['CHALLENGE'].to_s + ":" + nt_hash + ":" + nt_cli_challenge.to_s
+      when JTR_NTLMV1
+        user + "::" + domain + ":" + lm_cli_challenge.to_s + ":" + lm_hash + ":" + datastore['CHALLENGE']
+      end
+
       report_cred(
         ip: ip,
         port: 445,
         user: user,
         sname: 'smb_client',
-        password: domain + ":" +
-        ( lm_hash + lm_cli_challenge.to_s ? lm_hash + lm_cli_challenge.to_s : "00" * 24 ) + ":" +
-        ( nt_hash + nt_cli_challenge.to_s ? nt_hash + nt_cli_challenge.to_s :  "00" * 24 ) + ":" +
-        datastore['CHALLENGE'].to_s,
+        password: jtr_hash,
         proof: "DOMAIN=#{domain}",
         type: :nonreplayable_hash,
         jtr_format: smb_db_type_hash

--- a/modules/auxiliary/server/capture/mssql.rb
+++ b/modules/auxiliary/server/capture/mssql.rb
@@ -231,13 +231,13 @@ class MetasploitModule < Msf::Auxiliary
       capturedtime = Time.now.to_s
       case ntlm_ver
       when NTLM_CONST::NTLM_V1_RESPONSE
-        smb_db_type_hash = "netntlm"
+        smb_db_type_hash = JTR_NTLMV1
         capturelogmessage =
         "#{capturedtime}\nNTLMv1 Response Captured from #{host} \n" +
         "DOMAIN: #{domain} USER: #{user} \n" +
         "LMHASH:#{lm_hash_message ? lm_hash_message : "<NULL>"} \nNTHASH:#{nt_hash ? nt_hash : "<NULL>"}\n"
       when NTLM_CONST::NTLM_V2_RESPONSE
-        smb_db_type_hash = "netntlmv2"
+        smb_db_type_hash = JTR_NTLMV2
         capturelogmessage =
         "#{capturedtime}\nNTLMv2 Response Captured from #{host} \n" +
         "DOMAIN: #{domain} USER: #{user} \n" +
@@ -248,7 +248,7 @@ class MetasploitModule < Msf::Auxiliary
       when NTLM_CONST::NTLM_2_SESSION_RESPONSE
         #we can consider those as netv1 has they have the same size and i cracked the same way by cain/jtr
         #also 'real' netv1 is almost never seen nowadays except with smbmount or msf server capture
-        smb_db_type_hash = "netntlm"
+        smb_db_type_hash = JTR_NTLMV1
         capturelogmessage =
         "#{capturedtime}\nNTLM2_SESSION Response Captured from #{host} \n" +
         "DOMAIN: #{domain} USER: #{user} \n" +


### PR DESCRIPTION
My attempt at fixing #16474 .

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/server/capture/mssql`
- [ ] ...
- [ ] **Verify**  The warning is gone.
- [ ] **Verify** The module still works as intended.
