### PR TITLE
consolidate the config directory lookups

### DIFF
--- a/lib/metasploit/framework/database.rb
+++ b/lib/metasploit/framework/database.rb
@@ -93,7 +93,7 @@ module Metasploit
       # @return [Pathname] if the user has a `database.yml` in their config directory (`~/.msf4` by default).
       # @return [nil] if the user does not have a `database.yml` in their config directory.
       def self.user_configurations_pathname
-        Pathname.new(Msf::Config.get_config_root).join('database.yml')
+        Pathname.new(Msf::Config.config_directory).join('database.yml')
       end
     end
   end

--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -22,7 +22,7 @@ class Config < Hash
   # The installation's root directory for the distribution
   InstallRoot = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..'))
 
-  # Determines the base configuration directory.
+  # Determines the base configuration directory. This method should be considered `private`.
   #
   # @return [String] the base configuration directory
   def self.get_config_root

--- a/lib/msf/core/db_connector.rb
+++ b/lib/msf/core/db_connector.rb
@@ -130,7 +130,7 @@ module DbConnector
   # Connect to a database via the supplied yaml file
   #
   def self.db_connect_yaml(framework, opts)
-    file = opts[:yaml_file] || ::File.join(Msf::Config.get_config_root, 'database.yml')
+    file = opts[:yaml_file] || ::File.join(Msf::Config.config_directory, 'database.yml')
     file = ::File.expand_path(file)
     unless ::File.exist?(file)
       return { error: 'File not found' }

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def initialize_actions
-    user_config_file_path = File.join(::Msf::Config.get_config_root, 'ldap_queries.yaml')
+    user_config_file_path = File.join(::Msf::Config.config_directory, 'ldap_queries.yaml')
     default_config_file_path = File.join(::Msf::Config.data_directory, 'auxiliary', 'gather', 'ldap_query', 'ldap_queries_default.yaml')
 
     @loaded_queries = safe_load_queries(default_config_file_path) || []

--- a/modules/auxiliary/scanner/telephony/wardial.rb
+++ b/modules/auxiliary/scanner/telephony/wardial.rb
@@ -95,8 +95,8 @@ class MetasploitModule < Msf::Auxiliary
       raise RuntimeError, "Telephony not available"
     end
 
-    @confdir      = File.join(Msf::Config.get_config_root, 'wardial')
-    @datadir      = File.join(Msf::Config.get_config_root, 'logs', 'wardial')
+    @confdir      = File.join(Msf::Config.config_directory, 'wardial')
+    @datadir      = File.join(Msf::Config.config_directory, 'logs', 'wardial')
 
     # make sure working dirs exist
     FileUtils.mkdir_p(@confdir)

--- a/modules/post/windows/gather/screen_spy.rb
+++ b/modules/post/windows/gather/screen_spy.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Post
 
   def run
     host = session.session_host
-    screenshot = Msf::Config.get_config_root + '/logs/' + host + '.jpg'
+    screenshot = Msf::Config.config_directory + '/logs/' + host + '.jpg'
 
     # If no PID is specified, don't migrate.
     if datastore['PID'] != ''

--- a/msfdb
+++ b/msfdb
@@ -34,7 +34,7 @@ require 'msfenv'
 @script_name = File.basename(__FILE__)
 @framework = File.expand_path(File.dirname(__FILE__))
 
-@localconf = Msf::Config.get_config_root
+@localconf = Msf::Config.config_directory
 @db = "#{@localconf}/db"
 @db_conf = "#{@localconf}/database.yml"
 @pg_cluster_conf_root = "#{@localconf}/.local/etc/postgresql"

--- a/msfrpcd
+++ b/msfrpcd
@@ -122,10 +122,10 @@ if $PROGRAM_NAME == __FILE__
 
     require 'rex/parser/arguments'
 
-  ws_ssl_key_default = File.join(Msf::Config.get_config_root, "#{WS_TAG}-key.pem")
-  ws_ssl_cert_default = File.join(Msf::Config.get_config_root, "#{WS_TAG}-cert.pem")
-  ws_log = File.join(Msf::Config.get_config_root, 'logs', "#{WS_RPC_TAG}.log")
-  ws_rpc_pid = File.join(Msf::Config.get_config_root, "#{WS_RPC_TAG}.pid")
+  ws_ssl_key_default = File.join(Msf::Config.config_directory, "#{WS_TAG}-key.pem")
+  ws_ssl_cert_default = File.join(Msf::Config.config_directory, "#{WS_TAG}-cert.pem")
+  ws_log = File.join(Msf::Config.config_directory, 'logs', "#{WS_RPC_TAG}.log")
+  ws_rpc_pid = File.join(Msf::Config.config_directory, "#{WS_RPC_TAG}.pid")
   ws_ssl_key = ws_ssl_key_default
   ws_ssl_cert = ws_ssl_cert_default
   ssl_enable_verify = false

--- a/plugins/aggregator.rb
+++ b/plugins/aggregator.rb
@@ -7,7 +7,7 @@
 #
 
 module Msf
