### PR TITLE
Add in new LDAP queries to help with various attack paths

### DIFF
--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -10,6 +10,8 @@ queries:
       - cACertificateDN
       - dNSHostname
       - certificateTemplates
+      - objectGUID
+      - caCertificate
   - action: ENUM_ADCS_CERT_TEMPLATES
     description: 'Enumerate ADCS certificate templates.'
     base_dn_prefix: 'CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration'
@@ -23,6 +25,20 @@ queries:
       - msPKI-Certificate-Name-Flag
       - msPKI-RA-Signature
       - pKIExtendedKeyUsage
+  - action: ENUM_ADMIN_OBJECTS
+    description: 'Dump info about all objects with protected ACLs (i.e highly privileged objects).'
+    filter: '(adminCount=1)'
+    attributes:
+      - dn
+      - description
+      - distinguishedName
+      - name
+      - samAccountName
+      - objectSID
+      - objectGUID
+      - objectCategory
+      - member
+      - memberof
   - action: ENUM_ALL_OBJECT_CLASS
     description: 'Dump all objects containing any objectClass field.'
     filter: '(objectClass=*)'
@@ -37,20 +53,32 @@ queries:
       - objectCategory
   - action: ENUM_ACCOUNTS
     description: 'Dump info about all known user accounts in the domain.'
-    filter: '(|(objectClass=organizationalPerson)(sAMAccountType=805306368))'
+    filter: '(|(objectClass=organizationalPerson)(sAMAccountType=805306368)(objectcategory=user)(objectClass=user))'
     attributes:
       - dn
       - name
+      - description
       - displayName
-      - samAccountName
+      - sAMAccountName
       - userPrincipalName
       - userAccountControl
       - homeDirectory
       - homeDrive
       - profilePath
+      - memberof
+      - lastLogoff
+      - lastLogon
+      - lastLogonDate
+      - logonCount
+      - badPwdCount
+      - pwdLastSet
+      - SmartcardLogonRequired
+      - LastBadPasswordAttempt
+      - PasswordLastSet
+      - PaswordNeverExpires
   - action: ENUM_COMPUTERS
-    description: 'Dump all objects containing an objectCategory of Computer.'
-    filter: '(objectCategory=Computer)'
+    description: 'Dump all objects containing an objectCategory or objectClass of Computer.'
+    filter: '(|(objectCategory=computer)(objectClass=computer))'
     attributes:
       - dn
       - displayName
@@ -59,8 +87,12 @@ queries:
       - description
       - givenName
       - name
+      - operatingSystem
       - operatingSystemVersion
       - operatingSystemServicePack
+      - lastLogonTimestamp
+      - servicePrincipalName
+      - primaryGroupId
   - action: ENUM_DOMAIN_CONTROLLERS
     description: 'Dump all known domain controllers.'
     filter: '(&(objectCategory=Computer)(userAccountControl:1.2.840.113556.1.4.803:=8192))'
@@ -72,6 +104,7 @@ queries:
       - description
       - givenName
       - name
+      - operatingSystem
       - operatingSystemVersion
       - operatingSystemServicePack
   - action: ENUM_EXCHANGE_SERVERS
@@ -85,6 +118,7 @@ queries:
       - description
       - givenName
       - name
+      - operatingSystem
       - operatingSystemVersion
       - operatingSystemServicePack
   - action: ENUM_EXCHANGE_RECIPIENTS
@@ -97,17 +131,48 @@ queries:
       - name
   - action: ENUM_GROUPS
     description: 'Dump info about all known groups in the LDAP environment.'
-    filter: '(|(objectClass=group)(objectClass=groupOfNames)(groupType:1.2.840.113556.1.4.803:=2147483648)(objectClass=posixGroup))'
+    filter: '(|(objectClass=group)(objectClass=groupOfNames)(groupType:1.2.840.113556.1.4.803:=2147483648)(objectClass=posixGroup)(objectcategory=group))'
+    attributes:
+      - cn
+      - name
+      - description
+      - groupType
+      - memberof
+      - member
+      - owner
+      - adminCount
+      - managedBy
+      - groupAttributes
+  - action: ENUM_GROUP_POLICY_OBJECTS
+    description: 'Dump info about all known Group Policy Objects (GPOs) in the LDAP environment.'
+    filter: '(objectClass=groupPolicyContainer)'
+    attributes:
+      - displayName
+      - gPCFileSysPath
+      - objectCategory
+      - objectGUID
+  - action: ENUM_HOSTNAMES
+    description: 'Dump info about all known hostnames in the LDAP environment.'
+    filter: '(dnsHostName=*)'
     attributes:
       - dn
       - name
-      - groupType
-      - memberof
+      - dnsHostName
+      - serverName 
+  - action: ENUM_LDAP_SERVER_METADATA
+    description: 'Dump metadata about the setup of the domain.'
+    filter: '(objectClass=*)'
+    attributes:
+      - dn
+      - defaultNamingContext
+      - domainFunctionality
+      - forestFunctionality
+      - domainControllerFunctionality
+      - dnsHostName  
   - action: ENUM_ORGUNITS
     description: 'Dump info about all known organizational units in the LDAP environment.'
     filter: '(objectClass=organizationalUnit)'
     attributes:
