### PR TITLE
GSoC Project: Implement HTTP-Trace enabled login scanners 

### DIFF
--- a/lib/metasploit/framework/login_scanner/axis2.rb
+++ b/lib/metasploit/framework/login_scanner/axis2.rb
@@ -16,12 +16,6 @@ module Metasploit
 
         # (see Base#attempt_login)
         def attempt_login(credential)
-          http_client = Rex::Proto::Http::Client.new(
-            host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password
-          )
-
-          configure_http_client(http_client)
-
           result_opts = {
               credential: credential,
               host: host,
@@ -35,14 +29,18 @@ module Metasploit
           end
 
           begin
-            http_client.connect
-            body = "userName=#{Rex::Text.uri_encode(credential.public)}&password=#{Rex::Text.uri_encode(credential.private)}&submit=+Login+"
-            request = http_client.request_cgi(
+            # Refactor to access Metasploit::Framework::LoginScanner::HTTP#send_request()
+            # to send request to the HTTP server and obtain a response      
+            response = send_request({
               'uri' => uri,
-              'method' => "POST",
-              'data' => body,
-            )
-            response = http_client.send_recv(request)
+              'method' => 'POST',
+              'vars_post' =>
+               {
+                 'userName' => Rex::Text.uri_encode(credential.public),
+                 'password' => Rex::Text.uri_encode(credential.private),
+                 'submit' => '+Login+'
+               }
+            })
 
             if response && response.code == 200 && response.body.include?("upload")
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response)

--- a/lib/metasploit/framework/login_scanner/axis2.rb
+++ b/lib/metasploit/framework/login_scanner/axis2.rb
@@ -30,14 +30,14 @@ module Metasploit
 
           begin
             # Refactor to access Metasploit::Framework::LoginScanner::HTTP#send_request()
-            # to send request to the HTTP server and obtain a response      
+            # to send request to the HTTP server and obtain a response
             response = send_request({
               'uri' => uri,
               'method' => 'POST',
               'vars_post' =>
                {
-                 'userName' => Rex::Text.uri_encode(credential.public),
-                 'password' => Rex::Text.uri_encode(credential.private),
+                 'userName' => credential.public,
+                 'password' => credential.private,
                  'submit' => '+Login+'
                }
             })

--- a/lib/metasploit/framework/login_scanner/buffalo.rb
+++ b/lib/metasploit/framework/login_scanner/buffalo.rb
@@ -34,10 +34,7 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, http_username, http_password)
-            configure_http_client(cli)
-            cli.connect
-            req = cli.request_cgi({
+            res = send_request({
               'method'=>'POST',
               'uri'=>'/dynamic.pl',
               'vars_post'=> {
@@ -46,7 +43,7 @@ module Metasploit
                 'password'=>credential.private
                 }
             })
-            res = cli.send_recv(req)
+
             body = JSON.parse(res.body)
             if res && body.has_key?('success') && body['success']
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.body)

--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -47,8 +47,7 @@ module Metasploit
         def check_setup
           begin
             res = send_request({
-              'uri' => normalize_uri('/users/login'),
-              'cgi' => false
+              'uri' => normalize_uri('/users/login')
             })
             return "Connection failed" if res.nil?
 
@@ -71,7 +70,7 @@ module Metasploit
         #
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
-        def send_request(opts) 
+        def send_request(opts)
           res = super(opts)
 
           # Save the session ID cookie
@@ -102,8 +101,7 @@ module Metasploit
             'headers' => {
               'Content-Type'   => 'application/x-www-form-urlencoded',
               'Cookie'         => "#{self.session_name}=#{self.session_id}"
-            },
-            'cgi' => false
+            }
           }
 
           send_request(opts)
@@ -120,8 +118,7 @@ module Metasploit
 
           # Obtain a CSRF token first
           res = send_request({
-            'uri' => normalize_uri('/users/login'),
-            'cgi' => false  
+            'uri' => normalize_uri('/users/login')
           })
           unless (res && res.code == 200 && res.body =~ /input name="authenticity_token" type="hidden" value="([^"]+)"/m)
             return {:status => Metasploit::Model::Login::Status::UNTRIED, :proof => res.body}
@@ -136,8 +133,7 @@ module Metasploit
               'method'  => 'GET',
               'headers' => {
                 'Cookie'  => "#{self.session_name}=#{self.session_id}"
-              },
-              'cgi' => false
+              }
             }
             res = send_request(opts)
             if (res && res.code == 200 && res.body.to_s =~ /New password for the User/)

--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -46,7 +46,10 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = send_request({'uri' => normalize_uri('/users/login')})
+            res = send_request({
+              'uri' => normalize_uri('/users/login'),
+              'cgi' => false
+            })
             return "Connection failed" if res.nil?
 
             if res.code != 200
@@ -68,12 +71,8 @@ module Metasploit
         #
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
-        def send_request(opts)
-          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => self}, ssl, ssl_version, proxies, http_username, http_password)
-          configure_http_client(cli)
-          cli.connect
-          req = cli.request_raw(opts)
-          res = cli.send_recv(req)
+        def send_request(opts) 
+          res = super(opts)
 
           # Save the session ID cookie
           if res && res.get_cookies =~ /(_\w+_session)=([^;$]+)/i
@@ -103,7 +102,8 @@ module Metasploit
             'headers' => {
               'Content-Type'   => 'application/x-www-form-urlencoded',
               'Cookie'         => "#{self.session_name}=#{self.session_id}"
-            }
+            },
+            'cgi' => false
           }
 
           send_request(opts)
@@ -119,7 +119,10 @@ module Metasploit
         def try_login(credential)
 
           # Obtain a CSRF token first
-          res = send_request({'uri' => normalize_uri('/users/login')})
+          res = send_request({
+            'uri' => normalize_uri('/users/login'),
+            'cgi' => false  
+          })
           unless (res && res.code == 200 && res.body =~ /input name="authenticity_token" type="hidden" value="([^"]+)"/m)
             return {:status => Metasploit::Model::Login::Status::UNTRIED, :proof => res.body}
           end
@@ -133,7 +136,8 @@ module Metasploit
               'method'  => 'GET',
               'headers' => {
                 'Cookie'  => "#{self.session_name}=#{self.session_id}"
-              }
+              },
+              'cgi' => false
             }
             res = send_request(opts)
             if (res && res.code == 200 && res.body.to_s =~ /New password for the User/)

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -32,7 +32,6 @@ module Metasploit
           begin
             res = send_request({
               'uri' => '/common/index.jsf',
-              'cgi' => false
             })
             return "Connection failed" if res.nil?
             if !([200, 302].include?(res.code))

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -30,7 +30,10 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = send_request({'uri' => '/common/index.jsf'})
+            res = send_request({
+              'uri' => '/common/index.jsf',
+              'cgi' => false
+            })
             return "Connection failed" if res.nil?
             if !([200, 302].include?(res.code))
               return "Unexpected HTTP response code #{res.code} (is this really Glassfish?)"
