### PR TITLE
Support stored LDAP query Base DNs

### DIFF
--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -3,7 +3,7 @@ queries:
   - action: ENUM_ADCS_CAS
     description: 'Enumerate ADCS certificate authorities.'
     base_dn_prefix: 'CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration'
-    filter: (&(objectClass=pKIEnrollmentService))
+    filter: (objectClass=pKIEnrollmentService)
     attributes:
       - cn
       - name
@@ -13,7 +13,7 @@ queries:
   - action: ENUM_ADCS_CERT_TEMPLATES
     description: 'Enumerate ADCS certificate templates.'
     base_dn_prefix: 'CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration'
-    filter: (objectclass=pkicertificatetemplate)
+    filter: (objectClass=pkicertificatetemplate)
     attributes:
       - cn
       - name

--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -1,5 +1,28 @@
 ---
 queries:
+  - action: ENUM_ADCS_CAS
+    description: 'Enumerate ADCS certificate authorities.'
+    base_dn_prefix: 'CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration'
+    filter: (&(objectClass=pKIEnrollmentService))
+    attributes:
+      - cn
+      - name
+      - cACertificateDN
+      - dNSHostname
+      - certificateTemplates
+  - action: ENUM_ADCS_CERT_TEMPLATES
+    description: 'Enumerate ADCS certificate templates.'
+    base_dn_prefix: 'CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration'
+    filter: (objectclass=pkicertificatetemplate)
+    attributes:
+      - cn
+      - name
+      - displayName
+      - msPKI-Enrollment-Flag
+      - msPKI-Private-Key-Flag
+      - msPKI-Certificate-Name-Flag
+      - msPKI-RA-Signature
+      - pKIExtendedKeyUsage
   - action: ENUM_ALL_OBJECT_CLASS
     description: 'Dump all objects containing any objectClass field.'
     filter: '(objectClass=*)'

--- a/data/auxiliary/gather/ldap_query/ldap_queries_template.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_template.yaml
@@ -2,6 +2,7 @@
 queries:
 #  - action: SAMPLE_ACTION
 #    description: 'A description.'
+#    # base_dn_prefix: 'An optional string to prefix to the Base DN'
 #    filter: '(objectClass=*)'
 #    attributes:
 #      - dn


### PR DESCRIPTION
This updates the relatively new `ldap_query` module to allow the stored query templates to specify a Base DN prefix. This allows that automatic calculation to do it's thing, and then a query that needs a specific prefix to still work without additional configuration by the user. Prior to this, the user would have to get the Base DN by running some kind of query, seeing the value that's automatically determined and then set the `BASE_DN` to the correct value.

This also adds two ADCS-related queries that then use this to enumerate certificate authorities and certificate templates. The information is pretty basic right now and a dedicated module would be pretty helpful that would actually parse the information into a more understandable format. Currently, it's mostly useful for getting the CA and template names.

## Verification

- [x] Install a (or use an existing) Windows server and promote it to a domain controller
- [x] Install ADCS on either a new or existing domain controller
    - [x] Open the Server Manager
    - [x] Select Add roles and features
    - [x] Select "Active Directory Certificate Services" under the "Server Roles" section
    - [x] When prompted add all of the features and management tools
    - [x] On the AD CS "Role Services" tab, leave the default selection of only "Certificate Authority"
    - [x] Completion the installation and reboot the server
    - [x] Reopen the Server Manager
    - [x] Go to the AD CS tab and where it says "Configuration Required", hit "More" then "Configure Active Directory Certificate..."
    - [x] Select "Certificate Authority" in the Role Services tab
    - [x] Keep all of the default settings, noting the value of the "Common name for this CA" on the "CA Name" tab (this value corresponds to the `CA` datastore option)
    - [x] Accept the rest of the default settings and complete the configuration
- [x] Start `msfconsole`
- [x] `use auxiliary/gather/ldap_query`
- [x] Run the two new actions, see results

