### PR TITLE
Consolidate Kerberos Ticket Storage

### DIFF
--- a/lib/metasploit/framework/mssql/client.rb
+++ b/lib/metasploit/framework/mssql/client.rb
@@ -64,7 +64,8 @@ module Metasploit
               username: user,
               password: pass,
               framework: framework,
-              framework_module: framework_module
+              framework_module: framework_module,
+              ticket_storage: Msf::Exploit::Remote::Kerberos::Ticket::Storage::WriteOnly.new(framework: framework, framework_module: framework_module)
             )
 
             kerberos_result = kerberos_authenticator.authenticate

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -61,13 +61,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   @return [String] whether to send delegated creds (from the set Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base::Delegation)
   attr_reader :send_delegated_creds
 
-  # @!attribute [r] use_cached_credentials
-  #   @return [String] whether to use cached Kerberos credentials from the database
-  attr_reader :use_cached_credentials
-
-  # @!attribute [r] store_credential_cache
-  #   @return [String] whether to store Kerberos TGS MIT Credential Cache to the database
-  attr_reader :store_credential_cache
+  # @!attribute [r] ticket_storage
+  #   @return [Msf::Exploit::Remote::Kerberos::Kicket::Storage::Base] the ticket storage driver
+  attr_reader :ticket_storage
 
   # @!attribute [r] key
   #   @return [String] the encryption key for authentication
@@ -114,6 +110,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       cache_file: nil,
       use_cached_credentials: true,
       store_credential_cache: true,
+      ticket_storage: nil,
       key: nil,
       etype: nil
   )
@@ -130,8 +127,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @use_gss_checksum = use_gss_checksum
     @mechanism = mechanism
     @send_delegated_creds = send_delegated_creds
-    @use_cached_credentials = use_cached_credentials
-    @store_credential_cache = store_credential_cache
+    @ticket_storage = ticket_storage || Msf::Exploit::Remote::Kerberos::Ticket::Storage::ReadWrite.new(
+      framework: framework,
+      framework_module: framework_module
+    )
     @key = key
     @etype = etype
 
@@ -175,7 +174,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       if @credential
         # use an explicit credential
         options[:credential] = @credential
-      elsif use_cached_credentials
+      else
         # load a cached TGS
         options[:credential] = get_cached_credential(options)
         unless options[:credential]
@@ -283,28 +282,25 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   end
 
   # @param [Hash] options
-  # @option options [Boolean] :use_cached_credentials Override the @use_cached_credentials attribute
+  # @option options [Boolean] :ticket_storage Override the @ticket_storage attribute
   # @see #authenticate_via_kdc Options documentation
   # @see #get_cached_credential Other options documentation
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential
   def request_tgt_only(options = {})
