### PR TITLE
Add the retry_until_truthy library function

### DIFF
--- a/lib/msf/core/exploit/retry.rb
+++ b/lib/msf/core/exploit/retry.rb
@@ -5,7 +5,7 @@ module Msf::Exploit::Retry
   #
   # @param Integer timeout the number of seconds to wait before the operation times out
   # @return the truthy value of the block is returned or nil if it timed out
-  def retry_until_true(timeout:)
+  def retry_until_truthy(timeout:)
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
     ending_time = start_time + timeout
     retry_count = 0

--- a/lib/msf/core/exploit/retry.rb
+++ b/lib/msf/core/exploit/retry.rb
@@ -1,9 +1,10 @@
 module Msf::Exploit::Retry
   # Retry the block until it returns a truthy value. Each iteration attempt will
   # be performed with an exponential backoff. If the timeout period surpasses,
-  # false is returned.
+  # nil is returned.
   #
   # @param Integer timeout the number of seconds to wait before the operation times out
+  # @return the truthy value of the block is returned or nil if it timed out
   def retry_until_true(timeout:)
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
     ending_time = start_time + timeout
@@ -27,7 +28,6 @@ module Msf::Exploit::Retry
       sleep delay
     end
 
-    false
+    nil
   end
 end
-

--- a/lib/msf/core/exploit/retry.rb
+++ b/lib/msf/core/exploit/retry.rb
@@ -1,0 +1,33 @@
+module Msf::Exploit::Retry
+  # Retry the block until it returns a truthy value. Each iteration attempt will
+  # be performed with an exponential backoff. If the timeout period surpasses,
+  # false is returned.
+  #
+  # @param Integer timeout the number of seconds to wait before the operation times out
+  def retry_until_true(timeout:)
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+    ending_time = start_time + timeout
+    retry_count = 0
+    while Process.clock_gettime(Process::CLOCK_MONOTONIC, :second) < ending_time
+      result = yield
+      return result if result
+
+      retry_count += 1
+      remaining_time_budget = ending_time - Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+      break if remaining_time_budget <= 0
+
+      delay = 2**retry_count
+      if delay >= remaining_time_budget
+        delay = remaining_time_budget
+        vprint_status("Final attempt. Sleeping for the remaining #{delay} seconds out of total timeout #{timeout}")
+      else
+        vprint_status("Sleeping for #{delay} seconds before attempting again")
+      end
+
+      sleep delay
+    end
+
+    false
+  end
+end
+

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{peer} - Waiting for the server to flush the logfile")
     print_status("#{peer} - Executing JSP payload at #{full_uri(@jsp_file)}")
 
