### PR TITLE
Fixes a crash when `smb_login`'s domain option is blank

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -96,9 +96,9 @@ module Metasploit
           proof = nil
 
           begin
-            realm = (credential.realm || '').force_encoding('UTF-8')
-            username = (credential.public || '').force_encoding('UTF-8')
-            password = (credential.private || '').force_encoding('UTF-8')
+            realm = (credential.realm || '').dup.force_encoding('UTF-8')
+            username = (credential.public || '').dup.force_encoding('UTF-8')
+            password = (credential.private || '').dup.force_encoding('UTF-8')
             client = RubySMB::Client.new(dispatcher, username: username, password: password, domain: realm)
 
             if kerberos_authenticator_factory


### PR DESCRIPTION
Fixes a crash that occurs when `domain` option is set to blank. This was due to a freeze being added via Rubocop on a previous [PR](https://github.com/rapid7/metasploit-framework/pull/17175).

## Before
![image](https://user-images.githubusercontent.com/69522014/214648317-e4d05f76-4cbb-47ac-af3b-ab8745edc5d6.png)

## After
![image](https://user-images.githubusercontent.com/69522014/214648439-c31cea9b-b0b0-40c1-aa66-a86819f697e0.png)

## Verification

- [ ] Start `msfconsole`
- [ ] Run `use scanner/smb/smb_login`
- [ ] Run `set --clear smbdomain`
- [ ] Run the module with valid options apart from the `smbdomain` we cleared above
- [ ] **Verify** you no longer receive the crash