### PR TITLE
issue template: update doc links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,8 +8,8 @@ labels: "bug"
   Please fill out each section below, otherwise, your issue will be closed. This info allows Metasploit maintainers to diagnose (and fix!) your issue as quickly as possible.
 
   Useful Links:
-  - Wiki: https://github.com/rapid7/metasploit-framework/wiki
-  - Reporting a Bug: https://github.com/rapid7/metasploit-framework/wiki/Reporting-a-Bug
+  - Wiki: https://docs.metasploit.com/
+  - Reporting a Bug: https://docs.metasploit.com/docs/using-metasploit/getting-started/reporting-a-bug.html
 
   Before opening a new issue, please search existing issues: https://github.com/rapid7/metasploit-framework/issues
 -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -8,7 +8,7 @@ labels: "suggestion-docs"
   To make it easier for us to help you, please include as much useful information as possible.
 
   Useful Links:
-  - Wiki: https://github.com/rapid7/metasploit-framework/wiki
+  - Wiki: https://docs.metasploit.com/
 
   Before opening a new issue, please search existing issues https://github.com/rapid7/metasploit-framework/issues
 -->
@@ -33,7 +33,7 @@ Why should we document this and who will benefit from it?
 ### Draft the doc
 
 - [ ] Write the doc, following the format listed in these resources:
-  - [Overview on contributing module documentation](https://github.com/rapid7/metasploit-framework/wiki/Writing-Module-Documentation)
+  - [Overview on contributing module documentation](https://docs.metasploit.com/docs/development/quality/writing-module-documentation.html)
   - [Docs Templates](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/module_doc_template.md)
   - [Example of a similar article]()
 

--- a/.github/ISSUE_TEMPLATE/feature_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature_suggestion.md
@@ -8,7 +8,7 @@ labels: "suggestion-feature"
   To make it easier for us to help you, please include as much useful information as possible.
 
   Useful Links:
-  - Wiki: https://github.com/rapid7/metasploit-framework/wiki
+  - Wiki: https://docs.metasploit.com/
 
   Before opening a new issue, please search existing issues https://github.com/rapid7/metasploit-framework/issues
 -->

--- a/.github/ISSUE_TEMPLATE/module_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/module_suggestion.md
@@ -8,7 +8,7 @@ labels: "suggestion-module"
   To make it easier for us to help you, please include as much useful information as possible.
 
   Useful Links:
-  - Wiki: https://github.com/rapid7/metasploit-framework/wiki
+  - Wiki: https://docs.metasploit.com/
 
   Before opening a new issue, please search existing issues https://github.com/rapid7/metasploit-framework/issues
 -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,7 +8,7 @@ labels: "question"
   To make it easier for us to help you, please include as much useful information as possible.
 
   Useful Links:
-  - Wiki: https://github.com/rapid7/metasploit-framework/wiki
+  - Wiki: https://docs.metasploit.com/
 
   Before opening a new issue, please search existing issues https://github.com/rapid7/metasploit-framework/issues
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,4 +31,4 @@ Complex Software Examples:
 We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster!
 
 Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.
-If you wish to sanitize your pcap, please see the [wiki](https://github.com/rapid7/metasploit-framework/wiki/Sanitizing-PCAPs).
+If you wish to sanitize your pcap, please see the [wiki](https://docs.metasploit.com/docs/development/get-started/sanitizing-pcaps.html).


### PR DESCRIPTION
it only update the links in the github issue template, because rapid7 moved from the github wiki to a self hosted documentation