### PR TITLE
Update pre-commit-hook.rb so that we run msftidy_docs.rb on PR submissions that modify documentation

### DIFF
--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -117,7 +117,7 @@ class MsftidyDoc
 
   def check_start_with_vuln_app
     unless @lines.first =~ /^## Vulnerable Application$/
-      warn('Docs should start with ## Vulnerable Application')
+      error('Docs should start with ## Vulnerable Application')
     end
   end
 
@@ -168,15 +168,15 @@ class MsftidyDoc
     end
 
     unless has_vulnerable_application
-      warn('Missing Section: ## Vulnerable Application')
+      error('Missing Section: ## Vulnerable Application')
     end
 
     unless has_verification_steps
-      warn('Missing Section: ## Verification Steps')
+      error('Missing Section: ## Verification Steps')
     end
 
     unless has_scenarios
-      warn('Missing Section: ## Scenarios')
+      error('Missing Section: ## Scenarios')
     end
 
     unless has_options
@@ -185,28 +185,28 @@ class MsftidyDoc
     end
 
     if has_bad_description
-      warn('Descriptions should be within Vulnerable Application, or an H3 sub-section of Vulnerable Application')
+      error('Descriptions should be within Vulnerable Application, or an H3 sub-section of Vulnerable Application')
     end
 
     if has_bad_intro
-      warn('Intro/Introduction should be within Vulnerable Application, or an H3 sub-section of Vulnerable Application')
+      error('Intro/Introduction should be within Vulnerable Application, or an H3 sub-section of Vulnerable Application')
     end
 
     if has_bad_scenario_sub
-      warn('Scenario sub-sections should include the vulnerable application version and OS tested on in an H3, not just ### Version and OS')
+      error('Scenario sub-sections should include the vulnerable application version and OS tested on in an H3, not just ### Version and OS')
     end
   end
 
   def check_newline_eof
     if @source !~ /(?:\r\n|\n)\z/m
-      warn('Please add a newline at the end of the file')
+      error('Please add a newline at the end of the file')
     end
   end
 
   # This checks that the H2 headings are in the right order. Options are optional.
   def h2_order
     unless @source =~ /^## Vulnerable Application$.+^## (Verification Steps|Module usage)$.+(?:^## Options$.+)?^## Scenarios$/m
-      warn('H2 headings in incorrect order.  Should be: Vulnerable Application, Verification Steps/Module usage, Options, Scenarios')
+      error('H2 headings in incorrect order.  Should be: Vulnerable Application, Verification Steps/Module usage, Options, Scenarios')
     end
   end
 
@@ -221,13 +221,13 @@ class MsftidyDoc
       tback = ln.scan(/```/)
       if tback.length > 0
         if tback.length.even?
-          warn("Should use single backquotes (`) for single line literals instead of triple backquotes (```)", idx)
+          error("Should use single backquotes (`) for single line literals instead of triple backquotes (```)", idx)
         else
           in_codeblock = !in_codeblock
         end
 
         if ln =~ /^\s+```/
-          warn("Code blocks using triple backquotes (```) should not be indented", idx)
+          error("Code blocks using triple backquotes (```) should not be indented", idx)
         end
       end
 
@@ -241,24 +241,24 @@ class MsftidyDoc
       end
 
       if in_options && ln =~ /^\s*\*\*[a-z]+\*\*$/i # catch options in old format like **command** instead of ### comand
-        warn("Options should use ### instead of bolds (**)", idx)
+        error("Options should use ### instead of bolds (**)", idx)
       end
 
       # this will catch either bold or h2/3 universal options.  Defaults aren't needed since they're not unique to this exploit
       if in_options && ln =~ /^\s*[\*#]{2,3}\s*(rhost|rhosts|rport|lport|lhost|srvhost|srvport|ssl|uripath|session|proxies|payload)\*{0,2}$/i
-        warn('Universal options such as rhost(s), rport, lport, lhost, srvhost, srvport, ssl, uripath, session, proxies, payload can be removed.', idx)
+        error('Universal options such as rhost(s), rport, lport, lhost, srvhost, srvport, ssl, uripath, session, proxies, payload can be removed.', idx)
       end
       # find spaces at EOL not in a code block which is ``` or starts with four spaces
       if !in_codeblock && ln =~ /[ \t]$/ && !(ln =~ /^    /)
-        warn("Spaces at EOL", idx)
+        error("Spaces at EOL", idx)
       end
 
       if ln =~ /Example steps in this format/
-        warn("Instructional text not removed", idx)
+        error("Instructional text not removed", idx)
       end
 
       if ln =~ /^# /
-        warn("No H1 (#) headers.  If this is code, indent.", idx)
+        error("No H1 (#) headers.  If this is code, indent.", idx)
       end
 
       l = 140

--- a/tools/dev/pre-commit-hook.rb
+++ b/tools/dev/pre-commit-hook.rb
@@ -30,7 +30,17 @@ def run(command, exception: true)
   stdout
 end
 
-def merge_error_message
+def docs_merge_error_message
+  msg = []
+  msg << "[*] This merge contains modules failing msftidy_docs.rb"
+  msg << "[*] Please fix this if you intend to publish these"
+  msg << "[*] modules to a popular metasploit-framework repo"
+  puts "-" * 72
+  puts msg.join("\n")
+  puts "-" * 72
+end
+
+def module_merge_error_message
   msg = []
   msg << "[*] This merge contains modules failing msftidy.rb"
   msg << "[*] Please fix this if you intend to publish these"
@@ -112,10 +122,22 @@ end
 
 unless modules_valid
   if base_caller == :post_merge
-    puts merge_error_message
+    puts module_merge_error_message
     exit(0x10)
   else
     puts "[!] msftidy.rb objected, aborting commit"
+    puts "[!] To bypass this check use: git commit --no-verify"
+    puts "-" * 72
+    exit(0x01)
+  end
+end
+
+unless docs_valid
+  if base_caller == :post_merge
+    puts docs_merge_error_message
+    exit(0x10)
+  else
+    puts "[!] msftidy_docs.rb objected, aborting commit"
     puts "[!] To bypass this check use: git commit --no-verify"
     puts "-" * 72
     exit(0x01)


### PR DESCRIPTION
This updates the `pre-commit-hook.rb` file that is already run in our lint GitHub Actions via https://github.com/rapid7/metasploit-framework/blob/master/.github/workflows/lint.yml#L59-L63

This will ensure that both `msftidy.rb` and `msftidy_docs.rb` are run on PR submission and should prevent a lot of issues that we currently have with people running `rubocop` on their PRs to fix the module but not running `msftidy_docs.rb` on their PR's documentation and then us getting PRs that have different documentation formats.

I also updated `msftidy_docs.rb` since a lot of errors are currently labeled as warnings instead of errors so this update will make it easier to properly block PRs that don't conform to the expected format whilst also allowing exceptions for long lines and modules that might not have an Options section.

## Verification

List the steps needed to make sure this thing works

- [ ] Check out this PR and modify a random file in `documentation/modules/`.
- [ ] Run `git add <file you modified>`
- [ ] Run `tools/dev/pre-commit-hook.rb`
- [ ] Verify that this has `msftidy_docs.rb` run on the file you modified.
- [ ] Double check if we need to update our code in `msftidy_docs.rb` so this integration can work more appropriately.
