### PR TITLE
Specify peer hostname for ssl connections

### DIFF
--- a/lib/metasploit/framework/tcp/client.rb
+++ b/lib/metasploit/framework/tcp/client.rb
@@ -83,6 +83,7 @@ module Metasploit
 
           nsock = Rex::Socket::Tcp.create(
               'PeerHost'      =>  opts['RHOST'] || rhost,
+              'PeerHostname'  =>  opts['SSLServerNameIndication'] || opts['VHOST'] || opts['RHOSTNAME'],
               'PeerPort'      => (opts['RPORT'] || rport).to_i,
               'LocalHost'     =>  opts['CHOST'] || chost || "0.0.0.0",
               'LocalPort'     => (opts['CPORT'] || cport || 0).to_i,

--- a/lib/metasploit/framework/tcp/client.rb
+++ b/lib/metasploit/framework/tcp/client.rb
@@ -83,7 +83,7 @@ module Metasploit
 
           nsock = Rex::Socket::Tcp.create(
               'PeerHost'      =>  opts['RHOST'] || rhost,
-              'PeerHostname'  =>  opts['SSLServerNameIndication'] || opts['VHOST'] || opts['RHOSTNAME'],
+              'PeerHostname'  =>  opts['SSLServerNameIndication'] || opts['RHOSTNAME'],
               'PeerPort'      => (opts['RPORT'] || rport).to_i,
               'LocalHost'     =>  opts['CHOST'] || chost || "0.0.0.0",
               'LocalPort'     => (opts['CPORT'] || cport || 0).to_i,

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -490,8 +490,8 @@ module Exploit::Remote::HttpClient
       end
 
       opts['rhost'] = datastore['RHOST']
-      opts['vhost'] = opts['vhost'] || opts['rhost'] || self.vhost()
-      opts['ssl_server_name_indication'] = opts['vhost']
+      opts['vhost'] = opts['vhost'] || self.vhost() || opts['rhost']
+      opts['ssl_server_name_indication'] = datastore['SSLServerNameIndication'] || opts['vhost']
       opts['rport'] = datastore['RPORT']
 
       opts['SSL'] = ssl

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -47,7 +47,8 @@ module Exploit::Remote::HttpClient
         OptFloat.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
         OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false]),
         OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
-        OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu'])
+        OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu']),
+        OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil]),
       ], self.class
     )
 
@@ -91,7 +92,7 @@ module Exploit::Remote::HttpClient
   end
 
   def deregister_http_client_options
-    deregister_options('RHOST', 'RPORT', 'VHOST', 'SSL', 'Proxies')
+    deregister_options('RHOST', 'RPORT', 'VHOST', 'SSL', 'SSLServerNameIndication', 'Proxies')
   end
 
   #
@@ -163,9 +164,12 @@ module Exploit::Remote::HttpClient
       comm: opts['comm']
     )
 
+
     # Configure the HTTP client with the supplied parameter
