### PR TITLE
improve PR filter to reference `owner`

### DIFF
--- a/.github/workflows/weekly-dependencies-pr.yml
+++ b/.github/workflows/weekly-dependencies-pr.yml
@@ -33,10 +33,14 @@ jobs:
         with:
           script: |
             const { repo, owner } = context.repo;
+            console.log('repo:');
+            console.log(JSON.stringify(repo, null, 4));
+            console.log('owner:');
+            console.log(JSON.stringify(owner, null, 4));
             const hasPR = await github.rest.pulls.list({
               owner,
               repo,
-              head: '${{ github.ref_name }}' 
+              head: owner + ':' + '${{ github.ref_name }}' 
             });
             console.log('hasPR:');
             console.log(JSON.stringify({ data: hasPR.data, status: hasPR.status }, null, 4));


### PR DESCRIPTION
When using `head` to filter the PR list user or head organization
and branch name in the format of `user:ref-name` or `organization:ref-name`
are required.

## Verification

List the steps needed to make sure this thing works

- [ ] See: https://github.com/jmartin-r7/metasploit-framework/pull/21
Existing repo PR with no PR already open for the `weekly-dependency-updates` branch:
https://github.com/jmartin-r7/metasploit-framework/actions/runs/2259314398
Existing open PR for `weekly-dependency-updates` does not attempt to open another PR:
https://github.com/jmartin-r7/metasploit-framework/actions/runs/2259341901