### PR TITLE
Ensure HTML is escaped in markdown codeblocks

### DIFF
--- a/documentation/modules/exploit/windows/smb/smb_relay.md
+++ b/documentation/modules/exploit/windows/smb/smb_relay.md
@@ -44,9 +44,11 @@ Example relaying between:
 
 - Windows 7 <-> Metasploit framework <-> Windows 10
 
-Where windows 7 = 192.168.123.22
-Where msfconsole = 192.168.123.1
-Where windows 10 = 192.168.123.4
+Where:
+
+- Windows 7 = 192.168.123.22
+- msfconsole = 192.168.123.1
+- windows 10 = 192.168.123.4
 
 Example lab diagram:
 
@@ -114,11 +116,13 @@ msf6 exploit(windows/smb/smb_relay) > [*] Started reverse TCP handler on 192.168
 ```
 
 If the target machine connects:
+
 ```
 net use \\192.168.123.1\foo /u:admin password123
 ```
 
 msfconsole output with new session opened:
+
 ```
 msf6 exploit(windows/smb/smb_relay) > [*] New request from 192.168.123.22
 [*] Received request for \admin
@@ -149,6 +153,7 @@ Active sessions
 ```
 
 Multiple targets can be relayed to:
+
 ```
 msf6 exploit(windows/smb/smb_relay) > set RELAY_TARGETS 192.168.123.4 192.168.123.25
 RELAY_TARGETS => 192.168.123.4 192.168.123.25

--- a/lib/msf/util/document_generator/document_normalizer.rb
+++ b/lib/msf/util/document_generator/document_normalizer.rb
@@ -9,7 +9,7 @@ module Redcarpet
         code = $1 if code =~ /^<ruby>(.+)<\/ruby>/m
 
         "<pre>" \
-          "<code>#{code}</code>" \
+          "<code>#{CGI.escape_html(code)}</code>" \
         "</pre>"
       end
 


### PR DESCRIPTION
Ensure the `info -d` correctly escapes HTML in code blocks

### Before

![image](https://user-images.githubusercontent.com/60357436/165598871-83f65c57-9a38-4b1d-8568-11b4eafbbe17.png)

### After

![image](https://user-images.githubusercontent.com/60357436/165598848-8505c2ee-3a01-4615-a986-e270d733ac91.png)

## Verification

```
msfconsole
use windows/smb/smb_relay
info -d
```