### PR TITLE
Fix an error when a hostname fails to resolve

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb
@@ -71,7 +71,7 @@ class Resolve
       type = types[i]
       host = hostnames[i]
 
-      hosts << raw_to_host_ip_pair(host, raw.value, type.value)
+      hosts << raw_to_host_ip_pair(host, raw.value, type&.value)
     end
 
     return hosts

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb
@@ -38,10 +38,9 @@ class Resolve
 
     response = client.send_request(request)
 
-    type = response.get_tlv_value(TLV_TYPE_ADDR_TYPE)
     raw = response.get_tlv_value(TLV_TYPE_IP)
 
-    return raw_to_host_ip_pair(hostname, raw, type)
+    return raw_to_host_ip_pair(hostname, raw)
   end
 
   def resolve_hosts(hostnames, family=AF_INET)
@@ -56,40 +55,31 @@ class Resolve
 
     hosts = []
     raws = []
-    types = []
 
     response.each(TLV_TYPE_IP) do |raw|
       raws << raw
     end
 
-    response.each(TLV_TYPE_ADDR_TYPE) do |type|
-      types << type
-    end
-
     0.upto(hostnames.length - 1) do |i|
       raw = raws[i]
-      type = types[i]
       host = hostnames[i]
 
-      hosts << raw_to_host_ip_pair(host, raw.value, type&.value)
+      hosts << raw_to_host_ip_pair(host, raw&.value)
     end
 
     return hosts
   end
 
-  def raw_to_host_ip_pair(host, raw, type)
+  def raw_to_host_ip_pair(host, raw)
     if raw.nil? or host.nil?
       return nil
     end
 
-    if raw.empty?
-      ip = nil
-    else
-      if type == AF_INET
-        ip = Rex::Socket.addr_ntoa(raw[0..3])
-      else
-        ip = Rex::Socket.addr_ntoa(raw[0..16])
-      end
+    ip = nil
+    if raw.length == 4 || raw.length == 16
+      ip = Rex::Socket.addr_ntoa(raw)
+    elsif raw.length != 0
+      wlog("hostname resolution failed, the returned address is corrupt (hostname: #{host}, length: #{raw.length})")
     end
 
     result = { :hostname => host, :ip => ip }


### PR DESCRIPTION
This fixes an error that would occur when a user attempts to resolve an address that fails to resolve. It looks like it's specific to the Mettle meterpreters, Windows doesn't have the same problem.

This completely ignores the `TLV_TYPE_ADDR_TYPE` from the response. It's not necessary because the IP addresses are always packed. That means that each TLV_TYPE_IP response must be of a length of either 0 (failed to resolve), 4 (IPv4 / AF_INET), or 16 (IPv6 / AF_INET6). Having a type returned as well only serves to confuse the situation. [`Rex::Socket.addr_ntoa`](https://github.com/rapid7/rex-socket/blob/6ea0bb3b4e19c53d73e4337617be72c0ed351ceb/lib/rex/socket.rb#L356) which actually handles the conversion doesn't even accept the family and just uses the size. If the size is not 4 or 16, it'll raise a Runtime exception. These updates will log instances where the address size is not 0, 4 or 16 bytes long. I tested each of the Meterpreter instances to resolve both IPv4 and IPv6 addresses to ensure that they're always returning the proper length and that was the case. Tested PHP, Java, Python, Windows, Mettle.

The type would only [cause the response to be truncated](https://github.com/rapid7/metasploit-framework/blob/e2a463e26dbf40122780d599479fd51da72f291c/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb#L88-L91). That means if family was anything but AF_INET, (such as nil because the types array was misaligned as was the case in Mettle) then despite sorta treating it as an IPv6 address because it was only 4 bytes, the IPv4 address would be returned. We should just use the proper length of the address to avoid this.

These changes are backwards compatible and require no updates to the payloads because Metasploit is simply ignoring the type that's effectively echoed back to it. From what I can tell the input type *must* be either AF_INET or AF_INET6; AF_UNSPEC does not appear to be supported probably because it would end up being platform dependant. Once landed, I'll open a ticket marked as a breaking change to remove the now redundant `TLV_TYPE_ADDR_TYPE` responses from the resolve functions.

### Before
```
meterpreter > resolve doesnotexist.lan
[-] Error running command resolve: NoMethodError undefined method `value' for nil:NilClass
meterpreter >
```

<details>
<summary>framework.log stack trace</summary>

```
[11/09/2022 08:43:16] [e(0)] meterpreter: Error running command resolve: NoMethodError undefined method `value' for nil:NilClass
[11/09/2022 08:43:16] [d(0)] meterpreter: Call stack:
/home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb:74:in `block in resolve_hosts'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb:69:in `upto'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb:69:in `resolve_hosts'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb:632:in `cmd_resolve'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/ui/console.rb:102:in `run_command'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/ui/console.rb:64:in `block in interact'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:157:in `run'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/ui/console.rb:62:in `interact'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/sessions/meterpreter.rb:565:in `_interact'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/interactive.rb:53:in `interact'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1682:in `cmd_sessions'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```
</details>

### After
```
meterpreter > resolve doesnotexist.lan

Host resolutions
================

    Hostname          IP Address
    --------          ----------
    doesnotexist.lan  [Failed To Resolve]

meterpreter > 
```

## Verification

List the steps needed to make sure this thing works

- [ ] Establish a Mettle Meterpreter session
- [ ] Use the `resolve` command to resolve an address that does not exist
- [ ] Do not see a `NoMethodError` error message
