### PR TITLE
Msf::Post::Windows::ExtAPI: Remove load_extapi method

### DIFF
--- a/lib/msf/core/post/windows/accounts.rb
+++ b/lib/msf/core/post/windows/accounts.rb
@@ -5,8 +5,8 @@ module Msf
     module Windows
       module Accounts
         include Msf::Post::Windows::Error
+        include Msf::Post::Windows::ExtAPI
         include Msf::Post::Windows::Registry
-        require 'rex/post/meterpreter/extensions/extapi/command_ids'
 
         GUID = [
           ['Data1', :DWORD],

--- a/lib/msf/core/post/windows/extapi.rb
+++ b/lib/msf/core/post/windows/extapi.rb
@@ -1,25 +1,11 @@
 # -*- coding: binary -*-
 
 module Msf
-class Post
-module Windows
-
-module ExtAPI
-
-  def load_extapi
-    if session.extapi
-      return true
-    else
-      begin
-        return session.core.use("extapi")
-      rescue Errno::ENOENT
-        print_error("Unable to load Extended API.")
-        return false
+  class Post
+    module Windows
+      module ExtAPI
+        require 'rex/post/meterpreter/extensions/extapi/command_ids'
       end
     end
   end
-
-end # ExtAPI
-end # Windows
-end # Post
-end # Msf
+end

--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -11,7 +11,6 @@ module Msf
         include Msf::Post::Windows::Error
         include Msf::Post::Windows::ExtAPI
         include Msf::Post::Windows::Accounts
-        require 'rex/post/meterpreter/extensions/extapi/command_ids'
 
         LDAP_SIZELIMIT_EXCEEDED = 0x04
         LDAP_OPT_SIZELIMIT = 0x03

--- a/modules/exploits/windows/local/wmi.rb
+++ b/modules/exploits/windows/local/wmi.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Exploit::Powershell
+  include Msf::Post::Windows::ExtAPI
   include Msf::Post::Windows::WMIC
 
   def initialize(info={})
@@ -72,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def run_host(server)
-    if load_extapi
+    if session.extapi
       psh_options = { :remove_comspec => true,
                       :encode_final_payload => true }
     else
@@ -86,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Local
                           psh_options)
 
     begin
-      if load_extapi
+      if session.extapi
         exec_cmd = psh
       else
         # Get the PSH Payload and split it into bitesize chunks
@@ -131,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Local
         print_error("[#{server}] failed...)")
       end
 
-      unless load_extapi
+      unless session.extapi
         print_status("[#{server}] Cleaning up environment variables")
         env_vars.each do |env|
           cleanup_cmd = "cmd /c REG delete \"HKLM\\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\" /V #{env} /f"

--- a/modules/post/windows/gather/bitlocker_fvek.rb
+++ b/modules/post/windows/gather/bitlocker_fvek.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Error
-  include Msf::Post::Windows::ExtAPI
   include Msf::Post::Windows::FileInfo
   include Msf::Post::File
 

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -148,12 +148,11 @@ class MetasploitModule < Msf::Post
       return false
     end
 
-    unless session_compat?
-      return false
+    unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_NTDS_PARSE)
+      fail_with(Failure::BadConfig, 'Session does not support Meterpreter ExtAPI NTDS parser')
     end
 
-    load_extapi
-    return true
+    session_compat?
   end
 
   def repair_ntds(path = '')

--- a/modules/post/windows/gather/credentials/gpp.rb
+++ b/modules/post/windows/gather/credentials/gpp.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Post
   include Msf::Auxiliary::Report
   include Msf::Post::File
+  include Msf::Post::Windows::ExtAPI
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Registry
   include Msf::Post::Windows::NetAPI
@@ -219,7 +220,7 @@ class MetasploitModule < Msf::Post
   end
 
   def adsi_query(domain, adsi_filter, adsi_fields)
-    return "" unless session.core.use("extapi")
+    return "" unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_ADSI_DOMAIN_QUERY)
 
     query_result = session.extapi.adsi.domain_query(domain, adsi_filter, 255, 255, adsi_fields)
 

--- a/modules/post/windows/gather/enum_patches.rb
+++ b/modules/post/windows/gather/enum_patches.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Common
-  require 'rex/post/meterpreter/extensions/extapi/command_ids'
+  include Msf::Post::Windows::ExtAPI
 
   def initialize(info = {})
     super(


### PR DESCRIPTION
The `load_extapi` method is no longer required (since #15079). This PR removes the method and all remaining uses of this method.

The `Msf::Post::Windows::ExtAPI` mixin now only loads `rex/post/meterpreter/extensions/extapi/command_ids` which contains the command name constants necessary to perform granular session command capability checks.

For context see:

* https://github.com/rapid7/metasploit-framework/pull/17002#issuecomment-1253083357
* https://github.com/rapid7/metasploit-framework/pull/16921#issuecomment-1227746612

In `modules/exploits/windows/local/wmi.rb`, the three conditional branches based on presence of ExtAPI look dubious to me. For now, `if session.extapi` should work as a drop-in replacement for `if load_extapi`. In the future, someone should probably review this module and ammend the conditional branches to check for the required ExtAPI commands (likely `COMMAND_ID_EXTAPI_WMI_QUERY`). I've left that out of this PR, as the module could also use some additional cleanup.
