### PR TITLE
checkvm: Add notes and add powershell to supported SessionTypes

### DIFF
--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -25,7 +25,12 @@ class MetasploitModule < Msf::Post
           'Aaron Soto <aaron_soto[at]rapid7.com>'
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => %w[meterpreter powershell shell],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
   end


### PR DESCRIPTION
This change has had minimal testing. Tested on a Windows 7 SP1 (x64) VMware virtual machine.

The module uses Windows Registry and Windows Services. It is expected that the relevant `Post` libraries will work on PowerShell sessions.

A bunch of work was performed recently to add support for PowerShell sessions to `Msf::Post::Windows::Registry` (#16994) and enumerating Windows services was recently tested on PowerShell sessions in #16929.

# Before

```
msf6 post(windows/gather/checkvm) > [*] Powershell session session 5 opened (192.168.200.130:1338 -> 192.168.200.190:50114) at 2022-11-29 05:13:13 -0500

msf6 post(windows/gather/checkvm) > set session 5
session => 5
msf6 post(windows/gather/checkvm) > run

[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: powershell
[*] Checking if the target is a Virtual Machine ...
[+] This is a VMware Virtual Machine
[*] Post module execution completed
```

# After

```
msf6 post(windows/gather/checkvm) > rexploit 
[*] Reloading module...

[*] Checking if the target is a Virtual Machine ...
[+] This is a VMware Virtual Machine
[*] Post module execution completed
```