### PR TITLE
Catch Encryption Errors In inspect_ticket

### DIFF
--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
@@ -100,7 +100,7 @@ module Rex::Proto::Kerberos::CredentialCache
         output << 'Cipher:'.indent(4)
         output << Base64.strict_encode64(ticket.enc_part.cipher).indent(6)
       else
-        output << "Decrypted (with key: #{key.bytes.map { |x| "\\x#{x.to_s(16).rjust(2, '0')}" }.join}):".indent(4)
+        output << "Decrypted (with key: #{key.bytes.map { |x| "#{x.to_s(16).rjust(2, '0')}" }.join}):".indent(4)
         output << present_encrypted_ticket_part(ticket, key).indent(6)
       end
 
@@ -172,7 +172,7 @@ module Rex::Proto::Kerberos::CredentialCache
     def present_server_checksum(info_buffer)
       server_checksum = info_buffer.buffer.pac_element
 
-      sig = server_checksum.signature.bytes.map { |x| "\\x#{x.to_s(16).rjust(2, '0')}" }.join
+      sig = server_checksum.signature.bytes.map { |x| "#{x.to_s(16).rjust(2, '0')}" }.join
       "Pac Server Checksum:\n" +
         "Signature: #{sig}".indent(2)
     end
@@ -182,7 +182,7 @@ module Rex::Proto::Kerberos::CredentialCache
     def present_priv_server_checksum(info_buffer)
       priv_server_checksum = info_buffer.buffer.pac_element
 
-      sig = priv_server_checksum.signature.bytes.map { |x| "\\x#{x.to_s(16).rjust(2, '0')}" }.join
+      sig = priv_server_checksum.signature.bytes.map { |x| "#{x.to_s(16).rjust(2, '0')}" }.join
       "Pac Privilege Server Checksum:\n" +
         "Signature: #{sig}".indent(2)
     end
@@ -259,7 +259,7 @@ module Rex::Proto::Kerberos::CredentialCache
     # @param [Rex::Proto::Kerberos::Pac::UserSessionKey] user_session_key
     # @return [String] A human readable representation of a User Session Key
     def present_user_session_key(user_session_key)
-      user_session_key.session_key.flat_map(&:data).map { |x| "\\x#{x.to_i.to_s(16).rjust(2, '0')}" }.join
+      user_session_key.session_key.flat_map(&:data).map { |x| "#{x.to_i.to_s(16).rjust(2, '0')}" }.join
     end
 
     # @param [RubySMB::Dcerpc::Ndr::NdrFileTime] time

--- a/modules/auxiliary/admin/kerberos/inspect_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/inspect_ticket.rb
@@ -47,6 +47,8 @@ class MetasploitModule < Msf::Auxiliary
   def run
     enc_key = get_enc_key
     print_contents(datastore['TICKET_PATH'], key: enc_key)
+  rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
+    fail_with(Msf::Exploit::Failure::Unknown, "Could not print ticket contents (#{e})")
   end
 
   private

--- a/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
+++ b/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
             Encrypted Ticket Part:
               Ticket etype: 18 (AES256)
               Key Version Number: 2
-              Decrypted (with key: \\x4b\\x91\\x2b\\xe0\\x36\\x6a\\x6f\\x37\\xf4\\xa7\\xd5\\x71\\xbe\\xe1\\x8b\\x11\\x73\\xd9\\x31\\x95\\xef\\x76\\xf8\\xd1\\xe3\\xe8\\x1e\\xf6\\x17\\x2a\\xb3\\x26):
+              Decrypted (with key: 4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326):
                 Times:
                   Auth time: 2022-11-28 15:51:29 UTC
                   Start time: 2022-11-28 15:51:29 UTC
@@ -194,7 +194,7 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
                     User ID: 500
                     Primary Group ID: 513
                     User Flags: 0
-                    User Session Key: \\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
+                    User Session Key: 00000000000000000000000000000000
                     User Account Control: 528
                     Sub Auth Status: 0
                     Last Successful Interactive Logon: No Time Set (0)
@@ -222,9 +222,9 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
                     Name: 'Administrator'
                     Client ID: 2022-11-28 15:51:29 +0000
                   Pac Server Checksum:
-                    Signature: \\x5e\\xb9\\x40\\x0b\\xca\\xb4\\x2b\\xab\\xcd\\x59\\x82\\x10
+                    Signature: 5eb9400bcab42babcd598210
                   Pac Privilege Server Checksum:
-                    Signature: \\x58\\x58\\xaf\\xf1\\x9f\\x89\\xc9\\xb9\\xce\\x01\\xc4\\x37
+                    Signature: 5858aff19f89c9b9ce01c437
     EOF
   end
 

