### PR TITLE
scripts/resource/dev_checks: Add additional development-related modules

### DIFF
--- a/scripts/resource/dev_checks.rc
+++ b/scripts/resource/dev_checks.rc
@@ -79,19 +79,27 @@ def main
     framework.db.workspace.hosts.each do |host|
         print_line("Checking IP: #{host.address}, OS: #{host.os_name}...")
 
-        # Modules
-        { 'multi/misc/nodejs_v8_debugger':        [ Exploit::CheckCode::Appears ],
-          'unix/misc/distcc_exec':                [ Exploit::CheckCode::Vulnerable ],
-          'unix/misc/qnx_qconn_exec':             [ Exploit::CheckCode::Vulnerable ],
-          'linux/misc/jenkins_java_deserialize':  [ Exploit::CheckCode::Vulnerable ],
-          'linux/http/github_enterprise_secret':  [ Exploit::CheckCode::Vulnerable ],
-          'multi/http/traq_plugin_exec':          [ Exploit::CheckCode::Appears ],
-          'multi/http/builderengine_upload_exec': [ Exploit::CheckCode::Appears ],
-          'multi/http/mantisbt_php_exec':         [ Exploit::CheckCode::Appears ],
-          'multi/http/vbulletin_unserialize':     [ Exploit::CheckCode::Appears ],
-          'unix/webapp/vbulletin_vote_sqli_exec': [ Exploit::CheckCode::Appears ],
-          'multi/misc/java_jmx_server':           [ Exploit::CheckCode::Appears,
-                                                    Exploit::CheckCode::Detected ] }.each do |mod,ret_val|
+        # Exploits
+        { 'multi/misc/nodejs_v8_debugger':           [ Msf::Exploit::CheckCode::Appears ],
+          'unix/misc/distcc_exec':                   [ Msf::Exploit::CheckCode::Vulnerable ],
+          'qnx/qconn/qconn_exec':                    [ Msf::Exploit::CheckCode::Vulnerable ],
+          'linux/misc/jenkins_java_deserialize':     [ Msf::Exploit::CheckCode::Vulnerable ],
+          'linux/http/github_enterprise_secret':     [ Msf::Exploit::CheckCode::Vulnerable ],
+          'linux/http/sourcegraph_gitserver_sshcmd': [ Msf::Exploit::CheckCode::Vulnerable ],
+          'multi/http/builderengine_upload_exec':    [ Msf::Exploit::CheckCode::Appears ],
+          'multi/http/gitlab_exif_rce':              [ Msf::Exploit::CheckCode::Vulnerable ],
+          'multi/http/gitlab_file_read_rce':         [ Msf::Exploit::CheckCode::Appears ],
+          'multi/http/gitlist_arg_injection':        [ Msf::Exploit::CheckCode::Appears ],
+          'multi/http/mantisbt_php_exec':            [ Msf::Exploit::CheckCode::Appears ],
+          'multi/http/traq_plugin_exec':             [ Msf::Exploit::CheckCode::Appears ],
+          'multi/http/vbulletin_unserialize':        [ Msf::Exploit::CheckCode::Appears ],
+          'unix/webapp/vbulletin_vote_sqli_exec':    [ Msf::Exploit::CheckCode::Appears ],
+          'multi/http/werkzeug_debug_rce':           [ Msf::Exploit::CheckCode::Appears ],
+          'multi/misc/teamcity_agent_xmlrpc_exec':   [ Msf::Exploit::CheckCode::Appears ],
+          'multi/misc/java_jdwp_debugger':           [ Msf::Exploit::CheckCode::Appears ],
+          'multi/misc/java_jmx_server':              [ Msf::Exploit::CheckCode::Appears,
+                                                       Msf::Exploit::CheckCode::Detected ]
+        }.each do |mod,ret_val|
             check_exploit(host: host,
                 mod_name: mod.to_s,
                 vuln_check_ret_val: ret_val)


