### PR TITLE
Minor Refactor: Remove unneccessary use of len(cookie)

### DIFF
--- a/modules/auxiliary/admin/http/grafana_auth_bypass.py
+++ b/modules/auxiliary/admin/http/grafana_auth_bypass.py
@@ -86,7 +86,7 @@ def decrypt_version5(cookie):
     key = hashlib.pbkdf2_hmac('sha256', salt, salt, iterations, 16)
     aesgcm = AESGCM(key)
     nonce = binascii.unhexlify(cookie[:24])
-    ct = binascii.unhexlify(cookie[24:len(cookie)])
+    ct = binascii.unhexlify(cookie[24:])
     username = str(aesgcm.decrypt(nonce, ct, None), 'ascii')
     return username
 
@@ -97,7 +97,7 @@ def decrypt_version4(cookie):
     key = hashlib.pbkdf2_hmac('sha256', salt, salt, iterations, 16)
     aesgcm = AESGCM(key)
     nonce = binascii.unhexlify(cookie[:24])
-    ct = binascii.unhexlify(cookie[24:len(cookie)])
+    ct = binascii.unhexlify(cookie[24:])
     username = str(aesgcm.decrypt(nonce, ct, None), 'ascii')
     return username
 


### PR DESCRIPTION
you are calculating the unnecessary length of `cookie` causing high time complexity. Without providing `len(cookie)` this python automatically assumes the length till the end of the list.
