### PR TITLE
Update add_host_tag and delete_host_tag to properly handle tagging multiple hosts and then deleting these tags

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
@@ -119,10 +119,6 @@ module HostDataProxy
   end
 
   def add_host_id_to_opts(opts)
-    if opts[:id]
-      return true
-    end
-
     if opts[:address]
       self.data_service_operation do |data_service|
         host = data_service.get_host(opts)

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -382,9 +382,13 @@ class Db
     opts[:workspace] = framework.db.workspace
     opts[:tag_name] = tag_name
 
+    # This will be the case if no IP was passed in, and we are just trying to delete all
+    # instances of a given tag within the database.
     if rws == [nil]
-      unless framework.db.delete_host_tag(opts)
-        print_error("Host #{opts[:address].to_s + " " if opts[:address]}could not be found.")
+      wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+      wspace.hosts.each do |host|
+        opts[:address] = host.address
+        framework.db.delete_host_tag(opts)
       end
     else
       rws.each do |rw|
@@ -396,7 +400,6 @@ class Db
         end
       end
     end
-
   end
 
   @@hosts_columns = [ 'address', 'mac', 'name', 'os_name', 'os_flavor', 'os_sp', 'purpose', 'info', 'comments']


### PR DESCRIPTION
Fixes #12230

This is an old issue that I'm surprised we didn't fix fully earlier, however it seems like we fixed the first half of the issue at #12230 and then forgot about the issue....until now 😄 Whilst digging through old issues to close I noticed this one and dug into it deeper. Analysis can be found on the comments on #12230 but basically what this boiled down to was that we used `opts[:id]` which sounded like a good idea as in theory it should reference the ID of the entry in the database to use.

One problem though. This was being set to the first entry in the database that we wanted to use and was never being updated on each host, yet `opts[:address]` was correctly being updated on each iteration with the IP address of the host we wanted to use. 

I have since updated the code to now properly use `find_by_address` to find the correct host entry by the IP address. Its possible we could raise this fix higher up in the chain but this at least fixes the issue close to the source of where its important. Fixing this at a higher level is potentially beyond the scope of this PR given potential side effects.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole` with a database started and connected
- [ ] `hosts -d` to clear all host entries.
- [ ] `hosts -a 10.1.1.0/24`
- [ ] `hosts 10.1.1.0/24 -t mytag`
- [ ] `hosts -c address,tags`
- [ ] Verify that previously only the first host would be tagged with `mytag` as a tag, but now all hosts within the specified range are tagged.
- [ ] `hosts 10.1.1.0/24 -T mytag`
- [ ] `hosts -c address,tags` 
- [ ] Verify that previously only the first host would have its tag `mytag` deleted, but now all hosts within the specified range are untagged.
- [ ] `hosts 10.1.1.0/24 -t mytag` to add the tags back in
- [ ] `hosts -c address,tags` to double check the tags are added.
- [ ] `hosts -T mytag`
- [ ] Verify that previously this command would fail with a warning message about not being able to find the host, and that now we delete the tag from all hosts who possess this tag.
