### PR TITLE
Add SAN support to impersonate_ssl module

### DIFF
--- a/modules/auxiliary/gather/impersonate_ssl.rb
+++ b/modules/auxiliary/gather/impersonate_ssl.rb
@@ -38,7 +38,8 @@ class MetasploitModule < Msf::Auxiliary
         OptPath.new('PRIVKEY', [false, 'Sign the cert with your own CA private key', nil]),
         OptString.new('PRIVKEY_PASSWORD', [false, 'Password for private key specified in PRIV_KEY (if applicable)', nil]),
         OptPath.new('CA_CERT', [false, 'CA Public certificate', nil]),
-        OptString.new('ADD_CN', [false, 'Add CN to match spoofed site name (e.g. *.example.com)', nil])
+        OptString.new('ADD_CN', [false, 'Add CN to match spoofed site name (e.g. *.example.com)', nil]),
+        OptString.new('ADD_SAN', [false, 'Add SAN entries to certificate (e.g. alt.example.com,127.0.0.1)', nil])
       ]
     )
 
@@ -179,6 +180,16 @@ class MetasploitModule < Msf::Auxiliary
       ef.create_extension('basicConstraints', 'CA:FALSE', true),
       ef.create_extension('subjectKeyIdentifier', 'hash'),
     ]
+
+    # add additional SAN entries to the new cert
+    if !datastore['ADD_SAN'].nil? && !datastore['ADD_SAN'].empty?
+      sans = datastore['ADD_SAN'].to_s.split(/,/)
+      sans.map! do |san|
+        san = san =~ Resolv::IPv4::Regex || san =~ Resolv::IPv6::Regex ? "IP:#{san}" : "DNS:#{san}"
+      end
+      new_cert.add_extension(ef.create_extension('subjectAltName', sans.join(','), false))
+      print_status("Adding #{datastore['ADD_SAN']} to the certificate subject alternative names")
+    end
 
     if !datastore['PRIVKEY'].nil? && !datastore['PRIVKEY'].empty?
       new_cert.sign(ca_key, OpenSSL::Digest.new(hashtype))


### PR DESCRIPTION
Add Subject Alternative Names (SAN) support to impersonate_ssl module

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/impersonate_ssl`
- [x] `set RHOSTS www.example.com`
- [x] `set ADD_SAN alt.example.com,1.2.3.4`
- [x] `run`
- [x] **Verify** the SAN entries were added to the certificate:

```
$ sudo openssl x509 -noout -text -in /root/.msf4/loot/20220608112036_default_93.184.216.34_93.184.216.34_ce_782579.crt
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            06:1e:8e:b2:79:6f:05:87:ed:80:59:2f:15:00:32:4f:8e
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: C = US, ST = California, L = Los Angeles, O = Internet\C2\A0Corporation\C2\A0for\C2\A0Assigned\C2\A0Names\C2\A0and\C2\A0Numbers, CN = www.example.org
        ...
        X509v3 extensions:
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Subject Key Identifier: 
                41:A5:A7:9F:58:11:39:13:14:BD:F5:A7:1B:C7:93:0E:BE:4A:00:E0
            X509v3 Subject Alternative Name: 
                DNS:alt.example.com, IP Address:1.2.3.4
    Signature Algorithm: sha256WithRSAEncryption
         07:e1:02:ea:15:e0:77:ac:15:4b:da:13:c4:59:87:f6:10:93:
         ...
```
