### PR TITLE
Add loading test modules page

### DIFF
--- a/docs/navigation.rb
+++ b/docs/navigation.rb
@@ -639,6 +639,9 @@ NAVIGATION_CONFIG = [
           {
             path: 'Writing-Module-Documentation.md'
           },
+          {
+            path: 'Loading-Test-Modules.md'
+          }
         ]
       },
       {


### PR DESCRIPTION
Add an entry for loading Metasploit test modules that was added by @gwillcox-r7 

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/60357436/168784703-7b1b4d72-6172-4bf4-9fa7-7555d2be799b.png">

## Verification

- Ensure CI Passes