### PR TITLE
Updates deprecated methods in rservices modules 

### DIFF
--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -294,40 +294,40 @@ class MetasploitModule < Msf::Auxiliary
     disconnect()
   end
 
-
   def start_rlogin_session(host, port, user, luser, pass, proof)
-
-    auth_info = {
-      :host	=> host,
-      :port	=> port,
-      :sname => 'login',
-      :user	=> user,
-      :proof  => proof,
-      :source_type => "user_supplied",
-      :active => true
+    service_data = {
+      address: host,
+      port: port,
+      service_name: 'rlogin',
+      proof: proof,
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
     }
 
-    merge_me = {
-      'USERPASS_FILE' => nil,
-      'USER_FILE'     => nil,
-      'FROMUSER_FILE' => nil,
-      'PASS_FILE'     => nil,
-      'USERNAME'      => user,
-    }
+    credential_data = {
+      module_fullname: self.fullname,
+      origin_type: :service,
+      username: user
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
 
     if pass
-      auth_info.merge!(:pass => pass)
-      merge_me.merge!('PASSWORD' => pass)
+      service_data.merge!(:pass => pass)
+      credential_data.merge!('PASSWORD' => pass)
       info = "RLOGIN #{user}:#{pass} (#{host}:#{port})"
     else
-      auth_info.merge!(:luser => luser)
-      merge_me.merge!('FROMUSER'=> luser)
+      service_data.merge!(:luser => luser)
+      credential_data.merge!('FROMUSER'=> luser)
       info = "RLOGIN #{user} from #{luser} (#{host}:#{port})"
     end
 
-    report_auth_info(auth_info)
+    create_credential_login(login_data)
     if datastore['CreateSession']
-      start_session(self, info, merge_me, false, self.sock)
+      start_session(self, info, login_data, false, self.sock)
       # Don't tie the life of this socket to the exploit
       self.sock = nil
     end

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -244,28 +244,30 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def start_rsh_session(host, port, user, luser, proof, stderr_sock)
-    report_auth_info(
-      :host	=> host,
-      :port	=> port,
-      :sname => 'shell',
-      :user	=> user,
-      :luser => luser,
-      :proof  => proof,
-      :source_type => "user_supplied",
-      :active => true
-    )
-
-    merge_me = {
-      'USER_FILE'     => nil,
-      'FROMUSER_FILE' => nil,
-      'USERNAME'      => user,
-      'FROMUSER'      => user,
-      # Save a reference to the socket so we don't GC prematurely
-      :stderr_sock    => stderr_sock
+    service_data = {
+      address: host,
+      port: port,
+      service_name: 'shell',
+      proof: proof,
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
     }
 
+    credential_data = {
+      module_fullname: self.fullname,
+      origin_type: :service,
+      username: user,
+      # Save a reference to the socket so we don't GC prematurely
+      stderr_sock: stderr_sock
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
+
     if datastore['CreateSession']
-      start_session(self, "RSH #{user} from #{luser} (#{host}:#{port})", merge_me, nil, self.sock)
+      start_session(self, "RSH #{user} from #{luser} (#{host}:#{port})", login_data, nil, self.sock)
       # Don't tie the life of this socket to the exploit
       self.sockets.delete(stderr_sock)
       self.sock = nil


### PR DESCRIPTION
Addresses three of the modules listed as part of the following issue https://github.com/rapid7/metasploit-framework/issues/10314.

This PR updates the deprecated `report_auth_info` method calls in the rservices modules to now make use of `create_credential` instead:
- `modules/auxiliary/scanner/rservices/rexec_login.rb`
- `modules/auxiliary/scanner/rservices/rlogin_login.rb`
- `modules/auxiliary/scanner/rservices/rsh_login.rb`


## Before - `rsh_login`
![image](https://user-images.githubusercontent.com/69522014/193024016-a8006f28-860c-4583-968c-fbee55b69233.png)

## After - `rsh_login`
![image](https://user-images.githubusercontent.com/69522014/193024426-c4e6ec24-e2db-4e12-9152-3200d2aad2d2.png)


## Before - `rlogin_login`
![image](https://user-images.githubusercontent.com/69522014/193024136-8cfb1405-4fc5-4714-a075-a6d5f3d33ff1.png)

## After - `rlogin_login`
![image](https://user-images.githubusercontent.com/69522014/193024524-9c8874f6-39e5-4bd8-a25b-489e89bc8d16.png)

## `rexec_login`
We were unsuccessful in gaining a session for `rexec_login.rb` as we had no means to test it, or at least didn't know how. However the logic for updating the deprecated methods was consistent across all three modules so we could see the changes made for the other two modules would need to be implemented in `rexec_login.rb` as well.

An issue has also been opened to cover the issues found when working on these modules, which includes the issue with `rexec_login` not authenticating properly. See here for more context https://github.com/rapid7/metasploit-framework/issues/17076

## Prerequisites:
The following PR must be landed to fix session issues in these modules before this [PR](https://github.com/rapid7/metasploit-framework/pull/17073) can be tested. 

## Verification

### Note 
There are also docs for these modules: `documentation/modules/auxiliary/scanner/rservices/rlogin_login.md`.
Metasploitable 2 is an alternative target. We tested against both, so either should work.

- [ ] Start `msfconsole`
- [ ] Run `use auxiliary/scanner/rservices/rlogin_login`
- [ ] **Verify** the deprecation warnings are no longer present
- [ ] Run `sessions -1`
- [ ] **Verify** the session can be interacted with.