### PR TITLE
Add klist command

### DIFF
--- a/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
@@ -17,6 +17,7 @@ module RemoteLootDataService
       if loot[:data] && !loot[:data].empty?
         local_path = File.join(Msf::Config.loot_directory, File.basename(loot[:path]))
         rv[data.index(loot)].path = process_file(loot[:data], local_path)
+        rv[data.index(loot)].data = decode_loot_data(loot[:data])
       end
       if loot[:host]
         host_object = to_ar(RemoteHostDataService::HOST_MDM_CLASS.constantize, loot[:host])
@@ -41,5 +42,13 @@ module RemoteLootDataService
 
   def delete_loot(opts)
     json_to_mdm_object(self.delete_data(LOOT_API_PATH, opts), LOOT_MDM_CLASS)
+  end
+
+  private
+
+  # The loot API returns the data encoded
+  # @see [Msf::WebServices::ServletHelper#encode_loot_data]
+  def decode_loot_data(data)
+    Base64.urlsafe_decode64(data)
   end
 end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -280,7 +280,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   end
 
   # @param [Hash] options
-  # @option options [Boolean] :ticket_storage Override the @ticket_storage attribute
+  # @option options [Msf::Exploit::Remote::Kerberos::Ticket::Storage::Base] :ticket_storage Override the @ticket_storage attribute
   # @see #authenticate_via_kdc Options documentation
   # @see #get_cached_credential Other options documentation
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential
@@ -306,7 +306,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   end
 
   # @param [Hash] options
-  # @option options [Boolean] :ticket_storage Override the @ticket_storage attribute
+  # @option options [Msf::Exploit::Remote::Kerberos::Ticket::Storage::Base] :ticket_storage Override the @ticket_storage attribute
   # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] :credential
   #   The ccache credential from the TGT
   # @see #authenticate_via_krb5_ccache_credential_tgt Options dcoumentation
@@ -329,7 +329,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   The ccache credential from the TGT
   # @param [Hash] options
   # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname The target service principal name.
-  # @option options [Boolean] :ticket_storage Override the @ticket_storage attribute
+  # @option options [Msf::Exploit::Remote::Kerberos::Ticket::Storage::Base] :ticket_storage Override the @ticket_storage attribute
   # @option options [String] :impersonate The name of the user to request a ticket on behalf of
   # @return [Array] The TGS ticket and the decrypted TGS credentials as a MIT Cache Credential
   def s4u2self(credential, options = {})
@@ -381,7 +381,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname The target service principal name.
   # @option options [Rex::Proto::Kerberos::Model::Ticket] :tgs_ticket The service ticket to the first service.
   #   It must have the forwardable flag set. This ticket can be obtained with #s4u2self.
-  # @option options [Boolean] :ticket_storage Override the @ticket_storage attribute
+  # @option options [Msf::Exploit::Remote::Kerberos::Ticket::Storage::Base] :ticket_storage Override the @ticket_storage attribute
   # @option options [String] :impersonate The name of the user to request a ticket on behalf of
   # @return [Array] The new TGS ticket and the decrypted TGS credentials as a MIT Cache Credential
   def s4u2proxy(credential, options = {})
@@ -774,7 +774,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   Any additional tickets to add to the request
   # @option options [Array<Rex::Proto::Kerberos::Model::PreAuthDataEntry>] :pa_data
   #   Any additional pre-auth data entries to add to the request
-  # @option options [Boolean] :ticket_storage Override the @ticket_storage attribute
+  # @option options [Msf::Exploit::Remote::Kerberos::Ticket::Storage::Base] :ticket_storage Override the @ticket_storage attribute
   # @option options [String] :credential_cache_username The name of user
   #   corresponding to the requested TGS ticket. This name will be used in
   #   the info field when the tickets is stored in the database. This can be used

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
@@ -55,9 +55,10 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
     # @param [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache] ccache The credential cache object to store.
     # @param [Hash] options The information associated with the stored object. See the options hash description in
     #   {#tickets}.
