### PR TITLE
Fix Shell Upload Download Command For Directory Destinations

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -406,13 +406,13 @@ Shell Banner:
     print_line("Usage: download [src] [dst]")
     print_line
     print_line("Downloads remote files to the local machine.")
-    print_line("This command does not support to download a FOLDER yet")
+    print_line("This command does not support directories")
     print_line
   end
 
   def cmd_download(*args)
     if args.length != 2
-      # no argumnets, just print help message
+      # no arguments, just print help message
       return cmd_download_help
     end
 
@@ -425,13 +425,21 @@ Shell Banner:
       return
     end
 
+    if (::File.basename(dst) != File.basename(src))
+      # The destination when downloading is a local file so use this system's separator
+      dst += ::File::SEPARATOR + File.basename(src)
+    end
+    dir = ::File.dirname(dst)
+    ::FileUtils.mkdir_p(dir) if dir and not ::File.directory?(dir)
+
     # Get file content
-    print_status("Download #{src} => #{dst}")
+    # match the output style of the Meterpreter equivalent
+    print_status("Downloading: #{src} -> #{dst}")
     content = _file_transfer.read_file(src)
 
     # Write file to local machine
     File.binwrite(dst, content)
-    print_good("Done")
+    print_status("Completed  : #{src} -> #{dst}")
   end
 
   def cmd_upload_help
@@ -444,7 +452,7 @@ Shell Banner:
 
   def cmd_upload(*args)
     if args.length != 2
-      # no argumnets, just print help message
+      # no arguments, just print help message
       return cmd_upload_help
     end
 

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -425,12 +425,15 @@ Shell Banner:
       return
     end
 
-    if (::File.basename(dst) != File.basename(src))
-      # The destination when downloading is a local file so use this system's separator
-      dst += ::File::SEPARATOR + File.basename(src)
+    fs_sep = platform == 'windows' ? '\\' : '/'
+    if dst.blank?
+      dst = src.split(fs_sep).last
+    elsif ::File.directory?(dst)
+      dst += ::File::SEPARATOR unless dst.end_with?(::File::SEPARATOR)
+      dst += src.split(fs_sep).last
     end
-    dir = ::File.dirname(dst)
-    ::FileUtils.mkdir_p(dir) if dir and not ::File.directory?(dir)
+    dst_dir = ::File.dirname(dst)
+    ::FileUtils.mkdir_p(dst_dir) if dst_dir and not ::File.directory?(dst_dir)
 
     # Get file content
     # match the output style of the Meterpreter equivalent
@@ -438,7 +441,7 @@ Shell Banner:
     content = _file_transfer.read_file(src)
 
     # Write file to local machine
-    File.binwrite(dst, content)
+    ::File.binwrite(dst, content)
     print_status("Completed  : #{src} -> #{dst}")
   end
 
@@ -477,7 +480,8 @@ Shell Banner:
 
     print_status("Uploading  : #{src} -> #{dst}")
     begin
-      content = File.binread(src)
+      # Read file from local machine
+      content = ::File.binread(src)
       _file_transfer.write_file(dst, content)
       print_status("Completed  : #{src} -> #{dst}")
     rescue => e

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -421,7 +421,7 @@ Shell Banner:
 
     # Check if src exists
     if !_file_transfer.file_exist?(src)
-      print_error("The target file does not exist")
+      print_error('The target file does not exist')
       return
     end
 
@@ -446,7 +446,7 @@ Shell Banner:
     print_line("Usage: upload [src] [dst]")
     print_line
     print_line("Uploads load file to the victim machine.")
-    print_line("This command does not support to upload a FOLDER yet")
+    print_line("This command does not support directories")
     print_line
   end
 
@@ -459,22 +459,30 @@ Shell Banner:
     src = args[0]
     dst = args[1]
 
+    if dst.blank?
+      dst = ::File.basename(src)
+    elsif _file_transfer.directory?(dst)
+      fs_sep = platform == 'windows' ? '\\' : '/'
+      dst += fs_sep unless dst.end_with?(fs_sep)
+      dst += ::File.basename(src)
+    end
+
     # Check target file exists on the target machine
     if _file_transfer.file_exist?(dst)
-      print_warning("The file <#{dst}> already exists on the target machine")
-      unless prompt_yesno("Overwrite the target file <#{dst}>?")
+      print_warning('The target file already exists')
+      unless prompt_yesno("Overwrite the target file #{dst}?")
         return
       end
     end
 
+    print_status("Uploading  : #{src} -> #{dst}")
     begin
       content = File.binread(src)
       _file_transfer.write_file(dst, content)
