### PR TITLE
Adds support to display options with conditions

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -544,48 +544,66 @@ class ReadableText
   # @param missing [Boolean] dump only empty required options.
   # @return [String] the string form of the information.
   def self.dump_options(mod, indent = '', missing = false)
-    tbl = Rex::Text::Table.new(
-      'Indent'  => indent.length,
-      'Columns' =>
-        [
-          'Name',
-          'Current Setting',
-          'Required',
-          'Description'
-        ])
+    options = mod.options.map { |_name, option| option }
+    options_grouped_by_conditions = options.group_by(&:conditions)
 
-    mod.options.sorted.each do |name, opt|
-      if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
-        val = mod.datastore[name]
-      else
-        val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
-      end
+    options_with_conditions = ''.dup
+    options_without_conditions = ''.dup
 
-      next unless Msf::OptCondition.show_option(mod, opt)
-      next if (opt.advanced?)
-      next if (opt.evasion?)
-      next if (missing && opt.valid?(val))
+    options_grouped_by_conditions.each do |conditions, options|
+      tbl = Rex::Text::Table.new(
+        'Indent' => indent.length,
+        'Columns' =>
+          [
+            'Name',
+            'Current Setting',
+            'Required',
+            'Description'
+          ])
 
-      desc = opt.desc.dup
+      options.sort_by(&:name).each do |opt|
+        name = opt.name
+        if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
+          val = mod.datastore[name]
+        else
+          val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+        end
 
-      # Hint at RPORT proto by regexing mixins
-      if name == 'RPORT' && opt.kind_of?(Msf::OptPort)
-        mod.class.included_modules.each do |m|
-          case m.name
-          when /tcp/i, /HttpClient$/
-            desc << ' (TCP)'
-            break
-          when /udp/i
-            desc << ' (UDP)'
-            break
+        next if (opt.advanced?)
+        next if (opt.evasion?)
+        next if (missing && opt.valid?(val))
+
+        desc = opt.desc.dup
+
+        # Hint at RPORT proto by regexing mixins
+        if name == 'RPORT' && opt.kind_of?(Msf::OptPort)
+          mod.class.included_modules.each do |m|
+            case m.name
+            when /tcp/i, /HttpClient$/
+              desc << ' (TCP)'
+              break
+            when /udp/i
+              desc << ' (UDP)'
+              break
+            end
           end
         end
+
+        tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", desc ]
       end
 
-      tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", desc ]
+      next if conditions.any? && tbl.rows.empty?
+
+      if conditions.any?
+        options_with_conditions << "\n\n#{indent}When #{Msf::OptCondition.format_conditions(mod, options.first)}:\n\n"
+        options_with_conditions << tbl.to_s
+      else
+        options_without_conditions << tbl.to_s
+      end
     end
 
-    return tbl.to_s
+    result = "#{options_without_conditions}#{options_with_conditions}"
+    result
   end
 
   # Dumps the advanced options associated with the supplied module.
@@ -594,28 +612,47 @@ class ReadableText
   # @param indent [String] the indentation to use.
   # @return [String] the string form of the information.
   def self.dump_advanced_options(mod, indent = '')
-    tbl = Rex::Text::Table.new(
-      'Indent'  => indent.length,
-      'Columns' =>
-        [
-          'Name',
-          'Current Setting',
-          'Required',
-          'Description'
-        ])
+    options = mod.options.map { |_name, option| option }
+    options_grouped_by_conditions = options.group_by(&:conditions)
 
-    mod.options.sorted.each do |name, opt|
-      next unless opt.advanced?
-      next unless Msf::OptCondition.show_option(mod, opt)
-      if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
-        val = mod.datastore[name]
-      else
-        val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+    options_with_conditions = ''.dup
+    options_without_conditions = ''.dup
+
+    options_grouped_by_conditions.each do |conditions, options|
+      tbl = Rex::Text::Table.new(
+        'Indent' => indent.length,
+        'Columns' =>
+          [
+            'Name',
+            'Current Setting',
+            'Required',
+            'Description'
+          ])
+
+      options.sort_by(&:name).each do |opt|
+        next unless opt.advanced?
+
+        name = opt.name
+        if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
+          val = mod.datastore[name]
+        else
+          val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+        end
+        tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
       end
