### PR TITLE
Kerberos login enhancements

### DIFF
--- a/lib/metasploit/framework/login_scanner/kerberos.rb
+++ b/lib/metasploit/framework/login_scanner/kerberos.rb
@@ -41,7 +41,7 @@ module Metasploit
             result_options = result_options.merge({ status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e })
             return Metasploit::Framework::LoginScanner::Result.new(result_options)
           rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
-            status = status_for_error_code(e.error_code)
+            status = status_for_error_msg(e)
             result_options = result_options.merge({ status: status, proof: e })
             return Metasploit::Framework::LoginScanner::Result.new(result_options)
           end
@@ -56,17 +56,42 @@ module Metasploit
 
         private
 
-        def status_for_error_code(error_code)
-          map = {
-            # This might be because of an explicit disabling or because of other restrictions in place on the account. For example: account disabled, expired, or locked out
-            # Note this doesn't map cleanly to Metasploit's login status codes which are only DISABLED or DENIED_ACCESS, and not a union
-            Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CLIENT_REVOKED => Metasploit::Model::Login::Status::DISABLED,
-
+        def status_for_error_msg(error_msg)
+          error_code = error_msg.error_code
+          case error_code
+          when Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_C_PRINCIPAL_UNKNOWN
             # The username doesn't exist
-            Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_C_PRINCIPAL_UNKNOWN => Metasploit::Model::Login::Status::INVALID_PUBLIC_PART
-          }
-
-          map.fetch(error_code, Metasploit::Model::Login::Status::INCORRECT)
+            Metasploit::Model::Login::Status::INVALID_PUBLIC_PART
+          when Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CLIENT_REVOKED
+            # Locked out, disabled or expired
+            # It doesn't appear to be documented anywhere (RFC4120 says this is 
+            # "implementation-defined"), but Microsoft gives us a bit of extra information 
+            # in the e-data section
+            begin
+              pa_data_entry = error_msg.res.e_data_as_pa_data_entry
+              if pa_data_entry.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_PW_SALT
+                pw_salt = pa_data_entry.decoded_value
+                case pw_salt.nt_status
+                when 0xC0000234 # STATUS_ACCOUNT_LOCKED_OUT
+                  Metasploit::Model::Login::Status::LOCKED_OUT
+                when 0xC0000072 # STATUS_ACCOUNT_DISABLED
+                  Metasploit::Model::Login::Status::DISABLED
+                when 0xC0000193
+                  # Actually expired, which is effectively Disabled
+                  Metasploit::Model::Login::Status::DISABLED
+                else
+                  Metasploit::Model::Login::Status::DENIED_ACCESS
+                end
+              else
+                  Metasploit::Model::Login::Status::DENIED_ACCESS
+              end
+            rescue Rex::Proto::Kerberos::Model::Error::KerberosDecodingError
+              # Could be a non-MS implementation?
+              Metasploit::Model::Login::Status::DENIED_ACCESS
+            end
+          else
+            Metasploit::Model::Login::Status::INCORRECT
+          end
         end
 
         def set_sane_defaults

--- a/lib/metasploit/framework/login_scanner/kerberos.rb
+++ b/lib/metasploit/framework/login_scanner/kerberos.rb
@@ -71,7 +71,7 @@ module Metasploit
             # of extra information in the e-data section
             begin
               pa_data_entry = error_msg.res.e_data_as_pa_data_entry
-              if pa_data_entry.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_PW_SALT
+              if pa_data_entry && pa_data_entry.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_PW_SALT
                 pw_salt = pa_data_entry.decoded_value
                 case pw_salt.nt_status
                 when 0xC0000234 # STATUS_ACCOUNT_LOCKED_OUT
@@ -86,11 +86,11 @@ module Metasploit
                   Metasploit::Model::Login::Status::DISABLED
                 end
               else
-                  Metasploit::Model::Login::Status::DENIED_ACCESS
+                  Metasploit::Model::Login::Status::DISABLED
               end
             rescue Rex::Proto::Kerberos::Model::Error::KerberosDecodingError
               # Could be a non-MS implementation?
-              Metasploit::Model::Login::Status::DENIED_ACCESS
+              Metasploit::Model::Login::Status::DISABLED
             end
           else
             Metasploit::Model::Login::Status::INCORRECT

--- a/lib/metasploit/framework/login_scanner/kerberos.rb
+++ b/lib/metasploit/framework/login_scanner/kerberos.rb
@@ -56,7 +56,7 @@ module Metasploit
 
         private
 
