### PR TITLE
Fix crash when generating payload sizes

### DIFF
--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -139,9 +139,13 @@ class PayloadCachedSize
     opts = OPTS.clone
     # Assign this way to overwrite the Options key of the newly cloned hash
     opts['Options'] = opts['Options'].merge(mod.shortname =~ /6/ ? OPTS_IPV6 : OPTS_IPV4)
-    if mod.arch_to_s == ARCH_X64
+    # Extract the AdaptedArch for adaptor payloads, note `mod.adapted_arch` is not part of the public API
+    # at this time, but could be in the future. The use of send is safe for now as it is an internal tool
+    # with automated tests if the API were to change in the future
+    adapted_arch = mod.send(:module_info)['AdaptedArch']
+    if adapted_arch == ARCH_X64 || mod.arch_to_s == ARCH_X64
       opts['Options'].merge!(OPTS_ARCH_X64)
-    elsif mod.arch_to_s == ARCH_X86
+    elsif adapted_arch == ARCH_X86 || mod.arch_to_s == ARCH_X86
       opts['Options'].merge!(OPTS_ARCH_X86)
     end
     opts

--- a/modules/payloads/adapters/cmd/unix/python.rb
+++ b/modules/payloads/adapters/cmd/unix/python.rb
@@ -30,7 +30,7 @@ module MetasploitModule
     super
   end
 
-  def generate
+  def generate(_opts = {})
     payload = super
 
     if payload.include?("\n")

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/apple_ios/aarch64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/shell_reverse_tcp.rb
@@ -80,7 +80,7 @@ module MetasploitModule
       ])
   end
 
-  def generate
+  def generate(_opts = {})
     p = super
 
     sh = datastore['SHELL']

--- a/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/bsd/sparc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/sparc/shell_bind_tcp.rb
@@ -24,7 +24,7 @@ module MetasploitModule
       'Session'       => Msf::Sessions::CommandShell))
   end
 
-  def generate
+  def generate(_opts = {})
     port    = (datastore['RPORT'] || 0).to_i
     payload =
       "\x9c\x2b\xa0\x07\x94\x1a\xc0\x0b\x92\x10\x20\x01\x90\x10\x20\x02" +

--- a/modules/payloads/singles/bsd/sparc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/sparc/shell_reverse_tcp.rb
@@ -25,7 +25,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     port    = (datastore['RPORT'] || '0').to_i
     host    = nil
     begin

--- a/modules/payloads/singles/bsd/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_tcp.rb
@@ -36,7 +36,7 @@ module MetasploitModule
   end
 
   # build the shellcode payload dynamically based on the user-provided CMD
-  def generate
+  def generate(_opts = {})
     cmd  = (datastore['CMD'] || '') + "\x00"
     port = [datastore['LPORT'].to_i].pack('n')
     call = "\xe8" + [cmd.length].pack('V')

--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
@@ -38,7 +38,7 @@ module MetasploitModule
   end
 
   # build the shellcode payload dynamically based on the user-provided CMD
-  def generate
+  def generate(_opts = {})
     lhost = datastore['LHOST'] || '127.0.0.1'
 
     # OptAddress allows either an IP or hostname, we only want IPv4

--- a/modules/payloads/singles/bsd/x86/shell_find_tag.rb
+++ b/modules/payloads/singles/bsd/x86/shell_find_tag.rb
@@ -41,7 +41,7 @@ module MetasploitModule
   #
   # Ensures the setting of TAG to a four byte value
   #
-  def generate
+  def generate(_opts = {})
     datastore['TAG'] = _find_tag
 
     super

