### PR TITLE
Removing Rex::ConnectionError exception handler from module template

### DIFF
--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -96,30 +96,26 @@ class MetasploitModule < Msf::Exploit::Remote
   # we use a regex for the version number
   #
   def check
-    # we want to handle cases where the port/target isn't open/listening gracefully
-    begin
-      # only catch the response if we're going to use it, in this case we do for the version
-      # detection.
-      res = send_request_cgi(
-        'uri' => normalize_uri(target_uri.path, 'index.php'),
-        'method' => 'GET'
-      )
-      # gracefully handle if res comes back as nil, since we're not guaranteed a response
-      # also handle if we get an unexpected HTTP response code
-      return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
-      return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if res.code == 200
+    # only catch the response if we're going to use it, in this case we do for the version
+    # detection.
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'GET'
+    )
+    # gracefully handle if res comes back as nil, since we're not guaranteed a response
+    # also handle if we get an unexpected HTTP response code
+    return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
+    return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if res.code == 200
 
-      # here we're looking through html for the version string, similar to:
-      # Version 1.2
-      %r{Version: (?<version>\d{1,2}\.\d{1,2})</td>} =~ res.body
+    # here we're looking through html for the version string, similar to:
+    # Version 1.2
+    %r{Version: (?<version>\d{1,2}\.\d{1,2})</td>} =~ res.body
 
-      if version && Rex::Version.new(version) <= Rex::Version.new('1.3')
-        vprint_good("Version Detected: #{version}")
-        CheckCode::Appears
-      end
-    rescue ::Rex::ConnectionError
-      return CheckCode::Unknown("#{peer} - Could not connect to web service")
+    if version && Rex::Version.new(version) <= Rex::Version.new('1.3')
+      vprint_good("Version Detected: #{version}")
+      CheckCode::Appears
     end
+
     CheckCode::Safe
   end
 


### PR DESCRIPTION
`Rex::ConnectionError` exception handler is not needed since these exceptions are already handled by `send_request_raw` (called by `send_request_cgi`). It simply returns `nil` and it should never be reached.

This PR removes it from the template to avoid being used anymore.