### PR TITLE
enum_tokens: Cleanup

### DIFF
--- a/documentation/modules/post/windows/gather/enum_tokens.md
+++ b/documentation/modules/post/windows/gather/enum_tokens.md
@@ -1,0 +1,49 @@
+## Vulnerable Application
+
+This module enumerates Domain Admin account processes and delegation tokens.
+
+This module will first check if the session has sufficient privileges
+to replace process level tokens and adjust process quotas.
+
+The SeAssignPrimaryTokenPrivilege privilege will not be assigned if
+the session has been elevated to SYSTEM. In that case try first
+migrating to another process that is running as SYSTEM.
+
+
+## Verification Steps
+
+1. Start msfconsole
+1. Get a Meterpreter session on a Windows target on a domain
+1. Do: `use post/windows/gather/enum_tokens`
+1. Do: `set session [#]`
+1. Do: `run`
+1. You should receive a list of Domain Admin account processes and delegation tokens
+
+
+## Options
+
+### GETSYSTEM
+
+Attempt to get SYSTEM privilege on the target host. (default: `true`)
+
+
+## Scenarios
+
+### Local Administrator session on Windows Server 2008 SP1 (x64)
+
+```
+msf6 post(windows/gather/enum_tokens) > set session 1
+session => 1
+msf6 post(windows/gather/enum_tokens) > set getsystem false
+getsystem => false
+msf6 post(windows/gather/enum_tokens) > run
+
+[*] Running module against WIN-17B09RRRJTG (192.168.200.218)
+[+] Found token for session 1 (192.168.200.218) - Administrator (Delegation Token)
+[+] Found process on session 1 (192.168.200.218) - Administrator (PID: 3344) (cmd.exe)
+[+] Found process on session 1 (192.168.200.218) - Administrator (PID: 2420) (calc.exe)
+[+] Found process on session 1 (192.168.200.218) - Administrator (PID: 2220) (reverse.x64.1337.exe)
+[+] Found token for session 1 (192.168.200.218) - corpadmin (Delegation Token)
+[+] Found process on session 1 (192.168.200.218) - corpadmin (PID: 1764) (cmd.exe)
+[*] Post module execution completed
+```


### PR DESCRIPTION
Resolves Rubocop violations.

Adds documentation.

Adds `Notes` module meta information.

Updates module description. The existing description was uselessly vague.

Use new `get_domain_name` method introduced in #16952 to retrieve the domain name. Note that the `get_domain_name` method will not work on shell sessions on Windows systems prior to 2008. This is an existing bug in this module too as this module uses the same technique to retrieve the domain name. Also, this module only supports Metepreter sessions anyway.

Replace custom `get_members` method with `get_members_from_group` from the Post API.

Fixes the loop logic which was extremely inefficient. Prior to this PR, the module retrieved the process list and delegation tokens (using `session.incognito.incognito_list_tokens`) for every single user in the Domain Admins group. This is extremely inefficient and is problematic as Incognito leaks memory (https://github.com/rapid7/metasploit-payloads/issues/584), thus invoking this method multiple times leads to excessive memory usage. After this PR, the processes and tokens are retrieved only once.

---

tl/dr: the module still has many bugs, but now has less bugs and the code is readable.

The existing logic in the module has been preserved (including logic bugs). The module itself could use more work (in particular the privileges checks and `getsystem` functionality). I'm not interested in pursuing this. The cleanup performed in this PR will make subsequent improvements significantly easier if someone wants to improve the module.

This module has had no functional updates (only minor updates for style and library changes) since it was first added back in the SVN days 10+ years ago.

https://github.com/rapid7/metasploit-framework/commits/master/modules/post/windows/gather/enum_tokens.rb

It was likely intended as a module equivilent for the [token_hunter plugin](https://github.com/rapid7/metasploit-framework/blob/master/plugins/token_hunter.rb) which was added a couple of years prior (although the module only reports delegation tokens, where as the plugin reports both delegation and impersonation).

https://github.com/rapid7/metasploit-framework/commits/master/plugins/token_hunter.rb

This module is also very similar to the `enum_domain_tokens` module (which has updates pending merge in #16981). The `enum_tokens` module is intended as a "Token Hunter" to be run on many sessions and focuses only on tokens for Domain Admin user accounts. Where as `enum_domain_tokens` retrieves tokens for all domain user accounts (including Domain Admins).
