### PR TITLE
Fix openssl unsafe legacy renegotiation disabled error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.42)
+    rex-socket (0.1.43)
       rex-core
     rex-sslscan (0.1.8)
       rex-core


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/16954

Full context on the rex-socket PR

Before

```
msf6 auxiliary(scanner/http/title) > run https://www.courts.ie/

[*] Error: 137.191.225.100: OpenSSL::SSL::SSLError SSL_connect returned=1 errno=0 peeraddr=137.191.225.100:443 state=error: unsafe legacy renegotiation disabled
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

After

```
msf6 auxiliary(scanner/http/title) > run https://www.courts.ie/

[+] [137.191.225.100:443] [C:200] [R:] [S:Apache/2.4.38 (Win64) PHP/7.1.26] Home | The Courts Service of Ireland
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification

- [x] Verify you're using openssl 3 `openssl version`, i.e. on latest ubuntu/kali
- [x] Verify the described before/after scenarios above on master versus this branch