### PR TITLE
Present unsupported ul_types in a clearer way to the user

### DIFF
--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
@@ -190,7 +190,8 @@ module Rex::Proto::Kerberos::CredentialCache
     # @param [Rex::Proto::Kerberos::Pac::Krb5PacInfoBuffer] info_buffer
     # @return [String] A human readable representation of a Pac Info Buffer
     def present_pac_info_buffer(info_buffer)
-      case info_buffer.ul_type
+      ul_type = info_buffer.ul_type.to_i
+      case ul_type
       when Rex::Proto::Kerberos::Pac::Krb5PacElementType::LOGON_INFORMATION
         present_logon_info(info_buffer)
       when Rex::Proto::Kerberos::Pac::Krb5PacElementType::CLIENT_INFORMATION
@@ -200,7 +201,10 @@ module Rex::Proto::Kerberos::CredentialCache
       when Rex::Proto::Kerberos::Pac::Krb5PacElementType::PRIVILEGE_SERVER_CHECKSUM
         present_priv_server_checksum(info_buffer)
       else
-        info_buffer.to_s
+        ul_type_name = Rex::Proto::Kerberos::Pac::Krb5PacElementType.const_name(ul_type)
+        ul_type_name = ul_type_name.gsub('_', ' ').capitalize if ul_type_name
+        "#{ul_type_name || "Unknown ul type #{ul_type}"}:\n" +
+          "#{info_buffer.to_s}".indent(2)
       end
     end
 

--- a/lib/rex/proto/kerberos/pac/krb5_pac.rb
+++ b/lib/rex/proto/kerberos/pac/krb5_pac.rb
@@ -49,7 +49,7 @@ module Rex::Proto::Kerberos::Pac
     endian :little
     # @!attribute [r] ul_type
     #   @return [Integer] Describes the type of data present in the buffer
-    virtual :ul_type, value: 0x0A
+    virtual :ul_type, value: Krb5PacElementType::CLIENT_INFORMATION
 
     # @!attribute [rw] client_id
     #   @return [FileTime] Kerberos initial ticket-granting ticket (TGT) authentication time
@@ -69,7 +69,7 @@ module Rex::Proto::Kerberos::Pac
     # @see Rex::Proto::Kerberos::Crypto::Checksum
     def assign(val)
       # Handle the scenario of users setting the signature type to a negative value such as -138 for HMAC_RC4
-      # Convert it to two's complement representation explicitly to bypass bindata's clamping logic:
+      # Convert it to two's complement representation explicitly to bypass bindata's clamping logic in the super method:
       if val < 0
         val &= 0xffffffff
       end
@@ -94,13 +94,13 @@ module Rex::Proto::Kerberos::Pac
   class Krb5PacServerChecksum < Krb5PacSignatureData
     # @!attribute [r] ul_type
     #   @return [Integer] Describes the type of data present in the buffer
-    virtual :ul_type, value: 0x06
+    virtual :ul_type, value: Krb5PacElementType::SERVER_CHECKSUM
   end
 
   class Krb5PacPrivServerChecksum < Krb5PacSignatureData
     # @!attribute [r] ul_type
     #   @return [Integer] Describes the type of data present in the buffer
-    virtual :ul_type, value: 0x07
+    virtual :ul_type, value: Krb5PacElementType::PRIVILEGE_SERVER_CHECKSUM
   end
 
   # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/69e86ccc-85e3-41b9-b514-7d969cd0ed73
@@ -268,7 +268,7 @@ module Rex::Proto::Kerberos::Pac
     endian :little
     # @!attribute [r] ul_type
     #   @return [Integer] Describes the type of data present
-    virtual :ul_type, value: 0x01
+    virtual :ul_type, value: Krb5PacElementType::LOGON_INFORMATION
 
     krb5_validation_info_ptr :data
   end
@@ -364,7 +364,7 @@ module Rex::Proto::Kerberos::Pac
     endian :little
     # @!attribute [r] ul_type
     #   @return [Integer] Describes the type of data present
-    virtual :ul_type, value: 0x02
+    virtual :ul_type, value: Krb5PacElementType::CREDENTIAL_INFORMATION
 
     uint32 :version
     uint32 :encryption_type

--- a/lib/rex/proto/kerberos/pac/krb5_pac_element_type.rb
+++ b/lib/rex/proto/kerberos/pac/krb5_pac_element_type.rb
@@ -4,10 +4,29 @@ module Rex::Proto::Kerberos::Pac
 
   # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/3341cfa2-6ef5-42e0-b7bc-4544884bf399
   module Krb5PacElementType
