### PR TITLE
Set ccache status klist

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
@@ -1,3 +1,5 @@
+require 'metasploit/framework/data_service/remote/http/error'
+
 module LootDataProxy
 
   def report_loot(opts)
@@ -42,6 +44,9 @@ module LootDataProxy
         add_opts_workspace(opts)
         data_service.loot(opts)
       end
+    # Map remote db error to a local rails database exception for error handling consistency
+    rescue Metasploit::Framework::DataService::Remote::NotFound => _e
+      raise ActiveRecord::RecordNotFound, 'Loot not found'
     rescue => e
       self.log_error(e, "Problem retrieving loot")
     end

--- a/lib/metasploit/framework/data_service/remote/http/error.rb
+++ b/lib/metasploit/framework/data_service/remote/http/error.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Metasploit
+  module Framework
+    module DataService
+      module Remote
+        class HttpError < StandardError
+          def initialize(error:, status_code:, message: 'Unknown Error')
+            super(message)
+            @error = error
+            @status_code = status_code
+          end
+
+          attr_reader :error, :status_code
+        end
+
+        class ServerError < HttpError
+          def initialize(error:, status_code: 500, message: 'Internal Server Error')
+            super
+          end
+        end
+
+        class ClientError < HttpError
+          def initialize(error:, status_code: 400, message: 'Client Error')
+            super
+          end
+        end
+
+        class NotFound < HttpError
+          def initialize(error:, status_code: 404, message: 'Not Found')
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
@@ -11,7 +11,7 @@ module RemoteLootDataService
     data = self.get_data(path, nil, opts)
     rv = json_to_mdm_object(data, LOOT_MDM_CLASS)
     parsed_body = JSON.parse(data.response.body, symbolize_names: true)
-    data = parsed_body[:data]
+    data = Array.wrap(parsed_body[:data])
     data.each do |loot|
       # TODO: Add an option to toggle whether the file data is returned or not
       if loot[:data] && !loot[:data].empty?
@@ -28,7 +28,7 @@ module RemoteLootDataService
   end
 
   def report_loot(opts)
-    self.post_data_async(LOOT_API_PATH, opts)
+    json_to_mdm_object(self.post_data(LOOT_API_PATH, opts), LOOT_MDM_CLASS).first
   end
 
   def update_loot(opts)

--- a/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
+++ b/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
@@ -1,5 +1,5 @@
 require 'digest'
-
+require 'metasploit/framework/data_service/remote/http/error'
 #
 # HTTP response helper class
 #
@@ -56,8 +56,7 @@ module ResponseDataHelper
           raise "Mdm Object conversion failed #{e.message}"
         end
       elsif response_wrapper.is_a?(Metasploit::Framework::DataService::RemoteHTTPDataService::ErrorResponse)
-        # raise a local exception with the message of the server-side error
-        raise parsed_body[:error][:message]
+        handle_error_response(parsed_body)
       end
     elsif response_wrapper.is_a?(Metasploit::Framework::DataService::RemoteHTTPDataService::FailedResponse)
       raise response_wrapper.to_s
@@ -144,6 +143,23 @@ module ResponseDataHelper
       end
     end
     obj
+  end
+
+  private
+
+  def handle_error_response(parsed_body)
+    error = parsed_body[:error]
+    error_code = error[:code]
+    case error_code
+    when 404
+      raise Metasploit::Framework::DataService::Remote::NotFound.new(error: error)
+    when 400..499
+      raise Metasploit::Framework::DataService::Remote::ClientError.new(error: error, status_code: error_code)
+    when 500..599
+      raise Metasploit::Framework::DataService::Remote::ServerError.new(error: error, status_code: error_code)
+    else
+      raise Metasploit::Framework::DataService::Remote::HttpError.new(error: error, status_code: error_code)
+    end
   end
 
 end

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -210,7 +210,7 @@ module Auxiliary::Report
     raise ArgumentError.new("Missing required option :host") if opts[:host].nil?
     raise ArgumentError.new("Missing required option :port") if (opts[:port].nil? and opts[:service].nil?)
 
