### PR TITLE
Msf::Post::Windows: Replace load_extapi with ExtAPI capability check

### DIFF
--- a/lib/msf/core/post/windows/accounts.rb
+++ b/lib/msf/core/post/windows/accounts.rb
@@ -1,12 +1,12 @@
 # -*- coding: binary -*-
 
-
 module Msf
   class Post
     module Windows
       module Accounts
         include Msf::Post::Windows::Error
         include Msf::Post::Windows::Registry
+        require 'rex/post/meterpreter/extensions/extapi/command_ids'
 
         GUID = [
           ['Data1', :DWORD],
@@ -70,7 +70,7 @@ module Msf
         #
         # @return [Boolean] Target host is an Active Directory domain controller
         def domain_controller?
-          registry_enumkeys("HKLM\\SYSTEM\\CurrentControlSet\\Services\\NTDS")&.include?('Parameters') ? true : false
+          registry_enumkeys('HKLM\\SYSTEM\\CurrentControlSet\\Services\\NTDS')&.include?('Parameters') ? true : false
         end
 
         # @return [String] Active Directory primary domain controller FQDN
@@ -79,14 +79,15 @@ module Msf
             domain = get_domain('DomainControllerName')
           else
             # Use cached domain controller name
-            key = "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\History"
+            key = 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\History'
             return unless registry_key_exist?(key)
+
             domain = registry_getvaldata(key, 'DCName')
           end
 
           return unless domain
 
-          domain.gsub(%r{^\\\\}, '')
+          domain.gsub(/^\\\\/, '')
         end
 
         # @return [String] Active Directory domain FQDN
@@ -96,7 +97,7 @@ module Msf
           end
 
           # Use cached domain name
-          key = "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\History"
+          key = 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\History'
           return unless registry_key_exist?(key)
 
           registry_getvaldata(key, 'MachineDomain')
@@ -126,6 +127,10 @@ module Msf
         ##
         def get_domain(info_key = 'DomainName', server_name = nil)
           domain = nil
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           result = session.railgun.netapi32.DsGetDcNameA(
             server_name,
             nil,
@@ -174,6 +179,10 @@ module Msf
         #   Everything other than ':success' signifies failure
         ##
         def delete_user(username, server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           deletion = client.railgun.netapi32.NetUserDel(server_name, username)
 
           # http://msdn.microsoft.com/en-us/library/aa370674.aspx
@@ -230,6 +239,10 @@ module Msf
         #   If an invalid system_name is provided, there will be a Windows error and nil returned
         ##
         def resolve_sid(sid, system_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           adv = client.railgun.advapi32
 
           # Second param is the size of the buffer where the pointer will be written
@@ -316,9 +329,9 @@ module Msf
           sid_type = lookup_sid_name_use(lookup['peUse'].unpack1('C'))
 
           return {
-            name:   lookup['Name'],
+            name: lookup['Name'],
             domain: lookup['ReferencedDomainName'],
-            type:   sid_type,
+            type: sid_type,
             mapped: true
           }
         end
@@ -360,17 +373,21 @@ module Msf
         # @return [Integer] the impersonate token handle identifier if success, nil if
         #  fails
         def get_imperstoken
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           adv = session.railgun.advapi32
-          tok_all = "TOKEN_ASSIGN_PRIMARY |TOKEN_DUPLICATE | TOKEN_IMPERSONATE | TOKEN_QUERY | "
-          tok_all << "TOKEN_QUERY_SOURCE | TOKEN_ADJUST_PRIVILEGES | TOKEN_ADJUST_GROUPS"
-          tok_all << " | TOKEN_ADJUST_DEFAULT"
+          tok_all = 'TOKEN_ASSIGN_PRIMARY |TOKEN_DUPLICATE | TOKEN_IMPERSONATE | TOKEN_QUERY | '
+          tok_all << 'TOKEN_QUERY_SOURCE | TOKEN_ADJUST_PRIVILEGES | TOKEN_ADJUST_GROUPS'
+          tok_all << ' | TOKEN_ADJUST_DEFAULT'
 
           pid = session.sys.process.open.pid
           pr = session.sys.process.open(pid, PROCESS_ALL_ACCESS)
           pt = adv.OpenProcessToken(pr.handle, tok_all, 4) # get handle to primary token
-          it = adv.DuplicateToken(pt["TokenHandle"], 2, 4) # get an impersonation token
-          if it["return"] # if it fails return 0 for error handling
-            return it["DuplicateTokenHandle"]
+          it = adv.DuplicateToken(pt['TokenHandle'], 2, 4) # get an impersonation token
+          if it['return'] # if it fails return 0 for error handling
+            return it['DuplicateTokenHandle']
           else
             return nil
           end
@@ -383,21 +400,25 @@ module Msf
         # @param [Integer] token the access token
         # @return [String, nil] a String describing the permissions or nil
         def check_dir_perms(dir, token)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           adv = session.railgun.advapi32
-          si = "OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION"
-          result = ""
+          si = 'OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION'
+          result = ''
 
           # define generic mapping structure
           gen_map = [0, 0, 0, 0]
-          gen_map = gen_map.pack("V")
+          gen_map = gen_map.pack('V')
           buffer_size = 500
 
           # get Security Descriptor for the directory
           f = adv.GetFileSecurityA(dir, si, buffer_size, buffer_size, 4)
-          if f['return'] && f["lpnLengthNeeded"] <= buffer_size
-            sd = f["pSecurityDescriptor"]
+          if f['return'] && f['lpnLengthNeeded'] <= buffer_size
+            sd = f['pSecurityDescriptor']
           elsif f['GetLastError'] == 122 # ERROR_INSUFFICIENT_BUFFER
-            sd = adv.GetFileSecurityA(dir, si, f["lpnLengthNeeded"], f["lpnLengthNeeded"], 4)
+            sd = adv.GetFileSecurityA(dir, si, f['lpnLengthNeeded'], f['lpnLengthNeeded'], 4)
           elsif f['GetLastError'] == 2
             vprint_error("The system cannot find the file specified: #{dir}")
             return nil
@@ -407,18 +428,18 @@ module Msf
           end
 
           # check for write access, called once to get buffer size
-          a = adv.AccessCheck(sd, token, "ACCESS_READ | ACCESS_WRITE", gen_map, 0, 0, 4, 8)
-          len = a["PrivilegeSetLength"]
+          a = adv.AccessCheck(sd, token, 'ACCESS_READ | ACCESS_WRITE', gen_map, 0, 0, 4, 8)
+          len = a['PrivilegeSetLength']
 
-          r = adv.AccessCheck(sd, token, "ACCESS_READ", gen_map, len, len, 4, 8)
-          return nil if !r["return"]
+          r = adv.AccessCheck(sd, token, 'ACCESS_READ', gen_map, len, len, 4, 8)
+          return nil if !r['return']
 
-          result << "R" if r["GrantedAccess"] > 0
+          result << 'R' if r['GrantedAccess'] > 0
 
-          w = adv.AccessCheck(sd, token, "ACCESS_WRITE", gen_map, len, len, 4, 8)
-          return nil if !w["return"]
+          w = adv.AccessCheck(sd, token, 'ACCESS_WRITE', gen_map, len, len, 4, 8)
+          return nil if !w['return']
 
-          result << "W" if w["GrantedAccess"] > 0
+          result << 'W' if w['GrantedAccess'] > 0
 
           result
         end
@@ -435,6 +456,10 @@ module Msf
         #   password    - The password to be assigned to the new user account
         ##
         def add_user(username, password, server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           addr_username = session.railgun.util.alloc_and_write_wstring(username)
           addr_password = session.railgun.util.alloc_and_write_wstring(password)
           #  Set up the USER_INFO_1 structure.
@@ -448,11 +473,11 @@ module Msf
             0x0,
             client.railgun.const('UF_SCRIPT | UF_NORMAL_ACCOUNT|UF_DONT_EXPIRE_PASSWD'),
             0x0
-          ].pack(client.arch == ARCH_X86 ? "VVVVVVVV" : "QQVVQQVQ")
+          ].pack(client.arch == ARCH_X86 ? 'VVVVVVVV' : 'QQVVQQVQ')
           result = client.railgun.netapi32.NetUserAdd(server_name, 1, user_info, 4)
           client.railgun.multi([
-            ["kernel32", "VirtualFree", [addr_username, 0, MEM_RELEASE]], #  addr_username
-            ["kernel32", "VirtualFree", [addr_password, 0, MEM_RELEASE]], #  addr_password
+            ['kernel32', 'VirtualFree', [addr_username, 0, MEM_RELEASE]], #  addr_username
+            ['kernel32', 'VirtualFree', [addr_password, 0, MEM_RELEASE]], #  addr_password
           ])
           return result
         end
@@ -468,16 +493,20 @@ module Msf
         #   localgroup  - Specifies a local group name
         ##
         def add_localgroup(localgroup, server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           #  Set up the #  LOCALGROUP_INFO_1 structure.
           addr_group = session.railgun.util.alloc_and_write_wstring(localgroup)
           #  https://docs.microsoft.com/windows/desktop/api/lmaccess/ns-lmaccess-localgroup_info_1
           localgroup_info = [
             addr_group, #  lgrpi1_name
             0x0 #  lgrpi1_comment
-          ].pack(client.arch == ARCH_X86 ? "VV" : "QQ")
+          ].pack(client.arch == ARCH_X86 ? 'VV' : 'QQ')
           result = client.railgun.netapi32.NetLocalGroupAdd(server_name, 1, localgroup_info, 4)
           client.railgun.multi([
-            ["kernel32", "VirtualFree", [addr_group, 0, MEM_RELEASE]], #  addr_group
+            ['kernel32', 'VirtualFree', [addr_group, 0, MEM_RELEASE]], #  addr_group
           ])
           return result
         end
@@ -492,16 +521,20 @@ module Msf
         #   group       - Specifies a global group name
         ##
         def add_group(group, server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           addr_group = session.railgun.util.alloc_and_write_wstring(group)
           #  https://docs.microsoft.com/zh-cn/windows/win32/api/lmaccess/ns-lmaccess-group_info_1
           # Set up the GROUP_INFO_1 structure.
           group_info_1 = [
             addr_group,
             0x0
-          ].pack(client.arch == ARCH_X86 ? "VV" : "QQ")
+          ].pack(client.arch == ARCH_X86 ? 'VV' : 'QQ')
           result = client.railgun.netapi32.NetGroupAdd(server_name, 1, group_info_1, 4)
           client.railgun.multi([
-            ["kernel32", "VirtualFree", [addr_group, 0, MEM_RELEASE]], #  addr_group
+            ['kernel32', 'VirtualFree', [addr_group, 0, MEM_RELEASE]], #  addr_group
           ])
           return result
         end
@@ -517,15 +550,19 @@ module Msf
         #   username    - Specifies a local username
         ##
         def add_members_localgroup(localgroup, username, server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           addr_username = session.railgun.util.alloc_and_write_wstring(username)
           #  Set up the LOCALGROUP_MEMBERS_INFO_3 structure.
           #  https://docs.microsoft.com/windows/desktop/api/lmaccess/ns-lmaccess-localgroup_members_info_3
           localgroup_members = [
             addr_username,
-          ].pack(client.arch == ARCH_X86 ? "V" : "Q")
+          ].pack(client.arch == ARCH_X86 ? 'V' : 'Q')
           result = client.railgun.netapi32.NetLocalGroupAddMembers(server_name, localgroup, 3, localgroup_members, 1)
           client.railgun.multi([
-            ["kernel32", "VirtualFree", [addr_username, 0, MEM_RELEASE]],
+            ['kernel32', 'VirtualFree', [addr_username, 0, MEM_RELEASE]],
           ])
           return result
         end
@@ -541,6 +578,10 @@ module Msf
         #   username    - Specifies a global username
         ##
         def add_members_group(group, username, server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           result = client.railgun.netapi32.NetGroupAddUser(server_name, group, username)
           return result
         end
@@ -555,22 +596,26 @@ module Msf
         #   group       - Specifies a group name
         ##
         def get_members_from_group(groupname, server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           members = []
           result = client.railgun.netapi32.NetGroupGetUsers(server_name, groupname, 0, 4, 4096, 4, 4, 0)
           if (result['return'] == 0) && ((result['totalentries'] % 4294967296) != 0)
             begin
-                members_info_addr = result['bufptr'].unpack1("V")
-                unless members_info_addr == 0
-                  # Railgun assumes PDWORDS are pointers and returns 8 bytes for x64 architectures.
-                  # Therefore we need to truncate the result value to an actual
-                  # DWORD for entriesread or totalentries.
-                  members_info = session.railgun.util.read_array(GROUP_USERS_INFO, (result['totalentries'] % 4294967296), members_info_addr)
-                  for member in members_info
-                    members << member["grui0_name"]
-                  end
-                  return members
+              members_info_addr = result['bufptr'].unpack1('V')
+              unless members_info_addr == 0
+                # Railgun assumes PDWORDS are pointers and returns 8 bytes for x64 architectures.
+                # Therefore we need to truncate the result value to an actual
+                # DWORD for entriesread or totalentries.
+                members_info = session.railgun.util.read_array(GROUP_USERS_INFO, (result['totalentries'] % 4294967296), members_info_addr)
+                for member in members_info
+                  members << member['grui0_name']
                 end
+                return members
               end
+            end
           else
             return members
           end
@@ -588,19 +633,23 @@ module Msf
         #   group       - Specifies a group name
         ##
         def get_members_from_localgroup(localgroupname, server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           members = []
           result = client.railgun.netapi32.NetLocalGroupGetMembers(server_name, localgroupname, 3, 4, 4096, 4, 4, 0)
           if (result['return'] == 0) && ((result['totalentries'] % 4294967296) != 0)
             begin
-                members_info_addr = result['bufptr'].unpack1("V")
-                unless members_info_addr == 0
-                  members_info = session.railgun.util.read_array(LOCALGROUP_MEMBERS_INFO, (result['totalentries'] % 4294967296), members_info_addr)
-                  for member in members_info
-                    members << member["lgrmi3_domainandname"]
-                  end
-                  return members
+              members_info_addr = result['bufptr'].unpack1('V')
+              unless members_info_addr == 0
+                members_info = session.railgun.util.read_array(LOCALGROUP_MEMBERS_INFO, (result['totalentries'] % 4294967296), members_info_addr)
+                for member in members_info
+                  members << member['lgrmi3_domainandname']
                 end
+                return members
               end
+            end
           else
             return members
           end
@@ -617,16 +666,20 @@ module Msf
         #   server_name - The DNS or NetBIOS name of the remote server on which the function is to execute.
         ##
         def enum_user(server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           users = []
           filter = 'FILTER_NORMAL_ACCOUNT|FILTER_TEMP_DUPLICATE_ACCOUNT'
           result = client.railgun.netapi32.NetUserEnum(server_name, 0, client.railgun.const(filter), 4, 4096, 4, 4, 0)
           if (result['return'] == 0) && ((result['totalentries'] % 4294967296) != 0)
             begin
-              user_info_addr = result['bufptr'].unpack1("V")
+              user_info_addr = result['bufptr'].unpack1('V')
               unless user_info_addr == 0
                 user_info = session.railgun.util.read_array(USER_INFO, (result['totalentries'] % 4294967296), user_info_addr)
                 for member in user_info
-                  users << member["usri0_name"]
+                  users << member['usri0_name']
                 end
                 return users
               end
@@ -647,15 +700,19 @@ module Msf
         #   server_name - The DNS or NetBIOS name of the remote server on which the function is to execute.
         ##
         def enum_localgroup(server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           localgroups = []
           result = client.railgun.netapi32.NetLocalGroupEnum(server_name, 0, 4, 4096, 4, 4, 0)
           if (result['return'] == 0) && ((result['totalentries'] % 4294967296) != 0)
             begin
-              localgroup_info_addr = result['bufptr'].unpack1("V")
+              localgroup_info_addr = result['bufptr'].unpack1('V')
               unless localgroup_info_addr == 0
                 localgroup_info = session.railgun.util.read_array(LOCALGROUP_INFO, (result['totalentries'] % 4294967296), localgroup_info_addr)
                 for member in localgroup_info
-                  localgroups << member["lgrpi0_name"]
+                  localgroups << member['lgrpi0_name']
                 end
                 return localgroups
               end
@@ -676,15 +733,19 @@ module Msf
         #   server_name - The DNS or NetBIOS name of the remote server on which the function is to execute.
         ##
         def enum_group(server_name = nil)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
           groups = []
           result = client.railgun.netapi32.NetGroupEnum(server_name, 0, 4, 4096, 4, 4, 0)
           if (result['return'] == 0) && ((result['totalentries'] % 4294967296) != 0)
             begin
-              group_info_addr = result['bufptr'].unpack1("V")
+              group_info_addr = result['bufptr'].unpack1('V')
               unless group_info_addr == 0
                 group_info = session.railgun.util.read_array(GROUP_INFO, (result['totalentries'] % 4294967296), group_info_addr)
                 for member in group_info
-                  groups << member["grpi0_name"]
+                  groups << member['grpi0_name']
                 end
                 return groups
               end

--- a/lib/msf/core/post/windows/accounts.rb
+++ b/lib/msf/core/post/windows/accounts.rb
@@ -374,7 +374,7 @@ module Msf
         #  fails
         def get_imperstoken
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           adv = session.railgun.advapi32
@@ -401,7 +401,7 @@ module Msf
         # @return [String, nil] a String describing the permissions or nil
         def check_dir_perms(dir, token)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           adv = session.railgun.advapi32
@@ -457,7 +457,7 @@ module Msf
         ##
         def add_user(username, password, server_name = nil)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           addr_username = session.railgun.util.alloc_and_write_wstring(username)
@@ -494,7 +494,7 @@ module Msf
         ##
         def add_localgroup(localgroup, server_name = nil)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           #  Set up the #  LOCALGROUP_INFO_1 structure.
@@ -522,7 +522,7 @@ module Msf
         ##
         def add_group(group, server_name = nil)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           addr_group = session.railgun.util.alloc_and_write_wstring(group)
@@ -551,7 +551,7 @@ module Msf
         ##
         def add_members_localgroup(localgroup, username, server_name = nil)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           addr_username = session.railgun.util.alloc_and_write_wstring(username)
@@ -579,7 +579,7 @@ module Msf
         ##
         def add_members_group(group, username, server_name = nil)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           result = client.railgun.netapi32.NetGroupAddUser(server_name, group, username)
@@ -597,7 +597,7 @@ module Msf
         ##
         def get_members_from_group(groupname, server_name = nil)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           members = []
@@ -634,7 +634,7 @@ module Msf
         ##
         def get_members_from_localgroup(localgroupname, server_name = nil)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           members = []
@@ -667,7 +667,7 @@ module Msf
         ##
         def enum_user(server_name = nil)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           users = []
@@ -701,7 +701,7 @@ module Msf
         ##
         def enum_localgroup(server_name = nil)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           localgroups = []
@@ -734,7 +734,7 @@ module Msf
         ##
         def enum_group(server_name = nil)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           groups = []

--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -136,7 +136,7 @@ module LDAP
       raise "Unable to find the domain to query."
     end
 
-    if load_extapi
+    if session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_ADSI_DOMAIN_QUERY)
       return session.extapi.adsi.domain_query(domain, filter, max_results, DEFAULT_PAGE_SIZE, fields)
     else
       if domain and domain.include? "DC="

--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -262,7 +262,7 @@ module Msf
         # @return [Array] Entry data structure
         def get_entry(pEntry)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           return client.railgun.memread(pEntry, 41).unpack('VVVVVVVVVvCCC')
@@ -274,7 +274,7 @@ module Msf
         # @return [String] The BER data structure
         def get_ber(msg)
           unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            return nil
+            raise "Session doesn't support Railgun!"
           end
 
           ber = client.railgun.memread(msg[2], 60).unpack('V*')

--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -1,390 +1,399 @@
 # -*- coding: binary -*-
 
 module Msf
-class Post
-module Windows
+  class Post
+    module Windows
+      #
+      # @see
+      #   http://msdn.microsoft.com/en-us/library/windows/desktop/aa366961(v=vs.85).aspx
+      #   MSDN: Lightweight Directory Access Protocol
+      module LDAP
+        include Msf::Post::Windows::Error
+        include Msf::Post::Windows::ExtAPI
+        include Msf::Post::Windows::Accounts
+        require 'rex/post/meterpreter/extensions/extapi/command_ids'
 
-#
-# @see
-#   http://msdn.microsoft.com/en-us/library/windows/desktop/aa366961(v=vs.85).aspx
-#   MSDN: Lightweight Directory Access Protocol
-module LDAP
+        LDAP_SIZELIMIT_EXCEEDED = 0x04
+        LDAP_OPT_SIZELIMIT = 0x03
+        LDAP_AUTH_NEGOTIATE = 0x0486
 
-  include Msf::Post::Windows::Error
-  include Msf::Post::Windows::ExtAPI
-  include Msf::Post::Windows::Accounts
+        DEFAULT_PAGE_SIZE = 500
 
-  LDAP_SIZELIMIT_EXCEEDED = 0x04
-  LDAP_OPT_SIZELIMIT = 0x03
-  LDAP_AUTH_NEGOTIATE = 0x0486
-
-  DEFAULT_PAGE_SIZE = 500
-
-  ERROR_CODE_TO_CONSTANT =
-  {
-    0x0b => 'LDAP_ADMIN_LIMIT_EXCEEDED',
-    0x47 => 'LDAP_AFFECTS_MULTIPLE_DSAS',
-    0x24 => 'LDAP_ALIAS_DEREF_PROBLEM',
-    0x21 => 'LDAP_ALIAS_PROBLEM',
-    0x44 => 'LDAP_ALREADY_EXISTS',
-    0x14 => 'LDAP_ATTRIBUTE_OR_VALUE_EXISTS',
-    0x07 => 'LDAP_AUTH_METHOD_NOT_SUPPORTED',
-    0x56 => 'LDAP_AUTH_UNKNOWN',
-    0x33 => 'LDAP_BUSY',
-    0x60 => 'LDAP_CLIENT_LOOP',
-    0x05 => 'LDAP_COMPARE_FALSE',
-    0x06 => 'LDAP_COMPARE_TRUE',
-    0x0d => 'LDAP_CONFIDENTIALITY_REQUIRED',
-    0x5b => 'LDAP_CONNECT_ERROR',
-    0x13 => 'LDAP_CONSTRAINT_VIOLATION',
-    0x5d => 'LDAP_CONTROL_NOT_FOUND',
-    0x54 => 'LDAP_DECODING_ERROR',
-    0x53 => 'LDAP_ENCODING_ERROR',
-    0x57 => 'LDAP_FILTER_ERROR',
-    0x30 => 'LDAP_INAPPROPRIATE_AUTH',
-    0x12 => 'LDAP_INAPPROPRIATE_MATCHING',
-    0x32 => 'LDAP_INSUFFICIENT_RIGHTS',
-    0x31 => 'LDAP_INVALID_CREDENTIALS',
-    0x22 => 'LDAP_INVALID_DN_SYNTAX',
-    0x15 => 'LDAP_INVALID_SYNTAX',
-    0x23 => 'LDAP_IS_LEAF',
-    0x52 => 'LDAP_LOCAL_ERROR',
-    0x36 => 'LDAP_LOOP_DETECT',
-    0x5f => 'LDAP_MORE_RESULTS_TO_RETURN',
-    0x40 => 'LDAP_NAMING_VIOLATION',
-    0x5a => 'LDAP_NO_MEMORY',
-    0x45 => 'LDAP_NO_OBJECT_CLASS_MODS',
-    0x5e => 'LDAP_NO_RESULTS_RETURNED',
-    0x10 => 'LDAP_NO_SUCH_ATTRIBUTE',
-    0x20 => 'LDAP_NO_SUCH_OBJECT',
-    0x42 => 'LDAP_NOT_ALLOWED_ON_NONLEAF',
-    0x43 => 'LDAP_NOT_ALLOWED_ON_RDN',
-    0x5c => 'LDAP_NOT_SUPPORTED',
-    0x41 => 'LDAP_OBJECT_CLASS_VIOLATION',
-    0x01 => 'LDAP_OPERATIONS_ERROR',
-    0x50 => 'LDAP_OTHER',
-    0x59 => 'LDAP_PARAM_ERROR',
-    0x09 => 'LDAP_PARTIAL_RESULTS',
-    0x02 => 'LDAP_PROTOCOL_ERROR',
-    0x0a => 'LDAP_REFERRAL',
-    0x61 => 'LDAP_REFERRAL_LIMIT_EXCEEDED',
-    # 0x09 => 'LDAP_REFERRAL_V2', alias for LDAP_PARTIAL_RESULTS
-    0x46 => 'LDAP_RESULTS_TOO_LARGE',
-    0x51 => 'LDAP_SERVER_DOWN',
-    0x04 => 'LDAP_SIZELIMIT_EXCEEDED',
-    0x08 => 'LDAP_STRONG_AUTH_REQUIRED',
-    0x00 => 'LDAP_SUCCESS',
-    0x03 => 'LDAP_TIMELIMIT_EXCEEDED',
-    0x55 => 'LDAP_TIMEOUT',
-    0x34 => 'LDAP_UNAVAILABLE',
-    0x0c => 'LDAP_UNAVAILABLE_CRIT_EXTENSION',
-    0x11 => 'LDAP_UNDEFINED_TYPE',
-    0x35 => 'LDAP_UNWILLING_TO_PERFORM',
-    0x58 => 'LDAP_USER_CANCELLED',
-    0x4c => 'LDAP_VIRTUAL_LIST_VIEW_ERROR'
-  }
-
-    def initialize(info = {})
-      super(
-        update_info(
-          info,
-          'Compat' => {
-            'Meterpreter' => {
-              'Commands' => %w[
-                extapi_adsi_domain_query
-                stdapi_railgun_api
-                stdapi_railgun_memread
-              ]
-            }
+        ERROR_CODE_TO_CONSTANT =
+          {
+            0x0b => 'LDAP_ADMIN_LIMIT_EXCEEDED',
+            0x47 => 'LDAP_AFFECTS_MULTIPLE_DSAS',
+            0x24 => 'LDAP_ALIAS_DEREF_PROBLEM',
+            0x21 => 'LDAP_ALIAS_PROBLEM',
+            0x44 => 'LDAP_ALREADY_EXISTS',
+            0x14 => 'LDAP_ATTRIBUTE_OR_VALUE_EXISTS',
+            0x07 => 'LDAP_AUTH_METHOD_NOT_SUPPORTED',
+            0x56 => 'LDAP_AUTH_UNKNOWN',
+            0x33 => 'LDAP_BUSY',
+            0x60 => 'LDAP_CLIENT_LOOP',
+            0x05 => 'LDAP_COMPARE_FALSE',
+            0x06 => 'LDAP_COMPARE_TRUE',
+            0x0d => 'LDAP_CONFIDENTIALITY_REQUIRED',
+            0x5b => 'LDAP_CONNECT_ERROR',
+            0x13 => 'LDAP_CONSTRAINT_VIOLATION',
+            0x5d => 'LDAP_CONTROL_NOT_FOUND',
+            0x54 => 'LDAP_DECODING_ERROR',
+            0x53 => 'LDAP_ENCODING_ERROR',
+            0x57 => 'LDAP_FILTER_ERROR',
+            0x30 => 'LDAP_INAPPROPRIATE_AUTH',
+            0x12 => 'LDAP_INAPPROPRIATE_MATCHING',
+            0x32 => 'LDAP_INSUFFICIENT_RIGHTS',
+            0x31 => 'LDAP_INVALID_CREDENTIALS',
+            0x22 => 'LDAP_INVALID_DN_SYNTAX',
+            0x15 => 'LDAP_INVALID_SYNTAX',
+            0x23 => 'LDAP_IS_LEAF',
+            0x52 => 'LDAP_LOCAL_ERROR',
+            0x36 => 'LDAP_LOOP_DETECT',
+            0x5f => 'LDAP_MORE_RESULTS_TO_RETURN',
+            0x40 => 'LDAP_NAMING_VIOLATION',
+            0x5a => 'LDAP_NO_MEMORY',
+            0x45 => 'LDAP_NO_OBJECT_CLASS_MODS',
+            0x5e => 'LDAP_NO_RESULTS_RETURNED',
+            0x10 => 'LDAP_NO_SUCH_ATTRIBUTE',
+            0x20 => 'LDAP_NO_SUCH_OBJECT',
+            0x42 => 'LDAP_NOT_ALLOWED_ON_NONLEAF',
+            0x43 => 'LDAP_NOT_ALLOWED_ON_RDN',
+            0x5c => 'LDAP_NOT_SUPPORTED',
+            0x41 => 'LDAP_OBJECT_CLASS_VIOLATION',
+            0x01 => 'LDAP_OPERATIONS_ERROR',
+            0x50 => 'LDAP_OTHER',
+            0x59 => 'LDAP_PARAM_ERROR',
+            0x09 => 'LDAP_PARTIAL_RESULTS',
+            0x02 => 'LDAP_PROTOCOL_ERROR',
+            0x0a => 'LDAP_REFERRAL',
+            0x61 => 'LDAP_REFERRAL_LIMIT_EXCEEDED',
+            # 0x09 => 'LDAP_REFERRAL_V2', alias for LDAP_PARTIAL_RESULTS
+            0x46 => 'LDAP_RESULTS_TOO_LARGE',
+            0x51 => 'LDAP_SERVER_DOWN',
+            0x04 => 'LDAP_SIZELIMIT_EXCEEDED',
+            0x08 => 'LDAP_STRONG_AUTH_REQUIRED',
+            0x00 => 'LDAP_SUCCESS',
+            0x03 => 'LDAP_TIMELIMIT_EXCEEDED',
+            0x55 => 'LDAP_TIMEOUT',
+            0x34 => 'LDAP_UNAVAILABLE',
+            0x0c => 'LDAP_UNAVAILABLE_CRIT_EXTENSION',
+            0x11 => 'LDAP_UNDEFINED_TYPE',
+            0x35 => 'LDAP_UNWILLING_TO_PERFORM',
+            0x58 => 'LDAP_USER_CANCELLED',
+            0x4c => 'LDAP_VIRTUAL_LIST_VIEW_ERROR'
           }
-        )
-      )
 
-      register_options(
-      [
-        OptString.new('DOMAIN', [false, 'The domain to query or distinguished name (e.g. DC=test,DC=com)', nil]),
-        OptInt.new('MAX_SEARCH', [true, 'Maximum values to retrieve, 0 for all.', 500]),
-      ], self.class)
-    end
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    extapi_adsi_domain_query
+                    stdapi_railgun_api
+                    stdapi_railgun_memread
+                  ]
+                }
+              }
+            )
+          )
 
-  # Converts a Distinguished Name to DNS name
-  #
-  # @param dn [String] Distinguished Name
-  # @return [String] DNS name
-  def dn_to_domain(dn)
-    if dn.include? "DC="
-      return dn.gsub(',','').split('DC=')[1..-1].join('.')
-    else
-      return dn
-    end
-  end
+          register_options(
+            [
+              OptString.new('DOMAIN', [false, 'The domain to query or distinguished name (e.g. DC=test,DC=com)', nil]),
+              OptInt.new('MAX_SEARCH', [true, 'Maximum values to retrieve, 0 for all.', 500]),
+            ], self.class
+          )
+        end
 
-  # Performs an ldap query
-  #
-  # @param filter [String] LDAP search filter
-  # @param max_results [Integer] Maximum results
-  # @param fields [Array<String>] Attributes to retrieve
-  # @param domain [String] Optional domain or distinguished name
-  # @return [Hash] Entries found
-  # @raise [RuntimeError] Raised when the default naming context isn't
-  #   specified as distinguished name.
-  def query(filter, max_results, fields, domain=nil)
-    domain ||= datastore['DOMAIN']
-    domain ||= get_domain
+        # Converts a Distinguished Name to DNS name
+        #
+        # @param dn [String] Distinguished Name
+        # @return [String] DNS name
+        def dn_to_domain(dn)
+          if dn.include? 'DC='
+            return dn.gsub(',', '').split('DC=')[1..-1].join('.')
+          else
+            return dn
+          end
+        end
 
-    if domain.blank?
-      raise "Unable to find the domain to query."
-    end
+        # Performs an ldap query
+        #
+        # @param filter [String] LDAP search filter
+        # @param max_results [Integer] Maximum results
+        # @param fields [Array<String>] Attributes to retrieve
+        # @param domain [String] Optional domain or distinguished name
+        # @return [Hash] Entries found
+        # @raise [RuntimeError] Raised when the default naming context isn't
+        #   specified as distinguished name.
+        def query(filter, max_results, fields, domain = nil)
+          domain ||= datastore['DOMAIN']
+          domain ||= get_domain
 
-    if session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_ADSI_DOMAIN_QUERY)
-      return session.extapi.adsi.domain_query(domain, filter, max_results, DEFAULT_PAGE_SIZE, fields)
-    else
-      if domain and domain.include? "DC="
-        default_naming_context = domain
-        domain = dn_to_domain(domain)
-      else
-        default_naming_context = get_default_naming_context(domain)
+          if domain.blank?
+            raise 'Unable to find the domain to query.'
+          end
+
+          if session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_ADSI_DOMAIN_QUERY)
+            return session.extapi.adsi.domain_query(domain, filter, max_results, DEFAULT_PAGE_SIZE, fields)
+          else
+            if domain and domain.include? 'DC='
+              default_naming_context = domain
+              domain = dn_to_domain(domain)
+            else
+              default_naming_context = get_default_naming_context(domain)
+            end
+
+            bind_default_ldap_server(max_results, domain) do |session_handle|
+              return query_ldap(session_handle, default_naming_context, 2, filter, fields)
+            end
+          end
+        end
+
+        # Performs a query to retrieve the default naming context
+        #
+        # @param domain [String] Optional domain or distinguished name
+        # @return [String]
+        def get_default_naming_context(domain = nil)
+          bind_default_ldap_server(1, domain) do |session_handle|
+            print_status('Querying default naming context')
+
+            query_result = query_ldap(session_handle, '', 0, '(objectClass=computer)', ['defaultNamingContext'])
+            first_entry_fields = query_result[:results].first
+            # Value from First Attribute of First Entry
+            default_naming_context = first_entry_fields.first[:value]
+            vprint_status("Default naming context #{default_naming_context}")
+            return default_naming_context
+          end
+        end
+
+        # Performs a query on the LDAP session
+        #
+        # @param session_handle [Handle] LDAP Session Handle
+        # @param base [Integer] Pointer to string that contains distinguished
+        #   name of entry to start the search
+        # @param scope [Integer] Search Scope
+        # @param filter [String] Search Filter
+        # @param fields [Array<String>] Attributes to retrieve
+        # @return [Hash] Entries found
+        def query_ldap(session_handle, base, scope, filter, fields)
+          vprint_status('Searching LDAP directory')
+          search = wldap32.ldap_search_sA(session_handle, base, scope, filter, nil, 0, 4)
+          vprint_status("search: #{search}")
+
+          if search['return'] == LDAP_SIZELIMIT_EXCEEDED
+            print_error('LDAP_SIZELIMIT_EXCEEDED, parsing what we retrieved, try increasing the MAX_SEARCH value [0:LDAP_NO_LIMIT]')
+          elsif search['return'] != Error::SUCCESS
+            print_error('No results')
+            wldap32.ldap_msgfree(search['res'])
+            return
+          end
+
+          search_count = wldap32.ldap_count_entries(session_handle, search['res'])['return']
+
+          if search_count == 0
+            print_error('No entries retrieved')
+            wldap32.ldap_msgfree(search['res'])
+            return
+          end
+
+          print_status("Entries retrieved: #{search_count}")
+
+          pEntries = []
+          entry_results = []
+
+          if datastore['MAX_SEARCH'] == 0
+            max_search = search_count
+          else
+            max_search = [datastore['MAX_SEARCH'], search_count].min
+          end
+
+          0.upto(max_search - 1) do |i|
+            if (i == 0)
+              pEntries[0] = wldap32.ldap_first_entry(session_handle, search['res'])['return']
+            end
+
+            if (pEntries[i] == 0)
+              print_error('Failed to get entry')
+              wldap32.ldap_msgfree(search['res'])
+              return
+            end
+
+            vprint_status("Entry #{i}: 0x#{pEntries[i].to_s(16)}")
+
+            entry = get_entry(pEntries[i])
+
+            # Entries are a linked list...
+            if client.arch == ARCH_X64
+              pEntries[i + 1] = entry[4]
+            else
+              pEntries[i + 1] = entry[3]
+            end
+
+            ber = get_ber(entry)
+
+            field_results = []
+            fields.each do |field|
+              vprint_status("Field: #{field}")
+
+              values = get_values_from_ber(ber, field)
+
+              values_result = ''
+              values_result = values.join(',') if values
+              vprint_status("Values #{values}")
+
+              field_results << { type: 'unknown', value: values_result }
+            end
+
+            entry_results << field_results
+          end
+
+          return {
+            fields: fields,
+            results: entry_results
+          }
+        end
+
+        # Gets the LDAP Entry
+        #
+        # @param pEntry [Integer] Pointer to the Entry
+        # @return [Array] Entry data structure
+        def get_entry(pEntry)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
+          return client.railgun.memread(pEntry, 41).unpack('VVVVVVVVVvCCC')
+        end
+
+        # Get BER Element data structure from LDAPMessage
+        #
+        # @param msg [String] The LDAP Message from the server
+        # @return [String] The BER data structure
+        def get_ber(msg)
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            return nil
+          end
+
+          ber = client.railgun.memread(msg[2], 60).unpack('V*')
+
+          # BER Pointer is different between x86 and x64
+          if client.arch == ARCH_X64
+            ber_data = client.railgun.memread(ber[4], ber[0])
+          else
+            ber_data = client.railgun.memread(ber[3], ber[0])
+          end
+
+          return ber_data
+        end
+
+        # Search through the BER data structure for our Attribute.
+        # This doesn't attempt to parse the BER structure correctly
+        # instead it finds the first occurance of our field name
+        # tries to check the length of that value.
+        #
+        # @param ber_data [String] BER data structure
+        # @param field [String] Attribute name
+        # @return [Array] Values for the given +field+
+        def get_values_from_ber(ber_data, field)
+          field_offset = ber_data.index(field)
+
+          unless field_offset
+            vprint_status("Field not found in BER: #{field}")
+            return nil
+          end
+
+          # Value starts after our field string
+          values_offset = field_offset + field.length
+          values_start_offset = values_offset + 8
+          values_len_offset = values_offset + 5
+          curr_len_offset = values_offset + 7
+
+          values_length = ber_data[values_len_offset].unpack('C')[0]
+          values_end_offset = values_start_offset + values_length
+
+          curr_length = ber_data[curr_len_offset].unpack('C')[0]
+          curr_start_offset = values_start_offset
+
+          if (curr_length >= 127)
+            curr_length = ber_data[curr_len_offset + 1, 4].unpack('N')[0]
+            curr_start_offset += 4
+          end
+
+          curr_end_offset = curr_start_offset + curr_length
+
+          values = []
+          while (curr_end_offset < values_end_offset)
+            values << ber_data[curr_start_offset..curr_end_offset]
+
+            break unless ber_data[curr_end_offset] == "\x04"
+
+            curr_len_offset = curr_end_offset + 1
+            curr_length = ber_data[curr_len_offset].unpack('C')[0]
+            curr_start_offset = curr_end_offset + 2
+            curr_end_offset = curr_end_offset + curr_length + 2
+          end
+
+          # Strip trailing 0 or \x04 which is used to delimit values
+          values.map! { |x| x[0..x.length - 2] }
+
+          return values
+        end
+
+        # Shortcut to the WLDAP32 Railgun Object
+        # @return [Object] wldap32
+        def wldap32
+          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+            raise "Can't load wldap32: Session doesn't support Railgun!"
+          end
+
+          client.railgun.wldap32
+        end
+
+        # Binds to the default LDAP Server
+        # @param size_limit [Integer] Maximum number of results to return in a query
+        # @param domain [String] Optional domain or distinguished name
+        # @return LDAP session handle
+        def bind_default_ldap_server(size_limit, domain = nil)
+          vprint_status('Initializing LDAP connection.')
+
+          # If domain is still null the API may be able to handle it...
+          init_result = wldap32.ldap_sslinitA(domain, 389, 0)
+          session_handle = init_result['return']
+          if session_handle == 0
+            raise "Unable to initialize ldap server: #{init_result['ErrorMessage']}"
+          end
+
+          vprint_status("LDAP Handle: #{session_handle}")
+
+          vprint_status('Setting Sizelimit Option')
+          wldap32.ldap_set_option(session_handle, LDAP_OPT_SIZELIMIT, size_limit)
+
+          vprint_status('Binding to LDAP server')
+          bind_result = wldap32.ldap_bind_sA(session_handle, nil, nil, LDAP_AUTH_NEGOTIATE)
+
+          bind = bind_result['return']
+          unless bind == 0
+            wldap32.ldap_unbind(session_handle)
+            raise "Unable to bind to ldap server: #{ERROR_CODE_TO_CONSTANT[bind]}"
+          end
+
+          if block_given?
+            begin
+              yield session_handle
+            ensure
+              vprint_status('Unbinding from LDAP service')
+              wldap32.ldap_unbind(session_handle)
+            end
+          else
+            return session_handle
+          end
+
+          return session_handle
+        end
       end
-
-      bind_default_ldap_server(max_results, domain) do |session_handle|
-        return query_ldap(session_handle, default_naming_context, 2, filter, fields)
-      end
     end
   end
-
-  # Performs a query to retrieve the default naming context
-  #
-  # @param domain [String] Optional domain or distinguished name
-  # @return [String]
-  def get_default_naming_context(domain=nil)
-    bind_default_ldap_server(1, domain) do |session_handle|
-      print_status("Querying default naming context")
-
-      query_result = query_ldap(session_handle, "", 0, "(objectClass=computer)", ["defaultNamingContext"])
-      first_entry_fields = query_result[:results].first
-      # Value from First Attribute of First Entry
-      default_naming_context = first_entry_fields.first[:value]
-      vprint_status("Default naming context #{default_naming_context}")
-      return default_naming_context
-    end
-  end
-
-  # Performs a query on the LDAP session
-  #
-  # @param session_handle [Handle] LDAP Session Handle
-  # @param base [Integer] Pointer to string that contains distinguished
-  #   name of entry to start the search
-  # @param scope [Integer] Search Scope
-  # @param filter [String] Search Filter
-  # @param fields [Array<String>] Attributes to retrieve
-  # @return [Hash] Entries found
-  def query_ldap(session_handle, base, scope, filter, fields)
-    vprint_status("Searching LDAP directory")
-    search = wldap32.ldap_search_sA(session_handle, base, scope, filter, nil, 0, 4)
-    vprint_status("search: #{search}")
-
-    if search['return'] == LDAP_SIZELIMIT_EXCEEDED
-      print_error("LDAP_SIZELIMIT_EXCEEDED, parsing what we retrieved, try increasing the MAX_SEARCH value [0:LDAP_NO_LIMIT]")
-    elsif search['return'] != Error::SUCCESS
-      print_error("No results")
-      wldap32.ldap_msgfree(search['res'])
-      return
-    end
-
-    search_count = wldap32.ldap_count_entries(session_handle, search['res'])['return']
-
-    if search_count == 0
-      print_error("No entries retrieved")
-      wldap32.ldap_msgfree(search['res'])
-      return
-    end
-
-    print_status("Entries retrieved: #{search_count}")
-
-    pEntries = []
-    entry_results = []
-
-    if datastore['MAX_SEARCH'] == 0
-      max_search = search_count
-    else
-      max_search = [datastore['MAX_SEARCH'], search_count].min
-    end
-
-    0.upto(max_search - 1) do |i|
-
-      if(i==0)
-        pEntries[0] = wldap32.ldap_first_entry(session_handle, search['res'])['return']
-      end
-
-      if(pEntries[i] == 0)
-        print_error("Failed to get entry")
-        wldap32.ldap_msgfree(search['res'])
-        return
-      end
-
-      vprint_status("Entry #{i}: 0x#{pEntries[i].to_s(16)}")
-
-      entry = get_entry(pEntries[i])
-
-      # Entries are a linked list...
-      if client.arch == ARCH_X64
-        pEntries[i+1] = entry[4]
-      else
-        pEntries[i+1] = entry[3]
-      end
-
-      ber = get_ber(entry)
-
-      field_results = []
-      fields.each do |field|
-        vprint_status("Field: #{field}")
-
-        values = get_values_from_ber(ber, field)
-
-        values_result = ""
-        values_result = values.join(',') if values
-        vprint_status("Values #{values}")
-
-        field_results << {:type => 'unknown', :value => values_result}
-      end
-
-      entry_results << field_results
-    end
-
-    return {
-        :fields  => fields,
-        :results => entry_results
-    }
-  end
-
-  # Gets the LDAP Entry
-  #
-  # @param pEntry [Integer] Pointer to the Entry
-  # @return [Array] Entry data structure
-  def get_entry(pEntry)
-    return client.railgun.memread(pEntry,41).unpack('VVVVVVVVVvCCC')
-  end
-
-  # Get BER Element data structure from LDAPMessage
-  #
-  # @param msg [String] The LDAP Message from the server
-  # @return [String] The BER data structure
-  def get_ber(msg)
-    ber = client.railgun.memread(msg[2],60).unpack('V*')
-
-    # BER Pointer is different between x86 and x64
-    if client.arch == ARCH_X64
-      ber_data = client.railgun.memread(ber[4], ber[0])
-    else
-      ber_data = client.railgun.memread(ber[3], ber[0])
-    end
-
-    return ber_data
-  end
-
-  # Search through the BER data structure for our Attribute.
-  # This doesn't attempt to parse the BER structure correctly
-  # instead it finds the first occurance of our field name
-  # tries to check the length of that value.
-  #
-  # @param ber_data [String] BER data structure
-  # @param field [String] Attribute name
-  # @return [Array] Values for the given +field+
-  def get_values_from_ber(ber_data, field)
-    field_offset = ber_data.index(field)
-
-    unless field_offset
-      vprint_status("Field not found in BER: #{field}")
-      return nil
-    end
-
-    # Value starts after our field string
-    values_offset = field_offset + field.length
-    values_start_offset = values_offset + 8
-    values_len_offset = values_offset + 5
-    curr_len_offset = values_offset + 7
-
-    values_length =  ber_data[values_len_offset].unpack('C')[0]
-    values_end_offset = values_start_offset + values_length
-
-    curr_length = ber_data[curr_len_offset].unpack('C')[0]
-    curr_start_offset = values_start_offset
-
-    if (curr_length >= 127)
-      curr_length = ber_data[curr_len_offset+1,4].unpack('N')[0]
-      curr_start_offset += 4
-    end
-
-    curr_end_offset = curr_start_offset + curr_length
-
-    values = []
-    while (curr_end_offset < values_end_offset)
-      values << ber_data[curr_start_offset..curr_end_offset]
-
-      break unless ber_data[curr_end_offset] == "\x04"
-
-      curr_len_offset = curr_end_offset + 1
-      curr_length = ber_data[curr_len_offset].unpack('C')[0]
-      curr_start_offset = curr_end_offset + 2
-      curr_end_offset = curr_end_offset + curr_length + 2
-    end
-
-    # Strip trailing 0 or \x04 which is used to delimit values
-    values.map! {|x| x[0..x.length-2]}
-
-    return values
-  end
-
-  # Shortcut to the WLDAP32 Railgun Object
-  # @return [Object] wldap32
-  def wldap32
-    client.railgun.wldap32
-  end
-
-  # Binds to the default LDAP Server
-  # @param size_limit [Integer] Maximum number of results to return in a query
-  # @param domain [String] Optional domain or distinguished name
-  # @return LDAP session handle
-  def bind_default_ldap_server(size_limit, domain=nil)
-    vprint_status("Initializing LDAP connection.")
-
-    # If domain is still null the API may be able to handle it...
-    init_result = wldap32.ldap_sslinitA(domain, 389, 0)
-    session_handle = init_result['return']
-    if session_handle == 0
-      raise "Unable to initialize ldap server: #{init_result["ErrorMessage"]}"
-    end
-
-    vprint_status("LDAP Handle: #{session_handle}")
-
-    vprint_status("Setting Sizelimit Option")
-    wldap32.ldap_set_option(session_handle, LDAP_OPT_SIZELIMIT, size_limit)
-
-    vprint_status("Binding to LDAP server")
-    bind_result = wldap32.ldap_bind_sA(session_handle, nil, nil, LDAP_AUTH_NEGOTIATE)
-
-    bind = bind_result['return']
-    unless bind == 0
-      wldap32.ldap_unbind(session_handle)
-      raise "Unable to bind to ldap server: #{ERROR_CODE_TO_CONSTANT[bind]}"
-    end
-
-    if (block_given?)
-      begin
-        yield session_handle
-      ensure
-        vprint_status("Unbinding from LDAP service")
-        wldap32.ldap_unbind(session_handle)
-      end
-    else
-      return session_handle
-    end
-
-    return session_handle
-  end
-
-end
-
-end
-end
 end

--- a/lib/msf/core/post/windows/wmic.rb
+++ b/lib/msf/core/post/windows/wmic.rb
@@ -37,8 +37,6 @@ module WMIC
   end
 
   def wmic_query(query, server=datastore['RHOST'])
-    extapi = load_extapi
-
     result_text = ""
 
     if datastore['SMBUser']
@@ -47,7 +45,7 @@ module WMIC
       end
     end
 
-    if extapi && !is_system?
+    if session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_CLIPBOARD_SET_DATA) && !is_system?
       session.extapi.clipboard.set_text("")
       wcmd = "wmic #{wmic_user_pass_string}/output:CLIPBOARD /INTERACTIVE:off /node:#{server} #{query}"
     else
