### PR TITLE
Update PiHole module to not wait for sudo input

### DIFF
--- a/modules/exploits/linux/local/pihole_remove_commands_lpe.rb
+++ b/modules/exploits/linux/local/pihole_remove_commands_lpe.rb
@@ -63,11 +63,11 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def sudo_pihole
-    'sudo /usr/local/bin/pihole -a'
+    'sudo -n /usr/local/bin/pihole -a'
   end
 
   def pihole_version
-    version = cmd_exec('sudo /usr/local/bin/pihole -v')
+    version = cmd_exec('sudo -n /usr/local/bin/pihole -v')
     /Pi-hole version is v([^ ]+)/ =~ version
     Rex::Version.new(Regexp.last_match(1))
   end


### PR DESCRIPTION
This PR stops the `pihole_remove_commands_lpe` module from waiting for sudo prompt input as that seems to have been killing Python Meterpreter sessions.

```
-n, --non-interactive
                   Avoid prompting the user for input of any kind.  If a password is required for the command to run, sudo will display an error message and exit.
```

## Verification

- [ ] Start `msfconsole`
- [ ] Get a Python session against a Linux machine
- [ ] `modules/exploits/linux/local/pihole_remove_commands_lpe.rb`
- [ ] `set` the necessary values
- [ ] `check`
- [ ] **Verify** that the session doesn't die
- [ ] **Verify** that you get the correct pihole version

## Before
```
DEBUG:root:[*] starting process: ['/bin/sh', '-c', 'sudo /usr/local/bin/pihole -v']
DEBUG:root:[*] added process id: 2
DEBUG:root:[*] added channel id: 4 type: MeterpreterProcess
DEBUG:root:[*] sending response packet
DEBUG:root:[*] running method core_channel_read
DEBUG:root:[*] sending response packet
[sudo] password for kali: DEBUG:root:[*] running method core_channel_read
DEBUG:root:[*] sending response packet
DEBUG:root:[*] running method core_channel_read
DEBUG:root:[*] sending response packet
DEBUG:root:[*] running method core_channel_read
DEBUG:root:[*] sending response packet
DEBUG:root:[*] running method core_channel_read
DEBUG:root:[*] sending response packet
```
The above keeps happening until the timeout is reached, after which the session tends to die.

## After
```
DEBUG:root:[*] starting process: ['/bin/sh', '-c', 'sudo -n /usr/local/bin/pihole -v']
DEBUG:root:[*] added process id: 2
DEBUG:root:[*] added channel id: 4 type: MeterpreterProcess
DEBUG:root:[*] sending response packet
DEBUG:root:[*] running method core_channel_read
DEBUG:root:[*] sending response packet
DEBUG:root:[*] running method core_channel_read
DEBUG:root:[*] sending response packet
DEBUG:root:[*] running method stdapi_sys_process_close
```