### PR TITLE
Fix Kerberos flags decoding logic

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client/cache_credential.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/cache_credential.rb
@@ -134,7 +134,7 @@ module Msf
                 key: key,
                 time: time,
                 is_skey: is_skey,
-                tkt_flags:tkt_flags,
+                tkt_flags: tkt_flags.to_i,
                 addrs: addrs,
                 auth_data: auth_data,
                 ticket: ticket,

--- a/lib/rex/proto/kerberos/model.rb
+++ b/lib/rex/proto/kerberos/model.rb
@@ -17,23 +17,6 @@ module Rex
         AUTHENTICATOR = 2
         AP_REQ = 14
 
-        KDC_OPTION_RESERVED        = 0
-        KDC_OPTION_FORWARDABLE     = 1
-        KDC_OPTION_FORWARDED       = 2
-        KDC_OPTION_PROXIABLE       = 3
-        KDC_OPTION_PROXY           = 4
-        KDC_OPTION_ALLOW_POST_DATE = 5
-        KDC_OPTION_POST_DATED      = 6
-        KDC_OPTION_UNUSED_7        = 7
-        KDC_OPTION_RENEWABLE       = 8
-        KDC_OPTION_UNUSED_9        = 9
-        KDC_OPTION_UNUSED_10       = 10
-        KDC_OPTION_UNUSED_11       = 11
-        KDC_OPTION_RENEWABLE_OK    = 27
-        KDC_OPTION_ENC_TKT_IN_SKEY = 28
-        KDC_OPTION_RENEW           = 30
-        KDC_OPTION_VALIDATE        = 31
-
         # From Principal
 
         # Name type not known

--- a/lib/rex/proto/kerberos/model/enc_kdc_response.rb
+++ b/lib/rex/proto/kerberos/model/enc_kdc_response.rb
@@ -20,7 +20,7 @@ module Rex
           #   KDC and specifies the time that the client's secret key is due to expire
           attr_accessor :key_expiration
           # @!attribute flags
-          #   @return [Integer] This field indicates which of various options were used or
+          #   @return [Rex::Proto::Kerberos::Model::KdcOptionFlags] This field indicates which of various options were used or
           #   requested when the ticket was issued
           attr_accessor :flags
           # @!attribute auth_time
@@ -111,7 +111,7 @@ module Rex
               when 10
                 self.sname = decode_sname(val)
               else
-                raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode ENC-KDC-RESPONSE SEQUENCE'
+                raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, "Failed to decode tag #{val.tag.inspect} in ENC-KDC-RESPONSE SEQUENCE"
               end
             end
           end
@@ -156,9 +156,9 @@ module Rex
           # Decodes the flags field
           #
           # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [Integer]
+          # @return [Rex::Proto::Kerberos::Model::KdcOptionFlags]
           def decode_flags(input)
-            input.value[0].value.to_i
+            Rex::Proto::Kerberos::Model::KdcOptionFlags.new(input.value[0].value.unpack1('N'))
           end
 
           # Decodes the auth_time field

--- a/lib/rex/proto/kerberos/model/kdc_option_flag.rb
+++ b/lib/rex/proto/kerberos/model/kdc_option_flag.rb
@@ -1,0 +1,34 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # THe KdcOptions KerberosFlags are represented as a bit string.
+        # This module associates the human readable name, to the index the flag value is found at within the bit string.
+        # https://www.rfc-editor.org/rfc/rfc4120.txt - KDCOptions      ::= KerberosFlags
+        module KdcOptionFlag
+          RESERVED = 0
+          FORWARDABLE = 1
+          FORWARDED = 2
+          PROXIABLE = 3
+          PROXY = 4
+          ALLOW_POST_DATE = 5
+          POST_DATED = 6
+          INVALID = 7
+          RENEWABLE = 8
+          INITIAL = 9
+          PRE_AUTHENT = 10
+          HW_AUTHNET = 11
+          TRANSITED_POLICY_CHECKED = 12
+          OK_AS_DELEGATE = 13
+          CANONICALIZE = 15
+          RENEWABLE_OK = 27
+          ENC_TKT_IN_SKEY = 28
+          RENEW = 30
+          VALIDATE = 31
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/proto/kerberos/model/kdc_option_flags.rb
+++ b/lib/rex/proto/kerberos/model/kdc_option_flags.rb
@@ -1,0 +1,73 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # Represents the KdcOptions KerberosFlags.
+        # https://www.rfc-editor.org/rfc/rfc4120.txt - KDCOptions      ::= KerberosFlags
+        class KdcOptionFlags
+          # @return [Integer] the integer value of the kerberos flags
+          attr_reader :value
+
+          # @param [Integer] value the numerical value of the flags
+          # @raise [ArgumentError] if any of the parameters are of an invalid type
+          def initialize(value)
+            raise ArgumentError, 'Invalid value' unless value.is_a?(Integer)
+
+            @value = value
+          end
+
+          # @param [Array<Integer,Rex::Proto::Kerberos::Model::KdcOptionFlag>] flags an array of numerical values representing flags
+          # @return [Rex::Proto::Kerberos::Model::KdcOptionFlags]
+          def self.from_flags(flags)
+            value = 0
+            flags.each do |flag|
+              value |= 1 << (31 - flag)
+            end
+
+            new(value)
+          end
+
+          def to_i
+            @value
+          end
+
+          # @param [Integer,Rex::Proto::Kerberos::Model::KdcOptionFlag] flag the numerical value of the flag to test for.
+          # @return [Boolean] whether the flag is present within the current KdcOptionFlags
+          def include?(flag)
+            ((value >> (31 - flag)) & 1) == 1
+          end
+
+          # @return [Boolean] whether the flag is present within the current KdcOptionFlags
+          def enabled_flag_names
+            sorted_flag_names = KdcOptionFlag.constants.sort_by { |name| KdcOptionFlag.const_get(name) }
+            enabled_flag_names = sorted_flag_names.select { |flag| include?(KdcOptionFlag.const_get(flag)) }
+
+            enabled_flag_names
+          end
+
+          # Override the equality test for KdcOptionFlags. Equality is
+          # always tested against the #value of the KdcOptionFlags.
+          #
+          # @param [Object] other_object the object to test equality against
+          # @raise [ArgumentError] if the other object is not either another KdcOptionFlags or a Integer
+          # @return [Boolean] whether the equality test passed
+          def ==(other)
+            if other.is_a? self.class
+              value == other.value
+            elsif other.is_a? Integer
+              value == other
+            elsif other.nil?
+              false
+            else
+              raise ArgumentError, "Cannot compare a #{self.class} to a #{other.class}"
+            end
+          end
+
+          alias === ==
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/proto/kerberos/model/kdc_request_body.rb
+++ b/lib/rex/proto/kerberos/model/kdc_request_body.rb
@@ -103,7 +103,7 @@ module Rex
           #
           # @return [OpenSSL::ASN1::BitString]
           def encode_options
