### PR TITLE
Fix --tag for 'hosts' -t | --tag cmd command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -422,7 +422,7 @@ class Db
     [ '-i', '--info' ] => [ true, 'Change the info of a host', '<info>' ],
     [ '-n', '--name' ] => [ true, 'Change the name of a host', '<name>' ],
     [ '-m', '--comment' ] => [ true, 'Change the comment of a host', '<comment>' ],
-    [ '-t', '--tag' ] => [ false, 'Add or specify a tag to a range of hosts' ],
+    [ '-t', '--tag' ] => [ true, 'Add or specify a tag to a range of hosts', '<tag>' ],
     [ '-d', '--delete' ] => [ true, 'Delete the hosts instead of searching', '<hosts>' ],
     [ '-o', '--output' ] => [ true, 'Send output to a file in csv format', '<filename>' ],
     [ '-O', '--order' ] => [ true, 'Order rows by specified column number', '<column id>' ],

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "    -o, --output <filename>                Send output to a file in csv format",
           "    -R, --rhosts                           Set RHOSTS from the results of the search",
           "    -S, --search <filter>                  Search string to filter by",
-          "    -t, --tag                              Add or specify a tag to a range of hosts",
+          "    -t, --tag <tag>                        Add or specify a tag to a range of hosts",
           "    -u, --up                               Only show hosts which are up",
           "Available columns: address, arch, comm, comments, created_at, cred_count, detected_arch, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_family, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count, tags"
         ]


### PR DESCRIPTION
Enable parsing of the -t argument. Note that to my knowledge there is no way to remove a tag via the command-line at the moment. 

## Before
```bash
msf6 > hosts -t mytag 10.10.10.1
[-] Invalid host parameter, mytag.
```

## After

```bash
msf6 > hosts -t mytag 10.10.10.1
msf6 > hosts -C address,tags 10.10.10.1

Hosts
=====

address     tags
-------     ----
10.10.10.1  mytag

msf6 > 
```