### PR TITLE
Fix Regressions From #16774 (`set` Command Related)

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1827,14 +1827,23 @@ class Core
       append = true
     end
 
+    valid_options = []
     # Determine which data store we're operating on
     if (active_module and global == false)
       datastore = active_module.datastore
+
+      tab_complete_option_names(active_module, '', []).each do |opt_name|
+        valid_options << opt_name
+        option = active_module.options[opt_name]
+        next unless option
+
+        # aliases that are defined for backwards compatibility are not tab completed but are still valid option names
+        valid_options += active_module.options[opt_name].aliases
+      end
     else
       global = true
       datastore = self.framework.datastore
     end
-    valid_options = tab_complete_option_names(active_module, '', [])
 
     # Dump the contents of the active datastore if no args were supplied
     if (args.length == 0)

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1853,7 +1853,7 @@ class Core
           datastore) + "\n")
       return true
     elsif (args.length == 1)
-      if valid_options.any? { |vo| vo.casecmp?(args[0]) }
+      if global || valid_options.any? { |vo| vo.casecmp?(args[0]) }
         print_line("#{args[0]} => #{datastore[args[0]]}")
         return true
       else
@@ -1887,7 +1887,7 @@ class Core
       end
     end
 
-    unless valid_options.any? { |vo| vo.casecmp?(name) }
+    unless global || valid_options.any? { |vo| vo.casecmp?(name) }
       message = "Unknown datastore option: #{name}."
       suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first
       message << " Did you mean #{suggestion}?" if suggestion


### PR DESCRIPTION
This fixes an issue introduce in #16774 where the `setg` and `set -g` commands were broken. When setting options globally, just use the original functionality instead of searching the list based on the current context.

This issue was reported privately and there is no ticket for it.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Switch to a context where there is no module (make sure the prompt is `msf6 > `, use the `back` command if necessary)
- [x] Run the `setg` command to set a global variable
- [x] See it work
- [x] Switch to a module and set an aliased option (`RHOST` is valid for almost all remote exploits and is a good use case since it's an alias of `RHOSTS`)
- [x] See that work too

### Old Behavior (Broken)

```
./msfconsole -qx 'setg RHOSTS 127.0.0.1; resource scripts/resource/portscan.rc'
[*] Processing /home/smcintyre/.msf4/msfconsole.rc for ERB directives.
resource (/home/smcintyre/.msf4/msfconsole.rc)> load request
[*] Successfully loaded plugin: Request
resource (/home/smcintyre/.msf4/msfconsole.rc)> load versions
[*] versions plugin loaded.
[*] Successfully loaded plugin: versions
resource (/home/smcintyre/.msf4/msfconsole.rc)> loadpath test/modules
Loaded 38 modules:
    14 auxiliary modules
    13 exploit modules
    11 post modules
resource (/home/smcintyre/.msf4/msfconsole.rc)> workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
[-] Unknown datastore option: RHOSTS.
[*] Processing /home/smcintyre/Repositories/metasploit-framework.pr/scripts/resource/portscan.rc for ERB directives.
[*] resource (/home/smcintyre/Repositories/metasploit-framework.pr/scripts/resource/portscan.rc)> Ruby Code (2008 bytes)
[*] you have to set RHOSTS globally ... exiting
msf6 > setg RHOSTS 127.0.0.1
[-] Unknown datastore option: RHOSTS.
msf6 > use exploit/windows/smb/psexec 
^C[-] use: Interrupted
msf6 exploit(windows/smb/psexec) > set RHOST 192.168.159.10
[-] Unknown datastore option: RHOST. Did you mean RHOSTS?
msf6 exploit(windows/smb/psexec) > set RPRT ThisIsStillMakesASuggestion
[-] Unknown datastore option: RPRT. Did you mean RPORT?
msf6 exploit(windows/smb/psexec) > 
```

### New Behavior (Correct)

```
./msfconsole -qx 'setg RHOSTS 127.0.0.1; resource scripts/resource/portscan.rc'
[*] Processing /home/smcintyre/.msf4/msfconsole.rc for ERB directives.
resource (/home/smcintyre/.msf4/msfconsole.rc)> load request
[*] Successfully loaded plugin: Request
resource (/home/smcintyre/.msf4/msfconsole.rc)> load versions
[*] versions plugin loaded.
[*] Successfully loaded plugin: versions
resource (/home/smcintyre/.msf4/msfconsole.rc)> loadpath test/modules
Loaded 38 modules:
    14 auxiliary modules
    13 exploit modules
    11 post modules
resource (/home/smcintyre/.msf4/msfconsole.rc)> workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
RHOSTS => 127.0.0.1
[*] Processing /home/smcintyre/Repositories/metasploit-framework/scripts/resource/portscan.rc for ERB directives.
[*] resource (/home/smcintyre/Repositories/metasploit-framework/scripts/resource/portscan.rc)> Ruby Code (2008 bytes)
THREADS => 100

starting portscanners ...

Module: udp_sweep
[*] Auxiliary module running as background job 0.
Module: db_nmap
Using Nmap with the following options: -n -PN -P0 -O -sSV 127.0.0.1
[*] Sending 13 probes to 127.0.0.1->127.0.0.1 (1 hosts)
[*] Nmap: 'You requested a scan type which requires root privileges.'
[!] Running Nmap with sudo
[sudo] password for smcintyre: 
[-] db_nmap: Interrupted
[*] Scanned 1 of 1 hosts (100% complete)
msf6 > [*] Nmap: 'sudo: a password is required'

msf6 > setg RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf6 > use exploit/windows/smb/psexec 
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/smb/psexec) > set RHOST 192.168.159.10
RHOST => 192.168.159.10
msf6 exploit(windows/smb/psexec) > set RPRT ThisIsStillMakesASuggestion
[-] Unknown datastore option: RPRT. Did you mean RPORT?
msf6 exploit(windows/smb/psexec) > 
```