### PR TITLE
Return success code for writing and appending file in command shells

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -461,10 +461,11 @@ Shell Banner:
 
     begin
       content = File.binread(src)
-      _file_transfer.write_file(dst, content)
-      print_good("File <#{dst}> upload finished")
+      result = _file_transfer.write_file(dst, content)
+      print_good("File <#{dst}> upload finished") if result
+      print_error("Error occured while uploading <#{src}> to <#{dst}>") unless result
     rescue => e
-      print_error("Error occurs while uploading <#{src}> to <#{dst}> - #{e.message}")
+      print_error("Error occured while uploading <#{src}> to <#{dst}> - #{e.message}")
       elog(e)
       return
     end

--- a/lib/msf/base/sessions/powershell.rb
+++ b/lib/msf/base/sessions/powershell.rb
@@ -59,7 +59,7 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
     etime = ::Time.now.to_f + timeout
 
     buff = ''
-    # Keep reading data until the marker has been received or the 30 minture timeout has occured
+    # Keep reading data until the marker has been received or the 30 minute timeout has occured
     while (::Time.now.to_f < etime)
       res = shell_read(-1, timeout)
       break unless res

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -715,7 +715,7 @@ module Msf::Post::File
       success = _write_file_powershell_fragment(file_name, data, offset, chunk_size, append)
       unless success
         unless offset == 0
-          vprint_status("Write partially succeeded then failed. May need to manually clean up")
+          print_warning("Write partially succeeded then failed. May need to manually clean up #{file_name}")
         end
         return false
       end
@@ -730,7 +730,7 @@ module Msf::Post::File
   end
 
   def _write_file_powershell_fragment(file_name, data, offset, chunk_size, append = false)
-    token = ::Rex::Text.rand_text_alpha(32)
+    token = "_#{::Rex::Text.rand_text_alpha(32)}"
     chunk = data[offset..(offset + chunk_size-1)]
     length = chunk.length
     compressed_chunk = Rex::Text.gzip(chunk)
@@ -881,14 +881,14 @@ protected
       begin
         success = _shell_command_with_success_code("echo | set /p x=\"#{data[start_index, write_length]}\">> \"#{file_name}\"")
         unless success
-          vprint_status("Write partially succeeded then failed. May need to manually clean up") unless start_index == 0
+          print_warning("Write partially succeeded then failed. May need to manually clean up #{file_name}") unless start_index == 0
           return false
         end
         start_index += write_length
         write_length = [chunk_size, data.length - start_index].min
       rescue ::Exception => e
         print_error("Exception while running #{__method__}: #{e}")
-        vprint_status("May need to manually clean up") unless start_index == 0
+        print_warning("May need to manually clean up #{file_name}") unless start_index == 0
         file_rm(file_name)
         return false
       end
@@ -1091,7 +1091,7 @@ protected
 
       succeeded = _shell_command_with_success_code("#{cmd} >> '#{file_name}'")
       unless succeeded
-        vprint_status("Write partially succeeded then failed. May need to manually clean up")
+        print_warning("Write partially succeeded then failed. May need to manually clean up #{file_name}")
         return false
       end
     end
@@ -1100,7 +1100,7 @@ protected
   end
 
   def _shell_command_with_success_code(cmd)
-    token = ::Rex::Text.rand_text_alpha(32)
+    token = "_#{::Rex::Text.rand_text_alpha(32)}"
     result = session.shell_command_token("#{cmd} && echo #{token}")
 
     return result.include?(token)


### PR DESCRIPTION
This resolves #17365.

For Windows Cmd, PowerShell and Unix command shells, we now return `true` or `false` when `write_file` or `append_file` return, based on whether the command succeeded. This is achieved by just placing a `&& echo <token>` after each command, and checking that we received the token back. In one case (Windows cmd ANSI), this necessitated making a small change to the command run, since `set /p=Text` would always set `%errorlevel%` to 1, so the `echo <token>` would never run. Using a dummy variable sets it to 0 instead.

I also reduced the size of each PowerShell upload chunk; larger chunks would periodically fail, likely because the powerfun wrapper truncates to 20000 characters. I was also getting failures at much smaller sizes, though, so this may merit more investigation.

I also integrated the result of this into `cmd_upload`, so that uploading directly from a command shell reports success or failure.

## Verification

For each shell type, run several test cases, which will exercise the different code paths:

- Uploading a file from the shell that contains only letters and numbers
- Uploading a file from the shell that contains binary data
- Uploading a large-ish (~1MB is fine) file from the shell that contains binary data, to test chunking
- Appending to a file with plain text (I tested this by entering `irb` from within a module after setting the session, and just calling `append_file` directly)
- Appending to a file with binary datat
- Attempting to write to a privileged path (e.g. `C:\Windows` or `/root`)
- Uploading a large file, and then partway through, removing permissions on the file (in Windows, disable inheritance, then remove the ACL for the file while it's uploading; in linux, `chmod 000 file`)
- Same permission changing test, but for appending.

### Windows cmd shell

- [x] Write_file with text
- [x] Write_file with binary data
- [x] Write_file with binary data, chunked
- [x] Append_file with text
- [x] Append_file with binary
- [x] Invalid location
- [x] Write, interrupted partway through
- [x] Append, interrupted partway through

### PowerShell

- [x] Write_file with text
- [x] Write_file with binary data
- [x] Write_file with binary data, chunked
- [x] Append_file with text
- [x] Append_file with binary
- [x] Invalid location
- [x] Write, interrupted partway through
- [x] Append, interrupted partway through

### Linux


- [x] Write_file with text
- [x] Write_file with binary data
- [x] Write_file with binary data, chunked
- [x] Append_file with text
- [x] Append_file with binary
- [x] Invalid location
- [x] Write, interrupted partway through
- [x] Append, interrupted partway through