### PR TITLE
Update Dell iDRAC login scanner to work with v8 and v9

### DIFF
--- a/data/wordlists/idrac_default_pass.txt
+++ b/data/wordlists/idrac_default_pass.txt
@@ -1,3 +1,4 @@
 calvin
 123456
 password
+user1234

--- a/documentation/modules/auxiliary/scanner/http/dell_idrac.md
+++ b/documentation/modules/auxiliary/scanner/http/dell_idrac.md
@@ -5,6 +5,8 @@ default username and password.  Tested against Dell Remote Access:
 
 - Controller 6 - Express version 1.50 and 1.85,
 - Controller 7 - Enterprise 2.63.60.62
+- Controller 8 - Enterprise 2.83.05
+- Controller 9 - Enterprise 4.40.00.00
 
 ## Verification Steps
 

--- a/modules/auxiliary/scanner/http/dell_idrac.rb
+++ b/modules/auxiliary/scanner/http/dell_idrac.rb
@@ -67,7 +67,6 @@ class MetasploitModule < Msf::Auxiliary
 
   def do_login_pre9(user = nil, pass = nil)
     if @blockingtime > 0
-      vprint_error("\tServer throttled logins at #{@blockingtime} seconds")
       sleep(@blockingtime)
     end
     uri = pre_v9_url
@@ -101,6 +100,7 @@ class MetasploitModule < Msf::Auxiliary
       # seen on idrac 8
       if body =~ %r{<blockingTime>(\d+)</blockingTime>}
         @blockingtime = Regexp.last_match(1).to_i
+        vprint_error("\tServer throttled logins at #{@blockingtime} seconds")
       else
         @blockingtime = 0
       end
@@ -109,7 +109,6 @@ class MetasploitModule < Msf::Auxiliary
 
   def do_login_v9(user = nil, pass = nil)
     if @blockingtime > 0
-      vprint_error("\tServer throttled logins at #{@blockingtime} seconds")
       sleep(@blockingtime)
     end
     uri = v9_url
@@ -136,6 +135,7 @@ class MetasploitModule < Msf::Auxiliary
       vprint_error("#{target_url} - Dell iDRAC - Failed to login as '#{user}' with password '#{pass}'")
       if !json['blockingTime'].nil? && json['blockingTime'] > 0
         @blockingtime = json['blockingTime']
+        vprint_error("\tServer throttled logins at #{@blockingtime} seconds")
       else
         @blockingtime = 0
       end

--- a/modules/auxiliary/scanner/http/dell_idrac.rb
+++ b/modules/auxiliary/scanner/http/dell_idrac.rb
@@ -17,20 +17,21 @@ class MetasploitModule < Msf::Auxiliary
         default username and password.  Tested against Dell Remote Access
         Controller 6 - Express version 1.50 and 1.85,
         Controller 7 - Enterprise 2.63.60.62
+        Controller 8 - Enterprise 2.83.05
+        Controller 9 - Enterprise 4.40.00.00
       },
-      'Author' =>
-        [
-          'Cristiano Maruti <cmaruti[at]gmail.com>'
-        ],
-      'References' =>
-        [
-          ['CVE', '1999-0502'] # Weak password
-        ],
+      'Author' => [
+        'Cristiano Maruti <cmaruti[at]gmail.com>', # < v8
+        'h00die' # v8, v9
+      ],
+      'References' => [
+        ['CVE', '1999-0502'] # Weak password
+      ],
       'License' => MSF_LICENSE
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'Path to the iDRAC Administration page', '/data/login']),
+      OptString.new('TARGETURI', [true, 'Path to the iDRAC Administration Login page', '/']),
       OptPath.new('USER_FILE', [
         false, 'File containing users, one per line',
         File.join(Msf::Config.data_directory, 'wordlists', 'idrac_default_user.txt')
@@ -47,6 +48,14 @@ class MetasploitModule < Msf::Auxiliary
     ])
   end
 
+  def pre_v9_url
+    normalize_uri(target_uri.path, 'data', 'login')
+  end
+
+  def v9_url
+    normalize_uri(target_uri.path, 'sysmgmt', '2015', 'bmc', 'session')
+  end
+
   def target_url
     proto = 'http'
     if (rport == 443) || ssl
@@ -56,9 +65,8 @@ class MetasploitModule < Msf::Auxiliary
     "#{proto}://#{vhost}:#{rport}#{uri}"
   end
 
-  def do_login(user = nil, pass = nil)
-
-    uri = normalize_uri(target_uri.path)
+  def do_login_pre9(user = nil, pass = nil)
+    uri = pre_v9_url
     auth = send_request_cgi({
       'method' => 'POST',
       'uri' => uri,
@@ -68,8 +76,11 @@ class MetasploitModule < Msf::Auxiliary
         'password' => pass
       }
     })
