### PR TITLE
Msf::Post::Windows::Service: Multiple bug and consistency fixes

### DIFF
--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -1,266 +1,203 @@
 # -*- coding: binary -*-
 
 module Msf
-class Post
-module Windows
+  class Post
+    module Windows
+      # @deprecated Use {Services} instead
+      module WindowsServices
+        def self.included(_base)
+          include Services
+        end
 
-
-# @deprecated Use {Services} instead
-module WindowsServices
-  def self.included(base)
-    include Services
-  end
-
-  def setup
-    print_error("The Windows::WindowsServices mixin is deprecated, use Windows::Services instead")
-    super
-  end
-end
-
-#
-# Post module mixin for dealing with Windows services
-#
-module Services
-
-  # From https://docs.microsoft.com/en-us/windows/win32/msi/serviceinstall-table
-  START_TYPE = ["Boot","System","Auto","Manual","Disabled"]
-  START_TYPE_BOOT       = 0
-  START_TYPE_SYSTEM     = 1
-  START_TYPE_AUTO       = 2
-  START_TYPE_MANUAL     = 3
-  START_TYPE_DISABLED   = 4
-
-  SERVICE_STOPPED           = 1
-  SERVICE_START_PENDING     = 2
-  SERVICE_STOP_PENDING      = 3
-  SERVICE_RUNNING           = 4
-  SERVICE_CONTINUE_PENDING  = 5
-  SERVICE_PAUSE_PENDING     = 6
-  SERVICE_PAUSED            = 7
-
-  # 0x1            A Kernel device driver.
-  #
-  # 0x2            File system driver, which is also
-  #                a Kernel device driver.
-  #
-  # 0x4            A set of arguments for an adapter.
-  #
-  # 0x10           A Win32 program that can be started
-  #                by the Service Controller and that
-  #                obeys the service control protocol.
-  #                This type of Win32 service runs in
-  #                a process by itself.
-  #
-  # 0x20           A Win32 service that can share a process
-  #                with other Win32 services.
-  #
-  # 0x110          Same as 0x10 but allowed to interact with desktop.
-  #
-  # 0x120          Same as 0x20 but allowed to interact with desktop.
-  SERVICE_KERNEL_DRIVER                   = 0x1
-  SERVICE_FILE_SYSTEM_DRIVER              = 0x2
-  SERVICE_ADAPTER                         = 0x4
-  SERVICE_RECOGNIZER_DRIVER               = 0x8
-  SERVICE_WIN32_OWN_PROCESS               = 0x10
-  SERVICE_WIN32_SHARE_PROCESS             = 0x20
-  SERVICE_WIN32_OWN_PROCESS_INTERACTIVE   = 0x110
-  SERVICE_WIN32_SHARE_PROCESS_INTERACTIVE = 0x120
-
-  include ::Msf::Post::Windows::Error
-  include ::Msf::Post::Windows::ExtAPI
-  include ::Msf::Post::Windows::Registry
-
-  def initialize(info = {})
-    super(
-      update_info(
-        info,
-        'Compat' => {
-          'Meterpreter' => {
-            'Commands' => %w[
-              extapi_service_enum
-              extapi_service_query
-              stdapi_railgun_api
-            ]
-          }
-        }
-      )
-    )
-  end
-
-  def advapi32
-    session.railgun.advapi32
-  end
-
-  #
-  # Open the service manager with advapi32.dll!OpenSCManagerA on the
-  # given host or the local machine if :host option is nil. If called
-  # with a block, yields the manager and closes it when the block
-  # returns.
-  #
-  # @param opts [Hash]
-  # @option opts [String] :host (nil) The host on which to open the
-  #   service manager. May be a hostname or IP address.
-  # @option opts [Integer] :access (0xF003F) Bitwise-or of the
-  #   SC_MANAGER_* constants (see
-  #   {http://msdn.microsoft.com/en-us/library/windows/desktop/ms685981(v=vs.85).aspx})
-  #
-  # @return [Integer] Opaque Windows handle SC_HANDLE as returned by
-  #   OpenSCManagerA()
-  # @yield [manager] Gives the block a manager handle as returned by
-  #   advapi32.dll!OpenSCManagerA. When the block returns, the handle
-  #   will be closed with {#close_service_handle}.
-  # @raise [RuntimeError] if OpenSCManagerA returns a NULL handle
-  #
-  def open_sc_manager(opts={})
-    host = opts[:host] || nil
-    access = opts[:access] || "SC_MANAGER_ALL_ACCESS"
-    machine_str = host ? "\\\\#{host}" : nil
-
-    # SC_HANDLE WINAPI OpenSCManager(
-    #   _In_opt_  LPCTSTR lpMachineName,
-    #   _In_opt_  LPCTSTR lpDatabaseName,
-    #   _In_      DWORD dwDesiredAccess
-    # );
-    manag = advapi32.OpenSCManagerA(machine_str,nil,access)
-    if (manag["return"] == 0)
-      raise "Unable to open service manager: #{manag["ErrorMessage"]}"
-    end
-
-    if (block_given?)
-      begin
-        yield manag["return"]
-      ensure
-        close_service_handle(manag["return"])
-      end
-    else
-      return manag["return"]
-    end
-  end
-
-  #
-  # Call advapi32.dll!CloseServiceHandle on the given handle
-  #
-  def close_service_handle(handle)
-    if handle
-      advapi32.CloseServiceHandle(handle)
-    end
-  end
-
-  #
-  # Open the service with advapi32.dll!OpenServiceA on the
-  # target manager
-  #
-  # @return [Integer] Opaque Windows handle SC_HANDLE as returned by
-  #   OpenServiceA()
-  # @yield [manager] Gives the block a service handle as returned by
-  #   advapi32.dll!OpenServiceA. When the block returns, the handle
-  #   will be closed with {#close_service_handle}.
-  # @raise [RuntimeError] if OpenServiceA failed
-  #
-  def open_service_handle(manager, name, access)
-    handle = advapi32.OpenServiceA(manager, name, access)
-    if (handle["return"] == 0)
-      raise "Could not open service. OpenServiceA error: #{handle["ErrorMessage"]}"
-    end
-
-    if (block_given?)
-      begin
-        yield handle["return"]
-      ensure
-        close_service_handle(handle["return"])
-      end
-    else
-      return handle["return"]
-    end
-  end
-
-  #
-  # Yield each service name on the remote host
-  #
-  # @yield [String] Case-sensitive name of a service
-  #
-  # @todo Allow operating on a remote host
-  #
-  def each_service(&block)
-    if session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_REGISTRY_ENUM_KEY)
-      begin
-        return session.extapi.service.enumerate.each(&block)
-      rescue Rex::Post::Meterpreter::RequestError => e
-        vprint_error("Request Error #{e} falling back to registry technique")
-      end
-    end
-
-    serviceskey = "HKLM\\SYSTEM\\CurrentControlSet\\Services"
-
-    keys = registry_enumkeys(serviceskey)
-    keys.each do |sk|
-      service_type = registry_getvaldata("#{serviceskey}\\#{sk}", 'Type').to_s
-      service_type = (service_type.starts_with?('0x') ? service_type.to_i(16) : service_type.to_i)
-
-      next unless [
-        SERVICE_WIN32_OWN_PROCESS,
-        SERVICE_WIN32_OWN_PROCESS_INTERACTIVE,
-        SERVICE_WIN32_SHARE_PROCESS,
-        SERVICE_WIN32_SHARE_PROCESS_INTERACTIVE
-      ].include?(service_type)
-
-      yield sk
-    end
-
-    keys
-  end
-
-  #
-  # List all Windows Services present
-  #
-  # If ExtAPI is available we return the DACL, LOGroup, and Interactive
-  # values otherwise these values are nil
-  #
-  # @return [Array<Hash>] Array of Hashes containing Service details. May contain the following keys:
-  #   * :name
-  #   * :display
-  #   * :pid
-  #   * :status
-  #   * :interactive
-  #
-  # @todo Rewrite to allow operating on a remote host
-  #
-  def service_list
-    return meterpreter_service_list if session.type == 'meterpreter'
-
-    services = []
-    each_service do |s|
-      services << {:name => s}
-    end
-
-    services
-  end
-
-  def meterpreter_service_list
-    if session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_REGISTRY_ENUM_KEY)
-      begin
-        return session.extapi.service.enumerate
-      rescue Rex::Post::Meterpreter::RequestError => e
-        vprint_error("Request Error #{e} falling back to registry technique")
-      end
-    end
-
-    serviceskey = 'HKLM\\SYSTEM\\CurrentControlSet\\Services'
-    keys = registry_enumkeys(serviceskey)
-    threads = 10
-    services = []
-    until keys.empty?
-      t = []
-      threads = 1 if threads <= 0
-
-      if keys.length < threads
-        threads = keys.length
+        def setup
+          print_error('The Windows::WindowsServices mixin is deprecated, use Windows::Services instead')
+          super
+        end
       end
 
