### PR TITLE
Update rhost walker to handle interrupt signal

### DIFF
--- a/lib/msf/core/rhosts_walker.rb
+++ b/lib/msf/core/rhosts_walker.rb
@@ -151,6 +151,8 @@ module Msf
               results << datastore.merge(overrides)
             end
           end
+        rescue ::Interrupt
+          raise
         rescue StandardError => e
           results << Msf::RhostsWalker::Error.new(value, cause: e)
         end


### PR DESCRIPTION
Updates the rhost walker to handle interrupt signals from the user when pressing `ctrl+c` in msfconsole

Improves https://github.com/rapid7/metasploit-framework/issues/16765

Note that the `ctrl+c` interrupt signal won't be handled immediately - the DNS timeout will have to finish first. This seems like a bug in Ruby itself, where the the DNS resolve is blocking and the Ruby VM won't receive the interrupt signal until the DNS resolve timeout is hit - https://bugs.ruby-lang.org/issues/16476. So if the user spams ctrl+c, the multiple excess interrupt requests will bubble up after the DNS timeout ends - then msfconsole will be killed. Therefore the user will have to press ctrl+c once and wait patiently for invalid DNS requests to fail.

## Verification

Steps are in https://github.com/rapid7/metasploit-framework/issues/16765