-    succeeded = retry_until_true(timeout: 60) do
+    succeeded = retry_until_truthy(timeout: 60) do
       res = send_request_cgi({
         'method' => 'GET',
         'uri' => normalize_uri(@jsp_file)

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking # It's going to manipulate the Class Loader
 
   prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Retry
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
   include Msf::Exploit::EXE
@@ -298,33 +299,5 @@ class MetasploitModule < Msf::Exploit::Remote
     check_log_file
 
     handler
-  end
-
-  # Retry the block until it returns a truthy value. Each iteration attempt will
-  # be performed with expoential backoff. If the timeout period surpasses, false is returned.
-  def retry_until_true(timeout:)
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
-    ending_time = start_time + timeout
-    retry_count = 0
-    while Process.clock_gettime(Process::CLOCK_MONOTONIC, :second) < ending_time
-      result = yield
-      return result if result
-
-      retry_count += 1
-      remaining_time_budget = ending_time - Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
-      break if remaining_time_budget <= 0
-
-      delay = 2**retry_count
-      if delay >= remaining_time_budget
-        delay = remaining_time_budget
-        vprint_status("Final attempt. Sleeping for the remaining #{delay} seconds out of total timeout #{timeout}")
-      else
-        vprint_status("Sleeping for #{delay} seconds before attempting again")
-      end
-
-      sleep delay
-    end
-
-    false
   end
 end

--- a/modules/exploits/multi/http/wso2_file_upload_rce.rb
+++ b/modules/exploits/multi/http/wso2_file_upload_rce.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::Retry
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
@@ -135,37 +136,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  # Retry the block until it returns a truthy value. Each iteration attempt will
-  # be performed with expoential backoff. If the timeout period surpasses, false is returned.
-  def retry_until_true(timeout:)
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
-    ending_time = start_time + timeout
-    retry_count = 0
-    while Process.clock_gettime(Process::CLOCK_MONOTONIC, :second) < ending_time
-      result = yield
-      return result if result
-
-      retry_count += 1
-      remaining_time_budget = ending_time - Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
-      break if remaining_time_budget <= 0
-
-      delay = 2**retry_count
-      if delay >= remaining_time_budget
-        delay = remaining_time_budget
-        vprint_status("Final attempt. Sleeping for the remaining #{delay} seconds out of total timeout #{timeout}")
-      else
-        vprint_status("Sleeping for #{delay} seconds before attempting again")
-      end
-
-      sleep delay
-    end
-  end
-
   def exploit
     app_name = Rex::Text.rand_text_alpha(4..7)
     data = prepare_payload(app_name)
     upload_payload(data)
     execute_payload(app_name)
   end
-
 end

--- a/modules/exploits/multi/http/wso2_file_upload_rce.rb
+++ b/modules/exploits/multi/http/wso2_file_upload_rce.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_payload(app_name)
     res = nil
     print_status('Executing payload... ')
-    retry_until_true(timeout: datastore['WAR_DEPLOY_DELAY']) do
+    retry_until_truthy(timeout: datastore['WAR_DEPLOY_DELAY']) do
       print_status('Waiting for shell... ')
       res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path, app_name),

--- a/modules/exploits/multi/http/zabbix_script_exec.rb
+++ b/modules/exploits/multi/http/zabbix_script_exec.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::Retry
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
 
@@ -387,33 +388,4 @@ class MetasploitModule < Msf::Exploit::Remote
   ensure
     super
   end
-
-  # Retry the block until it returns a truthy value. Each iteration attempt will
-  # be performed with exponetial backoff. If the timeout period surpasses, false is returned.
-  def retry_until_true(timeout:)
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
-    ending_time = start_time + timeout
-    retry_count = 0
-    while Process.clock_gettime(Process::CLOCK_MONOTONIC, :second) < ending_time
-      result = yield
-      return result if result
-
-      retry_count += 1
-      remaining_time_budget = ending_time - Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
-      break if remaining_time_budget <= 0
-
-      delay = 2**retry_count
-      if delay >= remaining_time_budget
-        delay = remaining_time_budget
-        vprint_status("Final attempt. Sleeping for the remaining #{delay} seconds out of total timeout #{timeout}")
-      else
-        vprint_status("Sleeping for #{delay} seconds before attempting again")
-      end
-
-      sleep delay
-    end
-
-    false
-  end
-
 end

--- a/modules/exploits/multi/http/zabbix_script_exec.rb
+++ b/modules/exploits/multi/http/zabbix_script_exec.rb
@@ -184,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_script(auth_token, host_id, script_id)
     print_status('Executing the script...')
 
-    retry_until_true(timeout: datastore['TIMEOUT']) do
+    retry_until_truthy(timeout: datastore['TIMEOUT']) do
       params = {
         'scriptid' => script_id.to_s,
         'hostid' => host_id.to_s

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -8,6 +8,7 @@
 class MetasploitModule < Msf::Exploit
   Rank = ManualRanking
 
+  include Msf::Exploit::Retry
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HTTP::Kubernetes
@@ -282,33 +283,5 @@ class MetasploitModule < Msf::Exploit
 
     status = result&.dig(:error, 'status')
     fail_with(Failure::Unknown, "Status: #{status || 'Unknown'}") unless status == 'Success'
-  end
-
-  # Retry the block until it returns a truthy value. Each iteration attempt will
-  # be performed with expoential backoff. If the timeout period surpasses, false is returned.
-  def retry_until_true(timeout:)
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
-    ending_time = start_time + timeout
-    retry_count = 0
-    while Process.clock_gettime(Process::CLOCK_MONOTONIC, :second) < ending_time
-      result = yield
-      return result if result
-
-      retry_count += 1
-      remaining_time_budget = ending_time - Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
-      break if remaining_time_budget <= 0
-
-      delay = 2**retry_count
-      if delay >= remaining_time_budget
-        delay = remaining_time_budget
-        vprint_status("Final attempt. Sleeping for the remaining #{delay} seconds out of total timeout #{timeout}")
-      else
-        vprint_status("Sleeping for #{delay} seconds before attempting again")
-      end
-
-      sleep delay
-    end
-
-    false
   end
 end

--- a/modules/exploits/multi/kubernetes/exec.rb
+++ b/modules/exploits/multi/kubernetes/exec.rb
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Exploit
       print_good("Pod created: #{pod_name}")
 
       print_status('Waiting for the pod to be ready...')
-      ready = retry_until_true(timeout: datastore['PodReadyTimeout']) do
+      ready = retry_until_truthy(timeout: datastore['PodReadyTimeout']) do
         pod = @kubernetes_client.get_pod(pod_name, namespace)
         pod_status = pod[:status]
         next if pod_status == 'Failure'

--- a/spec/lib/msf/core/exploit/retry_spec.rb
+++ b/spec/lib/msf/core/exploit/retry_spec.rb
@@ -10,27 +10,123 @@ RSpec.describe Msf::Exploit::Retry do
   end
 
   describe '#retry_until_true' do
-    let(:timeout) { Proc.new { false } }
-
     subject do
       create_exploit
     end
 
-    it 'does not call the block if the timeout is negative' do
-      expect { |b| subject.retry_until_true(timeout: -1, &b) }.to_not yield_control
+    # Quick workaround for Timecop not supporting Process.clock_gettime
+    # Timecop feature request: https://github.com/travisjeffery/timecop/issues/220
+    let(:mock_clock) do
+      clazz = Class.new do
+        def initialize
+          @current_time = 0
+        end
+
+        def now
+          @current_time
+        end
+
+        def time_travel(new_time)
+          @current_time = new_time
+        end
+      end
+
+      clazz.new
     end
 
-    it 'does call the block if the timeout is positive' do
-      expect { |b| subject.retry_until_true(timeout: 1, &b) }.to yield_with_no_args
+    def increment_time_by(seconds)
+        mock_clock.time_travel(mock_clock.now + seconds)
     end
 
-    it 'returns false when the timeout elapses' do
-      expect(subject.retry_until_true(timeout: 1, &timeout)).to eq false
+    def expect_sleep_calls(calls)
+      expect(subject).to have_received(:sleep).exactly(calls.length).times
+      calls.each do |value|
+        expect(subject).to have_received(:sleep).with(value)
+      end
     end
 
-    it 'returns the block result' do
-      result = Object.new
-      expect(subject.retry_until_true(timeout: 1, &Proc.new { result })).to eq result
+    before(:each) do
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :second) { |*_args| mock_clock.now }
+      allow(subject).to receive(:sleep) { |seconds| increment_time_by(seconds) }
+    end
+
+    context 'when the timeout is negative' do
+      it 'does not yield control' do
+        result = nil
+        expect do |block|
+          result = subject.retry_until_true(timeout: -1, &block)
+        end.to_not yield_control
+        expect_sleep_calls([])
+        expect(result).to be false
+      end
+    end
+
+    context 'when the timeout is 0' do
+      it 'does not yield control' do
+        result = nil
+        expect do |block|
+          result = subject.retry_until_true(timeout: -1, &block)
+        end.to_not yield_control
+        expect_sleep_calls([])
+        expect(result).to be false
+      end
+    end
+
+    context 'when the timeout is 40' do
+      let(:timeout) { 40 }
+
+      it 'only yields once if the block takes longer than the allocated time' do
+        expect do |block|
+          subject.retry_until_true(timeout: timeout) do
+            block.to_proc.call
+            increment_time_by(timeout + 1)
+          end
+        end.to yield_control.once
+        expect_sleep_calls([])
+      end
+
+      it 'yields exponentially until the timeout has surpassed' do
+        result = nil
+        expect do |block|
+          result = subject.retry_until_true(timeout: timeout, &block)
+        end.to yield_control.exactly(5).times
+        expect_sleep_calls([2, 4, 8, 16, 10])
+        expect(result).to eq(false)
+      end
+
+      it 'returns the yielded value if it is immediately truthy' do
+        result = nil
+        expect do |block|
+          result = subject.retry_until_true(timeout: timeout) do
+            block.to_proc.call
+            :success
+          end
+        end.to yield_control.exactly(1).times
+        expect_sleep_calls([])
+        expect(result).to eq(:success)
+      end
+
+      it 'returns the yielded value if it is eventually truthy' do
+        result = nil
+        expect do |block|
+          result = subject.retry_until_true(timeout: timeout) do
+            block.to_proc.call
+            mock_clock.now >= 8
+          end
+        end.to yield_control.exactly(4).times
+        expect_sleep_calls([2, 4, 8])
+        expect(result).to eq(true)
+      end
+
+      it 'raises any unhandled exceptions' do
+        error = StandardError.new
+        expect do
+          subject.retry_until_true(timeout: timeout) do
+            raise error
+          end
+        end.to raise_error(error)
+        expect(subject).to_not have_received(:sleep)
+      end
     end
   end
 end

--- a/spec/lib/msf/core/exploit/retry_spec.rb
+++ b/spec/lib/msf/core/exploit/retry_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Msf::Exploit::Retry do
     mod
   end
 
-  describe '#retry_until_true' do
+  describe '#retry_until_truthy' do
     subject do
       create_exploit
     end
@@ -54,7 +54,7 @@ RSpec.describe Msf::Exploit::Retry do
       it 'does not yield control' do
         result = nil
         expect do |block|
-          result = subject.retry_until_true(timeout: -1, &block)
+          result = subject.retry_until_truthy(timeout: -1, &block)
         end.to_not yield_control
         expect_sleep_calls([])
         expect(result).to be_nil
@@ -65,7 +65,7 @@ RSpec.describe Msf::Exploit::Retry do
       it 'does not yield control' do
         result = nil
         expect do |block|
-          result = subject.retry_until_true(timeout: -1, &block)
+          result = subject.retry_until_truthy(timeout: -1, &block)
         end.to_not yield_control
         expect_sleep_calls([])
         expect(result).to be_nil
@@ -77,7 +77,7 @@ RSpec.describe Msf::Exploit::Retry do
 
       it 'only yields once if the block takes longer than the allocated time' do
         expect do |block|
-          subject.retry_until_true(timeout: timeout) do
+          subject.retry_until_truthy(timeout: timeout) do
             block.to_proc.call
             increment_time_by(timeout + 1)
           end
@@ -88,7 +88,7 @@ RSpec.describe Msf::Exploit::Retry do
       it 'yields exponentially until the timeout has surpassed' do
         result = nil
         expect do |block|
-          result = subject.retry_until_true(timeout: timeout, &block)
+          result = subject.retry_until_truthy(timeout: timeout, &block)
         end.to yield_control.exactly(5).times
         expect_sleep_calls([2, 4, 8, 16, 10])
         expect(result).to be_nil
@@ -97,7 +97,7 @@ RSpec.describe Msf::Exploit::Retry do
       it 'returns the yielded value if it is immediately truthy' do
         result = nil
         expect do |block|
-          result = subject.retry_until_true(timeout: timeout) do
+          result = subject.retry_until_truthy(timeout: timeout) do
             block.to_proc.call
             :success
           end
@@ -109,7 +109,7 @@ RSpec.describe Msf::Exploit::Retry do
       it 'returns the yielded value if it is eventually truthy' do
         result = nil
         expect do |block|
-          result = subject.retry_until_true(timeout: timeout) do
+          result = subject.retry_until_truthy(timeout: timeout) do
             block.to_proc.call
             mock_clock.now >= 8
           end
@@ -121,7 +121,7 @@ RSpec.describe Msf::Exploit::Retry do
       it 'raises any unhandled exceptions' do
         error = StandardError.new
         expect do
-          subject.retry_until_true(timeout: timeout) do
+          subject.retry_until_truthy(timeout: timeout) do
             raise error
           end
         end.to raise_error(error)

--- a/spec/lib/msf/core/exploit/retry_spec.rb
+++ b/spec/lib/msf/core/exploit/retry_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Retry do
+
+  def create_exploit(info = {})
+    mod = Msf::Exploit.allocate
+    mod.extend described_class
+    mod.send(:initialize, info)
+    mod
+  end
+
+  describe '#retry_until_true' do
+    let(:timeout) { Proc.new { false } }
+
+    subject do
+      create_exploit
+    end
+
+    it 'does not call the block if the timeout is negative' do
+      expect { |b| subject.retry_until_true(timeout: -1, &b) }.to_not yield_control
+    end
+
+    it 'does call the block if the timeout is positive' do
+      expect { |b| subject.retry_until_true(timeout: 1, &b) }.to yield_with_no_args
+    end
+
+    it 'returns false when the timeout elapses' do
+      expect(subject.retry_until_true(timeout: 1, &timeout)).to eq false
+    end
+
+    it 'returns the block result' do
+      result = Object.new
+      expect(subject.retry_until_true(timeout: 1, &Proc.new { result })).to eq result
+    end
+  end
+end

--- a/spec/lib/msf/core/exploit/retry_spec.rb
+++ b/spec/lib/msf/core/exploit/retry_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Msf::Exploit::Retry do
           result = subject.retry_until_true(timeout: -1, &block)
         end.to_not yield_control
         expect_sleep_calls([])
-        expect(result).to be false
+        expect(result).to be_nil
       end
     end
 
@@ -68,7 +68,7 @@ RSpec.describe Msf::Exploit::Retry do
           result = subject.retry_until_true(timeout: -1, &block)
         end.to_not yield_control
         expect_sleep_calls([])
-        expect(result).to be false
+        expect(result).to be_nil
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Msf::Exploit::Retry do
           result = subject.retry_until_true(timeout: timeout, &block)
         end.to yield_control.exactly(5).times
         expect_sleep_calls([2, 4, 8, 16, 10])
-        expect(result).to eq(false)
+        expect(result).to be_nil
       end
 
       it 'returns the yielded value if it is immediately truthy' do


### PR DESCRIPTION
This moves the `retry_until_true` function that's been copy-pasted into a few modules (some of which at my suggestion) into a dedicated library method. This particular method is super handy for waiting for some condition to be true before continuing on. Handy for waiting for something to have been deployed or whatever.

Also added a couple of specs for it, because I was writing specs today.

## Verification

The latest spring4shell module is probably the easiest to test this with since you can spin up a vulnerable docker container to use it.

- [ ] Start msfconsole
- [ ] Start a vulnerable docker container for Spring4Shell
- [ ] Use the Spring4Shell exploit module, and see that it still works
- [ ] See that the other three modules were using the exact same method, just with different timeout values