### PR TITLE
Check size for compatibility with powershell

### DIFF
--- a/modules/payloads/adapters/cmd/windows/powershell.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell.rb
@@ -24,6 +24,16 @@ module MetasploitModule
     )
   end
 
+  def compatible?(mod)
+    # size is not unlimited due to the standard command length limit, the final size depends on the options that are
+    # configured but 3,000 is in a good range (can go up to 4,000 with default settings at this time)
+    if mod.type == Msf::MODULE_PAYLOAD && (mod.class.const_defined?(:CachedSize) && mod.class::CachedSize != :dynamic) && (mod.class::CachedSize >= 3_000)
+      return false
+    end
+
+    super
+  end
+
   def generate
     payload = super
 

--- a/modules/payloads/adapters/cmd/windows/powershell/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell/x64.rb
@@ -24,6 +24,16 @@ module MetasploitModule
     )
   end
 
+  def compatible?(mod)
+    # size is not unlimited due to the standard command length limit, the final size depends on the options that are
+    # configured but 3,000 is in a good range (can go up to 4,000 with default settings at this time)
+    if mod.type == Msf::MODULE_PAYLOAD && (mod.class.const_defined?(:CachedSize) && mod.class::CachedSize != :dynamic) && (mod.class::CachedSize >= 3_000)
+      return false
+    end
+
+    super
+  end
+
   def generate
     payload = super
 


### PR DESCRIPTION
This adds a check to the two new Powershell adapter payload modules. The size check intends to ensure that payloads that are too large (like unstaged Meterpreters) are marked as incompatible. Without this change in place, the `tools/modules/update_payload_cached_sizes.rb` script was failing to execute successfully.

For the size, I landed on 3,000 because the space is largely dependent on the datastore options like if the bypasses are prepended, the method, inner / outer encoding settings etc. 4,000 worked reliably but IIRC there's not alot of payload in the size range of 3,000-4,000 so it seemed better to err on the side of smaller. It's possible that the theoretical size adjustment ratio could also change due to updates to the rex-powershell repo. The size is pretty dynamic, and all the adapted payloads are marked as dynamic.

Fixes #16582

# Testing

- [ ] Run `tools/modules/update_payload_cached_sizes.rb`
- [ ] Do not see the `Powershell command length is greater than the command line maximum (8192 characters) (Rex::Powershell::Exceptions::PowershellCommandLengthError)` error

It's possible there maybe other errors within that tool but I'm pretty sure the one I'm seeing is unrelated and can be tracked separately.