### PR TITLE
Update ranking for nft_set_elem_init

### DIFF
--- a/modules/exploits/linux/local/netfilter_nft_set_elem_init_privesc.rb
+++ b/modules/exploits/linux/local/netfilter_nft_set_elem_init_privesc.rb
@@ -6,7 +6,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = GreatRanking
+  Rank = AverageRanking
   include Msf::Post::Common
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::System


### PR DESCRIPTION
You can see in https://github.com/rapid7/metasploit-framework/pull/16794 that I struggled to get this to work; it definitely should not be excellent ranking.  The author suggested my setup might be less reliable than theirs, but I think calling Average is a good compromise.