### PR TITLE
Add faraday retry gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ PATH
       eventmachine
       faker
       faraday
+      faraday-retry
       faye-websocket
       filesize
       hrr_rb_ssh-ed25519
@@ -189,6 +190,7 @@ GEM
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.3)
+    faraday-retry (1.0.3)
     faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -224,6 +224,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'eventmachine'
 
   spec.add_runtime_dependency 'faraday'
+  spec.add_runtime_dependency 'faraday-retry'
 
   # Required for windows terminal colors as of Ruby 3.0
   spec.add_runtime_dependency 'win32api'


### PR DESCRIPTION
Fixes a warning on bootup about a faraday-retry. Thread with additional context:
https://github.com/rapid7/metasploit-framework/pull/16645#discussion_r889367555

### Before

```
$ bundle exec ruby ./msfconsole -q
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem <-------
[*] Using configured payload windows/meterpreter/reverse_tcp
msf6 exploit(windows/smb/kerberos_test) > 
```

### After

```
$ bundle exec ruby ./msfconsole -q
[*] Using configured payload windows/meterpreter/reverse_tcp
msf6 exploit(windows/smb/kerberos_test) > 
```

## Verification

Verify the warning is no longer present