### PR TITLE
Update CCache Reuse for TGTs (and Golden Tickets)

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client/tgs_response.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/tgs_response.rb
@@ -36,39 +36,7 @@ module Msf
             def extract_kerb_creds(res, key, msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_AUTHENTICATOR_SUB_KEY)
               enc_res = decrypt_kdc_tgs_rep_enc_part(res, key, msg_type: msg_type)
 
-              cache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.new(
-                default_principal: {
-                  name_type: res.cname.name_type, # NT_PRINCIPAL
-                  realm: res.crealm,
-                  components: res.cname.name_string
-                },
-                credentials: [
-                  {
-                    client: {
-                      name_type: res.cname.name_type,
-                      realm: res.crealm,
-                      components: res.cname.name_string
-                    },
-                    server: {
-                      name_type: enc_res.sname.name_type,
-                      realm: enc_res.srealm,
-                      components: enc_res.sname.name_string
-                    },
-                    keyblock: {
-                      enctype: enc_res.key.type,
-                      data: enc_res.key.value
-                    },
-                    authtime: enc_res.auth_time,
-                    starttime: enc_res.start_time,
-                    endtime: enc_res.end_time,
-                    renew_till: enc_res.renew_till,
-                    ticket_flags: enc_res.flags.to_i,
-                    ticket: res.ticket.encode
-                  }
-                ]
-              )
-
-              cache
+              Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(res, enc_res)
             end
           end
         end

--- a/lib/msf/core/exploit/remote/kerberos/client/tgs_response.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/tgs_response.rb
@@ -14,7 +14,7 @@ module Msf
             # @param res [Rex::Proto::Kerberos::Model::KdcResponse]
             # @param key [String]
             # @param msg_type [Rex::Proto::Kerberos::Crypto::KeyUsage]
-            # @return [Rex::Proto::Kerberos::CredentialCache::Cache]
+            # @return [Rex::Proto::Kerberos::Model::EncKdcResponse]
             # @see Rex::Proto::Kerberos::Model::EncKdcResponse
             # @see Rex::Proto::Kerberos::Model::EncKdcResponse.decode
             # @see Rex::Proto::Kerberos::CredentialCache::Krb5Ccache
@@ -28,7 +28,7 @@ module Msf
             #
             # @param res [Rex::Proto::Kerberos::Model::KdcResponse]
             # @param key [String]
-            # @return [Rex::Proto::Kerberos::CredentialCache::Cache]
+            # @return [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache]
             # @see Rex::Proto::Kerberos::Model::EncKdcResponse
             # @see Rex::Proto::Kerberos::Model::EncKdcResponse.decode
             # @see Msf::Kerberos::Client::CacheCredential

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -112,10 +112,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @send_delegated_creds = send_delegated_creds
 
     credential = nil
-    if cache_file
+    if cache_file.present?
       # the cache file is only used for loading credentials, it is *not* written to
       credential = load_credential_from_file(cache_file)
-      if credential.nil?
+      if credential.nil? && hostname.present?
         credential = load_credential_from_file(cache_file, sname: "krbtgt/#{hostname.split('.', 2).last}")
       end
       if credential.nil?
@@ -240,6 +240,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
   private
 
+  # Authenticate with credentials to the key distribution center (KDC). This will request a TGT before then pass it to
+  # #authenticate_via_krb5_ccache_credential_tgt.
+  #
+  # @param [Hash] options
   def authenticate_via_kdc(options = {})
     realm = self.realm.upcase
     client_name = username
@@ -250,7 +254,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
         Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
         Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
         Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK
       ]
     )
 
@@ -275,6 +279,11 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     authenticate_via_krb5_ccache_credential_tgt(credential, options)
   end
 
+  # Authenticate with a ticket-granting-service (TGS). This method will not contact the KDC and can not request a
+  # delegation ticket.
+  #
+  # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] credential
+  # @param [Hash] _options
   def authenticate_via_krb5_ccache_credential_tgs(credential, _options = {})
     unless credential.is_a?(Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential)
       raise TypeError, 'credential must be a Krb5CcacheCredential instance'
@@ -328,6 +337,11 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     }
   end
 
+  # Authenticate with a ticket-granting-ticket (TGT). This method will contact the KDC and can request a delegation
+  # ticket.
+  #
+  # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] credential
+  # @param [Hash] options
   def authenticate_via_krb5_ccache_credential_tgt(credential, options = {})
     realm = self.realm.upcase
     sname = options.fetch(:sname)