@@ -40,7 +43,10 @@ module Metasploit
             # same port.
             if !self.ssl && res.headers['Location'] =~ /^https:/
               self.ssl = true
-              res = send_request({'uri' => '/common/index.jsf'})
+              res = send_request({
+                'uri' => '/common/index.jsf',
+                'cgi' => false
+              })
               if res.nil?
                 return "Connection failed after SSL redirection"
               end
@@ -49,7 +55,10 @@ module Metasploit
               end
             end
 
-            res = send_request({'uri' => '/login.jsf'})
+            res = send_request({
+              'uri' => '/login.jsf',
+              'cgi' => false
+            })
             return "Connection failed" if res.nil?
             extract_version(res.headers['Server'])
 
@@ -68,11 +77,7 @@ module Metasploit
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
-          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password)
-          configure_http_client(cli)
-          cli.connect
-          req = cli.request_raw(opts)
-          res = cli.send_recv(req)
+          res = super(opts)
 
           # Found a cookie? Set it. We're going to need it.
           if res && res.get_cookies =~ /JSESSIONID=(\w*);/i
@@ -110,7 +115,8 @@ module Metasploit
             'headers' => {
               'Content-Type'   => 'application/x-www-form-urlencoded',
               'Cookie'         => "JSESSIONID=#{self.jsession}",
-            }
+            },
+            'cgi' => false
           }
 
           send_request(opts)
@@ -131,7 +137,8 @@ module Metasploit
               'method'  => 'GET',
               'headers' => {
                 'Cookie'  => "JSESSIONID=#{self.jsession}"
-              }
+              },
+              'cgi' => false
             }
             res = send_request(opts)
             p = /<title>Deploy Enterprise Applications\/Modules/
@@ -173,7 +180,8 @@ module Metasploit
               'method'  => 'GET',
               'headers' => {
                 'Cookie'  => "JSESSIONID=#{self.jsession}"
-              }
+              },
+              'cgi' => false
             }
             res = send_request(opts)
 

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -334,7 +334,7 @@ module Metasploit
             kerberos_authenticator = kerberos_authenticator_factory.call(username, password, realm)
           end
 
-          http_logger_subscriber = Rex::Proto::Http::HttpLoggerSubscriber.new(logger: framework_module)
+          http_logger_subscriber = framework_module.nil? ? nil : Rex::Proto::Http::HttpLoggerSubscriber.new(logger: framework_module)
           res = nil
           cli = Rex::Proto::Http::Client.new(
             rhost,

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -244,7 +244,9 @@ module Metasploit
 
           begin
             cli.connect
-            req = cli.request_cgi(opts)
+            # Send CGI compatible request by default
+            req = opts[:cgi] ? cli.request_cgi(opts) : cli.request_raw(opts)
+
             # Authenticate by default
             res = if opts['authenticate'].nil? || opts['authenticate']
                     cli.send_recv(req)
@@ -332,6 +334,7 @@ module Metasploit
             kerberos_authenticator = kerberos_authenticator_factory.call(username, password, realm)
           end
 
+          http_logger_subscriber = Rex::Proto::Http::HttpLoggerSubscriber.new(logger: framework_module)
           res = nil
           cli = Rex::Proto::Http::Client.new(
             rhost,
@@ -342,7 +345,8 @@ module Metasploit
             cli_proxies,
             username,
             password,
-            kerberos_authenticator: kerberos_authenticator
+            kerberos_authenticator: kerberos_authenticator,
+            subscriber: http_logger_subscriber
           )
           configure_http_client(cli)
 
@@ -457,3 +461,4 @@ module Metasploit
     end
   end
 end
+

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -244,8 +244,7 @@ module Metasploit
 
           begin
             cli.connect
-            # Send CGI compatible request by default
-            req = opts[:cgi] ? cli.request_cgi(opts) : cli.request_raw(opts)
+            req = cli.request_cgi(opts)
 
             # Authenticate by default
             res = if opts['authenticate'].nil? || opts['authenticate']

--- a/lib/metasploit/framework/login_scanner/ipboard.rb
+++ b/lib/metasploit/framework/login_scanner/ipboard.rb
@@ -16,12 +16,7 @@ module Metasploit
         attr_accessor :http_password
 
         # (see Base#attempt_login)
-        def attempt_login(credential)
-          http_client = Rex::Proto::Http::Client.new(
-              host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, self.http_username, self.http_password
-          )
-          configure_http_client(http_client)
-
+        def attempt_login(credential) 
           result_opts = {
               credential: credential,
               host: host,
@@ -35,14 +30,11 @@ module Metasploit
           end
 
           begin
-            http_client.connect
 
-            nonce_request = http_client.request_cgi(
+            nonce_response = send_request({
                 'uri' => uri,
                 'method'  => 'GET'
-            )
-
-            nonce_response = http_client.send_recv(nonce_request)
+            })
 
             if nonce_response.body =~ /name='auth_key'\s+value='.*?((?:[a-z0-9]*))'/i
               server_nonce = $1
@@ -55,7 +47,7 @@ module Metasploit
 
               auth_uri = "#{base_uri}/index.php"
 
-              request = http_client.request_cgi(
+              response = send_request({
                 'uri' => auth_uri,
                 'method'  => 'POST',
                 'vars_get' => {
@@ -69,9 +61,7 @@ module Metasploit
                   'ips_username' => credential.public,
                   'ips_password' => credential.private
                 }
-              )
-
-              response = http_client.send_recv(request)
+              })
 
               if response && response.get_cookies.include?('ipsconnect') && response.get_cookies.include?('coppa')
                 result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response)

--- a/lib/metasploit/framework/login_scanner/ipboard.rb
+++ b/lib/metasploit/framework/login_scanner/ipboard.rb
@@ -16,7 +16,7 @@ module Metasploit
         attr_accessor :http_password
 
         # (see Base#attempt_login)
-        def attempt_login(credential) 
+        def attempt_login(credential)
           result_opts = {
               credential: credential,
               host: host,

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -37,10 +37,7 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password)
-            configure_http_client(cli)
-            cli.connect
-            req = cli.request_cgi({
+            res = send_request({
               'method'=> method,
               'uri'=> uri,
               'vars_post'=> {
@@ -48,7 +45,7 @@ module Metasploit
                 'j_password'=> credential.private
                 }
             })
-            res = cli.send_recv(req)
+
             if res && res.headers['location'] && !res.headers['location'].include?('loginError')
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.headers)
             else

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -33,17 +33,16 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cred = Rex::Text.uri_encode(credential.private)
-            body = "data%5BLogin%5D%5Bowner_name%5D=admin&data%5BLogin%5D%5Bowner_passwd%5D=#{cred}"
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, http_username, http_password)
-            configure_http_client(cli)
-            cli.connect
-            req = cli.request_cgi(
+            cred = Rex::Text.uri_encode(credential.private) 
+            res = send_request({
               'method' => method,
               'uri' => uri,
-              'data' => body
-            )
-            res = cli.send_recv(req)
+              'vars_post' => {
+                 'data%5BLogin%5D%5Bowner_name%5D' => 'admin',
+                 'data%5BLogin%5D%5Bowner_passwd%5D' => cred
+              }
+            })
+
             if res && res.code == 302 && res.headers['location'] && res.headers['location'].include?('UI')
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.headers)
             elsif res.nil?

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -33,13 +33,12 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cred = Rex::Text.uri_encode(credential.private) 
             res = send_request({
               'method' => method,
               'uri' => uri,
               'vars_post' => {
                 'data[Login][owner_name]' => 'admin',
-                'data[Login][owner_passwd]' => cred
+                'data[Login][owner_passwd]' => credential.private
               }
             })
 

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -38,8 +38,8 @@ module Metasploit
               'method' => method,
               'uri' => uri,
               'vars_post' => {
-                 'data%5BLogin%5D%5Bowner_name%5D' => 'admin',
-                 'data%5BLogin%5D%5Bowner_passwd%5D' => cred
+                'data[Login][owner_name]' => 'admin',
+                'data[Login][owner_passwd]' => cred
               }
             })
 

