### PR TITLE
Fix Adapted Single (Unstaged) Payloads

### DIFF
--- a/lib/msf/core/payload/single.rb
+++ b/lib/msf/core/payload/single.rb
@@ -32,12 +32,13 @@ module Msf::Payload::Single
       # If they defined a custom method that will return the payload, then
       # call it
       if self.class.method_defined?(:generate_stage)
-        generate_stage
-      # Otherwise, just use the default method to generate the single
-      # payload
-      else
-        super
+        # this can safely be ignored for adapters
+        unless self.class.include?(Msf::Payload::Adapter)
+          wlog("Single payload '#{self.fullname}' has #generate_stage defined when it should be using #generate")
+        end
       end
+
+      super
     end
   end
 

--- a/modules/payloads/singles/bsd/x64/exec.rb
+++ b/modules/payloads/singles/bsd/x64/exec.rb
@@ -37,7 +37,7 @@ module MetasploitModule
   #
   # Dynamically builds the exec payload based on the user's options.
   #
-  def generate_stage(opts={})
+  def generate(opts={})
     cmd_str = datastore['CMD'] || ''
     # Split the cmd string into arg chunks
     cmd_parts = Shellwords.shellsplit(cmd_str)

--- a/modules/payloads/singles/bsd/x86/exec.rb
+++ b/modules/payloads/singles/bsd/x86/exec.rb
@@ -41,7 +41,7 @@ module MetasploitModule
   #
   # Dynamically builds the exec payload based on the user's options.
   #
-  def generate_stage(opts={})
+  def generate(opts={})
     bsd_x86_exec_payload
   end
 end

--- a/modules/payloads/singles/linux/armle/adduser.rb
+++ b/modules/payloads/singles/linux/armle/adduser.rb
@@ -40,7 +40,7 @@ module MetasploitModule
   #
   # Dynamically builds the adduser payload based on the user's options.
   #
-  def generate_stage(opts={})
+  def generate(opts={})
     user    = datastore['USER']  || 'metasploit'
     pass    = datastore['PASS']  || 'metasploit'
     shell   = datastore['SHELL'] || '/bin/sh'

--- a/modules/payloads/singles/linux/armle/exec.rb
+++ b/modules/payloads/singles/linux/armle/exec.rb
@@ -33,7 +33,7 @@ module MetasploitModule
       ])
   end
 
-  def generate_stage(opts={})
+  def generate(opts={})
     cmd     = datastore['CMD'] || ''
 
     payload =

--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -30,7 +30,7 @@ module MetasploitModule
       ])
   end
 
-  def generate_stage(opts={})
+  def generate(opts={})
     cmd             = datastore['CMD'] || ''
     nullfreeversion = datastore['NullFreeVersion']
 

--- a/modules/payloads/singles/linux/x64/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x64/pingback_bind_tcp.rb
@@ -25,7 +25,7 @@ module MetasploitModule
       'Handler'       => Msf::Handler::BindTcp,
       'Session'       => Msf::Sessions::Pingback
     ))
-    def generate_stage
+    def generate(opts={})
       # 22 -> "0x00,0x16"
       # 4444 -> "0x11,0x5c"
       encoded_port = [datastore['LPORT'].to_i,2].pack("vn").unpack("N").first

--- a/modules/payloads/singles/linux/x64/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/pingback_reverse_tcp.rb
@@ -25,7 +25,7 @@ module MetasploitModule
       'Handler'       => Msf::Handler::ReverseTcp,
       'Session'       => Msf::Sessions::Pingback
     ))
-    def generate_stage
+    def generate(opts={})
       # 22 -> "0x00,0x16"
       # 4444 -> "0x11,0x5c"
       encoded_port = [datastore['LPORT'].to_i,2].pack("vn").unpack("N").first

--- a/modules/payloads/singles/linux/x64/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_ipv6_tcp.rb
@@ -24,7 +24,7 @@ module MetasploitModule
       'Session'       => Msf::Sessions::CommandShellUnix,
       ))
 
-    def generate_stage
+    def generate(opts={})
       # tcp port conversion; shamelessly stolen from linux/x86/shell_reverse_tcp_ipv6.rb
       port_order = ([1,0]) # byte ordering
       tcp_port = [datastore['LPORT'].to_i].pack('n*').unpack('H*').to_s.scan(/../) # converts user input into integer and unpacked into a string array

--- a/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
@@ -25,7 +25,7 @@ module MetasploitModule
     ))
   end
 
