### PR TITLE
Update reline and suppress Fiddle issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,6 @@ PATH
       rb-readline
       recog
       redcarpet
-      reline (= 0.2.5)
       rex-arch
       rex-bin_tools
       rex-core
@@ -215,8 +214,8 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
-    irb (1.3.6)
-      reline (>= 0.2.5)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     jmespath (1.6.1)
     jsobfu (0.4.2)
       rkelly-remix
@@ -337,7 +336,7 @@ GEM
       nokogiri
     redcarpet (3.5.1)
     regexp_parser (2.5.0)
-    reline (0.2.5)
+    reline (0.3.1)
       io-console (~> 0.5)
     rex-arch (0.1.14)
       rex-text

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,6 @@
+require 'fiddle'
+Fiddle.const_set(:VERSION, '0.0.0') unless Fiddle.const_defined?(:VERSION)
+
 require 'rails'
 require File.expand_path('../boot', __FILE__)
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -211,8 +211,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'hrr_rb_ssh-ed25519'
   # Needed for irb internal command
   spec.add_runtime_dependency 'irb'
-  # Lock reline version until Fiddle concerns are addressed
-  spec.add_runtime_dependency 'reline', '0.2.5'
 
   # AWS enumeration modules
   spec.add_runtime_dependency 'aws-sdk-s3'


### PR DESCRIPTION
This reverts commit 6494603510376dc6afedfbe440742df6b0a5bf0e, reversing
changes made to 5d3b8f803060cf753afe2e9992c84a5f90cc8c1a.

By defining the missing constant early in startup we can force
reline to detect Fiddle as version '0.0.0' when the class is provide
by a Ruby 2.x implementation that has an documented version.

## Verification

List the steps needed to make sure this thing works

- [x] `rake -T` in a development install against Ruby 2.5, 2.6., 3.0
- [x] Start `msfconsole`
