### PR TITLE
Continue fixing versions of Ruby in YAML files not being properly quoted like they should be.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - 2.7
+          - '2.7'
 
     name: Ruby ${{ matrix.ruby }}
     steps:
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
           working-directory: docs
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - 2.7
+          - '2.7'
 
     name: Lint msftidy
     steps:
@@ -51,7 +51,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
         env:
           BUNDLE_WITHOUT: "coverage development pcap"


### PR DESCRIPTION
Continuation of previous fixes for making sure all Ruby version strings in YAML are appropriately quoted to make sure we don't run into issues like https://github.com/rapid7/metasploit-framework/pull/17419 with other parts of our infrastructure once we go and upgrade them to Ruby 3.x down the line.

Will likely need to do this for other repos but this should hopefully fix up the rest of the files from this repo.

## Verification
- [ ] Verify the changes look good and there are no concerns. Should be pretty simple.