### PR TITLE
Add openssl version to debug command

### DIFF
--- a/lib/msf/ui/debug.rb
+++ b/lib/msf/ui/debug.rb
@@ -258,6 +258,7 @@ module Msf
         str = <<~VERSIONS
           Framework: #{framework.version}
           Ruby: #{RUBY_DESCRIPTION}
+          OpenSSL: #{OpenSSL::OPENSSL_VERSION}
           Install Root: #{Msf::Config.install_root}
           Session Type: #{db_connection_info(framework)}
           Install Method: #{installation_method}

--- a/spec/lib/msf/debug_spec.rb
+++ b/spec/lib/msf/debug_spec.rb
@@ -1276,6 +1276,7 @@ RSpec.describe Msf::Ui::Debug do
       ```
       Framework: VERSION
       Ruby: #{RUBY_DESCRIPTION}
+      OpenSSL: #{OpenSSL::OPENSSL_VERSION}
       Install Root: bad/path
       Session Type: driver selected, no connection
       Install Method: Other - Please specify
@@ -1315,6 +1316,7 @@ RSpec.describe Msf::Ui::Debug do
       ```
       Framework: VERSION
       Ruby: #{RUBY_DESCRIPTION}
+      OpenSSL: #{OpenSSL::OPENSSL_VERSION}
       Install Root: bad/path
       Session Type: Connected to db_name. Connection type: http.
       Install Method: Other - Please specify
@@ -1362,6 +1364,7 @@ RSpec.describe Msf::Ui::Debug do
       ```
       Framework: VERSION
       Ruby: #{RUBY_DESCRIPTION}
+      OpenSSL: #{OpenSSL::OPENSSL_VERSION}
       Install Root: bad/path
       Session Type: Connected to current_db_connection. Connection type: local.
       Install Method: Other - Please specify
@@ -1400,6 +1403,7 @@ RSpec.describe Msf::Ui::Debug do
       ```
       Framework: VERSION
       Ruby: #{RUBY_DESCRIPTION}
+      OpenSSL: #{OpenSSL::OPENSSL_VERSION}
       Install Root: #{File.join(File::SEPARATOR, 'usr', 'share', 'metasploit-framework')}
       Session Type: driver selected, no connection
       Install Method: Other - Please specify
@@ -1438,6 +1442,7 @@ RSpec.describe Msf::Ui::Debug do
       ```
       Framework: VERSION
       Ruby: #{RUBY_DESCRIPTION}
+      OpenSSL: #{OpenSSL::OPENSSL_VERSION}
       Install Root: #{File.join(file_fixtures_path, 'debug', 'installs', 'omnibus')}
       Session Type: driver selected, no connection
       Install Method: Omnibus Installer
@@ -1477,6 +1482,7 @@ RSpec.describe Msf::Ui::Debug do
       ```
       Framework: VERSION
       Ruby: #{RUBY_DESCRIPTION}
+      OpenSSL: #{OpenSSL::OPENSSL_VERSION}
       Install Root: #{File.join(file_fixtures_path, 'debug', 'installs')}
       Session Type: driver selected, no connection
       Install Method: Git Clone
@@ -1515,6 +1521,7 @@ RSpec.describe Msf::Ui::Debug do
       ```
       Framework: VERSION
       Ruby: #{RUBY_DESCRIPTION}
+      OpenSSL: #{OpenSSL::OPENSSL_VERSION}
       Install Root: #{File.join(File::SEPARATOR, 'opt', 'metasploit')}
       Session Type: driver selected, no connection
       Install Method: Other - Please specify


### PR DESCRIPTION
With the recent update to OpenSSL3 - some of our modules which rely on crypto may fail. Let's log out the OpenSSL version to help with triaging issues reports.

Mac:
```
Framework: 6.2.8-dev-f02012a8ee
Ruby: ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-darwin20]
OpenSSL: OpenSSL 1.1.1m  14 Dec 2021
Install Root: /Users/user/foo
Session Type: Connected to msf. Connection type: postgresql.
Install Method: Git Clone
```

Ubuntu 22.04
```
Framework: 6.2.8-dev-f02012a8ee
Ruby: ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux-gnu]
OpenSSL: OpenSSL 3.0.2 15 Mar 2022
Install Root: /mnt/hgfs/metasploit-framework
Session Type: postgresql selected, no connection
Install Method: Git Clone
```

## Verification

- [ ] Start `msfconsole`
- [ ] Use `debug`
- [ ] Verify the OpenSSL version is present and correct