-        # @param [Rex::Proto::Kerberos::Model::Error::KerberosError] error The kerberos error
+        # @param [Rex::Proto::Kerberos::Model::Error::KerberosError] krb_err The kerberos error
         def login_status_for_kerberos_error(krb_err)
           error_code = krb_err.error_code
           case error_code

--- a/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
+++ b/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
@@ -99,6 +99,12 @@ module Msf::Exploit::Remote::Kerberos::AuthBrute
         else
           vprint_status("#{peer} - User: #{user.inspect} - #{proof}")
         end
+      when Metasploit::Model::Login::Status::LOCKED_OUT
+        print_error("#{peer} - User: #{user.inspect} account locked out")
+      when Metasploit::Model::Login::Status::DISABLED
+        print_error("#{peer} - User: #{user.inspect} account disabled or expired")
+      when Metasploit::Model::Login::Status::DENIED_ACCESS
+        print_error("#{peer} - User: #{user.inspect} account unable to log in")
       end
     end
   end

--- a/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
+++ b/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
@@ -63,14 +63,9 @@ module Msf::Exploit::Remote::Kerberos::AuthBrute
       when Metasploit::Model::Login::Status::SUCCESSFUL
         case proof
         when Rex::Proto::Kerberos::Model::Error::KerberosError
-        if proof.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_KEY_EXPIRED || proof.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KRB_AP_ERR_SKEW
           print_good("#{peer} - User found: #{user.inspect} with password #{password}, but no ticket received (#{proof})")
           report_cred(user: user, password: password)
-        else
-          raise ::RuntimeError, 'Successful login reported, but unknown error'
-        end
         when Msf::Exploit::Remote::Kerberos::Model::TgtResponse
-
           hash = format_as_rep_to_john_hash(proof.as_rep)
 
           # Accounts that have 'Do not require Kerberos preauthentication' enabled, will receive an ASREP response with a
@@ -82,7 +77,8 @@ module Msf::Exploit::Remote::Kerberos::AuthBrute
           end
           report_cred(user: user, password: password, asrep: hash)
         else
-          raise ::RuntimeError, 'Successful login reported, but unknown proof type'
+          print_good("#{peer} - User found: #{user.inspect} with password #{password}.")
+          report_cred(user: user, password: password)
         end
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         print_error("#{peer} - User: #{user.inspect} - Unable to connect - #{proof}")
@@ -117,6 +113,8 @@ module Msf::Exploit::Remote::Kerberos::AuthBrute
         print_error("#{peer} - User: #{user.inspect} account disabled or expired")
       when Metasploit::Model::Login::Status::DENIED_ACCESS
         print_error("#{peer} - User: #{user.inspect} account unable to log in")
+      else
+        print_error("#{peer} - User: #{user.inspect} #{proof}")
       end
     end
   end

--- a/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
+++ b/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
@@ -61,17 +61,29 @@ module Msf::Exploit::Remote::Kerberos::AuthBrute
 
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        hash = format_as_rep_to_john_hash(proof.as_rep)
-
-        # Accounts that have 'Do not require Kerberos preauthentication' enabled, will receive an ASREP response with a
-        # ticket present without requiring a password
-        if !proof.preauth_required
-          print_good("#{peer} - User: #{user.inspect} does not require preauthentication. Hash: #{hash}")
+        case proof
+        when Rex::Proto::Kerberos::Model::Error::KerberosError
+        if proof.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_KEY_EXPIRED || proof.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KRB_AP_ERR_SKEW
+          print_good("#{peer} - User found: #{user.inspect} with password #{password}, but no ticket received (#{proof})")
+          report_cred(user: user, password: password)
         else
-          print_good("#{peer} - User found: #{user.inspect} with password #{password}. Hash: #{hash}")
+          raise ::RuntimeError, 'Successful login reported, but unknown error'
         end
+        when Msf::Exploit::Remote::Kerberos::Model::TgtResponse
 
-        report_cred(user: user, password: password, asrep: hash)
+          hash = format_as_rep_to_john_hash(proof.as_rep)
+
+          # Accounts that have 'Do not require Kerberos preauthentication' enabled, will receive an ASREP response with a
+          # ticket present without requiring a password
+          if !proof.preauth_required
+            print_good("#{peer} - User: #{user.inspect} does not require preauthentication. Hash: #{hash}")
+          else
+            print_good("#{peer} - User found: #{user.inspect} with password #{password}. Hash: #{hash}")
+          end
+          report_cred(user: user, password: password, asrep: hash)
+        else
+          raise ::RuntimeError, 'Successful login reported, but unknown proof type'
+        end
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         print_error("#{peer} - User: #{user.inspect} - Unable to connect - #{proof}")
 

