### PR TITLE
Weekly dependency updates for Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,13 +129,13 @@ GEM
       activerecord (>= 3.1.0, < 8)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.598.0)
-    aws-sdk-core (3.131.1)
+    aws-partitions (1.602.0)
+    aws-sdk-core (3.131.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-ec2 (1.317.0)
+    aws-sdk-ec2 (1.320.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-iam (1.69.0)
@@ -190,7 +190,8 @@ GEM
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.3)
-    faraday-retry (1.0.3)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
@@ -243,7 +244,7 @@ GEM
       rex-socket
       rubyntlm
       rubyzip
-    metasploit-model (4.0.4)
+    metasploit-model (4.0.5)
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
@@ -261,9 +262,9 @@ GEM
     metasploit_payloads-mettle (1.0.18)
     method_source (1.0.0)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
+    minitest (5.16.1)
     mqtt (0.5.0)
-    msgpack (1.5.2)
+    msgpack (1.5.3)
     multi_json (1.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
@@ -275,7 +276,7 @@ GEM
       digest
       net-protocol
       timeout
-    net-ssh (6.1.0)
+    net-ssh (7.0.1)
     network_interface (0.0.2)
     nexpose (7.3.0)
     nio4r (2.5.8)
@@ -283,7 +284,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nori (2.6.0)
-    octokit (4.24.0)
+    octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     openssl-ccm (1.2.2)
@@ -302,7 +303,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pg (1.3.5)
+    pg (1.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -313,11 +314,11 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.3.1)
+    rack (2.2.4)
     rack-protection (2.2.0)
       rack
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
+    rack-test (2.0.2)
+      rack (>= 1.3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -376,7 +377,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.39)
+    rex-socket (0.1.40)
       rex-core
     rex-sslscan (0.1.7)
       rex-core
@@ -411,7 +412,8 @@ GEM
     rspec-rerun (1.1.0)
       rspec (~> 3.0)
     rspec-support (3.11.0)
-    rubocop (1.30.1)
+    rubocop (1.31.1)
+      json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -449,7 +451,7 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.0)
       tilt (~> 2.0)
-    sqlite3 (1.4.2)
+    sqlite3 (1.4.4)
     sshkey (2.0.0)
     swagger-blocks (3.0.0)
     thin (1.8.1)
@@ -468,7 +470,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode-display_width (2.1.0)
+    unicode-display_width (2.2.0)
     unix-crypt (1.3.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -494,7 +496,7 @@ GEM
       webrick
     yard (0.9.28)
       webrick (~> 1.7.0)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
This PR should have been auto-generated by [actions/github-script](https://github.com/actions/github-script). `bundle update` revealed the following gems have new version to be evaluated for update.

More adjustment to get automation are in progress, for now let us pickup here this week.

## Verification

List the steps needed to make sure this thing works

- [x] Security review diffs for updated gems
