### PR TITLE
enum_commands: Cleanup

### DIFF
--- a/documentation/modules/post/linux/gather/enum_commands.md
+++ b/documentation/modules/post/linux/gather/enum_commands.md
@@ -1,0 +1,52 @@
+## Vulnerable Application
+
+This module will check which shell commands are available on a system.
+
+
+## Verification Steps
+
+1. Start msfconsole
+1. Get a session
+1. Do: `use post/linux/gather/enum_commands`
+1. Do: `set session <session ID>`
+1. Do: `run`
+1. You should receive a list of shell commands
+
+
+## Options
+
+### DIR
+
+Optional directory name to list (in addition to default system PATH and common paths)
+
+
+## Scenarios
+
+### Ubuntu 22.04.1 (x86_64)
+
+```
+msf6 > use post/linux/gather/enum_commands 
+msf6 post(linux/gather/enum_commands) > set session 1
+session => 1
+msf6 post(linux/gather/enum_commands) > run
+
+[+] Found 3795 executable binaries/commands
+/bin/GET
+/bin/HEAD
+/bin/POST
+/bin/VGAuthService
+/bin/X
+/bin/X11
+/bin/Xephyr
+/bin/Xorg
+/bin/Xwayland
+/bin/[
+/bin/aa-enabled
+/bin/aa-exec
+/bin/aa-features-abi
+
+...
+
+[*] Post module execution completed
+msf6 post(linux/gather/enum_commands) > 
+```


### PR DESCRIPTION
* Resolves Rubocop violations.
* Adds documentation.
* Adds `Notes` module meta information.
* Changes the module name. "Gather Available Shell Commands" is a better fit for the Metasploit naming convention than "Testing commands needed in a function".

Also fixes a few bugs:

* Prior to this PR, this module would crash if any of the searched paths didn't exist. For example:

```
[-] Post failed: Rex::Post::Meterpreter::RequestError stdapi_fs_ls: Operation failed: 1
[-] Call stack:
[-]   /root/Desktop/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb:62:in `entries'
[-]   /root/Desktop/metasploit-framework/lib/msf/core/post/file.rb:88:in `dir'
[-]   /root/Desktop/metasploit-framework/modules/post/linux/gather/enum_commands.rb:45:in `block in run'
[-]   /root/Desktop/metasploit-framework/modules/post/linux/gather/enum_commands.rb:44:in `each'
[-]   /root/Desktop/metasploit-framework/modules/post/linux/gather/enum_commands.rb:44:in `run'
[*] Post module execution completed
```

* Duplicate paths were allowed, resulting in searching the same directory more than once.

* BusyBox commands were unnecessarily printed twice.

* BusyBox output was not parsed properly, resulting in messed up output. For example:


```
busybox 
	[
busybox  [[
busybox  acpid
busybox  adjtimex
busybox  ar
busybox  arch
busybox  arp
busybox  arping
busybox  ash
busybox  awk
busybox  basename
busybox  bc
busybox 
	blkdiscard
busybox  blockdev
busybox  brctl
busybox  bunzip2
...
```

---

This PR also adds `unix` to `Platform`. Not necessary, but there's no reason this module can't also run on UNIX sessions (ie, *NIX command sessions). Adding `unix` prevents a warning message.

Although untested, this module could likely be moved to `post/multi` as it should also work on Solaris, FreeBSD, Mac OSX, etc.

While `find -executable` could be used, my understanding is that this module is intended to be portable (`find` may not be available and `-executable` applies only to the user running the command, so this would skip "commands" which may be executable for other users). Thus the existing logic in this module has been left largely untouched.
