### PR TITLE
Fix force encoding issue on nil kerberos username

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -173,6 +173,7 @@ module Msf
             realm = options[:realm]
             server_name = options.fetch(:server_name, "krbtgt/#{realm}")
             client_name = options[:client_name]
+            client_name = client_name.dup.force_encoding('utf-8') if client_name
             ticket_options = options.fetch(:options) { 0x50800000 } # Forwardable, Proxiable, Renewable
 
             # The diffie hellman client parameters
@@ -238,10 +239,10 @@ module Msf
             realm = options[:realm]
             server_name = options[:server_name]
             client_name = options[:client_name]
+            client_name = client_name.dup.force_encoding('utf-8') if client_name
             password = options[:password]
-            password.dup.force_encoding('utf-8') if password
+            password = password.dup.force_encoding('utf-8') if password
             key = options[:key]
-            client_name.dup.force_encoding('utf-8')
             request_pac = options.fetch(:request_pac, true)
             ticket_options = options.fetch(:options) { 0x50800000 } # Forwardable, Proxiable, Renewable
 


### PR DESCRIPTION
Fixes a crash when Kerberos username was set to `nil`

Unfortunately I don't have end-user replication steps as I had a slightly broken module that caused the error to trigger; but the code change in isolation looks sane