### PR TITLE
Move debug ticket to new module

### DIFF
--- a/documentation/modules/auxiliary/admin/kerberos/forge_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/forge_ticket.md
@@ -41,7 +41,6 @@ There are two kind of actions the module can run:
 
 1. **FORGE_SILVER** - Forge a Silver ticket. [Default]
 2. **FORGE_GOLDEN** - Forge a Golden ticket.
-3. **DEBUG_TICKET** - Print the contents of a ccache or kirbi file.
 
 ## Scenarios
 
@@ -200,145 +199,6 @@ export KRB5CCNAME=/Users/user/.msf4/loot/20220901132003_default_192.168.123.13_k
 python3 $code/impacket/examples/smbexec.py 'adf3.local/Administrator@dc3.adf3.local' -dc-ip 192.168.123.13 -k -no-pass
 ```
 
-### Debugging Ticket contents
-
-This action allows you to see the contents of any ccache or kirbi file,
-If you are able to provide the decryption key we can also show the encrypted parts of the tickets.
-
-1. `TICKET_PATH` - The path to the ccache or kirbi file.
-2. `AES_KEY` - (Optional) Only set this if you have the decryption key and it is an AES128 or AES256 key.
-3. `NTHASH` - (Optional) Only set this if you have the decryption key and it is an NTHASH.
-No other options are used in this action.
-
-**With Key**
-```
-msf6 auxiliary(admin/kerberos/forge_ticket) > run action=DEBUG_TICKET AES_KEY=4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326 TICKET_PATH=/path/to/ticket
-```
-
-Example output:
-```
-Primary Principal: Administrator@WINDOMAIN.LOCAL
-Ccache version: 4
-
-Creds: 1
-  Credential[0]:
-    Server: cifs/dc.windomain.local@WINDOMAIN.LOCAL
-    Client: Administrator@WINDOMAIN.LOCAL
-    Ticket etype: 18 (AES256)
-    Key: 3436643936633032656264663030393931323461366635653364393932613763
-    Ticket Length: 978
-    Subkey: false
-    Addresses: 0
-    Authdatas: 0
-    Times:
-      Auth time: 2022-11-21 13:52:00 +0000
-      Start time: 2022-11-21 13:52:00 +0000
-      End time: 2032-11-18 13:52:00 +0000
-      Renew Till: 2032-11-18 13:52:00 +0000
-    Ticket:
-      Ticket Version Number: 5
-      Realm: WINDOMAIN.LOCAL
-      Server Name: cifs/dc.windomain.local
-      Encrypted Ticket Part:
-        Ticket etype: 18 (AES256)
-        Key Version Number: 2
-        Decrypted (with key: \x4b\x91\x2b\xe0\x36\x6a\x6f\x37\xf4\xa7\xd5\x71\xbe\xe1\x8b\x11\x73\xd9\x31\x95\xef\x76\xf8\xd1\xe3\xe8\x1e\xf6\x17\x2a\xb3\x26):
-          Times:
-            Auth time: 2022-11-21 13:52:00 UTC
-            Start time: 2022-11-21 13:52:00 UTC
-            End time: 2032-11-18 13:52:00 UTC
-            Renew Till: 2032-11-18 13:52:00 UTC
-          Client Addresses: 0
-          Transited: tr_type: 0, Contents: ""
-          Client Name: 'Administrator'
-          Client Realm: 'WINDOMAIN.LOCAL'
-          Ticket etype: 18 (AES256)
-          Encryption Key: 3436643936633032656264663030393931323461366635653364393932613763
-          Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT)
-          PAC:
-            Validation Info:
-              Logon Time: 2022-11-21 13:52:00 +0000
-              Logoff Time: Never Expires (inf)
-              Kick Off Time: Never Expires (inf)
-              Password Last Set: No Time Set (0)
-              Password Can Change: No Time Set (0)
-              Password Must Change: Never Expires (inf)
-              Logon Count: 0
-              Bad Password Count: 0
-              User ID: 500
-              Primary Group ID: 513
-              User Flags: 0
-              User Session Key: \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00
-              User Account Control: 528
-              Sub Auth Status: 0
-              Last Successful Interactive Logon: No Time Set (0)
-              Last Failed Interactive Logon: No Time Set (0)
-              Failed Interactive Logon Count: 0
-              SID Count: 0
-              Resource Group Count: 0
-              Group Count: 5
-              Group IDs:
-                Relative ID: 513, Attributes: 7
-                Relative ID: 512, Attributes: 7
-                Relative ID: 520, Attributes: 7
-                Relative ID: 518, Attributes: 7
-                Relative ID: 519, Attributes: 7
-              Logon Domain ID: S-1-5-21-3541430928-2051711210-1391384369
-              Effective Name: 'Administrator'
-              Full Name: ''
-              Logon Script: ''
-              Profile Path: ''
-              Home Directory: ''
-              Home Directory Drive: ''
-              Logon Server: ''
-              Logon Domain Name: 'WINDOMAIN.LOCAL'
-            Client Info:
-              Name: 'Administrator'
-              Client ID: 2022-11-21 13:52:00 +0000
-            Pac Server Checksum:
-              Signature: \x04\xe5\xab\x06\x1c\x7a\x90\x9a\x26\xb1\x22\xc2
-            Pac Privilege Server Checksum:
-              Signature: \x71\x0b\xb1\x83\x85\x82\x57\xf4\x10\x21\xbd\x7e
-```
-**Without Key**
-
-```
-msf6 auxiliary(admin/kerberos/forge_ticket) > run action=DEBUG_TICKET TICKET_PATH=/path/to/ticket
-```
-
-Example Output:
-```
-Primary Principal: Administrator@WINDOMAIN.LOCAL
-Ccache version: 4
-
-Creds: 1
-  Credential[0]:
-    Server: cifs/dc.windomain.local@WINDOMAIN.LOCAL
-    Client: Administrator@WINDOMAIN.LOCAL
-    Ticket etype: 18 (AES256)
-    Key: 3436643936633032656264663030393931323461366635653364393932613763
-    Ticket Length: 978
-    Subkey: false
-    Addresses: 0
-    Authdatas: 0
-    Times:
-      Auth time: 2022-11-21 13:52:00 +0000
-      Start time: 2022-11-21 13:52:00 +0000
-      End time: 2032-11-18 13:52:00 +0000
-      Renew Till: 2032-11-18 13:52:00 +0000
-    Ticket:
-      Ticket Version Number: 5
-      Realm: WINDOMAIN.LOCAL
-      Server Name: cifs/dc.windomain.local
-      Encrypted Ticket Part:
-        Ticket etype: 18 (AES256)
-        Key Version Number: 2
-        Cipher:
-          1YrnB+fhzeLEq+4NUcXvoEsSI29+gwCDg3qjYdb0YHhqx23BhZGOK9rIQ99uXeuLHSapJAanCE9g/PyyKDE1kggrEHfy6cxwsP25exmN2w3NXVm7P0PqMVON2RBp2S11eIdF/Zibhrs7JbaaVw0Hv8GpbpHdFI0l6Xx3Jz+y0bqFsFNEsU8nEW35Z3Oo2xpI/xTwNTyG1Bmg+bktSLyI6nEPtJXQKcoJTrNhSBNsZ18HZiUPim9EqSCHUh0VbDeLntryh+lt0TIgwhwipHPWnro+Y81dvX5j8ZeBdgKgnoX3jciU629u/RveQJgyw/vLk1KT0RzTbHSwdRk/xi6ghccvew33TKJ8q3nP/JuSWDzaDE6I6v3KgInSZP+XkCAV5VT//U49MtIVIKARcmtXQwVxztMXKlWjIaxQwl9BN6CuyWZjDcafAssjPWgWIAsesmEWHn3btv1BP0a4gvn5f1b7Fu4Gh6w0ARCryxZkSl+6UhJbcdaRT23WhqN24ECGEl0VIX4fuLs6x0gVtAQ2YsI+HkoQYuI+C28gXzJUCac6rJyFQSTsciwj/jVf18ttw1vfGGKa/BVcqscGZoJPpBiuGPBkIbeAOery0Sjn+0tP0tsPYw1OkpzZ7n/j/YdmTX6UAFZjCLbgvF8hoPyider1gntOiSjlLlEUITLTfe5zqWi4gs47Ly6lvggBWW9Yg0fIaPOHYMvsszMLcJz0+dFXtDVI452LIEatLDvp1aKkwGANWYyRgOMlHR3fD030SOTNEb5oa6WigWZQLlhuDbgrfFaWWAMp7opcNbNKy7Iv17EscL7pW2Ygc38VbmbFtdIfvpQ9niwLr2msjzhB7RPihZXcUAlVygLwykq0JDG4fRmoNXzNydbnYlX9E+KW0fHFjoBitAx1xrp9p5Ajwoyy+wIk0mt/aC4pbfcoRjt4GUF/9DhZnH3HiPn4lM9TLMzpiediEtDZtKgGvAAP2cJZn2gsLRlKAtBZvl+ibe1uDzC9g6rnObAx3c+OSG9rmHzBBCq6D8wW6ZjrQy8njNuriC5rnQxUpVhgGvTOkeTphSIHX+D4SuMd+XZ4zqa3DsrHzIeVWAvrTHCDBzy+DKt2RoQTwYmGT+a0YB0btQtgIfRj2OwDtlP65JUxC+/ANelHg73d0REoYistB5ZMmvk=
-```
-
-Both these examples Are printing the contents of the same ccache file and showing the difference in output if you have the decryption key available.
-
 ### Common Mistakes
 
 **Invalid hostname**
@@ -358,4 +218,4 @@ SPNs must be in the format `*/*`. If this is not identical to what Active Direct
 
 If you `set Verbose true` you will set the module to run in a more verbose mode.
 This would be useful in cases where the ticket you are forging does not work as expected and in this case
-we print out the contents of the ticket after it's been forged similar to the `DEBUG_TICKET` action with the key supplied.
+we print out the contents of the ticket after it's been forged similar to the `inspect_ticket` module with the key supplied.

--- a/documentation/modules/auxiliary/admin/kerberos/inspect_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/inspect_ticket.md
@@ -1,0 +1,157 @@
+# Kerberos Ticket Inspecting
+
+The `inspect_ticket` module allows you to print the contents of a ccache/kirbi file.
+
+## Pre-Verification steps
+
+1. Generate a ccache file using the `forge_ticket` module
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use auxiliary/admin/kerberos/inspect_ticket`
+3. Do: `set TICKET_PATH /path/to/ccache/file`
+4. Optional: either `set AES_KEY aes_key_here` or `set NTHASH nthash_here`
+5. Do: `run` to see the contents of the ticket 
+
+## Scenarios
+
+### Inspecting Ticket contents
+
+This action allows you to see the contents of any ccache or kirbi file,
+If you are able to provide the decryption key we can also show the encrypted parts of the tickets.
+
+1. `TICKET_PATH` - The path to the ccache or kirbi file.
+2. `AES_KEY` - (Optional) Only set this if you have the decryption key and it is an AES128 or AES256 key.
+3. `NTHASH` - (Optional) Only set this if you have the decryption key and it is an NTHASH.
+No other options are used in this action.
+
+**Without Key**
+
+```
+msf6 auxiliary(admin/kerberos/inspect_ticket) > run TICKET_PATH=/path/to/ticket
+```
+
+Example Output:
+```
+Primary Principal: Administrator@WINDOMAIN.LOCAL
+Ccache version: 4
+
+Creds: 1
+  Credential[0]:
+    Server: cifs/dc.windomain.local@WINDOMAIN.LOCAL
+    Client: Administrator@WINDOMAIN.LOCAL
+    Ticket etype: 18 (AES256)
+    Key: 3436643936633032656264663030393931323461366635653364393932613763
+    Ticket Length: 978
+    Subkey: false
+    Addresses: 0
+    Authdatas: 0
+    Times:
+      Auth time: 2022-11-21 13:52:00 +0000
+      Start time: 2022-11-21 13:52:00 +0000
+      End time: 2032-11-18 13:52:00 +0000
+      Renew Till: 2032-11-18 13:52:00 +0000
+    Ticket:
+      Ticket Version Number: 5
+      Realm: WINDOMAIN.LOCAL
+      Server Name: cifs/dc.windomain.local
+      Encrypted Ticket Part:
+        Ticket etype: 18 (AES256)
+        Key Version Number: 2
+        Cipher:
+          1YrnB+fhzeLEq+4NUcXvoEsSI29+gwCDg3qjYdb0YHhqx23BhZGOK9rIQ99uXeuLHSapJAanCE9g/PyyKDE1kggrEHfy6cxwsP25exmN2w3NXVm7P0PqMVON2RBp2S11eIdF/Zibhrs7JbaaVw0Hv8GpbpHdFI0l6Xx3Jz+y0bqFsFNEsU8nEW35Z3Oo2xpI/xTwNTyG1Bmg+bktSLyI6nEPtJXQKcoJTrNhSBNsZ18HZiUPim9EqSCHUh0VbDeLntryh+lt0TIgwhwipHPWnro+Y81dvX5j8ZeBdgKgnoX3jciU629u/RveQJgyw/vLk1KT0RzTbHSwdRk/xi6ghccvew33TKJ8q3nP/JuSWDzaDE6I6v3KgInSZP+XkCAV5VT//U49MtIVIKARcmtXQwVxztMXKlWjIaxQwl9BN6CuyWZjDcafAssjPWgWIAsesmEWHn3btv1BP0a4gvn5f1b7Fu4Gh6w0ARCryxZkSl+6UhJbcdaRT23WhqN24ECGEl0VIX4fuLs6x0gVtAQ2YsI+HkoQYuI+C28gXzJUCac6rJyFQSTsciwj/jVf18ttw1vfGGKa/BVcqscGZoJPpBiuGPBkIbeAOery0Sjn+0tP0tsPYw1OkpzZ7n/j/YdmTX6UAFZjCLbgvF8hoPyider1gntOiSjlLlEUITLTfe5zqWi4gs47Ly6lvggBWW9Yg0fIaPOHYMvsszMLcJz0+dFXtDVI452LIEatLDvp1aKkwGANWYyRgOMlHR3fD030SOTNEb5oa6WigWZQLlhuDbgrfFaWWAMp7opcNbNKy7Iv17EscL7pW2Ygc38VbmbFtdIfvpQ9niwLr2msjzhB7RPihZXcUAlVygLwykq0JDG4fRmoNXzNydbnYlX9E+KW0fHFjoBitAx1xrp9p5Ajwoyy+wIk0mt/aC4pbfcoRjt4GUF/9DhZnH3HiPn4lM9TLMzpiediEtDZtKgGvAAP2cJZn2gsLRlKAtBZvl+ibe1uDzC9g6rnObAx3c+OSG9rmHzBBCq6D8wW6ZjrQy8njNuriC5rnQxUpVhgGvTOkeTphSIHX+D4SuMd+XZ4zqa3DsrHzIeVWAvrTHCDBzy+DKt2RoQTwYmGT+a0YB0btQtgIfRj2OwDtlP65JUxC+/ANelHg73d0REoYistB5ZMmvk=
+```
+
+**With Key**
+```
+msf6 auxiliary(admin/kerberos/inspect_ticket) > run AES_KEY=4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326 TICKET_PATH=/path/to/ticket
+```
+
+Example output:
+```
+Primary Principal: Administrator@WINDOMAIN.LOCAL
+Ccache version: 4
+
+Creds: 1
+  Credential[0]:
+    Server: cifs/dc.windomain.local@WINDOMAIN.LOCAL
+    Client: Administrator@WINDOMAIN.LOCAL
+    Ticket etype: 18 (AES256)
+    Key: 3436643936633032656264663030393931323461366635653364393932613763
+    Ticket Length: 978
+    Subkey: false
+    Addresses: 0
+    Authdatas: 0
+    Times:
+      Auth time: 2022-11-21 13:52:00 +0000
+      Start time: 2022-11-21 13:52:00 +0000
+      End time: 2032-11-18 13:52:00 +0000
+      Renew Till: 2032-11-18 13:52:00 +0000
+    Ticket:
+      Ticket Version Number: 5
+      Realm: WINDOMAIN.LOCAL
+      Server Name: cifs/dc.windomain.local
+      Encrypted Ticket Part:
+        Ticket etype: 18 (AES256)
+        Key Version Number: 2
+        Decrypted (with key: \x4b\x91\x2b\xe0\x36\x6a\x6f\x37\xf4\xa7\xd5\x71\xbe\xe1\x8b\x11\x73\xd9\x31\x95\xef\x76\xf8\xd1\xe3\xe8\x1e\xf6\x17\x2a\xb3\x26):
+          Times:
+            Auth time: 2022-11-21 13:52:00 UTC
+            Start time: 2022-11-21 13:52:00 UTC
+            End time: 2032-11-18 13:52:00 UTC
+            Renew Till: 2032-11-18 13:52:00 UTC
+          Client Addresses: 0
+          Transited: tr_type: 0, Contents: ""
+          Client Name: 'Administrator'
+          Client Realm: 'WINDOMAIN.LOCAL'
+          Ticket etype: 18 (AES256)
+          Encryption Key: 3436643936633032656264663030393931323461366635653364393932613763
+          Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT)
+          PAC:
+            Validation Info:
+              Logon Time: 2022-11-21 13:52:00 +0000
+              Logoff Time: Never Expires (inf)
+              Kick Off Time: Never Expires (inf)
+              Password Last Set: No Time Set (0)
+              Password Can Change: No Time Set (0)
+              Password Must Change: Never Expires (inf)
+              Logon Count: 0
+              Bad Password Count: 0
+              User ID: 500
+              Primary Group ID: 513
+              User Flags: 0
+              User Session Key: \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00
+              User Account Control: 528
+              Sub Auth Status: 0
+              Last Successful Interactive Logon: No Time Set (0)
+              Last Failed Interactive Logon: No Time Set (0)
+              Failed Interactive Logon Count: 0
+              SID Count: 0
+              Resource Group Count: 0
+              Group Count: 5
+              Group IDs:
+                Relative ID: 513, Attributes: 7
+                Relative ID: 512, Attributes: 7
+                Relative ID: 520, Attributes: 7
+                Relative ID: 518, Attributes: 7
+                Relative ID: 519, Attributes: 7
+              Logon Domain ID: S-1-5-21-3541430928-2051711210-1391384369
+              Effective Name: 'Administrator'
+              Full Name: ''
+              Logon Script: ''
+              Profile Path: ''
+              Home Directory: ''
+              Home Directory Drive: ''
+              Logon Server: ''
+              Logon Domain Name: 'WINDOMAIN.LOCAL'
+            Client Info:
+              Name: 'Administrator'
+              Client ID: 2022-11-21 13:52:00 +0000
+            Pac Server Checksum:
+              Signature: \x04\xe5\xab\x06\x1c\x7a\x90\x9a\x26\xb1\x22\xc2
+            Pac Privilege Server Checksum:
+              Signature: \x71\x0b\xb1\x83\x85\x82\x57\xf4\x10\x21\xbd\x7e
+```
+
+Both these examples Are printing the contents of the same ccache file and showing the difference in output if you have the decryption key available.

--- a/documentation/modules/auxiliary/admin/kerberos/inspect_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/inspect_ticket.md
@@ -154,4 +154,4 @@ Creds: 1
               Signature: \x71\x0b\xb1\x83\x85\x82\x57\xf4\x10\x21\xbd\x7e
 ```
 
-Both these examples Are printing the contents of the same ccache file and showing the difference in output if you have the decryption key available.
+Both of these examples are printing the contents of the same ccache file and showing the difference in output if you have the decryption key available.

--- a/documentation/modules/auxiliary/admin/kerberos/inspect_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/inspect_ticket.md
@@ -12,7 +12,7 @@ The `inspect_ticket` module allows you to print the contents of a ccache/kirbi f
 2. Do: `use auxiliary/admin/kerberos/inspect_ticket`
 3. Do: `set TICKET_PATH /path/to/ccache/file`
 4. Optional: either `set AES_KEY aes_key_here` or `set NTHASH nthash_here`
-5. Do: `run` to see the contents of the ticket 
+5. Do: `run` to see the contents of the ticket
 
 ## Scenarios
 
@@ -30,10 +30,6 @@ No other options are used in this action.
 
 ```
 msf6 auxiliary(admin/kerberos/inspect_ticket) > run TICKET_PATH=/path/to/ticket
-```
-
-Example Output:
-```
 Primary Principal: Administrator@WINDOMAIN.LOCAL
 Ccache version: 4
 
@@ -66,10 +62,6 @@ Creds: 1
 **With Key**
 ```
 msf6 auxiliary(admin/kerberos/inspect_ticket) > run AES_KEY=4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326 TICKET_PATH=/path/to/ticket
-```
-
-Example output:
-```
 Primary Principal: Administrator@WINDOMAIN.LOCAL
 Ccache version: 4
 

--- a/modules/auxiliary/admin/kerberos/inspect_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/inspect_ticket.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::Kerberos::Client
+  include Msf::Exploit::Remote::Kerberos::Ticket
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Kerberos Ticket Inspecting',
+        'Description' => %q{
+          This module outputs the contents of a ccache/kirbi file
+        },
+        'Author' => [
+          'Dean Welch' # Metasploit Module
+        ],
+        'References' => [],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [],
+          'SideEffects' => [],
+          'Reliability' => [],
+          'AKA' => ['Klist']
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('NTHASH', [ false, 'The krbtgt/service nthash' ]),
+        OptString.new('AES_KEY', [ false, 'The krbtgt/service AES key' ]),
+        OptString.new('TICKET_PATH', [true, 'Path to the ticket (ccache/kirbi format) you wish to inspect'])
+      ]
+    )
+    deregister_options('RHOSTS', 'RPORT', 'Timeout')
+  end
+
+  SECS_IN_DAY = 60 * 60 * 24
+
+  def run
+    enc_key = get_enc_key
+    print_contents(datastore['TICKET_PATH'], key: enc_key)
+  end
+
+  private
+
+  def get_enc_key
+    key = validate_key
+    key.nil? ? nil : [key].pack('H*')
+  end
+
+  def validate_key
+    if datastore['NTHASH'].blank? && datastore['AES_KEY'].blank?
+      return nil
+    elsif datastore['NTHASH'].present? && datastore['AES_KEY'].present?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'NTHASH and AES_KEY may not both be set for inspecting a ticket')
+    end
+
+    if datastore['NTHASH'].present? && datastore['NTHASH'].size != 32
+      fail_with(Msf::Exploit::Failure::BadConfig, "NTHASH length was #{datastore['NTHASH'].size} should be 32")
+    else
+      return datastore['NTHASH']
+    end
+
+    if datastore['AES_KEY'].present? && (datastore['AES_KEY'].size != 32 && datastore['AES_KEY'].size != 64)
+      fail_with(Msf::Exploit::Failure::BadConfig, "AES key length was #{datastore['AES_KEY'].size} should be 32 or 64")
+    else
+      return datastore['AES_KEY']
+    end
+  end
+end

--- a/modules/auxiliary/admin/kerberos/inspect_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/inspect_ticket.rb
@@ -14,7 +14,9 @@ class MetasploitModule < Msf::Auxiliary
         info,
         'Name' => 'Kerberos Ticket Inspecting',
         'Description' => %q{
-          This module outputs the contents of a ccache/kirbi file
+          This module outputs the contents of a ccache/kirbi file and optionally (when provided with the appropriate key)
+          decrypts and displays the encrypted content too.
+          Can be used for inspecting tickets that aren't working as intended in an effort to debug them.
         },
         'Author' => [
           'Dean Welch' # Metasploit Module
@@ -25,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
           'Stability' => [],
           'SideEffects' => [],
           'Reliability' => [],
-          'AKA' => ['Klist']
+          'AKA' => ['klist']
         }
       )
     )
@@ -40,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options('RHOSTS', 'RPORT', 'Timeout')
   end
 
-  SECS_IN_DAY = 60 * 60 * 24
+  SECS_IN_DAY = 86400 # 60 * 60 * 24
 
   def run
     enc_key = get_enc_key
@@ -62,13 +64,13 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if datastore['NTHASH'].present? && datastore['NTHASH'].size != 32
-      fail_with(Msf::Exploit::Failure::BadConfig, "NTHASH length was #{datastore['NTHASH'].size} should be 32")
+      fail_with(Msf::Exploit::Failure::BadConfig, "NTHASH length was #{datastore['NTHASH'].size}. It should be 32")
     else
       return datastore['NTHASH']
     end
 
     if datastore['AES_KEY'].present? && (datastore['AES_KEY'].size != 32 && datastore['AES_KEY'].size != 64)
-      fail_with(Msf::Exploit::Failure::BadConfig, "AES key length was #{datastore['AES_KEY'].size} should be 32 or 64")
+      fail_with(Msf::Exploit::Failure::BadConfig, "AES key length was #{datastore['AES_KEY'].size}. It should be 32 or 64")
     else
       return datastore['AES_KEY']
     end


### PR DESCRIPTION
Just moving the `DEBUG_TICKET` action from the `forge_ticket` module to it's own module `inspect_ticket`

# Verification Steps
- [x] Start msfconsole
- [x] `use auxiliary/admin/kerberos/forge_ticket`
- [x] Follow the verification steps from [here](https://github.com/rapid7/metasploit-framework/blob/6cd2c6a82d0c12c8cbfe162b28c309ad55c4bc3a/documentation/modules/auxiliary/admin/kerberos/forge_ticket.md)
- [x] `use auxiliary/admin/kerberos/inspect_ticket`
- [x] Set `TICKET_PATH` to the ccache file you generated with the `forge_ticket` module
- [x] Optionally set NTHASH or AES_KEY (whichever you used when forging the ticket`
- [x] run