### PR TITLE
Update ldap_query logic to handle binary data

### DIFF
--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -3,7 +3,7 @@ queries:
   - action: ENUM_ADCS_CAS
     description: 'Enumerate ADCS certificate authorities.'
     base_dn_prefix: 'CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration'
-    filter: (objectClass=pKIEnrollmentService)
+    filter: '(objectClass=pKIEnrollmentService)'
     attributes:
       - cn
       - name
@@ -13,7 +13,7 @@ queries:
   - action: ENUM_ADCS_CERT_TEMPLATES
     description: 'Enumerate ADCS certificate templates.'
     base_dn_prefix: 'CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration'
-    filter: (objectClass=pkicertificatetemplate)
+    filter: '(objectClass=pkicertificatetemplate)'
     attributes:
       - cn
       - name

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
     unless @loaded_queries.empty? # Aka there is more than just RUN_QUERY_FILE and RUN_SINGLE_QUERY in the actions list...
       default_action = actions[0][0] # Get the first entry's action name and set this as the default action.
     end
-    return actions, default_action
+    [actions, default_action]
   end
 
   def safe_load_queries(filename)
@@ -208,14 +208,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def normalize_entries(entries)
     cleaned_entries = []
-    for entry in entries
+    entries.each do |entry|
       # Convert to a hash so we get only the data we need.
       entry = entry.to_h
       entry_keys = entry.keys
-      for key in entry_keys
-        entry[key][0] = entry[key][0].force_encoding('ISO-8859-1').encode('UTF-8')
+      entry_keys.each do |key|
+        entry[key][0] = Rex::Text.to_hex_ascii(entry[key][0])
       end
-
       cleaned_entries.append(entry)
     end
     cleaned_entries

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -336,7 +336,6 @@ class MetasploitModule < Msf::Auxiliary
           end
 
           entries = perform_ldap_query(ldap, filter, query['attributes'], base: (query['base_dn_prefix'] ? [query['base_dn_prefix'], @base_dn].join(',') : nil))
-          require 'pry'; binding.pry
         end
       end
     rescue Rex::ConnectionTimeout

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -213,7 +213,7 @@ class MetasploitModule < Msf::Auxiliary
       entry = entry.to_h
       entry_keys = entry.keys
       entry_keys.each do |key|
-        entry[key][0] = Rex::Text.to_hex_ascii(entry[key][0])
+        entry[key] = entry[key].map { |v| Rex::Text.to_hex_ascii(v) }
       end
       cleaned_entries.append(entry)
     end

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Auxiliary
         'Columns' => %w[Name Attributes]
       )
 
-      entry.keys.each do |attr|
+      entry.each_key do |attr|
         if format == 'table'
           tbl << [attr, entry[attr].join(' || ')] unless attr == :dn # Skip over DN entries for tables since DN information is shown in header.
         else
@@ -188,7 +188,7 @@ class MetasploitModule < Msf::Auxiliary
     entries.each do |entry|
       result = ''
       data = {}
-      entry.keys.each do |attr|
+      entry.each_key do |attr|
         data[attr] = entry[attr].join(' || ')
       end
       result << JSON.pretty_generate(data) + ",\n"
@@ -213,7 +213,7 @@ class MetasploitModule < Msf::Auxiliary
       entry = entry.to_h
       entry_keys = entry.keys
       for key in entry_keys
-        entry[key][0] = entry[key][0].force_encoding("ISO-8859-1").encode("UTF-8")
+        entry[key][0] = entry[key][0].force_encoding('ISO-8859-1').encode('UTF-8')
       end
 
       cleaned_entries.append(entry)


### PR DESCRIPTION
This updates the `ldap_query.rb` module to appropriately handle binary data instead of crashing. Note the data may not be pretty in the output but having that occur vs crashing is preferable for users.

## Verification

List the steps needed to make sure this thing works

- [ ] Install ADCS on either a new or existing domain controller
    - [ ] Open the Server Manager
    - [ ] Select Add roles and features
    - [ ] Select "Active Directory Certificate Services" under the "Server Roles" section
    - [ ] When prompted add all of the features and management tools
    - [ ] On the AD CS "Role Services" tab, leave the default selection of only "Certificate Authority"
    - [ ] Completion the installation and reboot the server
    - [ ] Reopen the Server Manager
    - [ ] Go to the AD CS tab and where it says "Configuration Required", hit "More" then "Configure Active Directory Certificate..."
    - [ ] Select "Certificate Authority" in the Role Services tab
    - [ ] Keep all of the default settings, noting the value of the "Common name for this CA" on the "CA Name" tab (this value corresponds to the `CA` datastore option)
    - [ ] Accept the rest of the default settings and complete the configuration
- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/ldap_query`
- [ ] `set ACTION ENUM_ADCS_CAS`
- [ ] `set OUTPUT_FORMAT json`
- [ ] Edit the `ENUM_ADCS_CAS` entry in `data/auxiliary/gather/ldap_query/ldap_queries_default` to have  `objectGUID` and `cACertificate` as additional attributes to search for.
- [ ] `run`
- [ ] **Verify** that with these changes these elements are gathered appropriately
- [ ] **Verify** that without these changes the module will crash when trying to output `json` formatted output.
