### PR TITLE
Adds support to RPC for automatically choosing module defaults

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -463,6 +463,66 @@ class Payload < Msf::Module
     return nops
   end
 
+  # Select a reasonable default payload and minimally configure it
+  # @param [Msf::Module] mod
+  def self.choose_payload(mod)
+    compatible_payloads = mod.compatible_payloads(
+      excluded_platforms: ['Multi'] # We don't want to select a multi payload
+    ).map(&:first)
+
+    # XXX: Determine LHOST based on global LHOST, RHOST or an arbitrary internet address
+    lhost = mod.datastore['LHOST'] || Rex::Socket.source_address(mod.datastore['RHOST'] || '50.50.50.50')
+
+    configure_payload = lambda do |payload|
+      if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
+        payload_defaults = { 'PAYLOAD' => payload }
+
+        # Set LHOST if this is a reverse payload
+        if payload.index('reverse')
+          payload_defaults['LHOST'] = lhost
+        end
+        mod.datastore.import_defaults_from_hash(payload_defaults, imported_by: 'choose_payload')
+      else
+        mod.datastore['PAYLOAD'] = payload
+        # Set LHOST if this is a reverse payload
+        if payload.index('reverse')
+          mod.datastore['LHOST'] = lhost
+        end
+      end
+
+      payload
+    end
+
+    # If there is only one compatible payload, return it immediately
+    if compatible_payloads.length == 1
+      return configure_payload.call(compatible_payloads.first)
+    end
+
+    # XXX: This approach is subpar, and payloads should really be ranked!
+    preferred_payloads = [
+      # These payloads are generally reliable and common enough in practice
+      '/meterpreter/reverse_tcp',
+      '/shell/reverse_tcp',
+      'cmd/unix/reverse_bash',
+      'cmd/unix/reverse_netcat',
+      'cmd/windows/powershell_reverse_tcp',
+      # Fall back on a generic payload to autoselect a specific payload
+      'generic/shell_reverse_tcp',
+      'generic/shell_bind_tcp'
+    ]
+
+    # XXX: This is not efficient in the slightest
+    preferred_payloads.each do |type|
+      payload = compatible_payloads.find { |name| name.end_with?(type) }
+
+      next unless payload
+
+      return configure_payload.call(payload)
+    end
+
+    nil
+  end
+
   #
   # A placeholder stub, to be overriden by mixins
   #

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -467,7 +467,6 @@ class RPC_Module < RPC_Base
     res
   end
 
-
   # Executes a module.
   #
   # @param [String] mtype Module type. Supported types include (case-sensitive):
@@ -738,6 +737,12 @@ private
   end
 
   def _run_exploit(mod, opts)