### PR DESCRIPTION
I'm not sure why this script thinks that developers use vBulletin, but I've left those checks in.

Also ninja patches a couple of bugs:

* `unix/misc/qnx_qconn_exec` has moved to `qnx/qconn/qconn_exec`.

* The script failed without `Msf::` prefix for `Exploit::CheckCode`:

```
msf6 > resource dev_checks.rc
[*] Processing /root/Desktop/metasploit-framework/scripts/resource/dev_checks.rc for ERB directives.
[*] resource (/root/Desktop/metasploit-framework/scripts/resource/dev_checks.rc)> Ruby Code (4497 bytes)
verbose => true
Checking IP: 192.168.200.135, OS: Unknown...
[-] resource (/root/Desktop/metasploit-framework/scripts/resource/dev_checks.rc)> Ruby Error: NameError uninitialized constant Rex::Ui::Text::Resource::Exploit
Did you mean?  Rex::Exploitation ["(eval):82:in `block in main'", "/var/lib/gems/3.0.0/gems/activerecord-6.1.6/lib/active_record/relation/delegation.rb:88:in `each'", "/var/lib/gems/3.0.0/gems/activerecord-6.1.6/lib/active_record/relation/delegation.rb:88:in `each'", "(eval):78:in `main'", "(eval):118:in `load_resource'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/resource.rb:60:in `eval'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/resource.rb:60:in `load_resource'", "/root/Desktop/metasploit-framework/lib/msf/ui/console/command_dispatcher/resource.rb:73:in `block in cmd_resource'", "/root/Desktop/metasploit-framework/lib/msf/ui/console/command_dispatcher/resource.rb:52:in `each'", "/root/Desktop/metasploit-framework/lib/msf/ui/console/command_dispatcher/resource.rb:52:in `cmd_resource'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'", "/root/Desktop/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'", "/root/Desktop/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'", "./msfconsole:23:in `<main>'"]
```

A bug still exists when invoking the `multi/misc/java_jmx_server` module which uses some magic shenanigans instead of specifying `rport` like every other module:

https://github.com/rapid7/metasploit-framework/blob/3f3bf215600498441701b5d5f4036874f8d3c32d/modules/exploits/multi/misc/java_jmx_server.rb#L57

```
msf6 > resource dev_checks.rc
[*] Processing /root/Desktop/metasploit-framework/scripts/resource/dev_checks.rc for ERB directives.
[*] resource (/root/Desktop/metasploit-framework/scripts/resource/dev_checks.rc)> Ruby Code (4503 bytes)
verbose => true
Checking IP: 192.168.200.135, OS: Unknown...
Looking for NodeJS Debugger Command Injection...
Looking for DistCC Daemon Command Execution...
Looking for QNX qconn Command Execution...
Looking for Jenkins CLI RMI Java Deserialization Vulnerability...
Looking for Github Enterprise Default Session Secret And Deserialization Vulnerability...
Looking for Sourcegraph gitserver sshCommand RCE...
Looking for BuilderEngine Arbitrary File Upload Vulnerability and execution...
Looking for GitLab Unauthenticated Remote ExifTool Command Injection...
Looking for GitLab File Read Remote Code Execution...
Looking for GitList v0.6.0 Argument Injection Vulnerability...
Looking for MantisBT XmlImportExport Plugin PHP Code Injection Vulnerability...
Looking for Traq admincp/common.php Remote Code Execution...
Looking for vBulletin 5.1.2 Unserialize Code Execution...
Looking for vBulletin index.php/ajax/api/reputation/vote nodeid Parameter SQL Injection...
Looking for Werkzeug Debug Shell Command Execution...
Looking for TeamCity Agent XML-RPC Command Execution...
Looking for Java Debug Wire Protocol Remote Code Execution...
Looking for Java JMX Server Insecure Configuration Java Code Execution...
[-] One or more options failed to validate: RPORT.
Running the Java RMI Server Insecure Endpoint Code Execution Scanner...
msf6 > 
```
