### PR TITLE
Bump Metasploit version to 6.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metasploit-framework (6.2.37)
+    metasploit-framework (6.3.0)
       actionpack (~> 6.0)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/lib/metasploit/framework/version.rb
+++ b/lib/metasploit/framework/version.rb
@@ -30,7 +30,7 @@ module Metasploit
         end
       end
 
-      VERSION = "6.2.37"
+      VERSION = "6.3.0"
       MAJOR, MINOR, PATCH = VERSION.split('.').map { |x| x.to_i }
       PRERELEASE = 'dev'
       HASH = get_hash


### PR DESCRIPTION
Placeholder pull request to bump the Metasploit version to 6.3.0