### PR TITLE
Fix #16684, Set @peer_info in #initialize

### DIFF
--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -24,6 +24,10 @@ module Interactive
     # A nil is passed in the case of non-stream interactive sessions (Meterpreter)
     if rstream
       self.rstream = rstream
+      begin
+        @peer_info = rstream.peerinfo
+      rescue ::Exception
+      end
     end
     super()
   end
@@ -43,7 +47,8 @@ module Interactive
     return @local_info if @local_info
     begin
       @local_info = rstream.localinfo
-    rescue ::Exception
+    rescue ::Exception => e
+      elog('Interactive#tunnel_local error', error: e)
       @local_info = '127.0.0.1'
     end
   end
@@ -55,7 +60,8 @@ module Interactive
     return @peer_info if @peer_info
     begin
       @peer_info = rstream.peerinfo
-    rescue ::Exception
+    rescue ::Exception => e
+      elog('Interactive#tunnel_peer error', error: e)
       @peer_info = '127.0.0.1'
     end
   end


### PR DESCRIPTION
Closes rapid7#16684

The `#tunnel_peer` method caches the value in the `@peer_info` attribute. If `#rstream` is closed when this is called, it'll raise an exception and return the address '127.0.0.1' which is incorrect. The `#rstream` is only open for a short period of time when serving an HTTP request, which means that if the information was not cached while the socket was opened, it's unavailable.

It would appear as though commit 38688e14 introduced in PR #14844 changed where `#tunnel_peer` is called for the first time. After that change, the socket is already closed in the case of the `reverse_http` transport, leading to the address '127.0.0.1' being incorrectly reported as the remote host.

This change fixes the issue by updating `#initialize` to proactively set `@peer_info` if `#rstream` is provided. This will ensure that the information is set for later use. If it fails for some reason then `@peer_info` will be left unset and `#tunnel_peer` will attempt to set it again. This should account for cases of `#rstream` being set later. I don't know of any cases of this happening but it seems like something worth accounting for.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Use an exploit or something to get a Meterpreter session using a `reverse_http(s)` handler
- [ ] See the correct peer address and not 127.0.0.1


## Demo

Unpatched on the left, patched on the right.
![image](https://user-images.githubusercontent.com/2058303/191077306-5d2b73c9-40ee-421c-9bd2-e14608ed53cb.png)
