### PR TITLE
Fix the Netapi32 bufptr data type

### DIFF
--- a/lib/msf/core/post/windows/accounts.rb
+++ b/lib/msf/core/post/windows/accounts.rb
@@ -604,7 +604,7 @@ module Msf
           result = client.railgun.netapi32.NetGroupGetUsers(server_name, groupname, 0, 4, 4096, 4, 4, 0)
           if (result['return'] == 0) && ((result['totalentries'] % 4294967296) != 0)
             begin
-              members_info_addr = result['bufptr'].unpack1('V')
+              members_info_addr = result['bufptr']
               unless members_info_addr == 0
                 # Railgun assumes PDWORDS are pointers and returns 8 bytes for x64 architectures.
                 # Therefore we need to truncate the result value to an actual
@@ -641,7 +641,7 @@ module Msf
           result = client.railgun.netapi32.NetLocalGroupGetMembers(server_name, localgroupname, 3, 4, 4096, 4, 4, 0)
           if (result['return'] == 0) && ((result['totalentries'] % 4294967296) != 0)
             begin
-              members_info_addr = result['bufptr'].unpack1('V')
+              members_info_addr = result['bufptr']
               unless members_info_addr == 0
                 members_info = session.railgun.util.read_array(LOCALGROUP_MEMBERS_INFO, (result['totalentries'] % 4294967296), members_info_addr)
                 for member in members_info
@@ -675,7 +675,7 @@ module Msf
           result = client.railgun.netapi32.NetUserEnum(server_name, 0, client.railgun.const(filter), 4, 4096, 4, 4, 0)
           if (result['return'] == 0) && ((result['totalentries'] % 4294967296) != 0)
             begin
-              user_info_addr = result['bufptr'].unpack1('V')
+              user_info_addr = result['bufptr']
               unless user_info_addr == 0
                 user_info = session.railgun.util.read_array(USER_INFO, (result['totalentries'] % 4294967296), user_info_addr)
                 for member in user_info
@@ -708,7 +708,7 @@ module Msf
           result = client.railgun.netapi32.NetLocalGroupEnum(server_name, 0, 4, 4096, 4, 4, 0)
           if (result['return'] == 0) && ((result['totalentries'] % 4294967296) != 0)
             begin
-              localgroup_info_addr = result['bufptr'].unpack1('V')
+              localgroup_info_addr = result['bufptr']
               unless localgroup_info_addr == 0
                 localgroup_info = session.railgun.util.read_array(LOCALGROUP_INFO, (result['totalentries'] % 4294967296), localgroup_info_addr)
                 for member in localgroup_info
@@ -741,7 +741,7 @@ module Msf
           result = client.railgun.netapi32.NetGroupEnum(server_name, 0, 4, 4096, 4, 4, 0)
           if (result['return'] == 0) && ((result['totalentries'] % 4294967296) != 0)
             begin
-              group_info_addr = result['bufptr'].unpack1('V')
+              group_info_addr = result['bufptr']
               unless group_info_addr == 0
                 group_info = session.railgun.util.read_array(GROUP_INFO, (result['totalentries'] % 4294967296), group_info_addr)
                 for member in group_info

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_netapi32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_netapi32.rb
@@ -22,14 +22,14 @@ class Def_windows_netapi32
       ["PBLOB","DomainGuid","in"],
       ["PWCHAR","SiteName","in"],
       ["DWORD","Flags","in"],
