### PR TITLE
Fix whitespace linting issues within the test folder

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# This file aims to document any commits which should be ignored from Git/Github history
+# Only whitespace changes should be added to this file where possible
+#
+# Additional details:
+#    https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+# 
+
+# Fixing whitespace on the tests folder with "rubocop --fix-layout test"
+29cc349649f978304712dd0c31dc8861e9627209

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -180,6 +180,7 @@ Metrics/ClassLength:
   Enabled: true
   Exclude:
     - 'modules/**/*'
+    - 'test/modules/**/*'
 
 Style/ClassAndModuleChildren:
   Enabled: false
@@ -257,6 +258,7 @@ Style/Documentation:
   Description: 'Most Metasploit modules do not have class documentation.'
   Exclude:
     - 'modules/**/*'
+    - 'test/modules/**/*'
     - 'spec/file_fixtures/modules/**/*'
 
 Layout/FirstArgumentIndentation:

--- a/test/functional/framework/msfconsole_spec.rb
+++ b/test/functional/framework/msfconsole_spec.rb
@@ -7,26 +7,84 @@ require 'fileutils'
 require 'msf_matchers'
 require 'msf_test_case'
 
-
 module MsfTest
+  include MsfTest::MsfMatchers
 
-include MsfTest::MsfMatchers
+  ## This spec exists to help us describe the behavior of msfconsole - TODO
 
+  describe "Msfconsole" do
+    ###
+    # Setup!
+    ###
 
-## This spec exists to help us describe the behavior of msfconsole - TODO
+    before :all do
+      @working_directory = File.dirname(__FILE__)
 
-describe "Msfconsole" do
-  
-  ###
-  # Setup!
-  ###
-  
-  before :all do
-    
+      ## Static specs will make use of RC files here
+      @static_resource_directory = "#{@working_directory}/msftest/resource"
+
+      ## Directories for the generated specs
+      @temp_directory = "#{@working_directory}/msfconsole_specs"
+      @temp_input_directory = "#{@temp_directory}/generated_rc"
+
+      ## Where all output from the runs will go
+      @temp_output_directory = "#{@temp_directory}/output"
+
+      ## Create a framework object
+      @framework = ::Msf::Simple::Framework.create
+    end
+
+    before :each do
+    end
+
+    after :each do
+    end
+
+    after :all do
+      ## Clean up
+      # FileUtils.rm_rf(@temp_directory)
+    end
+
+    ###
+    # Static Test cases!
+    ###
+
+    it "should start and let us run help" do
+      data = start_console_and_run_rc("help", "#{@static_resource_directory}/help.rc")
+
+      success_strings = [
+        'help',
+        'Database Backend Commands',
+        'Core Commands'
+      ]
+      failure_strings = [] | generic_failure_strings
+      failure_exception_strings = [] | generic_failure_exception_strings
+
+      data.should contain_all_successes(success_strings)
+      data.should contain_no_failures_except(failure_strings, failure_exception_strings)
+    end
+
+    it "should generate a meterpreter session against a vulnerable win32 host" do
+      ## Set input & output to something sane
+      input = Rex::Ui::Text::Input::Stdio.new
+      output = Rex::Ui::Text::Output::File.new("temp.output")
+      session = generate_x86_meterpreter_session(input, output)
+
+      session.should_not be_nil
+
+      if session
+        session.load_stdapi
+        session.run_cmd("help")
+      else
+        flunk "Error interacting with session"
+      end
+    end
+
+    ###
+    # Dynamic Test Cases!!
+    ###
+
     @working_directory = File.dirname(__FILE__)
-
-    ## Static specs will make use of RC files here
-    @static_resource_directory = "#{@working_directory}/msftest/resource"
 
     ## Directories for the generated specs
     @temp_directory = "#{@working_directory}/msfconsole_specs"
@@ -35,176 +93,112 @@ describe "Msfconsole" do
     ## Where all output from the runs will go
     @temp_output_directory = "#{@temp_directory}/output"
 
-    ## Create a framework object
-    @framework = ::Msf::Simple::Framework.create
-  end
+    if File.directory? @temp_directory
+      FileUtils.rm_rf(@temp_directory)
+    end
 
-  before :each do
-  end
+    Dir.mkdir(@temp_directory)
+    Dir.mkdir(@temp_input_directory)
+    Dir.mkdir(@temp_output_directory)
 
-  after :each do
-  
-  end
+    Dir.glob("#{@working_directory}/msftest/*.msftest").each do |filename|
+      ## Parse this test case
+      test_case = MsfTestCase.new(filename)
+      puts "Found #{test_case.name} in: #{filename}"
 
-  after :all do
-    ## Clean up
-    #FileUtils.rm_rf(@temp_directory)
-  end
+      ## Write the commands back to a temporary RC file
+      puts "Writing #{@temp_input_directory}/#{test_case.name}.rc"
+      File.open("#{@temp_input_directory}/#{test_case.name}.rc", 'w') { |f| f.puts test_case.commands }
 
-  ###
-  # Static Test cases!
-  ###
+      ## Create the rspec Test Case
+      it "should #{test_case.name}" do
+        ## Gather the success / failure strings, and combine with the generics
+        success_strings = test_case.expected_successes
+        failure_strings = test_case.expected_failures | generic_failure_strings
+        failure_exception_strings = test_case.expected_failure_exceptions | generic_failure_exception_strings
 
-  it "should start and let us run help" do
-      data = start_console_and_run_rc("help","#{@static_resource_directory}/help.rc")
-      
-      success_strings = [	'help',
-            'Database Backend Commands',
-            'Core Commands' ]
-      failure_strings = [] | generic_failure_strings
-      failure_exception_strings = [] | generic_failure_exception_strings
+        ## run the commands
+        data = start_console_and_run_rc(test_case.name, "#{@temp_input_directory}/#{test_case.name}.rc")
 
-      data.should contain_all_successes(success_strings)
-      data.should contain_no_failures_except(failure_strings, failure_exception_strings)
-  end
+        ## check the output
+        data.should contain_all_successes(success_strings)
+        data.should contain_no_failures_except(failure_strings, failure_exception_strings)
 
-  it "should generate a meterpreter session against a vulnerable win32 host" do
-    ## Set input & output to something sane
-    input        = Rex::Ui::Text::Input::Stdio.new
-    output       = Rex::Ui::Text::Output::File.new("temp.output")
-    session = generate_x86_meterpreter_session(input, output)
+        ## Clean up
+        # File.delete("#{@temp_input_directory}/#{test_case.name}.rc")
+        # File.delete("#{@temp_output_directory}/#{test_case.name}")
+      end
+    end
 
-    session.should_not be_nil	
-  
-    if session
-      session.load_stdapi
-      session.run_cmd("help")
-    else
-      flunk "Error interacting with session"
+    ###
+    # Test case helpers:
+    ###
+    def generic_success_strings
+      []
+    end
+
+    def generic_failure_strings
+      ['fatal', 'fail', 'error', 'exception']
+    end
+
+    def generic_failure_exception_strings
+      []
+    end
+
+    def start_console_and_run_rc(name, rc_file, database_file = false)
+      output_file = "#{@temp_output_directory}/#{name}"
+
+      if database_file
+        msfconsole_string = "ruby #{@working_directory}/../../../msfconsole -o #{output_file} -r #{rc_file} -y #{database_file}"
+      else
+        msfconsole_string = "ruby #{@working_directory}/../../../msfconsole -o #{output_file} -r #{rc_file}"
+      end
+
+      system("#{msfconsole_string}")
+
+      data = hlp_file_to_string("#{output_file}")
+    end
+
+    def generate_x86_meterpreter_session(input, output)
+      ## Setup for win32
+      exploit_name = 'windows/smb/psexec'
+      payload_name = 'windows/meterpreter/bind_tcp'
+
+      ## Fire it off against a known-vulnerable host
+      session = @framework.exploits.create(exploit_name).exploit_simple(
+        'Options' => { 'RHOST' => "vulnerable", "SMBUser" => "administrator", "SMBPass" => "" },
+        'Payload' => payload_name,
+        'LocalInput' => input,
+        'LocalOutput' => output
+      )
+
+      ## If a session came back, try to interact with it.
+      if session
+        return session
+      else
+        return nil
+      end
+    end
+
+    def generate_win64_meterpreter_session(input, output)
+      raise "Not Implemented"
+    end
+
+    def generate_java_meterpreter_session(input, output)
+      raise "Not Implemented"
+    end
+
+    def generate_php_meterpreter_session(input, output)
+      raise "Not Implemented"
+    end
+
+    def hlp_file_to_string(filename)
+      data = ""
+      f = File.open(filename, "r")
+      f.each_line do |line|
+        data += line
+      end
+      return data
     end
   end
-  
-  ###
-  # Dynamic Test Cases!!
-  ###
-
-  @working_directory = File.dirname(__FILE__)
-
-  ## Directories for the generated specs
-  @temp_directory = "#{@working_directory}/msfconsole_specs"
-  @temp_input_directory = "#{@temp_directory}/generated_rc"
-
-  ## Where all output from the runs will go
-  @temp_output_directory = "#{@temp_directory}/output"
-
-  if File.directory? @temp_directory
-    FileUtils.rm_rf(@temp_directory)
-  end
-
-  Dir.mkdir(@temp_directory)
-  Dir.mkdir(@temp_input_directory)
-  Dir.mkdir(@temp_output_directory)
-  
-  Dir.glob("#{@working_directory}/msftest/*.msftest").each do |filename|
-    
-    ## Parse this test case
-    test_case = MsfTestCase.new(filename)
-    puts "Found #{test_case.name} in: #{filename}" 	
-
-    ## Write the commands back to a temporary RC file
-    puts "Writing #{@temp_input_directory}/#{test_case.name}.rc"
-    File.open("#{@temp_input_directory}/#{test_case.name}.rc", 'w') { |f|  f.puts test_case.commands } 
-    
-    ## Create the rspec Test Case
-    it "should #{test_case.name}" do
-      
-      ## Gather the success / failure strings, and combine with the generics
-      success_strings = test_case.expected_successes
-      failure_strings = test_case.expected_failures | generic_failure_strings
-      failure_exception_strings = test_case.expected_failure_exceptions | generic_failure_exception_strings
-      
-      ## run the commands
-      data = start_console_and_run_rc( test_case.name, "#{@temp_input_directory}/#{test_case.name}.rc")	
-          
-      ## check the output		
-      data.should contain_all_successes(success_strings)
-      data.should contain_no_failures_except(failure_strings, failure_exception_strings)
-      
-      ## Clean up 
-      #File.delete("#{@temp_input_directory}/#{test_case.name}.rc")
-      #File.delete("#{@temp_output_directory}/#{test_case.name}")
-    end
-  end
-
-  ###
-  # Test case helpers:
-  ###
-  def generic_success_strings
-    []	
-  end
-  
-  def generic_failure_strings
-    ['fatal', 'fail', 'error', 'exception']
-  end
-  
-  def generic_failure_exception_strings
-    []
-  end
-
-  def start_console_and_run_rc(name,rc_file, database_file=false)
-    output_file = "#{@temp_output_directory}/#{name}"
-
-    if database_file
-      msfconsole_string = "ruby #{@working_directory}/../../../msfconsole -o #{output_file} -r #{rc_file} -y #{database_file}"
-    else
-      msfconsole_string = "ruby #{@working_directory}/../../../msfconsole -o #{output_file} -r #{rc_file}"
-    end
-    
-    system("#{msfconsole_string}")
-
-    data = hlp_file_to_string("#{output_file}")			
-  end
-  
-  	def generate_x86_meterpreter_session(input, output)
-    ## Setup for win32
-    exploit_name = 'windows/smb/psexec'
-    payload_name = 'windows/meterpreter/bind_tcp'
-      
-    ## Fire it off against a known-vulnerable host
-    session = @framework.exploits.create(exploit_name).exploit_simple(
-      'Options'     => {'RHOST' => "vulnerable", "SMBUser" => "administrator", "SMBPass" => ""},
-      'Payload'     => payload_name,
-      'LocalInput'  => input,
-      'LocalOutput' => output)
-
-    ## If a session came back, try to interact with it.
-    if session
-      return session
-    else
-      return nil
-    end
-  end
-
-  	def generate_win64_meterpreter_session(input, output)
-    raise "Not Implemented"
-  end
-
-
-  	def generate_java_meterpreter_session(input, output)
-    raise "Not Implemented"
-  end
- 
-   	def generate_php_meterpreter_session(input, output)
-    raise "Not Implemented"
-  end
-
-  def hlp_file_to_string(filename)
-    data = ""
-    f = File.open(filename, "r") 
-    f.each_line do |line|
-      data += line
-    end
-    return data
-  end
-end
 end

--- a/test/functional/meterpreter/java_meterpreter_specs.rb
+++ b/test/functional/meterpreter/java_meterpreter_specs.rb
@@ -1,19 +1,15 @@
 module MsfTest
-module JavaMeterpreterSpecs
+  module JavaMeterpreterSpecs
+    ## This file is intended to be used in conjunction with a harness,
+    ## such as meterpreter_win32_spec.rb
 
-  ## This file is intended to be used in conjunction with a harness, 
-  ## such as meterpreter_win32_spec.rb
-
-  def self.included(base)
-        	base.class_eval do
-
-      it "should not error when taking a screenshot" do
-        success_strings = [ 'Screenshot saved to' ]
-        hlp_run_command_check_output("screenshot","screenshot", success_strings)
+    def self.included(base)
+      base.class_eval do
+        it "should not error when taking a screenshot" do
+          success_strings = [ 'Screenshot saved to' ]
+          hlp_run_command_check_output("screenshot", "screenshot", success_strings)
+        end
       end
-            
     end
   end
-
-end
 end

--- a/test/functional/meterpreter/meterpreter_java_spec.rb
+++ b/test/functional/meterpreter/meterpreter_java_spec.rb
@@ -7,85 +7,80 @@ require 'meterpreter_spec_helper'
 require 'meterpreter_specs'
 
 module MsfTest
+  describe "JavaMeterpreter" do
+    # This include brings in all the spec helper methods
+    include MsfTest::MeterpreterSpecHelper
 
-describe "JavaMeterpreter" do
-  
-  # This include brings in all the spec helper methods
-  include MsfTest::MeterpreterSpecHelper
-  
-  # This include brings in all the specs that are generic across the 
-  # meterpreter platforms
-  include MsfTest::MeterpreterSpecs
-  
-  # This include brings in all the specs that are specific to the java
-  # meterpreter
-  include MsfTest::JavaMeterpreterSpecs
+    # This include brings in all the specs that are generic across the
+    # meterpreter platforms
+    include MsfTest::MeterpreterSpecs
 
-  before :all do
-    @verbose = true
-  
-    @meterpreter_type = "java"
-    
-    ## Set up an outupt directory
-    @output_directory = File.join(File.dirname(__FILE__), "test_output_#{@meterpreter_type}")
+    # This include brings in all the specs that are specific to the java
+    # meterpreter
+    include MsfTest::JavaMeterpreterSpecs
 
-    if File.directory? @output_directory
+    before :all do
+      @verbose = true
+
+      @meterpreter_type = "java"
+
+      ## Set up an outupt directory
+      @output_directory = File.join(File.dirname(__FILE__), "test_output_#{@meterpreter_type}")
+
+      if File.directory? @output_directory
+        FileUtils.rm_rf(@output_directory)
+      end
+
+      Dir.mkdir(@output_directory)
+      @default_file = "#{@output_directory}/default"
+
+      create_session_java
+    end
+
+    before :each do
+    end
+
+    after :each do
+      @session.init_ui(@input, @output)
+    end
+
+    after :all do
+      # FileUtils.rm_rf("*.jpeg")
+      # FileUtils.rm_rf("payload.jar")
       FileUtils.rm_rf(@output_directory)
     end
 
-    Dir.mkdir(@output_directory)
-    @default_file = "#{@output_directory}/default"
+    def create_session_java
+      ## Setup for win32
+      @framework = Msf::Simple::Framework.create
 
-    create_session_java
-  end
+      test_modules_path = File.join(File.dirname(__FILE__), '..', '..', 'modules')
+      @framework.modules.add_module_path(test_modules_path)
 
