### PR TITLE
Improve validation and error handling for forgeticket module

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -52,9 +52,9 @@ class DataStore < Hash
       if opt.validate_on_assignment?
         unless opt.valid?(v, check_empty: false)
           if self.options[k].examples.empty?
-            raise Msf::OptionValidateError.new(["Value '#{v}' is not TESTTESTTESTTESTTEST valid for option '#{k}'"])
+            raise Msf::OptionValidateError, ["Value '#{v}' is not valid for option '#{k}'"]
           else
-            raise Msf::OptionValidateError.new(["Value '#{v}' is not TESTTESTTESTTESTTEST valid for option '#{k}'. Example value: #{self.options[k].examples.first}"])
+            raise Msf::OptionValidateError, ["Value '#{v}' is not valid for option '#{k}'. Example value: #{self.options[k].examples.join(', ')}"]
           end
         end
         v = opt.normalize(v)

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -51,7 +51,11 @@ class DataStore < Hash
     unless opt.nil?
       if opt.validate_on_assignment?
         unless opt.valid?(v, check_empty: false)
-          raise Msf::OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'"])
+          if self.options[k].examples.empty?
+            raise Msf::OptionValidateError.new(["Value '#{v}' is not TESTTESTTESTTESTTEST valid for option '#{k}'"])
+          else
+            raise Msf::OptionValidateError.new(["Value '#{v}' is not TESTTESTTESTTESTTEST valid for option '#{k}'. Example value: #{self.options[k].examples.first}"])
+          end
         end
         v = opt.normalize(v)
       end

--- a/lib/msf/core/data_store_with_fallbacks.rb
+++ b/lib/msf/core/data_store_with_fallbacks.rb
@@ -71,9 +71,9 @@ class DataStoreWithFallbacks
       if opt.validate_on_assignment?
         unless opt.valid?(v, check_empty: false)
           if self.options[k].examples.empty?
-            raise Msf::OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'"])
+            raise Msf::OptionValidateError, ["Value '#{v}' is not valid for option '#{k}'"]
           else
-            raise Msf::OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'. Example value: #{self.options[k].examples.first}"])
+            raise Msf::OptionValidateError, ["Value '#{v}' is not valid for option '#{k}'. Example value: #{self.options[k].examples.join(', ')}"]
           end
         end
         v = opt.normalize(v)
@@ -417,7 +417,7 @@ class DataStoreWithFallbacks
   # Case-insensitive key lookup
   #
   # @return [String]
-  def  find_key_case(k)
+  def find_key_case(k)
     # Scan each alias looking for a key
     search_k = k.downcase
     if self.aliases.has_key?(search_k)

--- a/lib/msf/core/data_store_with_fallbacks.rb
+++ b/lib/msf/core/data_store_with_fallbacks.rb
@@ -70,7 +70,11 @@ class DataStoreWithFallbacks
     unless opt.nil?
       if opt.validate_on_assignment?
         unless opt.valid?(v, check_empty: false)
-          raise Msf::OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'"])
+          if self.options[k].examples.empty?
+            raise Msf::OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'"])
+          else
+            raise Msf::OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'. Example value: #{self.options[k].examples.first}"])
+          end
         end
         v = opt.normalize(v)
       end
@@ -413,7 +417,7 @@ class DataStoreWithFallbacks
   # Case-insensitive key lookup
   #
   # @return [String]
-  def find_key_case(k)
+  def  find_key_case(k)
     # Scan each alias looking for a key
     search_k = k.downcase
     if self.aliases.has_key?(search_k)

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -25,13 +25,14 @@ module Msf
     # also be a string as standin for the required description field.
     #
     def initialize(in_name, attrs = [],
-                   required: false, desc: nil, default: nil, conditions: [], enums: [], regex: nil, aliases: [], max_length: nil,
+                   required: false, desc: nil, default: nil, conditions: [], enums: [], regex: nil, examples: [], aliases: [], max_length: nil,
                    fallbacks: [])
       self.name     = in_name
       self.advanced = false
       self.evasion  = false
       self.aliases  = aliases
       self.max_length = max_length
+      self.examples = examples
       self.conditions = conditions
       self.fallbacks = fallbacks
 
@@ -224,6 +225,13 @@ module Msf
     #
     # @return [Array<String>] the array of fallbacks
     attr_accessor :fallbacks
+
+    #
+    # Array of examples for this option.
+    # This will be used for error handling to give more verbosity to user via examples as part of error messages.
+    #
+    # @return [Array<String>] the array of examples
+    attr_accessor :examples
 
     #
     # The max length of the input value

--- a/lib/msf/ui/formatter/option_validate_error.rb
+++ b/lib/msf/ui/formatter/option_validate_error.rb
@@ -12,16 +12,22 @@ module Msf
         def self.print_error(mod, error)
           raise ArgumentError, "invalid error type #{error.class}, expected ::Msf::OptionValidateError" unless error.is_a?(::Msf::OptionValidateError)
 