-    # @return [nil]
+    # @return [Hash]
+    #   * :path [String] The path to the persisted ccache file if successful
     def store_ccache(ccache, options = {})
-      nil
+      {}
     end
 
     # @return [String] The name of the workspace in which to operate.

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
@@ -36,7 +36,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       message << "MIT Credential Cache ticket saved to #{path}"
       print_status(message)
 
-      nil
+      { path: path }
     end
   end
 end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -18,6 +18,7 @@ class Db
   include Msf::Ui::Console::CommandDispatcher::Common
   include Msf::Ui::Console::CommandDispatcher::Db::Common
   include Msf::Ui::Console::CommandDispatcher::Db::Analyze
+  include Msf::Ui::Console::CommandDispatcher::Db::Klist
 
   DB_CONFIG_PATH = 'framework/database'
 
@@ -47,6 +48,7 @@ class Db
       "vulns"         => "List all vulnerabilities in the database",
       "notes"         => "List all notes in the database",
       "loot"          => "List all loot in the database",
+      "klist"         => "List Kerberos tickets in the database",
       "db_import"     => "Import a scan result file (filetype will be auto-detected)",
       "db_export"     => "Export a file containing the contents of the database",
       "db_nmap"       => "Executes nmap and records the output automatically",

--- a/lib/msf/ui/console/command_dispatcher/db/klist.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/klist.rb
@@ -1,0 +1,121 @@
+# -*- coding: binary -*-
+
+module Msf::Ui::Console::CommandDispatcher::Db::Klist
+  #
+  # Tab completion for the klist command
+  #
+  # @param str [String] the string currently being typed before tab was hit
+  # @param words [Array<String>] the previously completed words on the command line.  words is always
+  # at least 1 when tab completion has reached this stage since the command itself has been completed
+  def cmd_klist_tabs(str, words)
+    if words.length == 1
+      @@klist_opts.option_keys.select { |opt| opt.start_with?(str) }
+    end
+  end
+
+  def cmd_klist_help
+    print_line 'List Kerberos tickets in the database'
+    print_line 'Usage: klist [options]'
+    print_line
+    print @@klist_opts.usage
+    print_line
+  end
+
+  @@klist_opts = Rex::Parser::Arguments.new(
+    ['-v', '--verbose'] => [false, 'Verbose output'],
+    ['-d', '--delete'] => [ false, 'Delete *all* matching kerberos entries' ],
+    ['-h', '--help'] => [false, 'Help banner']
+  )
+
+  def cmd_klist(*args)
+    return unless active?
+
+    delete_count = 0
+    mode = :list
+    host_ranges = []
+    verbose = false
+    @@klist_opts.parse(args) do |opt, _idx, val|
+      case opt
+      when '-h', '--help'
+        cmd_klist_help
+        return
+      when '-v', '--vebose'
+        verbose = true
+      when '-d', '--delete'
+        mode = :delete
+      else
+        # Anything that wasn't an option is a host to search for
+        unless arg_host_range(val, host_ranges)
+          return
+        end
+      end
+    end
+
+    # Sentinel value meaning all
+    host_ranges.push(nil) if host_ranges.empty?
+
+    ticket_results = []
+    each_host_range_chunk(host_ranges) do |host_search|
+      next if host_search && host_search.empty?
+
+      ticket_results += kerberos_ticket_storage.tickets(
+        workspace: framework.db.workspace,
+        host: host_search
+      )
+    end
+    ticket_results.sort_by(&:host_address)
+
+    print_line('Kerberos Cache')
+    print_line('==============')
+
+    if ticket_results.empty?
+      print_line('No tickets')
+      print_line
+      return
+    end
+
+    if mode == :delete
+      result = kerberos_ticket_storage.delete_tickets(ids: ticket_results.map(&:id))
+      delete_count = result.size
+    end
+
+    if verbose
+      ticket_results.each.with_index do |ticket_result, index|
+        ticket_details = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter.new(ticket_result.ccache).present
+        print_line "Cache[#{index}]:"
+        print_line ticket_details.indent(2)
+        print_line
+      end
+    else
+      tbl = Rex::Text::Table.new(
+        {
+          'Columns' => ['host', 'principal', 'sname', 'issued', 'status', 'path'],
+          'SortIndex' => -1,
+          # For now, don't perform any word wrapping on the table as it breaks the workflow of
+          # copying file paths and pasting them into applications
+          'WordWrap' => false,
+          'Rows' => ticket_results.map do |ticket|
+            [
+              ticket.host_address,
+              ticket.principal,
+              ticket.sname,
+              ticket.starttime,
+              ticket.expired? ? '>>expired<<' : 'valid',
+              ticket.path
+            ]
+          end
+        }
+      )
+      print_line(tbl.to_s)
+    end
+
+    print_status("Deleted #{delete_count} #{delete_count > 1 ? 'entries' : 'entry'}") if delete_count > 0
+  end
+
+  protected
+
+  # @return [Msf::Exploit::Remote::Kerberos::Ticket::Storage::ReadWrite]
+  def kerberos_ticket_storage
+    @kerberos_ticket_storage ||= Msf::Exploit::Remote::Kerberos::Ticket::Storage::ReadWrite.new(framework: framework)
+  end
+end

