### PR TITLE
Post::Windows::Registry: Fix shell_registry_[enumvals|getvaldata] error check

### DIFF
--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -311,14 +311,17 @@ protected
     subkeys = []
     reg_data_types = 'REG_SZ|REG_MULTI_SZ|REG_DWORD_BIG_ENDIAN|REG_DWORD|REG_BINARY|'
     reg_data_types << 'REG_DWORD_LITTLE_ENDIAN|REG_NONE|REG_EXPAND_SZ|REG_LINK|REG_FULL_RESOURCE_DESCRIPTOR'
+
     bslashes = key.count('\\')
+    bslashes = bslashes - 1 if key.ends_with?('\\')
+
     results = shell_registry_cmd("query \"#{key}\"", view)
-    unless results.include?('Error')
+    unless results.to_s.upcase.starts_with?('ERROR:')
       results.each_line do |line|
         # now let's keep the ones that have a count = bslashes+1
         # feels like there's a smarter way to do this but...
         if (line.count('\\') == bslashes+1 && !line.ends_with?('\\'))
-          #then it's a first level subkey
+          # then it's a first level subkey
           subkeys << line.split('\\').last.chomp # take & chomp the last item only
         end
       end
@@ -336,7 +339,7 @@ protected
     reg_data_types << 'REG_DWORD_LITTLE_ENDIAN|REG_NONE|REG_EXPAND_SZ|REG_LINK|REG_FULL_RESOURCE_DESCRIPTOR'
     # REG QUERY KeyName [/v ValueName | /ve] [/s]
     results = shell_registry_cmd("query \"#{key}\"", view)
-    unless results.include?('Error')
+    unless results.to_s.upcase.starts_with?('ERROR:')
       if values = results.scan(/^ +.*[#{reg_data_types}].*/)
         # yanked the lines with legit REG value types like REG_SZ
         # now let's parse out the names (first field basically)


### PR DESCRIPTION
The `shell_registry_enumvals` and `shell_registry_getvaldata` methods are used for non-Meterpreter sessions (shell, PowerShell). The rudimentary error checking simply checks for `Error` in the response.

This is a problem when enumerating Software under `HKLM\\SOFTWARE\\Microsoft`. For example, checking whether PowerShell is installed:

```ruby
unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft\\').include?('PowerShell')
```

For Windows 7, the response string will contain:

```
Windows Error Reporting\r\n
```

Causing the method to return no results (`[]`).

Looking at the [library history](https://github.com/rapid7/metasploit-framework/commits/master/lib/msf/core/post/windows/registry.rb) it looks like this has been broken for many years.

Elsewhere in the library it is clear that the intention was to check if the response starts with `ERROR: `:

https://github.com/rapid7/metasploit-framework/blob/d6738c3b1832d7c007a4091ba34033a638706663/lib/msf/core/post/windows/registry.rb#L408-L414

For some unknown reason, this is a case insensitive regex match. Based on the fact that the existing methods used `Error` I'm going to guess that different versions of `reg.exe` on different versions of Windows use a different output format. As such, the changes introduced in this PR ensure the error checking is also case insensitive.

---

The PR also fixes a bug with slash counting in `shell_registry_enumkeys`. (The existing code is janky and contains a comment suggesting there's a better way to do it. Yes, there probably is. No, I don't care.)

The slash counting failed to account for instances where the user provides a registry path with a trailing slash (it also doesn't account for superfluous slashes, but this PR doesn't fix that. No, I don't care.). This causes the method to return no results when a trailing slash is present. This is also a problem as the associated Meterpreter library code works with trailing slashes, causing differences in library output between Meterpreter and non-Meterpreter sessions.

