### PR TITLE
scanner/smb/smb_login Kerberos Authentication Support

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -120,7 +120,7 @@ module Metasploit
                 if tree.permissions.add_file == 1
                   access_level = AccessLevels::ADMINISTRATOR
                 end
-              rescue StandardError
+              rescue StandardError => _e
                 client.tree_connect("\\\\#{host}\\IPC$")
               end
             end
@@ -140,8 +140,10 @@ module Metasploit
           rescue ::Rex::ConnectionError, Errno::EINVAL, RubySMB::Error::NetBiosSessionService => e
             status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             proof = e
-          rescue RubySMB::Error::UnexpectedStatusCode
+          rescue RubySMB::Error::UnexpectedStatusCode => _e
             status = Metasploit::Model::Login::Status::INCORRECT
+          rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
+            status = Metasploit::Framework::LoginScanner::Kerberos.login_status_for_kerberos_error(e)
           ensure
             client.disconnect! if client
           end

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -7,7 +7,6 @@ require 'ruby_smb'
 module Metasploit
   module Framework
     module LoginScanner
-
       # This is the LoginScanner class for dealing with the Server Messaging
       # Block protocol.
       class SMB
@@ -22,18 +21,18 @@ module Metasploit
           # This definition is not without its problems, but suffices to
           # conclude that such a user will most likely be able to use
           # psexec.
-          ADMINISTRATOR = "Administrator"
+          ADMINISTRATOR = 'Administrator'.freeze
           # Guest access means our creds were accepted but the logon
           # session is not associated with a real user account.
-          GUEST = "Guest"
+          GUEST = 'Guest'.freeze
         end
 
