### PR TITLE
Fix linux reverse_tcp_x64 rdx register value

### DIFF
--- a/lib/msf/core/payload/linux/x64/reverse_tcp_x64.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp_x64.rb
@@ -104,8 +104,8 @@ module Payload::Linux::ReverseTcp_x64
         xor    r9, r9
         push   0x22
         pop    r10
-        mov    dl, 0x7
-        syscall ; mmap(NULL, 4096, PROT_READ|PROT_WRITE|PROT_EXEC|0x1000, MAP_PRIVATE|MAP_ANONYMOUS, 0, 0)
+        mov    dx, 0x7
+        syscall ; mmap(NULL, 4096, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, 0, 0)
         test   rax, rax
         js failed
 


### PR DESCRIPTION
The `mmap` syscall will fail on WSL2 (4.4.0-19041-Microsoft) kernel, if its 3rd argument has extra undocumented bits.
This patch should fix it.
