### PR TITLE
Update min protocol for https server for openssl3

### DIFF
--- a/config/openssl.conf
+++ b/config/openssl.conf
@@ -2,6 +2,7 @@ openssl_conf = openssl_init
 
 [openssl_init]
 providers = provider_sect
+ssl_conf = ssl_sect
 
 [provider_sect]
 default = default_sect
@@ -12,3 +13,11 @@ activate = 1
 
 [legacy_sect]
 activate = 1
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+MinProtocol = SSLv3
+CipherString = ALL:@SECLEVEL=0
+Options = UnsafeLegacyRenegotiation


### PR DESCRIPTION
closes: https://github.com/rapid7/metasploit-framework/issues/17020

Fixes reverse_https stagers that are executed on Windows servers attempting to negotiate TLS1, by updating the MinProtocol for Metasploit's SSL server support when running OpenSSL3.

References:
- Openssl docs - setting MinProtocol https://www.openssl.org/docs/man1.1.1/man5/config.html
- Original post I found about seclevel https://discourse.ubuntu.com/t/default-to-tls-v1-2-in-all-tls-libraries-in-20-04-lts/12464/14

## Verification

Pre-requisite steps: Run a Metasploit https server on an accessible interface

```
use exploit/multi/handler
set payload windows/x64/meterpreter/reverse_https
set lhost 192.168.123.1
set lport 8443
run
```

### Before

Run sslscan openssl 1.1.1

```
$ sslscan 192.168.123.1
...
  SSL/TLS Protocols:
SSLv2     disabled
SSLv3     disabled
TLSv1.0   enabled	 <---
TLSv1.1   enabled	 <---
TLSv1.2   enabled
TLSv1.3   enabled
```

openssl version 3.x - using the latest kali/ubuntu release:

```
$ sslscan 192.168.123.132
...
  SSL/TLS Protocols:	
SSLv2     disabled	
SSLv3     disabled	
TLSv1.0   disabled	 <---
TLSv1.1   disabled	 <---
TLSv1.2   enabled	
TLSv1.3   enabled
```

### After

openssl version 3.x - using the latest kali/ubuntu release:

```
$ sslscan 192.168.123.132
...
  SSL/TLS Protocols:
SSLv2     disabled
SSLv3     disabled
TLSv1.0   enabled	 <---
TLSv1.1   enabled	 <---
TLSv1.2   enabled
TLSv1.3   enabled
```

Users can still configure the tls settings manually:

```
set sslversion TLS1.2
run
```

sslscan output

```
  SSL/TLS Protocols:
SSLv2     disabled
SSLv3     disabled
TLSv1.0   disabled
TLSv1.1   disabled
TLSv1.2   enabled
TLSv1.3   disabled
```