-  def generate_stage
+  def generate(opts={})
     payload = %Q^
       ; Creating the socket file descriptor
       ; int socket(int domain, int type, int protocol);

--- a/modules/payloads/singles/linux/x64/shell_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_reverse_ipv6_tcp.rb
@@ -40,7 +40,7 @@ module MetasploitModule
       arr.map{ |x| sprintf("0x%02x", x.hex) }.join(',')
   end
 
-  def generate_stage
+  def generate(opts={})
       # 22 -> "0x00,0x16"
       # 4444 -> "0x11,0x5c"
       tcp_port = convert_input(datastore['LPORT'], 4)

--- a/modules/payloads/singles/linux/x86/adduser.rb
+++ b/modules/payloads/singles/linux/x86/adduser.rb
@@ -40,7 +40,7 @@ module MetasploitModule
   #
   # Dynamically builds the adduser payload based on the user's options.
   #
-  def generate_stage(opts={})
+  def generate(opts={})
     user    = datastore['USER']  || 'metasploit'
     pass    = datastore['PASS']  || 'metasploit'
     shell   = datastore['SHELL'] || '/bin/sh'

--- a/modules/payloads/singles/linux/x86/chmod.rb
+++ b/modules/payloads/singles/linux/x86/chmod.rb
@@ -32,7 +32,7 @@ module MetasploitModule
   end
 
   # Dynamically generates chmod(FILE, MODE) + exit()
-  def generate_stage(opts={})
+  def generate(opts={})
     file    = datastore['FILE'] || '/etc/shadow'
     mode	= (datastore['MODE'] || "0666").oct
 

--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -42,7 +42,7 @@ module MetasploitModule
       ])
   end
 
-  def generate_stage(opts={})
+  def generate(opts={})
     cmd             = datastore['CMD'] || ''
     nullfreeversion = datastore['NullFreeVersion']
     if cmd.empty?

--- a/modules/payloads/singles/linux/x86/read_file.rb
+++ b/modules/payloads/singles/linux/x86/read_file.rb
@@ -28,7 +28,7 @@ module MetasploitModule
       ])
   end
 
-  def generate_stage(opts={})
+  def generate(opts={})
     fd = datastore['FD']
 
     payload_data =<<-EOS

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp_ipv6.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp_ipv6.rb
@@ -26,7 +26,7 @@ module MetasploitModule
     ))
   end
 
-def generate_stage
+def generate(opts={})
       # tcp port conversion
       port_order = ([1,0]) # byte ordering
       tcp_port = [datastore['LPORT'].to_i].pack('n*').unpack('H*').to_s.scan(/../) # converts user input into integer and unpacked into a string array

--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -41,7 +41,7 @@ module MetasploitModule
   #
   # Dynamically builds the exec payload based on the user's options.
   #
-  def generate_stage(opts={})
+  def generate(opts={})
     bsd_x86_exec_payload
   end
 end


### PR DESCRIPTION
This fixes an issue in how adapted, single payloads are generated. In #16597, to fix the encrypted shells, `#generate_stage` was defined to set the correct architecture before calling `super` which would use that information to compile the correct payload. Now when `#generate_stage` was defined, that caused *all* single payloads to call it due the logic in [`Msf::Payload::Single`](https://github.com/rapid7/metasploit-framework/blob/acc4f2d3782c44b701b6673252fc5248fb6dbf59/lib/msf/core/payload/single.rb#L34-L40). When the parent doesn't also define `#generate_stage`, it would crash. It's unclear why single, unstaged payloads would define `#generate_stage` when, by definition AFAIK they are not staged.

This fixes the issue by correcting every instance of a single payload that defined `#generate_stage` and renamed it to `#generate`. This fixes the adapted payloads, allowing them to be generated and their information to be displayed.

<details>
<summary>Original Stack Trace</summary>
This is the original issue where the issue is that the adapted payload's `#generate_stage` method is called because it's defined but there is no superclass method `#generate_stage`.

