### PR TITLE
Update Azure AD Scanner Error Code Check for Disabled Accounts

### DIFF
--- a/modules/auxiliary/scanner/http/azure_ad_login.rb
+++ b/modules/auxiliary/scanner/http/azure_ad_login.rb
@@ -161,6 +161,9 @@ class MetasploitModule < Msf::Auxiliary
     elsif auth_details.start_with?('AADSTS50053') # Account is locked
       print_error('Account is locked, consider taking time before continuuing to scan!')
       :next_user
+    elsif auth_details.start_with?('AADSTS50057') # User exists, but is disabled so we don't report
+      print_error("#{domain}\\#{username} exists but is disabled; it will not be reported")
+      :next_user
     else # Unknown error code
       print_error("Received unknown response with error code: #{auth_details}")
     end

--- a/modules/auxiliary/scanner/http/azure_ad_login.rb
+++ b/modules/auxiliary/scanner/http/azure_ad_login.rb
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Auxiliary
     elsif auth_details.start_with?('AADSTS50034') # User does not exist
       print_error("#{domain}\\#{username} is not a valid user")
     elsif auth_details.start_with?('AADSTS50053') # Account is locked
-      print_error('Account is locked, consider taking time before continuuing to scan!')
+      print_error('#{domain}\\#{username} is locked, consider taking time before continuing to scan!')
       :next_user
     elsif auth_details.start_with?('AADSTS50057') # User exists, but is disabled so we don't report
       print_error("#{domain}\\#{username} exists but is disabled; it will not be reported")

--- a/modules/auxiliary/scanner/http/azure_ad_login.rb
+++ b/modules/auxiliary/scanner/http/azure_ad_login.rb
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Auxiliary
     elsif auth_details.start_with?('AADSTS50034') # User does not exist
       print_error("#{domain}\\#{username} is not a valid user")
     elsif auth_details.start_with?('AADSTS50053') # Account is locked
-      print_error('#{domain}\\#{username} is locked, consider taking time before continuing to scan!')
+      print_error("#{domain}\\#{username} is locked, consider taking time before continuing to scan!")
       :next_user
     elsif auth_details.start_with?('AADSTS50057') # User exists, but is disabled so we don't report
       print_error("#{domain}\\#{username} exists but is disabled; it will not be reported")


### PR DESCRIPTION
This PR updates the error codes supported by the azure_ad_login auxiliary module to include the error code for a disabled account. It will go to the next user so that multiple passwords are not attempted on a disabled account. The original PR can be found here: https://github.com/rapid7/metasploit-framework/pull/15755 . 

This can be a pain to test if you don't have an Azure AD environment setup ready to go, so I included a screenshot of the new error code in use and with the rest of the module still working:
<img width="824" alt="azure_redacted" src="https://user-images.githubusercontent.com/9121784/193936013-eb50919b-1c2d-48fb-bad3-251ca83ec1c5.png">