--- a/spec/lib/msf/ui/console/command_dispatcher/db/klist_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db/klist_spec.rb
@@ -1,0 +1,277 @@
+require 'spec_helper'
+require 'tempfile'
+
+RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
+  include_context 'Msf::DBManager'
+  include_context 'Msf::UIDriver'
+
+  subject do
+    described_class = self.described_class
+    instance = Class.new do
+      include Msf::Ui::Console::CommandDispatcher
+      include Msf::Ui::Console::CommandDispatcher::Common
+      include Msf::Ui::Console::CommandDispatcher::Db::Common
+      include described_class
+    end.new(driver)
+    instance
+  end
+
+  def kerberos_ticket_storage
+    Msf::Exploit::Remote::Kerberos::Ticket::Storage::ReadWrite.new(framework: framework)
+  end
+
+  describe '#cmd_klist' do
+    before(:each) do
+      kerberos_ticket_storage.delete_tickets
+    end
+
+    context 'when the -h option is provided' do
+      it 'should show a help message' do
+        subject.cmd_klist '-h'
+        expect(@output.join("\n")).to match_table <<~TABLE
+          List Kerberos tickets in the database
+          Usage: klist [options]
+
+          OPTIONS:
+
+              -d, --delete   Delete *all* matching kerberos entries
+              -h, --help     Help banner
+              -v, --verbose  Verbose output
+
+        TABLE
+      end
+    end
+
+    context 'when there are no tickets' do
+      context 'when no options are provided' do
+        it 'should show no tickets' do
+          subject.cmd_klist
+          expect(@output.join("\n")).to match_table <<~TABLE
+            Kerberos Cache
+            ==============
+            No tickets
+          TABLE
+        end
+      end
+
+      context 'when the -v option is provided' do
+        it 'should show no tickets' do
+          subject.cmd_klist '-v'
+          expect(@output.join("\n")).to match_table <<~TABLE
+            Kerberos Cache
+            ==============
+            No tickets
+          TABLE
+        end
+      end
+    end
+
+    context 'when there are tickets' do
+      let(:valid_ccache_base64) do
+        <<~EOF
+          BQQAAAAAAAEAAAABAAAAD1dJTkRPTUFJTi5MT0NBTAAAAA1BZG1pbmlzdHJh
+          dG9yAAAAAQAAAAEAAAAPV0lORE9NQUlOLkxPQ0FMAAAADUFkbWluaXN0cmF0
+          b3IAAAABAAAAAgAAAA9XSU5ET01BSU4uTE9DQUwAAAAGa3JidGd0AAAAD1dJ
+          TkRPTUFJTi5MT0NBTAASAAAAIDg1NmI4ZGJhNjc2MmFhOTA3OGVmYzEzYTU1
+          Mjk0Mzc5Y4TZAWOE2QF2UNwBdlDcAQBQ4AAAAAAAAAAAAAAAAAPRYYIDzTCC
+          A8mgAwIBBaERGw9XSU5ET01BSU4uTE9DQUyiJDAioAMCAQGhGzAZGwZrcmJ0
+          Z3QbD1dJTkRPTUFJTi5MT0NBTKOCA4cwggODoAMCARKhAwIBAqKCA3UEggNx
+          SfCgea/1JxnrCZh8Tx+KB/z5rjaxo8cdmiQ+baACeDjI8hohc975Hjt16643
+          pQBhNwyLvqy7O9LJs+Qgt0+3nRLYuHE4Oal2auffQkBJCwf5NyYenRLYvfnX
+          pnFwUL4r7vzL4rEWjyIfuBdAC3o6NRJaHnakd5p5CWe1gXG5jNo8dIqRId5z
+          jtlbcL8Y3IEbuhtvPcnnZ9EIvMZD1oLQuJyf93Lt4sM4AZDMfaOzbC4o50K0
+          oc+0cFULIgEqTuULhIj6JD7fcZlSO7PDYD2Z7zJyNMTv5r/5vygmzuFPuGID
+          EkKtV/uOmxZwMNYlB+3swzp8vaYZQo6378z9O1J2nA/LTFhuwpoIR+VtY088
+          WoQpb9tD9BGOKH0WxDKvj5fl9ll6WY99XrVmZQZwjpP97SatTmSpGmpszCsC
+          pq+P/Zay8HwZWjdcR6OEP1Ymoy6Eg1yAIiMk5gRlVpa+wZAmTOXMpIFqkpC5
+          vFSu9OUp0qgGbScusZ64I7ylS8Kpy8AT0cBaSUTvDAxQid9+N65u07S5h2qB
+          kdP5lbH9QE46k+Z6Gnps4P1wNFccF8ukBWyEormPoN1paZZ96l7KeRtA6kRw
+          Nyd8C9p2yOojDI7ksU43ojYT5VS3a0c5odcs0pyAyhxyzR91toRkHJS4B7yl
+          cuFtBQ5HcgUXOgVHu4VjL5Ll8dY/QM7Va0nqDt2RtIwPr3/FuaRFuDKlR3zT
+          Fqf3H0DDjLD37VRU7tfm5L8nJZ9hzmA/nd7KCg9Em52R287eWcZ2LNWqJEXX
+          Lh7dn4aE6Z4Mnt2sIqBCBLxLln+ePGYkO4KoBTTEfeN4xUC/ZfM+wI7qLh9q
+          dwRltmarAqBk2nWeGze4tkw46H2qGd6RrbJgjNUwxX/KhyEGdEqKB2aaf8fR
+          JI4pJMJ1+pQa6796UDty32xgue8r1/0QfzinnMcQfQVqfGGazwVm7swo8aT1
+          BTGmiOx6iHlBoIkQ3HCUlW/9ynDbp2SBRFqD08n+1eQg39dlF+NVfB7RutFE
+          s4BEF/UdLr50/0xKrZzZEBuQSb/LWaggCakhPohfBVBrVEuoH9TDhNZrOrna
+          KCi0awaZQrvXPMnqvVqBYM3SsZRXOgDrcq/T79qR9cCvmQT2hhsmrh4c15ld
+          VpIpmeR2YS/msnk7iVVhPqec/jkVTvpB7/EAAAAA
+        EOF
+      end
+
+      let(:expired_ccache_base64) do
+        <<~EOF
+          BQQAAAAAAAEAAAABAAAACkFERjMuTE9DQUwAAAANQWRtaW5pc3RyYXRvcgAA
+          AAEAAAABAAAACkFERjMuTE9DQUwAAAANQWRtaW5pc3RyYXRvcgAAAAEAAAAC
+          AAAACkFERjMuTE9DQUwAAAAGa3JidGd0AAAACkFERjMuTE9DQUwAEgAAACDO
+          fwBYscwSotMS4+yZQ1OMO0AcTa7Vj+/2W/mw+kCzs2OcXvFjnF7xY5zrkWOd
+          sHEAUOEAAAAAAAAAAAAAAAAEQmGCBD4wggQ6oAMCAQWhDBsKQURGMy5MT0NB
+          TKIfMB2gAwIBAaEWMBQbBmtyYnRndBsKQURGMy5MT0NBTKOCBAIwggP+oAMC
+          ARKhAwIBAqKCA/AEggPs5JyYC0QViXJwK8TeX2uNlLyo1vX50A815LGykwJz
+          QXnsL4MKwjo+w99V2eB2O0i53rnRJycPHu2MZtkashcPp/XJHLFFqZ2rEB56
+          pax51sU5TExk+td5zyT3su9HNJe89ctXfDqFIzmg3LNhvicEJHcF+eg7DVgG
+          h2/h2/uHsbpq857XT/w3gq+NK8HIiwbYZLXDSv35qi58xHWm5uTJNBmn9vBS
+          V2YMHbFOzU+BhKxR9CaT5pLW0iNedkwbV539lvcAoNfcghKg4SkWU49q+pQJ
+          8R+giMvl7PltU9DAAB/tgJL8VK32lLbHQYSHZPO6TnBOgIaxfGR2vX0C6XRa
+          OIDu1wioM443Ekswe1MFBxVP5Hu/xWryW6q8nbGBFPL+37q/IB/j4vzuvkpx
+          5p/Izx8vwmJE3IyrvqNlxC1M1TbqhcpwLeqHRPWjgd+4WuyEqXw/TLycrISF
+          TFkgOW00DxUVY4ZD2IoQ1vjwoCngokcK6QXKictANJAinUMsqwVb2kcP3TJg
+          bD7EEGbvaDBsRmwMZTgF5ZgmmVs6SIwCAxf4hEf1EvEiMF1UaY1xckfGCnnO
+          lOwJZg2PGbqVciKLwdeRw9iK1u9pwmsmDr033/cvfrkFm1ggrA2T/VqQ7Uv/
+          5WQpt5/GuGv8WYD7F+CV1zWVr5I3ejbXFk2X7HVlHVW3zx2xaKrNdsk6yOSQ
+          cQREhfCQvCjFenH39uSMV36zM6c4Z97oYvcZUpPg6sazpA5KEm86DharyEhV
+          mTeGbpVAV7Asfq0ojh6nPQem6a6Hrim4fSqEH4rsMuwOPCDfritUBDCALB2b
+          hRrT54+290jFu0cRDE4FM34rAm4XXXxFF3wuHWJEeNWsvtnd/ot5ocmEenCB
+          fM695wfVVyDJq/VA90C7RNvvFG/rbTDTDmkZc2H5xCxRVn3HaSC6d4S/81KR
+          MnwEhjhhWHjC7l1an3gRamL33eDT2/y67huwDxoaaQMaI0u47hHaB4IxZBS2
+          8T4OusfJrwLgoWVp3DKmkTZD2vFWv0W0mtrdYHFOvgNNd3vU771Cc8AXMnW4
+          G5Ne3igy7vfI4GnIFeAz088E7sxDwCeXfXB1+Y3CNPGMn0DkUzIWd9nxjDXu
+          3bdN7shsEtntT+JEOgQAChqZ7ay5DigaC3P503NkBskOnFUHz1xLTvBKFicB
+          akAIyxtxqa7C2D8DM5v0i3pCcVwbMqcKXk46AUTmmcCMrra6WiXqHRZ/s/UZ
+          jWwnrBd80k8d1MFVotad/XPKxDmNLeTw5KiqJx4hTEWsvrXw0P5UMu3reeIk
+          WnABsFKVaMithek8a9aRyBsuwSSgkAIJHXy8tHsAAAAA
+        EOF
+      end
+
+      # @param [String] data Base64 encoded
+      def as_ccache(data)
+        Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(Base64.decode64(data))
+      end
+
+      let(:valid_ccache) do
+        kerberos_ticket_storage.store_ccache(as_ccache(valid_ccache_base64), host: '192.0.2.2')
+      end
+
+      let(:valid_ccache_path) do
+        kerberos_ticket_storage.tickets(host: '192.0.2.2').first.path
+      end
+
+      let(:expired_ccache) do
+        kerberos_ticket_storage.store_ccache(as_ccache(expired_ccache_base64), host: '192.0.2.24')
+      end
+
+      let(:expired_ccache_path) do
+        kerberos_ticket_storage.tickets(host: '192.0.2.24').first.path
+      end
+
+      let(:create_tickets) do
+        [valid_ccache, expired_ccache]
+      end
+
+      before(:each) do
+        Timecop.freeze(Time.parse('Dec 18, 2022 12:33:40.000000000 GMT'))
+        create_tickets
+      end
+
+      after do
+        Timecop.return
+      end
+
+      context 'when no options are provided' do
+        it 'should show tickets' do
+          subject.cmd_klist
+
+          expect(@output.join("\n")).to match_table <<~TABLE
+            Kerberos Cache
+            ==============
+            host        principal                      sname                                   issued                     status       path
+            ----        ---------                      -----                                   ------                     ------       ----
+            192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  valid        #{valid_ccache_path}
+            192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            2022-12-16 12:05:05 +0000  >>expired<<  #{expired_ccache_path}
+          TABLE
+        end
+      end
+
+      context 'when a host address is specified' do
+        it 'should show the matching host addresses' do
+          subject.cmd_klist '192.0.2.2'
+          expect(@output.join("\n")).to match_table <<~TABLE
+            Kerberos Cache
+            ==============
+            host       principal                      sname                                   issued                     status  path
+            ----       ---------                      -----                                   ------                     ------  ----
+            192.0.2.2  Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  valid   #{valid_ccache_path}
+          TABLE
+        end
+      end
+
+      context 'when the -v option is provided' do
+        it 'should show tickets' do
+          expected_cipher = <<~CIPHER.lines(chomp: true).join('')
+            SfCgea/1JxnrCZh8Tx+KB/z5rjaxo8cdmiQ+baACeDjI8hohc975Hjt16643pQBhNwyLvqy7
+            O9LJs+Qgt0+3nRLYuHE4Oal2auffQkBJCwf5NyYenRLYvfnXpnFwUL4r7vzL4rEWjyIfuBdA
+            C3o6NRJaHnakd5p5CWe1gXG5jNo8dIqRId5zjtlbcL8Y3IEbuhtvPcnnZ9EIvMZD1oLQuJyf
+            93Lt4sM4AZDMfaOzbC4o50K0oc+0cFULIgEqTuULhIj6JD7fcZlSO7PDYD2Z7zJyNMTv5r/5
+            vygmzuFPuGIDEkKtV/uOmxZwMNYlB+3swzp8vaYZQo6378z9O1J2nA/LTFhuwpoIR+VtY088
+            WoQpb9tD9BGOKH0WxDKvj5fl9ll6WY99XrVmZQZwjpP97SatTmSpGmpszCsCpq+P/Zay8HwZ
+            WjdcR6OEP1Ymoy6Eg1yAIiMk5gRlVpa+wZAmTOXMpIFqkpC5vFSu9OUp0qgGbScusZ64I7yl
+            S8Kpy8AT0cBaSUTvDAxQid9+N65u07S5h2qBkdP5lbH9QE46k+Z6Gnps4P1wNFccF8ukBWyE
+            ormPoN1paZZ96l7KeRtA6kRwNyd8C9p2yOojDI7ksU43ojYT5VS3a0c5odcs0pyAyhxyzR91
+            toRkHJS4B7ylcuFtBQ5HcgUXOgVHu4VjL5Ll8dY/QM7Va0nqDt2RtIwPr3/FuaRFuDKlR3zT
+            Fqf3H0DDjLD37VRU7tfm5L8nJZ9hzmA/nd7KCg9Em52R287eWcZ2LNWqJEXXLh7dn4aE6Z4M
+            nt2sIqBCBLxLln+ePGYkO4KoBTTEfeN4xUC/ZfM+wI7qLh9qdwRltmarAqBk2nWeGze4tkw4
+            6H2qGd6RrbJgjNUwxX/KhyEGdEqKB2aaf8fRJI4pJMJ1+pQa6796UDty32xgue8r1/0Qfzin
+            nMcQfQVqfGGazwVm7swo8aT1BTGmiOx6iHlBoIkQ3HCUlW/9ynDbp2SBRFqD08n+1eQg39dl
+            F+NVfB7RutFEs4BEF/UdLr50/0xKrZzZEBuQSb/LWaggCakhPohfBVBrVEuoH9TDhNZrOrna
+            KCi0awaZQrvXPMnqvVqBYM3SsZRXOgDrcq/T79qR9cCvmQT2hhsmrh4c15ldVpIpmeR2YS/m
+            snk7iVVhPqec/jkVTvpB7/E=
+          CIPHER
+
+          subject.cmd_klist '-v', '192.0.2.2'
+          expect(@output.join("\n")).to match_table <<~TABLE
+            Kerberos Cache
+            ==============
+            Cache[0]:
+              Primary Principal: Administrator@WINDOMAIN.LOCAL
+              Ccache version: 4
+
+              Creds: 1
+                Credential[0]:
+                  Server: krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL
+                  Client: Administrator@WINDOMAIN.LOCAL
+                  Ticket etype: 18 (AES256)
+                  Key: 3835366238646261363736326161393037386566633133613535323934333739
+                  Subkey: false
+                  Ticket Length: 977
+                  Ticket Flags: 0x50e00000 (FORWARDABLE, PROXIABLE, RENEWABLE, INITIAL, PRE_AUTHENT)
+                  Addresses: 0
+                  Authdatas: 0
+                  Times:
+                    Auth time: 2022-11-28 15:51:29 +0000
+                    Start time: 2022-11-28 15:51:29 +0000
+                    End time: 2032-11-25 15:51:29 +0000
+                    Renew Till: 2032-11-25 15:51:29 +0000
+                  Ticket:
+                    Ticket Version Number: 5
+                    Realm: WINDOMAIN.LOCAL
+                    Server Name: krbtgt/WINDOMAIN.LOCAL
+                    Encrypted Ticket Part:
+                      Ticket etype: 18 (AES256)
+                      Key Version Number: 2
+                      Cipher:
+                        #{expected_cipher}
+          TABLE
+        end
+      end
+
+      context 'when the -d flag is used' do
+        it 'should show the deleted tickets' do
+          # Store the paths first before they are deleted
+          old_valid_ccache_path = valid_ccache_path
+          old_expired_ccache_path = expired_ccache_path
+          subject.cmd_klist '-d'
+          expect(@output.join("\n")).to match_table <<~TABLE
+            Kerberos Cache
+            ==============
+            host        principal                      sname                                   issued                     status       path
+            ----        ---------                      -----                                   ------                     ------       ----
+            192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  valid        #{old_valid_ccache_path}
+            192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            2022-12-16 12:05:05 +0000  >>expired<<  #{old_expired_ccache_path}
+            Deleted 2 entries
+          TABLE
+          expect(kerberos_ticket_storage.tickets.length).to eq(0)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add msfconsole klist command support. I'm marking this as a draft for now until we've got the kerberos ticket persistence/retrieval logic extracted from `lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb`

