### PR TITLE
Module to request TGT/TGS Kerberos tickets from the KDC

### DIFF
--- a/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
@@ -3,24 +3,24 @@
 This module requests TGT/TGS tickets from the KDC. Two ACTIONS are available:
 
 - **TGT**: legally request a TGT from the KDC given a password, a NT hash or
-  an encryption key. The resulting TGT will be stored in the loot.
+  an encryption key. The resulting TGT will be cached.
 - **TGS**: legally request a TGS from the KDC given a password, a NT hash, an
   encryption key or a cached TGT. If the TGT is not provided, it will request
   it the same way the "TGT action" does. The resulting TGT and the TGS will be
-  stored in the loot.
+  cached.
 
 ## Verification Steps
 
 - Start `msfconsole`
 - Do: `use auxiliary/admin/kerberos/get_ticket`
-- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=TGT`
+- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGT`
 - **Verify** the TGT is correctly retrieved and stored in the loot
 - Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY`
   option) instead of the password
-- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=TGS spn=<SPN>`
+- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGS spn=<SPN>`
 - **Verify** the module uses the TGT in the cache and does not request a new one
 - **Verify** the TGS is correctly retrieved and stored in the loot
-- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=TGS spn=<SPN> KrbUseCachedCredentials=false`
+- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGS spn=<SPN> KrbUseCachedCredentials=false`
 - **Verify** the module does not use the TGT in the cache and requests a new one
 - **Verify** both the TGT and the TGS are correctly retrieved and stored in the loot
 - Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY`
@@ -68,7 +68,7 @@ Loot
 host  service  type  name  content  info  path
 ----  -------  ----  ----  -------  ----  ----
 
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator nthash=<redacted> action=TGT
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator nthash=<redacted> action=GET_TGT
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -81,7 +81,7 @@ Loot
 
 host             service  type                 name  content                   info                                                                          path
 ----             -------  ----                 ----  -------                   ----                                                                          ----
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104181416_default_10.0.0.24_mit.kerberos.cca_912121.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104181416_default_10.0.0.24_mit.kerberos.cca_912121.bin
 
 msf6 auxiliary(admin/kerberos/get_ticket) > hosts
 
@@ -90,7 +90,7 @@ Hosts
 
 address          mac  name  os_name  os_flavor  os_sp  purpose  info  comments
 -------          ---  ----  -------  ---------  -----  -------  ----  --------
-10.0.0.24             Unknown                    device
+10.0.0.24                   Unknown                    device
 
 msf6 auxiliary(admin/kerberos/get_ticket) > services
 Services
@@ -98,13 +98,13 @@ Services
 
 host             port  proto  name      state  info
 ----             ----  -----  ----      -----  ----
-10.0.0.24  88    tcp    kerberos  open   Module: auxiliary/admin/kerberos/get_ticket, KDC for domain mylab.local
+10.0.0.24        88    tcp    kerberos  open   Module: auxiliary/admin/kerberos/get_ticket, KDC for domain mylab.local
 ```
 
 - TGT with encryption key
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=TGT
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=GET_TGT
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -115,7 +115,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 - TGT with password
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator password=<redacted> action=TGT
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator password=<redacted> action=GET_TGT
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -129,7 +129,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 - TGS with NT hash
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator nthash=<redacted> action=TGS spn=cifs/dc02.mylab.local
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator nthash=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -144,14 +144,14 @@ Loot
 
 host             service  type                 name  content                   info                                                                             path
 ----             -------  ----                 ----  -------                   ----                                                                             ----
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_760650.bin
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_883314.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_760650.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_883314.bin
 ```
 
 - TGS with encryption key
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=TGS spn=cifs/dc02.mylab.local
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -164,7 +164,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 - TGS with password
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator password=<redacted> action=TGS spn=cifs/dc02.mylab.local
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator password=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -184,10 +184,10 @@ Loot
 
 host             service  type                 name  content                   info                                                                             path
 ----             -------  ----                 ----  -------                   ----                                                                             ----
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
 
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=TGS spn=cifs/dc02.mylab.local
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
 [*] 10.0.0.24:88 - Using cached credential for krbtgt/mylab.local Administrator
