### PR TITLE
Msf::Post::Windows::Accounts: Add domain_controller? method

### DIFF
--- a/lib/msf/core/post/windows/accounts.rb
+++ b/lib/msf/core/post/windows/accounts.rb
@@ -6,6 +6,7 @@ module Msf
     module Windows
       module Accounts
         include Msf::Post::Windows::Error
+        include Msf::Post::Windows::Registry
 
         GUID = [
           ['Data1', :DWORD],
@@ -63,6 +64,13 @@ module Msf
               }
             )
           )
+        end
+
+        # Check if target is a domain controller
+        #
+        # @return [Boolean] Target host is a domain controller
+        def domain_controller?
+          registry_key_exist?('HKLM\\SYSTEM\\CurrentControlSet\\Services\\NTDS\\Parameters')
         end
 
         ##

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -6,6 +6,7 @@
 require 'metasploit/framework/ntds/parser'
 
 class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Accounts
   include Msf::Post::Windows::Registry
   include Msf::Auxiliary::Report
   include Msf::Post::Windows::Priv
@@ -102,12 +103,10 @@ class MetasploitModule < Msf::Post
     database_file_path
   end
 
-  def domain_controller?
-    if ntds_location
-      file_exist?("#{ntds_location}\\ntds.dit")
-    else
-      false
-    end
+  def ntds_exists?
+    return false unless ntds_location
+
+    file_exist?("#{ntds_location}\\ntds.dit")
   end
 
   def ntds_location
@@ -130,18 +129,25 @@ class MetasploitModule < Msf::Post
   end
 
   def preconditions_met?
-    if is_admin?
-      print_status "Session has Admin privs"
-    else
-      print_error "This module requires Admin privs to run"
+    unless is_admin?
+      print_error('This module requires Admin privs to run')
       return false
     end
-    if domain_controller?
-      print_status "Session is on a Domain Controller"
-    else
-      print_error "This does not appear to be an AD Domain Controller"
+
+    print_status('Session has Admin privs')
+
+    unless domain_controller?
+      print_error('Host does not appear to be an AD Domain Controller')
       return false
     end
+
+    print_status('Session is on a Domain Controller')
+
+    unless ntds_exists?
+      print_error('Could not locate ntds.dit file')
+      return false
+    end
+
     unless session_compat?
       return false
     end

--- a/modules/post/windows/gather/enum_domain_tokens.rb
+++ b/modules/post/windows/gather/enum_domain_tokens.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::Accounts
-  include Msf::Post::Windows::Registry
 
   def initialize(info = {})
     super(
@@ -54,7 +53,7 @@ class MetasploitModule < Msf::Post
         end
       end
 
-      if !is_dc?
+      unless domain_controller?
         list_group_members(domain, dom_admins)
       end
 
@@ -221,18 +220,5 @@ class MetasploitModule < Msf::Post
     end
     results = tbl.to_s
     print_line("\n" + results + "\n")
-  end
-
-  # Function for checking if target is a DC
-  def is_dc?
-    is_dc_srv = false
-    serviceskey = "HKLM\\SYSTEM\\CurrentControlSet\\Services"
-    if registry_enumkeys(serviceskey).include?("NTDS")
-      if registry_enumkeys(serviceskey + "\\NTDS").include?("Parameters")
-        print_good("\tThis host is a Domain Controller!")
-        is_dc_srv = true
-      end
-    end
-    return is_dc_srv
   end
 end

--- a/modules/post/windows/gather/ntds_grabber.rb
+++ b/modules/post/windows/gather/ntds_grabber.rb
@@ -4,9 +4,9 @@
 ##
 
 class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Accounts
   include Msf::Post::Windows::Powershell
   include Msf::Post::Windows::Priv
-  include Msf::Post::Windows::Registry
   include Msf::Post::File
   include Msf::Post::Common
 
@@ -43,17 +43,6 @@ class MetasploitModule < Msf::Post
       ],
       self.class
     )
-  end
-
-  def dc_check
-    is_dc_srv = false
-    serviceskey = "HKLM\\SYSTEM\\CurrentControlSet\\Services"
-    if registry_enumkeys(serviceskey).include?("NTDS")
-      if registry_enumkeys("#{serviceskey}\\NTDS").include?("Parameters")
-        is_dc_srv = true
-      end
-    end
-    return is_dc_srv
   end
 
   def task_running(task)
@@ -96,12 +85,12 @@ class MetasploitModule < Msf::Post
       return
     end
 
-    if not dc_check
-      print_error('Not running on a domain controller, you need run this module on a domain controller! STOPPING')
+    unless domain_controller?
+      print_error('Host is not a domain controller. This module must be on a domain controller! STOPPING')
       return