-      - dn
       - displayName
       - name
       - description
@@ -115,7 +180,107 @@ queries:
     description: 'Dump info about all known organization roles in the LDAP environment.'
     filter: '(objectClass=organizationalRole)'
     attributes:
-      - dn
       - displayName
       - name
       - description
+  - action: ENUM_CONSTRAINED_DELEGATION
+    description: 'Dump info about all known objects that allow contrained delegation.'
+    filter: '(userAccountControl:1.2.840.113556.1.4.803:=16777216)'
+    attributes:
+      - cn
+      - sAMAccountName
+      - objectCategory
+      - msds-allowedtodelegateto
+      - servicePrincipalName
+  - action: ENUM_UNCONSTRAINED_DELEGATION
+    description: 'Dump info about all known objects that allow uncontrained delegation.'
+    filter: '(userAccountControl:1.2.840.113556.1.4.803:=524288)'
+    attributes:
+      - cn
+      - sAMAccountName
+      - objectCategory
+      - memberof
+      - member
+  - action: ENUM_USER_SPNS_KERBEROAST
+    description: 'Dump info about all user objects with Service Principal Names (SPNs) for kerberoasting'
+    filter: '(&(&(servicePrincipalName=*)(userAccountControl:1.2.840.113556.1.4.803:=512))(!(userAccountControl:1.2.840.113556.1.4.803:=2)))'
+    attributes:
+      - cn
+      - sAMAccountName
+      - servicePrincipalName
+  - action: ENUM_USER_PASSWORD_NEVER_EXPIRES
+    description: 'Dump info about all users whose password never expires'
+    filter: '(userAccountControl:1.2.840.113556.1.4.803:=65536)'
+    attributes:
+      - cn
+      - displayName
+      - description
+      - sAMAccountName
+      - userPrincipalName
+      - userAccountControl
+  - action: ENUM_USER_PASSWORD_NOT_REQUIRED
+    description: 'Dump info about all users whose password never expires and whose account is still enabled'
+    filter: '(&(userAccountControl:1.2.840.113556.1.4.803:=32)(!userAccountControl:1.2.840.113556.1.4.803:=2))'
+    attributes:
+      - cn
+      - displayName
+      - description
+      - sAMAccountName
+      - userPrincipalName
+      - userAccountControl
+  - action: ENUM_USER_ACCOUNT_DISABLED
+    description: 'Dump info about disabled user accounts'
+    filter: '(userAccountControl:1.2.840.113556.1.4.803:=2)'
+    attributes:
+      - cn
+      - displayName
+      - description
+      - sAMAccountName
+      - userPrincipalName
+      - userAccountControl
+  - action: ENUM_USER_ACCOUNT_LOCKED_OUT
+    description: 'Dump info about locked out user accounts'
+    filter: '(userAccountControl:1.2.840.113556.1.4.803:=16)'
+    attributes:
+      - cn
+      - displayName
+      - sAMAccountName
+      - userPrincipalName
+      - userAccountControl
+  - action: ENUM_USER_ASREP_ROASTABLE
+    description: 'Dump info about all users who are configured not to require kerberos pre-authentication and are therefore AS-REP roastable'
+    filter: '(userAccountControl:1.2.840.113556.1.4.803:=4194304)'
+    attributes:
+      - cn
+      - displayName
+      - description
+      - sAMAccountName
+      - userPrincipalName
+      - userAccountControl
+  - action: ENUM_LAPS_PASSWORDS
+    description: 'Dump info about computers that have LAPS enabled, and passwords for them if available'
+    filter: '(userAccountControl:1.2.840.113556.1.4.803:=4194304)'
+    attributes:
+      - cn
+      - displayName
+      - ms-Mcs-AdmPwd
+  - action: ENUM_GMSA_HASHES # See https://stealthbits.com/blog/securing-gmsa-passwords/ for more details
+    description: 'Dump info about GMSAs and their password hashes if available.'
+    filter: '(objectClass=msDS-GroupManagedServiceAccount)'
+    attributes:
+      - cn
+      - displayName
+      - msDS-ManagedPassword
+  - action: ENUM_DNS_RECORDS # Taken from public documentation and more specifically from https://github.com/dirkjanm/krbrelayx/blob/master/dnstool.py. More info also available at https://www.netspi.com/blog/technical/network-penetration-testing/exploiting-adidns/
+    description: 'Dump info about DNS records the server knows about using the dnsNode object class.'
+    filter: '(objectClass=dnsNode)'
+    attributes:
+      - dc
+      - cn
+      - dnsRecord
+      - dnsTombstoned
+      - name
+
+
+    
+  

--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -17,19 +17,19 @@ queries:
   - action: ENUM_ADCS_ESC1_VULN_TEMPLATES
     description: 'Enumerate ADCS ESC1 vulnerable certificate templates.'
     base_dn_prefix: 'CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration'
