### PR TITLE
Rewrite datastore, and add support for option fallback lookups

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -73,6 +73,10 @@ jobs:
         exclude:
           - { os: ubuntu-latest, ruby: 2.7 }
           - { os: ubuntu-latest, ruby: 3.0 }
+        include:
+          - os: ubuntu-latest
+            ruby: 3.1
+            test_cmd: 'bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content" DATASTORE_FALLBACKS=1'
         test_cmd:
           - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content"
           - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content"

--- a/docs/metasploit-framework.wiki/How-to-use-datastore-options.md
+++ b/docs/metasploit-framework.wiki/How-to-use-datastore-options.md
@@ -84,6 +84,10 @@ OptSomething.new(option_name, [boolean, description, value, *enums*], aliases: *
 * **conditions** - *optional*, *key-word only* An array of a condition for which the option should be displayed. This
   can be used to hide options when they are irrelevant based on other configurations. See the [Filtering datastore
   options](#Filtering-datastore-options) section for more information.
+* **fallbacks** *optional*, *key-word only* An array of names that will be used as a fallback if the main option name is
+  defined by the user. This is useful in the scenario of wanting specialised option names such as `SMBUser`, but to also
+  support gracefully checking a list of more generic fallbacks option names such as `Username`. This functionality is 
+  currently behind a feature flag, set with `features set datastore_fallbacks true` in msfconsole
 
 Now let's talk about what classes are available:
 

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -555,7 +555,11 @@ class ReadableText
         ])
 
     mod.options.sorted.each do |name, opt|
-      val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+      if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
+        val = mod.datastore[name]
+      else
+        val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+      end
 
       next unless Msf::OptCondition.show_option(mod, opt)
       next if (opt.advanced?)
@@ -603,7 +607,11 @@ class ReadableText
     mod.options.sorted.each do |name, opt|
       next unless opt.advanced?
       next unless Msf::OptCondition.show_option(mod, opt)
-      val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+      if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
+        val = mod.datastore[name]
+      else
+        val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+      end
       tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
     end
 
@@ -628,7 +636,11 @@ class ReadableText
 
     mod.options.sorted.each do |name, opt|
       next unless opt.evasion?
-      val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+      if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
+        val = mod.datastore[name]
+      else
+        val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+      end
       tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
     end
 

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -9,6 +9,20 @@ module Msf
 ###
 class DataStore < Hash
 
+  # Temporary forking logic for conditionally using the {Msf::ModuleDatastoreWithFallbacks} implementation.
+  #
+  # This method replaces the default `ModuleDataStore.new` with the ability to instantiate the `ModuleDataStoreWithFallbacks`
+  # class instead, if the feature is enabled
+  def self.new
+    if Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::DATASTORE_FALLBACKS)
+      return Msf::DataStoreWithFallbacks.new
+    end
+
+    instance = allocate
+    instance.send(:initialize)
+    instance
+  end
+
   #
   # Initializes the data store's internal state.
   #

--- a/lib/msf/core/data_store_with_fallbacks.rb
+++ b/lib/msf/core/data_store_with_fallbacks.rb
@@ -1,0 +1,547 @@
+# -*- coding: binary -*-
+module Msf
+
+###
+#
+# The data store is just a bitbucket that holds keyed values. It is used
+# by various classes to hold option values and other state information.
+#
+###
+class DataStoreWithFallbacks
+
+  # The global framework datastore doesn't currently import options
+  # For now, store an ad-hoc list of keys that the shell handles
+  #
+  # This list could be removed if framework's bootup sequence registers
+  # these as datastore options
+  GLOBAL_KEYS = %w[
+    ConsoleLogging
+    LogLevel
+    MinimumRank
+    SessionLogging
+    TimestampOutput
+    Prompt
+    PromptChar
+    PromptTimeFormat
+    MeterpreterPrompt
+    SessionTlvLogging
+  ]
+
+  #
+  # Initializes the data store's internal state.
+  #
+  def initialize
+    @options     = Hash.new
+    @aliases     = Hash.new
+
+    # default values which will be referenced when not defined by the user
+    @defaults = Hash.new
+
+    # values explicitly defined, which take precedence over default values
+    @user_defined = Hash.new
+  end
+
+  # @return [Hash{String => Msf::OptBase}] The options associated with this datastore. Used for validating values/defaults/etc
+  attr_accessor :options
+
+  #
+  # Returns a hash of user-defined datastore values. The returned hash does
+  # not include default option values.
+  #
+  # @return [Hash<String, Object>] values explicitly defined on the data store which will override any default datastore values
+  attr_accessor :user_defined
+
+  #
+  # Was this entry actually set or just using its default
+  #
+  # @return [TrueClass, FalseClass]
+  def default?(key)
+    search_for(key).default?
+  end
+
+  #
+  # Clears the imported flag for the supplied key since it's being set
+  # directly.
+  #
+  def []=(k, v)
+    k = find_key_case(k)
+
+    opt = @options[k]
+    unless opt.nil?
+      if opt.validate_on_assignment?
+        unless opt.valid?(v, check_empty: false)
+          raise Msf::OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'"])
+        end
+        v = opt.normalize(v)
+      end
+    end
+
+    @user_defined[k] = v
+  end
+
+  #
+  # Case-insensitive wrapper around hash lookup
+  #
+  def [](k)
+    search_result = search_for(k)
+
+    search_result.value
+  end
+
+  #
+  # Case-insensitive wrapper around store; Skips option validation entirely
+  #
+  def store(k,v)
+    @user_defined[find_key_case(k)] = v
+  end
+
+  #
+  # Updates a value in the datastore with the specified name, k, to the
+  # specified value, v. Skips option validation entirely.
+  #
+  def update_value(k, v)
+    store(k, v)
+  end
+
+  #
+  # unset the current key from the datastore
+  # @param [String] key The key to search for
+  def unset(key)
+    k = find_key_case(key)
+    search_result = search_for(k)
+    @user_defined.delete(k)
+
+    search_result.value
+  end
+
+  # @deprecated use #{unset} instead, or set the value explicitly to nil
+  # @param [String] key The key to search for
+  def delete(key)
+    unset(key)
+  end
+
+  #
+  # Removes an option and any associated value
+  #
+  # @param [String] name the option name
+  # @return [nil]
+  def remove_option(name)
+    k = find_key_case(name)
+    @user_defined.delete(k)
+    @aliases.delete_if { |_, v| v.casecmp?(k) }
+    @options.delete_if { |option_name, _v| option_name.casecmp?(k) || option_name.casecmp?(name) }
+
+    nil
+  end
+
+  #
+  # This method is a helper method that imports the default value for
+  # all of the supplied options
+  #
+  def import_options(options, imported_by = nil, overwrite = true)
+    options.each_option do |name, option|
+      if self.options[name].nil? || overwrite
+        key = name
+        option.aliases.each do |a|
+          @aliases[a.downcase] = key.downcase
+        end
+        @options[key] = option
+      end
+    end
+  end
+
+  #
+  # Imports option values from a whitespace separated string in
+  # VAR=VAL format.
+  #
+  def import_options_from_s(option_str, delim = nil)
+    hash = {}
+
+    # Figure out the delimeter, default to space.
+    if (delim.nil?)
+      delim = /\s/
+
+      if (option_str.split('=').length <= 2 or option_str.index(',') != nil)
+        delim = ','
+      end
+    end
+
+    # Split on the delimeter
+    option_str.split(delim).each { |opt|
+      var, val = opt.split('=')
+
+      next if (var =~ /^\s+$/)
+
+
+      # Invalid parse?  Raise an exception and let those bastards know.
+      if (var == nil or val == nil)
+        var = "unknown" if (!var)
+
+        raise Rex::ArgumentParseError, "Invalid option specified: #{var}",
+          caller
+      end
+
+      # Remove trailing whitespaces from the value
+      val.gsub!(/\s+$/, '')
+
+      # Store the value
+      hash[var] = val
+    }
+
+    merge!(hash)
+  end
+
+  #
+  # Imports values from a hash and stores them in the datastore.
+  #
+  # @deprecated use {#merge!} instead
+  # @return [nil]
+  def import_options_from_hash(option_hash, imported = true, imported_by = nil)
+    merge!(option_hash)
+  end
+
+  # Update defaults from a hash. These merged values are not validated by default.
+  #
+  # @param [Hash<String, Object>] hash The default values that should be used by the datastore
+  # @param [Object] imported_by Who imported the defaults, not currently used
+  # @return [nil]
+  def import_defaults_from_hash(hash, imported_by:)
+    @defaults.merge!(hash)
+  end
+
+  # TODO: Doesn't normalize data in the same vein as:
+  # https://github.com/rapid7/metasploit-framework/pull/6644
+  # @deprecated Use {#import_options}
+  def import_option(key, val, imported = true, imported_by = nil, option = nil)
+    store(key, val)
+
+    if option
+      option.aliases.each do |a|
+        @aliases[a.downcase] = key.downcase
+      end
+    end
+    @options[key] = option
+  end
+
+  # @return [Array<String>] The array of user defined datastore values, and registered option names
+  def keys
+    (@user_defined.keys + @options.keys).uniq(&:downcase)
+  end
+
+  # @return [Integer] The length of the registered keys
+  def length
+    keys.length
+  end
+
+  alias count length
+  alias size length
+
+  # @param [String] key
+  # @return [TrueClass, FalseClass] True if the key is present in the user defined values, or within registered options. False otherwise.
+  def key?(key)
+    matching_key = find_key_case(key)
+    keys.include?(matching_key)
+  end
+
+  alias has_key? key?
+  alias include? key?
+  alias member? key?
+
+  #
+  # Serializes the options in the datastore to a string.
+  #
+  def to_s(delim = ' ')
+    str = ''
+
+    keys.sort.each { |key|
+      str << "#{key}=#{self[key]}" + ((str.length) ? delim : '')
+    }
+
+    str
+  end
+
+  # Override Hash's to_h method so we can include the original case of each key
+  # (failing to do this breaks a number of places in framework and pro that use
+  # serialized datastores)
+  def to_h
+    datastore_hash = {}
+    self.keys.each do |k|
+      datastore_hash[k.to_s] = self[k].to_s
+    end
+    datastore_hash
+  end
+
+  # Hack on a hack for the external modules
+  def to_external_message_h
+    datastore_hash = {}
+
+    array_nester = ->(arr) do
+      if arr.first.is_a? Array
+        arr.map &array_nester
+      else
+        arr.map { |item| item.to_s.dup.force_encoding('UTF-8') }
+      end
+    end
+
+    self.keys.each do |k|
+      # TODO arbitrary depth
+      if self[k].is_a? Array
+        datastore_hash[k.to_s.dup.force_encoding('UTF-8')] = array_nester.call(self[k])
+      else
+        datastore_hash[k.to_s.dup.force_encoding('UTF-8')] = self[k].to_s.dup.force_encoding('UTF-8')
+      end
+    end
+    datastore_hash
+  end
+
+  #
+  # Persists the contents of the data store to a file
+  #
+  def to_file(path, name = 'global')
+    ini = Rex::Parser::Ini.new(path)
+
+    ini.add_group(name)
+
+    # Save all user-defined options to the file.
+    @user_defined.each_pair { |k, v|
+      ini[name][k] = v
+    }
+
+    ini.to_file(path)
+  end
+
+  #
+  # Imports datastore values from the specified file path using the supplied
+  # name
+  #
+  def from_file(path, name = 'global')
+    begin
+      ini = Rex::Parser::Ini.from_file(path)
+    rescue
+      return
+    end
+
+    if ini.group?(name)
+      merge!(ini[name])
+    end
+  end
+
+  #
+  # Return a copy of this datastore. Only string values will be duplicated, other values
+  # will share the same reference
+  # @return [Msf::DataStore] a new datastore instance
+  def copy
+    new_instance = self.class.new
+    new_instance.copy_state(self)
+    new_instance
+  end
+
+  #
+  # Merge the other object into the current datastore's aliases and imported hashes
+  #
+  # @param [Msf::Datastore, Hash] other
+  def merge!(other)
+    if other.is_a?(DataStoreWithFallbacks)
+      self.aliases.merge!(other.aliases)
+      self.options.merge!(other.options)
+      self.defaults.merge!(other.defaults)
+      other.user_defined.each do |k, v|
+        @user_defined[find_key_case(k)] = v
+      end
+    else
+      other.each do |k, v|
+        self.store(k, v)
+      end
+    end
+
+    self
+  end
+
+  alias update merge!
+
+  #
+  # Reverse Merge the other object into the current datastore's aliases and imported hashes
+  # Equivalent to ActiveSupport's reverse_merge! functionality.
+  #
+  # @param [Msf::Datastore] other
+  def reverse_merge!(other)
+    raise ArgumentError, "invalid error type #{other.class}, expected ::Msf::DataStore" unless other.is_a?(Msf::DataStoreWithFallbacks)
+
+    copy_state(other.merge(self))
+  end
+
+  #
+  # Override merge to ensure we merge the aliases and imported hashes
+  #
+  # @param [Msf::Datastore,Hash] other
+  def merge(other)
+    ds = self.copy
+    ds.merge!(other)
+  end
+
+  #
+  # Completely clear all values in the data store
+  #
+  def clear
+    self.options.clear
+    self.aliases.clear
+    self.defaults.clear
+    self.user_defined.clear
+
+    self
+  end
+
+  #
+  # Overrides the builtin 'each' operator to avoid the following exception on Ruby 1.9.2+
+  #    "can't add a new key into hash during iteration"
+  #
+  def each(&block)
+    list = []
+    self.keys.sort.each do |sidx|
+      list << [sidx, self[sidx]]
+    end
+    list.each(&block)
+  end
+
+  alias each_pair each
+
+  def each_key(&block)
+    self.keys.each(&block)
+  end
+
+  #
+  # Case-insensitive key lookup
+  #
+  # @return [String]
+  def find_key_case(k)
+    # Scan each alias looking for a key
+    search_k = k.downcase
+    if self.aliases.has_key?(search_k)
+      search_k = self.aliases[search_k]
+    end
+
+    # Check to see if we have an exact key match - otherwise we'll have to search manually to check case sensitivity
+    if @user_defined.key?(search_k) || options.key?(search_k)
+      return search_k
+    end
+
+    # Scan each key looking for a match
+    each_key do |rk|
+      if rk.casecmp(search_k) == 0
+        return rk
+      end
+    end
+
+    # Fall through to the non-existent value
+    k
+  end
+
+  # Search for a value within the current datastore, taking into consideration any registered aliases, fallbacks, etc.
+  #
+  # @param [String] key The key to search for
+  # @return [DataStoreSearchResult]
+  def search_for(key)
+    k = find_key_case(key)
+    return search_result(:user_defined, @user_defined[k]) if @user_defined.key?(k)
+
+    option = @options.fetch(k) { @options.find { |option_name, _option| option_name.casecmp?(k) }&.last }
+    if option
+      # If the key isn't present - check any additional fallbacks that have been registered with the option.
+      # i.e. handling the scenario of SMBUser not being explicitly set, but the option has registered a more
+      # generic 'Username' fallback
+      option.fallbacks.each do |fallback|
+      fallback_search = search_for(fallback)
+        if fallback_search.found?
+          return search_result(:option_fallback, fallback_search.value, fallback_key: fallback)
+        end
+      end
+    end
+
+    # Checking for imported default values, ignoring case again
+    imported_default_match = @defaults.find { |default_key, _default_value| default_key.casecmp?(k) }
+    return search_result(:imported_default, imported_default_match.last) if imported_default_match
+    return search_result(:option_default, option.default) if option
+
+    search_result(:not_found, nil)
+  end
+
+  protected
+
+  # These defaults will be used if the user has not explicitly defined a specific datastore value.
+  # These will be checked as a priority to any options that also provide defaults.
+  #
+  # @return [Hash{String => Msf::OptBase}] The hash of default values
+  attr_accessor :defaults
+
+  # @return [Hash{String => String}] The key is the old option name, the value is the new option name
+  attr_accessor :aliases
+
+  #
+  # Copy the state from the other Msf::DataStore. The state will be coped in a shallow fashion, other than
+  # imported and user_defined strings.
+  #
+  # @param [Msf::DataStore] other The other datastore to copy state from
+  # @return [Msf::DataStore] the current datastore instance
+  def copy_state(other)
+    self.options = other.options.dup
+    self.aliases = other.aliases.dup
+    self.defaults = other.defaults.transform_values { |value| value.kind_of?(String) ? value.dup : value }
+    self.user_defined = other.user_defined.transform_values { |value| value.kind_of?(String) ? value.dup : value }
+
+    self
+  end
+
+  # Raised when the specified key is not found
+  # @param [string] key
+  def key_error_for(key)
+    ::KeyError.new "key not found: #{key.inspect}"
+  end
+
+  #
+  # Simple dataclass for storing the result of a datastore search
+  #
+  class DataStoreSearchResult
+    # @return [String, nil] the key associated with the fallback value
+    attr_reader :fallback_key
+
+    # @return [object, nil] The value if found
+    attr_reader :value
+
+    def initialize(result, value, namespace: nil, fallback_key: nil)
+      @namespace = namespace
+      @result = result
+      @value = value
+      @fallback_key = fallback_key
+    end
+
+    def default?
+      result == :imported_default || result == :option_default || !found?
+    end
+
+    def found?
+      result != :not_found
+    end
+
+    def fallback?
+      result == :option_fallback
+    end
+
+    def global?
+      namespace == :global_data_store && found?
+    end
+
+  protected
+
+    # @return [Symbol] namespace Where the search result was found, i.e. a module datastore or global datastore
+    attr_reader :namespace
+
+    # @return [Symbol] result is one of `user_defined`, `not_found`, `option_fallback`, `option_default`, `imported_default`
+    attr_reader :result
+  end
+
+  def search_result(result, value, fallback_key: nil)
+    DataStoreSearchResult.new(result, value, namespace: :global_data_store, fallback_key: fallback_key)
+  end
+end
+
+end

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -69,7 +69,9 @@ module Exploit::Powershell
   # @return [String] Encoded script
   def encode_script(script_in, eof = nil)
     opts = {}
