### PR TITLE
report service_name in ManageEngineDesktopCentral

### DIFF
--- a/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
+++ b/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
@@ -115,7 +115,8 @@ module Metasploit
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            service_name: ssl ? 'https' : 'http',
           }
 
           begin

--- a/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
+++ b/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
@@ -54,8 +54,8 @@ class MetasploitModule < Msf::Auxiliary
     service_data = {
       address: ip,
       port: port,
-      service_name: 'http',
-      protocol: 'tcp',
+      service_name: result.service_name,
+      protocol: result.protocol,
       workspace_id: myworkspace_id
     }
 


### PR DESCRIPTION
The scanner now reports the `service_name` in the `Result` object.

[`LoginScanner::Result` objects](https://github.com/rapid7/metasploit-framework/blob/455476cfe2a111027169c16c1d01b1d06390f75d/lib/metasploit/framework/login_scanner/result.rb) should be filled in and utilized by `LoginScanner` modules.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/manageengine_desktop_central_login`
- [ ] **Verify** credentials are reported as expected