--- a/lib/rex/proto/kerberos/model/krb_error.rb
+++ b/lib/rex/proto/kerberos/model/krb_error.rb
@@ -89,8 +89,13 @@ module Rex
           #
           # @return [Rex::Proto::Kerberos::Model::PreAuthData]
           def e_data_as_pa_data_entry
-            decoded = OpenSSL::ASN1.decode(self.e_data)
-            Rex::Proto::Kerberos::Model::PreAuthDataEntry.decode(decoded)
+            if self.e_data
+              decoded = OpenSSL::ASN1.decode(self.e_data)
+              Rex::Proto::Kerberos::Model::PreAuthDataEntry.decode(decoded)
+            else
+              # This is implementation-defined, so may be different in some cases
+              nil
+            end
           end
 
           private

--- a/lib/rex/proto/kerberos/model/pre_auth_data_entry.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_data_entry.rb
@@ -59,7 +59,8 @@ module Rex
               decoded = OpenSSL::ASN1.decode(self.value)
               PreAuthEncTimeStamp.decode(decoded)
             when Rex::Proto::Kerberos::Model::PreAuthType::PA_PW_SALT
-              # Not yet supported
+              # This is not DER_encoded - just pass the string directly
+              PreAuthPwSalt.decode(self.value)
             when Rex::Proto::Kerberos::Model::PreAuthType::PA_ETYPE_INFO
               # Not yet supported
             when Rex::Proto::Kerberos::Model::PreAuthType::PA_ETYPE_INFO2

--- a/lib/rex/proto/kerberos/model/pre_auth_pw_salt.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_pw_salt.rb
@@ -7,10 +7,11 @@ module Rex
         # This class provides a representation of a PA-PW-SALT structure,
         # which in practise appears to be a MS-specific implementation detail
         # of Kerberos, which contains information about login status
+        # https://datatracker.ietf.org/doc/html/rfc4120#section-5.2.7.3
         class PreAuthPwSalt < Element
 
           # @!attribute nt_status
-          #   @return [Integer] The NT Status from a login attempt
+          #   @return [::WindowsError::NTStatus] The NT Status from a login attempt
           attr_accessor :nt_status
           # @!attribute Reserved
           #   @return [Integer] Reserved
@@ -18,9 +19,6 @@ module Rex
           # @!attribute type
           #   @return [Integer] Uncertain what this represents
           attr_accessor :flags
-
-
-
 
           # Decodes the Rex::Proto::Kerberos::Model::PreAuthPwSalt from an input
           #
@@ -39,7 +37,7 @@ module Rex
           end
 
           def encode
-            [self.nt_status, self.reserved, self.flags].pack('VVV')
+            [nt_status.value, reserved, flags].pack('VVV')
           end
 
           private
@@ -49,7 +47,9 @@ module Rex
           # @param input [String] the input to decode from
           def decode_string(input)
             return if input.length != 12 # Likely an older KDC server, or Linux server, which use this field differently
-            self.nt_status, self.reserved, self.flags = input.unpack('VVV')
+
+            status, self.reserved, self.flags = input.unpack('VVV')
+            self.nt_status = ::WindowsError::NTStatus.find_by_retval(status).first
           end
         end
       end

--- a/lib/rex/proto/kerberos/model/pre_auth_pw_salt.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_pw_salt.rb
@@ -48,9 +48,7 @@ module Rex
           #
           # @param input [String] the input to decode from
           def decode_string(input)
-            if input.length != 12
-              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode PA-PW-SALT, invalid input'
-            end
+            return if input.length != 12 # Likely an older KDC server, or Linux server, which use this field differently
             self.nt_status, self.reserved, self.flags = input.unpack('VVV')
           end
         end

--- a/lib/rex/proto/kerberos/model/pre_auth_pw_salt.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_pw_salt.rb
@@ -1,0 +1,60 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # This class provides a representation of a PA-PW-SALT structure,
+        # which in practise appears to be a MS-specific implementation detail
+        # of Kerberos, which contains information about login status
+        class PreAuthPwSalt < Element
+
+          # @!attribute nt_status
+          #   @return [Integer] The NT Status from a login attempt
+          attr_accessor :nt_status
+          # @!attribute Reserved
+          #   @return [Integer] Reserved
+          attr_accessor :reserved
+          # @!attribute type
+          #   @return [Integer] Uncertain what this represents
+          attr_accessor :flags
+
+
+
+
+          # Decodes the Rex::Proto::Kerberos::Model::PreAuthPwSalt from an input
+          #
+          # @param input [String] the input to decode from
+          # @return [self] if decoding succeeds
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
+          def decode(input)
+            case input
+            when String
+              decode_string(input)
+            else
+              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode PA-PW-SALT, invalid input'
+            end
+
+            self
+          end
+
+          def encode
+            [self.nt_status, self.reserved, self.flags].pack('VVV')
+          end
+
+          private
+
+          # Decodes a Rex::Proto::Kerberos::Model::PreuAuthPwSalt from a String
+          #
+          # @param input [String] the input to decode from
+          def decode_string(input)
+            if input.length != 12
+              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode PA-PW-SALT, invalid input'
+            end
+            self.nt_status, self.reserved, self.flags = input.unpack('VVV')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/metasploit/framework/login_scanner/kerberos_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/kerberos_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::Kerberos do
 
   let(:tgt_response_client_revoked) do
     ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(
-      error_code: ::Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CLIENT_REVOKED
+      error_code: ::Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CLIENT_REVOKED,
+      res: ::Rex::Proto::Kerberos::Model::KrbError.new
     )
   end
 