```
msf6 payload(cmd/windows/powershell/powershell_reverse_tcp) > info
[-] Error while running command info: super: no superclass method `generate_stage' for #<Module:payload/cmd/windows/powershell/powershell_reverse_tcp datastore=[{"WORKSPACE"=>nil, "VERBOSE"=>false, "LHOST"=>nil, "LPORT"=>4444, "ReverseListenerBindPort"=>nil, "ReverseAllowProxy"=>false, "ReverseListenerComm"=>nil, "ReverseListenerBindAddress"=>nil, "ReverseListenerThreaded"=>false, "StagerRetryCount"=>10, "StagerRetryWait"=>5, "PrependMigrate"=>false, "PrependMigrateProc"=>nil, "EXITFUNC"=>"process", "LOAD_MODULES"=>nil, "Powershell::persist"=>false, "Powershell::prepend_sleep"=>nil, "Powershell::prepend_protections_bypass"=>"auto", "Powershell::strip_comments"=>true, "Powershell::strip_whitespace"=>false, "Powershell::sub_vars"=>true, "Powershell::sub_funcs"=>false, "Powershell::exec_in_place"=>false, "Powershell::exec_rc4"=>false, "Powershell::remove_comspec"=>false, "Powershell::noninteractive"=>true, "Powershell::encode_final_payload"=>false, "Powershell::encode_inner_payload"=>false, "Powershell::wrap_double_quotes"=>true, "Powershell::no_equals"=>false, "Powershell::method"=>"reflection"}]>
Did you mean?  generate_simple

Call stack:
/home/smcintyre/Repositories/metasploit-framework/modules/payloads/adapters/cmd/windows/powershell.rb:46:in `generate_stage'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/core/payload/single.rb:35:in `generate'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/core/payload/windows/exec.rb:61:in `generate'
/home/smcintyre/Repositories/metasploit-framework/modules/payloads/adapters/cmd/windows/powershell.rb:39:in `generate'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/core/payload.rb:194:in `size'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/serializer/readable_text.rb:472:in `dump_payload_module'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/serializer/readable_text.rb:26:in `dump_module'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:129:in `print_module_info'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:152:in `cmd_info'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
msf6 payload(cmd/windows/powershell/powershell_reverse_tcp) >
```
</details>


## Verification

List the steps needed to make sure this thing works

- [ ] Validate that all updated payloads that were changed from `#generate_stage` to `#generate` are still correct
    - [ ] Use the included resource file from the PR branch and the master branch, then compare the results. The following steps assume that you use the path included which is `/tmp/payloads`
    - [ ] Calculate the hashes for all of the files `md5sum * > hashes.txt`
    - [ ] Run a diff on `hashes.txt`, see that everything is the exact same except for the pingback payloads which have a random UUID embedded within them. Manually review any differences that may have come up.
    - [ ] Now that the outputs are the same, see that for every modified payload the payload itself and information was generated (also that the payload binary was unchanged).
    - [ ] Also see that the handler was able to be started for every payload
- [ ] Validate that the original issue was fixed
    - [ ] Use `payload/cmd/windows/powershell/powershell_reverse_tcp` and generate the info for it, see no errors
    - [ ] Use the psexec module and the Command target
    - [ ] See that key adapted payload test cases still work
        - [ ] Test the `cmd/windows/powershell/powershell_reverse_tcp` payload to show that an adapted single works correctly
        - [ ] Test the `cmd/windows/powershell/meterpreter/reverse_tcp` payload to show that an adapted staged payload works correctly
        - [ ] Test the `cmd/windows/powershell/x64/encrypted_shell/reverse_tcp` payload to show that the fix for #16597 is still in place

<details>
<summary>Testing Resource Script</summary>

<details>
<summary>Testing Resource Script Template</summary>

This is the Jinja template from which the testing RC file was generated. It needs to be rendered.
```
{% set datastore = {
    'CMD': 'id'
} %}
{% set spool_file = None %}
{% set payloads = [
  'payload/bsd/x64/exec',
  'payload/bsd/x86/exec',
  'payload/linux/armle/adduser',
  'payload/linux/armle/exec',
  'payload/linux/x64/exec',
  'payload/linux/x64/pingback_bind_tcp',
  'payload/linux/x64/pingback_reverse_tcp',
  'payload/linux/x64/shell_bind_ipv6_tcp',
  'payload/linux/x64/shell_bind_tcp_random_port',
  'payload/linux/x64/shell_reverse_ipv6_tcp',
  'payload/linux/x86/adduser',
  'payload/linux/x86/chmod',
  'payload/linux/x86/exec',
  'payload/linux/x86/read_file',
  'payload/linux/x86/shell_reverse_tcp_ipv6',
  'payload/osx/x86/exec',
] %}

{% if spool_file %}
rm -f {{ spool_file }}
spool {{ spool_file }}
{% endif %}

{% for payload in payloads %}
use {{ payload }}
{% if 'ipv6' is in(payload) %}
set LHOST 'fe80::4566:a1f4:ea99:2182'
set RHOST 'fe80::4566:a1f4:ea99:2182'
{% else %}
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
{% endif %}
{% for key, value in datastore.items() %}
set {{ key }} {{ value }}
{% endfor %}
{# write the output 'info' to a file for inspection #}
spool /tmp/payloads/{{ payload | replace('/', ':') }}_info
info
spool off
{# write the output of 'to_handler' to a file for inspection #}
spool /tmp/payloads/{{ payload | replace('/', ':') }}_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/{{ payload | replace('/', ':') }}

{% endfor %}
```

