### PR TITLE
Handle KDC_ERR_CERTIFICATE_MISMATCH for certifried

### DIFF
--- a/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
@@ -372,7 +372,12 @@ class MetasploitModule < Msf::Auxiliary
 
       [ccache.credentials.first, tgt_result.krb_enc_key[:key]]
     rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
-      print_error("Failed: #{e.message}")
+      case e.error_code
+      when Rex::Proto::Kerberos::Model::Error::ErrorCodes::KDC_ERR_CERTIFICATE_MISMATCH
+        print_error("Failed: #{e.message}, Target system is likely not vulnerable to Certifried")
+      else
+        print_error("Failed: #{e.message}")
+      end
       nil
     end
   end


### PR DESCRIPTION
Related:
- https://github.com/rapid7/metasploit-framework/pull/17539 
- https://github.com/rapid7/metasploit-framework/pull/17535

The patch for certifried was returning an error code 66 which we didn't have a mapping for, this adds the mapping and handles that special case

I needed to disable the mitigation setting the reg keys mentioned here otherwise I was getting an "unknown" error 66 which is supposed to be 0x42 here https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4771
KDC_ERR_CERTIFICATE_MISMATCH

https://support.microsoft.com/en-us/topic/kb5014754-certificate-based-authentication-changes-on-windows-domain-controllers-ad2c23b0-15d8-4340-a468-4d4f3b188f16#bkmk_kdcregkey

Before: 
```
msf6 auxiliary(admin/dcerpc/cve_2022_26923_certifried) > authenticate
[*] Running module against 192.168.176.3

[+] [2023.01.25-16:51:04] 192.168.176.3:445 - Successfully authenticated to LDAP (192.168.176.3:636)
[+] [2023.01.25-16:51:07] 192.168.176.3:445 - Successfully created windomain.local\DESKTOP-Y6ZSFN9K$
[+] [2023.01.25-16:51:07] 192.168.176.3:445 -   Password: 5hZqAP5Y9AmXnVsnSw4EZcktAHDHxu0q
[+] [2023.01.25-16:51:07] 192.168.176.3:445 -   SID:      S-1-5-21-2380665626-1154582258-49301182-1120
[+] [2023.01.25-16:51:07] 192.168.176.3:445 - Successfully authenticated to LDAP (192.168.176.3:636)
[*] [2023.01.25-16:51:07] 192.168.176.3:445 - Attempting to set the DNS hostname for the computer DESKTOP-Y6ZSFN9K$ to the DNS hostname for the DC: dc2019
[+] [2023.01.25-16:51:07] 192.168.176.3:445 - Successfully changed the DNS hostname
[+] [2023.01.25-16:51:09] 192.168.176.3:445 - The requested certificate was issued.
[*] [2023.01.25-16:51:09] 192.168.176.3:445 - Certificate SID: S-1-5-21-2380665626-1154582258-49301182-1120
[*] [2023.01.25-16:51:09] 192.168.176.3:445 - Certificate stored at: /Users/dwelch/.msf4/loot/20230125165109_default_192.168.176.3_windows.ad.cs_208126.pfx
[*] [2023.01.25-16:51:09] 192.168.176.3:445 - Attempting PKINIT login for dc2019$@windomain.local
[-] [2023.01.25-16:51:09] 192.168.176.3:445 - Failed: Kerberos Error - UNKNOWN (66) - Unknown error
[*] [2023.01.25-16:51:09] 192.168.176.3:445 - Deleting the computer account DESKTOP-Y6ZSFN9K$
[+] [2023.01.25-16:51:09] 192.168.176.3:445 - The specified computer has been deleted.
[-] [2023.01.25-16:51:09] 192.168.176.3:445 - Auxiliary aborted due to failure: unexpected-reply: Unable to request the TGT.
[*] Auxiliary module execution completed
```

After:
```
msf6 auxiliary(admin/dcerpc/cve_2022_26923_certifried) > authenticate
[*] Running module against 192.168.176.3

[+] [2023.01.25-18:10:15] 192.168.176.3:445 - Successfully authenticated to LDAP (192.168.176.3:636)
[+] [2023.01.25-18:10:18] 192.168.176.3:445 - Successfully created windomain.local\DESKTOP-STLEQKVE$
[+] [2023.01.25-18:10:18] 192.168.176.3:445 -   Password: lGNoeavQTE83uTSdPfxWalyPRR2nC7bm
[+] [2023.01.25-18:10:18] 192.168.176.3:445 -   SID:      S-1-5-21-2380665626-1154582258-49301182-1135
[+] [2023.01.25-18:10:18] 192.168.176.3:445 - Successfully authenticated to LDAP (192.168.176.3:636)
[*] [2023.01.25-18:10:18] 192.168.176.3:445 - Attempting to set the DNS hostname for the computer DESKTOP-STLEQKVE$ to the DNS hostname for the DC: dc2019
[+] [2023.01.25-18:10:18] 192.168.176.3:445 - Successfully changed the DNS hostname
[+] [2023.01.25-18:10:20] 192.168.176.3:445 - The requested certificate was issued.
[*] [2023.01.25-18:10:20] 192.168.176.3:445 - Certificate SID: S-1-5-21-2380665626-1154582258-49301182-1135
[*] [2023.01.25-18:10:20] 192.168.176.3:445 - Certificate stored at: /Users/dwelch/.msf4/loot/20230125181020_default_192.168.176.3_windows.ad.cs_697875.pfx
[*] [2023.01.25-18:10:20] 192.168.176.3:445 - Attempting PKINIT login for dc2019$@windomain.local
[-] [2023.01.25-18:10:20] 192.168.176.3:445 - Failed: Kerberos Error - KDC_ERR_CERTIFICATE_MISMATCH (66) - PKINIT - KDC_ERR_CERTIFICATE_MISMATCH, Target system is likely not vulnerable to Certifried
[*] [2023.01.25-18:10:20] 192.168.176.3:445 - Deleting the computer account DESKTOP-STLEQKVE$
[+] [2023.01.25-18:10:21] 192.168.176.3:445 - The specified computer has been deleted.
[-] [2023.01.25-18:10:21] 192.168.176.3:445 - Auxiliary aborted due to failure: unexpected-reply: Unable to request the TGT.
[*] Auxiliary module execution completed
```