-    if opts[:host].kind_of?(::Mdm::Host)
+    if opts[:host].is_a?(::Mdm::Host)
       host = opts[:host].address
     else
       host = opts[:host]
@@ -235,7 +235,7 @@ module Auxiliary::Report
         proto = "tcp"
     end
 
-    if opts[:service] && opts[:service].kind_of?(Mdm::Service)
+    if opts[:service] && opts[:service].is_a?(Mdm::Service)
       port         = opts[:service].port
       proto        = opts[:service].proto
       service_name = opts[:service].name
@@ -395,7 +395,7 @@ module Auxiliary::Report
   # +filename+ and +info+ are only stored as metadata, and therefore both are
   # ignored if there is no database
   #
-  def store_loot(ltype, ctype, host, data, filename=nil, info=nil, service=nil)
+  def store_loot(ltype, ctype, host, data, filename=nil, info=nil, service=nil, &block)
     if ! ::File.directory?(Msf::Config.loot_directory)
       FileUtils.mkdir_p(Msf::Config.loot_directory)
     end
@@ -446,7 +446,8 @@ module Auxiliary::Report
         conf[:service] = service if service
       end
 
-      framework.db.report_loot(conf)
+      loot = framework.db.report_loot(conf)
+      yield loot if block_given?
     end
 
     return full_path.dup

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
@@ -61,6 +61,22 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       {}
     end
 
+    # Mark ccache(s) as inactive
+    #
+    # @param [Array<Integer>] ids The list of ccache IDs.
+    # @return [Array<StoredTicket>]
+    def deactivate_ccache(ids)
+      []
+    end
+
+    # Mark ccache(s) as active
+    #
+    # @param [Array<Integer>] ids The list of ccache IDs.
+    # @return [Array<StoredTicket>]
+    def activate_ccache(ids)
+      []
+    end
+
     # @return [String] The name of the workspace in which to operate.
     def workspace
       if @framework_module
@@ -100,32 +116,40 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
         end
       end
       unless (info = loot_info(options)).blank?
-        filter[:info] = info
+        filter[:info] = JSON.generate(info)
       end
-      framework.db.loots(workspace: myworkspace, ltype: 'mit.kerberos.ccache', **filter).each do |stored_loot|
+      loots = framework.db.loots(workspace: myworkspace, ltype: 'mit.kerberos.ccache', **filter).select do |loot|
+        # Remove any loot that isn't 'mit.kerberos.ccache'
+        # Necessary when an `id` is provided in which case the `ltype` search above is ignored
+        loot.ltype == 'mit.kerberos.ccache'
+        # Normally if you search for an id that does not exist in loots an `ActiveRecord::RecordNotFound` exception is raised
+        # Since the record does exist no exception is raised but that makes the user experience inconsistent
+        # I would feel weird about throwing an exception at this point so I decided not to and just deal with the inconsistency
+      end
+      loots.each do |stored_loot|
         block.call(stored_loot) if block_given?
       end
     end
 
     # Build a loot info string that can later be used in a lookup.
     #
-    # @return [String] the info string
+    # @return [Hash] the info hash
     def loot_info(options = {})
-      info = []
+      info = {}
 
       status = options.fetch(:status, :valid).downcase.to_sym
-      info << "status: #{status}" unless status == :valid
+      info[:status] = status unless status == :valid
 
       realm = options[:realm]
-      info << "realm: #{realm.to_s.upcase}" if realm.present?
+      info[:realm] = realm.to_s.upcase if realm.present?
 
       client = options[:client]
-      info << "client: #{client.to_s.downcase}" if client.present?
+      info[:client] == client.to_s.downcase if client.present?
 
       server = options[:server]
-      info << "server: #{server.to_s.downcase}" if server.present?
+      info[:server] = server.to_s.downcase if server.present?
 
