### PR TITLE
Add in docs site to banner

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -262,6 +262,7 @@ class Core
 
     banner << "\n"
     banner << Msf::Serializer::ReadableText.word_wrap("Metasploit tip: #{Tip.sample}\n", indent = 0, cols = 60)
+    banner << Msf::Serializer::ReadableText.word_wrap('Metasploit Documentation: https://docs.metasploit.com/', indent = 0, cols = 60)
 
     # Display the banner
     print_line(banner)


### PR DESCRIPTION
This change adds in the docs.metasploit.com site to the Metasploit Framework banner. This should allow people who are not aware of our other sites and who immediately open Metasploit to find our documentation straight away vs being confused as to where to find information when they load up Metasploit.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Verify the new banner looks good and if formatted correctly.
