### PR TITLE
Add MSFvenom support for Nim shellcode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,7 +383,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.3)
-    rex-text (0.2.44)
+    rex-text (0.2.45)
     rex-zip (0.1.4)
       rex-text
     rexml (3.2.5)

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -63,6 +63,8 @@ module Buffer
         buf = Rex::Text.encode_base64(buf)
       when 'go','golang'
         buf = Rex::Text.to_golang(buf)
+      when 'nim','nimlang'
+        buf = Rex::Text.to_nim(buf)
       else
         raise BufferFormatError, "Unsupported buffer format: #{fmt}", caller
     end
@@ -97,6 +99,8 @@ module Buffer
         buf = Rex::Text.to_psh_comment(buf)
       when 'go','golang'
         buf = Rex::Text.to_golang_comment(buf)
+      when 'nim','nimlang'
+        buf = Rex::Text.to_nim_comment(buf)
       else
         raise BufferFormatError, "Unsupported buffer format: #{fmt}", caller
     end
@@ -122,6 +126,8 @@ module Buffer
       'java',
       'js_be',
       'js_le',
+      'nim',
+      'nimlang',
       'num',
       'perl',
       'pl',


### PR DESCRIPTION
# This PR Requires the Nim shellcode format support PR from Rex-Text: https://github.com/rapid7/rex-text/pull/55
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use windows/x64/exec`
- [x] `set cmd calc.exe`
- [x] `generate -f nim` or `generate -f nimlang`
- [x] **Verify** Insert generated shellcode into a Nim shellcode runner (see Rex-Text PR)

msfconsole:
![image](https://user-images.githubusercontent.com/57866415/188152742-428f8520-fe00-4ede-bc2a-83bb755def9c.png)

msfvenom
![image](https://user-images.githubusercontent.com/57866415/188152821-e55f4a19-6dd2-422f-bedf-0b6c615f4b56.png)