### PR TITLE
Fix `-w` option flag for Meterpreter `reg` command

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -71,13 +71,13 @@ class Console::CommandDispatcher::Stdapi::Sys
   # Options used by the 'reg' command.
   #
   @@reg_opts = Rex::Parser::Arguments.new(
-    "-d" => [ true,  "The data to store in the registry value."		   ],
-    "-h" => [ false, "Help menu."						   ],
-    "-k" => [ true,  "The registry key path (E.g. HKLM\\Software\\Foo)."	   ],
-    "-t" => [ true,  "The registry value type (E.g. REG_SZ)."		   ],
-    "-v" => [ true,  "The registry value name (E.g. Stuff)."		   ],
+    "-d" => [ true,  "The data to store in the registry value." ],
+    "-h" => [ false, "Help menu." ],
+    "-k" => [ true,  "The registry key path (E.g. HKLM\\Software\\Foo)." ],
+    "-t" => [ true,  "The registry value type (E.g. REG_SZ)." ],
+    "-v" => [ true,  "The registry value name (E.g. Stuff)." ],
     "-r" => [ true,  "The remote machine name to connect to (with current process credentials" ],
-    "-w" => [ false, "Set KEY_WOW64 flag, valid values [32|64]."		   ])
+    "-w" => [ true,  "Set KEY_WOW64 flag, valid values [32|64]." ])
 
   #
   # Options for the 'ps' command.


### PR DESCRIPTION
The Meterpreter `reg` command accept a `-w` option to set the `KEY_WOW64` flag:
```
meterpreter > reg -h
Usage: reg [command] [options]
Interact with the target machine's registry.

OPTIONS:

    -d   The data to store in the registry value.
    -h   Help menu.
    -k   The registry key path (E.g. HKLM\Software\Foo).
    -r   The remote machine name to connect to (with current process credentials
    -t   The registry value type (E.g. REG_SZ).
    -v   The registry value name (E.g. Stuff).
    -w   Set KEY_WOW64 flag, valid values [32|64].
```

However, it is set to not accept argument value (`32` or `64`):
```
"-w" => [ false, "Set KEY_WOW64 flag, valid values [32|64]."        ])
```

This just change `false` to `true` to make it work properly.

The flag is parsed [here](https://github.com/rapid7/metasploit-framework/blob/82daa0c90f915cc3b4fc47bb5c8d733544d02582/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb#L901-L906) and the constant value is [added](https://github.com/rapid7/metasploit-framework/blob/82daa0c90f915cc3b4fc47bb5c8d733544d02582/lib/msf/core/post/windows/registry.rb#L420-L427) to the `PERMISSION` field in the TLV packet

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] get a Meterpreter session
- [ ] Enable TLV logging: `setg SessionTlvLogging file:/tmp/tlv_log.txt`
- [ ] Interact with the session: `session -1`
- [ ] `reg queryval -k 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer' -v 'Type'`
- [ ] `reg queryval -k 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer' -v 'Type' -w '64'`
- [ ] `reg queryval -k 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer' -v 'Type' -w '32'`
- [ ] Read the log file using: `grep '^SEND' -A6 /tmp/tlv_log.txt | grep -B1 -A6 command=stdapi_registry_open_key`
- [ ] **Verify** the 3 requests have a different `PERMISSION` TLV field

## Before
- without `-w` option:
```
meterpreter > reg queryval -k 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer' -v 'Type'
Key: HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer
Name: Type
Type: REG_DWORD
Data: 32
```

TLV logs:
```
SEND: #<Rex::Post::Meterpreter::Packet type=Request         tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1042 command=stdapi_registry_open_key>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="65945361745740335377418963234758">
  #<Rex::Post::Meterpreter::Tlv type=oneOf(HKEY,ROOT_KEY) meta=QWORD      value=2147483650>
  #<Rex::Post::Meterpreter::Tlv type=BASE_KEY        meta=STRING     value="SYSTEM\\\\CurrentControlSet\\\\Services\\\\Lanman ...">
  #<Rex::Post::Meterpreter::Tlv type=PERMISSION      meta=INT        value=131097>
]>
```
PERMISSION value: 131097

