### PR TITLE
Remove extra info from verbose mode of LDAP output

### DIFF
--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -158,8 +158,6 @@ module Msf
         return
       end
 
-      vprint_line(root_dse.to_ldif)
-
       naming_contexts = root_dse[:namingcontexts]
 
       # NOTE: Net::LDAP converts attribute names to lowercase


### PR DESCRIPTION
This removes some extra info from the VERBOSE mode of our LDAP library that isn't really useful anymore after some discussions with @smcintyre-r7.

## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/gather/ldap_query`
- [x] `set VERBOSE true`
- [x]  Set BIND_DN, BIND_PW, RHOSTS.
- [x] `run`
- [x] **Verify** that the output does not contain the extra info about naming context, supportedcapabilities, and supportedcontrol.


Example before:

```
msf6 > use auxiliary/gather/ldap_query 
msf6 auxiliary(gather/ldap_query) > set VERBOSE true
VERBOSE => true
msf6 auxiliary(gather/ldap_query) > set BIND_DN DAFOREST\\Administrator
BIND_DN => DAFOREST\Administrator
msf6 auxiliary(gather/ldap_query) > set BIND_PW theAdmin123
BIND_PW => theAdmin123
msf6 auxiliary(gather/ldap_query) > set RHOSTS 192.168.153.207A
RHOSTS => 192.168.153.207A
msf6 auxiliary(gather/ldap_query) > set RHOSTS 192.168.153.207
RHOSTS => 192.168.153.207
msf6 auxiliary(gather/ldap_query) > run
[*] Running module against 192.168.153.207

[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[*] 192.168.153.207:389 Getting root DSE
dn: 
namingcontexts: DC=daforest,DC=com
namingcontexts: CN=Configuration,DC=daforest,DC=com
namingcontexts: CN=Schema,CN=Configuration,DC=daforest,DC=com
namingcontexts: DC=DomainDnsZones,DC=daforest,DC=com
namingcontexts: DC=ForestDnsZones,DC=daforest,DC=com
supportedcapabilities: 1.2.840.113556.1.4.800
supportedcapabilities: 1.2.840.113556.1.4.1670
supportedcapabilities: 1.2.840.113556.1.4.1791
supportedcapabilities: 1.2.840.113556.1.4.1935
supportedcapabilities: 1.2.840.113556.1.4.2080
supportedcapabilities: 1.2.840.113556.1.4.2237
supportedcontrol: 1.2.840.113556.1.4.319
supportedcontrol: 1.2.840.113556.1.4.801
supportedcontrol: 1.2.840.113556.1.4.473
supportedcontrol: 1.2.840.113556.1.4.528
supportedcontrol: 1.2.840.113556.1.4.417
supportedcontrol: 1.2.840.113556.1.4.619
supportedcontrol: 1.2.840.113556.1.4.841
supportedcontrol: 1.2.840.113556.1.4.529
supportedcontrol: 1.2.840.113556.1.4.805
supportedcontrol: 1.2.840.113556.1.4.521
supportedcontrol: 1.2.840.113556.1.4.970
supportedcontrol: 1.2.840.113556.1.4.1338
supportedcontrol: 1.2.840.113556.1.4.474
supportedcontrol: 1.2.840.113556.1.4.1339
supportedcontrol: 1.2.840.113556.1.4.1340
supportedcontrol: 1.2.840.113556.1.4.1413
supportedcontrol: 2.16.840.1.113730.3.4.9
supportedcontrol: 2.16.840.1.113730.3.4.10
supportedcontrol: 1.2.840.113556.1.4.1504
supportedcontrol: 1.2.840.113556.1.4.1852
supportedcontrol: 1.2.840.113556.1.4.802
supportedcontrol: 1.2.840.113556.1.4.1907
supportedcontrol: 1.2.840.113556.1.4.1948
supportedcontrol: 1.2.840.113556.1.4.1974
supportedcontrol: 1.2.840.113556.1.4.1341
supportedcontrol: 1.2.840.113556.1.4.2026
supportedcontrol: 1.2.840.113556.1.4.2064
supportedcontrol: 1.2.840.113556.1.4.2065
supportedcontrol: 1.2.840.113556.1.4.2066
supportedcontrol: 1.2.840.113556.1.4.2090
supportedcontrol: 1.2.840.113556.1.4.2205
supportedcontrol: 1.2.840.113556.1.4.2204
supportedcontrol: 1.2.840.113556.1.4.2206
supportedcontrol: 1.2.840.113556.1.4.2211
supportedcontrol: 1.2.840.113556.1.4.2239
supportedcontrol: 1.2.840.113556.1.4.2255
supportedcontrol: 1.2.840.113556.1.4.2256
supportedcontrol: 1.2.840.113556.1.4.2309
supportedcontrol: 1.2.840.113556.1.4.2330
supportedcontrol: 1.2.840.113556.1.4.2354
supportedextension: 1.3.6.1.4.1.1466.20037
supportedextension: 1.3.6.1.4.1.1466.101.119.1
supportedextension: 1.2.840.113556.1.4.1781
supportedextension: 1.3.6.1.4.1.4203.1.11.3
supportedextension: 1.2.840.113556.1.4.2212
supportedldapversion: 3
supportedldapversion: 2
supportedsaslmechanisms: GSSAPI
supportedsaslmechanisms: GSS-SPNEGO
supportedsaslmechanisms: EXTERNAL
supportedsaslmechanisms: DIGEST-MD5

[+] 192.168.153.207:389 Discovered base DN: DC=daforest,DC=com
[*] Successfully queried (|(|(|(objectClass=organizationalPerson)(sAMAccountType=805306368))(objectcategory=user))(objectClass=user)).
[*] Successfully queried (|(LDAPDisplayName=description)(LDAPDisplayName=memberof)(LDAPDisplayName=name)(LDAPDisplayName=useraccountcontrol)(LDAPDisplayName=badpwdcount)(LDAPDisplayName=lastlogoff)(LDAPDisplayName=lastlogon)(LDAPDisplayName=pwdlastset)(LDAPDisplayName=logoncount)(LDAPDisplayName=samaccountname)).
CN=Administrator CN=Users DC=daforest DC=com
============================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Built-in account for administering the computer/domain
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2023-01-20 22:35:24 UTC
 logoncount          44
 memberof            CN=Group Policy Creator Owners,CN=Users,DC=daforest,DC=com || CN=Domain Admins,CN=Users,DC=daforest,DC=com || CN=Ent
                     erprise Admins,CN=Users,DC=daforest,DC=com || CN=Schema Admins,CN=Users,DC=daforest,DC=com || CN=Users,CN=Builtin,DC
                     =daforest,DC=com || CN=Administrators,CN=Builtin,DC=daforest,DC=com
 name                Administrator
 pwdlastset          133164016158726978
 samaccountname      Administrator
 useraccountcontrol  66048

CN=Guest CN=Users DC=daforest DC=com
====================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Built-in account for guest access to the computer/domain
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           1601-01-01 00:00:00 UTC
 logoncount          0
 memberof            CN=Guests,CN=Builtin,DC=daforest,DC=com
 name                Guest
 pwdlastset          0
 samaccountname      Guest
 useraccountcontrol  66082

CN=WIN-BRSHGJGIDFM OU=Domain Controllers DC=daforest DC=com
===========================================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2023-01-20 21:11:07 UTC
 logoncount          193
 memberof            CN=Pre-Windows 2000 Compatible Access,CN=Builtin,DC=daforest,DC=com || CN=Cert Publishers,CN=Users,DC=daforest,DC=co
                     m
 name                WIN-BRSHGJGIDFM
 pwdlastset          133164161927254513
 samaccountname      WIN-BRSHGJGIDFM$
 useraccountcontrol  532480

CN=krbtgt CN=Users DC=daforest DC=com
=====================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Key Distribution Center Service Account
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           1601-01-01 00:00:00 UTC
 logoncount          0
 memberof            CN=Denied RODC Password Replication Group,CN=Users,DC=daforest,DC=com
 name                krbtgt
 pwdlastset          133164161644084399
 samaccountname      krbtgt
 useraccountcontrol  514

[*] Auxiliary module execution completed
msf6 auxiliary(gather/ldap_query) > 
```

