### PR TITLE
Warn On Ignoring Bind Information for Reverse Port Forwarding

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -442,7 +442,6 @@ class Console::CommandDispatcher::Stdapi::Net
         print_line
 
       when 'add'
-
         if reverse
           # Validate parameters
           unless lport && lhost && rport
@@ -450,10 +449,14 @@ class Console::CommandDispatcher::Stdapi::Net
             return
           end
 
+          unless rhost.nil?
+            print_warning('The remote host (-r) option is ignored for reverse port forwards.')
+          end
+
           begin
             channel = client.net.socket.create(
               Rex::Socket::Parameters.new(
-                'LocalHost' => rhost,
+                'LocalHost' => '', # see: #17282, always bind to all interfaces
                 'LocalPort' => rport,
                 'Proto'     => 'tcp',
                 'Server'    => true

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -427,7 +427,7 @@ class Console::CommandDispatcher::Stdapi::Net
           direction = 'Forward'
           direction = 'Reverse' if opts['Reverse'] == true
 
-          table << [cnt + 1, "#{rhost}:#{rport}", "#{lhost}:#{lport}", direction]
+          table << [cnt + 1, "#{netloc(rhost, rport)}", "#{netloc(lhost, lport)}", direction]
 
           cnt += 1
         }
@@ -473,7 +473,7 @@ class Console::CommandDispatcher::Stdapi::Net
             return false
           end
 
-          print_status("Reverse TCP relay created: (remote) #{rhost}:#{rport} -> (local) #{lhost}:#{lport}")
+          print_status("Reverse TCP relay created: (remote) #{netloc(rhost, rport)} -> (local) #{netloc(lhost, lport)}")
         else
           # Validate parameters
           unless lport && rhost && rport
@@ -490,7 +490,7 @@ class Console::CommandDispatcher::Stdapi::Net
             'OnLocalConnection' => Proc.new { |relay, lfd| create_tcp_channel(relay) })
           lport = relay.opts['LocalPort']
 
-          print_status("Forward TCP relay created: (local) #{lhost}:#{lport} -> (remote) #{rhost}:#{rport}")
+          print_status("Forward TCP relay created: (local) #{netloc(lhost, lport)} -> (remote) #{netloc(rhost, rport)}")
         end
       # Delete local port forwards
       when 'delete', 'remove', 'del', 'rm'
@@ -535,9 +535,9 @@ class Console::CommandDispatcher::Stdapi::Net
 
           # Stop the service
           if service.stop_tcp_relay(lport, lhost)
-            print_status("Successfully stopped TCP relay on #{lhost || '0.0.0.0'}:#{lport}")
+            print_status("Successfully stopped TCP relay on #{netloc(lhost || '0.0.0.0', lport)}")
           else
-            print_error("Failed to stop TCP relay on #{lhost || '0.0.0.0'}:#{lport}")
+            print_error("Failed to stop TCP relay on #{netloc(lhost || '0.0.0.0', lport)}")
           end
         end
 
@@ -556,9 +556,9 @@ class Console::CommandDispatcher::Stdapi::Net
             end
           else
             if service.stop_tcp_relay(lport, lhost)
-              print_status("Successfully stopped TCP relay on #{lhost || '0.0.0.0'}:#{lport}")
+              print_status("Successfully stopped TCP relay on #{netloc(lhost || '0.0.0.0', lport)}")
             else
-              print_error("Failed to stop TCP relay on #{lhost || '0.0.0.0'}:#{lport}")
+              print_error("Failed to stop TCP relay on #{netloc(lhost || '0.0.0.0', lport)}")
               next
             end
           end
@@ -667,6 +667,10 @@ protected
     )
   end
 
+  def netloc(host, port)
+    host = "[#{host}]" if Rex::Socket.is_ipv6?(host)
+    "#{host}:#{port}"
+  end
 end
 
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -476,7 +476,7 @@ class Console::CommandDispatcher::Stdapi::Net
             return false
           end
 
