### PR TITLE
Update rspec thread counting logic

### DIFF
--- a/lib/metasploit/framework/spec/threads/suite.rb
+++ b/lib/metasploit/framework/spec/threads/suite.rb
@@ -12,7 +12,23 @@ module Metasploit
           #
 
           # Number of allowed threads when threads are counted in `after(:suite)` or `before(:suite)`
-          EXPECTED_THREAD_COUNT_AROUND_SUITE = ENV['REMOTE_DB'] ? 4 : 3
+          #
+          # Known threads:
+          #   1. Main Ruby thread
+          #   2. Active Record connection pool thread
+          #   3. Framework thread manager, a monitor thread for removing dead threads
+          #      https://github.com/rapid7/metasploit-framework/blame/04e8752b9b74cbaad7cb0ea6129c90e3172580a2/lib/msf/core/thread_manager.rb#L66-L89
+          #   4. Ruby's Timeout library thread, an automatically created monitor thread when using `Thread.timeout(1) { }`
+          #      https://github.com/ruby/timeout/blob/bd25f4b138b86ef076e6d9d7374b159fffe5e4e9/lib/timeout.rb#L129-L137
+          #   5. REMOTE_DB thread, if enabled
+          #
+          # Intermittent threads that are non-deterministically left behind, which should be fixed in the future:
+          #   1. metadata cache hydration
+          #      https://github.com/rapid7/metasploit-framework/blob/115946cd06faccac654e956e8ba9cf72ff328201/lib/msf/core/modules/metadata/cache.rb#L150-L153
+          #   2. session manager
+          #      https://github.com/rapid7/metasploit-framework/blob/115946cd06faccac654e956e8ba9cf72ff328201/lib/msf/core/session_manager.rb#L153-L168
+          #
+          EXPECTED_THREAD_COUNT_AROUND_SUITE = ENV['REMOTE_DB'] ? 7 : 6
 
           # `caller` for all Thread.new calls
           LOG_PATHNAME = Pathname.new('log/metasploit/framework/spec/threads/suite.log')


### PR DESCRIPTION
Document the known threads that can be left behind when running the rspec test suite

Fixes the following intermittent rspec crash:

```
An error occurred in an `after(:suite)` hook.
Failure/Error:
  raise RuntimeError,
        "#{thread_count} #{'thread'.pluralize(thread_count)} exist(s) when only " \
        "#{EXPECTED_THREAD_COUNT_AROUND_SUITE} " \
        "#{'thread'.pluralize(EXPECTED_THREAD_COUNT_AROUND_SUITE)} expected after suite runs:\n" \
        "#{error_lines.join}"

RuntimeError:
  4 threads exist(s) when only 3 threads expected after suite runs:
```

In a separate branch I improved the logging to output additional details about the threads

<details>
<summary>Collapse - Example 1</summary>

