### PR TITLE
Bump Go version from 1.11.2 to 1.19.3 In Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,9 @@ RUN apk add --no-cache \
 ENV GO111MODULE=off
 RUN mkdir -p $TOOLS_HOME/bin && \
     cd $TOOLS_HOME/bin && \
-    curl -O https://dl.google.com/go/go1.11.2.src.tar.gz && \
-    tar -zxf go1.11.2.src.tar.gz && \
-    rm go1.11.2.src.tar.gz && \
+    curl -O https://dl.google.com/go/go1.19.3.src.tar.gz && \
+    tar -zxf go1.19.3.src.tar.gz && \
+    rm go1.19.3.src.tar.gz && \
     cd go/src && \
     ./make.bash
 


### PR DESCRIPTION
Fixes #17230 

Update Go version from 1.11.2 to 1.19.3 in the Docker container.

## Verification

List the steps needed to make sure this thing works

- [ ] `docker compose` inside the Metasploit root directory.
- [ ] `./docker/bin/msfconsole`
- [ ] Load and run a Go module such as https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/msmail/exchange_enum.go and confirm that it still works as expected.