### PR TITLE
YARD Document LDAP Libraries

### DIFF
--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -8,18 +8,16 @@ require 'rex/proto/ldap'
 
 module Msf
   module Exploit::Remote::LDAP
-    #
     # Initialize the LDAP client and set up the LDAP specific datastore
-    #   options to allow the client to perform authentication and timeout
-    #   operations. Acts as a wrapper around the caller's
-    #   implementation of the `initialize` method, which will usually be
-    #   the module's class's implementation, such as lib/msf/core/auxiliary.rb.
+    # options to allow the client to perform authentication and timeout
+    # operations. Acts as a wrapper around the caller's
+    # implementation of the `initialize` method, which will usually be
+    # the module's class's implementation, such as lib/msf/core/auxiliary.rb.
     #
     # @param info [Hash] A hash containing information about the module
     #   using this library which includes its name, description, author, references,
     #   disclosure date, license, actions, default action, default options,
     #   and notes.
-    #
     def initialize(info = {})
       super
 
@@ -36,37 +34,30 @@ module Msf
       ])
     end
 
-    #
     # Alias to return the RHOST datastore option.
     #
-    # @return [String] The current value of `datastore['RHOST']`.
-    #
+    # @return [String] The current value of RHOST in the datastore.
     def rhost
       datastore['RHOST']
     end
 
-    #
     # Alias to return the RPORT datastore option.
     #
-    # @return [String] The current value of `datastore['RPORT']`.
-    #
+    # @return [String] The current value of RPORT in the datastore.
     def rport
       datastore['RPORT']
     end
 
-    #
     # Return the peer as a host:port formatted string.
     #
     # @return [String] A string containing the peer details in RHOST:RPORT format.
-    #
     def peer
       "#{rhost}:#{rport}"
     end
 
-    #
     # Set the various connection options to use when connecting to the
-    #   target LDAP server based on the current datastore options. Returns
-    #   the resulting connection configuration as a hash.
+    # target LDAP server based on the current datastore options. Returns
+    # the resulting connection configuration as a hash.
     #
     # @return [Hash] The options to use when connecting to the target
     #    LDAP server.
@@ -98,47 +89,42 @@ module Msf
       connect_opts
     end
 
-    #
     # Connect to the target LDAP server using the options provided,
-    #   and pass the resulting connection object to the proc provided.
-    #   Terminate the connection once the proc finishes executing.
+    # and pass the resulting connection object to the proc provided.
+    # Terminate the connection once the proc finishes executing.
     #
     # @param opts [Hash] Options for the LDAP connection.
     # @param &block [Proc] A proc containing the functionality to execute
     #   after the LDAP connection has succeeded. The connection is closed
     #   once this proc finishes executing.
     # @see Net::LDAP.open
-    # @return [Nil] Nothing is returned by this function.
-    #
+    # @return [Array<Hash>] An array of hashes containing the query results.
     def ldap_connect(opts = {}, &block)
       Net::LDAP.open(get_connect_opts.merge(opts), &block)
     end
 
-    #
     # Create a new LDAP connection using Net::LDAP.new and yield the
-    #   resulting connection object to the caller of this method.
+    # resulting connection object to the caller of this method.
     #
     # @param opts [Hash] A hash containing the connection options for the
     #   LDAP connection to the target server.
-    #
-    # @return [Nil] No return value.
-    #
+    # @yieldparam ldap [Net::LDAP] The LDAP connection handle to use for connecting to
+    #   the target LDAP server.
     def ldap_new(opts = {})
       ldap = Net::LDAP.new(get_connect_opts.merge(opts))
 
       # NASTY, but required
