### PR TITLE
exchange_proxylogon_collector bugfix: prevent empty on nil by changing empty to blank

### DIFF
--- a/modules/auxiliary/gather/exchange_proxylogon_collector.rb
+++ b/modules/auxiliary/gather/exchange_proxylogon_collector.rb
@@ -207,7 +207,7 @@ class MetasploitModule < Msf::Auxiliary
     xml = Nokogiri::XML.parse(response.body)
 
     legacy_dn = xml.at_xpath('//xmlns:User/xmlns:LegacyDN', xmlns)&.content
-    fail_with(Failure::NotFound, 'No \'LegacyDN\' was found') if legacy_dn.empty?
+    fail_with(Failure::NotFound, 'No \'LegacyDN\' was found') if legacy_dn.blank?
 
     server = ''
     owa_urls = []


### PR DESCRIPTION
## About
This change adds a minor bugfix to the `auxiliary/gather/exchange_proxylogon_collector.rb` module to prevent it from breaking when the `LegacyDN` attribute is not found in the server response.

## Details
```
207    xml = Nokogiri::XML.parse(response.body)
208
209    legacy_dn = xml.at_xpath('//xmlns:User/xmlns:LegacyDN', xmlns)&.content
210    fail_with(Failure::NotFound, 'No \'LegacyDN\' was found') if legacy_dn.empty?
```
- On line 207, the module uses Nokogiri to covert the response body to xml
- On line 209, an `xpath` lookup is performed for  `'//xmlns:User/xmlns:LegacyDN'`, the contents of which are extracted via a `content` call using the safe navigator `&.`.  The obtained contents are assigned to the `legacy_dn` variable
- On line 210, an `empty?` check is performed on `legacy_dn`

The bug here is that `legacy_dn` can be `nil` because ` xml.at_xpath('//xmlns:User/xmlns:LegacyDN', xmlns)` will be `nil` if this xpath is not found. In that case, the module crashes because it will try to perform `nil.empty?` on line 210, as you can see in the below binding.pry output:
```
From: /opt/metasploit-framework/modules/auxiliary/gather/exchange_proxylogon_collector.rb:211 Msf::Modules::Auxiliary__Gather__Exchange_proxylogon_collector::MetasploitModule#request_autodiscover:

    206:
    207:     xml = Nokogiri::XML.parse(response.body)
    208:
    209:     legacy_dn = xml.at_xpath('//xmlns:User/xmlns:LegacyDN', xmlns)&.content
    210:     binding.pry
 => 211:     fail_with(Failure::NotFound, 'No \'LegacyDN\' was found') if legacy_dn.empty?
    212:
    213:     server = ''
    214:     owa_urls = []
    215:     xml.xpath('//xmlns:Account/xmlns:Protocol', xmlns).each do |item|
    216:       type = item.at_xpath('./xmlns:Type', xmlns)&.content


[4] pry(#<Msf::Modules::Auxiliary__Gather__Exchange_proxylogon_collector::MetasploitModule>)> xml.at_xpath('//xmlns:User/xmlns:LegacyDN', xmlns)
=> nil
[5] pry(#<Msf::Modules::Auxiliary__Gather__Exchange_proxylogon_collector::MetasploitModule>)> xml.at_xpath('//xmlns:User/xmlns:LegacyDN', xmlns)&.content
=> nil
[6] pry(#<Msf::Modules::Auxiliary__Gather__Exchange_proxylogon_collector::MetasploitModule>)> legacy_dn = xml.at_xpath('//xmlns:User/xmlns:LegacyDN', xmlns)&.content
=> nil
[7] pry(#<Msf::Modules::Auxiliary__Gather__Exchange_proxylogon_collector::MetasploitModule>)> legacy_dn.empty?
NoMethodError: undefined method `empty?' for nil:NilClass
from (pry):6:in `request_autodiscover'
```

## The fix
We can just replace the `.empty?` call on line 210 with `.blank?`, which checks for `nil?` and `empty?`
```
[8] pry(#<Msf::Modules::Auxiliary__Gather__Exchange_proxylogon_collector::MetasploitModule>)> legacy_dn.blank?
=> true
```

## Other modules
I double checked the other proxylogon/proxyshell modules but they are not affected because an explicit `.nil?` check is performed there:
```
exploits/windows/http/exchange_proxyshell_rce.rb:    fail_with(Failure::NotFound, 'No \'LegacyDN\' was found') if legacy_dn.nil? || legacy_dn.empty?
exploits/windows/http/exchange_proxylogon_rce.rb:    fail_with(Failure::NotFound, 'No \'LegacyDN\' was found') if legacy_dn.nil? || legacy_dn.empty?
```

## Example before the fix
```
msf6 auxiliary(gather/exchange_proxylogon_collector) > run
[*] Running module against 192.168.1.1

[*] https://192.168.1.1:443 - Attempt to exploit for CVE-2021-26855
[*] Internal server name (MAILSVR01)
[*] https://192.168.1.1:443 - Sending autodiscover request
[-] Auxiliary failed: NoMethodError undefined method `empty?' for nil:NilClass
[-] Call stack:
[-]   /opt/metasploit-framework/embedded/framework/modules/auxiliary/gather/exchange_proxylogon_collector.rb:210:in `request_autodiscover'
[-]   /opt/metasploit-framework/embedded/framework/modules/auxiliary/gather/exchange_proxylogon_collector.rb:398:in `run'
[*] Auxiliary module execution completed
```

## Example after the fix
```
msf6 auxiliary(gather/exchange_proxylogon_collector) > run
[*] Running module against 192.168.1.1

[*] https://192.168.1.1:443 - Attempt to exploit for CVE-2021-26855
[*] Internal server name (MAILSVR01)
[*] https://192.168.1.1:443 - Sending autodiscover request
[-] Auxiliary aborted due to failure: not-found: No 'LegacyDN' was found
[*] Auxiliary module execution completed
```