### PR TITLE
fix enlightenment check method

### DIFF
--- a/modules/exploits/linux/local/ubuntu_enlightenment_mount_priv_esc.rb
+++ b/modules/exploits/linux/local/ubuntu_enlightenment_mount_priv_esc.rb
@@ -81,7 +81,11 @@ class MetasploitModule < Msf::Exploit::Local
       # https://github.com/MaherAzzouzi/CVE-2022-37706-LPE-exploit/blob/main/exploit.sh#L7
       binary = cmd_exec('find / -name enlightenment_sys -perm -4000 2>/dev/null | head -1')
 
-      vprint_good("Found SUID binary: #{enlightenment_sys}") unless binary.nil?
+      if binary.empty?
+        vprint_bad('Unable to locate enlightenment_sys')
+        return nil
+      end
+      vprint_good("Found SUID binary: #{enlightenment_sys}")
       return binary
     end
   end

--- a/modules/exploits/linux/local/ubuntu_enlightenment_mount_priv_esc.rb
+++ b/modules/exploits/linux/local/ubuntu_enlightenment_mount_priv_esc.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Local
       # https://github.com/MaherAzzouzi/CVE-2022-37706-LPE-exploit/blob/main/exploit.sh#L7
       binary = cmd_exec('find / -name enlightenment_sys -perm -4000 2>/dev/null | head -1')
 
-      if binary.empty?
+      if binary.blank?
         vprint_bad('Unable to locate enlightenment_sys')
         return nil
       end


### PR DESCRIPTION
The enlightenment module is throwing false positives since it incorrectly detects a missing `enlightenment_sys` file. The code checks for `binary.nil` but `nil` isn't thrown, its an empty string.

### On a system w/o `enlightenment_sys `
```
>> binary = cmd_exec('find / -name enlightenment_sys -perm -4000 2>/dev/null | head -1')
=> ""
>> binary.nil?
=> false
>> binary.empty?
=> true
>> exit
```

## Verification

- [ ] Start `msfconsole`
- [ ] get a session on a system without enlightenment
- [ ] `use exploits/linux/local/ubuntu_enlightenment_mount_priv_esc.rb`
- [ ] `check`
- [ ] make sure it correctly says the system isn't vulnerable