+    vhost = opts['vhost'] || opts['rhost'] || self.vhost
     nclient.set_config(
-      'vhost' => opts['vhost'] || opts['rhost'] || self.vhost(),
+      'vhost' => vhost,
+      'ssl_server_name_indication' => datastore['SSLServerNameIndication'] || vhost,
       'agent' => datastore['UserAgent'],
       'partial' => opts['partial'],
       'uri_encode_mode'        => datastore['HTTP::uri_encode_mode'],
@@ -487,6 +491,7 @@ module Exploit::Remote::HttpClient
 
       opts['rhost'] = datastore['RHOST']
       opts['vhost'] = opts['vhost'] || opts['rhost'] || self.vhost()
+      opts['ssl_server_name_indication'] = opts['vhost']
       opts['rport'] = datastore['RPORT']
 
       opts['SSL'] = ssl
@@ -497,6 +502,7 @@ module Exploit::Remote::HttpClient
       opts['uri'] = location.path
       opts['rhost'] = location.host
       opts['vhost'] = location.host
+      opts['ssl_server_name_indication'] = opts['vhost']
       opts['rport'] = location.port
 
       if location.scheme == 'https'

--- a/lib/msf/core/exploit/remote/tcp.rb
+++ b/lib/msf/core/exploit/remote/tcp.rb
@@ -63,6 +63,7 @@ module Exploit::Remote::Tcp
     register_advanced_options(
       [
         OptBool.new('SSL',        [ false, 'Negotiate SSL/TLS for outgoing connections', false]),
+        OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil]),
         Opt::SSLVersion,
         OptEnum.new('SSLVerifyMode',  [ false, 'SSL verification method', 'PEER', %W{CLIENT_ONCE FAIL_IF_NO_PEER_CERT NONE PEER}]),
         OptString.new('SSLCipher',    [ false, 'String for SSL cipher - "DHE-RSA-AES256-SHA" or "ADH"']),
@@ -100,6 +101,7 @@ module Exploit::Remote::Tcp
 
     nsock = Rex::Socket::Tcp.create(
       'PeerHost'      =>  opts['RHOST'] || rhost,
+      'PeerHostname'  =>  opts['SSLServerNameIndication'] || opts['VHOST'] || opts['RHOSTNAME'],
       'PeerPort'      => (opts['RPORT'] || rport).to_i,
       'LocalHost'     =>  opts['CHOST'] || chost || "0.0.0.0",
       'LocalPort'     => (opts['CPORT'] || cport || 0).to_i,

--- a/lib/msf/core/rhosts_walker.rb
+++ b/lib/msf/core/rhosts_walker.rb
@@ -147,7 +147,7 @@ module Msf
               overrides = {}
               overrides['UNPARSED_RHOSTS'] = value
               overrides['RHOSTS'] = rhost[:address]
-              overrides['VHOST'] = rhost[:hostname] if datastore.options.include?('VHOST') && datastore['VHOST'].blank?
+              set_hostname(datastore, overrides, rhost[:hostname])
               results << datastore.merge(overrides)
             end
           end
@@ -170,6 +170,7 @@ module Msf
       result['RHOSTS'] = uri.hostname
       result['RPORT'] = (uri.port || 445) if datastore.options.include?('RPORT')
 
+      set_hostname(datastore, result, uri.hostname)
       # Handle users in the format:
       #   user
       #   domain;user
@@ -207,8 +208,6 @@ module Msf
     def parse_http_uri(value, datastore)
       uri = ::Addressable::URI.parse(value)
       result = {}
-      # nil VHOST for now, this value will be calculated and overridden later
-      result['VHOST'] = nil
 
       result['RHOSTS'] = uri.hostname
       is_ssl = %w[ssl https].include?(uri.scheme)
@@ -224,7 +223,9 @@ module Msf
         result['URI'] = target_uri if datastore.options.include?('URI')
       end
 
-      result['VHOST'] = uri.hostname unless Rex::Socket.is_ip_addr?(uri.hostname)
+      result['HttpQueryString'] = uri.query if datastore.options.include?('HttpQueryString')
+
+      set_hostname(datastore, result, uri.hostname)
       set_username(datastore, result, uri.user) if uri.user
       set_password(datastore, result, uri.password) if uri.password
 
@@ -250,6 +251,7 @@ module Msf
         result['DATABASE'] = uri.path[1..-1]
       end
 
+      set_hostname(datastore, result, uri.hostname)
       set_username(datastore, result, uri.user) if uri.user
       set_password(datastore, result, uri.password) if uri.password
       result
@@ -272,6 +274,8 @@ module Msf
       if datastore.options.include?('DATABASE') && has_database_specified
         result['DATABASE'] = uri.path[1..-1]
       end
+
+      set_hostname(datastore, result, uri.hostname)
       set_username(datastore, result, uri.user) if uri.user
       set_password(datastore, result, uri.password) if uri.password
 
@@ -291,6 +295,7 @@ module Msf
       result['RHOSTS'] = uri.hostname
       result['RPORT'] = uri.port || 22
 
+      set_hostname(datastore, result, uri.hostname)
       set_username(datastore, result, uri.user) if uri.user
       set_password(datastore, result, uri.password) if uri.password
 
@@ -312,6 +317,7 @@ module Msf
         result['RPORT'] = uri.port
       end
 
+      set_hostname(datastore, result, uri.hostname)
       set_username(datastore, result, uri.user) if uri.user
       set_password(datastore, result, uri.password) if uri.password
 
@@ -319,6 +325,12 @@ module Msf
     end
 
     protected
+
+    def set_hostname(datastore, result, hostname)
+      hostname = Rex::Socket.is_ip_addr?(hostname) ? nil : hostname
+      result['RHOSTNAME'] = hostname if result['RHOSTNAME'].blank?
+      result['VHOST'] = hostname if datastore.options.include?('VHOST') && datastore['VHOST'].blank?
+    end
 
     def set_username(datastore, result, username)
       # Preference setting application specific values first

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -36,6 +36,7 @@ class Client
     self.config = Http::ClientRequest::DefaultConfig.merge({
       'read_max_data'   => (1024*1024*1),
       'vhost'           => self.hostname,
+      'ssl_server_name_indication' => self.hostname,
     })
     self.config['agent'] ||= Rex::UserAgent.session_agent
 
@@ -171,7 +172,8 @@ class Client
     timeout = (t.nil? or t == -1) ? 0 : t
 
     self.conn = Rex::Socket::Tcp.create(
-      'PeerHost'   => self.hostname,
+      'PeerHost'    => self.hostname,
+      'PeerHostname' => self.config['ssl_server_name_indication'] || self.config['vhost'],
       'PeerPort'   => self.port.to_i,
       'LocalHost'  => self.local_host,
       'LocalPort'  => self.local_port,

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -36,6 +36,7 @@ class ClientRequest
     'vars_form_data'         => [],
     'version'                => '1.1',
     'vhost'                  => nil,
+    'ssl_server_name_indication' => nil,
 
     #
     # Evasion options

--- a/modules/auxiliary/gather/impersonate_ssl.rb
+++ b/modules/auxiliary/gather/impersonate_ssl.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(443),
-        OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil]),
+        OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil], aliases: ['SNI']),
         OptEnum.new('OUT_FORMAT', [true, 'Output format', 'PEM', ['DER', 'PEM']]),
         OptString.new('EXPIRATION', [false, 'Date the new cert should expire (e.g. 06 May 2012, YESTERDAY or NOW)', nil]),
         OptPath.new('PRIVKEY', [false, 'Sign the cert with your own CA private key', nil]),

