### PR TITLE
Send delegated credentials using WinRM

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -157,6 +157,7 @@ module Msf
             password.dup.force_encoding('utf-8') if password
             client_name.dup.force_encoding('utf-8')
             request_pac = options.fetch(:request_pac, true)
+            ticket_options = options[:options]
 
             # First stage: Send an initial AS-REQ request, used to exchange supported encryption methods.
             # The server may respond with a ticket granting ticket (TGT) immediately,
@@ -179,8 +180,9 @@ module Msf
                 # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
                 from: nil,
                 till: expiry_time,
-                rtime: expiry_time
-              )
+                rtime: expiry_time,
+                options: ticket_options
+              ),
             )
 
             initial_as_res = send_request_as(req: initial_as_req)

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -68,6 +68,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   @return [String] the GSS mechanism being used (from Rex::Proto::Gss::Mechanism)
   attr_reader :mechanism
 
+  # @!attribute [r] send_delegated_creds
+  #   @return [String] whether to send delegated creds (from the set Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base::Delegation)
+  attr_reader :send_delegated_creds
+
   def_delegators :@framework_module,
                 :print_status,
                 :print_good,
@@ -85,6 +89,12 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   AP_USE_SESSION_KEY = 0x40000000
   AP_MUTUAL_REQUIRED = 0x20000000
 
+  module Delegation
+    ALWAYS = 'always' # Always send delegated creds
+    NEVER = 'never' # Never send delegated creds
+    WHEN_UNCONSTRAINED = 'when_unconstrained' # Send delegated creds when service is unconstrained delegation account
+  end
+
   def initialize(
       realm: nil,
       hostname: nil,
@@ -97,7 +107,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       framework_module: nil,
       mutual_auth: false,
       use_gss_checksum: false,
-      mechanism: Rex::Proto::Gss::Mechanism::SPNEGO
+      mechanism: Rex::Proto::Gss::Mechanism::SPNEGO,
+      send_delegated_creds: Delegation::ALWAYS
   )
     @realm = realm
     @hostname = hostname
@@ -111,6 +122,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @mutual_auth = mutual_auth
     @use_gss_checksum = use_gss_checksum
     @mechanism = mechanism
+    @send_delegated_creds = send_delegated_creds
   end
 
   # Returns the target host
@@ -137,11 +149,21 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     client_name = username
     mechanism = options.fetch(:mechanism) { self.mechanism }
 
+    ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+      [
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK,
+      ]
+    )
+
     tgt_result = send_request_tgt(
       server_name: server_name,
       client_name: client_name,
       password: password,
       realm: realm,
+      options: ticket_options
     )
 
     if !tgt_result.preauth_required
@@ -156,15 +178,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     now = Time.now.utc
     expiry_time = now + 1.day
 
-    options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
-      [
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK,
-      ]
-    )
-
     # TODO: From [MS-KILE]:
     #     The subkey in the EncAPRepPart of the KRB_AP_REP message (defined in [RFC4120] section 5.5.2) is used as the
     #     session key when MutualAuthentication is requested. When DES and RC4 are used, the implementation is as defined
@@ -173,6 +186,14 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     #     and the subkey in the KRB_AP_REP message is used. (The KRB_AP_REQ message is defined in [RFC4120] section 5.5.1).
     #   So for now, we set the subkey to nil
     subkey = nil
