### PR TITLE
Msf::Post::File.append_file: Append not overwrite on *nix shell sessions

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -540,7 +540,7 @@ module Msf::Post::File
           return _win_bin_append_file(file_name, data)
         end
       else
-        return _write_file_unix_shell(file_name, data)
+        return _append_file_unix_shell(file_name, data)
       end
     end
     true
@@ -907,6 +907,17 @@ protected
       file_rm(b64_filename)
       file_rm(tmp_filename)
     end
+  end
+
+  #
+  # Append +data+ to the remote file +file_name+.
+  #
+  # You should never call this method directly. Instead, call {#append_file}
+  # which will call this method if it is appropriate for the given session.
+  #
+  # @return [void]
+  def _append_file_unix_shell(file_name, data)
+    _write_file_unix_shell(file_name, data, true)
   end
 
   #


### PR DESCRIPTION
File append for Unix shell sessions was broken by e24dc806da17e996176afe946f61ffb8d98000c9 in #15362 when fixing support for file append for Windows hosts.

# Reproduce

```ruby
def exploit
  f = '/tmp/asdf'
  puts read_file(f)
  data = rand_text_alpha(10)
  print_status("Appending #{data} to #{f}")
  append_file(f, data)
  puts read_file(f)
end
```

# Before

```
msf6 exploit(linux/local/test) > rexploit 
[*] Reloading module...

[!] SESSION may not be compatible with this module:
[!]  * incompatible session architecture: cmd
[*] Started reverse TCP handler on 192.168.200.130:4444 

[*] Appending bEYzyAymud to /tmp/asdf
bEYzyAymud
[*] Exploit completed, but no session was created.
msf6 exploit(linux/local/test) > rexploit
[*] Reloading module...

[!] SESSION may not be compatible with this module:
[!]  * incompatible session architecture: cmd
[*] Started reverse TCP handler on 192.168.200.130:4444 
bEYzyAymud
[*] Appending dYLUQQkbbw to /tmp/asdf
dYLUQQkbbw
[*] Exploit completed, but no session was created.
msf6 exploit(linux/local/test) > rexploit
[*] Reloading module...

[!] SESSION may not be compatible with this module:
[!]  * incompatible session architecture: cmd
[*] Started reverse TCP handler on 192.168.200.130:4444 
dYLUQQkbbw
[*] Appending JPUCRkyccw to /tmp/asdf
JPUCRkyccw
[*] Exploit completed, but no session was created.
```

# After

```
msf6 exploit(linux/local/test) > rexploit 
[*] Reloading module...

[!] SESSION may not be compatible with this module:
[!]  * incompatible session architecture: cmd
[*] Started reverse TCP handler on 192.168.200.130:4444 
JPUCRkyccw
[*] Appending jQPlVwtFVY to /tmp/asdf
JPUCRkyccwjQPlVwtFVY
[*] Exploit completed, but no session was created.
msf6 exploit(linux/local/test) > 
```
