### PR TITLE
Fix broken kerberos login module

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -169,7 +169,7 @@ module Msf
             password.dup.force_encoding('utf-8') if password
             client_name.dup.force_encoding('utf-8')
             request_pac = options.fetch(:request_pac, true)
-            ticket_options = options[:options]
+            ticket_options = options.fetch(:options) { 0x50800000 } # Forwardable, Proxiable, Renewable
 
             # First stage: Send an initial AS-REQ request, used to exchange supported encryption methods.
             # The server may respond with a ticket granting ticket (TGT) immediately,


### PR DESCRIPTION
### before

Login fails:

```
msf6 auxiliary(scanner/kerberos/kerberos_login) > run rhosts=192.168.123.13 domain=ADF3.LOCAL username=Administrator password=p4$$w0rd verbose=true

[*] Using domain: ADF3.LOCAL - 192.168.123.13:88    ...
[-] 192.168.123.13 - User: "Administrator" - Unable to connect - Kerberos Client: failed to read response
[*] Auxiliary module execution completed
```

wireshark shows the request is malformed

<img width="1559" alt="image" src="https://user-images.githubusercontent.com/60357436/200611799-7e5f470c-a539-48d7-96df-f9cdf4ee78e6.png">

### after

Module works as expected:

```
msf6 auxiliary(scanner/kerberos/kerberos_login) > run rhosts=192.168.123.13 domain=ADF3.LOCAL username=Administrator password=p4$$w0rd verbose=true

[*] Using domain: ADF3.LOCAL - 192.168.123.13:88    ...
[+] 192.168.123.13 - User found: "Administrator" with password p4$$w0rd. Hash: $krb5asrep$18$Administrator@ADF3.LOCAL:4ebdb3bb0d58fb677cccb7b734c2b24d$afbaee83a0a7259d3c2a40a4db6592cc2e9e4316a9769192ce039f04f88604762c5b0255034e8de17c9d3db2910ecbc5da89ccbe1a73150ade39c1d7923b41419742bb30d562e393ac49dff762e229c7b9d40d794ca64fd7de9ff7fbf342e7223b538c85d6a383761d0e064e69f65f94325599603e2f9138c8b132ffdd771f630dbf33d484eb5743e0703e3544e7ab029bde9669db23f5df50e280c658e71698b2b50a4587acef1eaeb193b78d09dab6d6512947739754f38a706202752887a61e5a52e200927f6fd04dfe11635624a9551be62dd23c23fa9778e8f95ae424e898550b2f1485cea6c707d8199543e592c4bc9120c5c5a9b5384bc9
[*] Auxiliary module execution completed
```

The original issue was not sending any kdc options in the kdc req body:

```diff
Application 10 (1 elem)
  SEQUENCE (4 elem)
    [1] (1 elem)
      INTEGER 5
    [2] (1 elem)
      INTEGER 10
    [3] (1 elem)
      SEQUENCE (1 elem)
        SEQUENCE (2 elem)
          [1] (1 elem)
            INTEGER 128
          [2] (1 elem)
            OCTET STRING (7 byte) 3005A0030101FF
              SEQUENCE (1 elem)
                [0] (1 elem)
                  BOOLEAN true
    [4] (1 elem)
-      SEQUENCE (8 elem)
+      SEQUENCE (7 elem) 
-        [0] (1 elem)
-          BIT STRING (32 bit) 01010000100000000000000000000000
        [1] (1 elem)
          SEQUENCE (2 elem)
            [0] (1 elem)
              INTEGER 1
            [1] (1 elem)
              SEQUENCE (1 elem)
                GeneralString basic_user
        [2] (1 elem)
          GeneralString ADF3.LOCAL
        [3] (1 elem)
          SEQUENCE (2 elem)
            [0] (1 elem)
              INTEGER 1
            [1] (1 elem)
              SEQUENCE (2 elem)
                GeneralString krbtgt
                GeneralString ADF3.LOCAL
        [5] (1 elem)
          GeneralizedTime 2022-11-09 15:25:54 UTC
        [6] (1 elem)
          GeneralizedTime 2022-11-09 15:25:54 UTC
        [7] (1 elem)
          INTEGER 173238
        [8] (1 elem)
          SEQUENCE (5 elem)
            INTEGER 18
            INTEGER 17
            INTEGER 23
            INTEGER 3
            INTEGER 16
```

## Verification

- use kerberos_login against a kdc/domain controller
- verify valid creds work as expected `run rhosts=192.168.123.13 domain=ADF3.LOCAL username=Administrator password=p4$$w0rd verbose=true`