### PR TITLE
Update get ticket module to use aes_key and username convention

### DIFF
--- a/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
@@ -15,24 +15,24 @@ The following ACTIONS are supported:
 
 - Start `msfconsole`
 - Do: `use auxiliary/admin/kerberos/get_ticket`
-- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGT`
+- Do: `run rhosts=<remote host> domain=<domain> username=<username> password=<password> action=GET_TGT`
 - You should see that the TGT is correctly retrieved and stored in loot as well as the klist command
-- Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY`
+- Try with the NT hash (`NTHASH` option) and the encryption key (`AES_KEY`
   option) instead of the password
-- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGS spn=<SPN>`
+- Do: `run rhosts=<remote host> domain=<domain> username=<username> password=<password> action=GET_TGS spn=<SPN>`
 - You should see that the module uses the TGT in the cache and does not request a new one
 - You should see TGS is correctly retrieved and stored in the loot
-- Do: `run rhosts=<remote host> domain=<domain> user=<username> password=<password> action=GET_TGS spn=<SPN> KrbUseCachedCredentials=false`
+- Do: `run rhosts=<remote host> domain=<domain> username=<username> password=<password> action=GET_TGS spn=<SPN> KrbUseCachedCredentials=false`
 - You should see the module does not use the TGT in the cache and requests a new one
 - You should see both the TGT and the TGS are correctly retrieved and stored in the loot
-- Try with the NT hash (`NTHASH` option) and the encryption key (`AESKEY` option) instead of the password
+- Try with the NT hash (`NTHASH` option) and the encryption key (`AES_KEY` option) instead of the password
 
 ## Options
 
 ### DOMAIN
 The Fully Qualified Domain Name (FQDN). Ex: mydomain.local
 
-### USER
+### USERNAME
 The domain username to authenticate with.
 
 ### PASSWORD
@@ -42,7 +42,7 @@ The user's password to use.
 The user's NT hash in hex string to authenticate with. Not that the DC must
 support RC4 encryption.
 
-### AESKEY
+### AES_KEY
 The user's AES key to use for Kerberos authentication in hex string. Supported
 keys: 128 or 256 bits.
 
@@ -72,7 +72,7 @@ Kerberos Cache
 ==============
 No tickets
 
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator nthash=<redacted> action=GET_TGT
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator nthash=<redacted> action=GET_TGT
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -106,7 +106,7 @@ host             port  proto  name      state  info
 TGT with encryption key
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=GET_TGT
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator AES_KEY=<redacted> action=GET_TGT
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -117,7 +117,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 TGT with password
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator password=<redacted> action=GET_TGT
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator password=<redacted> action=GET_TGT
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -131,7 +131,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 TGS with NT hash:
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator nthash=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator nthash=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -153,7 +153,7 @@ host             service  type                 name  content                   i
 TGS with encryption key:
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator AESKEY=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator AES_KEY=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -166,7 +166,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 TGS with password:
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator password=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator password=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -189,7 +189,7 @@ host             service  type                 name  content                   i
 10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
 10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
 
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=GET_TGS spn=cifs/dc02.mylab.local
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
 [*] 10.0.0.24:88 - Using cached credential for krbtgt/mylab.local Administrator
@@ -211,12 +211,12 @@ host             service  type                 name  content                   i
 10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: krbtgt/mylab.local, username: administrator     /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_171694.bin
 10.0.0.24                 mit.kerberos.ccache        application/octet-stream  realm: MYLAB.LOCAL, serviceName: cifs/dc02.mylab.local, username: administrator  /home/msfuser/.msf4/loot/20221104183244_default_10.0.0.24_mit.kerberos.cca_360960.bin
 
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=GET_TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator action=GET_TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false
 [*] Running module against 10.0.0.24
 
-[-] Auxiliary aborted due to failure: unknown: Error while requesting a TGT: Kerberos Error - KDC_ERR_PREAUTH_REQUIRED (25) - Additional pre-authentication required - Check the authentication-related options (PASSWORD, NTHASH or AESKEY)
+[-] Auxiliary aborted due to failure: unknown: Error while requesting a TGT: Kerberos Error - KDC_ERR_PREAUTH_REQUIRED (25) - Additional pre-authentication required - Check the authentication-related options (PASSWORD, NTHASH or AES_KEY)
 [*] Auxiliary module execution completed
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=Administrator action=GET_TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false password=<redacted>
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator action=GET_TGS spn=cifs/dc02.mylab.local KrbUseCachedCredentials=false password=<redacted>
 [*] Running module against 10.0.0.24
 
 [+] 10.0.0.24:88 - Received a valid TGT-Response
@@ -240,7 +240,7 @@ host             service  type                 name  content                   i
 TGS impersonating the Administrator account:
 
 ```
-msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local user=serviceA password=123456 action=GET_TGS spn=cifs/dc02.mylab.local impersonate=Administrator
+msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=serviceA password=123456 action=GET_TGS spn=cifs/dc02.mylab.local impersonate=Administrator
 [*] Running module against 10.0.0.24
 
 [*] 10.0.0.24:88 - Getting TGS impersonating Administrator@mylab.local (SPN: cifs/dc02.mylab.local)


### PR DESCRIPTION
Let's update the get_ticket module to be consistent with the other recently added Kerberos modules, i.e. AES_KEY and USERNAME

## Verification

Request a TGT from the server:

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator password=p4$$w0rd action=GET_TGT
[*] Running module against 192.168.123.13

[*] 192.168.123.13:88 - Getting TGT for Administrator@adf3.local
[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103723_default_192.168.123.13_mit.kerberos.cca_055992.bin
[*] Auxiliary module execution completed
```

Request a TGT with AES_KEY:

```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator action=GET_TGT aes_key=56c3bf6629871a4e4b8ec894f37489e823bbaecc2a0a4a5749731afa9d158e01
[*] Running module against 192.168.123.13

[*] 192.168.123.13:88 - Getting TGT for Administrator@adf3.local
[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103832_default_192.168.123.13_mit.kerberos.cca_758170.bin
[*] Auxiliary module execution completed
```

Request a TGS from the server with password:

```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator password=p4$$w0rd action=GET_TGS spn=cifs/dc3.adf3.local
[*] Reloading module...
[*] Running module against 192.168.123.13

[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103858_default_192.168.123.13_mit.kerberos.cca_702563.bin
[*] 192.168.123.13:88 - Getting TGS for Administrator@adf3.local (SPN: cifs/dc3.adf3.local)
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:88 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103858_default_192.168.123.13_mit.kerberos.cca_008660.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[*] Auxiliary module execution completed
```

Request a TGS from the server with AES_KEY:
```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator action=GET_TGS spn=cifs/dc3.adf3.local aes_key=56c3bf6629871a4e4b8ec894f37489e823bbaecc2a0a4a5749731afa9d158e01
[*] Reloading module...
[*] Running module against 192.168.123.13

[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103955_default_192.168.123.13_mit.kerberos.cca_788121.bin
[*] 192.168.123.13:88 - Getting TGS for Administrator@adf3.local (SPN: cifs/dc3.adf3.local)
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:88 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120103955_default_192.168.123.13_mit.kerberos.cca_691948.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[*] Auxiliary module execution completed
```