-    filter: '(&(objectclass=pkicertificatetemplate)(!(mspki-enrollment-flag:1.2.840.113556.1.4.804:=2))(|(mspki-ra-signature=0)(!(mspki-ra-signature=*)))(|(pkiextendedkeyusage=1.3.6.1.4.1.311.20.2.2)(pkiextendedkeyusage=1.3.6.1.5.5.7.3.2) (pkiextendedkeyusage=1.3.6.1.5.2.3.4))(mspki-certificate-name-flag:1.2.840.113556.1.4.804:=1))'
+    filter: '(&(objectclass=pkicertificatetemplate)(!(mspki-enrollment-flag:1.2.840.113556.1.4.804:=2))(|(mspki-ra-signature=0)(!(mspki-ra-signature=*)))(|(pkiextendedkeyusage=1.3.6.1.4.1.311.20.2.2)(pkiextendedkeyusage=1.3.6.1.5.5.7.3.2)(pkiextendedkeyusage=1.3.6.1.5.2.3.4)(pkiextendedkeyusage=2.5.29.37.0)(!(pkiextendedkeyusage=*)))(mspki-certificate-name-flag:1.2.840.113556.1.4.804:=1))'
     attributes:
       - cn
       - name
       - displayName
       - msPKI-Cert-Template-OID
+      - msPKI-Template-Schema-Version
       - msPKI-Enrollment-Flag
-      - msPKI-Private-Key-Flag
-      - msPKI-Certificate-Name-Flag
       - msPKI-RA-Signature
       - pKIExtendedKeyUsage
+      - ntSecurityDescriptor
     references:
-      - https://ppn.snovvcrash.rocks/pentest/infrastructure/ad/ad-cs-abuse/esc1
+      - https://web.archive.org/web/20220818094600if_/https://specterops.io/assets/resources/Certified_Pre-Owned.pdf
   - action: ENUM_ADMIN_OBJECTS
     description: 'Dump info about all objects with protected ACLs (i.e highly privileged objects).'
     filter: '(adminCount=1)'
@@ -44,7 +44,7 @@ queries:
       - objectCategory
       - member
       - memberof
-    references: 
+    references:
       - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf
   - action: ENUM_ALL_OBJECT_CLASS
     description: 'Dump all objects containing any objectClass field.'
@@ -186,7 +186,7 @@ queries:
       - serverName
     references:
       - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf
-      - https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1 
+      - https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1
   - action: ENUM_LDAP_SERVER_METADATA
     description: 'Dump metadata about the setup of the domain.'
     filter: '(objectClass=*)'
@@ -198,7 +198,7 @@ queries:
       - domainControllerFunctionality
       - dnsHostName
     references:
-      - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf  
+      - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf
   - action: ENUM_ORGUNITS
     description: 'Dump info about all known organizational units in the LDAP environment.'
     filter: '(objectClass=organizationalUnit)'
@@ -340,7 +340,12 @@ queries:
     references:
       - https://www.netspi.com/blog/technical/network-penetration-testing/exploiting-adidns/
       - https://github.com/dirkjanm/krbrelayx/blob/master/dnstool.py
-
-
-    
-  
+  - action: ENUM_DNS_ZONES
+    description: 'Dump info about DNS zones the server knows about using the dnsZone object class under the DC DomainDnsZones. This is needed as without this BASEDN prefix we often miss certain entries'
+    filter: '(objectClass=dnsZone)'
+    base_dn_prefix: 'DC=DomainDnsZones'
+    attributes:
+      - name
+      - distinguishedName
+    references:
+      - https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1

--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -12,19 +12,24 @@ queries:
       - certificateTemplates
       - objectGUID
       - caCertificate
-  - action: ENUM_ADCS_CERT_TEMPLATES
-    description: 'Enumerate ADCS certificate templates.'
+    referemces:
+      - https://aaroneg.com/post/2018-05-15-enterprise-ca/
+  - action: ENUM_ADCS_ESC1_VULN_TEMPLATES
+    description: 'Enumerate ADCS ESC1 vulnerable certificate templates.'
     base_dn_prefix: 'CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration'
-    filter: '(objectClass=pkicertificatetemplate)'
+    filter: '(&(objectclass=pkicertificatetemplate)(!(mspki-enrollment-flag:1.2.840.113556.1.4.804:=2))(|(mspki-ra-signature=0)(!(mspki-ra-signature=*)))(|(pkiextendedkeyusage=1.3.6.1.4.1.311.20.2.2)(pkiextendedkeyusage=1.3.6.1.5.5.7.3.2) (pkiextendedkeyusage=1.3.6.1.5.2.3.4))(mspki-certificate-name-flag:1.2.840.113556.1.4.804:=1))'
     attributes:
       - cn
       - name
       - displayName
+      - msPKI-Cert-Template-OID
       - msPKI-Enrollment-Flag
       - msPKI-Private-Key-Flag
       - msPKI-Certificate-Name-Flag
       - msPKI-RA-Signature
       - pKIExtendedKeyUsage
+    references:
+      - https://ppn.snovvcrash.rocks/pentest/infrastructure/ad/ad-cs-abuse/esc1
   - action: ENUM_ADMIN_OBJECTS
     description: 'Dump info about all objects with protected ACLs (i.e highly privileged objects).'
     filter: '(adminCount=1)'
