### PR TITLE
Fix build.rb to properly handle ambiguity with relative paths that start with ./ or /

### DIFF
--- a/docs/build.rb
+++ b/docs/build.rb
@@ -259,7 +259,16 @@ module Build
     end
 
     def new_path_for(old_path, old_path_anchor)
+      # Strip out any leading `./` or `/` before the relative path.
+      # This is needed for our later code that does additional filtering for
+      # potential ambiguity with absolute paths since those comparisons occur
+      # against filenames without the leading ./ and / parts.
+      old_path = old_path.gsub(/^[.\/]+/, '')
+
+      # Replace any spaces in the file name with - separators, then
+      # make replace anchors with an empty string.
       old_path = old_path.gsub(' ', '-').gsub("##{old_path_anchor}", '')
+
       matched_pages = pages.select do |page|
         !page[:folder] &&
           (File.basename(page[:path]).downcase == "#{File.basename(old_path)}.md".downcase ||

--- a/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md
+++ b/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md
@@ -1,5 +1,5 @@
 # Setting Up An AD CS Target
-Follow the instructions [[here|ad-certificates/overview.md]] to set up an AD CS server
+Follow the instructions [[here|./ad-certificates/overview.md]] to set up an AD CS server
 for testing purposes.
 
 ## Introduction to AD CS Vulnerabilities


### PR DESCRIPTION
Due to a missing `gsub` statement, if there are multiple paths that could lead to a file and we start a relative path with `./` or `/`, then when we get to the part of the code that tries to deal with this ambiguity, we will end up using paths starting with `./` or `/` to compare against the same file paths but without these leading characters.

This updates `build.rb` so that one of the first actions we do is to strip these leading characters so that later parts of the same function, namely `new_path_for`, can operate safely on the assumption that the old path they are dealing with does not contain these leading characters, which seems to be the current expectation within the code.

## Verification

List the steps needed to make sure this thing works

- [ ] `cd docs/`
- [ ] `bundle exec ruby build.rb --serve`
- [ ] **Verify** that this builds without exceptions
- [ ] **Verify** that before this patch the build would fail due to an exception being thrown r.e ambiguity on which file to link to.
- [ ] **Verify** that navigating to the Attacking AD CS ESC Vulnerabilities page works and the `here` link at the beginning of the document links to the correct page.