-    datastore.select { |k, v| k =~ /^Powershell::(strip|sub)/ && v }.keys.map do |k|
+    datastore.keys.select { |k| k =~ /^Powershell::(strip|sub)/i }.each do |k|
+      next unless datastore[k]
+
       mod_method = k.split('::').last.intern
       opts[mod_method.to_sym] = true
     end
@@ -101,7 +103,9 @@ module Exploit::Powershell
   # @return [String] Compressed script with decompression stub
   def compress_script(script_in, eof = nil)
     opts = {}
-    datastore.select { |k, v| k =~ /^Powershell::(strip|sub)/ && v }.keys.map do |k|
+    datastore.keys.select { |k| k =~ /^Powershell::(strip|sub)/i }.each do |k|
+      next unless datastore[k]
+
       mod_method = k.split('::').last.intern
       opts[mod_method.to_sym] = true
     end

--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -23,8 +23,8 @@ module Exploit::Remote::Ftp
       [
         Opt::RHOST,
         Opt::RPORT(21),
-        OptString.new('FTPUSER', [ false, 'The username to authenticate as', 'anonymous']),
-        OptString.new('FTPPASS', [ false, 'The password for the specified username', 'mozilla@example.com'])
+        OptString.new('FTPUSER', [ false, 'The username to authenticate as', 'anonymous'], fallbacks: ['USERNAME']),
+        OptString.new('FTPPASS', [ false, 'The password for the specified username', 'mozilla@example.com'], fallbacks: ['PASSWORD']),
       ], Msf::Exploit::Remote::Ftp)
 
     register_advanced_options(

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -15,8 +15,8 @@ module Msf
         Opt::RHOST,
         Opt::RPORT(389),
         OptBool.new('SSL', [false, 'Enable SSL on the LDAP connection', false]),
-        OptString.new('BIND_DN', [false, 'The username to authenticate to LDAP server']),
-        OptString.new('BIND_PW', [false, 'Password for the BIND_DN'])
+        OptString.new('BIND_DN', [false, 'The username to authenticate to LDAP server'], fallbacks: ['USERNAME']),
+        OptString.new('BIND_PW', [false, 'Password for the BIND_DN'], fallbacks: ['PASSWORD'])
       ])
 
       register_advanced_options([

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -45,9 +45,9 @@ module Msf
         register_advanced_options(
         [
           OptBool.new('SMBDirect', [ false, 'The target port is a raw SMB service (not NetBIOS)', true ]),
-          OptString.new('SMBUser', [ false, 'The username to authenticate as', '']),
-          OptString.new('SMBPass', [ false, 'The password for the specified username', '']),
-          OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.']),
+          OptString.new('SMBUser', [ false, 'The username to authenticate as', ''], fallbacks: ['USERNAME']),
+          OptString.new('SMBPass', [ false, 'The password for the specified username', ''], fallbacks: ['PASSWORD']),
+          OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.'], fallbacks: ['DOMAIN']),
           OptString.new('SMBName', [ true, 'The NetBIOS hostname (required for port 139 connections)', '*SMBSERVER']),
           OptBool.new('SMB::VerifySignature', [ true, "Enforces client-side verification of server response signatures", false]),
           OptInt.new('SMB::ChunkSize', [ true, 'The chunk size for SMB segments, bigger values will increase speed but break NT 4.0 and SMB signing', 500]),

--- a/lib/msf/core/exploit/remote/smb/client/authenticated.rb
+++ b/lib/msf/core/exploit/remote/smb/client/authenticated.rb
@@ -12,9 +12,9 @@ module Exploit::Remote::SMB::Client::Authenticated
     super
     register_options(
       [
-        OptString.new('SMBUser', [ false, 'The username to authenticate as', '']),
-        OptString.new('SMBPass', [ false, 'The password for the specified username', '']),
-        OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.']),
+        OptString.new('SMBUser', [ false, 'The username to authenticate as', ''], fallbacks: ['USERNAME']),
+        OptString.new('SMBPass', [ false, 'The password for the specified username', ''], fallbacks: ['PASSWORD']),
+        OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.'], fallbacks: ['DOMAIN']),
       ], Msf::Exploit::Remote::SMB::Client::Authenticated)
   end
 end

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -87,7 +87,7 @@ class ExploitDriver
       raise IncompatiblePayloadError.new(payload.refname),
         "#{payload.refname} is not a compatible payload.", caller
     end
-    
+
     unless exploit.respond_to?(:allow_no_cleanup) && exploit.allow_no_cleanup
       # Being able to cleanup requires a session to be created from a handler, and for that
       # session to be able to be able to clean up files

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 # frozen_string_literal: true
 
+require 'rex/text'
 
 module Msf
   ###
@@ -14,6 +15,7 @@ module Msf
 
     CONFIG_KEY = 'framework/features'
     WRAPPED_TABLES = 'wrapped_tables'
+    DATASTORE_FALLBACKS = 'datastore_fallbacks'
     FULLY_INTERACTIVE_SHELLS = 'fully_interactive_shells'
     SERVICEMANAGER_COMMAND = 'servicemanager_command'
     DEFAULTS = [
@@ -30,6 +32,12 @@ module Msf
       {
         name: SERVICEMANAGER_COMMAND,
         description: 'When enabled you will have access to the _servicemanager command',
+        default_value: false
+      }.freeze,
+      {
+        name: DATASTORE_FALLBACKS,
+        description: 'When enabled you can consistently set username across modules, instead of setting SMBUser/FTPUser/BIND_DN/etc',
+        requires_restart: true,
         default_value: false
       }.freeze
     ].freeze
@@ -58,11 +66,21 @@ module Msf
       end
     end
 
+    # @param [String] name The feature name
+    # @return [TrueClass,FalseClass] True if the flag is be enabled, false otherwise
     def enabled?(name)
       return false unless @flag_lookup[name]
 
       feature = @flag_lookup[name]
       feature.key?(:user_preference) ? feature[:user_preference] : feature[:default_value]
+    end
+
+    # @param [String] name The feature name
+    # @return [TrueClass,FalseClass] True if the flag requires a console restart to work effectively
+    def requires_restart?(name)
+      return false unless @flag_lookup[name]
+
+      @flag_lookup[name][:requires_restart] == true
     end
 
     def exists?(name)

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -62,6 +62,9 @@ class Framework
     # Allow specific module types to be loaded
     types = options[:module_types] || Msf::MODULE_TYPES
 
+    self.features = FeatureManager.instance
+    self.features.load_config
+
     self.events    = EventDispatcher.new(self)
     self.modules   = ModuleManager.new(self,types)
     self.datastore = DataStore.new
@@ -69,7 +72,6 @@ class Framework
     self.analyze   = Analyze.new(self)
     self.plugins   = PluginManager.new(self)
     self.browser_profiles = Hash.new
-    self.features = FeatureManager.instance
 
     # Configure the thread factory
     Rex::ThreadFactory.provider = Metasploit::Framework::ThreadFactoryProvider.new(framework: self)

--- a/lib/msf/core/handler/bind_named_pipe.rb
+++ b/lib/msf/core/handler/bind_named_pipe.rb
@@ -207,9 +207,9 @@ module Msf
             OptString.new('PIPENAME', [true, 'Name of the pipe to connect to', 'msf-pipe']),
             OptString.new('RHOST', [false, 'Host of the pipe to connect to', '']),
             OptPort.new('LPORT', [true, 'SMB port', 445]),
-            OptString.new('SMBUser', [false, 'The username to authenticate as', '']),
-            OptString.new('SMBPass', [false, 'The password for the specified username', '']),
-            OptString.new('SMBDomain', [false, 'The Windows domain to use for authentication', '.']),
+            OptString.new('SMBUser', [false, 'The username to authenticate as', ''], fallbacks: ['USERNAME']),
+            OptString.new('SMBPass', [false, 'The password for the specified username', ''], fallbacks: ['PASSWORD']),
+            OptString.new('SMBDomain', [false, 'The Windows domain to use for authentication', '.'], fallbacks: ['DOMAIN']),
           ], Msf::Handler::BindNamedPipe)
         register_advanced_options(
           [

--- a/lib/msf/core/module/data_store.rb
+++ b/lib/msf/core/module/data_store.rb
@@ -6,7 +6,7 @@ module Msf::Module::DataStore
   # @attribute [r] datastore
   #   The module-specific datastore instance.
   #
-  #   @return [Hash{String => String}]
+  #   @return [Msf::DataStore]
   attr_reader   :datastore
 
   #
@@ -21,7 +21,11 @@ module Msf::Module::DataStore
 
     # If there are default options, import their values into the datastore
     if (module_info['DefaultOptions'])
-      self.datastore.import_options_from_hash(module_info['DefaultOptions'], true, 'self')
+      if datastore.is_a?(Msf::DataStoreWithFallbacks)
+        self.datastore.import_defaults_from_hash(module_info['DefaultOptions'], imported_by: 'import_defaults')
+      else
+        self.datastore.import_options_from_hash(module_info['DefaultOptions'], true, 'self')
+      end
     end
 
     # Preference the defaults for the currently set target
@@ -34,7 +38,11 @@ module Msf::Module::DataStore
   def import_target_defaults
     return unless defined?(targets) && targets && target && target.default_options
 
-    datastore.import_options_from_hash(target.default_options, true, 'self')
+    if self.datastore.is_a?(Msf::ModuleDataStoreWithFallbacks)
+      datastore.import_defaults_from_hash(target.default_options, imported_by: 'import_target_defaults')
+    else
+      datastore.import_options_from_hash(target.default_options, true, 'self')
+    end
   end
 
   #

--- a/lib/msf/core/module/options.rb
+++ b/lib/msf/core/module/options.rb
@@ -30,7 +30,11 @@ module Msf::Module::Options
   def deregister_options(*names)
     names.each { |name|
       real_name = self.datastore.find_key_case(name)
-      self.datastore.delete(name)
+      if self.datastore.is_a?(Msf::DataStoreWithFallbacks)
+        self.datastore.remove_option(name)
+      else
+        self.datastore.delete(name)
+      end
       self.options.remove_option(name)
       if real_name != name
         self.options.remove_option(real_name)

--- a/lib/msf/core/module_data_store.rb
+++ b/lib/msf/core/module_data_store.rb
@@ -10,6 +10,20 @@ module Msf
   ###
   class ModuleDataStore < DataStore
 
+    # Temporary forking logic for conditionally using the {Msf::ModuleDatastoreWithFallbacks} implementation.
+    #
+    # This method replaces the default `ModuleDataStore.new` with the ability to instantiate the `ModuleDataStoreWithFallbacks`
+    # class instead, if the feature is enabled
+    def self.new(m)
+      if Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::DATASTORE_FALLBACKS)
+        return Msf::ModuleDataStoreWithFallbacks.new(m)
+      end
+
+      instance = allocate
+      instance.send(:initialize, m)
+      instance
+    end
+
     def initialize(m)
       super()
 

--- a/lib/msf/core/module_data_store_with_fallbacks.rb
+++ b/lib/msf/core/module_data_store_with_fallbacks.rb
@@ -1,0 +1,80 @@
+# -*- coding: binary -*-
+module Msf
+
+  ###
+  #
+  # DataStore wrapper for modules that will attempt to back values against the
+  # framework's datastore if they aren't found in the module's datastore.  This
+  # is done to simulate global data store values.
+  #
+  ###
+  class ModuleDataStoreWithFallbacks < DataStoreWithFallbacks
+
+    # @param [Msf::Module] m
+    def initialize(m)
+      super()
+
+      @_module = m
+    end
+
+    #
+    # Return a copy of this datastore. Only string values will be duplicated, other values
+    # will share the same reference
+    # @return [Msf::DataStore] a new datastore instance
+    def copy
+      new_instance = self.class.new(@_module)
+      new_instance.copy_state(self)
+      new_instance
+    end
+
+    # Search for a value within the current datastore, taking into consideration any registered aliases, fallbacks, etc.
+    # If a value is not present in the current datastore, the global parent store will be referenced instead
+    #
+    # @param [String] key The key to search for
+    # @return [DataStoreSearchResult]
+    def search_for(key)
+      k = find_key_case(key)
+      return search_result(:user_defined, @user_defined[k]) if @user_defined.key?(k)
+
+      # Preference globally set values over a module's option default
+      framework_datastore_search = search_framework_datastore(key)
+      return framework_datastore_search if framework_datastore_search.found? && !framework_datastore_search.default?
+
+      option = @options.fetch(k) { @options.find { |option_name, _option| option_name.casecmp?(k) }&.last }
+      if option
+        # If the key isn't present - check any additional fallbacks that have been registered with the option.
+        # i.e. handling the scenario of SMBUser not being explicitly set, but the option has registered a more
+        # generic 'Username' fallback
+        option.fallbacks.each do |fallback|
+          fallback_search = search_for(fallback)
+          if fallback_search.found?
+            return search_result(:option_fallback, fallback_search.value, fallback_key: fallback)
+          end
+        end
+      end
+
+      # Checking for imported default values, ignoring case again TODO: add Alias test for this
+      imported_default_match = @defaults.find { |default_key, _default_value| default_key.casecmp?(k) }
+      return search_result(:imported_default, imported_default_match.last) if imported_default_match
+      return search_result(:option_default, option.default) if option
+
+      search_framework_datastore(k)
+    end
+
+    protected
+
+    # Search the framework datastore
+    #
+    # @param [String] key The key to search for
+    # @return [DataStoreSearchResult]
+    def search_framework_datastore(key)
+      return search_result(:not_found, nil) if @_module&.framework.nil?
+
+      @_module.framework.datastore.search_for(key)
+    end
+
+    def search_result(result, value, fallback_key: nil)
+      DataStoreSearchResult.new(result, value, namespace: :module_data_store, fallback_key: fallback_key)
+    end
+  end
+end

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -25,13 +25,15 @@ module Msf
     # also be a string as standin for the required description field.
     #
     def initialize(in_name, attrs = [],
-                   required: false, desc: nil, default: nil, conditions: [], enums: [], regex: nil, aliases: [], max_length: nil)
+                   required: false, desc: nil, default: nil, conditions: [], enums: [], regex: nil, aliases: [], max_length: nil,
+                   fallbacks: [])
       self.name     = in_name
       self.advanced = false
       self.evasion  = false
       self.aliases  = aliases
       self.max_length = max_length
       self.conditions = conditions
+      self.fallbacks = fallbacks
 
       if attrs.is_a?(String) || attrs.length == 0
         self.required = required
@@ -201,10 +203,28 @@ module Msf
     # A optional regex to validate the option value
     #
     attr_accessor :regex
+
     #
-    # Aliases for this option for backward compatibility
+    # Array of aliases for this option for backward compatibility.
     #
+    # This is useful in the scenario of an existing option being renamed
+    # to a new value. Either the current option name or list of aliases can
+    # be used in modules for retrieving datastore values, or by a user when
+    # setting datastore values manually.
+    #
+    # @return [Array<String>] the array of aliases
     attr_accessor :aliases
+
+    #
+    # Array of fallbacks for this option.
+    #
+    # This is useful in the scenario of wanting specialised option names such as
+    # {SMBUser}, but to also support gracefully checking a list of more generic fallbacks
+    # option names such as {Username}.
+    #
+    # @return [Array<String>] the array of fallbacks
+    attr_accessor :fallbacks
+
     #
     # The max length of the input value
     #

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -110,6 +110,7 @@ module Msf
     #
     # Removes an option.
     #
+    # @param [String] name the option name
     def remove_option(name)
       delete(name)
       sorted.each_with_index { |e, idx|

--- a/lib/msf/core/post/windows/wmic.rb
+++ b/lib/msf/core/post/windows/wmic.rb
@@ -28,9 +28,9 @@ module WMIC
     )
 
     register_options([
-                         OptString.new('SMBUser', [ false, 'The username to authenticate as' ]),
-                         OptString.new('SMBPass', [ false, 'The password for the specified username' ]),
-                         OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication' ]),
+                         OptString.new('SMBUser', [ false, 'The username to authenticate as' ], fallbacks: ['USERNAME']),
+                         OptString.new('SMBPass', [ false, 'The password for the specified username' ], fallbacks: ['PASSWORD']),
+                         OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication' ], fallbacks: ['DOMAIN']),
                          OptAddress.new("RHOST", [ true, "Target address range", "localhost" ]),
                          OptInt.new("TIMEOUT", [ true, "Timeout for WMI command in seconds", 10 ])
                      ], self.class)

--- a/lib/msf/core/rhosts_walker.rb
+++ b/lib/msf/core/rhosts_walker.rb
@@ -59,7 +59,7 @@ module Msf
       return unless block_given?
 
       parse(@value, @datastore).each do |result|
-        block.call(result) if result.is_a?(Msf::DataStore)
+        block.call(result) if result.is_a?(Msf::DataStore) || result.is_a?(Msf::DataStoreWithFallbacks)
       end
 
       nil
@@ -93,7 +93,7 @@ module Msf
     # @return [Boolean] True if all items are valid, and there are at least some items present to iterate over. False otherwise.
     def valid?
       parsed_values = parse(@value, @datastore)
-      parsed_values.all? { |result| result.is_a?(Msf::DataStore) } && parsed_values.count > 0
+      parsed_values.all? { |result| result.is_a?(Msf::DataStore) || result.is_a?(Msf::DataStoreWithFallbacks) } && parsed_values.count > 0
     rescue StandardError => e
       elog('rhosts walker invalid', error: e)
       false

--- a/lib/msf/core/rpc/v10/rpc_core.rb
+++ b/lib/msf/core/rpc/v10/rpc_core.rb
@@ -64,7 +64,12 @@ class RPC_Core < RPC_Base
   # @example Here's how you would use this from the client:
   #  rpc.call('core.unsetg', 'MyGlobal')
   def rpc_unsetg(var)
-    framework.datastore.delete(var)
+    if framework.datastore.is_a?(Msf::DataStoreWithFallbacks)
+      framework.datastore.unset(var)
+    else
+      framework.datastore.delete(var)
+    end
+
     { "result" => "success" }
   end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -96,6 +96,26 @@ class Core
     ["-l", "--load"]           => [ false, "Load the saved options for the active module."                                  ],
     ["-d", "--delete-all"]     => [ false, "Delete saved options for all modules from the config file."                     ])
 
+  # set command options
+  @@set_opts = Rex::Parser::Arguments.new(
+    ["-h", "--help"] => [ false, "Help banner."],
+    ["-c", "--clear"] => [ false, "Clear the values, explicitly setting to nil (default)"]
+  )
+
+  @@set_opts = Rex::Parser::Arguments.new(
+    ["-g", "--global"] => [ false, "Operate on global datastore variables"]
+  )
+
+  # unset command options
+  @@unsetg_opts = Rex::Parser::Arguments.new(
+    ["-h", "--help"] => [ false, "Help banner."],
+  )
+
+  # unset command options
+  @@unset_opts = @@unsetg_opts.merge(
+    ["-g", "--global"] => [ false, "Operate on global datastore variables"]
+  )
+
   # Returns the list of commands supported by this command dispatcher
   def commands
     {
@@ -644,8 +664,13 @@ class Core
 
       framework.features.set(feature_name, value == 'true')
       print_line("#{feature_name} => #{value}")
-      # Reload the current module, as feature flags may impact the available module options etc
-      driver.run_single("reload") if driver.active_module
+      # Some flags may require a full console restart
+      if framework.features.requires_restart?(feature_name)
+        print_warning("Run the #{Msf::Ui::Tip.highlight("save")} command and restart the console for this feature to take effect.")
+      else
+        # Reload the current module, as feature flags may impact the available module options etc
+        driver.run_single("reload") if driver.active_module
+      end
     when 'print'
       if framework.features.all.empty?
         print_line 'There are no features to enable at this time. Either the features have been removed, or integrated by default.'
@@ -1795,7 +1820,7 @@ class Core
   end
 
   def cmd_set_help
-    print_line "Usage: set [option] [value]"
+    print_line "Usage: set [options] [name] [value]"
     print_line
     print_line "Set the given option to value.  If value is omitted, print the current value."
     print_line "If both are omitted, print options that are currently set."
@@ -1804,6 +1829,7 @@ class Core
     print_line "datastore.  Use -g to operate on the global datastore."
     print_line
     print_line "If setting a PAYLOAD, this command can take an index from `show payloads'."
+    print @@set_opts.usage if framework.features.enabled?(Msf::FeatureManager::DATASTORE_FALLBACKS)
     print_line
   end
 
@@ -1813,18 +1839,24 @@ class Core
   def cmd_set(*args)
     # Figure out if these are global variables
     global = false
-
-    if (args[0] == '-g')
-      args.shift
-      global = true
-    end
-
-    # Decide if this is an append operation
     append = false
+    clear = false
 
-    if (args[0] == '-a')
-      args.shift
-      append = true
+    # Manually parse options to allow users to set the strings
+    # such as `-g` in a datastore value
+    loop do
+      if args[0] == '-g' || args[0] == '--global'
+        args.shift
+        global = true
+      elsif args[0] == '-a'
+        args.shift
+        append = true
+      elsif (args[0] == '-c' || args[0] == '--clear') && framework.features.enabled?(Msf::FeatureManager::DATASTORE_FALLBACKS)
+        args.shift
+        clear = true
+      else
+        break
+      end
     end
 
     valid_options = []
@@ -1861,7 +1893,7 @@ class Core
           (global) ? "Global" : "Module: #{active_module.refname}",
           datastore) + "\n")
       return true
-    elsif (args.length == 1)
+    elsif args.length == 1 && !clear
       if global || valid_options.any? { |vo| vo.casecmp?(args[0]) }
         print_line("#{args[0]} => #{datastore[args[0]]}")
         return true
@@ -1877,7 +1909,9 @@ class Core
 
     # Set the supplied name to the supplied value
     name, *values_array = args
-    if name.casecmp?('RHOST') || name.casecmp?('RHOSTS')
+    if clear
+      value = nil
+    elsif name.casecmp?('RHOST') || name.casecmp?('RHOSTS')
       # Wrap any values which contain spaces in quotes to ensure it's parsed correctly later
       value = values_array.map { |value| value.include?(' ') ? "\"#{value}\"" : value }.join(' ')
     else
@@ -1885,7 +1919,7 @@ class Core
     end
 
     # Set PAYLOAD
-    if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?)
+    if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?) && !clear
       value = trim_path(value, 'payload')
 
       index_from_list(payload_show_results, value) do |mod|
