### PR TITLE
Fixes broken sessions in rservices modules

### DIFF
--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -179,9 +179,11 @@ class MetasploitModule < Msf::Auxiliary
       :stderr_sock    => stderr_sock
     }
 
-    # Don't tie the life of this socket to the exploit
-    self.sockets.delete(stderr_sock)
-
-    start_session(self, "rexec #{user}:#{pass} (#{host}:#{port})", merge_me) if datastore['CreateSession']
+    if datastore['CreateSession']
+      start_session(self, "rexec #{user}:#{pass} (#{host}:#{port})", merge_me, false, self.sock)
+      # Don't tie the life of this socket to the exploit
+      self.sockets.delete(stderr_sock)
+      self.sock = nil
+    end
   end
 end

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -326,7 +326,10 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     report_auth_info(auth_info)
-    start_session(self, info, merge_me) if datastore['CreateSession']
-
+    if datastore['CreateSession']
+      start_session(self, info, merge_me, false, self.sock)
+      # Don't tie the life of this socket to the exploit
+      self.sock = nil
+    end
   end
 end

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -264,9 +264,11 @@ class MetasploitModule < Msf::Auxiliary
       :stderr_sock    => stderr_sock
     }
 
-    # Don't tie the life of this socket to the exploit
-    self.sockets.delete(stderr_sock)
-
-    start_session(self, "RSH #{user} from #{luser} (#{host}:#{port})", merge_me) if datastore['CreateSession']
+    if datastore['CreateSession']
+      start_session(self, "RSH #{user} from #{luser} (#{host}:#{port})", merge_me, nil, self.sock)
+      # Don't tie the life of this socket to the exploit
+      self.sockets.delete(stderr_sock)
+      self.sock = nil
+    end
   end
 end


### PR DESCRIPTION
Resolves #16769

This PR implements a fix to all three of the rservices modules. 
- `modules/auxiliary/scanner/rservices/rexec_login.rb`
- `modules/auxiliary/scanner/rservices/rlogin_login.rb`
- `modules/auxiliary/scanner/rservices/rsh_login.rb`

Previously when sessions opened they would exit as soon as a user attempted to interact with them. Now, both `rsh_login.rb` and `rlogin_login.rb` can now open sessions and are interactive. However we were unsuccessful in gaining a session for `rexec_login.rb` as we had no means to test it, or at least didn't know how. However the logic for sessions was consistent across all three modules so we could see the changes made for the other two modules would need to be implemented in `rexec_login.rb` as well.

## Before
![image](https://user-images.githubusercontent.com/69522014/192987342-9814b9fe-a3f8-4f48-9fb8-bf5522c883fd.png)

## After
![image](https://user-images.githubusercontent.com/69522014/192987666-40197847-49f1-48a9-bce2-88c8c6ef5fb8.png)

### Note
These issues were found as part of a ticket to fix the deprecated modules warning in the above screenshots. A PR to fix those issues will follow this.

## Verification

### Note 
There are also docs for these modules: `documentation/modules/auxiliary/scanner/rservices/rlogin_login.md`.
Metasploitable 2 is an alternative target. We tested against both, so either should work.

- [ ] Start `msfconsole`
- [ ] Run `use auxiliary/scanner/rservices/rlogin_login`
- [ ] Run `sessions -1`
- [ ] **Verify** the session does not exit after interacting with it.