### PR TITLE
Update smb enumshares to gracefully failover from port 139 to 445

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -354,15 +354,15 @@ class MetasploitModule < Msf::Auxiliary
         retry
       rescue Rex::ConnectionTimeout => e
         print_error(e.to_s)
-        return
+        next
       rescue Rex::Proto::SMB::Exceptions::LoginError => e
         print_error(e.to_s)
       rescue RubySMB::Error::RubySMBError => e
         print_error("RubySMB encountered an error: #{e}")
-        return
+        next
       rescue RuntimeError => e
         print_error e.to_s
-        return
+        next
       rescue StandardError => e
         vprint_error("Error: '#{ip}' '#{e.class}' '#{e}'")
       ensure


### PR DESCRIPTION
### Before

When port 139 times out, port 445 isn't tried:

```
msf6 auxiliary(scanner/smb/smb_enumshares) > rerun smbauth=kerberos 192.168.56.23 smbrhostname=braavos.essos.local domaincontrollerrhost=192.168.56.12 smbdomain=essos.local smbuser=khal.drogo smbpass=horse
[*] Reloading module...

[*] 192.168.56.23:139     - Starting module
[-] 192.168.56.23:139     - The connection with (192.168.56.23:139) timed out.
[*] 192.168.56.23:        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### After

Both port 139 and 445 are tried:

```
msf6 auxiliary(scanner/smb/smb_enumshares) > rerun smbauth=kerberos 192.168.56.23 smbrhostname=braavos.essos.local domaincontrollerrhost=192.168.56.12 smbdomain=essos.local smbuser=khal.drogo smbpass=horse
[*] Reloading module...

[*] 192.168.56.23:139     - Starting module
[-] 192.168.56.23:139     - The connection with (192.168.56.23:139) timed out.
[*] 192.168.56.23:445     - Starting module
[+] 192.168.56.23:445     - 192.168.56.12:88 - Received a valid TGT-Response
[*] 192.168.56.23:445     - 192.168.56.23:445     - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20221221202054_default_192.168.56.12_mit.kerberos.cca_632317.bin
[+] 192.168.56.23:445     - 192.168.56.12:88 - Received a valid TGS-Response
[*] 192.168.56.23:445     - 192.168.56.23:445     - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20221221202054_default_192.168.56.12_mit.kerberos.cca_660606.bin
[+] 192.168.56.23:445     - 192.168.56.12:88 - Received a valid delegation TGS-Response
[!] 192.168.56.23:445     - peer_native_os is only available with SMB1 (current version: SMB3)
[!] 192.168.56.23:445     - peer_native_lm is only available with SMB1 (current version: SMB3)
[+] 192.168.56.23:445     - ADMIN$ - (DISK|SPECIAL) Remote Admin
[+] 192.168.56.23:445     - C$ - (DISK|SPECIAL) Default share
[+] 192.168.56.23:445     - IPC$ - (IPC|SPECIAL) Remote IPC
[*] 192.168.56.23:        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification

- Review the code
- Verify when port 139 fails, port 445 is tried