- with `-w` set to `64`:
```
meterpreter > reg queryval -k 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer' -v 'Type' -w '64'
Key: HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer
Name: Type
Type: REG_DWORD
Data: 32
```

TLV logs:
```
SEND: #<Rex::Post::Meterpreter::Packet type=Request         tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1042 command=stdapi_registry_open_key>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="10374371934730260674858562334270">
  #<Rex::Post::Meterpreter::Tlv type=oneOf(HKEY,ROOT_KEY) meta=QWORD      value=2147483650>
  #<Rex::Post::Meterpreter::Tlv type=BASE_KEY        meta=STRING     value="SYSTEM\\\\CurrentControlSet\\\\Services\\\\Lanman ...">
  #<Rex::Post::Meterpreter::Tlv type=PERMISSION      meta=INT        value=131097>
]>
```
PERMISSION value: 131097

- with `-w` set to `32`:
```
meterpreter > reg queryval -k 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer' -v 'Type' -w '32'
Key: HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer
Name: Type
Type: REG_DWORD
Data: 32
```

TLV logs:
```
SEND: #<Rex::Post::Meterpreter::Packet type=Request         tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1042 command=stdapi_registry_open_key>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="02493852591411043688306748648909">
  #<Rex::Post::Meterpreter::Tlv type=oneOf(HKEY,ROOT_KEY) meta=QWORD      value=2147483650>
  #<Rex::Post::Meterpreter::Tlv type=BASE_KEY        meta=STRING     value="SYSTEM\\\\CurrentControlSet\\\\Services\\\\Lanman ...">
  #<Rex::Post::Meterpreter::Tlv type=PERMISSION      meta=INT        value=131097>
]>
```
PERMISSION value: 131097

## After
- without `-w` option:
```
meterpreter > reg queryval -k 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer' -v 'Type'
Key: HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer
Name: Type
Type: REG_DWORD
Data: 32
```

TLV logs:
```
SEND: #<Rex::Post::Meterpreter::Packet type=Request         tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1042 command=stdapi_registry_open_key>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="01697300599018968642167805477751">
  #<Rex::Post::Meterpreter::Tlv type=oneOf(HKEY,ROOT_KEY) meta=QWORD      value=2147483650>
  #<Rex::Post::Meterpreter::Tlv type=BASE_KEY        meta=STRING     value="SYSTEM\\\\CurrentControlSet\\\\Services\\\\Lanman ...">
  #<Rex::Post::Meterpreter::Tlv type=PERMISSION      meta=INT        value=131097>
]>
```
PERMISSION value: 131097

- with `-w` set to `64`:
```
meterpreter > reg queryval -k 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer' -v 'Type' -w '64'
Key: HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer
Name: Type
Type: REG_DWORD
Data: 32
```

TLV logs:
```
SEND: #<Rex::Post::Meterpreter::Packet type=Request         tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1042 command=stdapi_registry_open_key>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="27877978327699591316569639529230">
  #<Rex::Post::Meterpreter::Tlv type=oneOf(HKEY,ROOT_KEY) meta=QWORD      value=2147483650>
  #<Rex::Post::Meterpreter::Tlv type=BASE_KEY        meta=STRING     value="SYSTEM\\\\CurrentControlSet\\\\Services\\\\Lanman ...">
  #<Rex::Post::Meterpreter::Tlv type=PERMISSION      meta=INT        value=131353>
]>
```
PERMISSION value: 131353

- with `-w` set to `32`:
```
meterpreter > reg queryval -k 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer' -v 'Type' -w '32'
Key: HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer
Name: Type
Type: REG_DWORD
Data: 32
```

TLV logs:
```
SEND: #<Rex::Post::Meterpreter::Packet type=Request         tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1042 command=stdapi_registry_open_key>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="14416729750942384039145919167486">
  #<Rex::Post::Meterpreter::Tlv type=oneOf(HKEY,ROOT_KEY) meta=QWORD      value=2147483650>
  #<Rex::Post::Meterpreter::Tlv type=BASE_KEY        meta=STRING     value="SYSTEM\\\\CurrentControlSet\\\\Services\\\\Lanman ...">
  #<Rex::Post::Meterpreter::Tlv type=PERMISSION      meta=INT        value=131609>
]>
```
PERMISSION value: 131609