### PR TITLE
Bump RubySMB, Add File Server Tool

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,7 +445,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.1.2)
+    ruby_smb (3.1.3)
       bindata
       openssl-ccm
       openssl-cmac

--- a/tools/smb_file_server.rb
+++ b/tools/smb_file_server.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+require 'pathname'
+require 'ruby_smb'
+
+# we just need *a* default encoding to handle the strings from the NTLM messages
+Encoding.default_internal = 'UTF-8' if Encoding.default_internal.nil?
+
+options = RubySMB::Server::Cli.parse(defaults: { share_path: '.' }) do |options, parser|
+  parser.banner = <<~EOS
+    Usage: #{File.basename(__FILE__)} [options]
+
+    Start a read-only SMB file server.
+
+    Options:
+  EOS
+
+  parser.on("--share-path SHARE_PATH", "The path to share (default: #{options[:share_path]})") do |path|
+    options[:share_path] = path
+  end
+end
+
+server = RubySMB::Server::Cli.build(options)
+server.add_share(RubySMB::Server::Share::Provider::Disk.new(options[:share_name], options[:share_path]))
+
+RubySMB::Server::Cli.run(server)

--- a/tools/smb_file_server.rb
+++ b/tools/smb_file_server.rb
@@ -6,7 +6,7 @@ require 'ruby_smb'
 # we just need *a* default encoding to handle the strings from the NTLM messages
 Encoding.default_internal = 'UTF-8' if Encoding.default_internal.nil?
 
-options = RubySMB::Server::Cli.parse(defaults: { share_path: '.' }) do |options, parser|
+options = RubySMB::Server::Cli.parse(defaults: { share_path: '.', username: 'metasploit' }) do |options, parser|
   parser.banner = <<~EOS
     Usage: #{File.basename(__FILE__)} [options]
 


### PR DESCRIPTION
This bumps RubySMB from 3.1.2 to 3.1.3. It includes the following two changes and a stand-alone SMB file server tool.

* rapid7/ruby_smb#227
    * This one powers the new file server tool, reducing duplicate code.
* rapid7/ruby_smb#226
    * This one fixes our ability to anonymous authenticate to SMB servers, notably enabling us to exploit PetitPotam in it's most valuable scenario. See #16136.

