### PR TITLE
fix #16394: SMB_Version Module does not report SMB Version into Notes

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -225,7 +225,7 @@ class MetasploitModule < Msf::Auxiliary
 
         if res['os'] && res['os'] != 'Unknown'
           description = smb_os_description(res, nd_smb_fingerprint)
-          desc = description[:text]
+          desc << description[:text]
           nd_fingerprint_match = description[:fingerprint_match]
           nd_smb_fingerprint = description[:smb_fingerprint]
 
@@ -277,6 +277,15 @@ class MetasploitModule < Msf::Auxiliary
         else
           lines << { type: :status, message: '  Host could not be identified', verbose: true }
         end
+
+        report_service(
+          host: ip,
+          port: rport,
+          proto: 'tcp',
+          name: 'smb',
+          info: desc
+        )
+
 
         # Report a smb.fingerprint hash of attributes for OS fingerprinting
         report_note(


### PR DESCRIPTION
Closes #16394 

This pull request is a fix for the issue #16394 meant for the module `modules/auxiliary/scanner/smb/smb_version.rb`. Previously It was not possible to view the SMB Version in the services even though it was visible on execution of the module. This was so because there was a `desc` variable assigned with version details on line 193 but later was reassigned with additional information leading to overwrite of the data which further got stored in the services. Also the store functionality for the data in services was  present only for SMBv1 scenarios while for other cases, it was not getting stored at all. The fix is done by concatenating the additional information with the existing data in the `desc` variable and creating the store to services functionality for other SMB versions as well.

## Verification

Following were the steps followed to check the expected results

- [ ] Start `msfconsole`
- [ ] `use scanner/smb/smb_version`
- [ ] `set RHOSTS <the ip of target>`
- [ ] `run`
- [ ] `services` This displays the expected output

Before:
![image](https://user-images.githubusercontent.com/57354589/211974778-28ce939e-b4ae-4bce-baac-4827b51f812f.png)

After the fix:

Windows 10 pro N with SMBv1 enabled 
![image](https://user-images.githubusercontent.com/57354589/211974979-0c33ae18-5d32-4ca1-afee-c88d65bf8aa8.png)

Windows 10 pro N
![image](https://user-images.githubusercontent.com/57354589/211975073-5a72736d-80c0-4db2-ad82-fea1830fe482.png)

Linux (Ubuntu 20.04)
![image](https://user-images.githubusercontent.com/57354589/211975174-8fa95375-3ad7-4fb8-aaba-d3c3ff1601f7.png)

The services fields are seen as populated.

