### PR TITLE
improve http login result checks

### DIFF
--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -177,6 +177,10 @@ module Metasploit
         # @return [String]
         attr_accessor :http_password
 
+        # @!attribute redirects_on_success
+        # @return [String] whether the target is expected to redirect on successful login
+        attr_accessor :redirects_on_success
+
 
         validates :uri, presence: true, length: { minimum: 1 }
 
@@ -294,7 +298,7 @@ module Metasploit
 
           begin
             response = send_request('credential'=>credential, 'uri'=>uri, 'method'=>method)
-            if response && (response.code == 200 || (response.code >= 300 && response.code < 400))
+            if response && (response.code == 200 || (redirects_on_success && response.redirect?))
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response.headers)
             end
           rescue Rex::ConnectionError => e

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -372,6 +372,7 @@ module Metasploit
           self.connection_timeout ||= 20
           self.uri = '/' if self.uri.blank?
           self.method = 'GET' if self.method.blank?
+          self.http_success_codes = DEFAULT_HTTP_SUCCESS_CODES if self.http_success_codes.nil?
 
           # Note that this doesn't cover the case where ssl is unset and
           # port is something other than a default. In that situtation,
@@ -406,14 +407,10 @@ module Metasploit
         private
 
         def validate_http_codes
-          if http_success_codes.nil?
-            @http_success_codes = DEFAULT_HTTP_SUCCESS_CODES
-          else
-            errors.add(:http_success_codes, "HTTP codes must be an Array") unless @http_success_codes.is_a?(Array)
-            @http_success_codes.each do |code|
-              next if code >= 200 && code < 400
-              errors.add(:http_success_codes, "Invalid HTTP code provided #{code}")
-            end
+          errors.add(:http_success_codes, "HTTP codes must be an Array") unless @http_success_codes.is_a?(Array)
+          @http_success_codes.each do |code|
+            next if code >= 200 && code < 400
+            errors.add(:http_success_codes, "Invalid HTTP code provided #{code}")
           end
         end
       end

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -294,7 +294,7 @@ module Metasploit
 
           begin
             response = send_request('credential'=>credential, 'uri'=>uri, 'method'=>method)
-            if response && response.code == 200
+            if response && (response.code == 200 || (response.code >= 300 && response.code < 400))
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response.headers)
             end
           rescue Rex::ConnectionError => e

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -215,13 +215,13 @@ class MetasploitModule < Msf::Auxiliary
         int_start = code_parts[0].to_i
         int_end = code_parts[1].to_i
         unless int_start > 0 && int_end > 0
-          raise ArguementError.new("#{code} is not a valid response code range.")
+          raise ArgumentError.new("#{code} is not a valid response code range.")
         end
         codes.append(*(int_start..int_end))
       else
         int_code = code.to_i
         unless int_code > 0
-          raise ArguementError.new("#{code} is not a valid response code.")
+          raise ArgumentError.new("#{code} is not a valid response code.")
         end
         codes << int_code
       end

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -151,7 +151,12 @@ class MetasploitModule < Msf::Auxiliary
       password: datastore['HttpPassword']
     )
 
-    success_codes = parse_http_success_codes(datastore['HttpSuccessCodes'])
+    begin
+      success_codes = parse_http_success_codes(datastore['HttpSuccessCodes'])
+    rescue ArgumentError => e
+      fail_with(Msf::Exploit::Failure::BadConfig, "HttpSuccessCodes in invalid: #{e.message}")
+    end
+
     scanner = Metasploit::Framework::LoginScanner::HTTP.new(
       configure_http_login_scanner(
         uri: @uri,

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -44,6 +44,12 @@ class MetasploitModule < Msf::Auxiliary
       ])
     register_autofilter_ports([ 80, 443, 8080, 8081, 8000, 8008, 8443, 8444, 8880, 8888 ])
 
+    register_advanced_options(
+      [
+        OptBool.new('RedirectsOnSuccess', [ false, 'Login may redirect on successful login', false]),
+      ]
+    )
+
     deregister_options('USERNAME', 'PASSWORD', 'PASSWORD_SPRAY')
   end
 
@@ -152,6 +158,7 @@ class MetasploitModule < Msf::Auxiliary
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        redirects_on_success: datastore['RedirectsOnSuccess'],
         connection_timeout: 5
       )
     )

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptBool.new('RedirectsOnSuccess', [ false, 'Login may redirect on successful login', false]),
+        OptString.new('HttpSuccessCodes', [ false, 'Comma seperated list of HTTP response codes or ranges to promote as successful login', '200,201,300-308']),
       ]
     )
 
@@ -151,6 +151,7 @@ class MetasploitModule < Msf::Auxiliary
       password: datastore['HttpPassword']
     )
 
+    success_codes = parse_http_success_codes(datastore['HttpSuccessCodes'])
     scanner = Metasploit::Framework::LoginScanner::HTTP.new(
       configure_http_login_scanner(
         uri: @uri,
@@ -158,7 +159,7 @@ class MetasploitModule < Msf::Auxiliary
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-        redirects_on_success: datastore['RedirectsOnSuccess'],
+        http_success_codes: success_codes,
         connection_timeout: 5
       )
     )
@@ -199,5 +200,28 @@ class MetasploitModule < Msf::Auxiliary
 
   end
 
+  private
+  def parse_http_success_codes(codes_string)
+    codes = []
+    parts = codes_string.split(',')
+    parts.each do |code|
+      code_parts = code.split('-')
+      if code_parts.length > 1
+        int_start = code_parts[0].to_i
+        int_end = code_parts[1].to_i
+        unless int_start > 0 && int_end > 0
+          raise ArguementError.new("#{code} is not a valid response code range.")
+        end
+        codes.append(*(int_start..int_end))
+      else
+        int_code = code.to_i
+        unless int_code > 0
+          raise ArguementError.new("#{code} is not a valid response code.")
+        end
+        codes << int_code
+      end
+    end
+    codes
+  end
 
 end


### PR DESCRIPTION
When a login to a remote http service response returns a 3XX response code consider the authentication to have been successful.

Note this does not address an issue where setting `HttpUsername` and `HttpPassword` will set the credential on the http client object for all requests causing the `AUTH_URI` or `auto` detected uri values not to return the expected `401`.

## Verification

List the steps needed to make sure this thing works

- [ ] `echo "user pass" > test.pass`
- [ ] Start `msfconsole`
- [ ] `use scanner/http/http_login`
- [ ] `set RHOST authenticationtest.com`
- [ ] `set RPORT 443`
- [ ] `set SSL true`
- [ ] `set AUTH_URI HTTPAuth/`
- [ ] `set USERPASS_FILE test.pass`
- [ ] `set USER_FILE ""`
- [ ] `set PASS_FILE ""`
- [ ] `run`
- [ ] **Verify** successful login is reported

