### PR TITLE
Fix bugs in previous etypes work

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -155,8 +155,8 @@ module Msf
             server_name = options[:server_name]
             client_name = options[:client_name]
             password = options[:password]
-            password.freeze.dup.force_encoding('utf-8') if password
-            client_name.freeze.dup.force_encoding('utf-8')
+            password.dup.force_encoding('utf-8') if password
+            client_name.dup.force_encoding('utf-8')
             request_pac = options.fetch(:request_pac, true)
 
             # First stage: Send an initial AS-REQ request, used to exchange supported encryption methods.

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -155,8 +155,8 @@ module Msf
             server_name = options[:server_name]
             client_name = options[:client_name]
             password = options[:password]
-            password.force_encoding('utf-8') if password
-            client_name.force_encoding('utf-8')
+            password.freeze.dup.force_encoding('utf-8') if password
+            client_name.freeze.dup.force_encoding('utf-8')
             request_pac = options.fetch(:request_pac, true)
 
             # First stage: Send an initial AS-REQ request, used to exchange supported encryption methods.
@@ -194,6 +194,9 @@ module Msf
                 decrypted_part: nil
               )
             end
+
+            # If we're just AS_REP Roasting, we can't go any further
+            raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: initial_as_res) if password == nil
 
             # Verify error codes. Anything other than the server requiring an additional preauth request is considered a failure.
             if initial_as_res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR && initial_as_res.error_code != Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_PREAUTH_REQUIRED


### PR DESCRIPTION
This fixes a few issues in the `kerberos_login` module introduced as part of #16685 (see https://github.com/rapid7/metasploit-framework/pull/16685#issuecomment-1162934704)

In order from that comment:

1. Nil passwords caused a crash. Nil passwords, as I understand it, is intended to only perform an ASREP-roast. However, when using nil passwords, after receiving the `KRB-ERROR` (which is expected when pre-auth is required), the code continued performing a login attempt anyway. The initial code used `Rex::Text.to_unicode`, which has the behaviour of turning `nil` into an empty string - so a login attempt was mode with a blank password when the intention was to just perform the ASREP roast. However I changed the code to use Ruby's built in unicode functions, which instead crashes for `nil`. The fix here was just to return immediately when the initial ASREP-roast is complete, which also fixes the spurious login attempt.
2. This was the same issue as the first issue. Setting an empty value for `password` does not run with a blank password - rather, it sets a `nil` value for `password`. I confirmed that setting `blank_passwords` to `true` had no issues.
3. This was caused by the `force_encoding` concern noted here: https://github.com/rapid7/metasploit-framework/pull/16685#discussion_r903583289 - fixing that fixed the issue.
4. I have no idea what's going on here - our code succeeds against the RFC's unicode test cases; more investigation needed. After discussion with @adfoster-r7, we agreed to leave this for now.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/kerberos/kerberos_login`
- [ ] Run with nil passwords, on an account with pre-auth required
- [ ] Verify that it does not crash
- [ ] Verify that it does not perform a second AS-REQ request with an encrypted timestamp
- [ ] Run a successful login attempt against an account containing non-ASCII characters in both the username and password
- [ ] Verify that it succeeds, and does not crash