-  before :each do
+      @exploit_name = 'test/java_tester'
+      @payload_name = 'java/meterpreter/bind_tcp'
+      @input = Rex::Ui::Text::Input::Stdio.new
+      @output = Rex::Ui::Text::Output::File.new(@default_file)
 
-  end
+      # Initialize the exploit instance
+      exploit = @framework.exploits.create(@exploit_name)
 
-  after :each do
-    @session.init_ui(@input, @output)
-  end
-  
-  after :all do
-    #FileUtils.rm_rf("*.jpeg")		
-    #FileUtils.rm_rf("payload.jar")		
-    FileUtils.rm_rf(@output_directory)
-  end
+      ## Fire it off against a known-vulnerable host
+      @session = exploit.exploit_simple(
+        'Options' => {},
+        'Payload' => @payload_name,
+        'LocalInput' => @input,
+        'LocalOutput' => @output
+      )
 
-  
-  def create_session_java
+      puts @session.inspect
 
-    ## Setup for win32
-    @framework    = Msf::Simple::Framework.create
-    
-    test_modules_path = File.join(File.dirname(__FILE__), '..', '..', 'modules')
-    @framework.modules.add_module_path(test_modules_path)
-    
-    @exploit_name = 'test/java_tester'
-    @payload_name = 'java/meterpreter/bind_tcp'
-    @input        = Rex::Ui::Text::Input::Stdio.new 
-    @output       = Rex::Ui::Text::Output::File.new(@default_file)
-
-    # Initialize the exploit instance
-    exploit = @framework.exploits.create(@exploit_name)
-
-    ## Fire it off against a known-vulnerable host
-    @session = exploit.exploit_simple(
-      'Options'     => {},
-      'Payload'     => @payload_name,
-      'LocalInput'  => @input,
-      'LocalOutput' => @output)
-
-    puts @session.inspect
-
-    ## If a session came back, try to interact with it.
-    if @session
-      @session.load_stdapi
-    else
-      raise Exception "Couldn't get a session!"
+      ## If a session came back, try to interact with it.
+      if @session
+        @session.load_stdapi
+      else
+        raise Exception "Couldn't get a session!"
+      end
     end
   end
-  
-end
 end

--- a/test/functional/meterpreter/meterpreter_php_spec.rb
+++ b/test/functional/meterpreter/meterpreter_php_spec.rb
@@ -7,76 +7,71 @@ require 'meterpreter_spec_helper'
 require 'meterpreter_specs'
 
 module MsfTest
+  describe "PhpMeterpreter" do
+    # This include brings in all the spec helper methods
+    include MsfTest::MeterpreterSpecHelper
 
-describe "PhpMeterpreter" do
-  
-  # This include brings in all the spec helper methods
-  include MsfTest::MeterpreterSpecHelper
-  
-  # This include brings in all the specs that are generic across the 
-  # meterpreter platforms
-  include MsfTest::MeterpreterSpecs
+    # This include brings in all the specs that are generic across the
+    # meterpreter platforms
+    include MsfTest::MeterpreterSpecs
 
-  before :all do
-    @verbose = true
-  
-    @meterpreter_type = "php"
-    
-    ## Set up an outupt directory
-    @output_directory = File.join(File.dirname(__FILE__), "test_output_#{@meterpreter_type}")
+    before :all do
+      @verbose = true
 
-    if File.directory? @output_directory
+      @meterpreter_type = "php"
+
+      ## Set up an outupt directory
+      @output_directory = File.join(File.dirname(__FILE__), "test_output_#{@meterpreter_type}")
+
+      if File.directory? @output_directory
+        FileUtils.rm_rf(@output_directory)
+      end
+
+      Dir.mkdir(@output_directory)
+      @default_file = "#{@output_directory}/default"
+
+      create_session_php
+    end
+
+    before :each do
+    end
+
+    after :each do
+      @session.init_ui(@input, @output)
+    end
+
+    after :all do
       FileUtils.rm_rf(@output_directory)
     end
 
-    Dir.mkdir(@output_directory)
-    @default_file = "#{@output_directory}/default"
+    def create_session_php
+      ## Setup for php
+      @framework = Msf::Simple::Framework.create
 
-    create_session_php
-  end
+      @exploit_name = 'unix/webapp/tikiwiki_graph_formula_exec'
+      @payload_name = 'php/meterpreter/bind_tcp'
+      @input = Rex::Ui::Text::Input::Stdio.new
+      @output = Rex::Ui::Text::Output::File.new(@default_file)
 
-  before :each do
+      # Initialize the exploit instance
+      exploit = @framework.exploits.create(@exploit_name)
 
-  end
+      ## Fire it off against a known-vulnerable host
+      @session = exploit.exploit_simple(
+        'Options' => { 'RHOST' => "metasploitable" },
+        'Payload' => @payload_name,
+        'LocalInput' => @input,
+        'LocalOutput' => @output
+      )
 
-  after :each do
-    @session.init_ui(@input, @output)
-  end
-  
-  after :all do
-    FileUtils.rm_rf(@output_directory)
-  end
+      puts @session.inspect
 
-  
-  def create_session_php
-
-    ## Setup for php
-    @framework    = Msf::Simple::Framework.create
-    
-    @exploit_name = 'unix/webapp/tikiwiki_graph_formula_exec'
-    @payload_name = 'php/meterpreter/bind_tcp'
-    @input        = Rex::Ui::Text::Input::Stdio.new 
-    @output       = Rex::Ui::Text::Output::File.new(@default_file)
-
-    # Initialize the exploit instance
-    exploit = @framework.exploits.create(@exploit_name)
-
-    ## Fire it off against a known-vulnerable host
-    @session = exploit.exploit_simple(
-      'Options'     => {'RHOST' => "metasploitable"},
-      'Payload'     => @payload_name,
-      'LocalInput'  => @input,
-      'LocalOutput' => @output)
-
-    puts @session.inspect
-
-    ## If a session came back, try to interact with it.
-    if @session
-      @session.load_stdapi
-    else
-      raise Exception "Couldn't get a session!"
+      ## If a session came back, try to interact with it.
+      if @session
+        @session.load_stdapi
+      else
+        raise Exception "Couldn't get a session!"
+      end
     end
   end
-  
-end
 end

--- a/test/functional/meterpreter/meterpreter_spec_helper.rb
+++ b/test/functional/meterpreter/meterpreter_spec_helper.rb
@@ -1,58 +1,55 @@
 module MsfTest
-module MeterpreterSpecHelper
-
-  def self.included(base)
-        	base.class_eval do
-
-      def generic_failure_strings
-        ['fail', 'error', 'exception']
-      end
-      
-      def generic_failure_exception_strings
-        ['nserror.dll', 'tiki-error.php','tiki-error_simple.php','tiki-rss_error.php'] ##ugh, this is dependent on the target
-      end
-
-      def hlp_run_command_check_output(name,command,success_strings=[],fail_strings=[], fail_exception_strings=[])
-
-        fail_strings = fail_strings | generic_failure_strings
-        fail_exception_strings = fail_exception_strings | generic_failure_exception_strings
-
-        temp_command_file  = "#{@output_directory}/#{name}"
-    
-        command_output = Rex::Ui::Text::Output::File.new(temp_command_file)
-        @session.init_ui(@input, command_output)
-  
-        command_output.print_line("meterpreter_functional_test_start")
-        
-        if @verbose
-          puts "Running Command: " + command
+  module MeterpreterSpecHelper
+    def self.included(base)
+      base.class_eval do
+        def generic_failure_strings
+          ['fail', 'error', 'exception']
         end
-        
-        @session.run_cmd(command)
-        command_output.print_line("meterpreter_functional_test_end")		
-        data = hlp_file_to_string(temp_command_file)
-    
-        data.should contain_a_complete_test
-        data.should contain_all_successes
-        data.should contain_no_failures_except
-      end
-  
-      def hlp_file_to_string(filename)
-        data = ""
-        f = File.open(filename, "r") 
-        f.each_line do |line|
-          data += line
+
+        def generic_failure_exception_strings
+          ['nserror.dll', 'tiki-error.php', 'tiki-error_simple.php', 'tiki-rss_error.php'] # #ugh, this is dependent on the target
         end
-        return data
-      end
-  
-      def hlp_string_to_file(string, filepath)
-        # Create a new file and write to it  
-        File.open(filepath, 'w') do |f2|  
+
+        def hlp_run_command_check_output(name, command, success_strings = [], fail_strings = [], fail_exception_strings = [])
+          fail_strings = fail_strings | generic_failure_strings
+          fail_exception_strings = fail_exception_strings | generic_failure_exception_strings
+
+          temp_command_file = "#{@output_directory}/#{name}"
+
+          command_output = Rex::Ui::Text::Output::File.new(temp_command_file)
+          @session.init_ui(@input, command_output)
+
+          command_output.print_line("meterpreter_functional_test_start")
+
+          if @verbose
+            puts "Running Command: " + command
+          end
+
+          @session.run_cmd(command)
+          command_output.print_line("meterpreter_functional_test_end")
+          data = hlp_file_to_string(temp_command_file)
+
+          data.should contain_a_complete_test
+          data.should contain_all_successes
+          data.should contain_no_failures_except
+        end
+
+        def hlp_file_to_string(filename)
+          data = ""
+          f = File.open(filename, "r")
+          f.each_line do |line|
+            data += line
+          end
+          return data
+        end
+
+        def hlp_string_to_file(string, filepath)
+          # Create a new file and write to it
+          File.open(filepath, 'w') do |f2|
             f2.puts string
-        end 
+          end
+        end
       end
     end
   end
-end
 end

--- a/test/functional/meterpreter/meterpreter_specs.rb
+++ b/test/functional/meterpreter/meterpreter_specs.rb
@@ -1,11 +1,10 @@
 module MsfTest
-module MeterpreterSpecs
-
-  def self.included(base)
-        	base.class_eval do
-
-    it "should not error when running each command" do
-        commands = [ 	"?",
+  module MeterpreterSpecs
+    def self.included(base)
+      base.class_eval do
+        it "should not error when running each command" do
+          commands = [
+            "?",
             "background",
             "bgkill",
             "bglist",
@@ -15,9 +14,9 @@ module MeterpreterSpecs
             "exit",
             "help",
             "interact",
-            #"irb",
+            # "irb",
             "migrate",
-            #"quit",
+            # "quit",
             "read",
             "run",
             "use",
@@ -27,7 +26,7 @@ module MeterpreterSpecs
             "cd",
             "del",
             "download",
-            #"edit",
+            # "edit",
             "getlwd",
             "getwd",
             "lcd",
@@ -50,11 +49,11 @@ module MeterpreterSpecs
             "getuid",
             "kill",
             "ps",
-            #"reboot",
+            # "reboot",
             "reg",
             "rev2self",
-            #"shell",
-            #"shutdown",
+            # "shell",
+            # "shutdown",
             "steal_token",
             "sysinfo",
             "enumdesktops",
@@ -69,41 +68,43 @@ module MeterpreterSpecs
             "getsystem",
             "hashdump",
             "timestomp"
-            ]
+          ]
 
-        ## Run each command, check for execeptions
-        commands.each do |command|
-          hlp_run_command_check_output("basic_#{command}",command)
+          ## Run each command, check for execeptions
+          commands.each do |command|
+            hlp_run_command_check_output("basic_#{command}", command)
+          end
         end
-      end	
 
-      it "should not error when running help" do
-        success_strings = [ 	'Core Commands',
-              'Stdapi: File system Commands',
-              'Stdapi: Networking Commands',
-              'Stdapi: System Commands',
-              'Stdapi: User interface Commands']
-          
-        hlp_run_command_check_output("help","help", success_strings)
+        it "should not error when running help" do
+          success_strings = [
+            'Core Commands',
+            'Stdapi: File system Commands',
+            'Stdapi: Networking Commands',
+            'Stdapi: System Commands',
+            'Stdapi: User interface Commands'
+          ]
+
+          hlp_run_command_check_output("help", "help", success_strings)
+        end
+
+        it "should not error when running the help shortcut" do
+          success_strings = [
+            'Core Commands',
+            'Stdapi: File system Commands',
+            'Stdapi: Networking Commands',
+            'Stdapi: System Commands',
+            'Stdapi: User interface Commands'
+          ]
+
+          hlp_run_command_check_output("help_shortcut", "?", success_strings)
+        end
+
+        it "should not error when checking for background channels" do
+          success_strings = [ 'No active channels.' ]
+          hlp_run_command_check_output("channel_list_empty", "channel -l", success_strings)
+        end
       end
-  
-      it "should not error when running the help shortcut" do
-        success_strings = [ 	'Core Commands',
-              'Stdapi: File system Commands',
-              'Stdapi: Networking Commands',
-              'Stdapi: System Commands',
-              'Stdapi: User interface Commands' ]
-          
-        hlp_run_command_check_output("help_shortcut","?", success_strings)
-      end	
-    
-      it "should not error when checking for background channels" do
-        success_strings = [ 'No active channels.' ]
-        hlp_run_command_check_output("channel_list_empty","channel -l", success_strings)
-      end
-  
     end
   end
-
-end
 end

--- a/test/functional/meterpreter/meterpreter_win32_spec.rb
+++ b/test/functional/meterpreter/meterpreter_win32_spec.rb
@@ -10,94 +10,87 @@ require 'meterpreter_specs'
 require 'windows_meterpreter_specs'
 
 module MsfTest
+  describe "Win32Meterpreter" do
+    # Include Custom Matchers
+    include MsfTest::MsfMatchers
 
-describe "Win32Meterpreter" do
+    # This include brings in all the spec helper methods
+    include MsfTest::MeterpreterSpecHelper
 
-  # Include Custom Matchers
-  include MsfTest::MsfMatchers
+    # This include brings in all the specs that are generic across the
+    # meterpreter platforms
+    include MsfTest::MeterpreterSpecs
 
-  
-  # This include brings in all the spec helper methods
-  include MsfTest::MeterpreterSpecHelper
-  
-  # This include brings in all the specs that are generic across the 
-  # meterpreter platforms
-  include MsfTest::MeterpreterSpecs
+    # This include brings in all the specs that are specific to the
+    # windows meterpreter platforms
+    include MsfTest::WindowsMeterpreterSpecs
 
-  # This include brings in all the specs that are specific to the 
-  # windows meterpreter platforms
-  include MsfTest::WindowsMeterpreterSpecs
+    before :all do
+      @verbose = true
 
-  before :all do
-    @verbose = true
-  
-    @meterpreter_type = "win32"
-    
-    ## Set up an outupt directory
-    @output_directory = File.join(File.dirname(__FILE__), "test_output_#{@meterpreter_type}")
+      @meterpreter_type = "win32"
 
-    if File.directory? @output_directory
-      FileUtils.rm_rf(@output_directory)
+      ## Set up an outupt directory
+      @output_directory = File.join(File.dirname(__FILE__), "test_output_#{@meterpreter_type}")
+
+      if File.directory? @output_directory
+        FileUtils.rm_rf(@output_directory)
+      end
+
+      Dir.mkdir(@output_directory)
+      @default_file = "#{@output_directory}/default"
+
+      create_session_windows_x32
     end
 
-    Dir.mkdir(@output_directory)
-    @default_file = "#{@output_directory}/default"
+    before :each do
+    end
 
-    create_session_windows_x32
-  end
+    after :each do
+      @session.init_ui(@input, @output)
+    end
 
-  before :each do
+    after :all do
+      ## Clean up test output
+      FileUtils.rm_rf(@output_directory)
 
-  end
-
-  after :each do
-    @session.init_ui(@input, @output)
-  end		
-
-  after :all do
-    
-    ## Clean up test output
-    FileUtils.rm_rf(@output_directory)
-
-    ## Screenshot command leaves .jpegs :(
-    ## TODO - fix the meterpreter command to write to
-    ## TODO - an arbitrary file.
-    Dir.new(File.dirname(__FILE__)).each do |file|
-      if file =~ /.jpeg/
-        File.delete(file)
+      ## Screenshot command leaves .jpegs :(
+      ## TODO - fix the meterpreter command to write to
+      ## TODO - an arbitrary file.
+      Dir.new(File.dirname(__FILE__)).each do |file|
+        if file =~ /.jpeg/
+          File.delete(file)
+        end
       end
     end
