### PR TITLE
add 'favorite -l' and 'favorites' as aliases for show favorites

### DIFF
--- a/docs/metasploit-framework.wiki/How-to-use-the-Favorite-command.md
+++ b/docs/metasploit-framework.wiki/How-to-use-the-Favorite-command.md
@@ -27,6 +27,7 @@ OPTIONS:
     -c        Clear the contents of the favorite modules file
     -d        Delete module(s) or the current active module from the favorite modules file
     -h        Help banner
+    -l        Print the list of favorite modules (alias for `show favorites`)
 ```
 
 
@@ -89,3 +90,18 @@ msf6 > show favorites
 [!] The favorite modules file is empty
 ```
 
+### Printing the list of favorite modules
+
+The list of favorite modules can be printed by supplying the `-l` flag. This is an alias for the `show favorites` and `favorites` commands.
+
+```shell
+msf6 > favorite -l
+
+Favorites
+=========
+
+   #  Name                        Disclosure Date  Rank    Check  Description
+   -  ----                        ---------------  ----    -----  -----------
+   0  exploit/multi/handler                        manual  No     Generic Payload Handler
+   1  exploit/windows/smb/psexec  1999-01-01       manual  No     Microsoft Windows Authenticated User Code Execution
+```


### PR DESCRIPTION
## About
This change adds a solution for https://github.com/rapid7/metasploit-framework/issues/17410 by adding the `favorite -l` and `favorites` module commands as aliases for the existing `show favorites` command. This is in line with suggestions by @h00die  and @jmartin-r7. It also updates the relevant help menus and documentation.

Tbh I'm not sure if the separate addition of `favorites` is necessary, but it is in line with the way `options` and `advanced` can be called inside a module.

## Usage examples
### Show favorites (unchanged)
```
msf6 > show favorites

Favorites
=========

   #  Name                        Disclosure Date  Rank    Check  Description
   -  ----                        ---------------  ----    -----  -----------
   0  exploit/multi/handler                        manual  No     Generic Payload Handler
   1  exploit/windows/smb/psexec  1999-01-01       manual  No     Microsoft Windows Authenticated User Code Execution
```
### Favorites (new alias for show favorites)
```
msf6 > favorites -h
Usage: favorites

Print the list of favorite modules (alias for `show favorites`)

OPTIONS:

    -h  Help banner
msf6 > favorites

Favorites
=========

   #  Name                        Disclosure Date  Rank    Check  Description
   -  ----                        ---------------  ----    -----  -----------
   0  exploit/multi/handler                        manual  No     Generic Payload Handler
   1  exploit/windows/smb/psexec  1999-01-01       manual  No     Microsoft Windows Authenticated User Code Execution
```
### Favorite -l (new alias for show favorites)
```
msf6 > favorite -h
Usage: favorite [mod1 mod2 ...]

Add one or multiple modules to the list of favorite modules stored in /home/wynter/.msf4/fav_modules
If no module name is specified, the command will add the active module if there is one

OPTIONS:

    -c  Clear the contents of the favorite modules file
    -d  Delete module(s) or the current active module from the favorite modules file
    -h  Help banner
    -l  Print the list of favorite modules (alias for `show favorites`)
msf6 > favorite -l

Favorites
=========

   #  Name                        Disclosure Date  Rank    Check  Description
   -  ----                        ---------------  ----    -----  -----------
   0  exploit/multi/handler                        manual  No     Generic Payload Handler
   1  exploit/windows/smb/psexec  1999-01-01       manual  No     Microsoft Windows Authenticated User Code Execution
```