### PR TITLE
Fix ticket cache client metadata

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
@@ -144,7 +144,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       info[:realm] = realm.to_s.upcase if realm.present?
 
       client = options[:client]
-      info[:client] == client.to_s.downcase if client.present?
+      info[:client] = client.to_s.downcase if client.present?
 
       server = options[:server]
       info[:server] = server.to_s.downcase if server.present?


### PR DESCRIPTION
FIx ticket cache client metadata storing

## Verification

Enable the database

### Before

We lose track of 'client' information:

```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator action=GET_TGT password=p4$$w0rd
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] 192.168.123.13:88 - Getting TGT for Administrator@adf3.local
[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230125201856_default_192.168.123.13_mit.kerberos.cca_713729.bin
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > loot

Loot
====

host            service  type                 name  content                   info                                                 path
----            -------  ----                 ----  -------                   ----                                                 ----
192.168.123.13           mit.kerberos.ccache        application/octet-stream  {"realm":"ADF3.LOCAL","server":"krbtgt/adf3.local"}  /Users/adfoster/.msf4/loot/20230125201856_default_192.168.123.13_mit.kerberos.cca_713729.bin
```

Leading to other requests mis-using the cache:

```

msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=fake_computer password=p4$$w0rd action=GET_TGS spn=cifs/dc3.adf3.local impersonate=Administrator
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] 192.168.123.13:88 - Using cached credential for krbtgt/ADF3.LOCAL@ADF3.LOCAL Administrator@ADF3.LOCAL
[*] 192.168.123.13:88 - Getting TGS impersonating Administrator@adf3.local (SPN: cifs/dc3.adf3.local)
[-] Auxiliary aborted due to failure: unknown: Kerberos Error - KRB_AP_ERR_BADMATCH (36) - Ticket and authenticator don't match
[*] Auxiliary module execution completed
```

### After

We store the metadata correctly:

```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=Administrator action=GET_TGT password=p4$$w0rd
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] 192.168.123.13:88 - Getting TGT for Administrator@adf3.local
[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230125202141_default_192.168.123.13_mit.kerberos.cca_551144.bin
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > loot

Loot
====

host            service  type                 name  content                   info                                                                          path
----            -------  ----                 ----  -------                   ----                                                                          ----
192.168.123.13           mit.kerberos.ccache        application/octet-stream  {"realm":"ADF3.LOCAL","client":"administrator","server":"krbtgt/adf3.local"}  /Users/adfoster/.msf4/loot/20230125202141_default_192.168.123.13_mit.kerberos.cca_551144.bin
```

We later use the cache correctly:

```
msf6 auxiliary(admin/kerberos/get_ticket) > rerun verbose=true rhosts=192.168.123.13 domain=adf3.local username=fake_computer password=p4$$w0rd action=GET_TGS spn=cifs/dc3.adf3.local impersonate=Administrator
[*] Reloading module...
[*] Running module against 192.168.123.13

[+] 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:88 - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230125202217_default_192.168.123.13_mit.kerberos.cca_862425.bin
[*] 192.168.123.13:88 - Getting TGS impersonating Administrator@adf3.local (SPN: cifs/dc3.adf3.local)
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:88 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230125202217_default_192.168.123.13_mit.kerberos.cca_626595.bin
[+] 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:88 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230125202217_default_192.168.123.13_mit.kerberos.cca_723559.bin
[*] Auxiliary module execution completed
```