### PR TITLE
Add in ruby/debug to Gemfile To Allow Users to Easily Debug Metasploit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,10 @@ group :development do
   gem 'yard'
   # for development and testing purposes
   # lock to version with 2.6 support until project updates
-  gem 'pry-byebug', "~> 3.9.0"
+  gem 'pry-byebug', '~> 3.9.0'
+  # Ruby Debugging Library - rebuilt and included by default from Ruby 3.1 onwards.
+  # Replaces the old lib/debug.rb and provides more features.
+  gem 'debug', '>= 1.0.0'
   # module documentation
   gem 'octokit'
   # memory profiling
@@ -25,7 +28,7 @@ group :development do
   gem 'ruby-prof', '1.4.2'
   # Metasploit::Aggregator external session proxy
   # disabled during 2.5 transition until aggregator is available
-  #gem 'metasploit-aggregator'
+  # gem 'metasploit-aggregator'
 end
 
 group :development, :test do
@@ -46,4 +49,3 @@ group :test do
   # Manipulate Time.now in specs
   gem 'timecop'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,9 @@ GEM
     cookiejar (0.3.3)
     crass (1.0.6)
     daemons (1.4.1)
+    debug (1.6.2)
+      irb (>= 1.3.6)
+      reline (>= 0.3.1)
     diff-lcs (1.5.0)
     digest (3.1.0)
     dnsruby (1.61.9)
@@ -501,6 +504,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  debug (>= 1.0.0)
   factory_bot_rails
   fivemat
   memory_profiler

--- a/external/vscode/launch.json
+++ b/external/vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // Example file to showcase how to debug Metasploit using the ruby/debug gem along with the
+    // ruby/vscode-rdbg VSCode plugin. This file will be used by VSCode and the ruby/vscode-rdbg
+    // plugin to figure out how to connect to setup the rdbg instance for msfconsole and then connect
+    // to it properly, allowing you to debug Metasploit and more specifically msfconsole and any associated
+    // modules that you run within it.
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "rdbg",
+            "name": "Debug current file with rdbg",
+            "request": "launch",
+            "script": "${cwd}/msfconsole",
+            "args": [],
+            "askParameters": true,
+            "localfs": true,
+            "debugPort": "127.0.0.1:55634"
+        },
+        {
+            "type": "rdbg",
+            "name": "Attach with rdbg",
+            "request": "attach",
+            "localfs": true,
+            "debugPort": "127.0.0.1:55634"
+        }
+    ]
+}


### PR DESCRIPTION
This update adds the ruby/debug Gem from https://github.com/ruby/debug into our Gemfile. I also provided a launch.json file to use it with vscode-rdbg from https://github.com/ruby/vscode-rdbg and which can be installed from the Visual Studio Store at https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg.

Now you might be wondering, why would we want another debugger when we have Pry and ByeBug? Well http://rvm.jp/~ko1/activities/2021_10_ginzarails.pdf provides a great overview of this new tool and all of the additional features it adds but lets summarize some of it here:

1. The old `lib/debug.rb` library that `ruby/debug` replaces was old and not well maintained.
2. Starting with Ruby 3.1, `ruby/debug` is now included by default with Ruby and replaces the `lib/debug.rb` library, so this paves the way to this debugger being the new standard for debugging Ruby. See https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/ for more info.
3. There is ongoing work to support multi-process and multi-threaded debugging with this library, something that other debuggers for Ruby presently don't support.
4. Numberous extra features including conditional breakpoints, breakpoints that execute debugger code after being executed, ability to trace code and backstep, and other cool features. See the PDF I mentioned earlier for more.

However lets put this aside for a sec. This is great and all but lets be honest, not everyone is going to need tracing and not everyone uses anything beyond basic functionality. The real key change here though is the speed increase. There is little to no overhead when using `ruby/debug` when compared to `byebug` or `RubyMine`:

![image](https://user-images.githubusercontent.com/63261883/187793322-c4f39f10-5637-4f96-8455-022be83e49d0.png)

As you can see even RubyMine, which does a pretty good job with breakpoints enabled, still executes about 21 seconds slower if a breakpoint is enabled (even if it is a single breakpoint). The situation with `byebug` is worse with it taking nearly 75 seconds longer to execute. Worst of all is the old `lib/debug.rb` library which takes a whopping 285 seconds longer to execute. 

If we compare this to `ruby/debug`, listed as `rdbg` in the output above, we can see there is no discernable impact on the code execution, with both execution before and after the breakpoint taking roughly 0.92 seconds.

Hopefully this all makes sense, but if not let me know if you have any questions.

## Verification

1. Install VSCode (currently RubyMine will not work since they hardcoded the tool to run as `rdebug-ide` which is the old debug command and won't work with the newer interface. Why they don't let you change this command to run, I'm not sure, but the documentation lists it as being a static field and I wasn't able to change it via the GUI. Might be some hacky way to do this though.)
2. Install Ruby extension from https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby
3. Install vscode-rdbg from https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg
4. Reboot VSCode and then click `File->Open Folder` and open the folder with `msfconsole` inside of it.
5. Create a new `.vscode` directory in the same directory as `msfconsole` if it doesn't exist already, and copy the example `launch.json` file into `.vscode\launch.json`.
6. Hit F5 or click `Run -> Start Debugging`. You should see something similar to the following output in your Terminal prompt inside VSCode:

```
> rdbg --command --open --stop-at-load --port=55634:/run/user/1000/tcp_port --host=127.0.0.1 -- bundle exec ruby /home/gwillcox/git/metasploit-framework/msfconsole 
DEBUGGER: Debugger can attach via TCP/IP (127.0.0.1:55634)
DEBUGGER: wait for debugger connection...
DEBUGGER: Port is saved into /run/user/1000/tcp_port
```
7. At this point the status bar at the bottom of VSCode should be glowing (its pink for me but color may be different for you). If it glows and then stops glowing, the debug connection terminated early. Please let me know if this occurs.
8. Place a breakpoint in a sample module's `run` or `exploit` function in VSCode.
9. Load up the module, configure its options, and then type `run` followed by the ENTER key.
10. You should see VSCode highlight the respective line in yellow and there should be a positional arrow on the far left, to the left of the line numbers.

![Screenshot 2022-08-31 165151](https://user-images.githubusercontent.com/63261883/187795147-1eda2281-572f-4abe-8d41-db62ecc002b2.png)