--- a/modules/payloads/singles/cmd/mainframe/apf_privesc_jcl.rb
+++ b/modules/payloads/singles/cmd/mainframe/apf_privesc_jcl.rb
@@ -76,7 +76,7 @@ module MetasploitModule
   ##
   # Construct Payload
   ##
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/mainframe/bind_shell_jcl.rb
+++ b/modules/payloads/singles/cmd/mainframe/bind_shell_jcl.rb
@@ -60,7 +60,7 @@ module MetasploitModule
   ##
   # Construct Payload
   ##
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/mainframe/generic_jcl.rb
+++ b/modules/payloads/singles/cmd/mainframe/generic_jcl.rb
@@ -61,7 +61,7 @@ module MetasploitModule
   ##
   # Construct Payload
   ##
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/mainframe/reverse_shell_jcl.rb
+++ b/modules/payloads/singles/cmd/mainframe/reverse_shell_jcl.rb
@@ -60,7 +60,7 @@ module MetasploitModule
   ##
   # Construct Payload
   ##
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_awk.rb
+++ b/modules/payloads/singles/cmd/unix/bind_awk.rb
@@ -38,7 +38,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_busybox_telnetd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_busybox_telnetd.rb
@@ -45,7 +45,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_inetd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_inetd.rb
@@ -35,7 +35,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_jjs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_jjs.rb
@@ -38,7 +38,7 @@ module MetasploitModule
     ]
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_lua.rb
+++ b/modules/payloads/singles/cmd/unix/bind_lua.rb
@@ -37,7 +37,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -39,7 +39,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_nodejs.rb
@@ -28,7 +28,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_perl.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_r.rb
+++ b/modules/payloads/singles/cmd/unix/bind_r.rb
@@ -28,7 +28,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     return prepends(r_string)
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
+++ b/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/bind_stub.rb
+++ b/modules/payloads/singles/cmd/unix/bind_stub.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Generate an empty payload
   #
-  def generate
+  def generate(_opts = {})
     ''
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/bind_zsh.rb
@@ -41,7 +41,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/generic.rb
+++ b/modules/payloads/singles/cmd/unix/generic.rb
@@ -39,7 +39,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/pingback_bind.rb
+++ b/modules/payloads/singles/cmd/unix/pingback_bind.rb
@@ -33,7 +33,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super.to_s + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/pingback_reverse.rb
+++ b/modules/payloads/singles/cmd/unix/pingback_reverse.rb
@@ -33,7 +33,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super.to_s + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse.rb
+++ b/modules/payloads/singles/cmd/unix/reverse.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_awk.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_awk.rb
@@ -39,7 +39,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_bash.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash.rb
@@ -40,7 +40,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
@@ -39,7 +39,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
@@ -43,7 +43,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_jjs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_jjs.rb
@@ -38,7 +38,7 @@ module MetasploitModule
     ]
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_ksh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ksh.rb
@@ -30,7 +30,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_lua.rb
@@ -37,7 +37,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -39,7 +39,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
@@ -28,7 +28,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_openssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_openssl.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -32,7 +32,7 @@ module MetasploitModule
     ])
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -35,7 +35,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_r.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_r.rb
@@ -28,7 +28,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     return prepends(r_string)
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_socat_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_socat_udp.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_ssh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssh.rb
@@ -43,7 +43,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
@@ -37,7 +37,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     vprint_good(command_string)
     return super + command_string
   end

--- a/modules/payloads/singles/cmd/unix/reverse_stub.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_stub.rb
@@ -33,7 +33,7 @@ module MetasploitModule
   #
   # Generate an empty payload
   #
-  def generate
+  def generate(_opts = {})
     ''
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_zsh.rb
@@ -34,7 +34,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/adduser.rb
+++ b/modules/payloads/singles/cmd/windows/adduser.rb
@@ -53,7 +53,7 @@ module MetasploitModule
 
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/bind_lua.rb
+++ b/modules/payloads/singles/cmd/windows/bind_lua.rb
@@ -37,7 +37,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/bind_perl.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/bind_ruby.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/download_eval_vbs.rb
+++ b/modules/payloads/singles/cmd/windows/download_eval_vbs.rb
@@ -40,7 +40,7 @@ module MetasploitModule
       ])
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/download_exec_vbs.rb
+++ b/modules/payloads/singles/cmd/windows/download_exec_vbs.rb
@@ -39,7 +39,7 @@ module MetasploitModule
       ])
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/generic.rb
+++ b/modules/payloads/singles/cmd/windows/generic.rb
@@ -39,7 +39,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb
@@ -40,7 +40,7 @@ module MetasploitModule
     ]
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
       ))
   end
 
