### PR TITLE
Fixes analyze command crashing with a winrm session opened

### DIFF
--- a/lib/msf/core/analyze/result.rb
+++ b/lib/msf/core/analyze/result.rb
@@ -172,7 +172,7 @@ class Msf::Analyze::Result
   end
 
   def matches_session?(session)
-    session.stype == 'meterpreter' || !!@mod.session_types&.include?(session.type)
+    session.stype == 'meterpreter' || !!@mod.session_types&.include?(session.stype)
   end
 
   def required_sessions_list


### PR DESCRIPTION
This PR resolves #17554. 

Fixes a crash that was caused when running the analyze command against a `winrm` session. 

### Before
![image](https://user-images.githubusercontent.com/69522014/215068218-5b14277a-4078-404c-9b10-de052e0e4df9.png)

### After 
![image](https://user-images.githubusercontent.com/69522014/215068133-f6b5af8a-fb67-4a1d-8b2e-e3b0e2efd73e.png)


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use scanner/winrm/winrm_login`
- [ ] Get a winrm session
- [ ] **Verify** the analyze command no longer crashes
