### PR TITLE
force mixin to utilize `ruby_smb`

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -293,7 +293,9 @@ class MetasploitModule < Msf::Auxiliary
       begin
         print_status 'Starting module'
         if rport == SMB1_PORT
-          connect(versions: [1])
+          # force library in smb1 mode otherwise simple.client is a
+          # `Rex::Proto::SMB::Client` that does not supply `net_share_enum_all`
+          connect(versions: [1], backend: :ruby_smb)
         else
           connect(versions: [1, 2, 3])
         end


### PR DESCRIPTION
When refactored recently the new code expects a `RubySMB` object this ensures the client returned meets that expectation.

The following stack trace can occur (seen on macOS dev env):
```
[-] 10.10.10.10:139       - Error: '10.10.10.10' 'NoMethodError' 'undefined method `net_share_enum_all' for #<Rex::Proto::SMB::Client:0x00007fbf17523478 @socket=#<Socket:fd 15>, @native_os="Windows 2000 2195", @native_lm="Windows 2000 5.0", @encrypt_passwords=true, @extended_security=true, @multiplex_id=10968, @process_id=1767, @read_timeout=10, @evasion_opts={"pad_data"=>0, "pad_file"=>0, "obscure_trans_pipe"=>0}, @verify_signature=false, @use_ntlmv2=true, @usentlm2_session=true, @send_lm=true, @use_lanman_key=false, @send_ntlm=true, @sequence_counter=0, @signing_key="", @require_signing=false, @peer_require_signing=false, @spnopt={:use_spn=>true, :name=>"10.10.10.10"}, @default_max_buffer_size=65503, @smb_recv_cache=[], @dialect="NT LANMAN 1.0", @security_mode=3, @challenge_key="metasploitable-\x00`(\x06\x06+\x06\x01\x05\x05\x02\xA0\x1E0\x1C\xA0\x0E0\f\x06\n+\x06\x01\x04\x01\x827\x02\x02\n\xA3\n0\b\xA0\x06\e\x04NONE", @session_id=8867, @server_guid="metasploitable-\x00", @system_time=2022-12-12 13:10:00 -0600, @system_zone=-18000, @auth_user_id=100, @peer_native_os="Unix", @peer_native_lm="Samba 3.0.20-Debian", @default_domain="WORKGROUP", @last_tree_id=1>'
```

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/smb_enumshares`
- [x] **Verify** consistent function for SMB 1,2,3 for valid targets
- [x] Test against a metasploitable2 target and expect to receive the following for each port 139 & 445
```
msf6 auxiliary(scanner/smb/smb_enumshares) > run

[*] 10.10.10.10:139       - Starting module
[-] 10.10.10.10:139       - Invalid packet received when trying to enumerate shares - The response seems to be an SMB1 NtCreateAndxResponse but an error occurs while parsing it. It is probably missing the required extended information.
[*] 10.10.10.10:445       - Starting module
[-] 10.10.10.10:445       - Invalid packet received when trying to enumerate shares - The response seems to be an SMB1 NtCreateAndxResponse but an error occurs while parsing it. It is probably missing the required extended information.
[*] 10.10.10.10:          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```