-            OpenSSL::ASN1::BitString.new([options].pack('N'))
+            OpenSSL::ASN1::BitString.new([options.to_i].pack('N'))
           end
 
           # Encodes the cname

--- a/spec/lib/rex/proto/kerberos/model/enc_kdc_response_spec.rb
+++ b/spec/lib/rex/proto/kerberos/model/enc_kdc_response_spec.rb
@@ -272,7 +272,8 @@ RSpec.describe Rex::Proto::Kerberos::Model::EncKdcResponse do
 
       it "decodes the flags correctly" do
         enc_kdc_response.decode(enc_as_resp)
-        expect(enc_kdc_response.flags).to eq(0)
+        expect(enc_kdc_response.flags).to eq(0x50e00000)
+        expect(enc_kdc_response.flags.enabled_flag_names).to eq(%i[FORWARDABLE PROXIABLE RENEWABLE INITIAL PRE_AUTHENT])
       end
 
       it "decodes the auth_time correctly" do

--- a/spec/lib/rex/proto/kerberos/model/kdc_option_flags_spec.rb
+++ b/spec/lib/rex/proto/kerberos/model/kdc_option_flags_spec.rb
@@ -1,0 +1,57 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Rex::Proto::Kerberos::Model::KdcOptionFlags do
+  let(:subject) { described_class.new(0x50e10000) }
+
+  describe '.from_flags' do
+    it 'supports initialization from an array of values' do
+      result = described_class.from_flags(
+        [
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK,
+        ]
+      )
+
+      expect(result).to eq(described_class.new(0x40810010))
+      expect(result.enabled_flag_names).to eq(%i[FORWARDABLE RENEWABLE CANONICALIZE RENEWABLE_OK])
+    end
+  end
+
+  describe '#enabled_flag_names' do
+    it 'returns an array of the enabled human readable flag names' do
+      expect(subject.enabled_flag_names).to eq(%i[FORWARDABLE PROXIABLE RENEWABLE INITIAL PRE_AUTHENT CANONICALIZE])
+    end
+  end
+
+  describe '#include?' do
+    it 'returns true when the flag is enabled' do
+      expect(subject).to include(Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE)
+    end
+
+    it 'returns false when the flag is not enabled' do
+      expect(subject).to_not include(Rex::Proto::Kerberos::Model::KdcOptionFlag::ALLOW_POST_DATE)
+    end
+  end
+
+  describe '#==' do
+    it 'returns true for an equivalent integer value' do
+      expect(subject).to eq(0x50e10000)
+    end
+
+    it 'returns false for a different integer value' do
+      expect(subject).to_not eq(0x60e10000)
+    end
+
+    it 'returns true for an equivalent object value' do
+      expect(subject).to eq(described_class.new(0x50e10000))
+    end
+
+    it 'returns false for a different object value' do
+      expect(subject).to_not eq(described_class.new(0x50e10001))
+    end
+  end
+end


### PR DESCRIPTION
Updates the list of Kerberos constants, as well as handles correctly decoding the Kerberos flags.

Previously the flags would be decoded as 0 instead of handling the bit string appropriately

## Verification

- Ensure CI passes
- Validate that the magic values match the RFC