### PR TITLE
Solicited multicast-address creation bugfix

### DIFF
--- a/lib/msf/core/exploit/remote/ipv6.rb
+++ b/lib/msf/core/exploit/remote/ipv6.rb
@@ -251,13 +251,8 @@ module Exploit::Remote::Ipv6
   # From Jon Hart's Racket::L3::Misc#soll_mcast_addr6(),
   # which is from DDniele Belluci
   def ipv6_soll_mcast_addr6(addr)
-    h = addr.split(':')[-2, 2]
-    m = []
-    m << 'ff'
-    m << (h[0].to_i(16) & 0xff).to_s(16)
-    m << ((h[1].to_i(16) & (0xff << 8)) >> 8).to_s(16)
-    m << (h[1].to_i(16) & 0xff).to_s(16)
-    'ff02::1:' + [m[0,2].join, m[2,2].join].join(':')
+    solicited_address = -> {h = addr.split(':')[-2, 2]; m = []; x = h[0]; x[0..1] = 'ff'; m << x; x = h[1]; x.sub!(/^0*/, ""); m << x; 'ff02::1:' + m.join(':')}  
+    solicited_address.call()
   end
 
   # From Jon Hart's Racket::L3::Misc#soll_mcast_mac()

--- a/lib/msf/core/exploit/remote/ipv6.rb
+++ b/lib/msf/core/exploit/remote/ipv6.rb
@@ -251,8 +251,15 @@ module Exploit::Remote::Ipv6
   # From Jon Hart's Racket::L3::Misc#soll_mcast_addr6(),
   # which is from DDniele Belluci
   def ipv6_soll_mcast_addr6(addr)
-    solicited_address = -> {h = addr.split(':')[-2, 2]; m = []; x = h[0]; x[0..1] = 'ff'; m << x; x = h[1]; x.sub!(/^0*/, ""); m << x; 'ff02::1:' + m.join(':')}  
-    solicited_address.call()
+    h = addr.split(':')[-2, 2]
+    m = []  
+    x = h[0]
+    x[0..1] = 'ff'
+    m << x
+    x = h[1]
+    x.sub!(/^0*/, "")
+    m << x
+    'ff02::1:' + m.join(':')
   end
 
   # From Jon Hart's Racket::L3::Misc#soll_mcast_mac()


### PR DESCRIPTION
Fixes #16614
- This change is fixing solicited-multicast address creation, by finding leading zeros in last 16 bits of link-local address and removing them. 

- This change is also follows with fully rewritten function to easier logic for understanding. 

## Reference to issue

- Fixes #16614

## Verification

- copy ```ipv6_soll_mcast_addr6``` function and make changes according to code down below and save it as ruby file:

```ruby
def ipv6_soll_mcast_addr6(addr)
    h = addr.split(':')[-2, 2]
    m = []  
    x = h[0]
    x[0..1] = 'ff'
    m << x
    x = h[1]
    x.sub!(/^0*/, "")
    m << x
    puts 'ff02::1:' + m.join(':')
end

ipv6_soll_mcast_addr6("fe80::200:00ff:fe00:0002")
``` 

- run ruby file
```bash 
ruby file_name.rb
```
- output
```bash
ff02::1:ff00:2
```