### PR TITLE
fix #17404 , get_env("TEMP") gives wrong results

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
@@ -90,7 +90,7 @@ class Config
     response.each(TLV_TYPE_ENV_GROUP) do |env|
       var_name = env.get_tlv_value(TLV_TYPE_ENV_VARIABLE)
       var_value = env.get_tlv_value(TLV_TYPE_ENV_VALUE)
-      result[var_name] = var_value
+      result[var_name] = var_value.scan(/[[:print:]]/).join
     end
 
     result


### PR DESCRIPTION
Fixes #17404 

This pull request closes issue #17404. Previously, when the environment variable was not present, the `get_tlvs()` function present in `lib/rex/post/meterpreter/packet.rb` returned non printable ascii values. Now the regex is implemented that filters out those non printable ascii values from the values returned from the function, resulting in nil value in case of non existent environment variables.

## Verification
Steos followed for the verification of the fix, the test was performed using the payload `windows/x64/meterpreter_reverse_tcp`

- [ ] Start `msfconsole`
- [ ] `use multi/handler`
- [ ] `set payload windows/x64/meterpreter_reverse_tcp`
- [ ] `set LHOST <the interface ip>`
- [ ] `exploit`
- [ ] After meterpreter shell is obtained....
- [ ] `getenv TEMP` returns a value.
- [ ] `getenv FOOBAR` does not return any value.

The values come as blank for non existent environment variables rather than junk values.