-          print_status("Reverse TCP relay created: (remote) #{netloc(rhost, rport)} -> (local) #{netloc(lhost, lport)}")
+          print_status("Reverse TCP relay created: (remote) #{netloc(rhost, rport)} -> (local) #{netloc(channel.params.localhost, channel.params.localport)}")
         else
           # Validate parameters
           unless lport && rhost && rport

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -453,6 +453,7 @@ class Console::CommandDispatcher::Stdapi::Net
           begin
             channel = client.net.socket.create(
               Rex::Socket::Parameters.new(
+                'LocalHost' => rhost,
                 'LocalPort' => rport,
                 'Proto'     => 'tcp',
                 'Server'    => true
@@ -461,6 +462,7 @@ class Console::CommandDispatcher::Stdapi::Net
 
             # Start the local TCP reverse relay in association with this stream
             relay = service.start_reverse_tcp_relay(channel,
+              'LocalHost'         => channel.params.localhost,
               'LocalPort'         => channel.params.localport,
               'PeerHost'          => lhost,
               'PeerPort'          => lport,


### PR DESCRIPTION
~~This passes the bind information to the Meterpreter so the IP address that the user specifies is the one on which the socket is bound. This is only applicable for reverse port forwards where the bind information is used to create a server/listening TCP socket on the compromised host via Meterpreter.~~

This warns that the bind information is ignored when a reverse portfoward is created. See [this comment](https://github.com/rapid7/metasploit-framework/issues/17282#issuecomment-1341445522), paragraph three for the rationale.

This also fixes how the `host:port` is printed to properly place `host` in brackets when it is an IPv6 address.

Not all of the Meterpreters handle the information if it is passed to them:
* Python -- works and is ready for testing to demonstrate that this fixes the issue
    * There is a small bug where if the host to listen on is an empty string (`-r ""` vs `-r "0.0.0.0"`) it'll fail but if an address is specified, it will be used. I'll submit a patch to fix the empty string issue along with the Windows changes.
* Windows -- needs changes, I'll submit this in a dedicated PR once I've finished testing them
* Mettle -- also needs changes and a dedicated PR
* PHP -- does not support TCP server channels, so there's no code to update
* Java -- TBD

This is necessary to address some of the issues mentioned at #17282, though a Windows PR needs to be made as well. I have the changes, but need to test them on Windows XP.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a Python Meterpreter session
- [x] In the Python Meterpreter session run `portfwd add -R -l 8080 -L 127.0.0.1 -p 2222 -r 127.0.0.1`
- [x] See that the Python process is listening on both `0.0.0.0:2222` and `::` on port `2222`
- [x] See that we get a warning about binding information being ignored when a reverse portforward is created.

Note that due to the discussion point mentioned at https://github.com/rapid7/metasploit-framework/pull/17340#discussion_r1066260248, we won't be fully fixing the issue mentioned at #17282 due to concerns about impacting user's existing expectations of our tools. We have opted to instead add a warning message as part of this PR which will warn the user about this issue until further notice.

## Demo

```
msf6 payload(python/meterpreter/reverse_tcp) > sessions

Active sessions
===============

  Id  Name  Type                      Information                        Connection
  --  ----  ----                      -----------                        ----------
  1         meterpreter python/linux  smcintyre @ localhost.localdomain  192.168.159.128:4444 -> 192.168.159.128:58342 (192.168.159.128)

msf6 payload(python/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > portfwd add -R -l 8080 -L 127.0.0.1 -p 2222 -r 127.0.0.1
[*] Reverse TCP relay created: (remote) 127.0.0.1:2222 -> (local) 127.0.0.1:8080
meterpreter > netstat
[-] The "netstat" command is not supported by this Meterpreter type (python/linux)
meterpreter > shell
Process 55283 created.
Channel 2 created.
netstat -antp
(Not all processes could be identified, non-owned process info
 will not be shown, you would have to be root to see it all.)
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 127.0.0.54:53           0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:5432          0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:5054          0.0.0.0:*               LISTEN      2801/python3        
tcp        0      0 0.0.0.0:5355            0.0.0.0:*               LISTEN      -                   
tcp        0      0 0.0.0.0:139             0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.53:53           0.0.0.0:*               LISTEN      -                   
tcp        0      0 0.0.0.0:445             0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:631           0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:2222          0.0.0.0:*               LISTEN      55180/python    
...
```
