### PR TITLE
Use the access mask data type

### DIFF
--- a/lib/rex/proto/ms_dtyp.rb
+++ b/lib/rex/proto/ms_dtyp.rb
@@ -7,22 +7,22 @@ module Rex::Proto::MsDtyp
     hide   :reserved0, :reserved1
 
     # the protocol field id reserved for protocol-specific access rights
-    bit16 :protocol
+    uint16 :protocol
 
-    bit3  :reserved0
-    bit1  :sy
-    bit1  :wo
-    bit1  :wd
-    bit1  :rc
-    bit1  :de
+    bit3   :reserved0
+    bit1   :sy
+    bit1   :wo
+    bit1   :wd
+    bit1   :rc
+    bit1   :de
 
-    bit1  :gr
-    bit1  :gw
-    bit1  :gx
-    bit1  :ga
-    bit2  :reserved1
-    bit1  :ma
-    bit1  :as
+    bit1   :gr
+    bit1   :gw
+    bit1   :gx
+    bit1   :ga
+    bit2   :reserved1
+    bit1   :ma
+    bit1   :as
 
     ALL  = MsDtypAccessMask.new({ gr: 1, gw: 1, gx: 1, ga: 1, ma: 1, as: 1, sy: 1, wo: 1, wd: 1, rc: 1, de: 1, protocol: 0xffff })
     NONE = MsDtypAccessMask.new({ gr: 0, gw: 0, gx: 0, ga: 0, ma: 0, as: 0, sy: 0, wo: 0, wd: 0, rc: 0, de: 0, protocol: 0 })
@@ -113,15 +113,15 @@ module Rex::Proto::MsDtyp
   class MsDtypAceNonObjectBody < BinData::Record
     endian :little
 
-    uint32             :access_mask
-    ms_dtyp_sid        :sid, byte_align: 4
+    ms_dtyp_access_mask :access_mask
+    ms_dtyp_sid         :sid, byte_align: 4
   end
 
   class MsDtypAceObjectBody < BinData::Record
     endian :little
 
-    uint32             :access_mask
-    struct             :flags do
+    ms_dtyp_access_mask :access_mask
+    struct              :flags do
       bit1 :reserved5
       bit1 :reserved4
       bit1 :reserved3
@@ -131,9 +131,9 @@ module Rex::Proto::MsDtyp
       bit1 :ace_inherited_object_type_present
       bit1 :ace_object_type_present
     end
-    ms_dtyp_guid       :object_type, onlyif: -> { flags.ace_object_type_present != 0x0 }
-    ms_dtyp_guid       :inherited_object_type, onlyif: -> { flags.ace_inherited_object_type_present != 0x0 }
-    ms_dtyp_sid        :sid, byte_align: 4
+    ms_dtyp_guid        :object_type, onlyif: -> { flags.ace_object_type_present != 0x0 }
+    ms_dtyp_guid        :inherited_object_type, onlyif: -> { flags.ace_inherited_object_type_present != 0x0 }
+    ms_dtyp_sid         :sid, byte_align: 4
   end
 
   # [2.4.4.2 ACCESS_ALLOWED_ACE](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/72e7c7ea-bc02-4c74-a619-818a16bf6adb)

--- a/modules/auxiliary/admin/ldap/rbcd.rb
+++ b/modules/auxiliary/admin/ldap/rbcd.rb
@@ -53,7 +53,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def build_ace(sid)
-    Rex::Proto::MsDtyp::MsDtypAccessAllowedAce.new({
+    Rex::Proto::MsDtyp::MsDtypAce.new({
+      header: {
+        ace_type: Rex::Proto::MsDtyp::MsDtypAceType::ACCESS_ALLOWED_ACE_TYPE
+      },
       body: {
         access_mask: Rex::Proto::MsDtyp::MsDtypAccessMask::ALL,
         sid: sid

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
     acl.aces.each do |ace|
       ace_header = ace[:header]
       ace_body = ace[:body]
-      if ace_body['access_mask'].blank? # This won't work with Symbols for some reason, but will work with strings. Bite me.
+      if ace_body[:access_mask].blank?
         fail_with(Failure::UnexpectedReply, 'Encountered a DACL/SACL object without an access mask! Either data is an unrecognized type or we are reading it wrong!')
       end
       ace_string = Rex::Proto::MsDtyp::MsDtypAceType.name(ace_header[:ace_type])
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
 
       object_type = ace_body[:object_type]
 
-      if (ace_body[:access_mask] & CONTROL_ACCESS) == CONTROL_ACCESS && (object_type == CERTIFICATE_ENROLLMENT_EXTENDED_RIGHT || object_type == CERTIFICATE_AUTOENROLLMENT_EXTENDED_RIGHT)
+      if (ace_body.access_mask.protocol & CONTROL_ACCESS) != 0 && (object_type == CERTIFICATE_ENROLLMENT_EXTENDED_RIGHT || object_type == CERTIFICATE_AUTOENROLLMENT_EXTENDED_RIGHT)
         if ace_string.match(/DENIED/)
           flag_allowed_to_enroll = false
         elsif ace_string.match(/ALLOWED/)


### PR DESCRIPTION
This fixes the RBCD module which was broken when #17122 was landed because it switched the access mask type to an integer. This changes it back and redefines the protocol filed from `bit16` to `uint16` so it's properly processed as little endian.  BinData bit-based integers [are big endian by default.](https://github.com/dmendel/bindata/wiki/PrimitiveTypes#bit-based-integers)

Prior to these changes the WRITE action was broken.

<details>
<summary>Stack trace</summary>

```
msf6 auxiliary(admin/ldap/rbcd) > write
[*] Running module against 192.168.159.10

[*] Discovering base DN automatically
[+] 192.168.159.10:389 Discovered base DN: DC=msflab,DC=local
[*] Delegation from DESKTOP-CYEHNIL6$ to WS01$ is already enabled.
[-] Auxiliary failed: NameError uninitialized constant Rex::Proto::MsDtyp::MsDtypAccessAllowedAce
Did you mean?  Rex::Proto::MsDtyp::MsDtypAccessAllowedAceBody
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/ldap/rbcd.rb:56:in `build_ace'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/ldap/rbcd.rb:262:in `_action_write_update'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/ldap/rbcd.rb:225:in `action_write'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/ldap/rbcd.rb:151:in `block in run'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/net-ldap-0.17.1/lib/net/ldap.rb:644:in `block in open'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/net-ldap-0.17.1/lib/net/ldap.rb:716:in `block in open'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/net-ldap-0.17.1/lib/net/ldap/instrumentation.rb:19:in `instrument'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/net-ldap-0.17.1/lib/net/ldap.rb:711:in `open'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/net-ldap-0.17.1/lib/net/ldap.rb:644:in `open'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:68:in `ldap_connect'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/ldap/rbcd.rb:130:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(admin/ldap/rbcd) > 
```
</details>

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Test the `auxiliary/gather/ldap_esc_vulnerable_cert_finder` module
- [ ] Test the `auxiliary/admin/ldap/rbcd` module with the WRITE action.
