### PR TITLE
Update pkinit tgt response to include key

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -164,7 +164,7 @@ module Msf
           # @option [String] :username The username for the request
           # @option [String] :realm The realm for the request
           # @option [String] :server_name The server name (e.g. krbtgt) for the request
-          # @return [Array<Msf::Exploit::Remote::Kerberos::Model::TgtResponse, String>] The TGT response and the key
+          # @return [Msf::Exploit::Remote::Kerberos::Model::TgtResponse] The TGT response and the key
           def send_request_tgt_pkinit(options = {})
             pfx = options[:pfx]
             request_pac = options.fetch(:request_pac, true)
@@ -207,11 +207,15 @@ module Msf
 
               pa_pk_as_rep = entry.decoded_value
               key = calculate_shared_key(pa_pk_as_rep, dh, dh_nonce, as_res.enc_part.etype)
-              return [Msf::Exploit::Remote::Kerberos::Model::TgtResponse.new(
+              return Msf::Exploit::Remote::Kerberos::Model::TgtResponse.new(
                 as_rep: as_res,
-                preauth_required: false,
-                decrypted_part: nil
-              ), key]
+                preauth_required: true,
+                decrypted_part: decrypt_kdc_as_rep_enc_part(as_res, key),
+                krb_enc_key: {
+                  enctype: as_res.enc_part.etype,
+                  key: key
+                }
+              )
             elsif as_res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
               raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: as_res)
             else
@@ -266,12 +270,13 @@ module Msf
 
             initial_as_res = send_request_as(req: initial_as_req)
 
-            # If we receive a AS_REP response immediately, no-preauthentication was required and we can return immediately
+            # If we receive an AS_REP response immediately, no-preauthentication was required and we can return immediately
             if initial_as_res.msg_type == Rex::Proto::Kerberos::Model::AS_REP
               return Msf::Exploit::Remote::Kerberos::Model::TgtResponse.new(
                 as_rep: initial_as_res,
                 preauth_required: false,
-                decrypted_part: nil
+                decrypted_part: nil,
+                krb_enc_key: nil,
               )
             end
 
@@ -296,7 +301,6 @@ module Msf
             # No etypes specified - how are we supposed to negotiate ciphers?
             raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: initial_as_res) unless etype_entries
             server_ciphers = etype_entries.decoded_value
-
 
             selected_etypeinfo = select_cipher(offered_etypes, server_ciphers)
             selected_etype = selected_etypeinfo.etype
@@ -341,6 +345,11 @@ module Msf
             Msf::Exploit::Remote::Kerberos::Model::TgtResponse.new(
               as_rep: preauth_as_res,
               preauth_required: true,
+              krb_enc_key: {
+                enctype: selected_etype,
+                key: enc_key,
+                salt: salt
+              },
               decrypted_part: decrypt_kdc_as_rep_enc_part(
                 preauth_as_res,
                 enc_key,

--- a/lib/msf/core/exploit/remote/kerberos/model/tgt_response.rb
+++ b/lib/msf/core/exploit/remote/kerberos/model/tgt_response.rb
@@ -5,6 +5,10 @@ class Msf::Exploit::Remote::Kerberos::Model::TgtResponse
   # @return [Rex::Proto::Kerberos::Model::EncKdcResponse] The Kerberos AS REP
   attr_reader :as_rep
 
+  # @return [Hash{String => object},nil] The KrbEnctype used, including enctype, key, and a salt. Nil if pre-auth was not required
+  # @see Rex::Proto::Kerberos::Crypto::Encryption
+  attr_reader :krb_enc_key
+
   # @return [TrueClass, FalseClass] False if the ticket was created without requiring preauthentication, otherwise true.
   attr_reader :preauth_required
 
@@ -12,10 +16,15 @@ class Msf::Exploit::Remote::Kerberos::Model::TgtResponse
   attr_reader :decrypted_part
 
   # @param [Rex::Proto::Kerberos::Model::EncKdcResponse] as_rep The Kerberos AS REP
+  # @param [Hash{String => object}] The KrbEnctype used, including enctype, key, and a salt
   # @param [TrueClass, FalseClass] preauth_required False the ticket was created without requiring preauthentication, otherwise true.
   # @param [Rex::Proto::Kerberos::Model::EncKdcResponse] decrypted_part The decrypted response
-  def initialize(as_rep:, preauth_required:, decrypted_part:)
+  def initialize(as_rep:, krb_enc_key:, preauth_required:, decrypted_part:)
+    raise ArgumentError.new("Missing required option :enctype") if krb_enc_key && krb_enc_key[:enctype].blank?
+    raise ArgumentError.new("Missing required option :key") if krb_enc_key && krb_enc_key[:key].blank?
+
     @as_rep = as_rep
+    @krb_enc_key = krb_enc_key
     @preauth_required = preauth_required
     @decrypted_part = decrypted_part
   end

--- a/modules/auxiliary/admin/kerberos/pkinit_login.rb
+++ b/modules/auxiliary/admin/kerberos/pkinit_login.rb
@@ -65,12 +65,13 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Attempting PKINIT login for #{username}@#{realm}")
     begin
       server_name = "krbtgt/#{realm}"
-      tgt_result, key = send_request_tgt_pkinit(pfx: pfx,
-                                                username: username,
-                                                realm: realm,
-                                                server_name: server_name)
+      tgt_result = send_request_tgt_pkinit(
+        pfx: pfx,
+        username: username,
+        realm: realm,
+        server_name: server_name
+      )
       print_good('Successfully authenticated with certificate')
-      enc_part = decrypt_kdc_as_rep_enc_part(tgt_result.as_rep, key)
 
       report_service(
         host: rhost,
@@ -80,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
         info: "Module: #{fullname}, Realm: #{realm}"
       )
 
-      ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, enc_part)
+      ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, tgt_result.decrypted_part)
       Msf::Exploit::Remote::Kerberos::Ticket::Storage.store_ccache(ccache, host: rhost, framework_module: self)
     rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
       fail_with(Failure::Unknown, e.message)

