### PR TITLE
Fix the DH key construction for OpenSSL3

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb
@@ -12,15 +12,27 @@ module Msf
             #
             # @return [OpenSSL::PKey::DH, string] The Diffie Hellman object, and a random client nonce
             def build_dh
-              dh_p = '00ffffffffffffffffc90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74020bbea63b139b' \
-                     '22514a08798e3404ddef9519b3cd3a431b302b0a6df25f14374fe1356d6d51c245e485b576625e7ec' \
-                     '6f44c42e9a637ed6b0bff5cb6f406b7edee386bfb5a899fa5ae9f24117c4b1fe649286651ece65381' \
-                     'ffffffffffffffff'
-              dh = OpenSSL::PKey::DH.new
-              dh.set_pqg(dh_p.to_i(16), 0, 2)
-              priv_key = SecureRandom.random_bytes(32).unpack('H*')[0].to_i(16)
-              pub_key = dh.g.mod_exp(priv_key, dh.p)
-              dh.set_key(pub_key, priv_key)
+              prime_modulus = 0 # built 256 bits at a time
+              prime_modulus |= 0xffffffffffffffffc90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74 << (256 * 3)
+              prime_modulus |= 0x020bbea63b139b22514a08798e3404ddef9519b3cd3a431b302b0a6df25f1437 << (256 * 2)
+              prime_modulus |= 0x4fe1356d6d51c245e485b576625e7ec6f44c42e9a637ed6b0bff5cb6f406b7ed << (256 * 1)
+              prime_modulus |= 0xee386bfb5a899fa5ae9f24117c4b1fe649286651ece65381ffffffffffffffff
+              dh = OpenSSL::PKey::DH.new(
+                OpenSSL::ASN1::Sequence([
+                  OpenSSL::ASN1::Integer(prime_modulus),
+                  OpenSSL::ASN1::Integer(2),
+                ]).to_der
+              )
+              if OpenSSL::PKey.respond_to?(:generate_key)
+                # OpenSSL v3.x path
+                # see:
+                #  * https://github.com/rapid7/metasploit-framework/pull/17308
+                #  * https://ruby-doc.org/stdlib-3.1.0/libdoc/openssl/rdoc/OpenSSL/PKey/DH.html#method-i-generate_key-21
+                dh = OpenSSL::PKey.generate_key(dh)
+              else
+                dh.generate_key!
+              end
+
               dh_nonce = SecureRandom.random_bytes(32)
               [dh, dh_nonce]
             end


### PR DESCRIPTION
This fixes the CI test that's currently failing because of `#set_pqg`. This switches to setting the necessary parameters via `#new`.

# Testing

- [x] See the unit tests pass
- [x] See that the pkinit module still works