### PR TITLE
Fix Port Forwarding For Ruby 3

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -52,7 +52,8 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
       }
     )
 
-    client_channel = TcpClientChannel.new(client, cid, TcpClientChannel, CHANNEL_FLAG_SYNCHRONOUS, packet, {:sock_params => params})
+    client_channel = TcpClientChannel.new(client, cid, TcpClientChannel, CHANNEL_FLAG_SYNCHRONOUS, packet, sock_params: params)
+    ilog("enqueueing new TCP client with channel id #{cid}")
 
     @@server_channels[server_channel] ||= ::Queue.new
     @@server_channels[server_channel].enq(client_channel)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -471,6 +471,7 @@ class Console::CommandDispatcher::Stdapi::Net
             return false
           end
 
+          print_status("Reverse TCP relay created: (remote) #{rhost}:#{rport} -> (local) #{lhost}:#{lport}")
         else
           # Validate parameters
           unless lport && rhost && rport
@@ -486,10 +487,9 @@ class Console::CommandDispatcher::Stdapi::Net
             'MeterpreterRelay'  => true,
             'OnLocalConnection' => Proc.new { |relay, lfd| create_tcp_channel(relay) })
           lport = relay.opts['LocalPort']
+
+          print_status("Forward TCP relay created: (local) #{lhost}:#{lport} -> (remote) #{rhost}:#{rport}")
         end
-
-        print_status("Local TCP relay created: #{lhost}:#{lport} <-> #{rhost}:#{rport}")
-
       # Delete local port forwards
       when 'delete', 'remove', 'del', 'rm'
 


### PR DESCRIPTION
This fixes an issue with port forwarding that was due to a Ruby 3 syntax issue. When a client connection was received, the call to create the corresponding TCP channel was using a Ruby 2 format which caused the channel creation to fail. Since the channel creation failed, it was never able to be accepted. Closes #17124.

This also updates the output from the `portfwd` command to make it more clear what's happening. Before these changes, [users didn't realize](https://github.com/rapid7/metasploit-framework/issues/17158) that both normal and reverse port forwards were considered "local" (I guess because of the class name that handles them? I was confused too. 🤷🏻 ). This updates the output to note the direction and then uses a single arrow to show where the connection is accepted and where it goes to. In the case of reverse port forwards, rhost is on the left since the remote host is where the connection is accepted from. I think it makes more sense to show the direction of the connection as going in a single direction instead of the old format that seemed to imply that it was bidirectional, maybe because once established the data goes both ways IDK. Closes #17158.

## Verification

- [ ] Start `msfconsole`
- [ ] Obtain a Meterpreter session
- [ ] Use the `portfwd` command to start a reverse portfoward (run `portfwd add -R -p 8000 -l 8000 -L 192.168.159.128` where `192.168.159.128` is the machine running Metasploit)
- [ ] Run a simple HTTP server with Python using `python -m http.server` (Python 3.x) or `python -m SimpleHTTPServer` (Python 2.x)
- [ ] Browse to port 8000 on the compromised host, see the attackers HTTP server receive the connection and respond