-  def generate
+  def generate(_opts = {})
     generate_powershell_code("Bind")
   end
 end

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
@@ -38,7 +38,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     generate_powershell_code('Reverse')
   end
 end

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp_ssl.rb
@@ -38,7 +38,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     generate_powershell_code('SSL')
   end
 end

--- a/modules/payloads/singles/cmd/windows/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_lua.rb
@@ -37,7 +37,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_perl.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -43,7 +43,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_ruby.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string
   end
 

--- a/modules/payloads/singles/firefox/exec.rb
+++ b/modules/payloads/singles/firefox/exec.rb
@@ -30,7 +30,7 @@ module MetasploitModule
     ])
   end
 
-  def generate
+  def generate(_opts = {})
     <<-EOS
 
       (function(){

--- a/modules/payloads/singles/firefox/shell_bind_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_bind_tcp.rb
@@ -29,7 +29,7 @@ module MetasploitModule
   #
   # Returns the JS string to use for execution
   #
-  def generate
+  def generate(_opts = {})
     %Q|
     (function(){
       window = this;

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -26,7 +26,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     <<-EOS
 
       (function(){

--- a/modules/payloads/singles/generic/custom.rb
+++ b/modules/payloads/singles/generic/custom.rb
@@ -35,7 +35,7 @@ module MetasploitModule
   #
   # Construct the payload
   #
-  def generate
+  def generate(_opts = {})
     if datastore['ARCH']
       self.arch = actual_arch
     end

--- a/modules/payloads/singles/java/jsp_shell_bind_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_bind_tcp.rb
@@ -31,7 +31,7 @@ module MetasploitModule
   end
 
 
-  def generate
+  def generate(_opts = {})
     return super + jsp_bind_tcp
   end
 end

--- a/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
@@ -31,7 +31,7 @@ module MetasploitModule
   end
 
 
-  def generate
+  def generate(_opts = {})
 
     if( !datastore['LHOST'] or datastore['LHOST'].empty? )
       return super

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/aarch64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/shell_reverse_tcp.rb
@@ -80,7 +80,7 @@ module MetasploitModule
       ])
   end
 
-  def generate
+  def generate(_opts = {})
     p = super
 
     sh = datastore['SHELL']

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
@@ -31,7 +31,7 @@ module MetasploitModule
         Opt::LPORT(4444)
       ])
   end
-  def generate
+  def generate(_opts = {})
     cmd = (datastore['CMD'] || '') + "\x00"
     bytehigh = (datastore['LPORT'].to_i >> 8).chr
     bytelow = (datastore['LPORT'].to_i & 0xFF).chr

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/armle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armle/shell_bind_tcp.rb
@@ -114,7 +114,7 @@ module MetasploitModule
       ])
   end
 
-  def generate
+  def generate(_opts = {})
     p = super
 
     sh = datastore['SHELL']

--- a/modules/payloads/singles/linux/armle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/shell_reverse_tcp.rb
@@ -114,7 +114,7 @@ module MetasploitModule
       ])
   end
 
-  def generate
+  def generate(_opts = {})
     p = super
 
     sh = datastore['SHELL']

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/mipsbe/exec.rb
+++ b/modules/payloads/singles/linux/mipsbe/exec.rb
@@ -48,7 +48,7 @@ module MetasploitModule
     return datastore['CMD'] || ''
   end
 
-  def generate
+  def generate(_opts = {})
 
     shellcode =
       "\x24\x06\x06\x66" + #li a2,1638

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/mipsbe/reboot.rb
+++ b/modules/payloads/singles/linux/mipsbe/reboot.rb
@@ -38,7 +38,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     shellcode =
       "\x3c\x06\x43\x21" +  #lui     a2,0x4321
       "\x34\xc6\xfe\xdc" +  #ori     a2,a2,0xfedc

--- a/modules/payloads/singles/linux/mipsbe/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/shell_bind_tcp.rb
@@ -36,7 +36,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     if !datastore['LPORT']
       return super
     end