-  Aggregator_yaml = "#{Msf::Config.get_config_root}/aggregator.yaml" # location of the aggregator.yml containing saved aggregator creds
+  Aggregator_yaml = "#{Msf::Config.config_directory}/aggregator.yaml" # location of the aggregator.yml containing saved aggregator creds
 
   class Plugin::Aggregator < Msf::Plugin
     class AggregatorCommandDispatcher

--- a/plugins/beholder.rb
+++ b/plugins/beholder.rb
@@ -226,7 +226,7 @@ class Plugin::Beholder < Msf::Plugin
       webcam: false,
       keystrokes: true,
       automigrate: true,
-      base: ::File.join(Msf::Config.get_config_root, "beholder", Time.now.strftime("%Y-%m-%d.%s")),
+      base: ::File.join(Msf::Config.config_directory, "beholder", Time.now.strftime("%Y-%m-%d.%s")),
       freq: 30,
       # TODO: Only capture when the idle threshold has been reached
       idle: 0,

--- a/plugins/capture.rb
+++ b/plugins/capture.rb
@@ -463,7 +463,7 @@ module Msf
       end
 
       def parse_start_args(args)
-        config_file = File.join(Msf::Config.get_config_root, 'capture_config.yaml')
+        config_file = File.join(Msf::Config.config_directory, 'capture_config.yaml')
         # See if there was a config file set
         @start_opt_parser.parse(args) do |opt, _idx, val|
           case opt
@@ -623,7 +623,7 @@ module Msf
       super
       add_console_dispatcher(ConsoleCommandDispatcher)
       filename = 'capture_config.yaml'
-      user_config_file = File.join(Msf::Config.get_config_root, filename)
+      user_config_file = File.join(Msf::Config.config_directory, filename)
       unless File.exist?(user_config_file)
         # Initialise user config file with the installed one
         base_config_file = File.join(Msf::Config.data_directory, filename)

--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -24,11 +24,11 @@ module Msf
       end
 
       def xindex
-        "#{Msf::Config.get_config_root}/nessus_index"
+        "#{Msf::Config.config_directory}/nessus_index"
       end
 
       def nessus_yaml
-        "#{Msf::Config.get_config_root}/nessus.yaml"
+        "#{Msf::Config.config_directory}/nessus.yaml"
       end
 
       def msf_local
@@ -102,7 +102,7 @@ module Msf
         start = Time.now
         print_status("Creating Exploit Search Index - (#{xindex}) - this won't take long.")
         count = 0
-        #Use Msf::Config.get_config_root as the location.
+        #Use Msf::Config.config_directory as the location.
         File.open("#{xindex}", "w+") do |f|
           #need to add version line.
           f.puts(Msf::Framework::Version)

--- a/plugins/nexpose.rb
+++ b/plugins/nexpose.rb
@@ -8,7 +8,7 @@
 require 'nexpose'
 
 module Msf
-  Nexpose_yaml = "#{Msf::Config.get_config_root}/nexpose.yaml" #location of the nexpose.yml containing saved nexpose creds
+  Nexpose_yaml = "#{Msf::Config.config_directory}/nexpose.yaml" #location of the nexpose.yml containing saved nexpose creds
 
 class Plugin::Nexpose < Msf::Plugin
   class NexposeCommandDispatcher

--- a/spec/lib/metasploit/framework/database_spec.rb
+++ b/spec/lib/metasploit/framework/database_spec.rb
@@ -664,7 +664,7 @@ RSpec.describe Metasploit::Framework::Database do
     end
 
     before(:example) do
-      allow(Msf::Config).to receive(:get_config_root).and_return(config_root)
+      allow(Msf::Config).to receive(:config_directory).and_return(config_root)
     end
 
     it 'is database.yml under the user config root' do


### PR DESCRIPTION
The user configuration directory can be overridden via environment
variables or configuration files/values.

In the current implementation `Msf::Config.config_directory` should be
utilized for consistent location reporting. `Msf::Config.get_config_root`
is reserved to generation of a default location and should be considered
`private` as it ignores some injected configuration options. Currently
autoloading does not allow application of the `private` keyword to this method,
requiring guidance during development that module writers should access the
full configured `user` value of `Msf::Config.config_directory`.

## Verification

List the steps needed to make sure this thing works

```
metasploit-framework jmartin$ cat start_config.rb
require 'pathname'
require 'tmpdir'
require_relative 'config/boot'
require 'msfenv'
test_dir = Dir.mktmpdir("msf-test")
at_exit { FileUtils.remove_entry(test_dir) }

Msf::Simple::Framework.create(
 'ConfigDirectory' => test_dir,
 # don't load any module paths so we can just load the module under test and save time
 'DeferModuleLoads' => true,
 # Disable the monkey patching of ActiveRecord::ConnectionAdapters::ConnectionPool as it interfere's with rspec's
 # connection
 'DisableDatabase' => true
)

puts Msf::Config.get_config_root
puts Msf::Config.config_directory
```

```
metasploit-framework jmartin$ ruby start_config.rb
/Users/jmartin/.msf4
/var/folders/0m/mdc6j_ps1g7204s5wmmjt5k40000gp/T/msf-test20220725-49452-lvkquv
```

- [ ] **Verify** the difference in output expected for the values when `ConfigDirectory` is injected during `Msf::Simple::Framework.create`