--- a/spec/lib/metasploit/framework/login_scanner/kerberos_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/kerberos_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/kerberos'
+require 'windows_error'
+require 'windows_error/nt_status'
 
 RSpec.describe Metasploit::Framework::LoginScanner::Kerberos do
   let(:server_name) { 'demo.local_server' }
@@ -45,6 +47,25 @@ RSpec.describe Metasploit::Framework::LoginScanner::Kerberos do
     ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(
       error_code: ::Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CLIENT_REVOKED,
       res: ::Rex::Proto::Kerberos::Model::KrbError.new
+    )
+  end
+
+  let(:tgt_response_client_revoked_locked) do
+    err = ::Rex::Proto::Kerberos::Model::KrbError.new
+    pwsalt = ::Rex::Proto::Kerberos::Model::PreAuthPwSalt.new
+    pwsalt.nt_status = ::WindowsError::NTStatus::STATUS_ACCOUNT_LOCKED_OUT
+    pwsalt.flags = 0
+    pwsalt.reserved = 0
+
+    padata = ::Rex::Proto::Kerberos::Model::PreAuthDataEntry.new
+    padata.type = Rex::Proto::Kerberos::Model::PreAuthType::PA_PW_SALT
+    padata.value = pwsalt.encode
+
+    err.e_data = padata.encode
+
+    ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(
+      error_code: ::Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CLIENT_REVOKED,
+      res: err
     )
   end
 
@@ -100,6 +121,19 @@ RSpec.describe Metasploit::Framework::LoginScanner::Kerberos do
         result = subject.attempt_login(mock_credential)
 
         expect(result.status).to eq(Metasploit::Model::Login::Status::DISABLED)
+        expect(result.proof.error_code).to eq(::Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CLIENT_REVOKED)
+      end
+    end
+
+    context 'when the account is locked' do
+      before(:each) do
+        allow(subject).to receive(:send_request_tgt).with(expected_tgt_request).and_raise(tgt_response_client_revoked_locked)
+      end
+
+      it 'returns the correct login status' do
+        result = subject.attempt_login(mock_credential)
+
+        expect(result.status).to eq(Metasploit::Model::Login::Status::LOCKED_OUT)
         expect(result.proof.error_code).to eq(::Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CLIENT_REVOKED)
       end
     end


### PR DESCRIPTION
This produces clearer errors in some edge cases for the Kerberos scanner:

- Against Windows Kerberos servers, locked, expired and disabled accounts are able to be differentiated using the additional data found in a "pw-salt" entry in padata. This seems to be against the intended use of the field in RFC4120, but it's such an old field (superseded twice with etype_info and etype_info2), that I guess MS decided to coopt the field for this purpose. I've tested on 2012 and 2019, so seems to be reliable. It probably can't be 100% relied upon in every circumstance (see: https://gitlab.com/wireshark/wireshark/-/issues/5387) but I think the additional data most of the time it gives is useful. If the value is a string and parsing fails, it should just continue on anyway.
- When the password is correct but no ticket is provided (clock skew, expired password), 

## Verification

- [ ] Start `msfconsole`
- [ ] `use kerberos_login`
- [ ] Test against an account with its password set to "require change on next login"
- [ ] Verify that MSF shows "correct password, but expired"
- [ ] Reset the KDC's local time by an hour
- [ ] Verify that MSF shows "correct password, but Clock skew too great"
- [ ] Test against an account that is expired (just set the "account expires" value set in the past)
- [ ] Verify that MSF shows "disabled or expired" and stops immediately
- [ ] Test against a disabled account
- [ ] Verify that MSF shows "disabled or expired" and stops immediately
- [ ] Lock an account out
- [ ] Verify that MSF shows "account locked out" and stops immediately