+
+    ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+      [
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+      ]
+    )
 
     tgs_res = send_request_tgs(
       req: build_tgs_request(
@@ -183,14 +204,14 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
           ticket: tgt_result.ticket,
           realm: realm,
           client_name: client_name,
-          options: options,
+          options: ticket_options,
 
           body: build_tgs_request_body(
             cname: nil,
             sname: sname,
             realm: realm,
             etype: [tgt_etype],
-            options: options,
+            options: ticket_options,
 
             # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
             from: nil,
@@ -225,10 +246,30 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
     )
 
+    case send_delegated_creds
+    when Delegation::ALWAYS
+      do_delegation = true
+    when Delegation::NEVER
+      do_delegation = false
+    when Delegation::WHEN_UNCONSTRAINED
+      do_delegation = tgs_auth.flags.include?(Rex::Proto::Kerberos::Model::KdcOptionFlag::OK_AS_DELEGATE)
+    end
+
+    if do_delegation
+      delegated_tgs_ticket, delegated_tgs_auth = request_delegation_ticket(tgt_result.decrypted_part.key,
+                                                                           tgt_result.ticket,
+                                                                           realm,
+                                                                           client_name,
+                                                                           tgt_etype,
+                                                                           expiry_time,
+                                                                           now)
+
+    end
+
     ## Service Authentication
 
     checksum = nil
-    checksum = build_gss_ap_req_checksum_value(mutual_auth) if use_gss_checksum
+    checksum = build_gss_ap_req_checksum_value(mutual_auth, delegated_tgs_ticket, delegated_tgs_auth, tgs_auth.key, realm, client_name) if use_gss_checksum
 
     sequence_number = rand(1 << 32)
 
@@ -238,7 +279,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       ticket: tgs_ticket,
       realm: realm,
       client_name: client_name,
-      options: options,
+      options: ticket_options,
       sequence_number: sequence_number,
       subkey_type: tgt_etype # The AP-REP will come back with this same type of subkey
     )
@@ -258,6 +299,70 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       session_key: tgs_auth.key,
       client_sequence_number: sequence_number
     }
+  end
+
+  def request_delegation_ticket(session_key, tgt_ticket, realm, client_name, tgt_etype, expiry_time, now)
+    subkey = nil
+
+    ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+      [
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDED,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+      ]
+    )
+
+    krbtgt_sname = Rex::Proto::Kerberos::Model::PrincipalName.new(
+      name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+      name_string: [
+        "krbtgt",
+        realm
+      ]
+    )
+    delegated_tgs_res = send_request_tgs(
+      req: build_tgs_request(
+        {
+          session_key: session_key,
+          subkey: subkey,
+          checksum: nil,
+          ticket: tgt_ticket,
+          realm: realm,
+          client_name: client_name,
+          options: ticket_options,
+
+          body: build_tgs_request_body(
+            cname: nil,
+            sname: krbtgt_sname,
+            realm: realm,
+            etype: [tgt_etype],
+            options: ticket_options,
+
+            # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
+            from: nil,
+            till: expiry_time,
+            rtime: nil,
+
+            # certificate time
+            ctime: now,
+          )
+        }
+      )
+    )
+
+    # Verify error codes
+    if delegated_tgs_res.msg_type != Rex::Proto::Kerberos::Model::KRB_ERROR
+      print_good("#{peer} - Received a valid delegation TGS-Response")
+    end
+
+    delegated_tgs_ticket = delegated_tgs_res.ticket
+    delegated_tgs_auth = decrypt_kdc_tgs_rep_enc_part(
+      delegated_tgs_res,
+      session_key.value,
+      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
+    )
+
+    [delegated_tgs_ticket, delegated_tgs_auth]
   end
 
   def get_message_encryptor(key, client_sequence_number, server_sequence_number)
@@ -301,17 +406,46 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
   end
 
-  def build_gss_ap_req_checksum_value(mutual_auth)
+  def build_gss_ap_req_checksum_value(mutual_auth, ticket, decrypted_part, session_key, realm, client_name)
     # No channel binding
     channel_binding_info = "\x00" * 16
     channel_binding_info_len = [channel_binding_info.length].pack('V')
 
     flags = GSS_REPLAY_DETECT | GSS_SEQUENCE | GSS_CONFIDENTIAL | GSS_INTEGRITY
     flags |= GSS_MUTUAL if mutual_auth
+    flags |= GSS_DELEGATE if ticket
 
     flags = [flags].pack('V')
 
     checksum_val = channel_binding_info_len + channel_binding_info + flags
