### PR TITLE
enum_artifacts: Cleanup and support non-meterpreter sessions

### DIFF
--- a/documentation/modules/post/windows/gather/enum_artifacts.md
+++ b/documentation/modules/post/windows/gather/enum_artifacts.md
@@ -1,0 +1,44 @@
+## Vulnerable Application
+
+This module will check the file system and registry for particular artifacts.
+
+The list of artifacts is read in YAML format from `data/post/enum_artifacts_list.txt`
+or a user specified file. Any matches are written to the loot.
+
+
+## Verification Steps
+
+1. Start msfconsole
+1. Get a session
+1. Do: `use post/windows/gather/enum_artifcats`
+1. Do: `set SESSION <session id>`
+1. Do: `run`
+
+## Options
+
+### ARTIFACTS
+
+Full path to artifacts file.
+
+## Scenarios
+
+### Windows 7 (6.1 Build 7601, Service Pack 1)
+
+```
+msf6 > use post/windows/gather/enum_artifacts 
+msf6 post(windows/gather/enum_artifacts) > set session 1
+session => 1
+msf6 post(windows/gather/enum_artifacts) > set verbose true
+verbose => true
+msf6 post(windows/gather/enum_artifacts) > run
+
+[*] Searching for artifacts of test_evidence
+[*] Processing 2 file entries for test_evidence ...
+[*] Processing 2 registry entries for test_evidence ...
+[*] Artifacts of test_evidence found.
+Evidence of test_evidence found.
+	HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ACPI\DisplayName
+
+[+] Enumerated Artifacts stored in: /root/.msf4/loot/20220807015628_default_192.168.200.190_enumerated.artif_933981.txt
+[*] Post module execution completed
+```

