### PR TITLE
enum_services: Cleanup and support non-Meterpreter sessions

### DIFF
--- a/documentation/modules/post/windows/gather/enum_services.md
+++ b/documentation/modules/post/windows/gather/enum_services.md
@@ -1,13 +1,13 @@
 ## Vulnerable Application
 
-This module will query the system for services and display name and
-configuration info for each returned service. It allows you to
-optionally search the credentials, path, or start type for a string
-and only return the results that match. These query operations are
-cumulative and if no query strings are specified, it just returns all
-services.  NOTE: If the script hangs, windows firewall is most likely
-on and you did not migrate to a safe process (explorer.exe for
-example).
+This module will query the system for services and return the display name and
+configuration info for each returned service. You can also optionally
+filter the results by using query strings to match on specific
+credentials, paths, or start types and only return the results that match.
+These query operations are cumulative and if no query strings are specified,
+the module will just return all services. NOTE: If the script hangs,
+Windows Defender Firewall is most likely on and you did not migrate
+to a safe process (explorer.exe for example).
 
 ## Verification Steps
 
@@ -21,15 +21,15 @@ example).
 
 ### CRED
 
-String to search credentials for.
+String to search returned service credentials for.
 
 ### PATH
 
-String to search path for.
+String to search returned service paths for.
 
 ### TYPE
 
-Service startup option (`All`, `Auto`, `Manual`, `Disabled`) (default: `All`)
+Service startup types to display (`All`, `Auto`, `Manual`, `Disabled`) (default: `All`)
 
 ## Scenarios
 

