### PR TITLE
Remove lock on Pry version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,7 @@ group :development do
   # generating documentation
   gem 'yard'
   # for development and testing purposes
-  # lock to version with 2.6 support until project updates
-  gem 'pry-byebug', '~> 3.9.0'
+  gem 'pry-byebug'
   # Ruby Debugging Library - rebuilt and included by default from Ruby 3.1 onwards.
   # Replaces the old lib/debug.rb and provides more features.
   gem 'debug', '>= 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,7 +507,7 @@ DEPENDENCIES
   memory_profiler
   metasploit-framework!
   octokit
-  pry-byebug (~> 3.9.0)
+  pry-byebug
   rake
   redcarpet
   rspec-rails


### PR DESCRIPTION
Ruby 2.6 is no longer supported by Metasploit and so this lock no longer applies. This is needed to start supporting Ruby 3.2 as noted at https://github.com/pry/pry/issues/2261. This lock should have been removed when we dropped 2.6 support as noted in the discussion over at https://github.com/rapid7/metasploit-framework/pull/16958.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Start a pry session.
- [ ] **Verify** that nothing is amiss and you can still debug as expected.