### PR TITLE
Use .blank? instead of .empty? when handling SSH Key details to prevent crashes

### DIFF
--- a/modules/post/multi/gather/jenkins_gather.rb
+++ b/modules/post/multi/gather/jenkins_gather.rb
@@ -231,9 +231,9 @@ class MetasploitModule < Msf::Post
     @ssh_keys.uniq.each do |e|
       print_good("SSH Key")
       print_status(" ID: #{e[0]}")
-      print_status(" Description: #{e[1]}") if !e[1].nil? || !e[1].empty?
-      print_status(" Passphrase:  #{e[2]}") if !e[2].nil? || !e[2].empty?
-      print_status(" Username:    #{e[3]}") if !e[3].nil? || !e[3].empty?
+      print_status(" Description: #{e[1]}") if !e[1].blank?
+      print_status(" Passphrase:  #{e[2]}") if !e[2].blank?
+      print_status(" Username:    #{e[3]}") if !e[3].blank?
       print_status("\n#{e[4]}")
     end
     ssh_output = @ssh_keys.each { |e| e.join(",") + "\n\n\n" }


### PR DESCRIPTION
blank? should be used instead of empty?. When running this script on a host which has a blank SSH key, an error is encountered: 
```
[-] Post failed: NoMethodError undefined method `empty?' for nil:NilClass
[-] Call stack:
[-]   /opt/metasploit-framework/embedded/framework/modules/post/multi/gather/jenkins_gather.rb:235:in `block in pretty_print_gathered'
[-]   /opt/metasploit-framework/embedded/framework/modules/post/multi/gather/jenkins_gather.rb:231:in `each'
[-]   /opt/metasploit-framework/embedded/framework/modules/post/multi/gather/jenkins_gather.rb:231:in `pretty_print_gathered'
[-]   /opt/metasploit-framework/embedded/framework/modules/post/multi/gather/jenkins_gather.rb:348:in `gathernix'
[-]   /opt/metasploit-framework/embedded/framework/modules/post/multi/gather/jenkins_gather.rb:363:in `run'

```