--- a/lib/metasploit/framework/login_scanner/octopusdeploy.rb
+++ b/lib/metasploit/framework/login_scanner/octopusdeploy.rb
@@ -35,16 +35,13 @@ module Metasploit
           end
           begin
             json_post_data = JSON.pretty_generate({ Username: credential.public, Password: credential.private })
-            cli = Rex::Proto::Http::Client.new(host, port, { 'Msf' => framework, 'MsfExploit' => framework_module }, ssl, ssl_version, http_username, http_password)
-            configure_http_client(cli)
-            cli.connect
-            req = cli.request_cgi(
+            res = send_request({
               'method' => 'POST',
               'uri' => uri,
               'ctype' => 'application/json',
               'data' => json_post_data
-            )
-            res = cli.send_recv(req)
+            })
+
             body = JSON.parse(res.body)
             if res && res.code == 200 && body.key?('IsActive') && body['IsActive']
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.body)

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -33,11 +33,7 @@ module Metasploit
           res = nil
 
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password)
-            configure_http_client(cli)
-            cli.connect
-            req = cli.request_cgi(req_opts)
-            res = cli.send_recv(req)
+            res = send_request(req_opts)
 
           rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, ::EOFError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)

--- a/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
@@ -92,10 +92,7 @@ module Metasploit
               'ctype'   =>'text/xml'
             }
 
-          client = Rex::Proto::Http::Client.new(host, port, {}, ssl, ssl_version, proxies, http_username, http_password)
-          client.connect
-          req  = client.request_cgi(opts)
-          res  = client.send_recv(req)
+          res  = send_request(opts)
 
           if res && res.code != 200
             sleep(block_wait * 60)

--- a/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
@@ -9,11 +9,6 @@ module Metasploit
 
         # (see Base#attempt_login)
         def attempt_login(credential)
-          http_client = Rex::Proto::Http::Client.new(
-              host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password
-          )
-          configure_http_client(http_client)
-
           result_opts = {
               credential: credential,
               host: host,
@@ -27,14 +22,14 @@ module Metasploit
           end
 
           begin
-            http_client.connect
 
-            request = http_client.request_cgi(
+            response = send_request(
+              {
                 'uri' => uri,
                 'method' => method,
                 'data' => generate_xml_request(credential.public,credential.private)
+              }
             )
-            response = http_client.send_recv(request)
 
             if response && response.code == 200 && response.body =~ /<value><int>401<\/int><\/value>/ || response.body =~ /<name>user_id<\/name>/
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response)

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -41,7 +41,10 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = send_request({'uri' => normalize_uri('/')})
+            res = send_request({
+              'uri' => normalize_uri('/'),
+              'cgi' => false
+            })
             return "Connection failed" if res.nil?
 
             if res.code != 200
@@ -69,11 +72,7 @@ module Metasploit
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
-          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => self}, ssl, ssl_version, proxies, http_username, http_password)
-          configure_http_client(cli)
-          cli.connect
-          req = cli.request_raw(opts)
-          res = cli.send_recv(req)
+          res = super(opts)
 
           # Found a cookie? Set it. We're going to need it.
           if res && res.get_cookies =~ /(zbx_session(?:id)?=\w+(?:%3D){0,2};)/i
@@ -101,7 +100,8 @@ module Metasploit
             'data'    => data,
             'headers' => {
               'Content-Type'   => 'application/x-www-form-urlencoded'
-            }
+            },
+            'cgi' => false
           }
 
           send_request(opts)
@@ -114,7 +114,8 @@ module Metasploit
             'method'  => 'GET',
             'headers' => {
               'Cookie'  => "#{self.zsession}"
-            }
+            },
+            'cgi' => false
           }
           send_request(opts)
         end

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -42,8 +42,7 @@ module Metasploit
         def check_setup
           begin
             res = send_request({
-              'uri' => normalize_uri('/'),
-              'cgi' => false
+              'uri' => normalize_uri('/')
             })
             return "Connection failed" if res.nil?
 
@@ -100,8 +99,7 @@ module Metasploit
             'data'    => data,
             'headers' => {
               'Content-Type'   => 'application/x-www-form-urlencoded'
-            },
-            'cgi' => false
+            }
           }
 
           send_request(opts)
@@ -114,8 +112,7 @@ module Metasploit
             'method'  => 'GET',
             'headers' => {
               'Cookie'  => "#{self.zsession}"
-            },
-            'cgi' => false
+            }
           }
           send_request(opts)
         end

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -151,6 +151,8 @@ module Exploit::Remote::HttpClient
     client_username = opts['username'] || datastore['HttpUsername'] || ''
     client_password = opts['password'] || datastore['HttpPassword'] || ''
 
+    http_logger_subscriber = Rex::Proto::Http::HttpLoggerSubscriber.new(logger: self)
+    
     nclient = Rex::Proto::Http::Client.new(
       opts['rhost'] || rhost,
       (opts['rport'] || rport).to_i,
@@ -163,7 +165,8 @@ module Exploit::Remote::HttpClient
       proxies,
       client_username,
       client_password,
-      comm: opts['comm']
+      comm: opts['comm'],
+      subscriber: http_logger_subscriber
     )
 
 
@@ -369,33 +372,7 @@ module Exploit::Remote::HttpClient
     c = opts['client'] || connect(opts)
     r = opts[:cgi] ? c.request_cgi(opts) : c.request_raw(opts)
 
