### PR TITLE
Bump IRB version to 1.6.1 to bring in changes mentioned at https://st0012.dev/whats-new-in-ruby-3-2-irb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
-    irb (1.5.1)
+    irb (1.6.1)
       reline (>= 0.3.0)
     jmespath (1.6.2)
     jsobfu (0.4.2)


### PR DESCRIPTION
Bump IRB version to 1.6.1 to bring in the changes mentioned at https://st0012.dev/whats-new-in-ruby-3-2-irb. This will help users of IRB by providing them with better debugging capabilities using `debug.gem` which we already pulled into the framework, and adds some new commands to help edit the current file begin debugged easier, as well as more easily see the available IRB commands and associated documentation.

This will come by default in Ruby 3.2 so this is just a preemptive push, and we will inevitably have this pulled in with Ruby 3.2 once that is released.

## Verification

List the steps needed to make sure this thing works

- [x] Verify the tests pass
- [x] Run `msfconsole`
- [x] **Verify** that you can run `irb` without any crashes.
- [x] **Verify** that you can use the `edit` command with `irb` to now open the current file in an editor.
- [x] **Verify** that playing around with the new commands does not cause any issues.