-    LOGON_INFORMATION = 0x00000001
-    CREDENTIAL_INFORMATION = 0x00000002
-    SERVER_CHECKSUM = 0x00000006
-    PRIVILEGE_SERVER_CHECKSUM = 0x00000007
-    CLIENT_INFORMATION = 0x0000000A
+    LOGON_INFORMATION                             = 0x00000001
+    CREDENTIAL_INFORMATION                        = 0x00000002
+    SERVER_CHECKSUM                               = 0x00000006
+    PRIVILEGE_SERVER_CHECKSUM                     = 0x00000007
+    CLIENT_INFORMATION                            = 0x0000000A
+    CONSTRAINED_DELEGATION_INFORMATION            = 0x0000000B
+    USER_PRINCIPAL_NAME_AND_DNS_INFORMATION       = 0x0000000C
+    CLIENT_CLAIMS_INFORMATION                     = 0x0000000D
+    DEVICE_INFORMATION                            = 0x0000000E
+    DEVICE_CLAIMS_INFORMATION                     = 0x0000000F
+    TICKET_CHECKSUM                               = 0x00000010
+    PAC_ATTRIBUTES                                = 0x00000011
+    PAC_REQUESTOR                                 = 0x00000012
+
+    #
+    # Return a string representation of the constant for a number
+    #
+    # @param [Integer] code
+    def self.const_name(code)
+      self.constants.each do |c|
+        return c.to_s if self.const_get(c) == code
+      end
+      return nil
+    end
   end
 end


### PR DESCRIPTION
Updates the `inspect_ticket` module to show unsupported pac buffer ul_types in a clearer way to the user

It's still not perfect, but it's definitely a step in the right direction

### Before

```
msf6 auxiliary(admin/kerberos/inspect_ticket) > rerun ticket_path=first.kirbi aes_key=e1c5500ffb883e713288d8037651821b9ecb0dfad89e01d1b920fe136879e33c
... etc etc ...
          PAC:
            Validation Info:
              Logon Time: 2022-11-05 14:23:07 +0000
              Logoff Time: Never Expires (inf)
              Kick Off Time: Never Expires (inf)
              ...etc etc...
            Client Info:
              Name: 'DC3$'
              Client ID: 2023-01-14 03:42:54 +0000
            vvvvvvvvvvvv before vvvvvvvvvvvv
            {:ul_type=>12, :cb_buffer_size=>72, :offset=>560, :buffer=>{:pac_element=>{:ul_type=>12, :unknown_element=>"\x1E\x00\x10\x00\x14\x000\x00\x01\x00\x00\x00\x00\x00\x00\x00D\x00C\x003\x00$\x00@\x00a\x00d\x00f\x003\x00.\x00l\x00o\x00c\x00a\x00l\x00\x00\x00A\x00D\x00F\x003\x00.\x00L\x00O\x00C\x00A\x00L\x00\x00\x00\x00\x00"}, :padding=>""}}
            ^^^^^^^^^^^^ before ^^^^^^^^^^^^^
            Pac Server Checksum:
              Signature: \xe8\x0f\x40\xa6\xb9\x17\x77\x49\x4b\x8b\x36\x34
            Pac Privilege Server Checksum:
              Signature: \x1e\xc8\x24\x44\xff\x83\x4f\x41\xed\xea\xc7\x5f\x69\xb1\x35\xca
```

### After

```
msf6 auxiliary(admin/kerberos/inspect_ticket) > rerun ticket_path=first.kirbi aes_key=e1c5500ffb883e713288d8037651821b9ecb0dfad89e01d1b920fe136879e33c
... etc etc ...
          PAC:
            Validation Info:
              Logon Time: 2022-11-05 14:23:07 +0000
              Logoff Time: Never Expires (inf)
              Kick Off Time: Never Expires (inf)
              ...etc etc...
            Client Info:
              Name: 'DC3$'
              Client ID: 2023-01-14 03:42:54 +0000
            vvvvvvvvvvvv before vvvvvvvvvvvv
            User principal name and dns information:
              {:ul_type=>12, :cb_buffer_size=>72, :offset=>560, :buffer=>{:pac_element=>{:ul_type=>12, :unknown_element=>"\x1E\x00\x10\x00\x14\x000\x00\x01\x00\x00\x00\x00\x00\x00\x00D\x00C\x003\x00$\x00@\x00a\x00d\x00f\x003\x00.\x00l\x00o\x00c\x00a\x00l\x00\x00\x00A\x00D\x00F\x003\x00.\x00L\x00O\x00C\x00A\x00L\x00\x00\x00\x00\x00"}, :padding=>""}}
            ^^^^^^^^^^^^ after ^^^^^^^^^^^^^
            Pac Server Checksum:
              Signature: e80f40a6b91777494b8b3634
            Pac Privilege Server Checksum:
              Signature: 1ec82444ff834f41edeac75f69b135ca

```

## Verification

Steps from https://github.com/rapid7/metasploit-framework/pull/17468#issuecomment-1383801720