-  
-  end
-  
-  def create_session_windows_x32
 
-    ## Setup for win32
-    @framework    = Msf::Simple::Framework.create
-    @exploit_name = 'windows/smb/psexec'
-    @payload_name = 'windows/meterpreter/bind_tcp'
-    @input        = Rex::Ui::Text::Input::Stdio.new 
-    @output       = Rex::Ui::Text::Output::File.new(@default_file)
+    def create_session_windows_x32
+      ## Setup for win32
+      @framework = Msf::Simple::Framework.create
+      @exploit_name = 'windows/smb/psexec'
+      @payload_name = 'windows/meterpreter/bind_tcp'
+      @input = Rex::Ui::Text::Input::Stdio.new
+      @output = Rex::Ui::Text::Output::File.new(@default_file)
 
-    # Initialize the exploit instance
-    exploit = @framework.exploits.create(@exploit_name)
+      # Initialize the exploit instance
+      exploit = @framework.exploits.create(@exploit_name)
 
-    ## Fire it off against a known-vulnerable host
-    @session = exploit.exploit_simple(
-      'Options'     => {'RHOST' => "vulnerable", "SMBUser" => "administrator", "SMBPass" => ""},
-      'Payload'     => @payload_name,
-      'LocalInput'  => @input,
-      'LocalOutput' => @output)
+      ## Fire it off against a known-vulnerable host
+      @session = exploit.exploit_simple(
+        'Options' => { 'RHOST' => "vulnerable", "SMBUser" => "administrator", "SMBPass" => "" },
+        'Payload' => @payload_name,
+        'LocalInput' => @input,
+        'LocalOutput' => @output
+      )
 
-    ## If a session came back, try to interact with it.
-    if @session
-      puts "got a session"
-      @session.load_stdapi
-    else
-      puts "unable to get session"		
-      #flunk "Couldn't get a session!"
+      ## If a session came back, try to interact with it.
+      if @session
+        puts "got a session"
+        @session.load_stdapi
+      else
+        puts "unable to get session"
+        # flunk "Couldn't get a session!"
+      end
     end
   end
-  
-end
 end

--- a/test/functional/meterpreter/windows_meterpreter_specs.rb
+++ b/test/functional/meterpreter/windows_meterpreter_specs.rb
@@ -1,49 +1,46 @@
 module MsfTest
-module WindowsMeterpreterSpecs
+  module WindowsMeterpreterSpecs
+    ## This file is intended to be used in conjunction with a harness,
+    ## such as meterpreter_win32_spec.rb
 
-  ## This file is intended to be used in conjunction with a harness, 
-  ## such as meterpreter_win32_spec.rb
+    def self.included(base)
+      base.class_eval do
+        it "should not error when uploading a file to a windows box" do
+          upload_success_strings = [
+            'uploading',
+            'uploaded'
+          ]
 
-  def self.included(base)
-        	base.class_eval do
+          ## create a file to upload
+          filename = "/tmp/whatever"
+          if File.exist?(filename)
+            FileUtils.rm(filename)
+          end
+          hlp_string_to_file("owned!", filename)
 
-      it "should not error when uploading a file to a windows box" do
-        upload_success_strings = [ 	'uploading',
-                'uploaded' ]	
+          ## run the upload / quit commands
+          hlp_run_command_check_output("upload", "upload #{filename} C:\\", upload_success_strings)
+          # hlp_run_command_check_output("quit","quit")
 
-        ## create a file to upload
-        filename = "/tmp/whatever"
-        if File.exist?(filename)
+          ## clean up
           FileUtils.rm(filename)
         end
-        hlp_string_to_file("owned!", filename)
 
-        ## run the upload / quit commands
-        hlp_run_command_check_output("upload","upload #{filename} C:\\", upload_success_strings)
-        #hlp_run_command_check_output("quit","quit")
+        it "should show the priv commands when running help" do
+          success_strings =	[
+            'Priv: Elevate Commands',
+            'Priv: Password database Commands',
+            'Priv: Timestomp Commands'
+          ]
 
-        ## clean up
-        FileUtils.rm(filename)
-      end
-        
-        
-      it "should show the priv commands when running help" do
-      
-      success_strings =	['Priv: Elevate Commands',
-             'Priv: Password database Commands',
-             'Priv: Timestomp Commands' ]
-          
-        hlp_run_command_check_output("help_shortcut","help", success_strings)
+          hlp_run_command_check_output("help_shortcut", "help", success_strings)
+        end
 
+        it "should not error when taking a screenshot" do
+          success_strings = [ 'Screenshot saved to' ]
+          hlp_run_command_check_output("screenshot", "screenshot", success_strings)
+        end
       end
-      
-      it "should not error when taking a screenshot" do
-        success_strings = [ 'Screenshot saved to' ]
-        hlp_run_command_check_output("screenshot","screenshot", success_strings)
-      end
-            
     end
   end
-
-end
 end

--- a/test/hooks/array_to_s.rb
+++ b/test/hooks/array_to_s.rb
@@ -1,7 +1,7 @@
 class Array
   @@to_s_reported = {}
   def to_s(*args)
-    if(not @@to_s_reported[caller[0].to_s])
+    if (not @@to_s_reported[caller[0].to_s])
       $stderr.puts "HOOK: Array#to_s at #{caller.join("\t")}"
       @@to_s_reported[caller[0].to_s] = true
     end

--- a/test/hooks/string_idx.rb
+++ b/test/hooks/string_idx.rb
@@ -1,7 +1,6 @@
 class String
   @@idx_reported = {}
   def [](*args)
-
     if args.length == 1 && args[0].class == ::Integer && !@@idx_reported[caller[0].to_s]
       $stderr.puts "HOOK: String[idx] #{caller.join("\t")}\n\n"
       @@idx_reported[caller[0].to_s] = true

--- a/test/lib/module_test.rb
+++ b/test/lib/module_test.rb
@@ -1,68 +1,63 @@
-
-
 module Msf
+  module ModuleTest
+    attr_accessor :tests
+    attr_accessor :failures
 
-module ModuleTest
-  attr_accessor :tests
-  attr_accessor :failures
+    def initialize(info = {})
+      @tests = 0
+      @failures = 0
+      super
+    end
 
-  def initialize(info={})
-    @tests = 0
-    @failures = 0
-    super
-  end
+    def run_all_tests
+      tests = self.methods.select { |m| m.to_s =~ /^test_/ }
+      tests.each { |test_method|
+        self.send(test_method)
+      }
+    end
 
-  def run_all_tests
-    tests = self.methods.select { |m| m.to_s =~ /^test_/ }
-    tests.each { |test_method|
-      self.send(test_method)
-    }
-
-  end
-
-  def it(msg="", &block)
-    @tests  += 1
-    begin
-      result = block.call
-      unless result
+    def it(msg = "", &block)
+      @tests += 1
+      begin
+        result = block.call
+        unless result
+          print_error("FAILED: #{msg}")
+          print_error("FAILED: #{error}") if error
+          @failures += 1
+          return
+        end
+      rescue ::Exception => e
         print_error("FAILED: #{msg}")
-        print_error("FAILED: #{error}") if error
-        @failures  += 1
+        print_error("Exception: #{e.class} : #{e}")
+        dlog("Exception in testing - #{msg}")
+        dlog("Call stack: #{e.backtrace.join("\n")}")
         return
       end
-    rescue ::Exception => e
-      print_error("FAILED: #{msg}")
-      print_error("Exception: #{e.class} : #{e}")
-      dlog("Exception in testing - #{msg}")
-      dlog("Call stack: #{e.backtrace.join("\n")}")
-      return
+
+      print_good("#{msg}")
     end
 
-    print_good("#{msg}")
-  end
-
-  def pending(msg="", &block)
-    print_status("PENDING: #{msg}")
-  end
-end
-
-module ModuleTest::PostTest
-  include ModuleTest
-  def run
-    print_status("Running against session #{datastore["SESSION"]}")
-    print_status("Session type is #{session.type} and platform is #{session.platform}")
-
-    t = Time.now
-    @tests = 0; @failures = 0
-    run_all_tests
-
-    vprint_status("Testing complete in #{Time.now - t}")
-    if (@failures > 0)
-      print_error("Passed: #{@tests - @failures}; Failed: #{@failures}")
-    else
-      print_status("Passed: #{@tests - @failures}; Failed: #{@failures}")
+    def pending(msg = "", &block)
+      print_status("PENDING: #{msg}")
     end
   end
-end
 
+  module ModuleTest::PostTest
+    include ModuleTest
+    def run
+      print_status("Running against session #{datastore["SESSION"]}")
+      print_status("Session type is #{session.type} and platform is #{session.platform}")
+
+      t = Time.now
+      @tests = 0; @failures = 0
+      run_all_tests
+
+      vprint_status("Testing complete in #{Time.now - t}")
+      if (@failures > 0)
+        print_error("Passed: #{@tests - @failures}; Failed: #{@failures}")
+      else
+        print_status("Passed: #{@tests - @failures}; Failed: #{@failures}")
+      end
+    end
+  end
 end

--- a/test/lib/msf_matchers.rb
+++ b/test/lib/msf_matchers.rb
@@ -2,93 +2,91 @@ $:.unshift(File.join((File.dirname(__FILE__))))
 require 'regexr'
 
 module MsfTest
+  module MsfMatchers
+    class ContainACompleteTest
 
-module MsfMatchers
+      def initialize()
+        @r = Regexr.new(true)
+      end
 
-  class ContainACompleteTest
+      def matches?(data)
+        @data = data
+        return @r.verify_start_and_end(@data, "meterpreter_functional_test_start", "meterpreter_functional_test_end")
+      end
 
-    def initialize()
-      @r = Regexr.new(true)
+      def failure_message
+        "Beginning or end was incorrect."
+      end
+
+      def negative_failure_message
+        "Expected to find a no beginning or end, but it matched."
+      end
+
     end
 
-    def matches?(data)
-      @data = data
-      return @r.verify_start_and_end(@data,"meterpreter_functional_test_start", "meterpreter_functional_test_end")
+    def contain_a_complete_test
+      ContainACompleteTest.new
     end
 
-    def failure_message
-      "Beginning or end was incorrect."
+    class ContainAllSuccesses
+
+      def initialize(successes = [])
+        @successes = successes
+        @r = Regexr.new(true)
+      end
+
+      def matches?(data)
+        @data = data
+        @string = @r.find_strings_that_dont_exist_in_data(@data, @successes)
+        return true if !@string
+
+        nil
+      end
+
+      def failure_message
+        "expected all successes, but didn't find '#{@string}'"
+      end
+
+      def negative_failure_message
+        "expected to miss successes but found'm all :("
+      end
+
+      # alias :have_all_successes :contain_all_successes
     end
 
-    def negative_failure_message
-      "Expected to find a no beginning or end, but it matched."
+    def contain_all_successes(successes = [])
+      ContainAllSuccesses.new(successes)
     end
 
+    class ContainNoFailuresExcept
+
+      def initialize(failures = [], exceptions = [])
+        @failures = failures
+        @exceptions = exceptions
+        @r = Regexr.new(true)
+      end
+
+      def matches?(data)
+        @data = data
+        @string = @r.find_strings_that_exist_in_data_except(@data, @failures, @exceptions)
+        return true if !@string
+
+        nil
+      end
+
+      def failure_message
+        "expected no failure to be found, but found this: '#{@string}'"
+      end
+
+      def negative_falure_message
+        "expected to find failures, but didn't find any :("
+      end
+
+      # alias :have_no_failures :contain_no_failures
+    end
+
+    def contain_no_failures_except(failures = [], exceptions = [])
+      ContainNoFailuresExcept.new(failures, exceptions)
+    end
   end
-  
-  def contain_a_complete_test
-    ContainACompleteTest.new
-  end
-
-  class ContainAllSuccesses
-
-    def initialize(successes=[])
-      @successes = successes
-      @r = Regexr.new(true)
-    end
-
-    def matches?(data)
-      @data = data
-      @string = @r.find_strings_that_dont_exist_in_data(@data,@successes)
-      return true if !@string
-      nil
-    end
-
-    def failure_message
-      "expected all successes, but didn't find '#{@string}'"
-    end
-
-    def negative_failure_message
-      "expected to miss successes but found'm all :("
-    end
-
-    #alias :have_all_successes :contain_all_successes
-  end
-  
-  def contain_all_successes(successes=[])
-    ContainAllSuccesses.new(successes)
-  end
-  
-  class ContainNoFailuresExcept
-
-    def initialize(failures=[],exceptions=[])
-      @failures = failures
-      @exceptions = exceptions
-      @r = Regexr.new(true)
-    end
-
-    def matches?(data)
-      @data = data
-      @string = @r.find_strings_that_exist_in_data_except(@data,@failures,@exceptions)
-      return true if !@string
-      nil
-    end
-
-    def failure_message
-      "expected no failure to be found, but found this: '#{@string}'"
-    end
-
-    def negative_falure_message
-      "expected to find failures, but didn't find any :("
-    end
-
-    #alias :have_no_failures :contain_no_failures
-  end
-
-  def contain_no_failures_except(failures=[],exceptions=[])
-    ContainNoFailuresExcept.new(failures,exceptions)
-  end
-
-  
-end
 end

--- a/test/lib/regexr.rb
+++ b/test/lib/regexr.rb
@@ -6,84 +6,80 @@
 
 class Regexr
 
-  def initialize(verbose=false, case_insensitive=true)
+  def initialize(verbose = false, case_insensitive = true)
     @verbose = verbose
     @case_insensitive = case_insensitive
   end
 
   # Check for the beginning and end lines. Handy when you need to ensure a log has started & completed
-  def verify_start_and_end(data,the_start,the_end)
+  def verify_start_and_end(data, the_start, the_end)
     return false unless data
-    
+
     data_lines = data.split("\n")
-    regex_start   = Regexp.new(the_start, @case_insensitive)
+    regex_start = Regexp.new(the_start, @case_insensitive)
     regex_end = Regexp.new(the_end, @case_insensitive)
 
     if regex_start =~ data_lines.first
       return regex_end =~ data_lines.last
     end
-    
+
     return false
   end
 
   # Scan for any number of success lines. In order to pass, all successes must match.
-  def find_strings_that_dont_exist_in_data(data,regexes=[])
+  def find_strings_that_dont_exist_in_data(data, regexes = [])
     return false unless data
 
     data_lines = data.split("\n")
-    
+
     return nil unless regexes ## count as a pass
-    
+
     if regexes
       target_successes = regexes.size
       success_count = 0
       regexes.each { |condition|
-
         ## assume we haven't got it
         found = false
-         
+
         re = Regexp.new(condition, @case_insensitive)
-        
+
         ## for each of our data lines
-        data_lines.each {|line|
-        
+        data_lines.each { |line|
           ## if it's a match
           if line =~ re
             found = true
             break ## success!
           end
         }
-        
+
         if !found
           return condition ## return this string, it wasn't found.
         end
       }
     end
-    
+
     nil ## got all successes, woot!
   end
 
   # Scan for failures -- if any single failure matches, the test returns true.
-  def find_strings_that_exist_in_data_except(data,regexes=[],exceptions=[])
-
+  def find_strings_that_exist_in_data_except(data, regexes = [], exceptions = [])
     return false unless data
 
     data_lines = data.split("\n")
-    
+
     return nil unless regexes ## count as a pass
 
     regexes.each { |condition|
-
-      ## for each failure condition that we've been passed 
+      ## for each failure condition that we've been passed
       re = Regexp.new(condition, @case_insensitive)
 
       ## assume we're okay
-      found = false				
+      found = false
 
       data_lines.each { |line|
         if re =~ line
           found = true # oh, we found a match
-          
+
           # but let's check the exceptions
           exceptions.map { |exception|
             reg_exception = Regexp.new(exception, @case_insensitive)
@@ -95,12 +91,12 @@ class Regexr
             end
           }
 
-          # If we didn't find an exception, we have to fail it. do not pass go. 
+          # If we didn't find an exception, we have to fail it. do not pass go.
           return condition if found
         end
       }
     }
-    
+
     nil ## no failures found!
   end
 end

--- a/test/modules/auxiliary/test/capture.rb
+++ b/test/modules/auxiliary/test/capture.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
@@ -12,19 +10,17 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Simple Network Capture Tester',
+      'Name' => 'Simple Network Capture Tester',
       'Description' => 'This module sniffs HTTP GET requests from the network',
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE,
-      'Actions'     =>
-        [
-          [ 'Sniffer' ]
-        ],
-      'PassiveActions' =>
-        [
-          'Sniffer'
-        ],
-      'DefaultAction'  => 'Sniffer'
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE,
+      'Actions' => [
+        [ 'Sniffer' ]
+      ],
+      'PassiveActions' => [
+        'Sniffer'
+      ],
+      'DefaultAction' => 'Sniffer'
     )
 
     deregister_options('RHOST')
