### PR TITLE
Fix python reverse http stager crash

### DIFF
--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -63,7 +63,7 @@ module Payload::Python::ReverseHttp
     uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
 
     # Generate the short default URL if we don't have enough space
-    if self.available_space.nil? || required_space > self.available_space
+    if self.available_space.nil? || dynamic_size? || required_space > self.available_space
       uri_req_len = 30
     end
 

--- a/spec/lib/msf/core/payload/reverse_http_spec.rb
+++ b/spec/lib/msf/core/payload/reverse_http_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Payload::Python::ReverseHttp do
+  def create_payload(info = {})
+    klass = Class.new(Msf::Payload)
+    klass.include Msf::Handler::ReverseHttp
+    klass.include Msf::Payload::Python
+    klass.include described_class
+    mod = klass.new(info)
+    datastore.each { |k, v| mod.datastore[k] = v }
+    mod
+  end
+
+  let(:datastore) do
+    {
+      'LHOST' => '127.0.0.1',
+      'HttpUserAgent' => 'HttpUserAgent',
+    }
+  end
+
+  let(:cached_size) { 500 }
+  let(:is_dynamic_size) { false }
+
+  before(:each) do
+    allow(subject).to receive(:cached_size).and_return(cached_size)
+    allow(subject).to receive(:dynamic_size?).and_return(is_dynamic_size)
+  end
+
+  describe '#generate' do
+    let(:subject) { create_payload }
+
+    context 'when the payload is static' do
+      let(:cached_size) { 500 }
+      let(:is_dynamic_size) { false }
+
+      context 'when available space is nil' do
+        it 'generates a payload' do
+          expect(subject.generate).to be_a(String)
+        end
+      end
+
+      context 'when available space is defined' do
+        it 'generates a payload' do
+          subject.available_space = 2000
+          expect(subject.generate).to be_a(String)
+        end
+      end
+    end
+
+    context 'when the payload is dynamic' do
+      let(:cached_size) { nil }
+      let(:is_dynamic_size) { true }
+
+      context 'when available space is nil' do
+        it 'generates a payload' do
+          expect(subject.generate).to be_a(String)
+        end
+      end
+
+      context 'when available space is defined' do
+        it 'generates a payload' do
+          subject.available_space = 2000
+          expect(subject.generate).to be_a(String)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/17276

Fixes a crash with python reverse http stager:

```
bundle exec ruby ./msfvenom  -p python/meterpreter/reverse_http LHOST=127.0.0.1 LPORT=6063 -f raw

hrr_rb_ssh loaded
[-] No platform was selected, choosing Msf::Module::Platform::Python from the payload
[-] No arch selected, selecting arch: python from the payload
Error: undefined method `+' for nil:NilClass
```

## Verification

- [x] Verify CI passes
- [x] Verify the crash is fixed - https://github.com/rapid7/metasploit-framework/issues/17276