### PR TITLE
enum_logged_on_users: Cleanup

### DIFF
--- a/documentation/modules/post/windows/gather/enum_logged_on_users.md
+++ b/documentation/modules/post/windows/gather/enum_logged_on_users.md
@@ -1,64 +1,61 @@
-
 ## Vulnerable Application
 
 This module will enumerate current and recently logged on Windows users.
 
 ## Verification Steps
 
-  1. Start msfconsole
-  2. Get meterpreter session
-  3. Do: ```use post/windows/gather/enum_logged_on_users```
-  4. Do: ```set SESSION <session id>```
-  5. Do: ```run```
+1. Start msfconsole
+2. Get a session
+3. Do: `use post/windows/gather/enum_logged_on_users`
+4. Do: `set SESSION <session id>`
+5. Do: `run`
 
 ## Options
 
-  **CURRENT**
+### CURRENT
 
-  Enumerate currently logged on users. Default: ```true```
+Enumerate currently logged on users. (default: `true`)
 
-  **RECENT**
+### RECENT
 
-  Enumerate Recently logged on users. Default: ```true```
+Enumerate recently logged on users. (default: `true`)
 
-  **SESSION**
-
-  The session to run this module on.
 
 ## Scenarios
 
 ### Windows 7 (6.1 Build 7601, Service Pack 1).
 
-  ```
-  [*] Meterpreter session 1 opened (192.168.1.3:4444 -> 192.168.1.10:49196) at 2019-12-13 04:36:54 -0700
+```
+[*] Meterpreter session 1 opened (192.168.1.3:4444 -> 192.168.1.10:49196) at 2019-12-13 04:36:54 -0700
 
-  msf exploit(multi/handler) > use post/windows/gather/enum_logged_on_users
-  msf post(windows/gather/enum_logged_on_users) > set SESSION 1
-    SESSION => 1
-  msf post(windows/gather/enum_logged_on_users) > run
+msf exploit(multi/handler) > use post/windows/gather/enum_logged_on_users
+msf post(windows/gather/enum_logged_on_users) > set SESSION 1
+SESSION => 1
+msf post(windows/gather/enum_logged_on_users) > run
 
-  [*] Running against session 1
+[*] Running module against TEST-PC (192.168.1.10)
 
-    Current Logged Users
-    ====================
+Current Logged Users
+====================
 
-    SID                                            User
-    ---                                            ----
-    S-1-5-21-3113421791-4205713440-112141152-1000  TEST-PC\TEST
-
-
-    [+] Results saved in: /root/.msf4/loot/20191213054456_default_192.168.1.10_host.users.activ_424278.txt
-
-    Recently Logged Users
-    =====================
-
-    SID                                            Profile Path
-    ---                                            ------------
-    S-1-5-18                                       %systemroot%\system32\config\systemprofile
-    S-1-5-19                                       C:\Windows\ServiceProfiles\LocalService
-    S-1-5-20                                       C:\Windows\ServiceProfiles\NetworkService
-    S-1-5-21-3113421791-4205713440-112141152-1000  C:\Users\TEST
+ SID                                            User
+ ---                                            ----
+ S-1-5-21-3113421791-4205713440-112141152-1000  TEST-PC\TEST
 
 
-    [*] Post module execution completed
-  ```
+[+] Results saved in: /root/.msf4/loot/20191213054456_default_192.168.1.10_host.users.activ_424278.txt
+
+Recently Logged Users
+=====================
+
+ SID                                            Profile Path
+ ---                                            ------------
+ S-1-5-18                                       %systemroot%\system32\config\systemprofile
+ S-1-5-19                                       C:\Windows\ServiceProfiles\LocalService
+ S-1-5-20                                       C:\Windows\ServiceProfiles\NetworkService
+ S-1-5-21-3113421791-4205713440-112141152-1000  C:\Users\TEST
+
+
+[+] Results saved in: /root/.msf4/loot/20191213054458_default_192.168.1.10_host.users.recen_365577.txt
+[*] Post module execution completed
+```

--- a/modules/post/windows/gather/enum_logged_on_users.rb
+++ b/modules/post/windows/gather/enum_logged_on_users.rb
@@ -4,85 +4,122 @@
 ##
 
 class MetasploitModule < Msf::Post
-  include Msf::Post::Windows::Registry
   include Msf::Post::Windows::Accounts
+  include Msf::Post::Windows::Registry
+  include Msf::Post::Windows::UserProfiles
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Windows Gather Logged On User Enumeration (Registry)',
-        'Description'   => %q{ This module will enumerate current and recently logged on Windows users},
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'win' ],
-        'SessionTypes'  => [ 'meterpreter' ]
-      ))
-    register_options(
-      [
-        OptBool.new('CURRENT', [ true, 'Enumerate currently logged on users', true]),
-        OptBool.new('RECENT' , [ true, 'Enumerate Recently logged on users' , true])
-      ])
-
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather Logged On User Enumeration (Registry)',
+        'Description' => %q{ This module will enumerate current and recently logged on Windows users. },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => %w[powershell shell meterpreter],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
+      )
+    )
+    register_options([
+      OptBool.new('CURRENT', [ true, 'Enumerate currently logged on users', true]),
+      OptBool.new('RECENT', [ true, 'Enumerate recently logged on users', true])
+    ])
   end
 