--- a/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
@@ -38,7 +38,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     if( !datastore['LHOST'] or datastore['LHOST'].empty? )
       return super
     end

--- a/modules/payloads/singles/linux/mipsle/exec.rb
+++ b/modules/payloads/singles/linux/mipsle/exec.rb
@@ -49,7 +49,7 @@ module MetasploitModule
     return datastore['CMD'] || ''
   end
 
-  def generate
+  def generate(_opts = {})
 
     shellcode =
       "\x66\x06\x06\x24" + # li a2,1638

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/mipsle/reboot.rb
+++ b/modules/payloads/singles/linux/mipsle/reboot.rb
@@ -37,7 +37,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     shellcode =
       "\x21\x43\x06\x3c" +  # lui     a2,0x4321
       "\xdc\xfe\xc6\x34" +  # ori     a2,a2,0xfedc

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -36,7 +36,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     if !datastore['LPORT']
       return super
     end

--- a/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
@@ -34,7 +34,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     if( !datastore['LHOST'] or datastore['LHOST'].empty? )
       return super
     end

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/linux/x86/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_tcp_random_port.rb
@@ -27,7 +27,7 @@ module MetasploitModule
       ))
   end
 
-  def generate
+  def generate(_opts = {})
     unless self.available_space.nil? || self.available_space >= 57
       payload = <<-EOS
         preparation:

--- a/modules/payloads/singles/linux/x86/shell_find_tag.rb
+++ b/modules/payloads/singles/linux/x86/shell_find_tag.rb
@@ -41,7 +41,7 @@ module MetasploitModule
   #
   # Ensures the setting of TAG to a four byte value
   #
-  def generate
+  def generate(_opts = {})
     datastore['TAG'] = _find_tag
 
     super

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
@@ -29,7 +29,7 @@ module MetasploitModule
     ])
   end
 
-  def generate
+  def generate(_opts = {})
     # pad the shell path to a multiple of 4 with slashes
     shell = datastore['CMD']
     remainder = shell.bytes.length % 4

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
@@ -30,7 +30,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/osx/armle/vibrate.rb
+++ b/modules/payloads/singles/osx/armle/vibrate.rb
@@ -23,7 +23,7 @@ module MetasploitModule
       'Arch'          => ARCH_ARMLE))
   end
 
-  def generate
+  def generate(_opts = {})
     [
       0xe1a00820, #  mov r0, r0, lsr #16
       0xe51ff004, #  ldr pc, [pc, #-4]

--- a/modules/payloads/singles/osx/x64/exec.rb
+++ b/modules/payloads/singles/osx/x64/exec.rb
@@ -27,7 +27,7 @@ module MetasploitModule
   end
 
   # build the shellcode payload dynamically based on the user-provided CMD
-  def generate
+  def generate(_opts = {})
     cmd_str = datastore['CMD'] || ''
     # Split the cmd string into arg chunks
     cmd_parts = Shellwords.shellsplit(cmd_str)

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'http',
       stageless: true

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'https',
       stageless: true

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
     )
   end
 
