### PR TITLE
Fix typos: Replace 'the the' with 'the'

### DIFF
--- a/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb
@@ -13,7 +13,7 @@ class ManagedRemoteDataService
   include Singleton
 
   #
-  # Returns true if the the managed data service process is running.
+  # Returns true if the managed data service process is running.
   #
   def running?
     return @running

--- a/lib/msf/core/exploit/remote/http/nagios_xi/install.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/install.rb
@@ -69,7 +69,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Install
   #
   # @param cookies [String] cookies required to visit the license agreement page
   # @param nsp [String] nsp token required to visit the license agreement page
-  # @return [nil, Array] nil if signing the the license agreement succeeds, otherwise Array containing an error code and an error message
+  # @return [nil, Array] nil if signing the license agreement succeeds, otherwise Array containing an error code and an error message
   def sign_license_agreement(cookies, nsp)
     if cookies.blank?
       return [2, 'Cannot sign the license agreement. The provided cookies are empty or nil.']

--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -165,7 +165,7 @@ module Net # :nodoc:
       #   my $res = Net::DNS::Resolver->new(config_file => '/my/dns.conf');
       #
       # This is supported on both UNIX and Windows.  Values pulled from a custom
-      # configuration file override the the system's defaults, but can still be
+      # configuration file override the system's defaults, but can still be
       # overridden by the other arguments to Resolver::new.
       #
       # Explicit arguments to Resolver::new override both the system's defaults

--- a/lib/rex/parser/graphml.rb
+++ b/lib/rex/parser/graphml.rb
@@ -408,7 +408,7 @@ module Rex
         end
 
         #
-        # An error describing an issue that occurred while parsing the the data structure.
+        # An error describing an issue that occurred while parsing the data structure.
         #
         class ParserError < GraphMLError
         end

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -31,7 +31,7 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
   # Rex::Post::Meterpreter::Extensions::Stdapi::Net::Socket. All incoming requests from the meterpreter
   # for a COMMAND_ID_STDAPI_NET_TCP_CHANNEL_OPEN will be processed here. We create a new TcpClientChannel for each request
   # received and store it in the respective tcp server channels list of new pending client channels.
-  # These new tcp client channels are passed off via a call the the tcp server channels accept() method.
+  # These new tcp client channels are passed off via a call the tcp server channels accept() method.
   #
   def self.request_handler(client, packet)
     return false unless packet.method == COMMAND_ID_STDAPI_NET_TCP_CHANNEL_OPEN

--- a/lib/rex/proto/rmi/model/output_header.rb
+++ b/lib/rex/proto/rmi/model/output_header.rb
@@ -14,7 +14,7 @@ module Rex
           #   @return [Integer] the Java RMI version
           attr_accessor :version
           # @!attribute protocol
-          #   @return [Integer] the protocol where the the messages are wrapped within
+          #   @return [Integer] the protocol where the messages are wrapped within
           attr_accessor :protocol
 
           private

--- a/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
+++ b/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
     sploit << "ST:uuid:schemas:device:MX:3"
     # the packet can be at most 1500 bytes long, so add appropriate number of ' ' or '\t'
     # this makes the DoS exploit more probable, since we're occupying the stack with arbitrary
-    # characters: there's more chance that the the program will run off the stack.
+    # characters: there's more chance that the program will run off the stack.
     sploit += ' '*(1500-sploit.length)
 
 

--- a/modules/auxiliary/fileformat/multidrop.rb
+++ b/modules/auxiliary/fileformat/multidrop.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
         'Description'   => %q{
           This module dependent on the given filename extension creates either
           a .lnk, .scf, .url, .xml, or desktop.ini file which includes a reference
-          to the the specified remote host, causing SMB connections to be initiated
+          to the specified remote host, causing SMB connections to be initiated
           from any user that views the file.
         },
         'License'       => MSF_LICENSE,

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -328,7 +328,7 @@ class MetasploitModule < Msf::Auxiliary
             modified = true
           elsif attribute_properties[attribute_name][:attributesyntax] == '2.5.5.10' # OctetString
             if attribute_name.to_s.match(/guid$/i)
-              # Get the the entry[attribute_name] object will be an array containing a single string entry,
+              # Get the entry[attribute_name] object will be an array containing a single string entry,
               # so reach in and extract that string, which will contain binary data.
               bin_guid = entry[attribute_name][0]
               if bin_guid.length == 16 # Length of binary data in bytes since this is what .length uses. In bits its 128 bits.

