### PR TITLE
HTTP Crawler: don't expect page object for msg

### DIFF
--- a/lib/msf/core/auxiliary/http_crawler.rb
+++ b/lib/msf/core/auxiliary/http_crawler.rb
@@ -243,6 +243,7 @@ module Auxiliary::HttpCrawler
   # Specific module implementations should redefine this method
   # with whatever is meaningful to them.
   def crawler_process_page(t, page, cnt)
+    return if page.nil? # Skip over pages that don't contain any info aka page is nil. We can't process these types of pages since there is no data to process.
     msg = "[#{"%.5d" % cnt}/#{"%.5d" % max_page_count}]    #{page ? page.code || "ERR" : "ERR"} - #{@current_site.vhost} - #{page.url}"
     case page.code
       when 301,302

--- a/lib/msf/core/auxiliary/http_crawler.rb
+++ b/lib/msf/core/auxiliary/http_crawler.rb
@@ -243,7 +243,7 @@ module Auxiliary::HttpCrawler
   # Specific module implementations should redefine this method
   # with whatever is meaningful to them.
   def crawler_process_page(t, page, cnt)
-    msg = "[#{"%.5d" % cnt}/#{"%.5d" % max_page_count}]    #{page.code || "ERR"} - #{@current_site.vhost} - #{page.url}"
+    msg = "[#{"%.5d" % cnt}/#{"%.5d" % max_page_count}]    #{page ? page.code || "ERR" : "ERR"} - #{@current_site.vhost} - #{page.url}"
     case page.code
       when 301,302
         if page.headers and page.headers["location"]

--- a/modules/auxiliary/scanner/http/crawler.rb
+++ b/modules/auxiliary/scanner/http/crawler.rb
@@ -63,7 +63,8 @@ class MetasploitModule < Msf::Auxiliary
   # - The occurence of any form (web.form :path, :type (get|post|path_info), :params)
   #
   def crawler_process_page(t, page, cnt)
-    msg = "[#{"%.5d" % cnt}/#{"%.5d" % max_page_count}]    #{page.code || "ERR"} - #{t[:vhost]} - #{page.url}"
+    return if page.nil? # Skip over pages that don't contain any info aka page is nil. We can't process these types of pages since there is no data to process.
+    msg = "[#{"%.5d" % cnt}/#{"%.5d" % max_page_count}]    #{page ? page.code || "ERR" : "ERR"} - #{t[:vhost]} - #{page.url}"
     if page.error
       print_error("Error accessing page #{page.error.to_s}")
       elog(page.error)


### PR DESCRIPTION
The `crawler_process_page` method in HttpCrawler assumes that the
`page` object passed into the method is not nil when formatting the
`msg` string for printing to console.
Address the assumption with a ternary check leaving the `|| "ERR"`
handling for `page.code` itself being nil inside the assignment
when page is not nil.

Testing:
 `Error accessing page undefined method '[]' for nil:NilClass` is
no longer being thrown when scanning an odd HTTP service.