@@ -39,6 +44,8 @@ queries:
       - objectCategory
       - member
       - memberof
+    references: 
+      - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf
   - action: ENUM_ALL_OBJECT_CLASS
     description: 'Dump all objects containing any objectClass field.'
     filter: '(objectClass=*)'
@@ -76,6 +83,9 @@ queries:
       - LastBadPasswordAttempt
       - PasswordLastSet
       - PaswordNeverExpires
+    references:
+      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
+      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
   - action: ENUM_COMPUTERS
     description: 'Dump all objects containing an objectCategory or objectClass of Computer.'
     filter: '(|(objectCategory=computer)(objectClass=computer))'
@@ -93,6 +103,9 @@ queries:
       - lastLogonTimestamp
       - servicePrincipalName
       - primaryGroupId
+    references:
+      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
+      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
   - action: ENUM_DOMAIN_CONTROLLERS
     description: 'Dump all known domain controllers.'
     filter: '(&(objectCategory=Computer)(userAccountControl:1.2.840.113556.1.4.803:=8192))'
@@ -107,6 +120,9 @@ queries:
       - operatingSystem
       - operatingSystemVersion
       - operatingSystemServicePack
+    references:
+      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
+      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
   - action: ENUM_EXCHANGE_SERVERS
     description: 'Dump info about all known Exchange servers.'
     filter: '(&(objectClass=msExchExchangeServer)(!(objectClass=msExchExchangeServerPolicy)))'
@@ -121,6 +137,9 @@ queries:
       - operatingSystem
       - operatingSystemVersion
       - operatingSystemServicePack
+    references:
+      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
+      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
   - action: ENUM_EXCHANGE_RECIPIENTS
     description: 'Dump info about all known Exchange recipients.'
     filter: '(|(mailNickname=*)(proxyAddresses=FAX:*))'
@@ -129,6 +148,8 @@ queries:
       - mailNickname
       - proxyAddresses
       - name
+    references:
+      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
   - action: ENUM_GROUPS
     description: 'Dump info about all known groups in the LDAP environment.'
     filter: '(|(objectClass=group)(objectClass=groupOfNames)(groupType:1.2.840.113556.1.4.803:=2147483648)(objectClass=posixGroup)(objectcategory=group))'
@@ -143,6 +164,8 @@ queries:
       - adminCount
       - managedBy
       - groupAttributes
+    references:
+      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
   - action: ENUM_GROUP_POLICY_OBJECTS
     description: 'Dump info about all known Group Policy Objects (GPOs) in the LDAP environment.'
     filter: '(objectClass=groupPolicyContainer)'
@@ -151,6 +174,8 @@ queries:
       - gPCFileSysPath
       - objectCategory
       - objectGUID
+    references:
+      - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf
   - action: ENUM_HOSTNAMES
     description: 'Dump info about all known hostnames in the LDAP environment.'
     filter: '(dnsHostName=*)'
@@ -158,7 +183,10 @@ queries:
       - dn
       - name
       - dnsHostName
-      - serverName 
+      - serverName
+    references:
+      - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf
+      - https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1 
   - action: ENUM_LDAP_SERVER_METADATA
     description: 'Dump metadata about the setup of the domain.'
     filter: '(objectClass=*)'
@@ -168,7 +196,9 @@ queries:
       - domainFunctionality
       - forestFunctionality
       - domainControllerFunctionality
-      - dnsHostName  
+      - dnsHostName
+    references:
+      - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf  
   - action: ENUM_ORGUNITS
     description: 'Dump info about all known organizational units in the LDAP environment.'
     filter: '(objectClass=organizationalUnit)'
@@ -176,6 +206,8 @@ queries:
       - displayName
       - name
       - description
+    references:
+      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
   - action: ENUM_ORGROLES
     description: 'Dump info about all known organization roles in the LDAP environment.'
     filter: '(objectClass=organizationalRole)'
@@ -192,6 +224,9 @@ queries:
       - objectCategory
       - msds-allowedtodelegateto
       - servicePrincipalName
+    references:
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
+      - https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/abusing-kerberos-constrained-delegation
   - action: ENUM_UNCONSTRAINED_DELEGATION
     description: 'Dump info about all known objects that allow uncontrained delegation.'
     filter: '(userAccountControl:1.2.840.113556.1.4.803:=524288)'
@@ -201,6 +236,9 @@ queries:
       - objectCategory
       - memberof
       - member
+    references:
+      - https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/domain-compromise-via-unrestricted-kerberos-delegation
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
   - action: ENUM_USER_SPNS_KERBEROAST
     description: 'Dump info about all user objects with Service Principal Names (SPNs) for kerberoasting'
     filter: '(&(&(servicePrincipalName=*)(userAccountControl:1.2.840.113556.1.4.803:=512))(!(userAccountControl:1.2.840.113556.1.4.803:=2)))'
@@ -208,6 +246,10 @@ queries:
       - cn
       - sAMAccountName
       - servicePrincipalName
+    references:
+      - https://malicious.link/post/2022/ldapsearch-reference/
+      - https://burmat.gitbook.io/security/hacking/domain-exploitation
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
   - action: ENUM_USER_PASSWORD_NEVER_EXPIRES
     description: 'Dump info about all users whose password never expires'
     filter: '(userAccountControl:1.2.840.113556.1.4.803:=65536)'
