### PR TITLE
fix of improper neighbor advertisement filtering in ipv6_neighbor.rb

### DIFF
--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -210,7 +210,7 @@ class MetasploitModule < Msf::Auxiliary
     p = PacketFu::Packet.parse(pkt)
     return unless p.is_ipv6?
     return unless p.ipv6_next == 0x3a
-    return unless p.payload[0,2] == "\x88\x00"
+    return unless p.icmpv6_type == 136 && p.icmpv6_code == 0
     p
   end
 end


### PR DESCRIPTION
- This change fixing neighbor advertisement filtering.


## Reference to issue

-  #16618

## Verification without changes

- Run msfconsole

```bash
./msfconsole 
```

- Choose auxiliary scanner 
```bash
use ipv6_neighbor.rb
```

- Set ipv4 range
```bash
set rhosts 10.0.0.1-5
```

- Run module
```bash
run or exploit
```

### Output

```
[*] Discovering IPv4 nodes via ARP...
[+]           10.0.0.2 ALIVE
[+]           10.0.0.3 ALIVE
[*] Discovering IPv6 addresses for IPv4 nodes...
[*] 
[*] Scanned 5 of 5 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification with changes

### Output

```
[*] Discovering IPv4 nodes via ARP...
[+]           10.0.0.2 ALIVE
[+]           10.0.0.3 ALIVE
[*] Discovering IPv6 addresses for IPv4 nodes...
[*]           10.0.0.2 maps to fe80::d819:abff:fecc:4a35
[*]           10.0.0.3 maps to fe80::44bc:18ff:fe71:f5a2
[*] Scanned 5 of 5 hosts (100% complete)
[*] Auxiliary module execution completed
```
## Related issues
Solicited multicast-address creation bugfix #16615
fix race condition when scanning short ranges #16617