### PR TITLE
modules/post/linux/gather: Use Post::Linux::System.get_hostname method

### DIFF
--- a/modules/post/linux/gather/enum_network.rb
+++ b/modules/post/linux/gather/enum_network.rb
@@ -29,7 +29,8 @@ class MetasploitModule < Msf::Post
 
   # Run Method for when run command is issued
   def run
-    host = get_host
+    print_status("Running module against #{get_hostname} (#{session.session_host})")
+
     user = execute("/usr/bin/whoami")
     print_status("Module running as #{user}")
 
@@ -80,20 +81,6 @@ class MetasploitModule < Msf::Post
     ltype = "linux.enum.network"
     loot = store_loot(ltype, ctype, session, data, nil, msg)
     print_good("#{msg} stored in #{loot.to_s}")
-  end
-
-  # Get host name
-  def get_host
-    case session.type
-    when /meterpreter/
-      host = sysinfo["Computer"]
-    when /shell/
-      host = cmd_exec("hostname").chomp
-    end
-
-    print_status("Running module against #{host}")
-
-    return host
   end
 
   def execute(cmd)

--- a/modules/post/linux/gather/tor_hiddenservices.rb
+++ b/modules/post/linux/gather/tor_hiddenservices.rb
@@ -32,9 +32,9 @@ class MetasploitModule < Msf::Post
   end
 
   def run
+    print_status("Running module against #{get_hostname} (#{session.session_host})")
+
     distro = get_sysinfo
-    h = get_host
-    print_status("Running module against #{h}")
     print_status("Info:")
     print_status("\t#{distro[:version]}")
     print_status("\t#{distro[:kernel]}")
@@ -46,17 +46,6 @@ class MetasploitModule < Msf::Post
     fname = ::File.basename(file)
     loot = store_loot(ltype, ctype, session, data, fname)
     print_status("#{fname} stored in #{loot.to_s}")
-  end
-
-  def get_host
-    case session.type
-    when /meterpreter/
-      host = sysinfo["Computer"]
-    when /shell/
-      host = cmd_exec("hostname").chomp
-    end
-
-    return host
   end
 
   def find_torrc


### PR DESCRIPTION
These two Linux `Post` modules unnecessarily define a `get_host` method. We have a `Post::Linux::System.get_hostname` method for this.
