### PR TITLE
Fix missing ssh_login peerinfo

### DIFF
--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -246,7 +246,7 @@ module Msf::Sessions
       @rstream = Net::SSH::CommandStream.new(ssh_connection).lsock
       super
 
-      @info = "SSH #{username} @ #{@peer_info}"
+      @info = "SSH #{username} @ #{@rstream.peerinfo}"
     end
 
     def desc

--- a/lib/net/ssh/command_stream.rb
+++ b/lib/net/ssh/command_stream.rb
@@ -47,21 +47,22 @@ class Net::SSH::CommandStream
     self.rsock.extend(Rex::IO::Stream)
 
     self.ssh = ssh
+
+    info = ssh.transport.socket.getpeername_as_array
+    if Rex::Socket.is_ipv6?(info[1])
+      self.lsock.peerinfo = "[#{info[1]}]:#{info[2]}"
+    else
+      self.lsock.peerinfo = "#{info[1]}:#{info[2]}"
+    end
+
+    info = ssh.transport.socket.getsockname
+    if Rex::Socket.is_ipv6?(info[1])
+      self.lsock.localinfo = "[#{info[1]}]:#{info[2]}"
+    else
+      self.lsock.localinfo = "#{info[1]}:#{info[2]}"
+    end
+
     self.thread = Thread.new(ssh, cmd, pty, cleanup) do |rssh, rcmd, rpty, rcleanup|
-      info = rssh.transport.socket.getpeername_as_array
-      if Rex::Socket.is_ipv6?(info[1])
-        self.lsock.peerinfo = "[#{info[1]}]:#{info[2]}"
-      else
-        self.lsock.peerinfo = "#{info[1]}:#{info[2]}"
-      end
-
-      info = rssh.transport.socket.getsockname
-      if Rex::Socket.is_ipv6?(info[1])
-        self.lsock.localinfo = "[#{info[1]}]:#{info[2]}"
-      else
-        self.lsock.localinfo = "#{info[1]}:#{info[2]}"
-      end
-
       channel = rssh.open_channel do |rch|
         # A PTY will write us to {u,w}tmp and lastlog
         rch.request_pty if rpty


### PR DESCRIPTION
Fixes missing ssh_login peerinfo information which was introduced by https://github.com/rapid7/metasploit-framework/pull/15831

Before
```
$  rvm use; bundle; time bundle exec ruby ./msfconsole -qx "use scanner/ssh/ssh_login; set rhosts 192.168.123.128; set rport 2222; set username user; set password password; run; sleep 1; sessions; exit -y"

# ....

Active sessions
===============

  Id  Name  Type         Information     Connection
  --  ----  ----         -----------     ----------
  1         shell linux  SSH adfoster @  192.168.123.1:52223 -> 192.168.123.128:2222 (192.168.123.128)

```

After 
```
$  rvm use; bundle; time bundle exec ruby ./msfconsole -qx "use scanner/ssh/ssh_login; set rhosts 192.168.123.128; set rport 2222; set username user; set password password; run; sleep 1; sessions; exit -y"

# ....

Active sessions
===============

  Id  Name  Type         Information                          Connection
  --  ----  ----         -----------                          ----------
  1         shell linux  SSH adfoster @ 192.168.123.128:2222  192.168.123.1:52210 -> 192.168.123.128:2222 (192.168.123.128)

```


## Verification

- Run the ssh_login module against a target
- Verify there is not a regression in the behavior introduced by https://github.com/rapid7/metasploit-framework/pull/15831