### PR TITLE
Update Railgun definitions to be compatible with x64

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_advapi32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_advapi32.rb
@@ -55,14 +55,14 @@ class Def_windows_advapi32
 
     #Functions for Windows CryptoAPI
     dll.add_function( 'CryptAcquireContextW', 'BOOL',[
-        ['PDWORD', 'phProv', 'out'],
+        ['PHANDLE', 'phProv', 'out'],
         ['PWCHAR', 'pszContainer', 'in'],
         ['PWCHAR', 'pszProvider', 'in'],
         ['DWORD', 'dwProvType', 'in'],
         ['DWORD', 'dwflags', 'in']])
 
     dll.add_function( 'CryptAcquireContextA', 'BOOL',[
-        ['PDWORD', 'phProv', 'out'],
+        ['PHANDLE', 'phProv', 'out'],
         ['PWCHAR', 'pszContainer', 'in'],
         ['PWCHAR', 'pszProvider', 'in'],
         ['DWORD', 'dwProvType', 'in'],
@@ -84,7 +84,7 @@ class Def_windows_advapi32
 
     dll.add_function( 'CryptEnumProvidersA', 'BOOL', [
         ['DWORD', 'dwIndex', 'in'],
-        ['DWORD', 'pdwReserved', 'in'],
+        ['PDWORD', 'pdwReserved', 'in'],
         ['DWORD', 'dwFlags', 'in'],
         ['PDWORD', 'pdwProvType', 'out'],
         ['PCHAR', 'pszProvName', 'out'],
@@ -92,7 +92,7 @@ class Def_windows_advapi32
 
     dll.add_function( 'CryptEnumProviderTypesW', 'BOOL', [
         ['DWORD', 'dwIndex', 'in'],
-        ['DWORD', 'pdwReserved', 'in'],
+        ['PDWORD', 'pdwReserved', 'in'],
         ['DWORD', 'dwFlags', 'in'],
         ['PDWORD', 'pdwProvType', 'out'],
         ['PWCHAR', 'pszTypeName', 'out'],
@@ -157,7 +157,7 @@ class Def_windows_advapi32
         ['LPVOID', 'hKey', 'in'],
         ['DWORD', 'pdwReserved', 'in'],
         ['DWORD', 'dwFlags', 'in'],
-        ['PDWORD', 'phKey', 'out']])
+        ['PHANDLE', 'phKey', 'out']])
 
     dll.add_function( 'CryptExportKey', 'BOOL', [
         ['LPVOID', 'hKey', 'in'],
@@ -171,7 +171,7 @@ class Def_windows_advapi32
         ['LPVOID', 'hProv', 'in'],
         ['DWORD', 'Algid', 'in'],
         ['DWORD', 'dwFlags', 'in'],
-        ['PDWORD', 'phKey', 'out']])
+        ['PHANDLE', 'phKey', 'out']])
 
     dll.add_function( 'CryptGenRandom', 'BOOL', [
         ['LPVOID', 'hProv', 'in'],
@@ -188,7 +188,7 @@ class Def_windows_advapi32
     dll.add_function( 'CryptGetUserKey', 'BOOL', [
         ['LPVOID', 'hProv', 'in'],
         ['DWORD', 'dwKeySpec', 'in'],
-        ['PDWORD', 'phUserKey', 'out']])
+        ['PHANDLE', 'phUserKey', 'out']])
 
     dll.add_function( 'CryptImportKey', 'BOOL', [
         ['LPVOID', 'hProv', 'in'],
@@ -196,7 +196,7 @@ class Def_windows_advapi32
         ['DWORD', 'dwDataLen', 'in'],
         ['LPVOID', 'hPubKey', 'in'],
         ['DWORD', 'dwFlags', 'in'],
-        ['PDWORD', 'phKey', 'out']])
+        ['PHANDLE', 'phKey', 'out']])
 
     dll.add_function( 'CryptSetKeyParam', 'BOOL', [
         ['LPVOID', 'hKey', 'in'],
@@ -217,7 +217,7 @@ class Def_windows_advapi32
         ['LPVOID', 'hHash', 'in'],
         ['DWORD', 'pdwReserved', 'in'],
         ['DWORD', 'dwFlags', 'in'],
-        ['PDWORD', 'phHash', 'out']])
+        ['PHANDLE', 'phHash', 'out']])
 
     dll.add_function( 'CryptGetHashParam', 'BOOL', [
         ['LPVOID', 'hHash', 'in'],
@@ -274,7 +274,7 @@ class Def_windows_advapi32
         ['DWORD', 'Algid', 'in'],
         ['LPVOID', 'hKey', 'in'],
         ['DWORD', 'dwFlags', 'in'],
-        ['PDWORD', 'phHash', 'out']])
+        ['PHANDLE', 'phHash', 'out']])
 
     dll.add_function( 'CryptHashData', 'BOOL',[
         ['LPVOID', 'hHash', 'in'],
@@ -1201,7 +1201,7 @@ class Def_windows_advapi32
       ["DWORD","nSubAuthority5","in"],
       ["DWORD","nSubAuthority6","in"],
       ["DWORD","nSubAuthority7","in"],
-      ["PDWORD","pSid","out"],
+      ["PLPVOID","pSid","out"],
       ])
 
     dll.add_function('AllocateLocallyUniqueId', 'BOOL',[
@@ -1263,12 +1263,12 @@ class Def_windows_advapi32
 
     dll.add_function('ConvertStringSidToSidA', 'BOOL',[
       ["PCHAR","StringSid","in"],
-      ["PDWORD","pSid","out"],
+      ["PLPVOID","pSid","out"],
       ])
 
     dll.add_function('ConvertStringSidToSidW', 'BOOL',[
       ["PWCHAR","StringSid","in"],
-      ["PDWORD","pSid","out"],
+      ["PLPVOID","pSid","out"],
       ])
 
     dll.add_function('CopySid', 'BOOL',[
@@ -1686,7 +1686,7 @@ class Def_windows_advapi32
       ["DWORD","dwLogonType","in"],
       ["DWORD","dwLogonProvider","in"],
       ["PHANDLE","phToken","out"],
-      ["PDWORD","ppLogonSid","out"],
+      ["PLPVOID","ppLogonSid","out"],
       ["PBLOB","ppProfileBuffer","out"],
       ["PDWORD","pdwProfileLength","out"],
       ["PBLOB","pQuotaLimits","out"],
@@ -1699,7 +1699,7 @@ class Def_windows_advapi32
       ["DWORD","dwLogonType","in"],
       ["DWORD","dwLogonProvider","in"],
       ["PHANDLE","phToken","out"],
-      ["PDWORD","ppLogonSid","out"],
+      ["PLPVOID","ppLogonSid","out"],
       ["PBLOB","ppProfileBuffer","out"],
       ["PDWORD","pdwProfileLength","out"],
       ["PBLOB","pQuotaLimits","out"],

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
@@ -32,7 +32,7 @@ class Def_windows_wldap32
         ['PCHAR', 'filter', 'in'],
         ['PCHAR', 'attrs[]', 'in'],
         ['DWORD', 'attrsonly', 'in'],
-        ['PDWORD', 'res', 'out']
+        ['PLPVOID', 'res', 'out']
     ], 'ldap_search_sA', "cdecl")
 
     dll.add_function('ldap_set_option', 'DWORD',[
@@ -52,7 +52,7 @@ class Def_windows_wldap32
         ['DWORD', 'pClientControls', 'in'],
         ['DWORD', 'pTimeout', 'in'],
         ['DWORD', 'SizeLimit', 'in'],
-        ['PDWORD', 'res', 'out']
+        ['PLPVOID', 'res', 'out']
     ], 'ldap_search_ext_sA', "cdecl")
 
     dll.add_function('ldap_count_entries', 'DWORD',[

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_ws2_32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_ws2_32.rb
@@ -16,7 +16,7 @@ class Def_windows_ws2_32
       ["PCHAR","pNodeName","in"],
       ["PCHAR","pServiceName","in"],
       ["PDWORD","pHints","in"],
-      ["PDWORD","ppResult","out"]
+      ["PLPVOID","ppResult","out"]
       ])
 
     dll.add_function('gethostbyaddr', 'DWORD', [


### PR DESCRIPTION
Fixes the issue mentioned at https://github.com/rapid7/metasploit-framework/pull/17166#issuecomment-1374131359 which occurred due to pointer truncation on x64 payloads when the return values were incorrectly declared as being 32 bit long pointers for some Railgun functions. Whilst I was at it I also went ahead and updated several other functions in the code related to this one and fix one incorrect parameter type instance that was unrelated.

The good news is that most of these functions from what I can tell aren't currently being used by our code so there should be minimal side effects should something go wrong.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Open up an IRB session.
- [ ] Use `railgun.advapi32.<function name here>` and see if calling the function results in a crashing session or not. With the fixes this should not be the case.
- [ ] Alernatively also follow the testing steps I took over at https://github.com/rapid7/metasploit-framework/pull/17166 and confirm that the bug exists on `master` and not on this branch. You may also need to apply the changes from this branch to the `feature-kerberos-authentication` branch though in order for this to fully work. I haven't targeted that branch though since I don't think that is the right branch for this type of change but let me know if I'm wrong on this.