-      tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
+
+      next if conditions.any? && tbl.rows.empty?
+
+      if conditions.any?
+        options_with_conditions << "\n\n#{indent}Active when #{Msf::OptCondition.format_conditions(mod, options.first)}:\n\n"
+        options_with_conditions << tbl.to_s
+      else
+        options_without_conditions << tbl.to_s
+      end
     end
 
-    return tbl.to_s
+    result = "#{options_without_conditions}#{options_with_conditions}"
+    result
   end
 
   # Dumps the evasion options associated with the supplied module.
@@ -624,27 +661,46 @@ class ReadableText
   # @param indent [String] the indentation to use.
   # @return [String] the string form of the information.
   def self.dump_evasion_options(mod, indent = '')
-    tbl = Rex::Text::Table.new(
-      'Indent'  => indent.length,
-      'Columns' =>
-        [
-          'Name',
-          'Current Setting',
-          'Required',
-          'Description'
-        ])
+    options = mod.options.map { |_name, option| option }
+    options_grouped_by_conditions = options.group_by(&:conditions)
 
-    mod.options.sorted.each do |name, opt|
-      next unless opt.evasion?
-      if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
-        val = mod.datastore[name]
-      else
-        val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+    options_with_conditions = ''.dup
+    options_without_conditions = ''.dup
+
+    options_grouped_by_conditions.each do |conditions, options|
+      tbl = Rex::Text::Table.new(
+        'Indent'  => indent.length,
+        'Columns' =>
+          [
+            'Name',
+            'Current Setting',
+            'Required',
+            'Description'
+          ])
+
+      options.sort_by(&:name).each do |opt|
+        next unless opt.evasion?
+
+        name = opt.name
+        if mod.datastore.is_a?(Msf::DataStoreWithFallbacks)
+          val = mod.datastore[name]
+        else
+          val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
+        end
+        tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
       end
-      tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
-    end
 
-    return tbl.to_s
+      next if conditions.any? && tbl.rows.empty?
+
+      if conditions.any?
+        options_with_conditions << "\n\n#{indent}When #{Msf::OptCondition.format_conditions(mod, options.first)}:\n\n"
+        options_with_conditions << tbl.to_s
+      else
+        options_without_conditions << tbl.to_s
+      end
+    end
+    result = "#{options_without_conditions}#{options_with_conditions}"
+    result
   end
 
   # Dumps the references associated with the supplied module.
@@ -1063,4 +1119,3 @@ class ReadableText
 end
 
 end end
-

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
@@ -11,6 +11,8 @@ module Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
   # @param [Array<String>] auth_methods The allowed auth methods
   # @see Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options::Msf::Exploit::Remote::AuthOption
   def kerberos_auth_options(protocol:, auth_methods:)
+    option_conditions = ["#{protocol}::Auth", '==', 'kerberos']
+
     etype_regex = "(#{Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.map { |v| Regexp.escape(v) }.join('|')})"
     offered_enc_types_option = Msf::OptString.new(
       "#{protocol}KrbOfferedEncryptionTypes",
@@ -19,7 +21,8 @@ module Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
         'Kerberos encryption types to offer',
         Msf::Exploit::Remote::AuthOption::KERBEROS_DEFAULT_OFFERED_ENC_TYPES.join(',')
       ],
-      regex: Regexp.new("(#{etype_regex},)*#{etype_regex}", options: Regexp::IGNORECASE)
+      regex: Regexp.new("(#{etype_regex},)*#{etype_regex}", options: Regexp::IGNORECASE),
+      conditions: option_conditions
     )
 
     auth_options = [
@@ -31,14 +34,17 @@ module Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
         "#{protocol}Rhostname",
         [false, 'The rhostname which is required for kerberos - the SPN'],
         fallbacks: ['Rhostname'],
+        conditions: option_conditions
       ),
       Msf::OptAddress.new(
         'DomainControllerRhost',
         [false, 'The resolvable rhost for the Domain Controller'],
+        conditions: option_conditions
       ),
       Msf::OptPath.new(
         "#{protocol}Krb5Ccname",
         [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))],
