### PR TITLE
Post::Windows::UserProfiles: Update read_profile_list

### DIFF
--- a/lib/msf/core/post/windows/user_profiles.rb
+++ b/lib/msf/core/post/windows/user_profiles.rb
@@ -109,10 +109,12 @@ module UserProfiles
   # Read HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList to
   # get a list of user profiles on the machine.
   #
-  def read_profile_list
+  def read_profile_list(user_accounts_only: true)
     hives=[]
     registry_enumkeys('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList').each do |profkey|
-      next unless profkey.include? "S-1-5-21"
+      if user_accounts_only
+        next unless profkey.starts_with?('S-1-5-21')
+      end
       hive={}
       hive['SID']=profkey
       hive['HKU']= "HKU\\#{profkey}"
@@ -131,7 +133,7 @@ module UserProfiles
   def loaded_hives
     hives=[]
     registry_enumkeys('HKU').each do |k|
-      next unless k.include? "S-1-5-21"
+      next unless k.starts_with?('S-1-')
       next if k.include? "_Classes"
       hives<< k
     end

--- a/lib/msf/core/post/windows/user_profiles.rb
+++ b/lib/msf/core/post/windows/user_profiles.rb
@@ -4,6 +4,7 @@ class Post
 module Windows
 
 module UserProfiles
+  include Msf::Post::File
   include Msf::Post::Windows::Registry
   include Msf::Post::Windows::Accounts
 
@@ -92,7 +93,7 @@ module UserProfiles
     read_profile_list().each do |hive|
       hive['OURS']=false
       if hive['LOADED']== false
-        if session.fs.file.exist?(hive['DAT'])
+        if file_exist?(hive['DAT'])
           hive['OURS'] = registry_loadkey(hive['HKU'], hive['DAT'])
           print_error("Error loading USER #{hive['SID']}: Hive could not be loaded, are you Admin?") unless hive['OURS']
         else
@@ -116,7 +117,7 @@ module UserProfiles
       hive['SID']=profkey
       hive['HKU']= "HKU\\#{profkey}"
       hive['PROF']= registry_getvaldata("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\#{profkey}", 'ProfileImagePath')
-      hive['PROF']= session.fs.file.expand_path(hive['PROF']) if hive['PROF']
+      hive['PROF'] = expand_path(hive['PROF']) if hive['PROF']
       hive['DAT']= "#{hive['PROF']}\\NTUSER.DAT"
       hive['LOADED'] = loaded_hives.include?(profkey)
       hives << hive


### PR DESCRIPTION
# Post::Windows::UserProfiles: Use Msf::Post::File mixin

This removes a couple of Meterpreter-only method calls, which allows non-Meterpreter sessions to use `read_profile_list` and `load_missing_hives`.

Unfortunately, `grab_user_profiles` -> `parse_profiles` -> `parse_profile` performs SID resolution with `Post::Windows::Accounts.resolve_sid()`:

https://github.com/rapid7/metasploit-framework/blob/d6738c3b1832d7c007a4091ba34033a638706663/lib/msf/core/post/windows/user_profiles.rb#L78-L82

This depends on Railgun. As such, much of this mixin still cannot be used for shell and PowerShell sessions.

---

# Post::Windows::UserProfiles: read_profile_list: Add :user_accounts_only option

This allows the `read_profile_list` method to read profile information for all accounts (including service accounts) not just user accounts.

`:user_accounts_only` defaults to `true` to preserve existing behaviour.

I'm not entirely sure how useful this will be. There are modules which read `dir C:\Users\*` and filter default service accounts from the results. Perhaps this change will be useful in similar instances (although it is not useful in these example modules which only care whether the directory exists, not the associated user account).

```
# grep -rn "All Users|Default|Default User|Public|desktop.ini|LocalService|NetworkService" modules/
modules/post/windows/gather/enum_powershell_env.rb:57:        next if u =~ /^(\.|\.\.|All Users|Default|Default User|Public|desktop.ini|LocalService|NetworkService)$/
modules/post/multi/gather/apple_ios_backup.rb:140:          next if path =~ /^(\.|\.\.|All Users|Default|Default User|Public|desktop.ini|LocalService|NetworkService)$/i
```