@@ -206,15 +206,15 @@ Loot
 
 host             service  type                 name  content                   info                                                                             path
 ----             -------  ----                 ----  -------                   ----                                                                             ----
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
 
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=GET_TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false
 [*] Running module against 10.0.0.24
 
 [-] Auxiliary aborted due to failure: unknown: Error while requesting a TGT: Kerberos Error - KDC_ERR_PREAUTH_REQUIRED (25) - Additional pre-authentication required - Check the authentication-related options (PASSWORD, NTHASH or AESKEY)
 [*] Auxiliary module execution completed
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false password=<redacted>
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=GET_TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false password=<redacted>
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -229,9 +229,9 @@ Loot
 
 host             service  type                 name  content                   info                                                                             path
 ----             -------  ----                 ----  -------                   ----                                                                             ----
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_200958.bin
-10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_849639.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_200958.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_849639.bin
 ```
 

--- a/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
@@ -1,0 +1,237 @@
+## Vulnerable Application
+
+This module requests TGT/TGS tickets from the KDC. Two ACTIONS are available:
+
+- **TGT**: legally request a TGT from the KDC given a password, a NT hash or
+  an encryption key. The resulting TGT will be stored in the loot.
+- **TGS**: legally request a TGS from the KDC given a password, a NT hash, an
+  encryption key or a cached TGT. If the TGT is not provided, it will request
+  it the same way the "TGT action" does. The resulting TGT and the TGS will be
+  stored in the loot.
+
+## Verification Steps
+
+- Start `msfconsole`
+- Do: `use auxiliary/admin/kerberos/get_ticket`
+- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=TGT`
+- **Verify** the TGT is correctly retrieved and stored in the loot
+- Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY`
+  option) instead of the password
+- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=TGS spn=<SPN>`
+- **Verify** the module uses the TGT in the cache and does not request a new one
+- **Verify** the TGS is correctly retrieved and stored in the loot
+- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=TGS spn=<SPN> KrbUseCachedCredentials=false`
+- **Verify** the module does not use the TGT in the cache and requests a new one
+- **Verify** both the TGT and the TGS are correctly retrieved and stored in the loot
+- Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY`
+  option) instead of the password
+
+## Options
+
+### DOMAIN
+The Fully Qualified Domain Name (FQDN). Ex: mydomain.local
+
+### USER
+The domain username to authenticate with.
+
+### PASSWORD
+The user's password to use.
+
+### NTHASH
+The user's NT hash in hex string to authenticate with. Not that the DC must
+support RC4 encryption.
+
+### AESKEY
+The user's AES key to use for Kerberos authentication in hex string. Supported
+keys: 128 or 256 bits.
+
+### SPN
+The Service Principal Name, the format is `service_name/FQDN` . Ex:
+cifs/dc01.mydomain.local. This option is only used when requesting a TGS.
+
+### KrbUseCachedCredentials
+If set to `true`, it looks for a matching TGT in the database and, if found,
+use it for Kerberos authentication. Default is `true`.
+
+## Scenarios
+
+### Requesting a TGT
+
+- TGT with NT hash
+
+```
+msf6 auxiliary(admin/kerberos/get_ticket) > loot
+
+Loot
+====
+
+host  service  type  name  content  info  path
+----  -------  ----  ----  -------  ----  ----
+
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator nthash=<redacted> action=TGT
+[*] Running module against 10.0.0.24
+
+[+] 10.0.0.24:88 - Received a valid TGT-Response
+[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104181416_default_10.0.0.24_mit.kerberos.cca_912121.bin
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/kerberos/get_ticket) > loot
+
+Loot
+====
+
+host             service  type                 name  content                   info                                                                          path
+----             -------  ----                 ----  -------                   ----                                                                          ----
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104181416_default_10.0.0.24_mit.kerberos.cca_912121.bin
+
+msf6 auxiliary(admin/kerberos/get_ticket) > hosts
+
+Hosts
+=====
+
+address          mac  name  os_name  os_flavor  os_sp  purpose  info  comments
+-------          ---  ----  -------  ---------  -----  -------  ----  --------
+10.0.0.24             Unknown                    device
+
+msf6 auxiliary(admin/kerberos/get_ticket) > services
+Services
+========
+
+host             port  proto  name      state  info
+----             ----  -----  ----      -----  ----
+10.0.0.24  88    tcp    kerberos  open   Module: auxiliary/admin/kerberos/get_ticket, KDC for domain mylab.local
+```
+
+- TGT with encryption key
+
+```
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=TGT
+[*] Running module against 10.0.0.24
+
+[+] 10.0.0.24:88 - Received a valid TGT-Response
+[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104182051_default_10.0.0.24_mit.kerberos.cca_535003.bin
+[*] Auxiliary module execution completed
+```
+
+- TGT with password
+
+```
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator password=<redacted> action=TGT
+[*] Running module against 10.0.0.24
+
+[+] 10.0.0.24:88 - Received a valid TGT-Response
+[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104182219_default_10.0.0.24_mit.kerberos.cca_533360.bin
+[*] Auxiliary module execution completed
+```
+
+
+### Requesting a TGS
+
+- TGS with NT hash
+
+```
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator nthash=<redacted> action=TGS spn=cifs/dc02.mylab.local
+[*] Running module against 10.0.0.24
+
+[+] 10.0.0.24:88 - Received a valid TGT-Response
+[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_760650.bin
+[+] 10.0.0.24:88 - Received a valid TGS-Response
+[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_883314.bin
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/kerberos/get_ticket) > loot
+
+Loot
+====
+
+host             service  type                 name  content                   info                                                                             path
+----             -------  ----                 ----  -------                   ----                                                                             ----
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_760650.bin
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_883314.bin
+```
+
+- TGS with encryption key
+
+```
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=TGS spn=cifs/dc02.mylab.local
+[*] Running module against 10.0.0.24
+
+[+] 10.0.0.24:88 - Received a valid TGT-Response
+[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104183040_default_10.0.0.24_mit.kerberos.cca_140502.bin
+[+] 10.0.0.24:88 - Received a valid TGS-Response
+[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104183040_default_10.0.0.24_mit.kerberos.cca_500387.bin
+[*] Auxiliary module execution completed
+```
+
+- TGS with password
+
+```
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator password=<redacted> action=TGS spn=cifs/dc02.mylab.local
+[*] Running module against 10.0.0.24
+
+[+] 10.0.0.24:88 - Received a valid TGT-Response
+[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
+[+] 10.0.0.24:88 - Received a valid TGS-Response
+[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
+[*] Auxiliary module execution completed
+```
+
+- TGS with cached TGT
+
+```
+msf6 auxiliary(admin/kerberos/get_ticket) > loot
+
+Loot
+====
+
+host             service  type                 name  content                   info                                                                             path
+----             -------  ----                 ----  -------                   ----                                                                             ----
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
+
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=TGS spn=cifs/dc02.mylab.local
+[*] Running module against 10.0.0.24
+
+[*] 10.0.0.24:88 - Using cached credential for krbtgt/mylab.local Administrator
+[+] 10.0.0.24:88 - Received a valid TGS-Response
+[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104183346_default_10.0.0.24_mit.kerberos.cca_525186.bin
+[*] Auxiliary module execution completed
+```
+
+- TGS without cached TGT
+
+```
+msf6 auxiliary(admin/kerberos/get_ticket) > loot
+
+Loot
+====
+
+host             service  type                 name  content                   info                                                                             path
+----             -------  ----                 ----  -------                   ----                                                                             ----
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
+
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false
+[*] Running module against 10.0.0.24
+
+[-] Auxiliary aborted due to failure: unknown: Error while requesting a TGT: Kerberos Error - KDC_ERR_PREAUTH_REQUIRED (25) - Additional pre-authentication required - Check the authentication-related options (PASSWORD, NTHASH or AESKEY)
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false password=<redacted>
+[*] Running module against 10.0.0.24
+
+[+] 10.0.0.24:88 - Received a valid TGT-Response
+[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_200958.bin
+[+] 10.0.0.24:88 - Received a valid TGS-Response
+[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_849639.bin
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/kerberos/get_ticket) > loot
+
+Loot
+====
+
+host             service  type                 name  content                   info                                                                             path
+----             -------  ----                 ----  -------                   ----                                                                             ----
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_200958.bin
+10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_849639.bin
+```
+

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -167,6 +167,8 @@ module Msf
             client_name = options[:client_name]
             password = options[:password]
             password.dup.force_encoding('utf-8') if password
