### PR TITLE
Expand ~ for hosts and notes commands

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -493,6 +493,7 @@ class Db
         onlyup = true
       when '-o'
         output = val
+        output = ::File.expand_path(output)
       when '-R', '--rhosts'
         set_rhosts = true
       when '-S', '--search'
@@ -680,6 +681,8 @@ class Db
       return @@services_columns
     when '-O', '--order'
       return []
+    when '-o', '--output'
+      return tab_complete_filenames(str, words)
     when '-p', '--port'
       return []
     when '-r', '--protocol'
@@ -909,6 +912,10 @@ class Db
     if words.length == 1
       return @@vulns_opts.option_keys.select { |opt| opt.start_with?(str) }
     end
+    case words[-1]
+    when '-o', '--output'
+      return tab_complete_filenames(str, words)
+    end
   end
 
   def cmd_vulns_help
@@ -1083,6 +1090,8 @@ class Db
     case words[-1]
     when '-O', '--order'
       return []
+    when '-o', '--output'
+      return tab_complete_filenames(str, words)
     end
 
     []
@@ -1152,6 +1161,7 @@ class Db
         search_term = val
       when '-o', '--output'
         output_file = val
+        output_file = ::File.expand_path(output_file)
       when '-O'
         if (order_by = val.to_i - 1) < 0
           print_error('Please specify a column number starting from 1')


### PR DESCRIPTION
This resolves #14144 - allowing the use of the `~` character in certain commands (`hosts` and `notes`) for the output command. Also technically supports environment variables.

As part of this, I also allowed for tab completion of output files for commands in the relevant file.

## Verification

List the steps needed to make sure this thing works

- [x] Start the database with `msfdb start`
- [x] Start `msfconsole`
- [x] `hosts -c address,os_family,os_name -O 1 -o ~/hosts.csv` (should write to ~/hosts.csv)
- [x] `notes -o ~/notes.csv` (should write to ~/notes.csv)
- [x] Test tab completion of the `-o` parameter for the `services`, `vulns`, and `notes` commands (should autocomplete filenames on disk)