### PR TITLE
Update report api to return nil when no active db

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -30,6 +30,7 @@ module Auxiliary::Report
       framework.db.create_cracked_credential(opts)
     elsif !db_warning_given?
       vprint_warning('No active DB -- Credential data will not be saved!')
+      nil
     end
   end
 
@@ -39,6 +40,7 @@ module Auxiliary::Report
       framework.db.create_credential(opts)
     elsif !db_warning_given?
       vprint_warning('No active DB -- Credential data will not be saved!')
+      nil
     end
   end
 
@@ -48,6 +50,7 @@ module Auxiliary::Report
       framework.db.create_credential_login(opts)
     elsif !db_warning_given?
       vprint_warning('No active DB -- Credential data will not be saved!')
+      nil
     end
   end
 
@@ -57,6 +60,7 @@ module Auxiliary::Report
       framework.db.create_credential_and_login(opts)
     elsif !db_warning_given?
       vprint_warning('No active DB -- Credential data will not be saved!')
+      nil
     end
   end
 
@@ -66,6 +70,7 @@ module Auxiliary::Report
       framework.db.invalidate_login(opts)
     elsif !db_warning_given?
       vprint_warning('No active DB -- Credential data will not be saved!')
+      nil
     end
   end
 


### PR DESCRIPTION
Fixes a crash when using the report API when verbose mode enabled, and there is no active db enabled

When testing https://github.com/rapid7/metasploit-framework/pull/17236/files I ran into this issue

The following module code, with verbose=true, and no active db would result in a crash:

Module code:
```
credential_login = create_credential_and_login(credential_data)
credential_login&.core_id
```

Due to the following code returning a string when the db is not active:

https://github.com/rapid7/metasploit-framework/blob/c218063a1aca2545fa4071fefc5be4198c17fe37/lib/msf/core/auxiliary/report.rb#L54-L61

Generated error:
```
[-] 192.168.123.13:445 - Auxiliary failed: NoMethodError undefined method `core_id' for "\e[1m\e[33m[!]\e[0m 192.168.123.13:445 - No active DB -- Credential data will not be saved!\n":String
```

The crash only happens when verbose mode is enabled and there's no DB attached

## Verification

Disconnect from the database

### Master

```
msf6 > use auxiliary/gather/windows_secrets_dump
msf6 auxiliary(gather/windows_secrets_dump) > db_disconnect
Successfully disconnected from the data service: local_db_service.
msf6 auxiliary(gather/windows_secrets_dump) > irb -e 'mod = self.active_module.replicant; mod.datastore["VERBOSE"] = true; puts mod.create_credential_and_login({})&.core_id.inspect'

[!] 127.0.0.1:445 - No active DB -- Credential data will not be saved!
[-] Error while running command irb: undefined method `core_id' for "\e[1m\e[33m[!]\e[0m 127.0.0.1:445 - No active DB -- Credential data will not be saved!\n":String

Call stack:
(eval):1:in `block in cmd_irb'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/developer.rb:149:in `eval'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/developer.rb:149:in `block in cmd_irb'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/developer.rb:149:in `each'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/developer.rb:149:in `cmd_irb'
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/Users/adfoster/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/adfoster/Documents/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```


### This branch

No crash occurs

```
msf6 auxiliary(gather/windows_secrets_dump) > use auxiliary/gather/windows_secrets_dump
msf6 auxiliary(gather/windows_secrets_dump) > db_disconnect
Successfully disconnected from the data service: local_db_service.
msf6 auxiliary(gather/windows_secrets_dump) > irb -e 'mod = self.active_module.replicant; mod.datastore["VERBOSE"] = true; puts mod.create_credential_and_login({})&.core_id.inspect'

[!] 127.0.0.1:445 - No active DB -- Credential data will not be saved!
nil
```