### PR TITLE
add lotus domino hash extraction spec

### DIFF
--- a/spec/file_fixtures/modules/auxiliary/lotus_domino_hash_response.xml
+++ b/spec/file_fixtures/modules/auxiliary/lotus_domino_hash_response.xml
@@ -1,0 +1,500 @@
+<html>
+<head>
+<title>Bdn Alln</title><meta http-equiv='expires' content='0'>
+<link rel=stylesheet type='text/css' href='/names.nsf/cssForm?ReadForm'>
+<script>
+	var sElementType	= 'document'; 
+	var sDocType		= 'person'; 
+	var sDBFileName	= 'names.nsf'; 
+	var sDocUNID		= '9B3aaFA7a1A1bC54d798dB7afA5721E5'; 
+	var sDefaultView	= 'People';
+	var sWebDbName		= '/names.nsf/';
+	var isDom6		= true;
+</script><script src='/names.nsf/WebJSTools?OpenJavaScriptLibrary'></script>
+	 <script src='/names.nsf/WebJSNavigationTools?OpenJavaScriptLibrary'></script>
+<script language="JavaScript" type="text/javascript">
+<!-- 
+// ignore if not Domino 6if (navigator.appCodeName != 'Domino') {	if (isDom6) {		var hDlgListboxPolicy	= new cDlgListbox('Single')	}}
+// -->
+</script>
+
+<script language="JavaScript" type="text/javascript">
+<!-- 
+document._domino_target = "_self";
+function _doClick(v, o, t) {
+  var returnValue = false;
+  var url="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&Click=" + v;
+  if (o.href != null) {
+    o.href = url;
+    returnValue = true;
+  } else {
+    if (t == null)
+      t = document._domino_target;
+    window.open(url, t);
+  }
+  return returnValue;
+}
+// -->
+</script>
+
+<script language="JavaScript" type="text/javascript">
+<!-- 
+function Action1_onClick() {
+ntEditDoc('[UserModifier]')
+}
+
+function Action2_onClick() {
+ntCancel()
+}
+
+function Action(href,oc,t) { this.href = href; this.onClick = oc; this.target = t; }
+
+var dominoActions = new Array();
+dominoActions[1] = new Action(null,Action1_onClick,'_self');
+dominoActions[2] = new Action(null,Action2_onClick,'_self');
+function doAction(n) {
+   var action = dominoActions[n];
+   if (action.href)
+      window.open(action.href,action.target);
+   else if (action.onClick) {
+      currentTarget = document._domino_target;
+      document._domino_target = action.target;
+      action.onClick();
+      document._domino_target = currentTarget;
+   }}
+// -->
+</script>
+</head>
+<body text="#000000" bgcolor="#FFFFFF" topmargin=0 leftmargin=0 marginheight=0 marginwidth=0>
+
+<form onsubmit="// ignore if not Domino 6if (navigator.appCodeName != 'Domino') {	if (isDom6) {		syncFields(document.forms[0], 'Certificate')	}}return true;" action="">
+<applet name="dominoActionBar" code="lotus.notes.apps.actionbar.ActionBar.class" codebase="/domjava" archive="actionbar.jar" alt="Aktionsleiste" width="100%" height="38" mayscript>
+<param name="cabbase" value="actionbar.cab">
+<param name="BGColor" value="#B1B1D2">
+<param name="ButtonBGColor" value="#B1B1D2">
+<param name="BorderColor" value="#000000">
+<param name="ButtonTransparent" value="1">
+<param name="ButtonBorderStyle" value="ONMOUSEOVER">
+<param name="BorderStyle" value="1">
+<param name="BorderWidth" value="0,3,0,0">
+<param name="InnerWidth" value="0,0,0,0">
+<param name="OuterWidth" value="0,0,0,0">
+<param name="ShowHinkyAlways" value="1">
+<param name="ButtonHeightType" value="DEFAULT">
+<param name="ButtonHeight" value="8">
+<param name="ButtonWidthType" value="DEFAULT">
+<param name="ButtonWidth" value="0">
+<param name="ButtonTextJustify" value="3">
+<param name="FontName" value="Helvetica">
+<param name="FontSize" value="9">
+<param name="FontStyle" value="P">
+<param name="TextColor" value="#000000">
+<param name="Action1" value="Edit Person,/names.nsf/btnEdit.gif?OpenImageResource,1,0,1,1,0,0">
+<param name="Action2" value="Cancel,/names.nsf/btnCancel.gif?OpenImageResource,2,0,1,1,0,0">
+<param name="NumActions" value="2">
+</applet>
+
+<table cellpadding=10 width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td style="background-image:url(/names.nsf/people?OpenImageResource); background-repeat: repeat-x; " width="100%"><font size="5" color="#424282">Person</font><font size="5" color="#424282">: </font><b><font size="5" color="#424282">Bdn Alln</font></b><font size="5" color="#424282">  </font><font size="5" color="#424282">  </font><b><font color="#424282"></font></b></td></tr>
+</table>
+
+<table border="0" cellspacing="2">
+<tr><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><b>Basics</b></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.1#12." target="_self">Work/Home</a></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.2#12." target="_self">Other</a></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.3#12." target="_self">Miscellaneous</a></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.4#12." target="_self">Certificates</a></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.5#12." target="_self">Roaming</a></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.8#12." target="_self">Administration</a></div></td></tr>
+</table>
+</td></tr>
+</table>
+
+<table id="Person_Main" cellpadding=7 width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td width="100%">
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td width="54%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+
+<table id="Person_Basics" class="TableSpacing" width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td width="1%" bgcolor="#B1B1D2"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<b><font size="2" color="#FFFFFF">Basics</font></b></td><td width="100%" bgcolor="#B1B1D2"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">First name:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Bdn</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Middle name:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Last name:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Alln</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">User name:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Bdn Alln</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Alternate name:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font>
+<p><font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Short name/UserID:</font></td><td width="100%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Bdn Alln</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Personal title:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Generational qualifier:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Internet password:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Preferred language</font><font size="2">:</font></td><td width="100%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+</table>
+</td><td style="padding-left:10px;" width="0%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td><td width="46%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+
+<table id="Person_Mail" class="TableSpacing" width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td width="1%" bgcolor="#B1B1D2"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<b><font size="2" color="#FFFFFF">Mail</font></b></td><td width="100%" bgcolor="#B1B1D2"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Mail system:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Notes</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Domain:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Mail server:</font></td><td nowrap width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Mail file:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">portal/Alln_1.nsf</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Forwarding address:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Internet address:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Format preference for incoming mail:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Keep in senders' format</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">When receiving unencrypted mail, encrypt before storing in your mailfile:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">No</font></td></tr>
+</table>
+
+<table id="PerSchTable" class="TableSpacing" width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td id="PerSchTable_a" width="1%" bgcolor="#B1B1D2" valign="middle"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<b><font size="2" color="#FFFFFF">Collaboration</font></b></td><td id="PerSchTable_b" width="100%" bgcolor="#B1B1D2" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Instant messaging server:</font></td><td nowrap width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+</table>
+</td><td width="0%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td></tr>
+</table>
+</td></tr>
+</table>
+
+<input name="Type" type="hidden" value="Person">
+<input name="DisplayName" type="hidden" value="Bdn Alln">
+<input name="DisplayMailAddress" type="hidden" value="">
+<input name="$HTMLAttributes" type="hidden" value="">
+<input name="$dspFirstName" type="hidden" value="Bdn">
+<input name="$dspMiddleInitial" type="hidden" value="">
+<input name="$dspLastName" type="hidden" value="Alln">
+<input name="$dspFullName" type="hidden" value="Bdn Alln">
+<input name="$dspAltFullName" type="hidden" value="">
+<input name="$dspAltFullNamePdeyuageDisplay" type="hidden" value="">
+<input name="$dspShortName" type="hidden" value="Bdn Alln">
+<input name="$dspTitle" type="hidden" value="">
+<input name="$dspSuffix" type="hidden" value="">
+<input name="$dspHTTPPassword" type="hidden" value="(Da2Bd765Be64aF01b5652ce32eaA283d)">
+<input name="$dspMailSystem" type="hidden" value="1">
+<input name="$dspMailDomain" type="hidden" value="">
+<input name="$dspMailServer" type="hidden" value="">
+<input name="$dspMailFile" type="hidden" value="portal/Alln_1.nsf">
+<input name="$dspCcMailUserName" type="hidden" value="">
+<input name="$dspMailAddress" type="hidden" value="">
+<input name="$dspCcMailLocation" type="hidden" value="">
+<input name="$dspInternetAddress" type="hidden" value="">
+<input name="$dspMessageStorage" type="hidden" value="1">
+<input name="$dspEncryptIncomingMail" type="hidden" value="0">
+<input name="$dspJobTitle" type="hidden" value="">
+<input name="$dspOfficeStreetAddress" type="hidden" value="">
+<input name="$dspCompanyName" type="hidden" value="Regionalgas">
+<input name="$dspOfficeCity" type="hidden" value="">
+<input name="$dspDepartment" type="hidden" value="">
+<input name="$dspOfficeState" type="hidden" value="">
+<input name="$dspEmployeeID" type="hidden" value="">
+<input name="$dspOfficeZIP" type="hidden" value="">
+<input name="$dspLocation" type="hidden" value="">
+<input name="$dspOfficeCountry" type="hidden" value="">
+<input name="$dspManager" type="hidden" value="">
+<input name="$dspOfficeNumber" type="hidden" value="">
+<input name="$dspOfficePhoneNumber" type="hidden" value="">
+<input name="$dspOfficeFAXPhoneNumber" type="hidden" value="">
+<input name="$dspCellPhoneNumber" type="hidden" value="">
+<input name="$dspPhoneNumber_6" type="hidden" value="">
+<input name="$dspAssistant" type="hidden" value="">
+<input name="$dspStreetAddress" type="hidden" value="">
+<input name="$dspCity" type="hidden" value="">
+<input name="$dspState" type="hidden" value="">
+<input name="$dspZip" type="hidden" value="">
+<input name="$dspCountry" type="hidden" value="">
+<input name="$dspPhoneNumber" type="hidden" value="">
+<input name="$dspHomeFAXPhoneNumber" type="hidden" value="">
+<input name="$dspSpouse" type="hidden" value="">
+<input name="$dspChildren" type="hidden" value="">
+<input name="$dspPersonalID" type="hidden" value="">
+<input name="$dspLevel0" type="hidden" value="">
+<input name="$dspLevel0_1" type="hidden" value="">
+<input name="$dspLevel0_2" type="hidden" value="">
+<input name="$dspLevel0_3" type="hidden" value="">
+<input name="$dspLevel1" type="hidden" value="">
+<input name="$dspLevel1_1" type="hidden" value="">
+<input name="$dspLevel1_2" type="hidden" value="">
+<input name="$dspLevel1_3" type="hidden" value="">
+<input name="$dspLevel2" type="hidden" value="">
+<input name="$dspLevel2_1" type="hidden" value="">
+<input name="$dspLevel2_2" type="hidden" value="">
+<input name="$dspLevel2_3" type="hidden" value="">
+<input name="$dspLevel3" type="hidden" value="">
+<input name="$dspLevel3_1" type="hidden" value="">
+<input name="$dspLevel3_2" type="hidden" value="">
+<input name="$dspLevel3_3" type="hidden" value="">
+<input name="$dspLevel4" type="hidden" value="">
+<input name="$dspLevel4_1" type="hidden" value="">
+<input name="$dspLevel4_2" type="hidden" value="">
+<input name="$dspLevel4_3" type="hidden" value="">
+<input name="$dspLevel5" type="hidden" value="">
+<input name="$dspLevel5_1" type="hidden" value="">
+<input name="$dspLevel5_2" type="hidden" value="">
+<input name="$dspLevel5_3" type="hidden" value="">
+<input name="$dspLevel6" type="hidden" value="">
+<input name="$dspLevel6_1" type="hidden" value="">
+<input name="$dspLevel6_2" type="hidden" value="">
+<input name="$dspLevel6_3" type="hidden" value="">
+<input name="$dspComment" type="hidden" value="">
+<input name="$dspx400Address" type="hidden" value="">
+<input name="$dspCalendarDomain" type="hidden" value="">
+<input name="$dspWebSite" type="hidden" value="">
+<input name="$dspAltFullNameSort" type="hidden" value="">
+<input name="$dspCertificate" type="hidden" value="">
+<input name="$dspUserCertificateDisplay" type="hidden" value="0">
+<input name="$dspX509Issuers" type="hidden" value="">
+<input name="$dspPublicKey" type="hidden" value="">
+<input name="$dspOwner" type="hidden" value="">
+<input name="$dspClientType" type="hidden" value="">
+<input name="$dspLocalAdmin" type="hidden" value="">
+<input name="$dspProfiles" type="hidden" value="">
+<input name="$dspCheckPassword" type="hidden" value="0">
+<input name="$dspAvailableForDirSync" type="hidden" value="1">
+<input name="$dspPasswordChangeInterval" type="hidden" value="0">
+<input name="$dspNetUserName" type="hidden" value="">
+<input name="$dspPasswordGracePeriod" type="hidden" value="0">
+<input name="$dspSametimeServer" type="hidden" value="">
+<input name="$dspPasswordChangeDate" type="hidden" value="">
+<input name="$dspPasswordDigest" type="hidden" value="">
+<input name="$dspDisplayChangeRequest" type="hidden" value="None">
+<input name="FirstName" type="hidden" value="Bdn">
+<input name="MiddleInitial" type="hidden" value="">
+<input name="LastName" type="hidden" value="Alln">
+<input name="FullName" type="hidden" value="Bdn Alln">
+<input name="AltFullName" type="hidden" value="">
+<input name="AltFullNamePdeyuage" type="hidden" value="">
+<input name="AltFullNamePdeyuageDisplay" type="hidden" value="">
+<input name="ShortName" type="hidden" value="Bdn Alln">
+<input name="Title" type="hidden" value="">
+<input name="Suffix" type="hidden" value="">
+<input name="HTTPPassword" type="hidden" value="(Da2Bd765Be64aF01b5652ce32eaA283d)">
+<input name="dspHTTPPassword" type="hidden" value="(Da2Bd765Be64aF01b5652ce32eaA283d)">
+<input name="preferredPdeyuage" type="hidden" value="">
+<input name="MailSystem" type="hidden" value="1">
+<input name="MailDomain" type="hidden" value="">
+<input name="MailServer" type="hidden" value="">
+<input name="MailFile" type="hidden" value="portal/Alln_1.nsf">
+<input name="ccMailUserName" type="hidden" value="">
+<input name="MailAddress" type="hidden" value="">
+<input name="ccMailLocation" type="hidden" value="">
+<input name="InternetAddress" type="hidden" value="">
+<input name="MessageStorage" type="hidden" value="1">
+<input name="EncryptIncomingMail" type="hidden" value="0">
+<input name="SametimeServer" type="hidden" value="">
+<input name="JobTitle" type="hidden" value="">
+<input name="CompanyName" type="hidden" value="Regionalgas">
+<input name="Department" type="hidden" value="">
+<input name="EmployeeID" type="hidden" value="">
+<input name="Location" type="hidden" value="">
+<input name="Manager" type="hidden" value="">
+<input name="OfficePhoneNumber" type="hidden" value="">
+<input name="OfficeFAXPhoneNumber" type="hidden" value="">
+<input name="CellPhoneNumber" type="hidden" value="">
+<input name="PhoneNumber_6" type="hidden" value="">
+<input name="Assistant" type="hidden" value="">
+<input name="OfficeStreetAddress" type="hidden" value="">
+<input name="OfficeCity" type="hidden" value="">
+<input name="OfficeState" type="hidden" value="">
+<input name="OfficeZIP" type="hidden" value="">
+<input name="OfficeCountry" type="hidden" value="">
+<input name="OfficeNumber" type="hidden" value="">
+<input name="StreetAddress" type="hidden" value="">
+<input name="City" type="hidden" value="">
+<input name="State" type="hidden" value="">
+<input name="Zip" type="hidden" value="">
+<input name="Country" type="hidden" value="">
+<input name="PhoneNumber" type="hidden" value="">
+<input name="HomeFAXPhoneNumber" type="hidden" value="">
+<input name="Spouse" type="hidden" value="">
+<input name="Children" type="hidden" value="">
+<input name="PersonalID" type="hidden" value="">
+<input name="Level0" type="hidden" value="">
+<input name="Level0_1" type="hidden" value="">
+<input name="Level0_2" type="hidden" value="">
+<input name="Level0_3" type="hidden" value="">
+<input name="Level1" type="hidden" value="">
+<input name="Level1_1" type="hidden" value="">
+<input name="Level1_2" type="hidden" value="">
+<input name="Level1_3" type="hidden" value="">
+<input name="Level2" type="hidden" value="">
+<input name="Level2_1" type="hidden" value="">
+<input name="Level2_2" type="hidden" value="">
+<input name="Level2_3" type="hidden" value="">
+<input name="Level3" type="hidden" value="">
+<input name="Level3_1" type="hidden" value="">
+<input name="Level3_2" type="hidden" value="">
+<input name="Level3_3" type="hidden" value="">
+<input name="Level4" type="hidden" value="">
+<input name="Level4_1" type="hidden" value="">
+<input name="Level4_2" type="hidden" value="">
+<input name="Level4_3" type="hidden" value="">
+<input name="Level5" type="hidden" value="">
+<input name="Level5_1" type="hidden" value="">
+<input name="Level5_2" type="hidden" value="">
+<input name="Level5_3" type="hidden" value="">
+<input name="Level6" type="hidden" value="">
+<input name="Level6_1" type="hidden" value="">
+<input name="Level6_2" type="hidden" value="">
+<input name="Level6_3" type="hidden" value="">
+<input name="Comment" type="hidden" value="">
+<input name="x400Address" type="hidden" value="">
+<input name="CalendarDomain" type="hidden" value="">
+<input name="WebSite" type="hidden" value="">
+<input name="PhotoURL" type="hidden" value="">
+<input name="AltFullNameSort" type="hidden" value="">
+<input name="CertificateDisplay" type="hidden" value="0">
+<input name="Certificate" type="hidden" value="">
+<input name="ChangeRequest" type="hidden" value="">
+<input name="UserCertificateDisplay" type="hidden" value="0">
+<input name="X509Issuers" type="hidden" value="">
+<input name="PublicKey" type="hidden" value="">
+<input name="RoamingUser" type="hidden" value="0">
+<input name="RoamSrvr" type="hidden" value="">
+<input name="RoamRplSrvrs" type="hidden" value="">
+<input name="RoamSubdir" type="hidden" value="">
+<input name="RoamAB" type="hidden" value="">
+<input name="BkmksFile" type="hidden" value="">
+<input name="JrnlFile" type="hidden" value="">
+<input name="RoamExtFiles" type="hidden" value="">
+<input name="RoamMode" type="hidden" value="">
+<input name="RoamCleanSetting" type="hidden" value="0">
+<input name="RoamCleanSettingDsp" type="hidden" value="Do not clean-up">
+<input name="RoamCleanPer" type="hidden" value="1">
+<input name="Owner" type="hidden" value="">
+<input name="LocalAdmin" type="hidden" value="">
+<input name="AvailableForDirSync" type="hidden" value="1">
+<input name="LastMod" type="hidden" value="05/11/2017 08:22:13 AM CRM Portal/EUS/GVE">
+<input name="CheckPassword" type="hidden" value="0">
+<input name="PasswordChangeInterval" type="hidden" value="0">
+<input name="PasswordGracePeriod" type="hidden" value="0">
+<input name="PasswordChangeDate" type="hidden" value="">
+<input name="PasswordDigest" type="hidden" value="">
+<input name="HTTPPasswordChangeDate" type="hidden" value="">
+<input name="HTTPPasswordForceChange" type="hidden" value="1">
+<input name="DispPolicy" type="hidden" value="">
+<input name="Policy" type="hidden" value="">
+<input name="Profiles" type="hidden" value="">
+<input name="DisplayChangeRequest" type="hidden" value="None">
+<input name="NetUserName" type="hidden" value="">
+<input name="LTPA_UsrNm" type="hidden" value="">
+<input name="DB2UserName" type="hidden" value="">
+<input name="krbPrincipalName" type="hidden" value="">
+<input name="ClientType" type="hidden" value="">
+<input name="ClntMachine" type="hidden" value="">
+<input name="ClntBld" type="hidden" value="">
+<input name="ClntPltfrm" type="hidden" value="">
+<input name="ClntDate" type="hidden" value="">
+<input name="DocumentAccess" type="hidden" value="[UserModifier]">
+<input name="tmpNow" type="hidden" value="04/29/2022 04:17 PM CEDT">
+<input name="$CryptoCap" type="hidden" value="0">
+<input name="$Person_Main" type="hidden" value="0">
+<input name="$Person_Detail" type="hidden" value="0">
+<input name="$Person_Cert" type="hidden" value="0">
+<input name="$dspTTControl" type="hidden" value="">
+<input name="ibm_bhMailInfo" type="hidden" value="">
+<input name="OU" type="hidden" value="">
+<input name="PostalAddress" type="hidden" value="">
+<input name="HomePostalAddress" type="hidden" value="">
+<input name="Street" type="hidden" value="">
+<input name="businessCategory" type="hidden" value="">
+<input name="carLicense" type="hidden" value="">
+<input name="departmentNumber" type="hidden" value="">
+<input name="employeeNumber" type="hidden" value="">
+<input name="employeeType" type="hidden" value="">
+<input name="initials" type="hidden" value="">
+<input name="labeledURI" type="hidden" value="">
+<input name="o" type="hidden" value="">
+<input name="roomNumber" type="hidden" value="">
+<input name="UserCertificate" type="hidden" value="">
+<input name="x500UniqueIdentifier" type="hidden" value="">
+<input name="x121Address" type="hidden" value="">
+<input name="registeredAddress" type="hidden" value="">
+<input name="destinationIndicator" type="hidden" value="">
+<input name="preferredDeliveryMethod" type="hidden" value="">
+<input name="telexNumber" type="hidden" value="">
+<input name="telexGgkehgalIdentifier" type="hidden" value="">
+<input name="internationaliSDNNumber" type="hidden" value="">
+<input name="seeAlso" type="hidden" value=""></form>
+</body>
+</html>

