### PR TITLE
Set write timeout configuration for http client

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -252,7 +252,11 @@ class Client
   # @return [void]
   def send_request(req, t = -1)
     connect(t)
-    conn.put(req.to_s)
+    Timeout.timeout((t < 0) ? nil : t) do
+      conn.put(req.to_s)
+    end
+
+    nil
   end
 
   # Resends an HTTP Request with the propper authentcation headers


### PR DESCRIPTION
The HTTP Client has a timeout for the initial socket connection, as well as parsing the response, but the timeout value is lost for writing data to the socket.

Code path for the write is:

https://github.com/rapid7/rex-core/blob/1e43b174888d673a045aead891ed9c4085ad85f7/lib/rex/io/stream.rb#L191-L210

Then timed_write will go down the blocking non-timeout path by default:

https://github.com/rapid7/rex-core/blob/1e43b174888d673a045aead891ed9c4085ad85f7/lib/rex/io/stream.rb#L163-L171

This is a draft/investigatory fix for an issue we're seeing in production that I'm fielding initial comments for. I'll see if I can verify and replicate a more concrete error scenario that this fixes.

## Verification

Verify the http title scanner module still works as expected