-        CAN_GET_SESSION      = true
-        DEFAULT_REALM        = 'WORKSTATION'
-        LIKELY_PORTS         = [ 445 ]
-        LIKELY_SERVICE_NAMES = [ "smb" ]
-        PRIVATE_TYPES        = [ :password, :ntlm_hash ]
-        REALM_KEY            = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
+        CAN_GET_SESSION = true
+        DEFAULT_REALM = 'WORKSTATION'.freeze
+        LIKELY_PORTS = [ 445 ].freeze
+        LIKELY_SERVICE_NAMES = [ 'smb' ].freeze
+        PRIVATE_TYPES = %i[password ntlm_hash].freeze
+        REALM_KEY = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
 
         module StatusCodes
           CORRECT_CREDENTIAL_STATUS_CODES = [
@@ -66,26 +65,25 @@ module Metasploit
         #   empty string for local accounts.
         # @return [Result]
         def attempt_bogus_login(domain)
-          if defined?(@result_for_bogus)
-            return @result_for_bogus
+          if defined?(@attempt_bogus_login)
+            return @attempt_bogus_login
           end
+
           cred = Credential.new(
             public: Rex::Text.rand_text_alpha(8),
             private: Rex::Text.rand_text_alpha(8),
             realm: domain
           )
-          @result_for_bogus = attempt_login(cred)
+          @attempt_bogus_login = attempt_login(cred)
         end
-
 
         # (see Base#attempt_login)
         def attempt_login(credential)
-
           begin
             connect
           rescue ::Rex::ConnectionError => e
             result = Result.new(
-              credential:credential,
+              credential: credential,
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
               proof: e,
               host: host,
@@ -98,16 +96,15 @@ module Metasploit
           proof = nil
 
           begin
-            realm       = (credential.realm   || "").force_encoding('UTF-8')
-            username    = (credential.public  || "").force_encoding('UTF-8')
-            password    = (credential.private || "").force_encoding('UTF-8')
-            client      = RubySMB::Client.new(self.dispatcher, username: username, password: password, domain: realm)
+            realm = (credential.realm || '').force_encoding('UTF-8')
+            username = (credential.public || '').force_encoding('UTF-8')
+            password = (credential.private || '').force_encoding('UTF-8')
+            client = RubySMB::Client.new(dispatcher, username: username, password: password, domain: realm)
 
             if kerberos_authenticator_factory
               client.extend(Msf::Exploit::Remote::SMB::Client::KerberosAuthentication)
               client.kerberos_authenticator = kerberos_authenticator_factory.call(username, password, realm)
             end
-
 
             status_code = client.login
 
@@ -123,27 +120,27 @@ module Metasploit
                 if tree.permissions.add_file == 1
                   access_level = AccessLevels::ADMINISTRATOR
                 end
-              rescue Exception => e
+              rescue StandardError
                 client.tree_connect("\\\\#{host}\\IPC$")
               end
             end
 
             case status_code
-              when WindowsError::NTStatus::STATUS_SUCCESS, WindowsError::NTStatus::STATUS_PASSWORD_MUST_CHANGE, WindowsError::NTStatus::STATUS_PASSWORD_EXPIRED
-                status = Metasploit::Model::Login::Status::SUCCESSFUL
-              when WindowsError::NTStatus::STATUS_ACCOUNT_LOCKED_OUT
-                status = Metasploit::Model::Login::Status::LOCKED_OUT
-              when WindowsError::NTStatus::STATUS_LOGON_FAILURE, WindowsError::NTStatus::STATUS_ACCESS_DENIED
-                status = Metasploit::Model::Login::Status::INCORRECT
-              when *StatusCodes::CORRECT_CREDENTIAL_STATUS_CODES
-                status = Metasploit::Model::Login::Status::DENIED_ACCESS
-              else
-                status = Metasploit::Model::Login::Status::INCORRECT
+            when WindowsError::NTStatus::STATUS_SUCCESS, WindowsError::NTStatus::STATUS_PASSWORD_MUST_CHANGE, WindowsError::NTStatus::STATUS_PASSWORD_EXPIRED
+              status = Metasploit::Model::Login::Status::SUCCESSFUL
+            when WindowsError::NTStatus::STATUS_ACCOUNT_LOCKED_OUT
+              status = Metasploit::Model::Login::Status::LOCKED_OUT
+            when WindowsError::NTStatus::STATUS_LOGON_FAILURE, WindowsError::NTStatus::STATUS_ACCESS_DENIED
+              status = Metasploit::Model::Login::Status::INCORRECT
+            when *StatusCodes::CORRECT_CREDENTIAL_STATUS_CODES
+              status = Metasploit::Model::Login::Status::DENIED_ACCESS
+            else
+              status = Metasploit::Model::Login::Status::INCORRECT
             end
           rescue ::Rex::ConnectionError, Errno::EINVAL, RubySMB::Error::NetBiosSessionService => e
             status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             proof = e
-          rescue RubySMB::Error::UnexpectedStatusCode => e
+          rescue RubySMB::Error::UnexpectedStatusCode
             status = Metasploit::Model::Login::Status::INCORRECT
           ensure
             client.disconnect! if client
@@ -154,27 +151,26 @@ module Metasploit
           end
 
           result = Result.new(credential: credential, status: status, proof: proof, access_level: access_level)
-          result.host         = host
-          result.port         = port
-          result.protocol     = 'tcp'
+          result.host = host
+          result.port = port
+          result.protocol = 'tcp'
           result.service_name = 'smb'
           result
         end
 
         def connect
           disconnect
-          self.sock       = super
-          self.dispatcher = RubySMB::Dispatcher::Socket.new(self.sock)
+          self.sock = super
+          self.dispatcher = RubySMB::Dispatcher::Socket.new(sock)
         end
 
         def set_sane_defaults
-          self.connection_timeout           = 10 if self.connection_timeout.nil?
-          self.max_send_size                = 0 if self.max_send_size.nil?
-          self.send_delay                   = 0 if self.send_delay.nil?
+          self.connection_timeout = 10 if connection_timeout.nil?
+          self.max_send_size = 0 if max_send_size.nil?
+          self.send_delay = 0 if send_delay.nil?
         end
 
       end
     end
   end
 end
-

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -61,6 +61,14 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   @return [String] whether to send delegated creds (from the set Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base::Delegation)
   attr_reader :send_delegated_creds
 
+  # @!attribute [r] use_cached_credentials
+  #   @return [String] whether to use cached Kerberos credentials from the database
+  attr_reader :use_cached_credentials
+
+  # @!attribute [r] store_credential_cache
+  #   @return [String] whether to store Kerberos TGS MIT Credential Cache to the database
+  attr_reader :store_credential_cache
+
   def_delegators :@framework_module,
                 :print_status,
                 :print_good,
@@ -95,7 +103,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       use_gss_checksum: false,
       mechanism: Rex::Proto::Gss::Mechanism::SPNEGO,
       send_delegated_creds: Delegation::ALWAYS,
-      cache_file: nil
+      cache_file: nil,
+      use_cached_credentials: true,
+      store_credential_cache: true
   )
     @realm = realm
     @hostname = hostname
@@ -110,6 +120,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @use_gss_checksum = use_gss_checksum
     @mechanism = mechanism
     @send_delegated_creds = send_delegated_creds
+    @use_cached_credentials = use_cached_credentials
+    @store_credential_cache = store_credential_cache
 
     credential = nil
     if cache_file.present?
@@ -151,7 +163,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       if @credential
         # use an explicit credential
         options[:credential] = @credential
-      else
+      elsif use_cached_credentials
         # load a cached TGS
         options[:credential] = get_cached_credential(options)
         unless options[:credential]
@@ -617,13 +629,15 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     print_good("#{peer} - Received a valid TGS-Response")
 
-    cache = extract_kerb_creds(
-      tgs_res,
-      session_key.value,
-      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
-    )
-    path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode, nil, loot_info(sname: sname))
-    print_status("#{peer} - TGS MIT Credential Cache saved to #{path}")
+    if store_credential_cache
+      cache = extract_kerb_creds(
+        tgs_res,
+        session_key.value,
+        msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
+      )
+      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode, nil, loot_info(sname: sname))
+      print_status("#{peer} - TGS MIT Credential Cache saved to #{path}")
+    end
 
     tgs_ticket = tgs_res.ticket
     tgs_auth = decrypt_kdc_tgs_rep_enc_part(

--- a/lib/msf/core/exploit/remote/smb/client/authenticated.rb
+++ b/lib/msf/core/exploit/remote/smb/client/authenticated.rb
@@ -22,7 +22,9 @@ module Exploit::Remote::SMB::Client::Authenticated
         OptEnum.new('SMBAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::SMB_OPTIONS]),
         OptString.new('SmbRhostname', [false, 'The rhostname which is required for kerberos']),
         OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        OptPath.new('SmbKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ SMBAuth == kerberos ])
+        OptPath.new('SmbKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ SMBAuth == kerberos ]),
+        OptBool.new('UseCachedCredentials', [false, 'Use credentials stored in the database for kerberos authentication', true], conditions: %w[ SMBAuth == kerberos ]),
+        OptBool.new('StoreCredentialCache', [false, 'Store Kerberos TGS MIT Credential Cache to the database if authentication succeed', true], conditions: %w[ SMBAuth == kerberos ])
       ],
       Msf::Exploit::Remote::SMB::Client::Authenticated
     )

--- a/lib/msf/core/exploit/remote/smb/client/authenticated.rb
+++ b/lib/msf/core/exploit/remote/smb/client/authenticated.rb
@@ -23,8 +23,8 @@ module Exploit::Remote::SMB::Client::Authenticated
         OptString.new('SmbRhostname', [false, 'The rhostname which is required for kerberos']),
         OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
         OptPath.new('SmbKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ SMBAuth == kerberos ]),
-        OptBool.new('UseCachedCredentials', [false, 'Use credentials stored in the database for kerberos authentication', true], conditions: %w[ SMBAuth == kerberos ]),
-        OptBool.new('StoreCredentialCache', [false, 'Store Kerberos TGS MIT Credential Cache to the database if authentication succeed', true], conditions: %w[ SMBAuth == kerberos ])
+        OptBool.new('KrbUseCachedCredentials', [false, 'Use credentials stored in the database for kerberos authentication', false], conditions: %w[ SMBAuth == kerberos ]),
+        OptBool.new('KrbStoreCredentialCache', [false, 'Store Kerberos TGS MIT Credential Cache to the database if authentication succeed', true], conditions: %w[ SMBAuth == kerberos ])
       ],
       Msf::Exploit::Remote::SMB::Client::Authenticated
     )

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -18,38 +18,36 @@ class MetasploitModule < Msf::Auxiliary
 
   Aliases = [
     'auxiliary/scanner/smb/login'
-  ]
+  ].freeze
 
   def proto
     'smb'
   end
