### PR TITLE
Remote mouse version updates

### DIFF
--- a/documentation/modules/exploit/windows/misc/remote_mouse_rce.md
+++ b/documentation/modules/exploit/windows/misc/remote_mouse_rce.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 This module utilizes the Remote Mouse Server by Emote Interactive protocol
-to deploy a payload and run it from the server on versions < 4.502 (510 server response).
+to deploy a payload and run it from the server on versions < 4.200 (500 server response).
 This module will deploy
 a payload regardless if server authentication is required.
 Tested against 4.110, current at the time of module writing

--- a/documentation/modules/exploit/windows/misc/remote_mouse_rce.md
+++ b/documentation/modules/exploit/windows/misc/remote_mouse_rce.md
@@ -1,11 +1,13 @@
 ## Vulnerable Application
 
 This module utilizes the Remote Mouse Server by Emote Interactive protocol
-to deploy a payload and run it from the server.  This module will deploy
+to deploy a payload and run it from the server on versions < 4.502 (510 server response).
+This module will deploy
 a payload regardless if server authentication is required.
 Tested against 4.110, current at the time of module writing
 
-Version 4.110 can be downloaded from https://www.remotemouse.net/downloads/RemoteMouse.exe
+Version 4.110 can be downloaded from
+(unofficial site)[https://remote-mouse.en.uptodown.com/windows/download/4546712]
     
 ## Verification Steps
 

--- a/modules/exploits/windows/misc/remote_mouse_rce.rb
+++ b/modules/exploits/windows/misc/remote_mouse_rce.rb
@@ -19,7 +19,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Remote Mouse RCE',
         'Description' => %q{
           This module utilizes the Remote Mouse Server by Emote Interactive protocol
-          to deploy a payload and run it from the server.  This module will only deploy
+          to deploy a payload and run it from the server on versions < 4.502 (510 server response).
+          This module will only deploy
           a payload if the server is set without a password (default).
           Tested against 4.110, current at the time of module writing
         },
@@ -110,7 +111,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
     if response.include?('SIN 15win nop nop')
       splits = response.split(' ')
-      return CheckCode::Appears("Received handshake with version: #{splits.last}")
+      return CheckCode::Appears("Received handshake with version: #{splits.last}") if splits.last.to_i < 500
+
+      return CheckCode::Safe("Received handshake with version: #{splits.last}, which is not exploitable")
     end
 
     CheckCode::Unknown('Invalid response from target')

--- a/modules/exploits/windows/misc/remote_mouse_rce.rb
+++ b/modules/exploits/windows/misc/remote_mouse_rce.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Remote Mouse RCE',
         'Description' => %q{
           This module utilizes the Remote Mouse Server by Emote Interactive protocol
-          to deploy a payload and run it from the server on versions < 4.502 (510 server response).
+          to deploy a payload and run it from the server on versions < 4.200 (500 server response).
           This module will only deploy
           a payload if the server is set without a password (default).
           Tested against 4.110, current at the time of module writing


### PR DESCRIPTION
As per discussion here: https://github.com/rapid7/metasploit-framework/pull/17067#issuecomment-1279339260

Implement an upper bounds on the exploitable versions of remote mouse and update the documentation with a vulnerable download link.

## Verification

- [ ] update your remote mouse software
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/misc/remote_mouse_rce`
- [ ] `set rhost`
- [ ] run `check` and make sure it gracefully exits since the new version isn't exploitable
