### PR TITLE
Update get ticket module option names

### DIFF
--- a/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
@@ -17,7 +17,7 @@ The following ACTIONS are supported:
 - Do: `use auxiliary/admin/kerberos/get_ticket`
 - Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGT`
 - You should see that the TGT is correctly retrieved and stored in loot as well as the klist command
-- Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY`
+- Try with the NT hash (`NTHASH` option) and the encryption key (`AES_KEY`
   option) instead of the password
 - Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGS spn=<SPN>`
 - You should see that the module uses the TGT in the cache and does not request a new one
@@ -25,7 +25,7 @@ The following ACTIONS are supported:
 - Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGS spn=<SPN> KrbUseCachedCredentials=false`
 - You should see the module does not use the TGT in the cache and requests a new one
 - You should see both the TGT and the TGS are correctly retrieved and stored in the loot
-- Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY` option) instead of the password
+- Try with the NT hash (`NTHASH` option) and the encryption key (`AES_KEY` option) instead of the password
 
 ## Options
 
@@ -42,7 +42,7 @@ The user's password to use.
 The user's NT hash in hex string to authenticate with. Not that the DC must
 support RC4 encryption.
 
-### AESKEY
+### AES_KEY
 The user's AES key to use for Kerberos authentication in hex string. Supported
 keys: 128 or 256 bits.
 
@@ -106,7 +106,7 @@ host             port  proto  name      state  info
 TGT with encryption key
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=GET_TGT
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AES_KEY=<redacted> action=GET_TGT
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -153,7 +153,7 @@ host             service  type                 name  content                   i
 TGS with encryption key:
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AES_KEY=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -214,7 +214,7 @@ host             service  type                 name  content                   i
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=GET_TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false
 [*] Running module against 10.0.0.24
 
-[-] Auxiliary aborted due to failure: unknown: Error while requesting a TGT: Kerberos Error - KDC_ERR_PREAUTH_REQUIRED (25) - Additional pre-authentication required - Check the authentication-related options (PASSWORD, NTHASH or AESKEY)
+[-] Auxiliary aborted due to failure: unknown: Error while requesting a TGT: Kerberos Error - KDC_ERR_PREAUTH_REQUIRED (25) - Additional pre-authentication required - Check the authentication-related options (PASSWORD, NTHASH or AES_KEY)
 [*] Auxiliary module execution completed
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=GET_TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false password=<redacted>
 [*] Running module against 10.0.0.24

--- a/modules/auxiliary/admin/kerberos/get_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/get_ticket.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
           ]
         ),
         OptString.new(
-          'AESKEY', [
+          'AES_KEY', [
             false,
             'The AES key to use for Kerberos authentication in hex string. Supported keys: 128 or 256 bits'
           ]
@@ -77,9 +77,9 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Msf::Exploit::Failure::BadConfig, 'NTHASH must be a hex string of 32 characters (128 bits)')
     end
 
-    if datastore['AESKEY'].present? && !datastore['AESKEY'].match(/^(\h{32}|\h{64})$/)
+    if datastore['AES_KEY'].present? && !datastore['AES_KEY'].match(/^(\h{32}|\h{64})$/)
       fail_with(Msf::Exploit::Failure::BadConfig,
-                'AESKEY must be a hex string of 32 characters for 128-bits AES keys or 64 characters for 256-bits AES keys')
+                'AES_KEY must be a hex string of 32 characters for 128-bits AES keys or 64 characters for 256-bits AES keys')
     end
 
     if action.name == 'GET_TGS' && datastore['SPN'].blank?
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Auxiliary
     msg = e.to_s
     if e.respond_to?(:error_code) &&
        e.error_code == ::Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_PREAUTH_REQUIRED
-      msg << ' - Check the authentication-related options (PASSWORD, NTHASH or AESKEY)'
+      msg << ' - Check the authentication-related options (PASSWORD, NTHASH or AES_KEY)'
     end
     fail_with(Failure::Unknown, msg)
   end
@@ -129,8 +129,8 @@ class MetasploitModule < Msf::Auxiliary
       options[:key] = [datastore['NTHASH']].pack('H*')
       options[:offered_etypes] = [ Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC ]
     end
-    if datastore['AESKEY'].present?
-      options[:key] = [ datastore['AESKEY'] ].pack('H*')
+    if datastore['AES_KEY'].present?
+      options[:key] = [ datastore['AES_KEY'] ].pack('H*')
       options[:offered_etypes] = if options[:key].size == 32
                                    [ Rex::Proto::Kerberos::Crypto::Encryption::AES256 ]
                                  else


### PR DESCRIPTION
Let's update the get_ticket module to be consistent with the other recently added Kerberos modules, i.e. AES_KEY and USERNAME

## Verification

Request a TGT from the server:

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator password=p4$$w0rd action=GET_TGT
[*] Running module against 192.168.123.13

[*] 192.168.123.13:88 - Getting TGT for Administrator@adf3.local
[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103723_default_192.168.123.13_mit.kerberos.cca_055992.bin
[*] Auxiliary module execution completed
```

Request a TGT with AES_KEY:

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator action=GET_TGT aes_key=56c3bf6629871a4e4b8ec894f37489e823bbaecc2a0a4a5749731afa9d158e01
[*] Running module against 192.168.123.13

[*] 192.168.123.13:88 - Getting TGT for Administrator@adf3.local
[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103832_default_192.168.123.13_mit.kerberos.cca_758170.bin
[*] Auxiliary module execution completed
```

Request a TGS from the server with password:

```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator password=p4$$w0rd action=GET_TGS spn=cifs/dc3.adf3.local
[*] Reloading module...
[*] Running module against 192.168.123.13

[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103858_default_192.168.123.13_mit.kerberos.cca_702563.bin
[*] 192.168.123.13:88 - Getting TGS for Administrator@adf3.local (SPN: cifs/dc3.adf3.local)
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:88 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103858_default_192.168.123.13_mit.kerberos.cca_008660.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[*] Auxiliary module execution completed
```

Request a TGS from the server with AES_KEY:
```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator action=GET_TGS spn=cifs/dc3.adf3.local aes_key=56c3bf6629871a4e4b8ec894f37489e823bbaecc2a0a4a5749731afa9d158e01
[*] Reloading module...
[*] Running module against 192.168.123.13

[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103955_default_192.168.123.13_mit.kerberos.cca_788121.bin
[*] 192.168.123.13:88 - Getting TGS for Administrator@adf3.local (SPN: cifs/dc3.adf3.local)
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:88 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103955_default_192.168.123.13_mit.kerberos.cca_691948.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[*] Auxiliary module execution completed
```