### PR TITLE
fix #17436: scanner/smb/smb_enumshares truncates file names

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -257,12 +257,13 @@ class MetasploitModule < Msf::Auxiliary
 
           # Logging of the obtained data.
           logdata << "#{ip}\\#{share_name}#{subdirs.first}\\#{fname.encode}\n"
+          detailed_tbl << [ip.to_s, fa || 'Unknown', share_name, subdirs.first + '\\', fname, tcr, tac, twr, tch, sz]
 
           # Filename is too long for the UI table, cut it.
           fname = "#{fname[0, 35]}..." if fname.length > 35
 
           pretty_tbl << [fa || 'Unknown', fname, tcr, tac, twr, tch, sz]
-          detailed_tbl << [ip.to_s, fa || 'Unknown', share_name, subdirs.first + '\\', fname, tcr, tac, twr, tch, sz]
+
         end
         print_good(pretty_tbl.to_s) if datastore['ShowFiles']
         subdirs.shift

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -255,12 +255,14 @@ class MetasploitModule < Msf::Auxiliary
             sz = file.end_of_file
           end
 
+          # Logging of the obtained data.
+          logdata << "#{ip}\\#{share_name}#{subdirs.first}\\#{fname.encode}\n"
+
           # Filename is too long for the UI table, cut it.
           fname = "#{fname[0, 35]}..." if fname.length > 35
 
           pretty_tbl << [fa || 'Unknown', fname, tcr, tac, twr, tch, sz]
           detailed_tbl << [ip.to_s, fa || 'Unknown', share_name, subdirs.first + '\\', fname, tcr, tac, twr, tch, sz]
-          logdata << "#{ip}\\#{share_name}#{subdirs.first}\\#{fname.encode}\n"
         end
         print_good(pretty_tbl.to_s) if datastore['ShowFiles']
         subdirs.shift


### PR DESCRIPTION
Fixes #17436

This pull request is a fix for the issue #17436 meant for the module `auxiliary/scanner/smb/smb_enumshares.rb`. Previously It was not possible to view the full file name in the logged data, as it was truncated even before being placed into the txt file. The fix is done by shifting the logger function before the truncation code so that full pathnames get stored into the logged data.

The changes are applied in the branch "fix-issue_#17436"

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/smb_enumshares`
- [x] `run smbuser=<username> smbpass=<password> smbdomain=<domain> rhost=<ip_of_smbserver> spidershares=true showfiles=true`
- [x] `exit`
- [x] `cat <the path to the generated file>`

The logged filenames can be seen as untruncated.