### PR TITLE
Modules: Fix Stability/SideEffects/Reliability notes for several modules

### DIFF
--- a/modules/auxiliary/admin/http/tomcat_ghostcat.rb
+++ b/modules/auxiliary/admin/http/tomcat_ghostcat.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2020-02-20',
         'Notes' => {
           'AKA' => ['Ghostcat'],
-          'Stability' => ['CRASH_SAFE'],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         }

--- a/modules/auxiliary/dos/windows/http/http_sys_accept_encoding_dos_cve_2021_31166.rb
+++ b/modules/auxiliary/dos/windows/http/http_sys_accept_encoding_dos_cve_2021_31166.rb
@@ -40,8 +40,8 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2021-05-11',
         'Notes' => {
           'Stability' => [CRASH_OS_RESTARTS],
-          'Reliability' => [IOC_IN_LOGS],
-          'SideEffects' => [SCREEN_EFFECTS]
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS, SCREEN_EFFECTS]
         }
       )
     )

--- a/modules/exploits/android/local/janus.rb
+++ b/modules/exploits/android/local/janus.rb
@@ -50,8 +50,9 @@ class MetasploitModule < Msf::Exploit::Local
           },
           'DefaultTarget' => 0,
           'Notes' => {
-            'SideEffects' => ['ARTIFACTS_ON_DISK', 'SCREEN_EFFECTS'],
-            'Stability' => ['SERVICE_RESOURCE_LOSS'], # ZTE youtube app won't start anymore
+            'SideEffects' => [ARTIFACTS_ON_DISK, SCREEN_EFFECTS],
+            'Reliability' => [],
+            'Stability' => [SERVICE_RESOURCE_LOSS], # ZTE youtube app won't start anymore
           },
           'Compat' => {
             'Meterpreter' => {

--- a/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
+++ b/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
@@ -67,8 +67,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
-          'Reliability' => [ IOC_IN_LOGS ],
-          'SideEffects' => [ REPEATABLE_SESSION ]
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => [ IOC_IN_LOGS ]
         }
       )
     )

--- a/modules/exploits/linux/http/geutebruck_cmdinject_cve_2021_335xx.rb
+++ b/modules/exploits/linux/http/geutebruck_cmdinject_cve_2021_335xx.rb
@@ -120,9 +120,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
         },
         'Notes' => {
-          'Stability' => ['CRASH_SAFE'],
-          'Reliability' => ['REPEATABLE_SESSION'],
-          'SideEffects' => ['ARTIFACTS_ON_DISK']
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         }
       )
     )

--- a/modules/exploits/linux/http/geutebruck_instantrec_bof.rb
+++ b/modules/exploits/linux/http/geutebruck_instantrec_bof.rb
@@ -44,9 +44,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
         },
         'Notes' => {
-          'Stability' => ['CRASH_SAFE'],
-          'Reliability' => ['REPEATABLE_SESSION'],
-          'SideEffects' => ['ARTIFACTS_ON_DISK']
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         }
       )
     )

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -50,9 +50,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2020-11-21',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Stability' => ['CRASH_SAFE'],
-          'Reliability' => ['IOC_IN_LOGS'],
-          'SideEffects' => ['REPEATABLE_SESSION']
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES],
-          'SideEffects' => [REPEATABLE_SESSION]
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES]
         }
       )
     )

--- a/modules/post/windows/manage/persistence_exe.rb
+++ b/modules/post/windows/manage/persistence_exe.rb
@@ -42,8 +42,8 @@ class MetasploitModule < Msf::Post
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES],
-          'SideEffects' => [REPEATABLE_SESSION]
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES]
         }
       )
     )


### PR DESCRIPTION
The notes were switched around for some reason. Also some of the notes were strings. I didn't bother to check if these constants work as strings or not (seems unlikely?) but we should be consistent regardless.

We should probably validate these values in `msftidy`. I'll add this one day, but I'm in no hurry. If you're keen to do it first then be my guest.

See also: #16722 previous merged fixed for similar issue.
