### PR TITLE
Update msfconsole tables to support wordwrapping when Rex::Text::Color codes are present

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,7 +383,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.3)
-    rex-text (0.2.43)
+    rex-text (0.2.44)
     rex-zip (0.1.4)
       rex-text
     rexml (3.2.5)


### PR DESCRIPTION
This PR bumps [Rex::Text](https://github.com/rapid7/rex-text) from 0.2.43 to 0.2.44.

### Before

<img width="824" alt="image" src="https://user-images.githubusercontent.com/60357436/188140297-70619f8f-00a7-42ef-baa3-f699a78fdbbc.png">

### After

<img width="811" alt="image" src="https://user-images.githubusercontent.com/60357436/188140205-ed0668ee-0ef8-4795-a36a-ea4c6b4f6b97.png">

### Verification steps

1. Verify the before and after behavior of `show options`