### PR TITLE
Fix beagent sha auth linting

### DIFF
--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -133,8 +133,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     ndmp_payload = NdmpConfigGetServerInfoRes.from_xdr(ndmp_msg.body)
     print_status("Supported authentication by BE agent: #{ndmp_payload.auth_types.map do |k, _|
-                                                          "#{AUTH_TYPES[k]} (#{k})"
-                                                        end.join(', ')}")
+                                                            "#{AUTH_TYPES[k]} (#{k})"
+                                                          end.join(', ')}")
     print_status("BE agent revision: #{ndmp_payload.revision}")
 
     if ndmp_payload.auth_types.include?(5)


### PR DESCRIPTION
This was generating linting errors:

```
1 file inspected, 1 offense detected, 1 offense autocorrectable
modules/exploits/multi/veritas/beagent_sha_auth_rce.rb - [ERROR] Rubocop failed. Please run rubocop -a modules/exploits/multi/veritas/beagent_sha_auth_rce.rb and verify all issues are resolved
```

## Verification

- Verify CI passes