--- a/modules/auxiliary/gather/impersonate_ssl.rb
+++ b/modules/auxiliary/gather/impersonate_ssl.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(443),
-        OptString.new('SNI', [false, 'Server Name Indicator', nil]),
+        OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil]),
         OptEnum.new('OUT_FORMAT', [true, 'Output format', 'PEM', ['DER', 'PEM']]),
         OptString.new('EXPIRATION', [false, 'Date the new cert should expire (e.g. 06 May 2012, YESTERDAY or NOW)', nil]),
         OptPath.new('PRIVKEY', [false, 'Sign the cert with your own CA private key', nil]),
@@ -58,8 +58,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if !datastore['SNI'].nil?
-      sni = datastore['SNI']
+    if !datastore['SSLServerNameIndication'].nil?
+      sni = datastore['SSLServerNameIndication']
       print_status("Connecting to #{rhost}:#{rport} SNI:#{sni}")
     else
       sni = false


### PR DESCRIPTION
Closes https://github.com/rapid7/rex-socket/issues/29
Related to https://github.com/rapid7/metasploit-framework/pull/16378
Framework pull request: https://github.com/rapid7/metasploit-framework/pull/16499
rex-socket pull request: https://github.com/rapid7/rex-socket/pull/45

Allow for SNI information to be set explicitly by the caller

### Before

```
msf6 auxiliary(scanner/http/title) > run https://nvd.nist.gov verbose=true

[+] [2600:1f18:268d:1d01:f609:5e91:8a48:f546:443] [C:200] [R:] [S:] NVD - Home
[*] Scanned 1 of 2 hosts (50% complete)
[*] Error: 54.85.30.225: OpenSSL::SSL::SSLError SSL_connect returned=1 errno=0 state=error: tlsv1 unrecognized name
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/title) >
```

