### PR TITLE
Fix extraneous whitespace in tunnel info

### DIFF
--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -136,7 +136,9 @@ module Session
   # Returns a pretty representation of the tunnel.
   #
   def tunnel_to_s
-    "#{(tunnel_local || '??')} -> #{(tunnel_peer || '??')} #{comm_channel}"
+    tunnel_str = "#{tunnel_local || '??'} -> #{tunnel_peer || '??'}"
+    tunnel_str << " #{comm_channel}" if comm_channel
+    tunnel_str
   end
 
   ##


### PR DESCRIPTION
It's most commonly found in the "session opened" message.

## Before

```
[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:64565 ) at 2022-04-26 14:27:04 -0500
```

## After

```
[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:64576) at 2022-04-26 14:27:57 -0500
```

Fixes #15706.