### PR TITLE
Make the Kerberos Encryption Type Configurable

### DIFF
--- a/lib/msf/core/exploit/remote/auth_option.rb
+++ b/lib/msf/core/exploit/remote/auth_option.rb
@@ -10,6 +10,10 @@ module Msf::Exploit::Remote::AuthOption
   # Kerberos authentication is used
   KERBEROS = 'kerberos'
 
+  KERBEROS_DEFAULT_OFFERED_ENC_TYPES = Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes.map do |id|
+    Rex::Proto::Kerberos::Crypto::Encryption.const_name(id).gsub('_', '-')
+  end
+
   # plaintext authentication is used
   PLAINTEXT = 'plaintext'
 
@@ -56,4 +60,25 @@ module Msf::Exploit::Remote::AuthOption
     KERBEROS,
     PLAINTEXT
   ]
+
+  # @param [String] value String value with the user defined etypes, i.e. AES128,AES256,RC4_HMAC,etc
+  # @return [Array[Integer] The encryption types
+  # @see Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
+  def self.as_default_offered_etypes(value)
+    return Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes if value.blank?
+
+    value.split(',').map(&:strip).reject(&:blank?).map do |type|
+      Rex::Proto::Kerberos::Crypto::Encryption.value_for(type.upcase.gsub('-', '_'))
+    end.uniq
+  end
+
+  etype_regex = "(#{Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.map { |v| Regexp.escape(v) }.join('|')})"
+  OPT_KRB_OFFERED_ENC_TYPES = Msf::OptString.new(
+    'KrbOfferedEncTypes', [
+      true,
+      'Kerberos encryption types to offer',
+      Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.join(',')
+    ],
+    regex: Regexp.new("(#{etype_regex},)*#{etype_regex}", options: Regexp::IGNORECASE)
+  )
 end

