### PR TITLE
Update enum module tests to use include context

### DIFF
--- a/lib/msf/core/auxiliary/mikrotik.rb
+++ b/lib/msf/core/auxiliary/mikrotik.rb
@@ -90,11 +90,11 @@ module Msf
           module_fullname: fullname,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
-      end
 
-      # Default SNMP to UDP
-      if tport == 161
-        credential_data[:protocol] = 'udp'
+        # Default SNMP to UDP
+        if tport == 161
+          credential_data[:protocol] = 'udp'
+        end
       end
 
       store_loot('mikrotik.config', 'text/plain', thost, config.strip, 'config.txt', 'MikroTik Configuration')
@@ -185,11 +185,11 @@ module Msf
           module_fullname: fullname,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
-      end
 
-      # Default SNMP to UDP
-      if tport == 161
-        credential_data[:protocol] = 'udp'
+        # Default SNMP to UDP
+        if tport == 161
+          credential_data[:protocol] = 'udp'
+        end
       end
 
       store_loot('mikrotik.config', 'text/plain', thost, config.strip, 'config.txt', 'MikroTik Configuration')

--- a/spec/lib/msf/core/auxiliary/arista_spec.rb
+++ b/spec/lib/msf/core/auxiliary/arista_spec.rb
@@ -4,18 +4,23 @@ require 'spec_helper'
 
 
 RSpec.describe Msf::Auxiliary::Arista do
+  if ENV['REMOTE_DB']
+    # https://github.com/rapid7/metasploit-framework/pull/9939/files#diff-08c7b840568ae1bf6ed26d4d4288e5e8c1b817f8622dec8fb38417c74be6765d
+    before { skip('Awaiting cred port') }
+  end
+
+  include_context 'Msf::DBManager'
+  include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
+
   class DummyAristaClass
     include Msf::Auxiliary::Arista
+
     def framework
-      Msf::Simple::Framework.create(
-        'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,
-        # don't load any module paths so we can just load the module under test and save time
-        'DeferModuleLoads' => true
-      )
+      raise StandardError, 'This method needs to be stubbed.'
     end
 
     def active_db?
-      true
+      framework.db.active
     end
 
     def print_good(_str = nil)
@@ -42,6 +47,10 @@ RSpec.describe Msf::Auxiliary::Arista do
   subject(:aux_arista) { DummyAristaClass.new }
 
   let!(:workspace) { FactoryBot.create(:mdm_workspace) }
+
+  before(:each) do
+    allow_any_instance_of(DummyAristaClass).to receive(:framework).and_return(framework)
+  end
 
   context '#create_credential_and_login' do
     let(:session) { FactoryBot.create(:mdm_session) }

--- a/spec/lib/msf/core/auxiliary/brocade_spec.rb
+++ b/spec/lib/msf/core/auxiliary/brocade_spec.rb
@@ -1,20 +1,25 @@
 # -*- coding: binary -*-
 require 'spec_helper'
 
-
 RSpec.describe Msf::Auxiliary::Brocade do
+  if ENV['REMOTE_DB']
+    # https://github.com/rapid7/metasploit-framework/pull/9939/files#diff-08c7b840568ae1bf6ed26d4d4288e5e8c1b817f8622dec8fb38417c74be6765d
+    before { skip('Awaiting cred port') }
+  end
+
+  include_context 'Msf::DBManager'
+  include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
+
   class DummyBrocadeClass
     include Msf::Auxiliary::Brocade
     def framework
-      Msf::Simple::Framework.create(
-          'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,
-          # don't load any module paths so we can just load the module under test and save time
-          'DeferModuleLoads' => true
-      )
+      raise StandardError, 'This method needs to be stubbed.'
     end
+
     def active_db?
-      true
+      framework.db.active
     end
+
     def print_good(str=nil)
       raise StandardError.new("This method needs to be stubbed.")
     end
@@ -35,6 +40,10 @@ RSpec.describe Msf::Auxiliary::Brocade do
   subject(:aux_brocade) { DummyBrocadeClass.new }
 
   let!(:workspace) { FactoryBot.create(:mdm_workspace) }
+
+  before(:each) do
+    allow_any_instance_of(DummyBrocadeClass).to receive(:framework).and_return(framework)
+  end
 
   context '#create_credential_and_login' do
 

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -3,18 +3,25 @@ require 'spec_helper'
 
 
 RSpec.describe Msf::Auxiliary::Cisco do
