### PR TITLE
Fix crash in kerberos get ticket module

### DIFF
--- a/modules/auxiliary/admin/kerberos/get_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/get_ticket.rb
@@ -100,10 +100,10 @@ class MetasploitModule < Msf::Auxiliary
   def action_get_tgt
     ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
       [
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE_OK
+        Rex::Proto::Kerberos::Model::KdcOptionFlags::FORWARDABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlags::RENEWABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlags::CANONICALIZE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlags::RENEWABLE_OK
       ]
     )
     options = {
@@ -238,9 +238,9 @@ class MetasploitModule < Msf::Auxiliary
     )
     ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
       [
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::FORWARDABLE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::RENEWABLE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlag::CANONICALIZE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlags::FORWARDABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlags::RENEWABLE,
+        Rex::Proto::Kerberos::Model::KdcOptionFlags::CANONICALIZE,
       ]
     )
 


### PR DESCRIPTION
Fixes a crash in the kerberos get ticket module added by https://github.com/rapid7/metasploit-framework/pull/17309 - which broke due to an API change in the flags in https://github.com/rapid7/metasploit-framework/pull/17103 and a copy/pasta race condition with the original implementation

Before:

```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun domain=adf3.local user=Administrator password=p4$$w0rd rhost=192.168.123.13 action=GET_TGT verbose=true
[*] Reloading module...
[*] Running module against 192.168.123.13

[-] Auxiliary failed: NameError uninitialized constant Rex::Proto::Kerberos::Model::KdcOptionFlag
Did you mean?  Rex::Proto::Kerberos::Model::KdcOptionFlags
[-] Call stack:
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/admin/kerberos/get_ticket.rb:103:in `action_get_tgt'
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/admin/kerberos/get_ticket.rb:97:in `run'
[*] Auxiliary module execution completed
```

After:

```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun domain=adf3.local user=Administrator password=p4$$w0rd rhost=192.168.123.13 action=GET_TGT verbose=true
[*] Reloading module...
[*] Running module against 192.168.123.13

[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache saved on /Users/user/.msf4/loot/20221129101934_default_192.168.123.13_mit.kerberos.cca_408498.bin
[*] Auxiliary module execution completed
```


## Verification

- Verify get_ticket works - https://github.com/rapid7/metasploit-framework/pull/17226