### PR TITLE
[Spike] Consolidate and simplify kerberos options for users

### DIFF
--- a/docs/metasploit-framework.wiki/How-to-use-datastore-options.md
+++ b/docs/metasploit-framework.wiki/How-to-use-datastore-options.md
@@ -86,8 +86,8 @@ OptSomething.new(option_name, [boolean, description, value, *enums*], aliases: *
   options](#Filtering-datastore-options) section for more information.
 * **fallbacks** *optional*, *key-word only* An array of names that will be used as a fallback if the main option name is
   defined by the user. This is useful in the scenario of wanting specialised option names such as `SMBUser`, but to also
-  support gracefully checking a list of more generic fallbacks option names such as `Username`. This functionality is 
-  currently behind a feature flag, set with `features set datastore_fallbacks true` in msfconsole
+  support gracefully checking a list of more generic fallbacks option names such as `Username`.
+* **display_name** *optional*, *key-word only* Change the display name shown to the user
 
 Now let's talk about what classes are available:
 

--- a/docs/metasploit-framework.wiki/kerberos/service_authentication.md
+++ b/docs/metasploit-framework.wiki/kerberos/service_authentication.md
@@ -19,7 +19,7 @@ Open a WinRM session:
 
 ```
 msf6 > use auxiliary/scanner/winrm/winrm_login
-msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 winrmrhostname=dc3.demo.local domain=demo.local
+msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd auth=kerberos domaincontrollerrhost=192.168.123.13 rhostname=dc3.demo.local domain=demo.local
 
 [+] 192.168.123.13:88 - Received a valid TGT-Response
 [*] 192.168.123.13:5985   - TGT MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230118120604_default_192.168.123.13_mit.kerberos.cca_451736.bin
@@ -70,7 +70,7 @@ Running psexec against a host:
 
 ```
 msf6 > use exploit/windows/smb/psexec
-msf6 exploit(windows/smb/psexec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smbauth=kerberos domaincontrollerrhost=192.168.123.13 smbrhostname=dc3.demo.local domain=demo.local
+msf6 exploit(windows/smb/psexec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd auth=kerberos domaincontrollerrhost=192.168.123.13 hostname=dc3.demo.local domain=demo.local
 
 [*] Started reverse TCP handler on 192.168.123.1:4444
 [*] 192.168.123.13:445 - Connecting to the server...
@@ -93,7 +93,7 @@ Connect to a Microsoft SQL Server instance and run a query:
 
 ```
 msf6 > use auxiliary/admin/mssql/mssql_sql
-msf6 auxiliary(admin/mssql/mssql_sql) > rerun 192.168.123.13 domaincontrollerrhost=192.168.123.13 username=administrator password=p4$$w0rd mssqlauth=kerberos mssqlrhostname=dc3.demo.local mssqldomain=demo.local sql='select auth_scheme from sys.dm_exec_connections where session_id=@@spid'
+msf6 auxiliary(admin/mssql/mssql_sql) > rerun 192.168.123.13 domaincontrollerrhost=192.168.123.13 username=administrator password=p4$$w0rd auth=kerberos rhostname=dc3.demo.local domain=demo.local sql='select auth_scheme from sys.dm_exec_connections where session_id=@@spid'
 [*] Reloading module...
 [*] Running module against 192.168.123.13
 
@@ -116,20 +116,26 @@ Kerberos authentication requires additional options to be set. Some of them are 
 is authenticating. For example, the PSexec module which operates over SMB would use the "SMB" prefix.
 
 Required options:
-* `${Prefix}Auth` -- The authentication modes this module supports. Set it to "kerberos" to use Kerberos authentication. i.e. `SmbAuth=kerberos`
-* `${Prefix}Rhostname` -- The hostname of the target system. This value should be either the hostname `WIN-MIJZ318SQH` or
-  the FQDN like `WIN-MIJZ318SQH.msflab.local`. i.e. `SmbRhostname=WIN-MIJZ318SQH.msflab.local`
-* `${Prefix}Domain` -- The domain name of the target system, e.g. `msflab.local`. i.e. `SmbDomain=msflab.local`
+* `Auth` -- The authentication modes this module supports. Set it to "kerberos" to use Kerberos authentication. i.e. `Auth=kerberos`
+* `Rhostname` -- The hostname of the target system. This value should be either the hostname `WIN-MIJZ318SQH` or
+  the FQDN like `WIN-MIJZ318SQH.msflab.local`. i.e. `rhostname=WIN-MIJZ318SQH.msflab.local`
+* `Domain` -- The domain name of the target system, e.g. `msflab.local`. i.e. `Domain=msflab.local`
 * `DomainControllerRhost` -- The IP address of the domain controller to use for kerberos authentication. i.e. `DomainControllerRhost=192.168.123.13`
 
 Optional options:
-* `${Prefix}Krb5Ccname` -- The path to a CCACHE file to use for authentication. This is comparable to setting the
+* `Krb5Ccname` -- The path to a CCACHE file to use for authentication. This is comparable to setting the
   `KRB5CCNAME` environment variable for other tools. If specified, the tickets it contains will be used. i.e. `KRB5CCNAME=/path/to/Administrator.ccache`
 * `KrbCacheMode` -- The cache storage mode to use, one of the following four options:
     * `none` -- No cache storage is used, new tickets are requested and no tickets are stored.
     * `read-only` -- Stored tickets from the cache will be used, but no new tickets are stored.
     * `write-only` -- New tickets are requested and they are stored for reuse.
     * `read-write` -- Stored tickets from the cache will be used and new tickets will be stored for reuse.
+
+For complex modules that have multiple service protocols interacting with Kerberos, the following naming convention is used:
+
+- `${Protocol}::Auth` - i.e. `Smb::Auth=kerberos`
+- `${Protocol}::Rhostname` - i.e. `Smb::Rhostname=WIN-MIJZ318SQH.msflab.local`
+- `${Protocol}::Krb5Ccname` - i.e. `Smb::Krb5Ccname=/path/to/Administrator.ccache`
 
 ## Ticket management
 

--- a/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
@@ -17,7 +17,7 @@ The following ACTIONS are supported:
 - Do: `use auxiliary/admin/kerberos/get_ticket`
 - Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGT`
 - You should see that the TGT is correctly retrieved and stored in loot as well as the klist command
-- Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY`
+- Try with the NT hash (`NTHASH` option) and the encryption key (`AES_KEY`
   option) instead of the password
 - Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGS spn=<SPN>`
 - You should see that the module uses the TGT in the cache and does not request a new one
@@ -25,7 +25,7 @@ The following ACTIONS are supported:
 - Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGS spn=<SPN> KrbUseCachedCredentials=false`
 - You should see the module does not use the TGT in the cache and requests a new one
 - You should see both the TGT and the TGS are correctly retrieved and stored in the loot
-- Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY` option) instead of the password
+- Try with the NT hash (`NTHASH` option) and the encryption key (`AES_KEY` option) instead of the password
 
 ## Options
 
@@ -42,7 +42,7 @@ The user's password to use.
 The user's NT hash in hex string to authenticate with. Not that the DC must
 support RC4 encryption.
 
-### AESKEY
+### AES_KEY
 The user's AES key to use for Kerberos authentication in hex string. Supported
 keys: 128 or 256 bits.
 
@@ -106,7 +106,7 @@ host             port  proto  name      state  info
 TGT with encryption key
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=GET_TGT
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AES_KEY=<redacted> action=GET_TGT
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -153,7 +153,7 @@ host             service  type                 name  content                   i
 TGS with encryption key:
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AES_KEY=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -214,7 +214,7 @@ host             service  type                 name  content                   i
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=GET_TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false
 [*] Running module against 10.0.0.24
 
-[-] Auxiliary aborted due to failure: unknown: Error while requesting a TGT: Kerberos Error - KDC_ERR_PREAUTH_REQUIRED (25) - Additional pre-authentication required - Check the authentication-related options (PASSWORD, NTHASH or AESKEY)
+[-] Auxiliary aborted due to failure: unknown: Error while requesting a TGT: Kerberos Error - KDC_ERR_PREAUTH_REQUIRED (25) - Additional pre-authentication required - Check the authentication-related options (PASSWORD, NTHASH or AES_KEY)
 [*] Auxiliary module execution completed
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=GET_TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false password=<redacted>
 [*] Running module against 10.0.0.24

--- a/documentation/modules/auxiliary/admin/kerberos/ticket_converter.md
+++ b/documentation/modules/auxiliary/admin/kerberos/ticket_converter.md
@@ -92,7 +92,7 @@ cat ticket.b64 | base64 -D > ticket.kirbi
 8. Example usage in Metasploit:
    ```
    use windows/smb/psexec
-   run rhost=192.168.123.13 username=Administrator domaincontrollerrhost=192.168.123.1 smbauth=kerberos smbrhostname=host.demo.local smbdomain=demo.local smbkrb5ccname=/path/to/ccache/ticket 
+   run rhost=192.168.123.13 username=Administrator domaincontrollerrhost=192.168.123.1 auth=kerberos smbrhostname=host.demo.local domain=demo.local krb5ccname=/path/to/ccache/ticket
    ```
 9. Example usage in impacket:
    ```

--- a/lib/msf/core/exploit/remote/auth_option.rb
+++ b/lib/msf/core/exploit/remote/auth_option.rb
@@ -71,14 +71,4 @@ module Msf::Exploit::Remote::AuthOption
       Rex::Proto::Kerberos::Crypto::Encryption.value_for(type.upcase.gsub('-', '_'))
     end.uniq
   end
-
-  etype_regex = "(#{Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.map { |v| Regexp.escape(v) }.join('|')})"
-  OPT_KRB_OFFERED_ENC_TYPES = Msf::OptString.new(
-    'KrbOfferedEncryptionTypes', [
-      true,
-      'Kerberos encryption types to offer',
-      Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.join(',')
-    ],
-    regex: Regexp.new("(#{etype_regex},)*#{etype_regex}", options: Regexp::IGNORECASE)
-  )
 end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator.rb
@@ -1,0 +1,7 @@
+# -*- coding: binary -*-
+
+#
+# This module for remote Kerberos authentication
+#
+class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator
+end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
@@ -1,0 +1,62 @@
+# -*- coding: binary -*-
+
+#
+# This class stores Metasploit option configuration used across service authentication
+#
+module Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
+  # Create the list of options that a module must provide for Kerberos authethentication via the given protocol
+  # This method exists for ensuring consistency across service authentication modules
+  #
+  # @param [String] protocol The service protocol type, i.e. smb/ldap/winrm/mssql
+  # @param [Array<String>] auth_methods The allowed auth methods
+  # @see Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options::Msf::Exploit::Remote::AuthOption
+  def kerberos_auth_options(protocol:, auth_methods:)
+    option_conditions = ["#{protocol}::Auth", '==', 'kerberos']
+
+    etype_regex = "(#{Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.map { |v| Regexp.escape(v) }.join('|')})"
+    offered_enc_types_option = Msf::OptString.new(
+      "#{protocol}::KrbOfferedEncryptionTypes",
+      [
+        true,
+        'Kerberos encryption types to offer',
+        Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.join(',')
+      ],
+      display_name: 'KrbOfferedEncryptionTypes',
+      regex: Regexp.new("(#{etype_regex},)*#{etype_regex}", options: Regexp::IGNORECASE),
+      conditions: option_conditions
+    )
+
+    auth_options = [
+      Msf::OptEnum.new(
+        "#{protocol}::Auth",
+        [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, auth_methods],
+        fallbacks: ['Auth'],
+        display_name: 'Auth'
+      ),
+      Msf::OptString.new(
+        "#{protocol}::Rhostname",
+        [false, 'The rhostname which is required for kerberos - the SPN'],
+        fallbacks: ['Rhostname'],
+        conditions: option_conditions,
+        display_name: 'Rhostname'
+      ),
+      Msf::OptAddress.new(
+        'DomainControllerRhost',
+        [false, 'The resolvable rhost for the Domain Controller'],
+        conditions: option_conditions,
+      ),
+      Msf::OptPath.new(
+        "#{protocol}::Krb5Ccname",
+        [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))],
+        fallbacks: ['Krb5Ccname'],
+        conditions: option_conditions,
+        display_name: 'Krb5Ccname'
+      )
+    ]
+
+    [
+      *auth_options,
+      offered_enc_types_option
+    ]
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
@@ -13,18 +13,22 @@ module Msf::Exploit::Remote::Kerberos::Ticket
 
     def initialize(info = {})
       super
-      register_advanced_options(
-        [
-          Msf::OptEnum.new(
-            'KrbCacheMode', [
-              true,
-              'Kerberos ticket cache storage mode',
-              'read-write',
-              %w[ none read-only write-only read-write ]
-            ]
-          )
-        ]
-      )
+    end
+
+    # @param [String,nil] protocol The service protocol type, i.e. smb/ldap/winrm/mssql
+    def kerberos_storage_options(protocol: nil)
+      [
+        Msf::OptEnum.new(
+          'KrbCacheMode',
+          [
+            true,
+            'Kerberos ticket cache storage mode',
+            'read-write',
+            %w[ none read-only write-only read-write ]
+          ],
+          conditions: protocol ? ["#{protocol}::Auth", '==', 'kerberos' ] : []
+        )
+      ]
     end
 
     # Build a ticket storage object based on either the specified options or the datastore if no options are defined.

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -9,6 +9,7 @@ require 'rex/proto/ldap'
 module Msf
   module Exploit::Remote::LDAP
     include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+    include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
     # Initialize the LDAP client and set up the LDAP specific datastore
     # options to allow the client to perform authentication and timeout
@@ -28,18 +29,17 @@ module Msf
         Opt::RPORT(389),
         OptBool.new('SSL', [false, 'Enable SSL on the LDAP connection', false]),
         Msf::OptString.new('DOMAIN', [false, 'The domain to authenticate to']),
-        Msf::OptString.new('USERNAME', [false, 'The username to authenticate with'], aliases: ['BIND_DN']),
-        Msf::OptString.new('PASSWORD', [false, 'The password to authenticate with'], aliases: ['BIND_PW']),
+        Msf::OptString.new('BIND_DN', [false, 'The username to authenticate with'], fallbacks: ['USERNAME'], display_name: 'USERNAME'),
+        Msf::OptString.new('BIND_PW', [false, 'The password to authenticate with'], fallbacks: ['PASSWORD'], display_name: 'PASSWORD'),
       ])
 
-      register_advanced_options([
-        OptEnum.new('LDAPAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS]),
-        OptString.new('LdapRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptPath.new('LdapKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('LDAPKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ LDAPAuth == kerberos ]),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES,
-        OptFloat.new('LDAP::ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0])
-      ])
+      register_advanced_options(
+        [
+          *kerberos_storage_options(protocol: 'LDAP'),
+          *kerberos_auth_options(protocol: 'LDAP', auth_methods: Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS),
+          OptFloat.new('LDAP::ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0])
+        ]
+      )
     end
 
     # Alias to return the RHOST datastore option.
@@ -85,9 +85,9 @@ module Msf
         }
       end
 
-      case datastore['LDAPAuth']
+      case datastore['LDAP::Auth']
       when Msf::Exploit::Remote::AuthOption::KERBEROS
-        fail_with(Msf::Exploit::Failure::BadConfig, 'The LdapRhostname option is required when using Kerberos authentication.') if datastore['LdapRhostname'].blank?
+        fail_with(Msf::Exploit::Failure::BadConfig, 'The Ldap::Rhostname option is required when using Kerberos authentication.') if datastore['Ldap::Rhostname'].blank?
         fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
         fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
         offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
@@ -95,13 +95,13 @@ module Msf
 
         kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
           host: datastore['DomainControllerRhost'],
-          hostname: datastore['LdapRhostname'],
+          hostname: datastore['Ldap::Rhostname'],
           realm: datastore['DOMAIN'],
-          username: datastore['USERNAME'],
-          password: datastore['PASSWORD'],
+          username: datastore['BIND_DN'],
+          password: datastore['BIND_PW'],
           framework: framework,
           framework_module: self,
-          cache_file: datastore['LdapKrb5Ccname'].blank? ? nil : datastore['LdapKrb5Ccname'],
+          cache_file: datastore['Ldap::Krb5Ccname'].blank? ? nil : datastore['Ldap::Krb5Ccname'],
           ticket_storage: kerberos_ticket_storage,
           offered_etypes: offered_etypes
         )
@@ -116,8 +116,8 @@ module Msf
         }
       when Msf::Exploit::Remote::AuthOption::NTLM
         ntlm_client = RubySMB::NTLM::Client.new(
-          datastore['USERNAME'],
-          datastore['PASSWORD'],
+          datastore['BIND_DN'],
+          datastore['BIND_PW'],
           workstation: 'WORKSTATION',
           domain: datastore['DOMAIN'].blank? ? '.' : datastore['DOMAIN'],
           flags:
@@ -146,21 +146,21 @@ module Msf
           challenge_response: negotiate
         }
       when Msf::Exploit::Remote::AuthOption::PLAINTEXT
-        username = datastore['USERNAME'].dup
+        username = datastore['BIND_DN'].dup
         username << "@#{datastore['DOMAIN']}" unless datastore['DOMAIN'].blank?
         connect_opts[:auth] = {
           method: :simple,
           username: username,
-          password: datastore['PASSWORD']
+          password: datastore['BIND_PW']
         }
       when Msf::Exploit::Remote::AuthOption::AUTO
-        unless datastore['USERNAME'].blank? # plaintext if specified
-          username = datastore['USERNAME'].dup
+        unless datastore['BIND_DN'].blank? # plaintext if specified
+          username = datastore['BIND_DN'].dup
           username << "@#{datastore['DOMAIN']}" unless datastore['DOMAIN'].blank?
           connect_opts[:auth] = {
             method: :simple,
             username: username,
-            password: datastore['PASSWORD']
+            password: datastore['BIND_PW']
           }
         end
       end

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -16,7 +16,8 @@ module Exploit::Remote::MSSQL
   include Exploit::Remote::Tcp
   include Exploit::Remote::NTLM::Client
   include Metasploit::Framework::MSSQL::Base
-  include Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
   #
   # Creates an instance of a MSSQL exploit module.
@@ -29,8 +30,8 @@ module Exploit::Remote::MSSQL
       [
         Opt::RHOST,
         Opt::RPORT(1433),
-        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
-        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptString.new('Mssql::USERNAME', [ false, 'The username to authenticate as', 'sa'], fallbacks: ['USERNAME'], display_name: 'USERNAME'),
+        OptString.new('Mssql::PASSWORD', [ false, 'The password for the specified username', ''], fallbacks: ['PASSWORD'], display_name: 'PASSWORD'),
         OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
         OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentification (requires DOMAIN option set)', false]),
       ], Msf::Exploit::Remote::MSSQL)
@@ -39,15 +40,12 @@ module Exploit::Remote::MSSQL
         OptPath.new('HEX2BINARY',   [ false, "The path to the hex2binary script on the disk",
           File.join(Msf::Config.data_directory, "exploits", "mssql", "h2b")
         ]),
-        OptString.new('DOMAIN', [ true, 'The domain to use for windows authentication', 'WORKSTATION'], aliases: ['MssqlDomain']),
-        OptEnum.new('MssqlAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::MSSQL_OPTIONS]),
-        OptString.new('MssqlRhostname', [false, 'The mssql hostname, required for kerberos']),
-        OptPath.new('MssqlKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('MSSQLKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ MssqlAuth == kerberos ]),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES
+        *kerberos_storage_options(protocol: 'Mssql'),
+        *kerberos_auth_options(protocol: 'Mssql', auth_methods: Msf::Exploit::Remote::AuthOption::MSSQL_OPTIONS),
       ], Msf::Exploit::Remote::MSSQL)
     register_autofilter_ports([ 1433, 1434, 1435, 14330, 2533, 9152, 2638 ])
     register_autofilter_services(%W{ ms-sql-s ms-sql2000 sybase })
+    # TODO: There's no tab completion yet, i.e. `auth=<tab>` won't give tab completions for `mssql::auth`. In the case of multiple mixins, the values aren't merged together - i.e. tab completing auto/plaintext/kerberos/etc
   end
 
 
@@ -314,7 +312,7 @@ module Exploit::Remote::MSSQL
       return false
     end
 
-    if datastore['MssqlAuth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
+    if datastore['Mssql::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
       idx = 0
       pkt = ''
       pkt_hdr = ''
@@ -347,22 +345,22 @@ module Exploit::Remote::MSSQL
       aname = Rex::Text.to_unicode( Rex::Text.rand_text_alpha(rand(8)+1) ) #application and library name
       sname = Rex::Text.to_unicode( rhost )
 
-      fail_with(Msf::Exploit::Failure::BadConfig, 'The MssqlRhostname option is required when using Kerberos authentication.') if datastore['MssqlRhostname'].blank?
-      fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The Mssql::Rhostname option is required when using Kerberos authentication.') if datastore['Mssql::Rhostname'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The Mssql::DOMAIN option is required when using Kerberos authentication.') if datastore['Mssql::DOMAIN'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
       offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
       fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
 
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::MSSQL.new(
         host: datastore['DomainControllerRhost'],
-        hostname: datastore['MssqlRhostname'],
+        hostname: datastore['Mssql::Rhostname'],
         mssql_port: rport,
-        realm: datastore['MssqlDomain'],
-        username: datastore['username'],
-        password: datastore['password'],
+        realm: datastore['Mssql::Domain'],
+        username: datastore['Mssql::Username'],
+        password: datastore['Mssql::Password'],
         framework: framework,
         framework_module: self,
-        cache_file: datastore['MssqlKrb5Ccname'].blank? ? nil : datastore['MssqlKrb5Ccname'],
+        cache_file: datastore['Mssql::Krb5Ccname'].blank? ? nil : datastore['Mssql::Krb5Ccname'],
         ticket_storage: kerberos_ticket_storage,
         offered_etypes: offered_etypes
       )
@@ -655,7 +653,7 @@ module Exploit::Remote::MSSQL
   # Login to the SQL server using the standard USERNAME/PASSWORD options
   #
   def mssql_login_datastore(db='')
-    mssql_login(datastore['USERNAME'], datastore['PASSWORD'], db)
+    mssql_login(datastore['Mssql::USERNAME'], datastore['Mssql::PASSWORD'], db)
   end
 
   #

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -150,8 +150,8 @@ module Msf
       # @return [void]
       def smb_login(simple_client = self.simple)
         # Override the default RubySMB capabilities with Kerberos authentication
-        if datastore['SMBAuth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
-          fail_with(Msf::Exploit::Failure::BadConfig, 'The SmbRhostname option is required when using Kerberos authentication.') if datastore['SmbRhostname'].blank?
+        if datastore['SMB::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
+          fail_with(Msf::Exploit::Failure::BadConfig, 'The SMB::Rhostname option is required when using Kerberos authentication.') if datastore['SMB::Rhostname'].blank?
           fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
           fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
           offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
@@ -159,13 +159,13 @@ module Msf
 
           kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
             host: datastore['DomainControllerRhost'],
-            hostname: datastore['SmbRhostname'],
+            hostname: datastore['SMB::Rhostname'],
             realm: datastore['SMBDomain'],
             username: datastore['SMBUser'],
             password: datastore['SMBPass'],
             framework: framework,
             framework_module: self,
-            cache_file: datastore['SmbKrb5Ccname'].blank? ? nil : datastore['SmbKrb5Ccname'],
+            cache_file: datastore['Smb::Krb5Ccname'].blank? ? nil : datastore['Smb::Krb5Ccname'],
             ticket_storage: kerberos_ticket_storage,
             offered_etypes: offered_etypes
           )

--- a/lib/msf/core/exploit/remote/smb/client/authenticated.rb
+++ b/lib/msf/core/exploit/remote/smb/client/authenticated.rb
@@ -8,23 +8,21 @@ module Exploit::Remote::SMB::Client::Authenticated
 
   include Msf::Exploit::Remote::SMB::Client
   include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
   def initialize(info = {})
     super
     register_options(
       [
-        OptString.new('SMBUser', [ false, 'The username to authenticate as', ''], fallbacks: ['USERNAME']),
-        OptString.new('SMBPass', [ false, 'The password for the specified username', ''], fallbacks: ['PASSWORD']),
-        OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.'], fallbacks: ['DOMAIN']),
+        OptString.new('SMBUser', [ false, 'The username to authenticate as', ''], fallbacks: ['USERNAME'], display_name: 'USERNAME'),
+        OptString.new('SMBPass', [ false, 'The password for the specified username', ''], fallbacks: ['PASSWORD'], display_name: 'PASSWORD'),
+        OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.'], fallbacks: ['DOMAIN'], display_name: 'DOMAIN'),
       ], Msf::Exploit::Remote::SMB::Client::Authenticated)
 
     register_advanced_options(
       [
-        OptEnum.new('SMBAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::SMB_OPTIONS]),
-        OptString.new('SmbRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        OptPath.new('SmbKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ SMBAuth == kerberos ]),
-        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES
+        *kerberos_storage_options(protocol: 'SMB'),
+        *kerberos_auth_options(protocol: 'SMB', auth_methods: Msf::Exploit::Remote::AuthOption::SMB_OPTIONS),
       ],
       Msf::Exploit::Remote::SMB::Client::Authenticated
     )

--- a/lib/msf/core/exploit/remote/winrm.rb
+++ b/lib/msf/core/exploit/remote/winrm.rb
@@ -7,7 +7,9 @@ module Msf
 module Exploit::Remote::WinRM
   include Exploit::Remote::NTLM::Client
   include Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::AuthOption
+  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
+
   #
   # Constants
   #
@@ -30,12 +32,9 @@ module Exploit::Remote::WinRM
 
     register_advanced_options(
       [
-        OptEnum.new('WinrmAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS]),
-        OptString.new('WinrmRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        OptPath.new('WinrmKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('WINRMKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[WinrmAuth == kerberos]),
-        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES
-      ]
+        *kerberos_storage_options(protocol: 'Winrm'),
+        *kerberos_auth_options(protocol: 'Winrm', auth_methods: Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS),
+      ],
     )
 
     register_autofilter_ports([ 80,443,5985,5986 ])
@@ -43,8 +42,8 @@ module Exploit::Remote::WinRM
   end
 
   def check_winrm_parameters
-    if datastore['WinrmAuth'] == KERBEROS
-      fail_with(Msf::Exploit::Failure::BadConfig, 'The WinrmRhostname option is required when using Kerberos authentication.') if datastore['WinrmRhostname'].blank?
+    if datastore['Winrm::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The Winrm::Rhostname option is required when using Kerberos authentication.') if datastore['Winrm::Rhostname'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
       offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
@@ -77,19 +76,20 @@ module Exploit::Remote::WinRM
       retry_limit: 1,
       realm: datastore['DOMAIN']
     }
-    case datastore['WinrmAuth']
+    case datastore['Winrm::Auth']
     when KERBEROS
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
         host: datastore['DomainControllerRhost'],
-        hostname: datastore['WinrmRhostname'],
+        hostname: datastore['Winrm::Rhostname'],
         realm: datastore['DOMAIN'],
         username: datastore['USERNAME'],
         password: datastore['PASSWORD'],
         timeout: 20, # datastore['timeout']
         framework: framework,
         framework_module: self,
-        cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
-        offered_types: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes']),
+        cache_file: datastore['Winrm::Krb5Ccname'].blank? ? nil : datastore['Winrm::Krb5Ccname'],
+        # TODO: Fix this typo separately if the PR is not approved
+        offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes']),
         mutual_auth: true,
         use_gss_checksum: true
       )

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -26,7 +26,7 @@ module Msf
     #
     def initialize(in_name, attrs = [],
                    required: false, desc: nil, default: nil, conditions: [], enums: [], regex: nil, aliases: [], max_length: nil,
-                   fallbacks: [])
+                   fallbacks: [], display_name: nil)
       self.name     = in_name
       self.advanced = false
       self.evasion  = false
@@ -34,6 +34,11 @@ module Msf
       self.max_length = max_length
       self.conditions = conditions
       self.fallbacks = fallbacks
+      self.display_name = display_name || self.name
+
+      if fallbacks.include?(in_name)
+        raise ArgumentError, "Option #{in_name} contains self-referential fallback: #{fallbacks.join(",")}"
+      end
 
       if attrs.is_a?(String) || attrs.length == 0
         self.required = required
@@ -224,6 +229,9 @@ module Msf
     #
     # @return [Array<String>] the array of fallbacks
     attr_accessor :fallbacks
+
+    # @return String The display name shown to the user
+    attr_accessor :display_name
 
     #
     # The max length of the input value

--- a/lib/msf/core/opt_condition.rb
+++ b/lib/msf/core/opt_condition.rb
@@ -3,6 +3,9 @@ module Msf
   module OptCondition
 
     # Check a condition's result
+    # @param [Msf::Module] mod The module module
+    # @param [Msf::OptBase] opt the option which has conditions present
+    # @return [String]
     def self.eval_condition(left_value, operator, right_value)
       case operator.to_sym
       when :==
@@ -13,6 +16,34 @@ module Msf
         right_value.include?(left_value)
       when :nin
         !right_value.include?(left_value)
+      end
+    end
+
+    # Format an option's conditions as a human readable string
+    # @param [Msf::Module] mod The module module
+    # @param [Msf::OptBase] opt the option which has conditions present
+    # @return [String]
+    def self.format_conditions(_mod, opt)
+      left_source = opt.conditions[0]
+      operator = opt.conditions[1]
+      right_value = opt.conditions[2]
+      expects_blank_values = Array(right_value).all? { |value| value.blank? }
+
+      case operator.to_sym
+      when :==, :!=
+        "#{left_source} #{operator} #{right_value}"
+      when :in
+        if expects_blank_values
+          return "#{left_source} is blank"
+        end
+        "#{left_source} #{operator} #{right_value.join(",")}"
+      when :nin
+        if expects_blank_values
+          return "#{left_source} is not blank"
+        end
+        "#{left_source} not in #{right_value.join(",")}"
+      else
+        "placeholder"
       end
     end
 

--- a/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
@@ -63,7 +63,6 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     register_options([
-      # Using USERNAME, PASSWORD and DOMAIN options defined by the LDAP mixin
       OptString.new('DC_NAME', [ true, 'Name of the domain controller being targeted (must match RHOST)' ]),
       OptInt.new('LDAP_PORT', [true, 'LDAP port (default is 389 and default encrypted is 636)', 636]), # Set to 636 for legacy SSL
       OptString.new('DOMAIN', [true, 'The domain to authenticate to']),
@@ -160,8 +159,8 @@ class MetasploitModule < Msf::Auxiliary
       if @privesc_success
         # If the privilege escalation succeeded, let'use the cached TGS
         # impersonating the admin to delete the computer account
-        datastore['SMBAuth'] = Msf::Exploit::Remote::AuthOption::KERBEROS
-        datastore['SmbRhostname'] = "#{datastore['DC_NAME']}.#{datastore['DOMAIN']}"
+        datastore['SMB::Auth'] = Msf::Exploit::Remote::AuthOption::KERBEROS
+        datastore['SMB::Rhostname'] = "#{datastore['DC_NAME']}.#{datastore['DOMAIN']}"
         datastore['SMBDomain'] = datastore['DOMAIN']
         datastore['DomainControllerRhost'] = rhost
         tree = connect_smb(username: datastore['IMPERSONATE'])
@@ -213,7 +212,7 @@ class MetasploitModule < Msf::Auxiliary
     datastore['SMBPass'] = password
     datastore['SMBDomain'] = domain
 
-    if datastore['SMBAuth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
+    if datastore['SMB::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
       vprint_status("Connecting SMB with #{username}.#{domain} using Kerberos authentication")
     else
       vprint_status("Connecting SMB with #{username}.#{domain}:#{password}")

--- a/modules/auxiliary/admin/kerberos/get_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/get_ticket.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
           ]
         ),
         OptString.new(
-          'AESKEY', [
+          'AES_KEY', [
             false,
             'The AES key to use for Kerberos authentication in hex string. Supported keys: 128 or 256 bits'
           ]
@@ -68,8 +68,6 @@ class MetasploitModule < Msf::Auxiliary
         )
       ]
     )
-
-    deregister_options('KrbCacheMode')
   end
 
   def validate_options
@@ -77,9 +75,9 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Msf::Exploit::Failure::BadConfig, 'NTHASH must be a hex string of 32 characters (128 bits)')
     end
 
-    if datastore['AESKEY'].present? && !datastore['AESKEY'].match(/^(\h{32}|\h{64})$/)
+    if datastore['AES_KEY'].present? && !datastore['AES_KEY'].match(/^(\h{32}|\h{64})$/)
       fail_with(Msf::Exploit::Failure::BadConfig,
-                'AESKEY must be a hex string of 32 characters for 128-bits AES keys or 64 characters for 256-bits AES keys')
+                'AES_KEY must be a hex string of 32 characters for 128-bits AES keys or 64 characters for 256-bits AES keys')
     end
 
     if action.name == 'GET_TGS' && datastore['SPN'].blank?
@@ -111,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
     msg = e.to_s
     if e.respond_to?(:error_code) &&
        e.error_code == ::Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_PREAUTH_REQUIRED
-      msg << ' - Check the authentication-related options (PASSWORD, NTHASH or AESKEY)'
+      msg << ' - Check the authentication-related options (PASSWORD, NTHASH or AES_KEY)'
     end
     fail_with(Failure::Unknown, msg)
   end
@@ -129,8 +127,8 @@ class MetasploitModule < Msf::Auxiliary
       options[:key] = [datastore['NTHASH']].pack('H*')
       options[:offered_etypes] = [ Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC ]
     end
-    if datastore['AESKEY'].present?
-      options[:key] = [ datastore['AESKEY'] ].pack('H*')
+    if datastore['AES_KEY'].present?
+      options[:key] = [ datastore['AES_KEY'] ].pack('H*')
       options[:offered_etypes] = if options[:key].size == 32
                                    [ Rex::Proto::Kerberos::Crypto::Encryption::AES256 ]
                                  else

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -10,7 +10,6 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::SMB::Client
   include Msf::Exploit::Remote::SMB::Client::Authenticated
-  include Msf::Exploit::Remote::AuthOption
 
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
@@ -72,15 +71,15 @@ class MetasploitModule < Msf::Auxiliary
     domain = datastore['SMBDomain'] || ''
 
     kerberos_authenticator_factory = nil
-    if datastore['SMBAuth'] == KERBEROS
-      fail_with(Msf::Exploit::Failure::BadConfig, 'The SmbRhostname option is required when using Kerberos authentication.') if datastore['SmbRhostname'].blank?
+    if datastore['SMB::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The SMB::Rhostname option is required when using Kerberos authentication.') if datastore['SMB::Rhostname'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
 
       kerberos_authenticator_factory = lambda do |username, password, realm|
         Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
           host: datastore['DomainControllerRhost'],
-          hostname: datastore['SmbRhostname'],
+          hostname: datastore['SMB::Rhostname'],
           realm: realm,
           username: username,
           password: password,

--- a/modules/auxiliary/scanner/winrm/winrm_cmd.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_cmd.rb
@@ -9,8 +9,6 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::WinRM
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::Exploit::Remote::AuthOption
-  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
 
   def initialize
     super(
@@ -55,18 +53,18 @@ class MetasploitModule < Msf::Auxiliary
         retry_limit: 1,
         realm: datastore['DOMAIN']
     }
-    case datastore['WinrmAuth']
+    case datastore['Winrm::Auth']
     when KERBEROS
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
         host: datastore['DomainControllerRhost'],
-        hostname: datastore['WinrmRhostname'],
+        hostname: datastore['Winrm::Rhostname'],
         realm: datastore['DOMAIN'],
         username: datastore['USERNAME'],
         password: datastore['PASSWORD'],
         timeout: 20, # datastore['timeout']
         framework: framework,
         framework_module: self,
-        cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
+        cache_file: datastore['Winrm::Rhostname'].blank? ? nil : datastore['Winrm::Rhostname'],
         mutual_auth: true,
         use_gss_checksum: true,
         ticket_storage: kerberos_ticket_storage,

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -50,20 +50,21 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     kerberos_authenticator_factory = nil
+    # TODO: This is Marked as dead for some reason
     preferred_auth = 'Negotiate'
-    if datastore['WinrmAuth'] == KERBEROS
+    if datastore['Winrm::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
       preferred_auth = 'Kerberos'
       kerberos_authenticator_factory = -> (username, password, realm) do
         Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
           host: datastore['DomainControllerRhost'],
-          hostname: datastore['WinrmRhostname'],
+          hostname: datastore['Winrm::Rhostname'],
           realm: realm,
           username: username,
           password: password,
           timeout: 20,
           framework: framework,
           framework_module: self,
-          cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
+          cache_file: datastore['Winrm::Krb5Ccname'].blank? ? nil : datastore['Winrm::Krb5Ccname'],
           mutual_auth: true,
           use_gss_checksum: true,
           ticket_storage: kerberos_ticket_storage,

--- a/spec/lib/msf/core/opt_condition_spec.rb
+++ b/spec/lib/msf/core/opt_condition_spec.rb
@@ -1,0 +1,42 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::OptCondition do
+  describe '.format_conditions' do
+    [
+      {
+        conditions: ['Winrm::Auth', '==', 'kerberos'],
+        expected: 'Winrm::Auth == kerberos'
+      },
+      {
+        conditions: %w[TARGET != Automatic],
+        expected: 'TARGET != Automatic'
+      },
+      {
+        conditions: ['ACTION', 'in', %w[VSS_MOUNT VSS_UNMOUNT]],
+        expected: 'ACTION in VSS_MOUNT,VSS_UNMOUNT'
+      },
+      {
+        conditions: ['Winrm::Auth', 'nin', ['kerberos', 'plain']],
+        expected: 'Winrm::Auth not in kerberos,plain'
+      },
+      {
+        conditions: ['ScheduleRemoteSystem', 'in', [nil, '']],
+        expected: 'ScheduleRemoteSystem is blank'
+      },
+      {
+        conditions: ['ScheduleRemoteSystem', 'nin', [nil, '']],
+        expected: 'ScheduleRemoteSystem is not blank'
+      },
+    ].each do |test|
+      context "when the conditions are #{test[:conditions].inspect}" do
+        it "returns the expected string #{test[:expected]}" do
+          mod = instance_double(Msf::Module)
+          option = Msf::OptString.new('foo', conditions: test[:conditions])
+          expect(described_class.format_conditions(mod, option)).to eq test[:expected]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Option changes

**What problem is this solving?**

We want users to be able to consistently set kerberos options, and use it consistently across different modules without the protocol prefix. This makes it easier to swap across multiple modules without having to re-enter the same options:

```diff
- msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 WinrmRhostname=dc3.adf3.local domain=adf3.local
+ msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd auth=kerberos domaincontrollerrhost=192.168.123.13 rhostname=dc3.adf3.local domain=adf3.local
```

For certain scenarios we still want to allow users to be able to specify namespaced values with a slightly modified naming convention of `${protocol}::auth`. This would be required for complex modules that need access to multiple services at the same time. i.e. query ldap, and exploit a different protocol

```
msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrm::auth=kerberos domaincontrollerrhost=192.168.123.13 Winrm::Rhostname=dc3.adf3.local domain=adf3.local
```

### Changes to conditions

We also modify the behavior of an option's `conditions` to no longer hide options options when they're not enabled, but to instead logically group them in the console output:

```
msf6 auxiliary(scanner/smb/smb_login) > show advanced

Module advanced options (auxiliary/scanner/smb/smb_login):

   Name                     Current Setting    Required  Description
   ----                     ---------------    --------  -----------
   Auth                     auto               yes       The Authentication mechanism to use (Accepted: auto, ntlm, kerberos)
   CHOST                                       no        The local client address
   CPORT                                       no        The local client port
   ConnectTimeout           10                 yes       Maximum number of seconds to establish a TCP connection
   DCERPC::ReadTimeout      10                 yes       The number of seconds to wait for DCERPC responses
   MaxGuessesPerService     0                  no        Maximum number of credentials to try per service instance. If set to zero or a non-number, this option will not be used.
   MaxGuessesPerUser        0                  no        Maximum guesses for a particular username for the service instance. Note that users are considered unique among different services, so a user at 10.1.1.1:22 is different from one at 10.2.2.2:22,
                                                         and both will be tried up to the MaxGuessesPerUser limit. If set to zero or a non-number, this option will not be used.
   MaxMinutesPerService     0                  no        Maximum time in minutes to bruteforce the service instance. If set to zero or a non-number, this option will not be used.
   NTLM::SendLM             true               yes       Always send the LANMAN response (except when NTLMv2_session is specified)
   NTLM::SendNTLM           true               yes       Activate the 'Negotiate NTLM key' flag, indicating the use of NTLM responses
   NTLM::SendSPN            true               yes       Send an avp of type SPN in the ntlmv2 client blob, this allows authentication on Windows 7+/Server 2008 R2+ when SPN is required
   NTLM::UseLMKey           false              yes       Activate the 'Negotiate Lan Manager Key' flag, using the LM key when the LM response is sent
   NTLM::UseNTLM2_session   true               yes       Activate the 'Negotiate NTLM2 key' flag, forcing the use of a NTLMv2_session
   NTLM::UseNTLMv2          true               yes       Use NTLMv2 instead of NTLM2_session when 'Negotiate NTLM2' key is true
   REMOVE_PASS_FILE         false              yes       Automatically delete the PASS_FILE on module completion
   REMOVE_USERPASS_FILE     false              yes       Automatically delete the USERPASS_FILE on module completion
   REMOVE_USER_FILE         false              yes       Automatically delete the USER_FILE on module completion
   SMB::AlwaysEncrypt       true               yes       Enforces encryption even if the server does not require it (SMB3.x only). Note that when it is set to false, the SMB client will still encrypt the communication if the server requires it
   SMB::ChunkSize           500                yes       The chunk size for SMB segments, bigger values will increase speed but break NT 4.0 and SMB signing
   SMB::Native_LM           Windows 2000 5.0   yes       The Native LM to send during authentication
   SMB::Native_OS           Windows 2000 2195  yes       The Native OS to send during authentication
   SMB::ProtocolVersion     1,2,3              yes       One or a list of coma-separated SMB protocol versions to negotiate (e.g. "1" or "1,2" or "2,3,1")
   SMB::VerifySignature     false              yes       Enforces client-side verification of server response signatures
   SMBDirect                true               no        The target port is a raw SMB service (not NetBIOS)
   SMBName                  *SMBSERVER         yes       The NetBIOS hostname (required for port 139 connections)
   SSL                      false              no        Negotiate SSL/TLS for outgoing connections
   SSLCipher                                   no        String for SSL cipher - "DHE-RSA-AES256-SHA" or "ADH"
   SSLServerNameIndication                     no        SSL/TLS Server Name Indication (SNI)
   SSLVerifyMode            PEER               no        SSL verification method (Accepted: CLIENT_ONCE, FAIL_IF_NO_PEER_CERT, NONE, PEER)
   SSLVersion               Auto               yes       Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate) (Accepted: Auto, TLS, SSL23, SSL3, TLS1, TLS1.1, TLS1.2)
   ShowProgress             true               yes       Display progress messages during a scan
   ShowProgressPercent      10                 yes       The interval in percent that progress should be shown
   TRANSITION_DELAY         0                  no        Amount of time (in minutes) to delay before transitioning to the next user in the array (or password when PASSWORD_SPRAY=true)
   WORKSPACE                                   no        Specify the workspace for this module


   When SMB::Auth == kerberos:

   Name                       Current Setting                                   Required  Description
   ----                       ---------------                                   --------  -----------
   DomainControllerRhost                                                        no        The resolvable rhost for the Domain Controller
   Krb5Ccname                                                                   no        The ccache file to use for kerberos authentication
   KrbCacheMode               read-write                                        yes       Kerberos ticket cache storage mode (Accepted: none, read-only, write-only, read-write)
   KrbOfferedEncryptionTypes  AES256,AES128,RC4-HMAC,DES-CBC-MD5,DES3-CBC-SHA1  yes       Kerberos encryption types to offer
   Rhostname                                                                    no        The rhostname which is required for kerberos - the SPN


View the full module info with the info, or info -d command.
```

### How it works?

We add the namespace, and allow a fallback to an alternative human friendly value:

```
      Msf::OptEnum.new(
        "#{protocol}::Auth",
        [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, auth_methods],
        fallbacks: ['Auth'],
        display_name: 'Auth'
      ),
```

We then add a `display_name` which impacts the output of the option name to the user. For more complex values, we'll want to override the display_name to the more complex value.

This allows for internal modules to use the namespaced values, avoiding the 'mixin-madness' issue, but providing the flexibility for users to override the specific protocols that they care about

## Verification

Will update this list with verification steps; but a full run through of Kerberos modules, and some existing modules. I'll need to ensure the certifried module works.

WinRM

```
use scanner/winrm/winrm_login

# old
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 winrmrhostname=dc3.adf3.local domain=adf3.local

# new - explicit namespace
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrm::auth=kerberos domaincontrollerrhost=192.168.123.13 winrm::rhostname=dc3.adf3.local domain=adf3.local

# new - no namespace
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd auth=kerberos domaincontrollerrhost=192.168.123.13 rhostname=dc3.adf3.local domain=adf3.local
```

```
use windows/winrm/winrm_script_exec

# old
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 winrmrhostname=dc3.adf3.local domain=adf3.local

# new - explicit namespace
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrm::auth=kerberos domaincontrollerrhost=192.168.123.13 winrm::rhostname=dc3.adf3.local domain=adf3.local

# new - no namespace
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd auth=kerberos domaincontrollerrhost=192.168.123.13 rhostname=dc3.adf3.local domain=adf3.local
```

ldap

```
use gather/ldap_query

# old
run action=ENUM_ACCOUNTS rhost=192.168.123.13 username=Administrator password=p4$$w0rd ldapauth=kerberos ldaprhostname=dc3.adf3.local domain=adf3.local domaincontrollerrhost=192.168.123.13

# new - explicit namespace
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd ldap::auth=kerberos domaincontrollerrhost=192.168.123.13 ldap::rhostname=dc3.adf3.local domain=adf3.local

# new - no namespace
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd auth=kerberos domaincontrollerrhost=192.168.123.13 rhostname=dc3.adf3.local domain=adf3.local
```

psexec

```
use windows/smb/psexec

# old
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smbauth=kerberos domaincontrollerrhost=192.168.123.13 smbrhostname=dc3.adf3.local domain=adf3.local

# new - explicit namespace
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smb::auth=kerberos domaincontrollerrhost=192.168.123.13 smb::rhostname=dc3.adf3.local domain=adf3.local

# new - no namespace
run rhost=192.168.123.13 username=Administrator password=p4$$w0rd auth=kerberos domaincontrollerrhost=192.168.123.13 rhostname=dc3.adf3.local domain=adf3.local
```

And mssql