-    else
-      print_good('Running on a domain controller')
     end
+
+    print_good('Running on a domain controller')
 
     if have_powershell?
       print_good('PowerShell is installed.')

--- a/modules/post/windows/gather/ntds_location.rb
+++ b/modules/post/windows/gather/ntds_location.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
+  include Msf::Post::Windows::Accounts
   include Msf::Post::Windows::Registry
 
   def initialize(info = {})
@@ -33,8 +34,14 @@ class MetasploitModule < Msf::Post
   end
 
   def run
+    unless domain_controller?
+      print_error('Host does not appear to be an AD Domain Controller')
+      return
+    end
+
     # Find the location of NTDS.DIT in the Registry
     ntds = registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\Services\\NTDS\\Parameters', 'DSA Database file')
+
     unless ntds
       print_error('Unable to find the location of NTDS.DIT')
       return
@@ -43,10 +50,10 @@ class MetasploitModule < Msf::Post
     if file?(ntds)
       f = client.fs.file.stat(ntds)
       print_line("NTDS.DIT is located at: #{ntds}")
-      print_line("      Size: #{f.size.to_s} bytes")
-      print_line("   Created: #{f.ctime.to_s}")
-      print_line("  Modified: #{f.mtime.to_s}")
-      print_line("  Accessed: #{f.atime.to_s}")
+      print_line("      Size: #{f.size} bytes")
+      print_line("   Created: #{f.ctime}")
+      print_line("  Modified: #{f.mtime}")
+      print_line("  Accessed: #{f.atime}")
     else
       print_error("NTDS.DIT is reportedly located at `#{ntds}', but the file does not appear to exist")
     end

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -384,20 +384,6 @@ class MetasploitModule < Msf::Post
   end
   #-------------------------------------------------------------------------------
 
-  # Function for checking if target is a DC
-  def is_dc?
-    is_dc_srv = false
-    serviceskey = 'HKLM\\SYSTEM\\CurrentControlSet\\Services'
-    if registry_enumkeys(serviceskey).include?('NTDS')
-      if registry_enumkeys(serviceskey + '\\NTDS').include?('Parameters')
-        print_good("\tThis host is a Domain Controller!")
-        is_dc_srv = true
-      end
-    end
-    return is_dc_srv
-  end
-  #-------------------------------------------------------------------------------
-
   # Function to migrate to a process running as SYSTEM
   def move_to_sys
     # Make sure you got the correct SYSTEM Account Name no matter the OS Language
@@ -426,7 +412,9 @@ class MetasploitModule < Msf::Post
   #-------------------------------------------------------------------------------
 
   def smart_hash_dump(migrate_system, pwdfile)
-    domain_controller = is_dc?
+    domain_controller = domain_controller?
+    print_good('Host is a Domain Controller') if domain_controller
+
     if !is_uac_enabled? || is_admin?
       print_status('Dumping password hashes...')
       # Check if Running as SYSTEM


### PR DESCRIPTION
Adds a `Msf::Post::Windows::Accounts.domain_controller?` method and removes `is_dc?` methods from several modules in favor of using the new method.

`Msf::Post::Windows::Accounts` seemed like the best place to put this. We don't have an existing generic `Msf::Post::Window::System` mixin like we do for other platforms.

Despite retrieving values from the Registry, `Msf::Post::Windows::Registry` is not the right place for this method.

`Msf::Post::Windows::Accounts` makes heavy use of Railgun. This PR imports `Msf::Post::Windows::Registry` in `Msf::Post::Windows::Accounts` as a dependency. I'm not super keen on this, but on the other hand, this mixin will also be necessary if modifying other methods in `Msf::Post::Windows::Registry` to support non-Meterpreter sessions.

A method to determine whether the target host is a domain controller is useful, as evidenced by three modules which implemented this manually. Additionally, there are other modules which likely could or would have used this functionality if it was available.

For example, some modules attempt to access various NTDS  related Registry keys blindly, and bail out with a generic error message if the keys don't exist. Checking first whether the host was a DC would allow a more intuitive error message. (These two example modules are not updated in this PR).

https://github.com/rapid7/metasploit-framework/blob/015ccfe62a1e12771eaf2750e1bc755227e27d0b/modules/post/windows/gather/ntds_location.rb#L37-L41

https://github.com/rapid7/metasploit-framework/blob/015ccfe62a1e12771eaf2750e1bc755227e27d0b/modules/post/windows/gather/credentials/domain_hashdump.rb#L105-L115