@@ -399,7 +413,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
           Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
           Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
           Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
-          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK
         ]
       ),
       sequence_number: sequence_number,
@@ -460,9 +474,14 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       checksum: checksum_val)
   end
 
+  # @param [Rex::Proto::Kerberos::Model::EncryptionKey] session_key
+  # @param [Rex::Proto::Kerberos::Model::Ticket] tgt_ticket
+  # @param [String] realm
+  # @param [String] client_name
+  # @param [Integer] tgt_etype
+  # @param [Time] expiry_time
+  # @param [Time] now
   def request_delegation_ticket(session_key, tgt_ticket, realm, client_name, tgt_etype, expiry_time, now)
-    subkey = nil
-
     ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
       [
         Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
@@ -483,7 +502,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       req: build_tgs_request(
         {
           session_key: session_key,
-          subkey: subkey,
+          subkey: nil,
           checksum: nil,
           ticket: tgt_ticket,
           realm: realm,
@@ -503,7 +522,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
             rtime: nil,
 
             # certificate time
-            ctime: now,
+            ctime: now
           )
         }
       )

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -242,10 +242,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
   def authenticate_via_kdc(options = {})
     realm = self.realm.upcase
-    sname = options.fetch(:sname)
-
-    server_name = "krbtgt/#{realm}"
     client_name = username
+    server_name = "krbtgt/#{realm}"
 
     ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
       [
@@ -271,89 +269,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     end
 
     print_status("#{peer} - Received a valid TGT-Response")
-    tgt_etype = tgt_result.as_rep.enc_part.etype
 
-    now = Time.now.utc
-    expiry_time = now + 1.day
-
-    # TODO: From [MS-KILE]:
-    #     The subkey in the EncAPRepPart of the KRB_AP_REP message (defined in [RFC4120] section 5.5.2) is used as the
-    #     session key when MutualAuthentication is requested. When DES and RC4 are used, the implementation is as defined
-    #     in [RFC1964]. With DES and RC4, the subkey in the KRB_AP_REQ message can be used as the session key, as it is
-    #     the same as the subkey in KRB_AP_REP message. However, when AES is used (see [RFC4121]), the subkeys are different
-    #     and the subkey in the KRB_AP_REP message is used. (The KRB_AP_REQ message is defined in [RFC4120] section 5.5.1).
-    #     So for now, we set the subkey to nil
-
-    tgs_res = request_service_ticket(
-      tgt_result.decrypted_part.key,
-      tgt_result.ticket,
-      realm,
-      client_name,
-      tgt_etype,
-      expiry_time,
-      now,
-      sname
-    )
-
-    cache = extract_kerb_creds(
-      tgs_res,
-      tgt_result.decrypted_part.key.value,
-      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
-    )
-    path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode, nil, loot_info(options))
-    print_status("#{peer} - TGS MIT Credential Cache saved to #{path}")
-
-    tgs_ticket = tgs_res.ticket
-    tgs_auth = decrypt_kdc_tgs_rep_enc_part(
-      tgs_res,
-      tgt_result.decrypted_part.key.value,
-      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
-    )
-
-    case send_delegated_creds
-    when Delegation::ALWAYS
-      do_delegation = true
-    when Delegation::NEVER
-      do_delegation = false
-    when Delegation::WHEN_UNCONSTRAINED
-      do_delegation = tgs_auth.flags.include?(Rex::Proto::Kerberos::Model::KdcOptionFlag::OK_AS_DELEGATE)
-    end
-
-    if do_delegation
-      delegated_tgs_ticket, delegated_tgs_auth = request_delegation_ticket(
-        tgt_result.decrypted_part.key,
-        tgt_result.ticket,
-        realm,
-        client_name,
-        tgt_etype,
-        expiry_time,
-        now
-      )
-    end
-
-    ## Service Authentication
-
-    checksum = nil
-    checksum = build_gss_ap_req_checksum_value(mutual_auth, delegated_tgs_ticket, delegated_tgs_auth, tgs_auth.key, realm, client_name) if use_gss_checksum
-
-    sequence_number = rand(1 << 32)
-
-    service_ap_request = build_service_ap_request(
-      session_key: tgs_auth.key,
-      checksum: checksum,
-      ticket: tgs_ticket,
-      realm: realm,
-      client_name: client_name,
-      options: ticket_options,
-      sequence_number: sequence_number,
-      subkey_type: tgt_etype # The AP-REP will come back with this same type of subkey
-    )
-
-    {
-      service_ap_request: service_ap_request,
-      session_key: tgs_auth.key,
-      client_sequence_number: sequence_number
-    }
+    cache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, tgt_result.decrypted_part)
+    credential = cache.credentials.first
+    authenticate_via_krb5_ccache_credential_tgt(credential, options)
   end
 
   def authenticate_via_krb5_ccache_credential_tgs(credential, _options = {})
