### PR TITLE
Fix hosts crash when viewing tags

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -627,9 +627,8 @@ class Db
             when "workspace"; host.workspace.name
             when "tags"
               found_tags = find_host_tags(framework.db.workspace, host.id)
-              tag_names = []
-              found_tags.each { |t| tag_names << t.name }
-              found_tags * ", "
+              tag_names = found_tags.map(&:name).join(', ')
+              tag_names
             end
           # Otherwise, it's just an attribute
           else


### PR DESCRIPTION
Fix for issue spotted in https://github.com/rapid7/metasploit-framework/pull/16810 - https://github.com/rapid7/metasploit-framework/pull/16810#issuecomment-1194725664


### Before

```
msf6 auxiliary(scanner/vnc/vnc_login) > hosts -c address,tags
[-] Error while running command hosts: undefined method `*' for #<ActiveRecord::Associations::CollectionProxy [#<Mdm::Tag id: 2, user_id: nil, name: "foobar", desc: nil, report_summary: false, report_detail: false, critical: false, created_at: "2022-07-26 10:30:46.165341000 +0000", updated_at: "2022-07-26 10:30:46.165341000 +0000">, #<Mdm::Tag id: 3, user_id: nil, name: "baz", desc: nil, report_summary: false, report_detail: false, critical: false, created_at: "2022-07-26 11:06:48.054609000 +0000", updated_at: "2022-07-26 11:06:48.054609000 +0000">]>

Call stack:
/Users/user/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/activerecord-6.1.6/lib/active_record/relation/delegation.rb:110:in `method_missing'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:632:in `block (3 levels) in cmd_hosts'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:621:in `map'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:621:in `block (2 levels) in cmd_hosts'
/Users/user/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/activerecord-6.1.6/lib/active_record/relation/delegation.rb:88:in `each'
/Users/user/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/activerecord-6.1.6/lib/active_record/relation/delegation.rb:88:in `each'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:619:in `block in cmd_hosts'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:2157:in `block in each_host_range_chunk'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:2138:in `each'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:2138:in `each_host_range_chunk'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:616:in `cmd_hosts'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```

### After

```
msf6 auxiliary(scanner/vnc/vnc_login) > hosts -t baz 127.0.0.1
msf6 auxiliary(scanner/vnc/vnc_login) > hosts -c address,tags

Hosts
=====

address    tags
-------    ----
127.0.0.1  foobar, baz
```

## Verification

- Ensure the database is running
- Open msfconsole
- Populate msfconsole with hosts, and for each host have tags added
- Verify `hosts -c address,tags` previously crashed
- Verify `hosts -c address,tags` no longer crashes on this branch