+  if ENV['REMOTE_DB']
+    # https://github.com/rapid7/metasploit-framework/pull/9939/files#diff-08c7b840568ae1bf6ed26d4d4288e5e8c1b817f8622dec8fb38417c74be6765d
+    before { skip('Awaiting cred port') }
+  end
+
+  include_context 'Msf::DBManager'
+  include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
+
   class DummyCiscoClass
     include Msf::Auxiliary::Cisco
+
     def framework
-      Msf::Simple::Framework.create(
-          'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,
-          # don't load any module paths so we can just load the module under test and save time
-          'DeferModuleLoads' => true
-      )
+      raise StandardError, 'This method needs to be stubbed.'
     end
+
     def active_db?
-      true
+      framework.db.active
     end
+
     def print_good(str=nil)
       raise StandardError.new("This method needs to be stubbed.")
     end
@@ -32,6 +39,10 @@ RSpec.describe Msf::Auxiliary::Cisco do
   subject(:aux_cisco) { DummyCiscoClass.new }
 
   let!(:workspace) { FactoryBot.create(:mdm_workspace) }
+
+  before(:each) do
+    allow_any_instance_of(DummyCiscoClass).to receive(:framework).and_return(framework)
+  end
 
   context '#create_credential_and_login' do
 

--- a/spec/lib/msf/core/auxiliary/f5_spec.rb
+++ b/spec/lib/msf/core/auxiliary/f5_spec.rb
@@ -4,18 +4,23 @@ require 'spec_helper'
 
 
 RSpec.describe Msf::Auxiliary::F5 do
+  if ENV['REMOTE_DB']
+    # https://github.com/rapid7/metasploit-framework/pull/9939/files#diff-08c7b840568ae1bf6ed26d4d4288e5e8c1b817f8622dec8fb38417c74be6765d
+    before { skip('Awaiting cred port') }
+  end
+
+  include_context 'Msf::DBManager'
+  include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
+
   class DummyF5Class
     include Msf::Auxiliary::F5
+
     def framework
-      Msf::Simple::Framework.create(
-        'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,
-        # don't load any module paths so we can just load the module under test and save time
-        'DeferModuleLoads' => true
-      )
+      raise StandardError, 'This method needs to be stubbed.'
     end
 
     def active_db?
-      true
+      framework.db.active
     end
 
     def print_good(_str = nil)
@@ -42,6 +47,10 @@ RSpec.describe Msf::Auxiliary::F5 do
   subject(:aux_f5) { DummyF5Class.new }
 
   let!(:workspace) { FactoryBot.create(:mdm_workspace) }
+
+  before(:each) do
+    allow_any_instance_of(DummyF5Class).to receive(:framework).and_return(framework)
+  end
 
   context '#create_credential_and_login' do
     let(:session) { FactoryBot.create(:mdm_session) }

--- a/spec/lib/msf/core/auxiliary/juniper_spec.rb
+++ b/spec/lib/msf/core/auxiliary/juniper_spec.rb
@@ -3,18 +3,22 @@
 require 'spec_helper'
 
 RSpec.describe Msf::Auxiliary::Juniper do
+  if ENV['REMOTE_DB']
+    # https://github.com/rapid7/metasploit-framework/pull/9939/files#diff-08c7b840568ae1bf6ed26d4d4288e5e8c1b817f8622dec8fb38417c74be6765d
+    before { skip('Awaiting cred port') }
+  end
+
+  include_context 'Msf::DBManager'
+  include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
+
   class DummyJuniperClass
     include Msf::Auxiliary::Juniper
     def framework
-      Msf::Simple::Framework.create(
-        'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,
-        # don't load any module paths so we can just load the module under test and save time
-        'DeferModuleLoads' => true
-      )
+      raise StandardError, 'This method needs to be stubbed.'
     end
 
     def active_db?
-      true
+      framework.db.active
     end
 
     def print_good(_str = nil)
@@ -37,6 +41,10 @@ RSpec.describe Msf::Auxiliary::Juniper do
   subject(:aux_juniper) { DummyJuniperClass.new }
 
   let!(:workspace) { FactoryBot.create(:mdm_workspace) }
+
+  before(:each) do
+    allow_any_instance_of(DummyJuniperClass).to receive(:framework).and_return(framework)
+  end
 
   context '#create_credential_and_login' do
     let(:session) { FactoryBot.create(:mdm_session) }