-  def generate
+  def generate(_opts = {})
     opts = {
       scheme: 'tcp',
       stageless: true

--- a/modules/payloads/singles/osx/x64/say.rb
+++ b/modules/payloads/singles/osx/x64/say.rb
@@ -27,7 +27,7 @@ module MetasploitModule
   end
 
   # build the shellcode payload dynamically based on the user-provided CMD
-  def generate
+  def generate(_opts = {})
     say = (datastore['TEXT'] || '') << "\x00"
     call = "\xe8" + [say.length + 0xd].pack('V')
 

--- a/modules/payloads/singles/osx/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_bind_tcp.rb
@@ -33,7 +33,7 @@ module MetasploitModule
   end
 
   # build the shellcode payload dynamically based on the user-provided CMD
-  def generate
+  def generate(_opts = {})
     cmd  = (datastore['CMD'] || '') + "\x00"
     port = [datastore['LPORT'].to_i].pack('n')
     call = "\xe8" + [cmd.length].pack('V')

--- a/modules/payloads/singles/osx/x64/shell_find_tag.rb
+++ b/modules/payloads/singles/osx/x64/shell_find_tag.rb
@@ -35,7 +35,7 @@ module MetasploitModule
   #
   # ensures the setting of tag to a four byte value
   #
-  def generate
+  def generate(_opts = {})
     cmd  = (datastore['CMD'] || '') + "\x00"
     call = "\xe8" + [cmd.length].pack('V')
 

--- a/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
@@ -37,7 +37,7 @@ module MetasploitModule
   end
 
   # build the shellcode payload dynamically based on the user-provided CMD
-  def generate
+  def generate(_opts = {})
     lhost = datastore['LHOST'] || '127.0.0.1'
     # OptAddress allows either an IP or hostname, we only want IPv4
     unless Rex::Socket.is_ipv4?(lhost)

--- a/modules/payloads/singles/php/bind_perl.rb
+++ b/modules/payloads/singles/php/bind_perl.rb
@@ -33,7 +33,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + "system(base64_decode('#{Rex::Text.encode_base64(command_string)}'));"
   end
 

--- a/modules/payloads/singles/php/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/php/bind_perl_ipv6.rb
@@ -33,7 +33,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + "system(base64_decode('#{Rex::Text.encode_base64(command_string)}'));"
   end
 

--- a/modules/payloads/singles/php/bind_php.rb
+++ b/modules/payloads/singles/php/bind_php.rb
@@ -75,7 +75,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + php_bind_shell
   end
 end

--- a/modules/payloads/singles/php/bind_php_ipv6.rb
+++ b/modules/payloads/singles/php/bind_php_ipv6.rb
@@ -75,7 +75,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + php_bind_shell
   end
 end

--- a/modules/payloads/singles/php/download_exec.rb
+++ b/modules/payloads/singles/php/download_exec.rb
@@ -73,7 +73,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return php_exec_file
   end
 end

--- a/modules/payloads/singles/php/exec.rb
+++ b/modules/payloads/singles/php/exec.rb
@@ -43,7 +43,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return php_exec_cmd
   end
 end

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -25,7 +25,7 @@ module MetasploitModule
       'Session'       => Msf::Sessions::Meterpreter_Php_Php))
   end
 
-  def generate
+  def generate(_opts = {})
     met = MetasploitPayloads.read('meterpreter', 'meterpreter.php')
 
     met.gsub!("127.0.0.1", datastore['LHOST']) if datastore['LHOST']

--- a/modules/payloads/singles/php/reverse_perl.rb
+++ b/modules/payloads/singles/php/reverse_perl.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     buf = "#{php_preamble}"
     buf += "$c = base64_decode('#{Rex::Text.encode_base64(command_string)}');"
     buf += "#{php_system_block({:cmd_varname=>"$c"})}"

--- a/modules/payloads/singles/php/reverse_php.rb
+++ b/modules/payloads/singles/php/reverse_php.rb
@@ -121,7 +121,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return super + php_reverse_shell
   end
 end

--- a/modules/payloads/singles/php/shell_findsock.rb
+++ b/modules/payloads/singles/php/shell_findsock.rb
@@ -76,7 +76,7 @@ END_OF_PHP_CODE
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     return php_findsock
   end
 end

--- a/modules/payloads/singles/python/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/python/pingback_bind_tcp.rb
@@ -21,7 +21,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     super.to_s + command_string
   end
   def command_string

--- a/modules/payloads/singles/python/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/python/pingback_reverse_tcp.rb
@@ -21,7 +21,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     super.to_s + command_string
   end
 

--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -26,7 +26,7 @@ module MetasploitModule
       ))
   end
 
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super + command_string
   end
 

--- a/modules/payloads/singles/r/shell_bind_tcp.rb
+++ b/modules/payloads/singles/r/shell_bind_tcp.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     return prepends(r_string)
   end
 

--- a/modules/payloads/singles/r/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/r/shell_reverse_tcp.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     return prepends(r_string)
   end
 

--- a/modules/payloads/singles/ruby/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/ruby/pingback_bind_tcp.rb
@@ -22,7 +22,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     #return prepends(ruby_string)
     return ruby_string
   end

