### PR TITLE
Update zeitwerk to ignore go pkg folder

### DIFF
--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -51,6 +51,7 @@ class MsfAutoload
 
   def ignore_list
     [
+      "#{__dir__}/msf/core/modules/external/go/pkg",
       "#{__dir__}/msf/core/constants.rb",
       "#{__dir__}/msf/core/cert_provider.rb",
       "#{__dir__}/msf/core/rpc/json/",


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/16434

Ensure we no longer attempt to load Go pkg code as part of msfconsole bootup