+        conditions: option_conditions
       )
     ]
 

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage.rb
@@ -18,6 +18,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket
     # @param [String,nil] protocol The service protocol type, i.e. smb/ldap/winrm/mssql
     # @return [Array<Msf::OptEnum>]
     def kerberos_storage_options(protocol: nil)
+      option_conditions = ["#{protocol}::Auth", '==', 'kerberos']
       [
         Msf::OptEnum.new(
           'KrbCacheMode',
@@ -25,8 +26,9 @@ module Msf::Exploit::Remote::Kerberos::Ticket
             true,
             'Kerberos ticket cache storage mode',
             'read-write',
-            %w[ none read-only write-only read-write ]
-          ]
+            %w[none read-only write-only read-write]
+          ],
+          conditions: option_conditions
         )
       ]
     end

--- a/lib/msf/core/opt_condition.rb
+++ b/lib/msf/core/opt_condition.rb
@@ -1,8 +1,11 @@
 # -*- coding: binary -*-
+
 module Msf
   module OptCondition
-
     # Check a condition's result
+    # @param [Msf::Module] mod The module module
+    # @param [Msf::OptBase] opt the option which has conditions present
+    # @return [String]
     def self.eval_condition(left_value, operator, right_value)
       case operator.to_sym
       when :==
@@ -13,6 +16,38 @@ module Msf
         right_value.include?(left_value)
       when :nin
         !right_value.include?(left_value)
+      end
+    end
+
+    # Format an option's conditions as a human readable string
+    # @param [Msf::Module] mod The module module
+    # @param [Msf::OptBase] opt the option which has conditions present
+    # @return [String]
+    def self.format_conditions(_mod, opt)
+      left_source = opt.conditions[0]
+      operator = opt.conditions[1]
+      right_value = opt.conditions[2]
+      expects_blank_values = Array(right_value).all?(&:blank?)
+
+      case operator.to_sym
+      when :==
+        "#{left_source} is #{right_value}"
+      when :!=
+        "#{left_source} is not #{right_value}"
+      when :in
+        if expects_blank_values
+          return "#{left_source} is blank"
+        end
+
+        "#{left_source} is one of #{right_value.join(',')}"
+      when :nin
+        if expects_blank_values
+          return "#{left_source} is not blank"
+        end
+
+        "#{left_source} not in #{right_value.join(',')}"
+      else
+        "#{left_source} #{operator} #{right_value}"
       end
     end
 
@@ -36,6 +71,5 @@ module Msf
       show ||= eval_condition(left_value.to_s, operator, right_value) if left_value.is_a?(Symbol)
       show
     end
-
   end
 end

--- a/spec/lib/msf/base/serializer/readable_text_spec.rb
+++ b/spec/lib/msf/base/serializer/readable_text_spec.rb
@@ -8,6 +8,61 @@ RSpec.describe Msf::Serializer::ReadableText do
   let(:indent_string) { '' }
   let(:indent_length) { indent_string.length }
 
