### PR TITLE
[WIP] Added ducky.rb post-exploitation module and initial documentation

### DIFF
--- a/documentation/modules/post/windows/manage/ducky.md
+++ b/documentation/modules/post/windows/manage/ducky.md
@@ -1,0 +1,56 @@
+## Overview
+
+This module serves as a wrapper around keyboard_send and keyevent_send using familiar Ducky Script language.
+
+## Script Language
+- **STRING** - This uses keyboard_send to send a string.
+- **STRINGLN** - This sends a complete string followed by a new line.
+- **GUI** - This executes the run dialog by sending keyevents for Windows+R.
+- **KEYEVENT** - This allows for specific keycodes to be sent with specific key actions (press, down, and up).
+
+### Example Script
+```
+GUI
+STRINGLN notepad.exe
+KEYEVENT 82 press
+KEYEVENT 79 press
+KEYEVENT 79 press
+KEYEVENT 77 press
+```
+OR
+```
+GUI
+STRINGLN notepad.exe
+STRING This is a test.
+```
+
+## Options
+- **FILENAME** - This is the file you'd like to load keystrokes from.
+- **SLEEP** - Time in seconds between each line's execution.
+
+## Basic Usage
+
+1. Start msfconsole
+2. Get a session
+3. Do: `use post/windows/manage/ducky`
+4. Do: `set SESSION <session id>`
+5. Do: `set FILENAME <full-path of script file>`
+6. Do: `run`
+
+### Example Usage
+
+```
+msf6 > use post/windows/manage/ducky
+msf6 post(windows/manage/ducky) > set session 1
+session => 1
+msf6 post(windows/manage/ducky) > set FILENAME /tmp/test.txt
+FILENAME => /tmp/test.txt
+msf6 post(windows/manage/ducky) > set sleep 1
+sleep => 1
+msf6 post(windows/manage/ducky) > set VERBOSE false
+VERBOSE => true
+msf6 post(windows/manage/ducky) > run
+
+[+] Reading file /tmp/test.txt
+[*] Post module execution completed
+```

--- a/modules/post/windows/manage/ducky.rb
+++ b/modules/post/windows/manage/ducky.rb
@@ -11,12 +11,20 @@ class MetasploitModule < Msf::Post
         info,
         'Name' => 'Windows Ducky Script Parser',
         'Description' => %q{
-          This module can be used to execute supplied Ducky Scripts.
+          This *incomplete* module can be used to execute supplied Ducky Scripts.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          '@dru1d-foofus <tyler.booth[at]cdw.com>',
+          'dru1d <tyler.booth[at]cdw.com>',
         ],
+        'References' => [
+          'URL', 'https://docs.hak5.org/hak5-usb-rubber-ducky/duckyscript-tm-quick-reference',
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        },
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter', ],
         'Compat' => {
@@ -31,43 +39,43 @@ class MetasploitModule < Msf::Post
     )
     register_options(
       [
-        OptString.new('FILENAME', [true, "The Ducky Script you want to parse"]),
-        ], self.class)
+        OptString.new('FILENAME', [true, 'The Ducky Script you want to parse']),
+        OptInt.new('SLEEP', [false, 'Sleep time between commands.', 3])
+      ]
+    )
   end
 
-  def duckyParse(line)
+  def ducky_parse(line)
     # Define common key codes for initial testing; this can be expanded later
-    key_codes = {"8" => "backspace", "9" => "tab", "13" => "enter", "91" => "windows" }
-    actions = {"0" => "press", "1" => "down", "2" => "up"}
-    lineArray = line.split(' ', 2)
-    if lineArray[0] == "STRING"
-      session.ui.keyboard_send(lineArray[1])
+    key_codes = { '8' => 'backspace', '9' => 'tab', '13' => 'enter', '91' => 'windows' }
+    actions = { '0' => 'press', '1' => 'down', '2' => 'up' }
+    line_array = line.split(' ', 2)
+    if line_array[0] == 'STRING'
+      session.ui.keyboard_send(line_array[1])
     end
-    if lineArray[0] == "STRINGLN"
-      session.ui.keyboard_send(lineArray[1])
-      session.ui.keyevent_send(key_codes.key("enter").to_i, actions.key("press").to_i)
+    if line_array[0] == 'STRINGLN'
+      session.ui.keyboard_send(line_array[1])
+      session.ui.keyevent_send(key_codes.key('enter').to_i, actions.key('press').to_i)
     end
-    if lineArray[0] == "GUI"
-      session.ui.keyevent_send(key_codes.key("windows").to_i, actions.key("down").to_i)
-      session.ui.keyevent_send(82, actions.key("press").to_i)
-      session.ui.keyevent_send(key_codes.key("windows").to_i, actions.key("up").to_i)
+    if line_array[0] == 'GUI'
+      session.ui.keyevent_send(key_codes.key('windows').to_i, actions.key('down').to_i)
+      session.ui.keyevent_send(82, actions.key('press').to_i)
+      session.ui.keyevent_send(key_codes.key('windows').to_i, actions.key('up').to_i)
     end
   end
