### PR TITLE
enum_proxy: Cleanup and support non-Meterpreter sessions

### DIFF
--- a/documentation/modules/post/windows/gather/enum_proxy.md
+++ b/documentation/modules/post/windows/gather/enum_proxy.md
@@ -1,0 +1,59 @@
+## Vulnerable Application
+
+This module pulls a user's proxy settings. If neither RHOST or SID
+are set it pulls the current user, else it will pull the user's settings
+for the specified SID and target host.
+
+
+## Verification Steps
+
+1. Start msfconsole
+1. Get a session on a Windows host
+1. Do: `use post/windows/gather/enum_proxy`
+1. Do: `set session <session id>`
+1. Do: `run`
+1. You should receive system proxy information
+
+
+## Options
+
+### RHOST
+
+Remote host to clone settings to (defaults to local)
+
+### SID
+
+SID of user to clone settings to (SYSTEM is S-1-5-18) (default: blank)
+
+
+## Scenarios
+
+### Windows Server 2016 (x86_64)
+
+```
+msf6 > use post/windows/gather/enum_proxy
+msf6 post(windows/gather/enum_proxy) > set session 1
+session => 1
+msf6 post(windows/gather/enum_proxy) > run
+
+[*] Proxy Counter = 3
+[*] Setting: WPAD and Proxy server
+[*] Proxy Server: http=127.0.0.1:80;https=127.0.0.1:80;ftp=127.0.0.1:80
+[*] Post module execution completed
+```
+
+### Windows 7 SP1 (x86_64)
+
+```
+msf6 > use post/windows/gather/enum_proxy
+msf6 post(windows/gather/enum_proxy) > set session 1
+session => 1
+msf6 post(windows/gather/enum_proxy) > run
+
+[*] Proxy Counter = 77
+[*] Setting: WPAD, Proxy server and AutoConfigure script
+[*] Proxy Server: http=127.0.0.1:8080;https=127.0.0.1:8080;ftp=127.0.0.1:8080
+[*] AutoConfigURL: http://corp.local/wpad.dat
+[*] Post module execution completed
+msf6 post(windows/gather/enum_proxy) > 
+```

--- a/modules/post/windows/gather/enum_proxy.rb
+++ b/modules/post/windows/gather/enum_proxy.rb
@@ -4,7 +4,8 @@
 ##
 
 class MetasploitModule < Msf::Post