-      begin
-        1.upto(threads) do
-          t << framework.threads.spawn(self.refname + '-ServiceRegistryList', false, keys.shift) do |s|
-            service_type = registry_getvaldata("#{serviceskey}\\#{s}", 'Type').to_i
+      #
+      # Post module mixin for dealing with Windows services
+      #
+      module Services
+        # From https://docs.microsoft.com/en-us/windows/win32/msi/serviceinstall-table
+        START_TYPE = ['Boot', 'System', 'Auto', 'Manual', 'Disabled']
+        START_TYPE_BOOT = 0
+        START_TYPE_SYSTEM = 1
+        START_TYPE_AUTO = 2
+        START_TYPE_MANUAL = 3
+        START_TYPE_DISABLED = 4
+
+        SERVICE_STOPPED = 1
+        SERVICE_START_PENDING = 2
+        SERVICE_STOP_PENDING = 3
+        SERVICE_RUNNING = 4
+        SERVICE_CONTINUE_PENDING = 5
+        SERVICE_PAUSE_PENDING = 6
+        SERVICE_PAUSED = 7
+
+        # 0x1            A Kernel device driver.
+        #
+        # 0x2            File system driver, which is also
+        #                a Kernel device driver.
+        #
+        # 0x4            A set of arguments for an adapter.
+        #
+        # 0x10           A Win32 program that can be started
+        #                by the Service Controller and that
+        #                obeys the service control protocol.
+        #                This type of Win32 service runs in
+        #                a process by itself.
+        #
+        # 0x20           A Win32 service that can share a process
+        #                with other Win32 services.
+        #
+        # 0x110          Same as 0x10 but allowed to interact with desktop.
+        #
+        # 0x120          Same as 0x20 but allowed to interact with desktop.
+        SERVICE_KERNEL_DRIVER = 0x1
+        SERVICE_FILE_SYSTEM_DRIVER = 0x2
+        SERVICE_ADAPTER = 0x4
+        SERVICE_RECOGNIZER_DRIVER = 0x8
+        SERVICE_WIN32_OWN_PROCESS = 0x10
+        SERVICE_WIN32_SHARE_PROCESS = 0x20
+        SERVICE_WIN32_OWN_PROCESS_INTERACTIVE = 0x110
+        SERVICE_WIN32_SHARE_PROCESS_INTERACTIVE = 0x120
+
+        include ::Msf::Post::Windows::Error
+        include ::Msf::Post::Windows::ExtAPI
+        include ::Msf::Post::Windows::Registry
+
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    extapi_service_enum
+                    extapi_service_query
+                    stdapi_railgun_api
+                  ]
+                }
+              }
+            )
+          )
+        end
+
+        def advapi32
+          session.railgun.advapi32
+        end
+
+        #
+        # Open the service manager with advapi32.dll!OpenSCManagerA on the
+        # given host or the local machine if :host option is nil. If called
+        # with a block, yields the manager and closes it when the block
+        # returns.
+        #
+        # @param opts [Hash]
+        # @option opts [String] :host (nil) The host on which to open the
+        #   service manager. May be a hostname or IP address.
+        # @option opts [Integer] :access (0xF003F) Bitwise-or of the
+        #   SC_MANAGER_* constants (see
+        #   {http://msdn.microsoft.com/en-us/library/windows/desktop/ms685981(v=vs.85).aspx})
+        #
+        # @return [Integer] Opaque Windows handle SC_HANDLE as returned by
+        #   OpenSCManagerA()
+        # @yield [manager] Gives the block a manager handle as returned by
+        #   advapi32.dll!OpenSCManagerA. When the block returns, the handle
+        #   will be closed with {#close_service_handle}.
+        # @raise [RuntimeError] if OpenSCManagerA returns a NULL handle
+        #
+        def open_sc_manager(opts = {})
+          host = opts[:host] || nil
+          access = opts[:access] || 'SC_MANAGER_ALL_ACCESS'
+          machine_str = host ? "\\\\#{host}" : nil
+
+          # SC_HANDLE WINAPI OpenSCManager(
+          #   _In_opt_  LPCTSTR lpMachineName,
+          #   _In_opt_  LPCTSTR lpDatabaseName,
+          #   _In_      DWORD dwDesiredAccess
+          # );
+          manag = advapi32.OpenSCManagerA(machine_str, nil, access)
+          if (manag['return'] == 0)
+            raise "Unable to open service manager: #{manag['ErrorMessage']}"
+          end
+
+          if block_given?
+            begin
+              yield manag['return']
+            ensure
+              close_service_handle(manag['return'])
+            end
+          else
+            return manag['return']
+          end
+        end
+
+        #
+        # Call advapi32.dll!CloseServiceHandle on the given handle
+        #
+        def close_service_handle(handle)
+          if handle
+            advapi32.CloseServiceHandle(handle)
+          end
+        end
+
+        #
+        # Open the service with advapi32.dll!OpenServiceA on the
+        # target manager
+        #
+        # @return [Integer] Opaque Windows handle SC_HANDLE as returned by
+        #   OpenServiceA()
+        # @yield [manager] Gives the block a service handle as returned by
+        #   advapi32.dll!OpenServiceA. When the block returns, the handle
+        #   will be closed with {#close_service_handle}.
+        # @raise [RuntimeError] if OpenServiceA failed
+        #
+        def open_service_handle(manager, name, access)
+          handle = advapi32.OpenServiceA(manager, name, access)
+          if (handle['return'] == 0)
+            raise "Could not open service. OpenServiceA error: #{handle['ErrorMessage']}"
+          end
+
+          if block_given?
+            begin
+              yield handle['return']
+            ensure
+              close_service_handle(handle['return'])
+            end
+          else
+            return handle['return']
+          end
+        end
+
+        #
+        # Yield each service name on the remote host
+        #
+        # @yield [String] Case-sensitive name of a service
+        #
+        # @return [Array<Hash>] Array of Hashes containing Service details. May contain the following keys:
+        #   * :name
+        #
+        # @todo Allow operating on a remote host
+        #
+        def each_service(&block)
+          if session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_REGISTRY_ENUM_KEY)
+            begin
+              return session.extapi.service.enumerate.each(&block)
+            rescue Rex::Post::Meterpreter::RequestError => e
+              vprint_error("Request Error #{e} falling back to registry technique")
+            end
+          end
+
+          serviceskey = 'HKLM\\SYSTEM\\CurrentControlSet\\Services'
+
+          keys = registry_enumkeys(serviceskey)
+          keys.each do |sk|
+            service_type = registry_getvaldata("#{serviceskey}\\#{sk}", 'Type').to_s
+            next if service_type.empty?
+
+            service_type = (service_type.starts_with?('0x') ? service_type.to_i(16) : service_type.to_i)
 
             next unless [
               SERVICE_WIN32_OWN_PROCESS,
@@ -269,378 +206,447 @@ module Services
               SERVICE_WIN32_SHARE_PROCESS_INTERACTIVE
             ].include?(service_type)
 