-      #   monkey patch ldap object in order to ignore bind errors
-      #   Some servers (e.g. OpenLDAP) return result even after a bind
-      #   has failed, e.g. with LDAP_INAPPROPRIATE_AUTH - anonymous bind disallowed.
-      #   See: https://www.openldap.org/doc/admin23/security.html#Authentication%20Methods
-      #   "Note that disabling the anonymous bind mechanism does not prevent anonymous
-      #   access to the directory."
-      #   Bug created for Net:LDAP at https://github.com/ruby-ldap/ruby-net-ldap/issues/375
+      # monkey patch ldap object in order to ignore bind errors
+      # Some servers (e.g. OpenLDAP) return result even after a bind
+      # has failed, e.g. with LDAP_INAPPROPRIATE_AUTH - anonymous bind disallowed.
+      # See: https://www.openldap.org/doc/admin23/security.html#Authentication%20Methods
+      # "Note that disabling the anonymous bind mechanism does not prevent anonymous
+      # access to the directory."
+      # Bug created for Net:LDAP at https://github.com/ruby-ldap/ruby-net-ldap/issues/375
       #
+      # @yieldparam conn [Net::LDAP] The LDAP connection handle to use for connecting to
+      #   the target LDAP server.
       # @param args [Hash] A hash containing options for the ldap connection
-      #
-      # @return [Nil] No return value.
-      #
       def ldap.use_connection(args)
         if @open_connection
           yield @open_connection
@@ -158,14 +144,11 @@ module Msf
       yield ldap
     end
 
-    #
     # Get the naming contexts for the target LDAP server.
     #
     # @param ldap [Net::LDAP] The Net::LDAP connection handle for the
     #   current LDAP connection.
-    #
     # @return [Net::BER::BerIdentifiedArray] Array of naming contexts for the target LDAP server.
-    #
     def get_naming_contexts(ldap)
       vprint_status("#{peer} Getting root DSE")
 
@@ -187,15 +170,12 @@ module Msf
       naming_contexts
     end
 
-    #
     # Discover the base DN of the target LDAP server via the LDAP
-    #   server's naming contexts.
+    # server's naming contexts.
     #
     # @param ldap [Net::LDAP] The Net::LDAP connection handle for the
     #   current LDAP connection.
-    #
     # @return [String] A string containing the base DN of the target LDAP server.
-    #
     def discover_base_dn(ldap)
       # @type [Net::BER::BerIdentifiedArray]
       naming_contexts = get_naming_contexts(ldap)
@@ -212,18 +192,16 @@ module Msf
       base_dn
     end
 
-    #
     # Check whether it was possible to successfully bind to the target LDAP
-    #   server. Raise a RuntimeException with an appropriate error message
-    #   if not.
+    # server. Raise a RuntimeException with an appropriate error message
+    # if not.
     #
     # @param ldap [Net::LDAP] The Net::LDAP connection handle for the
     #   current LDAP connection.
     #
     # @raise [RuntimeError] A RuntimeError will be raised if the LDAP
     #   bind request failed.
-    # @return [Nil] No return value will be returned.
-    #
+    # @return [Nil] This function does not return any data.
     def validate_bind_success!(ldap)
       bind_result = ldap.as_json['result']['ldap_result']
 
@@ -248,9 +226,8 @@ module Msf
       end
     end
 
-    #
     # Validate the query result and check whether the query succeeded.
-    #   Fail with an appropriate error code if the query failed.
+    # Fail with an appropriate error code if the query failed.
     #
     # @param query_result [Hash] A hash containing the results of the query
     #   as a 'resultCode' with an integer representing the result code,
@@ -259,10 +236,10 @@ module Msf
     # @param filter [Net::LDAP::Filter]  A Net::LDAP::Filter to use to
     #   filter the results of the query.
     #
-    # @raise [RuntimeError] A RuntimeError will be raised if the LDAP
-    #   request failed.
-    # @return [Nil] Nothing is returned by this method.
-    #
+    # @raise [RuntimeError, ArgumentError] A RuntimeError will be raised if the LDAP
+    #   request failed. Alternatively, if the query_result parameter isn't a hash, then an
+    #   ArgumentError will be raised.
+    # @return [Nil] This function does not return any data.
     def validate_query_result!(query_result, filter)
       if query_result.class != Hash
         raise ArgumentError.new('Parameter to "validate_query_result!" function was not a Hash!')

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -98,7 +98,8 @@ module Msf
     #   after the LDAP connection has succeeded. The connection is closed
     #   once this proc finishes executing.
     # @see Net::LDAP.open