@@ -1974,6 +2008,7 @@ class Core
     print_line "Usage: setg [option] [value]"
     print_line
     print_line "Exactly like set -g, set a value in the global datastore."
+    print @@setg_opts.usage if framework.features.enabled?(Msf::FeatureManager::DATASTORE_FALLBACKS)
     print_line
   end
 
@@ -1985,7 +2020,10 @@ class Core
   #   line. `words` is always at least 1 when tab completion has reached this
   #   stage since the command itself has been completed.
   def cmd_unset_tabs(str, words)
-    tab_complete_datastore_names(active_module, str, words)
+    option_names = @@unset_opts.option_keys.select { |opt| opt.start_with?(str) }
+    datastore_names = tab_complete_module_datastore_names(active_module, str, words)
+
+    option_names + datastore_names
   end
 
   #
@@ -2128,18 +2166,30 @@ class Core
   end
 
   def cmd_unset_help
-    print_line "Usage: unset [-g] var1 var2 var3 ..."
-    print_line
-    print_line "The unset command is used to unset one or more variables."
-    print_line "To flush all entires, specify 'all' as the variable name."
-    print_line "With -g, operates on global datastore variables."
-    print_line
+    if framework.features.enabled?(Msf::FeatureManager::DATASTORE_FALLBACKS)
+      print_line "Usage: unset [-g] var1 var2 var3 ..."
+      print_line
+      print_line "The unset command is used to unset one or more variables."
+      print_line "To flush all entires, specify 'all' as the variable name."
+      print_line "With -g, operates on global datastore variables."
+      print_line
+    else
+      print_line "Usage: unset [options] var1 var2 var3 ..."
+      print_line
+      print_line "The unset command is used to unset one or more variables which have been set by the user."
+      print_line "To update all entries, specify 'all' as the variable name."
+      print @@unset_opts.usage
+      print_line
+    end
   end
 
   #
   # Unsets a value if it's been set.
   #
   def cmd_unset(*args)
+    if framework.features.enabled?(Msf::FeatureManager::DATASTORE_FALLBACKS)
+      return cmd_unset_with_fallbacks(*args)
+    end
 
     # Figure out if these are global variables
     global = false
@@ -2189,10 +2239,92 @@ class Core
     end
   end
 
+  #
+  # Unsets a value if it's been set, resetting the value back to a default value
+  #
+  def cmd_unset_with_fallbacks(*args)
+    if args.include?('-h') || args.include?('--help')
+      cmd_unset_help
+      return
+    end
+
+    # Figure out if these are global variables
+    global = false
+
+    @@unset_opts.parse(args) do |opt, idx, val|
+      case opt
+      when '-g'
+        global = true
+      end
+    end
+
+    variable_names = args.reject { |arg| arg.start_with?('-') }
+
+    # No variable names? No cookie.
+    if variable_names.empty?
+      cmd_unset_help
+      return false
+    end
+
+    # Determine which data store we're operating on
+    if active_module && !global
+      datastore = active_module.datastore
+    else
+      datastore = framework.datastore
+    end
+
+    is_all_variables = variable_names[0] == 'all'
+    if is_all_variables
+      variable_names = datastore.keys
+      variable_names += Msf::DataStore::GLOBAL_KEYS if global
+      variable_names += ['PAYLOAD'] if !global && active_module && (active_module.exploit? || active_module.evasion?)
+      variable_names = variable_names.uniq(&:downcase)
+    end
+
+    print_line("Unsetting datastore...") if is_all_variables
+
+    variable_names.each do |variable_name|
+      if driver.on_variable_unset(global, variable_name) == false
+        print_error("The variable #{variable_name} cannot be unset at this time.") # unless variable_name.casecmp?('PAYLOAD')
+        next
+      end
+
+      print_line("Unsetting #{variable_name}...") unless is_all_variables
+      datastore.unset(variable_name)
+    end
+
+    # Do a final pass over the datastore. If a user has unset a variable - but it continues to have a value either through
+    # option defaults, or being globally set it might be confusing to users. In this scenario, log out a helpful message.
+    #
+    # i.e. the scenario of a user unsetting 'RHOSTS', but the value continues to inherit from the global framework datastore.
+    unless is_all_variables
+      variable_names.each do |variable_name|
+        search_result = datastore.search_for(variable_name)
+        if search_result.fallback?
+          print_warning(
+            "Variable #{variable_name.inspect} unset - but will continue to use #{search_result.fallback_key.inspect} as a fallback preference. " \
+              "If this is not desired, either run #{Msf::Ui::Tip.highlight("set #{variable_name} new_value")} or #{Msf::Ui::Tip.highlight("unset #{search_result.fallback_key}")}"
+          )
+        elsif !global && search_result.global?
+          print_warning(
+            "Variable #{variable_name.inspect} unset - but will continue to use the globally set value as a preference. " \
+              "If this is not desired, either run #{Msf::Ui::Tip.highlight("set --clear #{variable_name}")} or #{Msf::Ui::Tip.highlight("unsetg #{variable_name}")}"
+          )
+        elsif !search_result.value.nil?
+          print_warning(
+            "Variable #{variable_name.inspect} unset - but will use a default value still. " \
+              "If this is not desired, set it to a new value or attempt to clear it with #{Msf::Ui::Tip.highlight("set --clear #{variable_name}")}"
+          )
+        end
+      end
+    end
+  end
+
   def cmd_unsetg_help
-    print_line "Usage: unsetg var1 [var2 ...]"
+    print_line "Usage: unsetg [options] var1 var2 var3 ..."
     print_line
     print_line "Exactly like unset -g, unset global variables, or all"
+    print @@unsetg_opts.usage if framework.features.enabled?(Msf::FeatureManager::DATASTORE_FALLBACKS)
     print_line
   end
 
@@ -2213,7 +2345,7 @@ class Core
   # at least 1 when tab completion has reached this stage since the command itself has been completed
 
   def cmd_unsetg_tabs(str, words)
-    self.framework.datastore.keys
+    tab_complete_datastore_names(framework.datastore, str, words)
   end
 
   alias cmd_unsetg_help cmd_unset_help

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -270,6 +270,7 @@ class Exploit
 
   # Select a reasonable default payload and minimally configure it
   # TODO: Move this somewhere better or make it more dynamic?
+  # @param [Msf::Module] mod
   def self.choose_payload(mod)
     compatible_payloads = mod.compatible_payloads(
       excluded_platforms: ['Multi'] # We don't want to select a multi payload
@@ -279,11 +280,20 @@ class Exploit
     lhost = Rex::Socket.source_address(mod.datastore['RHOST'] || '50.50.50.50')
 
     configure_payload = lambda do |payload|
-      mod.datastore['PAYLOAD'] = payload
+      if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
+        payload_defaults = { 'PAYLOAD' => payload }
 
-      # Set LHOST if this is a reverse payload
-      if payload.index('reverse')
-        mod.datastore['LHOST'] = lhost
+        # Set LHOST if this is a reverse payload
+        if payload.index('reverse')
+          payload_defaults['LHOST'] = lhost
+        end
+        mod.datastore.import_defaults_from_hash(payload_defaults, imported_by: 'choose_payload')
+      else
+        mod.datastore['PAYLOAD'] = payload
+        # Set LHOST if this is a reverse payload
+        if payload.index('reverse')
+          mod.datastore['LHOST'] = lhost
+        end
       end
 
       payload

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -570,9 +570,9 @@ protected
       return false
     elsif active_module && (active_module.exploit? || active_module.evasion?)
       return false unless active_module.is_payload_compatible?(val)
-    elsif active_module
+    elsif active_module && !framework.features.enabled?(Msf::FeatureManager::DATASTORE_FALLBACKS)
       active_module.datastore.clear_non_user_defined
-    elsif framework
+    elsif framework && !framework.features.enabled?(Msf::FeatureManager::DATASTORE_FALLBACKS)
       framework.datastore.clear_non_user_defined
     end
   end

--- a/lib/rex/parser/arguments.rb
+++ b/lib/rex/parser/arguments.rb
@@ -23,6 +23,7 @@ module Rex
       # Initializes the format list with an array of formats like:
       #
       # Arguments.new(
+      #    '-z'                => [ has_argument, "some text", "<argument_description>" ],
       #    '-b'                => [ false, "some text"                 ],
       #    ['-b']              => [ false, "some text"                 ],
       #    ['-x', '--execute'] => [ true, "mixing long and short args" ],

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/lanattacks/dhcp.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/lanattacks/dhcp.rb
@@ -189,7 +189,7 @@ class Console::CommandDispatcher::Lanattacks::Dhcp
 
     datastore = args.shift
 
-    if not datastore.is_a?(Hash)
+    unless datastore.is_a?(Hash) || datastore.is_a?(Msf::DataStoreWithFallbacks)
       print_dhcp_load_options_usage
       return true
     end

--- a/modules/auxiliary/admin/db2/db2rcmd.rb
+++ b/modules/auxiliary/admin/db2/db2rcmd.rb
@@ -28,8 +28,8 @@ class MetasploitModule < Msf::Auxiliary
       register_options(
         [
           OptString.new('CMD', [ true, 'The command to execute', 'ver']),
-          OptString.new('SMBUser', [ true, 'The username to authenticate as', 'db2admin']),
-          OptString.new('SMBPass', [ true, 'The password for the specified username', 'db2admin'])
+          OptString.new('SMBUser', [ true, 'The username to authenticate as', 'db2admin'], fallbacks: ['USERNAME']),
+          OptString.new('SMBPass', [ true, 'The password for the specified username', 'db2admin'], fallbacks: ['PASSWORD']),
         ])
 
       deregister_options('SMB::ProtocolVersion')

--- a/modules/auxiliary/admin/scada/modicon_password_recovery.rb
+++ b/modules/auxiliary/admin/scada/modicon_password_recovery.rb
@@ -33,8 +33,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(21),
-        OptString.new('FTPUSER', [true, "The backdoor account to use for login", 'ftpuser']),
-        OptString.new('FTPPASS', [true, "The backdoor password to use for login", 'password'])
+        OptString.new('FTPUSER', [true, "The backdoor account to use for login", 'ftpuser'], fallbacks: ['USERNAME']),
+        OptString.new('FTPPASS', [true, "The backdoor password to use for login", 'password'], fallbacks: ['PASSWORD'])
       ])
 
     register_advanced_options(

--- a/modules/auxiliary/dos/windows/ftp/guildftp_cwdlist.rb
+++ b/modules/auxiliary/dos/windows/ftp/guildftp_cwdlist.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Auxiliary
 
     # They're required
     register_options([
-      OptString.new('FTPUSER', [ true, 'Valid FTP username', 'anonymous' ]),
-      OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'anonymous' ])
+      OptString.new('FTPUSER', [ true, 'Valid FTP username', 'anonymous' ], fallbacks: ['USERNAME']),
+      OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'anonymous' ], fallbacks: ['PASSWORD'])
     ])
   end
 

