### PR TITLE
Suggest a correct datastore option

### DIFF
--- a/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
   def set_and_test_variable(name, framework_value, module_value, framework_re, module_re)
     # set the current module
     allow(core).to receive(:active_module).and_return(mod)
+    # always assume the variable is valid
+    allow(core).to receive(:tab_complete_option_names).and_return([ name ])
     # always assume set variables validate (largely irrelevant because ours are random)
     allow(driver).to receive(:on_variable_set).and_return(true)
     # the specified global value


### PR DESCRIPTION
Metasploit has a lot of datastore options. It's hard to keep track of them all and typos happen. This change updates the `set` command in two cases.

The first is when the only argument is an invalid datastore option (example: `set RPRT`). In this case the old version would print an error and simply said it was invalid, followed by the help message. Now the new one will echo the invalid option as well as attempt to make a suggestion, like hey did you actually mean RPORT with an O?

Next is when there are two options and the first is an invalid datastore option. Now in this case the original code would simply take the value and store it into the datastore. This behavior has been changed to also display an error message with a suggestion if available. I'm not entirely sure if setting invalid datastore options is the behavior we want to retain. If that's the case, maybe a warning would be better. Setting an invalid datastore option would be helpful for when you set the value for a payload before setting PAYLOAD to that payload that uses it (e.g. setting `CMD` before switching from `windows/meterpreter/reverse_tcp` to `cmd/windows/generic`).

Valid option names are taken from the tab completion routine since there are a few special cases like ACTION, TARGET, SessionTlvLogging, etc. This should help keep the logic used to enumerate valid option names consolidated.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Use a module with multiple `TARGET`s (windows/exploit/smb/psexec) works nicely
- [ ] Use different payloads and targets, set different datastore options, ensure everything works as expected
- [ ] Use a module with `ACTIONS`, see that you can set the action
- [ ] Make a typo, see that the option is invalid and maybe there's a suggestion (maybe because `DidYouMean` has it's limitations, if you ask it to autocorrect ZZZ, there may not be any option remotely close to that in which case there will be no suggestion.)


## Demo

### New
```
msf6 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set RPRT
[-] Unknown datastore option: RPRT. Did you mean RPORT?
Usage: set [option] [value]

Set the given option to value.  If value is omitted, print the current value.
If both are omitted, print options that are currently set.

If run from a module context, this will set the value in the module's
datastore.  Use -g to operate on the global datastore.

If setting a PAYLOAD, this command can take an index from `show payloads'.

msf6 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set RPRT 443
[-] Unknown datastore option: RPRT. Did you mean RPORT?
msf6 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > 
```

### Old
This is super confusing by the way, at first it says it's unknown then it accepts it. So you can set an invalid option but you can't show it at least not until after you've set it.
```
msf6 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set RPRT
[-] Unknown variable
Usage: set [option] [value]

Set the given option to value.  If value is omitted, print the current value.
If both are omitted, print options that are currently set.

If run from a module context, this will set the value in the module's
datastore.  Use -g to operate on the global datastore.

If setting a PAYLOAD, this command can take an index from `show payloads'.

msf6 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set RPRT 443
RPRT => 443
msf6 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set RPRT
RPRT => 443
msf6 auxiliary(admin/sap/cve_2020_6287_ws_add_user) >
```