-  include Post::Windows::Services
+  include Msf::Post::Windows::Registry
+  include Msf::Post::Windows::Services
 
   def initialize
     super(
@@ -12,12 +13,17 @@ class MetasploitModule < Msf::Post
       'Description' => %q{
         This module pulls a user's proxy settings. If neither RHOST or SID
         are set it pulls the current user, else it will pull the user's settings
-        specified SID and target host.
+        for the specified SID and target host.
       },
       'Author' => [ 'mubix' ],
       'License' => MSF_LICENSE,
       'Platform' => [ 'win' ],
-      'SessionTypes' => [ 'meterpreter' ],
+      'SessionTypes' => %w[meterpreter powershell shell],
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'Reliability' => [],
+        'SideEffects' => []
+      },
       'Compat' => {
         'Meterpreter' => {
           'Commands' => %w[
@@ -28,80 +34,84 @@ class MetasploitModule < Msf::Post
       }
     )
 
-    register_options(
-      [
-        OptAddress.new('RHOST', [ false, 'Remote host to clone settings to, defaults to local' ]),
-        OptString.new('SID', [ false, 'SID of user to clone settings to (SYSTEM is S-1-5-18)' ])
-      ]
-    )
+    register_options([
+      OptAddress.new('RHOST', [ false, 'Remote host to clone settings to, defaults to local' ]),
+      OptString.new('SID', [ false, 'SID of user to clone settings to (SYSTEM is S-1-5-18)' ])
+    ])
   end
 
   def run
     if datastore['SID']
-      root_key, base_key = session.sys.registry.splitkey("HKU\\#{datastore['SID']}\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Connections")
+      root_key, base_key = split_key("HKU\\#{datastore['SID']}\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Connections")
     else
-      root_key, base_key = session.sys.registry.splitkey("HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Connections")
+      root_key, base_key = split_key('HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Connections')
     end
 
     if datastore['RHOST']
+      if session.type != 'meterpreter'
+        fail_with(Failure::BadConfig, "Cannot query remote registry on #{datastore['RHOST']}. Unsupported sesssion type #{session.type}")
+      end
+
       begin
         key = session.sys.registry.open_remote_key(datastore['RHOST'], root_key)
       rescue ::Rex::Post::Meterpreter::RequestError
         print_error("Unable to contact remote registry service on #{datastore['RHOST']}")
-        print_status("Attempting to start service remotely...")
+        print_status('Attempting to start RemoteRegistry service remotely...')
         begin
           service_start('RemoteRegistry', datastore['RHOST'])
-        rescue
-          print_error('Unable to read registry or start the service, exiting...')
-          return
+        rescue StandardError
+          fail_with(Failure::Unknown, 'Unable to start RemoteRegistry service, exiting...')
         end
         startedreg = true
         key = session.sys.registry.open_remote_key(datastore['RHOST'], root_key)
       end
+
       open_key = key.open_key(base_key)
+      values = open_key.query_value('DefaultConnectionSettings')
+      data = values.data
+
+      # If we started the service we need to stop it.
+      service_stop('RemoteRegistry', datastore['RHOST']) if startedreg
     else
-      open_key = session.sys.registry.open_key(root_key, base_key)
+      data = registry_getvaldata("#{root_key}\\#{base_key}", 'DefaultConnectionSettings')
     end
 
-    values = open_key.query_value('DefaultConnectionSettings')
+    fail_with(Failure::Unknown, "Could not retrieve 'DefaultConnectionSettings' data") if data.blank?
+    fail_with(Failure::Unknown, "Retrieved malformed proxy settings (too small: #{data.length} bytes <= 24 bytes)") if data.length <= 24
 
-    # If we started the service we need to stop it.
-    service_stop('RemoteRegistry', datastore['RHOST']) if startedreg
+    print_status("Proxy Counter = #{data[4, 1].unpack('C*')[0]}")
 
-    data = values.data
-
-    print_status "Proxy Counter = #{(data[4, 1].unpack('C*'))[0]}"
-    case (data[8, 1].unpack('C*'))[0]
+    case data[8, 1].unpack('C*')[0]
     when 1
-      print_status "Setting: No proxy settings"
+      print_status('Setting: No proxy settings')
     when 3
-      print_status "Setting: Proxy server"
+      print_status('Setting: Proxy server')
     when 5
-      print_status "Setting: Set proxy via AutoConfigure script"
+      print_status('Setting: Set proxy via AutoConfigure script')
     when 7
-      print_status "Setting: Proxy server and AutoConfigure script"
+      print_status('Setting: Proxy server and AutoConfigure script')
     when 9
-      print_status "Setting: WPAD"
+      print_status('Setting: WPAD')
     when 11
-      print_status "Setting: WPAD and Proxy server"
+      print_status('Setting: WPAD and Proxy server')
     when 13
-      print_status "Setting: WPAD and AutoConfigure script"
+      print_status('Setting: WPAD and AutoConfigure script')
     when 15
-      print_status "Setting: WPAD, Proxy server and AutoConfigure script"
+      print_status('Setting: WPAD, Proxy server and AutoConfigure script')
     else
-      print_status "Setting: Unknown proxy setting found"
+      print_status('Setting: Unknown proxy setting found')
     end
 
     cursor = 12
-    proxyserver = data[cursor + 4, (data[cursor, 1].unpack('C*'))[0]]
-    print_status "Proxy Server: #{proxyserver}" if proxyserver != ""
+    proxyserver = data[cursor + 4, data[cursor, 1].unpack('C*')[0]]
+    print_status("Proxy Server: #{proxyserver}") unless proxyserver.blank?
 
-    cursor = cursor + 4 + (data[cursor].unpack('C*'))[0]
-    additionalinfo = data[cursor + 4, (data[cursor, 1].unpack('C*'))[0]]
-    print_status "Additional Info: #{additionalinfo}" if additionalinfo != ""
+    cursor = cursor + 4 + data[cursor].unpack('C*')[0]
+    additionalinfo = data[cursor + 4, data[cursor, 1].unpack('C*')[0]]
+    print_status("Additional Info: #{additionalinfo}") unless additionalinfo.blank?
 
-    cursor = cursor + 4 + (data[cursor].unpack('C*'))[0]
-    autoconfigurl = data[cursor + 4, (data[cursor, 1].unpack('C*'))[0]]
-    print_status "AutoConfigURL: #{autoconfigurl}" if autoconfigurl != ""
+    cursor = cursor + 4 + data[cursor].unpack('C*')[0]
+    autoconfigurl = data[cursor + 4, data[cursor, 1].unpack('C*')[0]]
+    print_status("AutoConfigURL: #{autoconfigurl}") unless autoconfigurl.blank?
   end
 end


### PR DESCRIPTION
* Resolves Rubocop violations.
* Adds documentation.
* Adds `Notes` module meta information.
* Adds support for non-Meterpreter sessions.

---

With a few small changes, this module now works for local sessions on non-Meterpreter sessions (shell, powershell).

Support for non-Meterpreter session with the Registry library has been improved recently. Unfortunately the Registry libraries do not support reading from a remote registry on non-Meterpreter sessions. For non-Meterpreter sessions, this module will fail with `BadConfig` if `rhost` is set. Given that this is a `post/gather` module I expect that gathering from the local system is the primary expected use case. I'm not too concerned about remote registry functionality.

For what it's worth, the remote registry functionality didn't work for me (both before and after this change). Possibly user error, but also outside my use case. Unless I've overlooked something silly, the changes in this module should preserve the existing logic for remote registry functionality.