@@ -218,6 +260,8 @@ queries:
       - sAMAccountName
       - userPrincipalName
       - userAccountControl
+    references:
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
   - action: ENUM_USER_PASSWORD_NOT_REQUIRED
     description: 'Dump info about all users whose password never expires and whose account is still enabled'
     filter: '(&(userAccountControl:1.2.840.113556.1.4.803:=32)(!userAccountControl:1.2.840.113556.1.4.803:=2))'
@@ -228,6 +272,8 @@ queries:
       - sAMAccountName
       - userPrincipalName
       - userAccountControl
+    references:
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
   - action: ENUM_USER_ACCOUNT_DISABLED
     description: 'Dump info about disabled user accounts'
     filter: '(userAccountControl:1.2.840.113556.1.4.803:=2)'
@@ -247,9 +293,11 @@ queries:
       - sAMAccountName
       - userPrincipalName
       - userAccountControl
+    references:
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
   - action: ENUM_USER_ASREP_ROASTABLE
     description: 'Dump info about all users who are configured not to require kerberos pre-authentication and are therefore AS-REP roastable'
-    filter: '(userAccountControl:1.2.840.113556.1.4.803:=4194304)'
+    filter: '(&(samAccountType=805306368)(userAccountControl:1.2.840.113556.1.4.803:=4194304))'
     attributes:
       - cn
       - displayName
@@ -257,21 +305,30 @@ queries:
       - sAMAccountName
       - userPrincipalName
       - userAccountControl
+    references:
+      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
+      - https://burmat.gitbook.io/security/hacking/domain-exploitation
   - action: ENUM_LAPS_PASSWORDS
     description: 'Dump info about computers that have LAPS enabled, and passwords for them if available'
-    filter: '(userAccountControl:1.2.840.113556.1.4.803:=4194304)'
+    filter: '(ms-MCS-AdmPwd=*)'
     attributes:
       - cn
       - displayName
-      - ms-Mcs-AdmPwd
-  - action: ENUM_GMSA_HASHES # See https://stealthbits.com/blog/securing-gmsa-passwords/ for more details
+      - ms-MCS-AdmPwd
+    references:
+      - https://ppn.snovvcrash.rocks/pentest/infrastructure/ad/ldap-ldaps
+  - action: ENUM_GMSA_HASHES
     description: 'Dump info about GMSAs and their password hashes if available.'
     filter: '(objectClass=msDS-GroupManagedServiceAccount)'
     attributes:
       - cn
       - displayName
       - msDS-ManagedPassword
-  - action: ENUM_DNS_RECORDS # Taken from public documentation and more specifically from https://github.com/dirkjanm/krbrelayx/blob/master/dnstool.py. More info also available at https://www.netspi.com/blog/technical/network-penetration-testing/exploiting-adidns/
+    references:
+      - https://stealthbits.com/blog/securing-gmsa-passwords/
+      - https://o365blog.com/post/gmsa/
+      - https://adsecurity.org/?p=4367
+  - action: ENUM_DNS_RECORDS
     description: 'Dump info about DNS records the server knows about using the dnsNode object class.'
     filter: '(objectClass=dnsNode)'
     attributes:
@@ -280,6 +337,9 @@ queries:
       - dnsRecord
       - dnsTombstoned
       - name
+    references:
+      - https://www.netspi.com/blog/technical/network-penetration-testing/exploiting-adidns/
+      - https://github.com/dirkjanm/krbrelayx/blob/master/dnstool.py
 
 
     

--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -1,5 +1,33 @@
 ---
 queries:
+  - action: ENUM_ACCOUNTS
+    description: 'Dump info about all known user accounts in the domain.'
+    filter: '(|(objectClass=organizationalPerson)(sAMAccountType=805306368)(objectcategory=user)(objectClass=user))'
+    attributes:
+      - dn
+      - name
+      - description
+      - displayName
+      - sAMAccountName
+      - userPrincipalName
+      - userAccountControl
+      - homeDirectory
+      - homeDrive
+      - profilePath
+      - memberof
+      - lastLogoff
+      - lastLogon
+      - lastLogonDate
+      - logonCount
+      - badPwdCount
+      - pwdLastSet
+      - SmartcardLogonRequired
+      - LastBadPasswordAttempt
+      - PasswordLastSet
+      - PaswordNeverExpires
+    references:
+      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
+      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
   - action: ENUM_ADCS_CAS
     description: 'Enumerate ADCS certificate authorities.'
     base_dn_prefix: 'CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration'
@@ -12,7 +40,7 @@ queries:
       - certificateTemplates
       - objectGUID
       - caCertificate
-    referemces:
+    references:
       - https://aaroneg.com/post/2018-05-15-enterprise-ca/
   - action: ENUM_ADCS_CERT_TEMPLATES
     description: 'Enumerate ADCS certificate templates.'
@@ -47,46 +75,18 @@ queries:
       - memberof
     references:
       - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf
-  - action: ENUM_ALL_OBJECT_CLASS
-    description: 'Dump all objects containing any objectClass field.'
-    filter: '(objectClass=*)'
-    attributes:
-      - dn
-      - objectClass
   - action: ENUM_ALL_OBJECT_CATEGORY
     description: 'Dump all objects containing any objectCategory field.'
     filter: '(objectCategory=*)'
     attributes:
       - dn
       - objectCategory
-  - action: ENUM_ACCOUNTS
-    description: 'Dump info about all known user accounts in the domain.'
-    filter: '(|(objectClass=organizationalPerson)(sAMAccountType=805306368)(objectcategory=user)(objectClass=user))'
+  - action: ENUM_ALL_OBJECT_CLASS
+    description: 'Dump all objects containing any objectClass field.'
+    filter: '(objectClass=*)'
     attributes:
       - dn
-      - name
-      - description
-      - displayName
-      - sAMAccountName
-      - userPrincipalName
-      - userAccountControl
-      - homeDirectory
-      - homeDrive
-      - profilePath
-      - memberof
-      - lastLogoff
-      - lastLogon
-      - lastLogonDate
-      - logonCount
-      - badPwdCount
-      - pwdLastSet
-      - SmartcardLogonRequired
-      - LastBadPasswordAttempt
-      - PasswordLastSet
-      - PaswordNeverExpires
-    references:
-      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
-      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
+      - objectClass
   - action: ENUM_COMPUTERS
     description: 'Dump all objects containing an objectCategory or objectClass of Computer.'
     filter: '(|(objectCategory=computer)(objectClass=computer))'
@@ -107,7 +107,40 @@ queries:
     references:
       - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
       - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
-  - action: ENUM_DOMAIN_CONTROLLERS
+ - action: ENUM_CONSTRAINED_DELEGATION
+    description: 'Dump info about all known objects that allow contrained delegation.'
+    filter: '(userAccountControl:1.2.840.113556.1.4.803:=16777216)'
+    attributes:
+      - cn
+      - sAMAccountName
+      - objectCategory
+      - msds-allowedtodelegateto
+      - servicePrincipalName
+    references:
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
+      - https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/abusing-kerberos-constrained-delegation
+  - action: ENUM_DNS_RECORDS
+    description: 'Dump info about DNS records the server knows about using the dnsNode object class.'
+    filter: '(objectClass=dnsNode)'
+    attributes:
+      - dc
+      - cn
+      - dnsRecord
+      - dnsTombstoned
+      - name
+    references:
+      - https://www.netspi.com/blog/technical/network-penetration-testing/exploiting-adidns/
+      - https://github.com/dirkjanm/krbrelayx/blob/master/dnstool.py
+  - action: ENUM_DNS_ZONES
+    description: 'Dump info about DNS zones the server knows about using the dnsZone object class under the DC DomainDnsZones. This is needed as without this BASEDN prefix we often miss certain entries'
+    filter: '(objectClass=dnsZone)'
+    base_dn_prefix: 'DC=DomainDnsZones'
+    attributes:
+      - name
+      - distinguishedName
+    references:
+      - https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1
+- action: ENUM_DOMAIN_CONTROLLERS
     description: 'Dump all known domain controllers.'
     filter: '(&(objectCategory=Computer)(userAccountControl:1.2.840.113556.1.4.803:=8192))'
     attributes:
@@ -123,7 +156,17 @@ queries:
       - operatingSystemServicePack
     references:
       - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
-      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
+      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf 
+  - action: ENUM_EXCHANGE_RECIPIENTS
+    description: 'Dump info about all known Exchange recipients.'
+    filter: '(|(mailNickname=*)(proxyAddresses=FAX:*))'
+    attributes:
+      - dn
+      - mailNickname
+      - proxyAddresses
+      - name
+    references:
+      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
   - action: ENUM_EXCHANGE_SERVERS
     description: 'Dump info about all known Exchange servers.'
     filter: '(&(objectClass=msExchExchangeServer)(!(objectClass=msExchExchangeServerPolicy)))'
@@ -141,16 +184,17 @@ queries:
     references:
       - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
       - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
-  - action: ENUM_EXCHANGE_RECIPIENTS
-    description: 'Dump info about all known Exchange recipients.'
-    filter: '(|(mailNickname=*)(proxyAddresses=FAX:*))'
+  - action: ENUM_GMSA_HASHES
+    description: 'Dump info about GMSAs and their password hashes if available.'
+    filter: '(objectClass=msDS-GroupManagedServiceAccount)'
     attributes:
-      - dn
-      - mailNickname
-      - proxyAddresses
-      - name
+      - cn
+      - displayName
+      - msDS-ManagedPassword
     references:
-      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
+      - https://stealthbits.com/blog/securing-gmsa-passwords/
+      - https://o365blog.com/post/gmsa/
+      - https://adsecurity.org/?p=4367
   - action: ENUM_GROUPS
     description: 'Dump info about all known groups in the LDAP environment.'
     filter: '(|(objectClass=group)(objectClass=groupOfNames)(groupType:1.2.840.113556.1.4.803:=2147483648)(objectClass=posixGroup)(objectcategory=group))'
@@ -187,7 +231,16 @@ queries:
       - serverName
     references:
       - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf
