### PR TITLE
Stdapi::AudioOutput.play_file: raise if file +path+ is not readable

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/audio_output/audio_output.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/audio_output/audio_output.rb
@@ -26,6 +26,8 @@ class AudioOutput
 
   # Upload file and play it
   def play_file(path)
+    raise "Could not read file: #{path}" unless ::File.readable?(path) && ::File.file?(path)
+
     channel = Channel.create(client, 'audio_output', Rex::Post::Meterpreter::Channels::Pools::StreamPool, CHANNEL_FLAG_SYNCHRONOUS)
 
     # Read file buffers after buffers and upload
@@ -41,8 +43,8 @@ class AudioOutput
       end
     ensure src_fd.close unless src_fd.nil?
     end
-
-    channel.close()
+  ensure
+    channel.close unless channel.nil?
   end
 
   attr_accessor :client


### PR DESCRIPTION
`Rex::Post::Meterpreter::Extensions::Stdapi::AudioOutput.play_file(path)` opens a channel to play a file `path`. The channel is opened immediately without any prior validation of `path`. Opening the channel is unnecessary if the file does not exist. Worse, failure to read the file will raise an error before `channel.close` is called, leaving the channel open.

This PR ensures that the file `path` is readable. No audio channel is opened if the file is not readable. It also ensures that the channel is closed in the event that something goes wrong.

# Before

```
meterpreter > channel -l
No active channels.
meterpreter > play /asdf
[*] Playing /asdf...
[-] Error running command play: Errno::ENOENT No such file or directory @ rb_sysopen - /asdf
meterpreter > channel -l

    Id  Class  Type
    --  -----  ----
    11  3      audio_output
```

# After

```
meterpreter > channel -l
No active channels.
meterpreter > play /asdf
[*] Playing /asdf...
[-] Error running command play: RuntimeError Could not read file: /asdf
meterpreter > channel -l
No active channels.
```