@@ -39,16 +35,15 @@ class MetasploitModule < Msf::Auxiliary
       p = PacketFu::Packet.parse(pkt)
       next unless p.is_tcp?
       next if p.payload.empty?
+
       if (p.payload =~ /GET\s+([^\s]+)\s+HTTP/smi)
         url = $1
         print_status("GET #{url}")
         break if url =~ /StopCapture/
       end
-
     end
     close_pcap()
     print_status("Finished sniffing")
   end
 
 end
-

--- a/test/modules/auxiliary/test/check.rb
+++ b/test/modules/auxiliary/test/check.rb
@@ -3,33 +3,34 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => "Check Test",
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => "Check Test",
+        'Description' => %q{
           This module ensures that 'check' actually functions for Auxiilary modules.
-      },
-      'References'     =>
-        [
+        },
+        'References' => [
           [ 'OSVDB', '0' ]
         ],
-      'Author'         =>
-        [
+        'Author' => [
           'todb'
         ],
-      'License'        => MSF_LICENSE
-    ))
+        'License' => MSF_LICENSE
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(80)
-      ], self.class)
+      ], self.class
+    )
   end
 
   def check

--- a/test/modules/auxiliary/test/eth_spoof.rb
+++ b/test/modules/auxiliary/test/eth_spoof.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
@@ -12,15 +10,14 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Simple Ethernet Frame Spoofer',
+      'Name' => 'Simple Ethernet Frame Spoofer',
       'Description' => 'This module sends spoofed ethernet frames',
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE,
-      'Actions'     =>
-        [
-          [ 'Spoofer' ]
-        ],
-      'DefaultAction'  => 'Spoofer'
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE,
+      'Actions' => [
+        [ 'Spoofer' ]
+      ],
+      'DefaultAction' => 'Spoofer'
     )
   end
 

--- a/test/modules/auxiliary/test/ftp_data.rb
+++ b/test/modules/auxiliary/test/ftp_data.rb
@@ -3,29 +3,26 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::Ftp
 
   def initialize
     super(
-      'Name'	      => 'FTP Client Exploit Mixin DATA test Exploit',
-      'Description'  => 'This module tests the "DATA" functionality of the ftp client exploit mixin.',
-      'Author'	      => [ 'Thomas Ring', 'jduck' ],
-      'License'      => MSF_LICENSE
+      'Name'	=> 'FTP Client Exploit Mixin DATA test Exploit',
+      'Description' => 'This module tests the "DATA" functionality of the ftp client exploit mixin.',
+      'Author'	=> [ 'Thomas Ring', 'jduck' ],
+      'License' => MSF_LICENSE
     )
-
 
     register_options(
       [
-        OptString.new('UPLOADDIR', [ true,  "The directory to use for the upload test", '/incoming' ])
+        OptString.new('UPLOADDIR', [ true, "The directory to use for the upload test", '/incoming' ])
       ]
     )
   end
 
   def run
-
     begin
       if (not connect_login)
         return
@@ -34,24 +31,24 @@ class MetasploitModule < Msf::Auxiliary
       curdir = ""
 
       # change to the upload directory
-      result = send_cmd( ["CWD", datastore['UPLOADDIR']], true )
+      result = send_cmd(["CWD", datastore['UPLOADDIR']], true)
       print_status("CWD response: #{result.inspect}")
 
       # find out what the server thinks this dir is
-      result = send_cmd( ["PWD"], true )
+      result = send_cmd(["PWD"], true)
       print_status("PWD response: #{result.inspect}")
       if (result =~ /257\s\"(.+)\"/)
         curdir = $1
       end
       curdir = "/" + curdir if curdir[0] != "/"
-      curdir << "/" if curdir[-1,1] != "/"
+      curdir << "/" if curdir[-1, 1] != "/"
 
       # generate some data to upload
       data = Rex::Text.rand_text_alphanumeric(1024)
-      #print_status("data:\n" + Rex::Text.to_hex_dump(data))
+      # print_status("data:\n" + Rex::Text.to_hex_dump(data))
 
       # test putting data
-      result = send_cmd_data(["PUT", curdir+"test"], data, "I")
+      result = send_cmd_data(["PUT", curdir + "test"], data, "I")
       print_status("PUT response: #{result.inspect}")
 
       # test fallthrough
@@ -63,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status("LS response: #{result.inspect}")
 
       # test getting file
-      result = send_cmd_data(["GET", curdir+"test"], "A")
+      result = send_cmd_data(["GET", curdir + "test"], "A")
       print_status("GET response: #{result[0].inspect}")
 
       # see if it matches
@@ -74,13 +71,11 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       # adios
-      result = send_cmd( ["QUIT"], true )
+      result = send_cmd(["QUIT"], true)
       print_status("QUIT response: #{result.inspect}")
-
     ensure
       disconnect
     end
-
   end
 
 end

--- a/test/modules/auxiliary/test/heaplib2.rb
+++ b/test/modules/auxiliary/test/heaplib2.rb
@@ -3,34 +3,34 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Heaplib2 Test",
-      'Description'    => %q{
-        This tests heaplib2. Since it is a test module, it's not intended to do much useful work in the field.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => [ 'sinn3r' ],
-      'References'     =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => "Heaplib2 Test",
+        'Description' => %q{
+          This tests heaplib2. Since it is a test module, it's not intended to do much useful work in the field.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'sinn3r' ],
+        'References' => [
           [ 'URL', 'https://metasploit.com' ]
         ],
-      'Platform'       => 'win',
-      'Targets'        =>
-        [
+        'Platform' => 'win',
+        'Targets' => [
           [ 'Automatic', {} ]
         ],
-      'Privileged'     => false,
-      'DisclosureDate' => '2014-03-01',
-      'DefaultTarget'  => 0))
+        'Privileged' => false,
+        'DisclosureDate' => '2014-03-01',
+        'DefaultTarget' => 0
+      )
+    )
   end
-
 
   def on_request_uri(cli, request)
     spray = %Q|
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
     |
 
     print_status("Sending html")
-    send_response(cli, html, {'Content-Type'=>'text/html'})
+    send_response(cli, html, { 'Content-Type' => 'text/html' })
   end
 
   def run

--- a/test/modules/auxiliary/test/httpserver.rb
+++ b/test/modules/auxiliary/test/httpserver.rb
@@ -3,45 +3,45 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::HttpServer
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Basic HttpServer Simulator',
-      'Description'    => %q{
-        This is example of a basic HttpServer simulator, good for PR scenarios when a module
-        is made, but the author no longer has access to the test box, no pcap or screenshot -
-        Basically no way to prove the functionality.
+    super(
+      update_info(
+        info,
+        'Name' => 'Basic HttpServer Simulator',
+        'Description' => %q{
+          This is example of a basic HttpServer simulator, good for PR scenarios when a module
+          is made, but the author no longer has access to the test box, no pcap or screenshot -
+          Basically no way to prove the functionality.
 
-        This particular simulator will pretend to act like a Cisco ASA ASDM, so the
-        cisco_asa_asdm.rb module can do a live test against it.
-      },
-      'References'     =>
-        [
+          This particular simulator will pretend to act like a Cisco ASA ASDM, so the
+          cisco_asa_asdm.rb module can do a live test against it.
+        },
+        'References' => [
           [ 'URL', 'https://github.com/rapid7/metasploit-framework/pull/2720' ],
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'SRVPORT' => 443,
-          'SSL'     => true,
+          'SSL' => true,
           'URIPATH' => '/'
         },
-      'Author'         => [ 'sinn3r' ],
-      'License'        => MSF_LICENSE
-    ))
+        'Author' => [ 'sinn3r' ],
+        'License' => MSF_LICENSE
+      )
+    )
 
     register_options(
       [
         OptString.new('USERNAME', [true, "The valid default username", "cisco"]),
         OptString.new('PASSWORD', [true, "The valid default password", "cisco"])
-      ], self.class)
+      ], self.class
+    )
 
     deregister_options('RHOST')
   end
-
 
   #
   # Returns a response when the client is trying to check the connection
@@ -49,7 +49,6 @@ class MetasploitModule < Msf::Auxiliary
   def res_check_conn(cli, req)
     send_response(cli, '')
   end
-
 
   #
   # Returns a response when the client is trying to authenticate
@@ -59,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
     when 'GET'
       # This must be the is_app_asdm? method asking
       print_status("Responding to the is_app_asdm? method")
-      send_response(cli, '', {'Set-Cookie'=>'webvpn'})
+      send_response(cli, '', { 'Set-Cookie' => 'webvpn' })
 
     when 'POST'
       # This must be the do_login method. But before it can login, it must meet
@@ -97,21 +96,19 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-
   def on_request_uri(cli, req)
     print_status("Received request: #{req.uri}")
 
     case req.uri
-      when '/'
-        res_check_conn(cli, req)
-      when /\+webvpn\+\/index\.html/
-        res_login(cli, req)
+    when '/'
+      res_check_conn(cli, req)
+    when /\+webvpn\+\/index\.html/
+      res_login(cli, req)
     end
 
     # Request not processed, send a 404
     send_not_found(cli)
   end
-
 
   def run
     exploit

--- a/test/modules/auxiliary/test/ip_spoof.rb
+++ b/test/modules/auxiliary/test/ip_spoof.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Capture
@@ -12,10 +10,10 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Simple IP Spoofing Tester',
+      'Name' => 'Simple IP Spoofing Tester',
       'Description' => 'Simple IP Spoofing Tester',
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE
     )
 
     begin
@@ -25,8 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       @@havepcap = false
     end
 
-    deregister_options('FILTER','PCAPFILE')
-
+    deregister_options('FILTER', 'PCAPFILE')
   end
 
   def run_host(ip)
@@ -37,9 +34,9 @@ class MetasploitModule < Msf::Auxiliary
     p.ip_ttl = 255
     p.udp_sport = 53
     p.udp_dport = 53
-    p.payload  = "HELLO WORLD"
+    p.payload = "HELLO WORLD"
     p.recalc
-    ret = send(ip,p)
+    ret = send(ip, p)
     if ret == :done
       print_good("#{ip}: Sent a packet to #{ip} from #{ip}")
     else
@@ -48,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
     close_pcap
   end
 
-  def send(ip,pkt)
+  def send(ip, pkt)
     begin
       capture_sendto(pkt, ip)
     rescue RuntimeError => e
@@ -56,6 +53,5 @@ class MetasploitModule < Msf::Auxiliary
     end
     return :done
   end
-
 
 end

--- a/test/modules/auxiliary/test/recon_passive.rb
+++ b/test/modules/auxiliary/test/recon_passive.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
@@ -12,26 +10,24 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Simple Recon Module Tester',
+      'Name' => 'Simple Recon Module Tester',
       'Description' => 'Simple Recon Module Tester',
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE,
-      'Actions'     =>
-        [
-          ['Continuous Port Sweep']
-        ],
-      'PassiveActions' =>
-        [
-          'Continuous Port Sweep'
-        ]
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE,
+      'Actions' => [
+        ['Continuous Port Sweep']
+      ],
+      'PassiveActions' => [
+        'Continuous Port Sweep'
+      ]
     )
 
     register_options(
       [
         Opt::RHOST,
         Opt::RPORT,
-      ], self.class)
-
+      ], self.class
+    )
   end
 
   def run
@@ -54,8 +50,8 @@ class MetasploitModule < Msf::Auxiliary
       disconnect
       report_host(:host => datastore['RHOST'])
       report_service(
-        :host  => datastore['RHOST'],
-        :port  => datastore['RPORT'],
+        :host => datastore['RHOST'],
+        :port => datastore['RPORT'],
         :proto => 'tcp'
       )
     rescue ::Exception => e

--- a/test/modules/auxiliary/test/report_auth_info.rb
+++ b/test/modules/auxiliary/test/report_auth_info.rb
@@ -3,24 +3,26 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
 
-  FAKE_IP    = '192.168.12.123'
-  FAKE_PORT  = 80
-  FAKE_USER  = 'user'
-  FAKE_PASS  = 'password'
+  FAKE_IP = '192.168.12.123'
+  FAKE_PORT = 80
+  FAKE_USER = 'user'
+  FAKE_PASS = 'password'
   FAKE_PROOF = 'proof'
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => "report_cred Test",
-      'Description'    => %q{
-        This module will test every auxiliary module's report_cred method
-      },
-      'Author'         => [ 'sinn3r' ],
-      'License'        => MSF_LICENSE
-    ))
+    super(
+      update_info(
+        info,
+        'Name' => "report_cred Test",
+        'Description' => %q{
+          This module will test every auxiliary module's report_cred method
+        },
+        'Author' => [ 'sinn3r' ],
+        'License' => MSF_LICENSE
+      )
+    )
   end
 
   def test_novell_mdm_creds
@@ -135,7 +137,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def test_dlink_dsl320b_password_extractor
     mod = framework.auxiliary.create('admin/http/dlink_dsl320b_password_extractor')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_nexpose_xxe_file_read
@@ -165,7 +167,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def test_vnc
     mod = framework.auxiliary.create('server/capture/vnc')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'vnc_client', user: '', password: FAKE_PASS, proof: FAKE_PROOF )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'vnc_client', user: '', password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_smtp
@@ -175,12 +177,12 @@ class MetasploitModule < Msf::Auxiliary
 
   def test_sip
     mod = framework.auxiliary.create('server/capture/sip')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'sip_client', user:FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'sip_client', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_oracle_login
     mod = framework.auxiliary.create('admin/oracle/oracle_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'oracle', user: FAKE_USER, password: FAKE_PASS )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'oracle', user: FAKE_USER, password: FAKE_PASS)
   end
 
   def test_postgresql
@@ -190,12 +192,12 @@ class MetasploitModule < Msf::Auxiliary
 
   def test_pop3
     mod = framework.auxiliary.create('server/capture/pop3')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'pop3', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'pop3', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_http_basic
     mod = framework.auxiliary.create('server/capture/http_basic')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'HTTP', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'HTTP', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_ftp
@@ -245,7 +247,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def test_msf_rpc_login
     mod = framework.auxiliary.create('scanner/msf/msf_rpc_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'msf-rpc', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'msf-rpc', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_mongodb_login
@@ -285,7 +287,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def test_sevone_enum
     mod = framework.auxiliary.create('scanner/http/sevone_enum')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: '') 
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: '')
   end
 
   def test_sentry_cdu_enum
@@ -305,7 +307,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def test_rfcode_reader_enum
     mod = framework.auxiliary.create('scanner/http/rfcode_reader_enum')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'RFCode Reader', user: FAKE_USER, password:FAKE_PASS, proof: FAKE_PROOF)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'RFCode Reader', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_radware_appdictor_enum
@@ -376,7 +378,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def test_vbulletin_vote_sqli_exec
     mod = framework.exploits.create('unix/webapp/vbulletin_vote_sqli_exec')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)    
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_sap_mgmt_con_brute_login
@@ -450,8 +452,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def test_d20pass
-     mod = framework.auxiliary.create('gather/d20pass')
-     mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'hp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+    mod = framework.auxiliary.create('gather/d20pass')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'hp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_doliwamp_traversal_creds
@@ -480,11 +482,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    counter_all  = 0
+    counter_all = 0
     counter_good = 0
     counter_bad = 0
     self.methods.each do |m|
       next if m.to_s !~ /^test_.+/
+
       print_status("Trying: ##{m.to_s}")
       begin
         self.send(m)