@@ -63,7 +61,7 @@ module WMIC
     session.railgun.kernel32.WaitForSingleObject(ps.handle, (datastore['TIMEOUT'] * 1000))
     ps.close
 
-    if extapi && !is_system?
+    if session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_CLIPBOARD_GET_DATA) && !is_system?
       result = session.extapi.clipboard.get_data.first
       if result && result[1] && result[1].has_key?('Text')
         result_text = result[1]['Text']

--- a/modules/post/windows/gather/wmic_command.rb
+++ b/modules/post/windows/gather/wmic_command.rb
@@ -6,43 +6,52 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::WMIC
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'Windows Gather Run Specified WMIC Command',
-      'Description'   => %q{ This module will execute a given WMIC command options or read
-        WMIC commands options from a resource file and execute the commands in the
-        specified Meterpreter session.},
-      'License'       => MSF_LICENSE,
-      'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-      'Platform'      => [ 'win' ],
-      'SessionTypes'  => [ 'meterpreter' ]
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather Run Specified WMIC Command',
+        'Description' => %q{
+          This module will execute a given WMIC command options or read
+          WMIC commands options from a resource file and execute the commands in the
+          specified Meterpreter session.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ]
+      )
+    )
 
     register_options(
       [
         OptPath.new('RESOURCE', [false, 'Full path to resource file to read commands from.']),
         OptString.new('COMMAND', [false, 'WMIC command options.']),
-      ])
+      ]
+    )
   end
 
   # Run Method for when run command is issued
   def run
