### PR TITLE
Update docs site to support mermaid

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,8 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 4.2.0'
+gem 'jekyll', '~> 4.3.0'
 gem 'just-the-docs', github: 'rapid7/just-the-docs', branch: 'r7_ver_custom'
+# Useful when testing local just-the-docs changes:
+#gem 'just-the-docs', path: '../../just-the-docs'
 gem 'webrick'
+gem 'rexml'
 
 group :jekyll_plugins do
   gem 'jekyll-sitemap'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rapid7/just-the-docs.git
-  revision: 9c5e78f98185406e50ab04f523a86bd857e186cf
+  revision: 5c7ea378f6392ea19b52e8019ebaca8fc2331733
   branch: r7_ver_custom
   specs:
     just-the-docs (0.3.3)
@@ -12,8 +12,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     byebug (11.1.3)
     coderay (1.1.3)
     colorator (1.1.0)
@@ -25,23 +25,24 @@ GEM
     ffi (1.15.5)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jekyll (4.2.2)
+    jekyll (4.3.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
-      jekyll-sass-converter (~> 2.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 2.3)
+      kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.4.0)
+      mercenary (>= 0.3.6, < 0.5)
       pathutil (~> 0.9)
-      rouge (~> 3.0)
+      rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
-      terminal-table (~> 2.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (2.2.0)
@@ -52,7 +53,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.2)
+    kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -64,35 +65,36 @@ GEM
     method_source (1.0.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    pry (0.13.1)
+    pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
+    pry-byebug (3.10.1)
       byebug (~> 11.0)
-      pry (~> 0.13.0)
-    public_suffix (4.0.7)
+      pry (>= 0.13, < 0.15)
+    public_suffix (5.0.1)
     rake (13.0.6)
-    rb-fsevent (0.11.1)
+    rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (3.28.0)
+    rouge (4.0.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
-    terminal-table (2.0.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
-    unicode-display_width (1.8.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.3.0)
     webrick (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 4.2.0)
+  jekyll (~> 4.3.0)
   jekyll-sitemap
   just-the-docs!
   pry-byebug
+  rexml
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -30,6 +30,9 @@ exclude:
   - README.md
 
 # just-the-docs config
+mermaid_enabled: true
+mermaid:
+  version: "9.2.2"
 heading_anchors: true
 aux_links_new_tab: true
 aux_links:


### PR DESCRIPTION
Update the docs site to support mermaid graphs

### Before

Mermaid code snippets render as text

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/60357436/206882115-1c106825-2f19-4072-989a-bc6f326dd749.png">

### After

Mermaid code snippets render as an svg

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/60357436/206882102-c15a549d-4328-4354-8670-95aa5972910f.png">

## Verification

- [x] `cd docs`
- [x] `bundle`
- [x] `bundle exec ruby build.rb --production --serve`
- [x] **Verify** the mermaid charts render at `http://localhost:4000/docs/development/propsals/java-meterpreter-feature-parity-proposal.html#supporting-native-system-calls`