--- a/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
+++ b/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
@@ -486,7 +486,7 @@ RSpec.describe 'kerberos inspect ticket' do
             Encrypted Ticket Part:
               Ticket etype: 18 (AES256)
               Key Version Number: 2
-              Decrypted (with key: \x4b\x91\x2b\xe0\x36\x6a\x6f\x37\xf4\xa7\xd5\x71\xbe\xe1\x8b\x11\x73\xd9\x31\x95\xef\x76\xf8\xd1\xe3\xe8\x1e\xf6\x17\x2a\xb3\x26):
+              Decrypted (with key: 4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326):
                 Times:
                   Auth time: 2023-01-13 14:31:25 UTC
                   Start time: 2023-01-13 14:31:25 UTC
@@ -512,7 +512,7 @@ RSpec.describe 'kerberos inspect ticket' do
                     User ID: 500
                     Primary Group ID: 513
                     User Flags: 0
-                    User Session Key: \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00
+                    User Session Key: 00000000000000000000000000000000
                     User Account Control: 528
                     Sub Auth Status: 0
                     Last Successful Interactive Logon: No Time Set (0)
@@ -540,9 +540,9 @@ RSpec.describe 'kerberos inspect ticket' do
                     Name: 'Administrator'
                     Client ID: 2023-01-13 14:31:25 +0000
                   Pac Server Checksum:
-                    Signature: \x81\xa2\x0d\xa7\x31\xb3\xb9\xbd\xd2\xe7\x56\xdc
+                    Signature: 81a20da731b3b9bdd2e756dc
                   Pac Privilege Server Checksum:
-                    Signature: \xe5\x52\xba\x92\xad\x31\x27\x55\xd8\x9e\xbc\xc7
+                    Signature: e552ba92ad312755d89ebcc7
     EOF
     expected_output.join("\n")
   end
@@ -612,7 +612,7 @@ RSpec.describe 'kerberos inspect ticket' do
             Encrypted Ticket Part:
               Ticket etype: 23 (RC4_HMAC)
               Key Version Number: 2
-              Decrypted (with key: \x88\xe4\xd9\xfa\xba\xec\xf3\xde\xc1\x8d\xd8\x09\x05\x52\x1b\x29):
+              Decrypted (with key: 88e4d9fabaecf3dec18dd80905521b29):
                 Times:
                   Auth time: 2023-01-13 14:36:39 UTC
                   Start time: 2023-01-13 14:36:39 UTC
@@ -638,7 +638,7 @@ RSpec.describe 'kerberos inspect ticket' do
                     User ID: 500
                     Primary Group ID: 513
                     User Flags: 0
-                    User Session Key: \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00
+                    User Session Key: 00000000000000000000000000000000
                     User Account Control: 528
                     Sub Auth Status: 0
                     Last Successful Interactive Logon: No Time Set (0)
@@ -666,9 +666,9 @@ RSpec.describe 'kerberos inspect ticket' do
                     Name: 'Administrator'
                     Client ID: 2023-01-13 14:36:39 +0000
                   Pac Server Checksum:
-                    Signature: \x1a\x03\x8d\x8d\xd2\x57\xa7\xd9\xb8\x75\x28\x02\x59\xab\x0e\x4a
+                    Signature: 1a038d8dd257a7d9b875280259ab0e4a
                   Pac Privilege Server Checksum:
-                    Signature: \x2f\x3a\x9e\x1e\x4f\xa7\xd3\x82\x3d\xcb\x7e\xdb\xda\xaa\x83\x85
+                    Signature: 2f3a9e1e4fa7d3823dcb7edbdaaa8385
     EOF
     expected_output.join("\n")
   end


### PR DESCRIPTION
This catches errors in the kerberos/inspect_ticket module so if the NTHASH or AES_KEY is wrong, a stack trace isn't displayed.

It also updates the presenter to consistently print binary data without the `\x` characters.

## Verification

List the steps needed to make sure this thing works

- [ ] Use the inspect_ticket module
- [ ] Set the TICKET_PATH to an MIT CCACHE file, (find one in loot or list)
- [ ] Set the AES_KEY and/or NTHASH to an incorrect value (but of the proper size for the setting)
- [ ] Run the module and see a message but not a stack trace.

## After

