### PR TITLE
Fix individual mssql login crashes stopping further login attempts

### DIFF
--- a/lib/metasploit/framework/login_scanner/mssql.rb
+++ b/lib/metasploit/framework/login_scanner/mssql.rb
@@ -52,8 +52,13 @@ module Metasploit
             else
               result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
             end
-          rescue ::Rex::ConnectionError
+          rescue ::Rex::ConnectionError => e
             result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+            result_options[:proof] = e
+          rescue => e
+            elog(e)
+            result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+            result_options[:proof] = e
           end
 
           ::Metasploit::Framework::LoginScanner::Result.new(result_options)


### PR DESCRIPTION
Improves https://github.com/rapid7/metasploit-framework/issues/11341

Before the module would crash:
![image](https://user-images.githubusercontent.com/60357436/177367846-f242d102-96c5-4ba2-ac2c-ab0c4e86c986.png)


Now we should log the error and continue

## Verification

**Verify** The module can run against a server that doesn't respond:

```
msf6 auxiliary(scanner/mssql/mssql_login) > rerun 127.0.0.1
[*] Reloading module...

[*] 127.0.0.1:1433        - 127.0.0.1:1433 - MSSQL - Starting authentication scanner.
[!] 127.0.0.1:1433        - No active DB -- Credential data will not be saved!
[-] 127.0.0.1:1433        - 127.0.0.1:1433 - LOGIN FAILED: WORKSTATION\sa: (Unable to Connect: The connection was refused by the remote host (127.0.0.1:1433).)
[*] 127.0.0.1:1433        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

**Verify** that the module can run against a non-mssql service. First run the mystery service:

```
ncat -lvp 1433 < /dev/random
```

Verify the module continues to run as expected, without crashing. Note that since it's /dev/random, it may not immediately crash

```
msf6 auxiliary(scanner/mssql/mssql_login) > rerun 127.0.0.1
[*] Reloading module...

[*] 127.0.0.1:1433        - 127.0.0.1:1433 - MSSQL - Starting authentication scanner.
[!] 127.0.0.1:1433        - No active DB -- Credential data will not be saved!
[-] 127.0.0.1:1433        - 127.0.0.1:1433 - LOGIN FAILED: WORKSTATION\sa: (Unable to Connect: undefined method `each' for nil:NilClass)
[*] 127.0.0.1:1433        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```