### PR TITLE
Fix Rex Table crashing on unknown characters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,7 +383,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.3)
-    rex-text (0.2.37)
+    rex-text (0.2.38)
     rex-zip (0.1.4)
       rex-text
     rexml (3.2.5)


### PR DESCRIPTION
Pulls in the change from https://github.com/rapid7/rex-text/pull/44

Should be simple to test using https://github.com/rapid7/metasploit-framework/pull/16598 and then adjusting the code so that you allow it to display the `objectGUID` field as a column of choice for one of the queries.

Before this change, you would get an error like so:

```
msf6 auxiliary(gather/query_ldap) > run
[*] Running module against 172.19.134.42

[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[+] 172.19.134.42:389 Discovered base DN: DC=daforest,DC=com
[-] Auxiliary failed: ArgumentError invalid byte sequence in UTF-8
[-] Call stack:
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:413:in `split'
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:413:in `block in chunk_values'
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:410:in `each'
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:410:in `each_with_index'
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:410:in `each'
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:410:in `map'
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:410:in `chunk_values'
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:395:in `row_to_s'
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:125:in `block in to_s'
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:121:in `each'
[-]   /home/gwillcox/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/rex-text-0.2.37/lib/rex/text/wrapped_table.rb:121:in `to_s'
[-]   /home/gwillcox/git/metasploit-framework/modules/auxiliary/gather/query_ldap.rb:210:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(gather/query_ldap) > exit
```


With this new gem version, you should now get something like this:

```
msf6 auxiliary(gather/query_ldap) > run
[*] Running module against 172.19.134.42

[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[+] 172.19.134.42:389 Discovered base DN: DC=daforest,DC=com
[*] ENUM_ALL_OBJECTCLASS Dump of 172.19.134.42:389
==============================================

 dn                                  objectClass                         objectGUID
 --                                  -----------                         ----------
 CN=0b7fb422-3609-4587-8c2e-94b10f6  top || container                    8�<y�|J���
��O
 7d1bf,CN=Operations,CN=DomainUpdat
 es,CN=System,DC=daforest,DC=com
 CN=0e660ea3-8a5e-4495-9ad7-ca1bd46  top || container                    �^fpg5�I�>�s/���
 38f9e,CN=Operations,CN=DomainUpdat
 es,CN=System,DC=daforest,DC=com
 CN=10b3ad2a-6883-4fa7-90fc-6377cbd  top || container                    ��`
d�M�!����E
 c1b26,CN=Operations,CN=DomainUpdat
 es,CN=System,DC=daforest,DC=com
 CN=13d15cf0-e6c8-11d6-9793-00c04f6  top || container                    !%CGX��E�4]4X3O
 13221,CN=Operations,CN=DomainUpdat
 es,CN=System,DC=daforest,DC=com

*cut a ton of data for brevity*

 DC=RootDNSServers,CN=MicrosoftDNS,  top || dnsZone                      �k���K�h�E>sX
 CN=System,DC=daforest,DC=com
 DC=daforest,DC=com                  top || domain || domainDNS          ����3�H�q�e���
 OU=Domain Controllers,DC=daforest,  top || organizationalUnit           t���E��A�xXf#���
 DC=com

[*] Auxiliary module execution completed
msf6 auxiliary(gather/query_ldap) > 
```


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/query_ldap`
- [ ] `set RHOST` to target AD controller hosting an LDAP server, such as the DC.
- [ ] `set BIND_DN <username>@<domain name>` ex `normal@dadomain.com`
- [ ] `set BIND_PW` to the password for the user.
- [ ] `set ACTION` to the action whose columns you have adjusted to include the `objectGUID` column.
- [ ] `run`
- [ ] **Verify** that you get the output and that you do not crash.
- [ ] **Verify** that the previous version of rex-text would crash.
