### PR TITLE
improve qualys import times

### DIFF
--- a/lib/msf/core/db_manager/import/qualys.rb
+++ b/lib/msf/core/db_manager/import/qualys.rb
@@ -7,7 +7,6 @@ module Msf::DBManager::Import::Qualys
 
   TCP_QID = 82023
   UDP_QID = 82004
-  RESULT_FILTER = %r{(?<needle><QID id=.qid_(?!#{TCP_QID}|!#{UDP_QID}).*?<\/QID>.*?)<RESULT[>| format="table">].*?<\/RESULT>}m
 
   #
   # Qualys report parsing/handling

--- a/lib/msf/core/db_manager/import/qualys.rb
+++ b/lib/msf/core/db_manager/import/qualys.rb
@@ -5,6 +5,10 @@ module Msf::DBManager::Import::Qualys
   include Msf::DBManager::Import::Qualys::Asset
   include Msf::DBManager::Import::Qualys::Scan
 
+  TCP_QID = 82023
+  UDP_QID = 82004
+  RESULT_FILTER = %r{(?<needle><QID id=.qid_(?!#{TCP_QID}|!#{UDP_QID}).*?<\/QID>.*?)<RESULT[>| format="table">].*?<\/RESULT>}m
+
   #
   # Qualys report parsing/handling
   #

--- a/lib/msf/core/db_manager/import/qualys/asset.rb
+++ b/lib/msf/core/db_manager/import/qualys/asset.rb
@@ -28,11 +28,11 @@ module Msf::DBManager::Import::Qualys::Asset
       vuln_refs[qid] ||= []
       vuln.xpath('CVE_ID_LIST/CVE_ID').each do |ref|
         id = ref.xpath("ID").first&.text
-        vuln_refs[qid].push("CVE-#{id}") if id
+        vuln_refs[qid].push(id) if id
       end
       vuln.xpath('BUGTRAQ_ID_LIST/BUGTRAQ_ID').each do |ref|
         id = ref.xpath("ID").first&.text
-        vuln_refs[qid].push("CVE-#{id}") if id
+        vuln_refs[qid].push("BID-#{id}") if id
       end
     end
     return vuln_refs

--- a/lib/msf/core/db_manager/import/qualys/asset.rb
+++ b/lib/msf/core/db_manager/import/qualys/asset.rb
@@ -24,7 +24,7 @@ module Msf::DBManager::Import::Qualys::Asset
     doc.xpath("/ASSET_DATA_REPORT/GLOSSARY/VULN_DETAILS_LIST/VULN_DETAILS").each do |vuln|
       qid_el = vuln.xpath('QID')
       next unless qid_el && qid_el.first
-      qid = vuln.xpath('QID').text
+      qid = qid_el.first.text
       vuln_refs[qid] ||= []
       vuln.xpath('CVE_ID_LIST/CVE_ID').each do |ref|
         id = ref.xpath("ID").first&.text

--- a/lib/msf/core/db_manager/import/qualys/asset.rb
+++ b/lib/msf/core/db_manager/import/qualys/asset.rb
@@ -2,8 +2,8 @@ module Msf::DBManager::Import::Qualys::Asset
   # Takes QID numbers and finds the discovered services in
   # a qualys_asset_xml.
   def find_qualys_asset_ports(i,host,wspace,hobj,task_id)
-    return unless (i == 82023 || i == 82004)
-    proto = i == 82023 ? 'tcp' : 'udp'
+    return unless (i == Msf::DBManager::Import::Qualys::TCP_QID || i == Msf::DBManager::Import::Qualys::UDP_QID)
+    proto = i == Msf::DBManager::Import::Qualys::TCP_QID ? 'tcp' : 'udp'
     qid = host.elements["VULN_INFO_LIST/VULN_INFO/QID[@id='qid_#{i}']"]
     qid_result = qid.parent.elements["RESULT[@format='table']"] if qid
     hports = qid_result.first.to_s if qid_result
@@ -51,7 +51,8 @@ module Msf::DBManager::Import::Qualys::Asset
   # Import Qualys's Asset Data Report format
   #
   def import_qualys_asset_xml(args={}, &block)
-    data = args[:data]
+    # drop `RESULT` tags not consumed by the parser to increase efficiency
+    data = args[:data].gsub(Msf::DBManager::Import::Qualys::RESULT_FILTER, '\k<needle>')
     wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
     doc = rexmlify(data)

--- a/lib/msf/core/db_manager/import/qualys/asset.rb
+++ b/lib/msf/core/db_manager/import/qualys/asset.rb
@@ -4,9 +4,9 @@ module Msf::DBManager::Import::Qualys::Asset
   def find_qualys_asset_ports(i,host,wspace,hobj,task_id)
     return unless (i == Msf::DBManager::Import::Qualys::TCP_QID || i == Msf::DBManager::Import::Qualys::UDP_QID)
     proto = i == Msf::DBManager::Import::Qualys::TCP_QID ? 'tcp' : 'udp'
-    qid = host.elements["VULN_INFO_LIST/VULN_INFO/QID[@id='qid_#{i}']"]
-    qid_result = qid.parent.elements["RESULT[@format='table']"] if qid
-    hports = qid_result.first.to_s if qid_result
+    qid = host.xpath("VULN_INFO_LIST/VULN_INFO/QID[@id='qid_#{i}']").first
+    qid_result = qid.parent.xpath("RESULT[@format='table']") if qid
+    hports = qid_result.first.text if qid_result
     if hports
       hports.scan(/([0-9]+)\t(.*?)\t.*?\t([^\t\n]*)/) do |match|
         if match[2] == nil or match[2].strip == 'unknown'
@@ -21,15 +21,18 @@ module Msf::DBManager::Import::Qualys::Asset
 
   def find_qualys_asset_vuln_refs(doc)
     vuln_refs = {}
-    doc.elements.each("/ASSET_DATA_REPORT/GLOSSARY/VULN_DETAILS_LIST/VULN_DETAILS") do |vuln|
-      next unless vuln.elements['QID'] && vuln.elements['QID'].first
-      qid = vuln.elements['QID'].first.to_s
+    doc.xpath("/ASSET_DATA_REPORT/GLOSSARY/VULN_DETAILS_LIST/VULN_DETAILS").each do |vuln|
+      qid_el = vuln.xpath('QID')
+      next unless qid_el && qid_el.first
+      qid = vuln.xpath('QID').text
       vuln_refs[qid] ||= []
-      vuln.elements.each('CVE_ID_LIST/CVE_ID') do |ref|
-        vuln_refs[qid].push('CVE-' + /C..-([0-9\-]{9,})/.match(ref.elements['ID'].text.to_s)[1])
+      vuln.xpath('CVE_ID_LIST/CVE_ID').each do |ref|
+        id = ref.xpath("ID").first&.text
+        vuln_refs[qid].push("CVE-#{id}") if id
       end
-      vuln.elements.each('BUGTRAQ_ID_LIST/BUGTRAQ_ID') do |ref|
-        vuln_refs[qid].push('BID-' + ref.elements['ID'].text.to_s)
+      vuln.xpath('BUGTRAQ_ID_LIST/BUGTRAQ_ID').each do |ref|
+        id = ref.xpath("ID").first&.text
+        vuln_refs[qid].push("CVE-#{id}") if id
       end
     end
     return vuln_refs
@@ -38,9 +41,9 @@ module Msf::DBManager::Import::Qualys::Asset
   # Pull out vulnerabilities that have at least one matching
   # ref -- many "vulns" are not vulns, just audit information.
   def find_qualys_asset_vulns(host,wspace,hobj,vuln_refs,task_id,&block)
-    host.elements.each("VULN_INFO_LIST/VULN_INFO") do |vi|
-      next unless vi.elements["QID"]
-      vi.elements.each("QID") do |qid|
+    host.xpath("VULN_INFO_LIST/VULN_INFO").each do |vi|
+      next unless vi.xpath("QID").first
+      vi.xpath("QID").each do |qid|
         next if vuln_refs[qid.text].nil? || vuln_refs[qid.text].empty?
         handle_qualys(wspace, hobj, nil, nil, qid.text, nil, vuln_refs[qid.text], nil, nil, task_id)
       end
@@ -51,32 +54,35 @@ module Msf::DBManager::Import::Qualys::Asset
   # Import Qualys's Asset Data Report format
   #
   def import_qualys_asset_xml(args={}, &block)
-    # drop `RESULT` tags not consumed by the parser to increase efficiency
-    data = args[:data].gsub(Msf::DBManager::Import::Qualys::RESULT_FILTER, '\k<needle>')
+    data = args[:data]
     wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
-    doc = rexmlify(data)
+    doc = Nokogiri.XML(data)
     vuln_refs = find_qualys_asset_vuln_refs(doc)
 
     # 2nd pass, actually grab the hosts.
-    doc.elements.each("/ASSET_DATA_REPORT/HOST_LIST/HOST") do |host|
+    doc.xpath("/ASSET_DATA_REPORT/HOST_LIST/HOST").each do |host|
       hobj = nil
-      addr = host.elements["IP"].text if host.elements["IP"]
+      addr_el = host.xpath("IP").first
+      addr = addr_el.text if addr_el
       next unless validate_ips(addr)
       if bl.include? addr
         next
       else
         yield(:address,addr) if block
       end
+      netbios_el = host.xpath("NETBIOS").first
+      dns_el = host.xpath("DNS").first
       hname = ( # Prefer NetBIOS over DNS
-        (host.elements["NETBIOS"].text if host.elements["NETBIOS"]) ||
-         (host.elements["DNS"].text if host.elements["DNS"]) ||
+        (netbios_el.text if netbios_el) ||
+         (dns_el.text if dns_el) ||
          "" )
       hobj = report_host(:workspace => wspace, :host => addr, :name => hname, :state => Msf::HostState::Alive, :task => args[:task])
       report_import_note(wspace,hobj)
 
-      if host.elements["OPERATING_SYSTEM"]
-        hos = host.elements["OPERATING_SYSTEM"].text
+      os_el = host.xpath("OPERATING_SYSTEM").first
+      if os_el
+        hos = os_el.text
         report_note(
           :workspace => wspace,
           :task => args[:task],

--- a/lib/msf/core/db_manager/import/qualys/scan.rb
+++ b/lib/msf/core/db_manager/import/qualys/scan.rb
@@ -5,22 +5,23 @@ module Msf::DBManager::Import::Qualys::Scan
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
 
 
-    doc = rexmlify(data)
-    doc.elements.each('/SCAN/IP') do |host|
+    doc = Nokogiri.XML(data)
+    doc.xpath('/SCAN/IP').each do |host|
       hobj = nil
-      addr  = host.attributes['value']
+      addr  = host.attr('value')
       if bl.include? addr
         next
       else
         yield(:address,addr) if block
       end
-      hname = host.attributes['name'] || ''
+      hname = host.attr('name') || ''
 
       hobj = report_host(:workspace => wspace, :host => addr, :name => hname, :state => Msf::HostState::Alive, :task => args[:task])
       report_import_note(wspace,hobj)
 
-      if host.elements["OS"]
-        hos = host.elements["OS"].text
+      os_el = host.xpath("OS").first
+      if os_el
+        hos = os_el.text
         report_note(
           :workspace => wspace,
           :task => args[:task],
@@ -33,7 +34,7 @@ module Msf::DBManager::Import::Qualys::Scan
       end
 
       # Open TCP Services List (Qualys ID 82023)
-      services_tcp = host.elements["SERVICES/CAT/SERVICE[@number='#{Msf::DBManager::Import::Qualys::TCP_QID}']/RESULT"]
+      services_tcp = host.xpath("SERVICES/CAT/SERVICE[@number='#{Msf::DBManager::Import::Qualys::TCP_QID}']/RESULT").first
       if services_tcp
         services_tcp.text.scan(/([0-9]+)\t(.*?)\t.*?\t([^\t\n]*)/) do |match|
           if match[2] == nil or match[2].strip == 'unknown'
@@ -45,7 +46,7 @@ module Msf::DBManager::Import::Qualys::Scan
         end
       end
       # Open UDP Services List (Qualys ID 82004)
-      services_udp = host.elements["SERVICES/CAT/SERVICE[@number='#{Msf::DBManager::Import::Qualys::UDP_QID}']/RESULT"]
+      services_udp = host.xpath("SERVICES/CAT/SERVICE[@number='#{Msf::DBManager::Import::Qualys::UDP_QID}']/RESULT").first
       if services_udp
         services_udp.text.scan(/([0-9]+)\t(.*?)\t.*?\t([^\t\n]*)/) do |match|
           if match[2] == nil or match[2].strip == 'unknown'
@@ -58,22 +59,25 @@ module Msf::DBManager::Import::Qualys::Scan
       end
 
       # VULNS are confirmed, PRACTICES are unconfirmed vulnerabilities
-      host.elements.each('VULNS/CAT | PRACTICES/CAT') do |cat|
-        port = cat.attributes['port']
-        protocol = cat.attributes['protocol']
-        cat.elements.each('VULN | PRACTICE') do |vuln|
+      host.xpath('VULNS/CAT | PRACTICES/CAT').each do |cat|
+        port = cat.attr('port')
+        protocol = cat.attr('protocol')
+        cat.xpath('VULN | PRACTICE').each do |vuln|
           refs = []
-          qid = vuln.attributes['number']
-          severity = vuln.attributes['severity']
-          title = vuln.elements['TITLE'].text.to_s
-          vuln.elements.each('VENDOR_REFERENCE_LIST/VENDOR_REFERENCE') do |ref|
-            refs.push(ref.elements['ID'].text.to_s)
+          qid = vuln.attr('number')
+          severity = vuln.attr('severity')
+          title = vuln.xpath('TITLE').first&.text
+          vuln.xpath('VENDOR_REFERENCE_LIST/VENDOR_REFERENCE').each do |ref|
+            id = ref.xpath('ID').first&.text
+            refs.push(id) if id
           end
-          vuln.elements.each('CVE_ID_LIST/CVE_ID') do |ref|
-            refs.push('CVE-' + /C..-([0-9\-]{9,})/.match(ref.elements['ID'].text.to_s)[1])
+          vuln.xpath('CVE_ID_LIST/CVE_ID').each do |ref|
+            id = ref.xpath("ID").first&.text
+            refs.push("CVE-#{id}") if id
           end
-          vuln.elements.each('BUGTRAQ_ID_LIST/BUGTRAQ_ID') do |ref|
-            refs.push('BID-' + ref.elements['ID'].text.to_s)
+          vuln.xpath('BUGTRAQ_ID_LIST/BUGTRAQ_ID').each do |ref|
+            id = ref.xpath("ID").first&.text
+            refs.push("CVE-#{id}") if id
           end
 
           handle_qualys(wspace, hobj, port, protocol, qid, severity, refs, nil,title, args[:task])
@@ -92,8 +96,6 @@ module Msf::DBManager::Import::Qualys::Scan
     ::File.open(filename, 'rb') do |f|
       data = f.read(f.stat.size)
     end
-    # drop `RESULT` tags not consumed by the parser to increase efficiency
-    data.gsub!(Msf::DBManager::Import::Qualys::RESULT_FILTER, '\k<needle>')
     import_qualys_scan_xml(args.merge(:data => data))
   end
 end

--- a/lib/msf/core/db_manager/import/qualys/scan.rb
+++ b/lib/msf/core/db_manager/import/qualys/scan.rb
@@ -73,11 +73,11 @@ module Msf::DBManager::Import::Qualys::Scan
           end
           vuln.xpath('CVE_ID_LIST/CVE_ID').each do |ref|
             id = ref.xpath("ID").first&.text
-            refs.push("CVE-#{id}") if id
+            refs.push(id) if id
           end
           vuln.xpath('BUGTRAQ_ID_LIST/BUGTRAQ_ID').each do |ref|
             id = ref.xpath("ID").first&.text
-            refs.push("CVE-#{id}") if id
+            refs.push("BID-#{id}") if id
           end
 
           handle_qualys(wspace, hobj, port, protocol, qid, severity, refs, nil,title, args[:task])

--- a/lib/msf/core/db_manager/import/qualys/scan.rb
+++ b/lib/msf/core/db_manager/import/qualys/scan.rb
@@ -33,7 +33,7 @@ module Msf::DBManager::Import::Qualys::Scan
       end
 
       # Open TCP Services List (Qualys ID 82023)
-      services_tcp = host.elements["SERVICES/CAT/SERVICE[@number='82023']/RESULT"]
+      services_tcp = host.elements["SERVICES/CAT/SERVICE[@number='#{Msf::DBManager::Import::Qualys::TCP_QID}']/RESULT"]
       if services_tcp
         services_tcp.text.scan(/([0-9]+)\t(.*?)\t.*?\t([^\t\n]*)/) do |match|
           if match[2] == nil or match[2].strip == 'unknown'
@@ -45,7 +45,7 @@ module Msf::DBManager::Import::Qualys::Scan
         end
       end
       # Open UDP Services List (Qualys ID 82004)
-      services_udp = host.elements["SERVICES/CAT/SERVICE[@number='82004']/RESULT"]
+      services_udp = host.elements["SERVICES/CAT/SERVICE[@number='#{Msf::DBManager::Import::Qualys::UDP_QID}']/RESULT"]
       if services_udp
         services_udp.text.scan(/([0-9]+)\t(.*?)\t.*?\t([^\t\n]*)/) do |match|
           if match[2] == nil or match[2].strip == 'unknown'
@@ -92,6 +92,8 @@ module Msf::DBManager::Import::Qualys::Scan
     ::File.open(filename, 'rb') do |f|
       data = f.read(f.stat.size)
     end
+    # drop `RESULT` tags not consumed by the parser to increase efficiency
+    data.gsub!(Msf::DBManager::Import::Qualys::RESULT_FILTER, '\k<needle>')
     import_qualys_scan_xml(args.merge(:data => data))
   end
 end


### PR DESCRIPTION
~When importing data from recent Qualys reports many `RESULT` tags contain extra long lines and significant content that result in extremely long processing times when parsed by REXML. By removing all `RESULT` tags not currently processed during import the time to process data can be significantly improved.~

~This drops all `RESULTS` not associated with TCP/UDP service listing prior to parsing the XML from the file.~

EDIT: Revised approach uses `Nokigiri::XML` document and Xpath for improved performance over REXML without mangling the input data.

I can see lots of possible iteration for improvement of import by processing more `RESULT` data from the Qualys report however at this time only hosts, services, and vulns are imported and no other parsing is done for `RESULT` tags.

If anyone has recommendations on a better way to organize the constants defined here please comment, the current change just attempts to adjust the values to a single definition.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `db_import <QUALYS_DATA_FILE>`
- [x] **Verify** Host / Service / Vuln data imports in to the database with same values as prior to change

