### PR TITLE
Add row indicator to `show targets` command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,7 +386,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.3)
-    rex-text (0.2.48)
+    rex-text (0.2.49)
     rex-zip (0.1.4)
       rex-text
     rexml (3.2.5)

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -55,13 +55,25 @@ class ReadableText
       'Header'  => h,
       'Columns' =>
         [
+          'IsTarget',
           'Id',
           'Name',
-        ])
+        ],
+      'SortIndex' => 1,
+      'ColProps' => {
+        'IsTarget' => {
+          'Stylers' => [Msf::Ui::Console::TablePrint::RowIndicatorStyler.new],
+          'ColumnStylers' => [Msf::Ui::Console::TablePrint::OmitColumnHeader.new],
+          'Width' => 2
+        }
+      }
+    )
 
-    mod.targets.each_with_index { |target, idx|
-      tbl << [ idx.to_s, target.name || 'All' ]
-    }
+    mod.targets.each_with_index do |target, idx|
+      is_target = mod.target == target
+
+      tbl << [is_target, idx.to_s, target.name || 'All' ]
+    end
 
     tbl.to_s + "\n"
   end
@@ -72,13 +84,25 @@ class ReadableText
       'Header'  => h,
       'Columns' =>
         [
+          'IsTarget',
           'Id',
           'Name',
-        ])
+        ],
+      'SortIndex' => 1,
+      'ColProps' => {
+        'IsTarget' => {
+          'Stylers' => [Msf::Ui::Console::TablePrint::RowIndicatorStyler.new],
+          'ColumnStylers' => [Msf::Ui::Console::TablePrint::OmitColumnHeader.new],
+          'Width' => 2
+        }
+      }
+    )
 
-    mod.targets.each_with_index { |target, idx|
-      tbl << [ idx.to_s, target.name || 'All' ]
-    }
+    mod.targets.each_with_index do |target, idx|
+      is_target = mod.target == target
+
+      tbl << [is_target, idx.to_s, target.name || 'All' ]
+    end
 
     tbl.to_s + "\n"
   end
@@ -139,12 +163,24 @@ class ReadableText
       'Header'  => h,
       'Columns' =>
         [
+          'ActionEnabled',
           'Name',
           'Description'
-        ])
+        ],
+      'SortIndex' => 1,
+      'ColProps' => {
+        'ActionEnabled' => {
+          'Stylers' => [Msf::Ui::Console::TablePrint::RowIndicatorStyler.new],
+          'ColumnStylers' => [Msf::Ui::Console::TablePrint::OmitColumnHeader.new],
+          'Width' => 2
+        }
+      }
+    )
 
     mod.actions.each_with_index { |target, idx|
-      tbl << [ target.name || 'All' , target.description || '' ]
+      action_enabled = mod.action == target
+
+      tbl << [ action_enabled, target.name || 'All' , target.description || '' ]
     }
 
     tbl.to_s + "\n"
@@ -321,7 +357,7 @@ class ReadableText
     # Actions
     if mod.actions.any?
       output << "Available actions:\n"
-      output << dump_module_actions(mod, indent)
+      output << dump_module_actions(mod)
     end
 
     # Check
@@ -386,7 +422,7 @@ class ReadableText
     # Actions
     if mod.actions.any?
       output << "Available actions:\n"
-      output << dump_module_actions(mod, indent)
+      output << dump_module_actions(mod)
     end
 
     # Options

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1185,8 +1185,8 @@ class Core
             ],
           'ColProps' =>
             {
-              'Subnet'  => { 'MaxWidth' => 17 },
-              'Netmask' => { 'MaxWidth' => 17 },
+              'Subnet'  => { 'Width' => 17 },
+              'Netmask' => { 'Width' => 17 },
             })
 
         # IPv6 Table
@@ -1203,8 +1203,8 @@ class Core
             ],
           'ColProps' =>
             {
-              'Subnet'  => { 'MaxWidth' => 17 },
-              'Netmask' => { 'MaxWidth' => 17 },
+              'Subnet'  => { 'Width' => 17 },
+              'Netmask' => { 'Width' => 17 },
             })
 
         # Populate Route Tables

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1495,11 +1495,11 @@ module Msf
           def show_targets(mod) # :nodoc:
             case mod
             when Msf::Exploit
-              mod_targs = Serializer::ReadableText.dump_exploit_targets(mod, '   ')
-              print("\nExploit targets:\n\n#{mod_targs}\n") if (mod_targs and mod_targs.length > 0)
+              mod_targs = Serializer::ReadableText.dump_exploit_targets(mod, '', "\nExploit targets:")
+              print("#{mod_targs}\n") if (mod_targs and mod_targs.length > 0)
             when Msf::Evasion
-              mod_targs = Serializer::ReadableText.dump_evasion_targets(mod, '   ')
-              print("\nEvasion targets:\n\n#{mod_targs}\n") if (mod_targs and mod_targs.length > 0)
+              mod_targs = Serializer::ReadableText.dump_evasion_targets(mod, '', "\nEvasion targets:")
+              print("#{mod_targs}\n") if (mod_targs and mod_targs.length > 0)
             end
           end
 

--- a/lib/msf/ui/console/table_print/omit_column_header.rb
+++ b/lib/msf/ui/console/table_print/omit_column_header.rb
@@ -1,0 +1,15 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Ui
+    module Console
+      module TablePrint
+        class OmitColumnHeader
+          def style(_column)
+            ''
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/ui/console/table_print/row_indicator_styler.rb
+++ b/lib/msf/ui/console/table_print/row_indicator_styler.rb
@@ -1,0 +1,15 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Ui
+    module Console
+      module TablePrint
+        class RowIndicatorStyler
+          def style(str)
+            str.to_s == 'true' ? '=>' : '  '
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -250,7 +250,7 @@ module DispatcherShell
           {
             'Command' =>
               {
-                'MaxWidth' => 12
+                'Width' => 12
               }
           })
 

