### PR TITLE
Update metasploit-payloads gem to 2.0.108

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.105)
+      metasploit-payloads (= 2.0.108)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.20)
       mqtt
@@ -248,7 +248,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.105)
+    metasploit-payloads (2.0.108)
     metasploit_data_models (5.0.6)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -72,7 +72,7 @@ metasploit-concern, 4.0.5, "New BSD"
 metasploit-credential, 6.0.1, "New BSD"
 metasploit-framework, 6.2.37, "New BSD"
 metasploit-model, 4.0.6, "New BSD"
-metasploit-payloads, 2.0.105, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.108, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 5.0.6, "New BSD"
 metasploit_payloads-mettle, 1.0.20, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.105'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.108'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.20'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Includes changes from:
  * rapid7/metasploit-payloads#599
  * rapid7/metasploit-payloads#600
  * rapid7/metasploit-payloads#602
