### PR TITLE
Add in support for GUIDs, Certificate Handling, and SIDs to ldap_query Module

### DIFF
--- a/lib/rex/proto/ms_dtyp.rb
+++ b/lib/rex/proto/ms_dtyp.rb
@@ -1,38 +1,37 @@
 # -*- coding: binary -*-
 
 module Rex::Proto::MsDtyp
-    # [2.4.2.2 SID--Packet Representation](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/f992ad60-0fe4-4b87-9fed-beb478836861)
-    class MsDtypSid < BinData::Record
-        endian :little
+  # [2.4.2.2 SID--Packet Representation](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/f992ad60-0fe4-4b87-9fed-beb478836861)
+  class MsDtypSid < BinData::Record
+    endian :little
 
-        uint8 :revision, initial_value: 1
-        uint8 :sub_authority_count, initial_value: -> { sub_authority.length }
-        array :identifier_authority, type: :uint8, initial_length: 6
-        array :sub_authority, type: :uint32, initial_length: :sub_authority_count
-
-        def assign(val)
-            # allow assignment from the human-readable string representation
-            if val.is_a?(String) && val =~ /^S-1-(\d+)(-\d+)+$/
-                _, _, ia, sa = val.split('-', 4)
-                val = {}
-                val[:identifier_authority] = [ia.to_i].pack('Q>')[2..].bytes
-                val[:sub_authority] = sa.split('-').map(&:to_i)
-            end
-
-            super
-        end
-
-        def to_s
-            str = 'S-1'
-            str << "-#{("\x00\x00" + identifier_authority.to_binary_s).unpack1('Q>')}"
-            str << '-' + sub_authority.map(&:to_s).join('-')
-        end
+    uint8 :revision, initial_value: 1
+    uint8 :sub_authority_count, initial_value: -> { sub_authority.length }
+    array :identifier_authority, type: :uint8, initial_length: 6
+    array :sub_authority, type: :uint32, initial_length: :sub_authority_count
+    def assign(val)
+      # allow assignment from the human-readable string representation
+      if val.is_a?(String) && val =~ /^S-1-(\d+)(-\d+)+$/
+          _, _, ia, sa = val.split('-', 4)
+          val = {}
+          val[:identifier_authority] = [ia.to_i].pack('Q>')[2..].bytes
+          val[:sub_authority] = sa.split('-').map(&:to_i)
+      end
+      
+      super
     end
 
-    # [Universal Unique Identifier](http://pubs.opengroup.org/onlinepubs/9629399/apdxa.htm)
-    # The online documentation at [2.3.4.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/001eec5a-7f8b-4293-9e21-ca349392db40)
-    # wierdly doesn't mention this needs to be 4 byte aligned for us to read it correctly,
-    # which the RubySMB::Dcerpc::Uuid definition takes care of.
-    class MsDtypGuid < RubySMB::Dcerpc::Uuid
+    def to_s
+        str = 'S-1'
+        str << "-#{("\x00\x00" + identifier_authority.to_binary_s).unpack1('Q>')}"
+        str << '-' + sub_authority.map(&:to_s).join('-')
     end
+  end
+
+  # [Universal Unique Identifier](http://pubs.opengroup.org/onlinepubs/9629399/apdxa.htm)
+  # The online documentation at [2.3.4.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/001eec5a-7f8b-4293-9e21-ca349392db40)
+  # wierdly doesn't mention this needs to be 4 byte aligned for us to read it correctly,
+  # which the RubySMB::Dcerpc::Uuid definition takes care of.
+  class MsDtypGuid < RubySMB::Dcerpc::Uuid
+  end
 end

--- a/lib/rex/proto/ms_dtyp.rb
+++ b/lib/rex/proto/ms_dtyp.rb
@@ -1,0 +1,38 @@
+# -*- coding: binary -*-
+
+module Rex::Proto::MsDtyp
+    # [2.4.2.2 SID--Packet Representation](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/f992ad60-0fe4-4b87-9fed-beb478836861)
+    class MsDtypSid < BinData::Record
+        endian :little
+
+        uint8 :revision, initial_value: 1
+        uint8 :sub_authority_count, initial_value: -> { sub_authority.length }
+        array :identifier_authority, type: :uint8, initial_length: 6
+        array :sub_authority, type: :uint32, initial_length: :sub_authority_count
+
+        def assign(val)
+            # allow assignment from the human-readable string representation
+            if val.is_a?(String) && val =~ /^S-1-(\d+)(-\d+)+$/
+                _, _, ia, sa = val.split('-', 4)
+                val = {}
+                val[:identifier_authority] = [ia.to_i].pack('Q>')[2..].bytes
+                val[:sub_authority] = sa.split('-').map(&:to_i)
+            end
+
+            super
+        end
+
+        def to_s
+            str = 'S-1'
+            str << "-#{("\x00\x00" + identifier_authority.to_binary_s).unpack1('Q>')}"
+            str << '-' + sub_authority.map(&:to_s).join('-')
+        end
+    end
+
+    # [Universal Unique Identifier](http://pubs.opengroup.org/onlinepubs/9629399/apdxa.htm)
+    # The online documentation at [2.3.4.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/001eec5a-7f8b-4293-9e21-ca349392db40)
+    # wierdly doesn't mention this needs to be 4 byte aligned for us to read it correctly,
+    # which the RubySMB::Dcerpc::Uuid definition takes care of.
+    class MsDtypGuid < RubySMB::Dcerpc::Uuid
+    end
+end

