### PR TITLE
Update kerberos login to support diacritics

### DIFF
--- a/docs/navigation.rb
+++ b/docs/navigation.rb
@@ -63,6 +63,10 @@ NAVIGATION_CONFIG = [
       {
         path: 'Metasploit-Guide-Kubernetes.md',
         title: without_prefix('Metasploit Guide ')
+      },
+      {
+        path: 'kerberoasting.md',
+        title: 'Kerberoasting'
       }
     ]
   },

--- a/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
+++ b/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
@@ -63,58 +63,58 @@ module Msf::Exploit::Remote::Kerberos::AuthBrute
       when Metasploit::Model::Login::Status::SUCCESSFUL
         case proof
         when Rex::Proto::Kerberos::Model::Error::KerberosError
-          print_good("#{peer} - User found: #{user.inspect} with password #{password}, but no ticket received (#{proof})")
+          print_good("#{peer} - User found: #{format_user(user)} with password #{password}, but no ticket received (#{proof})")
           report_cred(user: user, password: password)
         when Msf::Exploit::Remote::Kerberos::Model::TgtResponse
           hash = format_as_rep_to_john_hash(proof.as_rep)
 
           # Accounts that have 'Do not require Kerberos preauthentication' enabled, will receive an ASREP response with a
-          # ticket present without requiring a password
+          # ticket present without requiring a password. This can be cracked offline.
           if !proof.preauth_required
-            print_good("#{peer} - User: #{user.inspect} does not require preauthentication. Hash: #{hash}")
+            print_good("#{peer} - User: #{format_user(user)} does not require preauthentication. Hash: #{hash}")
           else
-            print_good("#{peer} - User found: #{user.inspect} with password #{password}. Hash: #{hash}")
+            print_good("#{peer} - User found: #{format_user(user)} with password #{password}. Hash: #{hash}")
           end
           report_cred(user: user, password: password, asrep: hash)
         else
-          print_good("#{peer} - User found: #{user.inspect} with password #{password}.")
+          print_good("#{peer} - User found: #{format_user(user)} with password #{password}.")
           report_cred(user: user, password: password)
         end
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        print_error("#{peer} - User: #{user.inspect} - Unable to connect - #{proof}")
+        print_error("#{peer} - User: #{format_user(user)} - Unable to connect - #{proof}")
 
       when Metasploit::Model::Login::Status::INCORRECT, Metasploit::Model::Login::Status::INVALID_PUBLIC_PART
         if proof.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_WRONG_REALM
-          print_error("#{peer} - User: #{user.inspect} - #{proof}. Domain option may be incorrect. Aborting...")
+          print_error("#{peer} - User: #{format_user(user)} - #{proof}. Domain option may be incorrect. Aborting...")
           # Stop further requests entirely
           break
         elsif proof.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_PREAUTH_REQUIRED
-          print_good("#{peer} - User: #{user.inspect} is present")
+          print_good("#{peer} - User: #{format_user(user)} is present")
           report_cred(user: user)
         elsif proof.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_PREAUTH_FAILED
           # If we haven't seen this user before, output that the user is present
           if !attempted_users.include?(user)
             attempted_users << user
-            print_good("#{peer} - User: #{user.inspect} is present")
+            print_good("#{peer} - User: #{format_user(user)} is present")
             report_cred(user: user)
           else
-            vprint_status("#{peer} - User: #{user.inspect} wrong password #{password}")
+            vprint_status("#{peer} - User: #{format_user(user)} wrong password #{password}")
           end
         elsif proof.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CLIENT_REVOKED
-          print_error("#{peer} - User: #{user.inspect} account disabled or locked out")
+          print_error("#{peer} - User: #{format_user(user)} account disabled or locked out")
         elsif proof.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_C_PRINCIPAL_UNKNOWN
-          vprint_status("#{peer} - User: #{user.inspect} user not found")
+          vprint_status("#{peer} - User: #{format_user(user)} user not found")
         else
-          vprint_status("#{peer} - User: #{user.inspect} - #{proof}")
+          vprint_status("#{peer} - User: #{format_user(user)} - #{proof}")
         end
       when Metasploit::Model::Login::Status::LOCKED_OUT
-        print_error("#{peer} - User: #{user.inspect} account locked out")
+        print_error("#{peer} - User: #{format_user(user)} account locked out")
       when Metasploit::Model::Login::Status::DISABLED
-        print_error("#{peer} - User: #{user.inspect} account disabled or expired")
+        print_error("#{peer} - User: #{format_user(user)} account disabled or expired")
       when Metasploit::Model::Login::Status::DENIED_ACCESS
-        print_error("#{peer} - User: #{user.inspect} account unable to log in")
+        print_error("#{peer} - User: #{format_user(user)} account unable to log in")
       else
-        print_error("#{peer} - User: #{user.inspect} #{proof}")
+        print_error("#{peer} - User: #{format_user(user)} #{proof}")
       end
     end
   end
@@ -158,5 +158,11 @@ module Msf::Exploit::Remote::Kerberos::AuthBrute
     }.merge(service_data)
 
     create_credential_login(login_data)
+  end
+
+  private
+
+  def format_user(user)
+    user.nil? ? 'nil' : "\"#{user}\""
   end
 end


### PR DESCRIPTION
### Verification

Create a users.txt with the contents:

```
basic_user
wîth.dìáçriticš
```

Run the module against your DC:

```
msf6 auxiliary(scanner/kerberos/kerberos_login) > run rhost=192.168.123.13 domain=adf3.local user_file=./users.txt pass_file=./wordlist.txt verbose=true
```

#### Before

```
[*] 192.168.123.13 - User: "w\xC3\xAEth.d\xC3\xAC\xC3\xA1\xC3\xA7ritic\xC5\xA1" user not found
```

#### After

```
[*] 192.168.123.13 - User: 'wîth.dìáçriticš' user not found
```