--- a/modules/payloads/singles/ruby/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/ruby/pingback_reverse_tcp.rb
@@ -22,7 +22,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     # return prepends(ruby_string)
     return ruby_string
   end

--- a/modules/payloads/singles/ruby/shell_bind_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     return prepends(ruby_string)
   end
 

--- a/modules/payloads/singles/ruby/shell_bind_tcp_ipv6.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp_ipv6.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     return prepends(ruby_string)
   end
 

--- a/modules/payloads/singles/ruby/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     return prepends(ruby_string)
   end
 

--- a/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
@@ -27,7 +27,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     rbs = prepends(ruby_string)
     vprint_good rbs
     return rbs

--- a/modules/payloads/singles/solaris/sparc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_bind_tcp.rb
@@ -24,7 +24,7 @@ module MetasploitModule
       'Session'       => Msf::Sessions::CommandShell))
   end
 
-  def generate
+  def generate(_opts = {})
     port    = (datastore['LPORT'] || '0').to_i
     payload =
       "\x9c\x2b\xa0\x07\x98\x10\x20\x01\x96\x1a\xc0\x0b\x94\x1a\xc0\x0b" +

--- a/modules/payloads/singles/solaris/sparc/shell_find_port.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_find_port.rb
@@ -24,7 +24,7 @@ module MetasploitModule
       'Session'       => Msf::Sessions::CommandShell))
   end
 
-  def generate
+  def generate(_opts = {})
     port    = (datastore['CPORT'] || '0').to_i
     payload =
       Rex::Arch::Sparc.set(port, "l6") +

--- a/modules/payloads/singles/solaris/sparc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_reverse_tcp.rb
@@ -25,7 +25,7 @@ module MetasploitModule
     ))
   end
 
-  def generate
+  def generate(_opts = {})
     port    = (datastore['LPORT'] || '0').to_i
     host    = nil
     begin

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -57,7 +57,7 @@ module MetasploitModule
   # b.corelan.eu	: contains the next 255 bytes of the alpha shellcode
   # c.corelan.eu	: contains the last 144 bytes of the alpha shellcode
 
-  def generate
+  def generate(_opts = {})
 
     dnsname		= datastore['DNSZONE']
     wType		= 0x0010	#DNS_TYPE_TEXT (TEXT)

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -34,7 +34,7 @@ module MetasploitModule
   #
   # Construct the payload
   #
-  def generate
+  def generate(_opts = {})
 
     target_uri = datastore['URL'] || ""
     filename = datastore['EXE'] || ""

--- a/modules/payloads/singles/windows/format_all_drives.rb
+++ b/modules/payloads/singles/windows/format_all_drives.rb
@@ -56,7 +56,7 @@ module MetasploitModule
       ])
   end
 
-  def generate
+  def generate(_opts = {})
 
     volume_label   = datastore['VOLUMELABEL'] || ""
     encoded_volume_label = volume_label.to_s.unpack("C*").pack("v*")

--- a/modules/payloads/singles/windows/loadlibrary.rb
+++ b/modules/payloads/singles/windows/loadlibrary.rb
@@ -11,7 +11,7 @@
 ###
 module MetasploitModule
 
-  CachedSize = 230
+  CachedSize = 202
 
   include Msf::Payload::Windows::LoadLibrary
 

--- a/modules/payloads/singles/windows/messagebox.rb
+++ b/modules/payloads/singles/windows/messagebox.rb
@@ -36,7 +36,7 @@ module MetasploitModule
   #
   # Construct the payload
   #
-  def generate
+  def generate(_opts = {})
 
     strTitle = datastore['TITLE'] + "X"
     if (strTitle.length < 1)

--- a/modules/payloads/singles/windows/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_bind_tcp.rb
@@ -37,7 +37,7 @@ module MetasploitModule
       space
     end
 
-    def generate
+    def generate(_opts = {})
       encoded_port = [datastore['LPORT'].to_i,2].pack("vn").unpack("N").first
       encoded_host = Rex::Socket.addr_aton(datastore['LHOST']||"127.127.127.127").unpack("V").first
       encoded_host_port = "0x%.8x%.8x" % [encoded_host, encoded_port]

