### PR TITLE
Support decoding pa_data as part of kdc enc response

### DIFF
--- a/lib/rex/proto/kerberos/model.rb
+++ b/lib/rex/proto/kerberos/model.rb
@@ -49,12 +49,13 @@ module Rex
         # Unique ID
         NT_UID = 5
 
-        # From padata
+        # From padata - https://www.iana.org/assignments/kerberos-parameters/kerberos-parameters.xhtml
 
         PA_TGS_REQ = 1
         PA_ENC_TIMESTAMP = 2
         PA_PW_SALT = 3
         PA_PAC_REQUEST = 128
+        PA_SUPPORTED_ETYPES = 165
 
         AD_IF_RELEVANT = 1
       end

--- a/lib/rex/proto/kerberos/model/element.rb
+++ b/lib/rex/proto/kerberos/model/element.rb
@@ -30,6 +30,8 @@ module Rex
           end
 
           def initialize(options = {})
+            raise ArgumentError, "Invalid options, expected hash, got #{options.class}" unless options.is_a?(Hash)
+
             self.class.attributes.each do |attr|
               if options.has_key?(attr)
                 m = (attr.to_s + '=').to_sym

--- a/spec/lib/rex/proto/kerberos/model/enc_kdc_response_spec.rb
+++ b/spec/lib/rex/proto/kerberos/model/enc_kdc_response_spec.rb
@@ -225,10 +225,49 @@ RSpec.describe Rex::Proto::Kerberos::Model::EncKdcResponse do
                    @tag=27,
                    @tag_class=:UNIVERSAL,
                    @tagging=nil,
-                   @value="DEMO.LOCAL">]>]>]>]>]>]>
+                   @value="DEMO.LOCAL">]>]>]>]>,
+      #<OpenSSL::ASN1::ASN1Data:0x00007ffd80e8cbc0
+       @indefinite_length=false,
+       @tag=12,
+       @tag_class=:CONTEXT_SPECIFIC,
+       @value=
+        [#<OpenSSL::ASN1::Sequence:0x00007ffd80e8cbe8
+          @indefinite_length=false,
+          @tag=16,
+          @tag_class=:UNIVERSAL,
+          @tagging=nil,
+          @value=
+           [#<OpenSSL::ASN1::Sequence:0x00007ffd80e8cc10
+             @indefinite_length=false,
+             @tag=16,
+             @tag_class=:UNIVERSAL,
+             @tagging=nil,
+             @value=
+              [#<OpenSSL::ASN1::ASN1Data:0x00007ffd80e8ccd8
+                @indefinite_length=false,
+                @tag=1,
+                @tag_class=:CONTEXT_SPECIFIC,
+                @value=
+                 [#<OpenSSL::ASN1::Integer:0x00007ffd80e8cd00
+                   @indefinite_length=false,
+                   @tag=2,
+                   @tag_class=:UNIVERSAL,
+                   @tagging=nil,
+                   @value=#<OpenSSL::BN 165>>]>,
+               #<OpenSSL::ASN1::ASN1Data:0x00007ffd80e8cc38
+                @indefinite_length=false,
+                @tag=2,
+                @tag_class=:CONTEXT_SPECIFIC,
+                @value=
+                 [#<OpenSSL::ASN1::OctetString:0x00007ffd80e8cc60
+                   @indefinite_length=false,
+                   @tag=4,
+                   @tag_class=:UNIVERSAL,
+                   @tagging=nil,
+                   @value="\x1F\x00\x00\x00">]>]>]>]>]>]>
 =end
   let(:enc_as_resp) do
-    "\x79\x81\xdd\x30\x81\xda\xa0\x1b\x30\x19\xa0\x03\x02\x01\x17\xa1" +
+    "\x79\x81\xf1\x30\x81\xee\xa0\x1b\x30\x19\xa0\x03\x02\x01\x17\xa1" +
     "\x12\x04\x10\xca\x5a\x4a\x62\x9f\xe5\x72\xc3\xdb\xd3\xbe\xac\x5e" +
     "\xc6\x6a\xc7\xa1\x1c\x30\x1a\x30\x18\xa0\x03\x02\x01\x00\xa1\x11" +
     "\x18\x0f\x32\x30\x31\x34\x31\x32\x30\x39\x30\x31\x30\x39\x30\x39" +
@@ -241,7 +280,9 @@ RSpec.describe Rex::Proto::Kerberos::Model::EncKdcResponse do
     "\x18\x0f\x32\x30\x31\x34\x31\x32\x31\x36\x30\x31\x30\x39\x30\x39" +
     "\x5a\xa9\x0c\x1b\x0a\x44\x45\x4d\x4f\x2e\x4c\x4f\x43\x41\x4c\xaa" +
     "\x1f\x30\x1d\xa0\x03\x02\x01\x01\xa1\x16\x30\x14\x1b\x06\x6b\x72" +
-    "\x62\x74\x67\x74\x1b\x0a\x44\x45\x4d\x4f\x2e\x4c\x4f\x43\x41\x4c"
+    "\x62\x74\x67\x74\x1b\x0a\x44\x45\x4d\x4f\x2e\x4c\x4f\x43\x41\x4c" +
+    "\xac\x12\x30\x10\x30\x0e\xa1\x04\x02\x02\x00\xa5\xa2\x06\x04\x04" +
+    "\x1f\x00\x00\x00"
   end
 
   describe "#decode" do
@@ -303,6 +344,15 @@ RSpec.describe Rex::Proto::Kerberos::Model::EncKdcResponse do
       it "decodes the sname correctly" do
         enc_kdc_response.decode(enc_as_resp)
         expect(enc_kdc_response.sname.name_string).to eq(['krbtgt', 'DEMO.LOCAL'])
+      end
+
+      it "decodes the pa_data correctly" do
+        enc_kdc_response.decode(enc_as_resp)
+
+        expect(enc_kdc_response.pa_data.length).to eql(1)
+        expect(enc_kdc_response.pa_data.first&.type).to eql(Rex::Proto::Kerberos::Model::PA_SUPPORTED_ETYPES)
+        # SupportedEnctypes: 0x0000001f, des-cbc-crc, des-cbc-md5, rc4-hmac, aes128-cts-hmac-sha1-96, aes256-cts-hmac-sha1-96
+        expect(enc_kdc_response.pa_data.first&.value).to eql("\x1F\x00\x00\x00")
       end
     end
   end


### PR DESCRIPTION
Fixes a crash when the AS_REP response contains pa_data when decoding the enc_kdc_response:

```
[-] 192.168.123.136:445 - Exploit failed: Rex::Proto::Kerberos::Model::Error::KerberosDecodingError Failed to decode tag 12 in ENC-KDC-RESPONSE SEQUENCE
```

## Verification

- [ ] Ensure CI passes