### PR TITLE
Fix the logon_time in the MS14-068 exploit

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client/as_response.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/as_response.rb
@@ -42,16 +42,14 @@ module Msf
             #
             # @param res [Rex::Proto::Kerberos::Model::KdcResponse]
             # @param key [String]
-            # @return [Integer]
+            # @return [Time]
             # @see Rex::Proto::Kerberos::Model::KdcResponse
             # @see Rex::Proto::Kerberos::Model::EncryptedData.decrypt
             # @see Rex::Proto::Kerberos::Model::EncKdcResponse
             # @see Rex::Proto::Kerberos::Model::EncKdcResponse.decode
             def extract_logon_time(res, key)
               kdc_res = decrypt_kdc_as_rep_enc_part(res, key)
-              auth_time = kdc_res.auth_time
-
-              auth_time.to_i
+              kdc_res.auth_time
             end
 
             # Format from

--- a/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
+++ b/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("#{peer} - Parsing AS-REP...")
 
     session_key = extract_session_key(res, password_digest)
-    logon_time = extract_logon_time(res, password_digest)
+    logon_time = decrypt_kdc_as_rep_enc_part(res, password_digest).auth_time
     ticket = res.ticket
 
     pre_auth = []
@@ -141,9 +141,7 @@ class MetasploitModule < Msf::Auxiliary
     print_good("#{peer} - Valid TGS-Response, extracting credentials...")
 
     cache = extract_kerb_creds(res, sub_key.value)
-
-    path = store_loot('windows.kerberos', 'application/octet-stream', rhost, cache.encode)
-    print_good("#{peer} - MIT Credential Cache saved on #{path}")
+    Msf::Exploit::Remote::Kerberos::Ticket::Storage.store_ccache(cache, framework_module: self, host: rhost)
   end
 
   def warn_error(res)

--- a/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
+++ b/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("#{peer} - Parsing AS-REP...")
 
     session_key = extract_session_key(res, password_digest)
-    logon_time = decrypt_kdc_as_rep_enc_part(res, password_digest).auth_time
+    logon_time = extract_logon_time(res, password_digest)
     ticket = res.ticket
 
     pre_auth = []

--- a/spec/lib/msf/core/exploit/remote/kerberos/client/as_response_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/kerberos/client/as_response_spec.rb
@@ -173,13 +173,13 @@ RSpec.describe Msf::Exploit::Remote::Kerberos::Client::AsResponse do
       context "when using a valid key" do
         it "returns the extracted Rex::Proto::Kerberos::CredentialCache::Cache" do
           response = Rex::Proto::Kerberos::Model::KdcResponse.decode(as_response)
-          expect(subject.extract_logon_time(response, valid_key)).to be_a(Integer)
+          expect(subject.extract_logon_time(response, valid_key)).to be_a(Time)
         end
 
         it "extracts the correct time" do
           response = Rex::Proto::Kerberos::Model::KdcResponse.decode(as_response)
           time = subject.extract_logon_time(response, valid_key)
-          expect(time).to eq(1419128917)
+          expect(time).to eq(Time.new(2014, 12, 21, 02, 28, 37, "+00:00"))
         end
       end
 


### PR DESCRIPTION
This fixes the logon timestamp in the MS14-068 exploit so the generated ticket works. Before, this was passing in logon_time as an integer which was seconds since epoch (from [`Time#to_i`](https://ruby-doc.org/core-2.6.3/Time.html#method-i-to_i)) as the raw value which is then placed in [FILETIME](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/2c57429b-fdd4-488f-b5fc-9e4cf020fcdf) which expected it as "the number of 100-nanosecond intervals that have elapsed since January 1, 1601, Coordinated Universal Time (UTC)."

Also, stored the ticket correctly so it shows up in `klist` and can be used from the cache.

## Verification

List the steps needed to make sure this thing works

- [ ] Run the exploit
- [ ] See the ticket was added by running `klist`
- [ ] Inspect the ticket using the `kerberos/inspect_ticket` module, and see that the Logon time field looks reasonable
- [ ] Use the cached TGT to prove it's all good
    * For this, I recommend psexecing into the DC that you originally targeted. Setup kerberos authentication options and see that the cached TGT is used to issue a new TGS that allows the exploit to work. Once completed there should be exactly 2 tickets in the output of `klist` (assuming you started with 0 tickets).