-    credential = nil
-    if options.fetch(:use_cached_credentials) { use_cached_credentials }
-      credential = get_cached_credential(
-        options.merge(
-          sname: Rex::Proto::Kerberos::Model::PrincipalName.new(
-            name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
-            name_string: [
-              "krbtgt",
-              realm
-            ]
-          )
+    credential = get_cached_credential(
+      options.merge(
+        sname: Rex::Proto::Kerberos::Model::PrincipalName.new(
+          name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+          name_string: [
+            "krbtgt",
+            realm
+          ]
         )
       )
-      if credential
-        print_status("#{peer} - Using cached credential for #{credential.server} #{credential.client}")
-        return credential
-      end
+    )
+    if credential
+      print_status("#{peer} - Using cached credential for #{credential.server} #{credential.client}")
+      return credential
     end
 
     auth_context = authenticate_via_kdc(options)
@@ -312,20 +308,17 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   end
 
   # @param [Hash] options
-  # @option options [Boolean] :use_cached_credentials Override the @use_cached_credentials attribute
+  # @option options [Boolean] :ticket_storage Override the @ticket_storage attribute
   # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] :credential
   #   The ccache credential from the TGT
   # @see #authenticate_via_krb5_ccache_credential_tgt Options dcoumentation
   # @see #get_cached_credential Other options dcoumentation
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential
   def request_tgs_only(credential, options = {})
-    if options.fetch(:use_cached_credentials) { use_cached_credentials }
-      # load a cached TGS
-      ccache = get_cached_credential(options)
-      if ccache
-        print_status("#{peer} - Using cached credential for #{ccache.server} #{ccache.client}")
-        return ccache
-      end
+    # load a cached TGS
+    if (ccache = get_cached_credential(options))
+      print_status("#{peer} - Using cached credential for #{ccache.server} #{ccache.client}")
+      return ccache
     end
 
     auth_context = authenticate_via_krb5_ccache_credential_tgt(credential, options)
@@ -338,7 +331,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   The ccache credential from the TGT
   # @param [Hash] options
   # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname The target service principal name.
-  # @option options [Boolean] :store_credential_cache Override the @store_credential_cache attribute
+  # @option options [Boolean] :ticket_storage Override the @ticket_storage attribute
   # @option options [String] :impersonate The name of the user to request a ticket on behalf of
   # @return [Array] The TGS ticket and the decrypted TGS credentials as a MIT Cache Credential
   def s4u2self(credential, options = {})
@@ -359,7 +352,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     etypes << Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC
 
     tgs_options = {
-      store_credential_cache: options.fetch(:store_credential_cache) { store_credential_cache },
+      ticket_storage: options.fetch(:ticket_storage, @ticket_storage),
       credential_cache_username: options[:impersonate],
       pa_data: build_pa_for_user(
         {
@@ -390,7 +383,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname The target service principal name.
   # @option options [Rex::Proto::Kerberos::Model::Ticket] :tgs_ticket The service ticket to the first service.
   #   It must have the forwardable flag set. This ticket can be obtained with #s4u2self.
-  # @option options [Boolean] :store_credential_cache Override the @store_credential_cache attribute
+  # @option options [Boolean] :ticket_storage Override the @ticket_storage attribute
   # @option options [String] :impersonate The name of the user to request a ticket on behalf of
   # @return [Array] The new TGS ticket and the decrypted TGS credentials as a MIT Cache Credential
   def s4u2proxy(credential, options = {})
@@ -429,7 +422,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       pa_data: pa_data_entry,
       additional_flags: [Rex::Proto::Kerberos::Model::KdcOptionFlags::CNAME_IN_ADDL_TKT],
       additional_tickets: [options[:tgs_ticket]],
-      store_credential_cache: options.fetch(:store_credential_cache) { store_credential_cache },
+      ticket_storage: options.fetch(:ticket_storage, @ticket_storage),
       credential_cache_username: options[:impersonate]
     }
 
@@ -485,10 +478,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     print_good("#{peer} - Received a valid TGT-Response")
 
     ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, tgt_result.decrypted_part)
-
-    if store_credential_cache
-      Msf::Exploit::Remote::Kerberos::TicketStorage.new(framework_module: @framework_module).store_ccache(ccache, host: rhost)
-    end
+    options.fetch(:ticket_storage, @ticket_storage).store_ccache(ccache, host: rhost)
 
     credential = ccache.credentials.first
     session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
@@ -579,7 +569,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     etypes = Set.new([ticket.enc_part.etype])
     tgs_options = {
       pa_data: [],
-      store_credential_cache: store_credential_cache
+      ticket_storage: ticket_storage
     }
 
     tgs_ticket, tgs_auth = request_service_ticket(
@@ -786,7 +776,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   Any additional tickets to add to the request
   # @option options [Array<Rex::Proto::Kerberos::Model::PreAuthDataEntry>] :pa_data
   #   Any additional pre-auth data entries to add to the request
-  # @option options [Boolean] :store_credential_cache Override the @store_credential_cache attribute
+  # @option options [Boolean] :ticket_storage Override the @ticket_storage attribute
   # @option options [String] :credential_cache_username The name of user
   #   corresponding to the requested TGS ticket. This name will be used in
   #   the info field when the tickets is stored in the database. This can be used
@@ -856,24 +846,22 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     print_good("#{peer} - Received a valid TGS-Response")
 
-    if options.fetch(:store_credential_cache) { store_credential_cache }
-      ccache = extract_kerb_creds(
-        tgs_res,
-        session_key.value,
-        msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
-      )
-      if options[:credential_cache_username].present?
-        client = options[:credential_cache_username]
-      else
-        client = self.username
-      end
-      Msf::Exploit::Remote::Kerberos::TicketStorage.new(framework_module: @framework_module).store_ccache(
-        ccache,
-        host: rhost,
-        client: client,
-        server: sname
-      )
+    ccache = extract_kerb_creds(
+      tgs_res,
+      session_key.value,
+      msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
+    )
+    if options[:credential_cache_username].present?
+      client = options[:credential_cache_username]
+    else
+      client = self.username
     end
+    options.fetch(:ticket_storage, @ticket_storage).store_ccache(
+      ccache,
+      host: rhost,
+      client: client,
+      server: sname
+    )
 
     tgs_ticket = tgs_res.ticket
     tgs_auth = decrypt_kdc_tgs_rep_enc_part(
@@ -891,7 +879,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CacheCredential] the credential object for authentication
   # @return [nil] returned if the database is not connected or no usable credentials are found
   def get_cached_credential(options = {})
-    Msf::Exploit::Remote::Kerberos::TicketStorage.new(framework_module: self).load_credential(
+    driver = options.fetch(:ticket_storage, @ticket_storage)
+    driver.load_credential(
       host: rhost,
       client: options.fetch(:username) { self.username },
       server: options.fetch(:sname, nil),

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -284,7 +284,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
   # @param [Hash] options
   # @option options [Boolean] :use_cached_credentials Override the @use_cached_credentials attribute
-  # @see #authenticate_via_kdc Options dcoumentation
+  # @see #authenticate_via_kdc Options documentation
   # @see #get_cached_credential Other options documentation
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential
   def request_tgt_only(options = {})
@@ -484,14 +484,13 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     print_good("#{peer} - Received a valid TGT-Response")
 
-    cache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, tgt_result.decrypted_part)
+    ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, tgt_result.decrypted_part)
 
     if store_credential_cache
-      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode, nil, loot_info(sname: server_name))
-      print_status("#{peer} - TGT MIT Credential Cache saved to #{path}")
+      Msf::Exploit::Remote::Kerberos::TicketStorage.new(framework_module: @framework_module).store_ccache(ccache, host: rhost)
     end
 
-    credential = cache.credentials.first
+    credential = ccache.credentials.first
     session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
       type: credential.keyblock.enctype.value,
       value: credential.keyblock.data.value
@@ -858,15 +857,22 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     print_good("#{peer} - Received a valid TGS-Response")
 
     if options.fetch(:store_credential_cache) { store_credential_cache }
-      cache = extract_kerb_creds(
+      ccache = extract_kerb_creds(
         tgs_res,
         session_key.value,
         msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
       )
-      loot_options = { sname: sname }
-      loot_options[:username] = options[:credential_cache_username] if options[:credential_cache_username].present?
-      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, cache.encode, nil, loot_info(loot_options))
-      print_status("#{peer} - TGS MIT Credential Cache saved to #{path}")
+      if options[:credential_cache_username].present?
+        client = options[:credential_cache_username]
+      else
+        client = self.username
+      end
+      Msf::Exploit::Remote::Kerberos::TicketStorage.new(framework_module: @framework_module).store_ccache(
+        ccache,
+        host: rhost,
+        client: client,
+        server: sname
+      )
     end
 
     tgs_ticket = tgs_res.ticket
@@ -885,21 +891,12 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CacheCredential] the credential object for authentication
   # @return [nil] returned if the database is not connected or no usable credentials are found
   def get_cached_credential(options = {})
-    return nil unless active_db?
-
-    now = Time.now.utc
-    host = report_host(workspace: myworkspace, host: @host)
-    framework.db.loot(workspace: myworkspace, host: host, ltype: 'mit.kerberos.ccache', info: loot_info(options)).each do |stored_loot|
-      ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(stored_loot.data)
-      # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
-      credential = ccache.credentials.first
-
-      tkt_start = credential.starttime == Time.at(0).utc ? credential.authtime : credential.starttime
-      tkt_end = credential.endtime
-      return credential if tkt_start < now && now < tkt_end
-    end
-
-    nil
+    Msf::Exploit::Remote::Kerberos::TicketStorage.new(framework_module: self).load_credential(
+      host: rhost,
+      client: options.fetch(:username) { self.username },
+      server: options.fetch(:sname, nil),
+      realm: options.fetch(:realm) { self.realm }
+    )
   end
 
   # Load a credential object from a file for authentication. Credentials in the file will be filtered by multiple
@@ -956,20 +953,5 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     end
 
     nil
-  end
-
-  # Build a loot info string that can later be used in a lookup.
-  #
-  # @param [Hash] options
-  # @option options [String] :realm the ticket realm
-  # @option options [String] :sname the ticket service name
-  # @option options [String] :username the ticket username
-  # @return [String] the info string
-  def loot_info(options = {})
-    Msf::Exploit::Remote::Kerberos::Ticket.loot_info(
-      client: options.fetch(:username) { self.username },
-      server: options.fetch(:sname, nil),
-      realm: options.fetch(:realm) { self.realm }
-    )
   end
 end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -961,17 +961,15 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # Build a loot info string that can later be used in a lookup.
   #
   # @param [Hash] options
-  # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname the service name (optional)
+  # @option options [String] :realm the ticket realm
+  # @option options [String] :sname the ticket service name
+  # @option options [String] :username the ticket username
   # @return [String] the info string
   def loot_info(options = {})
-    info = []
-
-    info << "realm: #{self.realm.upcase}" if self.realm
-    info << "serviceName: #{options[:sname].to_s.downcase}" if options[:sname]
-    username = options.fetch(:username) { self.username }
-    info << "username: #{username.downcase}" if username
-
-    info.join(', ')
+    Msf::Exploit::Remote::Kerberos::Ticket.loot_info(
+      client: options.fetch(:username) { self.username },
+      server: options.fetch(:sname, nil),
+      realm: options.fetch(:realm) { self.realm }
+    )
   end
-
 end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -41,7 +41,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   @return [Msf::Framework] the Metasploit framework instance
   attr_reader :framework
 
-  # @!attribute [r] framework
+  # @!attribute [r] framework_module
   #   @return [Msf::Module] the Metasploit framework module that is associated with the authentication instance
   attr_reader :framework_module
 
@@ -62,7 +62,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   attr_reader :send_delegated_creds
 
   # @!attribute [r] ticket_storage
-  #   @return [Msf::Exploit::Remote::Kerberos::Kicket::Storage::Base] the ticket storage driver
+  #   @return [Msf::Exploit::Remote::Kerberos::Ticket::Storage::Base] the ticket storage driver
   attr_reader :ticket_storage
 
   # @!attribute [r] key

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -108,8 +108,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       mechanism: Rex::Proto::Gss::Mechanism::SPNEGO,
       send_delegated_creds: Delegation::ALWAYS,
       cache_file: nil,
-      use_cached_credentials: true,
-      store_credential_cache: true,
       ticket_storage: nil,
       key: nil,
       etype: nil

--- a/lib/msf/core/exploit/remote/kerberos/ticket.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket.rb
@@ -63,7 +63,7 @@ module Msf
             ccache = ticket_as_krb5ccache(ticket, opts: opts)
 
             if save_ccache
-              Kerberos::TicketStorage.new(framework_module: self).store_ccache(ccache, host: domain)
+              Kerberos::Ticket::Storage.store_ccache(ccache, host: domain, framework_module: self)
             end
 
             ccache

--- a/lib/msf/core/exploit/remote/kerberos/ticket.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket.rb
@@ -63,10 +63,9 @@ module Msf
             ccache = ticket_as_krb5ccache(ticket, opts: opts)
 
             if save_ccache
-              loot_info = Kerberos::Ticket.loot_info(opts)
-              path = store_loot('mit.kerberos.ccache', 'application/octet-stream', domain, ccache.encode, nil, loot_info)
-              print_good("MIT Credential Cache ticket saved on #{path}")
+              Kerberos::TicketStorage.new(framework_module: self).store_ccache(ccache, host: domain)
             end
+
             ccache
           end
 
@@ -178,31 +177,6 @@ module Msf
           def print_ccache_contents(ccache, key: nil)
             presenter = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter.new(ccache)
             print_status presenter.present(key: key)
-          end
-
-          # Build a loot info string that can later be used in a lookup.
-          #
-          # @param [Hash] options
-          # @option options [String] :realm the realm of the ticket (optional)
-          # @option options [String] :server the service name of the ticket (optional)
-          # @option options [String] :client the client username of the ticket (optional)
-          # @option options [Boolean] :valid whether or not the ticket is valid, defaults to true (optional)
-          # @return [String] the info string
-          def self.loot_info(options = {})
-            info = []
-
-            info << '[invalid]' if !options.fetch(:valid, true)
-
-            realm = options[:realm]
-            info << "realm: #{realm.to_s.upcase}" if realm.present?
-
-            client = options[:client]
-            info << "client: #{client.to_s.downcase}" if client.present?
-
-            server = options[:server]
-            info << "server: #{server.to_s.downcase}" if server.present?
-
-            info.join(', ')
           end
         end
       end

--- a/lib/msf/core/exploit/remote/kerberos/ticket.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket.rb
@@ -63,12 +63,8 @@ module Msf
             ccache = ticket_as_krb5ccache(ticket, opts: opts)
 
             if save_ccache
-              info = []
-              info << "realm: #{opts[:realm].upcase}"
-              info << "serviceName: #{opts[:server].to_s.downcase}"
-              info << "username: #{opts[:client].to_s.downcase}"
-
-              path = store_loot('mit.kerberos.ccache', 'application/octet-stream', domain, ccache.encode, nil, info.join(', '))
+              loot_info = Kerberos::Ticket.loot_info(opts)
+              path = store_loot('mit.kerberos.ccache', 'application/octet-stream', domain, ccache.encode, nil, loot_info)
               print_good("MIT Credential Cache ticket saved on #{path}")
             end
             ccache
@@ -182,6 +178,31 @@ module Msf
           def print_ccache_contents(ccache, key: nil)
             presenter = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter.new(ccache)
             print_status presenter.present(key: key)
+          end
+
+          # Build a loot info string that can later be used in a lookup.
+          #
+          # @param [Hash] options
+          # @option options [String] :realm the realm of the ticket (optional)
+          # @option options [String] :server the service name of the ticket (optional)
+          # @option options [String] :client the client username of the ticket (optional)
+          # @option options [Boolean] :valid whether or not the ticket is valid, defaults to true (optional)
+          # @return [String] the info string
+          def self.loot_info(options = {})
+            info = []
+
+            info << '[invalid]' if !options.fetch(:valid, true)
+
+            realm = options[:realm]
+            info << "realm: #{realm.to_s.upcase}" if realm.present?
+
+            client = options[:client]
+            info << "client: #{client.to_s.downcase}" if client.present?
+
+            server = options[:server]
+            info << "server: #{server.to_s.downcase}" if server.present?
+
+            info.join(', ')
           end
         end
       end

--- a/lib/msf/core/exploit/remote/kerberos/ticket.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket.rb
@@ -63,7 +63,7 @@ module Msf
             ccache = ticket_as_krb5ccache(ticket, opts: opts)
 
             if save_ccache
-              Kerberos::Ticket::Storage.store_ccache(ccache, host: domain, framework_module: self)
+              Kerberos::Ticket::Storage.store_ccache(ccache, framework_module: self)
             end
 
             ccache

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
@@ -14,7 +14,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket
           Msf::OptEnum.new(
             'KrbCacheMode', [
               true,
-              'Kerberos ticket cache mode',
+              'Kerberos ticket cache storage mode',
               'read-write',
               %w[ none read-only write-only read-write ]
             ]

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
@@ -1,0 +1,10 @@
+require 'msf/core/exploit/remote/kerberos/ticket/storage/base'
+
+module Msf::Exploit::Remote::Kerberos::Ticket
+  module Storage
+    def self.store_ccache(ccache, options = {})
+      driver = WriteOnly.new(framework_module: options[:framework_module])
+      driver.store_ccache(ccache, options)
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
@@ -6,5 +6,54 @@ module Msf::Exploit::Remote::Kerberos::Ticket
       driver = WriteOnly.new(framework_module: options[:framework_module])
       driver.store_ccache(ccache, options)
     end
+
+    def initialize(info = {})
+      super
+      register_advanced_options(
+        [
+          Msf::OptEnum.new(
+            'KrbCacheMode', [
+              true,
+              'Kerberos ticket cache mode',
+              'read-write',
+              %w[ none read-only write-only read-write ]
+            ]
+          )
+        ]
+      )
+    end
+
+    # @param [Hash] options Options used to select the ticket storage driver backend. If this option is present, it
+    #   overrides the datastore configuration. All options it contains default to true, meaning it should only be
+    #   necessary to specify the operations (e.g. read) that should be disabled.
+    # @option options [Boolean] read Whether or not the storage mechanism should support reading
+    # @option options [Boolean] write Whether or not the storage mechanism should support writing
+    def kerberos_ticket_storage(options = {})
+      if options.present?
+        case [options.fetch(:read, true), options.fetch(:write, true)]
+        when [false, false]
+          mode = 'none'
+        when [false, true]
+          mode = 'write-only'
+        when [true, false]
+          mode = 'read-only'
+        when [true, true]
+          mode = 'read-write'
+        end
+      else
+        mode = datastore['KrbCacheMode']
+      end
+
+      case mode
+      when 'none'
+        None.new(framework_module: self)
+      when 'read-only'
+        ReadOnly.new(framework_module: self)
+      when 'write-only'
+        WriteOnly.new(framework_module: self)
+      when 'read-write'
+        ReadWrite.new(framework_module: self)
+      end
+    end
   end
 end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
@@ -2,6 +2,10 @@ require 'msf/core/exploit/remote/kerberos/ticket/storage/base'
 
 module Msf::Exploit::Remote::Kerberos::Ticket
   module Storage
+    # Storage a credential cache object.
+    #
+    # @param [Hash] options See the options description in Base#tickets.
+    # @option options [Msf::Module] The framework module associated with the store operation.
     def self.store_ccache(ccache, options = {})
       driver = WriteOnly.new(framework_module: options[:framework_module])
       driver.store_ccache(ccache, options)
@@ -23,6 +27,8 @@ module Msf::Exploit::Remote::Kerberos::Ticket
       )
     end
 
+    # Build a ticket storage object based on either the specified options or the datastore if no options are defined.
+    #
     # @param [Hash] options Options used to select the ticket storage driver backend. If this option is present, it
     #   overrides the datastore configuration. All options it contains default to true, meaning it should only be
     #   necessary to specify the operations (e.g. read) that should be disabled.

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
@@ -21,16 +21,18 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       @framework_module = framework_module
     end
 
-    # return [Array<FixMeKrbObj>]
-    def delete_credentials(options = {})
+    # return [Array<StoredTicket>]
+    def delete_tickets(options = {})
       []
     end
 
-    # return [Array<FixMeKrbObj>]
-    def credentials(options = {}, &block)
+    # return [Array<StoredTicket>]
+    def tickets(options = {}, &block)
       []
     end
 
+    # Load a stored credential object that is suitable for authenticaiton.
+    #
     # return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] credential
     def load_credential(options = {})
       nil

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
@@ -19,6 +19,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
     # Delete tickets matching the options query.
     #
     # @param [Hash] options See the options hash description in {#tickets}.
+    # @option options [Array<Integer>] :ids The identifiers of the tickets to delete (optional)
     # @return [Array<StoredTicket>]
     def delete_tickets(options = {})
       []
@@ -29,6 +30,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
     # @param [Hash] options The options for matching tickets. The :realm, :server, :client and :status options are all
     #   processed as a group. If any one or more of them are specified, they are all used for filtering. It can not for
     #   example specify client and fetch all tickets for a particular client where the server is different.
+    # @option options [Integer, Array<Integer>] :id The identifier of the ticket (optional)
     # @option options [String] :host The host for the ticket (optional)
     # @option options [String] :realm The realm of the ticket (optional)
     # @option options [String] :server The service name of the ticket (optional)
@@ -88,6 +90,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       return [] unless active_db?
 
       filter = {}
+      filter[:id] = options[:id] if options[:id].present?
       if options[:host].present?
         if options[:host].is_a?(Mdm::Host)
           filter[:host] = options[:host]

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
@@ -7,7 +7,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
     #   @return [Msf::Framework] the Metasploit framework instance
     attr_reader :framework
 
-    # @!attribute [r] framework
+    # @!attribute [r] framework_module
     #   @return [Msf::Module] the Metasploit framework module that is associated with the authentication instance
     attr_reader :framework_module
 
@@ -21,24 +21,43 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       @framework_module = framework_module
     end
 
-    # return [Array<StoredTicket>]
+    # Delete tickets matching the options query.
+    #
+    # @param [Hash] options See the options hash description in {#tickets}.
+    # @return [Array<StoredTicket>]
     def delete_tickets(options = {})
       []
     end
 
-    # return [Array<StoredTicket>]
+    # Get stored tickets matching the options query.
+    #
+    # @param [Hash] options The options for matching tickets. The :realm, :server, :client and :status options are all
+    #   processed as a group. If any one or more of them are specified, they are all used for filtering. It can not for
+    #   example specify client and fetch all tickets for a particular client where the server is different.
+    # @option options [String] :host The host for the ticket (optional)
+    # @option options [String] :realm The realm of the ticket (optional)
+    # @option options [String] :server The service name of the ticket (optional)
+    # @option options [String] :client The client username of the ticket (optional)
+    # @option options [Symbol] :status The ticket status, defaults to valid (optional)
+    # @return [Array<StoredTicket>]
     def tickets(options = {}, &block)
       []
     end
 
-    # Load a stored credential object that is suitable for authenticaiton.
+    # Load a stored credential object that is suitable for authentication.
     #
-    # return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] credential
+    # @param [Hash] options See the options description in #tickets.
+    # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential, nil] credential The credential if one was
+    #   found.
     def load_credential(options = {})
       nil
     end
 
-    # @param [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache] ccache
+    # Store the specified object.
+    #
+    # @param [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache] ccache The credential cache object to store.
+    # @param [Hash] options The information associated with the stored object. See the options hash description in
+    #   {#tickets}.
     # @return [nil]
     def store_ccache(ccache, options = {})
       nil
@@ -46,7 +65,10 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
 
     private
 
-    # return [Array<Mdm::Loot>]
+    # Return the raw stored objects.
+    #
+    # @param [Hash] options See the options hash description in {#tickets}.
+    # @return [Array<Mdm::Loot>]
     def objects(options, &block)
       return [] unless active_db?
 
@@ -68,16 +90,12 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
 
     # Build a loot info string that can later be used in a lookup.
     #
-    # @param [Hash] options
-    # @option options [String] :realm the realm of the ticket (optional)
-    # @option options [String] :server the service name of the ticket (optional)
-    # @option options [String] :client the client username of the ticket (optional)
-    # @option options [Boolean] :valid whether or not the ticket is valid, defaults to true (optional)
     # @return [String] the info string
     def loot_info(options = {})
       info = []
 
-      info << '[invalid]' if !options.fetch(:valid, true)
+      status = options.fetch(:status, :valid).downcase.to_sym
+      info << "status: #{status}" unless status == :valid
 
       realm = options[:realm]
       info << "realm: #{realm.to_s.upcase}" if realm.present?

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
@@ -11,11 +11,6 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
     #   @return [Msf::Module] the Metasploit framework module that is associated with the authentication instance
     attr_reader :framework_module
 
-    def_delegators :@framework_module,
-                  :print_status,
-                  :print_good,
-                  :workspace
-
     def initialize(framework: nil, framework_module: nil)
       @framework = framework || framework_module&.framework
       @framework_module = framework_module
@@ -63,7 +58,27 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       nil
     end
 
+    # @return [String] The name of the workspace in which to operate.
+    def workspace
+      if @framework_module
+        return @framework_module.workspace
+      elsif @framework&.db&.active
+        return @framework.db.workspace&.name
+      end
+    end
+
     private
+
+    # Forward whatever method calls this to the specified framework module, but
+    # only if it's present otherwise return nil.
+    def proxied_module_method(*args, **kwargs)
+      return nil unless @framework_module
+
+      @framework_module.send(__callee__, *args, **kwargs)
+    end
+
+    alias :print_good :proxied_module_method
+    alias :print_status :proxied_module_method
 
     # Return the raw stored objects.
     #

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
@@ -1,7 +1,6 @@
-module Msf::Exploit::Remote::Kerberos
-  class TicketStorage
+module Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  class Base
     extend Forwardable
-    include Msf::Exploit::Remote::Kerberos::Client
     include Msf::Auxiliary::Report
 
     # @!attribute [r] framework
@@ -15,7 +14,6 @@ module Msf::Exploit::Remote::Kerberos
     def_delegators :@framework_module,
                   :print_status,
                   :print_good,
-                  :vprint_error,
                   :workspace
 
     def initialize(framework: nil, framework_module: nil)
@@ -23,62 +21,30 @@ module Msf::Exploit::Remote::Kerberos
       @framework_module = framework_module
     end
 
+    # return [Array<FixMeKrbObj>]
     def delete_credentials(options = {})
-      creds = credentials(options)
-      framework.db.delete_loot(ids: creds.map(&:id))
-      creds
+      []
     end
 
+    # return [Array<FixMeKrbObj>]
     def credentials(options = {}, &block)
-      objects(options) do |stored_loot|
-        ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(stored_loot.data)
-        # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
-        credential = ccache.credentials.first
-        block.call(credential) if block_given?
-        credential
-      end
+      []
     end
 
+    # return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] credential
     def load_credential(options = {})
-      return nil unless active_db?
-
-      now = Time.now.utc
-      credentials(options) do |credential|
-        tkt_start = credential.starttime == Time.at(0).utc ? credential.authtime : credential.starttime
-        tkt_end = credential.endtime
-        return credential if tkt_start < now && now < tkt_end
-      end
-
       nil
     end
 
     # @param [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache] ccache
     # @return [nil]
     def store_ccache(ccache, options = {})
-      realm = options.fetch(:realm) { ccache.default_principal.realm }
-      # use #components.to_a.join('/') to omit the realm that #to_s includes
-      client = options.fetch(:client) { ccache.credentials.first&.client&.components.to_a.join('/') }
-      server = options.fetch(:server) { ccache.credentials.first&.server&.components.to_a.join('/') }
-      info = loot_info(realm: realm, client: client, server: server)
-
-      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', options[:host], ccache.encode, nil, info)
-      message = ''
-      if @framework_module.respond_to?(:peer) && @framework_module.peer.present? && @framework_module.peer != ':'
-        message << "#{@framework_module.peer} - "
-      end
-      if server && server.to_s.downcase.start_with?('krbtgt/')
-        message << 'TGT '
-      else
-        message << 'TGS '
-      end
-      message << "MIT Credential Cache ticket saved to #{path}"
-      print_status(message)
-
       nil
     end
 
     private
 
+    # return [Array<Mdm::Loot>]
     def objects(options, &block)
       return [] unless active_db?
 
@@ -94,7 +60,7 @@ module Msf::Exploit::Remote::Kerberos
         filter[:info] = info
       end
       framework.db.loots(workspace: myworkspace, ltype: 'mit.kerberos.ccache', **filter).each do |stored_loot|
-        block.call(stored_loot)
+        block.call(stored_loot) if block_given?
       end
     end
 
@@ -124,4 +90,3 @@ module Msf::Exploit::Remote::Kerberos
     end
   end
 end
-

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/none.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/none.rb
@@ -1,0 +1,4 @@
+module Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  class None < Base
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb
@@ -1,5 +1,7 @@
 module Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  # A mixin providing the ability to read previously stored tickets.
   module ReadMixin
+    # (see Base#load_credential)
     def load_credential(options = {})
       return nil unless active_db?
 
@@ -13,6 +15,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       nil
     end
 
+    # (see Base#tickets)
     def tickets(options = {}, &block)
       objects(options).map do |stored_loot|
         stored_ticket = StoredTicket.new(stored_loot)

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb
@@ -1,0 +1,28 @@
+module Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  module ReadMixin
+    # return [Array<FixMeKrbObj>]
+    def credentials(options = {}, &block)
+      objects(options) do |stored_loot|
+        ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(stored_loot.data)
+        # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
+        credential = ccache.credentials.first
+        block.call(credential) if block_given?
+        credential
+      end
+    end
+
+    # return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] credential
+    def load_credential(options = {})
+      return nil unless active_db?
+
+      now = Time.now.utc
+      credentials(options) do |credential|
+        tkt_start = credential.starttime == Time.at(0).utc ? credential.authtime : credential.starttime
+        tkt_end = credential.endtime
+        return credential if tkt_start < now && now < tkt_end
+      end
+
+      nil
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb
@@ -1,28 +1,24 @@
 module Msf::Exploit::Remote::Kerberos::Ticket::Storage
   module ReadMixin
-    # return [Array<FixMeKrbObj>]
-    def credentials(options = {}, &block)
-      objects(options) do |stored_loot|
-        ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(stored_loot.data)
-        # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
-        credential = ccache.credentials.first
-        block.call(credential) if block_given?
-        credential
-      end
-    end
-
-    # return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] credential
     def load_credential(options = {})
       return nil unless active_db?
 
       now = Time.now.utc
-      credentials(options) do |credential|
-        tkt_start = credential.starttime == Time.at(0).utc ? credential.authtime : credential.starttime
-        tkt_end = credential.endtime
-        return credential if tkt_start < now && now < tkt_end
+      tickets(options) do |ticket|
+        next if ticket.expired?(now)
+
+        return ticket.ccache.credentials.first
       end
 
       nil
+    end
+
+    def tickets(options = {}, &block)
+      objects(options).map do |stored_loot|
+        stored_ticket = StoredTicket.new(stored_loot)
+        block.call(stored_ticket) if block_given?
+        stored_ticket
+      end
     end
   end
 end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_only.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_only.rb
@@ -1,0 +1,5 @@
+module Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  class ReadOnly < Base
+    include ReadMixin
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_write.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_write.rb
@@ -1,0 +1,6 @@
+module Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  class ReadWrite < Base
+    include ReadMixin
+    include WriteMixin
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/stored_ticket.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/stored_ticket.rb
@@ -1,0 +1,63 @@
+module Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  # A StoredTicket object that internally holds a TGT/TGS object. This class abstracts the underlying persistence
+  # implementation, as currently this data is stored as {Mdm::Loot} - but in the future may be migrated to a
+  # {Metasploit::Credential::Login} or similar in the future.
+  class StoredTicket
+    # @param [Mdm::Loot] loot
+    def initialize(loot)
+      @loot = loot
+    end
+
+    def id
+      @loot.id
+    end
+
+    # @return [String] the host address
+    def host_address
+      loot.host && loot.host.address ? loot.host.address : ''
+    end
+
+    def path
+      loot.path
+    end
+
+    def principal
+      credential.client
+    end
+
+    def sname
+      credential.server
+    end
+
+    def starttime
+      credential.starttime
+    end
+
+    # @return [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache]
+    def ccache
+      @ccache ||= Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(loot.data)
+    end
+
+    # @return [String] human readable info about the ticket
+    def info
+      loot.info
+    end
+
+    # @return [TrueClass, FalseClass] True if the ticket is valid within the starttime/authtime/endtime, false otherwise
+    def expired?(now = Time.now)
+      tkt_start = credential.starttime == Time.at(0).utc ? credential.authtime : credential.starttime
+      tkt_end = credential.endtime
+      !(tkt_start < now && now < tkt_end)
+    end
+
+    private
+
+    # @return [Mdm::Loot] loot
+    attr_reader :loot
+
+    def credential
+      # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
+      ccache.credentials.first
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
@@ -3,9 +3,14 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
   module WriteMixin
     # (see Base#delete_tickets)
     def delete_tickets(options = {})
-      objects = objects(options)
-      framework.db.delete_loot(ids: objects.map(&:id))
-      objects.map do |stored_loot|
+      if options.keys == [:ids]
+        # skip calling #objects which issues a query when the IDs are specified
+        ids = options[:ids]
+      else
+        ids = objects(options).map(&:id)
+      end
+
+      framework.db.delete_loot(ids: ids).map do |stored_loot|
         StoredTicket.new(stored_loot)
       end
     end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
@@ -1,5 +1,7 @@
 module Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  # A mixin providing the ability to store new and delete existing tickets.
   module WriteMixin
+    # (see Base#delete_tickets)
     def delete_tickets(options = {})
       objects = objects(options)
       framework.db.delete_loot(ids: objects.map(&:id))
@@ -8,6 +10,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       end
     end
 
+    # (see Base#store_ccache)
     def store_ccache(ccache, options = {})
       realm = options.fetch(:realm) { ccache.default_principal.realm }
       # use #components.to_a.join('/') to omit the realm that #to_s includes

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
@@ -1,0 +1,39 @@
+module Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  module WriteMixin
+    # return [Array<FixMeKrbObj>]
+    def delete_credentials(options = {})
+      objects = objects(options)
+      framework.db.delete_loot(ids: objects.map(&:id))
+      objects.map do |stored_loot|
+        ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(stored_loot.data)
+        # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
+        ccache.credentials.first
+      end
+    end
+
+    # @param [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache] ccache
+    # @return [nil]
+    def store_ccache(ccache, options = {})
+      realm = options.fetch(:realm) { ccache.default_principal.realm }
+      # use #components.to_a.join('/') to omit the realm that #to_s includes
+      client = options.fetch(:client) { ccache.credentials.first&.client&.components.to_a.join('/') }
+      server = options.fetch(:server) { ccache.credentials.first&.server&.components.to_a.join('/') }
+      info = loot_info(realm: realm, client: client, server: server)
+
+      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', options[:host], ccache.encode, nil, info)
+      message = ''
+      if @framework_module.respond_to?(:peer) && @framework_module.peer.present? && @framework_module.peer != ':'
+        message << "#{@framework_module.peer} - "
+      end
+      if server && server.to_s.downcase.start_with?('krbtgt/')
+        message << 'TGT '
+      else
+        message << 'TGS '
+      end
+      message << "MIT Credential Cache ticket saved to #{path}"
+      print_status(message)
+
+      nil
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
@@ -1,18 +1,13 @@
 module Msf::Exploit::Remote::Kerberos::Ticket::Storage
   module WriteMixin
-    # return [Array<FixMeKrbObj>]
-    def delete_credentials(options = {})
+    def delete_tickets(options = {})
       objects = objects(options)
       framework.db.delete_loot(ids: objects.map(&:id))
       objects.map do |stored_loot|
-        ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(stored_loot.data)
-        # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
-        ccache.credentials.first
+        StoredTicket.new(stored_loot)
       end
     end
 
-    # @param [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache] ccache
-    # @return [nil]
     def store_ccache(ccache, options = {})
       realm = options.fetch(:realm) { ccache.default_principal.realm }
       # use #components.to_a.join('/') to omit the realm that #to_s includes

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_only.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_only.rb
@@ -1,0 +1,5 @@
+module Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  class WriteOnly < Base
+    include WriteMixin
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/ticket_storage.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket_storage.rb
@@ -1,0 +1,127 @@
+module Msf::Exploit::Remote::Kerberos
+  class TicketStorage
+    extend Forwardable
+    include Msf::Exploit::Remote::Kerberos::Client
+    include Msf::Auxiliary::Report
+
+    # @!attribute [r] framework
+    #   @return [Msf::Framework] the Metasploit framework instance
+    attr_reader :framework
+
+    # @!attribute [r] framework
+    #   @return [Msf::Module] the Metasploit framework module that is associated with the authentication instance
+    attr_reader :framework_module
+
+    def_delegators :@framework_module,
+                  :print_status,
+                  :print_good,
+                  :vprint_error,
+                  :workspace
+
+    def initialize(framework: nil, framework_module: nil)
+      @framework = framework || framework_module&.framework
+      @framework_module = framework_module
+    end
+
+    def delete_credentials(options = {})
+      creds = credentials(options)
+      framework.db.delete_loot(ids: creds.map(&:id))
+      creds
+    end
+
+    def credentials(options = {}, &block)
+      objects(options) do |stored_loot|
+        ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(stored_loot.data)
+        # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
+        credential = ccache.credentials.first
+        block.call(credential) if block_given?
+        credential
+      end
+    end
+
+    def load_credential(options = {})
+      return nil unless active_db?
+
+      now = Time.now.utc
+      credentials(options) do |credential|
+        tkt_start = credential.starttime == Time.at(0).utc ? credential.authtime : credential.starttime
+        tkt_end = credential.endtime
+        return credential if tkt_start < now && now < tkt_end
+      end
+
+      nil
+    end
+
+    # @param [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache] ccache
+    # @return [nil]
+    def store_ccache(ccache, options = {})
+      realm = options.fetch(:realm) { ccache.default_principal.realm }
+      # use #components.to_a.join('/') to omit the realm that #to_s includes
+      client = options.fetch(:client) { ccache.credentials.first&.client&.components.to_a.join('/') }
+      server = options.fetch(:server) { ccache.credentials.first&.server&.components.to_a.join('/') }
+      info = loot_info(realm: realm, client: client, server: server)
+
+      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', options[:host], ccache.encode, nil, info)
+      message = ''
+      if @framework_module.respond_to?(:peer) && @framework_module.peer.present? && @framework_module.peer != ':'
+        message << "#{@framework_module.peer} - "
+      end
+      if server && server.to_s.downcase.start_with?('krbtgt/')
+        message << 'TGT '
+      else
+        message << 'TGS '
+      end
+      message << "MIT Credential Cache ticket saved to #{path}"
+      print_status(message)
+
+      nil
+    end
+
+    private
+
+    def objects(options, &block)
+      return [] unless active_db?
+
+      filter = {}
+      if options[:host].present?
+        if options[:host].is_a?(Mdm::Host)
+          filter[:host] = options[:host]
+        else
+          filter[:host] = { address: options[:host] }
+        end
+      end
+      unless (info = loot_info(options)).blank?
+        filter[:info] = info
+      end
+      framework.db.loots(workspace: myworkspace, ltype: 'mit.kerberos.ccache', **filter).each do |stored_loot|
+        block.call(stored_loot)
+      end
+    end
+
+    # Build a loot info string that can later be used in a lookup.
+    #
+    # @param [Hash] options
+    # @option options [String] :realm the realm of the ticket (optional)
+    # @option options [String] :server the service name of the ticket (optional)
+    # @option options [String] :client the client username of the ticket (optional)
+    # @option options [Boolean] :valid whether or not the ticket is valid, defaults to true (optional)
+    # @return [String] the info string
+    def loot_info(options = {})
+      info = []
+
+      info << '[invalid]' if !options.fetch(:valid, true)
+
+      realm = options[:realm]
+      info << "realm: #{realm.to_s.upcase}" if realm.present?
+
+      client = options[:client]
+      info << "client: #{client.to_s.downcase}" if client.present?
+
+      server = options[:server]
+      info << "server: #{server.to_s.downcase}" if server.present?
+
+      info.join(', ')
+    end
+  end
+end
+

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -8,6 +8,8 @@ require 'rex/proto/ldap'
 
 module Msf
   module Exploit::Remote::LDAP
+    include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+
     def initialize(info = {})
       super
 
@@ -71,7 +73,8 @@ module Msf
           password: datastore['PASSWORD'],
           framework: framework,
           framework_module: self,
-          cache_file: datastore['LdapKrb5Ccname'].blank? ? nil : datastore['LdapKrb5Ccname']
+          cache_file: datastore['LdapKrb5Ccname'].blank? ? nil : datastore['LdapKrb5Ccname'],
+          ticket_storage: kerberos_ticket_storage
         )
 
         kerberos_result = kerberos_authenticator.authenticate

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -16,6 +16,7 @@ module Exploit::Remote::MSSQL
   include Exploit::Remote::Tcp
   include Exploit::Remote::NTLM::Client
   include Metasploit::Framework::MSSQL::Base
+  include Exploit::Remote::Kerberos::Ticket::Storage
 
   #
   # Creates an instance of a MSSQL exploit module.
@@ -358,7 +359,8 @@ module Exploit::Remote::MSSQL
         password: datastore['password'],
         framework: framework,
         framework_module: self,
-        cache_file: datastore['MssqlKrb5Ccname'].blank? ? nil : datastore['MssqlKrb5Ccname']
+        cache_file: datastore['MssqlKrb5Ccname'].blank? ? nil : datastore['MssqlKrb5Ccname'],
+        ticket_storage: kerberos_ticket_storage
       )
 
       kerberos_result = kerberos_authenticator.authenticate

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -163,7 +163,8 @@ module Msf
             password: datastore['SMBPass'],
             framework: framework,
             framework_module: self,