-            services << {:name => s}
+            yield sk
+          end
+
+          keys
+        end
+
+        #
+        # List all Windows Services present
+        #
+        # If ExtAPI is available we return the DACL, LOGroup, and Interactive
+        # values otherwise these values are nil
+        #
+        # @return [Array<Hash>] Array of Hashes containing Service details. May contain the following keys:
+        #   * :name
+        #   * :display
+        #   * :pid
+        #   * :status
+        #   * :interactive
+        #
+        # @todo Rewrite to allow operating on a remote host
+        #
+        def service_list
+          return meterpreter_service_list if session.type == 'meterpreter'
+
+          services = []
+          each_service do |s|
+            services << { name: s }
+          end
+
+          services
+        end
+
+        #
+        #
+        # @return
+        def meterpreter_service_list
+          if session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_REGISTRY_ENUM_KEY)
+            begin
+              return session.extapi.service.enumerate
+            rescue Rex::Post::Meterpreter::RequestError => e
+              vprint_error("Request Error #{e} falling back to registry technique")
+            end
+          end
+
+          serviceskey = 'HKLM\\SYSTEM\\CurrentControlSet\\Services'
+          keys = registry_enumkeys(serviceskey)
+          threads = 10
+          services = []
+          until keys.empty?
+            thread_list = []
+            threads = 1 if threads <= 0
+
+            if keys.length < threads
+              threads = keys.length
+            end
+
+            begin
+              1.upto(threads) do
+                thread_list << framework.threads.spawn(refname + '-ServiceRegistryList', false, keys.shift) do |service_name|
+                  service_type = registry_getvaldata("#{serviceskey}\\#{service_name}", 'Type').to_i
+
+                  next unless [
+                    SERVICE_WIN32_OWN_PROCESS,
+                    SERVICE_WIN32_OWN_PROCESS_INTERACTIVE,
+                    SERVICE_WIN32_SHARE_PROCESS,
+                    SERVICE_WIN32_SHARE_PROCESS_INTERACTIVE
+                  ].include?(service_type)
+
+                  services << { name: service_name }
+                end
+              end
+              thread_list.map(&:join)
+            rescue ::Timeout::Error
+            ensure
+              thread_list.each do |thread|
+                thread.kill
+              rescue StandardError
+                nil
+              end
+            end
+          end
+
+          services
+        end
+
+        #
+        # Get Windows Service information.
+        #
+        # Information returned in a hash with display name, startup mode and
+        # command executed by the service. Service name is case sensitive.  Hash
+        # keys are Name, Start, Command and Credentials.
+        #
+        # If ExtAPI is available we return the DACL, LOGroup, and Interactive
+        # values otherwise these values are nil
+        #
+        # @param name [String] The target service's name (not to be confused
+        #   with Display Name). Case sensitive.
+        #
+        # @return [Hash, nil] Hash containing service details on success, nil otherwise.
+        #
+        # @todo Rewrite to allow operating on a remote host
+        #
+        def service_info(name)
+          if session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_REGISTRY_QUERY_VALUE)
+            begin
+              return session.extapi.service.query(name)
+            rescue Rex::Post::Meterpreter::RequestError => e
+              vprint_error("Request Error #{e} falling back to registry technique")
+            end
+          end
+
+          servicekey = "HKLM\\SYSTEM\\CurrentControlSet\\Services\\#{name.chomp}"
+          start_type = registry_getvaldata(servicekey, 'Start').to_s
+          if start_type.empty?
+            print_error("Could not retrieve the start type of the #{name.chomp} service!")
+            return nil
+          end
+
+          {
+            display: registry_getvaldata(servicekey, 'DisplayName').to_s,
+            starttype: (start_type.starts_with?('0x') ? start_type.to_i(16) : start_type.to_i),
+            path: registry_getvaldata(servicekey, 'ImagePath').to_s,
+            startname: registry_getvaldata(servicekey, 'ObjectName').to_s,
+            dacl: nil,
+            logroup: nil,
+            interactive: nil
+          }
+        end
+
+        #
+        # Check if the specified Windows service exists.
+        #
+        # @param name [String] The target service's name (not to be confused
+        #   with Display Name). Case sensitive.
+        #
+        # @return [Boolean]
+        #
+        def service_exists?(service)
+          srv_info = service_info(service)
+
+          if srv_info.nil?
+            vprint_error('Unable to enumerate Windows services')
+            return false
+          end
+
+          if srv_info && srv_info[:display].empty?
+            return false
+          end
+
+          true
+        end
+
+        #
+        # Changes a given service startup mode, name must be provided and the mode.
+        #
+        # Mode is a string with either auto, manual or disable for the
+        # corresponding setting. The name of the service is case sensitive.
+        #
+        # @raise [RuntimeError] if an invalid startup mode is provided in the mode parameter
+        #
+        def service_change_startup(name, mode, server = nil)
+          if mode.is_a? Integer
+            startup_number = mode
+          else
+            case mode.downcase
+            when 'boot' then startup_number = START_TYPE_BOOT
+            when 'system' then startup_number = START_TYPE_SYSTEM
+            when 'auto' then startup_number = START_TYPE_AUTO
+            when 'manual' then startup_number = START_TYPE_MANUAL
+            when 'disable' then startup_number = START_TYPE_DISABLED
+            else
+              raise "Invalid Startup Mode: #{mode}"
+            end
+          end
+
+          if session.railgun
+            begin
+              ret = service_change_config(name, { starttype: startup_number }, server)
+              return (ret == Error::SUCCESS)
+            rescue Rex::Post::Meterpreter::RequestError => e
+              if server
+                # Cant do remote registry changes at present
+                return false
+              else
+                vprint_error("Request Error #{e} falling back to registry technique")
+              end
+            end
+          end
+
+          servicekey = "HKLM\\SYSTEM\\CurrentControlSet\\Services\\#{name.chomp}"
+          registry_setvaldata(servicekey, 'Start', startup_number, 'REG_DWORD')
+        end
+
+        #
+        # Modify a service on the session host
+        #
+        # @param name [String] Name of the service to be used as the key
+        # @param opts [Hash] Settings to be modified
+        # @param server [String,nil] A hostname or IP address. Default is the
+        #   remote localhost
+        #
+        # @return [GetLastError] 0 if the function succeeds
+        #
+        # @raise [RuntimeError] if OpenSCManagerA failed
+        #
+        def service_change_config(name, opts, server = nil)
+          open_sc_manager(host: server, access: 'SC_MANAGER_CONNECT') do |manager|
+            open_service_handle(manager, name, 'SERVICE_CHANGE_CONFIG') do |service_handle|
+              ret = advapi32.ChangeServiceConfigA(service_handle,
+                                                  opts[:service_type] || 'SERVICE_NO_CHANGE',
+                                                  opts[:starttype] || 'SERVICE_NO_CHANGE',
+                                                  opts[:error_control] || 'SERVICE_NO_CHANGE',
+                                                  opts[:path] || nil,
+                                                  opts[:logroup] || nil,
+                                                  opts[:tag_id] || nil,
+                                                  opts[:dependencies] || nil,
+                                                  opts[:startname] || nil,
+                                                  opts[:password] || nil,
+                                                  opts[:display] || nil)
+
+              return ret['GetLastError']
+            end
           end
         end