--- a/spec/lib/metasploit/framework/login_scanner/kerberos_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/kerberos_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::Kerberos do
   let(:tgt_response_no_preauth_required) do
     ::Msf::Exploit::Remote::Kerberos::Model::TgtResponse.new(
       as_rep: instance_double(::Rex::Proto::Kerberos::Model::EncKdcResponse),
-      preauth_required: true,
+      preauth_required: false,
+      krb_enc_key: nil,
       decrypted_part: nil
     )
   end
@@ -39,6 +40,11 @@ RSpec.describe Metasploit::Framework::LoginScanner::Kerberos do
     Msf::Exploit::Remote::Kerberos::Model::TgtResponse.new(
       as_rep: instance_double(::Rex::Proto::Kerberos::Model::KdcResponse),
       preauth_required: false,
+      krb_enc_key: {
+        enctype: Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC,
+        key: 'mock-key',
+        salt: 'mock-salt'
+      },
       decrypted_part: instance_double(::Rex::Proto::Kerberos::Model::EncKdcResponse)
     )
   end

--- a/spec/lib/msf/core/exploit/remote/kerberos/client_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/kerberos/client_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-RSpec.describe Msf::Exploit::Remote::Kerberos::Client::TgsResponse do
+RSpec.describe Msf::Exploit::Remote::Kerberos::Client do
   subject do
     mod = ::Msf::Exploit.new
-    mod.extend ::Msf::Exploit::Remote::Kerberos::Client
+    mod.extend described_class
 
     mod.send(:initialize)
     mod
@@ -164,6 +164,219 @@ RSpec.describe Msf::Exploit::Remote::Kerberos::Client::TgsResponse do
     Rex::Proto::Kerberos::Client.new.send(:decode_kerb_response, data)
   end
 
