### PR TITLE
Use proper permissions when opening a process

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -63,15 +63,15 @@ class Process < Rex::Post::Process
       perms = PROCESS_ALL
     end
 
-    if (perms & PROCESS_READ)
+    if (perms & PROCESS_READ) > 0
       real_perms |= PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_QUERY_INFORMATION
     end
 
-    if (perms & PROCESS_WRITE)
+    if (perms & PROCESS_WRITE) > 0
       real_perms |= PROCESS_SET_SESSIONID | PROCESS_VM_WRITE | PROCESS_DUP_HANDLE | PROCESS_SET_QUOTA | PROCESS_SET_INFORMATION
     end
 
-    if (perms & PROCESS_EXECUTE)
+    if (perms & PROCESS_EXECUTE) > 0
       real_perms |= PROCESS_TERMINATE | PROCESS_CREATE_THREAD | PROCESS_CREATE_PROCESS | PROCESS_SUSPEND_RESUME
     end
 


### PR DESCRIPTION
When `Process.open()` is called with a generic permission such as `PROCESS_READ`, `PROCESS_WRITE`, etc., the method will check if each generic permission is set and assign more granular permissions if so before calling `_open()`. The current version of the method will set all of the granular permissions whether the generic ones are set or not because 0 is truthy in Ruby. This change just makes sure that the generic permission is actually set before assigning the more specific permissions.

## Verification

List the steps needed to make sure this thing works

- [x] Get a Windows meterpreter session
- [x] Call `Process.open()` with `PROCESS_READ`, `PROCESS_WRITE`, `PROCESS_EXECUTE`, or with a combination of the permissions
- [x] Make sure that you get the permissions you expect

## Scenarios

<details><summary>Prior to fix</summary>

```
meterpreter > irb
[*] Starting IRB shell...
[*] You are in the "client" (session) object

irb: warn: can't alias kill from irb_kill.
>> PROCESS_READ
=> 1
>> sys.process.open(1469, PROCESS_READ)

From: /Users/space/rapid7/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb:79 #<Class:0x00007fc438519dd0>.open:

    59: def Process.open(pid = nil, perms = nil)
    60:   real_perms = 0
    61: 
    62:   if (perms == nil)
    63:     perms = PROCESS_ALL
    64:   end
    65: 
    66:   if (perms & PROCESS_READ)
    67:     real_perms |= PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_QUERY_INFORMATION
    68:   end
    69: 
    70:   if (perms & PROCESS_WRITE)
    71:     real_perms |= PROCESS_SET_SESSIONID | PROCESS_VM_WRITE | PROCESS_DUP_HANDLE | PROCESS_SET_QUOTA | PROCESS_SET_INFORMATION
    72:   end
    73: 
    74:   if (perms & PROCESS_EXECUTE)
    75:     real_perms |= PROCESS_TERMINATE | PROCESS_CREATE_THREAD | PROCESS_CREATE_PROCESS | PROCESS_SUSPEND_RESUME
    76:   end
    77: 
    78:   require 'pry';binding.pry
 => 79:   return _open(pid, real_perms)
    80: end

[1] pry(#<Class>)> real_perms
=> 4095
[2] pry(#<Class>)> PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_QUERY_INFORMATION
=> 1048
[3] pry(#<Class>)> exit
>> PROCESS_EXECUTE
=> 4
>> sys.process.open(1469, PROCESS_EXECUTE)

From: /Users/space/rapid7/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb:79 #<Class:0x00007fc438519dd0>.open:

    59: def Process.open(pid = nil, perms = nil)
    60:   real_perms = 0
    61: 
    62:   if (perms == nil)
    63:     perms = PROCESS_ALL
    64:   end
    65: 
    66:   if (perms & PROCESS_READ)
    67:     real_perms |= PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_QUERY_INFORMATION
    68:   end
    69: 
    70:   if (perms & PROCESS_WRITE)
    71:     real_perms |= PROCESS_SET_SESSIONID | PROCESS_VM_WRITE | PROCESS_DUP_HANDLE | PROCESS_SET_QUOTA | PROCESS_SET_INFORMATION
    72:   end
    73: 
    74:   if (perms & PROCESS_EXECUTE)
    75:     real_perms |= PROCESS_TERMINATE | PROCESS_CREATE_THREAD | PROCESS_CREATE_PROCESS | PROCESS_SUSPEND_RESUME
    76:   end
    77: 
    78:   require 'pry';binding.pry
 => 79:   return _open(pid, real_perms)
    80: end

[1] pry(#<Class>)> real_perms
=> 4095
[2] pry(#<Class>)> PROCESS_TERMINATE | PROCESS_CREATE_THREAD | PROCESS_CREATE_PROCESS | PROCESS_SUSPEND_RESUME
=> 2179
```

