### PR TITLE
Fix #16084, sessions -K should kill sessions in reverse order

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1625,7 +1625,7 @@ class Core
       end
     when 'killall'
       print_status("Killing all sessions...")
-      framework.sessions.each_sorted do |s|
+      framework.sessions.each_sorted.reverse_each do |s|
         session = framework.sessions.get(s)
         if session
           if session.respond_to?(:response_timeout)


### PR DESCRIPTION
Quick fix for https://github.com/rapid7/metasploit-framework/issues/16084

## Verification

- [ ] Get multiple meterpreter or shell sessions
- [ ] `msf6 exploit(multi/handler) > sessions -K`
- [ ] **Verify** the sessions are killed in reverse order


## Before
```
msf6 exploit(multi/handler) > sessions -K
[*] Killing all sessions...
[*] 192.168.13.37 - Meterpreter session 1 closed.
[*] 192.168.13.37 - Meterpreter session 2 closed.
[*] 192.168.13.37 - Meterpreter session 3 closed.
```

## After
```
msf6 exploit(multi/handler) > sessions -K
[*] Killing all sessions...
[*] 192.168.13.37 - Meterpreter session 3 closed.
[*] 192.168.13.37 - Meterpreter session 2 closed.
[*] 192.168.13.37 - Meterpreter session 1 closed.
```