@@ -492,7 +495,7 @@ class MetasploitModule < Msf::Auxiliary
         counter_good += 1
       rescue ::Exception => e
         print_error("That blew up :-(")
-        print_line("#{e.class} #{e.message}\n#{e.backtrace*"\n"}")
+        print_line("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
         counter_bad += 1
       ensure
         print_line

--- a/test/modules/auxiliary/test/scanner_batch.rb
+++ b/test/modules/auxiliary/test/scanner_batch.rb
@@ -3,25 +3,23 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Auxiliary::Scanner
 
   def initialize
     super(
-      'Name'        => 'Simple Recon Module Tester',
+      'Name' => 'Simple Recon Module Tester',
       'Description' => 'Simple Recon Module Tester',
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE
     )
 
     register_options(
       [
         Opt::RPORT,
-      ], self.class)
-
+      ], self.class
+    )
   end
 
   def run_batch_size

--- a/test/modules/auxiliary/test/scanner_host.rb
+++ b/test/modules/auxiliary/test/scanner_host.rb
@@ -3,25 +3,23 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Auxiliary::Scanner
 
   def initialize
     super(
-      'Name'        => 'Simple Recon Module Tester',
+      'Name' => 'Simple Recon Module Tester',
       'Description' => 'Simple Recon Module Tester',
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE
     )
 
     register_options(
       [
         Opt::RPORT,
-      ], self.class)
-
+      ], self.class
+    )
   end
 
   def run_host(ip)

--- a/test/modules/auxiliary/test/space_check.rb
+++ b/test/modules/auxiliary/test/space_check.rb
@@ -3,33 +3,34 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => "Check Test",
-      'Description'    => %q{
-       This module ensures that 'check' actually functions for Auxiilary modules.
-      },
-      'References'     =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => "Check Test",
+        'Description' => %q{
+          This module ensures that 'check' actually functions for Auxiilary modules.
+        },
+        'References' => [
           [ 'OSVDB', '0' ]
         ],
-      'Author'         =>
-        [
+        'Author' => [
           'todb'
         ],
-      'License'        => MSF_LICENSE
-    ))
+        'License' => MSF_LICENSE
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(80)
-      ], self.class)
+      ], self.class
+    )
   end
 
   def check

--- a/test/modules/auxiliary/test/sqlite_lab.rb
+++ b/test/modules/auxiliary/test/sqlite_lab.rb
@@ -8,18 +8,16 @@ class MetasploitModule < Msf::Auxiliary
       update_info(
         info,
         'Name' => 'SQLite injection testing module',
-        'Description' => '
+        'Description' => %q{
           This module tests the SQL injection library against the  SQLite database management system
           The target : https://github.com/incredibleindishell/sqlite-lab
-        ',
-        'Author' =>
-          [
-            'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>'
-          ],
+        },
+        'Author' => [
+          'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>'
+        ],
         'License' => MSF_LICENSE,
         'Platform' => %w[linux],
-        'References' =>
-          [],
+        'References' => [],
         'Targets' => [['Wildcard Target', {}]],
         'DefaultTarget' => 0
       )
@@ -41,18 +39,18 @@ class MetasploitModule < Msf::Auxiliary
   def boolean_blind
     encoder = datastore['Encoder'].empty? ? nil : datastore['Encoder'].intern
     sqli = create_sqli(dbms: SQLitei::BooleanBasedBlind, opts: {
-                         encoder: encoder,
-                         hex_encode_strings: datastore['HexEncodeStrings'],
-                         safe: datastore['Safe']
-                       }) do |payload|
+      encoder: encoder,
+      hex_encode_strings: datastore['HexEncodeStrings'],
+      safe: datastore['Safe']
+    }) do |payload|
       res = send_request_cgi({
-                               'uri' => normalize_uri(target_uri.path, 'index.php'),
-                               'method' => 'POST',
-                               'vars_post' => {
-                                 'tag' => "' or #{payload}--",
-                                 'search' => 'Check Plan'
-                               }
-                             })
+        'uri' => normalize_uri(target_uri.path, 'index.php'),
+        'method' => 'POST',
+        'vars_post' => {
+          'tag' => "' or #{payload}--",
+          'search' => 'Check Plan'
+        }
+      })
       res.body.include?('Dear')
     end
     unless sqli.test_vulnerable
@@ -66,18 +64,18 @@ class MetasploitModule < Msf::Auxiliary
     encoder = datastore['Encoder'].empty? ? nil : datastore['Encoder'].intern
     truncation = datastore['TruncationLength'] <= 0 ? nil : datastore['TruncationLength']
     sqli = create_sqli(dbms: SQLitei::Common, opts: {
-                         encoder: encoder,
-                         hex_encode_strings: datastore['HexEncodeStrings'],
-                         truncation_length: truncation,
-                         safe: datastore['Safe']
-                       }) do |payload|
+      encoder: encoder,
+      hex_encode_strings: datastore['HexEncodeStrings'],
+      truncation_length: truncation,
+      safe: datastore['Safe']
+    }) do |payload|
       res = send_request_cgi({
-                               'uri' => normalize_uri(target_uri.path, 'index.php'),
-                               'method' => 'GET',
-                               'vars_get' => {
-                                 'tag' => "' and 1=2 union select 1,(#{payload}),3,4,5--"
-                               }
-                             })
+        'uri' => normalize_uri(target_uri.path, 'index.php'),
+        'method' => 'GET',
+        'vars_get' => {
+          'tag' => "' and 1=2 union select 1,(#{payload}),3,4,5--"
+        }
+      })
       if !res
         ''
       else
@@ -100,18 +98,18 @@ class MetasploitModule < Msf::Auxiliary
   def time_blind
     encoder = datastore['Encoder'].empty? ? nil : datastore['Encoder'].intern
     sqli = create_sqli(dbms: SQLitei::TimeBasedBlind, opts: {
-                         encoder: encoder,
-                         hex_encode_strings: datastore['HexEncodeStrings'],
-                         safe: datastore['Safe']
-                       }) do |payload|
+      encoder: encoder,
+      hex_encode_strings: datastore['HexEncodeStrings'],
+      safe: datastore['Safe']
+    }) do |payload|
       res = send_request_cgi({
-                               'uri' => normalize_uri(target_uri.path, 'index.php'),
-                               'method' => 'POST',
-                               'vars_post' => {
-                                 'tag' => "' or #{payload}--",
-                                 'search' => 'Check Plan'
-                               }
-                             })
+        'uri' => normalize_uri(target_uri.path, 'index.php'),
+        'method' => 'POST',
+        'vars_post' => {
+          'tag' => "' or #{payload}--",
+          'search' => 'Check Plan'
+        }
+      })
       raise ArgumentError unless res
     end
     unless sqli.test_vulnerable
@@ -141,9 +139,9 @@ class MetasploitModule < Msf::Auxiliary
 
   def check
     res = send_request_cgi({
-                             'uri' => normalize_uri(target_uri.path, 'index.php'),
-                             'method' => 'GET'
-                           })
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'GET'
+    })
     if res&.body&.include?('--==[[IndiShell Lab]]==--')
       Exploit::CheckCode::Vulnerable
     else

--- a/test/modules/exploits/test/aggressive.rb
+++ b/test/modules/exploits/test/aggressive.rb
@@ -3,29 +3,27 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Internal Aggressive Test Exploit',
-      'Description'    =>
-        "This module tests the exploitation of a test service.",
-      'Author'         => 'skape',
-      'License'        => MSF_LICENSE,
-      'Arch'           => 'x86',
-      'Payload'        =>
-        {
-          'Space'    => 1000,
-          'MaxNops'  => 0,
+    super(
+      update_info(
+        info,
+        'Name' => 'Internal Aggressive Test Exploit',
+        'Description' => "This module tests the exploitation of a test service.",
+        'Author' => 'skape',
+        'License' => MSF_LICENSE,
+        'Arch' => 'x86',
+        'Payload' => {
+          'Space' => 1000,
+          'MaxNops' => 0,
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
         },
-      'Targets'        =>
-        [
+        'Targets' => [
           # Target 0: Universal
           [
             'Any Platform',
@@ -37,13 +35,13 @@ class MetasploitModule < Msf::Exploit::Remote
             'Test encoder specific',
             {
               'Platform' => [ 'linux', 'win' ],
-              'Payload'  =>
+              'Payload' =>
                 {
-                  'EncoderType'    => Msf::Encoder::Type::AlphanumUpper,
+                  'EncoderType' => Msf::Encoder::Type::AlphanumUpper,
                   'EncoderOptions' =>
                     {
                       'BufferRegister' => 'EBX',
-                      'BufferOffset'   => 4
+                      'BufferOffset' => 4
                     }
                 }
             },
@@ -52,31 +50,34 @@ class MetasploitModule < Msf::Exploit::Remote
             'Cannot be encoded',
             {
               'Platform' => [ 'linux', 'win' ],
-              'Payload'  =>
+              'Payload' =>
                 {
                   'BadChars' => (0..255).to_a.map { |x| x.chr }.to_s
                 }
             }
           ],
-          [ 'Test context encoder',
+          [
+            'Test context encoder',
             {
               'Platform' => [ 'linux', 'win' ],
-              'Payload'  =>
+              'Payload' =>
                 {
                   'BadChars' => "\x00"
                 }
             }
           ]
         ],
-      'DefaultTarget' => 0))
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
         OptBool.new('WaitForInput', [ false, "Wait for user input before returning from exploit", false ]),
         OptInt.new('TestInteger', [ false, "Testing an integer value", nil ])
-      ])
+      ]
+    )
   end
-
 
   def autofilter
     false
@@ -89,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     # Show disassembled payload for context encoder test
     if target.name =~ /context encoder/
-      puts Rex::Assembly::Nasm.disassemble(payload.encoded[0,40])
+      puts Rex::Assembly::Nasm.disassemble(payload.encoded[0, 40])
     end
 
     connect

--- a/test/modules/exploits/test/browserexploitserver.rb
+++ b/test/modules/exploits/test/browserexploitserver.rb
@@ -3,78 +3,77 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "IE Exploit for BrowserExploitServer Proof-of-Concept",
-      'Description'    => %q{
-        Here's an example of building an exploit using the BrowserExploitServer.
-        This example requires the target to be exploit. If not, the mixin will
-        send a fake 404 as a way to avoid engaging the target. The example is
-        for Windows only.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => [ 'sinn3r' ],
-      'References'     =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => "IE Exploit for BrowserExploitServer Proof-of-Concept",
+        'Description' => %q{
+          Here's an example of building an exploit using the BrowserExploitServer.
+          This example requires the target to be exploit. If not, the mixin will
+          send a fake 404 as a way to avoid engaging the target. The example is
+          for Windows only.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'sinn3r' ],
+        'References' => [
           [ 'URL', 'https://metasploit.com' ]
         ],
-      'Platform'       => 'win',
-      'BrowserRequirements' =>
-        {
+        'Platform' => 'win',
+        'BrowserRequirements' => {
           :source => /script|headers/i,
-          #:clsid  => "{D27CDB6E-AE6D-11cf-96B8-444553540000}", # ShockwaveFlash.ShockwaveFlash.1
-          #:method => "LoadMovie",
+          # :clsid  => "{D27CDB6E-AE6D-11cf-96B8-444553540000}", # ShockwaveFlash.ShockwaveFlash.1
+          # :method => "LoadMovie",
           :os_name => /win/i
         },
-      'Targets'        =>
-        [
+        'Targets' => [
           [ 'Automatic', {} ],
           [
             'Windows XP with IE 8',
             {
               'os_flavor' => 'XP',
-              'ua_name'   => 'MSIE',
-              'ua_ver'    => '8.0',
-              'Rop'       => true,
-              'Offset'    => 0x100
+              'ua_name' => 'MSIE',
+              'ua_ver' => '8.0',
+              'Rop' => true,
+              'Offset' => 0x100
             }
           ],
           [
             'Windows 7 with IE 9',
             {
               'os_flavor' => '7',
-              'ua_name'   => 'MSIE',
-              'ua_ver'    => '9.0',
-              'Rop'       => true,
-              'Offset'    => 0x100
+              'ua_name' => 'MSIE',
+              'ua_ver' => '9.0',
+              'Rop' => true,
+              'Offset' => 0x100
             }
           ],
           [
             'Windows 7 with IE 10',
             {
               'os_flavor' => '7',
-              'ua_name'   => 'MSIE',
-              'ua_ver'    => '10.0',
-              'Rop'       => true,
-              'Offset'    => 0x100
+              'ua_name' => 'MSIE',
+              'ua_ver' => '10.0',
+              'Rop' => true,
+              'Offset' => 0x100
             }
           ]
         ],
 
-      'Payload'        =>
-        {
-          'BadChars'        => "\x00",  #Our spray doesn't like null bytes
+        'Payload' => {
+          'BadChars' => "\x00", # Our spray doesn't like null bytes
           'StackAdjustment' => -3500
         },
-      'Privileged'     => false,
-      'DisclosureDate' => '2013-04-01',
-      'DefaultTarget'  => 0))
+        'Privileged' => false,
+        'DisclosureDate' => '2013-04-01',
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   #

--- a/test/modules/exploits/test/check.rb
+++ b/test/modules/exploits/test/check.rb
@@ -3,31 +3,32 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => "Check Test Exploit",
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => "Check Test Exploit",
+        'Description' => %q{
           This module ensures that 'check' actually functions for Exploit modules.
-      },
-      'References'     =>
-        [
+        },
+        'References' => [
           [ 'OSVDB', '0' ]
         ],
-      'Author'         =>
-        [
+        'Author' => [
           'todb'
         ],
-      'License'        => MSF_LICENSE,
-      'DisclosureDate' => '2013-05-23'
-    ))
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => '2013-05-23'
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(80)
-      ], self.class)
+      ], self.class
+    )
   end
 
   def check

--- a/test/modules/exploits/test/cmdweb.rb
+++ b/test/modules/exploits/test/cmdweb.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
   # =( need more targets and perhaps more OS specific return values OS specific would be preferred
@@ -12,46 +11,47 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'	      => 'Command Stager Web Test',
-      'Description'  => %q{
+    super(
+      update_info(
+        info,
+        'Name'	=> 'Command Stager Web Test',
+        'Description' => %q{
           This module tests the command stager mixin against a shell.jsp application installed
-        on an Apache Tomcat server.
-      },
-      'Author'	=> 'bannedit',
-      'References' =>
-        [
+          on an Apache Tomcat server.
+        },
+        'Author'	=> 'bannedit',
+        'References' => [
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
         },
-      'Payload' =>
-        {
+        'Payload' => {
         },
-      'Platform' => 'win',
-      'Privileged' => true,
-      'Targets' =>
-        [
+        'Platform' => 'win',
+        'Privileged' => true,
+        'Targets' => [
           # need more but this will likely cover most cases
-          [ 'Automatic Targeting',
+          [
+            'Automatic Targeting',
             {
               'auto' => true
             }
           ],
         ],
-      'DefaultTarget' => 0,
-      'DisclosureDate' => '2010-02-03'))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2010-02-03'
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(8080),
-      ], self.class)
+      ], self.class
+    )
   end
 
   def autofilter
     false
   end
-
 
   # This is method required for the CmdStager to work...
   def execute_command(cmd, opts)