</details>

<details><summary>After fix</summary>

```
>> PROCESS_READ
=> 1
>> sys.process.open(1469, PROCESS_READ)

From: /Users/space/rapid7/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb:79 #<Class:0x00007fe60511c450>.open:

    59: def Process.open(pid = nil, perms = nil)
    60:   real_perms = 0
    61: 
    62:   if (perms == nil)
    63:     perms = PROCESS_ALL
    64:   end
    65: 
    66:   if (perms & PROCESS_READ) > 0
    67:     real_perms |= PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_QUERY_INFORMATION
    68:   end
    69: 
    70:   if (perms & PROCESS_WRITE) > 0
    71:     real_perms |= PROCESS_SET_SESSIONID | PROCESS_VM_WRITE | PROCESS_DUP_HANDLE | PROCESS_SET_QUOTA | PROCESS_SET_INFORMATION
    72:   end
    73: 
    74:   if (perms & PROCESS_EXECUTE) > 0
    75:     real_perms |= PROCESS_TERMINATE | PROCESS_CREATE_THREAD | PROCESS_CREATE_PROCESS | PROCESS_SUSPEND_RESUME
    76:   end
    77: 
    78:   require 'pry';binding.pry
 => 79:   return _open(pid, real_perms)
    80: end

[1] pry(#<Class>)> real_perms
=> 1048
[2] pry(#<Class>)> PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_QUERY_INFORMATION
=> 1048
[3] pry(#<Class>)> exit
>> sys.process.open(1469, PROCESS_EXECUTE)

From: /Users/space/rapid7/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb:79 #<Class:0x00007fe60511c450>.open:

    59: def Process.open(pid = nil, perms = nil)
    60:   real_perms = 0
    61: 
    62:   if (perms == nil)
    63:     perms = PROCESS_ALL
    64:   end
    65: 
    66:   if (perms & PROCESS_READ) > 0
    67:     real_perms |= PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_QUERY_INFORMATION
    68:   end
    69: 
    70:   if (perms & PROCESS_WRITE) > 0
    71:     real_perms |= PROCESS_SET_SESSIONID | PROCESS_VM_WRITE | PROCESS_DUP_HANDLE | PROCESS_SET_QUOTA | PROCESS_SET_INFORMATION
    72:   end
    73: 
    74:   if (perms & PROCESS_EXECUTE) > 0
    75:     real_perms |= PROCESS_TERMINATE | PROCESS_CREATE_THREAD | PROCESS_CREATE_PROCESS | PROCESS_SUSPEND_RESUME
    76:   end
    77: 
    78:   require 'pry';binding.pry
 => 79:   return _open(pid, real_perms)
    80: end

[1] pry(#<Class>)> real_perms
=> 2179
[2] pry(#<Class>)> PROCESS_TERMINATE | PROCESS_CREATE_THREAD | PROCESS_CREATE_PROCESS | PROCESS_SUSPEND_RESUME
=> 2179
[3] pry(#<Class>)> exit
>> sys.process.open(1469, PROCESS_EXECUTE | PROCESS_READ)

From: /Users/space/rapid7/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb:79 #<Class:0x00007fe60511c450>.open:

    59: def Process.open(pid = nil, perms = nil)
    60:   real_perms = 0
    61: 
    62:   if (perms == nil)
    63:     perms = PROCESS_ALL
    64:   end
    65: 
    66:   if (perms & PROCESS_READ) > 0
    67:     real_perms |= PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_QUERY_INFORMATION
    68:   end
    69: 
    70:   if (perms & PROCESS_WRITE) > 0
    71:     real_perms |= PROCESS_SET_SESSIONID | PROCESS_VM_WRITE | PROCESS_DUP_HANDLE | PROCESS_SET_QUOTA | PROCESS_SET_INFORMATION
    72:   end
    73: 
    74:   if (perms & PROCESS_EXECUTE) > 0
    75:     real_perms |= PROCESS_TERMINATE | PROCESS_CREATE_THREAD | PROCESS_CREATE_PROCESS | PROCESS_SUSPEND_RESUME
    76:   end
    77: 
    78:   require 'pry';binding.pry
 => 79:   return _open(pid, real_perms)
    80: end

[1] pry(#<Class>)> real_perms
=> 3227
[2] pry(#<Class>)> PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_QUERY_INFORMATION | PROCESS_TERMINATE | PROCESS_CREATE_THREAD | PROCESS_CREATE_PROCESS | PROCESS_SUSPEND_RESUME
=> 3227
```

</details>