### PR TITLE
Add in Visual Studio Code .vscode directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ Gemfile.local
 Gemfile.local.lock
 # Rubymine project directory
 .idea
+# Visual Studio Code configuration settings directory
+.vscode
 # Sublime Text project directory (not created by ST by default)
 .sublime-project
 # RVM control file, keep this to avoid backdooring Metasploit


### PR DESCRIPTION
Very quick and easy PR, just adds in the `.vscode` directory to `.gitignore` so that you don't accidentally push up custom settings from Visual Studio Code in your commits.

## Verification
- [x] Review the changes and make sure they look okay
- [ ] Verify that creating files inside a `.vscode` directory under the root directory of Metasploit Framework will not cause those files to be considered as new files that are not yet tracked.