### PR TITLE
Juniper config processor enhancements

### DIFF
--- a/lib/msf/core/auxiliary/juniper.rb
+++ b/lib/msf/core/auxiliary/juniper.rb
@@ -3,257 +3,260 @@
 require 'metasploit/framework/hashes/identify'
 
 module Msf
-
 ###
 #
 # This module provides methods for working with Juniper equipment
 #
 ###
-module Auxiliary::Juniper
-  include Msf::Auxiliary::Report
+  module Auxiliary::Juniper
+    include Msf::Auxiliary::Report
 
-  def juniper_screenos_config_eater(thost, tport, config)
-    # this is for the netscreen OS, which came on SSG (ie SSG5) type devices.
-    # It is similar to cisco, however it doesn't always put all fields we care
-    # about on one line.
-    # Docs: snmp -> https://kb.juniper.net/InfoCenter/index?page=content&id=KB4223
-    #       ppp  -> https://kb.juniper.net/InfoCenter/index?page=content&id=KB22592
-    #       ike  -> https://kb.juniper.net/KB4147
-    #       https://github.com/h00die/MSF-Testing-Scripts/blob/master/juniper_strings.py#L171
+    def juniper_screenos_config_eater(thost, tport, config)
+      # this is for the netscreen OS, which came on SSG (ie SSG5) type devices.
+      # It is similar to cisco, however it doesn't always put all fields we care
+      # about on one line.
+      # Docs: snmp -> https://kb.juniper.net/InfoCenter/index?page=content&id=KB4223
+      #       ppp  -> https://kb.juniper.net/InfoCenter/index?page=content&id=KB22592
+      #       ike  -> https://kb.juniper.net/KB4147
+      #       https://github.com/h00die/MSF-Testing-Scripts/blob/master/juniper_strings.py#L171
 
-    report_host({
-      :host => thost,
-      :os_name => 'Juniper ScreenOS'
-    })
+      report_host({
+        host: thost,
+        os_name: 'Juniper ScreenOS'
+      })
 
-    if framework.db.active
-      credential_data = {
-        address: thost,
-        port: tport,
-        protocol: 'tcp',
-        workspace_id: myworkspace_id,
-        origin_type: :service,
-        service_name: '',
-        private_type: :nonreplayable_hash,
-        module_fullname: self.fullname,
-        status: Metasploit::Model::Login::Status::UNTRIED
-      }
-    end
-
-    store_loot('juniper.netscreen.config', 'text/plain', thost, config.strip, 'config.txt', 'Juniper Netscreen Configuration')
-
-    # admin name and password
-    # Example lines:
-    # set admin name "netscreen"
-    # set admin password "nKVUM2rwMUzPcrkG5sWIHdCtqkAibn"
-    config.scan(/set admin name "(?<admin_name>[a-z0-9]+)".+set admin password "(?<admin_password_hash>[a-z0-9]+)"/mi).each do |result|
-      admin_name = result[0].strip
-      admin_hash = result[1].strip
-      print_good("Admin user #{admin_name} found with password hash #{admin_hash}")
-      next unless framework.db.active
-      cred = credential_data.dup
-      cred[:username] = admin_name
-      cred[:private_data] = admin_hash
-      create_credential_and_login(cred)
-    end
-
-    # user account
-    # Example lines:
-    # set user "testuser" uid 1
-    # set user "testuser" type auth
-    # set user "testuser" hash-password "02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE="
-    # set user "testuser" enable
-    config.scan(/set user "(?<user_name>[a-z0-9]+)" uid (?<user_uid>\d+).+set user "\k<user_name>" type (?<user_type>\w+).+set user "\k<user_name>" hash-password "(?<user_hash>[0-9a-z=]{38})".+set user "\k<user_name>" (?<user_enable>enable).+/mi).each do |result|
-      user_name = result[0].strip
-      user_uid  = result[1].strip
-      user_enable = result[4].strip
-      user_hash = result[3].strip
-      print_good("User #{user_uid} named #{user_name} found with password hash #{user_hash}. Enable permission: #{user_enable}")
-      next unless framework.db.active
-      cred = credential_data.dup
-      cred[:username] = user_name
-      cred[:jtr_format] = 'sha1'
-      cred[:private_data] = user_hash
-      create_credential_and_login(cred)
-    end
-
-    # snmp
-    # Example lines:
-    # set snmp community "sales" Read-Write Trap-on traffic version v1
-    config.scan(/set snmp community "(?<snmp_community>[a-z0-9]+)" (?<snmp_permissions>Read-Write|Read-Only)/i).each do |result|
-      snmp_community = result[0].strip
-      snmp_permissions = result[1].strip
-      print_good("SNMP community #{snmp_community} with permissions #{snmp_permissions}")
-      next unless framework.db.active
-      cred = credential_data.dup
-      if snmp_permissions.downcase == 'read-write'
-        cred[:access_level] = 'RW'
-      else
-        cred[:access_level] = 'RO'
-      end
-      cred[:protocol] = 'udp'
-      cred[:port] = 161
-      cred[:service_name] = 'snmp'
-      cred[:private_data] = snmp_community
-      cred[:private_type] = :password
-      create_credential_and_login(cred)
-    end
-
-    # ppp
-    # Example lines:
-    # setppp profile "ISP" auth type pap
-    # setppp profile "ISP" auth local-name "username"
-    # setppp profile "ISP" auth secret "fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA=="
-    config.scan(/setppp profile "(?<ppp_name>[a-z0-9]+)" auth type (?<ppp_authtype>[a-z]+).+setppp profile "\k<ppp_name>" auth local-name "(?<ppp_username>[a-z0-9]+)".+setppp profile "\k<ppp_name>" auth secret "(?<ppp_hash>.+)"/mi).each do |result|
-      ppp_name = result[0].strip
-      ppp_username = result[2].strip
-      ppp_hash = result[3].strip
-      ppp_authtype = result[1].strip
-      print_good("PPTP Profile #{ppp_name} with username #{ppp_username} hash #{ppp_hash} via #{ppp_authtype}")
-      next unless framework.db.active
-      cred = credential_data.dup
-      cred[:username] = ppp_username
-      cred[:private_data] = ppp_hash
-      cred[:service_name] = 'pptp'
-      cred[:port] = 1723
-      create_credential_and_login(cred)
-    end
-
-    # ike
-    # Example lines:
-    # set ike gateway "To-Cisco" address 2.2.2.1 Main outgoing-interface "ethernet1" preshare "netscreen" proposal "pre-g2-des-sha"
-    config.scan(/set ike gateway "(?<ike_name>.+)" address (?<ike_address>[0-9.]+) Main outgoing-interface ".+" preshare "(?<ike_password>.+)" proposal "(?<ike_method>.+)"/i).each do |result|
-      ike_name = result[0].strip
-      ike_address = result[1].strip
-      ike_password = result[2].strip
-      ike_method = result[3].strip
-      print_good("IKE Profile #{ike_name} to #{ike_address} with password #{ike_password} via #{ike_method}")
-      next unless framework.db.active
-      cred = credential_data.dup
-      cred[:private_data] = ike_password
-      cred[:private_type] = :password
-      cred[:service_name] = 'ike'
-      cred[:port] = 500
-      cred[:address] = ike_address
-      cred[:protocol] = 'udp'
-      create_credential_and_login(cred)
-    end
-
-  end
-
-
-  def juniper_junos_config_eater(thost, tport, config)
-
-   report_host({
-      :host => thost,
-      :os_name => 'Juniper JunOS'
-    })
-
-
-    if framework.db.active
-      credential_data = {
-        address: thost,
-        port: tport,
-        protocol: 'tcp',
-        workspace_id: myworkspace_id,
-        origin_type: :service,
-        private_type: :nonreplayable_hash,
-        service_name: '',
-        module_fullname: self.fullname,
-        status: Metasploit::Model::Login::Status::UNTRIED
-      }
-    end
-
-    store_loot('juniper.junos.config', 'text/plain', thost, config.strip, 'config.txt', 'Juniper JunOS Configuration')
-
-    # we'll take out the pretty format so its easier to regex
-    config = config.split("\n").join('')
-
-    # Example:
-    #system {
-    #  root-authentication {
-    #    encrypted-password "$1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E."; ## SECRET-DATA
-    #  }
-    #}
-    if /root-authentication[\s]+\{[\s]+encrypted-password "(?<root_hash>[^"]+)";/i =~ config
-      root_hash = root_hash.strip
-      jtr_format = identify_hash root_hash
-
-      print_good("root password hash: #{root_hash}")
       if framework.db.active