-      - https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1
+      - https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1 
+  - action: ENUM_LAPS_PASSWORDS
+    description: 'Dump info about computers that have LAPS enabled, and passwords for them if available'
+    filter: '(ms-MCS-AdmPwd=*)'
+    attributes:
+      - cn
+      - displayName
+      - ms-MCS-AdmPwd
+    references:
+      - https://ppn.snovvcrash.rocks/pentest/infrastructure/ad/ldap-ldaps
   - action: ENUM_LDAP_SERVER_METADATA
     description: 'Dump metadata about the setup of the domain.'
     filter: '(objectClass=*)'
@@ -200,6 +253,13 @@ queries:
       - dnsHostName
     references:
       - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf
+  - action: ENUM_ORGROLES
+    description: 'Dump info about all known organization roles in the LDAP environment.'
+    filter: '(objectClass=organizationalRole)'
+    attributes:
+      - displayName
+      - name
+      - description
   - action: ENUM_ORGUNITS
     description: 'Dump info about all known organizational units in the LDAP environment.'
     filter: '(objectClass=organizationalUnit)'
@@ -209,25 +269,6 @@ queries:
       - description
     references:
       - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
-  - action: ENUM_ORGROLES
-    description: 'Dump info about all known organization roles in the LDAP environment.'
-    filter: '(objectClass=organizationalRole)'
-    attributes:
-      - displayName
-      - name
-      - description
-  - action: ENUM_CONSTRAINED_DELEGATION
-    description: 'Dump info about all known objects that allow contrained delegation.'
-    filter: '(userAccountControl:1.2.840.113556.1.4.803:=16777216)'
-    attributes:
-      - cn
-      - sAMAccountName
-      - objectCategory
-      - msds-allowedtodelegateto
-      - servicePrincipalName
-    references:
-      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
-      - https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/abusing-kerberos-constrained-delegation
   - action: ENUM_UNCONSTRAINED_DELEGATION
     description: 'Dump info about all known objects that allow uncontrained delegation.'
     filter: '(userAccountControl:1.2.840.113556.1.4.803:=524288)'
@@ -239,41 +280,6 @@ queries:
       - member
     references:
       - https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/domain-compromise-via-unrestricted-kerberos-delegation
-      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
-  - action: ENUM_USER_SPNS_KERBEROAST
-    description: 'Dump info about all user objects with Service Principal Names (SPNs) for kerberoasting'
-    filter: '(&(&(servicePrincipalName=*)(userAccountControl:1.2.840.113556.1.4.803:=512))(!(userAccountControl:1.2.840.113556.1.4.803:=2)))'
-    attributes:
-      - cn
-      - sAMAccountName
-      - servicePrincipalName
-    references:
-      - https://malicious.link/post/2022/ldapsearch-reference/
-      - https://burmat.gitbook.io/security/hacking/domain-exploitation
-      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
-  - action: ENUM_USER_PASSWORD_NEVER_EXPIRES
-    description: 'Dump info about all users whose password never expires'
-    filter: '(userAccountControl:1.2.840.113556.1.4.803:=65536)'
-    attributes:
-      - cn
-      - displayName
-      - description
-      - sAMAccountName
-      - userPrincipalName
-      - userAccountControl
-    references:
-      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
-  - action: ENUM_USER_PASSWORD_NOT_REQUIRED
-    description: 'Dump info about all users whose password never expires and whose account is still enabled'
-    filter: '(&(userAccountControl:1.2.840.113556.1.4.803:=32)(!userAccountControl:1.2.840.113556.1.4.803:=2))'
-    attributes:
-      - cn
-      - displayName
-      - description
-      - sAMAccountName
-      - userPrincipalName
-      - userAccountControl
-    references:
       - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
   - action: ENUM_USER_ACCOUNT_DISABLED
     description: 'Dump info about disabled user accounts'
@@ -309,44 +315,38 @@ queries:
     references:
       - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
       - https://burmat.gitbook.io/security/hacking/domain-exploitation
-  - action: ENUM_LAPS_PASSWORDS
-    description: 'Dump info about computers that have LAPS enabled, and passwords for them if available'
-    filter: '(ms-MCS-AdmPwd=*)'
+  - action: ENUM_USER_PASSWORD_NEVER_EXPIRES
+    description: 'Dump info about all users whose password never expires'
+    filter: '(userAccountControl:1.2.840.113556.1.4.803:=65536)'
     attributes:
       - cn
       - displayName
-      - ms-MCS-AdmPwd
+      - description
+      - sAMAccountName
+      - userPrincipalName
+      - userAccountControl
     references:
-      - https://ppn.snovvcrash.rocks/pentest/infrastructure/ad/ldap-ldaps
-  - action: ENUM_GMSA_HASHES
-    description: 'Dump info about GMSAs and their password hashes if available.'
-    filter: '(objectClass=msDS-GroupManagedServiceAccount)'
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
+  - action: ENUM_USER_PASSWORD_NOT_REQUIRED
+    description: 'Dump info about all users whose password never expires and whose account is still enabled'
+    filter: '(&(userAccountControl:1.2.840.113556.1.4.803:=32)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))'
     attributes:
       - cn
       - displayName