+  describe '#send_request_tgt_pkinit' do
+    let(:pfx) do
+      cert_string = <<~EOF
+        MIIMhgIBAzCCDFAGCSqGSIb3DQEHAaCCDEEEggw9MIIMOTCCBt8GCSqGSIb3
+        DQEHBqCCBtAwggbMAgEAMIIGxQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYw
+        DgQIgPy56+eB0goCAggAgIIGmOkWeSvCf4O/HACpvP0fcX/jlUajBJw0DtvZ
+        dnDHUHj4bZfjhoG7dOcCVO8wuSM8djnfXOtNcK+JUJSiMYN9uO1FpUex5v1H
+        Dl/H5SqqfH+iqu4/fDNDx+q/vJzzQKFJ7I+spSa4KnsFO/upU4f7B1TUtEOC
+        AG4CtM5Za2dXdCmbjReh812Rp1UUxhlCkbb177cj1WP0j+25Clu96q/gXNeI
+        CiwrEinbxCmPI5GcK68dwGEEYiGoBOsLWdRMBhwP0xt289sLPoKTnM07c+Ww
+        CDdlEtFI0AQhxAPbOYlQ5x7rT5tjUtzsefz/yYghH4MkmOi5YKVZd5KvS6O0
+        Ux3rhfXt4NS0vD+aATCDvxZ8mi9WDGH096lQm6KuOueljSaV6tIoJ+TZiQph
+        lvB8vlcpM3KvJTLqHS+tRKwRxZe1YGBthkLp9QFshaDmtx0e1q4HsiJm4yba
+        wf7R+EDoNxrP0lTAObY6QrZXiqHLPKbj4b30qYdsWmrV9v0EtbZN/U6P7ZFI
+        zcmw+dH13E50YLG7ytl0PSY6f7UcFmCtVjyCeHQU7Pk1hNUZ9J8nusMlWrA5
+        K+8QSJmpIzpdGT0dKnCWq7LN2uEkiHyOYFxWQUP4q6n+WaqcVDRMRG5MEl3Y
+        HoVQxqpM1itb4cgg2iByfVX5Baga34ZYbbCr/luJgbINRvzlDNBM9dpptXJ7
+        hf2YTpFrfj99RyBPPzU92GgFnqoSFn56/QKmef67V36Qjfj81cDxeAQ2SQo1
+        QsClMy58bFGqrDBvLZ6vZy4bxH4agvKYFLvx2JlEDi5cpJtRc1zYi59z2NDv
+        l/dCNer5tA/7oosAHOm8AMXOkkoLGfK+dlpa9brJqkIWzM8n4by1ruV+5G8d
+        GuVkjqSUij8ziN0wdMG8tDFt6Y3f4EgpOCcAxpC8MBiz2gp+H5xdOkmxGUz3
+        6MCBY13J1LBypT57eax0znhm7+g1QDPRTpGP9JweJER7eS2Frq9ODrTVxIoC
+        yj/qzdjnvYRq5NDTeHH4H1SPacXcJRU/aOS8O4IZJjzRP3AVBqwVzusIOxbv
+        FhgkEw1kUfuMjXkONLO5ziMuE5Xi8ErS+dLEK8m4BvZe8iGO0vdl3kamI58F
+        OZDSp6qTsf3/YUGLeR66nKVe9jnbJJ5mK3cWMS3RWkO6+GFs9K3s47Y5iF2z
+        OX2LrZNd4u1FdccUXmX5SgOY4VJoFOOQ8sGy7nCcn3Ri6tNzLqYAS8veHSob
+        kST66XOrElkcgAw37mHXiJ16wWD/HWXSaSv9+42mutOR1l2y/Gh+N5nXc7Vv
+        mk+9u71C7i4dIAYsq79H2U6TahYU/FGu62fZIkHfDVFJOz1sjuJgl4jokLs/
+        mPPYNf9dN3e0ipqAxCx/WkeH8lD2V+7i+6RLTI1UIrsy/kA/naIIHtaIOElE
+        IdhkNkBQyI4bneQKh0WuXeBCWnUO7TAap0bG6Utyq2Jr7YAfwXZmWF4lrl89
+        BA+RDu6+Y9rM2TNitwRvxnc/sGHweh70/IRHBO8jIhPBn02Z9RxDrXtvtHdh
+        qRjxMPGoGLLCcbBKT4/ZkSIGV2wI4ZFlGm3gR0qgeZVMQ4K7Y0b6VhhD880i
+        UZgthF1ScRGUOte5Z98v+uX/Pv9dUQGKRmAWNgZZQ9Jc/gH+3pf0dYq9xo/f
+        ZapH+bp26d63LkXqv6BbcW/Ij9fvzmO1COSbf442hRuTVDP3NyYGfqderu/1
+        eN+tySHofCeRem0GQBe9HLDrRY+rmbxTLoq7xiQOA15ZR5LuNlj/U9Xah/o+
+        GCp82VHuK+nmfbULQ5w0Oh2v5//uKH/ex73PfP5Dyo3YFRbV2gqpQsMc6tcf
+        PWjfsQW+F3UweP7TcJROflZerpMHVPkgC+gTXsOZRLFNxboMSmK9+AFto/10
+        FCqH6GMs2nNBTdar/9umZe6zl6+cEs8C869cb/fmWEnv5SUZWpT2OK5zB7e/
+        TjR4ykSiG/LehvnxIAt1lreApTHdTatAXFyyPaqfEw1E4YO73iO5PouZG+FL
+        8R3uomPMp0LcmpPm+SyXBAghf1STt51jpHVEc8pc3Rrymgr/xUTlyj2TSf6a
+        08jwmgybREgWicy9N3ErZLR95KY7V4pnBeKplG0DypFakQPZuBv9tph9sbpA
+        M4XzDCSe0CW6LHmdMu49qfcNJhhg8WL2w7ByUDOmnlLPlpZRttz45lQUssbN
+        QD6sWoH6jwLjKIoCVkwwlfohyuIlZOgx/x/cv2PbAKeRUrZeP3HXxRbFMIIF
+        UgYJKoZIhvcNAQcBoIIFQwSCBT8wggU7MIIFNwYLKoZIhvcNAQwKAQKgggTu
+        MIIE6jAcBgoqhkiG9w0BDAEDMA4ECAUPKVFnmFvtAgIIAASCBMg2fCv//SH2
+        xg4ihTz+4pNd+xBhfTXwaNYwgUH4q1VxW1VD8iOWj1geOH7IsGRLq7T8hNjD
+        RXMAE4pyDMBMKFQokGD0Zopp4pXL+6DSBCilT4mK67T2X3EsMRNER8XUoB6r
+        PSDvk4o63WQ9Ne+SvobqB/hbcVq2tH0LxBbznikrI7J84OQOhzY+L/mbYV1R
+        rPAj51XgS2M0Ogl/kzr/lnmXFDTyw7ThLvgCzt9rEoLekh9OpxESboAR7swl
+        Ynim8HRVpp2SAa+WKkHlDbCWk4SNjvhWpFwdGJxL7O6ZIGq62f/UEjbVy5yA
+        LnJnZBHNga4iM1rxHsyfeH26y/FY9pSw/BBxcImhBxExTd1Z4l/f9gc91B3S
+        Ssvr6bRHBE51KS6b2R9/pAIZYVXN5oLU6jzFrxuWvBcbKUunvw7yZBQbHOOh
+        1TQxCvX3xBBTBsMSRBB7nihxWpH7PgCFBHiQ8CxQMyS9ap6cvp2Bf4qjfPHE
+        LaVXxrlJQ7t7gpJ2wPqxlC9bCkvH9F14j0+62jD8Ofq39ZdYjELCM0LxAR5A
+        rJ2AM4Hl8veVko5e2OStsNIMsd4+StneNQQ3IIxpM6AeUMujOzQMUikj/S3J
+        VdyLrPl2fTCnaY4fpl0bWEDYKyAGi7Kjs5FrLRJsE0kX0MrRsKVs0NOoti51
+        v6d05Qs7TgfMIFturSRkk3BGC/Xp25U6PrwRKqO3NsUHO+8GYrGDFO/GfW8k
+        fO6N7DdBMXVyI0tsYxhDSZvjmv2EFmTKz7EBBSBQvf27Dy0Hw42YItVTPyZK
+        bzLexddpZmAU410cthopk08OR4JjmCOqTkfIWtF+ivfAguYOMMIfct4W0UgM
+        08sMKPayagqv+TZJT4pawCrmMuRE0XGrOjOqoiz5RDe074qsjwMTESKncuRG
+        OwzMMSIAToQFVerhW5i+7m6wzpxd/k4O9CyoXbVGwM9D0TEvpLTd6ouoEVDb
+        ID66QXdf/YvQCZ/bu0nq/h3qE9HaRtOVDW9WUyuzDLnJoTYKPiXKR2FBVl92
+        UkOc1zhD67Zhaj7ax8fPdJwv5zr0ovJuB/09+JF1IuGXGsThf1O/QbW/713l
+        QVJiI6k2NVGOPkFtHkNE0SuGOuygetw+lTLflhFt/YTeafm0Thz3awgHWhv5
+        HsblIzckk7G57eesP3u1YLZ7ZcbnQqtNfwuxQgT8KvdNv3skAlgz01Aq73Z0
+        UMpoV7gN3DJnE9Zpp7oqYswbR7hmEAj5MKUl644rgrQ8XaembvnF+CRu+cOi
+        Sq0neAkdeIBcw92PJBnHYaSyqSzPG1JKhbu/cpmwzYbYS3aOy7WSphbjQorc
+        g68FNbHvlcH+y05M4F7LlV8wIRQmmO2fqw3UgcqIbwpd63j72SOU5lhnua+y
+        a8gJNYDflc4z8qAOejBKy3cNzYmN3k2trn7ldirdAIETt2DBwtT7muXPZzm8
+        bdmpJLOe8w1yk+LEIrSO/MBSN+dcJ5RYkGv09Wl864ufbjEjHVy0WAG73FZZ
+        jvtabUeXlr5VwJX1LqvKKA2vu00LC/9J5DF+WkNvquY90KjoTVTcvLY3qNS8
+        3LjKiyW0kNGPix3c0qCbbclcC9T87HtIf9e+oCD4OMFo9kFtiE1N35JwL8al
+        5DAxNjAPBgkqhkiG9w0BCRQxAh4AMCMGCSqGSIb3DQEJFTEWBBSxQ8NE4vhV
+        ZrR4mpY5Wmy43NZn8DAtMCEwCQYFKw4DAhoFAAQUBJLM9HgQ9MyzGIMzfC+4
+        sOG5gYYECCOTwax2BRAH
+      EOF
+
+      cert = OpenSSL::PKCS12.new(Base64.decode64(cert_string), '')
+      cert
+    end
+
+    # Success - no error
+    let(:as_rep_success) do
+      pkinit_response = <<~EOF
+        a4IPCTCCDwWgAwIBBaEDAgELooIIvjCCCLowggi2oQMCARGiggitBIIIqaCC
+        CKUwggihgIIIeTCCCHUGCSqGSIb3DQEHAqCCCGYwgghiAgEDMQswCQYFKw4D
+        AhoFADCBuAYHKwYBBQIDAqCBrASBqTCBpqCBiAOBhQACgYEAw7l8V0njjkXl
+        aMjxG6XcDGbxAldiYMsLSxEJ7QX6439x6g2MDTrw5FKJCPNJSj+JOyhG9g5m
+        +GX4z615Pc7nxgAhkNGHpvP3EPHDGvufJRk+9RU6g2nDLvR6hj6Mpt4aMA6o
+        aisHOezi4ISEHpllZyKw+Kbbz/dWxrmCT4bb0rahBgIEKZ1nx6IRGA8yMDIy
+        MTEyODIyMDMxMFqgggXPMIIFyzCCBLOgAwIBAgITFgAAAAJ/t8m7NZmvIgAA
+        AAAAAjANBgkqhkiG9w0BAQsFADBDMRUwEwYKCZImiZPyLGQBGRYFbG9jYWwx
+        FDASBgoJkiaJk/IsZAEZFgRhZGYzMRQwEgYDVQQDEwthZGYzLURDMy1DQTAe
+        Fw0yMjExMjgxMzEzMDlaFw0yMzExMjgxMzEzMDlaMBkxFzAVBgNVBAMTDmRj
+        My5hZGYzLmxvY2FsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+        6AvxelytTQpx2h/I/SvxwE1KxWqxOox0m08ukGmf+ojnH4bvUsUUZpBi+mRM
+        kOajBVfTyT9qIkdVByDGJT+E0vD6BG4fxOvsXJyT8coJR3ZLEsYQvayd5BZE
+        M+TfeI66KGVrRZGLt7U8NFIRUczRanNbLCd8BsCHfNx7KQd82CuZGC32l9jV
+        h1ClEVKNnn0uk4Yw4z4d0EetUWK69ZHfRK2Y1nx+0A7C/IDCP1bwoTaUxGVm
+        e+DN5kRaZrhdtA6dhmFL4IZW1kMFINkH8NSvayiMWtW2r/rrdfaWlsuMe4ob
+        Jp2LEc1a9W9Tg7sRBEU1CxPPzIThkqeTCKy/WrfxwwIDAQABo4IC4DCCAtww
+        LwYJKwYBBAGCNxQCBCIeIABEAG8AbQBhAGkAbgBDAG8AbgB0AHIAbwBsAGwA
+        ZQByMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAOBgNVHQ8BAf8E
+        BAMCBaAweAYJKoZIhvcNAQkPBGswaTAOBggqhkiG9w0DAgICAIAwDgYIKoZI
+        hvcNAwQCAgCAMAsGCWCGSAFlAwQBKjALBglghkgBZQMEAS0wCwYJYIZIAWUD
+        BAECMAsGCWCGSAFlAwQBBTAHBgUrDgMCBzAKBggqhkiG9w0DBzAdBgNVHQ4E
+        FgQUtLDOLg5c1UUn/YoT/HhI7XdFMmYwHwYDVR0jBBgwFoAU2a27dSYdeH6z
+        1ZEEioxbeQvKO5QwgcQGA1UdHwSBvDCBuTCBtqCBs6CBsIaBrWxkYXA6Ly8v
+        Q049YWRmMy1EQzMtQ0EsQ049ZGMzLENOPUNEUCxDTj1QdWJsaWMlMjBLZXkl
+        MjBTZXJ2aWNlcyxDTj1TZXJ2aWNlcyxDTj1Db25maWd1cmF0aW9uLERDPWFk
+        ZjMsREM9bG9jYWw/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdD9iYXNlP29i
+        amVjdENsYXNzPWNSTERpc3RyaWJ1dGlvblBvaW50MIG8BggrBgEFBQcBAQSB
+        rzCBrDCBqQYIKwYBBQUHMAKGgZxsZGFwOi8vL0NOPWFkZjMtREMzLUNBLENO
+        PUFJQSxDTj1QdWJsaWMlMjBLZXklMjBTZXJ2aWNlcyxDTj1TZXJ2aWNlcyxD
+        Tj1Db25maWd1cmF0aW9uLERDPWFkZjMsREM9bG9jYWw/Y0FDZXJ0aWZpY2F0
+        ZT9iYXNlP29iamVjdENsYXNzPWNlcnRpZmljYXRpb25BdXRob3JpdHkwOgYD
+        VR0RBDMwMaAfBgkrBgEEAYI3GQGgEgQQjz4p0G/vtESwpSrqSJmOmIIOZGMz
+        LmFkZjMubG9jYWwwDQYJKoZIhvcNAQELBQADggEBABHQFEksHm4LJ0D6aiTZ
+        1nyVT13EfrTkcwfJmnFv+/+mjYDz2bzn9073izILSK2EW91kfObCklhPYJo7
+        gPmNKjVB8pJbX8jE0AOY46QxzrDkwyGwRjRYTtjwXHDKbaIaQHXXh2TDRWfL
+        AbUa2JqIJeC3WtAfQ/8RkMq7Zfmatcf9v7lVKvvLCIG+SCCAedtwU10weswc
+        0fnfrPevvQD4zZS44S4Zx5HDrKDqXqalBobO3UdLnwWYvOhaqk6nkbRUrkjf
+        NHu+6SiKa6DVkbzQ3tLuFAYhZd1LbXNtAZbBFA9JWCyZEyH21H4WE6zVO1Vl
+        h6NxtfPLgPBB3oK/8Pb7AmAxggHAMIIBvAIBATBaMEMxFTATBgoJkiaJk/Is
+        ZAEZFgVsb2NhbDEUMBIGCgmSJomT8ixkARkWBGFkZjMxFDASBgNVBAMTC2Fk
+        ZjMtREMzLUNBAhMWAAAAAn+3ybs1ma8iAAAAAAACMAkGBSsOAwIaBQCgPTAW
+        BgkqhkiG9w0BCQMxCQYHKwYBBQIDAjAjBgkqhkiG9w0BCQQxFgQUARFzJqbw
+        JrfNiB7Y9P2zldy9LccwDQYJKoZIhvcNAQEBBQAEggEAt+I1b5L4zFyZxvLE
+        iqBH1q8VpVxNdMgAg14Oimk/RFfA4+cRlnWdm64XwRY16G5JnNh0T9SzmwCm
+        t5RlxfSj6EZkw0W58FRjKPs/jRRNjzAV/cuc/9v4Cl78Vj21DfQAXgKG1I7z
+        ZhLSgtu6c7NIQQgq0thZRwaGvCAvOSW09Mlj56ke5vNw+x9SFnu17pWCU8PO
+        oZpH7JIZEpNQejQsp/MwmZXxJkEPFrcWgoZxpVfVmbFSmhtQSqBehoPs9KyF
+        nQf9KPfFDp8T7h6RoONy6vChdFVogsHyEq20YmIQfIOFn4+YCXsWwwoCT43a
+        QdMV5JIpgGUTgiBZLaDuU3xZH6EiBCCOyYypIoIchRxYS+flHwBgdXca1i6v
+        GUvwajyR9YCF26MMGwpBREYzLkxPQ0FMpBowGKADAgEBoREwDxsNQWRtaW5p
+        c3RyYXRvcqWCBOphggTmMIIE4qADAgEFoQwbCkFERjMuTE9DQUyiHzAdoAMC
+        AQGhFjAUGwZrcmJ0Z3QbCmFkZjMubG9jYWyjggSqMIIEpqADAgESoQMCAQKi
+        ggSYBIIElPkKnWSHxSwfVnyScyQbAZU3xkylltzhkTAZSMculnaqYtwzzThl
+        ZXWYpAScbI1RchDIBgRwQ17Dwj/aWUf2a2ao/EKzIGccQjs2pY1jJO1qYgis
+        ga7QdkqIQfrI9ruKszhdyJfEE4jrVD3aTnnQcFMuyrkITLVL3imY9Sb9j2QV
+        PBheDes6sTQT8ix7Zqvmapr+x8DGYKStT1JwgN5JER5LN3t5jWfTljuLNSLg
+        1AohCdCfFM6v4yRuWz/4QwkD1tLEr1PlNJBYfAAtG7qxTHbtcVGVro5lY7bC
+        fpT//1mgaBQG7DdGFXVQZ0CQ6catl/UWCAT5c5pLNPQLSoVDl88eCse1EjfN
+        S9cJhIbmZqhvLly2l3jg2nE9Gj/k1NYpcoZRu3uFIGzFAN5khqMvwzdZ73mD
+        0TpwXuQa5t2khaCNif9IR1v/yJ0L83Uu7E2zf1oNl+nH1m5+UtJGZnUhMSUW
+        FtuPemXWm0Cze+f+pG8+RdQH7CX0sMSKX6f73NQljMwTnHhNeiRJqjDDni5F
+        kJnHGjtbLLFyVGS5xKbtuc8yJ7iW9KbLskt/tgYtY8d68O40QN1/KcqMPsBc
+        XL5TPzfVPtZqsLH9xNxT3lf0Tth6zwXCnjhhGiDj9S7Q6OGVYTUiEBIPTW73
+        N/pML+7YAz1dvJz30EG8nN2Iz1DD6o3V5bOYOgCebLNhXhNvCzC0VM0iDgxE
+        VtIoCXGlKnBe6H1g8d+/41JTYaDlXpZGtsYZieNIrWqznufX+w0UgzDjmF+m
+        g+1x8Cn8nlbwlwRZk/iNKSorS4SmJi9uMIr47hyRunRmrRiJ4K9GbpjZMWET
+        EWdYaaNQpWAFqviCUrCxeVh6k5A0HE/JFQrFM4ok0TaW/uvsaqecL3LNU7ic
+        Fr29wB8FgLbXeO0jlxNu/nQlTSZvfX4k4uNARW6rbOaQVgsBjXoae3qHB4H7
+        llv7V1GsO3TmwFthSk/t/dNzF8FnrNcPJMBBNCUeA87IDcdtu0WG8M0O5ucI
+        v/phKRZ1Ce6Zj9tADo9n9b9Z8ejl0aLNj2HedHvwLQGEtMcFnQ3Z03yFEyD7
+        ypn9Qn1K0AIdDHUsXfPClPGtniML/0O1HjvzP6Z5zzaL7yoabHjpFLk0JXGR
+        iT45144EHekiDNSBndkOF+CV2c6Tzq8rqznTHytIHZpq5dfnXpWCUHEwWtKX
+        PGu7wEqO8nEZNZX3L2mQKvUX2A05wfBCAQiZ4h1eYnZeCzTnGOvqhHWKQ35P
+        kCLxhQUQ3w/gGrnYPuW9zRSqVf5WUhaXk2vxEqKMjbekuGMgQJawXWo4UZu5
+        Irh8nYUcsovdc7NaPubpdeuRmzJQXAoSWuTsUdU4IJZ+qbcIwmRfqGY5ayih
+        5p7NGUb/u/TwPyd1OrCkrDYYmeZ9tqgv09RnxIA9zWcTr4Zw41dPtknjiK44
+        rlF92OgvyvUHsRWuk9zgUCV9kurqdwZET23Sf8abcrPnsjjYyAozE1zNbUFx
+        n5eesIOX6cB/mwg3WjNUt00iPpnzcMe9g1w8qNw6qLV6vDd+MWNzr5Dmr0eu
+        kk2lGelQUfG3poIBHTCCARmgAwIBEqKCARAEggEMxIFR3IliLCO2dyA7boAI
+        BEgwINPqRmNKU8fWvsA9Mwmz8CydL6LviRz+hmT8qzFD4RqWXvP9MyuMx3WL
+        y1ESZukmO/W6+xyV2jo84qlyk4MWyMrSzTHQQWbnW5HiJf+X2qbHyItIewcO
+        gX/b5w6rNb738umvePb0QNc4lJrY9ml4lcgXpgzu8krUjcRTn9IeYs40zXg5
+        Hgy/LsSKJLSVbM+M84LW+wyfQGthfAp4asKZCISaF+yQMEmsGb/Y8zVNsZCL
+        yU5toVLzMeZDtHbot2dysOEMEw9+uSsH2s5MoA9blI7wVMajgUzGNy/XgqjO
+        DMKItGyr4fB5Z0NXQTgb3N0JN5f8KD6HjPDIpw==
+      EOF
+
+      decode_kerb_response(Base64.decode64(pkinit_response))
+    end
+
+    let(:mock_client) do
+      instance_double(Rex::Proto::Kerberos::Client, close: nil)
+    end
+
+    let(:mock_decrypted_part) { double :mock_decrypted_part }
+    let(:mock_kerberos_responses) { [] }
+
+    before(:each) do
+      allow(mock_client).to receive(:send_recv).and_return(*mock_kerberos_responses)
+      allow(Rex::Proto::Kerberos::Client).to receive(:new).and_return(mock_client)
+      # Skip decryption as part of the test; The use of build_dh in the implementation makes it impossible to decrypt the enc_part,
+      # as the call to generate_key can't be mocked in openssl3, only in openssl 1.1.1
+      allow(subject).to receive(:decrypt_kdc_as_rep_enc_part).and_return(mock_decrypted_part)
+    end
+
+    context 'when the authentication succeeds' do
+      let(:mock_kerberos_responses) do
+        [as_rep_success]
+      end
+
+      it 'returns the ticket' do
+        res = subject.send_request_tgt_pkinit(
+          server_name: 'krbtgt/adf3.local',
+          username: 'Administrator',
+          realm: 'adf3.local',
+          pfx: pfx,
+        )
+
+        expect(res.ticket.realm).to eq('ADF3.LOCAL')
+        expect(res.ticket.sname.name_string).to eq(['krbtgt', 'adf3.local'])
+        expect(res.preauth_required).to be true
+        expect(res.decrypted_part).to eq(mock_decrypted_part)
+        expect(res.krb_enc_key).to include({ enctype: 18, key: a_string_matching(/\A.{32}\Z/m) })
+        expect(mock_client).to have_received(:send_recv).once
+      end
+    end
+  end
+
   describe '#send_request_tgt' do
     let(:mock_client) do
       instance_double(Rex::Proto::Kerberos::Client, close: nil)