+        credential_data = {
+          address: thost,
+          port: tport,
+          protocol: 'tcp',
+          workspace_id: myworkspace_id,
+          origin_type: :service,
+          service_name: '',
+          private_type: :nonreplayable_hash,
+          module_fullname: fullname,
+          status: Metasploit::Model::Login::Status::UNTRIED
+        }
+      end
+
+      store_loot('juniper.netscreen.config', 'text/plain', thost, config.strip, 'config.txt', 'Juniper Netscreen Configuration')
+
+      # admin name and password
+      # Example lines:
+      # set admin name "netscreen"
+      # set admin password "nKVUM2rwMUzPcrkG5sWIHdCtqkAibn"
+      config.scan(/set admin name "(?<admin_name>[a-z0-9]+)".+set admin password "(?<admin_password_hash>[a-z0-9]+)"/mi).each do |result|
+        admin_name = result[0].strip
+        admin_hash = result[1].strip
+        print_good("Admin user #{admin_name} found with password hash #{admin_hash}")
+        next unless framework.db.active
+
         cred = credential_data.dup
-        cred[:username] = 'root'
-        cred[:jtr_format] = jtr_format
-        cred[:private_data] = root_hash
+        cred[:username] = admin_name
+        cred[:private_data] = admin_hash
+        create_credential_and_login(cred)
+      end
+
+      # user account
+      # Example lines:
+      # set user "testuser" uid 1
+      # set user "testuser" type auth
+      # set user "testuser" hash-password "02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE="
+      # set user "testuser" enable
+      config.scan(/set user "(?<user_name>[a-z0-9]+)" uid (?<user_uid>\d+).+set user "\k<user_name>" type (?<user_type>\w+).+set user "\k<user_name>" hash-password "(?<user_hash>[0-9a-z=]{38})".+set user "\k<user_name>" (?<user_enable>enable).+/mi).each do |result|
+        user_name = result[0].strip
+        user_uid = result[1].strip
+        user_enable = result[4].strip
+        user_hash = result[3].strip
+        print_good("User #{user_uid} named #{user_name} found with password hash #{user_hash}. Enable permission: #{user_enable}")
+        next unless framework.db.active
+
+        cred = credential_data.dup
+        cred[:username] = user_name
+        cred[:jtr_format] = 'sha1'
+        cred[:private_data] = user_hash
+        create_credential_and_login(cred)
+      end
+
+      # snmp
+      # Example lines:
+      # set snmp community "sales" Read-Write Trap-on traffic version v1
+      config.scan(/set snmp community "(?<snmp_community>[a-z0-9]+)" (?<snmp_permissions>Read-Write|Read-Only)/i).each do |result|
+        snmp_community = result[0].strip
+        snmp_permissions = result[1].strip
+        print_good("SNMP community #{snmp_community} with permissions #{snmp_permissions}")
+        next unless framework.db.active
+
+        cred = credential_data.dup
+        if snmp_permissions.downcase == 'read-write'
+          cred[:access_level] = 'RW'
+        else
+          cred[:access_level] = 'RO'
+        end
+        cred[:protocol] = 'udp'
+        cred[:port] = 161
+        cred[:service_name] = 'snmp'
+        cred[:private_data] = snmp_community
+        cred[:private_type] = :password
+        create_credential_and_login(cred)
+      end
+
+      # ppp
+      # Example lines:
+      # setppp profile "ISP" auth type pap
+      # setppp profile "ISP" auth local-name "username"
+      # setppp profile "ISP" auth secret "fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA=="
+      config.scan(/setppp profile "(?<ppp_name>[a-z0-9]+)" auth type (?<ppp_authtype>[a-z]+).+setppp profile "\k<ppp_name>" auth local-name "(?<ppp_username>[a-z0-9]+)".+setppp profile "\k<ppp_name>" auth secret "(?<ppp_hash>.+)"/mi).each do |result|
+        ppp_name = result[0].strip
+        ppp_username = result[2].strip
+        ppp_hash = result[3].strip
+        ppp_authtype = result[1].strip
+        print_good("PPTP Profile #{ppp_name} with username #{ppp_username} hash #{ppp_hash} via #{ppp_authtype}")
+        next unless framework.db.active
+
+        cred = credential_data.dup
+        cred[:username] = ppp_username
+        cred[:private_data] = ppp_hash
+        cred[:service_name] = 'pptp'
+        cred[:port] = 1723
+        create_credential_and_login(cred)
+      end
+
+      # ike
+      # Example lines:
+      # set ike gateway "To-Cisco" address 2.2.2.1 Main outgoing-interface "ethernet1" preshare "netscreen" proposal "pre-g2-des-sha"
+      config.scan(/set ike gateway "(?<ike_name>.+)" address (?<ike_address>[0-9.]+) Main outgoing-interface ".+" preshare "(?<ike_password>.+)" proposal "(?<ike_method>.+)"/i).each do |result|
+        ike_name = result[0].strip
+        ike_address = result[1].strip
+        ike_password = result[2].strip
+        ike_method = result[3].strip
+        print_good("IKE Profile #{ike_name} to #{ike_address} with password #{ike_password} via #{ike_method}")
+        next unless framework.db.active
+
+        cred = credential_data.dup
+        cred[:private_data] = ike_password
+        cred[:private_type] = :password
+        cred[:service_name] = 'ike'
+        cred[:port] = 500
+        cred[:address] = ike_address
+        cred[:protocol] = 'udp'
         create_credential_and_login(cred)
       end
     end
 