+  let(:default_module_options) do
+    [
+      Msf::Opt::RHOSTS,
+      Msf::Opt::RPORT(3000),
+      Msf::OptString.new(
+        'foo',
+        [true, 'Foo option', 'bar']
+      ),
+      Msf::OptString.new(
+        'fizz',
+        [true, 'fizz option', 'buzz']
+      ),
+      Msf::OptString.new(
+        'baz',
+        [true, 'baz option', 'qux']
+      ),
+      Msf::OptString.new(
+        'OptionWithModuleDefault',
+        [true, 'option with module default', true]
+      ),
+      Msf::OptFloat.new('FloatValue', [false, 'A FloatValue ', 3.5]),
+      Msf::OptString.new(
+        'NewOptionName',
+        [true, 'An option with a new name. Aliases ensure the old and new names are synchronized', 'default_value'],
+        aliases: ['OLD_OPTION_NAME']
+      ),
+      Msf::OptString.new(
+        'SMBUser',
+        [true, 'The SMB username'],
+        fallbacks: ['username']
+      ),
+      Msf::OptString.new(
+        'SMBDomain',
+        [true, 'The SMB username', 'WORKGROUP'],
+        aliases: ['WindowsDomain'],
+        fallbacks: ['domain']
+      )
+    ]
+  end
+
+  let(:default_advanced_module_options) do
+    [
+      Msf::OptEnum.new('DigestAlgorithm', [ true, 'The digest algorithm to use', 'SHA256', %w[SHA1 SHA256] ])
+    ]
+  end
+
+  let(:module_options) { default_module_options }
+  let(:advanced_module_options) { default_advanced_module_options }
+
+  # (see Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options#kerberos_auth_options)
+  def kerberos_auth_options(protocol:, auth_methods:)
+    mixin = Class.new.extend(Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options)
+    mixin.kerberos_auth_options(protocol: protocol, auth_methods: auth_methods)
+  end
+
   let(:aux_mod) do
     mod_klass = Class.new(Msf::Auxiliary) do
       def initialize
@@ -22,50 +77,12 @@ RSpec.describe Msf::Serializer::ReadableText do
             'baz' => 'baz_from_module'
           },
         )
-
-        register_options(
-          [
-            Msf::Opt::RHOSTS,
-            Msf::Opt::RPORT(3000),
-            Msf::OptString.new(
-              'foo',
-              [true, 'Foo option', 'bar']
-            ),
-            Msf::OptString.new(
-              'fizz',
-              [true, 'fizz option', 'buzz']
-            ),
-            Msf::OptString.new(
-              'baz',
-              [true, 'baz option', 'qux']
-            ),
-            Msf::OptString.new(
-              'OptionWithModuleDefault',
-              [true, 'option with module default', true]
-            ),
-            Msf::OptFloat.new('FloatValue', [false, 'A FloatValue ', 3.5]),
-            Msf::OptString.new(
-              'NewOptionName',
-              [true, 'An option with a new name. Aliases ensure the old and new names are synchronized', 'default_value'],
-              aliases: ['OLD_OPTION_NAME']
-            ),
-            Msf::OptString.new(
-              'SMBUser',
-              [true, 'The SMB username'],
-              fallbacks: ['username']
-            ),
-            Msf::OptString.new(
-              'SMBDomain',
-              [true, 'The SMB username', 'WORKGROUP'],
-              aliases: ['WindowsDomain'],
-              fallbacks: ['domain']
-            )
-          ]
-        )
       end
     end
 
     mod = mod_klass.new
+    mod.send(:register_options, module_options)
+    mod.send(:register_advanced_options, advanced_module_options)
     mock_framework = instance_double(::Msf::Framework, datastore: Msf::DataStore.new)
     allow(mod).to receive(:framework).and_return(mock_framework)
     mod
@@ -94,7 +111,7 @@ RSpec.describe Msf::Serializer::ReadableText do
         expect(described_class.dump_datastore('Table name', Msf::DataStore.new, indent_length)).to match_table <<~TABLE
           Table name
           ==========
-  
+
           No entries in data store.
         TABLE
       end
@@ -105,9 +122,10 @@ RSpec.describe Msf::Serializer::ReadableText do
         expect(described_class.dump_datastore('Table name', aux_mod_with_set_options.datastore, indent_length)).to match_table <<~TABLE
           Table name
           ==========
-  
+
           Name                     Value
           ----                     -----
+          DigestAlgorithm          SHA256
           FloatValue               5
           NewOptionName
           OptionWithModuleDefault  false
@@ -152,6 +170,38 @@ RSpec.describe Msf::Serializer::ReadableText do
           Name           Current Setting  Required  Description
           ----           ---------------  --------  -----------
           NewOptionName                   yes       An option with a new name. Aliases ensure the old and new names are synchronized
