### PR TITLE
Improve tlv packet logging for railgun

### DIFF
--- a/lib/rex/post/meterpreter/command_mapper.rb
+++ b/lib/rex/post/meterpreter/command_mapper.rb
@@ -115,7 +115,9 @@ class CommandMapper
 
     available_modules = [
       ::Rex::Post::Meterpreter,
-      *::Rex::Post::Meterpreter::ExtensionMapper.get_extension_klasses
+      *::Rex::Post::Meterpreter::ExtensionMapper.get_extension_klasses,
+      # Railgun is a special case that defines extra TLV_TYPES inside an extension
+      Rex::Post::Meterpreter::Extensions::Stdapi::Railgun
     ].uniq
 
     available_modules.each do |mod|


### PR DESCRIPTION
Improves the tlv packet logging for railgun, spotted as part of testing https://github.com/rapid7/metasploit-framework/pull/17229

Starting steps:
```
# Get a session
use psexec
...

# enable tlv logging
setg sessiontlvlogging true

# Run the module
run address=192.168.123.13 session=-1
```

Before:
```
SEND: #<Rex::Post::Meterpreter::Packet type=Request         tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1030 command=stdapi_railgun_memread>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="98027503696261019583256796793244">
  #<Rex::Post::Meterpreter::Tlv type=unknown-1068588 meta=QWORD      value=93970200>
  #<Rex::Post::Meterpreter::Tlv type=EXT_SERVICE_ENUM_STATUS meta=INT        value=255>
]>

RECV: #<Rex::Post::Meterpreter::Packet type=Response        tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1030 command=stdapi_railgun_memread>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="98027503696261019583256796793244">
  #<Rex::Post::Meterpreter::Tlv type=unknown-282157  meta=RAW        value="8\xDF\x99\x05(\xDF\x99\x05\x02\x00\x04\x00,\xDF\x ...">
  #<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="l\xB0\xE8\xD0\xE3\x91\x92\xE3\xD9\x93\xD8\x92\xBA ...">
]>
```

After:
```
SEND: #<Rex::Post::Meterpreter::Packet type=Request         tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1030 command=stdapi_railgun_memread>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="75808574843709220016190869479425">
  #<Rex::Post::Meterpreter::Tlv type=RAILGUN_MEM_ADDRESS meta=QWORD      value=93968968>
  #<Rex::Post::Meterpreter::Tlv type=oneOf(EXT_SERVICE_ENUM_STATUS,RAILGUN_MEM_LENGTH) meta=INT        value=255>
]>

RECV: #<Rex::Post::Meterpreter::Packet type=Response        tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=1030 command=stdapi_railgun_memread>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="75808574843709220016190869479425">
  #<Rex::Post::Meterpreter::Tlv type=RAILGUN_MEM_DATA meta=RAW        value="h\xDA\x99\x05X\xDA\x99\x05\x02\x00\x04\x00\\\xDA\ ...">
  #<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="l\xB0\xE8\xD0\xE3\x91\x92\xE3\xD9\x93\xD8\x92\xBA ...">
]>
```

Note that in the after, the name is `oneOf(EXT_SERVICE_ENUM_STATUS,RAILGUN_MEM_LENGTH)` - because we actually have duplicate IDs that map to the same tlv type - and the only differentiator is the calling context. I believe that's a bug that's too late to change - https://github.com/rapid7/metasploit-framework/issues/16267

## Verification

Run the steps as noted above