### PR TITLE
Fix uploading binary file to windows shell command with identical name

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -880,7 +880,7 @@ protected
     b64_filename = "#{file_name}.b64"
     begin
       _win_ansi_write_file(b64_filename, b64_data, chunk_size)
-      cmd_exec("certutil -decode #{b64_filename} #{file_name}")
+      cmd_exec("certutil -f -decode #{b64_filename} #{file_name}")
     rescue ::Exception => e
       print_error("Exception while running #{__method__}: #{e}")
     ensure


### PR DESCRIPTION
Fixes uploading binary files with identical names to a Windows shell session. Previously this would silently error and not write the new file contents, now the file contents will successfully be written out.


## Verification

0. Open a windows shell cmd session
1. Create a new file with binary data, i.e. in irb : `File.binwrite('example.bin', "🐂 hello world")`
2. Upload the file to windows, and verify the contents has the emoji and text
3. Modify the file locally `File.binwrite('example.bin', "🐂 hello world 1234")`
4. Upload the file again, and verify that `1234` is present as well as the emoji and text