### PR TITLE
Fix Default Action Error In ldap_query Module

### DIFF
--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -309,7 +309,7 @@ class MetasploitModule < Msf::Auxiliary
           entries = perform_ldap_query(ldap, filter, attributes)
           print_error("No entries could be found for #{datastore['QUERY_FILTER']}!") if entries.nil? || entries.empty?
         else
-          query = @loaded_queries[datastore['ACTION']]
+          query = @loaded_queries[datastore['ACTION']].nil? ? @loaded_queries[default_action] : @loaded_queries[datastore['ACTION']]
           fail_with(Failure::BadConfig, "Invalid action: #{datastore['ACTION']}") unless query
 
           begin


### PR DESCRIPTION
It appears I made a logical error bug in my ldap_query code whereby I assumed that `datastore['ACTION']` would never be `nil`. However it is possible that it may be `nil` in the case where the user is using the default action provided by the module without explicitly setting an action. 

In this case, the current code without these fixes will incorrectly state that the action is not valid.

The updated code now correctly grabs the details of the default action if the user didn't specify an action before running the module so that the module can run correctly.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/ldap_query`
- [x] Set BIND_DN
- [x] Set BIND_PW
- [x] Set RHOSTS
- [x] `run`
- [x] **Verify** that before this patch you would fail with the error message `[-] Auxiliary aborted due to failure: bad-config: Invalid action:`
- [x] **Verify** that after the patch the module works and runs using the default ACTION.
