### PR TITLE
Fix msfrpcd console read failures

### DIFF
--- a/lib/rex/ui/text/input/buffer.rb
+++ b/lib/rex/ui/text/input/buffer.rb
@@ -18,6 +18,10 @@ class Input::Buffer < Rex::Ui::Text::Input
     def write(buf, opts={})
       syswrite(buf)
     end
+
+    def monitor_rsock(*args, **kwargs)
+      dlog('monitor_rsock: Skipping - functionality not required')
+    end
   end
 
   def initialize

--- a/spec/lib/msf/core/rpc/v10/rpc_console_spec.rb
+++ b/spec/lib/msf/core/rpc/v10/rpc_console_spec.rb
@@ -1,0 +1,66 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+RSpec.describe Msf::RPC::RPC_Console do
+  include_context 'Msf::Simple::Framework'
+  include_context 'Metasploit::Framework::Spec::Constants cleaner'
+  include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
+
+  let(:service) do
+    Msf::RPC::Service.new(framework)
+  end
+
+  let(:rpc) do
+    described_class.new(service)
+  end
+
+  # Waits until the given expectations are all true. This function executes the given block,
+  # and if a failure occurs it will be retried `retry_count` times before finally failing.
+  # This is useful to expect against asynchronous/eventually consistent systems.
+  #
+  # @param retry_count [Integer] The total amount of times to retry the given expectation
+  # @param sleep_duration [Float] The total amount of time to sleep before trying again
+  def wait_for_expect(retry_count = 40, sleep_duration = 0.1)
+    failure_count = 0
+
+    begin
+      yield
+    rescue RSpec::Expectations::ExpectationNotMetError
+      failure_count += 1
+      if failure_count < retry_count
+        sleep sleep_duration
+        retry
+      else
+        raise
+      end
+    end
+  end
+
+  describe '#rpc_create' do
+    let(:console) { rpc.rpc_create({ 'DisableBanner' => true }) }
+    let(:console_id) { console['id'] }
+
+    after(:each) do
+      rpc.rpc_destroy(console_id)
+    end
+
+    it 'returns has an ID' do
+      expect(console).to eq({ "id" => "0", "prompt" => "", "busy" => false })
+    end
+
+    it 'supports reading and writing to a console' do
+      10.times do
+        rpc.rpc_write(console_id, "version\n")
+        wait_for_expect do
+          read_result = rpc.rpc_read(console_id)
+          expected_result = {
+            "data" => a_string_matching(/Framework: \d+.*\nConsole  : \d+.*\n/),
+            "prompt" => a_string_matching(/.* > /),
+            "busy" => false
+          }
+          expect(read_result).to match(expected_result)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/16580

I've added automated tests for this scenario, but this was my original test:

```ruby
require 'pathname'
require Pathname.new(__dir__).realpath.expand_path.join('config', 'boot')
require 'msfenv'

framework ||= Msf::Simple::Framework.create(
  'DeferModuleLoads' => true,
  'Logger' => 'Stdout',
  'LogLevel' => 3
)
service = OpenStruct.new(framework: framework)
rpc = Msf::RPC::RPC_Console.new(service)
console = rpc.rpc_create({ 'DisableBanner' => true })['id']
10.times do
  puts("Write result: #{rpc.rpc_write(console, "version\n")}")
  sleep 0.5
  puts("Read result: #{rpc.rpc_read(console)}")
end

rpc.rpc_destroy(console)
puts "finished"
```

### Latest framework release

The console is created successfully, but something causes the web console pipe to die/close - causing reads and writes to fail:

