### PR TITLE
Msf::Post::File.file_remote_digest[md5|sha1]: Cleanup and perform hashing remotely

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -352,10 +352,20 @@ module Msf::Post::File
   #
   # Returns a MD5 checksum of a given remote file
   #
-  # @note THIS DOWNLOADS THE FILE
+  # @note For non-Meterpreter sessions,
+  #       this method downloads the file from the remote host.
+  #
   # @param file_name [String] Remote file name
   # @return [String] Hex digest of file contents
   def file_remote_digestmd5(file_name)
+    if session.type == 'meterpreter'
+      begin
+        return session.fs.file.md5(file_name)&.unpack('H*').flatten.first
+      rescue StandardError
+        return nil
+      end
+    end
+
     data = read_file(file_name)
     chksum = nil
     if data
@@ -367,10 +377,20 @@ module Msf::Post::File
   #
   # Returns a SHA1 checksum of a given remote file
   #
-  # @note THIS DOWNLOADS THE FILE
+  # @note For non-Meterpreter sessions,
+  #       this method downloads the file from the remote host.
+  #
   # @param file_name [String] Remote file name
   # @return [String] Hex digest of file contents
   def file_remote_digestsha1(file_name)
+    if session.type == 'meterpreter'
+      begin
+        return session.fs.file.sha1(file_name)&.unpack('H*').flatten.first
+      rescue StandardError
+        return nil
+      end
+    end
+
     data = read_file(file_name)
     chksum = nil
     if data

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -363,7 +363,8 @@ module Msf::Post::File
     if session.type == 'meterpreter'
       begin
         return session.fs.file.md5(file_name)&.unpack('H*').flatten.first
-      rescue StandardError
+      rescue StandardError => e
+        print_error("Exception while running #{__method__}: #{e}")
         return nil
       end
     end
@@ -411,7 +412,8 @@ module Msf::Post::File
     if session.type == 'meterpreter'
       begin
         return session.fs.file.sha1(file_name)&.unpack('H*').flatten.first
-      rescue StandardError
+      rescue StandardError => e
+        print_error("Exception while running #{__method__}: #{e}")
         return nil
       end
     end


### PR DESCRIPTION
This PR modifies the remote file hashing methods to perform hashing remotely.

It also offers an option for users to specify a hashing utility with the `:util` option. No utility is selected by default to maintain the existing behaviour (stupidly downloading the file then hashing it locally).

Tested on Windows 7 SP1 (x64) with PowerShell, shell and Meterpreter sessions.

Tested with:

```ruby
puts 'md5:' + file_remote_digestmd5("C:\\doesnotexist").inspect
puts 'md5:' + file_remote_digestmd5("C:\\windows\\win.ini").to_s
puts 'md5:' + file_remote_digestmd5("C:\\windows\\win.ini", util: 'certutil').to_s

puts 'sha1:' + file_remote_digestsha1("C:\\doesnotexist").inspect
puts 'sha1:' + file_remote_digestsha1("C:\\windows\\win.ini").to_s
puts 'sha1:' + file_remote_digestsha1("C:\\windows\\win.ini", util: 'certutil').to_s
```

Also lazily tested `[sha1|md5]sum` utilities with a shell session on Linux.

```ruby
    puts 'md5:' + file_remote_digestmd5("/etc/passwd", util: 'md5sum').to_s
    puts 'md5:' + file_remote_digestmd5("/tmp/doesnotexist").inspect
    puts 'sha1:' + file_remote_digestsha1("/tmp/doesnotexist").inspect
    puts 'sha1:' + file_remote_digestsha1("/etc/passwd", util: 'sha1sum').to_s
```

This also indirectly fixes a bug. The `read_file` method can return operating system error message rather than the file contents; ie:

```
"The system cannot find the file specified.\r\n"
```

By adding support for PowerShell and Meterpreter sessions, the `read_file` branch is not called for sessions of these types.

This is an issue with the `read_file` method and is outside the scope of this PR. Ideally, `read_file` should return `nil` (or an empty string) if the file read fails.

I did fix this a while ago (fixed in #11342; previous discussion in #9854) for shell sessions (by first checking if the file is `readable?`), but only for non-Windows systems.