### PR TITLE
Msf::Post::Windows: Add Msf::Post::Windows::System mixin

### DIFF
--- a/lib/msf/core/post/windows/system.rb
+++ b/lib/msf/core/post/windows/system.rb
@@ -1,0 +1,58 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Post
+    module Windows
+      module System
+        include Msf::Post::Common
+
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_sys_config_sysinfo
+                  ]
+                }
+              }
+            )
+          )
+        end
+
+        #
+        # Gets the hostname of the system
+        #
+        # @return [String] hostname
+        #
+        def get_hostname
+          hostname = nil
+
+          if session.type == 'meterpreter'
+            hostname = session.sys.config.sysinfo['Computer'].to_s
+          end
+
+          if hostname.blank? && session.type == 'powershell'
+            hostname = cmd_exec('[System.Net.Dns]::GetHostName()').to_s
+          end
+
+          if hostname.blank? && command_exists?('hostname')
+            hostname = cmd_exec('hostname').to_s
+          end
+
+          if hostname.blank?
+            hostname = get_env('COMPUTERNAME').to_s
+          end
+
+          raise if hostname.blank?
+
+          report_host({ host: rhost, name: hostname.downcase })
+          hostname.downcase
+        rescue StandardError
+          raise 'Unable to retrieve hostname'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A suggestion.

This offers a `get_hostname` Windows counterpart for the `get_hostname` method for `Post::System::` Linux/Solaris mixins.

To do so it adds a `Msf::Post::Windows:System` mixin which contains only this method. I don't 100% like creating a new mixin just for this method, but it matches the existing naming convention, can be expanded later, and didn't really fit anywhere else. Also trying to merge this with the existing `get_hostname` methods into a common method seemed unnecessarily overly-complex.