Naming convention:
- We could have went for `cred klist` here - but that doesn't seem viable with the current data model
- `klist` shadows the existing system `klist` command, which is considered fine for now

klist:

```
msf6 auxiliary(gather/ldap_query) > klist
Kerberos Cache
==============
host            principal                 sname                           issued                     status       path
----            ---------                 -----                           ------                     ------       ----
192.168.123.13  Administrator@ADF3.LOCAL  krbtgt/ADF3.LOCAL@ADF3.LOCAL    2022-12-14 13:11:50 +0000  >>expired<<  /Users/adfoster/.msf4/loot/20221214011150_default_192.168.123.13_mit.kerberos.cca_905332.bin
192.168.123.13  Administrator@ADF3.LOCAL  http/dc3.adf3.local@ADF3.LOCAL  2022-12-14 13:11:50 +0000  >>expired<<  /Users/adfoster/.msf4/loot/20221214011150_default_192.168.123.13_mit.kerberos.cca_849328.bin
192.168.123.13  Administrator@ADF3.LOCAL  krbtgt/ADF3.LOCAL@ADF3.LOCAL    2022-12-15 15:12:02 +0000  valid        /Users/adfoster/.msf4/loot/20221215211202_default_192.168.123.13_mit.kerberos.cca_766098.bin
192.168.123.13  Administrator@ADF3.LOCAL  http/dc3.adf3.local@ADF3.LOCAL  2022-12-15 15:13:05 +0000  valid        /Users/adfoster/.msf4/loot/20221215211305_default_192.168.123.13_mit.kerberos.cca_710112.bin
```

