### PR TITLE
Add additional reliability metadata

### DIFF
--- a/data/markdown_doc/default_template.erb
+++ b/data/markdown_doc/default_template.erb
@@ -83,6 +83,8 @@
 <% description = "The module is expected to get a shell every time it runs." %>
 <% elsif reliability == "unreliable-session" %>
 <% description = "The module isn't expected to get a shell reliably (such as only once)." %>
+<% elsif reliability == "event-dependent" %>
+<% description = "The module may not execute the payload until an external event occurs. For instance, a cron job, machine restart, user interaction within a GUI element, etc." %>
 <% end %>
 
 * **<%= reliability %>:** <%= description %>

--- a/docs/metasploit-framework.wiki/Definition-of-Module-Reliability-Side-Effects-and-Stability.md
+++ b/docs/metasploit-framework.wiki/Definition-of-Module-Reliability-Side-Effects-and-Stability.md
@@ -70,3 +70,4 @@ Example:
 | FIRST_ATTEMPT_FAIL | The module may fail for the first attempt |
 | REPEATABLE_SESSION | The module is expected to get a session every time it runs |
 | UNRELIABLE_SESSION | The module isn't expected to get a shell reliably (such as only once) |
+| EVENT_DEPENDENT    | The module may not execute the payload until an external event occurs. For instance, a cron job, machine restart, user interaction within a GUI element, etc |

--- a/lib/msf/core/constants.rb
+++ b/lib/msf/core/constants.rb
@@ -99,6 +99,8 @@ FIRST_ATTEMPT_FAIL = 'first-attempt-fail'
 REPEATABLE_SESSION = 'repeatable-session'
 # The module isn't expected to get a shell reliably (such as only once).
 UNRELIABLE_SESSION = 'unreliable-session'
+# The module may not execute the payload until an external event occurs. For instance, a cron job, machine restart, user interaction within a GUI element, etc.
+EVENT_DEPENDENT = 'event-dependent'
 
 module HttpClients
   IE = "MSIE"


### PR DESCRIPTION
This pull request adds additional constants to the reliability metadata for modules. This requirement has come up before for @bcoles and @h00die on modules they have worked on - as well as previous internal Rapid7 requirements, i.e. running modules in an automated scanning scenario, and we wish to filter out modules that require a reboot of target machines.

## Verification

Verify we are okay adding this metadata to the module reliability information