### PR TITLE
Bump actions/checkout to version 3.x so we use NodeJs 16.x

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
         run: sudo apt-get install libpcap-dev graphviz
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # Required to checkout HEAD^ and 3a046f01dae340c124dd3895e670983aef5fe0c5 for the msftidy script
         # https://github.com/actions/checkout/tree/5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f#checkout-head
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -33,7 +33,7 @@ jobs:
     name: Docker Build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: docker-compose build
         run: |
@@ -93,7 +93,7 @@ jobs:
         run: sudo apt-get install libpcap-dev graphviz
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         env:


### PR DESCRIPTION
Bump the NodeJS version used for Verify.yml to fix the following issue:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout
```

Issue was first encountered on @h00die's PR at https://github.com/h00die/metasploit-framework/actions/runs/3267771315
