### PR TITLE
Return if there is no certificate to process

### DIFF
--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -198,8 +198,9 @@ module Exploit::Remote::MsIcpr
     else
       print_error('There was an error while requesting the certificate.')
       print_error(response[:disposition_message].strip.to_s) unless response[:disposition_message].blank?
-      return
     end
+
+    return unless response[:certificate]
 
     if (upn = get_cert_msext_upn(response[:certificate]))
       print_status("Certificate UPN: #{upn}")


### PR DESCRIPTION
This fixes an error where modules that issue certificates (`icpr_cert` and now `auxiliary/admin/dcerpc/cve_2022_26923_certifried`) would crash if the response from the server was that the certificate was submitted and no certificate was returned. This updates the code to check if the certificate is present before attempting to process it.

Requires rapid7/ruby_smb#244

## Before:

```
msf6 auxiliary(admin/dcerpc/icpr_cert) > show options 

Module options (auxiliary/admin/dcerpc/icpr_cert):

   Name           Current Setting                   Required  Description
   ----           ---------------                   --------  -----------
   ALT_DNS                                          no        Alternative certificate DNS
   ALT_UPN                                          no        Alternative certificate UPN (format: USER@DOMAIN)
   CA             MSFLAB-DC-CA                      yes       The target certificate authority
   CERT_TEMPLATE  Machine                           yes       The certificate template
   ON_BEHALF_OF                                     no        Username to request on behalf of (format: DOMAIN\USER)
   PFX                                              no        Certificate to request on behalf of
   RHOSTS         192.168.159.10                    yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT          445                               yes       The target port (TCP)
   SMBDomain      .                                 no        The Windows domain to use for authentication
   SMBPass        tuX5bQXSsonr7RL04VXIQSvAEw90eJIC  no        The password for the specified username
   SMBUser        DESKTOP-8GCC7SV7$                 no        The username to authenticate as


Auxiliary action:

   Name          Description
   ----          -----------
   REQUEST_CERT  Request a certificate



View the full module info with the info, or info -d command.

msf6 auxiliary(admin/dcerpc/icpr_cert) > run
[*] Running module against 192.168.159.10

[*] 192.168.159.10:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 192.168.159.10:445 - Binding to \cert...
[+] 192.168.159.10:445 - Bound to \cert
[*] 192.168.159.10:445 - Requesting a certificate for user DESKTOP-8GCC7SV7$ - digest algorithm: SHA256 - template: Machine
[-] 192.168.159.10:445 - Auxiliary failed: OpenSSL::X509::CertificateError header too long
[-] 192.168.159.10:445 - Call stack:
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/ruby_smb-3.2.1/lib/ruby_smb/dcerpc/icpr.rb:76:in `initialize'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/ruby_smb-3.2.1/lib/ruby_smb/dcerpc/icpr.rb:76:in `new'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/ruby_smb-3.2.1/lib/ruby_smb/dcerpc/icpr.rb:76:in `cert_server_request'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/ms_icpr.rb:188:in `do_request_cert'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/ms_icpr.rb:89:in `request_certificate'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:64:in `action_request_cert'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:50:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/icpr_cert) > 
```

## Verification

Use the setup steps below to create a stand-alone AD CS environment **not an Enterprise environment**

1. As a normal user, create a new computer account using the samr_computer module
2. Use the new computer account to issue a certificate using the icpr_module
    1. Set SMBUser to the computer name
    2. Set SMBPass to the computer password
    3. Set CERT_TEMPLATE to `Machine`
3. Run the icpr_module, see that it failed to issue the certificate (the status is submitted) but there is no stack trace

Without these changes, there would be a stack trace in step 3

## Demo