-      info.join(', ')
+      info
     end
   end
 end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/stored_ticket.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/stored_ticket.rb
@@ -6,6 +6,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
     # @param [Mdm::Loot] loot
     def initialize(loot)
       @loot = loot
+      parse_loot_info
     end
 
     def id
@@ -50,6 +51,8 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       !(tkt_start < now && now < tkt_end)
     end
 
+    attr_reader :status
+
     private
 
     # @return [Mdm::Loot] loot
@@ -58,6 +61,14 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
     def credential
       # at this time Metasploit stores 1 credential per ccache file, so no need to iterate through them
       ccache.credentials.first
+    end
+
+    def parse_loot_info
+      info = loot.info
+      return if info.blank?
+
+      info_hash = JSON.parse(info)
+      @status = info_hash['status']
     end
   end
 end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
@@ -21,9 +21,11 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       # use #components.to_a.join('/') to omit the realm that #to_s includes
       client = options.fetch(:client) { ccache.credentials.first&.client&.components.to_a.join('/') }
       server = options.fetch(:server) { ccache.credentials.first&.server&.components.to_a.join('/') }
-      info = loot_info(realm: realm, client: client, server: server)
-
-      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', options[:host], ccache.encode, nil, info)
+      info = generate_info_string(realm: realm, client: client, server: server)
+      loot = nil
+      path = store_loot('mit.kerberos.ccache', 'application/octet-stream', options[:host], ccache.encode, nil, info) do |mdm_loot|
+        loot = mdm_loot
+      end
       message = ''
       if @framework_module.respond_to?(:peer) && @framework_module.peer.present? && @framework_module.peer != ':'
         message << "#{@framework_module.peer} - "
@@ -36,7 +38,56 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       message << "MIT Credential Cache ticket saved to #{path}"
       print_status(message)
 
-      { path: path }
+      { path: path, loot: loot }
+    end
+
+    # (see Base#deactivate_ccache)
+    def deactivate_ccache(ids:)
+      set_ccache_status(ids: ids, status: 'inactive')
+    end
+
+    # (see Base#activate_ccache)
+    def activate_ccache(ids:)
+      set_ccache_status(ids: ids, status: 'active')
+    end
+
+    private
+
+    # @param [Array<Integer>] ids List of ticket IDs to update
+    # @param [String] status The status to set for the tickets
+    # @return [Array<StoredTicket>]
+    def set_ccache_status(ids:, status:)
+      updated_loots = []
+      ids.each do |id|
+        loot = objects({ id: id })
+        if loot.blank?
+          print_warning("Ccache with id: #{id} was not found in loot")
+          next
+        end
+        updated_loot_info = update_info_string(loot.first.info, status: status)
+        # I know this looks weird but the local db returns a single loot object, remote db returns an array of them
+        updated_loots << Array.wrap(framework.db.update_loot({ id: id, info: updated_loot_info })).first
+      end
+      updated_loots.map do |stored_loot|
+        StoredTicket.new(stored_loot)
+      end
+    end
+
+    def generate_info_string(options = {})
+      JSON.generate(loot_info(options))
+    end
+
+    def update_info_string(info, **kwargs)
+      info_hash = parse_json_no_errors(info)
+      updated_hash = loot_info(info_hash.merge(kwargs))
+      JSON.generate(updated_hash)
+    end
+
+    def parse_json_no_errors(json)
+      JSON.parse(json).symbolize_keys
+    rescue JSON::ParserError
+      wlog('Ccache info is invalid JSON')
+      {}
     end
   end
 end

--- a/lib/msf/core/web_services/servlet/loot_servlet.rb
+++ b/lib/msf/core/web_services/servlet/loot_servlet.rb
@@ -30,7 +30,9 @@ module Msf::WebServices::LootServlet
         data = encode_loot_data(data)
         data = data.first if is_single_object?(data, sanitized_params)
         set_json_data_response(response: data, includes: includes)