+            key = options[:key]
+            etype = options[:etype]
             client_name.dup.force_encoding('utf-8')
             request_pac = options.fetch(:request_pac, true)
             ticket_options = options[:options]
@@ -178,6 +180,7 @@ module Msf
             now = Time.now.utc
             expiry_time = now + 1.day
             offered_etypes = Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
+            offered_etypes = [ etype ] if !password && key && etype
             initial_as_req = build_as_request(
               pa_data: [
                 build_pa_pac_request(pac_request_value: request_pac)
@@ -209,7 +212,7 @@ module Msf
             end
 
             # If we're just AS_REP Roasting, we can't go any further
-            raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: initial_as_res) if password == nil
+            raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: initial_as_res) if password.nil? && key.nil?
 
             # Verify error codes. Anything other than the server requiring an additional preauth request is considered a failure.
             if initial_as_res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR && initial_as_res.error_code != Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_PREAUTH_REQUIRED
@@ -230,25 +233,32 @@ module Msf
             raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: initial_as_res) unless etype_entries
             server_ciphers = etype_entries.decoded_value
 
+
             selected_etypeinfo = select_cipher(offered_etypes, server_ciphers)
             selected_etype = selected_etypeinfo.etype
-            salt = selected_etypeinfo.salt
-            salt.force_encoding('utf-8') if salt
-            params = selected_etypeinfo.s2kparams
 
