### PR TITLE
enable MeterpreterTryToFork by default for aerohive_netconfig_lfi_log_poison_rce

### DIFF
--- a/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
+++ b/documentation/modules/exploit/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.md
@@ -19,10 +19,9 @@ This request includes two POST parameters:
 2. The parameter that is used to execute commands via `/tmp/messages`.
 In our example the name would be `cmd`, but the module sets this to an arbitrary value.
 
-Upon successful exploitation, the Aerohive NetConfig application will hang for as long as the spawned shell remains open.
-Closing the session should render the app responsive again.  It is also possible that enabling the meterpreter option
-'TryToFork` might prevent the application hang after exploitation, but given access constraints we were unable to verify the
-resultant behavior for enabling that option.  Try at your own risk (but let us know how it goes if you do).
+Upon successful exploitation, the Aerohive NetConfig application may hang for as long as the spawned shell remains open.
+If the Linux target is selected with a meterpreter payload, the `MeterpreterTryToFork` option is likely to prevent this,
+and is therefore enabled by default. If the app does hang, closing the session should render the app responsive again.
 
 The module provides an automatic cleanup option to clean the log.
 However, this option is disabled by default because any modifications to the /tmp/messages log, even via sed,

--- a/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
+++ b/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
@@ -26,8 +26,10 @@ class MetasploitModule < Msf::Exploit::Remote
           issue in conjunction with log poisoning to gain RCE as root.
 
           Upon successful exploitation, the Aerohive NetConfig application
-          will hang for as long as the spawned shell remains open. Closing
-          the session should render the app responsive again.
+          may hang for as long as the spawned shell remains open. For the
+          Linux target, the MeterpreterTryToFork option (enabled by default)
+          will likely prevent this. If the app hangs, closing the session
+          should render it responsive again.
 
           The module provides an automatic cleanup option to clean the log.
           However, this option is disabled by default because any modifications
@@ -59,7 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux',
               'DefaultOptions' => {
                 'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp',
-                'CMDSTAGER::FLAVOR' => 'curl'
+                'CMDSTAGER::FLAVOR' => 'curl',
+                'MeterpreterTryToFork' => true # prevent the web server from hanging when we get a meterpreter session
               }
             }
           ],


### PR DESCRIPTION
# About
This change sets the `MeterpreterTryToFork` advanced payload option to true by default for the Linux target in the `aerohive_netconfig_lfi_log_poison_rce` module. It also updates the documentation to reflect this.

# Justification
When this module was originally added in https://github.com/rapid7/metasploit-framework/pull/15700, it was suggested during code review that enabling `MeterpreterTryToFork` could possibly prevent the target app from hanging whenever a shell was obtained. At the time, I was unable to test this. so this option was only mentioned as a suggestion in the documentation. However, since then I have successfully tested this module with `MeterpreterTryToFork` enabled against about a dozen different target apps. Setting this option consistently prevented the app from hanging, while no side effects were observed. I have not saved spool files from these sessions because the difference was not observable in the spool files, other than that the option was shown to be enabled.