+
+    if ticket
+      krb_cred = Rex::Proto::Kerberos::Model::KrbCred.new
+      krb_cred.pvno = 5
+      krb_cred.msg_type = 0x16
+      krb_cred.tickets = [ticket]
+      ticket_info = Rex::Proto::Kerberos::Model::KrbCredInfo.new
+      ticket_info.key = decrypted_part.key
+      ticket_info.prealm = realm
+      ticket_info.pname = build_client_name(client_name: client_name)
+      ticket_info.flags = decrypted_part.flags
+      ticket_info.auth_time = decrypted_part.auth_time
+      ticket_info.start_time = decrypted_part.start_time
+      ticket_info.end_time = decrypted_part.end_time
+      ticket_info.renew_till = decrypted_part.renew_till
+      ticket_info.sname = decrypted_part.sname
+      ticket_info.srealm = decrypted_part.srealm
+
+      enc_part = Rex::Proto::Kerberos::Model::EncKrbCredPart.new
+      enc_part.ticket_info = [ticket_info]
+
+      krb_cred.enc_part = enc_part.encrypt(session_key)
+
+      dlg_opt = [1].pack('v')
+      dlg_val = krb_cred.encode
+      dlg_length = [dlg_val.length].pack('v')
+      checksum_val += dlg_opt + dlg_length + dlg_val
+    end
 
     checksum = Rex::Proto::Kerberos::Model::Checksum.new(
       type: Rex::Proto::Gss::KRB_AP_REQ_CHKSUM_TYPE,

--- a/lib/net/winrm/rex_http_transport.rb
+++ b/lib/net/winrm/rex_http_transport.rb
@@ -42,6 +42,7 @@ module Net
 
         str = response.body.force_encoding('BINARY')
         str.sub!(%r{^.*Content-Type: application/octet-stream\r\n(.*)--Encrypted.*$}m, '\1')
+        str.sub!(%r{^.*Content-Type: application/octet-stream\r\n(.*)-- Encrypted.*$}m, '\1')
 
         # Strip off the "encrypted message header length" token
         str = str[4, str.length-4]

--- a/lib/rex/proto/kerberos/model.rb
+++ b/lib/rex/proto/kerberos/model.rb
@@ -17,6 +17,8 @@ module Rex
         AUTHENTICATOR = 2
         AP_REQ = 14
         AP_REP = 15
+        KRB_CRED = 22
+        ENC_KRB_CRED_PART = 29
 
         # From Principal
         # https://datatracker.ietf.org/doc/html/rfc4120#section-6.2

--- a/lib/rex/proto/kerberos/model/enc_krb_cred_part.rb
+++ b/lib/rex/proto/kerberos/model/enc_krb_cred_part.rb
@@ -1,0 +1,53 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # This class provides a representation of an EncKrbCredPart, sent as the
+        # encrypted part of a KRB-CRED
+        class EncKrbCredPart < Element
+          # @!attribute ticket-info
+          #   @return [Array<Rex::Proto::Kerberos::Model::KrbCredInfo>] The information corresponding to tickets in a KrbCred object
+          attr_accessor :ticket_info
+
+          def decode(input)
+            raise ::NotImplementedError, 'EncApRepPart encoding not supported'
+          end
+
+          def encrypt(key)
+            encryptor = Rex::Proto::Kerberos::Crypto::Encryption.from_etype(key.type)
+            data = encryptor.encrypt(encode, key.value, Rex::Proto::Kerberos::Crypto::KeyUsage::KRB_CRED_ENCPART)
+
+            result = Rex::Proto::Kerberos::Model::EncryptedData.new(
+              etype: key.type,
+              cipher: data
+            )
+          end
+
+          # Encodes the Rex::Proto::Kerberos::Model::EncApRepPart into an ASN.1 String
+          #
+          # @return [String]
+          def encode
+            elems = []
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_ticket_info], 0, :CONTEXT_SPECIFIC)
+            seq = OpenSSL::ASN1::Sequence.new(elems)
+            seq_asn1 = OpenSSL::ASN1::ASN1Data.new([seq], ENC_KRB_CRED_PART, :APPLICATION)
+
+            seq_asn1.to_der
+          end
+
+          private
+
+          # Encodes the ticket_info field
+          #
+          # @return [OpenSSL::ASN1::Sequence]
+          def encode_ticket_info
+            encoded = ticket_info.map {|t| t.encode }
+            seq = OpenSSL::ASN1::Sequence.new(encoded)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/proto/kerberos/model/krb_cred.rb
+++ b/lib/rex/proto/kerberos/model/krb_cred.rb
@@ -14,213 +14,76 @@ module Rex
           #   @return [Integer] The type of a protocol message
           attr_accessor :msg_type
           # @!attribute tickets