-          if error.reasons.empty?
-            mod.print_error("#{error.class} The following options failed to validate: #{error.options.join(', ')}")
-          else
-            mod.print_error("#{error.class} The following options failed to validate:")
-            error.options.sort.each do |option_name|
-              reasons = error.reasons[option_name]
-              if reasons
-                mod.print_error("Invalid option #{option_name}: #{reasons.join(', ')}")
+          (0...error.options.length).each do |i|
+            if error.reasons.empty?
+              if mod.options[error.options[i]].examples.empty?
+                mod.print_error("#{error.class} The following option failed to validate: Value '#{mod.datastore.user_defined[error.options[i]]}' is not valid for option '#{error.options[i]}'.")
               else
-                mod.print_error("Invalid option #{option_name}")
+                mod.print_error("#{error.class} The following option failed to validate: Value '#{mod.datastore.user_defined[error.options[i]]}' is not valid for option '#{error.options[i]}'. Example value: #{mod.options[error.options[i]].examples.first}")
+              end
+            else
+              mod.print_error("#{error.class} The following options failed to validate:")
+              error.options.sort.each do |option_name|
+                reasons = error.reasons[option_name]
+                if reasons
+                  mod.print_error("Invalid option #{option_name}: #{reasons.join(', ')}")
+                else
+                  mod.print_error("Invalid option #{option_name}")
+                end
               end
             end
           end

--- a/modules/auxiliary/admin/kerberos/forge_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/forge_ticket.rb
@@ -42,12 +42,13 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptString.new('USER', [ true, 'The Domain User' ]),
         OptInt.new('USER_RID', [ true, "The Domain User's relative identifier(RID)", Rex::Proto::Kerberos::Pac::DEFAULT_ADMIN_RID]),
-        OptString.new('NTHASH', [ true, 'The krbtgt/service nthash' ]),
+        OptString.new('NTHASH', [ false, 'The krbtgt/service nthash' ]),
         OptString.new('AES_KEY', [ false, 'The krbtgt/service AES key' ]),
-        OptString.new('DOMAIN', [ true, 'The Domain (upper case) Ex: DEMO.LOCAL' ]),
-        OptString.new('DOMAIN_SID', [ true, 'The Domain SID, Ex: S-1-5-21-1755879683-3641577184-3486455962'], regex: /^S-\d-\d+-(\d+-){1,14}\d+$/, examples: %w[S-1-5-21-1755879683-3641577184-3486455962 S-1-5-21-1180699209-877415012-3182924384-1004]),
-        OptString.new('SPN', [ false, 'The Service Principal Name (Only used for silver ticket)'], conditions: %w[ACTION == FORGE_SILVER], regex: %r{.*/.*}, examples: %w[MSSqlSvc/host.domain.local:1433 MSSqlSvc/host.domain.local:1434]),
-        OptInt.new('DURATION', [ false, 'Duration of the ticket in days', 3650])
+        OptString.new('DOMAIN', [ false, 'The Domain (upper case) Ex: DEMO.LOCAL' ]),
+        OptString.new('DOMAIN_SID', [ false, 'The Domain SID, Ex: S-1-5-21-1755879683-3641577184-3486455962'], regex: /^S-\d-\d+-(\d+-){1,14}\d+$/, examples: %w[S-1-5-21-1755879683-3641577184-3486455962 S-1-5-21-1180699209-877415012-3182924384-1004]),
+        OptString.new('SPN', [ false, 'The Service Principal Name (Only used for silver ticket) Ex: MSSqlSvc/host.domain.local:1434'], conditions: %w[ACTION == FORGE_SILVER], regex: %r{.*/.*}, examples: %w[MSSqlSvc/host.domain.local:1433 MSSqlSvc/host.domain.local:1434]),
+        OptInt.new('DURATION', [ false, 'Duration of the ticket in days', 3650]),
+        OptString.new('TICKET_PATH', [false, 'Path to the ticket you wish to debug'])
       ]
     )
     deregister_options('RHOSTS', 'RPORT', 'Timeout')

--- a/modules/auxiliary/admin/kerberos/forge_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/forge_ticket.rb
@@ -42,12 +42,12 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptString.new('USER', [ true, 'The Domain User' ]),
         OptInt.new('USER_RID', [ true, "The Domain User's relative identifier(RID)", Rex::Proto::Kerberos::Pac::DEFAULT_ADMIN_RID]),
-        OptString.new('NTHASH', [ false, 'The krbtgt/service nthash' ]),
+        OptString.new('NTHASH', [ true, 'The krbtgt/service nthash' ]),
         OptString.new('AES_KEY', [ false, 'The krbtgt/service AES key' ]),
         OptString.new('DOMAIN', [ true, 'The Domain (upper case) Ex: DEMO.LOCAL' ]),
