### PR TITLE
Add ticket flags when outputting krb5 ccache

### DIFF
--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
@@ -62,10 +62,11 @@ module Rex::Proto::Kerberos::CredentialCache
       output << "Client: #{cred.client}"
       output << "Ticket etype: #{cred.keyblock.enctype} (#{Rex::Proto::Kerberos::Crypto::Encryption.const_name(cred.keyblock.enctype)})"
       output << "Key: #{cred.keyblock.data.unpack1('H*')}"
+      output << "Subkey: #{cred.is_skey == 1}"
       output << "Ticket Length: #{cred.ticket.length}"
+      output << "Ticket Flags: 0x#{cred.ticket_flags.to_i.to_s(16).rjust(8, '0')} (#{Rex::Proto::Kerberos::Model::KdcOptionFlags.new(cred.ticket_flags.to_i).enabled_flag_names.join(', ')})"
       ticket = Rex::Proto::Kerberos::Model::Ticket.decode(cred.ticket.value)
 
-      output << "Subkey: #{cred.is_skey == 1}"
       output << "Addresses: #{cred.address_count}"
 
       unless cred.address_count == 0

--- a/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
+++ b/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
@@ -118,8 +118,9 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
           Client: Administrator@WINDOMAIN.LOCAL
           Ticket etype: 18 (AES256)
           Key: 3835366238646261363736326161393037386566633133613535323934333739
-          Ticket Length: 977
           Subkey: false
+          Ticket Length: 977
+          Ticket Flags: 0x50e00000 (FORWARDABLE, PROXIABLE, RENEWABLE, INITIAL, PRE_AUTHENT)
           Addresses: 0
           Authdatas: 0
           Times:
@@ -150,8 +151,9 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
           Client: Administrator@WINDOMAIN.LOCAL
           Ticket etype: 18 (AES256)
           Key: 3835366238646261363736326161393037386566633133613535323934333739
-          Ticket Length: 977
           Subkey: false
+          Ticket Length: 977
+          Ticket Flags: 0x50e00000 (FORWARDABLE, PROXIABLE, RENEWABLE, INITIAL, PRE_AUTHENT)
           Addresses: 0
           Authdatas: 0
           Times:


### PR DESCRIPTION
Additionally outputs ticket flags when presenting krb5 ccaches on msfconsole

## Verification

- Verify tests pass
- Verify ticket forging shows the ticket flags:
```
msf6 auxiliary(admin/kerberos/forge_ticket) > run action=FORGE_SILVER domain=adf3.local domain_sid=S-1-5-21-1266190811-2419310613-1856291569 nthash=fbd103200439e14d4c8adad675d5f244 user=Administrator spn=cifs/dc3.adf3.local verbose=true 
[*] Running module against 127.0.0.1

[+] MIT Credential Cache ticket saved on /Users/adfoster/.msf4/loot/20221213122401_default_192.168.123.132_mit.kerberos.cca_271173.bin
[*] Primary Principal: Administrator@ADF3.LOCAL
Ccache version: 4

Creds: 1
  Credential[0]:
    Server: cifs/dc3.adf3.local@ADF3.LOCAL
    Client: Administrator@ADF3.LOCAL
    Ticket etype: 23 (RC4_HMAC)
    Key: 32396566336236316331633065313836
    Subkey: false
    Ticket Length: 952
    Ticket Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT) <-----------
... etc ...
```