--- a/modules/payloads/singles/windows/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_reverse_tcp.rb
@@ -40,7 +40,7 @@ module MetasploitModule
       space
     end
 
-    def generate
+    def generate(_opts = {})
       encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack1('N')
       encoded_host = Rex::Socket.addr_aton(datastore['LHOST'] || '127.127.127.127').unpack1('V')
       retry_count = [datastore['ReverseConnectRetries'].to_i, 1].max

--- a/modules/payloads/singles/windows/x64/exec.rb
+++ b/modules/payloads/singles/windows/x64/exec.rb
@@ -50,7 +50,7 @@ module MetasploitModule
       ])
   end
 
-  def generate
+  def generate(_opts = {})
     return super + command_string + "\x00"
   end
 

--- a/modules/payloads/singles/windows/x64/loadlibrary.rb
+++ b/modules/payloads/singles/windows/x64/loadlibrary.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 313
+  CachedSize = 285
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/x64/messagebox.rb
+++ b/modules/payloads/singles/windows/x64/messagebox.rb
@@ -58,7 +58,7 @@ module MetasploitModule
     return (hash(to_unicode(libname.upcase)) + hash(function)) & 0xffffffff
   end
 
-  def generate
+  def generate(_opts = {})
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO

--- a/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
@@ -36,7 +36,7 @@ module MetasploitModule
       space
     end
 
-    def generate
+    def generate(_opts = {})
       # 22 -> "0x00,0x16"
       # 4444 -> "0x11,0x5c"
       encoded_port = [datastore['LPORT'].to_i, 2].pack("vn").unpack("N").first

--- a/modules/payloads/stagers/python/reverse_https.rb
+++ b/modules/payloads/stagers/python/reverse_https.rb
@@ -27,7 +27,7 @@ module MetasploitModule
   #
   # Constructs the payload
   #
-  def generate
+  def generate(_opts = {})
     super({scheme: 'https'})
   end
 end

--- a/modules/payloads/stagers/windows/reverse_hop_http.rb
+++ b/modules/payloads/stagers/windows/reverse_hop_http.rb
@@ -59,7 +59,7 @@ module MetasploitModule
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     uri = URI(datastore['HOPURL'])
     #create actual payload
     payload_data = <<EOS

--- a/modules/payloads/stagers/windows/reverse_http_proxy_pstore.rb
+++ b/modules/payloads/stagers/windows/reverse_http_proxy_pstore.rb
@@ -93,7 +93,7 @@ module MetasploitModule
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     p = super
     i = p.index("/12345\x00")
     u = generate_uri_uuid_mode(:init_native, 5) + "\x00"

--- a/modules/payloads/stagers/windows/reverse_https_proxy.rb
+++ b/modules/payloads/stagers/windows/reverse_https_proxy.rb
@@ -70,7 +70,7 @@ module MetasploitModule
   #
   # Generate the first stage
   #
-  def generate
+  def generate(_opts = {})
     p = super
 
     i = p.index("/12345\x00")

--- a/spec/support/shared/examples/payload_cached_size_is_consistent.rb
+++ b/spec/support/shared/examples/payload_cached_size_is_consistent.rb
@@ -86,53 +86,6 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
 
   include_context 'Msf::Simple::Framework#modules loading'
 