-            cache_file: datastore['SmbKrb5Ccname'].blank? ? nil : datastore['SmbKrb5Ccname']
+            cache_file: datastore['SmbKrb5Ccname'].blank? ? nil : datastore['SmbKrb5Ccname'],
+            ticket_storage: kerberos_ticket_storage
           )
 
           simple_client.client.extend(Msf::Exploit::Remote::SMB::Client::KerberosAuthentication)

--- a/lib/msf/core/exploit/remote/smb/client/authenticated.rb
+++ b/lib/msf/core/exploit/remote/smb/client/authenticated.rb
@@ -7,6 +7,7 @@ module Msf
 module Exploit::Remote::SMB::Client::Authenticated
 
   include Msf::Exploit::Remote::SMB::Client
+  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
 
   def initialize(info = {})
     super
@@ -22,9 +23,7 @@ module Exploit::Remote::SMB::Client::Authenticated
         OptEnum.new('SMBAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::SMB_OPTIONS]),
         OptString.new('SmbRhostname', [false, 'The rhostname which is required for kerberos']),
         OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        OptPath.new('SmbKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ SMBAuth == kerberos ]),
-        OptBool.new('KrbUseCachedCredentials', [false, 'Use credentials stored in the database for kerberos authentication', false], conditions: %w[ SMBAuth == kerberos ]),
-        OptBool.new('KrbStoreCredentialCache', [false, 'Store Kerberos TGS MIT Credential Cache to the database if authentication succeed', true], conditions: %w[ SMBAuth == kerberos ])
+        OptPath.new('SmbKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ SMBAuth == kerberos ])
       ],
       Msf::Exploit::Remote::SMB::Client::Authenticated
     )

--- a/modules/auxiliary/admin/kerberos/pkinit_login.rb
+++ b/modules/auxiliary/admin/kerberos/pkinit_login.rb
@@ -72,10 +72,12 @@ class MetasploitModule < Msf::Auxiliary
       print_good('Successfully authenticated with certificate')
       enc_part = decrypt_kdc_as_rep_enc_part(tgt_result.as_rep, key)
 
-      info = []
-      info << "realm: #{realm.upcase}"
-      info << "serviceName: #{server_name.downcase}"
-      info << "username: #{username.downcase}"
+      loot_info = Msf::Exploit::Remote::Kerberos::Ticket.loot_info(
+        client: username,
+        server: server_name,
+        realm: realm,
+        valid: true
+      )
 
       report_service(
         host: rhost,
@@ -86,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, enc_part)
-      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, ccache.encode, nil, info.join(', '))
+      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, ccache.encode, nil, loot_info)
       print_status("#{peer} - TGT MIT Credential Cache saved to #{path}")
     rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
       fail_with(Failure::Unknown, e.message)

