### PR TITLE
Fix shell_to_meterpreter wmic OS detection under different language

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -85,11 +85,11 @@ class MetasploitModule < Msf::Post
       platform = 'windows'
       lplat = [Msf::Platform::Windows]
       arch = cmd_exec('wmic os get osarchitecture')
-      if arch =~ /64-bit/m
+      if arch =~ /64/m && arch =~ /bit/m
         payload_name = 'windows/x64/meterpreter/reverse_tcp'
         larch = [ARCH_X64]
         psh_arch = 'x64'
-      elsif arch =~ /32-bit/m
+      elsif arch =~ /32/m && arch =~ /bit/m
         payload_name = 'windows/meterpreter/reverse_tcp'
         larch = [ARCH_X86]
         psh_arch = 'x86'


### PR DESCRIPTION
This PR fixes `shell_to_meterpreter` behaviour under **Windows 10 environment**, when the OS language is set to some foreign language.

## Details

Module `shell_to_meterpreter` uses `wmic` command to detect Windows architecture. When windows language is set to something else than English, the output of `wmic` command will **not** be capture by the regexp.

## Verification

List the steps needed to make sure this thing works

- [ ] Set victims **Windows 10** machine's language to some other language ( e.g.: Italian, German, French, etc.)
- [ ] Start `msfconsole`
- [ ] Get a valid shell session to the victim machine
- [ ] `use post/multi/manage/shell_to_meterpreter`
- [ ] `exploit`
- [ ] Verify you get a **meterpreter session**