### PR TITLE
Include the correct platform specific mixins for mettle

### DIFF
--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Osx
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Osx
 
   def initialize(info = {})
     super(

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
   include Msf::Sessions::MettleConfig
+  include Msf::Payload::Osx
 
   def initialize(info = {})
     super(

--- a/tools/modules/generate_mettle_payloads.rb
+++ b/tools/modules/generate_mettle_payloads.rb
@@ -12,37 +12,37 @@ schemes = [
   'https'
 ]
 
-arches = [
-  ['aarch64',   'Linux', 'aarch64-linux-musl', 'Linux'],
-  ['armbe',     'Linux', 'armv5b-linux-musleabi', 'Linux'],
-  ['armle',     'Linux', 'armv5l-linux-musleabi', 'Linux'],
-  ['mips64',    'Linux', 'mips64-linux-muslsf', 'Linux'],
-  ['mipsbe',    'Linux', 'mips-linux-muslsf', 'Linux'],
-  ['mipsle',    'Linux', 'mipsel-linux-muslsf', 'Linux'],
-  ['ppc',       'Linux', 'powerpc-linux-muslsf', 'Linux'],
-  ['ppce500v2', 'Linux', 'powerpc-e500v2-linux-musl', 'Linux'],
-  ['ppc64le',   'Linux', 'powerpc64le-linux-musl', 'Linux'],
-  ['x64',       'Linux', 'x86_64-linux-musl', 'Linux'],
-  ['x86',       'Linux', 'i486-linux-musl', 'Linux'],
-  ['zarch',     'Linux', 's390x-linux-musl', 'Linux'],
-  ['x64',       'OSX',   'x86_64-apple-darwin', 'Osx'],
-  ['aarch64',   'Apple_iOS',   'aarch64-iphone-darwin', ''],
-  ['armle',     'Apple_iOS',   'arm-iphone-darwin', ''],
+arch_list = [
+  { arch: 'aarch64',   platform: 'Linux', payload: 'aarch64-linux-musl', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'armbe',     platform: 'Linux', payload: 'armv5b-linux-musleabi', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'armle',     platform: 'Linux', payload: 'armv5l-linux-musleabi', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'mips64',    platform: 'Linux', payload: 'mips64-linux-muslsf', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'mipsbe',    platform: 'Linux', payload: 'mips-linux-muslsf', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'mipsle',    platform: 'Linux', payload: 'mipsel-linux-muslsf', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'ppc',       platform: 'Linux', payload: 'powerpc-linux-muslsf', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'ppce500v2', platform: 'Linux', payload: 'powerpc-e500v2-linux-musl', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'ppc64le',   platform: 'Linux', payload: 'powerpc64le-linux-musl', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'x64',       platform: 'Linux', payload: 'x86_64-linux-musl', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'x86',       platform: 'Linux', payload: 'i486-linux-musl', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'zarch',     platform: 'Linux', payload: 's390x-linux-musl', mixins: ['Msf::Payload::Linux'] },
+  { arch: 'x64',       platform: 'OSX',   payload: 'x86_64-apple-darwin', mixins: ['Msf::Payload::Osx'] },
+  { arch: 'aarch64',   platform: 'Apple_iOS',   payload: 'aarch64-iphone-darwin', mixins: [] },
+  { arch: 'armle',     platform: 'Apple_iOS',   payload: 'arm-iphone-darwin', mixins: [] },
 ]
 
 arch = ''
 payload = ''
 platform = ''
-mixin = ''
+mixins = ''
 scheme = ''
 cwd = File::dirname(__FILE__)
 
-arches.each do |a, pl, pa, mix|
+arch_list.each do |arch_hash|
   schemes.each do |s|
-    arch = a
-    platform = pl
-    payload = pa
-    mixin = mix
+    arch = arch_hash[:arch]
+    platform = arch_hash[:platform]
+    payload = arch_hash[:payload]
+    mixins = arch_hash[:mixins].join("\n  include ")
     scheme = s
 
     template = File::read(File::join(cwd, "meterpreter_reverse.erb"))

--- a/tools/modules/generate_mettle_payloads.rb
+++ b/tools/modules/generate_mettle_payloads.rb
@@ -30,25 +30,15 @@ arch_list = [
   { arch: 'armle',     platform: 'Apple_iOS',   payload: 'arm-iphone-darwin', mixins: [] },
 ]
 
-arch = ''
-payload = ''
-platform = ''
-mixins = ''
-scheme = ''
 cwd = File::dirname(__FILE__)
 
 arch_list.each do |arch_hash|
-  schemes.each do |s|
-    arch = arch_hash[:arch]
-    platform = arch_hash[:platform]
-    payload = arch_hash[:payload]
-    mixins = arch_hash[:mixins].join("\n  include ")
-    scheme = s
-
-    template = File::read(File::join(cwd, "meterpreter_reverse.erb"))
-    renderer = ERB.new(template)
-    filename = File::join('modules', 'payloads', 'singles', platform.downcase, arch, "meterpreter_reverse_#{scheme}.rb")
-    File::write(filename, renderer.result())
+  schemes.each do |scheme |
+    arch_hash = arch_hash.merge(scheme: scheme)
+    template = File::read(File::join(cwd, 'meterpreter_reverse.erb'))
+    renderer = ERB.new(template, trim_mode: '-')
+    filename = File::join('modules', 'payloads', 'singles', arch_hash[:platform].downcase, arch_hash[:arch], "meterpreter_reverse_#{scheme}.rb")
+    File::write(filename, renderer.result_with_hash(arch_hash))
   end
 end
 

--- a/tools/modules/generate_mettle_payloads.rb
+++ b/tools/modules/generate_mettle_payloads.rb
@@ -13,34 +13,36 @@ schemes = [
 ]
 
 arches = [
-  ['aarch64',   'Linux', 'aarch64-linux-musl'],
-  ['armbe',     'Linux', 'armv5b-linux-musleabi'],
-  ['armle',     'Linux', 'armv5l-linux-musleabi'],
-  ['mips64',    'Linux', 'mips64-linux-muslsf'],
-  ['mipsbe',    'Linux', 'mips-linux-muslsf'],
-  ['mipsle',    'Linux', 'mipsel-linux-muslsf'],
-  ['ppc',       'Linux', 'powerpc-linux-muslsf'],
-  ['ppce500v2', 'Linux', 'powerpc-e500v2-linux-musl'],
-  ['ppc64le',   'Linux', 'powerpc64le-linux-musl'],
-  ['x64',       'Linux', 'x86_64-linux-musl'],
-  ['x86',       'Linux', 'i486-linux-musl'],
-  ['zarch',     'Linux', 's390x-linux-musl'],
-  ['x64',       'OSX',   'x86_64-apple-darwin'],
-  ['aarch64',   'Apple_iOS',   'aarch64-iphone-darwin'],
-  ['armle',     'Apple_iOS',   'arm-iphone-darwin'],
+  ['aarch64',   'Linux', 'aarch64-linux-musl', 'Linux'],
+  ['armbe',     'Linux', 'armv5b-linux-musleabi', 'Linux'],
+  ['armle',     'Linux', 'armv5l-linux-musleabi', 'Linux'],
+  ['mips64',    'Linux', 'mips64-linux-muslsf', 'Linux'],
+  ['mipsbe',    'Linux', 'mips-linux-muslsf', 'Linux'],
+  ['mipsle',    'Linux', 'mipsel-linux-muslsf', 'Linux'],
+  ['ppc',       'Linux', 'powerpc-linux-muslsf', 'Linux'],
+  ['ppce500v2', 'Linux', 'powerpc-e500v2-linux-musl', 'Linux'],
+  ['ppc64le',   'Linux', 'powerpc64le-linux-musl', 'Linux'],
+  ['x64',       'Linux', 'x86_64-linux-musl', 'Linux'],
+  ['x86',       'Linux', 'i486-linux-musl', 'Linux'],
+  ['zarch',     'Linux', 's390x-linux-musl', 'Linux'],
+  ['x64',       'OSX',   'x86_64-apple-darwin', 'Osx'],
+  ['aarch64',   'Apple_iOS',   'aarch64-iphone-darwin', ''],
+  ['armle',     'Apple_iOS',   'arm-iphone-darwin', ''],
 ]
 
 arch = ''
 payload = ''
 platform = ''
+mixin = ''
 scheme = ''
 cwd = File::dirname(__FILE__)
 
-arches.each do |a, pl, pa|
+arches.each do |a, pl, pa, mix|
   schemes.each do |s|
     arch = a
     platform = pl
     payload = pa
+    mixin = mix
     scheme = s
 
     template = File::read(File::join(cwd, "meterpreter_reverse.erb"))

--- a/tools/modules/meterpreter_reverse.erb
+++ b/tools/modules/meterpreter_reverse.erb
@@ -9,7 +9,8 @@ module MetasploitModule
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
-  include Msf::Sessions::MettleConfig
+  include Msf::Sessions::MettleConfig<% unless mixin.empty? %>
+  include Msf::Payload::<%= mixin %><% end %>
 
   def initialize(info = {})
     super(

--- a/tools/modules/meterpreter_reverse.erb
+++ b/tools/modules/meterpreter_reverse.erb
@@ -9,8 +9,10 @@ module MetasploitModule
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
-  include Msf::Sessions::MettleConfig<% unless mixins.empty? %>
-  include <%= mixins %><% end %>
+  include Msf::Sessions::MettleConfig
+<%- mixins.map do |mixin| -%>
+  include <%= mixin %>
+<%- end -%>
 
   def initialize(info = {})
     super(

--- a/tools/modules/meterpreter_reverse.erb
+++ b/tools/modules/meterpreter_reverse.erb
@@ -9,8 +9,8 @@ module MetasploitModule
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
-  include Msf::Sessions::MettleConfig<% unless mixin.empty? %>
-  include Msf::Payload::<%= mixin %><% end %>
+  include Msf::Sessions::MettleConfig<% unless mixins.empty? %>
+  include <%= mixins %><% end %>
 
   def initialize(info = {})
     super(


### PR DESCRIPTION
Not much to it, noticed mettle `stageless` payloads were missing platform specific mixins that the `staged` payloads had so I went ahead and added in the logic to include the correct mixin for the platform

# Verification steps
- [ ] Boot up console
- [ ] navigate to a `stageless` linux meterpreter payload (e.g. `use payload/linux/x86/meterpreter_reverse_tcp`
- [ ] run `advanced` 
- [ ] verify options such as `PrependSetgid` are now appearing (as well as other options from the respective mixins i.e. `lib/msf/core/payload/linux.rb`