--- a/modules/auxiliary/scanner/http/smt_ipmi_static_cert_scanner.rb
+++ b/modules/auxiliary/scanner/http/smt_ipmi_static_cert_scanner.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if result
       print_good("#{ip}:#{rport} - Vulnerable to CVE-2013-3619 (Static SSL Certificate)")
-      # Report with the the SSL Private Key hash for the host
+      # Report with the SSL Private Key hash for the host
       digest = OpenSSL::Digest::SHA1.new(pkey.public_key.to_der).to_s.scan(/../).join(":")
       report_note(
         :host  => ip,

--- a/modules/auxiliary/server/dns/native_server.rb
+++ b/modules/auxiliary/server/dns/native_server.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
       'Description'    => %q{
         This module provides a Rex based DNS service which can store static entries,
         resolve names over pivots, and serve DNS requests across routed session comms.
-        DNS tunnels can operate across the the Rex switchboard, and DNS other modules
+        DNS tunnels can operate across the Rex switchboard, and DNS other modules
         can use this as a template. Setting static records via hostfile allows for DNS
         spoofing attacks without direct traffic manipulation at the handlers. handlers
         for requests and responses provided here mimic the internal Rex functionality,

--- a/modules/exploits/linux/http/gravcms_exec.rb
+++ b/modules/exploits/linux/http/gravcms_exec.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_new_session(_session)
-    print_status 'Cleaning up the the scheduler...'
+    print_status 'Cleaning up the scheduler...'
 
     # Thanks to the YAML update method, we can remove the command details from the config file just by re-enabling
     # the scheduler without any parameter:) It will leave the only command name in the config file.

--- a/modules/exploits/windows/fileformat/microsoft_windows_contact.rb
+++ b/modules/exploits/windows/fileformat/microsoft_windows_contact.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The flaw is due to the processing of ".contact" files <c:Url> node param which takes an expected website value, however if an attacker references an
         executable file it will run that instead without warning instead of performing expected web navigation. This is dangerous and would be unexpected to an end user.
         Executable files can live in a sub-directory so when the ".contact" website link is clicked it traverses directories towards the executable and runs.
-        Making matters worse is if the the files are compressed then downloaded "mark of the web" (MOTW) may potentially not work as expected with certain archive utilitys.
+        Making matters worse is if the files are compressed then downloaded "mark of the web" (MOTW) may potentially not work as expected with certain archive utilitys.
         The ".\" chars allow directory traversal to occur in order to run the attackers supplied executable sitting unseen in the attackers directory.
         This advisory is a duplicate issue that currently affects Windows .VCF files, and released for the sake of completeness as it affects Windows .contact files as well.
       },

--- a/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
+++ b/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
@@ -304,7 +304,7 @@ class MetasploitModule < Msf::Exploit::Remote
           test_passphrases
 
           # If no working passphrase has been found,
-          # wait to allow the the chance for the last one to callback.
+          # wait to allow the chance for the last one to callback.
           if @passphrase.empty? && !@dry_run
             sleep(wfs_delay)
           end

--- a/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
+++ b/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
@@ -67,9 +67,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'v9.2.2 - v9.3.0-RC', { 'ReqEncrypt' => true, 'ReqSession' => true } ]
         ],
         'Stance' => Msf::Exploit::Stance::Aggressive,
-        'Payload' => {
-
-        },
         'Privileged' => false,
         'DisclosureDate' => '2017-07-20',
         'DefaultOptions' => { 'WfsDelay' => 5 },

--- a/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
+++ b/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
@@ -241,7 +241,7 @@ class MetasploitModule < Msf::Exploit::Local
     buf << [size_buffer].pack("V") # ecx
     buf << [@gadgets['mov [edi], ecx # ret']].pack("V")
 
-    # Copy the shellcode from the the registry to the
+    # Copy the shellcode from the registry to the
     # memory allocated with executable permissions and
     # ret into there
     buf << [@addresses['RegGetValueA']].pack("V")

--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Local
     run_injection(pid, dll_path, file_paths)
 
     # Windows 7 this is cleared up by DLL but on Windows
-    # 8.1 it fails to delete the the file.
+    # 8.1 it fails to delete the file.
     register_file_for_cleanup(file_paths[:szElevDllFull])
   end
 

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Post
   end
 
   #
-  # Returns the the key combinations required to invoke the exploit once installed.
+  # Returns the key combinations required to invoke the exploit once installed.
   #
   def get_target_key_combo
     case datastore['TARGET']


### PR DESCRIPTION
Replaces all instances of "the the" within the the codebase with "the".
