### PR TITLE
Use start_with? instead of starts_with?

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -603,7 +603,7 @@ class Client
           tries = 0
           begin
             # XXX: This doesn't deal with chunked encoding
-            while tries < 1000 and resp.headers["Content-Type"] and resp.headers["Content-Type"].starts_with?('text/html') and rblob !~ /<\/html>/i
+            while tries < 1000 and resp.headers["Content-Type"] and resp.headers["Content-Type"].start_with?('text/html') and rblob !~ /<\/html>/i
               buff = conn.get_once(-1, 0.05)
               break if not buff
               rblob += buff


### PR DESCRIPTION
Internal testing conducted by @jmartin-r7  flagged a change I made to the http client code. Jeffrey found the change caused issues when rails was not loaded because `starts_with?` doesn't exist in ruby proper. Ruby proper uses `start_with?` so that should be the preferred method.

I retested against the target I made the change for and all tests properly:

```
msf6 > use auxiliary/scanner/http/cisco_asa_clientless_vpn
msf6 auxiliary(scanner/http/cisco_asa_clientless_vpn) > run RHOSTS=10.9.49.204 verbose=true PASS_FILE="" USER_FILE="" USERPASS_FILE="" USERNAME=cisco PASSWORD=labpass1

[*] The remote target appears to host Cisco SSL VPN Service. The module will continue.
[*] Starting login brute force...
[*] 10.9.49.204:443 - [1/1] - Trying username:"cisco" with password:"labpass1"
[+] SUCCESSFUL LOGIN - "cisco":"labpass1"
[!] No active DB -- Credential data will not be saved!
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/cisco_asa_clientless_vpn) 
```