### PR TITLE
Post::Windows::Registry: Fix key and value parsing for shell sessions

### DIFF
--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -664,7 +664,7 @@ protected
     else
       raise ArgumentError, "Cannot normalize unknown key: #{key}"
     end
-    print_status("Normalized #{key} to #{keys.join("\\")}") if $blab
+    # print_status("Normalized #{key} to #{keys.join("\\")}")
     return keys.join("\\")
   end
 

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -668,7 +668,7 @@ protected
       raise ArgumentError, "Cannot normalize unknown key: #{key}"
     end
     # print_status("Normalized #{key} to #{keys.join("\\")}")
-    return keys.join("\\")
+    return keys.compact.join("\\")
   end
 
   #

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -368,19 +368,22 @@ protected
   #
   def shell_registry_getvalinfo(key, valname, view)
     key = normalize_key(key)
-    value = {}
-    value["Data"] = nil # defaults
-    value["Type"] = nil
+    value = {
+      'Data' => nil,
+      'Type' => nil
+    }
+
     # REG QUERY KeyName [/v ValueName | /ve] [/s]
     results = shell_registry_cmd("query \"#{key}\" /v \"#{valname}\"", view)
+
+    # pull out the interesting line (the one with the value name in it)
     if match_arr = /^ +#{valname}.*/i.match(results)
-      # pull out the interesting line (the one with the value name in it)
-      # and split it with ' ' yielding [valname,REGvaltype,REGdata]
-      split_arr = match_arr[0].split(' ')
-      value["Type"] = split_arr[1]
-      value["Data"] = split_arr[2]
-      # need to test to ensure all results can be parsed this way
+      # split with ' ' yielding [valname,REGvaltype,REGdata] and extract reg type
+      value['Type'] = match_arr[0].split[1]
+      # treat the remainder of the line after the reg type as the reg value
+      value['Data'] = match_arr[0].strip.scan(/#{value['Type']}\s+(.+)/).flatten.first
     end
+
     value
   end
 


### PR DESCRIPTION
# shell_registry_getvalinfo

Prior to this PR, registry key type and value were extracted by splitting the `reg` command output by space:

```ruby
      split_arr = match_arr[0].split(' ')
      value["Type"] = split_arr[1]
      value["Data"] = split_arr[2]
```

This is problematic as values can contain spaces, resulting in truncation of the key value after the first space. For example:

```
"\r\nHKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\ACPI\r\n    DisplayName    REG_SZ    Microsoft ACPI Driver\r\n"
```

Before this PR:

```
{"Data"=>"Microsoft", "Type"=>"REG_SZ"}
```

After this PR:

```
{"Data"=>"Microsoft ACPI Driver", "Type"=>"REG_SZ"}
```

You can use the `windows/gather/enum_artifacts` module to test this PR, which queries the above registry key by default. Note that this module does not support shell or powershell sessions by default (I'm fixing this in a separate PR #16873).

---

# normalize_key

`shell_registry_*` methods use `nomalize_key` to normalize the key name. This method calls `split_key` which splits the hive name from the key name and returns each as an element in an array:

https://github.com/rapid7/metasploit-framework/blob/365badb3696a90712d7810401b9bc08490f2bacf/lib/msf/core/post/windows/registry.rb#L676-L682

When only a hive name is provided, the returned key name is `nil`.

This is fine most of the time. However, when only a hive name  is provided (ie, `HKU`), `normalize_key` receives an array with two elements and attempts to join them with `\`, resulting in a key name with a trailing slash; ie, `HKU\\`.

Meterpreter registry methods don't care about trailing slashes, but the shell methods do, as the key name is passed directly to `reg.exe query`:

```
"ERROR: Invalid key name.\r\nType \"REG QUERY /?\" for usage."
```

This PR changes `normalize_key` to call `compact`  on the array before joining, thus removing the `nil` value. With no `nil` value there is nothing to join, and no trailing slash is appended.

---

Also removes `$blab` global variable. This variable is not defined or used anywhere in Framework. The line is now commented out instead. This is consistent with debug output elsewhere within the library which is also commented out.