@@ -63,7 +63,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
     opts = {
       :delay => 0.5,
       :uri => "/shell/shell.jsp?cmd=CMDS"
@@ -72,7 +71,6 @@ class MetasploitModule < Msf::Exploit::Remote
     execute_cmdstager(opts)
 
     handler
-
   end
 
 end

--- a/test/modules/exploits/test/dialup.rb
+++ b/test/modules/exploits/test/dialup.rb
@@ -3,37 +3,37 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::Dialup
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'		=> 'Test Dialup Exploit',
-      'Description'	=> %q{
-        This exploit connects to a system's modem over dialup and provides
-        the user with a readout of the login banner.
-      },
-      'Author'	=>
-        [
+    super(
+      update_info(
+        info,
+        'Name'	=> 'Test Dialup Exploit',
+        'Description'	=> %q{
+          This exploit connects to a system's modem over dialup and provides
+          the user with a readout of the login banner.
+        },
+        'Author' => [
           'I)ruid',
         ],
-      'Arch'		=> ARCH_TTY,
-      'Platform'	=> ['unix'],
-      'License'	=> MSF_LICENSE,
-      'Payload'        =>
-        {
-          'Space'    => 1000,
+        'Arch'	=> ARCH_TTY,
+        'Platform'	=> ['unix'],
+        'License'	=> MSF_LICENSE,
+        'Payload' => {
+          'Space' => 1000,
           'BadChars' => '',
           'DisableNops' => true,
         },
-      'Targets'        =>
-        [
-          [ 'Automatic', { } ],
+        'Targets' => [
+          [ 'Automatic', {} ],
         ],
-      'DefaultTarget' => 0))
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   def autofilter

--- a/test/modules/exploits/test/egghunter.rb
+++ b/test/modules/exploits/test/egghunter.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
@@ -11,42 +10,45 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Egghunter
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Internal Egghunter Test Exploit',
-      'Description'    =>
-        "This module tests the exploitation of a test service using the Egghunter.",
-      'Author'         => 'jduck',
-      'License'        => MSF_LICENSE,
-      'Arch'           => ARCH_X86,
-      'Payload'        =>
-        {
-          'Space'    => 1000,
-          'MaxNops'  => 0,
+    super(
+      update_info(
+        info,
+        'Name' => 'Internal Egghunter Test Exploit',
+        'Description' => "This module tests the exploitation of a test service using the Egghunter.",
+        'Author' => 'jduck',
+        'License' => MSF_LICENSE,
+        'Arch' => ARCH_X86,
+        'Payload' => {
+          'Space' => 1000,
+          'MaxNops' => 0,
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
         },
-      'Targets'        =>
-        [
-          [ 'Windows',
+        'Targets' => [
+          [
+            'Windows',
             {
               'Platform' => 'win'
             }
           ],
 
-          [ 'Linux',
+          [
+            'Linux',
             {
               'Platform' => 'linux'
             }
           ]
         ],
-      'DefaultTarget' => 0))
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
         OptBool.new('WaitForInput', [ false, "Wait for user input before returning from exploit", false ])
-      ])
+      ]
+    )
   end
-
 
   def autofilter
     false
@@ -57,20 +59,19 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
     connect
 
     print_status("Sending #{payload.encoded.length} byte payload...")
 
     eh_stub, eh_egg = generate_egghunter(payload.encoded, payload_badchars, {
-        :checksum => true
-      })
+      :checksum => true
+    })
     print_status("Egghunter: hunter stub #{eh_stub.length} bytes, egg #{eh_egg.length} bytes")
 
     sploit = ''
 
     # break before?
-    #sploit << "\xcc"
+    # sploit << "\xcc"
     sploit << eh_stub
     # just return otherwise
     sploit << "\xc3"

--- a/test/modules/exploits/test/explib2_ie11_drop_exec_test_case.rb
+++ b/test/modules/exploits/test/explib2_ie11_drop_exec_test_case.rb
@@ -3,47 +3,45 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
   include Msf::Exploit::EXE
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Explib2 Drop Exec Test Case",
-      'Description'    => %q{
-        This module allows to test integration of Explib2 into metasploit.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => "Explib2 Drop Exec Test Case",
+        'Description' => %q{
+          This module allows to test integration of Explib2 into metasploit.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'guhe120', # Original explib2 author
           'juan vazquez'
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'URL', 'https://github.com/jvazquez-r7/explib2' ] # The original repo has been deleted
         ],
-      'Platform'       => 'win',
-      'BrowserRequirements' =>
-        {
-          :source  => /script/i,
+        'Platform' => 'win',
+        'BrowserRequirements' => {
+          :source => /script/i,
           :os_name => OperatingSystems::WINDOWS,
           :ua_name => HttpClients::IE,
-          :ua_ver  => '11.0'
+          :ua_ver => '11.0'
         },
-      'Targets'        =>
-        [
-          [ 'Automatic', { } ]
+        'Targets' => [
+          [ 'Automatic', {} ]
         ],
-      'DisclosureDate' => '2014-03-28',
-      'DefaultTarget'  => 0))
+        'DisclosureDate' => '2014-03-28',
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   def exploit_html
-
     exe_js = Rex::Text.to_unescape(generate_payload_exe, ENDIAN_LITTLE, "\\u")
 
     template = %Q|<html>

--- a/test/modules/exploits/test/explib2_ie11_exec_test_case.rb
+++ b/test/modules/exploits/test/explib2_ie11_exec_test_case.rb
@@ -3,42 +3,41 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Explib2 Exec Test Case",
-      'Description'    => %q{
-        This module allows to test integration of Explib2 into metasploit.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => "Explib2 Exec Test Case",
+        'Description' => %q{
+          This module allows to test integration of Explib2 into metasploit.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'guhe120', # Original explib2 author
           'juan vazquez'
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'URL', 'https://github.com/jvazquez-r7/explib2' ] # The original repo has been deleted
         ],
-      'Platform'       => 'win',
-      'BrowserRequirements' =>
-        {
-          :source  => /script/i,
+        'Platform' => 'win',
+        'BrowserRequirements' => {
+          :source => /script/i,
           :os_name => OperatingSystems::WINDOWS,
           :ua_name => HttpClients::IE,
-          :ua_ver  => '11.0'
+          :ua_ver => '11.0'
         },
-      'Targets'        =>
-        [
-          [ 'Automatic', { } ]
+        'Targets' => [
+          [ 'Automatic', {} ]
         ],
-      'DisclosureDate' => '2014-03-28',
-      'DefaultTarget'  => 0))
+        'DisclosureDate' => '2014-03-28',
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   def exploit_html

--- a/test/modules/exploits/test/exploitme.rb
+++ b/test/modules/exploits/test/exploitme.rb
@@ -3,51 +3,50 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'MIPS Aggressive Test Exploit',
-      'Description'    => 'This module tests the exploitation of a test service',
-      'Author'         => ['skape', 'Julien Tinnes <julien[at]cr0.org>'],
-      'License'        => MSF_LICENSE,
-      #'Arch'           => ARCH_MIPSBE,
-      'Payload'        =>
-        {
-          'MaxNops'  => 0,
-          #'BadChars' => "\x00",
-          #'StackAdjustment' => -3500,
+    super(
+      update_info(
+        info,
+        'Name' => 'MIPS Aggressive Test Exploit',
+        'Description' => 'This module tests the exploitation of a test service',
+        'Author' => ['skape', 'Julien Tinnes <julien[at]cr0.org>'],
+        'License' => MSF_LICENSE,
+        # 'Arch'           => ARCH_MIPSBE,
+        'Payload' => {
+          'MaxNops' => 0,
+          # 'BadChars' => "\x00",
+          # 'StackAdjustment' => -3500,
         },
-      'Targets'        =>
-        [
+        'Targets' => [
           # Target 0: Universal
           [
             'Mips big endian',
             {
               'Platform' => [ 'linux', 'win' ],
-              'Arch'     => ARCH_MIPSBE
+              'Arch' => ARCH_MIPSBE
             }
           ],
-            [
+          [
             'Mips big endian cannot be encoded',
             {
               'Platform' => [ 'linux', 'win' ],
-              'Arch'     => ARCH_MIPSBE,
-              'Payload'  =>
+              'Arch' => ARCH_MIPSBE,
+              'Payload' =>
                 {
                   'BadChars' => (0..255).to_a.map { |x| x.chr }.to_s
                 }
             }
-          ],				[
+          ],	[
             'Mips big endian encoder needed',
             {
               'Platform' => [ 'linux', 'win' ],
-              'Arch'     => ARCH_MIPSBE,
-              'Payload'  =>
+              'Arch' => ARCH_MIPSBE,
+              'Payload' =>
                 {
                   'BadChars' => "\x00"
                 }
@@ -57,42 +56,43 @@ class MetasploitModule < Msf::Exploit::Remote
             'Mips little endian',
             {
               'Platform' => [ 'linux', 'win' ],
-              'Arch'     => ARCH_MIPSLE
+              'Arch' => ARCH_MIPSLE
             }
           ],
-            [
+          [
             'Mips little endian cannot be encoded',
             {
               'Platform' => [ 'linux', 'win' ],
-              'Arch'     => ARCH_MIPSLE,
-              'Payload'  =>
+              'Arch' => ARCH_MIPSLE,
+              'Payload' =>
                 {
                   'BadChars' => (0..255).to_a.map { |x| x.chr }.to_s
                 }
             }
-          ],				[
+          ],	[
             'Mips little endian encoder needed',
             {
               'Platform' => [ 'linux', 'win' ],
-              'Arch'     => ARCH_MIPSLE,
-              'Payload'  =>
+              'Arch' => ARCH_MIPSLE,
+              'Payload' =>
                 {
                   'BadChars' => "\x00"
                 }
             }
           ],
 
-
         ],
-      'DefaultTarget' => 0))
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
         OptBool.new('WaitForInput', [ false, "Wait for user input before returning from exploit", false ]),
         OptInt.new('TestInteger', [ false, "Testing an integer value", nil ])
-      ])
+      ]
+    )
   end
-
 
   def autofilter
     false
@@ -105,8 +105,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     # Show disassembled payload for context encoder test
     if target.name =~ /context encoder/
-      #puts Rex::Assembly::Nasm.disassemble(payload.encoded[0,40])
-      #FIXME: do this with metasm for MIPS (import new metasm version which fixes current bug!)
+      # puts Rex::Assembly::Nasm.disassemble(payload.encoded[0,40])
+      # FIXME: do this with metasm for MIPS (import new metasm version which fixes current bug!)
     end
 
     connect

--- a/test/modules/exploits/test/java_tester.rb
+++ b/test/modules/exploits/test/java_tester.rb
@@ -8,30 +8,35 @@ require 'rex'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
-  def initialize( info = {} )
-    super( update_info( info,
-      'Name'          => 'Exec',
-      'Description'   => %q{ },
-      'License'       => MSF_LICENSE,
-      'Author'        => [ 'egypt' ],
-      'References'    => [ ],
-      'Platform'      => [ 'java', 'linux' ],
-      'Arch'          => ARCH_JAVA,
-      'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
-      'Targets'       =>
-        [
-          [ 'Generic (Java Payload)', {
-            'Arch' => ARCH_JAVA,
-            'Platform' => 'java'
-          } ],
-          [ 'Linux', {
-            'Arch' => ARCH_X86,
-            'Platform' => 'linux'
-          } ],
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Exec',
+        'Description' => %q{ },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'egypt' ],
+        'References' => [ ],
+        'Platform' => [ 'java', 'linux' ],
+        'Arch' => ARCH_JAVA,
+        'Payload' => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
+        'Targets' => [
+          [
+            'Generic (Java Payload)', {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'java'
+            }
+          ],
+          [
+            'Linux', {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux'
+            }
+          ],
         ],
-      'DefaultTarget' => 0
-    ))
-
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   def exploit
@@ -47,4 +52,3 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 end
-

--- a/test/modules/exploits/test/js_tester.rb
+++ b/test/modules/exploits/test/js_tester.rb
@@ -1,28 +1,30 @@
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "IE Test for Javascript Libs",
-      'Description'    => %q{
-        Tests Javascript hotness
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => [ 'sinn3r' ],
-      'References'     => [ [ 'URL', 'https://metasploit.com' ] ],
-      'Platform'       => 'win',
-      'Targets'        => [ [ 'Automatic', {} ] ],
-      'Payload'        =>
-        {
-          'BadChars'        => "\x00",
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => "IE Test for Javascript Libs",
+        'Description' => %q{
+          Tests Javascript hotness
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'sinn3r' ],
+        'References' => [ [ 'URL', 'https://metasploit.com' ] ],
+        'Platform' => 'win',
+        'Targets' => [ [ 'Automatic', {} ] ],
+        'Payload' => {
+          'BadChars' => "\x00",
           'StackAdjustment' => -3500
         },
-      'Privileged'     => false,
-      'DisclosureDate' => '2013-04-01',
-      'DefaultTarget'  => 0))
+        'Privileged' => false,
+        'DisclosureDate' => '2013-04-01',
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   def test_base64
@@ -72,11 +74,9 @@ class MetasploitModule < Msf::Exploit::Remote
     |
   end
 
-
   def on_request_uri(cli, request)
     # Change the following to a specific function
     js = test_base64
-
 
     html = %Q|
     <!doctype html>
@@ -95,8 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     </html>
     |
 
-    send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control'=>'no-cache'})
+    send_response(cli, html, { 'Content-Type' => 'text/html', 'Cache-Control' => 'no-cache' })
   end
 
 end
-

--- a/test/modules/exploits/test/kernel.rb
+++ b/test/modules/exploits/test/kernel.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 #
 # This is a test exploit for testing kernel-mode payloads.
 #
@@ -14,39 +13,40 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::KernelMode
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Internal Kernel-mode Test Exploit',
-      'Description'    =>
-        "This module tests the exploitation of a kernel-mode test service.",
-      'Author'         => 'skape',
-      'License'        => MSF_LICENSE,
-      'Arch'           => 'x86',
-      'Payload'        =>
-        {
-          'Space'    => 1000,
-          'MaxNops'  => 0,
-          'Prepend'  => "\x81\xc4\x54\xf2\xff\xff", # add esp, -3500
+    super(
+      update_info(
+        info,
+        'Name' => 'Internal Kernel-mode Test Exploit',
+        'Description' => "This module tests the exploitation of a kernel-mode test service.",
+        'Author' => 'skape',
+        'License' => MSF_LICENSE,
+        'Arch' => 'x86',
+        'Payload' => {
+          'Space' => 1000,
+          'MaxNops' => 0,
+          'Prepend' => "\x81\xc4\x54\xf2\xff\xff", # add esp, -3500
           'PrependEncoder' => "\x81\xC4\x0C\xFE\xFF\xFF" # add esp, -500
         },
-      'Targets'        =>
-        [
+        'Targets' => [
           [
             'Windows XP SP2',
             {
-              'Ret'      => 0x80502d7f, # jmp esp
+              'Ret' => 0x80502d7f, # jmp esp
               'Platform' => 'win',
-              'Payload'  =>
+              'Payload' =>
                 {
                   'ExtendedOptions' =>
                     {
-                      'Stager'     => 'sud_syscall_hook',
-                      'Recovery'   => 'spin'
+                      'Stager' => 'sud_syscall_hook',
+                      'Recovery' => 'spin'
                     }
                 }
             }
           ],
         ],
-      'DefaultTarget' => 0))
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   def autofilter
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     udp_sock.put(buf)
 
-    select(nil,nil,nil,2)
+    select(nil, nil, nil, 2)
 
     disconnect_udp
   end

--- a/test/modules/exploits/test/shell.rb
+++ b/test/modules/exploits/test/shell.rb
@@ -3,38 +3,39 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'         => 'Command Test',
-      'Description'  => %q{
-        This module tests cmd payloads by targeting (for example) a server
-        like: nc -l -p 31337 -e /bin/sh
-      },
-      'Author'	=> 'egypt',
-      'References' => [ ],
-      'DefaultOptions' => { },
-      'Payload' =>
-        {
+    super(
+      update_info(
+        info,
+        'Name' => 'Command Test',
+        'Description' => %q{
+          This module tests cmd payloads by targeting (for example) a server
+          like: nc -l -p 31337 -e /bin/sh
         },
-      'Platform' => 'unix',
-      'Arch'     => ARCH_CMD,
-      'Targets' =>
-        [
-          [ 'Automatic Targeting', { } ],
+        'Author'	=> 'egypt',
+        'References' => [ ],
+        'DefaultOptions' => {},
+        'Payload' => {
+        },
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Targets' => [
+          [ 'Automatic Targeting', {} ],
         ],
-      'DefaultTarget' => 0
-    ))
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(31337),
-      ], self.class)
+      ], self.class
+    )
   end
 
   def autofilter

--- a/test/modules/post/test/cmd_exec.rb
+++ b/test/modules/post/test/cmd_exec.rb
@@ -9,13 +9,16 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
 
   def initialize(info = {})
-    super(update_info(info,
-        'Name'          => 'Meterpreter cmd_exec test',
-        'Description'   => %q( This module will test the meterpreter cmd_exec API ),
-        'License'       => MSF_LICENSE,
-        'Platform'      => ['windows', 'linux', 'unix'],
-        'SessionTypes'  => ['meterpreter']
-      ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Meterpreter cmd_exec test',
+        'Description' => %q( This module will test the meterpreter cmd_exec API ),
+        'License' => MSF_LICENSE,
+        'Platform' => ['windows', 'linux', 'unix'],
+        'SessionTypes' => ['meterpreter']
+      )
+    )
   end
 
   def test_cmd_exec
@@ -107,6 +110,5 @@ class MetasploitModule < Msf::Post
         output == test_string
       end
     end
-
   end
 end

--- a/test/modules/post/test/extapi.rb
+++ b/test/modules/post/test/extapi.rb
@@ -1,4 +1,3 @@
-
 require 'rex'
 
 lib = File.join(Msf::Config.install_root, "test", "lib")
@@ -9,23 +8,24 @@ class MetasploitModule < Msf::Post
 
   include Msf::ModuleTest::PostTest
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Test Meterpreter ExtAPI Stuff',
-        'Description'   => %q{ This module will test Windows Extended API methods },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Ben Campbell'],
-        'Platform'      => [ 'windows', ],
-        'SessionTypes'  => [ 'meterpreter' ]
-      ))
-
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Test Meterpreter ExtAPI Stuff',
+        'Description' => %q{ This module will test Windows Extended API methods },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Ben Campbell'],
+        'Platform' => [ 'windows', ],
+        'SessionTypes' => [ 'meterpreter' ]
+      )
+    )
   end
 
   #
   # Check the extension is loaded...
   #
   def setup