-        t.map(&:join)
-      rescue ::Timeout::Error
-      ensure
-        t.each { |x| x.kill rescue nil }
-      end
-    end
 
-    services
-  end
+        #
+        # Create a service that runs +executable_on_host+ on the session host
+        #
+        # @param name [String] Name of the service to be used as the key
+        # @param opts [Hash] Settings to be modified
+        # @param server [String,nil] A hostname or IP address. Default is the
+        #   remote localhost
+        #
+        # @return [GetLastError] 0 if the function succeeds
+        #
+        # @raise [RuntimeError] if OpenSCManagerA failed
+        #
+        def service_create(name, opts, server = nil)
+          access = 'SC_MANAGER_CONNECT | SC_MANAGER_CREATE_SERVICE | SC_MANAGER_QUERY_LOCK_STATUS'
+          open_sc_manager(host: server, access: access) do |manager|
+            opts[:display] ||= Rex::Text.rand_text_alpha(8)
+            opts[:desired_access] ||= 'SERVICE_START'
+            opts[:service_type] ||= 'SERVICE_WIN32_OWN_PROCESS'
+            opts[:starttype] ||= START_TYPE_AUTO
+            opts[:error_control] ||= 'SERVICE_ERROR_IGNORE'
+            opts[:path] ||= nil
+            opts[:logroup] ||= nil
+            opts[:tag_id] ||= nil
+            opts[:dependencies] ||= nil
+            opts[:startname] ||= nil
+            opts[:password] ||= nil
 
-  #
-  # Get Windows Service information.
-  #
-  # Information returned in a hash with display name, startup mode and
-  # command executed by the service. Service name is case sensitive.  Hash
-  # keys are Name, Start, Command and Credentials.
-  #
-  # If ExtAPI is available we return the DACL, LOGroup, and Interactive
-  # values otherwise these values are nil
-  #
-  # @param name [String] The target service's name (not to be confused
-  #   with Display Name). Case sensitive.
-  #
-  # @return [Hash]
-  #
-  # @todo Rewrite to allow operating on a remote host
-  #
-  def service_info(name)
-    if session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_REGISTRY_QUERY_VALUE)
-      begin
-        return session.extapi.service.query(name)
-      rescue Rex::Post::Meterpreter::RequestError => e
-        vprint_error("Request Error #{e} falling back to registry technique")
-      end
-    end
+            newservice = advapi32.CreateServiceA(manager,
+                                                 name,
+                                                 opts[:display],
+                                                 opts[:desired_access],
+                                                 opts[:service_type],
+                                                 opts[:starttype],
+                                                 opts[:error_control],
+                                                 opts[:path],
+                                                 opts[:logroup],
+                                                 opts[:tag_id], # out
+                                                 opts[:dependencies],
+                                                 opts[:startname],
+                                                 opts[:password])
 
-    servicekey = "HKLM\\SYSTEM\\CurrentControlSet\\Services\\#{name.chomp}"
-    start_type = registry_getvaldata(servicekey, 'Start').to_s
+            if newservice
+              close_service_handle(newservice['return'])
+            end
 
-    {
-      display: registry_getvaldata(servicekey, 'DisplayName').to_s,
-      starttype: (start_type.starts_with?('0x') ? start_type.to_i(16) : start_type.to_i),
-      path: registry_getvaldata(servicekey, 'ImagePath').to_s,
-      startname: registry_getvaldata(servicekey, 'ObjectName').to_s,
-      dacl: nil,
-      logroup: nil,
-      interactive: nil
-    }
-  end
+            return newservice['GetLastError']
+          end
+        end
 
-  #
-  # Check if the specified Windows service exists.
-  #
-  # @param name [String] The target service's name (not to be confused
-  #   with Display Name). Case sensitive.
-  #
-  # @return [Boolean]
-  #
-  def service_exists?(service)
-    srv_info = service_info(service)
+        #
+        # Start a service.
+        #
+        # @param name [String] Service name (not display name)
+        # @param server [String,nil] A hostname or IP address. Default is the
+        #   remote localhost
+        #
+        # @return [Integer] 0 if service started successfully, 1 if it failed
+        #   because the service is already running, 2 if it is disabled
+        #
+        # @raise [RuntimeError] if OpenServiceA failed
+        #
+        def service_start(name, server = nil)
+          open_sc_manager(host: server, access: 'SC_MANAGER_CONNECT') do |manager|
+            open_service_handle(manager, name, 'SERVICE_START') do |service_handle|
+              retval = advapi32.StartServiceA(service_handle, 0, nil)
 
-    if srv_info.nil?
-      vprint_error('Unable to enumerate Windows services')
-      return false
-    end
+              return retval['GetLastError']
+            end
+          end
+        end
 
-    if srv_info && srv_info[:display].empty?
-      return false
-    end
+        #
+        # Stop a service.
+        #
+        # @param (see #service_start)
+        # @return [Integer] 0 if service stopped successfully, 1 if it failed
+        #   because the service is already stopped or disabled, 2 if it
+        #   cannot be stopped for some other reason.
+        #
+        # @raise (see #service_start)
+        #
+        def service_stop(name, server = nil)
+          open_sc_manager(host: server, access: 'SC_MANAGER_CONNECT') do |manager|
+            open_service_handle(manager, name, 'SERVICE_STOP') do |service_handle|
+              retval = advapi32.ControlService(service_handle, 1, 28)
+              case retval['GetLastError']
+              when Error::SUCCESS,
+                  Error::INVALID_SERVICE_CONTROL,
+                  Error::SERVICE_CANNOT_ACCEPT_CTRL,
+                  Error::SERVICE_NOT_ACTIVE
+                status = parse_service_status_struct(retval['lpServiceStatus'])
+              else
+                status = nil
+              end
 
-    true
-  end
+              return retval['GetLastError']
+            end
+          end
+        end
 
-  #
-  # Changes a given service startup mode, name must be provided and the mode.
-  #
-  # Mode is a string with either auto, manual or disable for the
-  # corresponding setting. The name of the service is case sensitive.
-  #
-  # @raise [RuntimeError] if an invalid startup mode is provided in the mode parameter
-  #
-  def service_change_startup(name, mode, server=nil)
-    if mode.is_a? Integer
-      startup_number = mode
-    else
-      case mode.downcase
-        when "boot" then startup_number     = START_TYPE_BOOT
-        when "system" then startup_number   = START_TYPE_SYSTEM
-        when "auto" then startup_number     = START_TYPE_AUTO
-        when "manual" then startup_number   = START_TYPE_MANUAL
-        when "disable" then startup_number  = START_TYPE_DISABLED
-        else
-          raise "Invalid Startup Mode: #{mode}"
-      end
-    end
+        #
+        # Delete a service.
+        #
+        # @param (see #service_start)
+        #
+        # @raise [RuntimeError] if OpenServiceA failed
+        #
+        def service_delete(name, server = nil)
+          open_sc_manager(host: server) do |manager|
+            open_service_handle(manager, name, 'DELETE') do |service_handle|
+              ret = advapi32.DeleteService(service_handle)
+              return ret['GetLastError']
+            end
+          end
+        end
 