--- a/spec/file_fixtures/modules/auxiliary/lotus_domino_hash_response_no_cred.xml
+++ b/spec/file_fixtures/modules/auxiliary/lotus_domino_hash_response_no_cred.xml
@@ -1,0 +1,498 @@
+<html>
+<head>
+<title>Bdn Alln</title><meta http-equiv='expires' content='0'>
+<link rel=stylesheet type='text/css' href='/names.nsf/cssForm?ReadForm'>
+<script>
+	var sElementType	= 'document'; 
+	var sDocType		= 'person'; 
+	var sDBFileName	= 'names.nsf'; 
+	var sDocUNID		= '9B3aaFA7a1A1bC54d798dB7afA5721E5'; 
+	var sDefaultView	= 'People';
+	var sWebDbName		= '/names.nsf/';
+	var isDom6		= true;
+</script><script src='/names.nsf/WebJSTools?OpenJavaScriptLibrary'></script>
+	 <script src='/names.nsf/WebJSNavigationTools?OpenJavaScriptLibrary'></script>
+<script language="JavaScript" type="text/javascript">
+<!-- 
+// ignore if not Domino 6if (navigator.appCodeName != 'Domino') {	if (isDom6) {		var hDlgListboxPolicy	= new cDlgListbox('Single')	}}
+// -->
+</script>
+
+<script language="JavaScript" type="text/javascript">
+<!-- 
+document._domino_target = "_self";
+function _doClick(v, o, t) {
+  var returnValue = false;
+  var url="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&Click=" + v;
+  if (o.href != null) {
+    o.href = url;
+    returnValue = true;
+  } else {
+    if (t == null)
+      t = document._domino_target;
+    window.open(url, t);
+  }
+  return returnValue;
+}
+// -->
+</script>
+
+<script language="JavaScript" type="text/javascript">
+<!-- 
+function Action1_onClick() {
+ntEditDoc('[UserModifier]')
+}
+
+function Action2_onClick() {
+ntCancel()
+}
+
+function Action(href,oc,t) { this.href = href; this.onClick = oc; this.target = t; }
+
+var dominoActions = new Array();
+dominoActions[1] = new Action(null,Action1_onClick,'_self');
+dominoActions[2] = new Action(null,Action2_onClick,'_self');
+function doAction(n) {
+   var action = dominoActions[n];
+   if (action.href)
+      window.open(action.href,action.target);
+   else if (action.onClick) {
+      currentTarget = document._domino_target;
+      document._domino_target = action.target;
+      action.onClick();
+      document._domino_target = currentTarget;
+   }}
+// -->
+</script>
+</head>
+<body text="#000000" bgcolor="#FFFFFF" topmargin=0 leftmargin=0 marginheight=0 marginwidth=0>
+
+<form onsubmit="// ignore if not Domino 6if (navigator.appCodeName != 'Domino') {	if (isDom6) {		syncFields(document.forms[0], 'Certificate')	}}return true;" action="">
+<applet name="dominoActionBar" code="lotus.notes.apps.actionbar.ActionBar.class" codebase="/domjava" archive="actionbar.jar" alt="Aktionsleiste" width="100%" height="38" mayscript>
+<param name="cabbase" value="actionbar.cab">
+<param name="BGColor" value="#B1B1D2">
+<param name="ButtonBGColor" value="#B1B1D2">
+<param name="BorderColor" value="#000000">
+<param name="ButtonTransparent" value="1">
+<param name="ButtonBorderStyle" value="ONMOUSEOVER">
+<param name="BorderStyle" value="1">
+<param name="BorderWidth" value="0,3,0,0">
+<param name="InnerWidth" value="0,0,0,0">
+<param name="OuterWidth" value="0,0,0,0">
+<param name="ShowHinkyAlways" value="1">
+<param name="ButtonHeightType" value="DEFAULT">
+<param name="ButtonHeight" value="8">
+<param name="ButtonWidthType" value="DEFAULT">
+<param name="ButtonWidth" value="0">
+<param name="ButtonTextJustify" value="3">
+<param name="FontName" value="Helvetica">
+<param name="FontSize" value="9">
+<param name="FontStyle" value="P">
+<param name="TextColor" value="#000000">
+<param name="Action1" value="Edit Person,/names.nsf/btnEdit.gif?OpenImageResource,1,0,1,1,0,0">
+<param name="Action2" value="Cancel,/names.nsf/btnCancel.gif?OpenImageResource,2,0,1,1,0,0">
+<param name="NumActions" value="2">
+</applet>
+
+<table cellpadding=10 width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td style="background-image:url(/names.nsf/people?OpenImageResource); background-repeat: repeat-x; " width="100%"><font size="5" color="#424282">Person</font><font size="5" color="#424282">: </font><b><font size="5" color="#424282">Bdn Alln</font></b><font size="5" color="#424282">  </font><font size="5" color="#424282">  </font><b><font color="#424282"></font></b></td></tr>
+</table>
+
+<table border="0" cellspacing="2">
+<tr><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><b>Basics</b></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.1#12." target="_self">Work/Home</a></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.2#12." target="_self">Other</a></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.3#12." target="_self">Miscellaneous</a></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.4#12." target="_self">Certificates</a></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.5#12." target="_self">Roaming</a></div></td></tr>
+</table>
+</td><td>
+<table border="1" cellpadding="2">
+<tr><td><div align="center"><a name="12." href="/names.nsf/$defaultView/e8f61Ea0aE4DC043b926fe3Ab5aCf0DB?OpenDocument&amp;TableRow=12.8#12." target="_self">Administration</a></div></td></tr>
+</table>
+</td></tr>
+</table>
+
+<table id="Person_Main" cellpadding=7 width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td width="100%">
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td width="54%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+
+<table id="Person_Basics" class="TableSpacing" width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td width="1%" bgcolor="#B1B1D2"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<b><font size="2" color="#FFFFFF">Basics</font></b></td><td width="100%" bgcolor="#B1B1D2"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">First name:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Bdn</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Middle name:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Last name:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Alln</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">User name:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Bdn Alln</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Alternate name:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font>
+<p><font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Short name/UserID:</font></td><td width="100%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Bdn Alln</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Personal title:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Generational qualifier:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Internet password:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Preferred language</font><font size="2">:</font></td><td width="100%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+</table>
+</td><td style="padding-left:10px;" width="0%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td><td width="46%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+
+<table id="Person_Mail" class="TableSpacing" width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td width="1%" bgcolor="#B1B1D2"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<b><font size="2" color="#FFFFFF">Mail</font></b></td><td width="100%" bgcolor="#B1B1D2"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Mail system:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Notes</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Domain:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Mail server:</font></td><td nowrap width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Mail file:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">portal/Alln_1.nsf</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Forwarding address:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Internet address:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Format preference for incoming mail:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Keep in senders' format</font></td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">When receiving unencrypted mail, encrypt before storing in your mailfile:</font></td><td width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">No</font></td></tr>
+</table>
+
+<table id="PerSchTable" class="TableSpacing" width="100%" border="0" cellspacing="0" cellpadding="0">
+<tr valign="top"><td id="PerSchTable_a" width="1%" bgcolor="#B1B1D2" valign="middle"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<b><font size="2" color="#FFFFFF">Collaboration</font></b></td><td id="PerSchTable_b" width="100%" bgcolor="#B1B1D2" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td></tr>
+
+<tr valign="top"><td width="1%"><img width="144" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2">Instant messaging server:</font></td><td nowrap width="100%" valign="middle"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+<font size="2"></font></td></tr>
+</table>
+</td><td width="0%"><img width="1" height="1" src="/icons/ecblank.gif" border="0" alt=""><br>
+</td></tr>
+</table>
+</td></tr>
+</table>
+
+<input name="Type" type="hidden" value="Person">
+<input name="DisplayName" type="hidden" value="Bdn Alln">
+<input name="DisplayMailAddress" type="hidden" value="">
+<input name="$HTMLAttributes" type="hidden" value="">
+<input name="$dspFirstName" type="hidden" value="Bdn">
+<input name="$dspMiddleInitial" type="hidden" value="">
+<input name="$dspLastName" type="hidden" value="Alln">
+<input name="$dspFullName" type="hidden" value="Bdn Alln">
+<input name="$dspAltFullName" type="hidden" value="">
+<input name="$dspAltFullNamePdeyuageDisplay" type="hidden" value="">
+<input name="$dspShortName" type="hidden" value="Bdn Alln">
+<input name="$dspTitle" type="hidden" value="">
+<input name="$dspSuffix" type="hidden" value="">
+<input name="$dspMailSystem" type="hidden" value="1">
+<input name="$dspMailDomain" type="hidden" value="">
+<input name="$dspMailServer" type="hidden" value="">
+<input name="$dspMailFile" type="hidden" value="portal/Alln_1.nsf">
+<input name="$dspCcMailUserName" type="hidden" value="">
+<input name="$dspMailAddress" type="hidden" value="">
+<input name="$dspCcMailLocation" type="hidden" value="">
+<input name="$dspInternetAddress" type="hidden" value="">
+<input name="$dspMessageStorage" type="hidden" value="1">
+<input name="$dspEncryptIncomingMail" type="hidden" value="0">
+<input name="$dspJobTitle" type="hidden" value="">
+<input name="$dspOfficeStreetAddress" type="hidden" value="">
+<input name="$dspCompanyName" type="hidden" value="Regionalgas">
+<input name="$dspOfficeCity" type="hidden" value="">
+<input name="$dspDepartment" type="hidden" value="">
+<input name="$dspOfficeState" type="hidden" value="">
+<input name="$dspEmployeeID" type="hidden" value="">
+<input name="$dspOfficeZIP" type="hidden" value="">
+<input name="$dspLocation" type="hidden" value="">
+<input name="$dspOfficeCountry" type="hidden" value="">
+<input name="$dspManager" type="hidden" value="">
+<input name="$dspOfficeNumber" type="hidden" value="">
+<input name="$dspOfficePhoneNumber" type="hidden" value="">
+<input name="$dspOfficeFAXPhoneNumber" type="hidden" value="">
+<input name="$dspCellPhoneNumber" type="hidden" value="">
+<input name="$dspPhoneNumber_6" type="hidden" value="">
+<input name="$dspAssistant" type="hidden" value="">
+<input name="$dspStreetAddress" type="hidden" value="">
+<input name="$dspCity" type="hidden" value="">
+<input name="$dspState" type="hidden" value="">
+<input name="$dspZip" type="hidden" value="">
+<input name="$dspCountry" type="hidden" value="">
+<input name="$dspPhoneNumber" type="hidden" value="">
+<input name="$dspHomeFAXPhoneNumber" type="hidden" value="">
+<input name="$dspSpouse" type="hidden" value="">
+<input name="$dspChildren" type="hidden" value="">
+<input name="$dspPersonalID" type="hidden" value="">
+<input name="$dspLevel0" type="hidden" value="">
+<input name="$dspLevel0_1" type="hidden" value="">
+<input name="$dspLevel0_2" type="hidden" value="">
+<input name="$dspLevel0_3" type="hidden" value="">
+<input name="$dspLevel1" type="hidden" value="">
+<input name="$dspLevel1_1" type="hidden" value="">
+<input name="$dspLevel1_2" type="hidden" value="">
+<input name="$dspLevel1_3" type="hidden" value="">
+<input name="$dspLevel2" type="hidden" value="">
+<input name="$dspLevel2_1" type="hidden" value="">
+<input name="$dspLevel2_2" type="hidden" value="">
+<input name="$dspLevel2_3" type="hidden" value="">
+<input name="$dspLevel3" type="hidden" value="">
+<input name="$dspLevel3_1" type="hidden" value="">
+<input name="$dspLevel3_2" type="hidden" value="">
+<input name="$dspLevel3_3" type="hidden" value="">
+<input name="$dspLevel4" type="hidden" value="">
+<input name="$dspLevel4_1" type="hidden" value="">
+<input name="$dspLevel4_2" type="hidden" value="">
+<input name="$dspLevel4_3" type="hidden" value="">
+<input name="$dspLevel5" type="hidden" value="">
+<input name="$dspLevel5_1" type="hidden" value="">
+<input name="$dspLevel5_2" type="hidden" value="">
+<input name="$dspLevel5_3" type="hidden" value="">
+<input name="$dspLevel6" type="hidden" value="">
+<input name="$dspLevel6_1" type="hidden" value="">
+<input name="$dspLevel6_2" type="hidden" value="">
+<input name="$dspLevel6_3" type="hidden" value="">
+<input name="$dspComment" type="hidden" value="">
+<input name="$dspx400Address" type="hidden" value="">
+<input name="$dspCalendarDomain" type="hidden" value="">
+<input name="$dspWebSite" type="hidden" value="">
+<input name="$dspAltFullNameSort" type="hidden" value="">
+<input name="$dspCertificate" type="hidden" value="">
+<input name="$dspUserCertificateDisplay" type="hidden" value="0">
+<input name="$dspX509Issuers" type="hidden" value="">
+<input name="$dspPublicKey" type="hidden" value="">
+<input name="$dspOwner" type="hidden" value="">
+<input name="$dspClientType" type="hidden" value="">
+<input name="$dspLocalAdmin" type="hidden" value="">
+<input name="$dspProfiles" type="hidden" value="">
+<input name="$dspCheckPassword" type="hidden" value="0">
+<input name="$dspAvailableForDirSync" type="hidden" value="1">
+<input name="$dspPasswordChangeInterval" type="hidden" value="0">
+<input name="$dspNetUserName" type="hidden" value="">
+<input name="$dspPasswordGracePeriod" type="hidden" value="0">
+<input name="$dspSametimeServer" type="hidden" value="">
+<input name="$dspPasswordChangeDate" type="hidden" value="">
+<input name="$dspPasswordDigest" type="hidden" value="">
+<input name="$dspDisplayChangeRequest" type="hidden" value="None">
+<input name="FirstName" type="hidden" value="Bdn">
+<input name="MiddleInitial" type="hidden" value="">
+<input name="LastName" type="hidden" value="Alln">
+<input name="FullName" type="hidden" value="Bdn Alln">
+<input name="AltFullName" type="hidden" value="">
+<input name="AltFullNamePdeyuage" type="hidden" value="">
+<input name="AltFullNamePdeyuageDisplay" type="hidden" value="">
+<input name="ShortName" type="hidden" value="Bdn Alln">
+<input name="Title" type="hidden" value="">
+<input name="Suffix" type="hidden" value="">
+<input name="HTTPPassword" type="hidden" value="(Da2Bd765Be64aF01b5652ce32eaA283d)">
+<input name="preferredPdeyuage" type="hidden" value="">
+<input name="MailSystem" type="hidden" value="1">
+<input name="MailDomain" type="hidden" value="">
+<input name="MailServer" type="hidden" value="">
+<input name="MailFile" type="hidden" value="portal/Alln_1.nsf">
+<input name="ccMailUserName" type="hidden" value="">
+<input name="MailAddress" type="hidden" value="">
+<input name="ccMailLocation" type="hidden" value="">
+<input name="InternetAddress" type="hidden" value="">
+<input name="MessageStorage" type="hidden" value="1">
+<input name="EncryptIncomingMail" type="hidden" value="0">
+<input name="SametimeServer" type="hidden" value="">
+<input name="JobTitle" type="hidden" value="">
+<input name="CompanyName" type="hidden" value="Regionalgas">
+<input name="Department" type="hidden" value="">
+<input name="EmployeeID" type="hidden" value="">
+<input name="Location" type="hidden" value="">
+<input name="Manager" type="hidden" value="">
+<input name="OfficePhoneNumber" type="hidden" value="">
+<input name="OfficeFAXPhoneNumber" type="hidden" value="">
+<input name="CellPhoneNumber" type="hidden" value="">
+<input name="PhoneNumber_6" type="hidden" value="">
+<input name="Assistant" type="hidden" value="">
+<input name="OfficeStreetAddress" type="hidden" value="">
+<input name="OfficeCity" type="hidden" value="">
+<input name="OfficeState" type="hidden" value="">
+<input name="OfficeZIP" type="hidden" value="">
+<input name="OfficeCountry" type="hidden" value="">
+<input name="OfficeNumber" type="hidden" value="">
+<input name="StreetAddress" type="hidden" value="">
+<input name="City" type="hidden" value="">
+<input name="State" type="hidden" value="">
+<input name="Zip" type="hidden" value="">
+<input name="Country" type="hidden" value="">
+<input name="PhoneNumber" type="hidden" value="">
+<input name="HomeFAXPhoneNumber" type="hidden" value="">
+<input name="Spouse" type="hidden" value="">
+<input name="Children" type="hidden" value="">
+<input name="PersonalID" type="hidden" value="">
+<input name="Level0" type="hidden" value="">
+<input name="Level0_1" type="hidden" value="">
+<input name="Level0_2" type="hidden" value="">
+<input name="Level0_3" type="hidden" value="">
+<input name="Level1" type="hidden" value="">
+<input name="Level1_1" type="hidden" value="">
+<input name="Level1_2" type="hidden" value="">
+<input name="Level1_3" type="hidden" value="">
+<input name="Level2" type="hidden" value="">
+<input name="Level2_1" type="hidden" value="">
+<input name="Level2_2" type="hidden" value="">
+<input name="Level2_3" type="hidden" value="">
+<input name="Level3" type="hidden" value="">
+<input name="Level3_1" type="hidden" value="">
+<input name="Level3_2" type="hidden" value="">
+<input name="Level3_3" type="hidden" value="">
+<input name="Level4" type="hidden" value="">
+<input name="Level4_1" type="hidden" value="">
+<input name="Level4_2" type="hidden" value="">
+<input name="Level4_3" type="hidden" value="">
+<input name="Level5" type="hidden" value="">
+<input name="Level5_1" type="hidden" value="">
+<input name="Level5_2" type="hidden" value="">
+<input name="Level5_3" type="hidden" value="">
+<input name="Level6" type="hidden" value="">
+<input name="Level6_1" type="hidden" value="">
+<input name="Level6_2" type="hidden" value="">
+<input name="Level6_3" type="hidden" value="">
+<input name="Comment" type="hidden" value="">
+<input name="x400Address" type="hidden" value="">
+<input name="CalendarDomain" type="hidden" value="">
+<input name="WebSite" type="hidden" value="">
+<input name="PhotoURL" type="hidden" value="">
+<input name="AltFullNameSort" type="hidden" value="">
+<input name="CertificateDisplay" type="hidden" value="0">
+<input name="Certificate" type="hidden" value="">
+<input name="ChangeRequest" type="hidden" value="">
+<input name="UserCertificateDisplay" type="hidden" value="0">
+<input name="X509Issuers" type="hidden" value="">
+<input name="PublicKey" type="hidden" value="">
+<input name="RoamingUser" type="hidden" value="0">
+<input name="RoamSrvr" type="hidden" value="">
+<input name="RoamRplSrvrs" type="hidden" value="">
+<input name="RoamSubdir" type="hidden" value="">
+<input name="RoamAB" type="hidden" value="">
+<input name="BkmksFile" type="hidden" value="">
+<input name="JrnlFile" type="hidden" value="">
+<input name="RoamExtFiles" type="hidden" value="">
+<input name="RoamMode" type="hidden" value="">
+<input name="RoamCleanSetting" type="hidden" value="0">
+<input name="RoamCleanSettingDsp" type="hidden" value="Do not clean-up">
+<input name="RoamCleanPer" type="hidden" value="1">
+<input name="Owner" type="hidden" value="">
+<input name="LocalAdmin" type="hidden" value="">
+<input name="AvailableForDirSync" type="hidden" value="1">
+<input name="LastMod" type="hidden" value="05/11/2017 08:22:13 AM CRM Portal/EUS/GVE">
+<input name="CheckPassword" type="hidden" value="0">
+<input name="PasswordChangeInterval" type="hidden" value="0">
+<input name="PasswordGracePeriod" type="hidden" value="0">
+<input name="PasswordChangeDate" type="hidden" value="">
+<input name="PasswordDigest" type="hidden" value="">
+<input name="HTTPPasswordChangeDate" type="hidden" value="">
+<input name="HTTPPasswordForceChange" type="hidden" value="1">
+<input name="DispPolicy" type="hidden" value="">
+<input name="Policy" type="hidden" value="">
+<input name="Profiles" type="hidden" value="">
+<input name="DisplayChangeRequest" type="hidden" value="None">
+<input name="NetUserName" type="hidden" value="">
+<input name="LTPA_UsrNm" type="hidden" value="">
+<input name="DB2UserName" type="hidden" value="">
+<input name="krbPrincipalName" type="hidden" value="">
+<input name="ClientType" type="hidden" value="">
+<input name="ClntMachine" type="hidden" value="">
+<input name="ClntBld" type="hidden" value="">
+<input name="ClntPltfrm" type="hidden" value="">
+<input name="ClntDate" type="hidden" value="">
+<input name="DocumentAccess" type="hidden" value="[UserModifier]">
+<input name="tmpNow" type="hidden" value="04/29/2022 04:17 PM CEDT">
+<input name="$CryptoCap" type="hidden" value="0">
+<input name="$Person_Main" type="hidden" value="0">
+<input name="$Person_Detail" type="hidden" value="0">
+<input name="$Person_Cert" type="hidden" value="0">
+<input name="$dspTTControl" type="hidden" value="">
+<input name="ibm_bhMailInfo" type="hidden" value="">
+<input name="OU" type="hidden" value="">
+<input name="PostalAddress" type="hidden" value="">
+<input name="HomePostalAddress" type="hidden" value="">
+<input name="Street" type="hidden" value="">
+<input name="businessCategory" type="hidden" value="">
+<input name="carLicense" type="hidden" value="">
+<input name="departmentNumber" type="hidden" value="">
+<input name="employeeNumber" type="hidden" value="">
+<input name="employeeType" type="hidden" value="">
+<input name="initials" type="hidden" value="">
+<input name="labeledURI" type="hidden" value="">
+<input name="o" type="hidden" value="">
+<input name="roomNumber" type="hidden" value="">
+<input name="UserCertificate" type="hidden" value="">
+<input name="x500UniqueIdentifier" type="hidden" value="">
+<input name="x121Address" type="hidden" value="">
+<input name="registeredAddress" type="hidden" value="">
+<input name="destinationIndicator" type="hidden" value="">
+<input name="preferredDeliveryMethod" type="hidden" value="">
+<input name="telexNumber" type="hidden" value="">
+<input name="telexGgkehgalIdentifier" type="hidden" value="">
+<input name="internationaliSDNNumber" type="hidden" value="">
+<input name="seeAlso" type="hidden" value=""></form>
+</body>
+</html>

