### PR TITLE
Expand deps action logging

### DIFF
--- a/.github/workflows/weekly-dependencies-pr.yml
+++ b/.github/workflows/weekly-dependencies-pr.yml
@@ -50,10 +50,12 @@ jobs:
                   '`bundle update` revealed the following gems have new version to be evaluated for update.'
                 ].join('\n')
               });
-              github.rest.issues.addLabels({
+              console.log(JSON.stringify({ data: result.data, status: result.status }, null, 4));
+              const result = await github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: result.data.number,
                 labels: ['automation', 'rn-no-release-notes']
               });
+              console.log(JSON.stringify({ data: result.data, status: result.status }, null, 4));
             }

--- a/.github/workflows/weekly-dependencies-pr.yml
+++ b/.github/workflows/weekly-dependencies-pr.yml
@@ -38,6 +38,7 @@ jobs:
               repo,
               head: '${{ github.ref_name }}' 
             });
+            console.log(JSON.stringify({ data: hasPR.data, status: hasPR.status }, null, 4));
             if (Array.isArray(hasPR.data) && !hasPR.data.length) {
               const result = await github.rest.pulls.create({
                 title: 'Weekly dependency updates',

--- a/.github/workflows/weekly-dependencies-pr.yml
+++ b/.github/workflows/weekly-dependencies-pr.yml
@@ -51,11 +51,11 @@ jobs:
                 ].join('\n')
               });
               console.log(JSON.stringify({ data: result.data, status: result.status }, null, 4));
-              const result = await github.rest.issues.addLabels({
+              const labelResult = await github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: result.data.number,
                 labels: ['automation', 'rn-no-release-notes']
               });
-              console.log(JSON.stringify({ data: result.data, status: result.status }, null, 4));
+              console.log(JSON.stringify({ data: labelResult.data, status: labelResult.status }, null, 4));
             }

--- a/.github/workflows/weekly-dependencies-pr.yml
+++ b/.github/workflows/weekly-dependencies-pr.yml
@@ -38,6 +38,7 @@ jobs:
               repo,
               head: '${{ github.ref_name }}' 
             });
+            console.log('hasPR:');
             console.log(JSON.stringify({ data: hasPR.data, status: hasPR.status }, null, 4));
             if (Array.isArray(hasPR.data) && !hasPR.data.length) {
               const result = await github.rest.pulls.create({
@@ -51,6 +52,7 @@ jobs:
                   '`bundle update` revealed the following gems have new version to be evaluated for update.'
                 ].join('\n')
               });
+              console.log('result:');
               console.log(JSON.stringify({ data: result.data, status: result.status }, null, 4));
               const labelResult = await github.rest.issues.addLabels({
                 owner,
@@ -58,5 +60,6 @@ jobs:
                 issue_number: result.data.number,
                 labels: ['automation', 'rn-no-release-notes']
               });
+              console.log('labelResult:');
               console.log(JSON.stringify({ data: labelResult.data, status: labelResult.status }, null, 4));
             }


### PR DESCRIPTION
Add logging to dependency actions.

The new action to open PRs for weekly branch push by automation did not preform as expected, this adds logging to help ascertain why.

## Verification

List the steps needed to make sure this thing works

- [ ] See https://github.com/jmartin-r7/metasploit-framework/runs/6219439226?check_suite_focus=true