--- a/lib/rex/proto/ms_dtyp.rb
+++ b/lib/rex/proto/ms_dtyp.rb
@@ -12,19 +12,19 @@ module Rex::Proto::MsDtyp
     def assign(val)
       # allow assignment from the human-readable string representation
       if val.is_a?(String) && val =~ /^S-1-(\d+)(-\d+)+$/
-          _, _, ia, sa = val.split('-', 4)
-          val = {}
-          val[:identifier_authority] = [ia.to_i].pack('Q>')[2..].bytes
-          val[:sub_authority] = sa.split('-').map(&:to_i)
+        _, _, ia, sa = val.split('-', 4)
+        val = {}
+        val[:identifier_authority] = [ia.to_i].pack('Q>')[2..].bytes
+        val[:sub_authority] = sa.split('-').map(&:to_i)
       end
-      
+
       super
     end
 
     def to_s
-        str = 'S-1'
-        str << "-#{("\x00\x00" + identifier_authority.to_binary_s).unpack1('Q>')}"
-        str << '-' + sub_authority.map(&:to_s).join('-')
+      str = 'S-1'
+      str << "-#{("\x00\x00" + identifier_authority.to_binary_s).unpack1('Q>')}"
+      str << '-' + sub_authority.map(&:to_s).join('-')
     end
   end
 

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -373,7 +373,7 @@ class MetasploitModule < Msf::Auxiliary
                 entry[attribute_name][0] = decoded_guid
                 modified = true
               end
-            elsif attribute_name == :cacertificate || attribute_name == :userCertificate
+            elsif attribute_name == :cacertificate || attribute_name == :usercertificate
               entry[attribute_name].map! do |raw_key_data|
                 _certificate_file, read_data = read_der_certificate_file(raw_key_data)
                 modified = true
@@ -393,7 +393,7 @@ class MetasploitModule < Msf::Auxiliary
         when 27 # Case Sensitive String
         when 64 # DirectoryString String(Unicode)
         when 65 # LargeInteger
-          if attribute_name == :creationtime
+          if attribute_name == :creationtime || attribute_name.to_s.match(/lastlog(?:on|off)/)
             timestamp = entry[attribute_name][0]
             time_string = convert_nt_timestamp_to_time_string(timestamp)
             entry[attribute_name][0] = time_string


### PR DESCRIPTION
Adds support for GUIDs, reading certificates and outputting their details, and handling SIDs to `auxiliary/gather/ldap_query.rb`. Also add in some time related element support.

## Verification
- [ ] Install ADCS on either a new or existing domain controller
    - [ ] Open the Server Manager
    - [ ] Select Add roles and features
    - [ ] Select "Active Directory Certificate Services" under the "Server Roles" section
    - [ ] When prompted add all of the features and management tools
    - [ ] On the AD CS "Role Services" tab, leave the default selection of only "Certificate Authority"
    - [ ] Completion the installation and reboot the server
    - [ ] Reopen the Server Manager
    - [ ] Go to the AD CS tab and where it says "Configuration Required", hit "More" then "Configure Active Directory Certificate..."
    - [ ] Select "Certificate Authority" in the Role Services tab
    - [ ] Keep all of the default settings, noting the value of the "Common name for this CA" on the "CA Name" tab (this value corresponds to the `CA` datastore option)
    - [ ] Accept the rest of the default settings and complete the configuration
- [ ] Add a new entry to the `ldap_queries_default.yaml` with the following content (overwrite any existing entries with same name): 