--- a/modules/auxiliary/dos/windows/ftp/titan626_site.rb
+++ b/modules/auxiliary/dos/windows/ftp/titan626_site.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Auxiliary
 
     # They're required
     register_options([
-      OptString.new('FTPUSER', [ true, 'Valid FTP username', 'anonymous' ]),
-      OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'anonymous' ])
+      OptString.new('FTPUSER', [ true, 'Valid FTP username', 'anonymous' ], fallbacks: ['USERNAME']),
+      OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'anonymous' ], fallbacks: ['PASSWORD'])
     ])
   end
 

--- a/modules/auxiliary/dos/windows/ftp/vicftps50_list.rb
+++ b/modules/auxiliary/dos/windows/ftp/vicftps50_list.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Auxiliary
 
     # They're required
     register_options([
-      OptString.new('FTPUSER', [ true, 'Valid FTP username', 'anonymous' ]),
-      OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'anonymous' ])
+      OptString.new('FTPUSER', [ true, 'Valid FTP username', 'anonymous' ], fallbacks: ['USERNAME']),
+      OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'anonymous' ], fallbacks: ['PASSWORD'])
     ])
   end
 

--- a/modules/auxiliary/dos/windows/ftp/xmeasy560_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/xmeasy560_nlst.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Auxiliary
 
     # They're required
     register_options([
-      OptString.new('FTPUSER', [ true, 'Valid FTP username', 'anonymous' ]),
-      OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'anonymous' ])
+      OptString.new('FTPUSER', [ true, 'Valid FTP username', 'anonymous' ], fallbacks: ['USERNAME']),
+      OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'anonymous' ], fallbacks: ['PASSWORD'])
     ])
   end
 

--- a/modules/auxiliary/dos/windows/ftp/xmeasy570_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/xmeasy570_nlst.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Auxiliary
 
     # They're required
     register_options([
-      OptString.new('FTPUSER', [ true, 'Valid FTP username', 'anonymous' ]),
-      OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'anonymous' ])
+      OptString.new('FTPUSER', [ true, 'Valid FTP username', 'anonymous' ], fallbacks: ['USERNAME']),
+      OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'anonymous' ], fallbacks: ['PASSWORD'])
     ])
   end
 

--- a/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
@@ -38,8 +38,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the root folder)', 2 ]),
         OptString.new('PATH', [ true, 'Path to the file to disclose, relative to the root dir.', 'conf\\xml-users.xml']),
-        OptString.new('FTPUSER', [ true, 'Username to use for login', 'ftpuser']), #override default
-        OptString.new('FTPPASS', [ true, 'Password to use for login', 'ftpuser123']) #override default
+        OptString.new('FTPUSER', [ true, 'Username to use for login', 'ftpuser'], fallbacks: ['USERNAME']), #override default
+        OptString.new('FTPPASS', [ true, 'Password to use for login', 'ftpuser123'], fallbacks: ['PASSWORD']) #override default
       ])
 
   end

--- a/modules/auxiliary/server/ftp.rb
+++ b/modules/auxiliary/server/ftp.rb
@@ -29,8 +29,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('FTPROOT',    [ true,  "The FTP root directory to serve files from", '/tmp/ftproot' ]),
-        OptString.new('FTPUSER',    [ false, "Configure a specific username that should be allowed access"]),
-        OptString.new('FTPPASS',    [ false, "Configure a specific password that should be allowed access"]),
+        OptString.new('FTPUSER',    [ false, "Configure a specific username that should be allowed access"], fallbacks: ['USERNAME']),
+        OptString.new('FTPPASS',    [ false, "Configure a specific password that should be allowed access"], fallbacks: ['PASSWORD']),
       ])
   end
 

--- a/modules/exploits/windows/ftp/ability_server_stor.rb
+++ b/modules/exploits/windows/ftp/ability_server_stor.rb
@@ -68,8 +68,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(21),
-        OptString.new('FTPUSER', [ true, 'Valid FTP username', 'ftp' ]),
-        OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'ftp' ])
+        OptString.new('FTPUSER', [ true, 'Valid FTP username', 'ftp' ], fallbacks: ['USERNAME']),
+        OptString.new('FTPPASS', [ true, 'Valid FTP password for username', 'ftp' ], fallbacks: ['PASSWORD'])
       ])
     end
 

--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0))
 
     register_options([
-      OptString.new('FTPUSER', [ true, 'The username to authenticate with', 'anonymous' ]),
+      OptString.new('FTPUSER', [ true, 'The username to authenticate with', 'anonymous' ], fallbacks: ['USERNAME']),
 
     ])
 

--- a/modules/exploits/windows/ftp/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/ftp/httpdx_tolog_format.rb
@@ -114,8 +114,8 @@ For now, that will have to be done manually.
       [
         Opt::RPORT(21),
         # note the default user/pass
-        OptString.new('FTPUSER', [ true, 'The username to authenticate as', 'moderator']),
-        OptString.new('FTPPASS', [ true, 'The password to authenticate with', 'pass123'])
+        OptString.new('FTPUSER', [ true, 'The username to authenticate as', 'moderator'], fallbacks: ['USERNAME']),
+        OptString.new('FTPPASS', [ true, 'The password to authenticate with', 'pass123'], fallbacks: ['PASSWORD'])
       ])
   end
 

--- a/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
+++ b/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
@@ -57,8 +57,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       Opt::RPORT(2100),
-      OptString.new('FTPUSER', [ true, 'The username to authenticate as', 'DBSNMP']),
-      OptString.new('FTPPASS', [ true, 'The password to authenticate with', 'DBSNMP']),
+      OptString.new('FTPUSER', [ true, 'The username to authenticate as', 'DBSNMP'], fallbacks: ['USERNAME']),
+      OptString.new('FTPPASS', [ true, 'The password to authenticate with', 'DBSNMP'], fallbacks: ['PASSWORD']),
     ])
   end
 