+
   def initialize
     super(
-      'Name'           => 'SMB Login Check Scanner',
-      'Description'    => %q{
+      'Name' => 'SMB Login Check Scanner',
+      'Description' => %q{
         This module will test a SMB login on a range of machines and
         report successful logins.  If you have loaded a database plugin
         and connected to a database this module will record successful
         logins and hosts so you can track your access.
       },
-      'Author'         =>
-        [
-          'tebo <tebo[at]attackresearch.com>', # Original
-          'Ben Campbell', # Refactoring
-          'Brandon McCann "zeknox" <bmccann[at]accuvant.com>', # admin check
-          'Tom Sellers <tom[at]fadedcode.net>' # admin check/bug fix
-        ],
-      'References'     =>
-        [
-          [ 'CVE', '1999-0506'], # Weak password
-        ],
-      'License'     => MSF_LICENSE,
-      'DefaultOptions' =>
-        {
-          'DB_ALL_CREDS'    => false,
-          'BLANK_PASSWORDS' => false,
-          'USER_AS_PASS'    => false
-        }
+      'Author' => [
+        'tebo <tebo[at]attackresearch.com>', # Original
+        'Ben Campbell', # Refactoring
+        'Brandon McCann "zeknox" <bmccann[at]accuvant.com>', # admin check
+        'Tom Sellers <tom[at]fadedcode.net>' # admin check/bug fix
+      ],
+      'References' => [
+        [ 'CVE', '1999-0506'], # Weak password
+      ],
+      'License' => MSF_LICENSE,
+      'DefaultOptions' => {
+        'DB_ALL_CREDS' => false,
+        'BLANK_PASSWORDS' => false,
+        'USER_AS_PASS' => false
+      }
     )
 
     # These are normally advanced options, but for this module they have a
@@ -57,20 +55,21 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::Proxies,
-        OptBool.new('ABORT_ON_LOCKOUT', [ true, "Abort the run when an account lockout is detected", false ]),
-        OptBool.new('PRESERVE_DOMAINS', [ false, "Respect a username that contains a domain name.", true ]),
-        OptBool.new('RECORD_GUEST', [ false, "Record guest-privileged random logins to the database", false ]),
+        OptBool.new('ABORT_ON_LOCKOUT', [ true, 'Abort the run when an account lockout is detected', false ]),
+        OptBool.new('PRESERVE_DOMAINS', [ false, 'Respect a username that contains a domain name.', true ]),
+        OptBool.new('RECORD_GUEST', [ false, 'Record guest-privileged random logins to the database', false ]),
         OptBool.new('DETECT_ANY_AUTH', [false, 'Enable detection of systems accepting any authentication', false]),
         OptBool.new('DETECT_ANY_DOMAIN', [false, 'Detect if domain is required for the specified user', false])
-      ])
+      ]
+    )
 
