### PR TITLE
Remove SCHELEVATOR echo statement as its not needed anymore

### DIFF
--- a/modules/exploits/windows/local/ms10_092_schelevator.rb
+++ b/modules/exploits/windows/local/ms10_092_schelevator.rb
@@ -305,7 +305,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exec_schtasks(cmdline, purpose)
-    cmdline = "/c #{cmdline.strip} && echo SCHELEVATOR"
+    cmdline = "/c #{cmdline.strip}"
     lns = cmd_exec('cmd.exe', cmdline)
 
     success = false


### PR DESCRIPTION
Whilst reviewing the code for https://github.com/rapid7/metasploit-framework/pull/16801 I noticed the code at https://github.com/rapid7/metasploit-framework/pull/16801/files#diff-7596dc2160932b6b53fd815da0efd2923135e43edcbdf70d4bf04a1b9244ff8aL274-L286 was changed inside the module `ms10_092_schelevator.rb`. 

Specifically whilst we still echo the `SCHELEVATOR` string, its no longer being filtered out of the output to check that the command ran successfully. This effectively means that, as a static string, its actually making the exploit easier to detect, particularly given that the string is quite unique.

This PR removes this static string since the module code instead checks for `SUCCESS` in the output vs `SCHELEVATOR`.

## Verification

List the steps needed to make sure this thing works

- [ ] Verify that the change looks good.
- [ ] If you can, test the module against a vulnerable target and ensure it still operates as expected.