@@ -211,6 +424,7 @@ RSpec.describe Msf::Exploit::Remote::Kerberos::Client::TgsResponse do
         expect(res.ticket.sname.name_string).to eq(['krbtgt', 'DEMO.LOCAL'])
         expect(res.preauth_required).to be false
         expect(res.decrypted_part).to be_nil
+        expect(res.krb_enc_key).to be_nil
         expect(mock_client).to have_received(:send_recv).once
       end
     end
@@ -235,6 +449,7 @@ RSpec.describe Msf::Exploit::Remote::Kerberos::Client::TgsResponse do
           expect(res.decrypted_part.srealm).to eq('DEMO.LOCAL')
           expect(res.decrypted_part.sname.name_string).to eq(['krbtgt', 'DEMO.LOCAL'])
           expect(res.decrypted_part.flags.enabled_flag_names).to eq(%i[FORWARDABLE PROXIABLE RENEWABLE INITIAL PRE_AUTHENT])
+          expect(res.krb_enc_key).to eq({ enctype: 23, key: "\x88F\xF7\xEA\xEE\x8F\xB1\x17\xAD\x06\xBD\xD80\xB7Xl", salt: nil})
           expect(mock_client).to have_received(:send_recv).twice
         end
       end


### PR DESCRIPTION
Updates pkinit tgt response to include the negotiated key