```
  - action: ENUM_ADCS_CAS
    description: 'Enumerate ADCS certificate authorities.'
    base_dn_prefix: 'CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration'
    filter: '(objectClass=pKIEnrollmentService)'
    attributes:
      - cn
      - name
      - cACertificateDN
      - dNSHostname
      - certificateTemplates
      - objectGUID
      - caCertificate
```
- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/ldap_query`
- [ ] `set RHOSTS <target IP>`
- [ ] `set ACTION ENUM_ADCS_CAS`
- [ ] `set BIND_DN  <DOMAIN>\\<USERNAME>`
- [ ] `set BIND_PW <PASSWORD>`
- [ ] `run`
- [ ] Verify that the `cacertificate` field looks similar to the following and is no longer a binary blob of data:

```
 cacertificate         Version: 0x2, Subject: /DC=com/DC=daforest/CN=daforest-WIN-BR0CCBA
                       815B-CA, Issuer: /DC=com/DC=daforest/CN=daforest-WIN-BR0CCBA815B-C
                       A, Signature Algorithm: sha256WithRSAEncryption, Extensions: keyUs
                       age = Digital Signature, Certificate Sign, CRL Sign | basicConstra
                       ints = critical, CA:TRUE | subjectKeyIdentifier = DD:1C:7F:D8:EE:F
                       9:A8:D0:AA:6E:AC:55:61:E0:70:AC:45:03:70:6C | 1.3.6.1.4.1.311.21.1
                        = ...
```
- [ ] Verify that the `objectguid` field is now decoded into a valid GUID. You can verify if the GUID is valid by opening up a Active Directory Module for Powershell prompt and typing in `get-adobject -id <OBJECT GUID>` and if its valid you should see some output like the following, instead of an object not found error:

```
PS C:\Users\Administrator> get-adobject -id "87564274-339B-4CFB-8686-8CBE2F4AB035"

DistinguishedName                                          Name    ObjectClass              ObjectGUID
-----------------                                          ----    -----------              ----------
CN=S-1-5-4,CN=ForeignSecurityPrincipals,DC=daforest,DC=com S-1-5-4 foreignSecurityPrincipal 87564274-339b-4cfb-8686-8cbe2f4ab035


PS C:\Users\Administrator>
```

- [ ] Finally modify `ldap_queries_default.yaml` and include the following:

```
  - action: ENUM_SID
    description: 'Enumerate SIDs.'
    filter: '(objectSID=*)'
    attributes:
      - cn
      - name
      - objectSID
```
- [ ] `reload`
- [ ] `set ACTION ENUM_SID`
- [ ] `run`
- Verify you now see output similar to the following with the `objectSID` field properly decoded into an SID instead of being a binary blob.

```
CN=DnsUpdateProxy CN=Users DC=daforest DC=com
=============================================

 Name       Attributes
 ----       ----------
 cn         DnsUpdateProxy
 name       DnsUpdateProxy
 objectsid  S-1-5-21-3290009963-1772292745-3260174523-1102
```
- [ ] Update the `ldap_queries_default.yaml` file and add the follow entry:

```
  - action: ENUM_TIME_ELEMENTS
    description: 'Enumerate time elements'
    filter: '(CreationTime=*)'
    attributes:
      - cn
      - name
      - creationTime
      - lockoutDuration
      - maxPwdAge
      - minPwdAge
      - systemFlags
```
- [ ] `reload`
- [ ] `set ACTION ENUM_TIME_ELEMENTS`
- [ ] `run`
- [ ] Verify that you get decoded `maxPwdAge`, `minPwdAge` elements, that `lockoutDuration` is a time string and not an integer anymore, and that `systemFlags` is decoded into a string and isn't a negative integer anymore.

```
msf6 auxiliary(gather/ldap_query) > run
[*] Running module against 172.22.163.183

[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[+] 172.22.163.183:389 Discovered base DN: DC=daforest,DC=com
DC=daforest DC=com
==================

 Name             Attributes
 ----             ----------
 creationtime     2022-09-01 19:37:37 UTC
 lockoutduration  0:00:30:00
 maxpwdage        42:00:00:00
 minpwdage        1:00:00:00
 name             daforest
 systemflags      FLAG_DISALLOW_DELETE | FLAG_DOMAIN_DISALLOW_RENAME | FLAG_DOMAIN_DISALLOW_MOVE

CN=Builtin DC=daforest DC=com
=============================

 Name             Attributes
 ----             ----------
 cn               Builtin
 creationtime     2022-08-18 17:48:12 UTC
 lockoutduration  0:00:30:00
 maxpwdage        42:22:47:31
 minpwdage        0:00:00:00
 name             Builtin
 systemflags      FLAG_DISALLOW_DELETE | FLAG_DOMAIN_DISALLOW_RENAME | FLAG_DOMAIN_DISALLOW_MOVE

[*] Auxiliary module execution completed
msf6 auxiliary(gather/ldap_query) > 
```