### PR TITLE
[SQLi library] Ensure the encoder is always used in the #test_vulnerable methods

### DIFF
--- a/lib/msf/core/exploit/sqli/mssqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mssqli/common.rb
@@ -185,6 +185,7 @@ module Msf::Exploit::SQLi::Mssqli
       query_string = "'#{random_string}'"
       query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
       output = run_sql("select #{query_string}")
+      return false if output.nil?
       (@encoder ? @encoder[:decode].call(output) : output) == random_string
     end
 

--- a/lib/msf/core/exploit/sqli/mssqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mssqli/common.rb
@@ -182,7 +182,10 @@ module Msf::Exploit::SQLi::Mssqli
     def test_vulnerable
       random_string_len = @truncation_length ? [rand(2..10), @truncation_length].min : rand(2..10)
       random_string = Rex::Text.rand_text_alphanumeric(random_string_len)
-      run_sql("select '#{random_string}'") == random_string
+      query_string = "'#{random_string}'"
+      query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
+      output = run_sql("select #{query_string}")
+      (@encoder ? @encoder[:decode].call(output) : output) == random_string
     end
 
     #

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -200,6 +200,7 @@ module Msf::Exploit::SQLi::MySQLi
       query_string = "'#{random_string}'"
       query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
       output = run_sql("select #{query_string}")
+      return false if output.nil?
       (@encoder ? @encoder[:decode].call(output) : output) == random_string
     end
 

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -197,7 +197,10 @@ module Msf::Exploit::SQLi::MySQLi
     def test_vulnerable
       random_string_len = @truncation_length ? [rand(2..10), @truncation_length].min : rand(2..10)
       random_string = Rex::Text.rand_text_alphanumeric(random_string_len)
-      run_sql("select '#{random_string}'") == random_string
+      query_string = "'#{random_string}'"
+      query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
+      output = run_sql("select #{query_string}")
+      (@encoder ? @encoder[:decode].call(output) : output) == random_string
     end
 
     #

--- a/lib/msf/core/exploit/sqli/postgresqli/common.rb
+++ b/lib/msf/core/exploit/sqli/postgresqli/common.rb
@@ -189,7 +189,10 @@ module Msf::Exploit::SQLi::PostgreSQLi
     def test_vulnerable
       random_string_len = @truncation_length ? [rand(2..10), @truncation_length].min : rand(2..10)
       random_string = Rex::Text.rand_text_alphanumeric(random_string_len)
-      run_sql("select '#{random_string}'") == random_string
+      query_string = "'#{random_string}'"
+      query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
+      output = run_sql("select #{query_string}")
+      (@encoder ? @encoder[:decode].call(output) : output) == random_string
     end
 
     #

--- a/lib/msf/core/exploit/sqli/postgresqli/common.rb
+++ b/lib/msf/core/exploit/sqli/postgresqli/common.rb
@@ -192,6 +192,7 @@ module Msf::Exploit::SQLi::PostgreSQLi
       query_string = "'#{random_string}'"
       query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
       output = run_sql("select #{query_string}")
+      return false if output.nil?
       (@encoder ? @encoder[:decode].call(output) : output) == random_string
     end
 

--- a/lib/msf/core/exploit/sqli/sqlitei/common.rb
+++ b/lib/msf/core/exploit/sqli/sqlitei/common.rb
@@ -146,6 +146,7 @@ module Msf::Exploit::SQLi::SQLitei
       query_string = "'#{random_string}'"
       query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
       output = run_sql("select #{query_string}")
+      return false if output.nil?
       (@encoder ? @encoder[:decode].call(output) : output) == random_string
     end
 


### PR DESCRIPTION
`#test_vulnerable` methods currently call `run_sql` directly, and check if the output string is the one that was used in the query. However, if some alphanumeric characters must be avoided in the backend, an encoder will be useful.

This PR makes all the `#test_vulnerable` methods take the encoder into consideration.

## Verification

The [test module for SQLi](https://github.com/rapid7/metasploit-framework/blob/master/test/modules/auxiliary/test/sqli_test.rb) already uses `#test_vulnerable` before performing SQLi, just try running it again with the different encoders, and ensure it doesn't fail with `Doesn't seem to be vulnerable`.