### PR TITLE
guard for all possible RubySMBError conditions

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -128,11 +128,13 @@ module Metasploit
               else
                 status = Metasploit::Model::Login::Status::INCORRECT
             end
-          rescue ::Rex::ConnectionError, Errno::EINVAL, RubySMB::Error::NetBiosSessionService => e
+          rescue ::Rex::ConnectionError, Errno::EINVAL, RubySMB::Error::NetBiosSessionService, RubySMB::Error::NegotiationFailure, RubySMB::Error::CommunicationError  => e
             status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             proof = e
-          rescue RubySMB::Error::UnexpectedStatusCode => e
+          rescue RubySMB::Error::UnexpectedStatusCode => _e
             status = Metasploit::Model::Login::Status::INCORRECT
+          rescue RubySMB::Error::RubySMBError => _e
+            status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           ensure
             client.disconnect! if client
           end


### PR DESCRIPTION
Add guards for error conditions from ruby_smb. This ensures communication during a credential scan does not cause an exception that halts the entire module run.


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/smb/smb_login`
- [ ] **Verify** normal function against various targets

