### PR TITLE
Fix buggy default in s4u_persistence module

### DIFF
--- a/modules/exploits/windows/local/s4u_persistence.rb
+++ b/modules/exploits/windows/local/s4u_persistence.rb
@@ -215,7 +215,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     when 'schedule'
       # Change interval tag, insert into XML
-      if datastore['FREQUENCY'] != 0
+      unless datastore['FREQUENCY'].nil? || datastore['FREQUENCY'] == 0
         minutes = datastore['FREQUENCY']
       else
         print_status("Defaulting frequency to every hour")


### PR DESCRIPTION
The `s4u_persistence` module, by default, incorrectly set the `frequency` value, which led to a confusing error message. This fixes that by correctly providing a default in the case of the value being `nil`.

Previously, if it was `nil`, this would be treated as "Oh, the user provided a value for us", and this nothingness would be inserted into the XML. Then, you'd receive a failed exploit with the error message: 

```
[-] Error: ERROR: The task XML contains a value which is incorrectly formatted or out of range.
(10,25):Interval:PTM
```

The fix here is just to check for `nil`, and set an appropriate default.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Obtain a session (e.g. Win10)
- [ ] `use s4u_persistence`
- [ ] `set session <id>`
- [ ] `run`
- [ ] Should see the message "Defaulting frequency to every hour"
- [ ] Open Task Scheduler on the victim system, and verify that the task was created, with an interval of every hour