+    if mod.datastore['PAYLOAD']
+      opts['PAYLOAD'] = mod.datastore['PAYLOAD']
+    else
+      opts['PAYLOAD'] = Msf::Payload.choose_payload(mod)
+    end
+
     s = Msf::Simple::Exploit.exploit_simple(mod, {
       'Payload'  => opts['PAYLOAD'],
       'Target'   => opts['TARGET'],
@@ -846,4 +851,3 @@ private
 end
 end
 end
-

--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -56,12 +56,35 @@ class RPC_Session < RPC_Base
   end
 
 
-  # Stops a session.
+  # Stops a session - alias for killing a session in `msfconsole`
   #
   # @param [Integer] sid Session ID.
   # @raise [Msf::RPC::Exception] Unknown session ID.
   # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] A message that says 'success'.
+  # @example Here's how you would use this from the client:
+  #  # You have an active session, you run session list to view the session number, then pass that session number to the `stop` command:
+  # >> rpc.call('session.list')
+  #  {7=>
+  #   {"type"=>"meterpreter",
+  #    "tunnel_local"=>"192.168.xxx.xxx:4444",
+  #    "tunnel_peer"=>"192.168.xxx.xxx:64688",
+  #    "via_exploit"=>"exploit/windows/smb/ms17_010_eternalblue",
+  #    "via_payload"=>"payload/windows/x64/meterpreter/reverse_tcp",
+  #    "desc"=>"Meterpreter",
+  #    "info"=>"NT AUTHORITY\\SYSTEM @ DC1",
+  #    "workspace"=>"default",
+  #    "session_host"=>"192.168.xxx.xxx",
+  #    "session_port"=>445,
+  #    "target_host"=>"192.168.xxx.xxx",
+  #    "username"=>"foo",
+  #    "uuid"=>"h9pbmuoh",
+  #    "exploit_uuid"=>"tcjj1fqo",
+  #    "routes"=>"",
+  #    "arch"=>"x86",
+  #    "platform"=>"windows"}}
+  # >> rpc.call('session.stop', 7)
+  # => {"result"=>"success"}
   def rpc_stop( sid)
 
     s = self.framework.sessions[sid.to_i]
@@ -487,4 +510,3 @@ private
 end
 end
 end
-

--- a/lib/msf/ui/console/command_dispatcher/evasion.rb
+++ b/lib/msf/ui/console/command_dispatcher/evasion.rb
@@ -96,12 +96,6 @@ class Evasion
 
     print_status "Payload Handler Started as Job #{job_id}"
   end
-
-  # This is the same functionality as Exploit::choose_payload, so call it
-  def self.choose_payload(mod)
-    Msf::Ui::Console::CommandDispatcher::Exploit.choose_payload(mod)
-  end
-
 end
 end
 end

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -269,64 +269,9 @@ class Exploit
   alias cmd_rerun_help cmd_rexploit_help
 
   # Select a reasonable default payload and minimally configure it
-  # TODO: Move this somewhere better or make it more dynamic?
   # @param [Msf::Module] mod
   def self.choose_payload(mod)
-    compatible_payloads = mod.compatible_payloads(
-      excluded_platforms: ['Multi'] # We don't want to select a multi payload
-    ).map(&:first)
-
-    # XXX: Determine LHOST based on global LHOST, RHOST or an arbitrary internet address
-    lhost = mod.datastore['LHOST'] || Rex::Socket.source_address(mod.datastore['RHOST'] || '50.50.50.50')
-
-    configure_payload = lambda do |payload|
-      if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
-        payload_defaults = { 'PAYLOAD' => payload }
-
-        # Set LHOST if this is a reverse payload
-        if payload.index('reverse')
-          payload_defaults['LHOST'] = lhost
-        end
-        mod.datastore.import_defaults_from_hash(payload_defaults, imported_by: 'choose_payload')
-      else
-        mod.datastore['PAYLOAD'] = payload
-        # Set LHOST if this is a reverse payload
-        if payload.index('reverse')
-          mod.datastore['LHOST'] = lhost
-        end
-      end
-
-      payload
-    end
-
-    # If there is only one compatible payload, return it immediately
-    if compatible_payloads.length == 1
-      return configure_payload.call(compatible_payloads.first)
-    end
-
-    # XXX: This approach is subpar, and payloads should really be ranked!
-    preferred_payloads = [
-      # These payloads are generally reliable and common enough in practice
-      '/meterpreter/reverse_tcp',
-      '/shell/reverse_tcp',
-      'cmd/unix/reverse_bash',
-      'cmd/unix/reverse_netcat',
-      'cmd/windows/powershell_reverse_tcp',
-      # Fall back on a generic payload to autoselect a specific payload
-      'generic/shell_reverse_tcp',
-      'generic/shell_bind_tcp'
-    ]
-
-    # XXX: This is not efficient in the slightest
-    preferred_payloads.each do |type|
-      payload = compatible_payloads.find { |name| name.end_with?(type) }
-
-      next unless payload
-
-      return configure_payload.call(payload)
-    end
-
-    nil
+    Msf::Payload.choose_payload(mod)
   end
 
 end


### PR DESCRIPTION
Resolves #14042 

This PR fixes a bug where if a RPC call was made without a `payload` or `lhost`, it would return a `Msf::OptionValidateError` error. A [comment](https://github.com/rapid7/metasploit-framework/issues/14113#issuecomment-700458780) from [timwr](https://github.com/timwr) on a previous issue breaks the issue down nicely:

----------------
I think the problem is that not all options are being defaulted when you run the exploit via msfrpc:

First observe msfconsole:

```
$ ./msfconsole -q
msf6 > use exploit/linux/http/goahead_ldpreload
[*] No payload configured, defaulting to cmd/unix/reverse_stub
msf6 exploit(linux/http/goahead_ldpreload) > run

[-] Exploit failed: One or more options failed to validate: RHOSTS.
[*] Exploit completed, but no session was created.
msf6 exploit(linux/http/goahead_ldpreload) > set RHOSTS 192.168.13.37
RHOSTS => 192.168.13.37
msf6 exploit(linux/http/goahead_ldpreload) > run

[*] Started reverse TCP handler on 10.0.7.177:4444
[*] Searching 390 paths for an exploitable CGI endpoint...
(exploit executes successfully)
```

now compare this to msfrpc:

```
$ ./msfrpc -P msf1 -a 127.0.0.1 -U msf -p 55553 -S
[*] The 'rpc' object holds the RPC client interface
[*] Use rpc.call('group.command') to make RPC calls

>> rpc.call("module.execute", "exploit", "linux/http/goahead_ldpreload", {})
=> {"job_id"=>nil, "uuid"=>"aifsxw6e"}
# This fails because: core: Exploit failed (linux/http/goahead_ldpreload) - Msf::MissingPayloadError A payload has not been selected.

>> rpc.call("module.execute", "exploit", "linux/http/goahead_ldpreload", {"RHOSTS" => "192.168.13.37"})
=> {"job_id"=>nil, "uuid"=>"yqegp6uk"}
# This works on msfconsole, but fails on msfrpc with the same error (no payload).

>> rpc.call("module.execute", "exploit", "linux/http/goahead_ldpreload", {"PAYLOAD" => "cmd/unix/reverse_stub", "RHOSTS" => "192.168.13.37"})
=> {"job_id"=>nil, "uuid"=>"yodkqowh"}
# This fails too, because: Msf::OptionValidateError One or more options failed to validate: LHOST.

>> rpc.call("module.execute", "exploit", "linux/http/goahead_ldpreload", {"PAYLOAD" => "cmd/unix/reverse_stub", "LHOST"=>"127.0.0.1", "RHOSTS" => "192.168.13.37"})
=> {"job_id"=>1, "uuid"=>"wr9owwki"}
# This works!!!
```

This fix adds code to choose a default `payload` and `lhost` when none has been passed. Some extra comments were added in areas I thought necessary to hopefully aiding future travelers.

## Before
![image](https://user-images.githubusercontent.com/69522014/204263477-614928cb-7542-4447-84df-2779fb082b5c.png)


## After
![image](https://user-images.githubusercontent.com/69522014/204263399-f818b021-df7c-45b5-beba-b089356da977.png)


## Verification

I followed the RPC [docs](https://docs.rapid7.com/metasploit/rpc-api/#Connecting-with-the-Metasploit-RPC-Client-Gem) and followed the [MSFRPCD](https://docs.rapid7.com/metasploit/rpc-api/#starting-the-rpc-server-for-the-metasploit-framework-using-msfrpcd) section to get set-up.

- [ ] Run `ruby msfrpcd -U I3wL8TDe -P I3wL8TDe -f` to start server
- [ ] Run `ruby msfrpc -U I3wL8TDe -P I3wL8TDe -a 0.0.0.0` on a separate tab for client calls
- [ ] Within client tab I used the following commands:
- [ ] Run `rpc.call("module.execute", "exploit", "linux/http/goahead_ldpreload", {"RHOSTS" => "192.168.13.37"})`
- [ ] **Verify** that the following commands return the same output, returning `nil` for `job_id` until both the `payload` and `lhost` are passed.
```Bash
➜  metasploit-framework git:(upstream-master) ruby msfrpc -U I3wL8TDe -P I3wL8TDe -a 0.0.0.0
[*] The 'rpc' object holds the RPC client interface
[*] Use rpc.call('group.command') to make RPC calls

>> rpc.call("module.execute", "exploit", "linux/http/goahead_ldpreload", {"RHOSTS" => "192.168.13.37"})
=> {"job_id"=>nil, "uuid"=>"a07lec8q"}
>> rpc.call("module.execute", "exploit", "linux/http/goahead_ldpreload", {"PAYLOAD" => "cmd/unix/reverse_stub", "RHOSTS" => "192.168.13.37"})
=> {"job_id"=>nil, "uuid"=>"aup6tcjt"}
>> rpc.call("module.execute", "exploit", "linux/http/goahead_ldpreload", {"PAYLOAD" => "cmd/unix/reverse_stub", "LHOST"=>"127.0.0.1", "RHOSTS" => "192.168.13.37"})
=> {"job_id"=>1, "uuid"=>"nqcjllm8"}
```
- [ ] **Verify** then switch to the PR branch and confirm the first command above does not return the `job_id` as `nil` as it should be defaulted via the changes.