-          #   @return [Array<Rex::Proto::Kerberol::Model::Ticket>] Tickets encapsulated in this message
+          #   @return [Array<Rex::Proto::Kerberos::Model::Ticket>] Tickets encapsulated in this message
           attr_accessor :tickets
           # @!attribute enc_part
-          #   @return [String] Encrypted KRB-CRED blob
+          #   @return [Rex::Proto::Kerberos::Model::EncryptedData] Encrypted KRB-CRED blob
           attr_accessor :enc_part
 
-          # Decodes the Rex::Proto::Kerberos::Model::KrbError from an input
+          # Decodes the Rex::Proto::Kerberos::Model::KrbCred from an input
           #
           # @param input [String, OpenSSL::ASN1::ASN1Data] the input to decode from
           # @return [self] if decoding succeeds
           # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
           def decode(input)
-            case input
-            when String
-              decode_string(input)
-            when OpenSSL::ASN1::ASN1Data
-              decode_asn1(input)
-            else
-              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode KrbError, invalid input'
-            end
-
-            self
+            raise ::NotImplementedError, 'KrbCred decoding not supported'
           end
 
-          # Rex::Proto::Kerberos::Model::KrbError encoding isn't supported
+          # Rex::Proto::Kerberos::Model::KrbCred encoding isn't supported
           #
           # @raise [NotImplementedError]
           def encode
-            raise ::NotImplementedError, 'KrbError encoding not supported'
-          end
+            elems = []
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_pvno], 0, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_msg_type], 1, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_tickets], 2, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_enc_part], 3, :CONTEXT_SPECIFIC)
 
-          # Decodes the e_data field as an Array<PreAuthDataEntry>
-          #
-          # @return [Array<Rex::Proto::Kerberos::Model::PreAuthDataEntry>]
-          def e_data_as_pa_data
-            pre_auth = []
-            decoded = OpenSSL::ASN1.decode(self.e_data)
-            decoded.each do |pre_auth_data|
-              pre_auth << Rex::Proto::Kerberos::Model::PreAuthDataEntry.decode(pre_auth_data)
-            end
+            seq = OpenSSL::ASN1::Sequence.new(elems)
+            seq_asn1 = OpenSSL::ASN1::ASN1Data.new([seq], KRB_CRED, :APPLICATION)
 
-            pre_auth
-          end
-
-          # Decodes the e_data field as a PreAuthData
-          #
-          # @return [Rex::Proto::Kerberos::Model::PreAuthData]
-          def e_data_as_pa_data_entry
-            decoded = OpenSSL::ASN1.decode(self.e_data)
-            Rex::Proto::Kerberos::Model::PreAuthDataEntry.decode(decoded)
+            seq_asn1.to_der
           end
 
           private
 
-          # Decodes a Rex::Proto::Kerberos::Model::KrbError from an String
+          # Encodes the pvno
           #
-          # @param input [String] the input to decode from
-          def decode_string(input)
-            asn1 = OpenSSL::ASN1.decode(input)
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError]
+          def encode_pvno
+            bn = OpenSSL::BN.new(pvno.to_s)
+            int = OpenSSL::ASN1::Integer.new(bn)
 
-            decode_asn1(asn1)
+            int
+          rescue OpenSSL::ASN1::ASN1Error
+            raise Rex::Proto::Kerberos::Model::Error::KerberosDecodingError
           end
 
-          # Decodes a Rex::Proto::Kerberos::Model::KrbError
+          # Encodes the msg_type field
           #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
-          def decode_asn1(input)
-            input.value[0].value.each do |val|
-              case val.tag
-              when 0
-                self.pvno = decode_pvno(val)
-              when 1
-                self.msg_type = decode_msg_type(val)
-              when 2
-                self.ctime = decode_ctime(val)
-              when 3
-                self.cusec = decode_cusec(val)
-              when 4
-                self.stime = decode_stime(val)
-              when 5
-                self.susec = decode_susec(val)
-              when 6
-                self.error_code = decode_error_code(val)
-              when 7
-                self.crealm = decode_crealm(val)
-              when 8
-                self.cname = decode_cname(val)
-              when 9
-                self.realm = decode_realm(val)
-              when 10
-                self.sname = decode_sname(val)
-              when 11
-                self.etext = decode_etext(val)
-              when 12
-                self.e_data = decode_e_data(val)
-              else
-                raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, "Failed to decode KRB-ERROR SEQUENCE (#{val.tag})"
-              end
-            end
+          # @return [OpenSSL::ASN1::Integer]
+          def encode_msg_type
+            bn = OpenSSL::BN.new(msg_type.to_s)
+            int = OpenSSL::ASN1::Integer.new(bn)
+
+            int
           end
 
