### PR TITLE
Add better support for IMAP strings when capturing creds

### DIFF
--- a/modules/auxiliary/server/capture/imap.rb
+++ b/modules/auxiliary/server/capture/imap.rb
@@ -114,7 +114,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if cmd.upcase == 'ID'
-      c.put("* ID\r\n")
+      # RFC2971 specifies the ID command, and `NIL` is a valid response
+      c.put("* ID NIL\r\n")
       c.put("#{num} OK ID completed\r\n")
       return
     end

--- a/modules/auxiliary/server/capture/imap.rb
+++ b/modules/auxiliary/server/capture/imap.rb
@@ -52,7 +52,8 @@ class MetasploitModule < Msf::Auxiliary
     data = c.get_once
     return unless data
     num, cmd, arg = data.strip.split(/\s+/, 3)
-    arg ||= ""
+    cmd ||= ''
+    arg ||= ''
     args = []
 
     # If the argument is a number in braces, such as {3}, it means data is coming
@@ -66,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
         arg = (c.get_once || '').chomp
 
         # Remove the length field, if there is one
-        if arg =~ /(.*)\{[0-9]+\}$/
+        if arg =~ /(.*) \{[0-9]+\}$/
           args << $1
         else
           # If there's no length field, we're at the end
@@ -113,7 +114,6 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if cmd.upcase == 'ID'
-      print_status("Got ID command")
       c.put("* ID\r\n")
       c.put("#{num} OK ID completed\r\n")
       return


### PR DESCRIPTION
I ran into an issue while working on a Zimbra vulnerability ([CVE-2022-27924](https://nvd.nist.gov/vuln/detail/CVE-2022-27924)) - it tricks Zimbra into proxying my login. However, Metasploit's IMAP-capture module didn't actually work.

After diving into it, I noticed that the login doesn't send the username/password as parameters; instead, it sends them as separate lines with the lengths:

![image](https://user-images.githubusercontent.com/104588115/181121529-36fba0d1-9df2-4724-9914-b32ff78fcb06.png)

This is actually valid in [RFC3501 section 4.3](https://datatracker.ietf.org/doc/html/rfc3501#section-4.3):

>   A literal is a sequence of zero or more octets (including CR and
>   LF), prefix-quoted with an octet count in the form of an open
>   brace ("{"), the number of octets, close brace ("}"), and CRLF.
>   In the case of literals transmitted from server to client, the
>   CRLF is immediately followed by the octet data.  In the case of
>   literals transmitted from client to server, the client MUST wait
>   to receive a command continuation request (described later in
>   this document) before sending the octet data (and the remainder
>   of the command).

This patch fixes the current issue, but there are actually several other issues with the IMAP capture module:

* I didn't update other commands to use the new `args` structure - mostly they don't matter, but I also didn't want to break something by mistake
* This patch still treats the extra data as line data, rather than octet - that should work for usernames/passwords, so maybe it's fine
* The current implementation doesn't parse quoted strings at all - this is totally valid and not correctly parsed currently:

```
LOGIN "user with space" "password with space\"and\"quotes"
```

## Verification

The only service I could find that would use the `{number}`-string method is Zimbra's proxy, which would be a huge pain to test with.