### PR TITLE
Fix crashes on timeouts for multiple modules and Meterpreter

### DIFF
--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -342,7 +342,7 @@ module Msf::Sessions
       begin
         completed_event.wait(timeout)
         true
-      rescue TimeoutError
+      rescue ::Timeout::Error
         false
       end
     end

--- a/lib/msf/base/sessions/winrm_command_shell.rb
+++ b/lib/msf/base/sessions/winrm_command_shell.rb
@@ -62,7 +62,7 @@ module Msf::Sessions
           begin
             # We didn't receive anything - let's wait for some more
             @received_stdout_event.wait(time_remaining)
-          rescue TimeoutError
+          rescue ::Timeout::Error
           end
           # rubocop:enable Lint/SuppressedException
           # If we didn't get anything, let's hurry the background thread along
@@ -118,7 +118,7 @@ module Msf::Sessions
             begin
               @check_stdin_event.wait(loop_delay)
               # rubocop:disable Lint/SuppressedException
-            rescue TimeoutError
+            rescue ::Timeout::Error
             end
             # rubocop:enable Lint/SuppressedException
             Thread.pass

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -686,7 +686,7 @@ class ClientCore < Extension
               client.swap_sock_ssl_to_plain()
               client.swap_sock_plain_to_ssl()
             end
-          rescue TimeoutError
+          rescue ::Timeout::Error
             client.alive = false
             return false
           end

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -178,7 +178,7 @@ module PacketDispatcher
     if timeout.nil?
       return nil
     elsif response.nil?
-      raise TimeoutError.new("Send timed out")
+      raise Rex::TimeoutError.new("Send timed out")
     elsif (response.result != 0)
       einfo = lookup_error(response.result)
       e = RequestError.new(packet.method, einfo, response.result)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1208,7 +1208,7 @@ class Console::CommandDispatcher::Core
 
     begin
       server = client.sys.process.open
-    rescue TimeoutError => e
+    rescue Rex::TimeoutError, ::Timeout::Error => e
       elog('Server Timeout', error: e)
     rescue RequestError => e
       elog('Request Error', error: e)


### PR DESCRIPTION
### Before

```
msf6 auxiliary(scanner/winrm/winrm_login) > run  http://user:pass@192.168.123.139:5985

[!] No active DB -- Credential data will not be saved!
[+] 192.168.123.139:5985 - Login Successful: WORKSTATION\user:p4$$w0rd
[*] Command shell session 2 opened (192.168.123.1:58619 -> 192.168.123.139:5985 ) at 2022-04-23 02:33:27 +0100
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/winrm/winrm_login) > [*] 192.168.123.139 - Command shell session 2 closed.  Reason: uninitialized constant Msf::Sessions::WinrmCommandShell::WinRMStreamAdapter::TimeoutError
```

### After

```
msf6 auxiliary(scanner/winrm/winrm_login) > run http://user:pass@192.168.123.139:5985

[!] No active DB -- Credential data will not be saved!
[+] 192.168.123.139:5985 - Login Successful: WORKSTATION\user:pass
[*] Command shell session 7 opened (192.168.123.1:58673 -> 192.168.123.139:5985 ) at 2022-04-23 02:36:34 +0100
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/winrm/winrm_login) > sessions -i -1
[*] Starting interaction with 7...

Microsoft Windows [Version 10.0.14393]
(c) 2016 Microsoft Corporation. All rights reserved.

C:\Users\user>
```

## Verification

Either run this module against a machines machine with WinRM enabled, and verify the other modules too.
Or verify the specific timeout exception semantics various Ruby versions.

Create a test file `foo.rb`

```ruby
begin
  require 'timeout'
  Timeout.timeout(0.1) { sleep 1 }
rescue TimeoutError
  puts "Successfully caught timeout #{$!.class}"
end
```

Run against different ruby versions, 2.4:

```
$ docker run -it --rm -w $(pwd) -v $(pwd):$(pwd) ruby:2.4-alpine /bin/sh -c 'ruby foo.rb'   
foo.rb:4: warning: constant ::TimeoutError is deprecated
Successfully caught timeout Timeout::Error
```

2.7

```
$ docker run -it --rm -w $(pwd) -v $(pwd):$(pwd) ruby:2.7-alpine /bin/sh -c 'ruby foo.rb'
Successfully caught timeout Timeout::Error
```

3.0.x

```
$ docker run -it --rm -w $(pwd) -v $(pwd):$(pwd) ruby:3-alpine /bin/sh -c 'ruby foo.rb'
foo.rb:4:in `rescue in <main>': uninitialized constant TimeoutError (NameError)

rescue TimeoutError
       ^^^^^^^^^^^^
        from foo.rb:1:in `<main>'
foo.rb:3:in `sleep': execution expired (Timeout::Error)
        from foo.rb:3:in `block in <main>'
        from /usr/local/lib/ruby/3.1.0/timeout.rb:123:in `timeout'
        from foo.rb:3:in `<main>'
```

Fix working in Ruby 3.x:

```ruby
begin
  require 'timeout'
  Timeout.timeout(0.1) { sleep 1 }
rescue ::Timeout::Error
  puts "Successfully caught timeout #{$!.class}"
end
```

```
docker run -it --rm -w $(pwd) -v $(pwd):$(pwd) ruby:3-alpine /bin/sh -c 'ruby foo.rb'
Successfully caught timeout Timeout::Error
```

Fix still working in Ruby 2.4:

```
docker run -it --rm -w $(pwd) -v $(pwd):$(pwd) ruby:2.4-alpine /bin/sh -c 'ruby foo.rb'
Successfully caught timeout Timeout::Error
```