### PR TITLE
Fix deprecation warning in socks proxy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,7 +345,7 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.28)
+    rex-core (0.1.29)
     rex-encoder (0.1.6)
       metasm
       rex-arch
@@ -375,7 +375,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.43)
+    rex-socket (0.1.45)
       rex-core
     rex-sslscan (0.1.8)
       rex-core


### PR DESCRIPTION
closes https://github.com/rapid7/metasploit-framework/issues/15849
Original fix: https://github.com/rapid7/rex-socket/pull/54

Fixes a deprecation warning when using socks proxy support in Metasploit

## Verification

Steps:

```
use server/socks_proxy
run

use scanner/http/title
run proxies=socks5:127.0.0.1:1080 https://google.com
```

### Before

Warning generated:

```
msf6 auxiliary(scanner/http/title) > run proxies=socks5:127.0.0.1:1080 https://google.com
NOTE: Rex::Socket.gethostbyname is deprecated, use getaddress, resolve_nbo, or similar instead. It will be removed in the next Major version

[+] [142.250.200.46:443] [C:301] [R:https://www.google.com/] [S:gws] 301 Moved
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### After

No warning

```
msf6 auxiliary(scanner/http/title) > run proxies=socks5:127.0.0.1:1080 https://google.com

[+] [142.250.200.46:443] [C:301] [R:https://www.google.com/] [S:gws] 301 Moved
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
