### PR TITLE
Remove KRB5CCNAME env var on bootup

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
@@ -43,7 +43,7 @@ module Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
       ),
       Msf::OptPath.new(
         "#{protocol}Krb5Ccname",
-        [false, 'The ccache file to use for kerberos authentication', ENV.fetch('SMBKRB5CCNAME', ENV.fetch('KRB5CCNAME', nil))],
+        [false, 'The ccache file to use for kerberos authentication', nil],
         conditions: option_conditions
       )
     ]

--- a/lib/msfenv.rb
+++ b/lib/msfenv.rb
@@ -7,6 +7,11 @@ ENV['OPENSSL_CONF'] = File.expand_path(
   File.join(File.dirname(__FILE__), '..', 'config', 'openssl.conf')
 )
 
+if ENV['KRB5CCNAME']
+  $stderr.puts 'Warning: KRB5CCNAME environment variable not supported - unsetting'
+  ENV['KRB5CCNAME'] = nil
+end
+
 # Override the normal rails default, so that msfconsole will come up in production mode instead of development mode
 # unless the `--environment` flag is passed.
 ENV['RAILS_ENV'] ||= 'production'


### PR DESCRIPTION
Fixes an edgecase when having the `KRB5CCNAME` environment variable set on OSX would cause msfconsole to attempt to use the Kerberos credentials when connecting to Metasloit's database - which was most likely intended for use within a module.

It would be better if there was a way to configure the pgsql gem to ignore this environment variable instead, but for now this solution should unblock us

## Verification

### Before

The postgres gem tries to resolve the kerberos ticket via DNS and it can take multiple minutes:

```
$ time bundle exec ruby ./msfconsole -qx 'exit'
bundle exec ruby ./msfconsole -qx 'exit'  39.54s user 148.64s system 50% cpu 6:12.92 total
```

I verified the slowpath by running a process sample on mac via the activity monitor tool, as dtruss/dtrace wouldn't work without changes to codesigning

