### PR TITLE
Fix LDAP Failure References

### DIFF
--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -211,19 +211,19 @@ module Msf
       when 0
         vprint_good('Successfully bound to the LDAP server!')
       when 1
-        fail_with(Msf::Exploit::Remote::Failure::NoAccess, "An operational error occurred, perhaps due to lack of authorization. The error was: #{bind_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::NoAccess, "An operational error occurred, perhaps due to lack of authorization. The error was: #{bind_result['errorMessage'].strip}")
       when 7
-        fail_with(Msf::Exploit::Remote::Failure::NoTarget, 'Target does not support the simple authentication mechanism!')
+        fail_with(Msf::Module::Failure::NoTarget, 'Target does not support the simple authentication mechanism!')
       when 8
-        fail_with(Msf::Exploit::Remote::Failure::NoTarget, "Server requires a stronger form of authentication than we can provide! The error was: #{bind_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::NoTarget, "Server requires a stronger form of authentication than we can provide! The error was: #{bind_result['errorMessage'].strip}")
       when 14
-        fail_with(Msf::Exploit::Remote::Failure::NoTarget, "Server requires additional information to complete the bind. Error was: #{bind_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::NoTarget, "Server requires additional information to complete the bind. Error was: #{bind_result['errorMessage'].strip}")
       when 48
-        fail_with(Msf::Exploit::Remote::Failure::NoAccess, "Target doesn't support the requested authentication type we sent. Try binding to the same user without a password, or providing credentials if you were doing anonymous authentication.")
+        fail_with(Msf::Module::Failure::NoAccess, "Target doesn't support the requested authentication type we sent. Try binding to the same user without a password, or providing credentials if you were doing anonymous authentication.")
       when 49
-        fail_with(Msf::Exploit::Remote::Failure::NoAccess, 'Invalid credentials provided!')
+        fail_with(Msf::Module::Failure::NoAccess, 'Invalid credentials provided!')
       else
-        fail_with(Msf::Exploit::Remote::Failure::Unknown, "Unknown error occurred whilst binding: #{bind_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::Unknown, "Unknown error occurred whilst binding: #{bind_result['errorMessage'].strip}")
       end
     end
 
@@ -253,42 +253,42 @@ module Msf
       when 1
         # This is unknown as whilst we could fail on lack of authorization, this is not guaranteed with this error code.
         # The user will need to inspect the error message to determine the root cause of the issue.
-        fail_with(Failure::Unknown, "An LDAP operational error occurred on #{filter}. It is likely the client requires authorization! The error was: #{query_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::Unknown, "An LDAP operational error occurred on #{filter}. It is likely the client requires authorization! The error was: #{query_result['errorMessage'].strip}")
       when 2
-        fail_with(Failure::BadConfig, "The LDAP protocol being used by Metasploit isn't supported. The error was #{query_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::BadConfig, "The LDAP protocol being used by Metasploit isn't supported. The error was #{query_result['errorMessage'].strip}")
       when 3
-        fail_with(Failure::TimeoutExpired, "The LDAP server returned a timeout response to the query #{filter}.")
+        fail_with(Msf::Module::Failure::TimeoutExpired, "The LDAP server returned a timeout response to the query #{filter}.")
       when 4
-        fail_with(Failure::UnexpectedReply, "The LDAP query #{filter} was determined to result in too many entries for the LDAP server to return.")
+        fail_with(Msf::Module::Failure::UnexpectedReply, "The LDAP query #{filter} was determined to result in too many entries for the LDAP server to return.")
       when 11
-        fail_with(Failure::UnexpectedReply, "The LDAP server indicated that #{filter} hit some administrative limit within the server whilst the request was being processed.")
+        fail_with(Msf::Module::Failure::UnexpectedReply, "The LDAP server indicated that #{filter} hit some administrative limit within the server whilst the request was being processed.")
       when 16
-        fail_with(Failure::NotFound, "The LDAP operation failed for #{filter} because the referenced attribute does not exist.")
+        fail_with(Msf::Module::Failure::NotFound, "The LDAP operation failed for #{filter} because the referenced attribute does not exist.")
       when 18
-        fail_with(Failure::BadConfig, "The LDAP search with #{filter} failed because some matching is not supported for the target attribute type!")
+        fail_with(Msf::Module::Failure::BadConfig, "The LDAP search with #{filter} failed because some matching is not supported for the target attribute type!")
       when 32
-        fail_with(Failure::UnexpectedReply, "The LDAP search with #{filter} failed cause the operation targeted an entity within the base DN that does not exist.")
+        fail_with(Msf::Module::Failure::UnexpectedReply, "The LDAP search with #{filter} failed cause the operation targeted an entity within the base DN that does not exist.")
       when 33
-        fail_with(Failure::BadConfig, "An attempt was made to deference an alias that didn't resolve properly with #{filter}.")
+        fail_with(Msf::Module::Failure::BadConfig, "An attempt was made to deference an alias that didn't resolve properly with #{filter}.")
       when 34
-        fail_with(Failure::BadConfig, 'The request included an invalid base DN entry.')
+        fail_with(Msf::Module::Failure::BadConfig, 'The request included an invalid base DN entry.')
       when 50
-        fail_with(Failure::NoAccess, 'The LDAP operation failed due to insufficient access rights.')
+        fail_with(Msf::Module::Failure::NoAccess, 'The LDAP operation failed due to insufficient access rights.')
       when 51
-        fail_with(Failure::UnexpectedReply, 'The LDAP operation failed because the server is too busy to perform the request.')
+        fail_with(Msf::Module::Failure::UnexpectedReply, 'The LDAP operation failed because the server is too busy to perform the request.')
       when 52
-        fail_with(Failure::UnexpectedReply, 'The LDAP operation failed because the server is not currently available to process the request.')
+        fail_with(Msf::Module::Failure::UnexpectedReply, 'The LDAP operation failed because the server is not currently available to process the request.')
       when 53
-        fail_with(Failure::UnexpectedReply, 'The LDAP operation failed because the server is unwilling to perform the request.')
+        fail_with(Msf::Module::Failure::UnexpectedReply, 'The LDAP operation failed because the server is unwilling to perform the request.')
       when 64
-        fail_with(Failure::Unknown, "The LDAP operation failed due to a naming violation when using #{filter}.")
+        fail_with(Msf::Module::Failure::Unknown, "The LDAP operation failed due to a naming violation when using #{filter}.")
       when 65
-        fail_with(Failure::Unknown, "The LDAP operation failed due to an object class violation when using #{filter}.")
+        fail_with(Msf::Module::Failure::Unknown, "The LDAP operation failed due to an object class violation when using #{filter}.")
       else
         if query_result['errorMessage'].blank?
-          fail_with(Failure::Unknown, "Query #{filter} failed but no error message was returned!")
+          fail_with(Msf::Module::Failure::Unknown, "Query #{filter} failed but no error message was returned!")
         else
-          fail_with(Failure::Unknown, "Query #{filter} failed with error: #{query_result['errorMessage'].strip}")
+          fail_with(Msf::Module::Failure::Unknown, "Query #{filter} failed with error: #{query_result['errorMessage'].strip}")
         end
       end
     end


### PR DESCRIPTION
This fixes the following issue in the ldap_query module:

```
[+] 192.168.159.10:389 Discovered base DN: DC=msflab,DC=local
[-] Auxiliary failed: NameError uninitialized constant Msf::Exploit::Remote::LDAP::Failure
Did you mean?  Msf::Exploit::Remote::Failure
               Msf::Exploit::Failure
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:256:in `validate_query_result!'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/gather/ldap_query.rb:144:in `perform_ldap_query'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/gather/ldap_query.rb:501:in `block in run'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/net-ldap-0.17.1/lib/net/ldap.rb:644:in `block in open'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/net-ldap-0.17.1/lib/net/ldap.rb:716:in `block in open'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/net-ldap-0.17.1/lib/net/ldap/instrumentation.rb:19:in `instrument'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/net-ldap-0.17.1/lib/net/ldap.rb:711:in `open'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/net-ldap-0.17.1/lib/net/ldap.rb:644:in `open'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:104:in `ldap_connect'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/gather/ldap_query.rb:432:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(gather/ldap_query) >
```
You can see that `#validate_bind_success!` uses `Msf::Exploit::Remote::Failure` too.

## Verification

List the steps needed to make sure this thing works

- [ ] Run `ldap_query` see it not crash