@@ -423,23 +342,75 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       value: credential.keyblock.data.value
     )
 
-    tgs_res = request_service_ticket(
+    tgs_ticket, tgs_auth = request_service_ticket(
       session_key,
       ticket,
       realm,
       client_name,
-      ticket.enc_part.etypes,
+      ticket.enc_part.etype,
       expiry_time,
       now,
       sname
     )
 
-    cache = extract_kerb_creds(
-      tgs_res,
-      session_key.value,
-      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
+    case send_delegated_creds
+    when Delegation::ALWAYS
+      do_delegation = true
+    when Delegation::NEVER
+      do_delegation = false
+    when Delegation::WHEN_UNCONSTRAINED
+      do_delegation = tgs_auth.flags.include?(Rex::Proto::Kerberos::Model::KdcOptionFlag::OK_AS_DELEGATE)
+    end
+
+    if do_delegation
+      delegated_tgs_ticket, delegated_tgs_auth = request_delegation_ticket(
+        session_key,
+        ticket,
+        realm,
+        client_name,
+        ticket.enc_part.etype,
+        expiry_time,
+        now
+      )
+    end
+
+    ## Service Authentication
+    checksum = nil
+    if use_gss_checksum
+      checksum = build_gss_ap_req_checksum_value(
+        mutual_auth,
+        delegated_tgs_ticket,
+        delegated_tgs_auth,
+        tgs_auth.key,
+        realm,
+        client_name
+      )
+    end
+
+    sequence_number = rand(1 << 32)
+    service_ap_request = build_service_ap_request(
+      session_key: tgs_auth.key,
+      checksum: checksum,
+      ticket: tgs_ticket,
+      realm: realm,
+      client_name: client_name,
+      options: Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+        [
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK,
+        ]
+      ),
+      sequence_number: sequence_number,
+      subkey_type: ticket.enc_part.etype # The AP-REP will come back with this same type of subkey
     )
-    authenticate_via_krb5_ccache_credential_tgs(cache.credentials.first, options)
+
+    {
+      service_ap_request: service_ap_request,
+      session_key: tgs_auth.key,
+      client_sequence_number: sequence_number
+    }
   end
 
   def build_gss_ap_req_checksum_value(mutual_auth, ticket, decrypted_part, session_key, realm, client_name)
@@ -563,8 +534,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @param [Rex::Proto::Kerberos::Model::PrincipalName] sname
   # @raise [Rex::Proto::Kerberos::Model::Error::KerberosError]
   def request_service_ticket(session_key, tgt_ticket, realm, client_name, tgt_etype, expiry_time, now, sname)
-    subkey = nil
-
     ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
       [
         Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
@@ -577,7 +546,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       req: build_tgs_request(
         {
           session_key: session_key,
-          subkey: subkey,
+          subkey: nil,
           checksum: nil,
           ticket: tgt_ticket,
           realm: realm,
@@ -610,7 +579,22 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     print_good("#{peer} - Received a valid TGS-Response")
 
-    tgs_res
+    cache = extract_kerb_creds(
+      tgs_res,
+      session_key.value,
+      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
+    )
+    path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode, nil, loot_info(sname: sname))
+    print_status("#{peer} - TGS MIT Credential Cache saved to #{path}")
+
+    tgs_ticket = tgs_res.ticket
+    tgs_auth = decrypt_kdc_tgs_rep_enc_part(
+      tgs_res,
+      session_key.value,
+      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
+    )
+
+    [tgs_ticket, tgs_auth]
   end
 
   # Search the database for a credential object that can be used for authentication.
@@ -695,6 +679,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # Build a loot info string that can later be used in a lookup.
   #
   # @param [Hash] options
+  # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname the service name (optional)
   # @return [String] the info string
   def loot_info(options = {})
     info = []

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -149,9 +149,28 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     unless options[:credential]
       if @credential
+        # use an explicit credential
         options[:credential] = @credential
-      elsif (options[:credential] = get_cached_credential(options))
-        print_status("#{peer} - Using cached credential for #{options[:credential].server} #{options[:credential].client}")
+      else
+        # load a cached TGS
+        options[:credential] = get_cached_credential(options)
+        unless options[:credential]
+          # load a cached TGT
+          options[:credential] = get_cached_credential(
+            options.merge(
+              sname: Rex::Proto::Kerberos::Model::PrincipalName.new(
+                name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+                name_string: [
+                  "krbtgt",
+                  realm
+                ]
+              )
+            )
+          )
+        end
+        if options[:credential]
+          print_status("#{peer} - Using cached credential for #{options[:credential].server} #{options[:credential].client}")
+        end
       end
     end
 

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -116,6 +116,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       # the cache file is only used for loading credentials, it is *not* written to
       credential = load_credential_from_file(cache_file)
       if credential.nil?
+        credential = load_credential_from_file(cache_file, sname: "krbtgt/#{hostname.split('.', 2).last}")
+      end
+      if credential.nil?
         vprint_error("Failed to load a credential from ticket file: #{cache_file}")
       end
     end
@@ -152,8 +155,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       end
     end
 
-    if options[:credential]
-      auth_context = authenticate_via_krb5_ccache_credential(options[:credential], options)
+    if options[:credential] && options[:credential].server.to_s.start_with?('krbtgt/')
+      auth_context = authenticate_via_krb5_ccache_credential_tgt(options[:credential], options)
+    elsif options[:credential]
+      auth_context = authenticate_via_krb5_ccache_credential_tgs(options[:credential], options)
     else
       auth_context = authenticate_via_kdc(options)
     end
@@ -277,53 +282,19 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     #     in [RFC1964]. With DES and RC4, the subkey in the KRB_AP_REQ message can be used as the session key, as it is
     #     the same as the subkey in KRB_AP_REP message. However, when AES is used (see [RFC4121]), the subkeys are different
     #     and the subkey in the KRB_AP_REP message is used. (The KRB_AP_REQ message is defined in [RFC4120] section 5.5.1).
-    #   So for now, we set the subkey to nil
-    subkey = nil
+    #     So for now, we set the subkey to nil
 
-    ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
-      [
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
-      ]
+    tgs_res = request_service_ticket(
+      tgt_result.decrypted_part.key,
+      tgt_result.ticket,
+      realm,
+      client_name,
+      tgt_etype,
+      expiry_time,
+      now,
+      sname
     )
 
-    tgs_res = send_request_tgs(
-      req: build_tgs_request(
-        {
-          session_key: tgt_result.decrypted_part.key,
-          subkey: subkey,
-          checksum: nil,
-          ticket: tgt_result.ticket,
-          realm: realm,
-          client_name: client_name,
-          options: ticket_options,
-
-          body: build_tgs_request_body(
-            cname: nil,
-            sname: sname,
-            realm: realm,
-            etype: [tgt_etype],
-            options: ticket_options,
-
-            # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
-            from: nil,
-            till: expiry_time,
-            rtime: nil,
-
-            # certificate time
-            ctime: now,
-          )
-        }
-      )
-    )
-
-    # Verify error codes
-    if tgs_res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
-      raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: tgs_res)
-    end
-
-    print_good("#{peer} - Received a valid TGS-Response")
     cache = extract_kerb_creds(
       tgs_res,
       tgt_result.decrypted_part.key.value,
@@ -349,14 +320,15 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     end
 
     if do_delegation
-      delegated_tgs_ticket, delegated_tgs_auth = request_delegation_ticket(tgt_result.decrypted_part.key,
-                                                                           tgt_result.ticket,
-                                                                           realm,
-                                                                           client_name,
-                                                                           tgt_etype,
-                                                                           expiry_time,
-                                                                           now)
-
+      delegated_tgs_ticket, delegated_tgs_auth = request_delegation_ticket(
+        tgt_result.decrypted_part.key,
+        tgt_result.ticket,
+        realm,
+        client_name,
+        tgt_etype,
+        expiry_time,
+        now
+      )
     end
 
     ## Service Authentication
@@ -384,7 +356,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     }
   end
 
-  def authenticate_via_krb5_ccache_credential(credential, _options = {})
+  def authenticate_via_krb5_ccache_credential_tgs(credential, _options = {})
     unless credential.is_a?(Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential)
       raise TypeError, 'credential must be a Krb5CcacheCredential instance'
     end
@@ -435,6 +407,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       session_key: tgs_auth_key,
       client_sequence_number: sequence_number
     }
+  end
+
+  def authenticate_via_krb5_ccache_credential_tgt(credential, options = {})
+    raise NotImplementedError
   end
 
   def build_gss_ap_req_checksum_value(mutual_auth, ticket, decrypted_part, session_key, realm, client_name)
@@ -548,6 +524,65 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     [delegated_tgs_ticket, delegated_tgs_auth]
   end
 
+  # @param [Rex::Proto::Kerberos::Model::EncryptionKey] session_key
+  # @param [Rex::Proto::Kerberos::Model::Ticket] tgt_ticket
+  # @param [String] realm
+  # @param [String] client_name
+  # @param [Integer] tgt_etype
+  # @param [Time] expiry_time
+  # @param [Time] now
+  # @param [Rex::Proto::Kerberos::Model::PrincipalName] sname
+  def request_service_ticket(session_key, tgt_ticket, realm, client_name, tgt_etype, expiry_time, now, sname)
+    subkey = nil
+
+    ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+      [
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+      ]
+    )
+
+    tgs_res = send_request_tgs(
+      req: build_tgs_request(
+        {
+          session_key: session_key,
+          subkey: subkey,
+          checksum: nil,
+          ticket: tgt_ticket,
+          realm: realm,
+          client_name: client_name,
+          options: ticket_options,
+
+          body: build_tgs_request_body(
+            cname: nil,
+            sname: sname,
+            realm: realm,
+            etype: [tgt_etype],
+            options: ticket_options,
+
+            # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
+            from: nil,
+            till: expiry_time,
+            rtime: nil,
+
+            # certificate time
+            ctime: now
+          )
+        }
+      )
+    )
+
+    # Verify error codes
+    if tgs_res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
+      raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: tgs_res)
+    end
+
+    print_good("#{peer} - Received a valid TGS-Response")
+
+    tgs_res
+  end
+
   # Search the database for a credential object that can be used for authentication.
   #
   # @param [Hash] options