-            encryptor = Rex::Proto::Kerberos::Crypto::Encryption::from_etype(selected_etype)
-            password_digest = encryptor.string_to_key(password, salt, params: params)
+            if password
+              salt = selected_etypeinfo.salt
+              salt.force_encoding('utf-8') if salt
+              params = selected_etypeinfo.s2kparams
+
+              encryptor = Rex::Proto::Kerberos::Crypto::Encryption::from_etype(selected_etype)
+              enc_key = encryptor.string_to_key(password, salt, params: params)
+            elsif key
+              raise ArgumentError.new('Encryption key provided without encryption type') unless etype
+              enc_key = key
+            end
 
             preauth_as_req = build_as_request(
               pa_data: [
-                build_as_pa_time_stamp(key: password_digest, etype: selected_etype),
+                build_as_pa_time_stamp(key: enc_key, etype: selected_etype),
                 build_pa_pac_request(pac_request_value: request_pac)
               ],
               body: build_as_request_body(
                 client_name: client_name,
                 server_name: server_name,
                 realm: realm,
-                key: password_digest,
+                key: enc_key,
 
                 etype: offered_etypes,
 
@@ -269,7 +279,7 @@ module Msf
               preauth_required: true,
               decrypted_part: decrypt_kdc_as_rep_enc_part(
                 preauth_as_res,
-                password_digest,
+                enc_key,
               )
             )
           end

--- a/modules/auxiliary/admin/kerberos/get_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/get_ticket.rb
@@ -1,0 +1,286 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::Kerberos::Client
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Kerberos TGT/TGS Ticket Requestor',
+        'Description' => %q{
+          This module requests TGT/TGS Kerberos tickets from the KDC
+        },
+        'Author' => [
+          'Christophe De La Fuente' # MSF module
+        ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ],
+          'Reliability' => [ ]
+        },
+        'Actions' => [
+          [ 'TGT', { 'Description' => 'Request a TGT' } ],
+          [ 'TGS', { 'Description' => 'Request a TGS' } ],
+        ],
+        'DefaultAction' => 'TGT'
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('DOMAIN', [ true, 'The Fully Qualified Domain Name (FQDN). Ex: mydomain.local' ]),
+        OptString.new('USER', [ true, 'The domain user' ]),
+        OptString.new('PASSWORD', [ false, 'The domain user password' ]),
+        OptString.new(
+          'NTHASH', [
+            false,
+            'The NT hash in hex string. Server must support RC4'
+          ],
+          regex: /^\h{32}$/
+        ),
+        OptString.new(
+          'AESKEY', [
+            false,
+            'The AES key to use for Kerberos authentication in hex string. Supported keys: 128 or 256 bits'
+          ],
+          regex: /^(\h{32}|\h{64})$/
+        ),
+        OptString.new(
+          'SPN', [
+            false,
+            'The Service Principal Name, format is service_name/FQDN. Ex: cifs/dc01.mydomain.local'
+          ],
+          regex: %r{.+/.+},
+          conditions: %w[ACTION == TGS]
+        )
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptBool.new(
+          'KrbUseCachedCredentials', [
+            true,
+            'Use credentials stored in the database for Kerberos authentication',
+            true
+          ]
+        ),
+      ]
+    )
+  end
+
+  def run
+    if action.name == 'TGS' && datastore['SPN'].blank?
+      fail_with(Failure::BadConfig, 'SPN must be provided when requiring a TGS')
+    end
+
+    send("action_request_#{action.name.downcase}")
+  end
+
+  def action_request_tgt
+    ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+      [
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK
+      ]
+    )
+    options = {
+      realm: datastore['DOMAIN'],
+      server_name: "krbtgt/#{datastore['DOMAIN']}",
+      client_name: datastore['USER'],
+      options: ticket_options
+    }
+    options[:password] = datastore['PASSWORD'] if datastore['PASSWORD'].present?
+    if datastore['AESKEY'].present?
+      options[:key] = [ datastore['AESKEY'] ].pack('H*')
+      options[:etype] = if options[:key].size == 32
+                          Rex::Proto::Kerberos::Crypto::Encryption::AES256
+                        else
+                          Rex::Proto::Kerberos::Crypto::Encryption::AES128
+                        end
+    end
+    if datastore['NTHASH'].present?
+      options[:key] = [datastore['NTHASH']].pack('H*')
+      options[:etype] = Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC
+    end
+
+    tgt_result = send_request_tgt(options)
+    print_good("#{peer} - Received a valid TGT-Response")
+
+    report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'kerberos',
+      info: "Module: #{fullname}, KDC for domain #{options[:realm]}"
+    )
+
+    cache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(
+      tgt_result.as_rep,
+      tgt_result.decrypted_part
+    )
+    path = store_loot(
+      'mit.kerberos.ccache',
+      'application/octet-stream',
+      rhost,
+      cache.encode,
+      nil,
+      loot_info(options)
+    )
+    print_status("#{peer} - TGT MIT Credential Cache saved on #{path}")
+
+    cache.credentials.first
+  rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError,
+         ::EOFError => e
+    msg = e.to_s
+    if e.respond_to?(:error_code) &&
+       e.error_code == ::Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_PREAUTH_REQUIRED
+      msg << ' - Check the authentication-related options (PASSWORD, NTHASH or AESKEY)'
+    end
+    fail_with(Failure::Unknown, "Error while requesting a TGT: #{e}")
+  end
+
+  def action_request_tgs
+    credential = nil
+    options = {
+      realm: datastore['DOMAIN'],
+      client_name: datastore['USER']
+    }
+
+    if datastore['KrbUseCachedCredentials']
+      # load a cached TGT
+      options[:server_name] = "krbtgt/#{datastore['DOMAIN']}"
+      credential = get_cached_credential(options)
+    end
+
+    if credential
+      print_status("#{peer} - Using cached credential for #{credential.server} #{credential.client}")
+    else
+      credential = action_request_tgt
+    end
+
+    begin
+      options[:server_name] = datastore['SPN']
+      request_tgs_from_tgt(credential, options)
+    rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError,
+           ::EOFError => e
+      fail_with(Failure::Unknown, "Error while requesting a TGS: #{e}")
+    end
+  end
+
+  def loot_info(options = {})
+    info = []
+
+    info << "realm: #{options[:realm].upcase}" if options[:realm]
+    info << "serviceName: #{options[:server_name].downcase}" if options[:server_name]
+    info << "username: #{options[:client_name].downcase}" if options[:client_name]
+
+    info.join(', ')
+  end
+
+  def get_cached_credential(options = {})
+    return nil unless active_db?
+
+    now = Time.now.utc
+    host = report_host(workspace: myworkspace, host: rhost)
+    framework.db.loot(
+      workspace: myworkspace,
+      host: host,
+      ltype: 'mit.kerberos.ccache',
+      info: loot_info(options)
+    ).each do |stored_loot|
+      ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(stored_loot.data)
+      # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
+      credential = ccache.credentials.first
+
+      tkt_start = if credential.starttime == Time.at(0).utc
+                    credential.authtime
+                  else
+                    credential.starttime
+                  end
+      tkt_end = credential.endtime
+      return credential if tkt_start < now && now < tkt_end
+    end
+
+    nil
+  end
+
+  def request_tgs_from_tgt(credential, options)
+    now = Time.now.utc
+    expiry_time = now + 1.day
+
+    ticket = Rex::Proto::Kerberos::Model::Ticket.decode(credential.ticket.value)
+    session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
+      type: credential.keyblock.enctype.value,
+      value: credential.keyblock.data.value
+    )
+    ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+      [
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+      ]
+    )
+
+    tgs_res = send_request_tgs(
+      req: build_tgs_request(
+        {
+          session_key: session_key,
+          subkey: nil,
+          checksum: nil,
+          ticket: ticket,
+          realm: options[:realm],
+          client_name: options[:client_name],
+          options: ticket_options,
+
+          body: build_tgs_request_body(
+            cname: nil,
+            server_name: options[:server_name],
+            server_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+            realm: options[:realm],
+            etype: [ticket.enc_part.etype],
+            options: ticket_options,
+
+            # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
+            from: nil,
+            till: expiry_time,
+            rtime: nil,
+
+            # certificate time
+            ctime: now
+          )
+        }
+      )
+    )
+
+    if tgs_res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
+      raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: tgs_res)
+    end
+
+    print_good("#{peer} - Received a valid TGS-Response")
+
+    cache = extract_kerb_creds(
+      tgs_res,
+      session_key.value,
+      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
+    )
+    path = store_loot(
+      'mit.kerberos.ccache',
+      'application/octet-stream',
+      rhost,
+      cache.encode,
+      nil,
+      loot_info(options)
+    )
+    print_status("#{peer} - TGS MIT Credential Cache saved to #{path}")
+  end
+
+end


