### PR TITLE
Enable new datastore implementation by default

### DIFF
--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -38,7 +38,7 @@ module Msf
         name: DATASTORE_FALLBACKS,
         description: 'When enabled you can consistently set username across modules, instead of setting SMBUser/FTPUser/BIND_DN/etc',
         requires_restart: true,
-        default_value: false
+        default_value: true
       }.freeze
     ].freeze
 


### PR DESCRIPTION
Enables the `datastore_fallbacks` feature flag by default. This is a rewrite of Metasploit's datastore to fix multiple bugs and edgecases. The `unset` command will now consistently unset previously set datastore values, so that default values are used once again. Explicitly clearing a datastore value can be done with the `set --clear OptionName` command. Modules that require protocol specific option names such as SMBUser/FTPUser/BIND_DN/etc can now be consistently set with just username/password/domain options, i.e. `set username Administrator` instead of `set SMBUser Administrator`. This rewrite is currently behind a feature flag which can be disabled with `features set datastore_fallbacks false`

Originally implemented in https://github.com/rapid7/metasploit-framework/pull/16940

## Verification

Verify the new flag is enabled by default when booting up msfconsole. Note: You may have to delete your old feature flag configuration to avoid false positives/negatives:
```
cat ~/.msf4/config | grep -i datastore
datastore_fallbacks=true
```
Verify the behavior is as expected from https://github.com/rapid7/metasploit-framework/pull/16940