### PR TITLE
add safe navigation to ensure fs access valid

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -413,7 +413,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
   def update_session_info
     # sys.config.getuid, and fs.dir.getwd cache their results, so update them
-    fs.dir.getwd
+    fs&.dir&.getwd
     username = self.sys.config.getuid
     sysinfo  = self.sys.config.sysinfo
 


### PR DESCRIPTION
Address a possible stack trace when `fs` is not yet cached or `nil`.

Stack trace based on 6.1.29:
```
[08/01/2022 11:43:19] [e(0)] core: Error loading sysinfo - NoMethodError undefined method `dir' for nil:NilClass
[08/01/2022 11:43:19] [d(0)] core: Call stack:
	/opt/metasploit-framework/embedded/framework/lib/msf/base/sessions/meterpreter.rb:409:in `update_session_info'
	/opt/metasploit-framework/embedded/framework/lib/msf/base/sessions/meterpreter.rb:459:in `block in load_session_info'
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] obtain a session