### PR DESCRIPTION
This adds an auxiliary module that requests TGT/TGS tickets from the KDC. Two ACTIONS are available:
- TGT action: legally request a TGT from the KDC given a password, a NT hash or an encryption key. The resulting TGT will be stored in the loot.
- TGS action: legally request a TGS from the KDC given a password, a NT hash, an encryption key or a cached TGT. If the TGT is not provided, it will request it the same way the "TGT action" does. The resulting TGT and the TGS will be stored in the loot.

The Kerberos client class has been updated to support an encryption key instead of a password. Also, a lot of code has been taken from the existing `Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base` [class](https://github.com/rapid7/metasploit-framework/blob/e00cab3f11ebfe01bccb5d1a960ff4f54f243b1a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb). This class is not generic enough to be reused in this module context. I thought it was easier to only take the parts needed instead of trying to modifying this class.

Note that impersonation when the account has constrained delegation privileges is not supported (yet). Also, I will add the documentation soon.

This closes https://github.com/rapid7/metasploit-framework/issues/17216.

## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/admin/kerberos/get_ticket`
- [x] `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=TGT`
- [x] **Verify** the TGT is correctly retrieved and stored in the loot
- [x] Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY` option) instead of the password
- [x] `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=TGS spn=<SPN>`
- [x] **Verify** the module uses the TGT in the cache and does not request a new one
- [x] **Verify** the TGS is correctly retrieved and stored in the loot
- [x] `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=TGS spn=<SPN> KrbUseCachedCredentials=false`
- [x] **Verify** the module does not use the TGT in the cache and requests a new one
- [x] **Verify** both the TGT and the TGS are correctly retrieved and stored in the loot
- [x] Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY` option) instead of the password