-    # @return [Array<Hash>] An array of hashes containing the query results.
+    # @return [Object] The result of whatever the block that was
+    #   passed in via the "block" parameter yielded.
     def ldap_connect(opts = {}, &block)
       Net::LDAP.open(get_connect_opts.merge(opts), &block)
     end

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -8,6 +8,18 @@ require 'rex/proto/ldap'
 
 module Msf
   module Exploit::Remote::LDAP
+    #
+    # Initialize the LDAP client and set up the LDAP specific datastore
+    #   options to allow the client to perform authentication and timeout
+    #   operations. Acts as a wrapper around the caller's
+    #   implementation of the `initialize` method, which will usually be
+    #   the module's class's implementation, such as lib/msf/core/auxiliary.rb.
+    #
+    # @param info [Hash] A hash containing information about the module
+    #   using this library which includes its name, description, author, references,
+    #   disclosure date, license, actions, default action, default options,
+    #   and notes.
+    #
     def initialize(info = {})
       super
 
@@ -24,18 +36,40 @@ module Msf
       ])
     end
 
+    #
+    # Alias to return the RHOST datastore option.
+    #
+    # @return [String] The current value of `datastore['RHOST']`.
+    #
     def rhost
       datastore['RHOST']
     end
 
+    #
+    # Alias to return the RPORT datastore option.
+    #
+    # @return [String] The current value of `datastore['RPORT']`.
+    #
     def rport
       datastore['RPORT']
     end
 
+    #
+    # Return the peer as a host:port formatted string.
+    #
+    # @return [String] A string containing the peer details in RHOST:RPORT format.
+    #
     def peer
       "#{rhost}:#{rport}"
     end
 
