### PR TITLE
Widen rescue scope for reverse ssh handler

### DIFF
--- a/lib/msf/core/handler/reverse_ssh.rb
+++ b/lib/msf/core/handler/reverse_ssh.rb
@@ -145,7 +145,7 @@ module Msf
       def default_version_string
         require 'rex/proto/ssh/connection'
         Rex::Proto::Ssh::Connection.default_options['local_version']
-      rescue OpenSSL::Cipher::CipherError => e
+      rescue OpenSSL::OpenSSLError => e
         print_error("ReverseSSH handler did not load with OpenSSL version #{OpenSSL::VERSION}")
         elog(e)
         'SSH-2.0-OpenSSH_5.3p1'


### PR DESCRIPTION
As noted by Smortex - https://github.com/rapid7/metasploit-framework/issues/16767#issuecomment-1188563161 there's other SSL exceptions which can be raised. Let's just widen the scope of our rescue for now until we've fully upgraded framework to use OpenSSL 3.

We'll probably want a long term fix in the module loader/payload_set to ensure exceptions like this won't kill msfconsole from booting up.

## Verification

Verify msfconsole works on Ubuntu 22.04 and OpenSSL 3