### PR TITLE
Fix mssql crash when using tds encryption

### DIFF
--- a/lib/metasploit/framework/mssql/client.rb
+++ b/lib/metasploit/framework/mssql/client.rb
@@ -145,7 +145,7 @@ module Metasploit
             if tdsencryption == true
                proxy = TDSSSLProxy.new(sock)
                proxy.setup_ssl
-               resp = proxy.send_recv(pkt, 15, false)
+               resp = proxy.send_recv(pkt)
             else
                resp = mssql_send_recv(pkt, 15, false)
             end


### PR DESCRIPTION
### Before

Looks like this commit https://github.com/rapid7/metasploit-framework/commit/07f7e5e148e949a982d734a78daf074cfd54192e#diff-592abea037a308d31c0cb0b27af03335d8d87b2ece2bcfa2d6c9ce64f1bca15dR148 broke the tds encryption support with the mssql client

Crash:
```
msf6 auxiliary(scanner/mssql/mssql_login) > rerun 192.168.123.13 domaincontrollerrhost=192.168.123.13 username=administrator password=p4$$w0rd USE_WINDOWS_AUTHENT=true mssqlrhostname=dc3.adf3.local mssqldomain=adf3.local sql='select auth_scheme from sys.dm_exec_connections where session_id=@@spid' tdsencryption=true
[*] Reloading module...

[*] 192.168.123.13:1433   - 192.168.123.13:1433 - MSSQL - Starting authentication scanner.
[*] 192.168.123.13:1433   - Manually enabled TLS/SSL to encrypt TDS payloads.
[-] 192.168.123.13:1433   - Auxiliary failed: ArgumentError wrong number of arguments (given 3, expected 1)
[-] 192.168.123.13:1433   - Call stack:
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/metasploit/framework/mssql/tdssslproxy.rb:60:in `send_recv'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/metasploit/framework/mssql/client.rb:149:in `mssql_login'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/metasploit/framework/login_scanner/mssql.rb:50:in `attempt_login'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:231:in `block in scan!'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:154:in `block in each_credential'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/metasploit/framework/credential_collection.rb:82:in `block in each_filtered'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/metasploit/framework/credential_collection.rb:223:in `each_unfiltered'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/metasploit/framework/credential_collection.rb:79:in `each_filtered'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:141:in `each_credential'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:205:in `scan!'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/modules/auxiliary/scanner/mssql/mssql_login.rb:72:in `run_host'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:124:in `block (2 levels) in run'
[-] 192.168.123.13:1433   -   /Users/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[-] 192.168.123.13:1433   -   /Users/adfoster/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
[*] Auxiliary module execution completed
```

### After

No crash

```
msf6 auxiliary(scanner/mssql/mssql_login) > rerun 192.168.123.13 username=administrator password=p4$$w0rd USE_WINDOWS_AUTHENT=true tdsencryption=true
[*] Reloading module...

[*] 192.168.123.13:1433   - 192.168.123.13:1433 - MSSQL - Starting authentication scanner.
[*] 192.168.123.13:1433   - Manually enabled TLS/SSL to encrypt TDS payloads.
[!] 192.168.123.13:1433   - No active DB -- Credential data will not be saved!
[+] 192.168.123.13:1433   - 192.168.123.13:1433 - Login Successful: WORKSTATION\administrator:p4$$w0rd
[*] 192.168.123.13:1433   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Wireshark shows encryption working as expected:

<img width="1309" alt="image" src="https://user-images.githubusercontent.com/60357436/177138656-c841b812-7695-470a-b9fa-69b81b116e82.png">

## Verification

Verify both scenarios work as intended