### PR TITLE
wmic_command: Cleanup

### DIFF
--- a/documentation/modules/post/windows/gather/wmic_command.md
+++ b/documentation/modules/post/windows/gather/wmic_command.md
@@ -1,0 +1,51 @@
+## Vulnerable Application
+
+This module executes WMIC commands on the specified host.
+
+
+## Verification Steps
+
+1. Start msfconsole
+1. Get a Meterpreter session on a Windows target
+1. Do: `use post/windows/gather/wmic_command`
+1. Do: `set session [#]`
+1. Do: `set command [wmic command]`
+1. Do: `run`
+1. You should receive WMIC command output
+
+
+## Options
+
+### RESOURCE
+
+Full path to resource file containing WMIC commands.
+
+### COMMAND
+
+WMIC command.
+
+
+## Scenarios
+
+### Windows Server 2008 SP1 (x64)
+
+```
+msf6 > use post/windows/gather/wmic_command
+msf6 post(windows/gather/wmic_command) > set session 1
+session => 1
+msf6 post(windows/gather/wmic_command) > set command os
+command => os
+msf6 post(windows/gather/wmic_command) > run
+
+[*] Running module against WIN-17B09RRRJTG (192.168.200.218)
+[*] Running WMIC command: os
+[*] Command output saved to: /root/.msf4/loot/20220922071306_default_192.168.200.218_host.command.wmi_789917.txt
+[*] Post module execution completed
+msf6 post(windows/gather/wmic_command) > cat /root/.msf4/loot/20220922071306_default_192.168.200.218_host.command.wmi_789917.txt
+[*] exec: cat /root/.msf4/loot/20220922071306_default_192.168.200.218_host.command.wmi_789917.txt
+
+BootDevice               BuildNumber  BuildType            Caption                                     CodeSet  CountryCode  CreationClassName      CSCreationClassName   CSDVersion      CSName           CurrentTimeZone  DataExecutionPrevention_32BitApplications  DataExecutionPrevention_Available  DataExecutionPrevention_Drivers  DataExecutionPrevention_SupportPolicy  Debug  Description  Distributed  EncryptionLevel  ForegroundApplicationBoost  FreePhysicalMemory  FreeSpaceInPagingFiles  FreeVirtualMemory  InstallDate                LargeSystemCache  LastBootUpTime             LocalDateTime              Locale  Manufacturer           MaxNumberOfProcesses  MaxProcessMemorySize  MUILanguages  Name                                                                                 NumberOfLicensedUsers  NumberOfProcesses  NumberOfUsers  OperatingSystemSKU  Organization  OSArchitecture  OSLanguage  OSProductSuite  OSType  OtherTypeDescription  PAEEnabled  PlusProductID  PlusVersionNumber  Primary  ProductType  QuantumLength  QuantumType  RegisteredUser  SerialNumber             ServicePackMajorVersion  ServicePackMinorVersion  SizeStoredInPagingFiles  Status  SuiteMask  SystemDevice             SystemDirectory      SystemDrive  TotalSwapSpaceSize  TotalVirtualMemorySize  TotalVisibleMemorySize  Version   WindowsDirectory  
+\Device\HarddiskVolume1  6001         Multiprocessor Free  Microsoft� Windows Server� 2008 Enterprise  1252     1            Win32_OperatingSystem  Win32_ComputerSystem  Service Pack 1  WIN-17B09RRRJTG  600              TRUE                                       TRUE                               TRUE                             3                                      FALSE               FALSE        256              2                           507164              1354124                 1788752            20220722133039.000000+600                    20220922115509.500000+600  20220922211154.399000+600  0409    Microsoft Corporation  -1                    8589934464            {"en-US"}     Microsoft� Windows Server� 2008 Enterprise |C:\Windows|\Device\Harddisk0\Partition1                         47                 4              10                                64-bit          1033        274             18                                                                          TRUE     2            1              1            Windows User    92516-083-1766663-76902  1                        0                        1354124                  OK      274        \Device\HarddiskVolume1  C:\Windows\system32  C:                               2358168                 1046924                 6.0.6001  C:\Windows        
+
+msf6 post(windows/gather/wmic_command) > 
+```