-        OptString.new('DOMAIN_SID', [ true, 'The Domain SID, Ex: S-1-5-21-1755879683-3641577184-3486455962']),
-        OptString.new('SPN', [ false, 'The Service Principal Name (Only used for silver ticket)'], conditions: %w[ACTION == FORGE_SILVER]),
-        OptInt.new('DURATION', [ true, 'Duration of the ticket in days', 3650]),
+        OptString.new('DOMAIN_SID', [ true, 'The Domain SID, Ex: S-1-5-21-1755879683-3641577184-3486455962'], regex: /^S-\d-\d+-(\d+-){1,14}\d+$/, examples: %w[S-1-5-21-1755879683-3641577184-3486455962 S-1-5-21-1180699209-877415012-3182924384-1004]),
+        OptString.new('SPN', [ false, 'The Service Principal Name (Only used for silver ticket)'], conditions: %w[ACTION == FORGE_SILVER], regex: %r{.*/.*}, examples: %w[MSSqlSvc/host.domain.local:1433 MSSqlSvc/host.domain.local:1434]),
+        OptInt.new('DURATION', [ false, 'Duration of the ticket in days', 3650])
       ]
     )
     deregister_options('RHOSTS', 'RPORT', 'Timeout')

--- a/spec/lib/msf/ui/console/command_dispatcher/auxiliary_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/auxiliary_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
 
         subject.cmd_check
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          "Msf::OptionValidateError The following option failed to validate: A value is required for option 'RHOSTS'."
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -296,7 +296,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
         current_mod.datastore['RHOSTS'] = ''
         subject.cmd_check
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          "Msf::OptionValidateError The following option failed to validate: A value is required for option 'RHOSTS'."
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -397,7 +397,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
 
         subject.cmd_run
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          "Msf::OptionValidateError The following option failed to validate: A value is required for option 'RHOSTS'."
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -508,7 +508,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
 
         subject.cmd_run
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          "Msf::OptionValidateError The following option failed to validate: A value is required for option 'RHOSTS'."
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -609,7 +609,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
         current_mod.datastore['RHOSTS'] = ''
         subject.cmd_run
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          "Msf::OptionValidateError The following option failed to validate: A value is required for option 'RHOSTS'."
         ]
 
         expect(@combined_output).to match_array(expected_output)

--- a/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         current_mod.datastore['RHOSTS'] = ''
         subject.cmd_check
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          "Msf::OptionValidateError The following option failed to validate: A value is required for option 'RHOSTS'."
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -243,7 +243,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         current_mod.datastore['RHOSTS'] = nil
         subject.cmd_run
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          "Msf::OptionValidateError The following option failed to validate: A value is required for option 'RHOSTS'."
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -255,7 +255,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         current_mod.datastore['RHOSTS'] = ''
         subject.cmd_run
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          "Msf::OptionValidateError The following option failed to validate: A value is required for option 'RHOSTS'."
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -284,7 +284,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         subject.cmd_run
         expected_output = [
           'Exploit completed, but no session was created.',
-          'Msf::OptionValidateError The following options failed to validate: REQUIRED_PAYLOAD_OPTION'
+          "Msf::OptionValidateError The following option failed to validate: Value 'foo' is not valid for option 'REQUIRED_PAYLOAD_OPTION'."
         ]
 
         expect(@combined_output).to match_array(expected_output)


### PR DESCRIPTION
### Note
If a user had their `features set datastore_fallbacks false` as well as saved options. The options would continue to fail to validate and would accept any value and not honour the options regex check.
This error does not occur with the `features set datastore_fallbacks true`, therefore I'll leave this in draft for now until I I can figure out a way to fix this.

This PR adds validation to some of the options within the `forge_ticket.rb` module. As well as improving error affordance when setting options. Adding examples to the API to aid in making errors more transparent for users, and works for both inline options as well as setting options via the set command, also updates some tests to reflect the changes in error outputs.

## Before
```
[-] Msf::OptionValidateError The following options failed to validate: SPN 
```

## After 
```
[-] The following options failed to validate: Value 'test' is not valid for option 'SPN'. Example value: MSSqlSvc/host.domain.local:1433.
```

### `features set datastore_fallbacks true`
![image](https://user-images.githubusercontent.com/69522014/202156284-639e9799-0759-4bd2-9a6a-aa80b8b9a473.png)

### `features set datastore_fallbacks false`
![image](https://user-images.githubusercontent.com/69522014/202156263-07a5e037-8d80-4043-b7b4-8d6b18a2a2ae.png)

 ## Verification
Needs testing with the datastore_fallbacks set to true then false
- [ ] Below steps tested with `features set datastore_fallbacks false`
- [ ] Below steps tested with `features set datastore_fallbacks true`

Testing steps:
- [ ] Start `msfconsole`
- [ ] Use `auxiliary/admin/kerberos/forge_ticket`
- [ ] Attempt to set invalid option for `DOMAIN_SID` - `set DOMAIN_SID test`
- [ ] Attempt to set invalid option for `SPN` - `set SPN test`
- [ ] **Verify** the appropriate error message are returned
- [ ] **Verify** the step above only this time using inline options `run spn=test domain_sid=test`
