### PR TITLE
LDAP Kerberos and NTLM authentication

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/ldap.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/ldap.rb
@@ -1,0 +1,22 @@
+# -*- coding: binary -*-
+
+#
+# This class acts as standalone authenticator for Kerberos
+#
+class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP < Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
+  # @param [Hash] options
+  # @return [String] SPNEGO GSS Blob
+  def authenticate(options = {})
+    sname = options.fetch(:sname) do
+      Rex::Proto::Kerberos::Model::PrincipalName.new(
+        name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+        name_string: [
+          "ldap",
+          options.fetch(:hostname) { hostname }
+        ]
+      )
+    end
+
+    super(options.merge({ sname: sname }))
+  end
+end

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -15,11 +15,15 @@ module Msf
         Opt::RHOST,
         Opt::RPORT(389),
         OptBool.new('SSL', [false, 'Enable SSL on the LDAP connection', false]),
-        OptString.new('BIND_DN', [false, 'The username to authenticate to LDAP server']),
-        OptString.new('BIND_PW', [false, 'Password for the BIND_DN'])
+        Msf::OptString.new('DOMAIN', [false, 'The domain to authenticate to']),
+        Msf::OptString.new('USERNAME', [false, 'The username to authenticate with'], aliases: ['BIND_DN']),
+        Msf::OptString.new('PASSWORD', [false, 'The password to authenticate with'], aliases: ['BIND_PW']),
       ])
 
       register_advanced_options([
+        OptEnum.new('LDAPAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS]),
+        OptString.new('LdapRhostname', [false, 'The rhostname which is required for kerberos']),
+        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
         OptFloat.new('LDAP::ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0])
       ])
     end
@@ -52,15 +56,67 @@ module Msf
         }
       end
 
-      if datastore['BIND_DN']
+      case datastore['LDAPAuth']
+      when Msf::Exploit::Remote::AuthOption::KERBEROS
+        fail_with(Msf::Exploit::Failure::BadConfig, 'The LdapRhostname option is required when using kerberos authentication.') if datastore['LdapRhostname'].blank?
+
+        kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
+          host: datastore['DomainControllerRhost'],
+          hostname: datastore['LdapRhostname'],
+          realm: datastore['DOMAIN'],
+          username: datastore['USERNAME'],
+          password: datastore['PASSWORD'],
+          framework: framework,
+          framework_module: self
+        )
+
+        kerberos_result = kerberos_authenticator.authenticate
+
+        connect_opts[:auth] = {
+          method: :sasl,
+          mechanism: 'GSS-SPNEGO',
+          initial_credential: kerberos_result[:security_blob],
+          challenge_response: true
+        }
+      when Msf::Exploit::Remote::AuthOption::NTLM
+        ntlm_client = RubySMB::NTLM::Client.new(
+          datastore['USERNAME'],
+          datastore['PASSWORD'],
+          workstation: 'WORKSTATION',
+          domain: datastore['DOMAIN'].blank? ? '.' : datastore['DOMAIN'],
+          flags: RubySMB::NTLM::DEFAULT_CLIENT_FLAGS
+        )
+
+        negotiate = proc do |challenge|
+          ntlmssp_offset = challenge.index('NTLMSSP')
+          type2_blob = challenge.slice(ntlmssp_offset..-1)
+          challenge = [type2_blob].pack('m')
+          type3_message = ntlm_client.init_context(challenge)
+          type3_message.serialize
+        end
+
+        connect_opts[:auth] = {
+          method: :sasl,
+          mechanism: 'GSS-SPNEGO',
+          initial_credential: ntlm_client.init_context.serialize,
+          challenge_response: negotiate
+        }
+      when Msf::Exploit::Remote::AuthOption::PLAINTEXT
         connect_opts[:auth] = {
           method: :simple,
-          username: datastore['BIND_DN']
+          username: datastore['USERNAME'],
+          password: datastore['PASSWORD']
         }
-        if datastore['BIND_PW']
-          connect_opts[:auth][:password] = datastore['BIND_PW']
+      when Msf::Exploit::Remote::AuthOption::AUTO
+        unless datastore['USERNAME'].blank? # plaintext if specified
+          connect_opts[:auth] = {
+            method: :simple,
+            username: datastore['USERNAME'],
+            password: datastore['PASSWORD']
+          }
         end
       end
+
       connect_opts
     end
 

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -84,7 +84,15 @@ module Msf
           datastore['PASSWORD'],
           workstation: 'WORKSTATION',
           domain: datastore['DOMAIN'].blank? ? '.' : datastore['DOMAIN'],
-          flags: RubySMB::NTLM::DEFAULT_CLIENT_FLAGS
+          flags:
+            RubySMB::NTLM::NEGOTIATE_FLAGS[:UNICODE] |
+            RubySMB::NTLM::NEGOTIATE_FLAGS[:REQUEST_TARGET] |
+            RubySMB::NTLM::NEGOTIATE_FLAGS[:NTLM] |
+            RubySMB::NTLM::NEGOTIATE_FLAGS[:ALWAYS_SIGN] |
+            RubySMB::NTLM::NEGOTIATE_FLAGS[:EXTENDED_SECURITY] |
+            RubySMB::NTLM::NEGOTIATE_FLAGS[:KEY_EXCHANGE] |
+            RubySMB::NTLM::NEGOTIATE_FLAGS[:TARGET_INFO] |
+            RubySMB::NTLM::NEGOTIATE_FLAGS[:VERSION_INFO]
         )
 
         negotiate = proc do |challenge|


### PR DESCRIPTION
Requires #16670.

This adds NTLMSSP and Kerberos authentication to the LDAP client mixin. Users can specify the authentication mechanism to use from the `Auth` datastore option (following the convention of other Kerberos modules that now support multiple mechanisms).  This means that LDAP clients can authentication in one of 3 ways now (plain/simple, ntlm, kerberos).

I switched the BIND_DN and BIND_PW options to USERNAME and PASSWORD, again following the convention set by the rest of the in-progress kerberos work. The `Msf::Exploit::Remote::SMB::Client::MicrosoftKerberosAuthenticator` client works out of the box in this context. The service name of `cifs` should probably be configurable, but as long as the service name is valid, and the hostname is the LDAP server, it appears to be sufficient for authentication. Changing the service name to an invalid name or the hostname to a host that's not in AD will result in a kerberos error. If the hostname *is* a host in AD but not the LDAP server, the bind operation will result in a failure.

## Testing

- [ ] Use the LDAP module from #16598
- [ ] Set the `DOMAIN`, `USERNAME`, `PASSWORD`, `RHOSTNAME`, `DomainControllerIp`, `RHOSTS` options
- [ ] Load wireshark to watch and verify the authentication type, use a filter like `tcp.flags.push == 1` 
- [ ] Run `run Auth=kerberos`, see results from the module and a valid kerberos authentication exchange and bind from Wireshark
- [ ] Run `run Auth=ntlm`, see results from the module and a valid NTLMSSP authentication exchange and bind from Wireshark