### PR TITLE
Adds references to `info -d` command in `options` and `info` command outputs

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -136,6 +136,8 @@ module Common
       print("\n#{mod.type.capitalize} action:\n\n#{mod_action}\n") if (mod_action and mod_action.length > 0)
     end
 
+    print("\nView the full module info with the #{Msf::Ui::Tip.highlight('info')}, or #{Msf::Ui::Tip.highlight('info -d')} command.\n\n")
+
     # Uncomment this line if u want target like msf2 format
     #print("\nTarget: #{mod.target.name}\n\n")
   end

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -127,6 +127,7 @@ module Msf
               end
             else
               print(Serializer::ReadableText.dump_module(mod))
+              print("\nView the full module info with the #{Msf::Ui::Tip.highlight('info -d')} command.\n\n")
             end
           end
 
@@ -1489,6 +1490,7 @@ module Msf
                 print("\nPayload advanced options (#{mod.datastore['PAYLOAD']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
               end
             end
+            print("\nView the full module info with the #{Msf::Ui::Tip.highlight('info')}, or #{Msf::Ui::Tip.highlight('info -d')} command.\n\n")
           end
 
           def show_evasion_options(mod) # :nodoc:


### PR DESCRIPTION
This PR adds tips out to `info` and `options` commands. When the user runs `show options`, we should also output a tip for running the `info` command for additional information.

Example - `show options`:
![image](https://user-images.githubusercontent.com/69522014/200318580-61b6fafd-34b5-48be-a8aa-a34aad948cf3.png)

Example - `show info`:
![image](https://user-images.githubusercontent.com/69522014/200318840-0160f1b2-ba10-4d0f-a1e0-a36275f0ef4b.png)

## Verification

- [x] Start `msfconsole`
- [ ] `use exploit/windows/iis/ms01_023_printer`
- [ ] **Verify** the `options` command outputs the new `info -d` tip
- [ ] **Verify** the `info` command outputs the new `info -d` tip
- [ ] **Verify** the `advanced` command outputs the new `info -d` tip
