### PR TITLE
Add conditions metadata to forge_ticket module

### DIFF
--- a/modules/auxiliary/admin/kerberos/forge_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/forge_ticket.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('AES_KEY', [ false, 'The krbtgt/service AES key' ]),
         OptString.new('DOMAIN', [ true, 'The Domain (upper case) Ex: DEMO.LOCAL' ]),
         OptString.new('DOMAIN_SID', [ true, 'The Domain SID, Ex: S-1-5-21-1755879683-3641577184-3486455962']),
-        OptString.new('SPN', [ false, 'The Service Principal Name (Only used for silver ticket)']),
+        OptString.new('SPN', [ false, 'The Service Principal Name (Only used for silver ticket)'], conditions: %w[ACTION == FORGE_SILVER]),
         OptInt.new('DURATION', [ true, 'Duration of the ticket in days', 3650]),
       ]
     )


### PR DESCRIPTION
Addition to https://github.com/rapid7/metasploit-framework/pull/17526

Adds conditions metadata to the forge_ticket module

## Verification

Verify `show options` works as expected

![image](https://user-images.githubusercontent.com/60357436/214307628-598ef0a5-7fd7-4105-9a23-446c93a4d44e.png)