@@ -576,7 +611,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #
   # @param [String] file_path The file path to load a credential object from
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CacheCredential] the credential object for authentication
-  def load_credential_from_file(file_path)
+  def load_credential_from_file(file_path, options = {})
     unless File.readable?(file_path.to_s)
       wlog("Failed to load ticket file '#{file_path}' (file not readable)")
       return nil
@@ -589,7 +624,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       return nil
     end
 
-    sname = build_spn
+    sname = options.fetch(:sname) { build_spn&.to_s }
     now = Time.now.utc
 
     cache.credentials.to_ary.each.with_index(1) do |credential, index|
@@ -617,7 +652,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       end
 
       unless !@username || @username.casecmp?(credential.client.components.last.to_s)
-        wlog("Filtered credential #{file_path} ##{index} reason: username does not match (username: #{credential.client.components.last})")
+        wlog("Filtered credential #{file_path} ##{index} reason: Username does not match (username: #{credential.client.components.last})")
         next
       end
 

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -410,7 +410,36 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   end
 
   def authenticate_via_krb5_ccache_credential_tgt(credential, options = {})
-    raise NotImplementedError
+    realm = self.realm.upcase
+    sname = options.fetch(:sname)
+    client_name = username
+
+    now = Time.now.utc
+    expiry_time = now + 1.day
+
+    ticket = Rex::Proto::Kerberos::Model::Ticket.decode(credential.ticket.value)
+    session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
+      type: credential.keyblock.enctype.value,
+      value: credential.keyblock.data.value
+    )
+
+    tgs_res = request_service_ticket(
+      session_key,
+      ticket,
+      realm,
+      client_name,
+      ticket.enc_part.etypes,
+      expiry_time,
+      now,
+      sname
+    )
+
+    cache = extract_kerb_creds(
+      tgs_res,
+      session_key.value,
+      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
+    )
+    authenticate_via_krb5_ccache_credential_tgs(cache.credentials.first, options)
   end
 
   def build_gss_ap_req_checksum_value(mutual_auth, ticket, decrypted_part, session_key, realm, client_name)