-  opts = {
-    'Format'      => 'raw',
-    'Options'     => {
-      'CPORT' => 4444,
-      'LPORT' => 4444,
-      'LHOST' => '255.255.255.255',
-      'KHOST' => '255.255.255.255',
-      'AHOST' => '255.255.255.255',
-      'CMD' => '/bin/sh',
-      'URL' => 'http://a.com',
-      'PATH' => '/',
-      'BUNDLE' => 'data/isight.bundle',
-      'DLL' => 'external/source/byakugan/bin/XPSP2/detoured.dll',
-      'RC4PASSWORD' => 'Metasploit',
-      'DNSZONE' => 'corelan.eu',
-      'PEXEC' => '/bin/sh',
-      'HttpUserAgent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0',
-      'StagerURILength' => 5
-    },
-    'Encoder'     => nil,
-    'DisableNops' => true
-  }
-
-  opts6 = {
-      'Format'      => 'raw',
-      'Options'     => {
-          'CPORT' => 4444,
-          'LPORT' => 4444,
-          'LHOST' => 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
-          'KHOST' => 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
-          'AHOST' => 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
-          'CMD' => '/bin/sh',
-          'URL' => 'http://a.com',
-          'PATH' => '/',
-          'BUNDLE' => 'data/isight.bundle',
-          'DLL' => 'external/source/byakugan/bin/XPSP2/detoured.dll',
-          'RC4PASSWORD' => 'Metasploit',
-          'DNSZONE' => 'corelan.eu',
-          'PEXEC' => '/bin/sh',
-          'HttpUserAgent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0',
-          'StagerURILength' => 5
-      },
-      'Encoder'     => nil,
-      'DisableNops' => true
-  }
-
-
   #
   # lets
   #
@@ -182,11 +135,9 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
         )
         expect(pinst.cached_size).to_not(be_nil)
         expect(pinst.dynamic_size?).to be(false)
-        if pinst.shortname =~ /6/
-          expect(pinst.cached_size).to eq(pinst.generate_simple(opts6).size)
-        else
-          expect(pinst.cached_size).to eq(pinst.generate_simple(opts).size)
-        end
+
+        module_options = Msf::Util::PayloadCachedSize.module_options(pinst)
+        expect(pinst.cached_size).to eq(pinst.generate_simple(module_options).size)
       end
     end
   end

--- a/tools/modules/update_payload_cached_sizes.rb
+++ b/tools/modules/update_payload_cached_sizes.rb
@@ -31,17 +31,13 @@ framework.payloads.each_module do |name, mod|
     next if name =~ /generic/
     mod_inst = framework.payloads.create(name)
     #mod_inst.datastore.merge!(framework.datastore)
-    next if Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod_inst)
+    next if mod_inst.is_a?(Msf::Payload::Adapter) || Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod_inst)
     $stdout.puts "[*] Updating the CacheSize for #{mod.file_path}..."
     Msf::Util::PayloadCachedSize.update_module_cached_size(mod_inst)
   rescue => e
+    $stderr.puts "[!] Caught Error while updating #{name}:\n#{e}\n#{e.backtrace.map { |line| "\t#{line}" }.join("\n")}"
     exceptions << [ e, name ]
-    next
   end
 end
 
-exceptions.each do |e, name|
-  print_error("Caught Error while updating #{name}:\n#{e}")
-  elog(e)
-end
 exit(1) unless exceptions.empty?


### PR DESCRIPTION
Fixes a crash when generating payload sizes

### Before

Adaptor payloads are updated in size, and other modules crash:

```
$ ./tools/modules/update_payload_cached_sizes.rb
[*] Updating the CacheSize for /Users/adfoster/Documents/code/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /Users/adfoster/Documents/code/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
[*] Updating the CacheSize for /Users/adfoster/Documents/code/metasploit-framework/modules/payloads/adapters/cmd/unix/python.rb...
.... etc ...
[-] Caught Error while updating cmd/windows/powershell/custom/reverse_hop_http:
wrong number of arguments (given 1, expected 0)
[-] Caught Error while updating cmd/windows/powershell/custom/reverse_http_proxy_pstore:
wrong number of arguments (given 1, expected 0)
[-] Caught Error while updating cmd/windows/powershell/custom/reverse_https_proxy:
wrong number of arguments (given 1, expected 0)
[-] Caught Error while updating cmd/windows/powershell/dllinject/reverse_hop_http:
wrong number of arguments (given 1, expected 0)
```

The errors were being generated by payloads which used a method definition of `def generate(opts = {})` which called `super` with a parent class of `def generate`

### After

No crashes, and the adaptor payload's size is no longer updated multiple times

## Verification

- Verify no more crashes
- Verify the payload metadata is ignored for adaptors