### PR TITLE
Add cidr mask defaults to route add command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1084,6 +1084,7 @@ class Core
         if Rex::Socket.is_ip_addr?(args.first)
           netmask = args.shift
         elsif Rex::Socket.is_ip_addr?(subnet)
+          cidr_mask ||= Rex::Socket.is_ipv6?(subnet) ? 128 : 32
           netmask = Rex::Socket.addr_ctoa(cidr_mask, v6: Rex::Socket.is_ipv6?(subnet))
         end
 


### PR DESCRIPTION
closes https://github.com/rapid7/metasploit-framework/issues/17016 - which has the original list of replication and debugging steps

## Verification

Open a Mettle session via msfconsole, then verify the following behavior is broken on master, but works on this branch as expected:

```
jobs -K
route flush

route add 172.28.101.48 -1

use auxiliary/server/socks_proxy
run

curl --proxy socks5://localhost:1080 https://github.com >/dev/null && echo 'success'
# success
```

Also ensure that the host can still be routed to