### PR TITLE
Weekly dependency updates for Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,8 @@ group :development do
   # generating documentation
   gem 'yard'
   # for development and testing purposes
-  gem 'pry-byebug'
+  # lock to version with 2.6 support until project updates
+  gem 'pry-byebug', "~> 3.9.0"
   # module documentation
   gem 'octokit'
   # memory profiling

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,12 +303,12 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.4.3)
-    pry (0.14.1)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.10.1)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+      pry (~> 0.13.0)
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -506,7 +506,7 @@ DEPENDENCIES
   memory_profiler
   metasploit-framework!
   octokit
-  pry-byebug
+  pry-byebug (~> 3.9.0)
   rake
   redcarpet
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,6 @@ PATH
       rb-readline
       recog
       redcarpet
-      reline (= 0.2.5)
       rex-arch
       rex-bin_tools
       rex-core
@@ -122,23 +121,23 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     afm (0.2.2)
     arel-helpers (2.14.0)
       activerecord (>= 3.1.0, < 8)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.612.0)
-    aws-sdk-core (3.131.5)
+    aws-partitions (1.624.0)
+    aws-sdk-core (3.137.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-ec2 (1.325.0)
+    aws-sdk-ec2 (1.329.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-iam (1.69.0)
+    aws-sdk-iam (1.70.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-kms (1.58.0)
@@ -177,7 +176,7 @@ GEM
       http_parser.rb (>= 0.6.0)
     em-socksify (0.3.2)
       eventmachine (>= 1.0.0.beta.4)
-    erubi (1.10.0)
+    erubi (1.11.0)
     eventmachine (1.2.7)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -186,10 +185,10 @@ GEM
       railties (>= 5.0.0)
     faker (2.22.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.4.0)
-      faraday-net_http (~> 2.0)
+    faraday (2.5.2)
+      faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (2.1.0)
+    faraday-net_http (3.0.0)
     faraday-retry (2.0.0)
       faraday (~> 2.0)
     faye-websocket (0.11.1)
@@ -215,8 +214,8 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
-    irb (1.3.6)
-      reline (>= 0.2.5)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     jmespath (1.6.1)
     jsobfu (0.4.2)
       rkelly-remix
@@ -244,7 +243,7 @@ GEM
       rex-socket
       rubyntlm
       rubyzip
-    metasploit-model (4.0.5)
+    metasploit-model (4.0.6)
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
@@ -262,9 +261,9 @@ GEM
     metasploit_payloads-mettle (1.0.18)
     method_source (1.0.0)
     mini_portile2 (2.8.0)
-    minitest (5.16.2)
+    minitest (5.16.3)
     mqtt (0.5.0)
-    msgpack (1.5.4)
+    msgpack (1.5.6)
     multi_json (1.15.0)
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
@@ -293,7 +292,7 @@ GEM
     packetfu (1.1.13)
       pcaprub
     parallel (1.22.1)
-    parser (3.1.2.0)
+    parser (3.1.2.1)
       ast (~> 2.4.1)
     patch_finder (1.0.2)
     pcaprub (0.13.1)
@@ -303,15 +302,15 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pg (1.4.2)
-    pry (0.13.1)
+    pg (1.4.3)
+    pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
+    pry-byebug (3.10.1)
       byebug (~> 11.0)
-      pry (~> 0.13.0)
-    public_suffix (4.0.7)
-    puma (5.6.4)
+      pry (>= 0.13, < 0.15)
+    public_suffix (5.0.0)
+    puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
@@ -337,7 +336,7 @@ GEM
       nokogiri
     redcarpet (3.5.1)
     regexp_parser (2.5.0)
-    reline (0.2.5)
+    reline (0.3.1)
       io-console (~> 0.5)
     rex-arch (0.1.14)
       rex-text
@@ -377,14 +376,14 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.40)
+    rex-socket (0.1.41)
       rex-core
     rex-sslscan (0.1.7)
       rex-core
       rex-socket
       rex-text
     rex-struct2 (0.1.3)
-    rex-text (0.2.38)
+    rex-text (0.2.39)
     rex-zip (0.1.4)
       rex-text
     rexml (3.2.5)
@@ -412,17 +411,17 @@ GEM
     rspec-rerun (1.1.0)
       rspec (~> 3.0)
     rspec-support (3.11.0)
-    rubocop (1.32.0)
+    rubocop (1.35.1)
       json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.19.1, < 2.0)
+      rubocop-ast (>= 1.20.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.19.1)
+    rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
     ruby-macho (3.0.0)
     ruby-prof (1.4.2)
@@ -465,7 +464,7 @@ GEM
     ttfunk (1.7.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2022.1)
+    tzinfo-data (1.2022.3)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -211,8 +211,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'hrr_rb_ssh-ed25519'
   # Needed for irb internal command
   spec.add_runtime_dependency 'irb'
-  # Lock reline version until Fiddle concerns are addressed
-  spec.add_runtime_dependency 'reline', '0.2.5'
 
   # AWS enumeration modules
   spec.add_runtime_dependency 'aws-sdk-s3'


### PR DESCRIPTION
* unlock `reline` as new guards in 0.3.0 address load errors

This PR should have been auto-generated by [actions/github-script](https://github.com/actions/github-script). `bundle update` revealed the following gems have new version to be evaluated for update.

More adjustment to get automation are in progress, for now let us pickup here this week.

## Verification

List the steps needed to make sure this thing works

- [x] Security review diffs for updated gems