-          # Decodes the pvno from an OpenSSL::ASN1::ASN1Data
+          # Encodes the ticket field
           #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [Integer]
-          def decode_pvno(input)
-            input.value[0].value.to_i
+          # @return [OpenSSL::ASN1::Sequence]
+          def encode_tickets
+            encoded = tickets.map {|t| t.encode}
+            seq = OpenSSL::ASN1::Sequence.new(encoded)
           end
 
-          # Decodes the msg_type from an OpenSSL::ASN1::ASN1Data
+          # Encodes the enc_part field
           #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [Integer]
-          def decode_msg_type(input)
-            input.value[0].value.to_i
-          end
-
-          # Decodes the ctime field
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [Time]
-          def decode_ctime(input)
-            input.value[0].value
-          end
-
-          # Decodes the cusec field
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [Integer]
-          def decode_cusec(input)
-            input.value[0].value
-          end
-
-          # Decodes the stime field
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [Time]
-          def decode_stime(input)
-            input.value[0].value
-          end
-
-          # Decodes the susec field
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [Integer]
-          def decode_susec(input)
-            input.value[0].value.to_i
-          end
-
-          # Decodes the error_code field
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [Rex::Proto::Kerberos::Model::Error::ErrorCode]
-          def decode_error_code(input)
-            value = input.value[0].value.to_i
-
-            Error::ErrorCodes::ERROR_MAP[value] || Error::ErrorCode.new('UNKNOWN', value, 'Unknown error')
-          end
-
-          # Decodes the crealm field
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
           # @return [String]
-          def decode_crealm(input)
-            input.value[0].value
+          def encode_enc_part
+            encoded = enc_part.encode
           end
 
-          # Decodes the cname field
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [Rex::Proto::Kerberos::Model::PrincipalName]
-          def decode_cname(input)
-            Rex::Proto::Kerberos::Model::PrincipalName.decode(input.value[0])
-          end
-
-          # Decodes the realm field
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [String]
-          def decode_realm(input)
-            input.value[0].value
-          end
-
-          # Decodes the sname field
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [Rex::Proto::Kerberos::Model::PrincipalName]
-          def decode_sname(input)
-            Rex::Proto::Kerberos::Model::PrincipalName.decode(input.value[0])
-          end
-
-          # Decodes the e-text field
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [String]
-          def decode_etext(input)
-            input.value[0].value
-          end
-
-          # Decodes the e_data from an OpenSSL::ASN1::ASN1Data
-          #
-          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
-          # @return [String]
-          def decode_e_data(input)
-            input.value[0].value
-          end
         end
       end
     end