-    deregister_options('USERNAME','PASSWORD', 'PASSWORD_SPRAY')
+    deregister_options('USERNAME', 'PASSWORD', 'PASSWORD_SPRAY')
   end
 
   def run_host(ip)
-    print_brute(:level => :vstatus, :ip => ip, :msg => "Starting SMB login bruteforce")
+    print_brute(level: :vstatus, ip: ip, msg: 'Starting SMB login bruteforce')
 
-    domain = datastore['SMBDomain'] || ""
+    domain = datastore['SMBDomain'] || ''
 
     kerberos_authenticator_factory = nil
     if datastore['SMBAuth'] == KERBEROS
@@ -78,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
 
-      kerberos_authenticator_factory = -> (username, password, realm) do
+      kerberos_authenticator_factory = lambda do |username, password, realm|
         Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
           host: datastore['DomainControllerRhost'],
           hostname: datastore['SmbRhostname'],
@@ -113,9 +112,9 @@ class MetasploitModule < Msf::Auxiliary
       bogus_result = @scanner.attempt_bogus_login(domain)
       if bogus_result.success?
         if bogus_result.access_level == Metasploit::Framework::LoginScanner::SMB::AccessLevels::GUEST
-          print_status("This system allows guest sessions with random credentials")
+          print_status('This system allows guest sessions with random credentials')
         else
