### PR TITLE
Allows integration of creds into modules

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -98,6 +98,47 @@ module Common
     print_line
   end
 
+  def set_creds_from_database(public, private, realm)
+    if public.empty? && private.empty?
+      print_status("Invalid")
+    end
+    # check if a module is active
+    if active_module
+      mydatastore = active_module.datastore
+    else
+      print_error("No active module selected")
+      return
+    end
+    # options to check if ppresent for active module
+    user_options = ['USERNAME', 'HttpUsername', 'SMBUser', 'DBUSER', 'FTPUSER']
+    pass_options = ['PASSWORD', 'HttpPassword', 'SMBPass', 'DBPASS', 'FTPPASS']
+    domain_options = ['DOMAIN', 'SMBDomain', 'DOMAINNAME']
+    # set username
+    user_options.each do |user_option|
+      if mydatastore.options.include?(user_option)
+        mydatastore[user_option] = public
+        print_line "#{user_option} => #{mydatastore[user_option]}"
+        break
+      end
+    end
+    # set password
+    pass_options.each do |pass_option|
+      if mydatastore.options.include?(pass_option)
+        mydatastore[pass_option] = private
+        print_line "#{pass_option} => #{mydatastore[pass_option]}"
+        break
+      end
+    end
+    # set realm
+    domain_options.each do |domain_option|
+      if mydatastore.options.include?(domain_option)
+        mydatastore[domain_option] = realm
+        print_line "#{domain_option} => #{mydatastore[domain_option]}"
+        break
+      end
+    end
+  end
+
   def show_options(mod) # :nodoc:
     mod_opt = Serializer::ReadableText.dump_options(mod, '   ')
     print("\nModule options (#{mod.fullname}):\n\n#{mod_opt}\n") if (mod_opt and mod_opt.length > 0)

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('DBHOST', [ true, "The SQL Server host", 'local']),
         OptString.new('DBNAME', [ true, "The SQL Server database", 'master']),
         OptString.new('DBUID', [ true, "The SQL Server uid (default is sa)", 'sa']),
-        OptString.new('DBPASSWORD', [ false, "The SQL Server password (default is blank)", '']),
+        OptString.new('DBPASS', [ false, "The SQL Server password (default is blank)", '']),
       ]
     )
 
@@ -317,7 +317,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Step 8: Trying SQL xp_cmdshell method...")
-    ret = exec_cmd("EXEC master..xp_cmdshell", "cmd /c echo x", "driver={SQL Server};server=(#{datastore['DBHOST']});database=#{datastore['DBNAME']};uid=#{datastore['DBUID']};pwd=#{datastore['DBPASSWORD']}") # based on hdm's sqlrds.pl :)
+    ret = exec_cmd("EXEC master..xp_cmdshell", "cmd /c echo x", "driver={SQL Server};server=(#{datastore['DBHOST']});database=#{datastore['DBNAME']};uid=#{datastore['DBUID']};pwd=#{datastore['DBPASS']}") # based on hdm's sqlrds.pl :)
     return ret if (ret)
 
     return -1

--- a/modules/post/multi/manage/dbvis_add_db_admin.rb
+++ b/modules/post/multi/manage/dbvis_add_db_admin.rb
@@ -39,8 +39,8 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptString.new('DBALIAS', [true, 'Use dbvis_enum module to find out databases and aliases', 'localhost']),
-        OptString.new('DBUSERNAME', [true, 'The user you want to add to the remote database', 'msf']),
-        OptString.new('DBPASSWORD', [true, 'User password to set', 'msfRocks'])
+        OptString.new('DBUSER', [true, 'The user you want to add to the remote database', 'msf']),
+        OptString.new('DBPASS', [true, 'User password to set', 'msfRocks'])
       ]
     )
   end
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Post
         if errors == true
           print_error("No luck today, access is probably denied for configured user !? Try in verbose mode to know what happened. ")
         else
-          print_good("Privileged user created ! Try now to connect with user : #{datastore['DBUSERNAME']} and password : #{datastore['DBPASSWORD']}")
+          print_good("Privileged user created ! Try now to connect with user : #{datastore['DBUSER']} and password : #{datastore['DBPASS']}")
         end
       end
     end
@@ -239,11 +239,11 @@ class MetasploitModule < Msf::Post
   # Build proper sql
   def get_sql(db_type)
     if db_type =~ /mysql/i
-      sql = "CREATE USER '#{datastore['DBUSERNAME']}'@'localhost' IDENTIFIED BY '#{datastore['DBPASSWORD']}';"
-      sql << "GRANT ALL PRIVILEGES ON *.* TO '#{datastore['DBUSERNAME']}'@'localhost' WITH GRANT OPTION;"
+      sql = "CREATE USER '#{datastore['DBUSER']}'@'localhost' IDENTIFIED BY '#{datastore['DBPASS']}';"
+      sql << "GRANT ALL PRIVILEGES ON *.* TO '#{datastore['DBUSER']}'@'localhost' WITH GRANT OPTION;"
 