```
bundle exec ruby test.rb    
[07/27/2022 13:18:28] [e(0)] core: Module auxiliary/scanner/vnc/vnc_login not found, and no loading errors found. If you're using a custom module refer to our wiki: https://github.com/rapid7/metasploit-framework/wiki/Running-Private-Modules
Write result: {"wrote"=>8}
[07/27/2022 13:18:29] [d(0)] core: HistoryManager.push_context name: :msfconsole
Read result: {"data"=>"[-] Failed to load module: auxiliary/scanner/vnc/vnc_login\nFramework: 6.2.9-dev-4bbae96840\nConsole  : 6.2.9-dev-4bbae96840\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"Framework: 6.2.9-dev-4bbae96840\nConsole  : 6.2.9-dev-4bbae96840\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
[07/27/2022 13:18:29] [w(0)] core: monitor_rsock: exception during read: Errno::EAGAIN Resource temporarily unavailable
[07/27/2022 13:18:29] [d(0)] core: HistoryManager.pop_context name: :msfconsole
[07/27/2022 13:18:29] [e(0)] core: Thread Exception: WebConsoleShell  critical=false    source:
    /Users/user/Documents/code/metasploit-framework/lib/msf/ui/web/web_console.rb:84:in `initialize'
    /Users/user/Documents/code/metasploit-framework/lib/msf/ui/web/driver.rb:62:in `new'
    /Users/user/Documents/code/metasploit-framework/lib/msf/ui/web/driver.rb:62:in `create_console'
    /Users/user/Documents/code/metasploit-framework/lib/msf/core/rpc/v10/rpc_console.rb:28:in `rpc_create'
    test.rb:12:in `<main>' - IOError closed stream
Call stack:
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/input/buffer.rb:52:in `getc'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/input/buffer.rb:52:in `gets'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/bidirectional_pipe.rb:118:in `gets'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/bidirectional_pipe.rb:148:in `pgets'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:323:in `get_input_line'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:145:in `run'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/web/web_console.rb:84:in `block in initialize'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
/Users/user/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
Read result: {"data"=>"Framework: 6.2.9-dev-4bbae96840\nConsole  : 6.2.9-dev-4bbae96840\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>nil}
Read result: {"data"=>"", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>nil}
Read result: {"data"=>"", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>nil}
Read result: {"data"=>"", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>nil}
Read result: {"data"=>"", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>nil}
Read result: {"data"=>"", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>nil}
Read result: {"data"=>"", "prompt"=>"msf6 > ", "busy"=>false}
finished
```

## This Branch

The console is created successfully, and read/writes are supported:

```
[07/27/2022 13:17:17] [d(0)] core: monitor_rsock: Skipping - functionality not required.rb  
[07/27/2022 13:17:17] [e(0)] core: Module auxiliary/scanner/vnc/vnc_login not found, and no loading errors found. If you're using a custom module refer to our wiki: https://github.com/rapid7/metasploit-framework/wiki/Running-Private-Modules
Write result: {"wrote"=>8}
[07/27/2022 13:17:18] [d(0)] core: HistoryManager.push_context name: :msfconsole
Read result: {"data"=>"[-] Failed to load module: auxiliary/scanner/vnc/vnc_login\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"Framework: 6.2.9-dev-00b85e9bb4\nConsole  : 6.2.9-dev-00b85e9bb4\nFramework: 6.2.9-dev-00b85e9bb4\nConsole  : 6.2.9-dev-00b85e9bb4\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"Framework: 6.2.9-dev-00b85e9bb4\nConsole  : 6.2.9-dev-00b85e9bb4\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"Framework: 6.2.9-dev-00b85e9bb4\nConsole  : 6.2.9-dev-00b85e9bb4\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"Framework: 6.2.9-dev-00b85e9bb4\nConsole  : 6.2.9-dev-00b85e9bb4\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"Framework: 6.2.9-dev-00b85e9bb4\nConsole  : 6.2.9-dev-00b85e9bb4\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"Framework: 6.2.9-dev-00b85e9bb4\nConsole  : 6.2.9-dev-00b85e9bb4\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"Framework: 6.2.9-dev-00b85e9bb4\nConsole  : 6.2.9-dev-00b85e9bb4\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"Framework: 6.2.9-dev-00b85e9bb4\nConsole  : 6.2.9-dev-00b85e9bb4\n", "prompt"=>"msf6 > ", "busy"=>false}
Write result: {"wrote"=>8}
Read result: {"data"=>"Framework: 6.2.9-dev-00b85e9bb4\nConsole  : 6.2.9-dev-00b85e9bb4\n", "prompt"=>"msf6 > ", "busy"=>false}
[07/27/2022 13:17:24] [d(0)] core: HistoryManager.pop_context name: :msfconsole
finished
```

## Verification

Verify the automated tests pass, and the scenarios raised by users in the original issue