-          print_error("This system accepts authentication with random credentials, brute force is ineffective.")
+          print_error('This system accepts authentication with random credentials, brute force is ineffective.')
           return
         end
       else
@@ -137,38 +136,38 @@ class MetasploitModule < Msf::Auxiliary
       when Metasploit::Model::Login::Status::LOCKED_OUT
         if datastore['ABORT_ON_LOCKOUT']
           print_error("Account lockout detected on '#{result.credential.public}', aborting.")
-          return
+          break
         else
           print_error("Account lockout detected on '#{result.credential.public}', skipping this user.")
         end
 
       when Metasploit::Model::Login::Status::DENIED_ACCESS
-        print_brute :level => :status, :ip => ip, :msg => "Correct credentials, but unable to login: '#{result.credential}', #{result.proof}"
+        print_brute level: :status, ip: ip, msg: "Correct credentials, but unable to login: '#{result.credential}', #{result.proof}"
         report_creds(ip, rport, result)
         :next_user
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}' #{result.access_level}"
+        print_brute level: :good, ip: ip, msg: "Success: '#{result.credential}' #{result.access_level}"
         report_creds(ip, rport, result)
         :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         if datastore['VERBOSE']
-          print_brute :level => :verror, :ip => ip, :msg => "Could not connect"
+          print_brute level: :verror, ip: ip, msg: 'Could not connect'
         end
         invalidate_login(
-            address: ip,
-            port: rport,
-            protocol: 'tcp',
-            public: result.credential.public,
-            private: result.credential.private,
-            realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
-            realm_value: result.credential.realm,
-            last_attempted_at: DateTime.now,
-            status: result.status
+          address: ip,
+          port: rport,
+          protocol: 'tcp',
+          public: result.credential.public,
+          private: result.credential.private,
+          realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
+          realm_value: result.credential.realm,
+          last_attempted_at: DateTime.now,
+          status: result.status
         )
         :abort
       when Metasploit::Model::Login::Status::INCORRECT
         if datastore['VERBOSE']
-          print_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}', #{result.proof}"
+          print_brute level: :verror, ip: ip, msg: "Failed: '#{result.credential}', #{result.proof}"
         end
         invalidate_login(
           address: ip,
@@ -183,9 +182,7 @@ class MetasploitModule < Msf::Auxiliary
         )
       end
     end
-
   end
-
 
   # This logic is not universal ie a local account will not care about workgroup
   # but remote domain authentication will so check each instance