--- a/modules/auxiliary/admin/kerberos/pkinit_login.rb
+++ b/modules/auxiliary/admin/kerberos/pkinit_login.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, enc_part)
-      Kerberos::TicketStorage.new(framework_module: self).store_ccache(ccache, host: rhost)
+      Kerberos::Ticket::Storage.store_ccache(ccache, host: rhost, framework_module: self)
     rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
       fail_with(Failure::Unknown, e.message)
     rescue ::EOFError, Errno::ECONNRESET, Rex::ConnectionError, Rex::ConnectionTimeout, ::Timeout::Error => e

--- a/modules/auxiliary/admin/kerberos/pkinit_login.rb
+++ b/modules/auxiliary/admin/kerberos/pkinit_login.rb
@@ -72,13 +72,6 @@ class MetasploitModule < Msf::Auxiliary
       print_good('Successfully authenticated with certificate')
       enc_part = decrypt_kdc_as_rep_enc_part(tgt_result.as_rep, key)
 
-      loot_info = Msf::Exploit::Remote::Kerberos::Ticket.loot_info(
-        client: username,
-        server: server_name,
-        realm: realm,
-        valid: true
-      )
-
       report_service(
         host: rhost,
         port: rport,
@@ -88,8 +81,7 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, enc_part)
-      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', rhost, ccache.encode, nil, loot_info)
-      print_status("#{peer} - TGT MIT Credential Cache saved to #{path}")
+      Kerberos::TicketStorage.new(framework_module: self).store_ccache(ccache, host: rhost)
     rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
       fail_with(Failure::Unknown, e.message)
     rescue ::EOFError, Errno::ECONNRESET, Rex::ConnectionError, Rex::ConnectionTimeout, ::Timeout::Error => e

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -87,8 +87,7 @@ class MetasploitModule < Msf::Auxiliary
           framework: framework,
           framework_module: self,
           cache_file: datastore['SmbKrb5Ccname'].blank? ? nil : datastore['SmbKrb5Ccname'],