-    tmpout = ""
+    tmpout = ''
+    if sysinfo.blank?
+      fail_with(Failure::BadConfig, "The session this module is running against doesn't support the sysinfo command!")
+    end
     print_status("Running module against #{sysinfo['Computer']}")
     if datastore['RESOURCE']
       if ::File.exist?(datastore['RESOURCE'])
 
         ::File.open(datastore['RESOURCE']).each_line do |cmd|
-
           next if cmd.strip.length < 1
-          next if cmd[0,1] == "#"
+          next if cmd[0, 1] == '#'
+
           print_status "Running command #{cmd.chomp}"
 
           result = wmic_query(cmd.chomp)
           store_wmic_loot(result, cmd)
         end
       else
-        raise "Resource File does not exist!"
+        raise 'Resource File does not exist!'
       end
 
     elsif datastore['COMMAND']
@@ -53,11 +62,11 @@ class MetasploitModule < Msf::Post
   end
 
   def store_wmic_loot(result_text, cmd)
-    command_log = store_loot("host.command.wmic",
-                             "text/plain",
+    command_log = store_loot('host.command.wmic',
+                             'text/plain',
                              session,
                              result_text,
-                             "#{cmd.gsub(/\.|\/|\s/,"_")}.txt",
+                             "#{cmd.gsub(%r{\.|/|\s}, '_')}.txt",
                              "Command Output \'wmic #{cmd.chomp}\'")
 
     print_status("Command output saved to: #{command_log}")


### PR DESCRIPTION
See https://github.com/rapid7/metasploit-framework/pull/16921#issuecomment-1227746612 for context.

If ExtAPI can be loaded by Meterpreter then ExtAPI should already be loaded automatically.

Replacing `load_extapi` with a more granular capability check approach is cleaner and more intuitive.

Tested LDAP using `post/windows/gather/enum_ad_computers`.

Tested WMIC using `post/windows/gather/wmic_command`.

~~The `Msf::Post::Windows::Service` library still uses `load_extapi`; however, this will be removed by #16928.~~ Merged.

Several modules still use `load_extapi` which will need to be reviewed (in a separate PR) before the `load_extapi` method can be removed from Framework:

```
# grep -rn load_extapi modules/
modules/exploits/windows/local/wmi.rb:75:    if load_extapi
modules/exploits/windows/local/wmi.rb:89:      if load_extapi
modules/exploits/windows/local/wmi.rb:134:      unless load_extapi
modules/post/windows/gather/credentials/domain_hashdump.rb:155:    load_extapi
modules/post/windows/gather/enum_patches.rb:41:    unless load_extapi
```

~~`load_extapi` pending removal from `modules/post/windows/gather/enum_patches.rb` in #17003.~~ Merged.