Example after:

```
msf6 > use auxiliary/gather/ldap_query
msf6 auxiliary(gather/ldap_query) > set VERBOSE true
VERBOSE => true
msf6 auxiliary(gather/ldap_query) > set RHOSTS 192.168.153.207
RHOSTS => 192.168.153.207
msf6 auxiliary(gather/ldap_query) > set BIND_DN DAFOREST\\Administrator
BIND_DN => DAFOREST\Administrator
msf6 auxiliary(gather/ldap_query) > set BIND_PW theAdmin123
BIND_PW => theAdmin123
msf6 auxiliary(gather/ldap_query) > run
[*] Running module against 192.168.153.207

[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[*] 192.168.153.207:389 Getting root DSE
[+] 192.168.153.207:389 Discovered base DN: DC=daforest,DC=com
[*] Successfully queried (|(|(|(objectClass=organizationalPerson)(sAMAccountType=805306368))(objectcategory=user))(objectClass=user)).
[*] Successfully queried (|(LDAPDisplayName=description)(LDAPDisplayName=memberof)(LDAPDisplayName=name)(LDAPDisplayName=useraccountcontrol)(LDAPDisplayName=badpwdcount)(LDAPDisplayName=lastlogoff)(LDAPDisplayName=lastlogon)(LDAPDisplayName=pwdlastset)(LDAPDisplayName=logoncount)(LDAPDisplayName=samaccountname)).
CN=Administrator CN=Users DC=daforest DC=com
============================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Built-in account for administering the computer/domain
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2023-01-20 22:35:24 UTC
 logoncount          44
 memberof            CN=Group Policy Creator Owners,CN=Users,DC=daforest,DC=com || CN=Domain Admins,CN=Users,DC=daforest,DC=com || CN=Ent
                     erprise Admins,CN=Users,DC=daforest,DC=com || CN=Schema Admins,CN=Users,DC=daforest,DC=com || CN=Users,CN=Builtin,DC
                     =daforest,DC=com || CN=Administrators,CN=Builtin,DC=daforest,DC=com
 name                Administrator
 pwdlastset          133164016158726978
 samaccountname      Administrator
 useraccountcontrol  66048

CN=Guest CN=Users DC=daforest DC=com
====================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Built-in account for guest access to the computer/domain
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           1601-01-01 00:00:00 UTC
 logoncount          0
 memberof            CN=Guests,CN=Builtin,DC=daforest,DC=com
 name                Guest
 pwdlastset          0
 samaccountname      Guest
 useraccountcontrol  66082

CN=WIN-BRSHGJGIDFM OU=Domain Controllers DC=daforest DC=com
===========================================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2023-01-20 21:11:07 UTC
 logoncount          193
 memberof            CN=Pre-Windows 2000 Compatible Access,CN=Builtin,DC=daforest,DC=com || CN=Cert Publishers,CN=Users,DC=daforest,DC=co
                     m
 name                WIN-BRSHGJGIDFM
 pwdlastset          133164161927254513
 samaccountname      WIN-BRSHGJGIDFM$
 useraccountcontrol  532480

CN=krbtgt CN=Users DC=daforest DC=com
=====================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Key Distribution Center Service Account
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           1601-01-01 00:00:00 UTC
 logoncount          0
 memberof            CN=Denied RODC Password Replication Group,CN=Users,DC=daforest,DC=com
 name                krbtgt
 pwdlastset          133164161644084399
 samaccountname      krbtgt
 useraccountcontrol  514

[*] Auxiliary module execution completed
msf6 auxiliary(gather/ldap_query) > 
```