-    if datastore['HttpTrace']
-      request_color, response_color =
-        (datastore['HttpTraceColors'] || '').split('/').map { |color| "%bld%#{color}" }
-
-      request = r.to_s(headers_only: datastore['HttpTraceHeaders'])
-
-      print_line('#' * 20)
-      print_line('# Request:')
-      print_line('#' * 20)
-      print_line("%clr#{request_color}#{request}%clr")
-    end
-
     res = c.send_recv(r, actual_timeout)
-
-    if datastore['HttpTrace']
-      print_line('#' * 20)
-      print_line('# Response:')
-      print_line('#' * 20)
-
-      if res
-        response = res.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
-
-        print_line("%clr#{response_color}#{response}%clr")
-      else
-        print_line('No response received')
-      end
-    end
 
     disconnect(c) if disconnect
 
@@ -722,7 +699,6 @@ module Exploit::Remote::HttpClient
   def proxies
     datastore['Proxies']
   end
-
 
   #
   # Lookup HTTP fingerprints from the database that match the current

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -20,8 +20,10 @@ class Client
 
   #
   # Creates a new client instance
+  # @param http_trace_proc_request [Proc] A proc object passed to log HTTP requests if HTTP-Trace is set
+  # @param http_trace_proc_response [Proc] A proc object passed to log HTTP responses if HTTP-Trace is set
   #
-  def initialize(host, port = 80, context = {}, ssl = nil, ssl_version = nil, proxies = nil, username = '', password = '', kerberos_authenticator: nil, comm: nil)
+  def initialize(host, port = 80, context = {}, ssl = nil, ssl_version = nil, proxies = nil, username = '', password = '', kerberos_authenticator: nil, comm: nil, subscriber: nil)
     self.hostname = host
     self.port     = port.to_i
     self.context  = context
@@ -32,7 +34,8 @@ class Client
     self.password = password
     self.kerberos_authenticator = kerberos_authenticator
     self.comm = comm
