### PR TITLE
tor_hiddenservices: Check locate command exists

### DIFF
--- a/modules/post/linux/gather/tor_hiddenservices.rb
+++ b/modules/post/linux/gather/tor_hiddenservices.rb
@@ -60,6 +60,8 @@ class MetasploitModule < Msf::Post
   end
 
   def find_torrc
+    fail_with(Failure::BadConfig, "'locate' command does not exist") unless command_exists?('locate')
+
     config = cmd_exec("locate 'torrc' | grep -v 'torrc.5.gz'").split("\n")
     if config.length == 0
         print_error ("No torrc file found, maybe it goes by a different name?")


### PR DESCRIPTION
Stops this nonsense:

```
msf6 post(linux/gather/tor_hiddenservices) > rexploit 
[*] Reloading module...

[*] Running module against 192.168.200.204
[*] Info:
[*] 	Ubuntu 22.04.1 LTS
[*] 	Linux ubuntu 5.15.0-52-generic #58-Ubuntu SMP Thu Oct 13 08:03:55 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
[*] Looking for torrc...
[+] Torrc file found at /bin/sh: 1: locate: not found
[+] 5 hidden services have been found!
[-] Failed to open file: cat: '/bin/sh:': No such file or directoryhostname: core_channel_open: Operation failed: 1
[-] Failed to open file: cat: '1:': No such file or directoryhostname: core_channel_open: Operation failed: 1
[-] Failed to open file: cat: 'locate:': No such file or directoryhostname: core_channel_open: Operation failed: 1
[-] Failed to open file: cat: not: No such file or directoryhostname: core_channel_open: Operation failed: 1
[-] Failed to open file: cat: found: No such file or directoryhostname: core_channel_open: Operation failed: 1
[-] Failed to open file: cat: '/bin/sh:': No such file or directoryprivate_key: core_channel_open: Operation failed: 1
[-] Failed to open file: cat: '1:': No such file or directoryprivate_key: core_channel_open: Operation failed: 1
[-] Failed to open file: cat: 'locate:': No such file or directoryprivate_key: core_channel_open: Operation failed: 1
[-] Failed to open file: cat: not: No such file or directoryprivate_key: core_channel_open: Operation failed: 1
[-] Failed to open file: cat: found: No such file or directoryprivate_key: core_channel_open: Operation failed: 1
[*] Post module execution completed
```

After:

```
msf6 post(linux/gather/tor_hiddenservices) > rexploit 
[*] Reloading module...

[*] Running module against 192.168.200.204
[*] Info:
[*] 	Ubuntu 22.04.1 LTS
[*] 	Linux ubuntu 5.15.0-52-generic #58-Ubuntu SMP Thu Oct 13 08:03:55 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
[*] Looking for torrc...
[-] Post aborted due to failure: bad-config: 'locate' command does not exist
[*] Post module execution completed
```
