### PR TITLE
set keep_cookies value to boolean true instead of string true

### DIFF
--- a/lib/msf/core/exploit/remote/http/pihole.rb
+++ b/lib/msf/core/exploit/remote/http/pihole.rb
@@ -25,7 +25,7 @@ module Msf
             res = send_request_cgi(
               'uri' => normalize_uri(target_uri.path, 'admin', 'index.php'),
               'method' => 'GET',
-              'keep_cookies' => 'true'
+              'keep_cookies' => true
             )
             return nil if res.nil? || res.code != 200
 
@@ -59,7 +59,7 @@ module Msf
                 'pw' => password
               },
               'method' => 'POST',
-              'keep_cookies' => 'true'
+              'keep_cookies' => true
             )
             if res && res.code == 200 && res.body.exclude?('Sign in to start your session')
               return res.get_cookies
@@ -76,7 +76,7 @@ module Msf
             vprint_status('Forcing gravity pull')
             send_request_cgi(
               'uri' => normalize_uri(target_uri.path, 'admin', 'scripts', 'pi-hole', 'php', 'gravity.sh.php'),
-              'keep_cookies' => 'true'
+              'keep_cookies' => true
             )
           end
 
@@ -90,7 +90,7 @@ module Msf
               'vars_get' => {
                 'tab' => tab
               },
-              'keep_cookies' => 'true'
+              'keep_cookies' => true
             )
             return nil unless res or res.code == 200
             # <input type="hidden" name="token" value="t51q3YuxWT873Nn+6lCyMG4Lg840gRCgu03akuXcvTk=">

--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -188,7 +188,7 @@ class MetasploitModule < Msf::Auxiliary
     res = send_request_cgi(
       'uri' => '/top.html',
       'method' => 'GET',
-      'keep_cookies' => 'true'
+      'keep_cookies' => true
     )
 
     if res.nil?

--- a/modules/auxiliary/admin/http/pihole_domains_api_exec.rb
+++ b/modules/auxiliary/admin/http/pihole_domains_api_exec.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
       'vars_get' => {
         'tab' => 'api'
       },
-      'keep_cookies' => 'true'
+      'keep_cookies' => true
     )
 
     # check if we got hit by a login prompt
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Auxiliary
         'field' => 'API',
         'token' => token
       },
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'method' => 'POST'
     )
     fail_with(Failure::UnexpectedReply, 'Unable to save settings') unless res && res.body.include?('The API settings have been updated')

--- a/modules/auxiliary/admin/http/wp_automatic_plugin_privesc.rb
+++ b/modules/auxiliary/admin/http/wp_automatic_plugin_privesc.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-automatic', 'process_form.php'),
       'headers' => { 'X-Requested-With' => 'XMLHttpRequest' },
       'vars_post' => { key => value },
-      'keep_cookies' => 'true'
+      'keep_cookies' => true
     })
     fail_with(Failure::Unreachable, 'Site not responding') unless res
     res && res.code == 200 && res.body.include?('{"status":"success"}')

--- a/modules/auxiliary/admin/vmware/vcenter_forge_saml_token.rb
+++ b/modules/auxiliary/admin/vmware/vcenter_forge_saml_token.rb
@@ -324,7 +324,7 @@ class MetasploitModule < Msf::Auxiliary
           'SAMLResponse' => saml_response,
           'RelayState' => @vcenter_saml_relay_state
         },
