### PR TITLE
Add some error handling to update_payload_cache_size script

### DIFF
--- a/tools/modules/update_payload_cached_sizes.rb
+++ b/tools/modules/update_payload_cached_sizes.rb
@@ -27,10 +27,16 @@ require 'rex'
 framework = Msf::Simple::Framework.create('DisableDatabase' => true)
 
 framework.payloads.each_module do |name, mod|
-  next if name =~ /generic/
-  mod_inst = framework.payloads.create(name)
-  #mod_inst.datastore.merge!(framework.datastore)
-  next if Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod_inst)
-  $stdout.puts "[*] Updating the CacheSize for #{mod.file_path}..."
-  Msf::Util::PayloadCachedSize.update_module_cached_size(mod_inst)
+  begin
+    next if name =~ /generic/
+    mod_inst = framework.payloads.create(name)
+    #mod_inst.datastore.merge!(framework.datastore)
+    next if Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod_inst)
+    $stdout.puts "[*] Updating the CacheSize for #{mod.file_path}..."
+    Msf::Util::PayloadCachedSize.update_module_cached_size(mod_inst)
+  rescue => e
+    print_line("Caught Error while updating #{name}:\n#{e}")
+    elog(e)
+    next
+  end
 end

--- a/tools/modules/update_payload_cached_sizes.rb
+++ b/tools/modules/update_payload_cached_sizes.rb
@@ -25,7 +25,7 @@ require 'rex'
 
 # Initialize the simplified framework instance.
 framework = Msf::Simple::Framework.create('DisableDatabase' => true)
-
+exceptions = []
 framework.payloads.each_module do |name, mod|
   begin
     next if name =~ /generic/
@@ -35,8 +35,13 @@ framework.payloads.each_module do |name, mod|
     $stdout.puts "[*] Updating the CacheSize for #{mod.file_path}..."
     Msf::Util::PayloadCachedSize.update_module_cached_size(mod_inst)
   rescue => e
-    print_line("Caught Error while updating #{name}:\n#{e}")
-    elog(e)
+    exceptions << [ e, name ]
     next
   end
 end
+
+exceptions.each do |e, name|
+  print_error("Caught Error while updating #{name}:\n#{e}")
+  elog(e)
+end
+exit(1) unless exceptions.empty?


### PR DESCRIPTION
This mitigates https://github.com/rapid7/metasploit-framework/issues/16626 until we can get the fixes landed, but the script should be less brittle anyway, so these changes should be permanent, IMO.

My only concern is that we might rely on the script crashing in test/build environments to warn us about something, but I'm hoping that's not the case.

When the update_payload_cache_size script hits an error, it just dies and quits.  This adds some error handling and lets it continue to update cache sizes even if one of the update operations crashes.

## Verification

List the steps needed to make sure this thing works

- [x] run `./tools/modules/update_payload_cached_sizes.rb`
- [x] watch it catch exceptions and not fail

## Example:
```
tmoose@ubuntu:~/rapid7/metasploit-framework$ ./tools/modules/update_payload_cached_sizes.rb 
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb...
Caught Error while updating cmd/windows/powershell/encrypted_shell/reverse_tcp:
undefined method `compile_c' for nil:NilClass
Caught Error while updating cmd/windows/powershell/peinject/bind_hidden_ipknock_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/bind_hidden_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/bind_ipv6_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/bind_ipv6_tcp_uuid:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/bind_named_pipe:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/bind_nonx_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/bind_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/bind_tcp_rc4:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/bind_tcp_uuid:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/find_tag:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/reverse_ipv6_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/reverse_named_pipe:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/reverse_nonx_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/reverse_ord_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/reverse_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/reverse_tcp_allports:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/reverse_tcp_dns:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/reverse_tcp_rc4:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/reverse_tcp_rc4_dns:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/peinject/reverse_tcp_uuid:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/x64/encrypted_shell/reverse_tcp:
undefined method `compile_c' for nil:NilClass
Caught Error while updating cmd/windows/powershell/x64/peinject/bind_ipv6_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/x64/peinject/bind_ipv6_tcp_uuid:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/x64/peinject/bind_named_pipe:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/x64/peinject/bind_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/x64/peinject/bind_tcp_rc4:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/x64/peinject/bind_tcp_uuid:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/x64/peinject/reverse_named_pipe:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/x64/peinject/reverse_tcp:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/x64/peinject/reverse_tcp_rc4:
no implicit conversion of nil into String
Caught Error while updating cmd/windows/powershell/x64/peinject/reverse_tcp_uuid:
no implicit conversion of nil into String
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/windows/loadlibrary.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/windows/powershell_bind_tcp.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/windows/powershell_reverse_tcp.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/windows/powershell_reverse_tcp_ssl.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/windows/x64/loadlibrary.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb...
[*] Updating the CacheSize for /home/tmoose/rapid7/metasploit-framework/modules/payloads/singles/windows/x64/powershell_reverse_tcp_ssl.rb...
[ruby-3.0.2@metasploit-framework](add-errorhandling-payload-cache-size) tmoose@ubuntu:~/rapid7/metasploit-framework$
```