### PR TITLE
Update enum_system.rb

### DIFF
--- a/modules/post/linux/gather/enum_system.rb
+++ b/modules/post/linux/gather/enum_system.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Post
     diskspace = execute("/bin/df -ahT")
     disks = (mount + "\n\n" + diskspace)
     logfiles = execute("find /var/log -type f -perm -4 2> /dev/null")
-    uidgid = execute("find / -xdev -type f -perm +6000 -perm -1 2> /dev/null")
+    uidgid = execute("find / -xdev -type f -perm +6000 -perm -1 2> /dev/null || find / -xdev -type f -perm /6000 -perm -1 2> /dev/null")
 
     save("Linux version", distro)
     save("User accounts", users)


### PR DESCRIPTION
the command `"find / -xdev -type f -perm +6000 -perm -1 2> /dev/null"` don't work in new linux systems

-perm +mode
       Deprecated,  old  way  of  searching  for  files with any of the permission bits in mode set.  You
       should use -perm /mode instead. Trying to use the  '+'  syntax  with  symbolic  modes  will  yield
       surprising results.  For example, '+u+x' is a valid symbolic mode (equivalent to +u,+x, i.e. 0111)
       and will therefore not be evaluated as -perm +mode but instead as the exact mode  specifier  -perm
       mode  and  so  it  matches files with exact permissions 0111 instead of files with any execute bit
       set.  If you found this paragraph confusing, you're not alone - just use -perm /mode.   This  form
       of  the  -perm test is deprecated because the POSIX specification requires the interpretation of a
       leading '+' as being part of a symbolic mode, and so we switched to using '/' instead.

Ref.: [https://explainshell.com/explain?cmd=find+%2F++-perm+%2B6000](url)
