### PR TITLE
enum_patches: Cleanup, print patches as table, store patches as CSV

### DIFF
--- a/documentation/modules/post/windows/gather/enum_patches.md
+++ b/documentation/modules/post/windows/gather/enum_patches.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 This module enumerates patches applied to a Windows system using the
-WMI query: SELECT HotFixID, InstalledOn FROM Win32_QuickFixEngineering.
+WMI query: `SELECT HotFixID, InstalledOn FROM Win32_QuickFixEngineering`.
 
 
 ## Verification Steps

--- a/documentation/modules/post/windows/gather/enum_patches.md
+++ b/documentation/modules/post/windows/gather/enum_patches.md
@@ -1,59 +1,97 @@
-
 ## Vulnerable Application
 
-  This module will attempt to enumerate which patches are applied to a
-  Windows system, as well as on which date they were applied, based on
-  the result of the WMI query `SELECT HotFixID, InstalledOn FROM Win32_QuickFixEngineering`.
+This module enumerates patches applied to a Windows system using the
+WMI query: SELECT HotFixID, InstalledOn FROM Win32_QuickFixEngineering.
+
 
 ## Verification Steps
 
-  1. Start msfconsole
-  2. Get meterpreter session
-  3. Do: ```use post/windows/gather/enum_patches```
-  4. Do: ```set SESSION <session id>```
-  5. Do: ```run```
+1. Start msfconsole
+2. Get meterpreter session
+3. Do: `use post/windows/gather/enum_patches`
+4. Do: `set SESSION <session id>`
+5. Do: `run`
 
 ## Options
 
-  **KB**
-
-  A comma separated list of KB patches to search for. Default is: `KB2871997, KB2928120`
-
-  **MSFLOCALS**
-
-  Search for missing patches for which there is a MSF local module. Default is `true`.
-
-  **SESSION**
-
-  The session to run this module on.
 
 ## Scenarios
 
-### Windows 10 x64 v1909
+### Windows 11 Pro 10.0.22000 Build 22000 x64
 
-  ```
-  msf6 exploit(multi/handler) > use post/windows/gather/enum_patches
-  msf6 post(windows/gather/enum_patches) > show options
+```
+msf6 post(windows/gather/enum_patches) > set session 1
+session => 1
+msf6 post(windows/gather/enum_patches) > run
 
-  Module options (post/windows/gather/enum_patches):
+[*] Running module against WINDEV2110EVAL (192.168.200.140)
 
-    Name     Current Setting  Required  Description
-    ----     ---------------  --------  -----------
-    SESSION                   yes       The session to run this module on.
+Installed Patches
+=================
 
-  msf6 post(windows/gather/enum_patches) > set SESSION 1
-  SESSION => 1
-  msf6 post(windows/gather/enum_patches) > run
+  HotFix ID  Install Date
+  ---------  ------------
+  KB5009469  2/27/2022
+  KB5009641  2/26/2022
+  KB5011493  3/5/2022
 
-  [*] Patch list saved to /home/gwillcox/.msf4/loot/20200902125729_default_172.29.215.21_enum_patches_495652.txt
-  [+] KB4569751 installed on 8/17/2020
-  [+] KB4497165 installed on 8/17/2020
-  [+] KB4517245 installed on 4/10/2020
-  [+] KB4537759 installed on 4/10/2020
-  [+] KB4552152 installed on 4/10/2020
-  [+] KB4561600 installed on 8/17/2020
-  [+] KB4569073 installed on 8/17/2020
-  [+] KB4565351 installed on 8/17/2020
-  [*] Post module execution completed
-  msf6 post(windows/gather/enum_patches) >
-  ```
+[*] Patch list saved to /root/.msf4/loot/20220911234321_default_192.168.200.140_enum_patches_485106.txt
+[*] Post module execution completed
+```
+
+### Windows 7 SP1 x64
+
+```
+msf6 post(windows/gather/enum_patches) > set session 1
+session => 1
+msf6 post(windows/gather/enum_patches) > run
+
+[*] Running module against TEST (192.168.200.190)
+
+Installed Patches
+=================
+
+  HotFix ID  Install Date
+  ---------  ------------
+  KB2533623  3/29/2019
+  KB2534111  2/1/2016
+  KB2639308  3/29/2019
+  KB2670838  3/29/2019
+  KB2729094  3/29/2019
+  KB2731771  3/29/2019
+  KB2786081  3/29/2019
+  KB2834140  3/29/2019
+  KB2841134  3/29/2019
+  KB2849696  3/29/2019
+  KB2849697  3/29/2019
+  KB2882822  3/29/2019
+  KB2888049  3/29/2019
+  KB2999226  9/4/2017
+  KB958488   5/26/2017
+  KB976902   11/21/2010
+
+[*] Patch list saved to /root/.msf4/loot/20220911233948_default_192.168.200.190_enum_patches_697182.txt
+[*] Post module execution completed
+```
+
+### Windows XP SP3 x86
+
+```
+msf6 post(windows/gather/enum_patches) > set session 1
+session => 1
+msf6 post(windows/gather/enum_patches) > run
+
+[*] Running module against WINXP (192.168.200.164)
+
+Installed Patches
+=================
+
+  HotFix ID  Install Date
+  ---------  ------------
+  KB811113   4/5/2013
+  KB936929   4/5/2013
+  Q147222
+
+[*] Patch list saved to /root/.msf4/loot/20220911233635_default_192.168.200.164_enum_patches_552914.txt
+[*] Post module execution completed
+```