--- a/spec/lib/msf/core/auxiliary/mikrotik_spec.rb
+++ b/spec/lib/msf/core/auxiliary/mikrotik_spec.rb
@@ -2,20 +2,24 @@
 
 require 'spec_helper'
 
-
 RSpec.describe Msf::Auxiliary::Mikrotik do
+  if ENV['REMOTE_DB']
+    # https://github.com/rapid7/metasploit-framework/pull/9939/files#diff-08c7b840568ae1bf6ed26d4d4288e5e8c1b817f8622dec8fb38417c74be6765d
+    before { skip('Awaiting cred port') }
+  end
+
+  include_context 'Msf::DBManager'
+  include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
+
   class DummyMikrotikClass
     include Msf::Auxiliary::Mikrotik
+
     def framework
-      Msf::Simple::Framework.create(
-        'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,
-        # don't load any module paths so we can just load the module under test and save time
-        'DeferModuleLoads' => true
-      )
+      raise StandardError, 'This method needs to be stubbed.'
     end
 
     def active_db?
-      true
+      framework.db.active
     end
 
     def print_good(_str = nil)
@@ -46,6 +50,10 @@ RSpec.describe Msf::Auxiliary::Mikrotik do
   subject(:aux_mikrotik) { DummyMikrotikClass.new }
 
   let!(:workspace) { FactoryBot.create(:mdm_workspace) }
+
+  before(:each) do
+    allow_any_instance_of(DummyMikrotikClass).to receive(:framework).and_return(framework)
+  end
 
   context '#create_credential_and_login' do
     let(:session) { FactoryBot.create(:mdm_session) }

--- a/spec/lib/msf/core/auxiliary/vyos_spec.rb
+++ b/spec/lib/msf/core/auxiliary/vyos_spec.rb
@@ -3,18 +3,23 @@
 require 'spec_helper'
 
 RSpec.describe Msf::Auxiliary::VYOS do
+  if ENV['REMOTE_DB']
+    # https://github.com/rapid7/metasploit-framework/pull/9939/files#diff-08c7b840568ae1bf6ed26d4d4288e5e8c1b817f8622dec8fb38417c74be6765d
+    before { skip('Awaiting cred port') }
+  end
+
+  include_context 'Msf::DBManager'
+  include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
+
   class DummyVYOSClass
     include Msf::Auxiliary::VYOS
+
     def framework
-      Msf::Simple::Framework.create(
-        'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,
-        # don't load any module paths so we can just load the module under test and save time
-        'DeferModuleLoads' => true
-      )
+      raise StandardError, 'This method needs to be stubbed.'
     end
 
     def active_db?
-      true
+      framework.db.active
     end
 
     def vprint_good(_str = nil)
@@ -45,6 +50,10 @@ RSpec.describe Msf::Auxiliary::VYOS do
   subject(:aux_vyos) { DummyVYOSClass.new }
 
   let!(:workspace) { FactoryBot.create(:mdm_workspace) }
+
+  before(:each) do
+    allow_any_instance_of(DummyVYOSClass).to receive(:framework).and_return(framework)
+  end
 
   context '#create_credential_and_login' do
     let(:session) { FactoryBot.create(:mdm_session) }


### PR DESCRIPTION
These tests were failing for me locally as `framework.db.active` was false; I've updated these tests to use the shared include_context mechanism for instantiating framework instances.

Local failure example:

```
Msf::Auxiliary::Ubiquiti FFFFFFFFFFFFFFFFF...F

  1) Msf::Auxiliary::Ubiquiti handles firewallgroups prints correctly
     Failure/Error: expect(aux_unifi).to receive(:myworkspace).at_least(:once).and_return(workspace)
     
       (#<DummyUnifiClass:0x00007fb466373558>).myworkspace(*(any args))
           expected: at least 1 time with any arguments
           received: 0 times with any arguments
     # ./spec/lib/msf/core/auxiliary/ubiquiti_spec
```

## Verification

The following tests should pass locally:

```
bundle exec rspec ./spec/lib/msf/core/auxiliary/cisco_spec.rb ./spec/lib/msf/core/auxiliary/f5_spec.rb ./spec/lib/msf/core/auxiliary/juniper_spec.rb ./spec/lib/msf/core/auxiliary/ubiquiti_spec.rb
```