--- a/lib/msf/core/exploit/remote/auth_option.rb
+++ b/lib/msf/core/exploit/remote/auth_option.rb
@@ -74,7 +74,7 @@ module Msf::Exploit::Remote::AuthOption
 
   etype_regex = "(#{Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.map { |v| Regexp.escape(v) }.join('|')})"
   OPT_KRB_OFFERED_ENC_TYPES = Msf::OptString.new(
-    'KrbOfferedEncTypes', [
+    'KrbOfferedEncryptionTypes', [
       true,
       'Kerberos encryption types to offer',
       Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.join(',')

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -177,7 +177,7 @@ module Msf
 
             now = Time.now.utc
             expiry_time = now + 1.day
-            offered_etypes = Rex::Proto::Kerberos::Crypto::Encryption::PkinitEtypes
+            offered_etypes = options[:offered_etypes] || Rex::Proto::Kerberos::Crypto::Encryption::PkinitEtypes
             request_body = build_as_request_body(
               client_name: client_name,
               server_name: server_name,
@@ -247,7 +247,7 @@ module Msf
 
             now = Time.now.utc
             expiry_time = now + 1.day
-            offered_etypes = Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
+            offered_etypes = options[:offered_etypes] || Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
             offered_etypes = [ etype ] if !password && key && etype
             initial_as_req = build_as_request(
               pa_data: [

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -236,7 +236,6 @@ module Msf
             password = options[:password]
             password.dup.force_encoding('utf-8') if password
             key = options[:key]
-            etype = options[:etype]
             client_name.dup.force_encoding('utf-8')
             request_pac = options.fetch(:request_pac, true)
             ticket_options = options.fetch(:options) { 0x50800000 } # Forwardable, Proxiable, Renewable
@@ -247,8 +246,13 @@ module Msf
 
             now = Time.now.utc
             expiry_time = now + 1.day
+
             offered_etypes = options[:offered_etypes] || Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
-            offered_etypes = [ etype ] if !password && key && etype
+            offered_etypes = [ offered_etypes ] if offered_etypes.is_a?(Integer)
+            if !password && key && offered_etypes.length != 1
+              raise ArgumentError.new('Exactly one etype must be specified in :offered_etypes when a key is is defined without a password')
+            end
+
             initial_as_req = build_as_request(
               pa_data: [
                 build_pa_pac_request(pac_request_value: request_pac)
@@ -313,7 +317,7 @@ module Msf
               encryptor = Rex::Proto::Kerberos::Crypto::Encryption::from_etype(selected_etype)
               enc_key = encryptor.string_to_key(password, salt, params: params)
             elsif key
-              raise ArgumentError.new('Encryption key provided without encryption type') unless etype
+              raise ArgumentError.new('Encryption key provided without encryption type') unless options[:offered_etypes].is_a?(Integer)
               enc_key = key
             end
 

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -248,7 +248,6 @@ module Msf
             expiry_time = now + 1.day
 
             offered_etypes = options[:offered_etypes] || Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
-            offered_etypes = [ offered_etypes ] if offered_etypes.is_a?(Integer)
             if !password && key && offered_etypes.length != 1
               raise ArgumentError.new('Exactly one etype must be specified in :offered_etypes when a key is is defined without a password')
             end
@@ -317,7 +316,7 @@ module Msf
               encryptor = Rex::Proto::Kerberos::Crypto::Encryption::from_etype(selected_etype)
               enc_key = encryptor.string_to_key(password, salt, params: params)
             elsif key
-              raise ArgumentError.new('Encryption key provided without encryption type') unless options[:offered_etypes].is_a?(Integer)
+              raise ArgumentError.new('Encryption key provided without one offered encryption type') unless options[:offered_etypes]&.length == 1
               enc_key = key
             end
 

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -70,7 +70,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   attr_reader :key
 
   # @!attribute [r] offered_etypes
-  #   @return [Array[Integer],Integer,nil] the offered etypes, if not present the default values will be used
+  #   @return [Array[Integer],nil] the offered etypes, if not present the default values will be used
   # @see Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
   attr_reader :offered_etypes
 

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -73,6 +73,11 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   @return [String] the encryption key type
   attr_reader :etype
 
+  # @!attribute [r] offered_etypes
+  #   @return [Array[String],nil] the offered etypes, if not present the default values will be used
+  # @see Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
+  attr_reader :offered_etypes
+
   def_delegators :@framework_module,
                 :print_status,
                 :print_good,
@@ -110,7 +115,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       cache_file: nil,
       ticket_storage: nil,
       key: nil,
-      etype: nil
+      etype: nil,
+      offered_etypes: nil
   )
     @realm = realm
     @hostname = hostname
@@ -131,6 +137,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     )
     @key = key
     @etype = etype
+    @offered_etypes = offered_etypes
 
     credential = nil
     if cache_file.present?
@@ -447,6 +454,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     realm = self.realm.upcase
     client_name = username
     server_name = "krbtgt/#{realm}"
+    offered_etypes = options.fetch(:offered_etypes) do
+      self.offered_etypes || Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
+    end
 
     ticket_options = Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags(
       [
@@ -464,7 +474,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       key: key,
       etype: etype,
       realm: realm,
-      options: ticket_options
+      options: ticket_options,
+      offered_etypes: offered_etypes
     )
 
     if !tgt_result.preauth_required

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -69,12 +69,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   @return [String] the encryption key for authentication
   attr_reader :key
 
-  # @!attribute [r] etype
-  #   @return [String] the encryption key type
-  attr_reader :etype
-
   # @!attribute [r] offered_etypes
-  #   @return [Array[String],nil] the offered etypes, if not present the default values will be used
+  #   @return [Array[Integer],Integer,nil] the offered etypes, if not present the default values will be used
   # @see Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
   attr_reader :offered_etypes
 
@@ -115,7 +111,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       cache_file: nil,
       ticket_storage: nil,
       key: nil,
-      etype: nil,
       offered_etypes: nil
   )
     @realm = realm
@@ -136,7 +131,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       framework_module: framework_module
     )
     @key = key
-    @etype = etype
     @offered_etypes = offered_etypes
 
     credential = nil
@@ -472,7 +466,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       client_name: client_name,
       password: password,
       key: key,
-      etype: etype,
       realm: realm,
       options: ticket_options,
       offered_etypes: offered_etypes

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -27,6 +27,7 @@ module Msf
         OptString.new('LdapRhostname', [false, 'The rhostname which is required for kerberos']),
         OptPath.new('LdapKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('LDAPKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ LDAPAuth == kerberos ]),
         OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
+        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES,
         OptFloat.new('LDAP::ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0])
       ])
     end
@@ -64,6 +65,8 @@ module Msf
         fail_with(Msf::Exploit::Failure::BadConfig, 'The LdapRhostname option is required when using Kerberos authentication.') if datastore['LdapRhostname'].blank?
         fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
         fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
+        offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
+        fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
 
         kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
           host: datastore['DomainControllerRhost'],
@@ -74,7 +77,8 @@ module Msf
           framework: framework,
           framework_module: self,
           cache_file: datastore['LdapKrb5Ccname'].blank? ? nil : datastore['LdapKrb5Ccname'],
-          ticket_storage: kerberos_ticket_storage
+          ticket_storage: kerberos_ticket_storage,
+          offered_etypes: offered_etypes
         )
 
         kerberos_result = kerberos_authenticator.authenticate

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -43,7 +43,8 @@ module Exploit::Remote::MSSQL
         OptEnum.new('MssqlAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::MSSQL_OPTIONS]),
         OptString.new('MssqlRhostname', [false, 'The mssql hostname, required for kerberos']),
         OptPath.new('MssqlKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('MSSQLKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ MssqlAuth == kerberos ]),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller'])
+        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
+        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES
       ], Msf::Exploit::Remote::MSSQL)
     register_autofilter_ports([ 1433, 1434, 1435, 14330, 2533, 9152, 2638 ])
     register_autofilter_services(%W{ ms-sql-s ms-sql2000 sybase })
