### PR TITLE
Post::Windows::ExtAPI.load_extapi: Return false if ExtAPI load fails

### DIFF
--- a/lib/msf/core/post/windows/extapi.rb
+++ b/lib/msf/core/post/windows/extapi.rb
@@ -7,16 +7,18 @@ module Windows
 module ExtAPI
 
   def load_extapi
-    if session.extapi
+    if session.respond_to?(:extapi) && session.extapi
       return true
-    else
-      begin
-        return session.core.use("extapi")
-      rescue Errno::ENOENT
-        print_error("Unable to load Extended API.")
-        return false
-      end
     end
+
+    if session.respond_to?(:core)
+      return session.core.use('extapi')
+    end
+
+    false
+  rescue Errno::ENOENT
+    print_error('Unable to load Extended API.')
+    false
   end
 
 end # ExtAPI


### PR DESCRIPTION
Before this PR, ExtAPI load will only fail and return `false` on Meterpreter sessions. On other session types it will crash.

After this PR, failed ExtAPI load will return `false` on Meterpreter and non-Meterpreter sessions.

---

Various modules and libraries call `load_extapi` which loads the extended API if not already loaded.

```
# grep -rn "load_extapi" lib/
lib/msf/core/post/windows/extapi.rb:9:  def load_extapi
lib/msf/core/post/windows/services.rb:153:    if load_extapi
lib/msf/core/post/windows/services.rb:202:    if load_extapi
lib/msf/core/post/windows/services.rb:268:    if load_extapi
lib/msf/core/post/windows/ldap.rb:139:    if load_extapi
lib/msf/core/post/windows/wmic.rb:40:    extapi = load_extapi
# grep -rn "load_extapi" modules/
modules/exploits/windows/local/wmi.rb:75:    if load_extapi
modules/exploits/windows/local/wmi.rb:89:      if load_extapi
modules/exploits/windows/local/wmi.rb:134:      unless load_extapi
modules/post/windows/gather/credentials/domain_hashdump.rb:149:    load_extapi
modules/post/windows/gather/enum_patches.rb:41:    unless load_extapi
```

The method is expected to return `true` upon successful load, but will often crash with a stacktrace if called from the wrong context, where `session.extapi` or `session.core` are invalid properties, such as a shell session.

I'm not sure if this was intentional to catch code paths which attempted to load the extended API in error. A boolean is friendlier.