-
-  def ls_logged
-    sids = []
-    sids << registry_enumkeys("HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList")
+  def list_recently_logged_on_users
     tbl = Rex::Text::Table.new(
-      'Header'  => "Recently Logged Users",
-      'Indent'  => 1,
+      'Header' => 'Recently Logged Users',
+      'Indent' => 1,
       'Columns' =>
       [
-        "SID",
-        "Profile Path"
-      ])
-    sids.flatten.map do |sid|
-      profile_path = registry_getvaldata("HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\#{sid}","ProfileImagePath")
-      tbl << [sid,profile_path]
+        'SID',
+        'Profile Path'
+      ]
+    )
+
+    profiles = read_profile_list(user_accounts_only: false)
+
+    return if profiles.blank?
+
+    profiles.each do |profile|
+      tbl << [
+        profile['SID'],
+        profile['PROF']
+      ]
     end
-    print_line("\n" + tbl.to_s + "\n")
-    store_loot("host.users.recent", "text/plain", session, tbl.to_s, "recent_users.txt", "Recent Users")
+
+    return if tbl.rows.empty?
+
+    print_line("\n#{tbl}\n")
+    p = store_loot('host.users.recent', 'text/plain', session, tbl.to_s, 'recent_users.txt', 'Recent Users')
+    print_good("Results saved in: #{p}")
   end
 
+  def list_currently_logged_on_users
+    return unless session.type == 'meterpreter'
 
-  def ls_current
-    key_base, username = "",""
     tbl = Rex::Text::Table.new(
-      'Header'  => "Current Logged Users",
-      'Indent'  => 1,
+      'Header' => 'Current Logged Users',
+      'Indent' => 1,
       'Columns' =>
       [
-        "SID",
-        "User"
-      ])
-    registry_enumkeys("HKU").each do |maybe_sid|
-      # There is junk like .DEFAULT we want to avoid
-      if maybe_sid =~ /^S(?:-\d+){2,}$/
-        info = resolve_sid(maybe_sid)
+        'SID',
+        'User'
+      ]
+    )
+    keys = registry_enumkeys('HKU')
 
-        if !info.nil? && info[:type] == :user
-          username = info[:domain] << '\\' << info[:name]
+    return unless keys
 
-          tbl << [maybe_sid,username]
-        end
-      end
+    keys.each do |maybe_sid|
+      next unless maybe_sid.starts_with?('S-1-5-21-')
+      next if maybe_sid.ends_with?('_Classes')
+
+      info = resolve_sid(maybe_sid)
+
+      next if info.nil?
+
+      name = info[:name]
+      domain = info[:domain]
+
+      next if domain.blank? || name.blank?
+
+      tbl << [maybe_sid, "#{domain}\\#{name}"]
     end
 
-    print_line("\n" + tbl.to_s + "\n")
-    p = store_loot("host.users.active", "text/plain", session, tbl.to_s, "active_users.txt", "Active Users")
+    return if tbl.rows.empty?
+
+    print_line("\n#{tbl}\n")
+    p = store_loot('host.users.active', 'text/plain', session, tbl.to_s, 'active_users.txt', 'Active Users')
     print_good("Results saved in: #{p}")
   end
 
   def run
-    print_status("Running against session #{datastore['SESSION']}")
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Running module against #{hostname} (#{session.session_host})")
 
     if datastore['CURRENT']
-      ls_current
+      if session.type == 'meterpreter'
+        list_currently_logged_on_users
+      else
+        print_error("Incompatible session type '#{session.type}'. Can not retrieve list of currently logged in users.")
+      end
     end
 
     if datastore['RECENT']
-      ls_logged
+      list_recently_logged_on_users
     end
-
   end
 end


### PR DESCRIPTION
Tested on Windows Server 2008, Windows 7 (SP1), Windows 10 (1909), Windows XP SP3. (Although powershell sessions were tested only on Windows 7 and Windows 10).

Resolves Rubocop violations.

Resolves `msftidy_docs` violations.

Adds `Notes` module meta information.

Uses `Msf::Post::Windows::UserProfiles.read_profile_list` API rather than manually iterating through account SIDs in the registry.

Adds partial support for non-Meterpreter sessions. Recently logged on user accounts can now be retrieved using shell and powershell sessions.

Retrieving currently logged on users requires a Meterpreter session. `resolve_sid` performs dark magic and I want no part in it.
