### PR TITLE
Update rasn1 dependency for pkinit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,8 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    rasn1 (0.11.0)
+    rasn1 (0.12.0)
+      strptime (~> 0.2.5)
     rb-readline (0.5.5)
     recog (2.3.23)
       nokogiri
@@ -455,6 +456,7 @@ GEM
     sqlite3 (1.5.3)
       mini_portile2 (~> 2.8.0)
     sshkey (2.0.0)
+    strptime (0.2.5)
     swagger-blocks (3.0.0)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)

--- a/lib/rex/proto/kerberos/model/pkinit.rb
+++ b/lib/rex/proto/kerberos/model/pkinit.rb
@@ -40,7 +40,24 @@ module Rex
             end
 
             def to_der
-              self.options[:openssl_certificate].to_der
+              self.options[:openssl_certificate]&.to_der || ''
+            end
+
+            # RASN1 Glue method - Say if DER can be built (not default value, not optional without value, has a value)
+            # @return [Boolean]
+            # @since 0.12
+            def can_build?
+              !to_der.empty?
+            end
+
+            # RASN1 Glue method
+            def primitive?
+              false
+            end
+
+            # RASN1 Glue method
+            def value
+              options[:openssl_certificate]
             end
 
             def parse!(str, ber: false)

--- a/spec/lib/msf/core/exploit/remote/kerberos/client/pkinit_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/kerberos/client/pkinit_spec.rb
@@ -2,7 +2,6 @@
 require 'spec_helper'
 require 'rasn1'
 
-
 RSpec.describe Msf::Exploit::Remote::Kerberos::Client::Pkinit do
   subject do
     mod = ::Msf::Exploit.new


### PR DESCRIPTION
Updates the rasn1 dependency for pkinit

## Verification

First run through these test steps to create an ADCS environment - https://github.com/rapid7/metasploit-framework/pull/16939
Note: Requires at least windows server 2016 to work

Verify you can request a cert:
```
msf6 auxiliary(admin/dcerpc/icpr_cert) > rerun smbuser=Administrator smbpass=p4$$w0rd rhosts=192.168.123.13 ca=adf3-DC3-CA cert_template=ESC1-Test smbdomain=ADF3.LOCAL alt_upn=Administrator@adf3.local
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] 192.168.123.13:445 - Requesting a certificate...
[+] 192.168.123.13:445 - The requested certificate was issued.
[*] 192.168.123.13:445 - Certificate UPN: Administrator@adf3.local
[*] 192.168.123.13:445 - Certificate stored at: /Users/adfoster/.msf4/loot/20221214003328_default_unknown_windows.ad.cs_766198.pfx
[*] Auxiliary module execution completed
```

And use pkinit:

```
msf6 auxiliary(admin/kerberos/pkinit_login) >  rerun rhosts=192.168.123.13 cert_file=/Users/adfoster/.msf4/loot/20221214003328_default_unknown_windows.ad.cs_766198.pfx
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] Attempting PKINIT login for Administrator@adf3.local
[+] Successfully authenticated with certificate
[*] 192.168.123.13:88 - TGT MIT Credential Cache saved to /Users/adfoster/.msf4/loot/20221214003538_default_192.168.123.13_mit.kerberos.cca_746788.bin
[*] Auxiliary module execution completed
```