### PR TITLE
Fix error when service is already running and update exception documentation in lib/msf/core/post/windows/services.rb

### DIFF
--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -294,6 +294,7 @@ module Services
   # Mode is a string with either auto, manual or disable for the
   # corresponding setting. The name of the service is case sensitive.
   #
+  # @raise [RuntimeError] if an invalid startup mode is provided in the mode parameter
   #
   def service_change_startup(name, mode, server=nil)
     if mode.is_a? Integer
@@ -338,6 +339,8 @@ module Services
   #
   # @return [GetLastError] 0 if the function succeeds
   #
+  # @raise [RuntimeError] if OpenSCManagerA failed
+  #
   def service_change_config(name, opts, server=nil)
     open_sc_manager(:host=>server, :access=>"SC_MANAGER_CONNECT") do |manager|
       open_service_handle(manager, name, "SERVICE_CHANGE_CONFIG") do |service_handle|
@@ -368,6 +371,8 @@ module Services
   #   remote localhost
   #
   # @return [GetLastError] 0 if the function succeeds
+  #
+  # @raise [RuntimeError] if OpenSCManagerA failed
   #
   def service_create(name, opts, server=nil)
     access = "SC_MANAGER_CONNECT | SC_MANAGER_CREATE_SERVICE | SC_MANAGER_QUERY_LOCK_STATUS"
@@ -465,6 +470,8 @@ module Services
   #
   # @param (see #service_start)
   #
+  # @raise [RuntimeError] if OpenServiceA failed
+  #
   def service_delete(name, server=nil)
     open_sc_manager(:host=>server) do |manager|
       open_service_handle(manager, name, "DELETE") do |service_handle|
@@ -482,7 +489,6 @@ module Services
   # @return {} representing lpServiceStatus
   #
   # @raise (see #service_start)
-  #
   #
   def service_status(name, server=nil)
     ret = nil
@@ -513,53 +519,41 @@ module Services
   #
   # @return [Boolean] indicating success
   #
-  #
-  def service_restart(name, start_type=START_TYPE_AUTO, server=nil)
-    tried = false
+  def service_restart(name, start_type=START_TYPE_AUTO, server=nil, should_retry=true)
+    status = service_start(name, server)
 
-    begin
-      status = service_start(name, server)
+    if status == Error::SUCCESS
+      vprint_good("[#{name}] Service started")
+      return true
+    end
 
-      if status == Error::SUCCESS
-        vprint_good("[#{name}] Service started")
-        return true
-      else
-        raise status.to_s
-      end
-    rescue RuntimeError => s
-      if tried
-        vprint_error("[#{name}] Unhandled error: #{s}")
-        return false
-      else
-        tried = true
-      end
 
-      case s.message.to_i
-      when Error::ACCESS_DENIED
-        vprint_error("[#{name}] Access denied")
-      when Error::INVALID_HANDLE
-        vprint_error("[#{name}] Invalid handle")
-      when Error::PATH_NOT_FOUND
-        vprint_error("[#{name}] Service binary could not be found")
-      when Error::SERVICE_ALREADY_RUNNING
-        vprint_status("[#{name}] Service already running attempting to stop and restart")
-        stopped = service_stop(name, server)
-        if ((stopped == Error::SUCCESS) || (stopped == Error::SERVICE_NOT_ACTIVE))
-          retry
-        else
-          vprint_error("[#{name}] Service disabled, unable to change start type Error: #{stopped}")
-        end
-      when Error::SERVICE_DISABLED
-        vprint_status("[#{name}] Service disabled attempting to set to manual")
-        if (service_change_config(name, {:starttype => start_type}, server) == Error::SUCCESS)
-          retry
-        else
-          vprint_error("[#{name}] Service disabled, unable to change start type")
-        end
+    case status
+    when Error::ACCESS_DENIED
+      vprint_error("[#{name}] Access denied")
+    when Error::INVALID_HANDLE
+      vprint_error("[#{name}] Invalid handle")
+    when Error::PATH_NOT_FOUND
+      vprint_error("[#{name}] Service binary could not be found")
+    when Error::SERVICE_ALREADY_RUNNING
+      vprint_status("[#{name}] Service already running attempting to stop and restart")
+      stopped = service_stop(name, server)
+      if ((stopped == Error::SUCCESS) || (stopped == Error::SERVICE_NOT_ACTIVE))
+        service_restart(name, start_type, server, false) if should_retry
       else
-        vprint_error("[#{name}] Unhandled error: #{s}")
-        return false
+        vprint_error("[#{name}] Service disabled, unable to change start type Error: #{stopped}")
       end
+    when Error::SERVICE_DISABLED
+      vprint_status("[#{name}] Service disabled attempting to set to manual")
+      if (service_change_config(name, {:starttype => start_type}, server) == Error::SUCCESS)
+        service_restart(name, start_type, server, false) if should_retry
+      else
+        vprint_error("[#{name}] Service disabled, unable to change start type")
+      end
+    else
+      status = WindowsError::Win32.find_by_retval(s).first
+      vprint_error("[#{name}] Unhandled error: #{status.name}: #{status.description}")
+      return false
     end
   end
 

--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -425,7 +425,7 @@ module Services
       open_service_handle(manager, name, "SERVICE_START") do |service_handle|
         retval = advapi32.StartServiceA(service_handle,0,nil)
         if retval["GetLastError"] == Error::SERVICE_ALREADY_RUNNING
-          return Error::SERVICE_ALREADY_RUNNING.to_s
+          raise Error::SERVICE_ALREADY_RUNNING.to_s
         end
 
         return retval["GetLastError"]

--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -424,6 +424,9 @@ module Services
     open_sc_manager(:host=>server, :access=>"SC_MANAGER_CONNECT") do |manager|
       open_service_handle(manager, name, "SERVICE_START") do |service_handle|
         retval = advapi32.StartServiceA(service_handle,0,nil)
+        if retval["GetLastError"] == Error::SERVICE_ALREADY_RUNNING
+          return Error::SERVICE_ALREADY_RUNNING.to_s
+        end
 
         return retval["GetLastError"]
       end

--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -424,9 +424,6 @@ module Services
     open_sc_manager(:host=>server, :access=>"SC_MANAGER_CONNECT") do |manager|
       open_service_handle(manager, name, "SERVICE_START") do |service_handle|
         retval = advapi32.StartServiceA(service_handle,0,nil)
-        if retval["GetLastError"] == Error::SERVICE_ALREADY_RUNNING
-          raise Error::SERVICE_ALREADY_RUNNING.to_s
-        end
 
         return retval["GetLastError"]
       end
@@ -527,7 +524,7 @@ module Services
         vprint_good("[#{name}] Service started")
         return true
       else
-        raise status
+        raise status.to_s
       end
     rescue RuntimeError => s
       if tried


### PR DESCRIPTION
Fixes #16603 

https://github.com/rapid7/metasploit-framework/blob/20198a2ff5b7939f97ab1952b59d899409dd6fdb/lib/msf/core/post/windows/services.rb#L517-L564

https://github.com/rapid7/metasploit-framework/blob/20198a2ff5b7939f97ab1952b59d899409dd6fdb/lib/msf/core/post/windows/services.rb#L423-L431

`service_start()` function should return Error::SERVICE_ALREADY_RUNNING as string or raise Error::SERVICE_ALREADY_RUNNING, to get catch by `rescue RuntimeError => s` block and don't raise an error.

I suppose raising an error is better, since the function will keep returning only Integer.