-    if session.railgun
-      begin
-        ret = service_change_config(name, {:starttype => startup_number}, server)
-        return (ret == Error::SUCCESS)
-      rescue Rex::Post::Meterpreter::RequestError => e
-        if server
-          # Cant do remote registry changes at present
-          return false
-        else
-          vprint_error("Request Error #{e} falling back to registry technique")
+        #
+        # Query Service Status
+        #
+        # @param (see #service_start)
+        #
+        # @return {} representing lpServiceStatus
+        #
+        # @raise (see #service_start)
+        #
+        def service_status(name, server = nil)
+          ret = nil
+
+          open_sc_manager(host: server, access: 'GENERIC_READ') do |manager|
+            open_service_handle(manager, name, 'GENERIC_READ') do |service_handle|
+              status = advapi32.QueryServiceStatus(service_handle, 28)
+
+              if (status['return'] == 0)
+                raise "Could not query service. QueryServiceStatus error: #{status['ErrorMessage']}"
+              else
+                ret = parse_service_status_struct(status['lpServiceStatus'])
+              end
+            end
+          end
+
+          return ret
+        end
+
+        #
+        # Performs an aggressive service (re)start
+        # If service is disabled it will re-enable
+        # If service is running it will stop and restart
+        #
+        # @param name [String] The service name
+        # @param start_type [Integer] The start type to configure if disabled
+        # @param server [String] The server to target
+        #
+        # @return [Boolean] indicating success
+        #
+        def service_restart(name, start_type = START_TYPE_AUTO, server = nil, should_retry = true)
+          status = service_start(name, server)
+
+          if status == Error::SUCCESS
+            vprint_good("[#{name}] Service started")
+            return true
+          end
+
+          case status
+          when Error::ACCESS_DENIED
+            vprint_error("[#{name}] Access denied")
+          when Error::INVALID_HANDLE
+            vprint_error("[#{name}] Invalid handle")
+          when Error::PATH_NOT_FOUND
+            vprint_error("[#{name}] Service binary could not be found")
+          when Error::SERVICE_ALREADY_RUNNING
+            vprint_status("[#{name}] Service already running attempting to stop and restart")
+            stopped = service_stop(name, server)
+            if ((stopped == Error::SUCCESS) || (stopped == Error::SERVICE_NOT_ACTIVE))
+              service_restart(name, start_type, server, false) if should_retry
+            else
+              vprint_error("[#{name}] Service disabled, unable to change start type Error: #{stopped}")
+            end
+          when Error::SERVICE_DISABLED
+            vprint_status("[#{name}] Service disabled attempting to set to manual")
+            if (service_change_config(name, { starttype: start_type }, server) == Error::SUCCESS)
+              service_restart(name, start_type, server, false) if should_retry
+            else
+              vprint_error("[#{name}] Service disabled, unable to change start type")
+            end
+          else
+            status = WindowsError::Win32.find_by_retval(s).first
+            vprint_error("[#{name}] Unhandled error: #{status.name}: #{status.description}")
+            return false
+          end
+        end
+
+        #
+        # Parses out a SERVICE_STATUS struct from the
+        # lpServiceStatus out parameter
+        #
+        # @param lpServiceStatus [String] the latest status of calling service
+        #
+        # @return [Hash] Containing SERVICE_STATUS values
+        #
+        def parse_service_status_struct(lpServiceStatus)
+          if lpServiceStatus
+            vals = lpServiceStatus.unpack('V*')
+            return {
+              type: vals[0],
+              state: vals[1],
+              controls_accepted: vals[2],
+              win32_exit_code: vals[3],
+              service_exit_code: vals[4],
+              check_point: vals[5],
+              wait_hint: vals[6]
+            }
+          else
+            return nil
+          end
         end
       end
     end
-
-    servicekey = "HKLM\\SYSTEM\\CurrentControlSet\\Services\\#{name.chomp}"
-    registry_setvaldata(servicekey,"Start",startup_number,"REG_DWORD")
   end
