### PR TITLE
Add msfvenom / msfconsole support for Rust shellcode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,7 +383,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.3)
-    rex-text (0.2.45)
+    rex-text (0.2.46)
     rex-zip (0.1.4)
       rex-text
     rexml (3.2.5)

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -16,7 +16,7 @@ module Buffer
   class BufferFormatError < ::ArgumentError; end
   #
   # Serializes a buffer to a provided format.  The formats supported are raw,
-  # num, dword, ruby, python, perl, bash, c, js_be, js_le, java and psh
+  # num, dword, ruby, rust, python, perl, bash, c, js_be, js_le, java and psh
   #
   def self.transform(buf, fmt = "ruby", var_name = 'buf', encryption_opts={})
     default_wrap = 60
@@ -65,6 +65,8 @@ module Buffer
         buf = Rex::Text.to_golang(buf)
       when 'nim','nimlang'
         buf = Rex::Text.to_nim(buf)
+      when 'rust', 'rustlang'
+        buf = Rex::Text.to_rust(buf)
       else
         raise BufferFormatError, "Unsupported buffer format: #{fmt}", caller
     end
@@ -74,7 +76,7 @@ module Buffer
 
   #
   # Creates a comment using the supplied format.  The formats supported are
-  # raw, ruby, python, perl, bash, js_be, js_le, c, and java.
+  # raw, ruby, rust python, perl, bash, js_be, js_le, c, and java.
   #
   def self.comment(buf, fmt = "ruby")
     case fmt
@@ -101,6 +103,8 @@ module Buffer
         buf = Rex::Text.to_golang_comment(buf)
       when 'nim','nimlang'
         buf = Rex::Text.to_nim_comment(buf)
+      when 'rust', 'rustlang'
+        buf = Rext::Text.to_rust_comment(buf)
       else
         raise BufferFormatError, "Unsupported buffer format: #{fmt}", caller
     end
@@ -138,6 +142,8 @@ module Buffer
       'raw',
       'rb',
       'ruby',
+      'rust',
+      'rustlang',
       'sh',
       'vbapplication',
       'vbscript'

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -104,7 +104,7 @@ module Buffer
       when 'nim','nimlang'
         buf = Rex::Text.to_nim_comment(buf)
       when 'rust', 'rustlang'
-        buf = Rext::Text.to_rust_comment(buf)
+        buf = Rex::Text.to_rust_comment(buf)
       else
         raise BufferFormatError, "Unsupported buffer format: #{fmt}", caller
     end


### PR DESCRIPTION
### This PR requires the Rust shellcode format support PR from Rex-Text: https://github.com/rapid7/rex-text/pull/58

This PR adds support for Rust shellcode generation which supports both rust and rustlang formats. Please note that an [unmutable u8 array](https://doc.rust-lang.org/std/primitive.array.html) is created by default.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use windows/x64/exec`
- [x] `set cmd calc.exe`
- [x] `generate -f rust` / `generate -f rustlang`
- [x] Insert generated shellcode into a Rust shellcode injector as shown in the steps below.

Example `msfvenom` Rust shellcode for calc.exe:

![msfvenom-calc](https://user-images.githubusercontent.com/89628341/199114705-ba4282c5-1419-4b58-97e5-eaa31637b2c9.png)

Example `msfconsole` Rust shellcode for calc.exe:

![msfconsole-calc](https://user-images.githubusercontent.com/89628341/199114712-5be6b3f4-7bce-46ad-8a18-092f304686a5.png)

This has been tested with my own [Rust basic shellcode injector](https://github.com/memN0ps/arsenal-rs/tree/main/shellcode_runner_classic-rs)