### PR TITLE
Fix iax2 module crash

### DIFF
--- a/lib/rex/proto/iax2/client.rb
+++ b/lib/rex/proto/iax2/client.rb
@@ -21,7 +21,7 @@ class Client
     opts = {
       :caller_number => '15555555555',
       :caller_name   => '',
-      :server_port   => IAX2_DEFAULT_PORT,
+      :server_port   => Constants::IAX2_DEFAULT_PORT,
       :context       => { }
     }.merge(uopts)
 


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/16997

## Verification

I haven't verified this module against a real iax host, I've just fixed the immediate crash

Before - constant not found:

```
msf6 auxiliary(scanner/voice/recorder) > run iax_host=127.0.0.1 targets=1-555-555-5555 output_path=./foo
[*] Running module against 127.0.0.1

[-] Auxiliary failed: NameError uninitialized constant Rex::Proto::IAX2::Client::IAX2_DEFAULT_PORT
[-] Call stack:
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/rex/proto/iax2/client.rb:24:in `initialize'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/auxiliary/iax2.rb:38:in `new'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/auxiliary/iax2.rb:38:in `connect'
[-]   /Users/adfoster/Documents/code/metasploit-framework/modules/auxiliary/scanner/voice/recorder.rb:28:in `run'
[*] Auxiliary module execution completed
```

After - constant found, note the iax host isn't valid so the new error is expected for my local setup

```
msf6 auxiliary(scanner/voice/recorder) >  run iax_host=127.0.0.1 targets=1-555-555-5555 output_path=./foo
[*] Running module against 127.0.0.1

[-] Auxiliary failed: Errno::EISCONN Socket is already connected - sendto(2)

```