### PR TITLE
Fix keberos smb delegation crash for windows 2008 smb server

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/smb.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/smb.rb
@@ -4,6 +4,13 @@
 # This class acts as standalone authenticator for Kerberos
 #
 class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB < Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
+  def initialize(**kwargs)
+    super(
+      send_delegated_creds: kwargs.fetch(:send_delegated_creds, Delegation::NEVER),
+      **kwargs
+    )
+  end
+
   def build_spn(options = {})
     Rex::Proto::Kerberos::Model::PrincipalName.new(
       name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,


### PR DESCRIPTION
Fix a bug spotted by https://github.com/rapid7/metasploit-framework/pull/17079

Existing issue for windows 2008 server that can be fixed unrelated to this PR:
```
msf6 exploit(windows/smb/psexec) > run rhosts=192.168.123.136 smbuser=Administrator smbpass=p4$$w0rd smbauth=kerberos smbrhostname=win-0p19ull2nb6.demo.local domaincontrollerrhost=192.168.123.136 smbdomain=demo.local 

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] 192.168.123.136:445 - Connecting to the server...
[*] 192.168.123.136:445 - Authenticating to 192.168.123.136:445|demo.local as user 'Administrator'...
[*] 192.168.123.136:445 - 192.168.123.136:88 - Received a valid TGT-Response
[+] 192.168.123.136:445 - 192.168.123.136:88 - Received a valid TGS-Response
[*] 192.168.123.136:445 - 192.168.123.136:88 - TGS MIT Credential Cache saved to /Users/user/.msf4/loot/20220929143113_default_192.168.123.136_mit.kerberos.cca_521789.bin
[-] 192.168.123.136:445 - Exploit failed [no-access]: Rex::Proto::SMB::Exceptions::LoginError Login Failed: undefined method `ticket' for #<Rex::Proto::Kerberos::Model::KrbError:0x00007f81d5444a68 @pvno=5, @msg_type=30, @stime=2022-09-29 13:29:03 UTC, @susec=857539, @error_code=#<Rex::Proto::Kerberos::Model::Error::ErrorCode:0x00007f81f1d025d0 @name="KDC_ERR_ETYPE_NOSUPP", @value=14, @description="KDC has no support for encryption type">, @realm="DEMO.LOCAL", @sname=#<Rex::Proto::Kerberos::Model::PrincipalName:0x00007f81d5444900 @name_type=2, @name_string=["krbtgt", "DEMO.LOCAL"]>>
[*] Exploit completed, but no session was created.
```

Trace:
```
[09/29/2022 14:31:13] [e(0)] core: NoMethodError undefined method `ticket' for #<Rex::Proto::Kerberos::Model::KrbError:0x00007f81d5444a68 @pvno=5, @msg_type=30, @stime=2022-09-29 13:29:03 UTC, @susec=857539, @error_code=#<Rex::Proto::Kerberos::Model::Error::ErrorCode:0x00007f81f1d025d0 @name="KDC_ERR_ETYPE_NOSUPP", @value=14, @description="KDC has no support for encryption type">, @realm="DEMO.LOCAL", @sname=#<Rex::Proto::Kerberos::Model::PrincipalName:0x00007f81d5444900 @name_type=2, @name_string=["krbtgt", "DEMO.LOCAL"]>>
Call stack:
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb:541:in `request_delegation_ticket'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb:352:in `authenticate_via_kdc'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb:158:in `authenticate'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb:94:in `smb2_authenticate'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb:26:in `authenticate'
/Users/user/.rvm/gems/ruby-3.0.2@metasploit-framework/gems/ruby_smb-3.2.0/lib/ruby_smb/client.rb:429:in `session_setup'
/Users/user/Documents/code/metasploit-framework/lib/rex/proto/smb/simple_client.rb:101:in `login'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/smb/client.rb:173:in `smb_login'
/Users/user/Documents/code/metasploit-framework/modules/exploits/windows/smb/psexec.rb:132:in `exploit'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit_driver.rb:228:in `job_run_proc'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit_driver.rb:181:in `run'
/Users/user/Documents/code/metasploit-framework/lib/msf/base/simple/exploit.rb:144:in `exploit_simple'
/Users/user/Documents/code/metasploit-framework/lib/msf/base/simple/exploit.rb:171:in `exploit_simple'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:45:in `exploit_single'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:182:in `cmd_exploit'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
[09/29/2022 14:31:13] [e(0)] core: Exploit failed (windows/smb/psexec): Rex::Proto::SMB::Exceptions::LoginError Login Failed: undefined method `ticket' for #<Rex::Proto::Kerberos::Model::KrbError:0x00007f81d5444a68 @pvno=5, @msg_type=30, @stime=2022-09-29 13:29:03 UTC, @susec=857539, @error_code=#<Rex::Proto::Kerberos::Model::Error::ErrorCode:0x00007f81f1d025d0 @name="KDC_ERR_ETYPE_NOSUPP", @value=14, @description="KDC has no support for encryption type">, @realm="DEMO.LOCAL", @sname=#<Rex::Proto::Kerberos::Model::PrincipalName:0x00007f81d5444900 @name_type=2, @name_string=["krbtgt", "DEMO.LOCAL"]>> - Rex::Proto::SMB::Exceptions::LoginError Login Failed: undefined method `ticket' for #<Rex::Proto::Kerberos::Model::KrbError:0x00007f81d5444a68 @pvno=5, @msg_type=30, @stime=2022-09-29 13:29:03 UTC, @susec=857539, @error_code=#<Rex::Proto::Kerberos::Model::Error::ErrorCode:0x00007f81f1d025d0 @name="KDC_ERR_ETYPE_NOSUPP", @value=14, @description="KDC has no support for encryption type">, @realm="DEMO.LOCAL", @sname=#<Rex::Proto::Kerberos::Model::PrincipalName:0x00007f81d5444900 @name_type=2, @name_string=["krbtgt", "DEMO.LOCAL"]>>
Call stack:
/Users/user/Documents/code/metasploit-framework/lib/rex/proto/smb/simple_client.rb:112:in `rescue in login'
/Users/user/Documents/code/metasploit-framework/lib/rex/proto/smb/simple_client.rb:63:in `login'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/smb/client.rb:173:in `smb_login'
/Users/user/Documents/code/metasploit-framework/modules/exploits/windows/smb/psexec.rb:132:in `exploit'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit_driver.rb:228:in `job_run_proc'
/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit_driver.rb:181:in `run'
/Users/user/Documents/code/metasploit-framework/lib/msf/base/simple/exploit.rb:144:in `exploit_simple'
/Users/user/Documents/code/metasploit-framework/lib/msf/base/simple/exploit.rb:171:in `exploit_simple'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:45:in `exploit_single'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:182:in `cmd_exploit'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Target a windows 2008 domain controller
- [ ] Verify `windows/smb/psexec` works correctly - `run rhosts=192.168.123.136 smbuser=Administrator smbpass=p4$$w0rd smbauth=kerberos smbrhostname=win-0p19ull2nb6.demo.local domaincontrollerrhost=192.168.123.136 smbdomain=demo.local `