### PR TITLE
Fix missing and incomplete specs

### DIFF
--- a/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 863
+  CachedSize = 867
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -256,6 +256,10 @@ RSpec.describe "Metasploit's json-rpc" do
     end
 
     context 'when the module does not support a check method' do
+      before do
+        mock_rack_env('development')
+      end
+
       let(:module_name) { 'scanner/http/title' }
 
       it 'returns successful job results' do

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1116,6 +1116,22 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/windows/generic'
   end
 
+  context 'cmd/windows/powershell' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'adapters/cmd/windows/powershell'
+                          ],
+                          reference_name: 'cmd/windows/powershell'
+  end
+
+  context 'cmd/windows/powershell/x64' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'adapters/cmd/windows/powershell/x64'
+                          ],
+                          reference_name: 'cmd/windows/powershell/x64'
+  end
+
   context 'cmd/windows/powershell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -1184,6 +1200,16 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/reverse_ruby'
+  end
+
+  context 'cmd/windows/jjs_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/cmd/windows/jjs_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/windows/jjs_reverse_tcp'
   end
 
   context 'firefox/exec' do


### PR DESCRIPTION
The spec result has a precondition in the expectations.
The RACK_ENV must be `development` and causes the test to
fail based on test execution order in scenarios where a
previous test set a different expectation in the env.

Also adds missing payload tests.

## Verification

List the steps needed to make sure this thing works

- [x] `rake spec`