--- a/modules/exploits/windows/local/powershell_remoting.rb
+++ b/modules/exploits/windows/local/powershell_remoting.rb
@@ -38,9 +38,9 @@ class MetasploitModule < Msf::Exploit::Local
       ))
 
     register_options([
-      OptString.new('SMBUser', [ false, 'The username to authenticate as' ]),
-      OptString.new('SMBPass', [ false, 'The password for the specified username' ]),
-      OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication' ]),
+      OptString.new('SMBUser', [ false, 'The username to authenticate as' ], fallbacks: ['USERNAME']),
+      OptString.new('SMBPass', [ false, 'The password for the specified username' ], fallbacks: ['PASSWORD']),
+      OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication' ], fallbacks: ['DOMAIN']),
       OptAddressRange.new("RHOSTS", [ false, "Target address range or CIDR identifier" ]),
       OptPath.new('HOSTFILE', [ false, 'Line separated file with hostnames to target' ]),
       # Move this out of advanced

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -161,8 +161,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RHOSTS,
         Opt::RPORT(445),
-        OptString.new('SMBUser', [false, '(Optional) The username to authenticate as', '']),
-        OptString.new('SMBPass', [false, '(Optional) The password for the specified username', '']),
+        OptString.new('SMBUser', [false, '(Optional) The username to authenticate as', ''], fallbacks: ['USERNAME']),
+        OptString.new('SMBPass', [false, '(Optional) The password for the specified username', ''], fallbacks: ['PASSWORD']),
         OptString.new('SMBDomain', [
           false,
           '(Optional) The Windows domain to use for authentication. Only affects Windows Server 2008 R2, Windows 7,' \
@@ -717,8 +717,8 @@ module EternalBlueWin8
 
   def exploit_eb
     num_groom_conn = datastore['GroomAllocations'].to_i
-    smbuser = datastore.keys.include?('SMBUser') ? datastore['SMBUser'] : ''
-    smbpass = datastore.keys.include?('SMBPass') ? datastore['SMBPass'] : ''
+    smbuser = datastore['SMBUser'].present? ? datastore['SMBUser'] : ''
+    smbpass = datastore['SMBPass'].present? ? datastore['SMBPass'] : ''
 
     sc = make_kernel_user_payload(payload.encoded, datastore['ProcessName'])
 

--- a/modules/exploits/windows/smb/netidentity_xtierrpcpipe.rb
+++ b/modules/exploits/windows/smb/netidentity_xtierrpcpipe.rb
@@ -48,8 +48,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('SMBUser', [ true, 'The username to authenticate as', 'metasploit']),
-        OptString.new('SMBPass', [ true, 'The password for the specified username', 'metasploit'])
+        OptString.new('SMBUser', [ true, 'The username to authenticate as', 'metasploit'], fallbacks: ['USERNAME']),
+        OptString.new('SMBPass', [ true, 'The password for the specified username', 'metasploit'], fallbacks: ['PASSWORD'])
       ])
 
     deregister_options('SMB::ProtocolVersion')

--- a/modules/post/windows/manage/change_password.rb
+++ b/modules/post/windows/manage/change_password.rb
@@ -33,8 +33,8 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptString.new('SMBDomain', [false, 'Domain or Host to change password on, if not set will use the current login domain', nil]),
-        OptString.new('SMBUser', [true, 'Username to change password of']),
+        OptString.new('SMBDomain', [false, 'Domain or Host to change password on, if not set will use the current login domain', nil], fallbacks: ['DOMAIN']),
+        OptString.new('SMBUser', [true, 'Username to change password of'], fallbacks: ['PASSWORD']),
         OptString.new('OLD_PASSWORD', [true, 'Original password' ]),
         OptString.new('NEW_PASSWORD', [true, 'New password' ]),
       ]

--- a/spec/lib/metasploit/framework/aws/client_spec.rb
+++ b/spec/lib/metasploit/framework/aws/client_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Metasploit::Framework::Aws::Client do
 
   let(:service) { 'iam' }
 
-  let(:auth_header) { "AWS4-HMAC-SHA256 Credential=#{creds.fetch('AccessKeyId')}/#{now[0, 8]}/#{subject.datastore.fetch('Region')}/#{service}/aws4_request, SignedHeaders=#{headers_down_join}, Signature=#{signature}" }
+  let(:auth_header) { "AWS4-HMAC-SHA256 Credential=#{creds.fetch('AccessKeyId')}/#{now[0, 8]}/#{subject.datastore['Region']}/#{service}/aws4_request, SignedHeaders=#{headers_down_join}, Signature=#{signature}" }
 
   it 'should create a SHA 265 digest' do
     d = subject.hexdigest(value)
@@ -102,11 +102,11 @@ RSpec.describe Metasploit::Framework::Aws::Client do
     expect(h.fetch('Accept-Encoding')).to be_empty
     expect(h.fetch('User-Agent')).to eq(Metasploit::Framework::Aws::Client::USER_AGENT)
     expect(h.fetch('X-Amz-Date')).to eq(now)
-    expect(h.fetch('Host')).to eq(subject.datastore.fetch('RHOST'))
+    expect(h.fetch('Host')).to eq(subject.datastore['RHOST'])
     expect(h.fetch('X-Amz-Content-Sha256')).to eq(digest)
     expect(h.fetch('Accept')).to eq('*/*')
     expect(h.fetch('X-Amz-Security-Token')).to eq(creds.fetch('Token'))
-    expect(h.fetch('Authorization')).to eq("AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/#{now[0, 8]}/#{subject.datastore.fetch('Region')}/#{service}/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=275d7332d893de60eaf9f033e1f125f9f00e79c86b7b8902d620da778aff602b")
+    expect(h.fetch('Authorization')).to eq("AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/#{now[0, 8]}/#{subject.datastore['Region']}/#{service}/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=275d7332d893de60eaf9f033e1f125f9f00e79c86b7b8902d620da778aff602b")
   end
 
   it 'should not error out with weird input' do

--- a/spec/lib/msf/base/serializer/readable_text_spec.rb
+++ b/spec/lib/msf/base/serializer/readable_text_spec.rb
@@ -1,0 +1,159 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+require 'rex/text'
+
+RSpec.describe Msf::Serializer::ReadableText do
+  # The described_class API takes a mix of strings and whitespace character counts
+  let(:indent_string) { '' }
+  let(:indent_length) { indent_string.length }
+
+  let(:aux_mod) do
+    mod_klass = Class.new(Msf::Auxiliary) do
+      def initialize
+        super(
+          'Name' => 'mock module',
+          'Description' => 'mock module',
+          'Author' => ['Unknown'],
+          'License' => MSF_LICENSE,
+          'DefaultOptions' => {
+            'OptionWithModuleDefault' => false,
+            'foo' => 'foo_from_module',
+            'baz' => 'baz_from_module'
+          },
+        )
+
+        register_options(
+          [
+            Msf::Opt::RHOSTS,
+            Msf::Opt::RPORT(3000),
+            Msf::OptString.new(
+              'foo',
+              [true, 'Foo option', 'bar']
+            ),
+            Msf::OptString.new(
+              'fizz',
+              [true, 'fizz option', 'buzz']
+            ),
+            Msf::OptString.new(
+              'baz',
+              [true, 'baz option', 'qux']
+            ),
+            Msf::OptString.new(
+              'OptionWithModuleDefault',
+              [true, 'option with module default', true]
+            ),
+            Msf::OptFloat.new('FloatValue', [false, 'A FloatValue ', 3.5]),
+            Msf::OptString.new(
+              'NewOptionName',
+              [true, 'An option with a new name. Aliases ensure the old and new names are synchronized', 'default_value'],
+              aliases: ['OLD_OPTION_NAME']
+            ),
+            Msf::OptString.new(
+              'SMBUser',
+              [true, 'The SMB username'],
+              fallbacks: ['username']
+            ),
+            Msf::OptString.new(
+              'SMBDomain',
+              [true, 'The SMB username', 'WORKGROUP'],
+              aliases: ['WindowsDomain'],
+              fallbacks: ['domain']
+            )
+          ]
+        )
+      end
+    end
+
+    mod = mod_klass.new
+    mock_framework = instance_double(::Msf::Framework, datastore: Msf::DataStore.new)
+    allow(mod).to receive(:framework).and_return(mock_framework)
+    mod
+  end
+
+  let(:aux_mod_with_set_options) do
+    mod = aux_mod.replicant
+    mod.framework.datastore['RHOSTS'] = '192.0.2.2'
+    mod.framework.datastore['FloatValue'] = 5
+    mod.framework.datastore['foo'] = 'foo_from_framework'
+    mod.datastore['foo'] = 'new_value'
+    mod.datastore.unset('foo')
+    mod.datastore['OLD_OPTION_NAME'] = nil
+    mod.datastore['username'] = 'username'
+    mod.datastore['fizz'] = 'new_fizz'
+    mod
+  end
+
+  before(:each) do
+    allow(Rex::Text::Table).to receive(:wrapped_tables?).and_return(true)
+  end
+
+  describe '.dump_datastore', if: ENV['DATASTORE_FALLBACKS'] do
+    context 'when the datastore is empty' do
+      it 'returns the datastore as a table' do
+        expect(described_class.dump_datastore('Table name', Msf::DataStore.new, indent_length)).to match_table <<~TABLE
+          Table name
+          ==========
+  
+          No entries in data store.
+        TABLE
+      end
+    end
+
+    context 'when the datastore has values' do
+      it 'returns the datastore as a table' do
+        expect(described_class.dump_datastore('Table name', aux_mod_with_set_options.datastore, indent_length)).to match_table <<~TABLE
+          Table name
+          ==========
+  
+          Name                     Value
+          ----                     -----
+          FloatValue               5
+          NewOptionName
+          OptionWithModuleDefault  false
+          RHOSTS                   192.0.2.2
+          RPORT                    3000
+          SMBDomain                WORKGROUP
+          SMBUser                  username
+          VERBOSE                  false
+          WORKSPACE
+          baz                      baz_from_module
+          fizz                     new_fizz
+          foo                      foo_from_framework
+          username                 username
+        TABLE
+      end
+    end
+  end
+
+  describe '.dump_options', if: ENV['DATASTORE_FALLBACKS'] do
+    context 'when missing is false' do
+      it 'returns the options as a table' do
+        expect(described_class.dump_options(aux_mod_with_set_options, indent_string, false)).to match_table <<~TABLE
+          Name                     Current Setting     Required  Description
+          ----                     ---------------     --------  -----------
+          FloatValue               5                   no        A FloatValue
+          NewOptionName                                yes       An option with a new name. Aliases ensure the old and new names are synchronized
+          OptionWithModuleDefault  false               yes       option with module default
+          RHOSTS                   192.0.2.2           yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+          RPORT                    3000                yes       The target port
+          SMBDomain                WORKGROUP           yes       The SMB username
+          SMBUser                  username            yes       The SMB username
+          baz                      baz_from_module     yes       baz option
+          fizz                     new_fizz            yes       fizz option
+          foo                      foo_from_framework  yes       Foo option
+        TABLE
+      end
+    end
+
+    context 'when missing is true' do
+      it 'returns the options as a table' do
+        expect(described_class.dump_options(aux_mod_with_set_options, indent_string, true)).to match_table <<~TABLE
+          Name           Current Setting  Required  Description
+          ----           ---------------  --------  -----------
+          NewOptionName                   yes       An option with a new name. Aliases ensure the old and new names are synchronized
+        TABLE
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/data_store_with_fallbacks_spec.rb
+++ b/spec/lib/msf/core/data_store_with_fallbacks_spec.rb
@@ -1,0 +1,1350 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.shared_context 'datastore subjects', shared_context: :metadata do
+  subject(:default_subject) do
+    described_class.new
+  end
+
+  subject(:datastore_with_simple_options) do
+    s = default_subject.copy
+    options = Msf::OptionContainer.new(
+      [
+        Msf::OptString.new(
+          'foo',
+          [true, 'foo option', 'default_foo_value']
+        ),
+        Msf::OptString.new(
+          'bar',
+          [true, 'bar option', 'default_bar_value']
+        ),
+        Msf::OptString.new(
+          'baz',
+          [false, 'baz option']
+        )
+      ]
+    )
+    s.import_options(options)
+    s
+  end
+
+  subject(:datastore_with_aliases) do
+    s = default_subject.copy
+
+    options = Msf::OptionContainer.new(
+      [
+        Msf::OptString.new(
+          'NewOptionName',
+          [true, 'An option with a new name. Aliases ensure the old and new names are synchronized', 'default_value'],
+          aliases: ['OLD_OPTION_NAME']
+        )
+      ]
+    )
+
+    s.import_options(options)
+    s
+  end
+
+  subject(:datastore_with_fallbacks) do
+    s = default_subject.copy
+
+    options = Msf::OptionContainer.new(
+      [
+        Msf::OptString.new(
+          'SMBUser',
+          [true, 'The SMB username'],
+          fallbacks: ['username']
+        ),
+
+        Msf::OptString.new(
+          'SMBDomain',
+          [true, 'The SMB username', 'WORKGROUP'],
+          fallbacks: ['domain']
+        ),
+
+        Msf::OptString.new(
+          'USER_ATTR',
+          [true, 'The ldap username'],
+          fallbacks: ['username']
+        ),
+      ]
+    )
+
+    s.import_options(options)
+    s
+  end
+
+  subject(:complex_datastore) do
+    datastore_with_simple_options
+      .merge(datastore_with_aliases)
+      .merge(datastore_with_fallbacks)
+  end
+
+  subject(:complex_datastore_with_imported_defaults) do
+    s = complex_datastore.copy
+    s.import_defaults_from_hash(
+      {
+        'foo' => 'overridden_default_foo',
+        'NewOptionName' => 'overridden_default_new_option_name'
+      },
+      imported_by: 'datastore_spec'
+    )
+    s
+  end
+end
+
+RSpec.shared_examples_for 'a datastore with lookup support' do |opts = {}|
+  it { is_expected.to respond_to :[] }
+  it { is_expected.to respond_to :[]= }
+  it { is_expected.to respond_to :unset }
+  it { is_expected.to respond_to :delete }
+
+  describe '#[]' do
+    it 'should have default keyed values' do
+      expect(subject['foo']).to eq 'foo_value'
+      expect(subject['bar']).to eq 'bar_value'
+    end
+
+    it 'should have case-insensitive lookups' do
+      # Sorted by gray code, just for fun
+      expect(subject['foo']).to eq 'foo_value'
+      expect(subject['Foo']).to eq 'foo_value'
+      expect(subject['FOo']).to eq 'foo_value'
+      expect(subject['fOo']).to eq 'foo_value'
+      expect(subject['fOO']).to eq 'foo_value'
+      expect(subject['FOO']).to eq 'foo_value'
+      expect(subject['FoO']).to eq 'foo_value'
+      expect(subject['foO']).to eq 'foo_value'
+    end
+  end
+
+  describe '#length' do
+    it 'should return a number' do
+      expect(subject.length).to be > 0
+    end
+  end
+
+  describe '#count' do
+    it 'should return a number' do
+      expect(subject.length).to be > 0
+    end
+  end
+
+  context '#to_h' do
+    it 'should return a Hash with correct values' do
+      expected_to_h = opts.fetch(:expected_to_h) do
+        { 'foo' => 'foo_value', 'bar' => 'bar_value' }
+      end
+      expect(subject.to_h).to eq(expected_to_h)
+    end
+  end
+end
+
+RSpec.shared_examples_for 'a datastore' do
+  describe '#import_options' do
+    let(:foo_option) do
+      Msf::OptString.new(
+        'foo',
+        [true, 'foo option', 'default_foo_value']
+      )
+    end
+    let(:bar_option) do
+      Msf::OptString.new(
+        'bar',
+        [true, 'bar option', 'default_bar_value']
+      )
+    end
+    subject do
+      s = default_subject
+      options = Msf::OptionContainer.new(
+        [
+          foo_option,
+          bar_option
+        ]
+      )
+      s.import_options(options)
+      s
+    end
+
+    it 'should import the given options' do
+      expected_options = {
+        'foo' => foo_option,
+        'bar' => bar_option
+      }
+
+      expect(subject.options).to eq(expected_options)
+    end
+  end
+
+  describe '#import_options_from_hash' do
+    subject do
+      hash = { 'foo' => 'foo_value', 'bar' => 'bar_value' }
+      s = default_subject
+      s.import_options_from_hash(hash)
+      s
+    end
+    it_behaves_like 'a datastore with lookup support'
+  end
+
+  describe '#import_options_from_s' do
+    subject do
+      str = 'foo=foo_value bar=bar_value'
+      s = default_subject
+      s.import_options_from_s(str)
+      s
+    end
+    it_behaves_like 'a datastore with lookup support'
+  end
+
+  describe '#from_file' do
+    subject do
+      ini_instance = double group?: true,
+                            :[] => {
+                              'foo' => 'foo_value',
+                              'bar' => 'bar_value'
+                            }
+      ini_class = double from_file: ini_instance
+
+      stub_const('Rex::Parser::Ini', ini_class)
+
+      s = default_subject
+      s.from_file('path')
+      s
+    end
+
+    it_behaves_like 'a datastore with lookup support'
+  end
+
+  describe '#user_defined' do
+    subject do
+      complex_datastore
+    end
+
+    context 'when no options have been set' do
+      it 'should return an empty hash' do
+        expect(subject.user_defined).to eq({})
+      end
+    end
+
+    context 'when a value has been unset' do
+      before(:each) do
+        subject.unset('foo')
+      end
+
+      it 'should should not include the unset values' do
+        expect(subject.user_defined).to eq({})
+      end
+    end
+
+    context 'when values have been explicitly set' do
+      before(:each) do
+        subject['foo'] = 'foo_value'
+        subject['custom_key'] = 'custom_key_value'
+        subject['OLD_OPTION_NAME'] = 'old_option_name_value'
+        subject['SMBUser'] = 'smbuser_user'
+      end
+
+      it 'should return the set values' do
+        expected_values = {
+          'NewOptionName' => 'old_option_name_value',
+          'custom_key' => 'custom_key_value',
+          'foo' => 'foo_value',
+          'SMBUser' => 'smbuser_user'
+        }
+        expect(subject.user_defined).to eq(expected_values)
+      end
+    end
+
+    context 'when a fallback has been set' do
+      before(:each) do
+        subject.merge!(
+          {
+            'username' => 'username'
+          }
+        )
+      end
+
+      it 'should not return SMBUser/USER_ATTR etc' do
+        expected_values = {
+          'username' => 'username'
+        }
+        expect(subject.user_defined).to eq(expected_values)
+      end
+    end
+
+    context 'when values have been merged with a hash' do
+      before(:each) do
+        subject.merge!(
+          {
+            'NewOptionName' => 'old_option_name_value',
+            'custom_key' => 'custom_key_value',
+            'FOO' => 'foo_value'
+          }
+        )
+      end
+
+      it 'should return the set values' do
+        expected_values = {
+          'NewOptionName' => 'old_option_name_value',
+          'custom_key' => 'custom_key_value',
+          'foo' => 'foo_value'
+        }
+        expect(subject.user_defined).to eq(expected_values)
+      end
+    end
+
+    context 'when values have been merged with a datastore' do
+      before(:each) do
+        other_datastore = subject.copy
+        subject.unset('foo')
+        subject['bar'] = 'bar_value'
+        subject['foo_bar'] = 'foo_bar_value'
+
+        options = Msf::OptionContainer.new(
+          Msf::Opt.stager_retry_options + Msf::Opt.http_proxy_options
+        )
+
+        other_datastore.import_options(options)
+        other_datastore['BAR'] = 'new_bar_value'
+        other_datastore['HttpProxyPass'] = 'http_proxy_pass_value'
+        other_datastore['HttpProxyType'] = 'SOCKS'
+        other_datastore.unset('FOO_BAR')
+        other_datastore.import_defaults_from_hash({ 'PAYLOAD' => 'merged_default' }, imported_by: 'data_store_spec')
+
+        subject.merge!(other_datastore)
+      end
+
+      it 'should return the set values' do
+        expected_values = {
+          'HttpProxyPass' => 'http_proxy_pass_value',
+          'HttpProxyType' => 'SOCKS',
+          'foo_bar' => 'foo_bar_value',
+          'bar' => 'new_bar_value'
+        }
+        expect(subject.user_defined).to eq(expected_values)
+      end
+
+      it 'should still have defaults present' do
+        expect(subject['payload']).to eq 'merged_default'
+      end
+    end
+  end
+
+  describe '#[]' do
+    context 'when the datastore has no options registered' do
+      subject do
+        default_subject
+      end
+
+      it 'should reset the specified key' do
+        expect(subject['foo']).to eq nil
+        expect(subject['bar']).to eq nil
+      end
+
+      it 'should return imported defaults' do
+        subject.import_defaults_from_hash({ 'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp' }, imported_by: 'data_store_spec')
+
+        expect(subject.default?('payload')).to be true
+        expect(subject.default?('PAYLOAD')).to be true
+        expect(subject['PAYLOAD']).to eq 'linux/armle/meterpreter_reverse_tcp'
+        expect(subject['payload']).to eq 'linux/armle/meterpreter_reverse_tcp'
+      end
+    end
+
+    context 'when the datastore has aliases' do
+      subject do
+        datastore_with_aliases
+      end
+
+      it 'should have default keyed values' do
+        expect(subject['NewOptionName']).to eq('default_value')
+        expect(subject['OLD_OPTION_NAME']).to eq('default_value')
+      end
+
+      it 'should have case-insensitive lookups' do
+        expect(subject['NEWOPTIONNAME']).to eq('default_value')
+        expect(subject['Old_Option_Name']).to eq('default_value')
+      end
+    end
+
+    context 'when the datastore has fallbacks' do
+      subject do
+        datastore_with_fallbacks
+      end
+
+      it 'should have default keyed values' do
+        expect(subject['SMBUser']).to be(nil)
+        expect(subject['SMBDomain']).to eq('WORKGROUP')
+        expect(subject['USER_ATTR']).to be(nil)
+        expect(subject['username']).to be(nil)
+      end
+    end
+  end
+
+  describe '#merge!' do
+    context 'when merging with a hash' do
+      subject do
+        s = default_subject.copy
+        options = Msf::OptionContainer.new(
+          [
+            Msf::OptFloat.new(
+              'FloatValue',
+              [false, 'A FloatValue', 3.5]
+            )
+          ]
+        )
+        s.import_options(options)
+        s
+      end
+
+      # Note: This aligns the first implementation of the DataStore class.
+      # In certain scenarios it does not seem like desired behavior.
+      it 'does not perform option validation' do
+        subject.merge!({ 'FloatValue' => 'invalid_value' })
+
+        expect(subject['FloatValue']).to eq('invalid_value')
+      end
+    end
+  end
+
+  describe '#[]=' do
+    context 'when the datastore has aliases' do
+      subject do
+        datastore_with_aliases
+      end
+
+      [
+        nil,
+        false,
+        '',
+        'new_value'
+      ].each do |value|
+        context "when the value is #{value.inspect}" do
+          it 'should allow setting datastore values with the new option name' do
+            subject['NewOptionName'] = value
+
+            expect(subject['NewOptionName']).to eq(value)
+            expect(subject['OLD_OPTION_NAME']).to eq(value)
+          end
+
+          it 'should allow setting datastore values with the old option name' do
+            subject['OLD_OPTION_NAME'] = value
+
+            expect(subject['NewOptionName']).to eq(value)
+            expect(subject['OLD_OPTION_NAME']).to eq(value)
+          end
+        end
+      end
+    end
+
+    context 'when the datastore has fallbacks' do
+      subject do
+        datastore_with_fallbacks
+      end
+
+      it 'should allow setting a key with fallbacks' do
+        subject['SMBUser'] = 'username'
+        expect(subject['SMBUser']).to eq('username')
+        expect(subject['USER_ATTR']).to be(nil)
+        expect(subject['username']).to be(nil)
+      end
+
+      it 'should allow setting a generic key' do
+        subject['username'] = 'username'
+        expect(subject['SMBUser']).to eq('username')
+        expect(subject['USER_ATTR']).to eq('username')
+        expect(subject['username']).to eq('username')
+      end
+
+      it 'should allow setting multiple keys with fallbacks' do
+        subject['username'] = 'username_generic'
+        subject['user_attr'] = 'username_attr'
+        subject['smbuser'] = 'username_smb'
+        expect(subject['SMBUser']).to eq('username_smb')
+        expect(subject['USER_ATTR']).to eq('username_attr')
+        expect(subject['username']).to eq('username_generic')
+      end
+
+      it 'should use the fallback in preference of the option default value' do
+        subject['domain'] = 'example.local'
+        expect(subject['SMBDomain']).to eq('example.local')
+      end
+    end
+  end
+
+  describe '#import_defaults_from_hash' do
+    subject do
+      complex_datastore.import_defaults_from_hash(
+        {
+          'foo' => 'overridden_default_foo',
+          'NewOptionName' => 'overridden_default_new_option_name'
+          # TODO: Add alias/old_option_name test as well
+          # 'old_option_name' => 'overridden_default_old_option_name'
+        },
+        imported_by: 'self'
+      )
+
+      complex_datastore
+    end
+
+    it 'should have default keyed values' do
+      expect(subject['foo']).to eq 'overridden_default_foo'
+      expect(subject['bar']).to eq 'default_bar_value'
+      expect(subject['NewOptionName']).to eq('overridden_default_new_option_name')
+      expect(subject['OLD_OPTION_NAME']).to eq('overridden_default_new_option_name')
+    end
+  end
+
+  describe '#unset' do
+    context 'when the datastore has no options registered' do
+      subject do
+        default_subject
+      end
+
+      it 'should reset the value when it has been user defined' do
+        subject['foo'] = 'new_value'
+
+        expect(subject.unset('foo')).to eq 'new_value'
+        expect(subject.unset('foo')).to eq nil
+      end
+
+      it 'should not change the value if not previously set' do
+        expect(subject.unset('foo')).to eq nil
+        expect(subject.unset('foo')).to eq nil
+      end
+    end
+
+    context 'when the datastore has simple options' do
+      subject do
+        datastore_with_simple_options
+      end
+
+      it 'should reset the value when it has been user defined' do
+        subject['foo'] = 'new_value'
+
+        expect(subject.unset('foo')).to eq 'new_value'
+        expect(subject.unset('foo')).to eq 'default_foo_value'
+      end
+
+      it 'should not change the value if not previously set' do
+        expect(subject.unset('foo')).to eq 'default_foo_value'
+        expect(subject.unset('foo')).to eq 'default_foo_value'
+      end
+    end
+
+    context 'when the datastore has aliases' do
+      subject do
+        datastore_with_aliases
+      end
+
+      # Ensure that both the new name and old name can be used interchangeably
+      [
+        { set_key: 'NewOptionName', delete_key: 'NewOptionName' },
+        { set_key: 'OLD_OPTION_NAME', delete_key: 'OLD_OPTION_NAME' },
+        { set_key: 'NewOptionName', delete_key: 'OLD_OPTION_NAME' },
+        { set_key: 'OLD_OPTION_NAME', delete_key: 'NewOptionName' },
+      ].each do |test|
+        context "when using #{test[:delete_key].inspect} to set the value and deleting with #{test[:delete_key].inspect}" do
+          it 'should reset the value when it has been user defined' do
+            subject[test[:set_key]] = 'new_value'
+
+            expect(subject.unset(test[:delete_key])).to eq 'new_value'
+            expect(subject.unset(test[:delete_key])).to eq 'default_value'
+          end
+
+          it 'should not change the value if not previously set' do
+            expect(subject.unset(test[:delete_key])).to eq 'default_value'
+            expect(subject.unset(test[:delete_key])).to eq 'default_value'
+          end
+        end
+      end
+    end
+
+    context 'when the datastore has fallbacks' do
+      subject do
+        datastore_with_fallbacks
+      end
+
+      context 'when using the option name' do
+        it 'should reset the value when it has been user defined' do
+          subject['SMBDomain'] = 'new_value'
+
+          expect(subject.unset('SMBDomain')).to eq 'new_value'
+          expect(subject.unset('SMBDomain')).to eq 'WORKGROUP'
+        end
+
+        it 'should not change the value if not previously set' do
+          expect(subject.unset('SMBDomain')).to eq 'WORKGROUP'
+          expect(subject.unset('SMBDomain')).to eq 'WORKGROUP'
+        end
+      end
+
+      context 'when using the fallback option name' do
+        it 'should delete the value when it has been user defined' do
+          subject['domain'] = 'new_value'
+
+          # Explicitly unsetting SMBDomain shouldn't unset the domain
+          expect(subject['SMBDomain']).to eq 'new_value'
+          expect(subject.unset('SMBDomain')).to eq 'new_value'
+          expect(subject.unset('SMBDomain')).to eq 'new_value'
+
+          expect(subject['domain']).to eq 'new_value'
+          expect(subject.unset('domain')).to eq 'new_value'
+          expect(subject.unset('domain')).to eq nil
+        end
+
+        it 'should delete the value when it has not been user defined' do
+          expect(subject.unset('domain')).to eq nil
+          expect(subject.unset('SMBDomain')).to eq 'WORKGROUP'
+          expect(subject['domain']).to eq nil
+        end
+      end
+    end
+
+    context 'when the datastore has imported defaults' do
+      subject do
+        complex_datastore_with_imported_defaults
+      end
+
+      it 'should reset the specified key' do
+        subject['foo'] = 'new_value'
+        subject.unset('foo')
+
+        expect(subject['foo']).to eq 'overridden_default_foo'
+      end
+    end
+  end
+
+  context '#to_h' do
+    context 'when the datastore has no options registered' do
+      subject do
+        default_subject
+      end
+
+      it 'should return a Hash with correct values' do
+        expected_to_h = {
+        }
+        expect(subject.to_h).to eq(expected_to_h)
+      end
+    end
+
+    context 'when the datastore has aliases' do
+      subject do
+        datastore_with_aliases
+      end
+
+      it 'should return a Hash with correct values' do
+        expected_to_h = {
+          'NewOptionName' => 'default_value'
+        }
+        expect(subject.to_h).to eq(expected_to_h)
+      end
+    end
+
+    context 'when the datastore has fallbacks' do
+      subject do
+        datastore_with_fallbacks
+      end
+
+      it 'should return a Hash with correct values' do
+        expected_to_h = {
+          'SMBDomain' => 'WORKGROUP',
+          'SMBUser' => '',
+          'USER_ATTR' => ''
+        }
+        expect(subject.to_h).to eq(expected_to_h)
+      end
+    end
+
+    context 'when the datastore has imported defaults' do
+      subject do
+        complex_datastore_with_imported_defaults
+      end
+
+      it 'should return a Hash with correct values' do
+        expected_to_h = {
+          'NewOptionName' => 'overridden_default_new_option_name',
+          'SMBDomain' => 'WORKGROUP',
+          'SMBUser' => '',
+          'USER_ATTR' => '',
+          'foo' => 'overridden_default_foo',
+          'bar' => 'default_bar_value',
+          'baz' => ''
+        }
+        expect(subject.to_h).to eq(expected_to_h)
+      end
+    end
+  end
+end
+
+RSpec.describe Msf::DataStoreWithFallbacks do
+  include_context 'datastore subjects'
+
+  subject(:default_subject) do
+    described_class.new
+  end
+
+  subject { default_subject }
+
+  it_behaves_like 'a datastore'
+end
+
+RSpec.describe Msf::ModuleDataStoreWithFallbacks do
+  include_context 'datastore subjects'
+
+  let(:framework_datastore) do
+    Msf::DataStoreWithFallbacks.new
+  end
+  let(:mod) do
+    framework = instance_double(Msf::Framework, datastore: framework_datastore)
+    instance_double(
+      Msf::Exploit,
+      framework: framework
+    )
+  end
+  subject(:default_subject) do
+    described_class.new mod
+  end
+  subject { default_subject }
+
+  # @param [DataStoreSearchResult] search_result
+  # @return [Symbol] a human readable result for where the search result was found or not found
+  def human_readable_result_for(search_result)
+    "#{search_result.instance_variable_get(:@namespace)}__#{search_result.instance_variable_get(:@result)}".to_sym
+  end
+
+  context 'when the framework datastore is empty' do
+    it_behaves_like 'a datastore'
+  end
+
+  context 'when the global framework datastore has values' do
+    describe '#default?' do
+      context 'when the datastore has no options registered' do
+        subject do
+          default_subject
+        end
+
+        it 'should return true when the value is not set' do
+          expect(subject.default?('foo')).to be true
+        end
+
+        it 'should return false if the value is set' do
+          subject['foo'] = 'bar'
+
+          expect(subject.default?('foo')).to be false
+        end
+
+        it 'should return true if the value has been unset' do
+          expect(subject.default?('foo')).to be true
+        end
+
+        it 'should return imported defaults' do
+          subject.import_defaults_from_hash({ 'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp' }, imported_by: 'data_store_spec')
+
+          expect(subject.default?('payload')).to be true
+          expect(subject.default?('PAYLOAD')).to be true
+          expect(subject['PAYLOAD']).to eq 'linux/armle/meterpreter_reverse_tcp'
+          expect(subject['payload']).to eq 'linux/armle/meterpreter_reverse_tcp'
+        end
+      end
+
+      context 'when the datastore has aliases' do
+        subject do
+          datastore_with_aliases
+        end
+
+        # Ensure that both the new name and old name can be used interchangeably
+        [
+          { set_key: 'NewOptionName', read_key: 'NewOptionName' },
+          { set_key: 'OLD_OPTION_NAME', read_key: 'OLD_OPTION_NAME' },
+          { set_key: 'NewOptionName', read_key: 'OLD_OPTION_NAME' },
+          { set_key: 'OLD_OPTION_NAME', read_key: 'NewOptionName' },
+        ].each do |test|
+          context "when using #{test[:set_key].inspect} to set the value and reading with #{test[:read_key].inspect}" do
+            it 'should return true when the value is not set' do
+              expect(subject.default?(test[:read_key])).to be true
+            end
+
+            it 'should return false if the value is set' do
+              subject[test[:set_key]] = 'bar'
+
+              expect(subject.default?(test[:read_key])).to be false
+            end
+
+            it 'should return true if the value has been unset' do
+              subject.unset(test[:set_key])
+
+              expect(subject.default?(test[:read_key])).to be true
+            end
+          end
+        end
+      end
+
+      context 'when the datastore has fallbacks' do
+        subject do
+          datastore_with_fallbacks
+        end
+
+        it 'should return true when the value is not set' do
+          expect(subject.default?('SMBDomain')).to be true
+        end
+
+        it 'should return false if the value is set' do
+          subject['SMBDomain'] = 'bar'
+
+          expect(subject.default?('SMBDomain')).to be false
+        end
+
+        it 'should return true if the value has been unset' do
+          subject.unset('SMBDomain')
+
+          expect(subject.default?('SMBDomain')).to be true
+        end
+
+        it 'should return false if the fallback value has been set' do
+          subject['domain'] = 'foo'
+
+          expect(subject.default?('SMBDomain')).to be false
+        end
+
+        it 'should return true if the fallback value has been unset' do
+          subject['domain'] = 'foo'
+          subject.unset('domain')
+
+          expect(subject.default?('SMBDomain')).to be true
+        end
+      end
+    end
+
+    describe '#[]' do
+      context 'when the datastore has no options registered' do
+        subject do
+          default_subject
+        end
+
+        it 'should return nil by default' do
+          expect(subject['foo']).to eq nil
+          expect(subject['bar']).to eq nil
+        end
+
+        context 'when the key has been set in the framework datastore' do
+          it 'should fall back to the framework datastore' do
+            framework_datastore['foo'] = 'global_foo_value'
+
+            expect(subject['foo']).to eq 'global_foo_value'
+            expect(subject['bar']).to eq nil
+          end
+        end
+      end
+
+      context 'when the datastore has aliases' do
+        subject do
+          datastore_with_aliases
+        end
+
+        it 'should have default keyed values' do
+          expect(subject['NewOptionName']).to eq('default_value')
+          expect(subject['OLD_OPTION_NAME']).to eq('default_value')
+        end
+
+        it 'should have case-insensitive lookups' do
+          expect(subject['NEWOPTIONNAME']).to eq('default_value')
+          expect(subject['Old_Option_Name']).to eq('default_value')
+        end
+
+        context 'when the key has been set in the framework datastore' do
+          # Ensure that both the new name and old name can be used interchangeably
+          [
+            { set_key: 'NewOptionName', read_key: 'NewOptionName' },
+            { set_key: 'OLD_OPTION_NAME', read_key: 'OLD_OPTION_NAME' },
+            # Not supported/implemented - the global datastore does not have aliases registered
+            # { set_key: 'NewOptionName', read_key: 'OLD_OPTION_NAME' },
+            # { set_key: 'OLD_OPTION_NAME', read_key: 'NewOptionName' },
+          ].each do |test|
+            context "when using #{test[:set_key].inspect} to set the value and reading with #{test[:read_key].inspect}" do
+              it 'should fall back to the framework datastore if it is set' do
+                framework_datastore[test[:set_key]] = 'global_foo_value'
+
+                expect(subject[test[:read_key]]).to eq 'global_foo_value'
+              end
+
+              it 'should fallback to default value if the parent datastore is unset' do
+                framework_datastore.unset(test[:set_key])
+
+                expect(subject[test[:read_key]]).to eq 'default_value'
+              end
+            end
+          end
+        end
+      end
+
+      context 'when the datastore has fallbacks' do
+        subject do
+          datastore_with_fallbacks
+        end
+
+        it 'should allow setting a key with fallbacks' do
+          subject['SMBUser'] = 'username'
+          expect(subject['SMBUser']).to eq('username')
+          expect(subject['USER_ATTR']).to be(nil)
+          expect(subject['username']).to be(nil)
+        end
+
+        it 'should allow setting a generic key' do
+          subject['username'] = 'username'
+          expect(subject['SMBUser']).to eq('username')
+          expect(subject['USER_ATTR']).to eq('username')
+          expect(subject['username']).to eq('username')
+        end
+
+        it 'should allow setting multiple keys with fallbacks' do
+          subject['username'] = 'username_generic'
+          subject['user_attr'] = 'username_attr'
+          subject['smbuser'] = 'username_smb'
+          expect(subject['SMBUser']).to eq('username_smb')
+          expect(subject['USER_ATTR']).to eq('username_attr')
+          expect(subject['username']).to eq('username_generic')
+        end
+
+        it 'should use the fallback in preference of the option default value' do
+          subject['domain'] = 'example.local'
+          expect(subject['SMBDomain']).to eq('example.local')
+        end
+
+        context 'when the key has been set in the framework datastore' do
+          it 'should use the framework datastore if it is set' do
+            framework_datastore['SMBUser'] = 'global_username_value'
+            framework_datastore['SMBDomain'] = 'global_domain_value'
+
+            expect(subject['SMBUser']).to eq 'global_username_value'
+            expect(subject['USER_ATTR']).to eq nil
+            expect(subject['SMBDomain']).to eq 'global_domain_value'
+          end
+
+          it 'should use the framework fallback datastore value if it is set' do
+            framework_datastore['username'] = 'global_username_value'
+            framework_datastore['domain'] = 'global_domain_value'
+
+            expect(subject['SMBUser']).to eq 'global_username_value'
+            expect(subject['USER_ATTR']).to eq 'global_username_value'
+            expect(subject['SMBDomain']).to eq 'global_domain_value'
+          end
+
+          it 'should fallback to option default value if the parent datastore is unset' do
+            framework_datastore.unset('SMBUser')
+            framework_datastore.unset('SMBDomain')
+
+            # expect(subject['SMBUser']).to eq nil
+            # expect(subject['USER_ATTR']).to eq nil
+            expect(subject['SMBDomain']).to eq 'WORKGROUP'
+          end
+        end
+      end
+    end
+
+    describe '#[]=' do
+      context 'when the datastore has aliases' do
+        subject do
+          datastore_with_aliases
+        end
+
+        [
+          nil,
+          false,
+          '',
+          'new_value'
+        ].each do |value|
+          context "when the value is #{value.inspect}" do
+            it 'should allow setting datastore values with the new option name' do
+              subject['NewOptionName'] = value
+
+              expect(subject['NewOptionName']).to eq(value)
+              expect(subject['OLD_OPTION_NAME']).to eq(value)
+            end
+
+            it 'should allow setting datastore values with the old option name' do
+              subject['OLD_OPTION_NAME'] = value
+
+              expect(subject['NewOptionName']).to eq(value)
+              expect(subject['OLD_OPTION_NAME']).to eq(value)
+            end
+          end
+        end
+      end
+
+      context 'when the datastore has fallbacks' do
+        subject do
+          datastore_with_fallbacks
+        end
+
+        it 'should allow setting a key with fallbacks' do
+          subject['SMBUser'] = 'username'
+          expect(subject['SMBUser']).to eq('username')
+          expect(subject['USER_ATTR']).to be(nil)
+          expect(subject['username']).to be(nil)
+        end
+
+        it 'should allow setting a generic key' do
+          subject['username'] = 'username'
+          expect(subject['SMBUser']).to eq('username')
+          expect(subject['USER_ATTR']).to eq('username')
+          expect(subject['username']).to eq('username')
+        end
+
+        it 'should allow setting multiple keys with fallbacks' do
+          subject['username'] = 'username_generic'
+          subject['user_attr'] = 'username_attr'
+          subject['smbuser'] = 'username_smb'
+          expect(subject['SMBUser']).to eq('username_smb')
+          expect(subject['USER_ATTR']).to eq('username_attr')
+          expect(subject['username']).to eq('username_generic')
+        end
+
+        it 'should use the fallback in preference of the option default value' do
+          subject['domain'] = 'example.local'
+          expect(subject['SMBDomain']).to eq('example.local')
+        end
+      end
+    end
+  end
+
+  describe 'testing all the things' do
+    context 'when the datastore has simple options' do
+      subject do
+        datastore_with_simple_options
+      end
+
+      [
+        { option_default_value: nil, set_key: 'foo', set_value: nil },
+        { option_default_value: '', set_key: 'foo', set_value: nil },
+        { option_default_value: 'default_value', set_key: 'foo', set_value: nil },
+
+        { option_default_value: nil, set_key: 'foo', set_value: '' },
+        { option_default_value: '', set_key: 'foo', set_value: '' },
+        { option_default_value: 'default_value', set_key: 'foo', set_value: '' },
+
+        { option_default_value: nil, set_key: 'foo', set_value: 'set_value' },
+        { option_default_value: '', set_key: 'foo', set_value: 'set_value' },
+        { option_default_value: 'default_value', set_key: 'foo', set_value: 'set_value' },
+      ].each do |test|
+        context "when the option default value is #{test[:default_value]}" do
+          option_default_value = test[:option_default_value]
+          set_key = test[:set_key]
+          set_value = test[:set_value]
+          read_key = test[:set_key] || test[:read_key]
+
+          before(:each) do
+            subject.options['foo'].send(:default=, option_default_value)
+          end
+
+          # Test permutations, ints used for readability
+          [
+            # nothing changed on module
+            { mod_set: 0, mod_unset: 0, framework_set: 0, framework_unset: 0, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+            { mod_set: 0, mod_unset: 0, framework_set: 0, framework_unset: 1, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+            { mod_set: 0, mod_unset: 0, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :global_data_store__user_defined, is_default: false } },
+
+            # module datastore unset
+            { mod_set: 0, mod_unset: 1, framework_set: 0, framework_unset: 0, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+            { mod_set: 0, mod_unset: 1, framework_set: 0, framework_unset: 1, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+            { mod_set: 0, mod_unset: 1, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :global_data_store__user_defined, is_default: false } },
+
+            # module datastore set
+            { mod_set: 1, mod_unset: 0, framework_set: 0, framework_unset: 0, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+            { mod_set: 1, mod_unset: 0, framework_set: 0, framework_unset: 1, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+            { mod_set: 1, mod_unset: 0, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+          ].each do |opts|
+            context "when #{opts.inspect}" do
+              it 'returns the expected value' do
+                subject[set_key] = set_value if opts[:mod_set] == 1
+                subject.unset(set_key) if opts[:mod_unset] == 1
+
+                framework_datastore[set_key] = set_value if opts[:framework_set] == 1
+                framework_datastore.unset(set_key) if opts[:framework_unset] == 1
+
+                # Assertions
+                expected = opts[:expected]
+                search_result = subject.search_for(read_key)
+                expect(search_result.value).to eq expected[:value]
+                expect(human_readable_result_for(search_result)).to eq expected[:reason]
+                expect(subject[read_key]).to eq expected[:value]
+                expect(search_result.default?).to eq(expected[:is_default])
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'when the datastore has aliases options' do
+      subject do
+        datastore_with_aliases
+      end
+
+      # Ensure that both the new name and old name can be used interchangeably
+      [
+        { set_key: 'NewOptionName', read_key: 'NewOptionName' },
+        { set_key: 'OLD_OPTION_NAME', read_key: 'OLD_OPTION_NAME' },
+        { set_key: 'NewOptionName', read_key: 'OLD_OPTION_NAME' },
+        { set_key: 'OLD_OPTION_NAME', read_key: 'NewOptionName' },
+      ].each do |keys|
+        set_key = keys[:set_key]
+        read_key = keys[:read_key]
+
+        context "when using #{keys[:set_key].inspect} to set the value and reading with #{keys[:read_key].inspect}" do
+          [
+            { option_default_value: nil, set_key: set_key, set_value: nil, read_key: read_key },
+            { option_default_value: '', set_key: set_key, set_value: nil, read_key: read_key },
+            { option_default_value: 'default_value', set_key: set_key, set_value: nil, read_key: read_key },
+
+            { option_default_value: nil, set_key: set_key, set_value: '', read_key: read_key },
+            { option_default_value: '', set_key: set_key, set_value: '', read_key: read_key },
+            { option_default_value: 'default_value', set_key: set_key, set_value: '', read_key: read_key },
+
+            { option_default_value: nil, set_key: set_key, set_value: 'set_value', read_key: read_key },
+            { option_default_value: '', set_key: set_key, set_value: 'set_value', read_key: read_key },
+            { option_default_value: 'default_value', set_key: set_key, set_value: 'set_value', read_key: read_key },
+          ].each do |test|
+            context "when the default value is #{test[:default_value]}" do
+              option_default_value = test[:option_default_value]
+              set_key = test[:set_key]
+              set_value = test[:set_value]
+              read_key = test[:set_key] || test[:read_key]
+
+              before(:each) do
+                subject.options['NewOptionName'].send(:default=, option_default_value)
+              end
+
+              # Test permutations, ints used for readability
+              [
+                # nothing changed on module
+                { mod_set: 0, mod_unset: 0, framework_set: 0, framework_unset: 0, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+                { mod_set: 0, mod_unset: 0, framework_set: 0, framework_unset: 1, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+                { mod_set: 0, mod_unset: 0, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :global_data_store__user_defined, is_default: false } },
+
+                # module datastore unset
+                { mod_set: 0, mod_unset: 1, framework_set: 0, framework_unset: 0, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+                { mod_set: 0, mod_unset: 1, framework_set: 0, framework_unset: 1, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+                { mod_set: 0, mod_unset: 1, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :global_data_store__user_defined, is_default: false } },
+
+                # module datastore set
+                { mod_set: 1, mod_unset: 0, framework_set: 0, framework_unset: 0, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+                { mod_set: 1, mod_unset: 0, framework_set: 0, framework_unset: 1, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+                { mod_set: 1, mod_unset: 0, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+              ].each do |opts|
+                context "when #{opts.inspect}" do
+                  it 'returns the expected value' do
+                    subject[set_key] = set_value if opts[:mod_set] == 1
+                    subject.unset(set_key) if opts[:mod_unset] == 1
+
+                    framework_datastore[set_key] = set_value if opts[:framework_set] == 1
+                    framework_datastore.unset(set_key) if opts[:framework_unset] == 1
+
+                    # Assertions
+                    expected = opts[:expected]
+                    search_result = subject.search_for(read_key)
+                    expect(search_result.value).to eq expected[:value]
+                    expect(human_readable_result_for(search_result)).to eq expected[:reason]
+                    expect(subject[read_key]).to eq expected[:value]
+                    expect(search_result.default?).to eq(expected[:is_default])
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'when the datastore has defaults imported' do
+      subject do
+        complex_datastore_with_imported_defaults
+      end
+
+      [
+        { option_default_value: nil, set_key: 'foo', set_value: nil },
+        { option_default_value: '', set_key: 'foo', set_value: nil },
+        { option_default_value: 'default_value', set_key: 'foo', set_value: nil },
+
+        { option_default_value: nil, set_key: 'foo', set_value: '' },
+        { option_default_value: '', set_key: 'foo', set_value: '' },
+        { option_default_value: 'default_value', set_key: 'foo', set_value: '' },
+
+        { option_default_value: nil, set_key: 'foo', set_value: 'set_value' },
+        { option_default_value: '', set_key: 'foo', set_value: 'set_value' },
+        { option_default_value: 'default_value', set_key: 'foo', set_value: 'set_value' },
+      ].each do |test|
+        context "when the option default value is #{test[:option_default_value]}" do
+          option_default_value = test[:option_default_value]
+          import_default_value = 'test'
+          set_key = test[:set_key]
+          set_value = test[:set_value]
+          read_key = test[:set_key] || test[:read_key]
+
+          before(:each) do
+            subject.options[set_key].send(:default=, option_default_value)
+            subject.import_defaults_from_hash({ set_key => import_default_value }, imported_by: 'data_store_spec')
+          end
+
+          # Test permutations, ints used for readability
+          [
+            # nothing changed on module
+            { mod_set: 0, mod_unset: 0, framework_set: 0, framework_unset: 0, expected: { value: import_default_value, reason: :module_data_store__imported_default, is_default: true } },
+            { mod_set: 0, mod_unset: 0, framework_set: 0, framework_unset: 1, expected: { value: import_default_value, reason: :module_data_store__imported_default, is_default: true } },
+            { mod_set: 0, mod_unset: 0, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :global_data_store__user_defined, is_default: false } },
+
+            # module datastore unset
+            { mod_set: 0, mod_unset: 1, framework_set: 0, framework_unset: 0, expected: { value: import_default_value, reason: :module_data_store__imported_default, is_default: true } },
+            { mod_set: 0, mod_unset: 1, framework_set: 0, framework_unset: 1, expected: { value: import_default_value, reason: :module_data_store__imported_default, is_default: true } },
+            { mod_set: 0, mod_unset: 1, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :global_data_store__user_defined, is_default: false } },
+
+            # module datastore set
+            { mod_set: 1, mod_unset: 0, framework_set: 0, framework_unset: 0, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+            { mod_set: 1, mod_unset: 0, framework_set: 0, framework_unset: 1, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+            { mod_set: 1, mod_unset: 0, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+          ].each do |opts|
+            context "when #{opts.inspect}" do
+              it 'returns the expected value' do
+                subject[set_key] = set_value if opts[:mod_set] == 1
+                subject.unset(set_key) if opts[:mod_unset] == 1
+
+                framework_datastore[set_key] = set_value if opts[:framework_set] == 1
+                framework_datastore.unset(set_key) if opts[:framework_unset] == 1
+
+                # Assertions
+                expected = opts[:expected]
+                search_result = subject.search_for(read_key)
+                expect(search_result.value).to eq expected[:value]
+                expect(human_readable_result_for(search_result)).to eq expected[:reason]
+                expect(subject[read_key]).to eq expected[:value]
+                expect(search_result.default?).to eq(expected[:is_default])
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'when the datastore has aliases and fallbacks' do
+      subject do
+        s = default_subject.copy
+        options = Msf::OptionContainer.new(
+          [
+            Msf::OptString.new(
+              'SMBDomain',
+              [true, 'The SMB username', 'WORKGROUP'],
+              aliases: ['WindowsDomain'],
+              fallbacks: ['domain']
+            )
+          ]
+        )
+        s.import_options(options)
+        s
+      end
+
+      context 'when the fallback value is set' do
+        before(:each) do
+          subject['domain'] = 'domain_fallback'
+        end
+
+        it 'supports reading with the option name' do
+          expect(subject['SMBDomain']).to eq('domain_fallback')
+        end
+
+        it 'supports reading with the alias name' do
+          expect(subject['WindowsDomain']).to eq('domain_fallback')
+        end
+      end
+
+      context 'when the alias and fallback value are set' do
+        before(:each) do
+          subject['domain'] = 'domain_fallback'
+          subject['WindowsDomain'] = 'WindowsDomain'
+        end
+
+        it 'supports reading with the option name' do
+          expect(subject['SMBDomain']).to eq('WindowsDomain')
+        end
+
+        it 'supports reading with the alias name' do
+          expect(subject['SMBDomain']).to eq('WindowsDomain')
+        end
+      end
+
+      # Ensure that both the new name and old name can be used interchangeably, as well as fallbacks
+      [
+        { set_key: 'SMBDomain', read_key: 'SMBDomain' },
+        { set_key: 'WindowsDomain', read_key: 'WindowsDomain' },
+        { set_key: 'SMBDomain', read_key: 'WindowsDomain' },
+        { set_key: 'WindowsDomain', read_key: 'SMBDomain' },
+      ].each do |keys|
+        set_key = keys[:set_key]
+        read_key = keys[:read_key]
+
+        context "when using #{keys[:set_key].inspect} to set the value and reading with #{keys[:read_key].inspect}" do
+          [
+            { option_default_value: nil, set_key: set_key, set_value: nil, read_key: read_key },
+            { option_default_value: '', set_key: set_key, set_value: nil, read_key: read_key },
+            { option_default_value: 'default_value', set_key: set_key, set_value: nil, read_key: read_key },
+
+            { option_default_value: nil, set_key: set_key, set_value: '', read_key: read_key },
+            { option_default_value: '', set_key: set_key, set_value: '', read_key: read_key },
+            { option_default_value: 'default_value', set_key: set_key, set_value: '', read_key: read_key },
+
+            { option_default_value: nil, set_key: set_key, set_value: 'set_value', read_key: read_key },
+            { option_default_value: '', set_key: set_key, set_value: 'set_value', read_key: read_key },
+            { option_default_value: 'default_value', set_key: set_key, set_value: 'set_value', read_key: read_key },
+          ].each do |test|
+            context "when the default value is #{test[:default_value]}" do
+              option_default_value = test[:option_default_value]
+              set_key = test[:set_key]
+              set_value = test[:set_value]
+              read_key = test[:set_key] || test[:read_key]
+
+              before(:each) do
+                subject.options['SMBDomain'].send(:default=, option_default_value)
+              end
+
+              # Test permutations, ints used for readability
+              [
+                # nothing changed on module
+                { mod_set: 0, mod_unset: 0, framework_set: 0, framework_unset: 0, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+                { mod_set: 0, mod_unset: 0, framework_set: 0, framework_unset: 1, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+                { mod_set: 0, mod_unset: 0, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :global_data_store__user_defined, is_default: false } },
+
+                # module datastore unset
+                { mod_set: 0, mod_unset: 1, framework_set: 0, framework_unset: 0, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+                { mod_set: 0, mod_unset: 1, framework_set: 0, framework_unset: 1, expected: { value: option_default_value, reason: :module_data_store__option_default, is_default: true } },
+                { mod_set: 0, mod_unset: 1, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :global_data_store__user_defined, is_default: false } },
+
+                # module datastore set
+                { mod_set: 1, mod_unset: 0, framework_set: 0, framework_unset: 0, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+                { mod_set: 1, mod_unset: 0, framework_set: 0, framework_unset: 1, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+                { mod_set: 1, mod_unset: 0, framework_set: 1, framework_unset: 0, expected: { value: set_value, reason: :module_data_store__user_defined, is_default: false } },
+              ].each do |opts|
+                context "when #{opts.inspect}" do
+                  it 'returns the expected value' do
+                    subject[set_key] = set_value if opts[:mod_set] == 1
+                    subject.unset(set_key) if opts[:mod_unset] == 1
+
+                    framework_datastore[set_key] = set_value if opts[:framework_set] == 1
+                    framework_datastore.unset(set_key) if opts[:framework_unset] == 1
+
+                    # Assertions
+                    expected = opts[:expected]
+                    search_result = subject.search_for(read_key)
+                    expect(search_result.value).to eq expected[:value]
+                    expect(human_readable_result_for(search_result)).to eq expected[:reason]
+                    expect(subject[read_key]).to eq expected[:value]
+                    expect(search_result.default?).to eq(expected[:is_default])
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/exploit/browser_autopwn2_spec.rb
+++ b/spec/lib/msf/core/exploit/browser_autopwn2_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
   def mock_note_destroy
     # The destroy method doesn't pass the note as an argument startlike framework.jobs_stop_job.
     # So here's I'm just gonna clear them all, and that sort of mimics #destroy.
-    framework = double('Msf::Framework', datastore: {})
+    framework = double('Msf::Framework', datastore: Msf::DataStore.new)
 
     # This empties it
     notes = []
@@ -26,7 +26,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
   end
 
   def mock_report_note(arg)
-    framework = double('Msf::Framework', datastore: {})
+    framework = double('Msf::Framework', datastore: Msf::DataStore.new)
     notes = [create_fake_note('bap.clicks')]
     db = double('db2')
     allow(db).to receive(:notes).and_return(notes)
@@ -342,7 +342,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
   end
 
   before(:example) do
-    framework = double('Msf::Framework', datastore: {})
+    framework = double('Msf::Framework', datastore: Msf::DataStore.new)
 
     # Prepare fake notes
     notes = [create_fake_note("#{note_type_prefix}.#{profile_tag}", default_profile_data)]

--- a/spec/lib/msf/core/module_spec.rb
+++ b/spec/lib/msf/core/module_spec.rb
@@ -6,6 +6,19 @@ RSpec.describe Msf::Module do
     described_class.new
   }
 
+  let(:module_with_options) do
+    msf_module.instance_eval do
+      register_options(
+        [
+          Msf::Opt::RHOSTS,
+          Msf::Opt::RPORT(3000),
+        ] + Msf::Opt::stager_retry_options
+      )
+    end
+
+    msf_module
+  end
+
   it { is_expected.to respond_to :debugging? }
   it { is_expected.to respond_to :fail_with }
   it { is_expected.to respond_to :file_path }
@@ -40,6 +53,84 @@ RSpec.describe Msf::Module do
 
     it { is_expected.to respond_to :cached? }
     it { is_expected.to respond_to :usable? }
+  end
+
+  describe '#register_options' do
+    subject { module_with_options }
+
+    it 'should register the options' do
+      expected_options = hash_including(
+        {
+          'RHOSTS' => an_instance_of(Msf::OptRhosts),
+          'RPORT' => an_instance_of(Msf::OptPort),
+          'StagerRetryCount' => an_instance_of(Msf::OptInt),
+          'StagerRetryWait' => an_instance_of(Msf::OptInt),
+        }
+      )
+      expect(subject.options).to match(expected_options)
+    end
+
+    it 'should set defaults on the datastore' do
+      expect(subject.datastore['RHOSTS']).to be(nil)
+      expect(subject.datastore['RPORT']).to eq(3000)
+      expect(subject.datastore['StagerRetryCount']).to eq(10)
+      expect(subject.datastore['StagerRetryWait']).to eq(5)
+    end
+  end
+
+  describe '#deregister_options' do
+    subject { module_with_options }
+
+    context 'when the options have previously been registered' do
+      before(:each) do
+        subject.instance_eval do
+          deregister_options('RHOSTS', 'RPORT', 'StagerRetryCount', 'StagerRetryWait')
+        end
+      end
+
+      it 'should unregister the options' do
+        expect(subject.options).to_not have_key('RHOSTS')
+        expect(subject.options).to_not have_key('RPORT')
+        expect(subject.options).to_not have_key('StagerRetryCount')
+        expect(subject.options).to_not have_key('StagerRetryWait')
+      end
+
+      it 'should remove the values from the datastore' do
+        expect(subject.datastore['RHOSTS']).to be(nil)
+        expect(subject.datastore['RPORT']).to be(nil)
+        expect(subject.datastore['StagerRetryCount']).to be(nil)
+        expect(subject.datastore['StagerRetryWait']).to be(nil)
+      end
+    end
+
+    context 'when the using an alias to unregister options' do
+      before(:each) do
+        subject.instance_eval do
+          deregister_options(
+            # An alias of RHOSTS
+            'RHOST',
+            'RPORT',
+            # An alias of StagerRetryCount
+            'ReverseConnectRetries',
+            'StagerRetryWait'
+          )
+        end
+      end
+
+      it 'should unregister the options' do
+        expect(subject.options).to_not have_key('RHOSTS')
+        expect(subject.options).to_not have_key('RPORT')
+        expect(subject.options).to_not have_key('StagerRetryCount')
+        expect(subject.options).to_not have_key('StagerRetryWait')
+      end
+
+      it 'should remove the values from the datastore' do
+        expect(subject.datastore['RHOSTS']).to be(nil)
+        expect(subject.datastore['RPORT']).to be(nil)
+        expect(subject.datastore['StagerRetryCount']).to be(nil)
+        expect(subject.datastore['StagerRetryWait']).to be(nil)
+      end
+    end
   end
 
   describe "cloning modules into replicants" do
@@ -86,5 +177,4 @@ RSpec.describe Msf::Module do
 
     end
   end
-
 end

--- a/spec/lib/msf/core/modules/loader/directory_spec.rb
+++ b/spec/lib/msf/core/modules/loader/directory_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Msf::Modules::Loader::Directory do
         include_context 'Metasploit::Framework::Spec::Constants cleaner'
 
         let(:framework) do
-          framework = double('Msf::Framework', :datastore => {})
+          framework = double('Msf::Framework', datastore: Msf::DataStore.new)
 
           events = double('Events')
           allow(events).to receive(:on_module_load)

--- a/spec/lib/msf/core/rhosts_walker_spec.rb
+++ b/spec/lib/msf/core/rhosts_walker_spec.rb
@@ -728,8 +728,8 @@ RSpec.describe Msf::RhostsWalker do
         smb_scanner_mod.datastore.import_options(
           Msf::OptionContainer.new(
             [
-              Msf::OptString.new('SMBUser', [true, 'The username to authenticate as', 'db2admin']),
-              Msf::OptString.new('SMBPass', [true, 'The password for the specified username', 'db2admin'])
+              Msf::OptString.new('SMBUser', [true, 'The username to authenticate as', 'db2admin'], fallbacks: ['USERNAME']),
+              Msf::OptString.new('SMBPass', [true, 'The password for the specified username', 'db2admin'], fallbacks: ['PASSWORD']),
             ]
           ),
           smb_scanner_mod.class,

--- a/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
   it { is_expected.to respond_to :cmd_setg_tabs }
 
   def set_and_test_variable(name, framework_value, module_value, framework_re, module_re)
-    # set the current module
-    allow(core).to receive(:active_module).and_return(mod)
-    # always assume the variable is valid
-    allow(core).to receive(:tab_complete_option_names).and_return([ name ])
-    # always assume set variables validate (largely irrelevant because ours are random)
-    allow(driver).to receive(:on_variable_set).and_return(true)
     # the specified global value
     core.cmd_setg(name, framework_value) if framework_value
     # set the specified local value
@@ -43,7 +37,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
   end
 
   describe "#cmd_get and #cmd_getg" do
-    describe "without arguments" do
+    context "without arguments" do
       it "should show the correct help message" do
         core.cmd_get
         expect(@output.join).to match /Usage: get /
@@ -53,7 +47,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
       end
     end
 
-    describe "with arguments" do
+    context "with arguments" do
       let(:name) { ::Rex::Text.rand_text_alpha(10).upcase }
 
       context "with an active module" do
@@ -61,6 +55,12 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
           mod = ::Msf::Module.new
           mod.send(:initialize, {})
           mod
+        end
+
+        before(:each) do
+          allow(core).to receive(:active_module).and_return(mod)
+          allow(core).to receive(:tab_complete_option_names).and_return([ name ])
+          allow(driver).to receive(:on_variable_set).and_return(true)
         end
 
         it "should show no value if not set in the framework or module" do
@@ -83,6 +83,245 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
     end
   end
 
+  describe '#cmd_set', if: ENV['DATASTORE_FALLBACKS'] do
+    let(:mod) { nil }
+
+    before(:each) do
+      allow(subject).to receive(:active_module).and_return(mod)
+      allow(driver).to receive(:on_variable_set)
+    end
+
+    context 'with an exploit active module' do
+      let(:mod) do
+        mod_klass = Class.new(Msf::Exploit) do
+          def initialize
+            super
+
+            register_options(
+              [
+                Msf::OptString.new(
+                  'foo',
+                  [true, 'Foo option', 'default_foo_value']
+                )
+              ]
+            )
+          end
+        end
+        mod = mod_klass.new
+        allow(mod).to receive(:framework).and_return(framework)
+        mod
+      end
+
+      context 'when no arguments are supplied' do
+        before(:each) do
+          subject.cmd_set
+        end
+
+        it 'should output the datastore value' do
+          expect(@output.join).to match /foo                     default_foo_value/
+        end
+      end
+
+      context 'when setting the module datastore value' do
+        before(:each) do
+          subject.cmd_set('foo', 'bar')
+        end
+
+        it 'should not set the framework datastore' do
+          expect(framework.datastore['foo']).to eq nil
+        end
+
+        it 'should allow lookup via the active module' do
+          expect(mod.datastore['foo']).to eq 'bar'
+        end
+      end
+
+      context 'when setting the global datastore value' do
+        before(:each) do
+          subject.cmd_set('-g', 'foo', 'bar')
+        end
+
+        it 'should set the framework datastore' do
+          expect(framework.datastore['foo']).to eq 'bar'
+        end
+
+        it 'should allow lookup via the active module' do
+          expect(mod.datastore['foo']).to eq 'bar'
+        end
+      end
+
+      context 'when setting the global datastore value to nil' do
+        before(:each) do
+          framework.datastore['foo'] = 'global value'
+          subject.cmd_set('--clear', 'foo', 'ignored_value')
+        end
+
+        it 'should not set the framework datastore' do
+          expect(framework.datastore['foo']).to eq 'global value'
+        end
+
+        it 'should set the datastore value to nil' do
+          expect(mod.datastore['foo']).to eq nil
+        end
+      end
+
+      context 'when setting the module datastore value to nil' do
+        before(:each) do
+          framework.datastore['foo'] = 'global value'
+          subject.cmd_set('--clear', 'foo', 'ignored_value')
+        end
+
+        it 'should not set the framework datastore' do
+          expect(framework.datastore['foo']).to eq 'global value'
+        end
+
+        it 'should set the datastore value to nil' do
+          expect(mod.datastore['foo']).to eq nil
+        end
+      end
+    end
+  end
+
+  describe '#cmd_setg' do
+    before(:each) do
+      allow(subject).to receive(:cmd_set)
+    end
+
+    it 'should call cmd_set when no arguments are present' do
+      subject.cmd_setg
+      expect(subject).to have_received(:cmd_set).with('-g')
+    end
+
+    it 'should call cmd_set when no arguments present' do
+      subject.cmd_setg('foo', 'bar')
+      expect(subject).to have_received(:cmd_set).with('-g', 'foo', 'bar')
+    end
+  end
+
+  describe '#cmd_unset', if: ENV['DATASTORE_FALLBACKS'] do
+    let(:mod) { nil }
+
+    before(:each) do
+      allow(subject).to receive(:active_module).and_return(mod)
+      allow(driver).to receive(:on_variable_unset)
+    end
+
+    context 'with an exploit active module' do
+      let(:mod) do
+        mod_klass = Class.new(Msf::Exploit) do
+          def initialize
+            super
+
+            register_options(
+              [
+                Msf::OptString.new(
+                  'foo',
+                  [true, 'Foo option', 'default_foo_value']
+                ),
+                Msf::OptString.new(
+                  'SMBDomain',
+                  [ false, 'The Windows domain to use for authentication', 'WORKGROUP'],
+                  fallbacks: ['DOMAIN']
+                ),
+              ]
+            )
+          end
+        end
+        mod = mod_klass.new
+        allow(mod).to receive(:framework).and_return(framework)
+        mod
+      end
+
+      context 'when no arguments are supplied' do
+        before(:each) do
+          subject.cmd_unset
+        end
+
+        it 'should output the help information' do
+          expect(@output.join).to match /The unset command is used to .*/
+        end
+      end
+
+      context 'when unsetting a module datastore value without a registered option' do
+        before(:each) do
+          mod.datastore['PAYLOAD'] = 'linux/x86/meterpreter/reverse_tcp'
+          subject.cmd_unset('PAYLOAD')
+        end
+
+        it 'should reset the value' do
+          expect(mod.datastore['PAYLOAD']).to eq nil
+        end
+
+        it 'should output a message to the user' do
+          expect(@combined_output.join).to eq 'Unsetting PAYLOAD...'
+        end
+      end
+
+      context 'when unsetting a module datastore value with an existing default' do
+        before(:each) do
+          mod.datastore['foo'] = 'user_defined'
+          subject.cmd_unset('foo')
+        end
+
+        it 'should reset the value' do
+          expect(mod.datastore['foo']).to eq 'default_foo_value'
+        end
+
+        it 'should output an extra message indicating a default value will be used' do
+          expect(@combined_output.join).to match /Unsetting foo.../
+          expect(@combined_output.join).to match /"foo" unset - but will use a default value still/
+        end
+      end
+
+      context 'when unsetting a module datastore value with a fallback' do
+        before(:each) do
+          mod.datastore['domain'] = 'user_defined'
+          subject.cmd_unset('SMBDomain')
+        end
+
+        it 'should continue to fallback' do
+          expect(mod.datastore['SMBDomain']).to eq 'user_defined'
+        end
+
+        it 'should output an extra message indicating a fallback value will be used' do
+          expect(@combined_output.join).to match /Unsetting SMBDomain.../
+          expect(@combined_output.join).to match /Variable "SMBDomain" unset - but will continue to use "DOMAIN" as a fallback/
+        end
+      end
+
+      context 'when unsetting a module datastore value with a global value set' do
+        before(:each) do
+          mod.framework.datastore['foo'] = 'global_value'
+          subject.cmd_unset('foo')
+        end
+
+        it 'should continue to use the global value' do
+          expect(mod.datastore['foo']).to eq 'global_value'
+        end
+
+        it 'should output an extra message indicating a fallback value will be used' do
+          expect(@combined_output.join).to match /Unsetting foo.../
+          expect(@combined_output.join).to match /Variable "foo" unset - but will continue to use the globally set value/
+        end
+      end
+    end
+  end
+
+  describe '#cmd_unsetg' do
+    before(:each) do
+      allow(subject).to receive(:cmd_unset)
+    end
+
+    it 'should call cmd_unset when no arguments are present' do
+      subject.cmd_unsetg
+      expect(subject).to have_received(:cmd_unset).with('-g')
+    end
+
+    it 'should call cmd_unset when no arguments present' do
+      subject.cmd_unsetg('foo', 'bar')
+      expect(subject).to have_received(:cmd_unset).with('-g', 'foo', 'bar')
+    end
+  end
 
   def set_tabs_test(option)
     allow(core).to receive(:active_module).and_return(mod)
@@ -118,7 +357,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
       end
 
       all_options.each do |option|
-        describe "with #{option} arguments" do
+        context "with #{option} arguments" do
           it "should return array or nil" do
             set_tabs_test(option)
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -149,6 +149,11 @@ RSpec.configure do |config|
     end
   end
 
+  if ENV['DATASTORE_FALLBACKS']
+    config.before(:suite) do
+      Msf::FeatureManager.instance.set(Msf::FeatureManager::DATASTORE_FALLBACKS, true)
+    end
+  end
 end
 
 if load_metasploit

--- a/spec/support/matchers/match_table.rb
+++ b/spec/support/matchers/match_table.rb
@@ -1,0 +1,25 @@
+RSpec::Matchers.define :match_table do |expected|
+  diffable
+
+  match do |actual|
+    @actual = actual.to_s.strip
+    @expected = expected.to_s.strip
+
+    @actual == @expected
+  end
+
+  failure_message do |actual|
+    <<~MSG
+      Expected:
+      #{with_whitespace_highlighted(expected.to_s.strip)}
+      Received:
+      #{with_whitespace_highlighted(actual.to_s.strip)}
+      Raw Result:
+      #{actual}
+    MSG
+  end
+
+  def with_whitespace_highlighted(string)
+    string.lines.map { |line| "'#{line.gsub("\n", '')}'" }.join("\n")
+  end
+end


### PR DESCRIPTION
Rewrites the datastore to hopefully fix a lot of quirks and edgecases that we've run into the past, as well as adding support for option fallbacks.

## Supported scenarios/workflows

### unset

If a user has explicitly set a datastore value - it can be unset. This should fix https://github.com/rapid7/metasploit-framework/issues/3811

Before
- The `unset` command would do a mixture of setting values to `nil` and resetting values to their defaults
- `unset rhosts` would delete the local datastore value. Future lookups would return nil, or whatever was present in the global datastore
- `unset all` would import module defaults from scratch again, undoing user defined values
- `unset rhosts` would remove both the value, and the aliases map, which would break setting rhost/rhosts interchangeably in the future

After
- The `unset` command consistently unsets user defined values

### set

An extra flag has been added to `set` to allow setting values to nil. This is useful for removing default word lists, or opting out of using a globally set value.

Example

Showing options with a default word list:

```
msf6 auxiliary(scanner/http/cisco_asa_asdm_bruteforce) > options

Module options (auxiliary/scanner/http/cisco_asa_asdm_bruteforce):

   Name              Current Setting                                                                        Required  Description
   ----              ---------------                                                                        --------  -----------
   ... etc ...
   USER_FILE         /Users/user/Documents/code/metasploit-framework/data/wordlists/http_default_users.txt  no        File containing users, one per line
   ... etc ...
```

Attempting to unset the wordlist, but the default value will continue to be used:
```
msf6 auxiliary(scanner/http/cisco_asa_asdm_bruteforce) > unset user_file
Unsetting user_file...
[!] Variable "user_file" unset - but will use a default value still. If this is not desired, set it to a new value or attempt to clear it with set --clear user_file
```

Explicitly clearing the wordlist:
```
msf6 auxiliary(scanner/http/cisco_asa_asdm_bruteforce) > unset --clear user_file
Unsetting user_file...
```

Option set correctly:

```
msf6 auxiliary(scanner/http/cisco_asa_asdm_bruteforce) > options

Module options (auxiliary/scanner/http/cisco_asa_asdm_bruteforce):

   Name              Current Setting      Required  Description
   ----              ---------------      --------  -----------
   ... etc ... 
   USER_FILE                              no        File containing users, one per line
```

### Option fallback support

Modules often have protocol specific option names such as SMBUser/FTPUser/BIND_DN/etc, whilst a pentester most likely just wants to set `username` consistently across modules.

Registered options now have a `fallbacks` field which be used when evaluating datastore values

```ruby
OptString.new('SMBUser', [ false, 'The username to authenticate as', ''], fallbacks: ['USERNAME']),
OptString.new('SMBPass', [ false, 'The password for the specified username', ''], fallbacks: ['PASSWORD']),
OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.'], fallbacks: ['DOMAIN']),
```

Which allows users to consistently set module options with username/password:
```
msf6 exploit(windows/smb/psexec) > run 192.168.123.13  username=Administrator password=p4$$w0rd domain=adf3.local

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] 192.168.123.13:445 - Connecting to the server...
[*] 192.168.123.13:445 - Authenticating to 192.168.123.13:445|adf3.local as user 'Administrator'...
[*] 192.168.123.13:445 - Selecting PowerShell target
[*] 192.168.123.13:445 - Executing the payload...
[+] 192.168.123.13:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (175686 bytes) to 192.168.123.13
[*] Meterpreter session 3 opened (192.168.123.1:4444 -> 192.168.123.13:50487) at 2022-08-25 11:04:57 +0100

meterpreter >
```

In the scenario of a module having multiple protocols present, the same username/password could be shared across all of the protocols - or the user can set them individually as normal

## Verification steps

Verify that setting the feature works:

```
features set datastore_fallbacks true
save
```

Sanity test that common workflows work as expected for when the feature is enabled, and that nothing is broken when the flag is disabled

- Setting options
- Unsetting options
- Clearing options with --clear