+        TABLE
+      end
+    end
+  end
+
+  describe '.dump_advanced_options', if: ENV['DATASTORE_FALLBACKS'] do
+    context 'when kerberos options are present' do
+      let(:advanced_module_options) do
+        [
+          *default_advanced_module_options,
+          *kerberos_auth_options(protocol: 'Winrm', auth_methods: Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS),
+        ]
+      end
+
+      it 'returns the options as a table' do
+        expect(described_class.dump_advanced_options(aux_mod_with_set_options, indent_string)).to match_table <<~TABLE
+          Name             Current Setting  Required  Description
+          ----             ---------------  --------  -----------
+          DigestAlgorithm  SHA256           yes       The digest algorithm to use (Accepted: SHA1, SHA256)
+          VERBOSE          false            no        Enable detailed status messages
+          WORKSPACE                         no        Specify the workspace for this module
+          WinrmAuth        auto             yes       The Authentication mechanism to use (Accepted: auto, ntlm, kerberos, plaintext)
+
+
+          Active when Winrm::Auth is kerberos:
+
+          Name                            Current Setting                                   Required  Description
+          ----                            ---------------                                   --------  -----------
+          DomainControllerRhost                                                             no        The resolvable rhost for the Domain Controller
+          WinrmKrb5Ccname                                                                   no        The ccache file to use for kerberos authentication
+          WinrmKrbOfferedEncryptionTypes  AES256,AES128,RC4-HMAC,DES-CBC-MD5,DES3-CBC-SHA1  yes       Kerberos encryption types to offer
+          WinrmRhostname                                                                    no        The rhostname which is required for kerberos - the SPN
         TABLE
       end
     end

--- a/spec/lib/msf/core/opt_condition_spec.rb
+++ b/spec/lib/msf/core/opt_condition_spec.rb
@@ -1,0 +1,42 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::OptCondition do
+  describe '.format_conditions' do
+    [
+      {
+        conditions: ['Winrm::Auth', '==', 'kerberos'],
+        expected: 'Winrm::Auth is kerberos'
+      },
+      {
+        conditions: %w[TARGET != Automatic],
+        expected: 'TARGET is not Automatic'
+      },
+      {
+        conditions: ['ACTION', 'in', %w[VSS_MOUNT VSS_UNMOUNT]],
+        expected: 'ACTION is one of VSS_MOUNT,VSS_UNMOUNT'
+      },
+      {
+        conditions: ['Winrm::Auth', 'nin', ['kerberos', 'plain']],
+        expected: 'Winrm::Auth not in kerberos,plain'
+      },
+      {
+        conditions: ['ScheduleRemoteSystem', 'in', [nil, '']],
+        expected: 'ScheduleRemoteSystem is blank'
+      },
+      {
+        conditions: ['ScheduleRemoteSystem', 'nin', [nil, '']],
+        expected: 'ScheduleRemoteSystem is not blank'
+      },
+    ].each do |test|
+      context "when the conditions are #{test[:conditions].inspect}" do
+        it "returns the expected string #{test[:expected]}" do
+          mod = instance_double(Msf::Module)
+          option = Msf::OptString.new('foo', conditions: test[:conditions])
+          expect(described_class.format_conditions(mod, option)).to eq test[:expected]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support to the appropriate `show` commands to include options with conditions. This PR includes test for this new output as well.

Commands updated:
- `show options`
- `show advanced`
- `show evasion`

## Note
There are currently no `register_evasion_options` making use of conditions, so I added one in manually to test. See image below

### `show options`
![image](https://user-images.githubusercontent.com/69522014/214060732-71f149af-750b-4ca7-9391-654b96a058bc.png)

### `show advanced`
![image](https://user-images.githubusercontent.com/69522014/214060975-523b7a27-91f8-4dae-87ee-5a7945e1153d.png)

### `show evasion`
![image](https://user-images.githubusercontent.com/69522014/214061084-3610d6e4-09c5-4a2e-aca9-a76d0377adcd.png)

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use ldap_query`
- [ ] **Verify** that the conditional options are being output for `show options`
- [ ] **Verify** that the conditional options are being output for `show advanced`
- [ ] **Optional** verify that the conditional options are being output for `show evasions` (will require manually adding this)
