### PR TITLE
enum_shares: Cleanup and support non-meterpreter sessions

### DIFF
--- a/documentation/modules/post/windows/gather/enum_shares.md
+++ b/documentation/modules/post/windows/gather/enum_shares.md
@@ -1,0 +1,57 @@
+## Vulnerable Application
+
+This module will enumerate configured and recently used file shares.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get a session
+3. Do: `use post/windows/gather/enum_shares`
+4. Do: `set SESSION <session id>`
+5. Do: `run`
+
+## Options
+
+### CURRENT
+
+Enumerate currently configured shares (default: `true`)
+
+### RECENT
+
+Enumerate recently mapped shares (default: `true`)
+
+### ENTERED
+
+Enumerate recently entered UNC Paths in the Run Dialog (default: `true`)
+
+## Scenarios
+
+### Windows Server 2008 (x64)
+
+```
+msf6 > use post/windows/gather/enum_shares
+msf6 post(windows/gather/enum_shares) > set session 1
+session => 1
+msf6 post(windows/gather/enum_shares) > run
+
+[*] Running module against WIN-17B09RRRJTG (192.168.200.218)
+[*] The following shares were found:
+[*] 	Name: SYSVOL
+[*] 	Path: C:\Windows\SYSVOL\sysvol
+[*] 	Remark: Logon server share 
+[*] 	Type: DISK
+[*] 
+[*] 	Name: NETLOGON
+[*] 	Path: C:\Windows\SYSVOL\sysvol\corp.local\SCRIPTS
+[*] 	Remark: Logon server share 
+[*] 	Type: DISK
+[*] 
+[*] Recent mounts found:
+[*] 	\\127.0.0.1\C$
+[*] 
+[*] Recent UNC paths entered in Run dialog found:
+[*] 	\\10.1.1.100\
+[*] 	\\127.0.0.1\C$
+[*] 
+[*] Post module execution completed
+```

--- a/modules/post/windows/gather/enum_shares.rb
+++ b/modules/post/windows/gather/enum_shares.rb
@@ -7,6 +7,8 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
   include Msf::Post::Windows::Priv
 
+  SID_PREFIX_USER = 'S-1-5-21-'.freeze
+
   def initialize(info = {})
     super(
       update_info(
@@ -181,7 +183,6 @@ class MetasploitModule < Msf::Post
       mount_history = enum_recent_mounts('HKEY_CURRENT_USER') if datastore['RECENT']
       run_history = enum_run_unc('HKEY_CURRENT_USER') if datastore['ENTERED']
     else
-      SID_PREFIX_USER = 'S-1-5-21-'
       keys = registry_enumkeys('HKU') || []
       keys.each do |maybe_sid|
         next unless maybe_sid.starts_with?(SID_PREFIX_USER)

--- a/modules/post/windows/gather/enum_shares.rb
+++ b/modules/post/windows/gather/enum_shares.rb
@@ -12,174 +12,200 @@ class MetasploitModule < Msf::Post
       update_info(
         info,
         'Name' => 'Windows Gather SMB Share Enumeration via Registry',
-        'Description' => %q{ This module will enumerate configured and recently used file shares},
+        'Description' => %q{ This module will enumerate configured and recently used file shares. },
         'License' => MSF_LICENSE,
-        'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
+        'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ],
+        'SessionTypes' => %w[shell powershell meterpreter],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
               stdapi_registry_open_key
+              stdapi_registry_check_key_exists
             ]
           }
         }
       )
     )
-    register_options(
-      [
-        OptBool.new("CURRENT", [ true, "Enumerate currently configured shares", true]),
-        OptBool.new("RECENT", [ true, "Enumerate Recently mapped shares", true]),
-        OptBool.new("ENTERED", [ true, "Enumerate Recently entered UNC Paths in the Run Dialog", true])
-      ]
-    )
+    register_options([
+      OptBool.new('CURRENT', [ true, 'Enumerate currently configured shares', true]),
+      OptBool.new('RECENT', [ true, 'Enumerate recently mapped shares', true]),
+      OptBool.new('ENTERED', [ true, 'Enumerate recently entered UNC Paths in the Run Dialog', true])
+    ])
   end
 
-  # Stolen from modules/auxiliary/scanner/smb/smb_enumshares.rb
+  # Convert share type ID `val` to readable string
+  #
+  # @return [String] Share type as readable string
   def share_type(val)
