### PR TITLE
guard for addtional possible OS errno

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -80,7 +80,7 @@ module Metasploit
                 opt_hash
               )
             end
-          rescue OpenSSL::Cipher::CipherError, ::EOFError, Net::SSH::Disconnect, Rex::ConnectionError, ::Timeout::Error, Errno::ECONNRESET => e
+          rescue OpenSSL::Cipher::CipherError, ::EOFError, Net::SSH::Disconnect, Rex::ConnectionError, ::Timeout::Error, Errno::ECONNRESET, Errno::EPIPE => e
             result_options.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           rescue Net::SSH::Exception => e
             status = Metasploit::Model::Login::Status::INCORRECT


### PR DESCRIPTION
When communicating to ssh the OS may report `Errno::EPIPE`
this can be handled more gracefully to avoid crashing consumers
of the mixin library.

Example stack trace:
```
Auxiliary failed: Errno::EPIPE Broken pipe - send(2)
Call stack:
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/buffered_io.rb:102:in `send'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/buffered_io.rb:102:in `send_pending'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/buffered_io.rb:114:in `wait_for_pending_sends'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/packet_stream.rb:121:in `send_packet'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/session.rb:241:in `send_message'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/kex/diffie_hellman_group1_sha1.rb:94:in `send_kexinit'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/kex/abstract.rb:48:in `exchange_keys'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/algorithms.rb:445:in `exchange_keys'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/algorithms.rb:245:in `proceed!'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/algorithms.rb:184:in `accept_kexinit'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/session.rb:210:in `block in poll_message'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/session.rb:190:in `loop'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/session.rb:190:in `poll_message'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/session.rb:225:in `block in wait'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/session.rb:223:in `loop'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/session.rb:223:in `wait'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/session.rb:90:in `initialize'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh.rb:251:in `new'
	/opt/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/net-ssh-6.1.0/lib/net/ssh.rb:251:in `start'
	/opt/metasploit-framework/embedded/framework/lib/metasploit/framework/login_scanner/ssh.rb:77:in `block in attempt_login'
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_login`
- [ ] **Verify** module still executes as expected
