### PR TITLE
Fix SMB key calculation for AES-256 when authenticating with Kerberos

### DIFF
--- a/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
@@ -98,7 +98,12 @@ module Msf::Exploit::Remote::SMB::Client::KerberosAuthentication
     @kerberos_authenticator.validate_response!(response.buffer)
 
     @session_id = response.smb2_header.session_id
-    @application_key = @session_key = kerberos_result[:session_key].value[0...16]
+    if @encryption_algorithm.present?
+      key_len = OpenSSL::Cipher.new(@encryption_algorithm).key_len
+    else
+      key_len = 16
+    end
+    @application_key = @session_key = kerberos_result[:session_key].value[0...key_len]
 
     @session_is_guest = response.session_flags.guest == 1
 


### PR DESCRIPTION
Metasploit will negotiate the strongest mutually supported encryption algorithm with the target. When the target supports AES-256 as Server 2022 and Windows 11 do, the key needs to be 32 bytes long and not 16 as it is when AES-128 is in use. This updates the logic to check if the encryption algorithm is set to ensure that the key is the correct size.

## Verification

- [x] Run psexec against a Server 2022 or Windows 11 target, using Kerberos authentication
- [x] Use all of the default values, and SMB 3.1.1 with encryption should be selected, but validate that with Wireshark. Check the encryption algorithm by looking at the second "Negotiate Protocol Response" packet and then seeing the value in the SMB2_ENCRYPTION_CAPABILITIES. It should be AES-256-GCM which uses a 32-bit key.
- [x] See the module succeed

Prior to these changes, an error would be thrown and no session would be created:

```
[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] 192.168.159.20:445 - Connecting to the server...
[*] 192.168.159.20:445 - Authenticating to 192.168.159.20:445|msflab2022.local as user 'smcintyre'...
[*] 192.168.159.20:445 - 192.168.159.20:88 - Using cached credential for cifs/DC2022.msflab2022.local@MSFLAB2022.LOCAL smcintyre@MSFLAB2022.LOCAL
[-] 192.168.159.20:445 - Exploit failed [disconnected]: RubySMB::Error::EncryptionError Communication error with the remote host: An error occurred reading from the Socket Connection reset by peer. The server supports encryption but was not able to handle the encrypted request.
[*] Exploit completed, but no session was created.
```