-    stypes = [
-      'DISK',
-      'PRINTER',
-      'DEVICE',
-      'IPC',
-      'SPECIAL',
-      'TEMPORARY'
-    ]
-
-    if val > (stypes.length - 1)
-      return 'UNKNOWN'
-    end
-
-    stypes[val]
+    %w[DISK PRINTER DEVICE IPC SPECIAL TEMPORARY][val] || 'UNKNOWN'
   end
 
   # Method for enumerating recent mapped drives on target machine
+  #
+  # @return [Array] List of recently mounted UNC paths
   def enum_recent_mounts(base_key)
-    recent_mounts = []
-    partial_path = base_key + "\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer"
+    partial_path = base_key + '\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer'
+    explorer_keys = registry_enumkeys(partial_path).to_s || ''
+
+    return [] unless explorer_keys.include?('Map Network Drive MRU')
+
     full_path = "#{partial_path}\\Map Network Drive MRU"
-    explorer_keys = registry_enumkeys(partial_path) || ''
-    if explorer_keys.include?("Map Network Drive MRU")
-      vals_found = registry_enumvals(full_path)
-      if vals_found
-        registry_enumvals(full_path).each do |k|
-          if not k =~ /MRUList/
-            recent_mounts << registry_getvaldata(full_path, k)
-          end
-        end
-      end
+    vals_found = registry_enumvals(full_path)
+
+    return [] unless vals_found
+
+    recent_mounts = []
+    registry_enumvals(full_path).each do |k|
+      next if k.include?('MRUList')
+
+      mounted_path = registry_getvaldata(full_path, k)
+      recent_mounts << mounted_path if mounted_path.starts_with?('\\\\')
     end
-    return recent_mounts
+
+    recent_mounts
   end
 
-  # Method for enumerating UNC Paths entered in run dialog box
+  # Method for enumerating UNC paths entered in Run dialog box
+  #
+  # @return [Array] List of MRU historical UNC paths
   def enum_run_unc(base_key)
-    unc_paths = []
-    full_path = base_key + "\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RunMRU"
+    full_path = base_key + '\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RunMRU'
     vals_found = registry_enumvals(full_path)
-    if vals_found
-      vals_found.each do |k|
-        if k =~ /./
-          run_entrie = registry_getvaldata(full_path, k)
-          unc_paths << run_entrie if run_entrie =~ /^\\\\/
-        end
-      end
+
+    return [] unless vals_found
+
+    unc_paths = []
+    vals_found.each do |k|
+      next if k.include?('MRUList')
+
+      run_entry = registry_getvaldata(full_path, k).to_s
+      unc_paths << run_entry.gsub(/\\1$/, '') if run_entry.starts_with?('\\\\')
     end
 
-    return unc_paths
+    unc_paths
   end
 
   # Method for enumerating configured shares on a target box
-  def enum_conf_shares()
-    if sysinfo["OS"] =~ /Windows 7|Vista|2008/
-      shares_key = "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\LanmanServer\\Shares"
-    else
-      shares_key = "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\lanmanserver\\Shares"
+  #
+  # @return [Array] List of network shares in the form of [ name, type, remark, path ]
+  def enum_conf_shares
+    shares_key = nil
+
+    [
+      'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\LanmanServer\\Shares',
+      'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\lanmanserver\\Shares'
+    ].each do |k|
+      if registry_key_exist?(k)
+        shares_key = k
+        break
+      end
     end
+
+    if shares_key.blank?
+      print_status('No network shares were found')
+      return
+    end
+
     share_names = registry_enumvals(shares_key)
 
-    if share_names.length > 0
-      shares = []
-      print_status("The following shares were found:")
-      share_names.each do |sname|
-        info = registry_getvaldata(shares_key, sname)
-        next if info.nil?
-
-        share_info = info.split("\000")
-        print_status("\tName: #{sname}")
-        stype = remark = path = nil
-        share_info.each do |e|
-          name, val = e.split("=")
-          case name
-          when "Path"
-            print_status "\tPath: #{val}"
-            path = val
-          when "Type"
-            print_status "\tType: #{val}"
-            stype = share_type(val.to_i)
-          when "Remark"
-            remark = val
-          end
-        end
-        # Match the format used by auxiliary/scanner/smb/smb_enumshares
-        # with an added field for path
-        shares << [ sname, stype, remark, path ]
-        print_status()
-      end
-      report_note(
-        :host => session,
-        :type => 'smb.shares',
-        :data => { :shares => shares },
-        :update => :unique_data
-      )
-    else
-      print_status("No shares were found")
+    if share_names.empty?
+      print_status('No network shares were found')
+      return
     end
