### PR TITLE
Update git-blame-ignore-revs to ignore tabs to spaces commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,5 +5,11 @@
 #    https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
 # 
 
-# Fixing whitespace on the tests folder with "rubocop --fix-layout test"
+# 2013: Retabbing the majority of Metasploit Framework to use two-space soft tabs instead of hard tabs
+7e5e0f7fc814fee55a1eca148c51f2344da65e59
+41e4375e43443bb568729a3079d3bf9944cbc669
+84aaf2334ae2de73f27999d4c003448c8e891d3a
+9f3a5dc5d0424c2c1a067b140b1642319dee65c2
+
+# 2022: Fixing whitespace on the tests folder with "rubocop --fix-layout test"
 29cc349649f978304712dd0c31dc8861e9627209


### PR DESCRIPTION
Ignoring commits from the following pull request which converted tabs to spaces back in 2013:
https://github.com/rapid7/metasploit-framework/pull/2330

The .git-blame-ignore-revs file is useful for ignoring whitespace-only changes when performing Git blames: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view