### PR TITLE
Always autocomplete options regardless of condition filtering

### DIFF
--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -80,8 +80,6 @@ module Msf
 
           mod.options.sorted.each do |e|
             name, _opt = e
-            next unless Msf::OptCondition.show_option(mod, _opt)
-
             res << name
           end
           # Exploits provide these three default options


### PR DESCRIPTION
Updates tab completion for modules to show all available options - regardless of condition filtering. This improves the discoverability of module functionality by no longer hiding important options by default.

## Verification

### Before

The user performs tab completion in this scenario:
```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=192.168.123.13 domain=adf3.local user=Administrator password=p4$$w0rd action=GET_TGT sp<tab>
```

No options are suggested to the user - suggesting to the user that their option name is wrong, or the module doesn't support that functionality. Which is not the case.

### After

The user performs tab completion in this scenario:

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=192.168.123.13 domain=adf3.local user=Administrator password=p4$$w0rd action=GET_TGT s<tab>
```

The `spn` option name is tab completed successfully:

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=192.168.123.13 domain=adf3.local user=Administrator password=p4$$w0rd action=GET_TGT spn=
```