--- a/spec/modules/auxiliary/scanner/lotus/lotus_domino_hashes_spec.rb
+++ b/spec/modules/auxiliary/scanner/lotus/lotus_domino_hashes_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Lotus Domino Hashes' do
     File.binread(mock_doc)
   end
   let(:mock_doc) do
-    File.expand_path('lotus_domino_hash_response.xml', FILE_FIXTURES_PATH + 'modules/auxiliary/')
+    File.join(FILE_FIXTURES_PATH, 'modules', 'auxiliary', 'lotus_domino_hash_response.xml')
   end
 
   before do
@@ -54,7 +54,7 @@ RSpec.describe 'Lotus Domino Hashes' do
 
     context 'when the service response does not contain credentials' do
       let(:mock_doc) do
-        File.expand_path('lotus_domino_hash_response_no_cred.xml', FILE_FIXTURES_PATH + 'modules/auxiliary/')
+        File.join(FILE_FIXTURES_PATH, 'modules', 'auxiliary', 'lotus_domino_hash_response_no_cred.xml')
       end
       it 'when provided valid XML missing a credential' do
         subject.dump_hashes(view_id, cookie, uri)

--- a/spec/modules/auxiliary/scanner/lotus/lotus_domino_hashes_spec.rb
+++ b/spec/modules/auxiliary/scanner/lotus/lotus_domino_hashes_spec.rb
@@ -1,0 +1,62 @@
+require 'rspec'
+
+RSpec.describe 'Lotus Domino Hashes' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:subject) do
+    load_and_create_module(
+      module_type: 'auxiliary',
+      reference_name: 'scanner/lotus/lotus_domino_hashes'
+    )
+  end
+  let(:view_id) do
+    Faker::Number.new
+  end
+  let(:cookie) do
+    'invalid'
+  end
+  let(:uri) do
+    'http'
+  end
+  let(:workspace) do
+    FactoryBot.create(:mdm_workspace)
+  end
+  let(:service) do
+    FactoryBot.create(:mdm_service, host: FactoryBot.create(:mdm_host, workspace: workspace))
+  end
+  let(:result) do
+    resp = double(Rex::Proto::Http::Response)
+    allow(resp).to receive(:body).and_return(mock_doc_data)
+    allow(resp).to receive(:get_html_document).and_return(Nokogiri::XML(mock_doc_data))
+    resp
+  end
+  let(:mock_doc_data) do
+    File.binread(mock_doc)
+  end
+  let(:mock_doc) do
+    File.expand_path('lotus_domino_hash_response.xml', FILE_FIXTURES_PATH + 'modules/auxiliary/')
+  end
+
+  before do
+    allow(subject).to receive(:send_request_raw).and_return(result)
+    allow(subject).to receive(:report_service).and_return(service)
+    allow(subject).to receive(:report_auth_info)
+  end
+
+  describe '#dump_hashes' do
+    it 'when provided valid XML' do
+      subject.dump_hashes(view_id, cookie, uri)
+      expect(subject).to have_received(:report_auth_info).with(hash_including({ user: 'Bdn Alln', pass: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/NULL/) }))
+    end
+
+    describe 'incomplete XML' do
+      let(:mock_doc) do
+        File.expand_path('lotus_domino_hash_response_no_cred.xml', FILE_FIXTURES_PATH + 'modules/auxiliary/')
+      end
+      it 'when provided valid XML missing a credential' do
+        subject.dump_hashes(view_id, cookie, uri)
+        expect(subject).not_to have_received(:report_auth_info)
+      end
+    end
+  end
+end

--- a/spec/modules/auxiliary/scanner/lotus/lotus_domino_hashes_spec.rb
+++ b/spec/modules/auxiliary/scanner/lotus/lotus_domino_hashes_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Lotus Domino Hashes' do
     context 'when the service response contains credentials' do
       it 'reports the extracted user and password' do
         subject.dump_hashes(view_id, cookie, uri)
-        expect(subject).to have_received(:report_auth_info).with(hash_including({ user: 'Bdn Alln', pass: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/NULL/) }))
+        expect(subject).to have_received(:report_auth_info).with(hash_including({ user: 'Bdn Alln', pass: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/USER_MAIL=NULL/) }))
       end
     end
 


### PR DESCRIPTION
Adds a spec targeting a single method in the `lotus_domino_hashes` module. This is a start on
offering an example on how a spec can be written to test part of the code in a module using example
responses from a unit testing perspective.

File fixtures are sanitized output for a single user enum response with credential data parsed. Further expansion of this spec is valid feedback and will be incorporated in a timely fashion if possible.

Ref: #16505 

## Verification

List the steps needed to make sure this thing works

- [ ] **Verify** rspec tests pass