-      rescue => e
+      rescue ActiveRecord::RecordNotFound => e
+        create_error_response(error: e, message: 'Loot record was not found', code: 404)
+      rescue StandardError => e
         print_error_and_create_response(error: e, message: 'There was an error retrieving the loot:', code: 500)
       end
     }
@@ -72,7 +74,7 @@ module Msf::WebServices::LootServlet
         data = get_db.update_loot(opts)
         data = encode_loot_data(data)
         set_json_data_response(response: data)
-      rescue => e
+      rescue StandardError => e
         print_error_and_create_response(error: e, message: 'There was an error updating the loot:', code: 500)
       end
     }
@@ -89,7 +91,7 @@ module Msf::WebServices::LootServlet
         data.map! { |loot| loot.dup if loot.frozen? }
         data = encode_loot_data(data)
         set_json_data_response(response: data)
-      rescue => e
+      rescue StandardError => e
         print_error_and_create_response(error: e, message: 'There was an error deleting the loot:', code: 500)
       end
     }

--- a/lib/msf/core/web_services/servlet_helper.rb
+++ b/lib/msf/core/web_services/servlet_helper.rb
@@ -54,9 +54,13 @@ module Msf::WebServices::ServletHelper
 
   def print_error_and_create_response(error: , message:, code:)
     print_error "Error handling request: #{error.message}.", error
+    create_error_response(error: error, message: message, code: code)
+  end
+
+  def create_error_response(error:, message:, code:)
     error_response = {
-        code: code,
-        message: "#{message} #{error.message}"
+      code: code,
+      message: "#{message} #{error.message}"
     }
     set_json_error_response(response: error_response, code: code)
   end

--- a/lib/msf/ui/console/command_dispatcher/db/klist.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/klist.rb
@@ -15,7 +15,7 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
 
   def cmd_klist_help
     print_line 'List Kerberos tickets in the database'
-    print_line 'Usage: klist [options]'
+    print_line 'Usage: klist [options] [hosts]'
     print_line
     print @@klist_opts.usage
     print_line
@@ -23,26 +23,36 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
 
   @@klist_opts = Rex::Parser::Arguments.new(
     ['-v', '--verbose'] => [false, 'Verbose output'],
-    ['-d', '--delete'] => [ false, 'Delete *all* matching kerberos entries' ],
-    ['-h', '--help'] => [false, 'Help banner']
+    ['-d', '--delete'] => [ false, 'Delete *all* matching kerberos entries'],
+    ['-h', '--help'] => [false, 'Help banner'],
+    ['-i', '--index'] => [true, 'Kerberos entry ID(s) to search for, e.g. `-i 1` or `-i 1,2,3` or `-i 1 -i 2 -i 3`'],
+    ['-a', '--activate'] => [false, 'Activates *all* matching kerberos entries'],
+    ['-A', '--deactivate'] => [false, 'Deactivates *all* matching kerberos entries']
   )
 
   def cmd_klist(*args)
     return unless active?
 
-    delete_count = 0
+    entries_affected = 0
     mode = :list
     host_ranges = []
+    id_search = []
     verbose = false
     @@klist_opts.parse(args) do |opt, _idx, val|
       case opt
       when '-h', '--help'
         cmd_klist_help
         return
-      when '-v', '--vebose'
+      when '-v', '--verbose'
         verbose = true
       when '-d', '--delete'
         mode = :delete
+      when '-i', '--id'
+        id_search = (id_search + val.split(/,\s*|\s+/)).uniq # allows 1 or 1,2,3 or "1 2 3" or "1, 2, 3"
+      when '-a', '--activate'
+        mode = :activate
+      when '-A', '--deactivate'
+        mode = :deactivate
       else
         # Anything that wasn't an option is a host to search for
         unless arg_host_range(val, host_ranges)
@@ -53,17 +63,9 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
 
     # Sentinel value meaning all
     host_ranges.push(nil) if host_ranges.empty?