--- a/documentation/modules/post/windows/gather/enum_services.md
+++ b/documentation/modules/post/windows/gather/enum_services.md
@@ -1,0 +1,172 @@
+## Vulnerable Application
+
+This module will query the system for services and display name and
+configuration info for each returned service. It allows you to
+optionally search the credentials, path, or start type for a string
+and only return the results that match. These query operations are
+cumulative and if no query strings are specified, it just returns all
+services.  NOTE: If the script hangs, windows firewall is most likely
+on and you did not migrate to a safe process (explorer.exe for
+example).
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get a session
+3. Do: `use post/windows/gather/enum_services`
+4. Do: `set SESSION <session id>`
+5. Do: `run`
+
+## Options
+
+### CRED
+
+String to search credentials for.
+
+### PATH
+
+String to search path for.
+
+### TYPE
+
+Service startup option (`All`, `Auto`, `Manual`, `Disabled`) (default: `All`)
+
+## Scenarios
+
+### Windows Server 2008 SP1 (x64)
+
+```
+msf6 > use post/windows/gather/enum_services
+msf6 post(windows/gather/enum_services) > set session 1
+session => 1
+msf6 post(windows/gather/enum_services) > run
+
+[*] Listing Service Info for matching services, please wait...
+[+] New service credential detected: AeLookupSvc is running as 'localSystem'
+[+] New service credential detected: ALG is running as 'NT AUTHORITY\LocalService'
+[+] New service credential detected: CryptSvc is running as 'NT Authority\NetworkService'
+[*] Found 114 Windows services matching filters
+
+Services
+========
+
+ Name                            Credentials                  Command   Startup
+ ----                            -----------                  -------   -------
+ ALG                             NT AUTHORITY\LocalService    Manual    C:\Windows\System32\alg.exe
+ AeLookupSvc                     localSystem                  Auto      C:\Windows\system32\svchost.exe -k netsvcs
+ AppMgmt                         LocalSystem                  Manual    C:\Windows\system32\svchost.exe -k netsvcs
+ Appinfo                         LocalSystem                  Manual    C:\Windows\system32\svchost.exe -k netsvcs
+ AudioEndpointBuilder            LocalSystem                  Manual    C:\Windows\System32\svchost.exe -k LocalSystemNetworkRestricted
+ AudioSrv                        NT AUTHORITY\LocalService    Manual    C:\Windows\System32\svchost.exe -k LocalServiceNetworkRestricted
+ BFE                             NT AUTHORITY\LocalService    Auto      C:\Windows\system32\svchost.exe -k LocalServiceNoNetwork
+ BITS                            LocalSystem                  Auto      C:\Windows\System32\svchost.exe -k netsvcs
+ Browser                         LocalSystem                  Disabled  C:\Windows\System32\svchost.exe -k netsvcs
+ COMSysApp                       LocalSystem                  Manual    C:\Windows\system32\dllhost.exe /Processid:{02D4B3F1-FD88-11D1-960D-00805FC79235}
+ CertPropSvc                     LocalSystem                  Manual    C:\Windows\system32\svchost.exe -k netsvcs
+ CryptSvc                        NT Authority\NetworkService  Auto      C:\Windows\system32\svchost.exe -k NetworkService
+ CscService                      LocalSystem                  Disabled  C:\Windows\System32\svchost.exe -k LocalSystemNetworkRestricted
+ DFSR                            LocalSystem                  Auto      C:\Windows\system32\DFSRs.exe
+ DNS                             LocalSystem                  Auto      C:\Windows\system32\dns.exe
+ DPS                             NT AUTHORITY\LocalService    Auto      C:\Windows\System32\svchost.exe -k LocalServiceNoNetwork
+ DcomLaunch                      LocalSystem                  Auto      %SystemRoot%\system32\svchost.exe -k DcomLaunch
+ Dfs                             LocalSystem                  Auto      C:\Windows\system32\dfssvc.exe
+ Dhcp                            NT Authority\LocalService    Auto      C:\Windows\system32\svchost.exe -k LocalServiceNetworkRestricted
+ Dnscache                        NT AUTHORITY\NetworkService  Auto      C:\Windows\system32\svchost.exe -k NetworkService
+ EapHost                         localSystem                  Manual    C:\Windows\System32\svchost.exe -k netsvcs
+ EventLog                        NT AUTHORITY\LocalService    Auto      C:\Windows\System32\svchost.exe -k LocalServiceNetworkRestricted
+ EventSystem                     NT AUTHORITY\LocalService    Auto      C:\Windows\system32\svchost.exe -k LocalService
+ FCRegSvc                        NT AUTHORITY\LocalService    Manual    C:\Windows\system32\svchost.exe -k LocalServiceNetworkRestricted
+ FDResPub                        NT AUTHORITY\LocalService    Manual    C:\Windows\system32\svchost.exe -k LocalService
+ IKEEXT                          LocalSystem                  Auto      C:\Windows\system32\svchost.exe -k netsvcs
+ IPBusEnum                       LocalSystem                  Disabled  C:\Windows\system32\svchost.exe -k LocalSystemNetworkRestricted
+ IsmServ                         LocalSystem                  Auto      C:\Windows\System32\ismserv.exe
+ KeyIso                          LocalSystem                  Manual    C:\Windows\system32\lsass.exe
+ KtmRm                           NT AUTHORITY\NetworkService  Auto      C:\Windows\System32\svchost.exe -k NetworkService
+ LanmanServer                    LocalSystem                  Auto      C:\Windows\system32\svchost.exe -k netsvcs
+ LanmanWorkstation               NT AUTHORITY\LocalService    Auto      C:\Windows\System32\svchost.exe -k LocalService
+ MMCSS                           LocalSystem                  Manual    C:\Windows\system32\svchost.exe -k netsvcs
+ MSDTC                           NT AUTHORITY\NetworkService  Auto      C:\Windows\System32\msdtc.exe
+ MSiSCSI                         LocalSystem                  Manual    C:\Windows\system32\svchost.exe -k netsvcs
+ MpsSvc                          NT Authority\LocalService    Auto      C:\Windows\system32\svchost.exe -k LocalServiceNoNetwork
+ Netlogon                        LocalSystem                  Auto      C:\Windows\system32\lsass.exe
+ Netman                          LocalSystem                  Manual    C:\Windows\System32\svchost.exe -k LocalSystemNetworkRestricted
+ NlaSvc                          NT AUTHORITY\NetworkService  Auto      C:\Windows\System32\svchost.exe -k NetworkService
+ NtFrs                           LocalSystem                  Auto      C:\Windows\system32\ntfrs.exe
+ PerfHost                        NT AUTHORITY\LocalService    Manual    C:\Windows\SysWow64\perfhost.exe
+ PlugPlay                        LocalSystem                  Auto      C:\Windows\system32\svchost.exe -k DcomLaunch
+ PolicyAgent                     NT Authority\NetworkService  Auto      C:\Windows\system32\svchost.exe -k NetworkServiceNetworkRestricted
+ ProfSvc                         LocalSystem                  Auto      C:\Windows\system32\svchost.exe -k netsvcs
+ ProtectedStorage                LocalSystem                  Manual    C:\Windows\system32\lsass.exe
+ RSoPProv                        LocalSystem                  Manual    C:\Windows\system32\RSoPProv.exe
+ RasAuto                         localSystem                  Manual    C:\Windows\System32\svchost.exe -k netsvcs
+ RasMan                          localSystem                  Manual    C:\Windows\System32\svchost.exe -k netsvcs
+ RemoteAccess                    localSystem                  Disabled  C:\Windows\System32\svchost.exe -k netsvcs
+ RemoteRegistry                  NT AUTHORITY\LocalService    Auto      C:\Windows\system32\svchost.exe -k regsvc
+ RpcLocator                      NT AUTHORITY\NetworkService  Manual    C:\Windows\system32\locator.exe
+ RpcSs                           NT AUTHORITY\NetworkService  Auto      %SystemRoot%\system32\svchost.exe -k rpcss
+ SCPolicySvc                     LocalSystem                  Manual    C:\Windows\system32\svchost.exe -k netsvcs
+ SCardSvr                        NT AUTHORITY\LocalService    Manual    C:\Windows\system32\svchost.exe -k LocalService
+ SENS                            LocalSystem                  Auto      C:\Windows\system32\svchost.exe -k netsvcs
+ SLUINotify                      NT AUTHORITY\LocalService    Manual    C:\Windows\system32\svchost.exe -k LocalService
+ SNMP                            LocalSystem                  Auto      C:\Windows\System32\snmp.exe
+ SNMPTRAP                        NT AUTHORITY\LocalService    Manual    C:\Windows\System32\snmptrap.exe
+ SSDPSRV                         NT AUTHORITY\LocalService    Disabled  C:\Windows\system32\svchost.exe -k LocalService
+ SamSs                           LocalSystem                  Auto      C:\Windows\system32\lsass.exe
+ Schedule                        LocalSystem                  Auto      C:\Windows\system32\svchost.exe -k netsvcs
+ SessionEnv                      localSystem                  Manual    C:\Windows\System32\svchost.exe -k netsvcs
+ SharedAccess                    LocalSystem                  Disabled  C:\Windows\System32\svchost.exe -k netsvcs
+ ShellHWDetection                LocalSystem                  Auto      C:\Windows\System32\svchost.exe -k netsvcs
+ Spooler                         LocalSystem                  Auto      C:\Windows\System32\spoolsv.exe
+ SstpSvc                         NT Authority\LocalService    Manual    C:\Windows\system32\svchost.exe -k LocalService
+ SysMain                         LocalSystem                  Disabled  C:\Windows\system32\svchost.exe -k LocalSystemNetworkRestricted
+ TBS                             NT AUTHORITY\LocalService    Auto      C:\Windows\System32\svchost.exe -k LocalService
+ THREADORDER                     NT AUTHORITY\LocalService    Manual    C:\Windows\system32\svchost.exe -k LocalService
+ TapiSrv                         NT AUTHORITY\NetworkService  Manual    C:\Windows\System32\svchost.exe -k tapisrv
+ TermService                     NT Authority\NetworkService  Auto      C:\Windows\System32\svchost.exe -k NetworkService
+ Themes                          LocalSystem                  Disabled  C:\Windows\System32\svchost.exe -k netsvcs
+ TrkWks                          LocalSystem                  Manual    C:\Windows\System32\svchost.exe -k LocalSystemNetworkRestricted
+ TrustedInstaller                localSystem                  Manual    C:\Windows\servicing\TrustedInstaller.exe
+ UI0Detect                       LocalSystem                  Manual    C:\Windows\system32\UI0Detect.exe
+ UmRdpService                    localSystem                  Manual    C:\Windows\System32\svchost.exe -k LocalSystemNetworkRestricted
+ UxSms                           localSystem                  Auto      C:\Windows\System32\svchost.exe -k LocalSystemNetworkRestricted
+ VSS                             LocalSystem                  Manual    C:\Windows\system32\vssvc.exe
+ W32Time                         NT AUTHORITY\LocalService    Auto      C:\Windows\system32\svchost.exe -k LocalService
+ WPDBusEnum                      LocalSystem                  Manual    C:\Windows\system32\svchost.exe -k LocalSystemNetworkRestricted
+ WcsPlugInService                NT AUTHORITY\LocalService    Manual    C:\Windows\system32\svchost.exe -k wcssvc
+ WdiServiceHost                  NT AUTHORITY\LocalService    Manual    C:\Windows\System32\svchost.exe -k wdisvc
+ WdiSystemHost                   LocalSystem                  Manual    C:\Windows\System32\svchost.exe -k LocalSystemNetworkRestricted
+ Wecsvc                          NT AUTHORITY\NetworkService  Manual    C:\Windows\system32\svchost.exe -k NetworkService
+ WerSvc                          localSystem                  Auto      C:\Windows\System32\svchost.exe -k WerSvcGroup
+ WinHttpAutoProxySvc             NT AUTHORITY\LocalService    Manual    C:\Windows\system32\svchost.exe -k LocalService
+ WinRM                           NT AUTHORITY\NetworkService  Auto      C:\Windows\System32\svchost.exe -k NetworkService
+ Winmgmt                         localSystem                  Auto      C:\Windows\system32\svchost.exe -k netsvcs
+ clr_optimization_v2.0.50727_32  LocalSystem                  Manual    C:\Windows\Microsoft.NET\Framework\v2.0.50727\mscorsvw.exe
+ clr_optimization_v2.0.50727_64  LocalSystem                  Manual    C:\Windows\Microsoft.NET\Framework64\v2.0.50727\mscorsvw.exe
+ dot3svc                         localSystem                  Manual    C:\Windows\system32\svchost.exe -k LocalSystemNetworkRestricted
+ fdPHost                         NT AUTHORITY\LocalService    Manual    C:\Windows\system32\svchost.exe -k LocalService
+ gpsvc                           LocalSystem                  Auto      C:\Windows\system32\svchost.exe -k GPSvcGroup
+ hidserv                         LocalSystem                  Manual    C:\Windows\system32\svchost.exe -k LocalSystemNetworkRestricted
+ hkmsvc                          localSystem                  Manual    C:\Windows\System32\svchost.exe -k netsvcs
+ iphlpsvc                        LocalSystem                  Auto      C:\Windows\System32\svchost.exe -k NetSvcs
+ kdc                             LocalSystem                  Auto      C:\Windows\System32\lsass.exe
+ lltdsvc                         NT AUTHORITY\LocalService    Manual    C:\Windows\System32\svchost.exe -k LocalService
+ lmhosts                         NT AUTHORITY\LocalService    Auto      C:\Windows\system32\svchost.exe -k LocalServiceNetworkRestricted
+ msiserver                       LocalSystem                  Manual    C:\Windows\system32\msiexec /V
+ napagent                        NT AUTHORITY\NetworkService  Manual    C:\Windows\System32\svchost.exe -k NetworkService
+ netprofm                        NT AUTHORITY\LocalService    Auto      C:\Windows\System32\svchost.exe -k LocalService
+ nsi                             NT Authority\LocalService    Auto      C:\Windows\system32\svchost.exe -k LocalService
+ pla                             NT AUTHORITY\LocalService    Manual    %SystemRoot%\System32\svchost.exe -k LocalServiceNoNetwork
+ sacsvr                          LocalSystem                  Manual    C:\Windows\System32\svchost.exe -k netsvcs
+ seclogon                        LocalSystem                  Auto      C:\Windows\system32\svchost.exe -k netsvcs
+ slsvc                           NT AUTHORITY\NetworkService  Auto      C:\Windows\system32\SLsvc.exe
+ swprv                           LocalSystem                  Manual    C:\Windows\System32\svchost.exe -k swprv
+ upnphost                        NT AUTHORITY\LocalService    Disabled  C:\Windows\system32\svchost.exe -k LocalService
+ vds                             LocalSystem                  Manual    C:\Windows\System32\vds.exe
+ wercplsupport                   localSystem                  Manual    C:\Windows\System32\svchost.exe -k netsvcs
+ wmiApSrv                        localSystem                  Manual    C:\Windows\system32\wbem\WmiApSrv.exe
+ wuauserv                        LocalSystem                  Auto      C:\Windows\system32\svchost.exe -k netsvcs
+ wudfsvc                         LocalSystem                  Manual    C:\Windows\system32\svchost.exe -k LocalSystemNetworkRestricted
+
+[+] Loot file stored in: /root/.msf4/loot/20220820231513_default_192.168.200.218_windows.services_350986.txt
+[*] Post module execution completed
+```