--- a/modules/post/multi/manage/autoroute.rb
+++ b/modules/post/multi/manage/autoroute.rb
@@ -142,8 +142,8 @@ class MetasploitModule < Msf::Post
         ],
       'ColProps' =>
         {
-          'Subnet' => { 'MaxWidth' => 17 },
-          'Netmask' => { 'MaxWidth' => 17 },
+          'Subnet' => { 'Width' => 17 },
+          'Netmask' => { 'Width' => 17 },
         }
     )
 
@@ -161,8 +161,8 @@ class MetasploitModule < Msf::Post
         ],
       'ColProps' =>
         {
-          'Subnet' => { 'MaxWidth' => 17 },
-          'Netmask' => { 'MaxWidth' => 17 },
+          'Subnet' => { 'Width' => 17 },
+          'Netmask' => { 'Width' => 17 },
         }
     )
 

--- a/scripts/meterpreter/autoroute.rb
+++ b/scripts/meterpreter/autoroute.rb
@@ -102,8 +102,8 @@ def print_routes
         ],
       'ColProps' =>
         {
-          'Subnet'  => { 'MaxWidth' => 17 },
-          'Netmask' => { 'MaxWidth' => 17 },
+          'Subnet'  => { 'Width' => 17 },
+          'Netmask' => { 'Width' => 17 },
         })
     ret = []
 


### PR DESCRIPTION
## This PR cannot be merged until this [PR](https://github.com/rapid7/rex-text/pull/49) in rex-text is merged.

This PR adds support for row indicators for `show targets` and `show actions` commands.

# Expected output
![image](https://user-images.githubusercontent.com/69522014/216301058-45227ca5-80a7-4e3d-aeb8-47b010bef1a0.png)

## JSON output
<details>
<summary>Output</summary>

```JSON
{
   "header":"\nExploit targets:",
   "headeri":0,
   "columns":[
      "IsTarget",
      "Id",
      "Name"
   ],
   "rows":[
      [
         "false",
         "0",
         "Windows 2000 SP0-SP1 (Arabic)"
      ],
      [
         "false",
         "1",
         "Windows 2000 SP0-SP1 (Czech)"
      ],
      [
         "false",
         "2",
         "Windows 2000 SP0-SP1 (Chinese)"
      ],
      [
         "false",
         "3",
         "Windows 2000 SP0-SP1 (Dutch)"
      ],
      [
         "true",
         "4",
         "Windows 2000 SP0-SP1 (English)"
      ],
      [
         "false",
         "5",
         "Windows 2000 SP0-SP1 (French)"
      ],
      [
         "false",
         "6",
         "Windows 2000 SP0-SP1 (Finnish)"
      ],
      [
         "false",
         "7",
         "Windows 2000 SP0-SP1 (German)"
      ],
      [
         "false",
         "8",
         "Windows 2000 SP0-SP1 (Korean)"
      ],
      [
         "false",
         "9",
         "Windows 2000 SP0-SP1 (Hungarian)"
      ],
      [
         "false",
         "10",
         "Windows 2000 SP0-SP1 (Italian)"
      ],
      [
         "false",
         "11",
         "Windows 2000 SP0-SP1 (Portuguese)"
      ],
      [
         "false",
         "12",
         "Windows 2000 SP0-SP1 (Spanish)"
      ],
      [
         "false",
         "13",
         "Windows 2000 SP0-SP1 (Swedish)"
      ],
      [
         "false",
         "14",
         "Windows 2000 SP0-SP1 (Turkish)"
      ],
      [
         "false",
         "15",
         "Windows 2000 Pro SP0 (Greek)"
      ],
      [
         "false",
         "16",
         "Windows 2000 Pro SP1 (Greek)"
      ]
   ],
   "width":189,
   "indent":0,
   "cellpad":2,
   "prefix":"",
   "postfix":"",
   "colprops":[
      {
         "Width":2,
         "WordWrap":true,
         "Stylers":[
            {
               
            }
         ],
         "Formatters":[
            
         ],
         "ColumnStylers":[
            {
               
            }
         ]
      },
      {
         "Width":null,
         "WordWrap":true,
         "Stylers":[
            
         ],
         "Formatters":[
            
         ],
         "ColumnStylers":[
            
         ]
      },
      {
         "Width":null,
         "WordWrap":true,
         "Stylers":[
            
         ],
         "Formatters":[
            
         ],
         "ColumnStylers":[
            
         ]
      }
   ],
   "sort_index":1,
   "sort_order":"forward"
}
```
</details>

### Note
Also made some changes to how headers were being handled in the `show_targets` method. It wasn't making use of `Serializer::ReadableText.dump_exploit_targets(mod, '   ', "\nExploit targets:")` method already being able to handle headers if they were passed. So made that changed as I thought it made more sense than adding it to the print statement below. Hopefully there wasn't unknown reasons for that but I couldn't see any reason.

## Verification

This will need to be tested along side a rex-text [PR](https://github.com/rapid7/rex-text/pull/49). Follow prerequisite steps within that PR before completing the steps below.

- [ ] Start `msfconsole`
- [ ] run `use windows/iis/ms01_023_printer` 
- [ ] Verify `show targets` has a row indicator and works as expected
- [ ] Change target by running `set target 1` and verify row indicator adjusts as expected 
- [ ] Repeat steps for an evasion module
- [ ] Repeat steps for `show actions` command