@@ -202,10 +199,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def report_creds(ip, port, result)
-    if !datastore['RECORD_GUEST']
-      if result.access_level == Metasploit::Framework::LoginScanner::SMB::AccessLevels::GUEST
-        return
-      end
+    if !datastore['RECORD_GUEST'] && (result.access_level == Metasploit::Framework::LoginScanner::SMB::AccessLevels::GUEST)
+      return
     end
 
     service_data = {
@@ -217,18 +212,18 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     credential_data = {
-      module_fullname: self.fullname,
+      module_fullname: fullname,
       origin_type: :service,
       private_data: result.credential.private,
       private_type: (
         Rex::Proto::NTLM::Utils.is_pass_ntlm_hash?(result.credential.private) ? :ntlm_hash : :password
       ),
-      username: result.credential.public,
+      username: result.credential.public
     }.merge(service_data)
 
     if datastore['DETECT_ANY_DOMAIN'] && domain.present?
       if accepts_bogus_domains?(result.credential.public, result.credential.private)
-        print_brute(:level => :vstatus, :ip => ip, :msg => "Domain is ignored for user #{result.credential.public}")
+        print_brute(level: :vstatus, ip: ip, msg: "Domain is ignored for user #{result.credential.public}")
       else
         credential_data.merge!(
           realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -87,8 +87,8 @@ class MetasploitModule < Msf::Auxiliary
           framework: framework,
           framework_module: self,
           cache_file: datastore['SmbKrb5Ccname'].blank? ? nil : datastore['SmbKrb5Ccname'],
-          use_cached_credentials: datastore['UseCachedCredentials'].nil? ? true : datastore['UseCachedCredentials'],
-          store_credential_cache: datastore['StoreCredentialCache'].nil? ? true : datastore['StoreCredentialCache']
+          use_cached_credentials: datastore['KrbUseCachedCredentials'].nil? ? false : datastore['KrbUseCachedCredentials'],
+          store_credential_cache: datastore['KrbStoreCredentialCache'].nil? ? true : datastore['KrbStoreCredentialCache']
         )
       end
     end


### PR DESCRIPTION
This updates `scanner/smb/smb_login` to support Kerberos authentication (close #17169).

This also adds two new attributes to the `Kerberos::ServiceAuthenticator::Base` class (`use_cached_credentials` and `store_credential_cache`) and the corresponding datastore options to the `Exploit::Remote::SMB::Client::Authenticated` mixin (`UseCachedCredentials` and `StoreCredentialCache` respectively). The former will enables/disables the use of cached Kerberos credentials from the database, which makes sense in a login scanner scenario since we usually want to check usernames and passwords and not using any credentials cached in the database. The latter enables/disables storing `.ccache` (Kerberos TGS MIT Credential Cache) to the loot. This option makes sense if we want to disable the use of cached credentials and avoid storing the new fresh ticket for the same principal. These options are both set to true by default, which keeps the original behavior (store credentials and use stored credentials).

**Note for reviewers**: There are a good number of changes due to Rubocop complaining. Those are all in the last commit. You should be able to see the actual interesting changes in the first commit.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/smb_login`
- [x] `set SMBAuth kerberos`
- [x] `set RHOSTS <remote IP>`
- [x] `set SmbRhostname <remote hostname>`
- [x] `set DomainControllerRhost <domain controller IP>`
- [x] `set SMBUser <username>`
- [x] `set SMBPass <password>`
- [x] `set SMBDomain <fully qualified domain name>`
- [x] `exploit`
- [x] **Verify** the initial Kerberos authentication to the KDC occurs
- [x] **Verify** the TGS is stored in the loot
- [x] **Verify** the SMB authentication succeeds
- [x] `exploit`
- [x] **Verify** the cached credential is used
- [x] **Verify** the SMB authentication succeeds

Check the new datastore options:
- [ ] `set UseCachedCredentials false`
- [ ] `exploit`
- [ ] **Verify** the cached credential is **not** used
- [ ] **Verify** the SMB authentication succeeds
- [ ] **Verify** the new TGS is stored in the loot
- [ ] `set UseCachedCredentials true`
- [ ] `set StoreCredentialCache false`
- [ ] `exploit`
- [ ] **Verify** the cached credential is used
- [ ] **Verify** the SMB authentication succeeds
- [ ] **Verify** the new TGS is **not** stored in the loot
- [ ] `set UseCachedCredentials false`
- [ ] `exploit`
- [ ] **Verify** the cached credential is **not** used
- [ ] **Verify** the SMB authentication succeeds
- [ ] **Verify** the new TGS is **not** stored in the loot

### Scenarios
- NTLM authentication
```
msf6 auxiliary(scanner/smb/smb_login) > exploit verbose=true lhost=10.0.0.1 rhosts=10.0.0.24 SmbRhostname=dc01 DomainControllerRhost=10.0.0.24 smbuser=Administrator smbpass=123456 smbdomain=testlab.local

[*] 10.0.0.24:445   - 10.0.0.24:445 - Starting SMB login bruteforce
[+] 10.0.0.24:445   - 10.0.0.24:445 - Success: 'testlab.local\Administrator:123456' Administrator
[*] 10.0.0.24:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_login) > creds
Credentials
===========

host       origin     service        public         private  realm  private_type  JtR Format
----       ------     -------        ------         -------  -----  ------------  ----------
10.0.0.24  10.0.0.24  445/tcp (smb)  Administrator  123456          Password
```

- Kerberos authentication
```
msf6 auxiliary(scanner/smb/smb_login) > exploit verbose=true SMBAuth=kerberos lhost=10.0.0.1 rhosts=10.0.0.24 SmbRhostname=dc01 DomainControllerRhost=10.0.0.24 smbuser=Administrator smbpass=123456 smbdomain=testlab.local

[*] 10.0.0.24:445   - 10.0.0.24:445 - Starting SMB login bruteforce
[*] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid TGT-Response
[+] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid TGS-Response
[*] 10.0.0.24:445   - 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221021165819_default_10.0.0.24_mit.kerberos.cca_545917.bin
[+] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid delegation TGS-Response
[+] 10.0.0.24:445   - 10.0.0.24:445 - Success: 'testlab.local\Administrator:123456' Administrator
[*] 10.0.0.24:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_login) > creds
Credentials
===========

