### PR TITLE
Adds support to specify a shared directory to iterate through and highlight keywords

### DIFF
--- a/documentation/modules/auxiliary/scanner/smb/smb_enumshares.md
+++ b/documentation/modules/auxiliary/scanner/smb/smb_enumshares.md
@@ -1,15 +1,49 @@
-## Description
+## Vulnerable Application
+
+This module has been tested successfully against:
+- Windows server 2019
+- Windows server 2016
+- Windows 10
+
+### Description
 
 The `smb_enumshares` module, as would be expected, enumerates any SMB shares that are available on a remote system.
 The module can also recursively go through each directory in each share and gather information about the files inside them.
 On some systems such as Windows 7, it can also iterate over user directories and `%appdata%`.
 
+## Options
+
+```
+set RHOSTS [string]
+```
+This is the target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit for more information.
+
+```
+set SpiderProfiles [boolean]
+```
+This is used to enable the module to only spider user profiles when share is a disk share.
+
+```
+set SpiderShares [boolean]
+```
+This is used to enable the module to spider shares recursively.
+
+```
+set ShowFiles [boolean]
+```
+This is used to enable the module to show detailed information when spidering.
+
+```
+set Share [string]
+```
+Can be set to only enumerate over a specific share.
+
 ## Verification Steps
 
-1. Do: ```use auxiliary/scanner/smb/smb_enumshares```
-2. Do: ```set RHOSTS [IP]```
-3. Do: ```set THREADS [number of threads]```
-4. Do: ```run```
+1. Do: `use auxiliary/scanner/smb/smb_enumshares`
+2. Do: `set RHOSTS [IP]`
+3. Do: `set THREADS [number of threads]`
+4. Do: `run`
 
 ## Scenarios
 
@@ -59,3 +93,31 @@ msf6 auxiliary(scanner/smb/smb_enumshares) > run
 [*] Auxiliary module execution completed
 ```
 The disconnect on port 139 happens because Windows 10 uses SMB3, which operates on port 445 instead.
+
+### Credentialed - Windows server 2019
+
+This scenario makes use of the `Share` option, that is used to pass a specific share to be enumerated. The module is
+also being ran with inline options in this scenario.
+
+```
+msf6 auxiliary(scanner/smb/smb_enumshares) > run smb://<Account>:<Password>@<TargetIP> spidershares=true showfiles=true share=<Share directory name>
+
+[*] <TargetIP>   - Starting module
+[-] <TargetIP>   - Login Failed: The SMB server did not reply to our request
+[*] <TargetIP>   - Starting module
+[!] <TargetIP>   - peer_native_os is only available with SMB1 (current version: SMB3)
+[!] <TargetIP>   - peer_native_lm is only available with SMB1 (current version: SMB3)
+[+] <TargetIP>   - my_share - (DISK)
+[+] <TargetIP>   -  \\VB\my_share
+==============
+
+ Type  Name            Created                    Accessed                   Written                    Changed                    Size
+ ----  ----            -------                    --------                   -------                    -------                    ----
+ FILE  Passwords.txt   2022-10-12T11:41:51+01:00  2022-10-12T11:41:51+01:00  2022-10-12T11:41:51+01:00  2022-10-12T17:08:44+01:00  0
+ FILE  paSsWords1.txt  2022-10-12T11:52:00+01:00  2022-10-12T11:52:00+01:00  2022-10-12T11:52:00+01:00  2022-10-12T17:08:59+01:00  0
+ FILE  test.txt        2022-10-07T17:49:36+01:00  2022-10-07T17:49:36+01:00  2022-10-07T17:49:36+01:00  2022-10-07T17:49:39+01:00  0
+
+[+] 192.168.175.129:445   - info saved in: /Users/<user>/.msf4/loot/20221026120037_default_192.168.175.129_smb.enumshares_935447.txt
+[*] smb://<Account>:<Password>@<TargetIP>: - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```


### PR DESCRIPTION
This PR makes changes to the `modules/auxiliary/scanner/smb/smb_enumshares.rb` module, the PR will add support for users to be able to specify which shared directory they would like to iterate through. It also adds support for keyword highlighting, currently it only highlights filenames with that include "password".

Also updates the docs.

## Examples
**When a shared directory that exists on the target machine is passed as a module option:**
![image](https://user-images.githubusercontent.com/69522014/198273892-175b04c0-4845-4b46-b6ed-d5f05d06800e.png)

**When a shared directory is passed that does not exist on the target machine is passed as a module option:**
![image](https://user-images.githubusercontent.com/69522014/198273933-185d9964-f14b-49e5-b363-5e51ed3d5f6d.png)

In this scenario an error will be returned to the user and will instead return all shares present on the target machine.
```
[-] 192.168.175.135:445   - No shares match my_shar
```

**If no option is set for `Share`, the module will function as normal and return all shares**
## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Run `use auxiliary/scanner/smb/smb_enumshares`
- [ ] Run `run smb://<Account>:<Password>@<TargetIP> spidershares=true showfiles=true share=<Share directory name>`
- [ ] **Verify** the module functions as it did before these changes
- [ ] **Verify** the module functions as the example above demonstrate