--- a/lib/rex/proto/kerberos/model/krb_cred_info.rb
+++ b/lib/rex/proto/kerberos/model/krb_cred_info.rb
@@ -1,0 +1,139 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # This class provides a representation of a KrbCredInfo object
+        class KrbCredInfo < Element
+          # @!attribute key
+          #   @return [Rex::Proto::Kerberos::Model::EncryptionKey] The session key associated with a corresponding ticket in the enclosing KrbCred object
+          attr_accessor :key
+          # @!attribute prealm
+          #   @return [String] The realm for the principal identity
+          attr_accessor :prealm
+          # @!attribute pname
+          #   @return [Rex::Proto::Kerberos::Model::PrincipalName] The name of the principal identity
+          attr_accessor :pname
+          # @!attribute flags
+          #   @return [Rex::Proto::Kerberos::Model::KdcOptionFlags] This field indicates which of various options were used or
+          #   requested when the ticket was issued
+          attr_accessor :flags
+          # @!attribute auth_time
+          #   @return [Time] the time of initial authentication for the named principal
+          attr_accessor :auth_time
+          # @!attribute start_time
+          #   @return [Time] Specifies the time after which the ticket is valid
+          attr_accessor :start_time
+          # @!attribute end_time
+          #   @return [Time] This field contains the time after which the ticket will
+          #   not be honored (its expiration time)
+          attr_accessor :end_time
+          # @!attribute renew_till
+          #   @return [Time] This field is only present in tickets that have the
+          #   RENEWABLE flag set in the flags field.  It indicates the maximum
+          #   endtime that may be included in a renewal
+          attr_accessor :renew_till
+          # @!attribute srealm
+          #   @return [String] The realm part of the server's principal identifier
+          attr_accessor :srealm
+          # @!attribute sname
+          #   @return [Rex::Proto::Kerberos::Model::PrincipalName] The name part of the server's identity
+          attr_accessor :sname
+
+          # Not Implemented
+          def decode(input)
+            raise ::NotImplementedError, 'KrbCredInfo encoding not supported'
+          end
+
+          def encode
+            elems = []
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_key], 0, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_prealm], 1, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_pname], 2, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_flags], 3, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_auth_time], 4, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_start_time], 5, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_end_time], 6, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_renew_till], 7, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_srealm], 8, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_sname], 9, :CONTEXT_SPECIFIC)
+            seq = OpenSSL::ASN1::Sequence.new(elems)
+          end
+
+          private
+
+          # Encodes the key field
+          #
+          # @return [String]
+          def encode_key
+            key.encode
+          end
+
+          # Encodes the prealm field
+          #
+          # @return [OpenSSL::ASN1::GeneralString]
+          def encode_prealm
+            OpenSSL::ASN1::GeneralString.new(prealm)
+          end
+
+          # Encodes the pname field
+          #
+          # @return [String]
+          def encode_pname
+            pname.encode
+          end
+
+          # Encodes the flags
+          #
+          # @return [OpenSSL::ASN1::Integer]
+          def encode_flags
+            OpenSSL::ASN1::BitString.new([flags.value].pack('N'))
+          end
+
+          # Encodes the auth_time
+          #
+          # @return [OpenSSL::ASN1::GeneralizedTime]
+          def encode_auth_time
+            OpenSSL::ASN1::GeneralizedTime.new(auth_time)
+          end
+
+          # Encodes the start_time
+          #
+          # @return [OpenSSL::ASN1::GeneralizedTime]
+          def encode_start_time
+            OpenSSL::ASN1::GeneralizedTime.new(start_time)
+          end
+
+          # Encodes the end_time
+          #
+          # @return [OpenSSL::ASN1::GeneralizedTime]
+          def encode_end_time
+            OpenSSL::ASN1::GeneralizedTime.new(end_time)
+          end
+
+          # Encodes the renew_till
+          #
+          # @return [OpenSSL::ASN1::GeneralizedTime]
+          def encode_renew_till
+            OpenSSL::ASN1::GeneralizedTime.new(renew_till)
+          end
+
+          # Encodes the srealm field
+          #
+          # @return [OpenSSL::ASN1::GeneralString]
+          def encode_srealm
+            OpenSSL::ASN1::GeneralString.new(srealm)
+          end
+
+          # Encodes the sname field
+          #
+          # @return [String]
+          def encode_sname
+            sname.encode
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Requires (or rather, includes) #16749 

This provides the option of sending a delegated credential to the WinRM server, to be able to access network resources from the compromised server.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use winrm_login`
- [ ] `set winrmauth kerberos`
- [ ] Provide login details to a WinRM service
- [ ] Once a command shell has been received:
- [ ] Verify that `klist` shows a ticket for the `krbtgt` service (i.e. `Server: krbtgt/domain_name`)
- [ ] Verify that you can access a network resource (e.g. \\dc\sysvol)
- [ ] Test this on various OSes
- [ ] If you're feeling fancy, verify that the module works when you change `lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb`
 such that `send_delegated_creds` is set to `ALWAYS`, `NEVER`, and `WHEN_UNCONSTRAINED` (against both a server with unconstrained delegation enabled, and one without)