+    id_search = nil if id_search.empty?
 
-    ticket_results = []
-    each_host_range_chunk(host_ranges) do |host_search|
-      next if host_search && host_search.empty?
-
-      ticket_results += kerberos_ticket_storage.tickets(
-        workspace: framework.db.workspace,
-        host: host_search
-      )
-    end
-    ticket_results.sort_by(&:host_address)
+    ticket_results = ticket_search(host_ranges, id_search)
 
     print_line('Kerberos Cache')
     print_line('==============')
@@ -76,7 +78,16 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
 
     if mode == :delete
       result = kerberos_ticket_storage.delete_tickets(ids: ticket_results.map(&:id))
-      delete_count = result.size
+      entries_affected = result.size
+    end
+
+    if mode == :activate || mode == :deactivate
+      result = set_activation_status(mode, ticket_results)
+      entries_affected = result.size
+      # Update the contents of ticket results to display the updated status values
+      # TODO: should be able to use the results returned from updating loot
+      # but it returns a base 64'd data field which breaks when bindata tries to parse it as a ccache
+      ticket_results = ticket_search(host_ranges, id_search)
     end
 
     if verbose
@@ -89,18 +100,19 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
     else
       tbl = Rex::Text::Table.new(
         {
-          'Columns' => ['host', 'principal', 'sname', 'issued', 'status', 'path'],
+          'Columns' => ['id', 'host', 'principal', 'sname', 'issued', 'status', 'path'],
           'SortIndex' => -1,
           # For now, don't perform any word wrapping on the table as it breaks the workflow of
           # copying file paths and pasting them into applications
           'WordWrap' => false,
           'Rows' => ticket_results.map do |ticket|
             [
+              ticket.id,
               ticket.host_address,
               ticket.principal,
               ticket.sname,
               ticket.starttime,
-              ticket.expired? ? '>>expired<<' : 'valid',
+              ticket_status(ticket),
               ticket.path
             ]
           end
@@ -109,7 +121,14 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
       print_line(tbl.to_s)
     end
 
-    print_status("Deleted #{delete_count} #{delete_count > 1 ? 'entries' : 'entry'}") if delete_count > 0
+    case mode
+    when :delete
+      print_status("Deleted #{entries_affected} #{entries_affected > 1 ? 'entries' : 'entry'}") if entries_affected > 0
+    when :activate
+      print_status("Activated #{entries_affected} #{entries_affected > 1 ? 'entries' : 'entry'}") if entries_affected > 0
+    when :deactivate
+      print_status("Deactivated #{entries_affected} #{entries_affected > 1 ? 'entries' : 'entry'}") if entries_affected > 0
+    end
   end
 
   protected
@@ -117,5 +136,72 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
   # @return [Msf::Exploit::Remote::Kerberos::Ticket::Storage::ReadWrite]
   def kerberos_ticket_storage
     @kerberos_ticket_storage ||= Msf::Exploit::Remote::Kerberos::Ticket::Storage::ReadWrite.new(framework: framework)
+  end
+
+  private
+
+  # Gets the status of a ticket
+  #
+  # @param [Msf::Exploit::Remote::Kerberos::Ticket::Storage::StoredTicket]
+  # @return [String] Status of the ticket
+  def ticket_status(ticket)
+    if ticket.expired?
+      '>>expired<<'
+    elsif ticket.status.blank?
+      'active'
+    else
+      ticket.status
+    end
+  end
+
+  # Sets the status of the tickets
+  #
+  # @param [Symbol] mode The status (:activate or :deactivate) to apply to the ticket(s)
+  # @param [Array<StoredTicket>] tickets The tickets which statuses are to be updated
+  # @return [Array<StoredTicket>]
+  def set_activation_status(mode, tickets)
+    if mode == :activate
+      kerberos_ticket_storage.activate_ccache(ids: tickets.map(&:id))
+    elsif mode == :deactivate
+      kerberos_ticket_storage.deactivate_ccache(ids: tickets.map(&:id))
+    end
+  end
+
+  # @param [Array<Rex::Socket::RangeWalker>] host_ranges Search for tickets associated with these hosts
+  # @param [Array<Integer>, nil] id_search List of ticket IDs to search for
+  # @return [Array<Msf::Exploit::Remote::Kerberos::Ticket::Storage::StoredTicket>]
+  def ticket_search(host_ranges, id_search)
+    ticket_results = []
+
+    # Iterating over each id here since the remote db doesn't support bulk id searches
+    if id_search
+      begin
+        ticket_results += id_search.flat_map do |id|
+          kerberos_ticket_storage.tickets(
+            workspace: framework.db.workspace,
+            id: id
+          )
+        end
+      rescue ActiveRecord::RecordNotFound => e
+        wlog("Record Not Found: #{e.message}")
+        print_warning("Not all records with the ids: #{id_search} could be found.")
+        print_warning('Please ensure all ids specified are available.')
+      end
+    else
+      each_host_range_chunk(host_ranges) do |host_search|
+        next if host_search&.empty?
+
+        ticket_results += kerberos_ticket_storage.tickets(
+          workspace: framework.db.workspace,
+          host: host_search
+        )
+      end
+      host_ranges.each { |range| range.reset unless range.nil? } # Reset the Rex::Socket::RangeWalker so it can be re-used
+    end
+
+    ticket_results.sort_by do |ticket|
+      ticket_host_address = ticket.host_address.blank? ? '0.0.0.0' : ticket.host_address
+      [::IPAddr.new(ticket_host_address).to_i, ticket.starttime.to_i]
+    end
   end
 end

--- a/spec/support/shared/contexts/msf/ui_driver.rb
+++ b/spec/support/shared/contexts/msf/ui_driver.rb
@@ -20,6 +20,12 @@ RSpec.shared_context 'Msf::UIDriver' do
     instance
   end
 
+  def reset_logging!
+    @output = []
+    @error = []
+    @combined_output = []
+  end
+
   def capture_logging(target)
     append_output = proc do |string = ''|
       lines = string.split("\n")


### PR DESCRIPTION
This PR adds the capability to activate and/or deactivate a kerberos ccache/ticket we have stored in he DB via the klist command added here #17374 
Originally we were going to go for "invalidate" but I thought that activate/deactivate was better for a couple of reasons:
- We have no way to "validate" a ticket, but being able to invalidate implies it was previously valid
- Invalidate felt like a one way street, if a ticket is invalid then you need a new ticket since we can't edit the ticket contents to make it "valid" again
- The terms activate/deactivate make it more clear (to me anyway) what the intent is, activate meaning this ticket is active and can be used, deactivate this ticket is now inactive and not to be used, and you can swap between the two at will depending on what's required for your current workflow

I'm happy to discuss/change this, whether that's renaming the terms, the flags used for it (-a|-A) or additionally adding in an option to invalidate a ticket that can't be undone but you don't want to delete the ticket (maybe for record keeping/report reasons)

Additionally I've also added the ability to select a ccache/ticket based on it's index so you can select one or more individual tickets without needing to apply it to all in a certain host range and for tickets without an associated host (i.e. forged tickets)

# Verification Steps
- [ ] Put some tickets in your db (I used the forge ticket module and just forged them as and when I needed them)
- [ ] run `klist` all your tickets should appear and be "active"
- [ ] run `klist -i <id> -A` the ticket you selected should now be "inactive"
- [ ] run `klist -i <id> -a` make sure <id> is that of an "inactive" ticket, it should now be active
- [ ] run `klist -A` and `klist -a` see that not specifiying an id will apply it to all entries
- [ ] run `klist -i <id> -d` this should delete the single entry with the id specified
- [ ] run `klist -i <id> ` this should display the single entry with the id specified


The index should work for formats such as `klist -i 1`, `klist -i 1,2,3`, `klist -i 1 -i 2 -i 3`