-          use_cached_credentials: datastore['KrbUseCachedCredentials'].nil? ? false : datastore['KrbUseCachedCredentials'],
-          store_credential_cache: datastore['KrbStoreCredentialCache'].nil? ? true : datastore['KrbStoreCredentialCache']
+          ticket_storage: kerberos_ticket_storage
         )
       end
     end

--- a/modules/auxiliary/scanner/winrm/winrm_cmd.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_cmd.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::AuthOption
+  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
 
   def initialize
     super(
@@ -82,7 +83,8 @@ class MetasploitModule < Msf::Auxiliary
         framework_module: self,
         cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
         mutual_auth: true,
-        use_gss_checksum: true
+        use_gss_checksum: true,
+        ticket_storage: kerberos_ticket_storage
       )
       opts = opts.merge({
         user: '', # Need to provide it, otherwise the WinRM module complains

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -15,6 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::AuthOption
+  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
 
   def initialize
     super(
@@ -75,7 +76,8 @@ class MetasploitModule < Msf::Auxiliary
           framework_module: self,
           cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
           mutual_auth: true,
-          use_gss_checksum: true
+          use_gss_checksum: true,
+          ticket_storage: kerberos_ticket_storage
         )
       end
     end


### PR DESCRIPTION
Since we're keeping the loot-based storage for the foreseeable future, we should consolidate how tickets are stored in loot. This creates a series of new `TicketStorage::Base` classes that expose a common interface. The classes include:

* `TicketStorage::None` -- Storage is not used at all, nothing is read from it and nothing is saved.
* `TicketStorage::ReadOnly` -- Previously stored tickets are used, but new tickets are not saved and no tickets can be deleted.
* `TicketStorage::WriteOnly` -- Previously stored tickets are not used, but new tickets are saved and tickets can be deleted.
* `TicketStorage::ReadWrite` -- Previously stored tickets are used, new tickets are saved and tickets can be deleted.

These classes replace the `use_cached_credentials` and `store_credential_cache` options as used by `ServiceAuthenticator::Base`. The original uses of these options have been replaced. More modules have also been updated with the new `KrbCacheMode` option allowing the user to switch between the 4 available modes (none, read-only, write-only and read-write).

The storage classes also return `TicketStorage::StoredTicket` instead of `Mdm::Loot` objects. The intention is to abstract away how they're stored so the Mdm object itself should not be leaked. In the future, the stored tickets should expose the same API.



## Verification

List the steps needed to make sure this thing works

- [ ] Test that tickets from `kerberos/forge_ticket` are stored in a way that they can be fetched from the cache
- [ ] Test that tickets from `kerberos/pkinit_login` are stored in a way that they can be fetched from the cache
- [ ] Test that the service authenticator base is storing and fetching tickets correctly

There should be no different in functionality.