```
msf6 auxiliary(admin/kerberos/inspect_ticket) > run nthash=d1d0fe6ab7d9f5330694998d4ac9abf4 ticket_path=/home/smcintyre/.msf4/loot/20230126090608_default_192.168.159.40_mit.kerberos.cca_276090.bin

[*] Credentials cache: File:/home/smcintyre/.msf4/loot/20230126090608_default_192.168.159.40_mit.kerberos.cca_276090.bin
[*] Primary Principal: aliddle@MSFLAB08.LOCAL
Ccache version: 4

Creds: 1
  Credential[0]:
    Server: cifs/dc08.msflab08.local@MSFLAB08.LOCAL
    Client: aliddle@MSFLAB08.LOCAL
    Ticket etype: 23 (RC4_HMAC)
    Key: e1edb48dca58c15028268418d1f3caeb
    Subkey: false
    Ticket Length: 983
    Ticket Flags: 0x40a40000 (FORWARDABLE, RENEWABLE, PRE_AUTHENT, OK_AS_DELEGATE)
    Addresses: 0
    Authdatas: 0
    Times:
      Auth time: 2023-01-26 09:05:39 -0500
      Start time: 2023-01-26 09:06:10 -0500
      End time: 2023-01-26 19:05:39 -0500
      Renew Till: 2023-02-02 09:05:39 -0500
    Ticket:
      Ticket Version Number: 5
      Realm: MSFLAB08.LOCAL
      Server Name: cifs/dc08.msflab08.local
      Encrypted Ticket Part:
        Ticket etype: 23 (RC4_HMAC)
        Key Version Number: 3
        Decrypted (with key: d1d0fe6ab7d9f5330694998d4ac9abf4):
          Times:
            Auth time: 2023-01-26 14:05:39 UTC
            Start time: 2023-01-26 14:06:10 UTC
            End time: 2023-01-27 00:05:39 UTC
            Renew Till: 2023-02-02 14:05:39 UTC
          Client Addresses: 0
          Transited: tr_type: 1, Contents: ""
          Client Name: 'aliddle'
          Client Realm: 'MSFLAB08.LOCAL'
          Ticket etype: 23 (RC4_HMAC)
          Encryption Key: e1edb48dca58c15028268418d1f3caeb
          Flags: 0x40a40000 (FORWARDABLE, RENEWABLE, PRE_AUTHENT, OK_AS_DELEGATE)
          PAC:
            Validation Info:
              Logon Time: 1600-12-31 19:06:45 -0456
              Logoff Time: Never Expires (inf)
              Kick Off Time: Never Expires (inf)
              Password Last Set: No Time Set (0)
              Password Can Change: No Time Set (0)
              Password Must Change: Never Expires (inf)
              Logon Count: 0
              Bad Password Count: 0
              User ID: 1104
              Primary Group ID: 513
              User Flags: 32
              User Session Key: 00000000000000000000000000000000
              User Account Control: 528
              Sub Auth Status: 0
              Last Successful Interactive Logon: No Time Set (0)
              Last Failed Interactive Logon: No Time Set (0)
              Failed Interactive Logon Count: 0
              SID Count: 1
              Resource Group Count: 0
              Group Count: 5
              Group IDs:
                Relative ID: 512, Attributes: 7
                Relative ID: 513, Attributes: 7
                Relative ID: 518, Attributes: 7
                Relative ID: 519, Attributes: 7
                Relative ID: 520, Attributes: 7
              Logon Domain ID: S-1-5-21-127401007-1154576506-3983393241
              Effective Name: 'aliddle'
              Full Name: ''
              Logon Script: ''
              Profile Path: ''
              Home Directory: ''
              Home Directory Drive: ''
              Logon Server: ''
              Logon Domain Name: 'MSFLAB08.LOCAL'
            Client Info:
              Name: 'aliddle'
              Client ID: 1600-12-31 19:06:45 -0456
            Pac Server Checksum:
              Signature: fa2c8ec5310e241fec6c273309e7c226
            Pac Privilege Server Checksum:
              Signature: 3ac5dfb685f79a5b54964f234144b2b8
[*] Auxiliary module execution completed
```

## Before

```
msf6 auxiliary(admin/kerberos/inspect_ticket) > run nthash=218c2ec8cc8e6d42e809e0084b268beb ticket_path=/home/smcintyre/.msf4/loot/20230126090608_default_192.168.159.40_mit.kerberos.cca_276090.bin

[*] Credentials cache: File:/home/smcintyre/.msf4/loot/20230126090608_default_192.168.159.40_mit.kerberos.cca_276090.bin
[-] Auxiliary failed: Rex::Proto::Kerberos::Model::Error::KerberosError RC4-HMAC decryption failed, incorrect checksum verification
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/crypto/rc4_hmac.rb:67:in `decrypt'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:213:in `present_encrypted_ticket_part'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:104:in `present_cred'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:46:in `block in present'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/bindata-2.4.14/lib/bindata/array.rb:220:in `block in each'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/bindata-2.4.14/lib/bindata/array.rb:220:in `each'
[-]   /home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/bindata-2.4.14/lib/bindata/array.rb:220:in `each'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:45:in `map'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:45:in `with_index'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:45:in `present'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/kerberos/ticket.rb:179:in `print_ccache_contents'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/kerberos/ticket.rb:166:in `print_contents'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/kerberos/inspect_ticket.rb:49:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/inspect_ticket) >
```