--- a/modules/post/windows/gather/enum_services.rb
+++ b/modules/post/windows/gather/enum_services.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Post
       srv_conf = {}
 
       # make sure we got a service name
-      unless srv[:name]
+      if srv[:name].blank?
         print_error("Problem retrieving service information - no name found for service: #{srv}")
         next
       end
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Post
       begin
         srv_conf = service_info(srv[:name])
 
-        next unless srv_conf[:startname]
+        next unless srv_conf && srv_conf[:startname] && srv_conf[:path]
 
         # filter service based on provided filters
         next if qcred && !srv_conf[:startname].downcase.include?(qcred)
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Post
 
         # There may not be a 'Startup', need to check nil
         start_type = srv_conf[:starttype]
-        start_type = start_type.blank? ? nil : START_TYPE[start_type]
+        start_type = start_type.blank? ? '' : START_TYPE[start_type].to_s
 
         next if qtype && !start_type.downcase.include?(qtype)
 

--- a/modules/post/windows/gather/enum_services.rb
+++ b/modules/post/windows/gather/enum_services.rb
@@ -6,44 +6,49 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Services
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'                 => "Windows Gather Service Info Enumeration",
-      'Description'          => %q{
-        This module will query the system for services and display name and
-        configuration info for each returned service. It allows you to
-        optionally search the credentials, path, or start type for a string
-        and only return the results that match. These query operations are
-        cumulative and if no query strings are specified, it just returns all
-        services.  NOTE: If the script hangs, windows firewall is most likely
-        on and you did not migrate to a safe process (explorer.exe for
-        example).
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather Service Info Enumeration',
+        'Description' => %q{
+          This module will query the system for services and display name and
+          configuration info for each returned service. It allows you to
+          optionally search the credentials, path, or start type for a string
+          and only return the results that match. These query operations are
+          cumulative and if no query strings are specified, it just returns all
+          services.  NOTE: If the script hangs, windows firewall is most likely
+          on and you did not migrate to a safe process (explorer.exe for
+          example).
         },
-      'License'              => MSF_LICENSE,
-      'Platform'             => ['win'],
-      'SessionTypes'         => ['meterpreter'],
-      'Author'               => ['Keith Faber', 'Kx499']
-    ))
-    register_options(
-      [
-        OptString.new('CRED', [ false, 'String to search credentials for' ]),
-        OptString.new('PATH', [ false, 'String to search path for' ]),
-        OptEnum.new('TYPE', [true, 'Service startup Option', 'All', ['All', 'Auto', 'Manual', 'Disabled' ]])
-      ])
+        'License' => MSF_LICENSE,
+        'Author' => ['Keith Faber', 'Kx499'],
+        'Platform' => ['win'],
+        'SessionTypes' => %w[meterpreter powershell shell],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+    register_options([
+      OptString.new('CRED', [ false, 'String to search credentials for' ]),
+      OptString.new('PATH', [ false, 'String to search path for' ]),
+      OptEnum.new('TYPE', [true, 'Service startup option', 'All', ['All', 'Auto', 'Manual', 'Disabled' ]])
+    ])
   end
 
