### PR TITLE
Fix slow msfvenom payload generation for large payloads when outputting as hex format

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.3)
-    rex-text (0.2.46)
+    rex-text (0.2.47)
     rex-zip (0.1.4)
       rex-text
     rexml (3.2.5)


### PR DESCRIPTION
Fix slow msfvenom payload generation for large payloads when outputting as hex format

Pulls in https://github.com/rapid7/rex-text/pull/59
Fixes https://github.com/rapid7/metasploit-framework/issues/17245

## Verification

Master:
```
$ time ./msfvenom -p windows/meterpreter_reverse_tcp lhost=192.168.56.1 lport=4444 -f csharp
...
-- 333.91s user 24.30s system 99% cpu 5:59.45 total
```

This branch:
```
$ time ./msfvenom -p windows/meterpreter_reverse_tcp lhost=192.168.56.1 lport=4444 -f csharp
...
-- 7.25s user 6.48s system 95% cpu 14.376 total
```