### PR TITLE
Update nessus.rb for Issue #16556

### DIFF
--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -348,7 +348,7 @@ module Msf
         case args.length
         when 1,2
           if args[0].include? "@"
-            cred,targ = args[0].split('@', 2)
+            cred,doesnotmatter,targ = args[0].rpartition('@')
             @user,@pass = cred.split(':', 2)
             targ ||= '127.0.0.1:8834'
             @host,@port = targ.split(':', 2)


### PR DESCRIPTION
Changed the line that parses the input for the nessus_connect password. It will now split the user input by the last occurrence of the at sign (@) instead of the first occurrence. This will prevent improperly parsed passwords due to an at sign (@) in the password.

## Verification

- change a password for a nessus user to something that contains an at sign (@) 
- start nessus
- start msfconsole
- load nessus
- connect to nessus using the following example
- nessus_connect test:tester@testing@localhost:8834 ssl_ignore
- it should connect properly