-
   def run
+    credential_count = {}
+    qcred = datastore['CRED'] || nil
+    qpath = datastore['PATH'] || nil
 
-    # set vars
-    credentialCount = {}
-    qcred = datastore["CRED"] || nil
-    qpath = datastore["PATH"] || nil
-
-    if datastore["TYPE"] == "All"
+    if datastore['TYPE'] == 'All'
       qtype = nil
     else
-      qtype = datastore["TYPE"].downcase
+      qtype = datastore['TYPE'].downcase
+      print_status("Start Type Filter: #{qtype}")
     end
 
     if qcred
@@ -56,71 +61,74 @@ class MetasploitModule < Msf::Post
       print_status("Executable Path Filter: #{qpath}")
     end
 
-    if qtype
-      print_status("Start Type Filter: #{qtype}")
-    end
-
     results_table = Rex::Text::Table.new(
-        'Header'     => 'Services',
-        'Indent'     => 1,
-        'SortIndex'  => 0,
-        'Columns'    => ['Name', 'Credentials', 'Command', 'Startup']
+      'Header' => 'Services',
+      'Indent' => 1,
+      'SortIndex' => 0,
+      'Columns' => ['Name', 'Credentials', 'Command', 'Startup']
     )
 
-    print_status("Listing Service Info for matching services, please wait...")
-    service_list.each do |srv|
+    print_status('Listing Service Info for matching services, please wait...')
+
+    services = service_list
+
+    vprint_status("Found #{services.length} Windows services")
+
+    services.each do |srv|
       srv_conf = {}
 
       # make sure we got a service name