+    #
+    # Set the various connection options to use when connecting to the
+    #   target LDAP server based on the current datastore options. Returns
+    #   the resulting connection configuration as a hash.
+    #
+    # @return [Hash] The options to use when connecting to the target
+    #    LDAP server.
     def get_connect_opts
       connect_opts = {
         host: rhost,
@@ -64,22 +98,46 @@ module Msf
       connect_opts
     end
 
+    #
+    # Connect to the target LDAP server using the options provided,
+    #   and pass the resulting connection object to the proc provided.
+    #   Terminate the connection once the proc finishes executing.
+    #
+    # @param opts [Hash] Options for the LDAP connection.
+    # @param &block [Proc] A proc containing the functionality to execute
+    #   after the LDAP connection has succeeded. The connection is closed
+    #   once this proc finishes executing.
+    # @see Net::LDAP.open
+    # @return [Nil] Nothing is returned by this function.
+    #
     def ldap_connect(opts = {}, &block)
       Net::LDAP.open(get_connect_opts.merge(opts), &block)
     end
 
+    #
+    # Create a new LDAP connection using Net::LDAP.new and yield the
+    #   resulting connection object to the caller of this method.
+    #
+    # @param opts [Hash] A hash containing the connection options for the
+    #   LDAP connection to the target server.
+    #
+    # @return [Nil] No return value.
+    #
     def ldap_new(opts = {})
       ldap = Net::LDAP.new(get_connect_opts.merge(opts))
 
       # NASTY, but required
-      # monkey patch ldap object in order to ignore bind errors
-      # Some servers (e.g. OpenLDAP) return result even after a bind
-      # has failed, e.g. with LDAP_INAPPROPRIATE_AUTH - anonymous bind disallowed.
-      # See: https://www.openldap.org/doc/admin23/security.html#Authentication%20Methods
-      # "Note that disabling the anonymous bind mechanism does not prevent anonymous
-      # access to the directory."
+      #   monkey patch ldap object in order to ignore bind errors
+      #   Some servers (e.g. OpenLDAP) return result even after a bind
+      #   has failed, e.g. with LDAP_INAPPROPRIATE_AUTH - anonymous bind disallowed.
+      #   See: https://www.openldap.org/doc/admin23/security.html#Authentication%20Methods
+      #   "Note that disabling the anonymous bind mechanism does not prevent anonymous
+      #   access to the directory."
+      #   Bug created for Net:LDAP at https://github.com/ruby-ldap/ruby-net-ldap/issues/375
       #
-      # Bug created for Net:LDAP https://github.com/ruby-ldap/ruby-net-ldap/issues/375
+      # @param args [Hash] A hash containing options for the ldap connection
+      #
+      # @return [Nil] No return value.
       #
       def ldap.use_connection(args)
         if @open_connection
@@ -100,6 +158,14 @@ module Msf
       yield ldap
     end
 
+    #
+    # Get the naming contexts for the target LDAP server.
+    #
+    # @param ldap [Net::LDAP] The Net::LDAP connection handle for the
+    #   current LDAP connection.
+    #
+    # @return [Net::BER::BerIdentifiedArray] Array of naming contexts for the target LDAP server.
+    #
     def get_naming_contexts(ldap)
       vprint_status("#{peer} Getting root DSE")
 
@@ -121,7 +187,17 @@ module Msf
       naming_contexts
     end
 
+    #
+    # Discover the base DN of the target LDAP server via the LDAP
+    #   server's naming contexts.
+    #
+    # @param ldap [Net::LDAP] The Net::LDAP connection handle for the
+    #   current LDAP connection.
+    #
+    # @return [String] A string containing the base DN of the target LDAP server.
+    #
     def discover_base_dn(ldap)
+      # @type [Net::BER::BerIdentifiedArray]
       naming_contexts = get_naming_contexts(ldap)
 
       unless naming_contexts
@@ -136,6 +212,18 @@ module Msf
       base_dn
     end
 
+    #
+    # Check whether it was possible to successfully bind to the target LDAP
+    #   server. Raise a RuntimeException with an appropriate error message
+    #   if not.
+    #
+    # @param ldap [Net::LDAP] The Net::LDAP connection handle for the
+    #   current LDAP connection.
+    #
+    # @raise [RuntimeError] A RuntimeError will be raised if the LDAP
+    #   bind request failed.
+    # @return [Nil] No return value will be returned.
+    #
     def validate_bind_success!(ldap)
       bind_result = ldap.as_json['result']['ldap_result']
 
@@ -160,6 +248,21 @@ module Msf
       end
     end
 
+    #
+    # Validate the query result and check whether the query succeeded.
+    #   Fail with an appropriate error code if the query failed.
+    #
+    # @param query_result [Hash] A hash containing the results of the query
+    #   as a 'resultCode' with an integer representing the result code,
+    #   'errorMessage' containing an optional error message, and
+    #   'matchedDN' containing the matched DN.
+    # @param filter [Net::LDAP::Filter]  A Net::LDAP::Filter to use to
+    #   filter the results of the query.
+    #
+    # @raise [RuntimeError] A RuntimeError will be raised if the LDAP
+    #   request failed.
+    # @return [Nil] Nothing is returned by this method.
+    #
     def validate_query_result!(query_result, filter)
       if query_result.class != Hash
         raise ArgumentError.new('Parameter to "validate_query_result!" function was not a Hash!')

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -94,7 +94,7 @@ module Msf
     # Terminate the connection once the proc finishes executing.
     #
     # @param opts [Hash] Options for the LDAP connection.
-    # @param &block [Proc] A proc containing the functionality to execute
+    # @param block [Proc] A proc containing the functionality to execute
     #   after the LDAP connection has succeeded. The connection is closed
     #   once this proc finishes executing.
     # @see Net::LDAP.open

--- a/lib/rex/proto/ldap.rb
+++ b/lib/rex/proto/ldap.rb
@@ -5,7 +5,16 @@ require 'rex/socket'
 # TODO: write a real LDAP client in Rex and migrate all consumers
 class Net::LDAP::Connection # :nodoc:
   module SynchronousRead
-    def read(length = nil, opts = {})
+    #
+    # Read `length` bytes of data from the LDAP connection socket and
+    #  return this data as a string.
+    #
+    # @param length [Integer] Length of the data to be read from the LDAP connection socket.
+    # @param _opts [Hash] Unused
+    #
+    # @return [String] A string containing the data read from the LDAP connection socket.
+    #
+    def read(length = nil, _opts = {})
       data = ''
       loop do
         chunk = super(length - data.length)
@@ -21,6 +30,13 @@ class Net::LDAP::Connection # :nodoc:
     end
   end
 
+  # Initialize the LDAP connection using Rex::Socket::TCP,
+  #   and optionally set up encryption on the connection if configured.
+  #
+  # @param server [Hash] Hash of the options needed to set
+  #   up the Rex::Socket::TCP socket for the LDAP connection.
+  # @see create_param
+  # @see Rex::Socket::Parameters.from_hash
   def initialize(server)
     begin
       @conn = Rex::Socket::Tcp.create(

--- a/lib/rex/proto/ldap.rb
+++ b/lib/rex/proto/ldap.rb
@@ -5,15 +5,13 @@ require 'rex/socket'
 # TODO: write a real LDAP client in Rex and migrate all consumers
 class Net::LDAP::Connection # :nodoc:
   module SynchronousRead
-    #
     # Read `length` bytes of data from the LDAP connection socket and
-    #  return this data as a string.
+    # return this data as a string.
     #
     # @param length [Integer] Length of the data to be read from the LDAP connection socket.
     # @param _opts [Hash] Unused
     #
     # @return [String] A string containing the data read from the LDAP connection socket.
-    #
     def read(length = nil, _opts = {})
       data = ''
       loop do
@@ -31,12 +29,13 @@ class Net::LDAP::Connection # :nodoc:
   end
 
   # Initialize the LDAP connection using Rex::Socket::TCP,
-  #   and optionally set up encryption on the connection if configured.
+  # and optionally set up encryption on the connection if configured.
   #
   # @param server [Hash] Hash of the options needed to set
   #   up the Rex::Socket::TCP socket for the LDAP connection.
-  # @see create_param
-  # @see Rex::Socket::Parameters.from_hash
+  # @see http://gemdocs.org/gems/rex-socket/0.1.43/Rex/Socket.html#create-class_method
+  # @see http://gemdocs.org/gems/rex-socket/0.1.43/Rex/Socket.html#create_param-class_method
+  # @see http://gemdocs.org/gems/rex-socket/0.1.43/Rex/Socket/Parameters.html#from_hash-class_method
   def initialize(server)
     begin
       @conn = Rex::Socket::Tcp.create(
@@ -71,9 +70,8 @@ class Net::LDAP::Connection # :nodoc:
   # @see https://github.com/ruby-ldap/ruby-net-ldap/pull/411
   #
   # @param [Hash] args A hash of the arguments to be utilized by the search operation.
-  #
-  # @return [Net::LDAP::PDU] A Protocol Data Unit (PDU) object, represented by the Net::LDAP::PDU class, containing the results of the search operation.
-  #
+  # @return [Net::LDAP::PDU] A Protocol Data Unit (PDU) object, represented by
+  #   the Net::LDAP::PDU class, containing the results of the search operation.
   def search(args = nil)
     args ||= {}
 


### PR DESCRIPTION
Add in additional YARD documentation for the LDAP libraries.

## Verification
- [x] Verify the new documentation looks good
- [ ] Use `yard server --reload --cache` to run a local documentation server and verify the documentation renders correctly.