### PR TITLE
Increase timeout for laravel rce check method

### DIFF
--- a/modules/exploits/multi/php/ignition_laravel_debug_rce.rb
+++ b/modules/exploits/multi/php/ignition_laravel_debug_rce.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path.to_s),
       'method' => 'PUT'
-    }, 1)
+    })
     # Check whether it is using facade/ignition
     # If is using it should respond method not allowed
     # checking if debug mode is enable


### PR DESCRIPTION
Increases the timeout for the laravel rce check method from 1 second to the default http timeout value behavior

## Verification

Run the application with docker-compose https://github.com/vulhub/vulhub/blob/master/laravel/CVE-2021-3129/docker-compose.yml

Run the app:
```
docker-compose up
```

Exec into the application
```
docker-compose exec web /bin/bash
```

Touch the log file:
```
touch /var/www/storage/logs/laravel.log
chown -R www-data:www-data /var/www/storage/logs/laravel.log
```

Run the exploit and verify shells
```
run -z http://10.10.65.245:8080 lhost=....
```
