### PR TITLE
Fix nil channel id when trying to close channels

### DIFF
--- a/lib/rex/post/meterpreter/channel.rb
+++ b/lib/rex/post/meterpreter/channel.rb
@@ -377,11 +377,12 @@ class Channel
   # Stub close handler.
   #
   def dio_close_handler(packet)
+    temp_cid = nil
     @mutex.synchronize {
-      cid = self.cid
+      temp_cid = self.cid
       self.cid = nil
     }
-    client.remove_channel(cid)
+    client.remove_channel(temp_cid)
 
     # Trap IOErrors as parts of the channel may have already been closed
     begin
@@ -467,4 +468,3 @@ protected
 end
 
 end; end; end
-


### PR DESCRIPTION
This PR fixes a bug where open channels were not being closed properly due to receiving a nil channel id because of a mutex.

## Verification

- [ ] Start `msfconsole -q`
- [ ] Get a session (e.g. `python/meterpreter/reverse_tcp`)
- [ ] `use local_exploit_suggester` (as an example of a module that can run `cmd_exec` and has access to `session`)
- [ ] `irb`
- [ ] `cmd_exec('uname -a', nil, 15, {'Channelized' => true} )` a few times
- [ ] **Verify** that still still in `irb`, `session.channels` doesn't endlessly increase