### PR TITLE
improve SMTP delivery error handling

### DIFF
--- a/lib/msf/core/exploit/remote/smtp_deliver.rb
+++ b/lib/msf/core/exploit/remote/smtp_deliver.rb
@@ -223,10 +223,20 @@ module Exploit::Remote::SMTPDeliver
     end
 
     send_status
+  rescue SMTPCommunicationError => e
+    print_error(e.message)
+    if already_connected
+      print_error("Closing and reconnecting...")
+      disconnect(nsock)
+      connect_login
+    end
   end
 
   def disconnect(nsock=self.sock)
-    smtp_send_recv("QUIT\r\n", nsock)
+    begin
+      smtp_send_recv("QUIT\r\n", nsock)
+    rescue SMTPCommunicationError => _e
+    end
     super
     @connected = false
   end
@@ -246,10 +256,16 @@ module Exploit::Remote::SMTPDeliver
     begin
       nsock.put(cmd)
       res = nsock.get_once
-      while !(res =~ /(^|\r\n)\d{3}( .*|)\r\n$/) && chunk = nsock.get_once
-        res += chunk
+      while !(res =~ /(^|\r\n)\d{3}( .*|)\r\n$/)
+        chunk = nsock.get_once
+        break unless chunk
+        if res
+          res += chunk
+        else
+          res = chunk
+        end
       end
-      raise RuntimeError.new("SMTP response is incomplete or contains extra data") unless res =~ /(^|\r\n)\d{3}( .*|)\r\n$/
+      raise SMTPCommunicationError.new("SMTP response is incomplete or contains extra data") unless res =~ /(^|\r\n)\d{3}( .*|)\r\n$/
     rescue EOFError
       return nil
     end
@@ -296,6 +312,9 @@ protected
     end
   end
 
+  class SMTPCommunicationError < RuntimeError
+    # private error class for detecting protocol errors
+  end
 end
 
 end

--- a/spec/lib/msf/core/exploit/remote/smtp_delivery_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/smtp_delivery_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Msf::Exploit::Remote::SMTPDeliver do
       }
 
       it "should raise error when the response is incomplete" do
-        expect {instance.smtp_send_recv(cmd, socket)}.to raise_error RuntimeError
+        expect {instance.smtp_send_recv(cmd, socket)}.to raise_error Msf::Exploit::Remote::SMTPDeliver::SMTPCommunicationError
       end
     end
 
@@ -86,7 +86,7 @@ RSpec.describe Msf::Exploit::Remote::SMTPDeliver do
       }
 
       it "should raise error when the response is incomplete" do
-        expect {instance.smtp_send_recv(cmd, socket)}.to raise_error RuntimeError
+        expect {instance.smtp_send_recv(cmd, socket)}.to raise_error Msf::Exploit::Remote::SMTPDeliver::SMTPCommunicationError
       end
     end
   end


### PR DESCRIPTION
Expands on #16153

In an attempt to improve reliability of smtp delivery, this Namespaces the raised exceptions and updates the 
`send_message` method to ensure a socket that raises an error is closed and new connection is created if a global existing connection was in place.

This also improves socket read detection in the event that the initial `#get_once` returns `nil`.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/client/smtp/emailer`
- [ ] **Verify** email can still be sent as expected