-      print_good("File <#{dst}> upload finished")
+      print_status("Completed  : #{src} -> #{dst}")
     rescue => e
-      print_error("Error occurs while uploading <#{src}> to <#{dst}> - #{e.message}")
+      print_error("Failed     : #{src} -> #{dst} - #{e.message}")
       elog(e)
-      return
     end
   end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -293,7 +293,8 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   def File.upload(dest, *src_files, &stat)
     src_files.each { |src|
       if (self.basename(dest) != ::File.basename(src))
-        dest += self.separator + ::File.basename(src) unless dest.end_with?(self.separator)
+        dest += self.separator unless dest.end_with?(self.separator)
+        dest += ::File.basename(src)
       end
       stat.call('Uploading', src, dest) if (stat)
 
@@ -350,7 +351,8 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       if (::File.basename(dest) != File.basename(src))
         # The destination when downloading is a local file so use this
         # system's separator
-        dest += ::File::SEPARATOR + File.basename(src) unless dest.end_with?(::File::SEPARATOR)
+        dest += ::File::SEPARATOR unless dest.end_with?(::File::SEPARATOR)
+        dest += File.basename(src)
       end
 
       # XXX: dest can be the same object as src, so we use += instead of <<

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -290,17 +290,15 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   # If a block is given, it will be called before each file is uploaded and
   # again when each upload is complete.
   #
-  def File.upload(destination, *src_files, &stat)
+  def File.upload(dest, *src_files, &stat)
     src_files.each { |src|
-      dest = destination
-
-      stat.call('uploading', src, dest) if (stat)
-      if (self.basename(destination) != ::File.basename(src))
-        dest += self.separator + ::File.basename(src)
+      if (self.basename(dest) != ::File.basename(src))
+        dest += self.separator + ::File.basename(src) unless dest.end_with?(self.separator)
       end
+      stat.call('Uploading', src, dest) if (stat)
 
       upload_file(dest, src)
-      stat.call('uploaded', src, dest) if (stat)
+      stat.call('Completed', src, dest) if (stat)
     }
   end
 
@@ -310,7 +308,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   def File.upload_file(dest_file, src_file, &stat)
     # Open the file on the remote side for writing and read
     # all of the contents of the local file
-    stat.call('uploading', src_file, dest_file) if stat
+    stat.call('Uploading', src_file, dest_file) if stat
     dest_fd = nil
     src_fd = nil
     buf_size = 8 * 1024 * 1024
@@ -330,7 +328,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       src_fd.close unless src_fd.nil?
       dest_fd.close unless dest_fd.nil?
     end
-    stat.call('uploaded', src_file, dest_file) if stat
+    stat.call('Completed', src_file, dest_file) if stat
   end
 
   def File.is_glob?(name)
@@ -352,7 +350,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       if (::File.basename(dest) != File.basename(src))
         # The destination when downloading is a local file so use this
         # system's separator
-        dest += ::File::SEPARATOR + File.basename(src)
+        dest += ::File::SEPARATOR + File.basename(src) unless dest.end_with?(::File::SEPARATOR)
       end
 
       # XXX: dest can be the same object as src, so we use += instead of <<

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -386,7 +386,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       dst_stat = ::File.stat(dest_file)
       if src_stat.size == dst_stat.size && src_stat.mtime == dst_stat.mtime
         src_fd.close
-        return 'skipped'
+        return 'Skipped'
       end
     end
 
@@ -429,7 +429,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
               seek_back = false
               stat.call("Resuming at #{Filesize.new(in_pos).pretty} of #{src_size}", src_file, dest_file)
             else
-              # succesfully read and wrote - reset the counter
+              # successfully read and wrote - reset the counter
               tries_cnt = 0
             end
             adjust_block = true
@@ -477,7 +477,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
 
     # Clone the times from the remote file
     ::File.utime(src_stat.atime, src_stat.mtime, dest_file)
-    return 'download'
+    return 'Completed'
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -338,7 +338,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     true
   end
 
-  # 
+  #
   # Tab completion for the lcat command
   #
   def cmd_lcat_tabs(str, words)
@@ -1053,7 +1053,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     src_items << last if src_items.empty?
 
     if args.size == 1
-      dest = last.split(/(\/|\\)/).last
+      dest = client.fs.file.basename(last)
     else
       dest = last
     end


### PR DESCRIPTION
This fixes the upload and download command used by shell sessions to handle directory destinations in the same way as the Meterpreter equivalents do.

On uploading, this fixes an issue where the write would fail, but no error would be displayed. Now the file will be created in the directory with the same name. If the directory does not exist, it will fail silently and incorrectly report that it succeeded, see #17365 for the underlying reason.

On downloading, the original would crash and exit the user from interacting with the session. The session would stay established, but the user would have to re-interact with it again. Now when downloading, if the destination is a directory, the file is created in that directory with the same name. If parent directories are missing, they will be created [just like they are by Meterpreter](https://github.com/rapid7/metasploit-framework/blob/c9aab1201c3a0b3cfc6dfc279b35228448bb0b52/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb#L395).

This PR also adjusts some of the messages to make them all consistent with each other. Status messages start with a capital, and file paths are not enclosed in `<>`.

## Verification

List the steps needed to make sure this thing works

- [x] Establish a shell session
- [x] Download a file to a directory (run `download /etc/passwd /tmp`)
- [x] See that the file was created in the directory with the same name
- [x] Download a file to a full path (run `download /etc/passwd /tmp/downloaded_passwd`)
- [x] See the file was created as expected
- [x] Upload a file to a directory (run `upload /etc/passwd /tmp`)
- [x] See that the file was created in the directory with the same name
- [x] Upload a file to a full path (run `upload /etc/passwd /tmp/uploaded_passwd`)
- [x] See the file was created as expected

## Demo
<details>
<summary>Old and broken</summary>

```
msf6 payload(linux/x64/shell_reverse_tcp) > [*] Command shell session 2 opened (192.168.159.128:4444 -> 192.168.159.128:38254) at 2022-12-12 13:36:05 -0500

msf6 payload(linux/x64/shell_reverse_tcp) > sessions -i -1
[*] Starting interaction with 2...

upload /etc/resolv.conf /tmp

[*] Max line length is 65537
[*] Writing 927 bytes in 1 chunks of 3481 bytes (octal-encoded), using printf
[+] File </tmp> upload finished
cat /tmp/resolv.conf
cat: /tmp/resolv.conf: No such file or directory
download /etc/resolv.conf
Usage: download [src] [dst]

Downloads remote files to the local machine.
This command does not support to download a FOLDER yet

download /etc/resolv.conf .
[*] Download /etc/resolv.conf => .
[-] Session manipulation failed: Is a directory @ rb_sysopen - . ["/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/sessions/command_shell.rb:433:in `binwrite'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/sessions/command_shell.rb:433:in `cmd_download'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/sessions/command_shell.rb:617:in `run_builtin_cmd'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/sessions/command_shell.rb:605:in `run_single'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/sessions/command_shell.rb:769:in `_interact_stream'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/sessions/command_shell.rb:745:in `block in _interact'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell/history_manager.rb:49:in `with_context'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/sessions/command_shell.rb:744:in `_interact'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/interactive.rb:53:in `interact'", "/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1682:in `cmd_sessions'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'", "/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'", "/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'", "/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'", "./msfconsole:23:in `<main>'"]
msf6 payload(linux/x64/shell_reverse_tcp) >
```
</details>

<details>
<summary>New and fixed</summary>

```
msf6 payload(linux/x64/shell_reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

upload /etc/resolv.conf /tmp

[*] Uploading  : /etc/resolv.conf -> /tmp/resolv.conf
[*] Max line length is 65537
[*] Writing 927 bytes in 1 chunks of 3481 bytes (octal-encoded), using printf
[*] Completed  : /etc/resolv.conf -> /tmp/resolv.conf
cat /tmp/resolv.conf
# This is /run/systemd/resolve/stub-resolv.conf managed by man:systemd-resolved(8).
# Do not edit.
#
# This file might be symlinked as /etc/resolv.conf. If you're looking at
# /etc/resolv.conf and seeing this text, you have followed the symlink.
#
# This is a dynamic resolv.conf file for connecting local clients to the
# internal DNS stub resolver of systemd-resolved. This file lists all
# configured search domains.
#
# Run "resolvectl status" to see details about the uplink DNS servers
# currently in use.
#
# Third party programs should typically not access this file directly, but only
# through the symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a
# different way, replace this symlink by a static file or a different symlink.
#
# See man:systemd-resolved.service(8) for details about the supported modes of
# operation for /etc/resolv.conf.

nameserver 127.0.0.53
options edns0 trust-ad
search msflab.local
download /etc/resolv.conf .
[*] Downloading: /etc/resolv.conf -> ./resolv.conf
[*] Completed  : /etc/resolv.conf -> ./resolv.conf
^Z
Background session 1? [y/N]  y
msf6 payload(linux/x64/shell_reverse_tcp) > 
```