### PR TITLE
Update YARD documentation to use proper @return instead of @returns

### DIFF
--- a/lib/msf/core/rpc/json/client.rb
+++ b/lib/msf/core/rpc/json/client.rb
@@ -41,7 +41,7 @@ module Msf::RPC::JSON
     # @param symbol [Symbol] the symbol for the method called
     # @param args [Array] any positional arguments passed to the method
     # @param keyword_args [Hash] any keyword arguments passed to the method
-    # @returns [Msf::RPC::JSON::Request] an EM::Deferrable for the RPC method invocation.
+    # @return [Msf::RPC::JSON::Request] an EM::Deferrable for the RPC method invocation.
     def method_missing(symbol, *args, **keyword_args, &block)
       # assemble method parameters
       if !args.empty? && !keyword_args.empty?
@@ -60,7 +60,7 @@ module Msf::RPC::JSON
     # Asynchronously processes the RPC method invocation.
     # @param method [Symbol] the method
     # @param params [Array, Hash] any arguments passed to the method
-    # @returns [Msf::RPC::JSON::Request] an EM::Deferrable for the RPC method invocation.
+    # @return [Msf::RPC::JSON::Request] an EM::Deferrable for the RPC method invocation.
     def process_call_async(method, params)
       req = Request.new(@uri,
                         api_token: @api_token,

--- a/lib/msf/core/rpc/json/dispatcher.rb
+++ b/lib/msf/core/rpc/json/dispatcher.rb
@@ -82,12 +82,9 @@ module Msf::RPC::JSON
 
     # Validate and execute the JSON-RPC request.
     # @param request [Hash] the JSON-RPC request
-    # @returns [RpcCommand] an RpcCommand for the specified version
     # @raise [InvalidParams] ArgumentError occurred during execution.
-    # @raise [ApplicationServerError] General server-error wrapper around an
-    # Msf::RPC::Exception that occurred during execution.
-    # @returns [Hash] JSON-RPC response that encapsulates the RPC result
-    # if successful; otherwise, a JSON-RPC error response.
+    # @raise [ApplicationServerError] General server-error wrapper around an Msf::RPC::Exception that occurred during execution.
+    # @return [Hash, nil] JSON-RPC response that encapsulates the RPC result, or Nil if a Notification request was sent.
     def process_request(request)
       begin
         if !validate_rpc_request(request)
@@ -123,7 +120,7 @@ module Msf::RPC::JSON
 
     # Validate the JSON-RPC request.
     # @param request [Hash] the JSON-RPC request
-    # @returns [Boolean] true if the JSON-RPC request is valid; otherwise, false.
+    # @return [Boolean] true if the JSON-RPC request is valid; otherwise, false.
     def validate_rpc_request(request)
       # validate request is an object
       return false unless request.is_a?(Hash)
@@ -168,7 +165,7 @@ module Msf::RPC::JSON
     # Create a JSON-RPC success response.
     # @param result [Object] the RPC method's return value
     # @param request [Hash] the JSON-RPC request
-    # @returns [Hash] JSON-RPC success response.
+    # @return [Hash] JSON-RPC success response.
     def self.create_success_response(result, request = nil)
       response = {
           # A String specifying the version of the JSON-RPC protocol.
@@ -188,7 +185,7 @@ module Msf::RPC::JSON
     # Create a JSON-RPC error response.
     # @param error [RpcError] a RpcError instance
     # @param request [Hash] the JSON-RPC request
-    # @returns [Hash] JSON-RPC error response.
+    # @return [Hash] JSON-RPC error response.
     def self.create_error_response(error, request = nil)
       response = {
           # A String specifying the version of the JSON-RPC protocol.

--- a/lib/msf/core/rpc/json/dispatcher_helper.rb
+++ b/lib/msf/core/rpc/json/dispatcher_helper.rb
@@ -6,7 +6,7 @@ module Msf::RPC::JSON
     # @param dispatchers [Hash] hash of version Symbol - Msf::RPC::JSON::Dispatcher object pairs
     # @param version [Symbol] the RPC version
     # @param framework [Msf::Simple::Framework] Framework wrapper instance
-    # @returns [Msf::RPC::JSON::Dispatcher] an RPC Dispatcher for the specified version
+    # @return [Msf::RPC::JSON::Dispatcher] an RPC Dispatcher for the specified version
     def get_dispatcher(dispatchers, version, framework)
       unless dispatchers.key?(version)
         dispatchers[version] = create_dispatcher(version, framework)
@@ -18,7 +18,7 @@ module Msf::RPC::JSON
     # Create an RPC Dispatcher composed of an RpcCommand for the provided version.
     # @param version [Symbol] the RPC version
     # @param framework [Msf::Simple::Framework] Framework wrapper instance
-    # @returns [Msf::RPC::JSON::Dispatcher] an RPC Dispatcher for the specified version
+    # @return [Msf::RPC::JSON::Dispatcher] an RPC Dispatcher for the specified version
     def create_dispatcher(version, framework)
       command = RpcCommandFactory.create(version, framework)
       dispatcher = Dispatcher.new(framework)

--- a/lib/msf/core/rpc/json/error.rb
+++ b/lib/msf/core/rpc/json/error.rb
@@ -178,7 +178,7 @@ module Msf::RPC::JSON
     # @param response [Hash] A response hash.
     # @param symbolize_names [Boolean] If true, symbols are used for the names (keys) when
     #   processing JSON objects; otherwise, strings are used. Default: true
-    # @returns [ErrorResponse] ErrorResponse object that represents the response hash.
+    # @return [ErrorResponse] ErrorResponse object that represents the response hash.
     def self.parse(response, symbolize_names: true)
       id_key = symbolize_names ? :id : :id.to_s
       error_key = symbolize_names ? :error : :error.to_s

--- a/lib/msf/core/rpc/json/request.rb
+++ b/lib/msf/core/rpc/json/request.rb
@@ -138,7 +138,7 @@ module Msf::RPC::JSON
 
     # Validate the JSON-RPC response.
     # @param response [Hash] the JSON-RPC response
-    # @returns [Boolean] true if the JSON-RPC response is valid; otherwise, false.
+    # @return [Boolean] true if the JSON-RPC response is valid; otherwise, false.
     def valid_rpc_response?(response)
       # validate response is an object
       return false unless response.is_a?(Hash)

--- a/lib/msf/core/rpc/json/response.rb
+++ b/lib/msf/core/rpc/json/response.rb
@@ -10,7 +10,7 @@ module Msf::RPC::JSON
     # @param response [Hash] A response hash.
     # @param symbolize_names [Boolean] If true, symbols are used for the names (keys) when
     #   processing JSON objects; otherwise, strings are used. Default: true
-    # @returns [Response] Response object that represents the response hash.
+    # @return [Response] Response object that represents the response hash.
     def self.parse(response, symbolize_names: true)
       id_key = symbolize_names ? :id : :id.to_s
       result_key = symbolize_names ? :result : :result.to_s

--- a/lib/msf/core/rpc/json/rpc_command.rb
+++ b/lib/msf/core/rpc/json/rpc_command.rb
@@ -15,7 +15,7 @@ module Msf::RPC::JSON
     # Add a method to the RPC Command
     # @param method [Method] the Method
     # @param name [String] the name the method is register under. The method name is used if nil.
-    # @returns [Method] the Method.
+    # @return [Method] the Method.
     def register_method(method, name: nil)
       if name.nil?
         if method.is_a?(Method)
@@ -33,7 +33,7 @@ module Msf::RPC::JSON
     # @param params [Array, Hash] parameters for the RPC call
     # @raise [MethodNotFound] The method does not exist
     # @raise [Timeout::Error] The method failed to terminate in @execute_timeout seconds
-    # @returns [Object] the method's return value.
+    # @return [Object] the method's return value.
     def execute(method, params)
       unless @methods.key?(method)
         raise MethodNotFound.new(method)

--- a/lib/msf/core/rpc/json/rpc_command_factory.rb
+++ b/lib/msf/core/rpc/json/rpc_command_factory.rb
@@ -7,7 +7,7 @@ module Msf::RPC::JSON
     # @param version [Symbol] the RPC version
     # @param framework [Msf::Simple::Framework] Framework wrapper instance
     # @raise [ArgumentError] invalid RPC version
-    # @returns [RpcCommand] an RpcCommand for the specified version
+    # @return [RpcCommand] an RpcCommand for the specified version
     def self.create(version, framework)
       case version
       when :v1, :v1_0, :v10
@@ -21,7 +21,7 @@ module Msf::RPC::JSON
 
     # Creates an RpcCommand for a demonstration RPC version 2.0.
     # @param framework [Msf::Simple::Framework] Framework wrapper instance
-    # @returns [RpcCommand] an RpcCommand for a demonstration RPC version 2.0
+    # @return [RpcCommand] an RpcCommand for a demonstration RPC version 2.0
     def self.create_rpc_command_v2_0(framework)
       # TODO: does belong in some sort of loader class for an RPC version?
       # instantiate receiver

--- a/lib/msf/core/rpc/json/v1_0/rpc_command.rb
+++ b/lib/msf/core/rpc/json/v1_0/rpc_command.rb
@@ -32,7 +32,7 @@ module Msf::RPC::JSON
       # returning the method's return value.
       # @param method [String] the RPC method name
       # @param params [Array, Hash] parameters for the RPC call
-      # @returns [Object] the method's return value.
+      # @return [Object] the method's return value.
       def execute(method, params)
         result = execute_internal(method, params)
         result = post_process_result(result, method, params)
@@ -48,7 +48,7 @@ module Msf::RPC::JSON
       # @param params [Array, Hash] parameters for the RPC call
       # @raise [MethodNotFound] The method does not exist
       # @raise [Timeout::Error] The method failed to terminate in @execute_timeout seconds
-      # @returns [Object] the method's return value.
+      # @return [Object] the method's return value.
       def execute_internal(method, params)
         group, base_method = parse_method_group(method)
 
@@ -78,7 +78,7 @@ module Msf::RPC::JSON
 
       # Parse method string in the format "group.base_method_name".
       # @param method [String] the RPC method name
-      # @returns [Array] Tuple of strings, group and base_method
+      # @return [Array] Tuple of strings, group and base_method
       def parse_method_group(method)
         idx = method.rindex(METHOD_GROUP_SEPARATOR)
         if idx.nil?
@@ -95,7 +95,7 @@ module Msf::RPC::JSON
       # @param handlers [Hash] hash of group String - Msf::RPC::RPC_Base object pairs
       # @param group [String] the RPC group
       # @param method_name [String] the RPC method name
-      # @returns [Msf::RPC::RPC_Base] concrete Msf::RPC::RPC_Base instance if one exists; otherwise, nil.
+      # @return [Msf::RPC::RPC_Base] concrete Msf::RPC::RPC_Base instance if one exists; otherwise, nil.
       def find_handler(handlers, group, method_name)
         handler = nil
         if !handlers[group].nil? && handlers[group].respond_to?(method_name)
@@ -108,7 +108,7 @@ module Msf::RPC::JSON
       # Prepare params for use by RPC methods by converting all hashes
       # inside of Arrays to use strings for their names (keys).
       # @param params [Object] parameters for the RPC call
-      # @returns [Object] If params is an Array all hashes it contains will be
+      # @return [Object] If params is an Array all hashes it contains will be
       # modified; otherwise, the object will simply pass-through.
       def prepare_params(params)
         clean_params = params
@@ -127,7 +127,7 @@ module Msf::RPC::JSON
 
       # Stringify the names (keys) in hash.
       # @param hash [Hash] input hash
-      # @returns [Hash] a new hash with strings for the keys.
+      # @return [Hash] a new hash with strings for the keys.
       def stringify_names(hash)
         JSON.parse(JSON.dump(hash), symbolize_names: false)
       end
@@ -136,7 +136,7 @@ module Msf::RPC::JSON
       # @param result [Object] the method's return value
       # @param method [String] the RPC method name
       # @param params [Array, Hash] parameters for the RPC call
-      # @returns [Object] processed method's return value
+      # @return [Object] processed method's return value
       def post_process_result(result, method, params)
         # post-process payload module result for JSON output
         if method == MODULE_EXECUTE_KEY && params.size >= 2 &&


### PR DESCRIPTION
According to https://rubydoc.info/gems/yard/file/docs/Tags.md#List_of_Available_Tags YARD has the `@return` tag for documenting return values. It does not have a `@returns` value which is what we are using in some files.

This fixes this up to use `@return` tag instead of the nonexistant `@returns` tag. It also updates one or two files that had multiple definitions of return values to have a singular one that defines all the potential return values more clearly.