-
-    if (auth && !auth.body.to_s.match(%r{<authResult>[0|5]</authResult>}).nil?)
+    unless auth
+      print_error('iDRAC failed to respond to login attempt')
+      return :next_user # assume this is a temporary error
+    end
+    if !auth.body.to_s.match(%r{<authResult>[0|5]</authResult>}).nil?
       print_good("#{target_url} - SUCCESSFUL login for user '#{user}' with password '#{pass}'")
       report_cred(
         ip: rhost,
@@ -81,7 +92,43 @@ class MetasploitModule < Msf::Auxiliary
       )
       return :next_user
     else
-      print_error("#{target_url} - Dell iDRAC - Failed to login as '#{user}' with password '#{pass}'")
+      vprint_error("#{target_url} - Dell iDRAC - Failed to login as '#{user}' with password '#{pass}'")
+    end
+  end
+
+  def do_login_v9(user = nil, pass = nil)
+    uri = v9_url
+    auth = send_request_cgi({
+      'method' => 'POST',
+      'uri' => uri,
+      'SSL' => true,
+      'headers' => { 'user' => user, 'password' => pass },
+      'vars_post' => {
+        'user' => user,
+        'password' => pass
+      }
+    })
+    unless auth
+      print_error('iDRAC failed to respond to login attempt')
+      return :next_user # assume this is a temporary error
+    end
+    json = JSON.parse(auth.body)
+    if json['authResult'] == 1
+      vprint_error("#{target_url} - Dell iDRAC - Failed to login as '#{user}' with password '#{pass}'")
+      unless json['blockingTime'] == 0
+        vprint_error("\tServer throttled logins at #{json['blockingTime']} seconds")
+      end
+    else
+      print_good("#{target_url} - SUCCESSFUL login for user '#{user}' with password '#{pass}'")
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: (ssl ? 'https' : 'http'),
+        user: user,
+        password: pass,
+        proof: auth.body.to_s
+      )
+      return :next_user
     end
   end
 
@@ -114,25 +161,58 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     print_status("Verifying that login page exists at #{ip}")
-    uri = normalize_uri(target_uri.path)
+    server_response = false
     begin
+      # <= v8
       res = send_request_raw({
         'method' => 'GET',
-        'uri' => uri
+        'uri' => pre_v9_url
       })
 
-      if (res && (res.code == 200) && !res.body.to_s.match(/<authResult>1/).nil?)
-        print_status('Attempting authentication')
+      if res && res.code == 200
+        server_response = true
+        if !res.body.to_s.match(/<authResult>1/).nil? || # version <8
+           !res.body.to_s.match(/<authResult>99/).nil? # version 8 of idrac shows 99 on first connect
+          print_status('Attempting authentication against iDRAC version < 9')
 
-        each_user_pass do |user, pass|
-          do_login(user, pass)
+          each_user_pass do |user, pass|
+            do_login_pre9(user, pass)
+          end
+        elsif res.code == 301
+          print_error("#{target_url} - Page redirect to #{res.headers['Location']}")
+          return :abort
+        else
+          print_error("The iDRAC login page not detected on #{ip}")
+          return :abort
         end
+      end
 
-      elsif (res && (res.code == 301))
-        print_error("#{target_url} - Page redirect to #{res.headers['Location']}")
-        return :abort
-      else
-        print_error("The iDRAC login page does not exist at #{ip}")
+      # v9
+      res = send_request_raw({
+        'method' => 'GET',
+        'uri' => v9_url
+      })
+
+      if res && res.code == 401
+        server_response = true
+        json = JSON.parse(res.body)
+        if !json['authResult'].nil? # version 9
+          print_status('Attempting authentication against iDRAC version 9')
+
+          each_user_pass do |user, pass|
+            do_login_v9(user, pass)
+          end
+        elsif res.code == 301
+          print_error("#{target_url} - Page redirect to #{res.headers['Location']}")
+          return :abort
+        else
+          print_error("The iDRAC login page not detected on #{ip}")
+          return :abort
+        end
+      end
+
+      unless server_response
+        print_error("The iDRAC login page not detected on #{ip}")
         return :abort
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout


### PR DESCRIPTION
Fixes #16690 

Updates the Dell iDRAC login scanner to work with version 8 and version 9. Also prints backoff times (although doesn't implement any backing off itself) for v9

**WHOEVER TESTS THIS** I don't own a version 8 or 9, so please verify that the successful login works.

Also adding user1:user1234 to the creds list since https://twitter.com/e1m1sk/status/103339127835082752 and @ErikWynter mentioned seeing it often.

## Verification

- [ ] Start `msfconsole`
- [ ] `use modules/auxiliary/scanner/http/dell_idrac`
- [ ] `set rhosts`
- [ ] `run`
- [ ] **Verify** it finds the iDRAC and logs successful & failed logins correctly