-        'keep_cookies' => 'true'
+        'keep_cookies' => true
       })
     else
       res = send_request_cgi({
@@ -333,7 +333,7 @@ class MetasploitModule < Msf::Auxiliary
         'vars_post' => {
           'SAMLResponse' => saml_response
         },
-        'keep_cookies' => 'true'
+        'keep_cookies' => true
       })
     end
 

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
       # automatically handle cookies with keep_cookies.  Alternatively use cookie = res.get_cookies and 'cookie' => cookie,
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'vars_post' => {
         'username' => datastore['USERNAME'],
         'password' => datastore['PASSWORD']

--- a/modules/exploits/linux/http/panos_op_cmd_exec.rb
+++ b/modules/exploits/linux/http/panos_op_cmd_exec.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     res = send_request_cgi({
       'method' => 'GET',
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'uri' => normalize_uri(target_uri.path, 'api/'),
       'vars_get' => {
         'type' => 'version',

--- a/modules/exploits/multi/http/wp_catch_themes_demo_import.rb
+++ b/modules/exploits/multi/http/wp_catch_themes_demo_import.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
       'method' => 'POST',
       'cookie' => cookie,
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
       'data' => multipart_form.to_s
     )
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'wp-content', 'uploads', Date.today.year, month, random_filename),
       'method' => 'GET',
-      'keep_cookies' => 'true'
+      'keep_cookies' => true
     )
   end
 end

--- a/modules/exploits/multi/http/wp_popular_posts_rce.rb
+++ b/modules/exploits/multi/http/wp_popular_posts_rce.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def trigger_payload(on_disk_payload_name)
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path),
-      'keep_cookies' => 'true'
+      'keep_cookies' => true
     )
     # loop this 5 times just incase there is a time delay in writing the file by the server
     (1..5).each do |i|
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
       Rex.sleep(10)
       res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path, 'wp-content', 'uploads', 'wordpress-popular-posts', on_disk_payload_name),
-        'keep_cookies' => 'true'
+        'keep_cookies' => true
       )
     end
     if res && res.code == 404
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'wp-admin', 'options-general.php'),
       'method' => 'GET',
       'cookie' => cookie,
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'vars_get' => {
         'page' => 'wordpress-popular-posts',
         'tab' => 'debug'
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'wp-admin', 'options-general.php'),
       'method' => 'GET',
       'cookie' => cookie,
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'vars_get' => {
         'page' => 'wordpress-popular-posts',
         'tab' => 'tools'
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'wp-admin', 'options-general.php'),
       'method' => 'POST',
       'cookie' => cookie,
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'vars_get' => {
         'page' => 'wordpress-popular-posts',
         'tab' => 'debug'
@@ -191,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'wp-admin', 'options-general.php'),
       'method' => 'POST',
       'cookie' => cookie,
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'vars_get' => {
         'page' => 'wordpress-popular-posts',
         'tab' => 'debug'
@@ -210,7 +210,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi!(
       'uri' => normalize_uri(target_uri.path, 'wp-admin', 'post.php'),
       'cookie' => cookie,
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'method' => 'POST',
       'vars_post' => {
         'toggle-custom-fields-nonce' => custom_nonce,
@@ -228,7 +228,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'wp-admin', 'post-new.php'),
       'cookie' => cookie,
-      'keep_cookies' => 'true'
+      'keep_cookies' => true
     )
     fail_with(Failure::Unreachable, 'Site not responding') unless res
     fail_with(Failure::UnexpectedReply, 'Failed to retrieve page') unless res.code == 200
@@ -258,7 +258,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'index.php'),
       'method' => 'POST',
       'cookie' => cookie,
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'ctype' => 'application/json',
       'accept' => 'application/json',
       'vars_get' => {
@@ -290,7 +290,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
       'method' => 'POST',
       'cookie' => cookie,
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'vars_post' => {
         '_ajax_nonce' => 0,
         'action' => 'add-meta',
@@ -310,7 +310,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # redirect as needed
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'index.php'),
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'cookie' => cookie,
       'vars_get' => { 'page_id' => post_id }
     )
@@ -322,7 +322,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi!(
         'uri' => "/#{location}",
         'cookie' => cookie,
-        'keep_cookies' => 'true'
+        'keep_cookies' => true
       )
       # just send away, who cares about the response
       fail_with(Failure::Unreachable, 'Site not responding') unless res
@@ -333,7 +333,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'vars_get' => {
           'rest_route' => normalize_uri('wordpress-popular-posts', 'v1', 'popular-posts')
         },
-        'keep_cookies' => 'true',
+        'keep_cookies' => true,
         'method' => 'POST',
         'cookie' => cookie,
         'vars_post' => {
@@ -369,7 +369,7 @@ class MetasploitModule < Msf::Exploit::Remote
     (1..10).each do |_|
       @res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path),
