### PR TITLE
Initial update of ADCS to be AD CS for appropriate spelling

### DIFF
--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -28,8 +28,8 @@ queries:
     references:
       - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
       - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
-  - action: ENUM_ADCS_CAS
-    description: 'Enumerate ADCS certificate authorities.'
+  - action: ENUM_AD_CS_CAS
+    description: 'Enumerate AD Certificate Service certificate authorities.'
     base_dn_prefix: 'CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration'
     filter: '(objectClass=pKIEnrollmentService)'
     attributes:
@@ -42,8 +42,8 @@ queries:
       - caCertificate
     references:
       - https://aaroneg.com/post/2018-05-15-enterprise-ca/
-  - action: ENUM_ADCS_CERT_TEMPLATES
-    description: 'Enumerate ADCS certificate templates.'
+  - action: ENUM_AD_CS_CERT_TEMPLATES
+    description: 'Enumerate AD Certificate Service certificate templates.'
     base_dn_prefix: 'CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration'
     filter: '(objectClass=pkicertificatetemplate)'
     attributes:
@@ -156,7 +156,7 @@ queries:
       - operatingSystemServicePack
     references:
       - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
-      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf 
+      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
   - action: ENUM_EXCHANGE_RECIPIENTS
     description: 'Dump info about all known Exchange recipients.'
     filter: '(|(mailNickname=*)(proxyAddresses=FAX:*))'
@@ -231,7 +231,7 @@ queries:
       - serverName
     references:
       - https://troopers.de/downloads/troopers19/TROOPERS19_AD_Fun_With_LDAP.pdf
-      - https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1 
+      - https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1
   - action: ENUM_LAPS_PASSWORDS
     description: 'Dump info about computers that have LAPS enabled, and passwords for them if available.'
     filter: '(ms-MCS-AdmPwd=*)'
@@ -349,4 +349,4 @@ queries:
     references:
       - https://malicious.link/post/2022/ldapsearch-reference/
       - https://burmat.gitbook.io/security/hacking/domain-exploitation
-      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties 
+      - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties

--- a/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
@@ -37,13 +37,13 @@ For this module to work, it's necessary to know the name of a CA and certificate
 by a normal user via LDAP.
 
 ```
-msf6 > use auxiliary/gather/ldap_query 
+msf6 > use auxiliary/gather/ldap_query
 msf6 auxiliary(gather/ldap_query) > set BIND_DN aliddle@msflab.local
 BIND_DN => aliddle@msflab.local
 msf6 auxiliary(gather/ldap_query) > set BIND_PW Password1!
 BIND_PW => Password1!
-msf6 auxiliary(gather/ldap_query) > set ACTION ENUM_ADCS_CAS 
-ACTION => ENUM_ADCS_CAS
+msf6 auxiliary(gather/ldap_query) > set ACTION ENUM_AD_CS_CAS
+ACTION => ENUM_AD_CS_CAS
 msf6 auxiliary(gather/ldap_query) > run
 [*] Running module against 192.168.159.10
 
@@ -71,7 +71,7 @@ In this scenario, an authenticated user issues a certificate for themselves usin
 by default. The user must know the CA name, which in this case is `msflab-DC-CA`.
 
 ```
-msf6 > use auxiliary/admin/dcerpc/icpr_cert 
+msf6 > use auxiliary/admin/dcerpc/icpr_cert
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set RHOSTS 192.168.159.10
 RHOSTS => 192.168.159.10
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set SMBUser aliddle
@@ -111,7 +111,7 @@ See [Certified Pre-Owned](https://posts.specterops.io/certified-pre-owned-d95910
 information.
 
 ```
-msf6 > use auxiliary/admin/dcerpc/icpr_cert 
+msf6 > use auxiliary/admin/dcerpc/icpr_cert
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set RHOSTS 192.168.159.10
 RHOSTS => 192.168.159.10
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set SMBUser aliddle

--- a/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md
+++ b/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md
@@ -11,8 +11,8 @@ perform this enrollment operation.
 
 Currently the module is capable of checking for ESC1, ESC2, and ESC3 vulnerable certificates.
 
-### Installing ADCS
-1. Install ADCS on either a new or existing domain controller
+### Installing AD CS
+1. Install AD CS on either a new or existing domain controller
 1. Open the Server Manager
 1. Select Add roles and features
 1. Select "Active Directory Certificate Services" under the "Server Roles" section
@@ -96,9 +96,9 @@ that are both vulnerable and enrollable.
 
 ## Scenarios
 
-### Windows Server 2022 with ADCS
+### Windows Server 2022 with AD CS
 ```
-msf6 > use auxiliary/gather/ldap_esc_vulnerable_cert_finder 
+msf6 > use auxiliary/gather/ldap_esc_vulnerable_cert_finder
 msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set RHOST 172.26.104.157
 RHOST => 172.26.104.157
 msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set BIND_DN DAFOREST\\Administrator
@@ -234,10 +234,10 @@ msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run
 [*]          Enrollment SIDs:
 [*]             * S-1-5-11 (Authenticated Users)
 [*] Auxiliary module execution completed
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > 
+msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) >
 ```
 
-### Windows Server 2022 with ADCS and REPORT_NONENROLLABLE Set To TRUE
+### Windows Server 2022 with AD CS and REPORT_NONENROLLABLE Set To TRUE
 ```
 msf6 > use auxiliary/gather/ldap_esc_vulnerable_cert_finder
 msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set RHOST 172.26.104.157
@@ -449,5 +449,5 @@ msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run
 [*]          Enrollment SIDs:
 [*]             * S-1-5-11 (Authenticated Users)
 [*] Auxiliary module execution completed
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > 
+msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) >
 ```


### PR DESCRIPTION
As per @ccondon-r7's message in Slack, we should be spelling ADCS as AD CS, so lets go ahead and update a few places in our code so long to reflect this. This is likely not the complete set of work and we will need to do another pass through once 6.3 is released, but at least this will fix some of the issues.

## Verification
- [ ] Check that the changes look good and that there are no additional locations that need updating.
