### PR TITLE
Compress Python payloads before base64 encoding

### DIFF
--- a/lib/msf/core/payload/python.rb
+++ b/lib/msf/core/payload/python.rb
@@ -12,8 +12,9 @@ module Msf::Payload::Python
   # @return [String] Full python stub to execute the command.
   #
   def self.create_exec_stub(cmd)
-    # Base64 encoding is required in order to handle Python's formatting
-    b64_stub = "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('#{Rex::Text.encode_base64(cmd)}')[0]))"
+    # Encoding is required in order to handle Python's formatting
+    payload = Rex::Text.encode_base64(Rex::Text.zlib_deflate(cmd))
+    b64_stub = "exec(__import__('zlib').decompress(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('#{payload}')[0])))"
     b64_stub
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 629
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 96033
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 96025
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 96025
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 95933
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/python/pingback_bind_tcp.rb
@@ -40,5 +40,7 @@ module MetasploitModule
       except:
        pass
     PYTHON
+
+    py_create_exec_stub(cmd)
   end
 end

--- a/modules/payloads/singles/python/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/python/pingback_bind_tcp.rb
@@ -1,7 +1,7 @@
 
 module MetasploitModule
 
-  CachedSize = 262
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Pingback

--- a/modules/payloads/singles/python/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/python/pingback_reverse_tcp.rb
@@ -38,5 +38,7 @@ module MetasploitModule
       except:
        pass
     PYTHON
+
+    py_create_exec_stub(cmd)
   end
 end

--- a/modules/payloads/singles/python/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/python/pingback_reverse_tcp.rb
@@ -1,7 +1,7 @@
 
 module MetasploitModule
 
-  CachedSize = 193
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Pingback

--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -1,7 +1,7 @@
 
 module MetasploitModule
 
-  CachedSize = 481
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 461
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 509
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 453
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 429
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/bind_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/bind_tcp_uuid.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 533
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 593
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_https.rb
+++ b/modules/payloads/stagers/python/reverse_https.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 865
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 501
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcp

--- a/modules/payloads/stagers/python/reverse_tcp_ssl.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_ssl.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 517
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcpSsl

--- a/modules/payloads/stagers/python/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_uuid.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 601
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -961,7 +961,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_python_ssl'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_python_ssl'
   end
@@ -2605,7 +2605,7 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/python/bind_tcp',
                               'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/bind_tcp'
   end
@@ -2616,7 +2616,7 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/python/bind_tcp_uuid',
                               'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/bind_tcp_uuid'
   end
@@ -2627,7 +2627,7 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/python/reverse_http',
                             'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_http'
   end
@@ -2638,7 +2638,7 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/python/reverse_https',
                             'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_https'
   end
@@ -2649,7 +2649,7 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/python/reverse_tcp',
                               'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_tcp'
   end
@@ -2660,7 +2660,7 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/python/reverse_tcp_ssl',
                             'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_tcp_ssl'
   end
@@ -2671,7 +2671,7 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/python/reverse_tcp_uuid',
                               'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_tcp_uuid'
   end
@@ -2681,7 +2681,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/meterpreter_bind_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter_bind_tcp'
   end
@@ -2691,7 +2691,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter_reverse_http'
   end
@@ -2701,7 +2701,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter_reverse_https'
   end
@@ -2711,7 +2711,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter_reverse_tcp'
   end
@@ -2721,7 +2721,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/pingback_bind_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/pingback_bind_tcp'
   end
@@ -2731,7 +2731,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/pingback_reverse_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/pingback_reverse_tcp'
   end
@@ -2741,7 +2741,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_bind_tcp'
   end
@@ -2751,7 +2751,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_reverse_tcp'
   end
@@ -2761,7 +2761,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/shell_reverse_tcp_ssl'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_reverse_tcp_ssl'
   end
@@ -2771,7 +2771,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/shell_reverse_udp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_reverse_udp'
   end


### PR DESCRIPTION
The internal AES and RSA implementations use base64+zlib to save space so it only makes sense that the final encoding should use it as well. This reduces the overall payload size considerably.  Fixes #17205 

## Verification

I generated multiple Python payloads for Meterpreter and reverse shells and they worked as expected on Python 2.6, 2.7, and 3.7.

The inclusion of zlib doesn't affect which versions of Python are supported because zlib is already a requirement for Meterpreter.  While it's technically possible to build Python without zlib support, it would require manually building Python from source as no standard distribution of Python omits it.