### PR TITLE
Add easier way to delete host tags

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -423,6 +423,7 @@ class Db
     [ '-n', '--name' ] => [ true, 'Change the name of a host', '<name>' ],
     [ '-m', '--comment' ] => [ true, 'Change the comment of a host', '<comment>' ],
     [ '-t', '--tag' ] => [ true, 'Add or specify a tag to a range of hosts', '<tag>' ],
+    [ '-T', '--delete-tag' ] => [ true, 'Remove a tag from a range of hosts', '<tag>' ],
     [ '-d', '--delete' ] => [ true, 'Delete the hosts instead of searching', '<hosts>' ],
     [ '-o', '--output' ] => [ true, 'Send output to a file in csv format', '<filename>' ],
     [ '-O', '--order' ] => [ true, 'Order rows by specified column number', '<column id>' ],
@@ -522,6 +523,9 @@ class Db
       when '-t', '--tag'
         mode << :tag
         tag_name = val
+      when '-T', '--delete-tag'
+        mode << :delete_tag
+        tag_name = val
       when '-c', '-C'
         list = val
         if(!list)
@@ -607,8 +611,16 @@ class Db
         end
       end
       return
-    when mode.include?(:tag) && mode.include?(:delete)
-      delete_host_tag(host_ranges, tag_name)
+    when mode == [:delete_tag]
+      begin
+        delete_host_tag(host_ranges, tag_name)
+      rescue => e
+        if e.message.include?('Validation failed')
+          print_error(e.message)
+        else
+          raise e
+        end
+      end
       return
     end
 

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "    -o, --output <filename>                Send output to a file in csv format",
           "    -R, --rhosts                           Set RHOSTS from the results of the search",
           "    -S, --search <filter>                  Search string to filter by",
+          "    -T, --delete-tag <tag>                 Remove a tag from a range of hosts",
           "    -t, --tag <tag>                        Add or specify a tag to a range of hosts",
           "    -u, --up                               Only show hosts which are up",
           "Available columns: address, arch, comm, comments, created_at, cred_count, detected_arch, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_family, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count, tags"


### PR DESCRIPTION
Currently the only way to delete a host tag is to do this odd syntax:

```
msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts

Hosts
=====

address  mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------  ---  ----  -------  ---------  -----  -------  ----  --------

msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts -a 127.0.0.1
[*] Time: 2022-07-28 19:54:27 UTC Host: host=127.0.0.1
msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts -c address,tags

Hosts
=====

address    tags
-------    ----
127.0.0.1

msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts -t test 127.0.0.1
msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
127.0.0.1

msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts -c address,tags

Hosts
=====

address    tags
-------    ----
127.0.0.1  test

msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts -d -t test 127.0.0.1
[-] Invalid host parameter, -t.
[-] Invalid host parameter, test.
msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts 

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
127.0.0.1

msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts -d 127.0.0.1 -t test
msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts -c address,tags

Hosts
=====

address    tags
-------    ----
127.0.0.1

msf6 payload(windows/x64/meterpreter/reverse_tcp) > 
```

Note that the documentation for the `hosts` command makes it so that it seems like the `-d` and `-t` options are the own options and should not be combined as the `-d` option should just delete the host itself:

```
msf6 payload(windows/x64/meterpreter/reverse_tcp) > hosts --help
Usage: hosts [ options ] [addr1 addr2 ...]


OPTIONS:

    -a, --add <host>                       Add the hosts instead of searching
    -c, --columns <columns>                Only show the given columns (see list below)
    -C, --columns-until-restart <columns>  Only show the given columns until the next restart (see list below)
    -d, --delete <hosts>                   Delete the hosts instead of searching
    -h, --help                             Show this help information
    -i, --info <info>                      Change the info of a host
    -m, --comment <comment>                Change the comment of a host
    -n, --name <name>                      Change the name of a host
    -O, --order <column id>                Order rows by specified column number
    -o, --output <filename>                Send output to a file in csv format
    -R, --rhosts                           Set RHOSTS from the results of the search
    -S, --search <filter>                  Search string to filter by
    -t, --tag <tag>                        Add or specify a tag to a range of hosts
    -u, --up                               Only show hosts which are up

Available columns: address, arch, comm, comments, created_at, cred_count, detected_arch, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_family, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count, tags

msf6 payload(windows/x64/meterpreter/reverse_tcp) > 
```

However in the code it seems like we have this odd switch whereby if you specify the `-d` and `-t` options and also specify the parameters to them correctly, _defying the _documentation_, only then is it possible to delete the host tags. Considering this is completely against good practice and basically falls into the realm of undocumented behavior, I decided to fix this.

The new option `-T` will act like `-t` however it will delete the tag instead of adding it. It performs the same operations that were being done before but exposes it via a proper option with associated documentation.

Spec files have not yet been added but will be soon.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `hosts -a 127.0.0.1`
- [ ] `hosts -t test 127.0.0.1`
- [ ] `hosts -c address,tags 127.0.0.1`
- [ ] **Verify** that you see the "test" tag.
- [ ] `hosts -T test 127.0.0.1`
- [ ] `hosts`
- [ ] **Verify** that the "test" tag was removed from 127.0.0.1
- [ ] `hosts --help`
- [ ] **Verify** that the "-T" option is appropriately documented.