### PR TITLE
Fix evasion module crashes

### DIFF
--- a/lib/msf/core/evasion.rb
+++ b/lib/msf/core/evasion.rb
@@ -101,8 +101,14 @@ module Msf
     # @param [FlaseClass] Payload is not compatible.
     def is_payload_compatible?(name)
       p = framework.payloads[name]
+      return false unless p
 
-      pi = p.new
+      begin
+        pi = p.new
+      rescue ::Exception, ::LoadError => e
+        wlog("Module #{name} failed to initialize payload when checking evasion compatibility: #{e}", 'core', LEV_0)
+        return false
+      end
 
       # Are we compatible in terms of conventions and connections and
       # what not?

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -704,7 +704,6 @@ class Exploit < Msf::Module
   #
   def is_payload_compatible?(name)
     p = framework.payloads[name]
-
     return false unless p
 
     # Skip over payloads that are too big
@@ -713,7 +712,7 @@ class Exploit < Msf::Module
     begin
       pi = p.new
     rescue ::Exception, ::LoadError => e
-      wlog("Module #{name} failed to initialize: #{e}", 'core', LEV_0)
+      wlog("Module #{name} failed to initialize payload when checking exploit compatibility: #{e}", 'core', LEV_0)
       return false
     end
 


### PR DESCRIPTION
Fixes a crash when using evasion modules when mingw is not present on the host machine for generating encrypted payloads.

Original error:

```
msf6 evasion(windows/applocker_evasion_install_util) > use evasion/windows/applocker_evasion_install_util 
[-] Error while running command use: undefined method `new' for nil:NilClass

Call stack:
/Users/user/Documents/code/metasploit-framework/lib/msf/core/evasion.rb:105:in `is_payload_compatible?'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/evasion.rb:133:in `block in compatible_payloads'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/evasion.rb:132:in `each'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/evasion.rb:132:in `compatible_payloads'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:274:in `choose_payload'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/evasion.rb:102:in `choose_payload'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:796:in `cmd_use'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```

The payload may not always load, identified by adding quick logging snippet:

```diff
diff --git a/lib/msf/core/evasion.rb b/lib/msf/core/evasion.rb
index cb3c2d41c8..936707cbc9 100644
--- a/lib/msf/core/evasion.rb
+++ b/lib/msf/core/evasion.rb
@@ -102,6 +102,8 @@ module Msf
     def is_payload_compatible?(name)
       p = framework.payloads[name]
 
+      $stderr.puts "attempting to load payload: #{name}"
+
       pi = p.new
 
       # Are we compatible in terms of conventions and connections and
```

To verify which payload was causing the crash:
```
name is: windows/x64/encrypted_shell/reverse_tcp
[-] Error while running command use: undefined method `new' for nil:NilClass

Call stack:
/Users/user/Documents/code/metasploit-framework/lib/msf/core/evasion.rb:106:in `is_payload_compatible?'
```

## Verification

List the steps needed to make sure this thing works

- [x] Verify `use windows/applocker_evasion_install_util` on master outputs an error, but does not on this branch