## Demo
```
msf6 auxiliary(gather/ldap_query) > show options 

Module options (auxiliary/gather/ldap_query):

   Name           Current Setting         Required  Description
   ----           ---------------         --------  -----------
   BASE_DN        DC=msflab,DC=local      no        LDAP base DN if you already have it
   BIND_DN        smcintyre@msflab.local  no        The username to authenticate to LDAP server
   BIND_PW        Password1!              no        Password for the BIND_DN
   OUTPUT_FORMAT  table                   yes       The output format to use (Accepted: csv, table, json)
   RHOSTS         192.168.159.10          yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT          389                     yes       The target port
   SSL            false                   no        Enable SSL on the LDAP connection


Auxiliary action:

   Name           Description
   ----           -----------
   ENUM_ADCS_CAS  Enumerate ADCS certificate authorities.


msf6 auxiliary(gather/ldap_query) > enum_adcs_cas 
[*] Running module against 192.168.159.10

[+] Successfully bound to the LDAP server!
[*] User-specified base DN: DC=msflab,DC=local
[+] Successfully queried LDAP server!
CN=msflab-DC-CA CN=Enrollment Services CN=Public Key Services CN=Services CN=Configuration DC=msflab DC=local
=============================================================================================================

 Name                  Attributes
 ----                  ----------
 cacertificatedn       CN=msflab-DC-CA, DC=msflab, DC=local
 certificatetemplates  ESC1-Test || Workstation || ClientAuth || DirectoryEmailReplication || DomainControllerAuthentication || KerberosAuthentication || EFSRecovery || EFS || DomainController || WebServer || Machine || User || SubCA || Administrator
 cn                    msflab-DC-CA
 dnshostname           DC.msflab.local
 name                  msflab-DC-CA

[*] Auxiliary module execution completed
msf6 auxiliary(gather/ldap_query) > enum_adcs_cert_templates 
[*] Running module against 192.168.159.10

[+] Successfully bound to the LDAP server!
[*] User-specified base DN: DC=msflab,DC=local
[+] Successfully queried LDAP server!
CN=User CN=Certificate Templates CN=Public Key Services CN=Services CN=Configuration DC=msflab DC=local
=======================================================================================================

 Name                         Attributes
 ----                         ----------
 cn                           User
 displayname                  User
 mspki-certificate-name-flag  -1509949440
 mspki-enrollment-flag        41
 mspki-private-key-flag       16
 mspki-ra-signature           0
 name                         User
 pkiextendedkeyusage          1.3.6.1.4.1.311.10.3.4 || 1.3.6.1.5.5.7.3.4 || 1.3.6.1.5.5.7.3.2

CN=UserSignature CN=Certificate Templates CN=Public Key Services CN=Services CN=Configuration DC=msflab DC=local
================================================================================================================

 Name                         Attributes
 ----                         ----------
 cn                           UserSignature
 displayname                  User Signature Only
 mspki-certificate-name-flag  -1509949440
 mspki-enrollment-flag        32
 mspki-private-key-flag       0
 mspki-ra-signature           0
 name                         UserSignature
 pkiextendedkeyusage          1.3.6.1.5.5.7.3.4 || 1.3.6.1.5.5.7.3.2

CN=SmartcardUser CN=Certificate Templates CN=Public Key Services CN=Services CN=Configuration DC=msflab DC=local
================================================================================================================

 Name                         Attributes
 ----                         ----------
 cn                           SmartcardUser
 displayname                  Smartcard User
 mspki-certificate-name-flag  -1509949440
 mspki-enrollment-flag        9
 mspki-private-key-flag       0
 mspki-ra-signature           0
 name                         SmartcardUser
 pkiextendedkeyusage          1.3.6.1.5.5.7.3.4 || 1.3.6.1.5.5.7.3.2 || 1.3.6.1.4.1.311.20.2.2
```