+
+    shares = []
+    print_status('The following shares were found:')
+    share_names.each do |sname|
+      info = registry_getvaldata(shares_key, sname)
+      next if info.nil?
+
+      print_status("\tName: #{sname}")
+
+      # NOTE: Extracting these values will fail on Meterpreter.
+      # Share info keys are REG_MULTI_SZ. Meterpreter stdapi registry
+      # query_value() function returns malformed REG_MULTI_SZ values.
+      share_info = info.split('\\0')
+      stype = remark = path = nil
+      share_info.each do |e|
+        name, val = e.split('=')
+        case name
+        when 'Path'
+          path = val
+          print_status "\tPath: #{path}"
+        when 'Type'
+          stype = share_type(val.to_i)
+          print_status "\tType: #{stype}"
+        when 'Remark'
+          remark = val
+          print_status("\tRemark: #{remark}") unless remark.blank?
+        end
+      end
+
+      print_status
+
+      # Match the format used by auxiliary/scanner/smb/smb_enumshares
+      # with an added field for path
+      shares << [ sname, stype, remark, path ]
+    end
+
+    report_note(
+      host: session,
+      type: 'smb.shares',
+      data: { shares: shares },
+      update: :unique_data
+    )
   end
 
   def run
-    print_status("Running against session #{datastore["SESSION"]}")
+    unless datastore['CURRENT'] || datastore['RECENT'] || datastore['ENTERED']
+      fail_with(Failure::BadConfig, 'At least one option (CURRENT, RECENT, ENTERED) must be enabled. Nothing to do.')
+    end
 
-    # Variables to hold info
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Running module against #{hostname} (#{session.session_host})")
+
+    enum_conf_shares if datastore['CURRENT']
+
+    return unless datastore['RECENT'] || datastore['ENTERED']
+
     mount_history = []
     run_history = []
 
-    # Enumerate shares being offered
-    enum_conf_shares() if datastore["CURRENT"]
-    if is_system?
-      mount_history = enum_recent_mounts("HKEY_CURRENT_USER")
-      run_history = enum_run_unc("HKEY_CURRENT_USER")
+    if is_system? || is_admin?
+      mount_history = enum_recent_mounts('HKEY_CURRENT_USER') if datastore['RECENT']
+      run_history = enum_run_unc('HKEY_CURRENT_USER') if datastore['ENTERED']
     else
-      user_sid = []
-      key = "HKU\\"
-      root_key, base_key = session.sys.registry.splitkey(key)
-      open_key = session.sys.registry.open_key(root_key, base_key)
-      keys = open_key.enum_key
-      keys.each do |k|
-        user_sid << k if k =~ /S-1-5-21-\d*-\d*-\d*-\d{3,6}$/
-      end
-      user_sid.each do |us|
-        mount_history = mount_history + enum_recent_mounts("HKU\\#{us.chomp}") if datastore["RECENT"]
-        run_history = run_history + enum_run_unc("HKU\\#{us.chomp}") if datastore["ENTERED"]
+      SID_PREFIX_USER = 'S-1-5-21-'
+      keys = registry_enumkeys('HKU') || []
+      keys.each do |maybe_sid|
+        next unless maybe_sid.starts_with?(SID_PREFIX_USER)
+        next if maybe_sid.include?('_Classes')
+
+        mount_history += enum_recent_mounts("HKU\\#{maybe_sid.chomp}") if datastore['RECENT']
+        run_history += enum_run_unc("HKU\\#{maybe_sid.chomp}") if datastore['ENTERED']
       end
     end
 
-    # Enumerate Mount History
-    if mount_history.length > 0
-      print_status("Recent Mounts found:")
+    unless mount_history.empty?
+      print_status('Recent mounts found:')
       mount_history.each do |i|
         print_status("\t#{i}")
       end
-      print_status()
+      print_status
     end
 
-    # Enumerate UNC Paths entered in the Dialog box
-    if run_history.length > 0
-      print_status("Recent UNC paths entered in Run Dialog found:")
+    unless run_history.empty?
+      print_status('Recent UNC paths entered in Run dialog found:')
       run_history.each do |i|
         print_status("\t#{i}")
       end
-      print_status()
+      print_status
     end
   end
 end


### PR DESCRIPTION
Resolves Rubocop violations.

Adds documentation.

Adds `Notes` module meta information.

Adds support for non-Meterpreter sessions.
