### PR TITLE
Add edit link to docs website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,5 +55,4 @@ jobs:
       - name: build
         working-directory: docs
         run: |
-          bundle exec ruby build.rb
           bundle exec ruby build.rb --production

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -41,7 +41,7 @@ aux_links:
 
 nav_cache: true
 
-# False until the wiki's markdown files are migrated into the Metasploit repository
+# We set gh_edit_link to false to opt out of the default edit link support - and instead use a custom implementation in _includes/footer_custom.html
 gh_edit_link: false
 gh_edit_link_text: 'Edit this page on GitHub'
 gh_edit_repository: 'https://github.com/rapid7/metasploit-framework'

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -1,0 +1,17 @@
+{% comment %}
+Modification of https://github.com/just-the-docs/just-the-docs/blob/2495d3e6bb5720ae23e35caf16888f0c7f37ede0/_includes/components/footer.html
+The 'edit this page' page link now only appears when the root folder entry has content, and also includes linking directly to module documentation,
+or site wiki content
+{% endcomment %}
+
+{% if
+    site.gh_edit_link_text and
+    site.gh_edit_repository and
+    site.gh_edit_branch and
+    site.gh_edit_view_mode and
+    page.has_content == 'true'
+%}
+    <p class="text-small text-grey-dk-000 mb-0">
+        <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.old_path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
+    </p>
+{% endif %}


### PR DESCRIPTION
Updates the docs site to have an edit link at the bottom of each page which will take you to the markdown file on Github for editing

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/60357436/212334085-3ff9ca0a-e062-41af-a41c-bd0a128ae20a.png">

## Verification

- Ensure CI passes
- Build branch: https://github.com/rapid7/metasploit-framework/tree/c4d9206d9c4b6b2507b99a256d356f806389fc82/docs#developer-build

Verify the links at the bottom of the pages work as expected.
Note: There won't be edit links available for the 'root' level menu links
Note: The links hard code `https://github.com/rapid7/metasploit-framework` in the repository URL - so the links won't always be valid, for instance if you're adding additional docs on a custom user branch on your own fork