-      if srv[:name]
-        begin
-          srv_conf = service_info(srv[:name])
-          if srv_conf[:startname]
-            # filter service based on filters passed, the are cumulative
-            if qcred && !srv_conf[:startname].downcase.include?(qcred)
-              next
-            end
+      unless srv[:name]
+        print_error("Problem retrieving service information - no name found for service: #{srv}")
+        next
+      end
 
-            if qpath && !srv_conf[:path].downcase.include?(qpath)
-              next
-            end
+      begin
+        srv_conf = service_info(srv[:name])
 
-            # There may not be a 'Startup', need to check nil
-            if qtype && !(START_TYPE[srv_conf[:starttype]] || '').downcase.include?(qtype)
-              next
-            end
+        next unless srv_conf[:startname]
 
-            # count the occurance of specific credentials services are running as
-            serviceCred = srv_conf[:startname].upcase
-            unless serviceCred.empty?
-              if credentialCount.has_key?(serviceCred)
-                credentialCount[serviceCred] += 1
-              else
-                credentialCount[serviceCred] = 1
-                # let the user know a new service account has been detected for possible lateral
-                # movement opportunities
-                print_good("New service credential detected: #{srv[:name]} is running as '#{srv_conf[:startname]}'")
-              end
-            end
+        # filter service based on provided filters
+        next if qcred && !srv_conf[:startname].downcase.include?(qcred)
+        next if qpath && !srv_conf[:path].downcase.include?(qpath)
 
