### PR TITLE
Fix smb login crash with kerberos options set

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -10,6 +10,8 @@ class MetasploitModule < Msf::Auxiliary
   # Exploit mixins should be called first
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::SMB::Client
+  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
   # Scanner mixin should be near last
   include Msf::Auxiliary::Scanner
@@ -36,6 +38,13 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author' => ['hdm', 'Spencer McIntyre', 'Christophe De La Fuente'],
       'License' => MSF_LICENSE
+    )
+
+    register_advanced_options(
+      [
+        *kerberos_storage_options(protocol: 'SMB'),
+        *kerberos_auth_options(protocol: 'SMB', auth_methods: Msf::Exploit::Remote::AuthOption::SMB_OPTIONS),
+      ]
     )
 
     deregister_options('RPORT', 'SMBDIRECT', 'SMB::ProtocolVersion')


### PR DESCRIPTION
Updates `scanner/smb/smb_version` to no longer crash if Kerberos options are specified

This fixes the crash, but I feel like we should do additional fingerprinting if Kerberos details are supplied

## Verification

### Before

Crashes looking for kerberos storage

```
msf6 auxiliary(scanner/smb/smb_version) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smbauth=kerberos domaincontrollerrhost=192.168.123.13 smbrhostname=dc3.adf3.local domain=adf3.local krbofferedencryptiontypes=RC4-HMAC

[-] 192.168.123.13:445    - 192.168.123.13: NameError undefined local variable or method `kerberos_ticket_storage' for #<Module:auxiliary/scanner/smb/smb_version etc...

```

### After

No crash looking for kerberos storage

```
msf6 auxiliary(scanner/smb/smb_version) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smbauth=kerberos domaincontrollerrhost=192.168.123.13 smbrhostname=dc3.adf3.local domain=adf3.local

[*] 192.168.123.13:445    - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:) (encryption capabilities:AES-128-GCM) (signatures:required) (uptime:21m 9s) (guid:{36ff5567-d592-4344-8d89-21a1c931b02c}) (authentication domain:ADF3)
[*] 192.168.123.13:       - Scanned 1 of 
```