### PR TITLE
Update the creds command to allow viewing ssh key contents

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -452,7 +452,12 @@ class Creds
 
       unless tbl.nil?
         public_val = core.public ? core.public.username : ''
-        private_val = core.private ? core.private.to_s : ''
+        if core.private
+          # Show the human readable description by default, unless the user ran with `--verbose` and wants to see the cred data
+          private_val = truncate ? core.private.to_s : core.private.data
+        else
+          private_val = ''
+        end
         if truncate && private_val.to_s.length > 87
           private_val = "#{private_val[0,87]} (TRUNCATED)"
         end


### PR DESCRIPTION
Improvement to https://github.com/rapid7/metasploit-framework/pull/11058

Updates the `creds` command to show the full ssh key contents when running the `creds -v` command or when exporting to a file with `creds -o output.txt`. Previously only a shortened fingerprint string would be shown to the user.

## Verification

List the steps needed to make sure this thing works

- [x] Ensure you have msfconsole's database setup
- [x] Start `msfconsole`
- [x] Create a pem file `irb -e "File.binwrite('example.pem', OpenSSL::PKey::RSA.generate(2048).to_s)"`
- [x] Import the cred `creds add user:sshadmin ssh-key:./example.pem`

Verify the creds output shows the `to_s` representation by default:

```
msf6 auxiliary(admin/dcerpc/icpr_cert) > creds
Credentials
===========

host  origin  service  public    private                                          realm  private_type  JtR Format
----  ------  -------  ------    -------                                          -----  ------------  ----------
                       sshadmin  b6:51:b0:bd:b5:98:97:fa:a8:75:db:c3:92:28:07:ed         SSH key       
```

Verify the `-v` verbose/no truncate mode shows the full pem:

```
msf6 auxiliary(admin/dcerpc/icpr_cert) > creds -v
Credentials
===========

host  origin  service  public    private                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         realm  private_type  JtR Format
----  ------  -------  ------    -------                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         -----  ------------  ----------
                       sshadmin  -----BEGIN RSA PRIVATE KEY-----
MIIEpQIBAAKCAQEAzvM....etc...etc...YBczcfOK7W7Buz
Q8TtVUi1qwWKuDoW8Ec0zXxvQa4LupMAu8DIcvONoooBYujVHOBMmaY=
-----END RSA PRIVATE KEY-----         SSH key       
```

Verify the `-o` flag exports the ssh key still:

```
msf6 auxiliary(admin/dcerpc/icpr_cert) > creds -o foo.txt
[*] Wrote creds to /Users/adfoster/Documents/code/metasploit-framework/foo.txt
msf6 auxiliary(admin/dcerpc/icpr_cert) > cat foo.txt
[*] exec: cat foo.txt

host,origin,service,public,private,realm,private_type,JtR Format
"","","","sshadmin","-----BEGIN RSA PRIVATE KEY----- MIIEpQIBAAKCAQEAzvM....etc...etc...YBczcfOK7W7Buz
Q8TtVUi1qwWKuDoW8Ec0zXxvQa4LupMAu8DIcvONoooBYujVHOBMmaY=","","SSH key",""

```