### PR TITLE
Fix msfconsole crashing with openssl3

### DIFF
--- a/lib/msf/core/handler/reverse_ssh.rb
+++ b/lib/msf/core/handler/reverse_ssh.rb
@@ -145,8 +145,12 @@ module Msf
       def default_version_string
         require 'rex/proto/ssh/connection'
         Rex::Proto::Ssh::Connection.default_options['local_version']
+      rescue OpenSSL::Cipher::CipherError => e
+        print_error("ReverseSSH handler did not load with OpenSSL version #{OpenSSL::VERSION}")
+        elog(e)
+        'SSH-2.0-OpenSSH_5.3p1'
       rescue LoadError => e
-        print_error("This handler requires PTY access not available on all platforms.")
+        print_error('ReverseSSH handler did not load as PTY access is not available on all platforms.')
         elog(e)
         'SSH-2.0-OpenSSH_5.3p1'
       end


### PR DESCRIPTION
Improves https://github.com/rapid7/metasploit-framework/issues/16767

Ubuntu 2022 ships with OpenSSL 3 which has backwards incompatible changes, as well as no longer loading all ciphers by default - https://github.com/rapid7/metasploit-framework/issues/16767#issuecomment-1183098771

This is an interim solution to ensure msfconsole continues to boot, there will be other OpenSSL issues present with Ubuntu 2022.

## Verification

Verify the following crash on ubuntu 2022 with OpenSSL 3:
```
$ bundle exec ruby ./msfconsole
/var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/encryption_algorithm/functionable.rb:13:in `initialize': unsupported (OpenSSL::Cipher::CipherError)
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/encryption_algorithm/functionable.rb:13:in `new'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/encryption_algorithm/functionable.rb:13:in `included'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/encryption_algorithm/blowfish_cbc.rb:14:in `include'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/encryption_algorithm/blowfish_cbc.rb:14:in `<class:BlowfishCbc>'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/encryption_algorithm/blowfish_cbc.rb:9:in `<class:EncryptionAlgorithm>'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/encryption_algorithm/blowfish_cbc.rb:8:in `<class:Transport>'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/encryption_algorithm/blowfish_cbc.rb:7:in `<module:HrrRbSsh>'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/encryption_algorithm/blowfish_cbc.rb:6:in `<top (required)>'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/encryption_algorithm.rb:19:in `<top (required)>'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/kex_algorithm/iv_computable.rb:5:in `<top (required)>'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/kex_algorithm/diffie_hellman.rb:7:in `<top (required)>'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/kex_algorithm/diffie_hellman_group1_sha1.rb:4:in `<top (required)>'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport/kex_algorithm.rb:17:in `<top (required)>'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/transport.rb:15:in `<top (required)>'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh.rb:15:in `<top (required)>'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /home/a/metasploit-framework/lib/rex/proto/ssh/hrr_rb_ssh.rb:3:in `<top (required)>'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /home/a/metasploit-framework/lib/rex/proto/ssh/connection.rb:2:in `<top (required)>'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /var/lib/gems/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /home/a/metasploit-framework/lib/msf/core/handler/reverse_ssh.rb:146:in `default_version_string'
	from /home/a/metasploit-framework/lib/msf/core/handler/reverse_ssh.rb:40:in `initialize'
	from /home/a/metasploit-framework/lib/msf/base/sessions/command_shell_options.rb:16:in `initialize'
	from /home/a/metasploit-framework/modules/payloads/singles/cmd/unix/reverse_ssh.rb:16:in `initialize'
	from /home/a/metasploit-framework/lib/msf/core/payload_set.rb:95:in `new'
	from /home/a/metasploit-framework/lib/msf/core/payload_set.rb:95:in `block (2 levels) in recalculate'
	from /home/a/metasploit-framework/lib/msf/core/payload_set.rb:93:in `each_pair'
	from /home/a/metasploit-framework/lib/msf/core/payload_set.rb:93:in `block in recalculate'
	from /home/a/metasploit-framework/lib/msf/core/payload_set.rb:73:in `each_pair'
	from /home/a/metasploit-framework/lib/msf/core/payload_set.rb:73:in `recalculate'
	from /home/a/metasploit-framework/lib/msf/core/modules/loader/base.rb:258:in `block in load_modules'
	from /home/a/metasploit-framework/lib/msf/core/modules/loader/base.rb:255:in `each'
	from /home/a/metasploit-framework/lib/msf/core/modules/loader/base.rb:255:in `load_modules'
	from /home/a/metasploit-framework/lib/msf/core/module_manager/loading.rb:170:in `block in load_modules'
	from /home/a/metasploit-framework/lib/msf/core/module_manager/loading.rb:168:in `each'
	from /home/a/metasploit-framework/lib/msf/core/module_manager/loading.rb:168:in `load_modules'
	from /home/a/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:41:in `block in add_module_path'
	from /home/a/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:40:in `each'
	from /home/a/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:40:in `add_module_path'
	from /home/a/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:51:in `block in init_module_paths'
	from /home/a/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:50:in `each'
	from /home/a/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:50:in `init_module_paths'
	from /home/a/metasploit-framework/lib/msf/ui/console/driver.rb:160:in `initialize'
	from /home/a/metasploit-framework/lib/metasploit/framework/command/console.rb:60:in `new'
	from /home/a/metasploit-framework/lib/metasploit/framework/command/console.rb:60:in `driver'
	from /home/a/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
	from /home/a/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
	from ./msfconsole:23:in `<main>'
```

Verify the fix allows msfconsole to continue to boot; There will be constant redefinition errors present as this code path loads three times but it can be ignored.