--- a/modules/post/windows/gather/enum_patches.rb
+++ b/modules/post/windows/gather/enum_patches.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Common
+  require 'rex/post/meterpreter/extensions/extapi/command_ids'
 
   def initialize(info = {})
     super(
@@ -80,14 +81,14 @@ class MetasploitModule < Msf::Post
     end
 
     if results.rows.empty?
-      print_status('Found no patches installed')
+      print_status("No patches were found to be installed on #{hostname} (#{session.session_host})")
       return
     end
 
     print_line
     print_line(results.to_s)
 
-    l = store_loot('enum_patches', 'text/plain', session, results.to_csv)
-    print_status("Patch list saved to #{l}")
+    loot_file = store_loot('enum_patches', 'text/plain', session, results.to_csv)
+    print_status("Patch list saved to #{loot_file}")
   end
 end

--- a/modules/post/windows/gather/enum_patches.rb
+++ b/modules/post/windows/gather/enum_patches.rb
@@ -5,16 +5,15 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Common
-  include Msf::Post::Windows::ExtAPI
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => "Windows Gather Applied Patches",
+        'Name' => 'Windows Gather Applied Patches',
         'Description' => %q{
-          This module will attempt to enumerate which patches are applied to a windows system
-          based on the result of the WMI query: SELECT HotFixID, InstalledOn FROM Win32_QuickFixEngineering.
+          This module enumerates patches applied to a Windows system using the
+          WMI query: SELECT HotFixID, InstalledOn FROM Win32_QuickFixEngineering.
         },
         'License' => MSF_LICENSE,
         'Platform' => ['win'],
@@ -26,6 +25,11 @@ class MetasploitModule < Msf::Post
         'References' => [
           ['URL', 'http://msdn.microsoft.com/en-us/library/aa394391(v=vs.85).aspx']
         ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -38,34 +42,52 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    unless load_extapi
-      print_error 'ExtAPI failed to load'
-      return
+    unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_WMI_QUERY)
+      fail_with(Failure::NoTarget, 'Session does not support Meterpreter ExtAPI WMI queries')
     end
+
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Running module against #{hostname} (#{session.session_host})")
 
     begin
-      objects = session.extapi.wmi.query("SELECT HotFixID, InstalledOn FROM Win32_QuickFixEngineering")
+      objects = session.extapi.wmi.query('SELECT HotFixID, InstalledOn FROM Win32_QuickFixEngineering')
     rescue RuntimeError
-      print_error 'Known bug in WMI query, try migrating to another process'
+      fail_with(Failure::BadConfig, 'Known bug in WMI query, try migrating to another process')
+    end
+
+    if objects.nil?
+      print_error('Could not retrieve patch information. WMI query returned no data.')
       return
     end
 
-    if objects[:values].nil?
-      kb_ids = []
-    else
-      kb_ids = objects[:values].reject(&:nil?).map { |kb| kb }
-    end
-
-    if kb_ids.empty?
-      print_status 'Found no patches installed'
+    if objects[:values].blank?
+      print_status('Found no patches installed')
       return
     end
 
-    l = store_loot('enum_patches', 'text/plain', session, kb_ids.join("\n"))
+    results = Rex::Text::Table.new(
+      'Header' => 'Installed Patches',
+      'Indent' => 2,
+      'Columns' =>
+      [
+        'HotFix ID',
+        'Install Date'
+      ]
+    )
+
+    objects[:values].compact.each do |k|
+      results << k
+    end
+
+    if results.rows.empty?
+      print_status('Found no patches installed')
+      return
+    end
+
+    print_line
+    print_line(results.to_s)
+
+    l = store_loot('enum_patches', 'text/plain', session, results.to_csv)
     print_status("Patch list saved to #{l}")
-
-    kb_ids.each do |kb|
-      print_good("#{kb[0]} installed on #{kb[1]}")
-    end
   end
 end


### PR DESCRIPTION
This module used to print only installed patches and was later updated to also print the patch installation date. The output format and loot format is much more suited to printing in a table and storing as CSV.

---

Resolves Rubocop violations.

Adds `Notes` module meta information.

Updates outdated documentation which mentioned old `options` which have since been removed from the module.

Prints patches and install date as table and stores as CSV. This also fixes an output issue when there was no install date, which would print `KB1234 installed on `.

Fixes a bug where the WMI query was not checked for a `nil` response.

Replaces `load_extapi` with Meterpreter ExtAPI capability check.


# Before

```
msf6 post(windows/gather/enum_patches) > run

[*] Patch list saved to /root/.msf4/loot/20220911234700_default_192.168.200.164_enum_patches_799692.txt
[+] Q147222 installed on 
[+] KB811113 installed on 4/5/2013
[+] KB936929 installed on 4/5/2013
[*] Post module execution completed
msf6 post(windows/gather/enum_patches) > cat /root/.msf4/loot/20220911234700_default_192.168.200.164_enum_patches_799692.txt
[*] exec: cat /root/.msf4/loot/20220911234700_default_192.168.200.164_enum_patches_799692.txt

Q147222

KB811113
4/5/2013
KB936929
4/5/2013msf6 post(windows/gather/enum_patches) > 
```

# After

```
msf6 post(windows/gather/enum_patches) > run

[*] Running module against WINXP (192.168.200.164)

Installed Patches
=================

  HotFix ID  Install Date
  ---------  ------------
  KB811113   4/5/2013
  KB936929   4/5/2013
  Q147222

[*] Patch list saved to /root/.msf4/loot/20220911233635_default_192.168.200.164_enum_patches_552914.txt
[*] Post module execution completed
msf6 post(windows/gather/enum_patches) > cat /root/.msf4/loot/20220911233635_default_192.168.200.164_enum_patches_552914.txt
[*] exec: cat /root/.msf4/loot/20220911233635_default_192.168.200.164_enum_patches_552914.txt

HotFix ID,Install Date
"KB811113","4/5/2013"
"KB936929","4/5/2013"
"Q147222",""
msf6 post(windows/gather/enum_patches) > 
```