## Verification

First run through these test steps to create an ADCS environment - https://github.com/rapid7/metasploit-framework/pull/16939
Note: Requires at least windows server 2016 to work

Verify tests pass

Verify you can request a cert:
```
msf6 auxiliary(admin/dcerpc/icpr_cert) > rerun smbuser=Administrator smbpass=p4$$w0rd rhosts=192.168.123.13 ca=adf3-DC3-CA cert_template=ESC1-Test smbdomain=ADF3.LOCAL alt_upn=Administrator@adf3.local
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] 192.168.123.13:445 - Requesting a certificate...
[+] 192.168.123.13:445 - The requested certificate was issued.
[*] 192.168.123.13:445 - Certificate UPN: Administrator@adf3.local
[*] 192.168.123.13:445 - Certificate stored at: /Users/adfoster/.msf4/loot/20221214003328_default_unknown_windows.ad.cs_766198.pfx
[*] Auxiliary module execution completed
```

And use pkinit:

```
msf6 auxiliary(admin/kerberos/pkinit_login) >  rerun rhosts=192.168.123.13 cert_file=/Users/adfoster/.msf4/loot/20221214003328_default_unknown_windows.ad.cs_766198.pfx
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] Attempting PKINIT login for Administrator@adf3.local
[+] Successfully authenticated with certificate
[*] 192.168.123.13:88 - TGT MIT Credential Cache saved to /Users/adfoster/.msf4/loot/20221214003538_default_192.168.123.13_mit.kerberos.cca_746788.bin
[*] Auxiliary module execution completed
```

And login with the normal service authenticator workflow:

```
msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 winrmrhostname=dc3.adf3.local domain=adf3.local

[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache saved to /Users/adfoster/.msf4/loot/20221214011150_default_192.168.123.13_mit.kerberos.cca_905332.bin
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:88 - TGS MIT Credential Cache saved to /Users/adfoster/.msf4/loot/20221214011150_default_192.168.123.13_mit.kerberos.cca_849328.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[+] 192.168.123.13:88 - Received AP-REQ. Extracting session key...
[+] 192.168.123.13:5985 - Login Successful: adf3.local\Administrator:p4$$w0rd
[*] Command shell session 2 opened (192.168.123.1:55731 -> 192.168.123.13:5985) at 2022-12-14 01:11:51 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```