-
-  #
-  # Modify a service on the session host
-  #
-  # @param name [String] Name of the service to be used as the key
-  # @param opts [Hash] Settings to be modified
-  # @param server [String,nil] A hostname or IP address. Default is the
-  #   remote localhost
-  #
-  # @return [GetLastError] 0 if the function succeeds
-  #
-  # @raise [RuntimeError] if OpenSCManagerA failed
-  #
-  def service_change_config(name, opts, server=nil)
-    open_sc_manager(:host=>server, :access=>"SC_MANAGER_CONNECT") do |manager|
-      open_service_handle(manager, name, "SERVICE_CHANGE_CONFIG") do |service_handle|
-        ret = advapi32.ChangeServiceConfigA(service_handle,
-                                 opts[:service_type]        || "SERVICE_NO_CHANGE",
-                                 opts[:starttype]           || "SERVICE_NO_CHANGE",
-                                 opts[:error_control]       || "SERVICE_NO_CHANGE",
-                                 opts[:path]                || nil,
-                                 opts[:logroup]             || nil,
-                                 opts[:tag_id]              || nil,
-                                 opts[:dependencies]        || nil,
-                                 opts[:startname]           || nil,
-                                 opts[:password]            || nil,
-                                 opts[:display]             || nil
-        )
-
-        return ret['GetLastError']
-      end
-    end
-  end
-
-  #
-  # Create a service that runs +executable_on_host+ on the session host
-  #
-  # @param name [String] Name of the service to be used as the key
-  # @param opts [Hash] Settings to be modified
-  # @param server [String,nil] A hostname or IP address. Default is the
-  #   remote localhost
-  #
-  # @return [GetLastError] 0 if the function succeeds
-  #
-  # @raise [RuntimeError] if OpenSCManagerA failed
-  #
-  def service_create(name, opts, server=nil)
-    access = "SC_MANAGER_CONNECT | SC_MANAGER_CREATE_SERVICE | SC_MANAGER_QUERY_LOCK_STATUS"
-    open_sc_manager(:host=>server, :access=>access) do |manager|
-
-      opts[:display]             ||= Rex::Text.rand_text_alpha(8)
-      opts[:desired_access]      ||= "SERVICE_START"
-      opts[:service_type]        ||= "SERVICE_WIN32_OWN_PROCESS"
-      opts[:starttype]           ||= START_TYPE_AUTO
-      opts[:error_control]       ||= "SERVICE_ERROR_IGNORE"
-      opts[:path]                ||= nil
-      opts[:logroup]             ||= nil
-      opts[:tag_id]              ||= nil
-      opts[:dependencies]        ||= nil
-      opts[:startname]           ||= nil
-      opts[:password]            ||= nil
-
-      newservice = advapi32.CreateServiceA(manager,
-                                      name,
-                                      opts[:display],
-                                      opts[:desired_access],
-                                      opts[:service_type],
-                                      opts[:starttype],
-                                      opts[:error_control],
-                                      opts[:path],
-                                      opts[:logroup],
-                                      opts[:tag_id], # out
-                                      opts[:dependencies],
-                                      opts[:startname],
-                                      opts[:password]
-      )
-
-      if newservice
-        close_service_handle(newservice["return"])
-      end
-
-      return newservice["GetLastError"]
-    end
-  end
-
-  #
-  # Start a service.
-  #
-  # @param name [String] Service name (not display name)
-  # @param server [String,nil] A hostname or IP address. Default is the
-  #   remote localhost
-  #
-  # @return [Integer] 0 if service started successfully, 1 if it failed
-  #   because the service is already running, 2 if it is disabled
-  #
-  # @raise [RuntimeError] if OpenServiceA failed
-  #
-  def service_start(name, server=nil)
-    open_sc_manager(:host=>server, :access=>"SC_MANAGER_CONNECT") do |manager|
-      open_service_handle(manager, name, "SERVICE_START") do |service_handle|
-        retval = advapi32.StartServiceA(service_handle,0,nil)
-
-        return retval["GetLastError"]
-      end
-    end
-  end
-
-  #
-  # Stop a service.
-  #
-  # @param (see #service_start)
-  # @return [Integer] 0 if service stopped successfully, 1 if it failed
-  #   because the service is already stopped or disabled, 2 if it
-  #   cannot be stopped for some other reason.
-  #
-  # @raise (see #service_start)
-  #
-  def service_stop(name, server=nil)
-    open_sc_manager(:host=>server, :access=>"SC_MANAGER_CONNECT") do |manager|
-      open_service_handle(manager, name, "SERVICE_STOP") do |service_handle|
-
-        retval = advapi32.ControlService(service_handle,1,28)
-        case retval["GetLastError"]
-        when Error::SUCCESS,
-            Error::INVALID_SERVICE_CONTROL,
-            Error::SERVICE_CANNOT_ACCEPT_CTRL,
-            Error::SERVICE_NOT_ACTIVE
-          status = parse_service_status_struct(retval['lpServiceStatus'])
-        else
-          status = nil
-        end
-
-        return retval["GetLastError"]
-      end
-    end
-  end
-
-  #
-  # Delete a service.
-  #
-  # @param (see #service_start)
-  #
-  # @raise [RuntimeError] if OpenServiceA failed
-  #
-  def service_delete(name, server=nil)
-    open_sc_manager(:host=>server) do |manager|
-      open_service_handle(manager, name, "DELETE") do |service_handle|
-        ret = advapi32.DeleteService(service_handle)
-        return ret["GetLastError"]
-      end
-    end
-  end
-
-  #
-  # Query Service Status
-  #
-  # @param (see #service_start)
-  #
-  # @return {} representing lpServiceStatus
-  #
-  # @raise (see #service_start)
-  #
-  def service_status(name, server=nil)
-    ret = nil
-
-    open_sc_manager(:host => server, :access => "GENERIC_READ") do |manager|
-      open_service_handle(manager, name, "GENERIC_READ") do |service_handle|
-        status = advapi32.QueryServiceStatus(service_handle,28)
-
-        if (status["return"] == 0)
-          raise "Could not query service. QueryServiceStatus error: #{status["ErrorMessage"]}"
-        else
-          ret = parse_service_status_struct(status['lpServiceStatus'])
-        end
-      end
-    end
-
-    return ret
-  end
-
-  #
-  # Performs an aggressive service (re)start
-  # If service is disabled it will re-enable
-  # If service is running it will stop and restart
-  #
-  # @param name [String] The service name
-  # @param start_type [Integer] The start type to configure if disabled
-  # @param server [String] The server to target
-  #
-  # @return [Boolean] indicating success
-  #
-  def service_restart(name, start_type=START_TYPE_AUTO, server=nil, should_retry=true)
-    status = service_start(name, server)
-
-    if status == Error::SUCCESS
-      vprint_good("[#{name}] Service started")
-      return true
-    end
-
-
-    case status
-    when Error::ACCESS_DENIED
-      vprint_error("[#{name}] Access denied")
-    when Error::INVALID_HANDLE
-      vprint_error("[#{name}] Invalid handle")
-    when Error::PATH_NOT_FOUND
-      vprint_error("[#{name}] Service binary could not be found")
-    when Error::SERVICE_ALREADY_RUNNING
-      vprint_status("[#{name}] Service already running attempting to stop and restart")
-      stopped = service_stop(name, server)
-      if ((stopped == Error::SUCCESS) || (stopped == Error::SERVICE_NOT_ACTIVE))
-        service_restart(name, start_type, server, false) if should_retry
-      else
-        vprint_error("[#{name}] Service disabled, unable to change start type Error: #{stopped}")
-      end
-    when Error::SERVICE_DISABLED
-      vprint_status("[#{name}] Service disabled attempting to set to manual")
-      if (service_change_config(name, {:starttype => start_type}, server) == Error::SUCCESS)
-        service_restart(name, start_type, server, false) if should_retry
-      else
-        vprint_error("[#{name}] Service disabled, unable to change start type")
-      end
-    else
-      status = WindowsError::Win32.find_by_retval(s).first
-      vprint_error("[#{name}] Unhandled error: #{status.name}: #{status.description}")
-      return false
-    end
-  end
-
-  #
-  # Parses out a SERVICE_STATUS struct from the
-  # lpServiceStatus out parameter
-  #
-  # @param lpServiceStatus [String] the latest status of calling service
-  #
-  # @return [Hash] Containing SERVICE_STATUS values
-  #
-  def parse_service_status_struct(lpServiceStatus)
-    if lpServiceStatus
-      vals = lpServiceStatus.unpack('V*')
-      return {
-          :type              => vals[0],
-          :state             => vals[1],
-          :controls_accepted => vals[2],
-          :win32_exit_code   => vals[3],
-          :service_exit_code => vals[4],
-          :check_point       => vals[5],
-          :wait_hint         => vals[6]
-      }
-    else
-     return nil
-    end
-  end
-
-end
-
-end
-end
 end

--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -238,10 +238,19 @@ module Msf
           services
         end
 
+        # Meterpreter specific function to list out all Windows Services present on the target.
+        # Uses threading to help speed up the information retrieval.
         #
+        # @return [Array<Hash>] Array of Hashes containing Service details. May contain the following keys:
+        #   * :name
+        #   * :display
+        #   * :pid
+        #   * :status
+        #   * :interactive
         #
-        # @return
         def meterpreter_service_list
+          return [] if session.type != 'meterpreter' # This function isn't compatible with non-Meterpreter sessions.
+
           if session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_REGISTRY_ENUM_KEY)
             begin
               return session.extapi.service.enumerate


### PR DESCRIPTION
~~Note: This requires #16921 to be merged first. This makes ExtAPI load failure not fatal. See PR description.~~
No longer required as per https://github.com/rapid7/metasploit-framework/pull/16921#issuecomment-1227746612.

Tested on Windows 7 SP1 (x64):

* windows/meterpreter/reverse_tcp
* windows/x64/meterpreter/reverse_tcp
* windows/shell/reverse_tcp
* windows/x64/shell/reverse_tcp
* windows/powershell_reverse_tcp

Tested on Windows Server 2008 SP1 (x64):

* windows/meterpreter/reverse_tcp
* windows/x64/meterpreter/reverse_tcp
* windows/shell/reverse_tcp
* windows/x64/shell/reverse_tcp

---