```
Date/Time:       2023-01-26 11:46:36.540 +0000
Launch Time:     2023-01-26 11:45:52.015 +0000
OS Version:      macOS 11.7.3 (20G1116)
Report Version:  7
Analysis Tool:   /usr/bin/sample

Physical footprint:         167.4M
Physical footprint (peak):  167.4M
----

Call graph:
    2748 Thread_943062   DispatchQueue_1: com.apple.main-thread  (serial)
    + 2748 start  (in libdyld.dylib) + 1  [0x7fff203c6f3d]
    +   2748 main  (in ruby) + 93  [0x10e9b2f0d]
    +     2748 ruby_run_node  (in libruby.3.0.dylib) + 87  [0x10ea6f187]
    +       2748 rb_ec_exec_node  (in libruby.3.0.dylib) + 310  [0x10ea6f316]
    +         2748 rb_vm_exec  (in libruby.3.0.dylib) + 3002  [0x10ec32f8a]
    +           2748 vm_exec_core  (in libruby.3.0.dylib) + 14944  [0x10ec1c2f0]
    +             2748 vm_sendish  (in libruby.3.0.dylib) + 1507  [0x10ec37963]
    +               2748 vm_call_cfunc_with_frame  (in libruby.3.0.dylib) + 341  [0x10ec3f8b5]
    +                 2748 rb_class_new_instance_pass_kw  (in libruby.3.0.dylib) + 48  [0x10eb03c50]
    +                   2748 rb_funcallv_kw  (in libruby.3.0.dylib) + 67  [0x10ec29913]
    +                     2748 rb_call0  (in libruby.3.0.dylib) + 1708  [0x10ec42f1c]
    +                       2748 rb_vm_exec  (in libruby.3.0.dylib) + 3002  [0x10ec32f8a]
    +                         2748 vm_exec_core  (in libruby.3.0.dylib) + 14853  [0x10ec1c295]
    +                           2748 vm_sendish  (in libruby.3.0.dylib) + 1507  [0x10ec37963]
    +                             2748 vm_call_cfunc_with_frame  (in libruby.3.0.dylib) + 341  [0x10ec3f8b5]
    +                               2748 rb_ensure  (in libruby.3.0.dylib) + 359  [0x10ea703d7]
    +                                 2748 rb_yield_values  (in libruby.3.0.dylib) + 1006  [0x10ec2b0ce]
    +                                   2748 invoke_block_from_c_bh  (in libruby.3.0.dylib) + 1829  [0x10ec43af5]
    +                                     2748 rb_vm_exec  (in libruby.3.0.dylib) + 3002  [0x10ec32f8a]
    +                                       2748 vm_exec_core  (in libruby.3.0.dylib) + 14944  [0x10ec1c2f0]
    +                                         2748 vm_sendish  (in libruby.3.0.dylib) + 1507  [0x10ec37963]
    +                                           2748 vm_call_cfunc_with_frame  (in libruby.3.0.dylib) + 341  [0x10ec3f8b5]
    +                                             2748 send_internal  (in libruby.3.0.dylib) + 651  [0x10ec427db]
    +                                               2748 rb_call0  (in libruby.3.0.dylib) + 1708  [0x10ec42f1c]
    +                                                 2748 rb_vm_exec  (in libruby.3.0.dylib) + 3002  [0x10ec32f8a]
    +                                                   2748 vm_exec_core  (in libruby.3.0.dylib) + 14944  [0x10ec1c2f0]
    +                                                     2748 vm_sendish  (in libruby.3.0.dylib) + 1507  [0x10ec37963]
    +                                                       2748 vm_call_symbol  (in libruby.3.0.dylib) + 644  [0x10ec3ff24]
    +                                                         2748 vm_call_cfunc_with_frame  (in libruby.3.0.dylib) + 341  [0x10ec3f8b5]
    +                                                           2748 pgconn_connect_poll  (in pg_ext.bundle) + 43  [0x110ef6f4b]
    +                                                             2748 gvl_PQconnectPoll  (in pg_ext.bundle) + 44  [0x110ef157c]
    +                                                               2748 rb_nogvl  (in libruby.3.0.dylib) + 154  [0x10ebe2aba]
    +                                                                 2748 gvl_PQconnectPoll_skeleton  (in pg_ext.bundle) + 17  [0x110ef15a1]
    +                                                                   2748 PQconnectPoll  (in libpq.5.dylib) + 2952  [0x110f3468c]
    +                                                                     2748 pqsecure_open_gss  (in libpq.5.dylib) + 794  [0x110f47633]
    +                                                                       2748 gss_init_sec_context  (in libgssapi_krb5.2.2.dylib) + 497  [0x110f87231]
    +                                                                         2748 krb5_gss_init_sec_context  (in libgssapi_krb5.2.2.dylib) + 63  [0x110f98303]
    +                                                                           2748 krb5_gss_init_sec_context_ext  (in libgssapi_krb5.2.2.dylib) + 2775  [0x110f97c81]
    +                                                                             2748 krb5_get_credentials  (in libkrb5.3.3.dylib) + 113  [0x110fe57d5]
    +                                                                               2748 krb5_tkt_creds_get  (in libkrb5.3.3.dylib) + 214  [0x110fe4b85]
    +                                                                                 2748 krb5_sendto_kdc  (in libkrb5.3.3.dylib) + 201  [0x1110093fd]
    +                                                                                   2748 k5_locate_server  (in libkrb5.3.3.dylib) + 73  [0x111007cd6]
    +                                                                                     2748 locate_server  (in libkrb5.3.3.dylib) + 1723  [0x1110083f5]
    +                                                                                       2748 locate_srv_dns_1  (in libkrb5.3.3.dylib) + 37  [0x111008975]
    +                                                                                         2748 krb5int_make_srv_query_realm  (in libkrb5.3.3.dylib) + 144  [0x111003c29]
    +                                                                                           2748 krb5int_dns_init  (in libkrb5.3.3.dylib) + 188  [0x11100353b]
    +                                                                                             2748 dns_search  (in libresolv.9.dylib) + 172  [0x7fff2ce2dfdf]
    +                                                                                               2748 _sdns_search  (in libresolv.9.dylib) + 735  [0x7fff2ce2d8d2]
    +                                                                                                 2748 _pdns_query  (in libresolv.9.dylib) + 176  [0x7fff2ce2de46]
    +                                                                                                   2748 res_query_mDNSResponder  (in libresolv.9.dylib) + 745  [0x7fff2ce3713d]
    +                                                                                                     2748 kevent  (in libsystem_kernel.dylib) + 10  [0x7fff2037ac3a]
    2748 Thread_943068
```

### After

We'll unset the `KRB5CCNAME` variable, warn the user, and boot up as normal:

```
$ time bundle exec ruby ./msfconsole -qx 'exit'
Warning: KRB5CCNAME environment variable not supported - unsetting
bundle exec ruby ./msfconsole -qx 'exit'  8.33s user 3.41s system 90% cpu 13.012 total
```