-      ["PDWORD","DomainControllerInfo","out"]
+      ["PLPVOID","DomainControllerInfo","out"]
     ])
 
     dll.add_function('NetUserEnum', 'DWORD', [
       ["PWCHAR","servername","in"],
       ["DWORD","level","in"],
       ["DWORD","filter","in"],
-      ["PBLOB","bufptr","out"],
+      ["PLPVOID","bufptr","out"],
       ["DWORD","prefmaxlen","in"],
       ["PDWORD","entriesread","out"],
       ["PDWORD","totalentries","out"],
@@ -39,7 +39,7 @@ class Def_windows_netapi32
     dll.add_function('NetLocalGroupEnum', 'DWORD', [
       ["PWCHAR","servername","in"],
       ["DWORD","level","in"],
-      ["PBLOB","bufptr","out"],
+      ["PLPVOID","bufptr","out"],
       ["DWORD","prefmaxlen","in"],
       ["PDWORD","entriesread","out"],
       ["PDWORD","totalentries","out"],
@@ -49,7 +49,7 @@ class Def_windows_netapi32
     dll.add_function('NetGroupEnum', 'DWORD', [
       ["PWCHAR","servername","in"],
       ["DWORD","level","in"],
-      ["PBLOB","bufptr","out"],
+      ["PLPVOID","bufptr","out"],
       ["DWORD","prefmaxlen","in"],
       ["PDWORD","entriesread","out"],
       ["PDWORD","totalentries","out"],
@@ -72,7 +72,7 @@ class Def_windows_netapi32
       ["PWCHAR","servername","in"],
       ["PWCHAR","groupname","in"],
       ["DWORD","level","in"],
-      ["PBLOB","bufptr","out"],
+      ["PLPVOID","bufptr","out"],
       ["DWORD","prefmaxlen","in"],
       ["PDWORD","entriesread","out"],
       ["PDWORD","totalentries","out"],
@@ -83,7 +83,7 @@ class Def_windows_netapi32
       ["PWCHAR","servername","in"],
       ["PWCHAR","localgroupname","in"],
       ["DWORD","level","in"],
-      ["PBLOB","bufptr","out"],
+      ["PLPVOID","bufptr","out"],
       ["DWORD","prefmaxlen","in"],
       ["PDWORD","entriesread","out"],
       ["PDWORD","totalentries","out"],
@@ -127,7 +127,7 @@ class Def_windows_netapi32
     dll.add_function('NetServerEnum', 'DWORD',[
       ["PWCHAR","servername","in"],
       ["DWORD","level","in"],
-      ["PDWORD","bufptr","out"],
+      ["PLPVOID","bufptr","out"],
       ["DWORD","prefmaxlen","in"],
       ["PDWORD","entriesread","out"],
       ["PDWORD","totalentries","out"],
@@ -139,7 +139,7 @@ class Def_windows_netapi32
     dll.add_function('NetWkstaUserEnum', 'DWORD', [
       ["PWCHAR","servername","in"],
       ["DWORD","level","in"],
-      ["PDWORD","bufptr","out"],
+      ["PLPVOID","bufptr","out"],
       ["DWORD","prefmaxlen","in"],
       ["PDWORD","entriesread","out"],
       ["PDWORD","totalentries","out"],
@@ -150,7 +150,7 @@ class Def_windows_netapi32
       ["PWCHAR","servername","in"],
       ["PWCHAR","username","in"],
       ["DWORD","level","in"],
-      ["PDWORD","bufptr","out"],
+      ["PLPVOID","bufptr","out"],
       ["DWORD","prefmaxlen","in"],
       ["PDWORD","entriesread","out"],
       ["PDWORD","totalentries","out"]
@@ -161,7 +161,7 @@ class Def_windows_netapi32
         ['PWCHAR','UncClientName','in'],
         ['PWCHAR','username','in'],
         ['DWORD','level','in'],
-        ['PDWORD','bufptr','out'],
+        ['PLPVOID','bufptr','out'],
         ['DWORD','prefmaxlen','in'],
         ['PDWORD','entriesread','out'],
         ['PDWORD','totalentries','out'],

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
@@ -50,6 +50,7 @@ class Library
     'PHANDLE' => 'PULONG_PTR',
     'SIZE_T'  => 'ULONG_PTR',
     'PSIZE_T' => 'PULONG_PTR',
+    'PLPVOID' => 'PULONG_PTR'
   }.freeze
 
   attr_accessor :functions


### PR DESCRIPTION
This fixes the data type used for the common `bufptr` parameter in multiple functions provided by `netapi32`. PBLOB and PDWORD are both incorrect for different reasons. PBLOB is very incorrect because it would return the pointer as a binary string that'd need to be unpacked which would require the user to know and select the correct architecture. That's why you see removed instances of `.unpack1('V')`. PDWORD is also incorrect, because it assumes that the size of a pointer is always 32-bits. The returned datatype is correct (Integer) but the value is wrong which this assumption is incorrect, as is the case on 64-bit systems.

These issues result in faulty values being returned by the functions which when used to perform read operations would result in a crash as noted in #17063. This PR fixes multiple methods in the `Post::Windows::Accounts` mixin to work on 64-bit systems. For instances where the `bufptr` datatype was changed from a string (PBLOB) to a proper integer, I searched for other references to those functions in modules and libraries and found none. For instances where it was changed from PDWORD to PLPVOID, no changes should be necessary since now the value should just be correct.

The new `PLPVOID` data type is defined as an alias of `PULONG_PTR` which ensures that the size is always correct. As with existing usages of `PULONG_PTR` when the parameter is an "out" only parameter, the size is *always* 4 to maintain backward compatibility.

## Verification


- [x] Start `msfconsole`
- [x] Establish a 64-bit Meterpreter session
- [x] See the `post/windows/gather/enum_domain_tokens` module work
- [x] See all of the `post/test/railgun` tests pass

## Example

```
msf6 exploit(windows/smb/psexec) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Executing the payload...
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (200774 bytes) to 192.168.159.10
[*] Session ID 1 (192.168.159.128:4444 -> 192.168.159.10:59509) processing AutoRunScript 'post/test/railgun'
[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: meterpreter
[*] Running against session 1
[*] Session type is meterpreter and platform is windows
[+] Should include error information in the results
[+] Should support functions with no parameters
[+] Should support functions with literal parameters
[+] Should support functions with in/out/inout parameter types
[+] Should support calling multiple functions at once
[+] Should support writing memory
[+] Should support reading memory
[+] Should retrieve the win32k file version
[*] Passed: 8; Failed: 0
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.10:59509) at 2022-10-27 15:54:34 -0400

meterpreter > run post/windows/gather/enum_domain_tokens

[*] Running module against DC (192.168.159.10)
[+] Current session is running as SYSTEM on a domain controller
[*] Checking for processes running under domain user
[*] No processes running as domain users
[*] Checking for Domain group and user tokens

Impersonation Tokens with Domain Context
========================================

 Token Type  Account Type  Account Name                                   Domain Admin
 ----------  ------------  ------------                                   ------------
 Delegation  Group         MSFLAB\Cert Publishers                         false
 Delegation  Group         MSFLAB\DC$                                     false
 Delegation  Group         MSFLAB\Denied RODC Password Replication Group  false
 Delegation  Group         MSFLAB\Domain Controllers                      false


meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.159.10 - Meterpreter session 1 closed.  Reason: User exit
msf6 exploit(windows/smb/psexec) > exit
```