### PR TITLE
fix race condition when scanning short ranges

### DIFF
--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptString.new('SHOST', [false, "Source IP Address"]),
         OptString.new('SMAC', [false, "Source MAC Address"]),
+        OptInt.new('TIMEOUT', [true, 'The number of seconds to wait for new data', 5]),
     ])
 
     deregister_options('SNAPLEN', 'FILTER')
@@ -74,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
 
-      etime = ::Time.now.to_f + [1, hosts.length * 0.05].max
+      etime = ::Time.now.to_f + datastore['TIMEOUT']
 
       while (::Time.now.to_f < etime)
         while(reply = getreply())

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
 
-      etime = ::Time.now.to_f + 1
+      etime = ::Time.now.to_f + [1, hosts.length * 0.05].max
 
       while (::Time.now.to_f < etime)
         while(reply = getreply())

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
 
-      etime = ::Time.now.to_f + (hosts.length * 0.05)
+      etime = ::Time.now.to_f + 1
 
       while (::Time.now.to_f < etime)
         while(reply = getreply())


### PR DESCRIPTION
- This change fix race condition in ARP while scanning hosts 

## Reference to Issue

-  #16616

## Verification without changes

- run ```./msfconsole```

- use ```ipv6_neighbor.rb``` module without changes. 

- set rhosts ```10.0.0.1-6```

- run module ```run or exploit```

### Current behavior
```
[*] Discovering IPv4 nodes via ARP...
[+]           10.0.0.2 ALIVE
[*] Discovering IPv6 addresses for IPv4 nodes...
[*] 
[*] Scanned 6 of 6 hosts (100% complete)
[*] Auxiliary module execution completed
```
## Verification with changes

- run ```./msfconsole```

- use ```ipv6_neighbor.rb``` module with changes. 

- set rhosts ```10.0.0.1-6```

- run module ```run or exploit```

### Fixed behavior
```
[*] Discovering IPv4 nodes via ARP...
[+]           10.0.0.2 ALIVE
[+]           10.0.0.6 ALIVE
[*] Discovering IPv6 addresses for IPv4 nodes...
[*] 
[*] Scanned 6 of 6 hosts (100% complete)
[*] Auxiliary module execution completed
```