host       origin     service        public         private  realm  private_type  JtR Format
----       ------     -------        ------         -------  -----  ------------  ----------
10.0.0.24  10.0.0.24  445/tcp (smb)  Administrator  123456          Password

msf6 auxiliary(scanner/smb/smb_login) > loot

Loot
====

host       service  type                 name  content                   info                                                                   path
----       -------  ----                 ----  -------                   ----                                                                   ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: testlab.local, serviceName: cifs/dc01, username: administrator  /home/msfuser/.msf4/loot/20221021165819_default_10.0.0.24_mit.kerberos.cca_545917.bin
```

- Kerberos authentication - Using cached credential (default behavior)
```
msf6 auxiliary(scanner/smb/smb_login) > loot

Loot
====

host       service  type                 name  content                   info                                                                   path
----       -------  ----                 ----  -------                   ----                                                                   ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: testlab.local, serviceName: cifs/dc01, username: administrator  /home/msfuser/.msf4/loot/20221021170140_default_10.0.0.24_mit.kerberos.cca_267956.bin

msf6 auxiliary(scanner/smb/smb_login) > exploit verbose=true SMBAuth=kerberos lhost=10.0.0.1 rhosts=10.0.0.24 SmbRhostname=dc01 DomainControllerRhost=10.0.0.24 smbuser=Administrator smbpass=123456 smbdomain=testlab.local

[*] 10.0.0.24:445   - 10.0.0.24:445 - Starting SMB login bruteforce
[*] 10.0.0.24:445   - 10.0.0.24:88 - Using cached credential for cifs/dc01 Administrator
[+] 10.0.0.24:445   - 10.0.0.24:445 - Success: 'testlab.local\Administrator:123456' Administrator
[*] 10.0.0.24:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