--- a/modules/post/windows/gather/enum_artifacts.rb
+++ b/modules/post/windows/gather/enum_artifacts.rb
@@ -10,86 +10,106 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::Registry
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'Windows Gather File and Registry Artifacts Enumeration',
-      'Description'   => %q{
-        This module will check the file system and registry for particular artifacts. The
-        list of artifacts is read from data/post/enum_artifacts_list.txt or a user specified file. Any
-        matches are written to the loot. },
-      'License'       => MSF_LICENSE,
-      'Author'        => [ 'averagesecurityguy <stephen[at]averagesecurityguy.info>' ],
-      'Platform'      => [ 'win' ],
-      'SessionTypes'  => [ 'meterpreter' ]
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather File and Registry Artifacts Enumeration',
+        'Description' => %q{
+          This module will check the file system and registry for particular artifacts.
 
-    register_options(
-      [
-        OptPath.new( 'ARTIFACTS',
-          [
-            true,
-            'Full path to artifacts file.',
-            ::File.join(Msf::Config.data_directory, 'post', 'enum_artifacts_list.txt')
-          ])
-      ])
+          The list of artifacts is read in YAML format from data/post/enum_artifacts_list.txt
+          or a user specified file. Any matches are written to the loot.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'averagesecurityguy <stephen[at]averagesecurityguy.info>' ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => %w[shell powershell meterpreter],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options([
+      OptPath.new(
+        'ARTIFACTS',
+        [
+          true,
+          'Full path to artifacts file.',
+          ::File.join(Msf::Config.data_directory, 'post', 'enum_artifacts_list.txt')
+        ]
+      )
+    ])
   end
 
   def run
-    # Store any found artifacts so they can be written to loot
-    evidence = {}
+    # Load artifacts from yaml file. Artifacts are organized by what they are evidence of.
+    begin
+      yaml = YAML.load_file(datastore['ARTIFACTS'])
+      raise 'File is not valid YAML' unless yaml.instance_of?(Hash)
+    rescue StandardError => e
+      fail_with(Failure::BadConfig, "Could not load artifacts YAML file '#{datastore['ARTIFACTS']}' : #{e.message}")
+    end
 
-    # Load artifacts from yaml file. Artifacts are organized by what they
-    # are evidence of.
-    yaml = YAML::load_file(datastore['ARTIFACTS'])
+    loot_data = ''
+
     yaml.each_key do |key|
       print_status("Searching for artifacts of #{key}")
-      files = yaml[key]['files']
-      regs = yaml[key]['reg_entries']
-      found = []
+      artifacts = []
 
       # Process file entries
-      vprint_status("Processing #{files.length.to_s} file entries for #{key}.")
+      files = yaml[key]['files']
+      vprint_status("Processing #{files.length} file entries for #{key} ...")
 
       files.each do |file|
-        digest = file_remote_digestmd5(file['name'])
-        # if the file doesn't exist then digest will be nil
-        next if digest == nil
-        if digest == file['csum'] then found << file['name'] end
-      end
+        fname = file['name']
+        csum = file['csum']
 
-      # Process registry entries
-      vprint_status("Processing #{regs.length.to_s} registry entries for #{key}.")
-
-      regs.each do |reg|
-        rdata = registry_getvaldata(reg['key'], reg['val'])
-        if rdata.to_s == reg['data']
-          found << reg['key'] + '\\' + reg['val']
+        digest = file_remote_digestmd5(fname)
+        if digest == csum
+          artifacts << fname
         end
       end
 
-      # Did we find anything? If so store it in the evidence hash to be
-      # saved in the loot.
-      if found.empty?
+      # Process registry entries
+      regs = yaml[key]['reg_entries']
+      vprint_status("Processing #{regs.length} registry entries for #{key} ...")
+
+      regs.each do |reg|
+        k = reg['key']
+        v = reg['val']
+        rdata = registry_getvaldata(k, v)
+        if rdata.to_s == reg['data']
+          artifacts << "#{k}\\#{v}"
+        end
+      end
+
+      # Process matches
+      if artifacts.empty?
         print_status("No artifacts of #{key} found.")
-      else
-        print_status("Artifacts of #{key} found.")
-        evidence[key] = found
+        next
       end
+
+      print_status("Artifacts of #{key} found.")
+      loot_data << "Evidence of #{key} found.\n"
+      loot_data << artifacts.map { |a| "\t#{a}\n" }.join
     end
 
-    save(evidence, "Enumerated Artifacts")
-  end
+    return if loot_data.blank?
 
-  def save(data, name)
-    str = ""
-    data.each_pair do |key, val|
-      str << "Evidence of #{key} found.\n"
-      val.each do |v|
-        str << "\t" + v + "\n"
-      end
-    end
+    vprint_line(loot_data)
 
-    f = store_loot('enumerated.artifacts', 'text/plain', session, str, name)
-    print_good("#{name} stored in: #{f}")
+    loot_name = 'Enumerated Artifacts'
+    f = store_loot(
+      loot_name.downcase.split.join('.'),
+      'text/plain',
+      session,
+      loot_data,
+      loot_name
+    )
+    print_good("#{loot_name} stored in: #{f}")
   end
 end


### PR DESCRIPTION
Resolves Rubocop violations.

Adds documentation.

Adds `Notes` module meta information.

Adds support for non-Meterpreter sessions.

Adds some YAML parsing error handling.

---

This module will work on non-Meterpreter sessions as is; however, `Post::Windows::Registry.shell_registry_getvalinfo` contains a bug which will cause false negatives if the registry value contains whitespace. This is resolved in #16872. It would be a good idea to merge the bug fix PR first, but not necessary. This is a bug in the library and should not be a blocker for this PR. This module uses standard library methods which in turn call library methods prefixed with `shell_` and intended for use on shell/powershell sessions. The fact that it will often fail (including with the default values) on shell/powershell sessions is inconsequential.

The module documentation is lazy. I could have added some documentation describing how the YAML is supposed to be formatted. But I don't want to. The formatting is described in:

* https://github.com/rapid7/metasploit-framework/blob/master/data/post/enum_artifacts_list.txt