-            results_table << [srv[:name],
-                              srv_conf[:startname],
-                              START_TYPE[srv_conf[:starttype]],
-                              srv_conf[:path]]
+        # There may not be a 'Startup', need to check nil
+        start_type = srv_conf[:starttype]
+        start_type = start_type.blank? ? nil : START_TYPE[start_type]
+
+        next if qtype && !start_type.downcase.include?(qtype)
+
+        # count the occurance of specific credentials services are running as
+        service_cred = srv_conf[:startname].upcase
+        unless service_cred.empty?
+          if credential_count.key?(service_cred)
+            credential_count[service_cred] += 1
+          else
+            credential_count[service_cred] = 1
+            # let the user know a new service account has been detected for possible lateral
+            # movement opportunities
+            print_good("New service credential detected: #{srv[:name]} is running as '#{srv_conf[:startname]}'")
           end
-
-        rescue RuntimeError => e
-          print_error("An error occurred enumerating service: #{srv[:name]}: #{e}")
         end
-      else
-        print_error("Problem enumerating service - no service name found")
+
+        results_table << [
+          srv[:name],
+          srv_conf[:startname],
+          start_type,
+          srv_conf[:path]
+        ]
+      rescue RuntimeError => e
+        print_error("An error occurred enumerating service: #{srv[:name]}: #{e}")
       end
     end
 
-    print_line results_table.to_s
+    print_status("Found #{results_table.rows.size} Windows services matching filters")
 
-    # store loot on completion of collection
-    p = store_loot("windows.services", "text/plain", session, results_table.to_s, "windows_services.txt", "Windows Services")
-    print_good("Loot file stored in: #{p.to_s}")
+    return if results_table.rows.empty?
+
+    print_line("\n#{results_table}")
+
+    p = store_loot('windows.services', 'text/plain', session, results_table.to_s, 'windows_services.txt', 'Windows Services')
+    print_good("Loot file stored in: #{p}")
   end
 end


### PR DESCRIPTION
Note: This requires #16928 to be merged first. This fixes a bunch of bugs in the `Msf::Post::Windows::Service` library. See PR description.

---

Resolves Rubocop violations.

Adds documentation.

Adds `Notes` module meta information.

Adds support for non-Meterpreter sessions.

Ensure no service startup type is printed if the service has no startup type (rather than print "Boot"),

If a service does not have a service name, print the service details in addition to the error message "Problem enumerating service - no service name found".

If no services matching the specified filter are identified, don't print an empty service table and don't store empty loot.

---

Tested on Windows 7 SP1 (x64):

* windows/meterpreter/reverse_tcp
* windows/x64/meterpreter/reverse_tcp
* windows/shell/reverse_tcp
* windows/x64/shell/reverse_tcp
* windows/powershell_reverse_tcp

Tested on Windows Server 2008 SP1 (x64):

* windows/meterpreter/reverse_tcp
* windows/x64/meterpreter/reverse_tcp
* windows/shell/reverse_tcp
* windows/x64/shell/reverse_tcp