-      sql << "CREATE USER '#{datastore['DBUSERNAME']}'@'%' IDENTIFIED BY '#{datastore['DBPASSWORD']}';"
-      sql << "GRANT ALL PRIVILEGES ON *.* TO '#{datastore['DBUSERNAME']}'@'%' WITH GRANT OPTION;"
+      sql << "CREATE USER '#{datastore['DBUSER']}'@'%' IDENTIFIED BY '#{datastore['DBPASS']}';"
+      sql << "GRANT ALL PRIVILEGES ON *.* TO '#{datastore['DBUSER']}'@'%' WITH GRANT OPTION;"
       return sql
     end
     return nil

--- a/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
               'Credentials',
               '===========',
               '',
-              'host  origin  service  public    private   realm  private_type  JtR Format',
-              '----  ------  -------  ------    -------   -----  ------------  ----------',
-              '                       thisuser  thispass         Password      '
+              'id  host  origin  service  public    private   realm  private_type  JtR Format',
+              '--  ----  ------  -------  ------    -------   -----  ------------  ----------',
+              '1                          thisuser  thispass         Password      '
             ])
           end
 
@@ -83,9 +83,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
               'Credentials',
               '===========',
               '',
-              'host  origin  service  public    private   realm  private_type  JtR Format',
-              '----  ------  -------  ------    -------   -----  ------------  ----------',
-              '                       thisuser  thispass         Password      '
+              'id  host  origin  service  public    private   realm  private_type  JtR Format',
+              '--  ----  ------  -------  ------    -------   -----  ------------  ----------',
+              '1                          thisuser  thispass         Password      '
             ])
           end
 
@@ -96,9 +96,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  origin  service  public  private        realm  private_type  JtR Format',
-                '----  ------  -------  ------  -------        -----  ------------  ----------',
-                '                               nonblank_pass         Password      '
+                'id  host  origin  service  public  private        realm  private_type  JtR Format',
+                '--  ----  ------  -------  ------  -------        -----  ------------  ----------',
+                '1                                  nonblank_pass         Password      '
               ])
             end
           end
@@ -109,9 +109,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  origin  service  public         private  realm  private_type  JtR Format',
-                '----  ------  -------  ------         -------  -----  ------------  ----------',
-                '                       nonblank_user                  Password      '
+                'id  host  origin  service  public         private  realm  private_type  JtR Format',
+                '--  ----  ------  -------  ------         -------  -----  ------------  ----------',
+                '1                          nonblank_user                  Password      '
               ])
             end
           end
@@ -125,8 +125,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  origin  service  public  private  realm  private_type  JtR Format',
-                '----  ------  -------  ------  -------  -----  ------------  ----------'
+                'id  host  origin  service  public  private  realm  private_type  JtR Format',
+                '--  ----  ------  -------  ------  -------  -----  ------------  ----------'
               ])
             end
           end
@@ -137,8 +137,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  origin  service  public  private  realm  private_type  JtR Format',
-                '----  ------  -------  ------  -------  -----  ------------  ----------'
+                'id  host  origin  service  public  private  realm  private_type  JtR Format',
+                '--  ----  ------  -------  ------  -------  -----  ------------  ----------'
               ])
             end
           end
@@ -206,9 +206,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  origin  service  public    private   realm  private_type  JtR Format',
-                '----  ------  -------  ------    -------   -----  ------------  ----------',
-                '                       thisuser  thispass         Password      '
+                'id  host  origin  service  public    private   realm  private_type  JtR Format',
+                '--  ----  ------  -------  ------    -------   -----  ------------  ----------',
+                '1                          thisuser  thispass         Password      '
               ])
             end
           end


### PR DESCRIPTION
Fix #17367 . (Though it currently allows only single credential to be filled)

This change adds the feature to fill creds into modules directly instead of manually adding them to modules.
The credentials stored in database from auxiliary modules which can be seen by `creds` can be filled to modules like
`smb/psexec.rb` using `creds fill <index of the cred>` command.
Although currently this allows addition of **username** and authentication like **password** or **password hash** of single entry from database. It can be generalized for more module options.

Also changed options like `IMAP[USER | PASS]`, etc to standardized `[USERNAME|PASSWORD]` for the implementation of the feature

The above changes were successfully observed in Metasploit v6.2.37-dev-1021d2d700

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] use a auxiliary module like `auxiliary/gather/smtp` to get creds or add them manually with `creds add`
- [ ] `creds` will display the creds along with index.
- [ ] Use a module like `smb/psexec` with username and password options.
- [ ] `creds fill <index of cred>` will add them to the module.
- [ ] **Verify** it with `show options`