-
+    self.subscriber = subscriber || HttpSubscriber.new
+    
     # Take ClientRequest's defaults, but override with our own
     self.config = Http::ClientRequest::DefaultConfig.merge({
       'read_max_data'   => (1024*1024*1),
@@ -234,10 +237,11 @@ class Client
     elsif req.respond_to?(:opts) && req.opts['krb_transform_request'] && self.krb_encryptor
       req = req.opts['krb_transform_request'].call(self.krb_encryptor, req)
     end
-
+    subscriber.on_request(req)
     send_request(req, t)
 
     res = read_response(t, :original_request => req)
+    subscriber.on_response(res)
     if req.respond_to?(:opts) && req.opts['ntlm_transform_response'] && self.ntlm_client
       req.opts['ntlm_transform_response'].call(self.ntlm_client, res)
     elsif req.respond_to?(:opts) && req.opts['krb_transform_response'] && self.krb_encryptor
@@ -748,7 +752,7 @@ class Client
     end
     nil
   end
-
+  
   #
   # An optional comm to use for creating the underlying socket.
   #
@@ -791,6 +795,9 @@ class Client
 
   # When parsing the request, thunk off the first response from the server, since junk
   attr_accessor :junk_pipeline
+
+  # HTTP subscriber
+  attr_accessor :subscriber
 
 protected
 

--- a/lib/rex/proto/http/http_logger_subscriber.rb
+++ b/lib/rex/proto/http/http_logger_subscriber.rb
@@ -1,0 +1,49 @@
+# -*- coding: binary -*-
+
+require 'rex/socket'
+require 'rex/text'
+require 'digest'
+
+module Rex
+module Proto
+module Http
+
+class HttpLoggerSubscriber < HttpSubscriber
+  def initialize(logger:)
+    raise RuntimeError, "Incompatible logger" unless logger.respond_to?(:print_line) && logger.respond_to?(:datastore)
+    @logger = logger
+  end
+
+  def on_request(request)
+    if @logger.datastore['HttpTrace']
+      http_trace_colors = @logger.datastore['HttpTraceColors'].blank? ? 'red/blu' : @logger.datastore['HttpTraceColors'] # Set the default colors if none were provided.
+      http_trace_colors += '/' if http_trace_colors.count('/') == 0 # Append "/"" to the end of the string if no "/" were found in the string to ensure consistent formatting.
+      request_color, response_color = http_trace_colors.gsub('/', ' / ').split('/').map { |color| color&.strip.blank? ? '' : "%bld%#{color.strip}" }
+      request = request.to_s(headers_only: @logger.datastore['HttpTraceHeadersOnly'])
+      @logger.print_line("#"*20)
+      @logger.print_line("# Request:")
+      @logger.print_line("#"*20)
+      @logger.print_line("%clr#{request_color}#{request}%clr")
+    end
+  end
+  
+  def on_response(response)
+    if @logger.datastore['HttpTrace']
+      http_trace_colors = @logger.datastore['HttpTraceColors'].blank? ? 'red/blu' : @logger.datastore['HttpTraceColors'] # Set the default colors if none were provided.
+      http_trace_colors += '/' if http_trace_colors.count('/') == 0 # Append "/"" to the end of the string if no "/" were found in the string to ensure consistent formatting.
+      request_color, response_color = http_trace_colors.gsub('/', ' / ').split('/').map { |color| color&.strip.blank? ? '' : "%bld%#{color.strip}" }
+      @logger.print_line("#"*20)
+      @logger.print_line("# Response:")
+      @logger.print_line("#"*20)
+      if response
+        response = response.to_terminal_output(headers_only: @logger.datastore['HttpTraceHeadersOnly'])
+        @logger.print_line("%clr#{response_color}#{response}%clr")
+      else
+        @logger.print_line("No response received")
+      end
+    end
+  end
+end
+end
+end
+end

--- a/lib/rex/proto/http/http_logger_subscriber.rb
+++ b/lib/rex/proto/http/http_logger_subscriber.rb
@@ -14,6 +14,7 @@ class HttpLoggerSubscriber < HttpSubscriber
     @logger = logger
   end
 
+  # (see Rex::Proto::Http::HttpSubscriber#on_request)
   def on_request(request)
     if @logger.datastore['HttpTrace']
       http_trace_colors = @logger.datastore['HttpTraceColors'].blank? ? 'red/blu' : @logger.datastore['HttpTraceColors'] # Set the default colors if none were provided.
@@ -26,7 +27,8 @@ class HttpLoggerSubscriber < HttpSubscriber
       @logger.print_line("%clr#{request_color}#{request}%clr")
     end
   end
-  
+
+  # (see Rex::Proto::HttpSubscriber#on_response)
   def on_response(response)
     if @logger.datastore['HttpTrace']
       http_trace_colors = @logger.datastore['HttpTraceColors'].blank? ? 'red/blu' : @logger.datastore['HttpTraceColors'] # Set the default colors if none were provided.

--- a/lib/rex/proto/http/http_subscriber.rb
+++ b/lib/rex/proto/http/http_subscriber.rb
@@ -1,0 +1,20 @@
+# -*- coding: binary -*-
+
+require 'rex/socket'
+require 'rex/text'
+require 'digest'
+
+module Rex
+module Proto
+module Http
+
+class HttpSubscriber
+  def on_request(request)
+  end
+
+  def on_response(response)
+  end
+end
+end
+end
+end

--- a/lib/rex/proto/http/http_subscriber.rb
+++ b/lib/rex/proto/http/http_subscriber.rb
@@ -9,9 +9,11 @@ module Proto
 module Http
 
 class HttpSubscriber
+  # @param request [Rex::Proto::Http::ClientRequest]
   def on_request(request)
   end
 
+  # @param response [Rex::Proto::Http::Response]
   def on_response(response)
   end
 end

--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -43,6 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     @scanner = Metasploit::Framework::LoginScanner::Nessus.new(
+      configure_http_login_scanner(
         host: ip,
         port: datastore['RPORT'],
         uri: datastore['TARGETURI'],
@@ -51,6 +52,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5
+      )
     )
     @scanner.ssl         = datastore['SSL']
     @scanner.ssl_version = datastore['SSLVERSION']

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 require 'metasploit/framework/login_scanner/http'
 
 RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
-
-  it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
+  
+  it_behaves_like 'Metasploit::Framework::LoginScanner::Base', has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
   it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
 
@@ -25,7 +25,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   describe '#send_request' do
     context 'when a valid request is sent' do
       it 'returns a response object' do
-        expect(subject.send_request({'uri'=>'/'})).to be_kind_of(Rex::Proto::Http::Response)
+        expect(subject.send_request({ 'uri' => '/' })).to be_kind_of(Rex::Proto::Http::Response)
       end
     end
   end

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -225,7 +225,6 @@ RSpec.describe Rex::Proto::Http::Client do
     expect(cli).to respond_to :password
     expect(cli).to respond_to :junk_pipeline
   end
-
   # Not super sure why these are protected...
   # Me either...
   # Same here...
@@ -243,7 +242,6 @@ RSpec.describe Rex::Proto::Http::Client do
       cli.config['method'] = 'POST'
       cli
     end
-
     let(:file_path) do
       ::File.join(::Msf::Config.install_root, 'spec', 'file_fixtures', 'string_list.txt')
     end
@@ -253,7 +251,6 @@ RSpec.describe Rex::Proto::Http::Client do
     let(:mock_boundary_suffix) do
       'MockBoundary1234'
     end
-
     before(:each) do
       allow(Rex::Text).to receive(:rand_text_numeric).with(30).and_return(mock_boundary_suffix)
     end
@@ -269,17 +266,13 @@ RSpec.describe Rex::Proto::Http::Client do
         Content-Length: 0\r
         \r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should parse field name and file object as data' do
       vars_form_data = [
         { 'name' => 'field1', 'data' => file, 'content_type' => 'text/plain' }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       # We are gsub'ing here as HttpClient does this gsub to non-binary file data
       file_contents = file.read.gsub("\r", '').gsub("\n", "\r\n")
       expected = <<~EOF
@@ -296,17 +289,13 @@ RSpec.describe Rex::Proto::Http::Client do
         #{file_contents}\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should parse field name and binary file object as data' do
       vars_form_data = [
         { 'name' => 'field1', 'data' => file, 'encoding' => 'binary' }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -321,17 +310,13 @@ RSpec.describe Rex::Proto::Http::Client do
         #{file.read}\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should parse field name and binary file object as data with filename override' do
       vars_form_data = [
         { 'name' => 'field1', 'data' => file, 'encoding' => 'binary', 'content_type' => 'text/plain', 'filename' => 'my_file.txt' }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -347,18 +332,14 @@ RSpec.describe Rex::Proto::Http::Client do
         #{file.read}\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should parse data correctly when provided with a string' do
       data = 'hello world'
       vars_form_data = [
         { 'name' => 'file1', 'data' => data, 'filename' => 'file1' }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -372,18 +353,14 @@ RSpec.describe Rex::Proto::Http::Client do
         #{data}\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should parse data correctly when provided with a string and content type' do
       data = 'hello world'
       vars_form_data = [
         { 'name' => 'file1', 'data' => data, 'filename' => 'file1', 'content_type' => 'text/plain' }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -398,18 +375,14 @@ RSpec.describe Rex::Proto::Http::Client do
         #{data}\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should parse data correctly when provided with a string, content type and filename' do
       data = 'hello world'
       vars_form_data = [
         { 'name' => 'file1', 'data' => data, 'content_type' => 'text/plain', 'filename' => 'my_file.txt' }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -424,18 +397,14 @@ RSpec.describe Rex::Proto::Http::Client do
         #{data}\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should parse data correctly when provided with a number' do
       data = 123
       vars_form_data = [
         { 'name' => 'file1', 'data' => data, 'content_type' => 'text/plain' }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -450,20 +419,15 @@ RSpec.describe Rex::Proto::Http::Client do
         #{data}\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should parse dat correctly when provided with an IO object' do
       require 'stringio'
-
       str = 'Hello World!'
       vars_form_data = [
         { 'name' => 'file1', 'data' => ::StringIO.new(str), 'content_type' => 'text/plain', 'filename' => 'my_file.txt' }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -478,17 +442,13 @@ RSpec.describe Rex::Proto::Http::Client do
         #{str}\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should handle nil data values correctly' do
       vars_form_data = [
         { 'name' => 'nil_value', 'data' => nil }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       # This could potentially return one less '\r'.
       expected = <<~EOF
         POST / HTTP/1.1\r
@@ -503,18 +463,14 @@ RSpec.describe Rex::Proto::Http::Client do
         \r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should handle nil field values correctly' do
       vars_form_data = [
         { 'name' => nil, 'data' => '123' },
         { 'data' => '456' },
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -532,17 +488,13 @@ RSpec.describe Rex::Proto::Http::Client do
         456\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should handle nil field values and data correctly' do
       vars_form_data = [
         { 'name' => nil, 'data' => nil }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -556,10 +508,8 @@ RSpec.describe Rex::Proto::Http::Client do
         \r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should raise an error on non-string field names' do
       invalid_names = [
         false,
@@ -568,7 +518,6 @@ RSpec.describe Rex::Proto::Http::Client do
         ['hello'],
         { k: 'val' }
       ]
-
       invalid_names.each do |name|
         vars_form_data = [
           { 'name' => name, 'data' => '123' }
@@ -584,9 +533,7 @@ RSpec.describe Rex::Proto::Http::Client do
       vars_form_data = [
         { 'name' => 'field1', 'data' => binary_data, 'encoding' => 'binary' }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -601,10 +548,8 @@ RSpec.describe Rex::Proto::Http::Client do
         #{binary_data}\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should handle duplicate file and field names correctly' do
       vars_form_data = [
         { 'name' => 'file', 'data' => 'file1_content', 'filename' => 'duplicate.txt' },
@@ -613,9 +558,7 @@ RSpec.describe Rex::Proto::Http::Client do
         # Note, this won't actually attempt to read a file - the content will be set to 'file.txt'
         { 'name' => 'file', 'data' => 'file.txt', 'filename' => 'duplicate.txt' }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -641,17 +584,13 @@ RSpec.describe Rex::Proto::Http::Client do
         file.txt\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'does not encode special characters in file name by default as it may be used as part of an exploit' do
       vars_form_data = [
         { 'name' => 'file', 'data' => 'abc', 'content_type' => 'text/plain', 'encoding' => '8bit', 'filename' => "'t \"e 'st.txt'" }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -667,17 +606,13 @@ RSpec.describe Rex::Proto::Http::Client do
         abc\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should handle nil filename values correctly' do
       vars_form_data = [
         { 'name' => 'example_name', 'data' => 'example_data', 'filename' => nil }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -693,14 +628,11 @@ RSpec.describe Rex::Proto::Http::Client do
       EOF
       expect(request.to_s).to eq(expected)
     end
-
     it 'should handle nil encoding values correctly' do
       vars_form_data = [
         { 'name' => 'example_name', 'data' => 'example_data', 'encoding' => nil }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -714,17 +646,13 @@ RSpec.describe Rex::Proto::Http::Client do
         example_data\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
-
     it 'should handle nil content type values correctly' do
       vars_form_data = [
         { 'name' => 'example_name', 'data' => 'example_data', 'content_type' => nil }
       ]
-
       request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
       expected = <<~EOF
         POST / HTTP/1.1\r
         Host: #{ip}\r
@@ -738,7 +666,6 @@ RSpec.describe Rex::Proto::Http::Client do
         example_data\r
         -----------------------------MockBoundary1234--\r
       EOF
-
       expect(request.to_s).to eq(expected)
     end
 

--- a/spec/lib/rex/proto/http/http_logger_subscriber_spec.rb
+++ b/spec/lib/rex/proto/http/http_logger_subscriber_spec.rb
@@ -1,0 +1,469 @@
+# -*- coding:binary -*-
+
+RSpec.describe Rex::Proto::Http::HttpLoggerSubscriber do
+  include_context 'Msf::UIDriver'
+  let(:mock_module) {instance_double Msf::Exploit}
+
+  subject do
+    capture_logging(mock_module)
+    Rex::Proto::Http::HttpLoggerSubscriber.new(logger: mock_module)
+  end
+
+  let(:response) { Rex::Proto::Http::Response.new(200, 'OK') }
+
+  before(:example) do
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:close)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect)
+  end
+ 
+  describe '#on_request' do
+    let(:sample_request) do
+      req = Rex::Proto::Http::ClientRequest.new({
+        'agent' => 'Met',
+        'data' => 'bufaction=verifyLogin&user=admin&password=turnkey'
+      })
+      req
+    end
+
+    let(:normal_request_output) do
+      [
+        '####################',
+        '# Request:',
+        '####################',
+        "%clr%bld%redGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr'
+      ]
+    end
+
+    let(:headers_only_request_output) do
+      [
+        '####################',
+        '# Request:',
+        '####################',
+        "%clr%bld%redGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        '%clr'
+      ]
+    end
+    
+    let(:http_trace_colors_request_output) do
+      [
+        '####################',
+        '# Request:',
+        '####################',
+        "%clr%bld%bluGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr'
+      ]
+    end
+    
+    let(:http_trace_single_color_request_output) do
+      [
+        '####################',
+        '# Request:',
+        '####################',
+        "%clr%bld%yelGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr'
+      ]
+    end
+    
+    let(:http_trace_single_color_request_output_leading_slash) do
+      [
+        '####################',
+        '# Request:',
+        '####################',
+        "%clrGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr'
+      ]
+    end
+    
+    let(:http_trace_no_color_request_output) do
+      [
+        '####################',
+        '# Request:',
+        '####################',
+        "%clrGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr'
+      ]
+    end
+
+    let(:mock_module) { instance_double Msf::Exploit, datastore: mock_datastore } 
+
+    context 'when HttpTrace is set' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true
+      }
+      end
+
+      it 'should output the provided request with headers when HttpTrace is set' do
+        subject.on_request(sample_request)
+        expect(@output).to eq normal_request_output
+      end
+    end
+
+    context 'when HttpTraceHeadersOnly is set' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceHeadersOnly' => true
+      }
+      end
+
+      it 'should log HTTP request with headers only when HttpTraceHeadersOnly is set' do
+        subject.on_request(sample_request)
+        expect(@output).to eq headers_only_request_output
+      end
+    end
+
+    context 'when HttpTraceHeadersOnly is unset' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceHeadersOnly' => nil
+      }
+      end
+
+      it 'should log HTTP request with body when HttpTraceHeadersOnly is unset' do
+        subject.on_request(sample_request)
+        expect(@output).to eq normal_request_output
+      end
+    end
+
+    context 'when HttpTraceColors is set' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceColors' => 'blu/grn'
+      }
+      end
+
+      it 'should log HTTP request in the respective color specified' do
+        subject.on_request(sample_request)
+        expect(@output).to eq http_trace_colors_request_output
+      end
+    end
+
+    context 'when HttpTraceColors is set to a single color' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceColors' => 'yel/'
+      }
+      end
+
+      it 'should only log HTTP request in color when only one color is specified followed by a trailing "/"' do
+        subject.on_request(sample_request)
+        expect(@output).to eq http_trace_single_color_request_output
+      end
+    end 
+
+    context 'when HttpTraceColors is set to a single color after a leading "/"' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceColors' => '/yel'
+      }
+      end
+
+      it 'should only log HTTP request in no color' do
+        subject.on_request(sample_request)
+        expect(@output).to eq http_trace_single_color_request_output_leading_slash
+      end
+    end
+
+    context 'when HttpTraceColors is set to "/"' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceColors' => '/'
+      }
+      end
+
+      it 'should not log HTTP request in color' do
+        subject.on_request(sample_request)
+        expect(@output).to eq http_trace_no_color_request_output
+      end
+    end
+
+    context 'when HttpTraceColors is set to only one color without "/"' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceColors' => 'yel'
+      }
+      end
+
+      it 'should only log HTTP request in color when only one color is specified without any "/"s' do
+        subject.on_request(sample_request)
+        expect(@output).to eq http_trace_single_color_request_output
+      end
+    end
+
+    context 'when HttpTraceColors is set to false' do
+      let(:mock_datastore) do {
+        'HttpTrace' => false
+      }
+      end
+
+      it 'should not log HTTP request' do
+        subject.on_request(sample_request)
+        expect(@output).to eq nil
+      end
+    end
+
+    context 'when HttpTraceColors is unset' do
+      let(:mock_datastore) do {
+        'HttpTrace' => nil
+      }
+      end
+
+      it 'should not log HTTP request' do
+        subject.on_request(sample_request)
+        expect(@output).to eq nil
+      end
+    end
+
+  end
+
+  describe '#on_response' do
+    let(:sample_response) do
+      res = Rex::Proto::Http::Response.new(302, 'Found')
+      allow(res).to receive(:body).and_return('Location: https://www.google.com/?gws_rd=ssl')
+      res
+    end
+
+    
+    let(:normal_response_output) do
+      [
+        '####################',
+        '# Response:',
+        '####################',
+        "%clr%bld%bluHTTP/1.1 302 Found\r",
+        "\r",
+        'Location: https://www.google.com/?gws_rd=ssl%clr'
+      ]
+    end
+
+    let(:nil_response_output) do
+      [
+        '####################',
+        '# Response:',
+        '####################',
+        'No response received'
+      ]
+    end
+
+    
+    let(:headers_only_response_output) do
+      [
+        '####################',
+        '# Response:',
+        '####################',
+        "%clr%bld%bluHTTP/1.1 302 Found\r",
+        "\r",
+        '%clr'
+      ]
+    end
+
+    
+    let(:http_trace_colors_response_output) do
+      [
+        '####################',
+        '# Response:',
+        '####################',
+        "%clr%bld%grnHTTP/1.1 302 Found\r",
+        "\r",
+        'Location: https://www.google.com/?gws_rd=ssl%clr'
+      ]
+    end
+
+    
+    let(:http_trace_single_color_response_output) do
+      [
+        '####################',
+        '# Response:',
+        '####################',
+        "%clrHTTP/1.1 302 Found\r",
+        "\r",
+        'Location: https://www.google.com/?gws_rd=ssl%clr'
+      ]
+    end
+
+    
+    let(:http_trace_single_color_response_output_leading_slash) do
+      [
+        '####################',
+        '# Response:',
+        '####################',
+        "%clr%bld%yelHTTP/1.1 302 Found\r",
+        "\r",
+        'Location: https://www.google.com/?gws_rd=ssl%clr'
+      ]
+    end
+
+    
+    let(:http_trace_no_color_response_output) do
+      [
+        '####################',
+        '# Response:',
+        '####################',
+        "%clrHTTP/1.1 302 Found\r",
+        "\r",
+        'Location: https://www.google.com/?gws_rd=ssl%clr'
+      ]
+    end
+
+    let(:mock_module) { instance_double Msf::Exploit, datastore: mock_datastore } 
+
+    context 'when HttpTrace is set' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true
+      }
+      end
+
+      it 'should output the provided response with headers when HttpTrace is set' do
+        subject.on_response(sample_response)
+        expect(@output).to eq normal_response_output
+      end
+
+      it 'should give "no response received" message for nil response' do
+        subject.on_response(nil)
+        expect(@output).to eq nil_response_output
+      end
+    end
+
+    context 'when HttpTraceHeadersOnly is set' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceHeadersOnly' => true
+      }
+      end
+
+      it 'should log HTTP response with headers only when HttpTraceHeadersOnly is set' do
+        subject.on_response(sample_response)
+        expect(@output).to eq headers_only_response_output
+      end
+    end
+
+    context 'when HttpTraceHeadersOnly is unset' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceHeadersOnly' => nil
+      }
+      end
+
+      it 'should log HTTP response with body when HttpTraceHeadersOnly is unset' do
+        subject.on_response(sample_response)
+        expect(@output).to eq normal_response_output
+      end
+    end
+
+    context 'when HttpTraceColors is set' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceColors' => 'blu/grn'
+      }
+      end
+
+      it 'should log HTTP response in the respective color specified' do
+        subject.on_response(sample_response)
+        expect(@output).to eq http_trace_colors_response_output
+      end
+    end
+
+    context 'when HttpTraceColors is set to a single color' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceColors' => 'yel/'
+      }
+      end
+
+      it 'should log HTTP response in no color' do
+        subject.on_response(sample_response)
+        expect(@output).to eq http_trace_single_color_response_output
+      end
+    end 
+
+    context 'when HttpTraceColors is set to a single color after a leading "/"' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceColors' => '/yel'
+      }
+      end
+
+      it 'should log HTTP response in color when only one color is specified after a leading "/"' do
+        subject.on_response(sample_response)
+        expect(@output).to eq http_trace_single_color_response_output_leading_slash
+      end
+    end
+
+    context 'when HttpTraceColors is set to "/"' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceColors' => '/'
+      }
+      end
+
+      it 'should not log HTTP response in color' do
+        subject.on_response(sample_response)
+        expect(@output).to eq http_trace_no_color_response_output
+      end
+    end
+
+    context 'when HttpTraceColors is set to only one color without "/"' do
+      let(:mock_datastore) do {
+        'HttpTrace' => true,
+        'HttpTraceColors' => 'yel'
+      }
+      end
+
+      it 'should not log HTTP response in color' do
+        subject.on_response(sample_response)
+        expect(@output).to eq http_trace_single_color_response_output
+      end
+    end
+
+    context 'when HttpTraceColors is set to false' do
+      let(:mock_datastore) do {
+        'HttpTrace' => false
+      }
+      end
+
+      it 'should not log HTTP response' do
+        subject.on_response(sample_response)
+        expect(@output).to eq nil
+      end
+    end
+
+    context 'when HttpTraceColors is unset' do
+      let(:mock_datastore) do {
+        'HttpTrace' => nil
+      }
+      end
+
+      it 'should not log HTTP response' do
+        subject.on_response(sample_response)
+        expect(@output).to eq nil
+      end
+    end
+  end
+
+end
+


### PR DESCRIPTION
This PR implements the **HTTP-Trace** option for login scanners of the framework. This is achieved by crafting a logging proc and passing it over to **Rex::Proto::Http::Client** while any HTTP request is sent.  
  
## Cause of Bug
Currently the HTTP-Trace feature is implemented in the `Msf::Core::Exploit::Remote::HttpClient` mixin, hence it is only available for the exploit modules which import its functionality. The Login Scanner library is defined in the `Metasploit::Framework::LoginScanner::HTTP` mixin and thus is unable to access the HTTP-Trace feature.

## Approach
The idea is to implement a proc in `Metasploit::Framework::LoginScanner::HTTP` library for logging the HTTP requests and responses to the console. The `Metasploit::Framework::LoginScanner::HTTP` library is the central class to handle the HTTP requests and responses of all the login scanner modules. The `Metasploit::Framework::LoginScanner::HTTP library ultimately forwards the HTTP request to `Rex::Proto::Http::Client` for transmitting the request to the server and obtaining its response back.  
  
So, the logging proc defined in `Metasploit::Framework::LoginScanner::HTTP` is passed to `Rex::Proto::Http::Client` along with the HTTP request, and gets executed on the context of the Rex class. Once the proc is executed, the HTTP requests and responses are logged to the console.  
  
Note:
While majority of the Login Scanner libraries (like `Metasploit::Framework::LoginScanner::Caidao`) access `Metasploit::Framework::LoginScanner::HTTP` class for sending requests, there are some libraries  (like `Metasploit::Framework::LoginScanner::Zabbix`) which do not access `Metasploit::Framework::LoginScanner::HTTP`, rather directly transmit the request via `Rex::Proto::Http::Client`. This PR also takes care of normalizing those login scanner libraries to follow the ideal template of accessing `Metasploit::Framework::LoginScanner::HTTP` library for sending HTTP requests and receiving responses.

## Work Done in the project
- Implemented **HttpTrace**, **HttpTraceHeadersOnly**, **HttpTraceColors** options for login scanner modules.
- Normalized all login scanner modules to follow one template.
- Covered RSpec unit tests for the functionality added.
  
## Before
```
msf6 > use auxiliary/scanner/http/buffalo_login 
msf6 auxiliary(scanner/http/buffalo_login) > set RHOSTS www.google.com
RHOSTS => www.google.com
msf6 auxiliary(scanner/http/buffalo_login) > set HttpTrace true
HttpTrace => true
msf6 auxiliary(scanner/http/buffalo_login) > set USERPASS_FILE data/wordlists/http_default_userpass.txt
USERPASS_FILE => data/wordlists/http_default_userpass.txt
msf6 auxiliary(scanner/http/buffalo_login) > run

[-] 142.250.193.164:80 - LOGIN FAILED: connect:connect (Incorrect)
[-] 142.250.193.164:80 - LOGIN FAILED: sitecom:sitecom (Incorrect)
[-] 142.250.193.164:80 - LOGIN FAILED: admin:1234 (Incorrect)
[-] 142.250.193.164:80 - LOGIN FAILED: cisco:cisco (Incorrect)
[-] 142.250.193.164:80 - LOGIN FAILED: cisco:sanfran (Incorrect)
[-] 142.250.193.164:80 - LOGIN FAILED: private:private (Incorrect)
[-] 142.250.193.164:80 - LOGIN FAILED: wampp:xampp (Incorrect)
[-] 142.250.193.164:80 - LOGIN FAILED: newuser:wampp (Incorrect)
[-] 142.250.193.164:80 - LOGIN FAILED: xampp-dav-unsecure:ppmax2011  (Incorrect)
[-] 142.250.193.164:80 - LOGIN FAILED: admin:turnkey (Incorrect)
[-] 142.250.193.164:80 - LOGIN FAILED: vagrant:vagrant (Incorrect)
[*] Scanned 1 of 2 hosts (50% complete)
[-] 2404:6800:4007:821::2004:80 - LOGIN FAILED: connect:connect (Unable to Connect)
[-] 2404:6800:4007:821::2004:80 - LOGIN FAILED: sitecom:sitecom (Unable to Connect)
[-] 2404:6800:4007:821::2004:80 - LOGIN FAILED: admin:1234 (Unable to Connect)
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
## After
<details>
<summary>output</summary>

```
msf6 > use auxiliary/scanner/http/buffalo_login 
msf6 auxiliary(scanner/http/buffalo_login) > set RHOSTS www.google.com
RHOSTS => www.google.com
msf6 auxiliary(scanner/http/buffalo_login) > set USERPASS_FILE data/wordlists/http_default_userpass.txt
USERPASS_FILE => data/wordlists/http_default_userpass.txt
msf6 auxiliary(scanner/http/buffalo_login) > set HttpTrace true
HttpTrace => true
msf6 auxiliary(scanner/http/buffalo_login) > run

####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 51

bufaction=verifyLogin&user=connect&password=connect
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:16 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: connect:connect (Incorrect)
####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 51

bufaction=verifyLogin&user=sitecom&password=sitecom
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:17 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: sitecom:sitecom (Incorrect)
####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 46

bufaction=verifyLogin&user=admin&password=1234
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:17 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: admin:1234 (Incorrect)
####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 47

bufaction=verifyLogin&user=cisco&password=cisco
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:17 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: cisco:cisco (Incorrect)
####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 49

bufaction=verifyLogin&user=cisco&password=sanfran
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:17 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: cisco:sanfran (Incorrect)
####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 51

bufaction=verifyLogin&user=private&password=private
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:17 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: private:private (Incorrect)
####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 47

bufaction=verifyLogin&user=wampp&password=xampp
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:17 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: wampp:xampp (Incorrect)
####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 49

bufaction=verifyLogin&user=newuser&password=wampp
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:17 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: newuser:wampp (Incorrect)
####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 67

bufaction=verifyLogin&user=xampp-dav-unsecure&password=ppmax2011%20
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:17 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: xampp-dav-unsecure:ppmax2011  (Incorrect)
####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 49

bufaction=verifyLogin&user=admin&password=turnkey
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:18 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: admin:turnkey (Incorrect)
####################
# Request:
####################
POST /dynamic.pl HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
Content-Type: application/x-www-form-urlencoded
Content-Length: 51

bufaction=verifyLogin&user=vagrant&password=vagrant
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1571
Date: Mon, 26 Sep 2022 06:21:18 GMT
Connection: close

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/dynamic.pl</code> was not found on this server.  <ins>That’s all we know.</ins>

[-] 142.250.193.164:80 - LOGIN FAILED: vagrant:vagrant (Incorrect)
[*] Scanned 1 of 2 hosts (50% complete)
[-] 2404:6800:4007:821::2004:80 - LOGIN FAILED: connect:connect (Unable to Connect)
[-] 2404:6800:4007:821::2004:80 - LOGIN FAILED: sitecom:sitecom (Unable to Connect)
[-] 2404:6800:4007:821::2004:80 - LOGIN FAILED: admin:1234 (Unable to Connect)
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
</details>

## Verification
List the steps needed to make sure this thing works

- Start `msfconsole`
- Use any login scanner. (ex - `use auxiliary/scanner/http/buffalo_login`)
- `set RHOSTS www.google.com`
- `set USERPASS_FILE data/wordlists/http_default_userpass.txt`
- `set HttpTrace true`
- `run`
- **Verify** that the HTTP requests and responses are tracked to the console for every credential tested.
- `set HttpTraceHeadersOnly true`
- `run`
- **Verify** that only the Headers of HTTP requests and responses are tracked to the console for every credential tested.
- `set HttpTraceColors blu/grn`
- `run`
- **Verify** that the requests and responses are tracked to the console in **blue** and **green** color respectively.

## Acknowledgement
I extend my heartfelt thanks to @gwillcox-r7 @zeroSteiner @adfoster-r7 @jmartin-r7 to guide me throughout the course of the project and for always helping me when I was stuck with the code. This wouldn't be possible without your helping hand :)