### PR TITLE
Add NTLM Hash Extraction via PKINIT to get_ticket

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -444,8 +444,57 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     )
   end
 
+  # Request a service ticket to a user on behalf of themselves
+  # This is mostly useful for PKINIT to recover the NT hash
+  #
+  # @see https://learn.microsoft.com/en-us/archive/blogs/openspecification/how-kerberos-user-to-user-authentication-works
+  #
+  # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential from the TGT
+  # @param [Hash] options
+  def u2uself(credential, options = {})
+    realm = self.realm.upcase
+    client_name = options.fetch(:username) { self.username }
+    sname = options.fetch(:sname) {
+      Rex::Proto::Kerberos::Model::PrincipalName.new(
+        name_type: Rex::Proto::Kerberos::Model::NameType::NT_UNKNOWN,
+        name_string: [ client_name ]
+      )
+    }
 
-  private
+    now = Time.now.utc
+    expiry_time = now + 1.day
+
+    ticket = Rex::Proto::Kerberos::Model::Ticket.decode(credential.ticket.value)
+    session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
+      type: credential.keyblock.enctype.value,
+      value: credential.keyblock.data.value
+    )
+
+    etypes = Set.new([ticket.enc_part.etype])
+    etypes << Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC
+
+    tgs_options = {
+      ticket_storage: options.fetch(:ticket_storage, @ticket_storage),
+      credential_cache_username: client_name,
+      additional_flags: [
+        Rex::Proto::Kerberos::Model::KdcOptionFlags::ENC_TKT_IN_SKEY,
+        Rex::Proto::Kerberos::Model::KdcOptionFlags::RENEWABLE_OK
+      ],
+      additional_tickets: [ticket]
+    }
+
+    request_service_ticket(
+      session_key,
+      ticket,
+      realm,
+      client_name,
+      etypes,
+      expiry_time,
+      now,
+      sname,
+      tgs_options
+    )
+  end
 
   # Authenticate with credentials to the key distribution center (KDC). This will request a TGT only.
   #
@@ -510,8 +559,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       value: credential.keyblock.data.value
     )
 
-    { credential: credential, session_key: session_key }
+    { credential: credential, session_key: session_key, krb_enc_key: tgt_result.krb_enc_key }
   end
+
+  private
 
   # Authenticate with a ticket-granting-service (TGS). This method will not contact the KDC and can not request a
   # delegation ticket.

--- a/lib/rex/proto/kerberos/pac/krb5_pac.rb
+++ b/lib/rex/proto/kerberos/pac/krb5_pac.rb
@@ -237,7 +237,7 @@ module Rex::Proto::Kerberos::Pac
     # @!attribute [rw] extra_sids_ptr
     #   @return [Integer] A pointer to a list of KERB_SID_AND_ATTRIBUTES structures that contain a list of SIDs
     #   corresponding to groups in domains other than the account domain to which the principal belongs
-    krb5_sid_and_attributes_ptr :extra_sids_ptr, length: :sid_count
+    krb5_sid_and_attributes_ptr :extra_sids_ptr
 
     # @!attribute [rw] resource_group_domain_sid_ptr
     #   @return [Integer] Pointer to SID of the domain for the server whose resources the client is authenticating to

--- a/lib/rex/proto/kerberos/pac/krb5_pac.rb
+++ b/lib/rex/proto/kerberos/pac/krb5_pac.rb
@@ -38,8 +38,9 @@ module Rex::Proto::Kerberos::Pac
     ndr_uint32 :attributes
   end
 
-  class Krb5SidAndAttributesPtr < Krb5SidAndAttributes
-    default_parameters byte_align: 1
+  class Krb5SidAndAttributesPtr < RubySMB::Dcerpc::Ndr::NdrConfArray
+    default_parameters byte_align: 1, type: :krb5_sid_and_attributes
+
     extend RubySMB::Dcerpc::Ndr::PointerClassPlugin
   end
 


### PR DESCRIPTION
This adds NTLM hash recover to the `kerberos/get_ticket` module. It moved the code from the certifiried module where it was originally implemented and adds a new `GET_HASH` action. Maybe the action would be more clear as GET_TGS_U2U_HASH, I'm open to suggestions.

This requires #17533. If you merge this first, you'll be merging those changes as well. This is just the last two commits.

## Verification
- [ ] Use the `kerberos/get_ticket` module
- [ ] Run the `GET_HASH` 
- [ ] Confirm certified is still working
- [ ] See the tickets are stored in `klist` and the NTLM hash is stored in creds
