### PR TITLE
Fix reference URL link in hikvision_rtsp_bof.rb

### DIFF
--- a/modules/exploits/linux/misc/hikvision_rtsp_bof.rb
+++ b/modules/exploits/linux/misc/hikvision_rtsp_bof.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2014-4880' ],
-          [ 'URL', 'https://www.rapid7.com/blog/post/2014/11/19/r7-2014-18-hikvision-dvr-devices--multiple-vulnerabilities' ]
+          [ 'URL', 'https://www.rapid7.com/blog/post/2014/11/19/r7-2014-18-hikvision-dvr-devices-multiple-vulnerabilities' ]
         ],
       'Platform'       => 'linux',
       'Arch'           => ARCH_ARMLE,


### PR DESCRIPTION
Fixes #16595 

Basically a simple change to fix a extra - that was typo'd in the reference link.

## Verification
- [ ] Review the changes and verify the new link works.