Service retrieval may miss services which contain special PowerShell characters such as `$` in the registry key name (#16927). This is a systemic issue in Framework. Resolving this issue is outside the scope of this PR.

---

This PR addresses only service queries / information retrieval. Service modification methods were not modified nor tested. I have no interest in pursuing this.

---

* Define service types as constants.

* Ensure service startup type is always returned as Integer.

* Check for supported stdapi commands, rather than attempt to load ExtAPI if it is not already loaded.

* Fix a threading issue for Meterpreter sessions when ExtAPI was not loaded, causing inconsistent results with some services missing sometimes.

* Include interactive services (0x110 and 0x120) in service listing.

* Support service listing and service information retrieval for non-Meterpreter sessions.

---

Fixes a bug for Meterpreter sessions when loading ExtAPI fails.

Various `Post::Windows::Service` methods attempt to load ExtAPI, and fall back to using the Windows Registry if load fails.

The `session.extapi.service.enumerate` Meterpreter ExtAPI function returns the service startup type as integer.

Comparatively, when querying the registry, the service startup type is returned as a hex string, ie "0x2".

Furthermore, Meterpreter request errors will also fall back to the registry technique:

```
[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
```

Worse, the fallback is effectively invisible as the fallback error is printed with `vprint_error`. Thus the startup type will sometimes be an integer and sometimes be a hex string for no immediately obvious reason.

Returning the startup type as a hex string is problematic, as subsequent startup type conditional statements expect an integer, which fails. For example, converting the startup type to a human readable string expects an integer as an array index. Using a string results in a startup type of zero (array index zero), causing all services to be incorrectly displayed as `START_TYPE_BOOT`.

You can replicate this behaviour by preventing ExtAPI load in `service_list`:

```ruby
    if false #load_extapi
      begin
        return session.extapi.service.enumerate
      rescue Rex::Post::Meterpreter::RequestError => e
        vprint_error("Request Error #{e} falling back to registry technique")
      end
    end
```

```
msf6 post(windows/gather/enum_services) > rexploit 
[*] Reloading module...

[*] Listing Service Info for matching services, please wait...
"0x2"
[+] New service credential detected: AeLookupSvc is running as 'localSystem'
"0x3"
[+] New service credential detected: ALG is running as 'NT AUTHORITY\LocalService'
"0x3"
"0x3"
"0x3"
"0x3"
"0x2"
"0x2"
"0x4"
"0x3"
"0x3"
"0x3"
"0x3"
"0x2"
[+] New service credential detected: CryptSvc is running as 'NT Authority\NetworkService'
"0x4"
"0x2"
"0x2"
"0x2"
"0x2"
"0x2"
"0x2"
"0x3"
"0x2"
"0x3"
"0x2"
"0x2"
"0x3"
"0x3"
"0x3"
"0x2"
"0x3"
"0x3"
"0x2"
"0x4"
"0x2"
"0x2"
"0x2"
"0x3"
"0x2"
"0x2"
"0x2"
"0x3"
"0x2"
"0x3"
"0x2"
"0x2"
"0x3"
"0x3"
"0x3"
"0x2"
"0x3"
"0x2"
"0x2"
"0x2"
"0x2"
"0x2"
"0x3"
"0x3"
"0x2"
"0x2"
"0x2"
"0x3"
"0x3"
"0x3"
"0x4"
"0x2"
"0x3"
"0x2"
"0x3"
"0x3"
"0x2"
"0x3"
"0x2"
"0x3"
"0x2"
"0x2"
"0x3"
"0x4"
"0x2"
"0x2"
"0x3"
"0x2"
"0x3"
"0x4"
"0x3"
"0x3"
"0x4"
"0x3"
"0x2"
"0x2"
"0x4"
"0x3"
"0x3"
"0x3"
"0x3"
"0x4"
"0x2"
"0x3"
"0x3"
"0x2"
"0x3"
"0x3"
"0x3"
"0x3"
"0x3"
"0x2"
"0x3"
"0x2"
"0x2"
"0x3"
"0x3"
"0x2"
"0x3"
Services
========

 Name                            Credentials                  Command  Startup
 ----                            -----------                  -------  -------
 ALG                             NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\alg.exe
 AeLookupSvc                     localSystem                  Boot     %systemroot%\system32\svchost.exe -k netsvcs
 AppMgmt                         LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k netsvcs
 Appinfo                         LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k netsvcs
 AudioEndpointBuilder            LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k LocalSystemNetworkRestricted
 AudioSrv                        NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\svchost.exe -k LocalServiceNetworkRestricted
 BFE                             NT AUTHORITY\LocalService    Boot     %systemroot%\system32\svchost.exe -k LocalServiceNoNetwork
 BITS                            LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 Browser                         LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 COMSysApp                       LocalSystem                  Boot     %SystemRoot%\system32\dllhost.exe /Processid:{02D4B3F1-FD88-11D1-960D-00805FC79235}
 CertPropSvc                     LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k netsvcs
 CryptSvc                        NT Authority\NetworkService  Boot     %SystemRoot%\system32\svchost.exe -k NetworkService
 CscService                      LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k LocalSystemNetworkRestricted
 DFSR                            LocalSystem                  Boot     %SystemRoot%\system32\DFSRs.exe
 DNS                             LocalSystem                  Boot     %systemroot%\system32\dns.exe
 DPS                             NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\svchost.exe -k LocalServiceNoNetwork
 DcomLaunch                      LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k DcomLaunch
 Dfs                             LocalSystem                  Boot     %SystemRoot%\system32\dfssvc.exe
 Dhcp                            NT Authority\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalServiceNetworkRestricted
 Dnscache                        NT AUTHORITY\NetworkService  Boot     %SystemRoot%\system32\svchost.exe -k NetworkService
 EapHost                         localSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 EventLog                        NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\svchost.exe -k LocalServiceNetworkRestricted
 EventSystem                     NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 FCRegSvc                        NT AUTHORITY\LocalService    Boot     %systemroot%\system32\svchost.exe -k LocalServiceNetworkRestricted
 FDResPub                        NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 IKEEXT                          LocalSystem                  Boot     %systemroot%\system32\svchost.exe -k netsvcs
 IPBusEnum                       LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k LocalSystemNetworkRestricted
 IsmServ                         LocalSystem                  Boot     %SystemRoot%\System32\ismserv.exe
 KeyIso                          LocalSystem                  Boot     %SystemRoot%\system32\lsass.exe
 KtmRm                           NT AUTHORITY\NetworkService  Boot     %SystemRoot%\System32\svchost.exe -k NetworkService
 LanmanServer                    LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k netsvcs
 LanmanWorkstation               NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\svchost.exe -k LocalService
 MMCSS                           LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k netsvcs
 MSDTC                           NT AUTHORITY\NetworkService  Boot     %SystemRoot%\System32\msdtc.exe
 MSiSCSI                         LocalSystem                  Boot     %systemroot%\system32\svchost.exe -k netsvcs
 MpsSvc                          NT Authority\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalServiceNoNetwork
 NTDS                            LocalSystem                  Boot     %SystemRoot%\System32\lsass.exe
 Netlogon                        LocalSystem                  Boot     %systemroot%\system32\lsass.exe
 Netman                          LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k LocalSystemNetworkRestricted
 NlaSvc                          NT AUTHORITY\NetworkService  Boot     %SystemRoot%\System32\svchost.exe -k NetworkService
 NtFrs                           LocalSystem                  Boot     %SystemRoot%\system32\ntfrs.exe
 PerfHost                        NT AUTHORITY\LocalService    Boot     %SystemRoot%\SysWow64\perfhost.exe
 PlugPlay                        LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k DcomLaunch
 PolicyAgent                     NT Authority\NetworkService  Boot     %SystemRoot%\system32\svchost.exe -k NetworkServiceNetworkRestricted
 ProfSvc                         LocalSystem                  Boot     %systemroot%\system32\svchost.exe -k netsvcs
 ProtectedStorage                LocalSystem                  Boot     %SystemRoot%\system32\lsass.exe
 RSoPProv                        LocalSystem                  Boot     %SystemRoot%\system32\RSoPProv.exe
 RasAuto                         localSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 RasMan                          localSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 RemoteAccess                    localSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 RemoteRegistry                  NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k regsvc
 RpcLocator                      NT AUTHORITY\NetworkService  Boot     %SystemRoot%\system32\locator.exe
 RpcSs                           NT AUTHORITY\NetworkService  Boot     %SystemRoot%\system32\svchost.exe -k rpcss
 SCPolicySvc                     LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k netsvcs
 SCardSvr                        NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 SENS                            LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k netsvcs
 SLUINotify                      NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 SNMP                            LocalSystem                  Boot     %SystemRoot%\System32\snmp.exe
 SNMPTRAP                        NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\snmptrap.exe
 SSDPSRV                         NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 SamSs                           LocalSystem                  Boot     %SystemRoot%\system32\lsass.exe
 Schedule                        LocalSystem                  Boot     %systemroot%\system32\svchost.exe -k netsvcs
 SessionEnv                      localSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 SharedAccess                    LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 ShellHWDetection                LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 SstpSvc                         NT Authority\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 SysMain                         LocalSystem                  Boot     %systemroot%\system32\svchost.exe -k LocalSystemNetworkRestricted
 TBS                             NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\svchost.exe -k LocalService
 THREADORDER                     NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 TapiSrv                         NT AUTHORITY\NetworkService  Boot     %SystemRoot%\System32\svchost.exe -k tapisrv
 TermService                     NT Authority\NetworkService  Boot     %SystemRoot%\System32\svchost.exe -k NetworkService
 Themes                          LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 TrkWks                          LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k LocalSystemNetworkRestricted
 TrustedInstaller                localSystem                  Boot     %SystemRoot%\servicing\TrustedInstaller.exe
 UmRdpService                    localSystem                  Boot     %SystemRoot%\System32\svchost.exe -k LocalSystemNetworkRestricted
 UxSms                           localSystem                  Boot     %SystemRoot%\System32\svchost.exe -k LocalSystemNetworkRestricted
 VSS                             LocalSystem                  Boot     %systemroot%\system32\vssvc.exe
 W32Time                         NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 WPDBusEnum                      LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k LocalSystemNetworkRestricted
 WcsPlugInService                NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k wcssvc
 WdiServiceHost                  NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\svchost.exe -k wdisvc
 WdiSystemHost                   LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k LocalSystemNetworkRestricted
 Wecsvc                          NT AUTHORITY\NetworkService  Boot     %SystemRoot%\system32\svchost.exe -k NetworkService
 WerSvc                          localSystem                  Boot     %SystemRoot%\System32\svchost.exe -k WerSvcGroup
 WinHttpAutoProxySvc             NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 WinRM                           NT AUTHORITY\NetworkService  Boot     %SystemRoot%\System32\svchost.exe -k NetworkService
 Winmgmt                         localSystem                  Boot     %systemroot%\system32\svchost.exe -k netsvcs
 clr_optimization_v2.0.50727_32  LocalSystem                  Boot     %systemroot%\Microsoft.NET\Framework\v2.0.50727\mscorsvw.exe
 clr_optimization_v2.0.50727_64  LocalSystem                  Boot     %systemroot%\Microsoft.NET\Framework64\v2.0.50727\mscorsvw.exe
 dot3svc                         localSystem                  Boot     %SystemRoot%\system32\svchost.exe -k LocalSystemNetworkRestricted
 fdPHost                         NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 gpsvc                           LocalSystem                  Boot     %windir%\system32\svchost.exe -k GPSvcGroup
 hidserv                         LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k LocalSystemNetworkRestricted
 hkmsvc                          localSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 iphlpsvc                        LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k NetSvcs
 kdc                             LocalSystem                  Boot     %SystemRoot%\System32\lsass.exe
 lltdsvc                         NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\svchost.exe -k LocalService
 lmhosts                         NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalServiceNetworkRestricted
 msiserver                       LocalSystem                  Boot     %systemroot%\system32\msiexec /V
 napagent                        NT AUTHORITY\NetworkService  Boot     %SystemRoot%\System32\svchost.exe -k NetworkService
 netprofm                        NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\svchost.exe -k LocalService
 nsi                             NT Authority\LocalService    Boot     %systemroot%\system32\svchost.exe -k LocalService
 pla                             NT AUTHORITY\LocalService    Boot     %SystemRoot%\System32\svchost.exe -k LocalServiceNoNetwork
 sacsvr                          LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 seclogon                        LocalSystem                  Boot     %windir%\system32\svchost.exe -k netsvcs
 slsvc                           NT AUTHORITY\NetworkService  Boot     %SystemRoot%\system32\SLsvc.exe
 swprv                           LocalSystem                  Boot     %SystemRoot%\System32\svchost.exe -k swprv
 upnphost                        NT AUTHORITY\LocalService    Boot     %SystemRoot%\system32\svchost.exe -k LocalService
 vds                             LocalSystem                  Boot     %SystemRoot%\System32\vds.exe
 wercplsupport                   localSystem                  Boot     %SystemRoot%\System32\svchost.exe -k netsvcs
 wmiApSrv                        localSystem                  Boot     %systemroot%\system32\wbem\WmiApSrv.exe
 wuauserv                        LocalSystem                  Boot     %systemroot%\system32\svchost.exe -k netsvcs
 wudfsvc                         LocalSystem                  Boot     %SystemRoot%\system32\svchost.exe -k LocalSystemNetworkRestricted

[+] Loot file stored in: /root/.msf4/loot/20220819230552_default_192.168.200.218_windows.services_818772.txt
[*] Post module execution completed

```

Note the startup type is incorrectly listed as `Boot` for all services; whereas puts-debugging clearly shows the values are non-zero.

This PR resolves this inconsistency by normalizing the startup type to always be an Integer.

A handful of modules currently query (or set) service `:starttype`. All of these modules require a `SessionType` of `meterpreter`. At worst, the changes in this PR won't break any of these modules. At best, it will fix some of these modules when ExtAPI cannot be loaded.

```
# grep -rn starttype modules/
modules/exploits/windows/local/current_user_psexec.rb:126:                           :starttype => "START_TYPE_MANUAL"
modules/exploits/windows/local/webexec.rb:81:    case START_TYPE[srv_info[:starttype]]
modules/exploits/windows/local/webexec.rb:171:      if service_information[:starttype] == START_TYPE_AUTO
modules/exploits/windows/local/ikeext_service.rb:78:    case START_TYPE[srv_info[:starttype]]
modules/exploits/windows/local/ikeext_service.rb:250:      if service_information[:starttype] == START_TYPE_AUTO
modules/post/windows/gather/enum_services.rb:91:        start_type = srv_conf[:starttype]
modules/post/windows/manage/enable_rdp.rb:97:      if srv_info[:starttype] != START_TYPE_AUTO
modules/post/windows/manage/enable_rdp.rb:99:        unless service_change_config(service_name, starttype: "START_TYPE_AUTO") == Windows::Error::SUCCESS
modules/post/windows/manage/rpcapd_start.rb:46:        start_type = serv[:starttype]
modules/post/windows/manage/driver_loader.rb:79:    inst = install_driver(name, path: driver, starttype: start, error_control: error, service_type: service)
```

This PR also adds support for service listing and querying service details on non-Meterpreter sessions, and ensures the above behaviour for these sessions.