-        'keep_cookies' => 'true'
+        'keep_cookies' => true
       )
       break unless @res.nil?
     end
@@ -379,7 +379,7 @@ class MetasploitModule < Msf::Exploit::Remote
     (1..10).each do |_|
       @res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path, 'index.php', 'wp-json', 'wordpress-popular-posts', 'v1', 'popular-posts', 'widget', widget_id),
-        'keep_cookies' => 'true',
+        'keep_cookies' => true,
         'vars_get' => {
           'is_single' => 0
         }

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
       'method' => 'POST',
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'vars_get' => {
         'tab' => 'blocklists'
       },
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status('Popping root shell')
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin', 'scripts', 'pi-hole', 'php', backdoor_name),
-      'keep_cookies' => 'true'
+      'keep_cookies' => true
     )
   end
 
@@ -170,13 +170,13 @@ class MetasploitModule < Msf::Exploit::Remote
       # get cookie
       res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path, 'admin', 'index.php'),
-        'keep_cookies' => 'true'
+        'keep_cookies' => true
       )
 
       # check if we need to login
       res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
-        'keep_cookies' => 'true',
+        'keep_cookies' => true,
         'vars_get' => {
           'tab' => 'blocklists'
         }

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
       'ctype' => 'application/x-www-form-urlencoded',
       'method' => 'POST',
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'vars_get' => {
         'tab' => 'piholedhcp'
       },
@@ -115,13 +115,13 @@ class MetasploitModule < Msf::Exploit::Remote
       # get cookie
       res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path, 'admin', 'index.php'),
-        'keep_cookies' => 'true'
+        'keep_cookies' => true
       )
 
       # check login
       res = send_request_cgi(
         'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
-        'keep_cookies' => 'true',
+        'keep_cookies' => true,
         'vars_get' => {
           'tab' => 'piholedhcp'
         }
@@ -197,7 +197,7 @@ class MetasploitModule < Msf::Exploit::Remote
       send_request_cgi(
         'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
         'ctype' => 'application/x-www-form-urlencoded',
-        'keep_cookies' => 'true',
+        'keep_cookies' => true,
         'method' => 'POST',
         'vars_get' => {
           'tab' => 'piholedhcp'

--- a/modules/exploits/unix/http/pihole_whitelist_exec.rb
+++ b/modules/exploits/unix/http/pihole_whitelist_exec.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # get token
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin', 'list.php'),
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'vars_get' => {
         'l' => 'white'
       }
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::BadConfig, 'Incorrect Password') if res.nil?
       # res = send_request_cgi(
       #   'uri' => normalize_uri(target_uri.path, 'admin', 'list.php'),
-      #   'keep_cookies' => 'true',
+      #   'keep_cookies' => true,
       #   'ctype' => 'application/x-www-form-urlencoded',
       #   'cookie' => cookie,
       #   'vars_get' => {
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'method' => 'POST',
       'ctype' => 'application/x-www-form-urlencoded',
-      'keep_cookies' => 'true',
+      'keep_cookies' => true,
       'uri' => normalize_uri(target_uri.path, 'admin', 'scripts', 'pi-hole', 'php', 'add.php'),
       'vars_post' => {
         'domain' => "#{rand_text_alphanumeric(3..5)}.com;#{cmd}",

--- a/modules/exploits/unix/webapp/wp_pie_register_bypass_rce.rb
+++ b/modules/exploits/unix/webapp/wp_pie_register_bypass_rce.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'log' => 'null',
         'pwd' => 'null'
       },
-      'keep_cookies' => 'true'
+      'keep_cookies' => true
     })
     fail_with(Failure::Unreachable, 'Site not responding') unless res
 


### PR DESCRIPTION
While it still validates correctly:

https://github.com/rapid7/metasploit-framework/blob/44e4714b9b9e147a80f5d07d79d08e77d8ea5619/lib/msf/core/exploit/remote/http_client.rb#L443

the original author intended `keep_cookies` to be passed a Boolean value, not a string of a Boolean.

This PR updates all the strings to Booleans.

- [ ] test any module to ensure it still works, although this is a stylistic change, not a functional code change.