### PR TITLE
Check global LHOST before generating it from RHOSTS

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -276,8 +276,8 @@ class Exploit
       excluded_platforms: ['Multi'] # We don't want to select a multi payload
     ).map(&:first)
 
-    # XXX: Determine LHOST based on RHOST or an arbitrary internet address
-    lhost = Rex::Socket.source_address(mod.datastore['RHOST'] || '50.50.50.50')
+    # XXX: Determine LHOST based on global LHOST, RHOST or an arbitrary internet address
+    lhost = mod.datastore['LHOST'] || Rex::Socket.source_address(mod.datastore['RHOST'] || '50.50.50.50')
 
     configure_payload = lambda do |payload|
       if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)


### PR DESCRIPTION
Fixes #17107

This change fixes [Issue 17107](https://github.com/rapid7/metasploit-framework/issues/17107) by checking the global value of LHOST before generating it from RHOSTS

## Verification

- [x] Start `msfconsole`
- [x] `setg LHOST 127.0.0.1`
- [x] `setg RHOSTS 192.168.1.124` (or other host on different interface)
- [x] `use exploit/windows/http/netgear_nms_rce`  (any exploit module works)
- [x] `options`
- [x] See global LHOST is respected 🥲 
<img width="1075" alt="respec_lhost" src="https://user-images.githubusercontent.com/9121784/196300307-65f1f39a-f38b-4c90-ae58-32d8a9fd660f.png">