klist -v:

```
msf6 auxiliary(scanner/winrm/winrm_login) > klist -v
Kerberos Cache
==============
Cache[0]:
  Primary Principal: Administrator@ADF3.LOCAL
  Ccache version: 4

  Creds: 1
    Credential[0]:
      Server: krbtgt/ADF3.LOCAL@ADF3.LOCAL
      Client: Administrator@ADF3.LOCAL
      Ticket etype: 18 (AES256)
      Key: 9c66cb7de8f4d3100690771a753012eafa44a3d128342939ff9230b39aeb1713
      Subkey: false
      Ticket Length: 1090
      Ticket Flags: 0x50e10000 (FORWARDABLE, PROXIABLE, RENEWABLE, INITIAL, PRE_AUTHENT, CANONICALIZE)
      Addresses: 0
      Authdatas: 0
      Times:
        Auth time: 2022-12-13 12:57:49 +0000
        Start time: 2022-12-13 12:57:49 +0000
        End time: 2022-12-13 22:57:49 +0000
        Renew Till: 2022-12-14 12:57:49 +0000
      Ticket:
        Ticket Version Number: 5
        Realm: ADF3.LOCAL
        Server Name: krbtgt/ADF3.LOCAL
        Encrypted Ticket Part:
          Ticket etype: 18 (AES256)
          Key Version Number: 2
          Cipher:
          ...etc etc...
```

## Verification

List the steps needed to make sure this thing works

- [ ] Acquire tickets, with smb_login:
```
msf6 auxiliary(scanner/smb/smb_login) > run smb://adf3.local;Administrator:p4$$w0rd@192.168.123.13 domaincontrollerrhost=192.168.123.13 smbauth=kerberos smbrhostname=dc3.adf3.local smbdomain=ADF3.LOCAL verbose=true
[*] Reloading module...

[*] 192.168.123.13:445    - 192.168.123.13:445 - Starting SMB login bruteforce
[+] 192.168.123.13:445    - 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:445    - 192.168.123.13:88 - TGT MIT Credential Cache saved to /Users/adfoster/.msf4/loot/20221213130846_default_192.168.123.13_mit.kerberos.cca_768912.bin
[+] 192.168.123.13:445    - 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:445    - 192.168.123.13:88 - TGS MIT Credential Cache saved to /Users/adfoster/.msf4/loot/20221213130846_default_192.168.123.13_mit.kerberos.cca_908013.bin
[+] 192.168.123.13:445    - 192.168.123.13:88 - Received a valid delegation TGS-Response
... etc ..
```
- [ ] Verify `klist` and `klist -v` output values 