### PR TITLE
lock reline again until better support is solved

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ PATH
       rb-readline
       recog
       redcarpet
+      reline (= 0.2.5)
       rex-arch
       rex-bin_tools
       rex-core
@@ -214,8 +215,8 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
-    irb (1.4.1)
-      reline (>= 0.3.0)
+    irb (1.3.6)
+      reline (>= 0.2.5)
     jmespath (1.6.1)
     jsobfu (0.4.2)
       rkelly-remix
@@ -336,7 +337,7 @@ GEM
       nokogiri
     redcarpet (3.5.1)
     regexp_parser (2.5.0)
-    reline (0.3.1)
+    reline (0.2.5)
       io-console (~> 0.5)
     rex-arch (0.1.14)
       rex-text

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -211,6 +211,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'hrr_rb_ssh-ed25519'
   # Needed for irb internal command
   spec.add_runtime_dependency 'irb'
+  # Lock reline version until Fiddle concerns are addressed
+  spec.add_runtime_dependency 'reline', '0.2.5'
 
   # AWS enumeration modules
   spec.add_runtime_dependency 'aws-sdk-s3'


### PR DESCRIPTION
Rollback reline as it still causes exceptions in Ruby 2.6 and 2.7

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole` with a valid bundle in Ruby 2.6 and 2.7
