### PR TITLE
Fix a typo in _msfvenom

### DIFF
--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -231,7 +231,7 @@ _arguments \
   "--list-options[List --payload <value>'s standard, advanced and evasion options]" \
   "--pad-nops[Use nopsled size specified by -n \<length\> as the total payload size, auto-prepending a nopsled of quantity (nops minus payload length)]" \
   "--platform[The platform for --payload (use --list platforms to list)]:target platform:_msfvenom_platform" \
-  {-a,--arch}"[The architecture to use for --payload and --encoders (use --list archs to list)]:architecture:_msfvenom_archs" \
+  {-a,--arch}"[The architecture to use for --payload and --encoders (use --list archs to list)]:architecture:_msfvenom_arch" \
   {-b,--bad-chars}"[Characters to avoid example: '\x00\xff']:bad characters" \
   {-c,--add-code}"[Specify an additional win32 shellcode file to include]:shellcode file:_files" \
   {-e,--encoder}"[The encoder to use (use --list encoders to list)]:encoder:_msfvenom_encoder" \


### PR DESCRIPTION
Fixes #16838

This fixes a typo in the ZSH completion file for `_msfvenom` that would cause an error when completing the `--arch` argument.

## Verification

- [x] Install zsh
- [x] Install the `_msfvenom` completion file
- [x] Initialize it so the completions are loaded
- [x] Type `./msfvenom --arch ` and hit tab, you should see architectures and not an error