### PR TITLE
Extract db command helpers to standalone module

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -16,7 +16,8 @@ class Db
 
   include Msf::Ui::Console::CommandDispatcher
   include Msf::Ui::Console::CommandDispatcher::Common
-  include Msf::Ui::Console::CommandDispatcher::Analyze
+  include Msf::Ui::Console::CommandDispatcher::Db::Common
+  include Msf::Ui::Console::CommandDispatcher::Db::Analyze
 
   DB_CONFIG_PATH = 'framework/database'
 
@@ -84,21 +85,6 @@ class Db
     if result[:data_service_name]
       @current_data_service = result[:data_service_name]
     end
-  end
-
-  #
-  # Returns true if the db is connected, prints an error and returns
-  # false if not.
-  #
-  # All commands that require an active database should call this before
-  # doing anything.
-  #
-  def active?
-    if not framework.db.active
-      print_error("Database not connected")
-      return false
-    end
-    true
   end
 
   @@workspace_opts = Rex::Parser::Arguments.new(
@@ -2129,48 +2115,6 @@ class Db
       return
     end
     true
-  end
-
-
-  #
-  # Miscellaneous option helpers
-  #
-
-  #
-  # Takes +host_ranges+, an Array of RangeWalkers, and chunks it up into
-  # blocks of 1024.
-  #
-  def each_host_range_chunk(host_ranges, &block)
-    # Chunk it up and do the query in batches. The naive implementation
-    # uses so much memory for a /8 that it's basically unusable (1.6
-    # billion IP addresses take a rather long time to allocate).
-    # Chunking has roughly the same performance for small batches, so
-    # don't worry about it too much.
-    host_ranges.each do |range|
-      if range.nil? or range.length.nil?
-        chunk = nil
-        end_of_range = true
-      else
-        chunk = []
-        end_of_range = false
-        # Set up this chunk of hosts to search for
-        while chunk.length < 1024 and chunk.length < range.length
-          n = range.next_ip
-          if n.nil?
-            end_of_range = true
-            break
-          end
-          chunk << n
-        end
-      end
-
-      # The block will do some
-      yield chunk
-
-      # Restart the loop with the same RangeWalker if we didn't get
-      # to the end of it in this chunk.
-      redo unless end_of_range
-    end
   end
 
   #######

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -1,4 +1,4 @@
-module Msf::Ui::Console::CommandDispatcher::Analyze
+module Msf::Ui::Console::CommandDispatcher::Db::Analyze
 
   def cmd_analyze_help
     print_line "Usage: analyze [OPTIONS] [addr1 addr2 ...]"

--- a/lib/msf/ui/console/command_dispatcher/db/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/common.rb
@@ -1,0 +1,60 @@
+# -*- coding: binary -*-
+
+module Msf::Ui::Console::CommandDispatcher::Db::Common
+
+  #
+  # Returns true if the db is connected, prints an error and returns
+  # false if not.
+  #
+  # All commands that require an active database should call this before
+  # doing anything.
+  #
+  def active?
+    unless framework.db.active
+      print_error("Database not connected")
+      return false
+    end
+    true
+  end
+
+  #
+  # Miscellaneous option helpers
+  #
+
+  #
+  # Takes +host_ranges+, an Array of RangeWalkers, and chunks it up into
+  # blocks of 1024.
+  #
+  def each_host_range_chunk(host_ranges, &block)
+    # Chunk it up and do the query in batches. The naive implementation
+    # uses so much memory for a /8 that it's basically unusable (1.6
+    # billion IP addresses take a rather long time to allocate).
+    # Chunking has roughly the same performance for small batches, so
+    # don't worry about it too much.
+    host_ranges.each do |range|
+      if range.nil? or range.length.nil?
+        chunk = nil
+        end_of_range = true
+      else
+        chunk = []
+        end_of_range = false
+        # Set up this chunk of hosts to search for
+        while chunk.length < 1024 and chunk.length < range.length
+          n = range.next_ip
+          if n.nil?
+            end_of_range = true
+            break
+          end
+          chunk << n
+        end
+      end
+
+      # The block will do some
+      yield chunk
+
+      # Restart the loop with the same RangeWalker if we didn't get
+      # to the end of it in this chunk.
+      redo unless end_of_range
+    end
+  end
+end

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -75,7 +75,6 @@ class MsfAutoload
       "#{__dir__}/msf/core/payload/linux/x64",
       "#{__dir__}/msf/core/web_services/servlet",
       "#{__dir__}/msf/base",
-      "#{__dir__}/msf/ui/console/command_dispatcher/db",
       "#{__dir__}/rex/parser/fs"
     ]
   end


### PR DESCRIPTION
This PR does a small code shuffle in preparation for https://github.com/rapid7/metasploit-framework/pull/17374

- Fix `Db` namespace for the analyze command
- Fix zeitwerk `Db` `collapse_list ` namespace hack
- Move db helpers into a common module

## Verification

- [ ] Start `msfconsole`
- [ ] Verify the `creds` command still works when connected to the database or not