### PR TITLE
Msf::Post::Windows::Priv: Fix is_admin? / is_system? for shell sessions

### DIFF
--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -50,15 +50,12 @@ module Msf::Post::Windows::Priv
   def is_admin?
     if session_has_ext
       # Assume true if the OS doesn't expose this (Windows 2000)
-      session.railgun.shell32.IsUserAnAdmin()["return"] rescue true
-    else
-      local_service_key = registry_enumkeys('HKU\S-1-5-19')
-      if local_service_key
-        return true
-      else
-        return false
-      end
+      return session.railgun.shell32.IsUserAnAdmin()['return'] rescue true
     end
+
+    local_service_key = registry_enumkeys('HKU\S-1-5-19')
+
+    !local_service_key.blank?
   end
 
   # Steals the current user's token.
@@ -125,14 +122,11 @@ module Msf::Post::Windows::Priv
   def is_system?
     if session_has_ext
       return session.sys.config.is_system?
-    else
-      results = registry_enumkeys('HKLM\SAM\SAM')
-      if results
-        return true
-      else
-        return false
-      end
     end
+
+    sam = registry_enumkeys('HKLM\SAM\SAM')
+
+    !sam.blank?
   end
 
   #


### PR DESCRIPTION
For sessions without extended capabilities (ie, shell sessions), `Msf::Post::Windows::Priv.is_admin?` and `Msf::Post::Windows::Priv.is_system?` use `shell_registry_enumkeys` to read registry keys and evaluate the returned value for truthiness.

This method returns an array and can return an empty array `[]`.

https://github.com/rapid7/metasploit-framework/blob/1ac4a74070d1f5fc39d15d7f3a6baea3e32258ad/lib/msf/core/post/windows/registry.rb#L306-L327

An empty array evaluates to `true`, causing both `is_admin?` and `is_system?` to return `true` when they should return `false`.

```
irb(main):001:0> puts 'unintuitive' if []
unintuitive
=> nil
```