--- a/modules/post/windows/gather/wmic_command.rb
+++ b/modules/post/windows/gather/wmic_command.rb
@@ -10,64 +10,81 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Windows Gather Run Specified WMIC Command',
+        'Name' => 'Windows Gather Run WMIC Commands',
         'Description' => %q{
-          This module will execute a given WMIC command options or read
-          WMIC commands options from a resource file and execute the commands in the
-          specified Meterpreter session.
+          This module executes WMIC commands on the specified host.
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
 
-    register_options(
-      [
-        OptPath.new('RESOURCE', [false, 'Full path to resource file to read commands from.']),
-        OptString.new('COMMAND', [false, 'WMIC command options.']),
-      ]
-    )
+    register_options([
+      OptPath.new('RESOURCE', [false, 'Full path to resource file containing WMIC commands']),
+      OptString.new('COMMAND', [false, 'WMIC command']),
+    ])
   end
 
-  # Run Method for when run command is issued
   def run
-    tmpout = ''
-    if sysinfo.blank?
-      fail_with(Failure::BadConfig, "The session this module is running against doesn't support the sysinfo command!")
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Running module against #{hostname} (#{session.session_host})")
+
+    resource_file = datastore['RESOURCE']
+    command = datastore['COMMAND']
+
+    if command.blank? && resource_file.blank?
+      fail_with(Failure::BadConfig, 'Please specify COMMAND or RESOURCE file.')
     end
-    print_status("Running module against #{sysinfo['Computer']}")
-    if datastore['RESOURCE']
-      if ::File.exist?(datastore['RESOURCE'])
 
-        ::File.open(datastore['RESOURCE']).each_line do |cmd|
-          next if cmd.strip.length < 1
-          next if cmd[0, 1] == '#'
+    commands = []
 
-          print_status "Running command #{cmd.chomp}"
+    if resource_file
+      fail_with(Failure::BadConfig, "Resource file #{resource_file} does not exist!") unless ::File.exist?(resource_file)
 
-          result = wmic_query(cmd.chomp)
-          store_wmic_loot(result, cmd)
-        end
-      else
-        raise 'Resource File does not exist!'
+      ::File.open(resource_file).each_line(chomp: true) do |cmd|
+        next if cmd.strip.empty?
+        next if cmd.starts_with?('#')
+
+        commands << cmd
+      end
+    else
+      commands << command
+    end
+
+    commands.each do |cmd|
+      next if cmd.strip.empty?
+
+      print_status("Running WMIC command: #{cmd}")
+
+      result = wmic_query(cmd)
+
+      if result.blank?
+        print_error('No results for command')
+        next
       end
 
-    elsif datastore['COMMAND']
-      cmd = datastore['COMMAND']
-      result = wmic_query(cmd)
+      vprint_line(result)
+
       store_wmic_loot(result, cmd)
     end
   end
 
   def store_wmic_loot(result_text, cmd)
-    command_log = store_loot('host.command.wmic',
-                             'text/plain',
-                             session,
-                             result_text,
-                             "#{cmd.gsub(%r{\.|/|\s}, '_')}.txt",
-                             "Command Output \'wmic #{cmd.chomp}\'")
+    command_log = store_loot(
+      'host.command.wmic',
+      'text/plain',
+      session,
+      result_text,
+      "#{cmd.gsub(%r{\.|/|\s}, '_')}.txt",
+      "Command Output 'wmic #{cmd}'"
+    )
 
     print_status("Command output saved to: #{command_log}")
   end


### PR DESCRIPTION
Resolves Rubocop violations.

Adds documentation.

Adds `Notes` module meta information.

Use `fail_with` instead of raising an error when the specified `RESOURCE` file does not exist.

`vprint` the command results.
