### PR TITLE
Fix bad DN discovery code and fix bug with querying schema data

### DIFF
--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -265,8 +265,14 @@ module Msf
         return
       end
 
-      # NOTE: We assume the first namingContexts value is the base DN
-      base_dn = naming_contexts.first
+      # NOTE: Find the first entry that starts with `DC=` as this will likely be the base DN.
+      naming_contexts.select! {|context| context =~ /^(DC=[A-Za-z0-9-]+,?)+$/}
+      naming_contexts.reject! {|context| context =~ /(Configuration)|(Schema)|(ForestDnsZones)/}
+      if naming_contexts.blank?
+        print_error("#{peer} A base DN matching the expected format could not be found!")
+        return
+      end
+      base_dn = naming_contexts[0]
 
       print_good("#{peer} Discovered base DN: #{base_dn}")
       base_dn


### PR DESCRIPTION
Fix #17429 

Previously the code was failing when querying a child domain due to two reasons:
1. We assumed when automatically discovering the naming contexts that the first naming context returned would always be the base DN. This is not always the case as with child domains it can sometimes be the last entry as noted in my tests. To solve this and to avoid positional issues, I updated the code to use some regexes to first filter out only entries that start with `DN=`, and then to not include certain known bad entries that we want to ignore.
2. We were trying to retrieve schema information using the child domain's base DN. All schema information is stored under the parent domain's DN and we need to use this when querying for schema information. I added a new function, `find_schema_dn` to do this, which will simply grab the `objectCategory` of the base DN object for the domain we are currently querying and then perform some regex to remove the extra `CA=` entries so we just get the naming context of the parent domain we need to query for the schema information.

## Verification

List the steps needed to make sure this thing works

- [ ] Set up an environment where you have a parent domain.
- [ ] Add a new domain using the same type of machine, but set it up as a child domain linked to the parent.
- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/ldap_query`
- [ ] Set RHOST, DOMAIN, USERNAME, PASSWORD
- [ ] `run`
- [ ] **Verify** that the full data is returned and you don't get any errors about incorrect names or redirects.
