### PR TITLE
Fix up text so we capitalize all words of Metasploit Framework

### DIFF
--- a/docs/metasploit-framework.wiki/Metasploit-Data-Service-Enhancements-Goliath.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Data-Service-Enhancements-Goliath.md
@@ -25,14 +25,14 @@ The current data storage mechanism couples the metasploit core framework code to
 * The ability to support/use different data storage technologies is difficult
 * Promotes a monolithic architecture where poor performance in any segment of the software affects the entire system (large network scans)
 
-Our solution to this is a data service proxy.  A data service proxy allows us to separate core metasploit framework code from the underlying data service technology.  The `framework.db` reference to data services is no longer tied directly to the underlying data storage, but instead all calls are proxied to an underlying implementation.
+Our solution to this is a data service proxy.  A data service proxy allows us to separate core Metasploit Framework code from the underlying data service technology.  The `framework.db` reference to data services is no longer tied directly to the underlying data storage, but instead all calls are proxied to an underlying implementation.
 
 Currently we plan to support the legacy data storage technology stack (RAILS/PostgreSQL) which we hope to eventually phase out.  The new implementation will use a RESTful (https://en.wikipedia.org/wiki/Representational_state_transfer) approach whereby calls to `framework.db` can be proxied to a remote web service that supports the same data service API.  We have built a web service that runs atop the current data storage service for the community.
 
 This approach enables us to:
-* More easily enhance the metasploit data model 
-* Run a web-based data service independent of the metasploit framework
-    * Reduces the memory used by a metasploit framework instance using a data service by no longer requiring a DB client
+* More easily enhance the metasploit data model
+* Run a web-based data service independent of the Metasploit Framework
+    * Reduces the memory used by a Metasploit Framework instance using a data service by no longer requiring a DB client
     *  Increases throughput as storage calls don't necessarily need to be asynchronous
     *  Allow teams to collaborate easily by connecting to a centralized data service
 * Quickly build out data services that leverage different technology stacks

--- a/external/burp-proxy/readme.txt
+++ b/external/burp-proxy/readme.txt
@@ -1,9 +1,9 @@
-=[Burp proxy WMAP Plugin				                     spinbad.security@googlemail.com 
+=[Burp proxy WMAP Plugin				                     spinbad.security@googlemail.com
 ------------------------------------------------------------------------------------------------------------
 
 
 =[ Intro.
-	
+
 Simple plugin for the burp proxy 1.1/1.2 which stores the requests
 in the metasploit/wmap database. At the moment only
 sqlite3 is supported, I will add support for other databases
@@ -14,14 +14,14 @@ in later releases...
 
 1. Download burp proxy 1.2: http://portswigger.net/suite/burpsuite_v1.2.zip
 2. Download SQLiteJDBC Jar: http://www.zentus.com/sqlitejdbc/
-3. Copy sqlitejdbc-v054.jar and wmapplugin.jar into the burp proxy directory 
+3. Copy sqlitejdbc-v054.jar and wmapplugin.jar into the burp proxy directory
 4. Run the following command:
 
-   java -cp sqlitejdbc-v054.jar;burpsuite_v1.2.jar;wmap_plugin_v0.1-burp_v1.2.jar burp.StartBurp database=test.db   
+   java -cp sqlitejdbc-v054.jar;burpsuite_v1.2.jar;wmap_plugin_v0.1-burp_v1.2.jar burp.StartBurp database=test.db
 
    test.db is the name/path of your metasploit sqlite3 database file. You must create the db schema
-   in the metasploit framework first (by using "db_create")   
-	
+   in the Metasploit Framework first (by using "db_create")
+
 
 =[ Questions/Answers
 
@@ -29,14 +29,14 @@ in later releases...
 1. Can I use the burp spider to fill my WMAP request table?
 
    Sorry, no you can't. The reason is that the spider doesn't call implementations of the IBurpExtender
-   interface. So you can only use the MITM Proxy. 
+   interface. So you can only use the MITM Proxy.
 
 
 2. I found a bug, what can I do?
-  
+
    You can send a description to spinbad.security@googlemail.com. I will try to fix it.
 
 3. Is there a way to extend the stuff you wrote?
-   Shure, I included the source code in the jar file. Feel free to use it.      
+   Shure, I included the source code in the jar file. Feel free to use it.
 
-=[ EOF. 
+=[ EOF.

--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -1,5 +1,5 @@
 #
-# Web assessment for the metasploit framework
+# Web assessment for the Metasploit Framework
 # Efrain Torres    - et[ ] metasploit.com  2012
 #
 

--- a/tools/hardware/README.md
+++ b/tools/hardware/README.md
@@ -3,7 +3,7 @@ HWBridge Tools
 This folder contains hardware related tools that are compatible with the HWBridge interface.
 Commonly this will be a repository of different hardware relay services.  If your device
 requires communication via serial or USB or some other non-ethernet means and you want
-to utilize the metasploit framework for handling the HTTP server then feel free to put
+to utilize the Metasploit Framework for handling the HTTP server then feel free to put
 your relay here.
 
 If however your device supports WiFi or Ethernet, then consider building the HWBridge


### PR DESCRIPTION
This fixes another one of @ccondon-r7's requests and capitalizes both words in Metasploit Framework throughout all of the code. I skipped one instance that was in a spec test since that change seems to be for code in Metasploit Pro and will likely break things.

## Verification
- [ ] Verify changes look good.
