### PR TITLE
Fix random compile c tool

### DIFF
--- a/tools/exploit/random_compile_c.rb
+++ b/tools/exploit/random_compile_c.rb
@@ -16,7 +16,7 @@ while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
-
+require 'msfenv'
 require 'metasploit/framework/compiler/windows'
 
 weight = ARGV.shift


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/16664

## Verification

Create `foo.c`:
```
#include <stdio.h>

int main(void) {

        printf("test");
        return 0;
}
```

Master:
```
$ ./tools/exploit/random_compile_c.rb 80 ./foo.c foo.exe
/usr/share/metasploit-framework/lib/metasploit/framework/compiler/headers/windows.rb:16:in `initialize': uninitialized constant Metasploit::Framework::Compiler::Headers::Windows::Msf (NameError)
	from /usr/share/metasploit-framework/lib/metasploit/framework/compiler/windows.rb:55:in `new'
	from /usr/share/metasploit-framework/lib/metasploit/framework/compiler/windows.rb:55:in `generate_random_c'
	from /usr/share/metasploit-framework/lib/metasploit/framework/compiler/windows.rb:73:in `compile_random_c'
	from /usr/share/metasploit-framework/lib/metasploit/framework/compiler/windows.rb:84:in `compile_random_c_to_file'
	from /usr/share/metasploit-framework/tools/exploit/random_compile_c.rb:35:in `<main>'
```

This branch:
```
$ ./tools/exploit/random_compile_c.rb 80 ./foo.c foo.exe
File saved as foo.exe
```