### PR TITLE
Fix pe inject payload crash

### DIFF
--- a/lib/msf/core/payload/windows/pe_inject.rb
+++ b/lib/msf/core/payload/windows/pe_inject.rb
@@ -46,7 +46,7 @@ module Msf
 
     def valid?(value, check_empty: nil)
       return false unless super
-      return false unless File.exist?(File.expand_path(value)) # no memory: locations
+      return false unless value && File.file?(File.expand_path(value)) # no memory: locations
 
       begin
         self.class.assert_compatible(Rex::PeParsey::Pe.new_from_file(value, true), @arch)


### PR DESCRIPTION
Fixes a crash when running `cmd/windows/powershell/x64/peinject/bind_tcp_uuid` without supplying a `PE` value

---


Before:

```
msf6 > use cmd/windows/powershell/x64/peinject/bind_tcp_uuid
msf6 payload(cmd/windows/powershell/x64/peinject/bind_tcp_uuid) > generate
[-] Payload generation failed: no implicit conversion of nil into String
```

After:

```
msf6 > use cmd/windows/powershell/x64/peinject/bind_tcp_uuid
msf6 payload(cmd/windows/powershell/x64/peinject/bind_tcp_uuid) > generate
[-] Payload generation failed: One or more options failed to validate: PE.
```