```
msf6 auxiliary(admin/dcerpc/samr_computer) > show options 

Module options (auxiliary/admin/dcerpc/samr_computer):

   Name               Current Setting  Required  Description
   ----               ---------------  --------  -----------
   COMPUTER_NAME                       no        The computer name
   COMPUTER_PASSWORD                   no        The password for the new computer
   RHOSTS             192.168.159.10   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT              445              yes       The target port (TCP)
   SMBDomain          .                no        The Windows domain to use for authentication
   SMBPass            Password1!       no        The password for the specified username
   SMBUser            aliddle          no        The username to authenticate as


Auxiliary action:

   Name          Description
   ----          -----------
   ADD_COMPUTER  Add a computer account



View the full module info with the info, or info -d command.

msf6 auxiliary(admin/dcerpc/samr_computer) > run
msf6 auxiliary(admin/dcerpc/samr_computer) > run
[*] Running module against 192.168.159.10

[*] 192.168.159.10:445 - Using automatically identified domain: MSFLAB
[+] 192.168.159.10:445 - Successfully created MSFLAB\DESKTOP-8GCC7SV7$
[+] 192.168.159.10:445 -   Password: tuX5bQXSsonr7RL04VXIQSvAEw90eJIC
[+] 192.168.159.10:445 -   SID:      S-1-5-21-3402587289-1488798532-3618296993-1603
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/samr_computer) > creds
Credentials
===========

host            origin          service        public             private                           realm   private_type  JtR Format
----            ------          -------        ------             -------                           -----   ------------  ----------
192.168.159.10  192.168.159.10  445/tcp (smb)  DESKTOP-8GCC7SV7$  tuX5bQXSsonr7RL04VXIQSvAEw90eJIC  MSFLAB  Password      

msf6 auxiliary(admin/dcerpc/samr_computer) > use icpr_cert

Matching Modules
================

   #  Name                              Disclosure Date  Rank    Check  Description
   -  ----                              ---------------  ----    -----  -----------
   0  auxiliary/admin/dcerpc/icpr_cert                   normal  No     ICPR Certificate Management


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/admin/dcerpc/icpr_cert

[*] Using auxiliary/admin/dcerpc/icpr_cert
msf6 auxiliary(admin/dcerpc/icpr_cert) > set SMBUser DESKTOP-8GCC7SV7$
SMBUser => DESKTOP-8GCC7SV7$
msf6 auxiliary(admin/dcerpc/icpr_cert) > set SMBPass tuX5bQXSsonr7RL04VXIQSvAEw90eJIC
SMBPass => tuX5bQXSsonr7RL04VXIQSvAEw90eJIC
msf6 auxiliary(admin/dcerpc/icpr_cert) > set CERT_TEMPLATE Machine
CERT_TEMPLATE => Machine
msf6 auxiliary(admin/dcerpc/icpr_cert) >   run
[*] Running module against 192.168.159.10

[*] 192.168.159.10:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 192.168.159.10:445 - Binding to \cert...
[+] 192.168.159.10:445 - Bound to \cert
[*] 192.168.159.10:445 - Requesting a certificate for user DESKTOP-8GCC7SV7$ - digest algorithm: SHA256 - template: Machine
[!] 192.168.159.10:445 - The requested certificate was submitted for review.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/icpr_cert) > 
```

<details>
<summary>AD CS Setup</summary>
Use the following steps to setup a standalone (as opposed to enterprise) CA to reproduce this issue.

1. Open the Server Manager
1. Select “Add roles and features”
1. In the "Server Roles" section, select "Active Directory Certificate Services"
1. When prompted, add all of the features and management tools
1. On the AD CS "Role Services" tab, leave the default selection of only "Certificate Authority"
1. Completion the installation and reboot the server
1. Reopen the Server Manager
1. Go to the AD CS tab and where it says "Configuration Required,” hit "More" then "Configure Active Directory Certificate..."
1. In the “Role Services” tab, select "Certificate Authority"
1. In the “Setup Type” tab, select “Standalone CA” (or whatever the option other than Enterprise CA is)
1. In the “CA Type” tab, select “Root CA”
1. In the “Private Key” tab and subtabs, keep all of the default settings, noting the value of the "Common name for this CA" on the "CA Name" tab (this value corresponds to the CA datastore option)
1. Accept the rest of the default settings and complete the configuration
</details