-
     unless session.extapi
       vprint_status("Loading extapi extension...")
       begin
@@ -60,9 +60,9 @@ class MetasploitModule < Msf::Post
         it "should return clipboard jpg dimensions" do
           ret = false
 
-          #VK_PRINTSCREEN 154 Maybe needed on XP?
-          #VK_SNAPSHOT 44
-          session.railgun.user32.keybd_event(44,0,0,0)
+          # VK_PRINTSCREEN 154 Maybe needed on XP?
+          # VK_SNAPSHOT 44
+          session.railgun.user32.keybd_event(44, 0, 0, 0)
           session.railgun.user32.keybd_event(44, 0, 'KEYEVENTF_KEYUP', 0)
 
           clipboard = session.extapi.clipboard.get_data(false)
@@ -96,22 +96,22 @@ class MetasploitModule < Msf::Post
         text = Rex::Text.rand_text_alphanumeric(1024)
         ret = session.extapi.clipboard.set_text(text)
         clipboard = session.extapi.clipboard.get_data(true)
-        ret =  clipboard && clipboard.first && (clipboard.first[:type] == :text) && (clipboard.first[:data] == text)
+        ret = clipboard && clipboard.first && (clipboard.first[:type] == :text) && (clipboard.first[:data] == text)
       end
 
       if session.railgun.user32
         it "should download clipboard jpg data" do
           ret = false
 
-          #VK_PRINTSCREEN 154 Maybe needed on XP?
-          #VK_SNAPSHOT 44
-          session.railgun.user32.keybd_event(44,0,0,0)
+          # VK_PRINTSCREEN 154 Maybe needed on XP?
+          # VK_SNAPSHOT 44
+          session.railgun.user32.keybd_event(44, 0, 0, 0)
           session.railgun.user32.keybd_event(44, 0, 'KEYEVENTF_KEYUP', 0)
 
           clipboard = session.extapi.clipboard.get_data(true)
           if clipboard && clipboard.first && (clipboard.first[:type] == :jpg) && !(clipboard.first[:data].empty?)
             # JPG Magic Bytes
-            ret = (clipboard.first[:data][0,2] == "\xFF\xD8")
+            ret = (clipboard.first[:data][0, 2] == "\xFF\xD8")
           end
 
           ret
@@ -183,14 +183,14 @@ class MetasploitModule < Msf::Post
         windows = session.extapi.window.enumerate(true, nil)
 
         if windows && windows.any?
-          unknowns = windows.select {|w| w[:title] == "<unknown>"}
+          unknowns = windows.select { |w| w[:title] == "<unknown>" }
           ret = !unknowns.empty?
         end
 
         ret
       end
 
-      parent = windows.select {|w| w[:title] =~ /program manager/i}
+      parent = windows.select { |w| w[:title] =~ /program manager/i }
 
       if parent && parent.first
         it "should return an array of a windows children" do

--- a/test/modules/post/test/get_env.rb
+++ b/test/modules/post/test/get_env.rb
@@ -1,25 +1,27 @@
-
 lib = File.join(Msf::Config.install_root, "test", "lib")
 require 'module_test'
 
-#load 'test/lib/module_test.rb'
-#load 'lib/rex/text.rb'
-#load 'lib/msf/core/post/common.rb'
+# load 'test/lib/module_test.rb'
+# load 'lib/rex/text.rb'
+# load 'lib/msf/core/post/common.rb'
 
 class MetasploitModule < Msf::Post
 
   include Msf::ModuleTest::PostTest
   include Msf::Post::Common
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Test Post::Common Get Envs',
-        'Description'   => %q{ This module will test Post::Common get envs API methods },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Ben Campbell'],
-        'Platform'      => [ 'windows', 'linux', 'java', 'python' ],
-        'SessionTypes'  => [ 'meterpreter', 'shell' ]
-      ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Test Post::Common Get Envs',
+        'Description' => %q{ This module will test Post::Common get envs API methods },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Ben Campbell'],
+        'Platform' => [ 'windows', 'linux', 'java', 'python' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ]
+      )
+    )
   end
 
   def test_get_env_windows
@@ -41,7 +43,7 @@ class MetasploitModule < Msf::Post
       it "should return user" do
         user = get_env('USER')
         !user.blank?
-     end
+      end
 
       it "should handle $ sign" do
         user = get_env('$USER')
@@ -52,7 +54,7 @@ class MetasploitModule < Msf::Post
 
   def test_get_envs
     it "should return multiple envs" do
-      res = get_envs('PATH','USERNAME','USER')
+      res = get_envs('PATH', 'USERNAME', 'USER')
       if session.platform =~ /win/i
         !res['PATH'].blank? && !res['USERNAME'].blank?
       else
@@ -62,4 +64,3 @@ class MetasploitModule < Msf::Post
   end
 
 end
-

--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -1,4 +1,3 @@
-
 require 'rex/post/meterpreter/extensions/stdapi/command_ids'
 require 'rex'
 
@@ -10,20 +9,24 @@ class MetasploitModule < Msf::Post
 
   include Msf::ModuleTest::PostTest
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Testing Meterpreter Stuff',
-        'Description'   => %q{ This module will test meterpreter API methods },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'egypt'],
-        'Platform'      => [ 'windows', 'linux', 'java' ],
-        'SessionTypes'  => [ 'meterpreter' ]
-      ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Testing Meterpreter Stuff',
+        'Description' => %q{ This module will test meterpreter API methods },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'egypt'],
+        'Platform' => [ 'windows', 'linux', 'java' ],
+        'SessionTypes' => [ 'meterpreter' ]
+      )
+    )
     register_options(
       [
-        OptBool.new("AddEntropy" , [false, "Add entropy token to file and directory names.", false]),
-        OptString.new("BaseFileName" , [true, "File/dir base name", "meterpreter-test"])
-      ], self.class)
+        OptBool.new("AddEntropy", [false, "Add entropy token to file and directory names.", false]),
+        OptString.new("BaseFileName", [true, "File/dir base name", "meterpreter-test"])
+      ], self.class
+    )
   end
 
   #
@@ -81,7 +84,7 @@ class MetasploitModule < Msf::Post
       ret &&= (list && list.length > 0)
       if session.commands.include? Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_SYS_PROCESS_GETPID
         pid ||= session.sys.process.getpid
-        process = list.find{ |p| p['pid'] == pid }
+        process = list.find { |p| p['pid'] == pid }
         vprint_status("PID info: #{process.inspect}")
         ret &&= !(process.nil?)
       else
@@ -90,7 +93,6 @@ class MetasploitModule < Msf::Post
 
       ret
     end
-
   end
 
   def test_sys_config
@@ -125,7 +127,7 @@ class MetasploitModule < Msf::Post
       ifaces = session.net.config.get_interfaces
       res = !!(ifaces and ifaces.length > 0)
 
-      res &&= !! ifaces.find { |iface|
+      res &&= !!ifaces.find { |iface|
         iface.addrs.find { |addr|
           addr == session.session_host
         }
@@ -141,13 +143,12 @@ class MetasploitModule < Msf::Post
         routes and routes.length > 0
       end
     end
-
   end
 
   def test_fs
     vprint_status("Starting filesystem tests")
     if datastore["AddEntropy"]
-      entropy_value = '-' + ('a'..'z').to_a.shuffle[0,8].join
+      entropy_value = '-' + ('a'..'z').to_a.shuffle[0, 8].join
     else
       entropy_value = ""
     end
@@ -252,7 +253,7 @@ class MetasploitModule < Msf::Post
       res = true
       remote = "#{datastore["BaseFileName"]}-file#{entropy_value}.txt"
       vprint_status("Remote File Name: #{remote}")
-      local  = __FILE__
+      local = __FILE__
       vprint_status("uploading")
       session.fs.file.upload_file(remote, local)
       vprint_status("done")
@@ -333,7 +334,7 @@ class MetasploitModule < Msf::Post
       res = true
       remote = "#{datastore["BaseFileName"]}-file#{entropy_value}.txt"
       vprint_status("Remote File Name: #{remote}")
-      local  = __FILE__
+      local = __FILE__
       vprint_status("uploading")
       session.fs.file.upload_file(remote, local)
       vprint_status("done")
@@ -342,20 +343,19 @@ class MetasploitModule < Msf::Post
 
       if res
         remote_md5 = session.fs.file.md5(remote)
-        local_md5  = Digest::MD5.digest(::File.read(local, mode: 'rb'))
+        local_md5 = Digest::MD5.digest(::File.read(local, mode: 'rb'))
         remote_sha = session.fs.file.sha1(remote)
-        local_sha  = Digest::SHA1.digest(::File.read(local, mode: 'rb'))
-        vprint_status("remote md5: #{Rex::Text.to_hex(remote_md5,'')}")
-        vprint_status("local md5 : #{Rex::Text.to_hex(local_md5,'')}")
-        vprint_status("remote sha: #{Rex::Text.to_hex(remote_sha,'')}")
-        vprint_status("local sha : #{Rex::Text.to_hex(local_sha,'')}")
+        local_sha = Digest::SHA1.digest(::File.read(local, mode: 'rb'))
+        vprint_status("remote md5: #{Rex::Text.to_hex(remote_md5, '')}")
+        vprint_status("local md5 : #{Rex::Text.to_hex(local_md5, '')}")
+        vprint_status("remote sha: #{Rex::Text.to_hex(remote_sha, '')}")
+        vprint_status("local sha : #{Rex::Text.to_hex(local_sha, '')}")
         res &&= (remote_md5 == local_md5)
       end
 
       session.fs.file.rm(remote)
       res
     end
-
   end
 
 =begin
@@ -387,7 +387,7 @@ class MetasploitModule < Msf::Post
     super
   end
 
-protected
+  protected
 
   def create_directory(name)
     res = true
@@ -402,6 +402,5 @@ protected
 
     res
   end
-
 
 end

--- a/test/modules/post/test/railgun.rb
+++ b/test/modules/post/test/railgun.rb
@@ -1,5 +1,3 @@
-
-
 lib = File.join(Msf::Config.install_root, "test", "lib")
 require 'module_test'
 
@@ -9,14 +7,17 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::FileInfo
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'Railgun API Tests',
-      'Description'   => %q{ This module will test railgun api functions },
-      'License'       => MSF_LICENSE,
-      'Author'        => [ 'Spencer McIntyre' ],
-      'Platform'      => [ 'linux', 'osx', 'windows' ]
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Railgun API Tests',
+        'Description' => %q{ This module will test railgun api functions },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Spencer McIntyre' ],
+        'Platform' => [ 'linux', 'osx', 'windows' ]
+      )
+    )
   end
 
   def test_api_function_calls_libc
@@ -89,6 +90,7 @@ class MetasploitModule < Msf::Post
 
   def test_api_function_file_info_windows
     return unless session.platform == 'windows'
+
     it "Should retrieve the win32k file version" do
       path = expand_path('%WINDIR%\\system32\\win32k.sys')
       major, minor, build, revision, brand = file_version(path)
@@ -98,6 +100,7 @@ class MetasploitModule < Msf::Post
 
   def test_api_function_calls_windows
     return unless session.platform == 'windows'
+
     it "Should include error information in the results" do
       ret = true
       result = session.railgun.kernel32.GetCurrentProcess()

--- a/test/modules/post/test/railgun_reverse_lookups.rb
+++ b/test/modules/post/test/railgun_reverse_lookups.rb
@@ -1,4 +1,3 @@
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -14,43 +13,45 @@ class MetasploitModule < Msf::Post
 
   include Msf::ModuleTest::PostTest
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'railgun_testing',
-        'Description'   => %q{ This module will test railgun code used in post modules},
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'kernelsmith'],
-        'Platform'      => [ 'windows' ]
-      ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'railgun_testing',
+        'Description' => %q{ This module will test railgun code used in post modules},
+        'License' => MSF_LICENSE,
+        'Author' => [ 'kernelsmith'],
+        'Platform' => [ 'windows' ]
+      )
+    )
 
     register_options(
       [
-        OptInt.new("ERR_CODE",   [ false, "Error code to reverse lookup" ]),
-        OptInt.new("WIN_CONST",  [ false, "Windows constant to reverse lookup" ]),
+        OptInt.new("ERR_CODE", [ false, "Error code to reverse lookup" ]),
+        OptInt.new("WIN_CONST", [ false, "Windows constant to reverse lookup" ]),
         OptRegexp.new("WCREGEX", [ false, "Regexp to apply to constant rev lookup" ]),
         OptRegexp.new("ECREGEX", [ false, "Regexp to apply to error code lookup" ]),
-      ], self.class)
-
+      ], self.class
+    )
   end
 
   #
   # Return an array of windows constants names matching +winconst+
   #
-  def select_const_names(winconst, filter_regex=nil)
+  def select_const_names(winconst, filter_regex = nil)
     session.railgun.constant_manager.select_const_names(winconst, filter_regex)
   end
 
   #
   # Returns an array of windows error code names for a given windows error code matching +err_code+
   #
-  def lookup_error(err_code, filter_regex=nil)
+  def lookup_error(err_code, filter_regex = nil)
     select_const_names(err_code, /^ERROR_/).select do |name|
       name =~ filter_regex
     end
   end
 
   def test_static
-
     it "should return a constant name given a const and a filter" do
       ret = true
       results = select_const_names(4, /^SERVICE/)
@@ -78,16 +79,14 @@ class MetasploitModule < Msf::Post
 
       ret
     end
-
   end
 
   def test_datastore
-
     if (datastore["WIN_CONST"])
       it "should look up arbitrary constants" do
         ret = true
         results = select_const_names(datastore['WIN_CONST'], datastore['WCREGEX'])
-        #vprint_status("RESULTS:  #{results.class} #{results.pretty_inspect}")
+        # vprint_status("RESULTS:  #{results.class} #{results.pretty_inspect}")
 
         ret
       end
@@ -97,13 +96,10 @@ class MetasploitModule < Msf::Post
       it "should look up arbitrary error codes" do
         ret = true
         results = lookup_error(datastore['ERR_CODE'], datastore['ECREGEX'])
-        #vprint_status("RESULTS:  #{results.class} #{results.inspect}")
+        # vprint_status("RESULTS:  #{results.class} #{results.inspect}")
 
         ret
       end
     end
-
   end
 end
-
-

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -1,4 +1,3 @@
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -15,23 +14,26 @@ class MetasploitModule < Msf::Post
   include Msf::ModuleTest::PostTest
   include Msf::Post::Windows::Registry
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'registry_post_testing',
-        'Description'   => %q{ This module will test Post::Windows::Registry API methods },
-        'License'       => MSF_LICENSE,
-        'Author'        => [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'registry_post_testing',
+        'Description' => %q{ This module will test Post::Windows::Registry API methods },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'kernelsmith', # original
           'egypt',       # PostTest conversion
         ],
