### PR TITLE
Fix input and output buffers for some mislabeled functions in def_iphlpapi.rb

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_iphlpapi.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_iphlpapi.rb
@@ -43,12 +43,12 @@ class Def_windows_iphlpapi
 
     dll.add_function('GetBestInterface', 'DWORD',[
       ["DWORD","dwDestAddr","in"],
-      ["PDWORD","pdwBestIfIndex","inout"],
+      ["PDWORD","pdwBestIfIndex","out"],
       ])
 
     dll.add_function('GetBestInterfaceEx', 'DWORD',[
       ["PBLOB","pDestAddr","in"],
-      ["PDWORD","pdwBestIfIndex","inout"],
+      ["PDWORD","pdwBestIfIndex","out"],
       ])
 
     dll.add_function('GetFriendlyIfIndex', 'DWORD',[
@@ -56,14 +56,14 @@ class Def_windows_iphlpapi
       ])
 
     dll.add_function('GetNumberOfInterfaces', 'DWORD',[
-      ["PDWORD","pdwNumIf","inout"],
+      ["PDWORD","pdwNumIf","out"],
       ])
 
     dll.add_function('GetRTTAndHopCount', 'BOOL',[
       ["DWORD","DestIpAddress","in"],
-      ["PDWORD","HopCount","inout"],
+      ["PDWORD","HopCount","out"],
       ["DWORD","MaxHops","in"],
-      ["PDWORD","RTT","inout"],
+      ["PDWORD","RTT","out"],
       ])
 
     dll.add_function('NotifyAddrChange', 'DWORD',[

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_iphlpapi.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_iphlpapi.rb
@@ -61,9 +61,9 @@ class Def_windows_iphlpapi
 
     dll.add_function('GetRTTAndHopCount', 'BOOL',[
       ["DWORD","DestIpAddress","in"],
-      ["PDWORD","HopCount","out"],
+      ["PULONG","HopCount","out"],
       ["DWORD","MaxHops","in"],
-      ["PDWORD","RTT","out"],
+      ["PULONG","RTT","out"],
       ])
 
     dll.add_function('NotifyAddrChange', 'DWORD',[

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
@@ -50,7 +50,8 @@ class Library
     'PHANDLE' => 'PULONG_PTR',
     'SIZE_T'  => 'ULONG_PTR',
     'PSIZE_T' => 'PULONG_PTR',
-    'PLPVOID' => 'PULONG_PTR'
+    'PLPVOID' => 'PULONG_PTR',
+    'PULONG'  => 'PDWORD'
   }.freeze
 
   attr_accessor :functions


### PR DESCRIPTION
This fixes a few incorrectly labeled `inout` buffers for a few RailGun definitions within `def_iphlpapi.rb`. None of these functions are actively being used to the best of my knowledge, so they should be safe to change without any side effects.

## Verification
- [ ] Review the PR and confirm the definitions match MSDN's documentation.
- [ ] Get a Meterpreter session on a Windows x64 host.
- [ ] From the main console run `loadpath test/modules/` to load the test modules.
- [ ] `post/test/railgun` should work, all tests should pass
- [ ] `post/test/railgun_reverse_lookups` should also work with all tests passing.
