### PR TITLE
Fix GitHub Actions Verify Action Using Wrong Version of Ruby for 3.0.x Tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -64,18 +64,18 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - 2.7
-          - 3.0
-          - 3.1
+          - '2.7'
+          - '3.0'
+          - '3.1'
         os:
           - ubuntu-20.04
           - ubuntu-latest
         exclude:
-          - { os: ubuntu-latest, ruby: 2.7 }
-          - { os: ubuntu-latest, ruby: 3.0 }
+          - { os: ubuntu-latest, ruby: '2.7' }
+          - { os: ubuntu-latest, ruby: '3.0' }
         include:
           - os: ubuntu-latest
-            ruby: 3.1
+            ruby: '3.1'
             test_cmd: 'bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content" DATASTORE_FALLBACKS=1'
         test_cmd:
           - bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content"
@@ -100,7 +100,7 @@ jobs:
           BUNDLE_WITHOUT: "coverage development pcap"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
 
       - name: Create database


### PR DESCRIPTION
# Overview - The Casting Issue

When we specified the versions for our Verify GitHub Action, we mistakenly specified the version numbers as floating point numbers vs as strings. This was fine for most numbers since they contained a non-zero number after the decimal point, such as 2.7, or 3.1, and so they would be converted into a string fine. 

However for version 3.0 of Ruby, this would be interpreted as a float with a value of 3, so instead of using version 3.0 of Ruby, we would use the latest version 3 release of Ruby for testing, instead of the expected latest 3.0.X release.

This was explained in a solution at https://github.com/orgs/community/discussions/35109, though the specific issue r.e values and casting is based on my own speculation of what is going on behind the scenes, given this only affects the Ruby 3.0 releases.

# But Why Did We Only Notice this Now?
Well as it turns out, Christmas Day was when Ruby 3.2.0 was released. This meant that any PR submitted before this day used the latest Ruby version at the time, which was 3.1.3. When Christmas rolled around, the latest Ruby 3 version suddenly became Ruby 3.2.0, which meant any PRs submitted on or after the time of release now started to use Ruby 3.2.0, which ended up breaking things due to Ruby 3.2 incompatibilities with Nokogiri (to be fixed as noted at https://github.com/sparklemotion/nokogiri/issues/2740).

## Verification

- Verify that the checks now state `Ruby 3.0`, whereas other PRs on `master` are stating `Ruby 3` as being tested. This indicates that the string wasn't being interpreted correctly due to the casting issue.
- Verify that the checks under `Ruby 3.0` are now utilizing Ruby 3.0.5 for testing. You can see this under something like https://github.com/rapid7/metasploit-framework/actions/runs/3789002645/jobs/6442338931 in the `Setup Ruby->Print Ruby Version` section.
- Verify that `master` is using Ruby 3.2.0 for the `Ruby 3` testing atm. Can check this by looking at a PR such as https://github.com/rapid7/metasploit-framework/pull/17416 and following the same steps as above to look at one of the `Verify / ubuntu-20.04 - Ruby 3` checks.