### PR TITLE
Update Ubuntu 18.04 to ubuntu-latest in Github CI script

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   # Ensures that the docs site builds successfully. Note that this workflow does not deploy the docs site.
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   msftidy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     strategy:


### PR DESCRIPTION
Updates Github CI scripts that were missed previously.

Updates Github CI script to run `ubuntu-latest` for now as Ubuntu 18.04 [EOL](https://endoflife.software/operating-systems/linux/ubuntu) was announced, updating early to avoid confusion with the brownout period:

> This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on December 1st, 2022. For more details, see https://github.com/actions/runner-images/issues/6002