</details>


```
use payload/bsd/x86/exec
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:bsd:x86:exec_info
info
spool off
spool /tmp/payloads/payload:bsd:x86:exec_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:bsd:x86:exec

use payload/linux/armle/adduser
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:linux:armle:adduser_info
info
spool off
spool /tmp/payloads/payload:linux:armle:adduser_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:armle:adduser

use payload/linux/armle/exec
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:linux:armle:exec_info
info
spool off
spool /tmp/payloads/payload:linux:armle:exec_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:armle:exec

use payload/linux/x64/exec
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:linux:x64:exec_info
info
spool off
spool /tmp/payloads/payload:linux:x64:exec_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x64:exec

use payload/linux/x64/pingback_bind_tcp
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:linux:x64:pingback_bind_tcp_info
info
spool off
spool /tmp/payloads/payload:linux:x64:pingback_bind_tcp_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x64:pingback_bind_tcp

use payload/linux/x64/pingback_reverse_tcp
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:linux:x64:pingback_reverse_tcp_info
info
spool off
spool /tmp/payloads/payload:linux:x64:pingback_reverse_tcp_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x64:pingback_reverse_tcp

use payload/linux/x64/shell_bind_ipv6_tcp
set LHOST 'fe80::4566:a1f4:ea99:2182'
set RHOST 'fe80::4566:a1f4:ea99:2182'
set CMD id
spool /tmp/payloads/payload:linux:x64:shell_bind_ipv6_tcp_info
info
spool off
spool /tmp/payloads/payload:linux:x64:shell_bind_ipv6_tcp_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x64:shell_bind_ipv6_tcp

use payload/linux/x64/shell_bind_tcp_random_port
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:linux:x64:shell_bind_tcp_random_port_info
info
spool off
spool /tmp/payloads/payload:linux:x64:shell_bind_tcp_random_port_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x64:shell_bind_tcp_random_port

use payload/linux/x64/shell_reverse_ipv6_tcp
set LHOST 'fe80::4566:a1f4:ea99:2182'
set RHOST 'fe80::4566:a1f4:ea99:2182'
set CMD id
spool /tmp/payloads/payload:linux:x64:shell_reverse_ipv6_tcp_info
info
spool off
spool /tmp/payloads/payload:linux:x64:shell_reverse_ipv6_tcp_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x64:shell_reverse_ipv6_tcp

use payload/linux/x86/adduser
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:linux:x86:adduser_info
info
spool off
spool /tmp/payloads/payload:linux:x86:adduser_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x86:adduser

use payload/linux/x86/chmod
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:linux:x86:chmod_info
info
spool off
spool /tmp/payloads/payload:linux:x86:chmod_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x86:chmod

use payload/linux/x86/exec
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:linux:x86:exec_info
info
spool off
spool /tmp/payloads/payload:linux:x86:exec_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x86:exec

use payload/linux/x86/read_file
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:linux:x86:read_file_info
info
spool off
spool /tmp/payloads/payload:linux:x86:read_file_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x86:read_file

use payload/linux/x86/shell_reverse_tcp_ipv6
set LHOST 'fe80::4566:a1f4:ea99:2182'
set RHOST 'fe80::4566:a1f4:ea99:2182'
set CMD id
spool /tmp/payloads/payload:linux:x86:shell_reverse_tcp_ipv6_info
info
spool off
spool /tmp/payloads/payload:linux:x86:shell_reverse_tcp_ipv6_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:linux:x86:shell_reverse_tcp_ipv6

use payload/osx/x86/exec
set LHOST '192.168.159.128'
set RHOST '192.168.159.128'
set CMD id
spool /tmp/payloads/payload:osx:x86:exec_info
info
spool off
spool /tmp/payloads/payload:osx:x86:exec_to_handler
to_handler
spool off
jobs -K
generate -f raw -o /tmp/payloads/payload:osx:x86:exec
```
</details>