-      - msDS-ManagedPassword
+      - description
+      - sAMAccountName
+      - userPrincipalName
+      - userAccountControl
     references:
-      - https://stealthbits.com/blog/securing-gmsa-passwords/
-      - https://o365blog.com/post/gmsa/
-      - https://adsecurity.org/?p=4367
-  - action: ENUM_DNS_RECORDS
-    description: 'Dump info about DNS records the server knows about using the dnsNode object class.'
-    filter: '(objectClass=dnsNode)'
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
+  - action: ENUM_USER_SPNS_KERBEROAST
+    description: 'Dump info about all user objects with Service Principal Names (SPNs) for kerberoasting'
+    filter: '(&(&(servicePrincipalName=*)(userAccountControl:1.2.840.113556.1.4.803:=512))(!(userAccountControl:1.2.840.113556.1.4.803:=2)))'
     attributes:
-      - dc
       - cn
-      - dnsRecord
-      - dnsTombstoned
-      - name
+      - sAMAccountName
+      - servicePrincipalName
     references:
-      - https://www.netspi.com/blog/technical/network-penetration-testing/exploiting-adidns/
-      - https://github.com/dirkjanm/krbrelayx/blob/master/dnstool.py
-  - action: ENUM_DNS_ZONES
-    description: 'Dump info about DNS zones the server knows about using the dnsZone object class under the DC DomainDnsZones. This is needed as without this BASEDN prefix we often miss certain entries'
-    filter: '(objectClass=dnsZone)'
-    base_dn_prefix: 'DC=DomainDnsZones'
-    attributes:
-      - name
-      - distinguishedName
-    references:
-      - https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1
+      - https://malicious.link/post/2022/ldapsearch-reference/
+      - https://burmat.gitbook.io/security/hacking/domain-exploitation
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties 

--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -14,10 +14,10 @@ queries:
       - caCertificate
     referemces:
       - https://aaroneg.com/post/2018-05-15-enterprise-ca/
-  - action: ENUM_ADCS_ESC1_VULN_TEMPLATES
-    description: 'Enumerate ADCS ESC1 vulnerable certificate templates.'
+  - action: ENUM_ADCS_CERT_TEMPLATES
+    description: 'Enumerate ADCS certificate templates.'
     base_dn_prefix: 'CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration'
-    filter: '(&(objectclass=pkicertificatetemplate)(!(mspki-enrollment-flag:1.2.840.113556.1.4.804:=2))(|(mspki-ra-signature=0)(!(mspki-ra-signature=*)))(|(pkiextendedkeyusage=1.3.6.1.4.1.311.20.2.2)(pkiextendedkeyusage=1.3.6.1.5.5.7.3.2)(pkiextendedkeyusage=1.3.6.1.5.2.3.4)(pkiextendedkeyusage=2.5.29.37.0)(!(pkiextendedkeyusage=*)))(mspki-certificate-name-flag:1.2.840.113556.1.4.804:=1))'
+    filter: '(objectClass=pkicertificatetemplate)'
     attributes:
       - cn
       - name
@@ -25,9 +25,10 @@ queries:
       - msPKI-Cert-Template-OID
       - msPKI-Template-Schema-Version
       - msPKI-Enrollment-Flag
+      - msPKI-Certificate-Name-Flag
+      - msPKI-Private-Key-Flag
       - msPKI-RA-Signature
       - pKIExtendedKeyUsage
-      - ntSecurityDescriptor
     references:
       - https://web.archive.org/web/20220818094600if_/https://specterops.io/assets/resources/Certified_Pre-Owned.pdf
   - action: ENUM_ADMIN_OBJECTS


### PR DESCRIPTION
This adds in a bunch of new query types to help with discovering things like AS-REP roastable accounts,  potential honeypot accounts via login counts + password set dates + last login times, KerberRoastable accounts, Constrained and Unconstrained delegation, and more.

There is still more work to be done here as I'm going through PowerView now to try map out some of the other remaining entries. Also note that `dnsRecord` in particular will require a lot more processing. I think that should be the only one, but it is a serialized object that requires a lot of effort to unserialize properly however should we get that to work I believe we may be able to get the IPv6 or IPv4 address of the servers that the DC is aware of, without having to ever send a DNS request at all. That may be helpful in certain scenarios where DNS traffic is heavily restricted.

## Verification
-   Install ADCS on either a new or existing domain controller
    -    Open the Server Manager
    -    Select Add roles and features
    -    Select "Active Directory Certificate Services" under the "Server Roles" section
    -    When prompted add all of the features and management tools
    -    On the AD CS "Role Services" tab, leave the default selection of only "Certificate Authority"
    -    Completion the installation and reboot the server
    -    Reopen the Server Manager
    -    Go to the AD CS tab and where it says "Configuration Required", hit "More" then "Configure Active Directory Certificate..."
    -    Select "Certificate Authority" in the Role Services tab
    -    Keep all of the default settings, noting the value of the "Common name for this CA" on the "CA Name" tab (this value corresponds to the `CA` datastore option)
    -    Accept the rest of the default settings and complete the configuration