```
An error occurred in an `after(:suite)` hook.
Failure/Error:
  raise RuntimeError,
        "#{thread_count} #{'thread'.pluralize(thread_count)} exist(s) when only " \
        "#{EXPECTED_THREAD_COUNT_AROUND_SUITE} " \
        "#{'thread'.pluralize(EXPECTED_THREAD_COUNT_AROUND_SUITE)} expected after suite runs:\n" \
        "#{error_lines.join}"

RuntimeError:
  5 threads exist(s) when only 4 threads expected after suite runs:
  thread 1
  --------------
  name: nil
  status: "run"
  creator: unknown
  uuid: unknown
  backtrace:     /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:118:in `backtrace' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:118:in `block (3 levels) in configure!' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:110:in `each' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:110:in `flat_map' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:110:in `with_index' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:110:in `block (2 levels) in configure!' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:372:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2155:in `block in run_suite_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2153:in `each' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2153:in `run_suite_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2071:in `with_suite_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:116:in `block in run_specs' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/reporter.rb:74:in `report' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:115:in `run_specs' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:89:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:71:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:45:in `invoke' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec:4:in `<main>' 
  thread 2
  --------------
  name: nil
  status: "sleep"
  creator: unknown
  uuid: unknown
  backtrace:     /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:329:in `sleep' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:329:in `block in spawn_thread' 
  thread 3
  --------------
  name: nil
  status: "sleep"
  creator: unknown
  uuid: unknown
  backtrace: 
  thread 4
  --------------
  name: nil
  status: "sleep"
  creator:     /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:101:in `create_timeout_thread' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:130:in `block in ensure_timeout_thread_created' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:128:in `synchronize' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:128:in `ensure_timeout_thread_created' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:171:in `timeout' 
      /opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/3.1.0/net/http.rb:1016:in `connect' 
      /opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/3.1.0/net/http.rb:995:in `do_start' 
      /opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/3.1.0/net/http.rb:984:in `start' 
      /opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/3.1.0/net/http.rb:1564:in `request' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/data_service/remote/http/core.rb:177:in `make_request' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/data_service/remote/http/core.rb:116:in `get_data' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/data_service/remote/http/remote_msf_data_service.rb:10:in `get_msf_version' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/data_service/remote/http/core.rb:209:in `is_online?' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb:55:in `block (2 levels) in start' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb:47:in `loop' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb:47:in `block in start' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb:33:in `synchronize' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb:33:in `start' 
      /home/runner/work/metasploit-framework/metasploit-framework/spec/spec_helper.rb:144:in `block (2 levels) in <top (required)>' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:365:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2155:in `block in run_suite_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2153:in `each' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2153:in `run_suite_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:116:in `block in run_specs' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/reporter.rb:74:in `report' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:115:in `run_specs' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:89:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:71:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:45:in `invoke' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec:4:in `<main>' 
  uuid: 9623c2e0-a4b8-4ca4-b35b-d70f4b9936f4
  backtrace:     /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:113:in `sleep' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:113:in `wait' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:113:in `block (2 levels) in create_timeout_thread' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:111:in `synchronize' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:111:in `block in create_timeout_thread' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:41:in `block (2 levels) in <top (required)>' 
  thread 5
  --------------
  name: nil
  status: "sleep"
  creator:     /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/modules/metadata/cache.rb:150:in `initialize' 
      /opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/3.1.0/singleton.rb:127:in `new' 
      /opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/3.1.0/singleton.rb:127:in `block in instance' 
      /opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/3.1.0/singleton.rb:125:in `synchronize' 
      /opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/3.1.0/singleton.rb:125:in `instance' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/module_manager/cache.rb:123:in `refresh_cache_from_module_files' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/ui/console/driver.rb:165:in `block in initialize' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:41:in `block (2 levels) in <top (required)>' 
  uuid: 71cd6a33-eb8c-46a1-8205-b3def78108fa
  backtrace:     /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/modules/metadata/store.rb:70:in `exist?' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/modules/metadata/store.rb:70:in `block in validate_data' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/modules/metadata/store.rb:70:in `delete_if' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/modules/metadata/store.rb:70:in `validate_data' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/modules/metadata/store.rb:50:in `load_metadata' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/modules/metadata/store.rb:22:in `init_store' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/modules/metadata/cache.rb:151:in `block in initialize' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:41:in `block (2 levels) in <top (required)>' 