@@ -349,6 +350,8 @@ module Exploit::Remote::MSSQL
       fail_with(Msf::Exploit::Failure::BadConfig, 'The MssqlRhostname option is required when using Kerberos authentication.') if datastore['MssqlRhostname'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
+      offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
+      fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
 
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::MSSQL.new(
         host: datastore['DomainControllerRhost'],
@@ -360,7 +363,8 @@ module Exploit::Remote::MSSQL
         framework: framework,
         framework_module: self,
         cache_file: datastore['MssqlKrb5Ccname'].blank? ? nil : datastore['MssqlKrb5Ccname'],
-        ticket_storage: kerberos_ticket_storage
+        ticket_storage: kerberos_ticket_storage,
+        offered_etypes: offered_etypes
       )
 
       kerberos_result = kerberos_authenticator.authenticate

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -154,6 +154,8 @@ module Msf
           fail_with(Msf::Exploit::Failure::BadConfig, 'The SmbRhostname option is required when using Kerberos authentication.') if datastore['SmbRhostname'].blank?
           fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
           fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
+          offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
+          fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
 
           kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
             host: datastore['DomainControllerRhost'],
@@ -164,7 +166,8 @@ module Msf
             framework: framework,
             framework_module: self,
             cache_file: datastore['SmbKrb5Ccname'].blank? ? nil : datastore['SmbKrb5Ccname'],
-            ticket_storage: kerberos_ticket_storage
+            ticket_storage: kerberos_ticket_storage,
+            offered_etypes: offered_etypes
           )
 
           simple_client.client.extend(Msf::Exploit::Remote::SMB::Client::KerberosAuthentication)

--- a/lib/msf/core/exploit/remote/smb/client/authenticated.rb
+++ b/lib/msf/core/exploit/remote/smb/client/authenticated.rb
@@ -23,7 +23,8 @@ module Exploit::Remote::SMB::Client::Authenticated
         OptEnum.new('SMBAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::SMB_OPTIONS]),
         OptString.new('SmbRhostname', [false, 'The rhostname which is required for kerberos']),
         OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        OptPath.new('SmbKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ SMBAuth == kerberos ])
+        OptPath.new('SmbKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ SMBAuth == kerberos ]),
+        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES
       ],
       Msf::Exploit::Remote::SMB::Client::Authenticated
     )

--- a/lib/msf/core/exploit/remote/winrm.rb
+++ b/lib/msf/core/exploit/remote/winrm.rb
@@ -33,7 +33,8 @@ module Exploit::Remote::WinRM
         OptEnum.new('WinrmAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS]),
         OptString.new('WinrmRhostname', [false, 'The rhostname which is required for kerberos']),
         OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        OptPath.new('WinrmKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('WINRMKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[WinrmAuth == kerberos])
+        OptPath.new('WinrmKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('WINRMKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[WinrmAuth == kerberos]),
+        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES
       ]
     )
 