### After

```
msf6 auxiliary(scanner/http/title) > rerun https://nvd.nist.gov verbose=true
[*] Reloading module...

[+] [2600:1f18:268d:1d01:f609:5e91:8a48:f546:443] [C:200] [R:] [S:] NVD - Home
[*] Scanned 1 of 2 hosts (50% complete)
[+] [54.85.30.225:443] [C:200] [R:] [S:] NVD - Home
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/title) >
```

## Verification

- Code review
- Replicate the before/after steps of https://github.com/rapid7/metasploit-framework/pull/16378

Other scenarios, explicitly specifying SslServerNameIndication, VHOST, etc, individually/separately. Note the IP was resolved manually ahead of time

Just IP:

```
msf6 auxiliary(scanner/http/title) > rerun https://54.85.30.225:443
[*] Reloading module...

[*] Error: 54.85.30.225: OpenSSL::SSL::SSLError SSL_connect returned=1 errno=0 state=error: tlsv1 unrecognized name
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

IP and SNI:
```
msf6 auxiliary(scanner/http/title) > rerun https://54.85.30.225:443 SslServerNameIndication=nvd.nist.gov
[*] Reloading module...

[+] [54.85.30.225:443] [C:404] [R:] [S:Microsoft-HTTPAPI/2.0] Not Found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

SNI and VHOST:

```
msf6 auxiliary(scanner/http/title) > rerun https://54.85.30.225:443 SslServerNameIndication=nvd.nist.gov vhost=nvd.nist.gov
[*] Reloading module...

[+] [54.85.30.225:443] [C:200] [R:] [S:] NVD - Home
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Test redirects to different domains are handled correctly:

```
msf6 auxiliary(scanner/http/title) > rerun http://httpbin.org/redirect-to?url=https://nvd.nist.gov/ FollowRedirect=true 
[*] Reloading module...

[+] [35.169.55.235:80] [C:200] [R:] [S:] NVD - Home
[*] Scanned 1 of 6 hosts (16% complete)
[+] [72.44.59.17:80] [C:200] [R:] [S:] NVD - Home
[*] Scanned 2 of 6 hosts (33% complete)
[*] Scanned 2 of 6 hosts (33% complete)
[+] [18.215.122.215:80] [C:200] [R:] [S:] NVD - Home
[*] Scanned 3 of 6 hosts (50% complete)
[*] Scanned 3 of 6 hosts (50% complete)
[+] [44.195.242.112:80] [C:200] [R:] [S:] NVD - Home
[*] Scanned 4 of 6 hosts (66% complete)
[+] [3.226.124.170:80] [C:200] [R:] [S:] NVD - Home
[*] Scanned 5 of 6 hosts (83% complete)
[*] Scanned 5 of 6 hosts (83% complete)
[+] [34.197.247.180:80] [C:200] [R:] [S:] NVD - Home
[*] Scanned 6 of 6 hosts (100% complete)
[*] Auxiliary module execution completed
```

Test relative redirects work:
```
msf6 auxiliary(scanner/http/title) > run https://blog.xpnsec.com/tailoring-cobalt-strike-on-target FollowRedirect=true

[+] [2a03:b0c0:3:d0::1440:1:443] [C:200] [R:] [S:Netlify] Tailoring Cobalt Strike on Target - XPN InfoSec Blog
[*] Scanned 1 of 4 hosts (25% complete)
[+] [2a05:d014:275:cb02:66df:50b:6e56:a6bf:443] [C:200] [R:] [S:Netlify] Tailoring Cobalt Strike on Target - XPN InfoSec Blog
[*] Scanned 2 of 4 hosts (50% complete)
[+] [18.192.76.182:443] [C:200] [R:] [S:Netlify] Tailoring Cobalt Strike on Target - XPN InfoSec Blog
[*] Scanned 3 of 4 hosts (75% complete)
[+] [206.189.52.23:443] [C:200] [R:] [S:Netlify] Tailoring Cobalt Strike on Target - XPN InfoSec Blog
[*] Scanned 4 of 4 hosts (100% complete)
[*] Auxiliary module execution completed
```