# ./lib/metasploit/framework/spec/threads/suite.rb:126:in `block (2 levels) in configure!'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:372:in `run'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2155:in `block in run_suite_hooks'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2153:in `each'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2153:in `run_suite_hooks'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2071:in `with_suite_hooks'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:116:in `block in run_specs'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/reporter.rb:74:in `report'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:115:in `run_specs'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:89:in `run'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:71:in `run'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:45:in `invoke'
# ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec:4:in `<main>'
/home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec: warning: Exception in finalizer #<Proc:0x00007f468b420530 /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `new': can't alloc thread (ThreadError)
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `call'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `block in <top (required)>'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
/home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec: warning: Exception in finalizer #<Proc:0x00007f468b420[698](https://github.com/adfoster-r7/metasploit-framework/actions/runs/3631036277/jobs/6125128972#step:7:699) /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `new': can't alloc thread (ThreadError)
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `call'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `block in <top (required)>'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
/home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec: warning: Exception in finalizer #<Proc:0x00007f468e073dd0 /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `new': can't alloc thread (ThreadError)
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `call'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `block in <top (required)>'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
/home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec: warning: Exception in finalizer #<Proc:0x00007f468e06c008 /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `new': can't alloc thread (ThreadError)
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `call'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `block in <top (required)>'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
```

</details>


<details>
<summary>Collapse - Example 2</summary>

```
RuntimeError:
  4 threads exist(s) when only 3 threads expected after suite runs:
  thread 1
  --------------
  name: nil
  status: "run"
  creator: unknown
  uuid: unknown
  backtrace:     /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:118:in `backtrace' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:118:in `block (3 levels) in configure!' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:110:in `each' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:110:in `flat_map' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:110:in `with_index' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/suite.rb:110:in `block (2 levels) in configure!' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:372:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2155:in `block in run_suite_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2153:in `each' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2153:in `run_suite_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2071:in `with_suite_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:116:in `block in run_specs' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/reporter.rb:74:in `report' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:115:in `run_specs' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:89:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:71:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:45:in `invoke' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec:4:in `<main>' 
  thread 2
  --------------
  name: nil
  status: "sleep"
  creator: unknown
  uuid: unknown
  backtrace:     /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rex-core-0.1.28/lib/rex/sync/thread_safe.rb:36:in `select' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rex-core-0.1.28/lib/rex/sync/thread_safe.rb:36:in `select' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rex-core-0.1.28/lib/rex/sync/thread_safe.rb:76:in `sleep' 
      (eval):3:in `sleep' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:329:in `block in spawn_thread' 
  thread 3
  --------------
  name: nil
  status: "sleep"
  creator:     /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/thread_manager.rb:98:in `spawn' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/session_manager.rb:156:in `block in initialize_scheduler_threads' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/session_manager.rb:155:in `upto' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/session_manager.rb:155:in `initialize_scheduler_threads' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/session_manager.rb:31:in `initialize' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/framework.rb:211:in `new' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/framework.rb:211:in `block in sessions' 
      /opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/3.1.0/monitor.rb:202:in `synchronize' 
      /opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/3.1.0/monitor.rb:202:in `mon_synchronize' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/framework.rb:210:in `sessions' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/rex/ui/text/shell.rb:400:in `format_prompt' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/rex/ui/text/shell.rb:207:in `update_prompt' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/ui/console/driver.rb:434:in `update_prompt' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/rex/ui/text/shell.rb:143:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/ui/web/web_console.rb:84:in `block in initialize' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:41:in `block (2 levels) in <top (required)>' 
  uuid: b682dfbd-a2c7-45b9-9f30-aa8048f60b69
  backtrace:     /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/session_manager.rb:158:in `pop' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/session_manager.rb:158:in `block (2 levels) in initialize_scheduler_threads' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:41:in `block (2 levels) in <top (required)>' 
  thread 4
  --------------
  name: nil
  status: "sleep"
  creator:     /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:101:in `create_timeout_thread' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:130:in `block in ensure_timeout_thread_created' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:128:in `synchronize' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:128:in `ensure_timeout_thread_created' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:171:in `timeout' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rex-socket-0.1.40/lib/rex/socket/comm/local.rb:267:in `create_by_type' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rex-socket-0.1.40/lib/rex/socket/comm/local.rb:34:in `create' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rex-socket-0.1.40/lib/rex/socket.rb:51:in `create_param' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rex-socket-0.1.40/lib/rex/socket/tcp.rb:37:in `create_param' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rex-socket-0.1.40/lib/rex/socket/tcp.rb:28:in `create' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/rex/proto/http/client.rb:176:in `connect' 
      /home/runner/work/metasploit-framework/metasploit-framework/spec/lib/rex/proto/http/client_spec.rb:152:in `block (3 levels) in <top (required)>' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.11.0/lib/rspec/matchers/built_in/raise_error.rb:59:in `matches?' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.11.0/lib/rspec/expectations/handler.rb:51:in `block in handle_matcher' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.11.0/lib/rspec/expectations/handler.rb:27:in `with_matcher' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.11.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.11.0/lib/rspec/expectations/expectation_target.rb:65:in `to' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.11.0/lib/rspec/expectations/expectation_target.rb:139:in `to' 
      /home/runner/work/metasploit-framework/metasploit-framework/spec/lib/rex/proto/http/client_spec.rb:152:in `block (2 levels) in <top (required)>' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:263:in `instance_exec' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:263:in `block in run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:[511](https://github.com/adfoster-r7/metasploit-framework/actions/runs/3616778530/jobs/6095029049#step:7:512):in `block in with_around_and_singleton_context_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:486:in `block in run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:352:in `call' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-rails-5.1.2/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in <module:MinitestLifecycleAdapter>' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:390:in `execute_with' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:352:in `call' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:486:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:468:in `with_around_example_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:259:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:646:in `block in run_examples' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:642:in `map' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:642:in `run_examples' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:607:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:121:in `map' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:116:in `block in run_specs' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/reporter.rb:74:in `report' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:115:in `run_specs' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:89:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:71:in `run' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:45:in `invoke' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec:4:in `<main>' 
  uuid: 185bcc9f-e3aa-4eab-82c0-d2240b1d2ba9
  backtrace:     /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:113:in `sleep' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:113:in `wait' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:113:in `block (2 levels) in create_timeout_thread' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:111:in `synchronize' 
      /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/timeout-0.3.0/lib/timeout.rb:111:in `block in create_timeout_thread' 
      /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:41:in `block (2 levels) in <top (required)>' 
# ./lib/metasploit/framework/spec/threads/suite.rb:126:in `block (2 levels) in configure!'
/home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec: warning: Exception in finalizer #<Proc:0x00007f67c7200e00 /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `new': can't alloc thread (ThreadError)
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `call'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `block in <top (required)>'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:471:in `create_with_logging_context'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:436:in `new'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
/home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec: warning: Exception in finalizer #<Proc:0x00007f67c7200f90 /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `new': can't alloc thread (ThreadError)
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `call'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `block in <top (required)>'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:471:in `create_with_logging_context'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:436:in `new'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
/home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec: warning: Exception in finalizer #<Proc:0x00007f67c9e51180 /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `new': can't alloc thread (ThreadError)
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `call'
	from /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/spec/threads/logger.rb:36:in `block in <top (required)>'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:471:in `create_with_logging_context'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:436:in `new'
	from /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
/home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec: warning: Exception in finalizer #<Proc:0x00007f67c9e[516](https://github.com/adfoster-r7/metasploit-framework/actions/runs/3616778530/jobs/6095029049#step:7:517)58 /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/runner/work/metasploit-framework
```
</details>