### PR TITLE
unlock concurrent-ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ PATH
       bcrypt
       bcrypt_pbkdf
       bson
-      concurrent-ruby (= 1.0.5)
       dnsruby
       ed25519
       em-http-request
@@ -156,7 +155,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.10)
     cookiejar (0.3.3)
     crass (1.0.6)
     daemons (1.4.1)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -205,8 +205,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'xdr'
   # Needed for ::Msf...CertProvider
   spec.add_runtime_dependency 'faker'
-  # Pinned as a dependency of i18n to the last working version
-  spec.add_runtime_dependency 'concurrent-ruby','1.0.5'
   # SSH server library with ed25519
   spec.add_runtime_dependency 'hrr_rb_ssh-ed25519'
   # Needed for irb internal command


### PR DESCRIPTION
Version was locked due to yanked ver 1.1.0, this should have been unlocked long ago.

Update resolves an issue on `exit` in Ruby 3.1.x

```
msf6 > exit
./msfconsole: warning: Exception in finalizer #<Proc:0x00007f70d56d9b40 /home/msfuser/.rvm/gems/ruby-3.1.3@metasploit-framework/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/msfuser/.rvm/gems/ruby-3.1.3@metasploit-framework/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:471:in `new': can't alloc thread (ThreadError)
	from /home/msfuser/.rvm/gems/ruby-3.1.3@metasploit-framework/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:471:in `create_with_logging_context'
	from /home/msfuser/.rvm/gems/ruby-3.1.3@metasploit-framework/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:436:in `new'
	from /home/msfuser/.rvm/gems/ruby-3.1.3@metasploit-framework/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
./msfconsole: warning: Exception in finalizer #<Proc:0x00007f70d56d9cd0 /home/msfuser/.rvm/gems/ruby-3.1.3@metasploit-framework/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:85>
/home/msfuser/.rvm/gems/ruby-3.1.3@metasploit-framework/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:471:in `new': can't alloc thread (ThreadError)
	from /home/msfuser/.rvm/gems/ruby-3.1.3@metasploit-framework/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:471:in `create_with_logging_context'
	from /home/msfuser/.rvm/gems/ruby-3.1.3@metasploit-framework/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:436:in `new'
	from /home/msfuser/.rvm/gems/ruby-3.1.3@metasploit-framework/gems/concurrent-ruby-1.0.5/lib/concurrent/atomic/ruby_thread_local_var.rb:86:in `block in threadlocal_finalizer'
```
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole` on Ruby 3.1.x
- [x] `exit`
