### PR TITLE
Fixes #16674 - Fixed "Manage Engine" and Updated the link

### DIFF
--- a/documentation/modules/exploit/windows/http/manageengine_adshacluster_rce.md
+++ b/documentation/modules/exploit/windows/http/manageengine_adshacluster_rce.md
@@ -1,6 +1,6 @@
 ## Description
 This module exploits a remote code execution vulnerability that exists in Exchange Reporter Plus <= 5310, caused by execution of bcp.exe file inside ADSHACluster servlet.
-Additional information can be viewed on https://security.szurek.pl/manage-engine-exchange-reporter-plus-unauthenticated-rce.html
+Additional information can be viewed on https://security.szurek.pl/en/manage-engine-exchange-reporter-plus-unauthenticated-rce/
 
 ## Verification Steps
 [Exchange Reporter Plus 5216](https://mega.nz/#!XG5CTC5I!IuG91CbrcdcpQj4teYRiBWNwy9pULRkV69U3DQ6nCyU)

--- a/modules/exploits/windows/http/manageengine_adshacluster_rce.rb
+++ b/modules/exploits/windows/http/manageengine_adshacluster_rce.rb
@@ -11,7 +11,7 @@ class MetasploitModule  < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Manage Engine Exchange Reporter Plus Unauthenticated RCE',
+      'Name'           => 'ManageEngine Exchange Reporter Plus Unauthenticated RCE',
       'Description'    => %q{
         This module exploits a remote code execution vulnerability that
         exists in Exchange Reporter Plus <= 5310, caused by execution of
@@ -24,7 +24,7 @@ class MetasploitModule  < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['URL', 'https://security.szurek.pl/manage-engine-exchange-reporter-plus-unauthenticated-rce.html']
+          ['URL', 'https://security.szurek.pl/en/manage-engine-exchange-reporter-plus-unauthenticated-rce/']
         ],
       'Platform'       => ['win'],
       'Arch'           => [ARCH_X86, ARCH_X64],
@@ -56,7 +56,7 @@ class MetasploitModule  < Msf::Exploit::Remote
     end
 
     unless res.code == 200
-      vprint_status 'Target is not Manage Engine Exchange Reporter Plus'
+      vprint_status 'Target is not ManageEngine Exchange Reporter Plus'
       return CheckCode::Safe
     end
 
@@ -64,7 +64,7 @@ class MetasploitModule  < Msf::Exploit::Remote
       json = res.get_json_document
       raise if json.empty? || !json['BUILD_NUMBER']
     rescue
-      vprint_status 'Target is not Manage Engine Exchange Reporter Plus'
+      vprint_status 'Target is not ManageEngine Exchange Reporter Plus'
       return CheckCode::Safe
     end
 


### PR DESCRIPTION
Fixes #16674 

This change Fixes "**Manage Engine**" to be "**ManageEngine**" in 
_"exploit/windows/http/manageengine_adshacluster_rce"_ to be consistent
with literally every other module and update the link as well to 
"https://security.szurek.pl/en/manage-engine-exchange-reporter-plus-unauthenticated-rce/"
as requested in Issue #16674.

This change has been observed in metasploit v6.2.22-dev-36f4c702b3
on Linux kali 5.18 (x86_64) with kernel version 5.18.0-kali5-amd64

## Verification

Steps to check the changes:

- [x] Start `msfconsole`
- [x] `use exploit/windows/http/manageengine_adshacluster_rce`
- [x] 'show info'
- [x] **Verify** the changes results with the unchanged results

![link update and 'Manage Engine' bugfix](https://user-images.githubusercontent.com/97749978/194489559-89b1d9d7-15ce-4293-b879-5e147ea9891d.png)