-
 
   def run
-    return 0 if session.type != "meterpreter"
+    return 0 if session.type != 'meterpreter'
 
     if datastore['FILENAME'].blank?
-      print_error("A file needs to be provided!")
+      print_error('A file needs to be provided!')
       return 0
     end
-    print_good("Readining file #{datastore['FILENAME']}")
+    print_good("Reading file #{datastore['FILENAME']}")
     File.readlines(datastore['FILENAME']).each do |line|
       print("Line: #{line}")
-      sleep(3)
-      duckyParse(line)
+      sleep(datastore['SLEEP'])
+      ducky_parse(line)
     end
   end
-
 end

--- a/modules/post/windows/manage/ducky.rb
+++ b/modules/post/windows/manage/ducky.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Post
     end
     # Parse keyevents; example format, KEYEVENT 82 press
     if line_array[0] == 'KEYEVENT'
-      session.ui.keyevent_send(line_array[1].to_i, line_array[2].to_i)
+      session.ui.keyevent_send(line_array[1].to_i, actions.key(line_array[2]).to_i)
     end
   end
 

--- a/modules/post/windows/manage/ducky.rb
+++ b/modules/post/windows/manage/ducky.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Ducky Script Parser',
+        'Description' => %q{
+          This module can be used to execute supplied Ducky Scripts.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          '@dru1d-foofus <tyler.booth[at]cdw.com>',
+        ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter', ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_ui_keyevent_send,
+              stdapi_ui_keyboard_send
+            ]
+          }
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('FILENAME', [true, "The Ducky Script you want to parse"]),
+        ], self.class)
+  end
+
+  def duckyParse(line)
+    # Define common key codes for initial testing; this can be expanded later
+    key_codes = {"8" => "backspace", "9" => "tab", "13" => "enter", "91" => "windows" }
+    actions = {"0" => "press", "1" => "down", "2" => "up"}
+    lineArray = line.split(' ', 2)
+    if lineArray[0] == "STRING"
+      session.ui.keyboard_send(lineArray[1])
+    end
+    if lineArray[0] == "STRINGLN"
+      session.ui.keyboard_send(lineArray[1])
+      session.ui.keyevent_send(key_codes.key("enter").to_i, actions.key("press").to_i)
+    end
+    if lineArray[0] == "GUI"
+      session.ui.keyevent_send(key_codes.key("windows").to_i, actions.key("down").to_i)
+      session.ui.keyevent_send(82, actions.key("press").to_i)
+      session.ui.keyevent_send(key_codes.key("windows").to_i, actions.key("up").to_i)
+    end
+  end
+
+
+  def run
+    return 0 if session.type != "meterpreter"
+
+    if datastore['FILENAME'].blank?
+      print_error("A file needs to be provided!")
+      return 0
+    end
+    print_good("Readining file #{datastore['FILENAME']}")
+    File.readlines(datastore['FILENAME']).each do |line|
+      print("Line: #{line}")
+      sleep(3)
+      duckyParse(line)
+    end
+  end
+
+end


### PR DESCRIPTION
I've put together a wrapper around the keyevent_send / keyboard_send meterpreter commands. This wrapper is intended to parse a file (similar to a Ducky Script) to send keystrokes to the target session. It should be noted in the initial commit that the entirety of the Ducky Scripting language is not supported. 

## Script Language
- **STRING** - This uses keyboard_send to send a string.
- **STRINGLN** - This sends a complete string followed by a new line.
- **GUI** - This executes the run dialog by sending keyevents for Windows+R.
- **KEYEVENT** - This allows for specific keycodes to be sent with specific key actions (press, down, and up).

### Example Script
```
GUI
STRINGLN notepad.exe
KEYEVENT 82 press
KEYEVENT 79 press
KEYEVENT 79 press
KEYEVENT 77 press
```
OR
```
GUI
STRINGLN notepad.exe
STRING This is a test.
```

## Usage Example
```
msf6 > use post/windows/manage/ducky
msf6 post(windows/manage/ducky) > set session 1
session => 1
msf6 post(windows/manage/ducky) > set FILENAME /tmp/test.txt
FILENAME => /tmp/test.txt
msf6 post(windows/manage/ducky) > set sleep 1
sleep => 1
msf6 post(windows/manage/ducky) > set VERBOSE false
VERBOSE => true
msf6 post(windows/manage/ducky) > run

[+] Reading file /tmp/test.txt
[*] Post module execution completed
```
