### PR TITLE
Improve regex parsing in lotus_domino_hashes

### DIFF
--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -157,9 +157,14 @@ class MetasploitModule < Msf::Auxiliary
       }, 25)
 
       if res && res.body
-        short_name = res.body.scan(/<INPUT NAME=\"ShortName\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
-        user_mail = res.body.scan(/<INPUT NAME=\"InternetAddress\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
-        pass_hash = res.body.scan(/<INPUT NAME=\"\$?dspHTTPPassword\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
+        short_name = res.body.scan(/<INPUT NAME=\"ShortName\" TYPE=(?:.*) VALUE=\"([^"]+)\"/i).join
+        user_mail = res.body.scan(/<INPUT NAME=\"InternetAddress\" TYPE=(?:.*) VALUE=\"([^"]+)\"/i).join
+        pass_hash_candidates = res.body.scan(/<INPUT NAME=\"\$?dspHTTPPassword\" TYPE=(?:.*) VALUE=\"([^"]+)\"/i)
+        if not pass_hash_candidates[0][0].strip.empty?
+          pass_hash = pass_hash_candidates[0][0]
+        else
+          pass_hash = pass_hash_candidates[1][0]
+        end
 
         short_name = 'NULL' if short_name.to_s.strip.empty?
         user_mail = 'NULL' if user_mail.to_s.strip.empty?

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -160,10 +160,10 @@ class MetasploitModule < Msf::Auxiliary
         short_name = res.body.scan(/<INPUT NAME=\"ShortName\" TYPE=(?:.*) VALUE=\"([^"]+)\"/i).join
         user_mail = res.body.scan(/<INPUT NAME=\"InternetAddress\" TYPE=(?:.*) VALUE=\"([^"]+)\"/i).join
         pass_hash_candidates = res.body.scan(/<INPUT NAME=\"\$?dspHTTPPassword\" TYPE=(?:.*) VALUE=\"([^"]+)\"/i)
-        if not pass_hash_candidates[0][0].strip.empty?
-          pass_hash = pass_hash_candidates[0][0]
+        if pass_hash_candidates[0][0].nil? || pass_hash_candidates[0][0].strip.empty?
+          pass_hash = pass_hash_candidates[1][0] unless (pass_hash_candidates[1][0].nil? || pass_hash_candidates[1][0].strip.empty?)
         else
-          pass_hash = pass_hash_candidates[1][0]
+          pass_hash = pass_hash_candidates[0][0]
         end
 
         short_name = 'NULL' if short_name.to_s.strip.empty?

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -157,14 +157,10 @@ class MetasploitModule < Msf::Auxiliary
       }, 25)
 
       if res && res.body
-        short_name = res.body.scan(/<INPUT NAME=\"ShortName\" TYPE=(?:.*) VALUE=\"([^"]+)\"/i).join
-        user_mail = res.body.scan(/<INPUT NAME=\"InternetAddress\" TYPE=(?:.*) VALUE=\"([^"]+)\"/i).join
-        pass_hash_candidates = res.body.scan(/<INPUT NAME=\"\$?dspHTTPPassword\" TYPE=(?:.*) VALUE=\"([^"]+)\"/i)
-        if pass_hash_candidates[0][0].nil? || pass_hash_candidates[0][0].strip.empty?
-          pass_hash = pass_hash_candidates[1][0] unless (pass_hash_candidates[1][0].nil? || pass_hash_candidates[1][0].strip.empty?)
-        else
-          pass_hash = pass_hash_candidates[0][0]
-        end
+        doc = res.get_html_document
+        short_name =  doc.xpath('//input[@name="ShortName"]/@value').text
+        user_mail =  doc.xpath('//input[@name="InternetAddress"]/@value').text
+        pass_hash = doc.xpath('//input[@name="$dspHTTPPassword" or @name="dspHTTPPassword"]/@value').first&.text
 
         short_name = 'NULL' if short_name.to_s.strip.empty?
         user_mail = 'NULL' if user_mail.to_s.strip.empty?


### PR DESCRIPTION
* The closing quotes after the `VALUE` attribute were not escaped. This
  commit adds them.
* The regex assumed that the short name does not contain whitespace.
  I am looking at a Domino instance where the short name DOES contain
  whitespace. This commit changes the regex such that the value is
  assumed to not contain a quote before the closing quote. Of course,
  there could be an escaped quote inside quotes in the HTML source, but
  if we want to do it properly, we'd need an HTML parser which exceeds
  my modest ruby skills.
* The fields `$dspHTTPPassword` and `dspHTTPPassword` (without the
  dollar sign) can both contain the hash. The code assumed that only up
  to one of those fields contain a hash. This leads to the hash being
  printed twice in the output in my case. This commit fixes this.

Note that I did not replace the deprecated `report_auth_info` function.

## Verification

1. Locate a vulnerable instance of Lotus Domino where at least one account uses a whitespace
2. run `msfconsole`
3. `use auxillary/scanner/lotus/lotus_domino_hashes`
4. Provide RHOST and credentials
5. Run
6. Observe that reported user name is `NULL`
7. Repeat after applying this patch and observe correct user name

Unfortunately I can't provide a PCAP (it's TLS encrypted anyway) or screen recordings because it would contain data protected by an NDA. I do not have a test instance. All I can offer is this:

Before:
```
14:43:44>192.168.137.16[0] auxiliary(scanner/lotus/lotus_domino_hashes) > run

[*] [2022.04.26-14:43:44] XX.XX.XX.XX:443       - Lotus Domino - Trying dump password hashes with given credentials
[+] [2022.04.26-14:43:44] XX.XX.XX.XX:443       - Lotus Domino - SUCCESSFUL authentication for 'XXXXXXXX'
[*] [2022.04.26-14:43:44] XX.XX.XX.XX:443       - Lotus Domino - Getting password hashes
[+] [2022.04.26-14:43:45] XX.XX.XX.XX:443       - Lotus Domino - Account Found: NULL, NULL, (FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)(FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
```
After:

```
14:51:13>192.168.137.16[0] auxiliary(scanner/lotus/lotus_domino_hashes) > run

[*] [2022.04.26-14:51:13] XX.XX.XX.XX:443       - Lotus Domino - Trying dump password hashes with given credentials
[+] [2022.04.26-14:51:13] XX.XX.XX.XX:443       - Lotus Domino - SUCCESSFUL authentication for 'XXXXXXXX'
[*] [2022.04.26-14:51:13] XX.XX.XX.XX:443       - Lotus Domino - Getting password hashes
[+] [2022.04.26-14:51:14] XX.XX.XX.XX:443       - Lotus Domino - Account Found: <Firstname> <Lastname>, NULL, (FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
```
