### PR TITLE
Show extended error information for ICPR

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,7 +430,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.2.1)
+    ruby_smb (3.2.2)
       bindata
       openssl-ccm
       openssl-cmac

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,7 +482,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     win32api (0.1.0)
-    windows_error (0.1.4)
+    windows_error (0.1.5)
     winrm (2.3.6)
       builder (>= 2.1.2)
       erubi (~> 1.8)

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -5,6 +5,8 @@
 #
 # -*- coding: binary -*-
 
+require 'windows_error/h_result'
+
 module Msf
 
 module Exploit::Remote::MsIcpr
@@ -198,6 +200,13 @@ module Exploit::Remote::MsIcpr
     else
       print_error('There was an error while requesting the certificate.')
       print_error(response[:disposition_message].strip.to_s) unless response[:disposition_message].blank?
+      hresult = ::WindowsError::HResult.find_by_retval(response[:disposition]).first
+
+      if hresult
+        print_error('Error details:')
+        print_error("  Source:  #{hresult.facility}") if hresult.facility
+        print_error("  HRESULT: #{hresult}")
+      end
     end
 
     return unless response[:certificate]

--- a/lib/msf/core/exploit/remote/ms_samr.rb
+++ b/lib/msf/core/exploit/remote/ms_samr.rb
@@ -108,9 +108,11 @@ module Exploit::Remote::MsSamr
   rescue RubySMB::Dcerpc::Error::SamrError => e
     raise MsSamrUnknownError, "A DCERPC SAMR error occured: #{e.message}"
   ensure
-    samr_con.samr.close_handle(user_handle) if user_handle
-    samr_con.samr.close_handle(samr_con.domain_handle) if samr_con.domain_handle
-    samr_con.samr.close_handle(samr_con.server_handle) if samr_con.server_handle
+    if samr_con
+      samr_con.samr.close_handle(user_handle) if user_handle
+      samr_con.samr.close_handle(samr_con.domain_handle) if samr_con.domain_handle
+      samr_con.samr.close_handle(samr_con.server_handle) if samr_con.server_handle
+    end
   end
 
   def delete_computer(opts = {})


### PR DESCRIPTION
Requires rapid7/windows_error#5

This adds extended error information to the ICPR library code which is used by the icpr_cert module and the new certifried exploit. When the certificate fails to issue for some reason, it looks up the error result as an [HRESULT](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/0642cb2f-2075-4469-918c-4441e69c548a) and prints the details for the user to assist in troubleshooting.

Before these changes, the extended error information was simply missing.

## Verification

- [x] Follow the setup steps from #16939, skipping the "Configure a certificate template to be vulnerable via ESC1" section
- [x] Run the module as a real user but try to issue a certificate as a machine (which you are not)
    - [x] Set SMBUser / SMBPass to the credentials of the real user
    - [x] Set CERT_TEMPLATE to `Machine` to trigger the failure and see the error details
- [x] See detailed error messages saying that the use can not enroll in that type of certificate

## Example

```
msf6 auxiliary(admin/dcerpc/icpr_cert) > run
[*] Running module against 192.168.159.10

[*] 192.168.159.10:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 192.168.159.10:445 - Binding to \cert...
[+] 192.168.159.10:445 - Bound to \cert
[*] 192.168.159.10:445 - Requesting a certificate for user aliddle - digest algorithm: SHA256 - template: Machine
[-] 192.168.159.10:445 - There was an error while requesting the certificate.
[-] 192.168.159.10:445 - Denied by Policy Module
[-] 192.168.159.10:445 - Error details:
[-] 192.168.159.10:445 -   Source:  (0x0009) FACILITY_SECURITY: The source of the error code is the Security API layer.
[-] 192.168.159.10:445 -   HRESULT: (0x80094012) CERTSRV_E_TEMPLATE_DENIED: The permissions on the certificate template do not allow the current user to enroll for this type of certificate.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/icpr_cert) > 
```