### PR TITLE
nfs_mount more intelligent mountability

### DIFF
--- a/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
+++ b/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
@@ -5,19 +5,30 @@ The [Ubuntu 14.04](https://help.ubuntu.com/14.04/serverguide/network-file-system
 following was done on Kali linux:
   
   1. `apt-get install nfs-kernel-server`
-  2. Create 2 folders to share:
+  2. Create folders to share and add them to exports (adjust 192.168.1.x as needed):
     ```
-    mkdir /tmp/open_share
-    mkdir /tmp/closed_share
+    mkdir /tmp/star
+    echo "/tmp/star    *(rw,no_subtree_check)" >> /etc/exports
+    mkdir /tmp/not_us_hostname
+    echo "/tmp/not_us_hostname    foo(rw,no_subtree_check)" >> /etc/exports
+    mkdir /tmp/us_hostname
+    echo "/tmp/us_hostname    bar(rw,no_subtree_check)" >> /etc/exports
+    mkdir /tmp/not_us_ip
+    echo "/tmp/not_us_ip    1.1.1.1(rw,no_subtree_check)" >> /etc/exports
+    mkdir /tmp/us_ip
+    echo "/tmp/us_ip    192.168.1.111(rw,no_subtree_check)" >> /etc/exports
+    mkdir /tmp/not_us_subnet
+    echo "/tmp/not_us_subnet    1.1.1.1/24(rw,no_subtree_check)" >> /etc/exports
+    mkdir /tmp/us_subnet
+    echo "/tmp/us_subnet    192.168.1.1/24(rw,no_subtree_check)" >> /etc/exports
+    mkdir /tmp/not_us_netmask
+    echo "/tmp/not_us_netmask    1.1.1.1/255.255.255.0(rw,no_subtree_check)" >> /etc/exports
+    mkdir /tmp/us_netmask
+    echo "/tmp/us_netmask    192.168.1.1/255.255.255.0(rw,no_subtree_check)" >> /etc/exports
+    mkdir /tmp/empty
+    echo "/tmp/empty    (rw,no_subtree_check)" >> /etc/exports
     ```
-  3. Add them to the list of shares:
-  ```
-  echo "/tmp/closed_share  10.1.2.3(ro,sync,no_root_squash)" >> /etc/exports
-  echo "/tmp/open_share    *(rw,sync,no_root_squash)" >> /etc/exports
-  ```
-  4. Restart the service: `service nfs-kernel-server restart`
-
-In this scenario, `closed_share` is set to read only, and only mountable by the IP 10.1.2.3.  `open_share` is mountable by anyone (`*`) in read/write mode.
+  3. Restart the service: `service nfs-kernel-server restart`
 
 ## Verification Steps
 
@@ -36,9 +47,15 @@ In this scenario, `closed_share` is set to read only, and only mountable by the 
     rhosts => 127.0.0.1
     msf auxiliary(nfsmount) > run
     
-    [+] 127.0.0.1:111         - 127.0.0.1 NFS Export: /tmp/open_share [*]
-    [+] 127.0.0.1:111         - 127.0.0.1 NFS Export: /tmp/closed_share [10.1.2.3]
-    [*] Scanned 1 of 1 hosts (100% complete)
+    [+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/empty [*]
+    [+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/star [*]
+    [+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_netmask [10.1.1.1/255.255.255.0]
+    [*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_netmask [1.1.1.1/255.255.255.0]
+    [+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_subnet [10.1.1.1/24]
+    [*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_subnet [1.1.1.1/24]
+    [+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_ip [192.168.1.111]
+    [*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_ip [1.1.1.1]
+    [*] 127.0.0.1:111       - Scanned 1 of 1 hosts (100% complete)
     [*] Auxiliary module execution completed
   ```
   
@@ -73,8 +90,14 @@ Host is up (0.000037s latency).
 PORT    STATE SERVICE
 111/tcp open  rpcbind
 | nfs-showmount: 
-|   /tmp/open_share *
-|_  /tmp/closed_share 10.1.2.3
+|   /tmp/empty *
+|   /tmp/star *
+|   /tmp/us_netmask 10.1.1.1/255.255.255.0
+|   /tmp/not_us_netmask 1.1.1.1/255.255.255.0
+|   /tmp/us_subnet 10.1.1.1/24
+|   /tmp/not_us_subnet 1.1.1.1/24
+|   /tmp/us_ip 192.168.1.111
+|_  /tmp/not_us_ip 1.1.1.1
 
 Nmap done: 1 IP address (1 host up) scanned in 0.32 seconds
 ```
@@ -86,8 +109,14 @@ showmount is a part of the `nfs-common` package for debian.
 ```
 showmount -e 127.0.0.1
 Export list for 127.0.0.1:
-/tmp/open_share   *
-/tmp/closed_share 10.1.2.3
+/tmp/empty          *
+/tmp/star           *
+/tmp/us_netmask     10.1.1.1/255.255.255.0
+/tmp/not_us_netmask 1.1.1.1/255.255.255.0
+/tmp/us_subnet      10.1.1.1/24
+/tmp/not_us_subnet  1.1.1.1/24
+/tmp/us_ip          192.168.1.111
+/tmp/not_us_ip      1.1.1.1
 ```
 
 ## Exploitation

--- a/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
+++ b/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
@@ -1,82 +1,102 @@
 ## Vulnerable Application
 
-NFS is very common, and this scanner searches for a mis-configuration, not a vulnerable software version.  Installation instructions for NFS can be found for every operating system.
-The [Ubuntu 14.04](https://help.ubuntu.com/14.04/serverguide/network-file-system.html) instructions can be used as an example for installing and configuring NFS.  The
+NFS is very common, and this scanner searches for a mis-configuration, not a vulnerable software version.
+Installation instructions for NFS can be found for every operating system.
+The [Ubuntu 14.04](https://help.ubuntu.com/14.04/serverguide/network-file-system.html)
+instructions can be used as an example for installing and configuring NFS.  The
 following was done on Kali linux:
-  
-  1. `apt-get install nfs-kernel-server`
-  2. Create folders to share and add them to exports (adjust 192.168.1.x as needed):
-    ```
-    mkdir /tmp/star
-    echo "/tmp/star    *(rw,no_subtree_check)" >> /etc/exports
-    mkdir /tmp/not_us_hostname
-    echo "/tmp/not_us_hostname    foo(rw,no_subtree_check)" >> /etc/exports
-    mkdir /tmp/us_hostname
-    echo "/tmp/us_hostname    bar(rw,no_subtree_check)" >> /etc/exports
-    mkdir /tmp/not_us_ip
-    echo "/tmp/not_us_ip    1.1.1.1(rw,no_subtree_check)" >> /etc/exports
-    mkdir /tmp/us_ip
-    echo "/tmp/us_ip    192.168.1.111(rw,no_subtree_check)" >> /etc/exports
-    mkdir /tmp/not_us_subnet
-    echo "/tmp/not_us_subnet    1.1.1.1/24(rw,no_subtree_check)" >> /etc/exports
-    mkdir /tmp/us_subnet
-    echo "/tmp/us_subnet    192.168.1.1/24(rw,no_subtree_check)" >> /etc/exports
-    mkdir /tmp/not_us_netmask
-    echo "/tmp/not_us_netmask    1.1.1.1/255.255.255.0(rw,no_subtree_check)" >> /etc/exports
-    mkdir /tmp/us_netmask
-    echo "/tmp/us_netmask    192.168.1.1/255.255.255.0(rw,no_subtree_check)" >> /etc/exports
-    mkdir /tmp/empty
-    echo "/tmp/empty    (rw,no_subtree_check)" >> /etc/exports
-    ```
-  3. Restart the service: `service nfs-kernel-server restart`
+
+1. `apt-get install nfs-kernel-server`
+2. Create folders to share and add them to exports (adjust 192.168.1.x as needed):
+```
+mkdir /tmp/star
+echo "/tmp/star    *(rw,no_subtree_check)" >> /etc/exports
+mkdir /tmp/not_us_hostname
+echo "/tmp/not_us_hostname    foo(rw,no_subtree_check)" >> /etc/exports
+mkdir /tmp/us_hostname
+echo "/tmp/us_hostname    bar(rw,no_subtree_check)" >> /etc/exports
+mkdir /tmp/not_us_ip
+echo "/tmp/not_us_ip    1.1.1.1(rw,no_subtree_check)" >> /etc/exports
+mkdir /tmp/us_ip
+echo "/tmp/us_ip    192.168.1.111(rw,no_subtree_check)" >> /etc/exports
+mkdir /tmp/not_us_subnet
+echo "/tmp/not_us_subnet    1.1.1.1/24(rw,no_subtree_check)" >> /etc/exports
+mkdir /tmp/us_subnet
+echo "/tmp/us_subnet    192.168.1.1/24(rw,no_subtree_check)" >> /etc/exports
+mkdir /tmp/not_us_netmask
+echo "/tmp/not_us_netmask    1.1.1.1/255.255.255.0(rw,no_subtree_check)" >> /etc/exports
+mkdir /tmp/us_netmask
+echo "/tmp/us_netmask    192.168.1.1/255.255.255.0(rw,no_subtree_check)" >> /etc/exports
+mkdir /tmp/empty
+echo "/tmp/empty    (rw,no_subtree_check)" >> /etc/exports
+```
+3. Restart the service: `service nfs-kernel-server restart`
+
+## Options
+
+### PROTOCOL
+Which networking protocol to use. Options are `udp` and `tcp`. Defaults to `udp`.
+
+### LHOST
+IP to match shares against if `Mountable` is true. Defaults to the detected local IP address.
+
+### HOSTNAME
+Hostname to match shares against if `Mountable` is true. Defaults to `` (empty string)
+
+## Advanced Options
+
+### Mountable
+
+Determine if an export is mountable based on `LHOST` and `HOSTNAME`. Defaults to `true`. Pre 2022 behavior was `false`
 
 ## Verification Steps
 
-  1. Install and configure NFS
-  2. Start msfconsole
-  3. Do: `use auxiliary/scanner/nfs/nfsmount`
-  4. Do: `run`
+1. Install and configure NFS
+2. Start msfconsole
+3. Do: `use auxiliary/scanner/nfs/nfsmount`
+4. Do: `run`
 
 ## Scenarios
 
-  A run against the configuration from these docs
+A run against the configuration from these docs
 
-  ```
-    msf > use auxiliary/scanner/nfs/nfsmount
-    msf auxiliary(nfsmount) > set rhosts 127.0.0.1
-    rhosts => 127.0.0.1
-    msf auxiliary(nfsmount) > run
-    
-    [+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/empty [*]
-    [+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/star [*]
-    [+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_netmask [10.1.1.1/255.255.255.0]
-    [*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_netmask [1.1.1.1/255.255.255.0]
-    [+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_subnet [10.1.1.1/24]
-    [*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_subnet [1.1.1.1/24]
-    [+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_ip [192.168.1.111]
-    [*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_ip [1.1.1.1]
-    [*] 127.0.0.1:111       - Scanned 1 of 1 hosts (100% complete)
-    [*] Auxiliary module execution completed
-  ```
-  
-  Another example can be found at this [source](http://bitvijays.github.io/blog/2016/03/03/learning-from-the-field-basic-network-hygiene/):
-  
-  ```
-    [*] Scanned  24 of 240 hosts (10% complete)
-    [+] 10.10.xx.xx NFS Export: /data/iso [0.0.0.0/0.0.0.0]
-    [*] Scanned  48 of 240 hosts (20% complete)
-    [+] 10.10.xx.xx NFS Export: /DataVolume/Public [*]
-    [+] 10.10.xx.xx NFS Export: /DataVolume/Download [*]
-    [+] 10.10.xx.xx NFS Export: /DataVolume/Softshare [*]
-    [*] Scanned  72 of 240 hosts (30% complete)
-    [+] 10.10.xx.xx NFS Export: /var/ftp/pub [10.0.0.0/255.255.255.0]
-    [*] Scanned  96 of 240 hosts (40% complete)
-    [+] 10.10.xx.xx NFS Export: /common []
-  ```
+```
+msf > use auxiliary/scanner/nfs/nfsmount
+msf auxiliary(nfsmount) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf auxiliary(nfsmount) > run
+
+[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/empty [*]
+[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/star [*]
+[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_netmask [10.1.1.1/255.255.255.0]
+[*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_netmask [1.1.1.1/255.255.255.0]
+[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_subnet [10.1.1.1/24]
+[*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_subnet [1.1.1.1/24]
+[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_ip [192.168.1.111]
+[*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_ip [1.1.1.1]
+[*] 127.0.0.1:111       - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+Another example can be found at this [source](http://bitvijays.github.io/blog/2016/03/03/learning-from-the-field-basic-network-hygiene/):
+
+```
+[*] Scanned  24 of 240 hosts (10% complete)
+[+] 10.10.xx.xx NFS Export: /data/iso [0.0.0.0/0.0.0.0]
+[*] Scanned  48 of 240 hosts (20% complete)
+[+] 10.10.xx.xx NFS Export: /DataVolume/Public [*]
+[+] 10.10.xx.xx NFS Export: /DataVolume/Download [*]
+[+] 10.10.xx.xx NFS Export: /DataVolume/Softshare [*]
+[*] Scanned  72 of 240 hosts (30% complete)
+[+] 10.10.xx.xx NFS Export: /var/ftp/pub [10.0.0.0/255.255.255.0]
+[*] Scanned  96 of 240 hosts (40% complete)
+[+] 10.10.xx.xx NFS Export: /common []
+```
 
 ## Confirming
 
-Since NFS has been around since 1989, with modern NFS(v4) being released in 2000, there are many tools which can also be used to verify this configuration issue.
+Since NFS has been around since 1989, with modern NFS(v4) being released in 2000, there are many tools which can also be used to
+verify this configuration issue.
 The following are other industry tools which can also be used.
 
 ### [nmap](https://nmap.org/nsedoc/scripts/nfs-showmount.html)
@@ -122,7 +142,8 @@ Export list for 127.0.0.1:
 ## Exploitation
 
 Exploiting this mis-configuration is trivial, however exploitation doesn't necessarily give access (command execution) to the system.
-If a share is mountable, ie you either are the IP listed in the filter (or could assume it through a DoS), or it is open (*), mounting is trivial.
+If a share is mountable, ie you either are the IP listed in the filter (or could assume it through a DoS),
+or it is open (*), mounting is trivial.
 The following instructions were written for Kali linux.
 
 1. Create a new directory to mount the remote volume to: `mkdir /mnt/remote`

--- a/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
+++ b/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
@@ -2,7 +2,7 @@
 
 NFS is very common, and this scanner searches for a mis-configuration, not a vulnerable software version.
 Installation instructions for NFS can be found for every operating system.
-The [Ubuntu 14.04](https://help.ubuntu.com/14.04/serverguide/network-file-system.html)
+The [Ubuntu](https://ubuntu.com/server/docs/service-nfs)
 instructions can be used as an example for installing and configuring NFS.  The
 following was done on Kali linux:
 

--- a/lib/msf/core/auxiliary/nfs.rb
+++ b/lib/msf/core/auxiliary/nfs.rb
@@ -19,26 +19,26 @@ module Msf
       )
     end
 
-    def can_mount?(locations)
+    def can_mount?(locations, mountable = true, hostname = '', lhost = '')
       # attempts to validate if we'll be able to open it or not based on:
       # 1. its a wildcard, thus we can open it
       # 2. hostname isn't blank and its in the list
       # 3. our IP is explicitly listed
       # 4. theres a CIDR notation that we're included in.
-      return true unless datastore['Mountable']
+      return true unless mountable
       return true if locations.include? '*'
-      return true if !datastore['HOSTNAME'].blank? && locations.include?(datastore['HOSTNAME'])
-      return true if !datastore['LHOST'].empty? && locations.include?(datastore['LHOST'])
+      return true if !hostname.blank? && locations.include?(hostname)
+      return true if !lhost.empty? && locations.include?(lhost)
 
       locations.each do |location|
         # if it has a subnet mask, convert it to cidr
         if %r{(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})} =~ location
           location = "#{Regexp.last_match(1)}#{Rex::Socket.addr_atoc(Regexp.last_match(2))}"
         end
-        return true if Rex::Socket::RangeWalker.new(location).include?(datastore['LHOST'])
+        return true if Rex::Socket::RangeWalker.new(location).include?(lhost)
         # at this point we assume its a hostname, so we use Ruby's File fnmatch so that it proceses the wildcards
         # as its a quick and easy way to use glob matching for wildcards and get a boolean response
-        return true if File.fnmatch(location, datastore['HOSTNAME'])
+        return true if File.fnmatch(location, hostname)
       end
       false
     end

--- a/lib/msf/core/auxiliary/nfs.rb
+++ b/lib/msf/core/auxiliary/nfs.rb
@@ -1,0 +1,46 @@
+# -*- coding: binary -*-
+
+module Msf
+  ###
+  #
+  # This module provides methods for working with NFS
+  #
+  ###
+  module Auxiliary::Nfs
+    include Auxiliary::Scanner
+
+    def initialize(info = {})
+      super
+      register_options(
+        [
+          OptAddressLocal.new('LHOST', [false, 'IP to match shares against', Rex::Socket.source_address]),
+          OptString.new('HOSTNAME', [false, 'Hostname to match shares against', ''])
+        ]
+      )
+    end
+
+    def can_mount?(locations)
+      # attempts to validate if we'll be able to open it or not based on:
+      # 1. its a wildcard, thus we can open it
+      # 2. hostname isn't blank and its in the list
+      # 3. our IP is explicitly listed
+      # 4. theres a CIDR notation that we're included in.
+      return true unless datastore['Mountable']
+      return true if locations.include? '*'
+      return true if !datastore['HOSTNAME'].blank? && locations.include?(datastore['HOSTNAME'])
+      return true if !datastore['LHOST'].empty? && locations.include?(datastore['LHOST'])
+
+      locations.each do |location|
+        # if it has a subnet mask, convert it to cidr
+        if %r{(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})} =~ location
+          location = "#{Regexp.last_match(1)}#{Rex::Socket.addr_atoc(Regexp.last_match(2))}"
+        end
+        return true if Rex::Socket::RangeWalker.new(location).include?(datastore['LHOST'])
+        # at this point we assume its a hostname, so we use Ruby's File fnmatch so that it proceses the wildcards
+        # as its a quick and easy way to use glob matching for wildcards and get a boolean response
+        return true if File.fnmatch(location, datastore['HOSTNAME'])
+      end
+      false
+    end
+  end
+end

--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
         grp = []
         grp << Rex::Encoder::XDR.decode_string!(resp) while Rex::Encoder::XDR.decode_int!(resp) == 1
 
-        if can_mount? grp
+        if can_mount?(grp, datastore['Mountable'], datastore['HOSTNAME'], datastore['LHOST'] || '')
           print_good("#{ip} Mountable NFS Export: #{dir} [#{grp.join(', ')}]")
         else
           print_status("#{ip} NFS Export: #{dir} [#{grp.join(', ')}]")

--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -10,74 +10,101 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'          => 'NFS Mount Scanner',
-      'Description'   => %q{
+      'Name' => 'NFS Mount Scanner',
+      'Description' => %q{
         This module scans NFS mounts and their permissions.
       },
-      'Author'	       => ['<tebo[at]attackresearch.com>'],
-      'References'     =>
-        [
-          ['CVE', '1999-0170'],
-          ['URL',	'https://www.ietf.org/rfc/rfc1094.txt']
-        ],
+      'Author'	=> ['<tebo[at]attackresearch.com>'],
+      'References' => [
+        ['CVE', '1999-0170'],
+        ['URL',	'https://www.ietf.org/rfc/rfc1094.txt']
+      ],
       'License'	=> MSF_LICENSE
     )
 
     register_options([
-      OptEnum.new('PROTOCOL', [ true, 'The protocol to use', 'udp', ['udp', 'tcp']])
+      OptEnum.new('PROTOCOL', [ true, 'The protocol to use', 'udp', ['udp', 'tcp']]),
+      OptAddressLocal.new('LHOST', [false, 'The local listener IP', Rex::Socket.source_address]),
+      OptString.new('HOSTNAME', [false, 'The local hostname', ''])
     ])
 
+    register_advanced_options(
+      [
+        OptBool.new('Mountable', [false, 'Determine if an export is mountable', true]),
+      ]
+    )
+  end
+
+  def can_mount?(locations)
+    # attempts to validate if we'll be able to open it or not based on:
+    # 1. its a wildcard, thus we can open it
+    # 2. hostname isn't blank and its in the list
+    # 3. our IP is explicitly listed
+    # 4. theres a CIDR notation that we're included in.
+    return true unless datastore['Mountable']
+    return true if locations.include? '*' ||
+                                      (locations.include?(datastore['HOSTNAME']) && !datastore['HOSTNAME'].blank?) ||
+                                      locations.include?(datastore['LHOST'])
+
+    locations.each do |location|
+      # if it has a subnet mask, convert it to cidr
+      if %r{(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})} =~ location
+        location = "#{Regexp.last_match(1)}#{Rex::Socket.addr_atoc(Regexp.last_match(2))}"
+      end
+      return true if Rex::Socket::RangeWalker.new(location).include?(datastore['LHOST'])
+    end
+    false
   end
 
   def run_host(ip)
+    program	= 100005
+    progver	= 1
+    procedure	= 5
 
-    begin
-      program		= 100005
-      progver		= 1
-      procedure	= 5
+    sunrpc_create(datastore['PROTOCOL'], program, progver)
+    sunrpc_authnull
+    resp = sunrpc_call(procedure, '')
 
-      sunrpc_create(datastore['PROTOCOL'], program, progver)
-      sunrpc_authnull()
-      resp = sunrpc_call(procedure, "")
+    # XXX: Assume that transport is udp and port is 2049
+    # Technically we are talking to mountd not nfsd
 
-      # XXX: Assume that transport is udp and port is 2049
-      # Technically we are talking to mountd not nfsd
+    report_service(
+      host: ip,
+      proto: datastore['PROTOCOL'],
+      port: 2049,
+      name: 'nfsd',
+      info: "NFS Daemon #{program} v#{progver}"
+    )
 
-      report_service(
-        :host  => ip,
-        :proto => datastore['PROTOCOL'],
-        :port  => 2049,
-        :name  => 'nfsd',
-        :info  => "NFS Daemon #{program} v#{progver}"
-      )
+    exports = resp[3, 1].unpack('C')[0]
+    if (exports == 0x01)
+      shares = []
+      while Rex::Encoder::XDR.decode_int!(resp) == 1
+        dir = Rex::Encoder::XDR.decode_string!(resp)
+        grp = []
+        grp << Rex::Encoder::XDR.decode_string!(resp) while Rex::Encoder::XDR.decode_int!(resp) == 1
 
-      exports = resp[3,1].unpack('C')[0]
-      if (exports == 0x01)
-        shares = []
-        while Rex::Encoder::XDR.decode_int!(resp) == 1 do
-          dir = Rex::Encoder::XDR.decode_string!(resp)
-          grp = []
-          while Rex::Encoder::XDR.decode_int!(resp) == 1 do
-            grp << Rex::Encoder::XDR.decode_string!(resp)
-          end
-          print_good("#{ip} NFS Export: #{dir} [#{grp.join(", ")}]")
-          shares << [dir, grp]
+        if can_mount? grp
+          print_good("#{ip} NFS Export: #{dir} [#{grp.join(', ')}]")
+        else
+          print_status("#{ip} NFS Export: #{dir} [#{grp.join(', ')}]")
         end
-        report_note(
-          :host => ip,
-          :proto => datastore['PROTOCOL'],
-          :port => 2049,
-          :type => 'nfs.exports',
-          :data => { :exports => shares },
-          :update => :unique_data
-        )
-      elsif(exports == 0x00)
-        vprint_status("#{ip} - No exported directories")
+        shares << [dir, grp]
       end
-
-      sunrpc_destroy
-    rescue ::Rex::Proto::SunRPC::RPCTimeout, ::Rex::Proto::SunRPC::RPCError => e
-      vprint_error(e.to_s)
+      report_note(
+        host: ip,
+        proto: datastore['PROTOCOL'],
+        port: 2049,
+        type: 'nfs.exports',
+        data: { exports: shares },
+        update: :unique_data
+      )
+    elsif (exports == 0x00)
+      vprint_status("#{ip} - No exported directories")
     end
+
+    sunrpc_destroy
+  rescue ::Rex::Proto::SunRPC::RPCTimeout, ::Rex::Proto::SunRPC::RPCError => e
+    vprint_error(e.to_s)
   end
 end

--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -24,8 +24,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptEnum.new('PROTOCOL', [ true, 'The protocol to use', 'udp', ['udp', 'tcp']]),
-      OptAddressLocal.new('LHOST', [false, 'The local listener IP', Rex::Socket.source_address]),
-      OptString.new('HOSTNAME', [false, 'The local hostname', ''])
+      OptAddressLocal.new('LHOST', [false, 'IP to match shares against', Rex::Socket.source_address]),
+      OptString.new('HOSTNAME', [false, 'Hostname to match shares against', ''])
     ])
 
     register_advanced_options(

--- a/spec/lib/msf/core/auxiliary/nfs_spec.rb
+++ b/spec/lib/msf/core/auxiliary/nfs_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Msf::Auxiliary::Nfs do
     mod
   end
 
-  context 'NFS mountability check' do
+  context '#can_mount?' do
     it 'deals with astericks' do
       expect(subject.can_mount?(['*'], true, 'my.hostname', '1.1.1.1')).to be true
     end

--- a/spec/lib/msf/core/auxiliary/nfs_spec.rb
+++ b/spec/lib/msf/core/auxiliary/nfs_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Msf::Auxiliary::Nfs do
     end
 
     it 'bad hostname' do
-      expect(subject.can_mount?(['not.my.hostname'], true, 'my.hostname', '1.1.1.1')).to be false
+      expect(subject.can_mount?(['not.my.hostname'], true, 'foo.bar', '1.1.1.1')).to be false
     end
 
     it 'hostname with wildcard' do
@@ -59,7 +59,7 @@ RSpec.describe Msf::Auxiliary::Nfs do
     end
 
     it 'bad hostname with wildcard' do
-      expect(subject.can_mount?(['*.not.my.hostname'], true, 'my.hostname', '1.1.1.1')).to be false
+      expect(subject.can_mount?(['*.not.my.hostname'], true, 'foo.bar', '1.1.1.1')).to be false
     end
   end
 end

--- a/spec/lib/msf/core/auxiliary/nfs_spec.rb
+++ b/spec/lib/msf/core/auxiliary/nfs_spec.rb
@@ -6,63 +6,60 @@ RSpec.describe Msf::Auxiliary::Nfs do
   subject do
     mod = Msf::Module.new
     mod.extend(Msf::Auxiliary::Nfs)
-    mod.datastore['LHOST'] = '1.1.1.1'
-    mod.datastore['HOSTNAME'] = 'my.hostname'
-    mod.datastore['Mountable'] = true
     mod
   end
 
   context 'NFS mountability check' do
     it 'deals with astericks' do
-      expect(subject.can_mount?(['*'])).to be true
+      expect(subject.can_mount?(['*'], true, 'my.hostname', '1.1.1.1')).to be true
     end
 
     it 'deals with empty' do
-      expect(subject.can_mount?([''])).to be false
+      expect(subject.can_mount?([''], true, 'my.hostname', '1.1.1.1')).to be false
     end
 
     it 'deals with my IP' do
-      expect(subject.can_mount?(['1.1.1.1'])).to be true
+      expect(subject.can_mount?(['1.1.1.1'], true, 'my.hostname', '1.1.1.1')).to be true
     end
 
     it 'deals with not my IP' do
-      expect(subject.can_mount?(['2.2.2.2'])).to be false
+      expect(subject.can_mount?(['2.2.2.2'], true, 'my.hostname', '1.1.1.1')).to be false
     end
 
     it 'correctly handles lists' do
-      expect(subject.can_mount?(['2.2.2.2/255.255.255.0', '1.1.1.1/255.255.255.0'])).to be true
+      expect(subject.can_mount?(['2.2.2.2/255.255.255.0', '1.1.1.1/255.255.255.0'], true, 'my.hostname', '1.1.1.1')).to be true
     end
 
     it 'deals with my IP with subnet' do
-      expect(subject.can_mount?(['1.1.1.1/255.255.255.0'])).to be true
+      expect(subject.can_mount?(['1.1.1.1/255.255.255.0'], true, 'my.hostname', '1.1.1.1')).to be true
     end
 
     it 'deals with not my IP with subnet' do
-      expect(subject.can_mount?(['2.2.2.2/255.255.255.0'])).to be false
+      expect(subject.can_mount?(['2.2.2.2/255.255.255.0'], true, 'my.hostname', '1.1.1.1')).to be false
     end
 
     it 'deals with my IP with cidr' do
-      expect(subject.can_mount?(['1.1.1.1/24'])).to be true
+      expect(subject.can_mount?(['1.1.1.1/24'], true, 'my.hostname', '1.1.1.1')).to be true
     end
 
     it 'deals with not my IP with cidr' do
-      expect(subject.can_mount?(['2.2.2.2/24'])).to be false
+      expect(subject.can_mount?(['2.2.2.2/24'], true, 'my.hostname', '1.1.1.1')).to be false
     end
 
     it 'exact hostname' do
-      expect(subject.can_mount?(['my.hostname'])).to be true
+      expect(subject.can_mount?(['my.hostname'], true, 'my.hostname', '1.1.1.1')).to be true
     end
 
     it 'bad hostname' do
-      expect(subject.can_mount?(['not.my.hostname'])).to be false
+      expect(subject.can_mount?(['not.my.hostname'], true, 'my.hostname', '1.1.1.1')).to be false
     end
 
     it 'hostname with wildcard' do
-      expect(subject.can_mount?(['*.hostname'])).to be true
+      expect(subject.can_mount?(['*.hostname'], true, 'my.hostname', '1.1.1.1')).to be true
     end
 
     it 'bad hostname with wildcard' do
-      expect(subject.can_mount?(['*.not.my.hostname'])).to be false
+      expect(subject.can_mount?(['*.not.my.hostname'], true, 'my.hostname', '1.1.1.1')).to be false
     end
   end
 end

--- a/spec/lib/msf/core/auxiliary/nfs_spec.rb
+++ b/spec/lib/msf/core/auxiliary/nfs_spec.rb
@@ -1,0 +1,68 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::Auxiliary::Nfs do
+  subject do
+    mod = Msf::Module.new
+    mod.extend(Msf::Auxiliary::Nfs)
+    mod.datastore['LHOST'] = '1.1.1.1'
+    mod.datastore['HOSTNAME'] = 'my.hostname'
+    mod.datastore['Mountable'] = true
+    mod
+  end
+
+  context 'NFS mountability check' do
+    it 'deals with astericks' do
+      expect(subject.can_mount?(['*'])).to be true
+    end
+
+    it 'deals with empty' do
+      expect(subject.can_mount?([''])).to be false
+    end
+
+    it 'deals with my IP' do
+      expect(subject.can_mount?(['1.1.1.1'])).to be true
+    end
+
+    it 'deals with not my IP' do
+      expect(subject.can_mount?(['2.2.2.2'])).to be false
+    end
+
+    it 'correctly handles lists' do
+      expect(subject.can_mount?(['2.2.2.2/255.255.255.0', '1.1.1.1/255.255.255.0'])).to be true
+    end
+
+    it 'deals with my IP with subnet' do
+      expect(subject.can_mount?(['1.1.1.1/255.255.255.0'])).to be true
+    end
+
+    it 'deals with not my IP with subnet' do
+      expect(subject.can_mount?(['2.2.2.2/255.255.255.0'])).to be false
+    end
+
+    it 'deals with my IP with cidr' do
+      expect(subject.can_mount?(['1.1.1.1/24'])).to be true
+    end
+
+    it 'deals with not my IP with cidr' do
+      expect(subject.can_mount?(['2.2.2.2/24'])).to be false
+    end
+
+    it 'exact hostname' do
+      expect(subject.can_mount?(['my.hostname'])).to be true
+    end
+
+    it 'bad hostname' do
+      expect(subject.can_mount?(['not.my.hostname'])).to be false
+    end
+
+    it 'hostname with wildcard' do
+      expect(subject.can_mount?(['*.hostname'])).to be true
+    end
+
+    it 'bad hostname with wildcard' do
+      expect(subject.can_mount?(['*.not.my.hostname'])).to be false
+    end
+  end
+end


### PR DESCRIPTION
fixes #16416

This PR attempts to add optional (but default) logic to the `nfs_mount` scanner module so that it can intelligently print if a network share is mountable or not.  The motivation for this PR was a pentest w/ 4,000+ nfs mount points and all of them printing `print_good` and taking a lot of time to go through.

While this is functional in my testing against:

- `*`
- my local ip
- my local ip vs a subnet mask
- my local ip vs a cidr

I was unable to get my server to create a hostname based mount.  The logic is there for a direct (non-wildcard) match, but I'd like to get some other people's thoughts on how to handle this.

I also wanted to get some wider testing for this since NFS may have some other export lists items I'm not thinking of.


## Verification

see the docs, i have a script to create a bunch of shares that I tested against.

### old output

```
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/empty [*]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/star [*]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_netmask [192.168.1.1/255.255.255.0]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_netmask [1.1.1.1/255.255.255.0]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_subnet [192.168.1.1/24]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_subnet [1.1.1.1/24]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_ip [192.168.1.55]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_ip [1.1.1.1]
[+] 127.0.0.1:111       - Scanned 1 of 1 hosts (100% complete)
```

### new output

```
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/empty [*]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/star [*]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_netmask [192.168.1.1/255.255.255.0]
[*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_netmask [1.1.1.1/255.255.255.0]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_subnet [192.168.1.1/24]
[*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_subnet [1.1.1.1/24]
[+] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/us_ip [192.168.1.55]
[*] 127.0.0.1:111       - 127.0.0.1 NFS Export: /tmp/not_us_ip [1.1.1.1]
[*] 127.0.0.1:111       - Scanned 1 of 1 hosts (100% complete)
```