@@ -46,6 +47,8 @@ module Exploit::Remote::WinRM
       fail_with(Msf::Exploit::Failure::BadConfig, 'The WinrmRhostname option is required when using Kerberos authentication.') if datastore['WinrmRhostname'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
+      offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
+      fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
     else
       fail_with(Msf::Exploit::Failure::BadConfig, 'The PASSWORD option is required unless using Kerberos authentication.') if datastore['PASSWORD'].blank?
     end
@@ -86,6 +89,7 @@ module Exploit::Remote::WinRM
         framework: framework,
         framework_module: self,
         cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
+        offered_types: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes']),
         mutual_auth: true,
         use_gss_checksum: true
       )

--- a/modules/auxiliary/admin/kerberos/get_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/get_ticket.rb
@@ -125,14 +125,14 @@ class MetasploitModule < Msf::Auxiliary
     options[:password] = datastore['PASSWORD'] if datastore['PASSWORD'].present?
     if datastore['NTHASH'].present?
       options[:key] = [datastore['NTHASH']].pack('H*')
-      options[:offered_etypes] = Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC
+      options[:offered_etypes] = [ Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC ]
     end
     if datastore['AESKEY'].present?
       options[:key] = [ datastore['AESKEY'] ].pack('H*')
       options[:offered_etypes] = if options[:key].size == 32
-                                   Rex::Proto::Kerberos::Crypto::Encryption::AES256
+                                   [ Rex::Proto::Kerberos::Crypto::Encryption::AES256 ]
                                  else
-                                   Rex::Proto::Kerberos::Crypto::Encryption::AES128
+                                   [ Rex::Proto::Kerberos::Crypto::Encryption::AES128 ]
                                  end
     end
 

--- a/modules/auxiliary/scanner/winrm/winrm_cmd.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_cmd.rb
@@ -28,15 +28,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [ true, 'The username to authenticate as'])
       ]
     )
-
-    register_advanced_options(
-      [
-        OptEnum.new('WinrmAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS]),
-        OptString.new('WinrmRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        OptPath.new('WinrmKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('WINRMKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ WinrmAuth == kerberos ])
-      ]
-    )
   end
 
   def run
@@ -78,7 +69,8 @@ class MetasploitModule < Msf::Auxiliary
         cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
         mutual_auth: true,
         use_gss_checksum: true,
-        ticket_storage: kerberos_ticket_storage
+        ticket_storage: kerberos_ticket_storage,
+        offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
       )
       opts = opts.merge({
         user: '', # Need to provide it, otherwise the WinRM module complains

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -35,15 +35,6 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     deregister_options('PASSWORD_SPRAY')
-
-    register_advanced_options(
-      [
-        OptEnum.new('WinrmAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS]),
-        OptString.new('WinrmRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        OptPath.new('WinrmKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('WINRMKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ WinrmAuth == kerberos ])
-      ]
-    )
   end
 
   def run
@@ -75,7 +66,8 @@ class MetasploitModule < Msf::Auxiliary
           cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
           mutual_auth: true,
           use_gss_checksum: true,
-          ticket_storage: kerberos_ticket_storage
+          ticket_storage: kerberos_ticket_storage,
+          offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
         )
       end
     end


### PR DESCRIPTION
This adds a new `KrbOfferedEncryptionTypes` option that allows users to configure what encryption types are used with the KDC. It's useful for debugging.

## Verification

List the steps needed to make sure this thing works

- [x] Load a module that's enabled for kerberos
- [x] Start wireshark with the `kerberos.msg_type == 10` filter to show `AS-REQ` messages
- [x] Clear your loot so a fresh ticket is requested with `loot -d`
- [x] Run the module, see in wireshark that the five default encryption types are offered
- [x] Clear your loot so a fresh ticket is requested again with `loot -d`
- [x] Set the `KrbOfferedEncryptionTypes` option to a subset of `AES256,AES128,RC4-HMAC,DES-CBC-MD5,DES3-CBC-SHA1`
- [x] See the subset in wireshark
- [x] Set a bogus value for `KrbOfferedEncryptionTypes` see that it fails validation
