### PR TITLE
Bump Metasploit framework version to 6.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metasploit-framework (6.1.44)
+    metasploit-framework (6.2.0)
       actionpack (~> 6.0)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/lib/metasploit/framework/version.rb
+++ b/lib/metasploit/framework/version.rb
@@ -30,7 +30,7 @@ module Metasploit
         end
       end
 
-      VERSION = "6.1.44"
+      VERSION = "6.2.0"
       MAJOR, MINOR, PATCH = VERSION.split('.').map { |x| x.to_i }
       PRERELEASE = 'dev'
       HASH = get_hash


### PR DESCRIPTION
Updating to Metasploit 6.2.0 which is being used to signify another milestone for bundling together multiple new modules, features, improvements, and bug fixes over the past months.

I'll post the blog post/wrapup here when it's available

Edit: Blog post available - https://www.rapid7.com/blog/post/2022/06/09/announcing-metasploit-6-2/