- Kerberos authentication - Not storing ccache
```
msf6 auxiliary(scanner/smb/smb_login) > exploit verbose=true SMBAuth=kerberos lhost=10.0.0.1 rhosts=10.0.0.24 SmbRhostname=dc01 DomainControllerRhost=10.0.0.24 smbuser=Administrator smbpass=123456 smbdomain=testlab.local StoreCredentialCache=false

[*] 10.0.0.24:445   - 10.0.0.24:445 - Starting SMB login bruteforce
[*] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid TGT-Response
[+] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid TGS-Response
[+] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid delegation TGS-Response
[+] 10.0.0.24:445   - 10.0.0.24:445 - Success: 'testlab.local\Administrator:123456' Administrator
[*] 10.0.0.24:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_login) > loot

Loot
====

host  service  type  name  content  info  path
----  -------  ----  ----  -------  ----  ----
```

- Kerberos authentication - Not using cached credential, but storing ccache again (default behavior)
```
msf6 auxiliary(scanner/smb/smb_login) > loot

Loot
====

host       service  type                 name  content                   info                                                                   path
----       -------  ----                 ----  -------                   ----                                                                   ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: testlab.local, serviceName: cifs/dc01, username: administrator  /home/msfuser/.msf4/loot/20221021170140_default_10.0.0.24_mit.kerberos.cca_267956.bin

msf6 auxiliary(scanner/smb/smb_login) > exploit verbose=true SMBAuth=kerberos lhost=10.0.0.1 rhosts=10.0.0.24 SmbRhostname=dc01 DomainControllerRhost=10.0.0.24 smbuser=Administrator smbpass=123456 smbdomain=testlab.local UseCachedCredentials=false

[*] 10.0.0.24:445   - 10.0.0.24:445 - Starting SMB login bruteforce
[*] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid TGT-Response
[+] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid TGS-Response
[*] 10.0.0.24:445   - 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221021170521_default_10.0.0.24_mit.kerberos.cca_202033.bin
[+] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid delegation TGS-Response
[+] 10.0.0.24:445   - 10.0.0.24:445 - Success: 'testlab.local\Administrator:123456' Administrator
[*] 10.0.0.24:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_login) > loot

Loot
====

host       service  type                 name  content                   info                                                                   path
----       -------  ----                 ----  -------                   ----                                                                   ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: testlab.local, serviceName: cifs/dc01, username: administrator  /home/msfuser/.msf4/loot/20221021170140_default_10.0.0.24_mit.kerberos.cca_267956.bin
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: testlab.local, serviceName: cifs/dc01, username: administrator  /home/msfuser/.msf4/loot/20221021170521_default_10.0.0.24_mit.kerberos.cca_202033.bin
```

- Kerberos authentication - Not using cached credential and not storing ccache
```
msf6 auxiliary(scanner/smb/smb_login) > loot

Loot
====

host       service  type                 name  content                   info                                                                   path
----       -------  ----                 ----  -------                   ----                                                                   ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: testlab.local, serviceName: cifs/dc01, username: administrator  /home/msfuser/.msf4/loot/20221021170806_default_10.0.0.24_mit.kerberos.cca_972078.bin

msf6 auxiliary(scanner/smb/smb_login) > exploit verbose=true SMBAuth=kerberos lhost=10.0.0.1 rhosts=10.0.0.24 SmbRhostname=dc01 DomainControllerRhost=10.0.0.24 smbuser=Administrator smbpass=123456 smbdomain=testlab.local UseCachedCredentials=false StoreCredentialCache=false

[*] 10.0.0.24:445   - 10.0.0.24:445 - Starting SMB login bruteforce
[*] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid TGT-Response
[+] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid TGS-Response
[+] 10.0.0.24:445   - 10.0.0.24:88 - Received a valid delegation TGS-Response
[+] 10.0.0.24:445   - 10.0.0.24:445 - Success: 'testlab.local\Administrator:123456' Administrator
[*] 10.0.0.24:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_login) > loot

Loot
====

host       service  type                 name  content                   info                                                                   path
----       -------  ----                 ----  -------                   ----                                                                   ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: testlab.local, serviceName: cifs/dc01, username: administrator  /home/msfuser/.msf4/loot/20221021170806_default_10.0.0.24_mit.kerberos.cca_972078.bin
```

