### PR TITLE
fix: Handle search terms ending in colons.

### DIFF
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -42,9 +42,16 @@ module Msf::Modules::Metadata::Search
     res = {}
 
     terms.each do |term|
-      keyword, search_term = term.split(":", 2)
-      if search_term.nil? || search_term.length == 0
-        search_term = keyword.sub(/:+$/, '')
+      # Split it on the `:`, with the part before the first `:` going into keyword, the part after first `:`
+      # but before any later instances of `:` going into search_term, and the characters after the second 
+      # `:` or later in the string going into _excess to be ignored.
+      #
+      # Example is `use exploit/linux/local/nested_namespace_idmap_limit_priv_esc::a`
+      # which would make keyword become `exploit/linux/local/nested_namespace_idmap_limit_priv_esc`,
+      # search_term become blank, and _excess become "a".
+      keyword, search_term, _excess = term.split(":", 3)
+      if search_term.blank?
+        search_term = keyword
         keyword = 'text'
       end
       next if search_term.length == 0

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -43,8 +43,8 @@ module Msf::Modules::Metadata::Search
 
     terms.each do |term|
       keyword, search_term = term.split(":", 2)
-      unless search_term
-        search_term = keyword
+      if search_term.nil? || search_term.length == 0
+        search_term = keyword.sub(/:+$/, '')
         keyword = 'text'
       end
       next if search_term.length == 0

--- a/spec/lib/msf/core/modules/metadata/search_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/search_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Msf::Modules::Metadata::Search do
 
   describe '#parse_search_string' do
     it { expect(described_class.parse_search_string(nil)).to eq({}) }
+    it { expect(described_class.parse_search_string("")).to eq({}) }
     it { expect(described_class.parse_search_string(" ")).to eq({}) }
     it { expect(described_class.parse_search_string("os:osx os:windows")).to eq({"os"=>[["osx", "windows"], []]}) }
     it { expect(described_class.parse_search_string("postgres login")).to eq({"text"=>[["postgres", "login"], []]}) }
@@ -43,9 +44,8 @@ RSpec.describe Msf::Modules::Metadata::Search do
     it { expect(described_class.parse_search_string("  author:egypt   arch:x64  ")).to eq({"author"=>[["egypt"], []], "arch"=>[["x64"], []]}) }
     it { expect(described_class.parse_search_string("postgres:")).to eq({"text"=>[["postgres"], []]}) }
     it { expect(described_class.parse_search_string("postgres;")).to eq({"text"=>[["postgres;"], []]}) }
-    it { expect(described_class.parse_search_string("text:postgres:")).to eq({"text"=>[["postgres:"], []]}) }
-    it { expect(described_class.parse_search_string("postgres::")).to eq({"postgres"=>[[":"], []]}) }
-    it { expect(described_class.parse_search_string("postgres:::")).to eq({"postgres"=>[["::"], []]}) }
+    it { expect(described_class.parse_search_string("text:postgres:")).to eq({"text"=>[["postgres"], []]}) }
+    it { expect(described_class.parse_search_string("postgres::::")).to eq({"text"=>[["postgres"], []]}) }
     it { expect(described_class.parse_search_string("turtle:bobcat postgres:")).to eq({"text"=>[["postgres"], []], "turtle"=>[["bobcat"], []]}) }
   end
 

--- a/spec/lib/msf/core/modules/metadata/search_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/search_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe Msf::Modules::Metadata::Search do
     it { expect(described_class.parse_search_string("platform:-android")).to eq({"platform"=>[[], ["android"]]}) }
     it { expect(described_class.parse_search_string("author:egypt arch:x64")).to eq({"author"=>[["egypt"], []], "arch"=>[["x64"], []]}) }
     it { expect(described_class.parse_search_string("  author:egypt   arch:x64  ")).to eq({"author"=>[["egypt"], []], "arch"=>[["x64"], []]}) }
+    it { expect(described_class.parse_search_string("postgres:")).to eq({"text"=>[["postgres"], []]}) }
+    it { expect(described_class.parse_search_string("postgres;")).to eq({"text"=>[["postgres;"], []]}) }
+    it { expect(described_class.parse_search_string("text:postgres:")).to eq({"text"=>[["postgres:"], []]}) }
+    it { expect(described_class.parse_search_string("postgres::")).to eq({"postgres"=>[[":"], []]}) }
+    it { expect(described_class.parse_search_string("postgres:::")).to eq({"postgres"=>[["::"], []]}) }
+    it { expect(described_class.parse_search_string("turtle:bobcat postgres:")).to eq({"text"=>[["postgres"], []], "turtle"=>[["bobcat"], []]}) }
   end
 
   describe '#find' do


### PR DESCRIPTION
This fixes #14768.

Search terms with trailing colons will now be treated as if the colons were not present.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/local/nested_namespace_idmap_limit_priv_esc:`
- [x] exploit/linux/local/nested_namespace_idmap_limit_priv_esc is selected
- [x] The entire list of modules is not printed.