@@ -532,6 +561,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @param [Time] expiry_time
   # @param [Time] now
   # @param [Rex::Proto::Kerberos::Model::PrincipalName] sname
+  # @raise [Rex::Proto::Kerberos::Model::Error::KerberosError]
   def request_service_ticket(session_key, tgt_ticket, realm, client_name, tgt_etype, expiry_time, now, sname)
     subkey = nil
 

--- a/lib/msf/core/exploit/remote/kerberos/ticket.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket.rb
@@ -46,7 +46,13 @@ module Msf
             )
             if save_ccache
               ccache = generate_ccache(ticket, opts: opts)
-              path = store_loot('kerberos_ticket.ccache', 'application/octet-stream', domain, ccache.encode)
+
+              info = []
+              info << "realm: #{opts[:realm].upcase}"
+              info << "serviceName: #{opts[:server].to_s.downcase}"
+              info << "username: #{opts[:client].to_s.downcase}"
+
+              path = store_loot('mit.kerberos.ccache', 'application/octet-stream', domain, ccache.encode, nil, info.join(', '))
               print_good("MIT Credential Cache ticket saved on #{path}")
             end
             ticket

--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache.rb
@@ -41,6 +41,9 @@ module Rex::Proto::Kerberos::CredentialCache
     # the other kerberos models use #encode so alias that for simplicity
     alias_method :encode, :to_binary_s
 
