### PR TITLE
Don't raise a space violation exception when space is 0

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -284,7 +284,9 @@ class EncodedPayload
         ilog("#{pinst.refname}: payload contains no badchars, skipping automatic encoding", 'core', LEV_0)
       end
 
-      if reqs['Space'] and (reqs['Space'] < raw.length + min)
+      # Space = 0 is a special value used by msfvenom to generate the smallest payload possible, int that case do not
+      # raise an exception indicating that the payload is too large.
+      if reqs['Space'] && reqs['Space'] > 0 && reqs['Space'] < raw.length + min
         wlog("#{pinst.refname}: Raw (unencoded) payload is too large (#{raw.length} bytes)", 'core', LEV_1)
         raise PayloadSpaceViolation, 'The payload exceeds the specified space', caller
       end


### PR DESCRIPTION
This change will prevent the `PayloadSpaceViolation` exception from being raised when space is not a positive integer. The `msfvenom` utility sets the space to 0 when the `--smallest` flag is set, which would cause this exception to be thrown. This allows 0 to continue to be used as the special value indicating that the smallest payload possible should be generated.

Fixes #16471 
Related to #16228

## Verification

List the steps needed to make sure this thing works

- [x] Run: `./msfvenom -p windows/meterpreter/reverse_tcp LHOST=192.168.159.128 --smallest`
- [x] See it complete successfully

Without this change, the following error would be displayed:

```
./msfvenom -p windows/meterpreter/reverse_tcp LHOST=192.168.159.128 --smallest
[-] No platform was selected, choosing Msf::Module::Platform::Windows from the payload
[-] No arch selected, selecting arch: x86 from the payload
Error: The payload exceeds the specified space
```