### PR TITLE
Ignore Content-Length header for the purpose of HEAD requests

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -234,7 +234,7 @@ class Client
 
     send_request(req, t)
 
-    res = read_response(req, t)
+    res = read_response(t, :original_request => req)
     if req.respond_to?(:opts) && req.opts['ntlm_transform_response'] && self.ntlm_client
       req.opts['ntlm_transform_response'].call(self.ntlm_client, res)
     end
@@ -561,14 +561,18 @@ class Client
   # If t is specified as nil or 0, it indicates no response parsing is required.
   #
   # @return [Response]
-  def read_response(original_request, t = -1, opts = {})
+  def read_response(t = -1, opts = {})
     # Return a nil response if timeout is nil or 0
     return if t.nil? || t == 0
 
     resp = Response.new
     resp.max_data = config['read_max_data']
 
-    parse_opts = { :orig_method => original_request.opts['method'] }
+    original_request = opts.fetch(:original_request) { nil }
+    parse_opts = {}
+    unless original_request.nil?
+      parse_opts = { :orig_method => original_request.opts['method'] }
+    end
 
     Timeout.timeout((t < 0) ? nil : t) do
 

--- a/lib/rex/proto/http/packet.rb
+++ b/lib/rex/proto/http/packet.rb
@@ -88,10 +88,10 @@ class Packet
 
       # Continue on to the body if the header was processed
       if(self.state == ParseState::ProcessingBody)
-        # Chunked encoding sets the parsing state on its own
-        # HEAD requests can return immediately
+        # Chunked encoding sets the parsing state on its own.
+        # HEAD requests can return immediately.
         orig_method = opts.fetch(:orig_method) { '' }
-        if (self.body_bytes_left == 0 and (not self.transfer_chunked or orig_method == 'HEAD'))
+        if (self.body_bytes_left == 0 && (!self.transfer_chunked || orig_method == 'HEAD'))
           self.state = ParseState::Completed
         else
           parse_body
@@ -285,7 +285,7 @@ protected
 
   ##
   #
-  # Parsing
+  # Parse the HTTP header returned by the target server.
   #
   # @param [Hash] opts Parsing options
   # @option [Boolean] orig_method The HTTP method used in an associated request, if applicable


### PR DESCRIPTION
Fixes #3865, by making our parser more compliant with RFC9110, which states:

"...a client MUST retain knowledge of the request when parsing... a corresponding response. For example, responses to the HEAD method look just like the beginning of a response to GET but cannot be parsed in the same manner."

Previously we did not take into account the request's method, and so were parsing a HEAD response like a GET response.
That turned out to be the root cause of this issue, as was suggested in that issue conversation.

As a result of this fix, the `auxiliary/scanner/http/http_header` module now works, which has been broken for a while, I gather.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/http_header`
- [x] `set rhosts google.com`
- [x] `run`
- [x] Verify that the headers are returned (previously would just hang then fail)
- [x] Verify that other HTTP modules are not affected