+    # @param [Rex::Proto::Kerberos::Model::KdcResponse] res The KDC response
+    # @param [Rex::Proto::Kerberos::Model::EncKdcResponse] enc_res The encrypted KDC response
+    # @return [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache]
     def self.from_responses(res, enc_res)
       self.new(
         default_principal: {

--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache.rb
@@ -40,5 +40,39 @@ module Rex::Proto::Kerberos::CredentialCache
 
     # the other kerberos models use #encode so alias that for simplicity
     alias_method :encode, :to_binary_s
+
+    def self.from_responses(res, enc_res)
+      self.new(
+        default_principal: {
+          name_type: res.cname.name_type, # NT_PRINCIPAL
+          realm: res.crealm,
+          components: res.cname.name_string
+        },
+        credentials: [
+          {
+            client: {
+              name_type: res.cname.name_type,
+              realm: res.crealm,
+              components: res.cname.name_string
+            },
+            server: {
+              name_type: enc_res.sname.name_type,
+              realm: enc_res.srealm,
+              components: enc_res.sname.name_string
+            },
+            keyblock: {
+              enctype: enc_res.key.type,
+              data: enc_res.key.value
+            },
+            authtime: enc_res.auth_time,
+            starttime: enc_res.start_time,
+            endtime: enc_res.end_time,
+            renew_till: enc_res.renew_till,
+            ticket_flags: enc_res.flags.to_i,
+            ticket: res.ticket.encode
+          }
+        ]
+      )
+    end
   end
 end


### PR DESCRIPTION
This improves the ccache work I started in #16770. That allowed stored TGS tickets to be used to authenticate to services. This takes it a step further and allows TGTs to be used as well. When a TGT is used, the KDC is contacted so it's not as quite, but the necessary service ticket will be requested and cached for future use.

The explicit ticket specified by the user takes priority over any cached tickets. This means that if the sure runs a module with a golden ticket multiple times, they'll issue a TGS each time. If this isn't the behavior we want, I'll update things to prioritize explicit TGS, then cached TGS, then explicit TGTs, and finally cached TGTs.

I tested this with tickets from Metasploit's own `kerberos/forge_ticket` module as well as impacket's `examples/ticketer.py` script. In both cases it works. I also tweaked how the `kerberos/forge_ticket` module stores the tickets in loot so they are capable of being retrieved by other modules for ingestion. That means that once you've forged a golden or silver ticket, the user does not need to copy the path and use it with the `Krb5Ccname` datastore option, instead it'll just work (TM).

## Verification

- [x] Test authenticating directly via the KDC using a username and password (make sure there's nothing cached and see the messages that a TGT and a TGS were received)
- [x] Test authenticating directly with the cached TGS (just rerun the same module and see no messages about TGTs or TGS being received)
- [x] Test authenticating directly with a specified TGT (set `SmbKrb5Ccname`) (only see a message that a TGS was receveied, no TGT)
    - [x] Delete any cached TGS tickets to avoid using those which are prioritized, run `workspace -D` (note that this *must* be done before the golden ticket is generated lest it be deleted too) 
    - [x] To test this new code path, generate a golden ticket, follow the steps from #16976 in the "Forge Golden Ticket" section
    - [x] Test authenticating directly with a cached TGT (clear `SmbKrb5Ccname` and rely on the cached entry from the `kerberos/forge_ticket` module)
- [ ] Test a cached silver ticket from the `kerberos/forge_ticket` module 