## Scenarios

<details>
<summary>TGT with NT hash</summary>

```
msf6 auxiliary(admin/kerberos/get_ticket) > loot

Loot
====

host  service  type  name  content  info  path
----  -------  ----  ----  -------  ----  ----

msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator nthash=<redacted> action=TGT
[*] Running module against 10.0.0.24

[+] 10.0.0.24:88 - Received a valid TGT-Response
[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104181416_default_10.0.0.24_mit.kerberos.cca_912121.bin
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > loot

Loot
====

host             service  type                 name  content                   info                                                                          path
----             -------  ----                 ----  -------                   ----                                                                          ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104181416_default_10.0.0.24_mit.kerberos.cca_912121.bin

msf6 auxiliary(admin/kerberos/get_ticket) > hosts

Hosts
=====

address          mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------          ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.24             Unknown                    device

msf6 auxiliary(admin/kerberos/get_ticket) > services
Services
========

host             port  proto  name      state  info
----             ----  -----  ----      -----  ----
10.0.0.24  88    tcp    kerberos  open   Module: auxiliary/admin/kerberos/get_ticket, KDC for domain mylab.local
```

</details>

<details>
<summary>TGT with encryption key (128 bits)</summary>

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=TGT
[*] Running module against 10.0.0.24

[+] 10.0.0.24:88 - Received a valid TGT-Response
[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104181917_default_10.0.0.24_mit.kerberos.cca_006508.bin
[*] Auxiliary module execution completed
```

</details>

<details>
<summary>TGT with encryption key (256 bits)</summary>

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=TGT
[*] Running module against 10.0.0.24

[+] 10.0.0.24:88 - Received a valid TGT-Response
[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104182051_default_10.0.0.24_mit.kerberos.cca_535003.bin
[*] Auxiliary module execution completed
```

</details>

<details>
<summary>TGT with password</summary>

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator password=<redacted> action=TGT
[*] Running module against 10.0.0.24

[+] 10.0.0.24:88 - Received a valid TGT-Response
[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104182219_default_10.0.0.24_mit.kerberos.cca_533360.bin
[*] Auxiliary module execution completed
```

</details>

<details>
<summary>TGS with NT hash</summary>

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator nthash=<redacted> action=TGS spn=cifs/dc02.mylab.local
[*] Running module against 10.0.0.24

[+] 10.0.0.24:88 - Received a valid TGT-Response
[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_760650.bin
[+] 10.0.0.24:88 - Received a valid TGS-Response
[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_883314.bin
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > loot

Loot
====

host             service  type                 name  content                   info                                                                             path
----             -------  ----                 ----  -------                   ----                                                                             ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_760650.bin
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104182601_default_10.0.0.24_mit.kerberos.cca_883314.bin
```

</details>

<details>
<summary>TGS with encryption key (128 bits)</summary>

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=TGS spn=cifs/dc02.mylab.local
[*] Running module against 10.0.0.24

[+] 10.0.0.24:88 - Received a valid TGT-Response
[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104183150_default_10.0.0.24_mit.kerberos.cca_790958.bin
[+] 10.0.0.24:88 - Received a valid TGS-Response
[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104183150_default_10.0.0.24_mit.kerberos.cca_893551.bin
[*] Auxiliary module execution completed
```

</details>

<details>
<summary>TGS with encryption key (256 bits)</summary>

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=TGS spn=cifs/dc02.mylab.local
[*] Running module against 10.0.0.24

[+] 10.0.0.24:88 - Received a valid TGT-Response
[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104183040_default_10.0.0.24_mit.kerberos.cca_140502.bin
[+] 10.0.0.24:88 - Received a valid TGS-Response
[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104183040_default_10.0.0.24_mit.kerberos.cca_500387.bin
[*] Auxiliary module execution completed
```

</details>

<details>
<summary>TGS with password</summary>

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator password=<redacted> action=TGS spn=cifs/dc02.mylab.local
[*] Running module against 10.0.0.24

[+] 10.0.0.24:88 - Received a valid TGT-Response
[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
[+] 10.0.0.24:88 - Received a valid TGS-Response
[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
[*] Auxiliary module execution completed
```

</details>

<details>
<summary>TGS with cached TGT</summary>

```
msf6 auxiliary(admin/kerberos/get_ticket) > loot

Loot
====

host             service  type                 name  content                   info                                                                             path
----             -------  ----                 ----  -------                   ----                                                                             ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin

msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=TGS spn=cifs/dc02.mylab.local
[*] Running module against 10.0.0.24

[*] 10.0.0.24:88 - Using cached credential for krbtgt/mylab.local Administrator
[+] 10.0.0.24:88 - Received a valid TGS-Response
[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104183346_default_10.0.0.24_mit.kerberos.cca_525186.bin
[*] Auxiliary module execution completed
```

</details>

<details>
<summary>TGS without cached TGT</summary>

```
msf6 auxiliary(admin/kerberos/get_ticket) > loot

Loot
====

host             service  type                 name  content                   info                                                                             path
----             -------  ----                 ----  -------                   ----                                                                             ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin

msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false
[*] Running module against 10.0.0.24

[-] Auxiliary aborted due to failure: unknown: Error while requesting a TGT: Kerberos Error - KDC_ERR_PREAUTH_REQUIRED (25) - Additional pre-authentication required - Check the authentication-related options (PASSWORD, NTHASH or AESKEY)
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false password=<redacted>
[*] Running module against 10.0.0.24

[+] 10.0.0.24:88 - Received a valid TGT-Response
[*] 10.0.0.24:88 - TGT MIT Credential Cache saved on /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_200958.bin
[+] 10.0.0.24:88 - Received a valid TGS-Response
[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_849639.bin
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > loot

Loot
====

host             service  type                 name  content                   info                                                                             path
----             -------  ----                 ----  -------                   ----                                                                             ----
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_200958.bin
10.0.0.24           mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_849639.bin
```

</details>

