### PR TITLE
Fixes crash in meterp when file_version asks for a file that doesn't exist

### DIFF
--- a/lib/msf/core/post/windows/file_info.rb
+++ b/lib/msf/core/post/windows/file_info.rb
@@ -40,6 +40,11 @@ module FileInfo
       nil
     )['return']
 
+    if file_version_info_size == 0
+      # Indicates an error - should not continue
+      return nil
+    end
+
     buffer = session.railgun.kernel32.VirtualAlloc(
       nil,
       file_version_info_size,


### PR DESCRIPTION
This PR fixes a crash in the `file_version` method for Windows meterpreter. 

If the file in question doesn't exist, the program crashes. I came across this when testing `windows/local/ms15_078_atmfd_bof` on various OSes (beyond what is officially supported), which fails on Server 2022, since `atmfd.dll` is not present. So, haven't found a specific place where it's a problem - but certainly you could envisage:

- Bad assumptions about a file being on a certain OS (e.g. deleted, removed in a later version)
- Race conditions (deleted after checking for existence)

```
msf6 exploit(multi/handler) > use windows/local/ms15_078_atmfd_bof
[*] No payload configured, defaulting to windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/local/ms15_078_atmfd_bof) > set session 1
session => 1
msf6 exploit(windows/local/ms15_078_atmfd_bof) > check
[*] 20.211.33.250 - Meterpreter session 1 closed.  Reason: Died
```

The root cause is that railgun's GetFileVersionInfoSizeA returns 0 (error condition). Then VirtualAlloc, which is now asked for a size of 0, returns 0 itself. Eventually VerQueryValueA tries to fill a NULL buffer, and I presume it's an access violation at that point.

The fix is just to check for the `GetFileVersionInfoA` error condition, and bug out early.

## Verification

We can test this using the interactive ruby shell:

- [ ] Open a meterpreter session
- [ ] `use windows/local/ms15_078_atmfd_bof`
- [ ] `set session <id>`
- [ ] `irb` to open the interactive shell
- [ ] `file_version('asdf')`
- [ ] Should return `nil` (not crash the shell)