-        'Platform'      => [ 'windows' ]
-      ))
+        'Platform' => [ 'windows' ]
+      )
+    )
   end
 
   def test_0_registry_read
     it "should evaluate key existence" do
       k_exists = registry_key_exist?(%q#HKCU\Environment#)
-      k_dne    = registry_key_exist?(%q#HKLM\\Non\Existent\Key#)
+      k_dne = registry_key_exist?(%q#HKLM\\Non\Existent\Key#)
 
       (k_exists && !k_dne)
     end
@@ -39,7 +41,7 @@ class MetasploitModule < Msf::Post
     pending "should evaluate value existence" do
       # these methods are not implemented
       v_exists = registry_value_exist?(%q#HKCU\Environment#, "TEMP")
-      v_dne    = registry_value_exist?(%q#HKLM\\Non\Existent\Key#, "asdf")
+      v_dne = registry_value_exist?(%q#HKLM\\Non\Existent\Key#, "asdf")
 
       (v_exists && !v_dne)
     end
@@ -99,7 +101,6 @@ class MetasploitModule < Msf::Post
 
       ret
     end
-
   end
 
   def test_1_registry_write
@@ -172,7 +173,6 @@ class MetasploitModule < Msf::Post
       ret
     end
 
-
     it "should delete unicode keys" do
       ret = registry_deleteval(%q#HKCU\σονσλυσιονεμκυε#, "test_val_str")
       valinfo = registry_getvalinfo(%q#HKCU\σονσλυσιονεμκυε#, "test_val_str")
@@ -185,9 +185,6 @@ class MetasploitModule < Msf::Post
 
       ret
     end
-
   end
 
 end
-
-

--- a/test/modules/post/test/search.rb
+++ b/test/modules/post/test/search.rb
@@ -1,4 +1,3 @@
-
 require 'rex/post/meterpreter/extensions/stdapi/command_ids'
 require 'rex'
 
@@ -10,20 +9,24 @@ class MetasploitModule < Msf::Post
 
   include Msf::ModuleTest::PostTest
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Testing Meterpreter Search',
-        'Description'   => %q{ This module will test the meterpreter search method },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'timwr'],
-        'Platform'      => [ 'windows', 'linux', 'java' ],
-        'SessionTypes'  => [ 'meterpreter' ]
-      ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Testing Meterpreter Search',
+        'Description' => %q{ This module will test the meterpreter search method },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'timwr'],
+        'Platform' => [ 'windows', 'linux', 'java' ],
+        'SessionTypes' => [ 'meterpreter' ]
+      )
+    )
     register_options(
       [
-        OptBool.new("AddEntropy" , [false, "Add entropy token to file and directory names.", false]),
-        OptString.new("BaseFileName" , [true, "File/dir base name", "meterpreter-test"])
-      ], self.class)
+        OptBool.new("AddEntropy", [false, "Add entropy token to file and directory names.", false]),
+        OptString.new("BaseFileName", [true, "File/dir base name", "meterpreter-test"])
+      ], self.class
+    )
   end
 
   def setup
@@ -38,7 +41,7 @@ class MetasploitModule < Msf::Post
     session.fs.dir.chdir(tmp)
 
     if datastore["AddEntropy"]
-      entropy_value = '-' + ('a'..'z').to_a.shuffle[0,8].join
+      entropy_value = '-' + ('a'..'z').to_a.shuffle[0, 8].join
     else
       entropy_value = ""
     end

--- a/test/modules/post/test/services.rb
+++ b/test/modules/post/test/services.rb
@@ -13,27 +13,31 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Services
   include Msf::ModuleTest::PostTest
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Test Post::Windows::Services',
-        'Description'   => %q{ This module will test windows services methods within a shell},
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'kernelsmith', 'egypt' ],
-        'Platform'      => [ 'windows' ],
-        'SessionTypes'  => [ 'meterpreter', 'shell' ]
-      ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Test Post::Windows::Services',
+        'Description' => %q{ This module will test windows services methods within a shell},
+        'License' => MSF_LICENSE,
+        'Author' => [ 'kernelsmith', 'egypt' ],
+        'Platform' => [ 'windows' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ]
+      )
+    )
     register_options(
       [
-        OptString.new("QSERVICE" , [true, "Service (keyname) to query", "winmgmt"]),
-        OptString.new("NSERVICE" , [true, "New Service (keyname) to create/del", "testes"]),
-        OptString.new("SSERVICE" , [true, "Service (keyname) to start/stop", "W32Time"]),
-        OptString.new("DNAME" , [true, "Display name used for create test", "Cool display name"]),
-        OptString.new("BINPATH" , [true, "Binary path for create test", "C:\\WINDOWS\\system32\\svchost.exe -k netsvcs"]),
-        OptEnum.new("MODE", [true, "Mode to use for startup/create tests", "auto",
-            ["auto", "manual", "disable"]
-          ]),
-      ], self.class)
-
+        OptString.new("QSERVICE", [true, "Service (keyname) to query", "winmgmt"]),
+        OptString.new("NSERVICE", [true, "New Service (keyname) to create/del", "testes"]),
+        OptString.new("SSERVICE", [true, "Service (keyname) to start/stop", "W32Time"]),
+        OptString.new("DNAME", [true, "Display name used for create test", "Cool display name"]),
+        OptString.new("BINPATH", [true, "Binary path for create test", "C:\\WINDOWS\\system32\\svchost.exe -k netsvcs"]),
+        OptEnum.new("MODE", [
+          true, "Mode to use for startup/create tests", "auto",
+          ["auto", "manual", "disable"]
+        ]),
+      ], self.class
+    )
   end
 
   def test_start
@@ -65,7 +69,7 @@ class MetasploitModule < Msf::Post
 
       ret &&= results.kind_of? Array
       ret &&= results.length > 0
-      ret &&= results.select{|service| service[:name] == datastore["QSERVICE"]}
+      ret &&= results.select { |service| service[:name] == datastore["QSERVICE"] }
 
       ret
     end
@@ -92,11 +96,11 @@ class MetasploitModule < Msf::Post
   def test_create
     it "should create a service  #{datastore["NSERVICE"]}" do
       mode = case datastore["MODE"]
-        when "disable"; START_TYPE_DISABLED
-        when "manual"; START_TYPE_MANUAL
-        when "auto"; START_TYPE_AUTO
-        else; START_TYPE AUTO
-        end
+             when "disable"; START_TYPE_DISABLED
+             when "manual"; START_TYPE_MANUAL
+             when "auto"; START_TYPE_AUTO
+             else; START_TYPE AUTO
+             end
 
       ret = service_create(datastore['NSERVICE'],
                            display: datastore['DNAME'],
@@ -151,16 +155,16 @@ class MetasploitModule < Msf::Post
       ret = true
 
       results = service_create(service_name,
-                           display: display_name,
-                           path: datastore['BINPATH'],
-                           starttype: START_TYPE_DISABLED)
+                               display: display_name,
+                               path: datastore['BINPATH'],
+                               starttype: START_TYPE_DISABLED)
 
       ret &&= (results == Windows::Error::SUCCESS)
       results = service_status(service_name)
       ret &&= results.kind_of? Hash
       if ret
         original_display = results[:display]
-        results = service_change_config(service_name, {:display => Rex::Text.rand_text_alpha(5)})
+        results = service_change_config(service_name, { :display => Rex::Text.rand_text_alpha(5) })
         ret &&= (results == Windows::Error::SUCCESS)
 
         results = service_info(service_name)
@@ -181,9 +185,9 @@ class MetasploitModule < Msf::Post
     it "should start a disabled service #{service_name}" do
       ret = true
       results = service_create(service_name,
-                           display: display_name,
-                           path: datastore['BINPATH'],
-                           starttype: START_TYPE_DISABLED)
+                               display: display_name,
+                               path: datastore['BINPATH'],
+                               starttype: START_TYPE_DISABLED)
 
       ret &&= (results == Windows::Error::SUCCESS)
       if ret

--- a/test/modules/post/test/unix.rb
+++ b/test/modules/post/test/unix.rb
@@ -1,12 +1,11 @@
-
 lib = File.join(Msf::Config.install_root, "test", "lib")
 $:.push(lib) unless $:.include?(lib)
 require 'module_test'
 
-#load 'test/lib/module_test.rb'
-#load 'lib/rex/text.rb'
-#load 'lib/msf/core/post/linux/system.rb'
-#load 'lib/msf/core/post/unix/enum_user_dirs.rb'
+# load 'test/lib/module_test.rb'
+# load 'lib/rex/text.rb'
+# load 'lib/msf/core/post/linux/system.rb'
+# load 'lib/msf/core/post/unix/enum_user_dirs.rb'
 
 class MetasploitModule < Msf::Post
 
@@ -15,15 +14,18 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Unix
   include Msf::Post::Common
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Testing Remote Unix System Manipulation',
-        'Description'   => %q{ This module will test Post::File API methods },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'egypt'],
-        'Platform'      => [ 'linux', 'java' ],
-        'SessionTypes'  => [ 'meterpreter', 'shell' ]
-      ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Testing Remote Unix System Manipulation',
+        'Description' => %q{ This module will test Post::File API methods },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'egypt'],
+        'Platform' => [ 'linux', 'java' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ]
+      )
+    )
   end
 
   def test_unix
@@ -36,6 +38,7 @@ class MetasploitModule < Msf::Post
       if ret
         users.each { |u|
           next unless u[:name] == "root"
+
           have_root = true
         }
       end
@@ -44,8 +47,6 @@ class MetasploitModule < Msf::Post
 
       ret
     end
-
   end
 
 end
-

--- a/test/tests/00_create_all_modules_test.rb
+++ b/test/tests/00_create_all_modules_test.rb
@@ -6,7 +6,7 @@ describe Msf::Simple::Framework do
     klass = mod
     it "should be able create #{ref}" do
       e = $msf.modules.create(ref)
-    		e.should_not == nil
+      e.should_not == nil
     end
   end
 end

--- a/test/tests/rakefile
+++ b/test/tests/rakefile
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'spec/rake/spectask'
 Spec::Rake::SpecTask.new do |t|
-	t.ruby_opts = ['-rtest/unit']
-	t.spec_files = FileList['*_test.rb']
+  t.ruby_opts = ['-rtest/unit']
+  t.spec_files = FileList['*_test.rb']
 end
-

--- a/test/tests/test_encoders.rb
+++ b/test/tests/test_encoders.rb
@@ -1,5 +1,5 @@
 #
-# Simple script to test a group of encoders against every exploit in the framework, 
+# Simple script to test a group of encoders against every exploit in the framework,
 # specifically for the exploits badchars, to see if a payload can be encoded. We ignore
 # the target arch/platform of the exploit as we just want to pull out real world bad chars.
 #
@@ -17,101 +17,92 @@ $msf = Msf::Simple::Framework.create
 
 EXPLOITS = $msf.exploits
 
-def print_line( message )
-  $stdout.puts( message )
+def print_line(message)
+  $stdout.puts(message)
 end
 
-def format_badchars( badchars )
+def format_badchars(badchars)
   str = ''
-  if( badchars )
-    badchars.each_byte do | b |
+  if (badchars)
+    badchars.each_byte do |b|
       str << "\\x%02X" % [ b ]
     end
   end
   str
 end
 
-def encoder_v_payload( encoder_name, payload, verbose=false )
+def encoder_v_payload(encoder_name, payload, verbose = false)
   success = 0
-  fail    = 0
-  EXPLOITS.each_module do | name, mod |
-  
+  fail = 0
+  EXPLOITS.each_module do |name, mod|
     exploit = mod.new
-    print_line( "\n#{encoder_name} v #{name} (#{ format_badchars( exploit.payload_badchars ) })" ) if verbose
+    print_line("\n#{encoder_name} v #{name} (#{format_badchars(exploit.payload_badchars)})") if verbose
     begin
-      encoder = $msf.encoders.create( encoder_name )
-      raw = encoder.encode( payload, exploit.payload_badchars, nil, nil )
+      encoder = $msf.encoders.create(encoder_name)
+      raw = encoder.encode(payload, exploit.payload_badchars, nil, nil)
       success += 1
     rescue
-      print_line( "    FAILED! badchars=#{ format_badchars( exploit.payload_badchars ) }\n" ) if verbose
+      print_line("    FAILED! badchars=#{format_badchars(exploit.payload_badchars)}\n") if verbose
       fail += 1
     end
   end
   return [ success, fail ]
 end
 
-def generate_payload( name )
+def generate_payload(name)
+  payload = $msf.payloads.create(name)
 
-  payload = $msf.payloads.create( name )
-  
   # set options for a reverse_tcp payload
-  payload.datastore['LHOST']    = '192.168.2.1'
-  payload.datastore['RHOST']    = '192.168.2.254'
-  payload.datastore['RPORT']    = '5432'
-  payload.datastore['LPORT']    = '4444'
+  payload.datastore['LHOST'] = '192.168.2.1'
+  payload.datastore['RHOST'] = '192.168.2.254'
+  payload.datastore['RPORT'] = '5432'
+  payload.datastore['LPORT'] = '4444'
   # set options for an exec payload
-  payload.datastore['CMD']      = 'calc'
+  payload.datastore['CMD'] = 'calc'
   # set generic options
   payload.datastore['EXITFUNC'] = 'thread'
 
   return payload.generate
 end
 
-def run( encoders, payload_name, verbose=false )
-
-  payload = generate_payload( payload_name )
+def run(encoders, payload_name, verbose = false)
+  payload = generate_payload(payload_name)
 
   table = Rex::Text::Table.new(
-    'Header'  => 'Encoder v Payload Test - ' + ::Time.new.strftime( "%d-%b-%Y %H:%M:%S" ),
-    'Indent'  => 4,
+    'Header' => 'Encoder v Payload Test - ' + ::Time.new.strftime("%d-%b-%Y %H:%M:%S"),
+    'Indent' => 4,
     'Columns' => [ 'Encoder Name', 'Success', 'Fail' ]
   )
 
-  encoders.each do | encoder_name |
-
-    success, fail = encoder_v_payload( encoder_name, payload, verbose )
+  encoders.each do |encoder_name|
+    success, fail = encoder_v_payload(encoder_name, payload, verbose)
 
     table << [ encoder_name, success, fail ]
-    
   end
 
-  return table	
+  return table
 end
 
-if( $0 == __FILE__ )
+if ($0 == __FILE__)
 
-  print_line( "[+] Starting.\n" )
+  print_line("[+] Starting.\n")
 
-  encoders = [ 
-    'x86/bloxor', 
-    'x86/shikata_ga_nai', 
-    'x86/jmp_call_additive', 
-    'x86/fnstenv_mov', 
-    'x86/countdown', 
+  encoders = [
+    'x86/bloxor',
+    'x86/shikata_ga_nai',
+    'x86/jmp_call_additive',
+    'x86/fnstenv_mov',
+    'x86/countdown',
     'x86/call4_dword_xor'
   ]
 
   payload_name = 'windows/shell/reverse_tcp'
-  
+
   verbose = false
-  
-  result_table = run( encoders, payload_name, verbose )
 
-  print_line( "\n\n#{result_table.to_s}\n\n" )
+  result_table = run(encoders, payload_name, verbose)
 
-  print_line( "[+] Finished.\n" )
+  print_line("\n\n#{result_table.to_s}\n\n")
+
+  print_line("[+] Finished.\n")
 end
-
-
-
-  


### PR DESCRIPTION
This pull request:
- Applies rules aimed at `modules/` to `test/modules` as well
- Fixes whitespace linting issues for `test/modules`
- Introduce `.git-blame-ignore-revs`

The `.git-blame-ignore-revs` file should hopefully be useful for ignoring whitespace-only changes when performing Git blames: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

I've opted to separate fixing rubocop whitespace changes from other fixes, to ensure that subtle bugs introduced by operator precedence bugs etc don't creep in. i.e. Automatically swapping `not foo` to `!foo` in some circumstances may break code