### PR TITLE
update http options module

### DIFF
--- a/modules/auxiliary/scanner/http/options.rb
+++ b/modules/auxiliary/scanner/http/options.rb
@@ -14,60 +14,75 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'HTTP Options Detection',
+      'Name' => 'HTTP Options Detection',
       'Description' => 'Display available HTTP options for each system',
-      'Author'       => ['CG'],
-      'License'     => MSF_LICENSE,
-      'References' =>
+      'Author' => ['CG'],
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['CVE', '2005-3398'], # HTTP Trace related
+        ['CVE', '2005-3498'], # HTTP Trace related
+        ['OSVDB', '877'],
+        ['BID', '11604'],
+        ['BID', '9506'],
+        ['BID', '9561'],
+        ['URL', 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS']
+      ]
+    )
+    register_options(
       [
-        [ 'CVE', '2005-3398'],
-        [ 'CVE', '2005-3498'],
-        [ 'OSVDB', '877'],
-        [ 'BID', '11604'],
-        [ 'BID', '9506'],
-        [ 'BID', '9561']
+        OptString.new('TARGETURI', [true, 'URI to test', '/']),
       ]
     )
   end
 
   def run_host(target_host)
+    res = send_request_cgi({
+      'uri' => datastore['TARGETURI'],
+      'method' => 'OPTIONS'
+    })
+    return unless res
 
-    begin
-      res = send_request_raw({
-        'version'      => '1.0',
-        'uri'          => '/',
-        'method'       => 'OPTIONS'
-      }, 10)
-
-      if (res and res.headers['Allow'])
-        print_good("#{target_host} allows #{res.headers['Allow']} methods")
-
-        report_note(
-          :host	=> target_host,
-          :proto => 'tcp',
-          :sname => (ssl ? 'https' : 'http'),
-          :port	=> rport,
-          :type	=> 'HTTP_OPTIONS',
-          :data	=> res.headers['Allow']
-        )
-
-        if(res.headers['Allow'].index('TRACE'))
-          print_good "#{target_host}:#{rport} - TRACE method allowed."
-          report_vuln(
-            :host	=> target_host,
-            :port	=> rport,
-            :proto => 'tcp',
-            :sname => (ssl ? 'https' : 'http'),
-            :name	=> "HTTP Trace Method Allowed",
-            :info	=> "Module #{self.fullname} detected TRACE access through the Allow header: #{res.headers['Allow']}",
-            :refs   => self.references,
-            :exploited_at => Time.now.utc
-          )
-        end
-      end
-
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-    rescue ::Timeout::Error, ::Errno::EPIPE
+    # Patch so that we can catch a Tomcat edge case.
+    # Tomcat may respond to OPTIONS requests with the verbs in the
+    # HTTP body, instead of the Allow header.
+    # https://github.com/rapid7/metasploit-framework/issues/12557#issuecomment-552263162
+    # https://stackoverflow.com/questions/23886941/http-status-405-jsps-only-permit-get-post-or-head
+    if res.body && res.body =~ %r{<h1>HTTP Status 405 - JSPs only permit ([^<]*)</h1>}
+      res.headers['Allow'] = ::Regexp.last_match(1).sub(' or ', ' ').gsub(' ', ', ')
     end
+
+    unless res.headers['Allow']
+      vprint_error("#{target_host} missing Allow header")
+      return
+    end
+
+    allowed_methods = res.headers['Allow']
+
+    print_good("#{target_host} allows #{allowed_methods} methods")
+
+    report_note(
+      host: target_host,
+      proto: 'tcp',
+      sname: (ssl ? 'https' : 'http'),
+      port: rport,
+      type: 'HTTP_OPTIONS',
+      data: allowed_methods
+    )
+
+    if allowed_methods.index('TRACE')
+      print_good "#{target_host}:#{rport} - TRACE method allowed."
+      report_vuln(
+        host: target_host,
+        port: rport,
+        proto: 'tcp',
+        sname: (ssl ? 'https' : 'http'),
+        name: 'HTTP Trace Method Allowed',
+        info: "Module #{fullname} detected TRACE access through the Allow header: #{allowed_methods}",
+        refs: references,
+        exploited_at: Time.now.utc
+      )
+    end
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+  rescue ::Timeout::Error, ::Errno::EPIPE
   end
 end


### PR DESCRIPTION
fix #12557

This PR fixes some of the issues with the http options module:
1. adds `targeturi` option as `/` isn't always the right answer
2. uses `send_request_cgi` because `raw` was just not needed
3. updated to http 1.1 instead of 1.0
4. lint
5. if a host doesn't give an `allow` header, print something so we have *some* feedback
6. attempt to handle the Tomcat error page

I was unable to find a host that had the Tomcat error page, but there are a bunch of internet references to it, so I did my best to code it in.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/options`
- [x] `set rhosts`
- [x] `set verbose true`
- [x] `run`
- [x] **Verify** if the host doesn't respond with `Allow` header, you get an error message
- [x] **Verify** hosts with `Allow` headers still work


# old output

```
msf6 auxiliary(scanner/http/options) > run

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

# new output

```
msf6 auxiliary(scanner/http/options) > run

[-] 1.1.1.1 missing Allow header
[*] Scanned 1 of 1 hosts (100% complete)
```