### PR TITLE
Fix incorrect definitions for ldap_search functions in def_wldap32.rb

### DIFF
--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -368,7 +368,7 @@ module Msf
           vprint_status("LDAP Handle: #{session_handle}")
 
           vprint_status('Setting Sizelimit Option')
-          wldap32.ldap_set_option(session_handle, LDAP_OPT_SIZELIMIT, size_limit)
+          wldap32.ldap_set_option(session_handle, LDAP_OPT_SIZELIMIT, [size_limit].pack('V'))
 
           vprint_status('Binding to LDAP server')
           bind_result = wldap32.ldap_bind_sA(session_handle, nil, nil, LDAP_AUTH_NEGOTIATE)

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
@@ -26,13 +26,13 @@ class Def_windows_wldap32
     ], 'ldap_bind_sA', "cdecl")
 
     dll.add_function('ldap_search_sA', 'DWORD',[
-        ['DWORD', 'ld', 'in'],
+        ['PHANDLE', 'ld', 'in'],
         ['PCHAR', 'base', 'in'],
         ['DWORD', 'scope', 'in'],
         ['PCHAR', 'filter', 'in'],
         ['PCHAR', 'attrs[]', 'in'],
         ['DWORD', 'attrsonly', 'in'],
-        ['PDWORD', 'res', 'out']
+        ['PULONG_PTR', 'res', 'out']
     ], 'ldap_search_sA', "cdecl")
 
     dll.add_function('ldap_set_option', 'DWORD',[
@@ -42,17 +42,17 @@ class Def_windows_wldap32
     ], 'ldap_set_option', "cdecl")
 
     dll.add_function('ldap_search_ext_sA', 'DWORD',[
-        ['DWORD', 'ld', 'in'],
+        ['PHANDLE', 'ld', 'in'],
         ['PCHAR', 'base', 'in'],
         ['DWORD', 'scope', 'in'],
         ['PCHAR', 'filter', 'in'],
         ['PCHAR', 'attrs[]', 'in'],
         ['DWORD', 'attrsonly', 'in'],
-        ['DWORD', 'pServerControls', 'in'],
-        ['DWORD', 'pClientControls', 'in'],
-        ['DWORD', 'pTimeout', 'in'],
+        ['PVOID', 'pServerControls', 'in'],
+        ['PVOID', 'pClientControls', 'in'],
+        ['PLONGLONG', 'pTimeout', 'in'],
         ['DWORD', 'SizeLimit', 'in'],
-        ['PDWORD', 'res', 'out']
+        ['PULONG_PTR', 'res', 'out']
     ], 'ldap_search_ext_sA', "cdecl")
 
     dll.add_function('ldap_count_entries', 'DWORD',[

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
@@ -32,7 +32,7 @@ class Def_windows_wldap32
         ['PCHAR', 'filter', 'in'],
         ['PCHAR', 'attrs[]', 'in'],
         ['DWORD', 'attrsonly', 'in'],
-        ['PULONG_PTR', 'res', 'out']
+        ['PLPVOID', 'res', 'out']
     ], 'ldap_search_sA', "cdecl")
 
     dll.add_function('ldap_set_option', 'DWORD',[
@@ -50,9 +50,9 @@ class Def_windows_wldap32
         ['DWORD', 'attrsonly', 'in'],
         ['PVOID', 'pServerControls', 'in'],
         ['PVOID', 'pClientControls', 'in'],
-        ['PLONGLONG', 'pTimeout', 'in'],
+        ['PBLOB', 'pTimeout', 'in'],
         ['DWORD', 'SizeLimit', 'in'],
-        ['PULONG_PTR', 'res', 'out']
+        ['PLPVOID', 'res', 'out']
     ], 'ldap_search_ext_sA', "cdecl")
 
     dll.add_function('ldap_count_entries', 'DWORD',[

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
@@ -12,111 +12,111 @@ class Def_windows_wldap32
   def self.create_library(constant_manager, library_path = 'wldap32')
     dll = Library.new(library_path, constant_manager)
 
-    dll.add_function('ldap_sslinitA', 'DWORD',[
+    dll.add_function('ldap_sslinitA', 'LPVOID',[
         ['PCHAR', 'HostName', 'in'],
-        ['DWORD', 'PortNumber', 'in'],
+        ['ULONG', 'PortNumber', 'in'],
         ['DWORD', 'secure', 'in']
     ], 'ldap_sslinitA', "cdecl")
 
-    dll.add_function('ldap_bind_sA', 'DWORD',[
-        ['DWORD', 'ld', 'in'],
+    dll.add_function('ldap_bind_sA', 'ULONG',[
+        ['LPVOID', 'ld', 'in'],
         ['PCHAR', 'dn', 'in'],
         ['PCHAR', 'cred', 'in'],
-        ['DWORD', 'method', 'in']
+        ['ULONG', 'method', 'in']
     ], 'ldap_bind_sA', "cdecl")
 
-    dll.add_function('ldap_search_sA', 'DWORD',[
-        ['PHANDLE', 'ld', 'in'],
+    dll.add_function('ldap_search_sA', 'ULONG',[
+        ['LPVOID', 'ld', 'in'],
         ['PCHAR', 'base', 'in'],
-        ['DWORD', 'scope', 'in'],
+        ['ULONG', 'scope', 'in'],
         ['PCHAR', 'filter', 'in'],
         ['PCHAR', 'attrs[]', 'in'],
-        ['DWORD', 'attrsonly', 'in'],
+        ['ULONG', 'attrsonly', 'in'],
         ['PLPVOID', 'res', 'out']
     ], 'ldap_search_sA', "cdecl")
 
-    dll.add_function('ldap_set_option', 'DWORD',[
-        ['DWORD', 'ld', 'in'],
+    dll.add_function('ldap_set_option', 'ULONG',[
+        ['LPVOID', 'ld', 'in'],
         ['DWORD', 'option', 'in'],
-        ['PDWORD', 'invalue', 'in']
+        ['PBLOB', 'invalue', 'in']
     ], 'ldap_set_option', "cdecl")
 
-    dll.add_function('ldap_search_ext_sA', 'DWORD',[
-        ['PHANDLE', 'ld', 'in'],
+    dll.add_function('ldap_search_ext_sA', 'ULONG',[
+        ['LPVOID', 'ld', 'in'],
         ['PCHAR', 'base', 'in'],
-        ['DWORD', 'scope', 'in'],
+        ['ULONG', 'scope', 'in'],
         ['PCHAR', 'filter', 'in'],
         ['PCHAR', 'attrs[]', 'in'],
-        ['DWORD', 'attrsonly', 'in'],
-        ['PVOID', 'pServerControls', 'in'],
-        ['PVOID', 'pClientControls', 'in'],
+        ['ULONG', 'attrsonly', 'in'],
+        ['LPVOID', 'pServerControls', 'in'],
+        ['LPVOID', 'pClientControls', 'in'],
         ['PBLOB', 'pTimeout', 'in'],
-        ['DWORD', 'SizeLimit', 'in'],
+        ['ULONG', 'SizeLimit', 'in'],
         ['PLPVOID', 'res', 'out']
     ], 'ldap_search_ext_sA', "cdecl")
 
-    dll.add_function('ldap_count_entries', 'DWORD',[
-        ['DWORD', 'ld', 'in'],
-        ['DWORD', 'res', 'in']
+    dll.add_function('ldap_count_entries', 'ULONG',[
+        ['LPVOID', 'ld', 'in'],
+        ['LPVOID', 'res', 'in']
     ], "ldap_count_entries", "cdecl")
 
-    dll.add_function('ldap_first_entry', 'DWORD',[
-        ['DWORD', 'ld', 'in'],
-        ['DWORD', 'res', 'in']
+    dll.add_function('ldap_first_entry', 'LPVOID',[
+        ['LPVOID', 'ld', 'in'],
+        ['LPVOID', 'res', 'in']
     ], 'ldap_first_entry', "cdecl")
 
-    dll.add_function('ldap_next_entry', 'DWORD',[
-        ['DWORD', 'ld', 'in'],
-        ['DWORD', 'entry', 'in']
+    dll.add_function('ldap_next_entry', 'LPVOID',[
+        ['LPVOID', 'ld', 'in'],
+        ['LPVOID', 'entry', 'in']
     ], 'ldap_next_entry', "cdecl")
 
-    dll.add_function('ldap_first_attributeA', 'DWORD',[
-        ['DWORD', 'ld', 'in'],
-        ['DWORD', 'entry', 'in'],
-        ['DWORD', 'ptr', 'in']
+    dll.add_function('ldap_first_attributeA', 'PCHAR',[
+        ['LPVOID', 'ld', 'in'],
+        ['LPVOID', 'entry', 'in'],
+        ['PLPVOID', 'ptr', 'out']
     ], 'ldap_first_attributeA', "cdecl")
 
-    dll.add_function('ldap_next_attributeA', 'DWORD',[
-        ['DWORD', 'ld', 'in'],
-        ['DWORD', 'entry', 'in'],
-        ['DWORD', 'ptr', 'inout']
+    dll.add_function('ldap_next_attributeA', 'PCHAR',[
+        ['LPVOID', 'ld', 'in'],
+        ['LPVOID', 'entry', 'in'],
+        ['PBLOB', 'ptr', 'inout']
     ], 'ldap_next_attributeA', "cdecl")
 
-    dll.add_function('ldap_count_values', 'DWORD',[
-        ['DWORD', 'vals', 'in'],
+    dll.add_function('ldap_count_values', 'ULONG',[
+        ['PLPVOID', 'vals', 'in'],
     ], 'ldap_count_values', "cdecl")
 
-    dll.add_function('ldap_get_values', 'DWORD',[
-        ['DWORD', 'ld', 'in'],
-        ['DWORD', 'entry', 'in'],
+    dll.add_function('ldap_get_values', 'PLPVOID',[
+        ['LPVOID', 'ld', 'in'],
+        ['LPVOID', 'entry', 'in'],
         ['PCHAR', 'attr', 'in']
     ], 'ldap_get_values', "cdecl")
 
-    dll.add_function('ldap_value_free', 'DWORD',[
-        ['DWORD', 'vals', 'in'],
+    dll.add_function('ldap_value_free', 'ULONG',[
+        ['PLPVOID', 'vals', 'in'],
     ], 'ldap_value_free', "cdecl")
 
     dll.add_function('ldap_memfree', 'VOID',[
-        ['DWORD', 'block', 'in'],
+        ['PCHAR', 'block', 'in'],
     ], 'ldap_memfree', "cdecl")
 
     dll.add_function('ber_free', 'VOID',[
-        ['DWORD', 'pBerElement', 'in'],
+        ['LPVOID', 'pBerElement', 'in'],
         ['DWORD', 'fbuf', 'in'],
     ], 'ber_free', "cdecl")
 
-    dll.add_function('LdapGetLastError', 'DWORD',[], 'LdapGetLastError', "cdecl")
+    dll.add_function('LdapGetLastError', 'ULONG', [], 'LdapGetLastError', "cdecl")
 
-    dll.add_function('ldap_err2string', 'DWORD',[
-        ['DWORD', 'err', 'in']
+    dll.add_function('ldap_err2string', 'PCHAR',[
+        ['ULONG', 'err', 'in']
     ], 'ldap_err2string', "cdecl")
 
-    dll.add_function('ldap_msgfree', 'DWORD', [
-      ['DWORD', 'res', 'in']
+    dll.add_function('ldap_msgfree', 'ULONG', [
+      ['LPVOID', 'res', 'in']
     ], 'ldap_msgfree', "cdecl")
 
-    dll.add_function('ldap_unbind', 'DWORD', [
-      ['DWORD', 'ld', 'in']
+    dll.add_function('ldap_unbind', 'ULONG', [
+      ['LPVOID', 'ld', 'in']
     ], 'ldap_unbind', "cdecl")
     return dll
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
@@ -79,21 +79,21 @@ class Def_windows_wldap32
     dll.add_function('ldap_next_attributeA', 'PCHAR',[
         ['LPVOID', 'ld', 'in'],
         ['LPVOID', 'entry', 'in'],
-        ['PBLOB', 'ptr', 'inout']
+        ['LPVOID', 'ptr', 'inout']
     ], 'ldap_next_attributeA', "cdecl")
 
     dll.add_function('ldap_count_values', 'ULONG',[
-        ['PLPVOID', 'vals', 'in'],
+        ['LPVOID', 'vals', 'in'],
     ], 'ldap_count_values', "cdecl")
 
-    dll.add_function('ldap_get_values', 'PLPVOID',[
+    dll.add_function('ldap_get_values', 'LPVOID',[
         ['LPVOID', 'ld', 'in'],
         ['LPVOID', 'entry', 'in'],
         ['PCHAR', 'attr', 'in']
     ], 'ldap_get_values', "cdecl")
 
     dll.add_function('ldap_value_free', 'ULONG',[
-        ['PLPVOID', 'vals', 'in'],
+        ['LPVOID', 'vals', 'in'],
     ], 'ldap_value_free', "cdecl")
 
     dll.add_function('ldap_memfree', 'VOID',[

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
@@ -317,9 +317,9 @@ class Library
       when 'VOID'
         return_hash['return'] = nil
       when 'PCHAR'
-        return_hash['return'] = read_string(rec_return_value)
+        return_hash['return'] = rec_return_value == 0 ? nil : read_string(rec_return_value)
       when 'PWCHAR'
-        return_hash['return'] = read_wstring(rec_return_value)
+        return_hash['return'] = rec_return_value == 0 ? nil : read_wstring(rec_return_value)
       else
         raise "unexpected return type: #{function.return_type}"
     end

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
@@ -51,6 +51,7 @@ class Library
     'SIZE_T'  => 'ULONG_PTR',
     'PSIZE_T' => 'PULONG_PTR',
     'PLPVOID' => 'PULONG_PTR',
+    'ULONG'   => 'DWORD',
     'PULONG'  => 'PDWORD'
   }.freeze
 
@@ -227,7 +228,7 @@ class Library
         # it's not a pointer (LPVOID is a pointer but is not backed by railgun memory, ala PBLOB)
         buffer = [0].pack(native)
         case param_desc[0]
-          when 'LPVOID', 'ULONG_PTR'
+          when 'LPVOID', 'PULONG_PTR', 'ULONG_PTR'
             num     = param_to_number(args[param_idx])
             buffer += [num].pack(native)
           when 'DWORD'
@@ -315,6 +316,10 @@ class Library
         return_hash['return'] = (rec_return_value != 0)
       when 'VOID'
         return_hash['return'] = nil
+      when 'PCHAR'
+        return_hash['return'] = read_string(rec_return_value)
+      when 'PWCHAR'
+        return_hash['return'] = read_wstring(rec_return_value)
       else
         raise "unexpected return type: #{function.return_type}"
     end

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library_function.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library_function.rb
@@ -43,9 +43,9 @@ class LibraryFunction
     'LPVOID'     => ['in', 'return'], # sf: for specifying a memory address (e.g. VirtualAlloc/HeapAlloc/...) where we don't want to back it up with actual mem ala PBLOB
     'ULONG_PTR'  => ['in', 'return'],
     'PDWORD'     => ['in', 'out', 'inout'], # todo: support for functions that return pointers to strings
-    'PULONG_PTR' => ['in', 'out', 'inout'],
-    'PWCHAR'     => ['in', 'out', 'inout'],
-    'PCHAR'      => ['in', 'out', 'inout'],
+    'PULONG_PTR' => ['in', 'out', 'inout', 'return'],
+    'PWCHAR'     => ['in', 'out', 'inout', 'return'],
+    'PCHAR'      => ['in', 'out', 'inout', 'return'],
     'PBLOB'      => ['in', 'out', 'inout'],
   }.freeze
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/multicall.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/multicall.rb
@@ -90,7 +90,7 @@ class MultiCaller
       lib_name, function, args = f
       library = @parent.get_library(lib_name)
       function = library.functions[function] unless function.instance_of? LibraryFunction
-      function_results << library.build_response(call_results.shift, function, call_layouts.shift, @client.native_arch)
+      function_results << library.build_response(call_results.shift, function, call_layouts.shift, @client)
     end
 
     function_results


### PR DESCRIPTION
This fixes up some incorrect definitions within `def_wldap32.rb` so it can work with x64 Windows. Note that I'm not 100% sure if these definitions are correct or not so some verification might be needed.

Also note `ldap_search_sA` is presently used by the `lib/msf/core/post/windows/ldap.rb` library via the `query_ldap` function, which is in turned used by the `get_default_naming_context` and `query` functions.

Therefore, this might need some verification to make sure it doesn't break anything.


## Verification
- [ ] Review the PR and confirm the definitions match MSDN's documentation.
- [ ] Get a Meterpreter session on a Windows x64 host.
- [ ] From the main console run `loadpath test/modules/` to load the test modules.
- [ ] `post/test/railgun` should work, all tests should pass
- [ ] `post/test/railgun_reverse_lookups` should also work with all tests passing
