### PR TITLE
Fix broken file writes on windows when newlines are present

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -778,17 +778,18 @@ module Msf::Post::File
 
 protected
 
-  # Checks to see if there are non-ansi or newline characters in a given string
+  # Checks to see if there are non-printable characters in a given string
   #
-  # @param data [String] String to check for non-ansi or newline chars
+  # @param data [String] String to check for non-printable characters
   # @return bool
   def _can_echo?(data)
-    data.each_char do |char|
-      unless char.ascii_only? || char == '\n' || char == '"'
-        return false
-      end
+    # Ensure all bytes are between ascii 0x20 to 0x7e (ie. [[:print]]), excluding quotes etc
+    data.bytes.all? do|b|
+      (b >= 0x20 && b <= 0x7e) &&
+        b != '"'.ord &&
+        b != '%'.ord &&
+        b != '$'.ord
     end
-    return true
   end
 
   #

--- a/spec/lib/msf/core/post/file_spec.rb
+++ b/spec/lib/msf/core/post/file_spec.rb
@@ -1,0 +1,34 @@
+require 'rspec'
+
+RSpec.describe Msf::Post::File do
+  subject do
+    described_mixin = described_class
+    klass = Class.new do
+      include described_mixin
+    end
+    klass.allocate
+  end
+
+  describe '#_can_echo?' do
+    [
+      # printable examples
+      { input: '', expected: true },
+      { input: 'hello world', expected: true },
+      { input: "hello 'world'", expected: true },
+      { input: "!@^&*()_+[]{}:|<>?,./;'\\[]1234567890-='", expected: true },
+
+      # non-printable character examples, or breaking characters such as new line or quotes etc
+      { input: "a\nb\nc", expected: false },
+      { input: "\xff\x00", expected: false },
+      { input: "\x00\x01\x02\x03\x04\x1f", expected: false },
+      { input: "hello \"world\"", expected: false },
+      { input: "🐂", expected: false },
+      { input: "%APPDATA%", expected: false },
+      { input: "$HOME", expected: false }
+    ].each do |test|
+      it "should return #{test[:expected]} for #{test[:input].inspect}" do
+        expect(subject.send(:_can_echo?, test[:input])).to eql(test[:expected])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Spotted as part of - https://github.com/rapid7/metasploit-framework/pull/17184

Fixes broken file writes on windows targets when newlines are present.

### Before

The file isn't uploaded correctly when new line characters are present:

<img width="436" alt="image" src="https://user-images.githubusercontent.com/60357436/198165628-1b8327fa-b2e4-49ab-8fd0-77ea662d1e94.png">

### After

The file is uploaded correctly when new line characters are present:

<img width="440" alt="image" src="https://user-images.githubusercontent.com/60357436/198165654-2651b287-02f2-41b3-a036-4fcabc689104.png">


## Verification

Easier to test when https://github.com/rapid7/metasploit-framework/pull/17184 is merged

- Verify the tests are as expected
- Verify that the functionality works with windows cmd shell with new lines