-    # access privileges https://kb.juniper.net/InfoCenter/index?page=content&id=KB10902
-    config.scan(/user (?<user_name>[^\s]+) {[\s]+ uid (?<user_uid>[\d]+);[\s]+ class (?<user_permission>super-user|operator|read-only|unauthorized);[\s]+ authentication {[\s]+encrypted-password "(?<user_hash>[^\s]+)";/i).each do |result|
-      user_name = result[0].strip
-      user_uid  = result[1].strip
-      user_permission = result[2].strip
-      user_hash = result[3].strip
-      jtr_format = identify_hash user_hash
+    def juniper_junos_config_eater(thost, tport, config)
+     report_host({
+       host: thost,
+        os_name: 'Juniper JunOS'
+     })
 
-      print_good("User #{user_uid} named #{user_name} in group #{user_permission} found with password hash #{user_hash}.")
-      next unless framework.db.active
-      cred = credential_data.dup
-      cred[:username] = user_name
-      cred[:jtr_format] = jtr_format
-      cred[:private_data] = user_hash
-      create_credential_and_login(cred)
+
+     if framework.db.active
+       credential_data = {
+         address: thost,
+         port: tport,
+         protocol: 'tcp',
+         workspace_id: myworkspace_id,
+         origin_type: :service,
+         private_type: :nonreplayable_hash,
+         service_name: '',
+         module_fullname: fullname,
+         status: Metasploit::Model::Login::Status::UNTRIED
+       }
+     end
+
+     store_loot('juniper.junos.config', 'text/plain', thost, config.strip, 'config.txt', 'Juniper JunOS Configuration')
+
+      # we'll take out the pretty format so its easier to regex
+     config = config.split("\n").join('')
+
+      # Example:
+      # system {
+      #  root-authentication {
+      #    encrypted-password "$1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E."; ## SECRET-DATA
+      #  }
+      # }
+     if /root-authentication\s+\{\s+encrypted-password "(?<root_hash>[^"]+)";/i =~ config
+       root_hash = root_hash.strip
+       jtr_format = identify_hash root_hash
+
+       print_good("root password hash: #{root_hash}")
+       if framework.db.active
+         cred = credential_data.dup
+         cred[:username] = 'root'
+         cred[:jtr_format] = jtr_format
+         cred[:private_data] = root_hash
+         create_credential_and_login(cred)
+       end
+     end
+
+      # access privileges https://kb.juniper.net/InfoCenter/index?page=content&id=KB10902
+     config.scan(/user (?<user_name>[^\s]+) {\s+ uid (?<user_uid>\d+);\s+ class (?<user_permission>super-user|operator|read-only|unauthorized);\s+ authentication {\s+encrypted-password "(?<user_hash>[^\s]+)";/i).each do |result|
+       user_name = result[0].strip
+       user_uid = result[1].strip
+       user_permission = result[2].strip
+       user_hash = result[3].strip
+       jtr_format = identify_hash user_hash
+
+       print_good("User #{user_uid} named #{user_name} in group #{user_permission} found with password hash #{user_hash}.")
+       next unless framework.db.active
+
+       cred = credential_data.dup
+       cred[:username] = user_name
+       cred[:jtr_format] = jtr_format
+       cred[:private_data] = user_hash
+       create_credential_and_login(cred)
+     end
+
+      # https://supportf5.com/csp/article/K6449 special characters allowed in snmp community strings
+     config.scan(%r{community "?(?<snmp_community>[\w\d\s().*/-:_?=@,&%$]+)"? {(\s+view [\w\-]+;)?\s+authorization read-(?<snmp_permission>only|write)}i).each do |result|
+       snmp_community = result[0].strip
+       snmp_permissions = result[1].strip
+       print_good("SNMP community #{snmp_community} with permissions read-#{snmp_permissions}")
+       next unless framework.db.active
+
+       cred = credential_data.dup
+       if snmp_permissions.downcase == 'write'
+         cred[:access_level] = 'RW'
+       else
+         cred[:access_level] = 'RO'
+       end
+       cred[:protocol] = 'udp'
+       cred[:port] = 161
+       cred[:private_data] = snmp_community
+       cred[:private_type] = :password
+       cred[:service_name] = 'snmp'
+       create_credential_and_login(cred)
+     end
+
+     config.scan(/radius-server \{\s+(?<radius_server>[0-9.]{7,15}) secret "(?<radius_hash>[^"]+)";/i).each do |result|
+       radius_hash = result[1].strip
+       radius_server = result[0].strip
+       print_good("radius server #{radius_server} password hash: #{radius_hash}")
+       next unless framework.db.active
+
+       cred = credential_data.dup
+       cred[:address] = radius_server
+       cred[:port] = 1812
+       cred[:protocol] = 'udp'
+       cred[:private_data] = radius_hash
+       cred[:service_name] = 'radius'
+       create_credential_and_login(cred)
+     end
+
+     config.scan(/pap {\s+local-name "(?<ppp_username>.+)";\s+local-password "(?<ppp_hash>[^"]+)";/i).each do |result|
+       ppp_username = result[0].strip
+       ppp_hash = result[1].strip
+       print_good("PPTP username #{ppp_username} hash #{ppp_hash} via PAP")
+       next unless framework.db.active
+
+       cred = credential_data.dup
+       cred[:username] = ppp_username
+       cred[:private_data] = ppp_hash
+       cred[:service_name] = 'pptp'
+       cred[:port] = 1723
+       create_credential_and_login(cred)
+     end
     end
-
-    # https://supportf5.com/csp/article/K6449 special characters allowed in snmp community strings
-    config.scan(/community "?(?<snmp_community>[\w\d\s\(\)\.\*\/-:_\?=@\,&%\$]+)"? {(\s+view [\w\-]+;)?\s+authorization read-(?<snmp_permission>only|write)/i).each do |result|
-      snmp_community = result[0].strip
-      snmp_permissions = result[1].strip
-      print_good("SNMP community #{snmp_community} with permissions read-#{snmp_permissions}")
-      next unless framework.db.active
-      cred = credential_data.dup
-      if snmp_permissions.downcase == 'write'
-        cred[:access_level] = 'RW'
-      else
-        cred[:access_level] = 'RO'
-      end
-      cred[:protocol] = 'udp'
-      cred[:port] = 161
-      cred[:private_data] = snmp_community
-      cred[:private_type] = :password
-      cred[:service_name] = 'snmp'
-      create_credential_and_login(cred)
-    end
-
-    config.scan(/radius-server \{[\s]+(?<radius_server>[0-9\.]{7,15}) secret "(?<radius_hash>[^"]+)";/i).each do |result|
-      radius_hash = result[1].strip
-      radius_server = result[0].strip
-      print_good("radius server #{radius_server} password hash: #{radius_hash}")
-      next unless framework.db.active
-      cred = credential_data.dup
-      cred[:address] = radius_server
-      cred[:port] = 1812
-      cred[:protocol] = 'udp'
-      cred[:private_data] = radius_hash
-      cred[:service_name] = 'radius'
-      create_credential_and_login(cred)
-    end
-
-    config.scan(/pap {[\s]+local-name "(?<ppp_username>.+)";[\s]+local-password "(?<ppp_hash>[^"]+)";/i).each do |result|
-      ppp_username = result[0].strip
-      ppp_hash = result[1].strip
-      print_good("PPTP username #{ppp_username} hash #{ppp_hash} via PAP")
-      next unless framework.db.active
-      cred = credential_data.dup
-      cred[:username] = ppp_username
-      cred[:private_data] = ppp_hash
-      cred[:service_name] = 'pptp'
-      cred[:port] = 1723
-      create_credential_and_login(cred)
-    end
-
   end
 end
-end
-

--- a/spec/lib/msf/core/auxiliary/juniper_spec.rb
+++ b/spec/lib/msf/core/auxiliary/juniper_spec.rb
@@ -1,31 +1,36 @@
 # -*- coding: binary -*-
-require 'spec_helper'
 
+require 'spec_helper'
 
 RSpec.describe Msf::Auxiliary::Juniper do
   class DummyJuniperClass
     include Msf::Auxiliary::Juniper
     def framework
       Msf::Simple::Framework.create(
-          'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,
-          # don't load any module paths so we can just load the module under test and save time
-          'DeferModuleLoads' => true
+        'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,
+        # don't load any module paths so we can just load the module under test and save time
+        'DeferModuleLoads' => true
       )
     end
+
     def active_db?
       true
     end
-    def print_good(str=nil)
-      raise StandardError.new("This method needs to be stubbed.")
+
+    def print_good(_str = nil)
+      raise StandardError, 'This method needs to be stubbed.'
     end
-    def store_cred(hsh=nil)
-      raise StandardError.new("This method needs to be stubbed.")
+
+    def store_cred(_hsh = nil)
+      raise StandardError, 'This method needs to be stubbed.'
     end
+
     def fullname
-      "auxiliary/scanner/snmp/juniper_dummy"
+      'auxiliary/scanner/snmp/juniper_dummy'
     end
+
     def myworkspace
-      raise StandardError.new("This method needs to be stubbed.")
+      raise StandardError, 'This method needs to be stubbed.'
     end
   end
 
@@ -34,12 +39,11 @@ RSpec.describe Msf::Auxiliary::Juniper do
   let!(:workspace) { FactoryBot.create(:mdm_workspace) }
 
   context '#create_credential_and_login' do
-
     let(:session) { FactoryBot.create(:mdm_session) }
 
-    let(:task) { FactoryBot.create(:mdm_task, workspace: workspace)}
+    let(:task) { FactoryBot.create(:mdm_task, workspace: workspace) }
 
-    let(:user) { FactoryBot.create(:mdm_user)}
+    let(:user) { FactoryBot.create(:mdm_user) }
 
     subject(:test_object) { DummyJuniperClass.new }
 
@@ -47,7 +51,7 @@ RSpec.describe Msf::Auxiliary::Juniper do
     let(:service) { FactoryBot.create(:mdm_service, host: FactoryBot.create(:mdm_host, workspace: workspace)) }
     let(:task) { FactoryBot.create(:mdm_task, workspace: workspace) }
 
-    let(:login_data) {
+    let(:login_data) do
       {
         address: service.host.address,
         port: service.port,
@@ -63,12 +67,12 @@ RSpec.describe Msf::Auxiliary::Juniper do
         private_type: :nonreplayable_hash,
         status: Metasploit::Model::Login::Status::UNTRIED
       }
-    }
+    end
 
     it 'creates a Metasploit::Credential::Login' do
-      expect{test_object.create_credential_and_login(login_data)}.to change{Metasploit::Credential::Login.count}.by(1)
+      expect { test_object.create_credential_and_login(login_data) }.to change { Metasploit::Credential::Login.count }.by(1)
     end
-    it "associates the Metasploit::Credential::Core with a task if passed" do
+    it 'associates the Metasploit::Credential::Core with a task if passed' do
       login = test_object.create_credential_and_login(login_data.merge(task_id: task.id))
       expect(login.tasks).to include(task)
     end
@@ -81,164 +85,159 @@ RSpec.describe Msf::Auxiliary::Juniper do
 
     it 'deals with admin credentials' do
       expect(aux_juniper).to receive(:print_good).with('Admin user netscreen found with password hash nKVUM2rwMUzPcrkG5sWIHdCtqkAibn')
-      expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
+      expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper ScreenOS' })
       expect(aux_juniper).to receive(:create_credential_and_login).with(
         {
-          address: "127.0.0.1",
+          address: '127.0.0.1',
           port: 161,
-          protocol: "tcp",
+          protocol: 'tcp',
           workspace_id: workspace.id,
           origin_type: :service,
           service_name: '',
-          module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-          username: "netscreen",
-          private_data: "nKVUM2rwMUzPcrkG5sWIHdCtqkAibn",
+          module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+          username: 'netscreen',
+          private_data: 'nKVUM2rwMUzPcrkG5sWIHdCtqkAibn',
           private_type: :nonreplayable_hash,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
-      aux_juniper.juniper_screenos_config_eater('127.0.0.1',161,
-        "set admin name \"netscreen\"\n" <<
-        "set admin password \"nKVUM2rwMUzPcrkG5sWIHdCtqkAibn\"\n")
+      aux_juniper.juniper_screenos_config_eater('127.0.0.1', 161,
+                                                "set admin name \"netscreen\"\n" <<
+                                                "set admin password \"nKVUM2rwMUzPcrkG5sWIHdCtqkAibn\"\n")
     end
 
     it 'deals with user account with password hash' do
       expect(aux_juniper).to receive(:print_good).with('User 1 named testuser found with password hash 02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE=. Enable permission: enable')
-      expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
-      expect(aux_juniper).to receive(:store_loot).with("juniper.netscreen.config", "text/plain", "127.0.0.1",
-          "set user \"testuser\" uid 1\n" <<
-          "set user \"testuser\" type auth\n" <<
-          "set user \"testuser\" hash-password \"02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE=\"\n" <<
-          "set user \"testuser\" enable",
-        "config.txt", "Juniper Netscreen Configuration"
-      )
+      expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper ScreenOS' })
+      expect(aux_juniper).to receive(:store_loot).with('juniper.netscreen.config', 'text/plain', '127.0.0.1',
+                                                       "set user \"testuser\" uid 1\n" <<
+                                                       "set user \"testuser\" type auth\n" <<
+                                                       "set user \"testuser\" hash-password \"02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE=\"\n" <<
+                                                       'set user "testuser" enable',
+                                                       'config.txt', 'Juniper Netscreen Configuration')
       expect(aux_juniper).to receive(:create_credential_and_login).with(
         {
-          address: "127.0.0.1",
+          address: '127.0.0.1',
           port: 1337,
-          protocol: "tcp",
+          protocol: 'tcp',
           workspace_id: workspace.id,
           origin_type: :service,
           service_name: '',
-          module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-          username: "testuser",
-          jtr_format: "sha1",
-          private_data: "02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE=",
+          module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+          username: 'testuser',
+          jtr_format: 'sha1',
+          private_data: '02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE=',
           private_type: :nonreplayable_hash,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
 
-      aux_juniper.juniper_screenos_config_eater('127.0.0.1',1337,
-        "set user \"testuser\" uid 1\n" <<
-        "set user \"testuser\" type auth\n" <<
-        "set user \"testuser\" hash-password \"02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE=\"\n" <<
-        "set user \"testuser\" enable\n")
+      aux_juniper.juniper_screenos_config_eater('127.0.0.1', 1337,
+                                                "set user \"testuser\" uid 1\n" <<
+                                                "set user \"testuser\" type auth\n" <<
+                                                "set user \"testuser\" hash-password \"02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE=\"\n" <<
+                                                "set user \"testuser\" enable\n")
     end
 
     context 'deals with snmp-server community' do
-
       it 'with Read permission' do
         expect(aux_juniper).to receive(:print_good).with('SNMP community sales with permissions Read-Only')
-        expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper ScreenOS' })
         expect(aux_juniper).to receive(:create_credential_and_login).with(
           {
-            address: "127.0.0.1",
+            address: '127.0.0.1',
             port: 161,
-            protocol: "udp",
+            protocol: 'udp',
             workspace_id: workspace.id,
             origin_type: :service,
             service_name: 'snmp',
-            module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-            private_data: "sales",
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            private_data: 'sales',
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED,
             access_level: 'RO'
           }
         )
-        aux_juniper.juniper_screenos_config_eater('127.0.0.1',1337,'set snmp community "sales" Read-Only Trap-on traffic version v1')
+        aux_juniper.juniper_screenos_config_eater('127.0.0.1', 1337, 'set snmp community "sales" Read-Only Trap-on traffic version v1')
       end
 
       it 'with Read-Write permission' do
         expect(aux_juniper).to receive(:print_good).with('SNMP community sales with permissions Read-Write')
-        expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper ScreenOS' })
         expect(aux_juniper).to receive(:create_credential_and_login).with(
           {
-            address: "127.0.0.1",
+            address: '127.0.0.1',
             port: 161,
-            protocol: "udp",
+            protocol: 'udp',
             workspace_id: workspace.id,
             origin_type: :service,
             service_name: 'snmp',
-            module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-            private_data: "sales",
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            private_data: 'sales',
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED,
             access_level: 'RW'
           }
         )
-        aux_juniper.juniper_screenos_config_eater('127.0.0.1',1337,'set snmp community "sales" Read-Write Trap-on traffic version v1')
+        aux_juniper.juniper_screenos_config_eater('127.0.0.1', 1337, 'set snmp community "sales" Read-Write Trap-on traffic version v1')
       end
-
     end
 
     it 'deals with ppp configurations' do
       expect(aux_juniper).to receive(:print_good).with('PPTP Profile ISP with username username hash fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA== via pap')
-      expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
+      expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper ScreenOS' })
       expect(aux_juniper).to receive(:store_loot).with(
-        "juniper.netscreen.config", "text/plain", "127.0.0.1",
-          "setppp profile \"ISP\" auth type pap\n" <<
-          "setppp profile \"ISP\" auth local-name \"username\"\n" <<
-          "setppp profile \"ISP\" auth secret \"fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA==\"",
-        "config.txt", "Juniper Netscreen Configuration"
+        'juniper.netscreen.config', 'text/plain', '127.0.0.1',
+        "setppp profile \"ISP\" auth type pap\n" <<
+        "setppp profile \"ISP\" auth local-name \"username\"\n" <<
+        'setppp profile "ISP" auth secret "fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA=="',
+        'config.txt', 'Juniper Netscreen Configuration'
       )
       expect(aux_juniper).to receive(:create_credential_and_login).with(
         {
-          address: "127.0.0.1",
+          address: '127.0.0.1',
           port: 1723,
-          protocol: "tcp",
+          protocol: 'tcp',
           workspace_id: workspace.id,
           origin_type: :service,
           service_name: 'pptp',
-          module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-          username: "username",
-          private_data: "fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA==",
+          module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+          username: 'username',
+          private_data: 'fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA==',
           private_type: :nonreplayable_hash,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
-      aux_juniper.juniper_screenos_config_eater('127.0.0.1',1337,
-        "setppp profile \"ISP\" auth type pap\n" <<
-        "setppp profile \"ISP\" auth local-name \"username\"\n" <<
-        "setppp profile \"ISP\" auth secret \"fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA==\"\n"
-      )
+      aux_juniper.juniper_screenos_config_eater('127.0.0.1', 1337,
+                                                "setppp profile \"ISP\" auth type pap\n" <<
+                                                "setppp profile \"ISP\" auth local-name \"username\"\n" <<
+                                                "setppp profile \"ISP\" auth secret \"fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA==\"\n")
     end
 
     it 'deals with ike configurations' do
       expect(aux_juniper).to receive(:print_good).with('IKE Profile To-Cisco to 2.2.2.1 with password netscreen via pre-g2-des-sha')
-      expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
+      expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper ScreenOS' })
       expect(aux_juniper).to receive(:store_loot).with(
-        "juniper.netscreen.config", "text/plain", "127.0.0.1",
-        "set ike gateway \"To-Cisco\" address 2.2.2.1 Main outgoing-interface \"ethernet1\" preshare \"netscreen\" proposal \"pre-g2-des-sha\"",
-        "config.txt", "Juniper Netscreen Configuration"
+        'juniper.netscreen.config', 'text/plain', '127.0.0.1',
+        'set ike gateway "To-Cisco" address 2.2.2.1 Main outgoing-interface "ethernet1" preshare "netscreen" proposal "pre-g2-des-sha"',
+        'config.txt', 'Juniper Netscreen Configuration'
       )
       expect(aux_juniper).to receive(:create_credential_and_login).with(
         {
-          address: "2.2.2.1",
+          address: '2.2.2.1',
           port: 500,
-          protocol: "udp",
+          protocol: 'udp',
           workspace_id: workspace.id,
           origin_type: :service,
           service_name: 'ike',
-          module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-          private_data: "netscreen",
+          module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+          private_data: 'netscreen',
           private_type: :password,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
-      aux_juniper.juniper_screenos_config_eater('127.0.0.1',1337,'set ike gateway "To-Cisco" address 2.2.2.1 Main outgoing-interface "ethernet1" preshare "netscreen" proposal "pre-g2-des-sha"')
+      aux_juniper.juniper_screenos_config_eater('127.0.0.1', 1337, 'set ike gateway "To-Cisco" address 2.2.2.1 Main outgoing-interface "ethernet1" preshare "netscreen" proposal "pre-g2-des-sha"')
     end
-
   end
 
   context '#juniper_junos_config_eater' do
@@ -248,63 +247,61 @@ RSpec.describe Msf::Auxiliary::Juniper do
 
     it 'deals with root credentials' do
       expect(aux_juniper).to receive(:print_good).with('root password hash: $1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E.')
-      expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
-      #expect(aux_juniper).to receive(:store_loot).with(
+      expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
+      # expect(aux_juniper).to receive(:store_loot).with(
       #  "juniper.netscreen.config", "text/plain", "127.0.0.1", "enable password 1511021F0725", "config.txt", "Cisco IOS Configuration"
-      #)
+      # )
       expect(aux_juniper).to receive(:create_credential_and_login).with(
         {
-          address: "127.0.0.1",
+          address: '127.0.0.1',
           port: 161,
-          protocol: "tcp",
+          protocol: 'tcp',
           workspace_id: workspace.id,
           origin_type: :service,
           service_name: '',
-          module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-          username: "root",
-          private_data: "$1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E.",
-          jtr_format: "md5",
+          module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+          username: 'root',
+          private_data: '$1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E.',
+          jtr_format: 'md5',
           private_type: :nonreplayable_hash,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
-      aux_juniper.juniper_junos_config_eater('127.0.0.1',161,
-        %q(system {
+      aux_juniper.juniper_junos_config_eater('127.0.0.1', 161,
+                                             %q(system {
              root-authentication {
                encrypted-password "$1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E."; ## SECRET-DATA
              }
            }
-        )
-      )
+        ))
     end
 
     context 'deals with user account with password hash' do
       it 'with super-user' do
         expect(aux_juniper).to receive(:print_good).with('User 2000 named newuser in group super-user found with password hash $1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/.')
-        expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
-        expect(aux_juniper).to receive(:store_loot).with("juniper.junos.config", "text/plain", "127.0.0.1",
-          "system {\n                 login {\n                     user newuser {\n                         uid 2000;\n                         class super-user;\n                         authentication {\n                             encrypted-password \"$1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/\"; ## SECRET-DATA\n                         }\n                     }\n                 }\n             }",
-          "config.txt", "Juniper JunOS Configuration"
-        )
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
+        expect(aux_juniper).to receive(:store_loot).with('juniper.junos.config', 'text/plain', '127.0.0.1',
+                                                         "system {\n                 login {\n                     user newuser {\n                         uid 2000;\n                         class super-user;\n                         authentication {\n                             encrypted-password \"$1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/\"; ## SECRET-DATA\n                         }\n                     }\n                 }\n             }",
+                                                         'config.txt', 'Juniper JunOS Configuration')
         expect(aux_juniper).to receive(:create_credential_and_login).with(
           {
-            address: "127.0.0.1",
+            address: '127.0.0.1',
             port: 1337,
-            protocol: "tcp",
+            protocol: 'tcp',
             workspace_id: workspace.id,
             origin_type: :service,
             service_name: '',
-            module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-            username: "newuser",
-            jtr_format: "md5",
-            private_data: "$1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/",
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            username: 'newuser',
+            jtr_format: 'md5',
+            private_data: '$1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/',
             private_type: :nonreplayable_hash,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
 
-        aux_juniper.juniper_junos_config_eater('127.0.0.1',1337,
-          %q(system {
+        aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                               %q(system {
                  login {
                      user newuser {
                          uid 2000;
@@ -315,36 +312,34 @@ RSpec.describe Msf::Auxiliary::Juniper do
                      }
                  }
              }
-          )
-        )
+          ))
       end
 
       it 'with operator' do
         expect(aux_juniper).to receive(:print_good).with('User 2002 named newuser2 in group operator found with password hash $1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0.')
-        expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
-        expect(aux_juniper).to receive(:store_loot).with("juniper.junos.config", "text/plain", "127.0.0.1",
-          "system {\n                 login {\n                     user newuser2 {\n                         uid 2002;\n                         class operator;\n                         authentication {\n                             encrypted-password \"$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0\"; ## SECRET-DATA\n                         }\n                     }\n                 }\n             }",
-          "config.txt", "Juniper JunOS Configuration"
-        )
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
+        expect(aux_juniper).to receive(:store_loot).with('juniper.junos.config', 'text/plain', '127.0.0.1',
+                                                         "system {\n                 login {\n                     user newuser2 {\n                         uid 2002;\n                         class operator;\n                         authentication {\n                             encrypted-password \"$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0\"; ## SECRET-DATA\n                         }\n                     }\n                 }\n             }",
+                                                         'config.txt', 'Juniper JunOS Configuration')
         expect(aux_juniper).to receive(:create_credential_and_login).with(
           {
-            address: "127.0.0.1",
+            address: '127.0.0.1',
             port: 1337,
-            protocol: "tcp",
+            protocol: 'tcp',
             workspace_id: workspace.id,
             origin_type: :service,
             service_name: '',
-            module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-            username: "newuser2",
-            jtr_format: "md5",
-            private_data: "$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0",
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            username: 'newuser2',
+            jtr_format: 'md5',
+            private_data: '$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0',
             private_type: :nonreplayable_hash,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
 
-        aux_juniper.juniper_junos_config_eater('127.0.0.1',1337,
-          %q(system {
+        aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                               %q(system {
                  login {
                      user newuser2 {
                          uid 2002;
@@ -355,36 +350,73 @@ RSpec.describe Msf::Auxiliary::Juniper do
                      }
                  }
              }
-          )
-        )
+          ))
       end
 
-      it 'with read-only' do
-        expect(aux_juniper).to receive(:print_good).with('User 2003 named newuser3 in group read-only found with password hash $1$1.YvKzUY$dcAj99KngGhFZTpxGjA93..')
-        expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
-        expect(aux_juniper).to receive(:store_loot).with("juniper.junos.config", "text/plain", "127.0.0.1",
-          "system {\n                 login {\n                     user newuser3 {\n                         uid 2003;\n                         class read-only;\n                         authentication {\n                             encrypted-password \"$1$1.YvKzUY$dcAj99KngGhFZTpxGjA93.\"; ## SECRET-DATA\n                         }\n                     }\n                 }\n             }",
-          "config.txt", "Juniper JunOS Configuration"
-        )
+      it 'with a full-name and custom class' do
+        expect(aux_juniper).to receive(:print_good).with('User 2002 named newuser2 in group EXAMPLE found with password hash $1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0.')
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
+        expect(aux_juniper).to receive(:store_loot).with('juniper.junos.config', 'text/plain', '127.0.0.1',
+                                                         "system {\n            login {\n                user newuser2 {\n                    full-name \"test\";\n                    uid 2002;\n                    class EXAMPLE;\n                    authentication {\n                        encrypted-password \"$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0\"; ## SECRET-DATA\n                    }\n                }\n            }\n        }",
+                                                         'config.txt', 'Juniper JunOS Configuration')
         expect(aux_juniper).to receive(:create_credential_and_login).with(
           {
-            address: "127.0.0.1",
+            address: '127.0.0.1',
             port: 1337,
-            protocol: "tcp",
+            protocol: 'tcp',
             workspace_id: workspace.id,
             origin_type: :service,
             service_name: '',
-            module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-            username: "newuser3",
-            jtr_format: "md5",
-            private_data: "$1$1.YvKzUY$dcAj99KngGhFZTpxGjA93.",
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            username: 'newuser2',
+            jtr_format: 'md5',
+            private_data: '$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0',
             private_type: :nonreplayable_hash,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
 
-        aux_juniper.juniper_junos_config_eater('127.0.0.1',1337,
-          %q(system {
+        aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                               %q(system {
+            login {
+                user newuser2 {
+                    full-name "test";
+                    uid 2002;
+                    class EXAMPLE;
+                    authentication {
+                        encrypted-password "$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0"; ## SECRET-DATA
+                    }
+                }
+            }
+        }
+     ))
+      end
+
+      it 'with read-only' do
+        expect(aux_juniper).to receive(:print_good).with('User 2003 named newuser3 in group read-only found with password hash $1$1.YvKzUY$dcAj99KngGhFZTpxGjA93..')
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
+        expect(aux_juniper).to receive(:store_loot).with('juniper.junos.config', 'text/plain', '127.0.0.1',
+                                                         "system {\n                 login {\n                     user newuser3 {\n                         uid 2003;\n                         class read-only;\n                         authentication {\n                             encrypted-password \"$1$1.YvKzUY$dcAj99KngGhFZTpxGjA93.\"; ## SECRET-DATA\n                         }\n                     }\n                 }\n             }",
+                                                         'config.txt', 'Juniper JunOS Configuration')
+        expect(aux_juniper).to receive(:create_credential_and_login).with(
+          {
+            address: '127.0.0.1',
+            port: 1337,
+            protocol: 'tcp',
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            username: 'newuser3',
+            jtr_format: 'md5',
+            private_data: '$1$1.YvKzUY$dcAj99KngGhFZTpxGjA93.',
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
+          }
+        )
+
+        aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                               %q(system {
                  login {
                      user newuser3 {
                          uid 2003;
@@ -395,36 +427,34 @@ RSpec.describe Msf::Auxiliary::Juniper do
                      }
                  }
              }
-          )
-        )
+          ))
       end
 
       it 'with unauthorized' do
         expect(aux_juniper).to receive(:print_good).with('User 2004 named newuser4 in group unauthorized found with password hash $1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/.')
-        expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
-        expect(aux_juniper).to receive(:store_loot).with("juniper.junos.config", "text/plain", "127.0.0.1",
-          "system {\n                 login {\n                     user newuser4 {\n                         uid 2004;\n                         class unauthorized;\n                         authentication {\n                             encrypted-password \"$1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/\"; ## SECRET-DATA\n                         }\n                     }\n                 }\n             }",
-          "config.txt", "Juniper JunOS Configuration"
-        )
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
+        expect(aux_juniper).to receive(:store_loot).with('juniper.junos.config', 'text/plain', '127.0.0.1',
+                                                         "system {\n                 login {\n                     user newuser4 {\n                         uid 2004;\n                         class unauthorized;\n                         authentication {\n                             encrypted-password \"$1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/\"; ## SECRET-DATA\n                         }\n                     }\n                 }\n             }",
+                                                         'config.txt', 'Juniper JunOS Configuration')
         expect(aux_juniper).to receive(:create_credential_and_login).with(
           {
-            address: "127.0.0.1",
+            address: '127.0.0.1',
             port: 1337,
-            protocol: "tcp",
+            protocol: 'tcp',
             workspace_id: workspace.id,
             origin_type: :service,
             service_name: '',
-            module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-            username: "newuser4",
-            jtr_format: "md5",
-            private_data: "$1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/",
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            username: 'newuser4',
+            jtr_format: 'md5',
+            private_data: '$1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/',
             private_type: :nonreplayable_hash,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
 
-        aux_juniper.juniper_junos_config_eater('127.0.0.1',1337,
-          %q(system {
+        aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                               %q(system {
                  login {
                      user newuser4 {
                          uid 2004;
@@ -435,160 +465,176 @@ RSpec.describe Msf::Auxiliary::Juniper do
                      }
                  }
              }
-          )
-        )
+          ))
       end
-
     end
 
     context 'deals with snmp-server community' do
-
       it 'with Read permissions' do
         expect(aux_juniper).to receive(:print_good).with('SNMP community read with permissions read-only')
-        expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
         expect(aux_juniper).to receive(:create_credential_and_login).with(
           {
-            address: "127.0.0.1",
+            address: '127.0.0.1',
             port: 161,
-            protocol: "udp",
+            protocol: 'udp',
             workspace_id: workspace.id,
             origin_type: :service,
             service_name: 'snmp',
-            module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-            private_data: "read",
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            private_data: 'read',
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED,
             access_level: 'RO'
           }
         )
-        aux_juniper.juniper_junos_config_eater('127.0.0.1',1337,
-          %q(snmp {
+        aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                               %q(snmp {
                  community read {
                      authorization read-only;
                  }
              }
-          )
-        )
+          ))
       end
 
       it 'with Read-Write permissions and view' do
         expect(aux_juniper).to receive(:print_good).with('SNMP community write with permissions read-write')
-        expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
         expect(aux_juniper).to receive(:create_credential_and_login).with(
           {
-            address: "127.0.0.1",
+            address: '127.0.0.1',
             port: 161,
-            protocol: "udp",
+            protocol: 'udp',
             workspace_id: workspace.id,
             origin_type: :service,
             service_name: 'snmp',
-            module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-            private_data: "write",
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            private_data: 'write',
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED,
             access_level: 'RW'
           }
         )
-        aux_juniper.juniper_junos_config_eater('127.0.0.1',1337,
-          %q(snmp {
+        aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                               %q(snmp {
                  community write {
                      view jweb-view-all;
                      authorization read-write;
                  }
              }
-          )
-        )
+          ))
       end
 
       it 'with a space in the community string' do
         expect(aux_juniper).to receive(:print_good).with('SNMP community hello there with permissions read-write')
-        expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
         expect(aux_juniper).to receive(:create_credential_and_login).with(
           {
-            address: "127.0.0.1",
+            address: '127.0.0.1',
             port: 161,
-            protocol: "udp",
+            protocol: 'udp',
             workspace_id: workspace.id,
             origin_type: :service,
             service_name: 'snmp',
-            module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-            private_data: "hello there",
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            private_data: 'hello there',
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED,
             access_level: 'RW'
           }
         )
-        aux_juniper.juniper_junos_config_eater('127.0.0.1',1337,
-          %q(snmp {
+        aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                               %q(snmp {
                  community "hello there" {
                      authorization read-write;
                  }
              }
-          )
-        )
+          ))
       end
 
-
+      it 'with special characters in the community string' do
+        expect(aux_juniper).to receive(:print_good).with('SNMP community aAa321$+!AaAaaa with permissions read-only')
+        expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
+        expect(aux_juniper).to receive(:create_credential_and_login).with(
+          {
+            address: '127.0.0.1',
+            port: 161,
+            protocol: 'udp',
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: 'snmp',
+            module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+            private_data: 'aAa321$+!AaAaaa',
+            private_type: :password,
+            status: Metasploit::Model::Login::Status::UNTRIED,
+            access_level: 'RO'
+          }
+        )
+        aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                               %q(snmp {
+                 community "aAa321$+!AaAaaa" {
+                     authorization read-only;
+                 }
+             }
+          ))
+      end
     end
 
     it 'deals with radius' do
       expect(aux_juniper).to receive(:print_good).with('radius server 1.1.1.1 password hash: $9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV')
-      expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
-      expect(aux_juniper).to receive(:store_loot).with("juniper.junos.config", "text/plain", "127.0.0.1",
-        "access {\n              radius-server {\n                  1.1.1.1 secret \"$9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV\"; ## SECRET-DATA\n              }\n           }",
-        "config.txt", "Juniper JunOS Configuration"
-      )
+      expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
+      expect(aux_juniper).to receive(:store_loot).with('juniper.junos.config', 'text/plain', '127.0.0.1',
+                                                       "access {\n              radius-server {\n                  1.1.1.1 secret \"$9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV\"; ## SECRET-DATA\n              }\n           }",
+                                                       'config.txt', 'Juniper JunOS Configuration')
       expect(aux_juniper).to receive(:create_credential_and_login).with(
         {
-          address: "1.1.1.1",
+          address: '1.1.1.1',
           port: 1812,
-          protocol: "udp",
+          protocol: 'udp',
           workspace_id: workspace.id,
           origin_type: :service,
           service_name: 'radius',
-          module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-          private_data: "$9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV",
+          module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+          private_data: '$9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV',
           private_type: :nonreplayable_hash,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
-      aux_juniper.juniper_junos_config_eater('127.0.0.1',1337,
-        %q(access {
+      aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                             %q(access {
               radius-server {
                   1.1.1.1 secret "$9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV"; ## SECRET-DATA
               }
            }
-        )
-      )
+        ))
     end
 
     it 'deals with pap' do
       expect(aux_juniper).to receive(:print_good).with('PPTP username \'pap_username\' hash $9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR via PAP')
-      expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
-      expect(aux_juniper).to receive(:store_loot).with("juniper.junos.config", "text/plain", "127.0.0.1",
-        "interfaces {\n               pp0 {\n                   unit 0 {\n                       ppp-options {\n                           pap {\n                               local-name \"'pap_username'\";\n                               local-password \"$9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR\"; ## SECRET-DATA\n                           }\n                      }\n                  }\n               }\n           }",
-        "config.txt", "Juniper JunOS Configuration"
-      )
-      #expect(aux_juniper).to receive(:store_loot).with(
+      expect(aux_juniper).to receive(:report_host).with({ host: '127.0.0.1', os_name: 'Juniper JunOS' })
+      expect(aux_juniper).to receive(:store_loot).with('juniper.junos.config', 'text/plain', '127.0.0.1',
+                                                       "interfaces {\n               pp0 {\n                   unit 0 {\n                       ppp-options {\n                           pap {\n                               local-name \"'pap_username'\";\n                               local-password \"$9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR\"; ## SECRET-DATA\n                           }\n                      }\n                  }\n               }\n           }",
+                                                       'config.txt', 'Juniper JunOS Configuration')
+      # expect(aux_juniper).to receive(:store_loot).with(
       #  "cisco.ios.config", "text/plain", "127.0.0.1", "password 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
-      #)
+      # )
       expect(aux_juniper).to receive(:create_credential_and_login).with(
         {
-          address: "127.0.0.1",
+          address: '127.0.0.1',
           port: 1723,
-          protocol: "tcp",
+          protocol: 'tcp',
           workspace_id: workspace.id,
           origin_type: :service,
           service_name: 'pptp',
-          module_fullname: "auxiliary/scanner/snmp/juniper_dummy",
-          private_data: "$9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR",
+          module_fullname: 'auxiliary/scanner/snmp/juniper_dummy',
+          private_data: '$9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR',
           username: "'pap_username'",
           private_type: :nonreplayable_hash,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
-      aux_juniper.juniper_junos_config_eater('127.0.0.1',1337,
-        %q(interfaces {
+      aux_juniper.juniper_junos_config_eater('127.0.0.1', 1337,
+                                             %q(interfaces {
                pp0 {
                    unit 0 {
                        ppp-options {
@@ -600,11 +646,7 @@ RSpec.describe Msf::Auxiliary::Juniper do
                   }
                }
            }
-       )
-      )
+       ))
     end
-
   end
-
-
 end


### PR DESCRIPTION
fixes #16552

Fixes the user, tacas, radius, and snmp sections. also cleans up the formatting

To test this module:

- [ ] ensure spec passes `bundle exec rspec spec/lib/msf/core/auxiliary/juniper_spec.rb`
- [ ] See testing notes below for running module.

## Test Run

Use the following file as test data, which is based on the [outdated one](https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/juniper_ex2200.config):

<details>
<summary>Test Data based on Outdated juniper_ex2200.config</summary>

```
show configuration 
## Last commit: 2016-08-15 13:35:48 UTC by root
version 12.3R7.7;
system {
    host-name h00dieJuniperEx2200;
    root-authentication {
        encrypted-password "$1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E."; ## SECRET-DATA
    }
    tacplus-server {
        1.1.1.1 secret "$9$aaAAAAAeAA1AAAb2AAjAqmAA"; ## SECRET-DATA
        2.2.2.2 secret "$9$aaaAa/1aAAAa1aaaAAaa11aAA"; ## SECRET-DATA
    }
    login {
        class EXAMPLE {
            idle-timeout 10;
            permissions all;
        }
        user newuser {
            uid 2000;
            class super-user;
            authentication {
                encrypted-password "$1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/"; ## SECRET-DATA
            }
        }
        user newuser2 {
            uid 2002;
            class operator;
            authentication {
                encrypted-password "$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0"; ## SECRET-DATA
            }
        }
        user newuser3 {
            uid 2003;
            class read-only;
            authentication {
                encrypted-password "$1$1.YvKzUY$dcAj99KngGhFZTpxGjA93."; ## SECRET-DATA
            }
        }
        user newuser4 {
            uid 2004;
            class unauthorized;
            authentication {
                encrypted-password "$1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/"; ## SECRET-DATA
            }
        }
        user newuser5 {
            uid 2005;
            class EXAMPLE;
            authentication {
                encrypted-password "$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0"; ## SECRET-DATA
            }
        }
        user newuser6 {
            full-name "full name";
            uid 2006;
            class EXAMPLE;
            authentication {
                encrypted-password "$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0"; ## SECRET-DATA
            }
        }
    }
    services {
        ssh {
            root-login allow;
        }
        web-management {
            http;
        }
        dhcp {
            traceoptions {
                file dhcp_logfile;
                level all;
                flag all;
            }
            pool 192.168.10.0/24 {
                address-range low 192.168.10.2 high 192.168.10.254;
            }
        }
    }
    syslog {
        user * {
            any emergency;
        }
        file messages {
            any notice;
            authorization info;
        }
        file interactive-commands {
            interactive-commands any;
        }
    }
}
chassis {
    alarm {
        management-ethernet {
            link-down ignore;
        }
    }
    auto-image-upgrade;
}
interfaces {
    ge-0/0/0 {
        unit 0 {
            family inet {
                address 192.168.1.3/32;
            }
        }
    }
    ge-0/0/1 {
        unit 0 {
            family inet {
                address 192.168.1.4/32;
            }
        }
    }
    ge-0/0/2 {
        unit 0 {
            family inet {
                address 192.168.1.5/24;
            }
        }
    }
    ge-0/0/3 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/4 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/5 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/6 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/7 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/8 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/9 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/10 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/11 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/12 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/13 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/14 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/15 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/16 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/17 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/18 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/19 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/20 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/21 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/22 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/23 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/24 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/25 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/26 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/27 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/28 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/29 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/30 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/31 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/32 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/33 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/34 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/35 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/36 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/37 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/38 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/39 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/40 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/41 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/42 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/43 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/44 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/45 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/46 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/0/47 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/1/0 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/1/1 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/1/2 {
        unit 0 {
            family ethernet-switching;
        }
    }
    ge-0/1/3 {
        unit 0 {
            family ethernet-switching;
        }
    }
    me0 {
        unit 0 {
            family inet {
                address 192.168.1.1/24;
            }
        }
    }
    pp0 {
        unit 0 {
            ppp-options {
                pap {
                    local-name "'pap_username'";
                    local-password "$9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR"; ## SECRET-DATA
                }
            }
        }
    }
    st0 {
        unit 1;
    }
    vlan {
        unit 0 {
            family inet {
                dhcp {
                    vendor-id Juniper-ex2200-48t-4g;
                }
            }
        }
    }
}
snmp {
    name "snmp name";
    description "snmp description";
    location basement;
    contact admin;
    view jweb-view-all {
        oid .1 include;
    }
    community read {
        authorization read-only;
    }
    community write {
        view jweb-view-all;
        authorization read-write;
    }
    community public {
        authorization read-only;
    }
    community private {
        authorization read-write;
    }
    community secretsauce {
        authorization read-write;
    }
    community "hello there" {
        authorization read-write;
    }
    community "aAa321$+!AaAaaa" {
        authorization read-write;
    }
}
routing-options {
    static {
        route 0.0.0.0/0 next-hop 192.168.1.254;
    }
}
protocols {
    igmp-snooping {
        vlan all;
    }
    rstp;
    lldp {
        interface all;
    }
    lldp-med {
        interface all;
    }
}
access {
    radius-server {
        1.1.1.1 secret "$9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV"; ## SECRET-DATA
    }
}
ethernet-switching-options {
    storm-control {
        interface all;
    }
}
vlans {
    default {
        l3-interface vlan.0;
    }
}

{master:0}
newuser@h00dieJuniperEx2200>
```
</details>

Now run it with the following command (adjust for file location):
```
use auxiliary/admin/networking/juniper_config
set rhosts 127.0.0.1
set config /tmp/juniper.config
```

### Pre

```
[*] Running module against 127.0.0.1

[*] Importing config
[+] root password hash: $1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E.
[+] User 2000 named newuser in group super-user found with password hash $1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/.
[+] User 2002 named newuser2 in group operator found with password hash $1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0.
[+] User 2003 named newuser3 in group read-only found with password hash $1$1.YvKzUY$dcAj99KngGhFZTpxGjA93..
[+] User 2004 named newuser4 in group unauthorized found with password hash $1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/.
[+] SNMP community read with permissions read-only
[+] SNMP community write with permissions read-write
[+] SNMP community public with permissions read-only
[+] SNMP community private with permissions read-write
[+] SNMP community secretsauce with permissions read-write
[+] SNMP community hello there with permissions read-write
[+] radius server 1.1.1.1 password hash: $9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV
[+] PPTP username 'pap_username' hash $9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR via PAP
[+] Config import successful
[*] Auxiliary module execution completed
```

### Post

```
[*] Running module against 127.0.0.1

[*] Importing config
[+] root password hash: $1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E.
[+] User 2000 named newuser in group super-user found with password hash $1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/.
[+] User 2002 named newuser2 in group operator found with password hash $1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0.
[+] User 2003 named newuser3 in group read-only found with password hash $1$1.YvKzUY$dcAj99KngGhFZTpxGjA93..
[+] User 2004 named newuser4 in group unauthorized found with password hash $1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/.
[+] User 2005 named newuser5 in group EXAMPLE found with password hash $1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0.
[+] User 2006 named newuser6 in group EXAMPLE found with password hash $1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0.
[+] SNMP community read with permissions read-only
[+] SNMP community write with permissions read-write
[+] SNMP community public with permissions read-only
[+] SNMP community private with permissions read-write
[+] SNMP community secretsauce with permissions read-write
[+] SNMP community hello there with permissions read-write
[+] SNMP community aAa321$+!AaAaaa with permissions read-write
[+] radius server 1.1.1.1 password hash: $9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV
[+] tacplus server 1.1.1.1 with password hash $9$aaAAAAAeAA1AAAb2AAjAqmAA
[+] tacplus server 2.2.2.2 with password hash $9$aaaAa/1aAAAa1aaaAAaa11aAA
[+] PPTP username 'pap_username' hash $9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR via PAP
[+] Config import successful
[*] Auxiliary module execution completed
```

Note that we are now processing the following things which we had previously missed: `newuser5`, `newuser6` , `[+] SNMP community aAa321$+!AaAaaa with permissions read-write`, and the 2 `tacplus` lines.