### PR TITLE
Fix missed references to old wiki site and update them to point to new docs website

### DIFF
--- a/docs/metasploit-framework.wiki/Metasploit-5.0-Release-Notes.md
+++ b/docs/metasploit-framework.wiki/Metasploit-5.0-Release-Notes.md
@@ -28,6 +28,6 @@ The following is a high-level overview of Metasploit 5.0's features and capabili
 
 You can get Metasploit 5.0 by checking out the [5.0.0 tag](https://github.com/rapid7/metasploit-framework/releases/tag/5.0.0) in the Metasploit GitHub project.
 
-Need a primer on Framework architecture and usage? Take a look at [our wiki here](https://github.com/rapid7/metasploit-framework/wiki), and feel free to reach out to the broader community [on Slack](https://metasploit.com/slack). There are also myriad public and user-generated resources on Metasploit tips, tricks, and content, so if you can't find something you want in our wiki, ask Google or the community what they recommend.
+Need a primer on Framework architecture and usage? Take a look at [our wiki here](https://docs.metasploit.com/), and feel free to reach out to the broader community [on Slack](https://metasploit.com/slack). There are also myriad public and user-generated resources on Metasploit tips, tricks, and content, so if you can't find something you want in our wiki, ask Google or the community what they recommend.
 
 See all the ways to stay informed and get involved at <https://metasploit.com>.

--- a/docs/metasploit-framework.wiki/Metasploit-6.0-Development-Notes.md
+++ b/docs/metasploit-framework.wiki/Metasploit-6.0-Development-Notes.md
@@ -48,6 +48,6 @@ A complete list of pull requests included as part of the initial version 6 work:
 
 You can get Metasploit 6.0 by checking out the [6.0.0 tag](https://github.com/rapid7/metasploit-framework/releases/tag/6.0.0) in the Metasploit GitHub project.
 
-Need a primer on Framework architecture and usage? Take a look at [our wiki here](https://github.com/rapid7/metasploit-framework/wiki), and feel free to reach out to the broader community [on Slack](https://metasploit.com/slack). There are also myriad public and user-generated resources on Metasploit tips, tricks, and content, so if you can't find something you want in our wiki, ask Google or the community what they recommend.
+Need a primer on Framework architecture and usage? Take a look at [our wiki here](https://docs.metasploit.com/), and feel free to reach out to the broader community [on Slack](https://metasploit.com/slack). There are also myriad public and user-generated resources on Metasploit tips, tricks, and content, so if you can't find something you want in our wiki, ask Google or the community what they recommend.
 
 See all the ways to stay informed and get involved at <https://metasploit.com>.

--- a/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
+++ b/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
@@ -247,7 +247,7 @@ Finally, we welcome your feedback on this guide, so feel free to reach out to us
 
 [git aliases]:https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases
 [rspec]:https://www.rubyguides.com/2018/07/rspec-tutorial/
-[wiki-documentation]:https://github.com/rapid7/metasploit-framework/wiki#metasploit-development
+[wiki-documentation]:https://docs.metasploit.com/#metasploit-development
 [newbie-friendly-prs-issues]:https://github.com/rapid7/metasploit-framework/issues?q=is%3Aopen+label%3Anewbie-friendly
 [howto-PR]:https://help.github.com/articles/about-pull-requests/
 [new issue]:https://github.com/rapid7/metasploit-framework/issues/new/choose

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,13 +1,11 @@
 # Metasploit Developer Documentation
 
-*(last updated December 1, 2014)
-
 Metasploit is actively supported by a community of hundreds of
 contributors and thousands of users world-wide. As a result, the
 accompanying documentation moves quite quickly.
 
 The best source of documentation on Metasploit development is
-https://github.com/rapid7/metasploit-framework/wiki. There are many
+https://docs.metasploit.com/. There are many
 treasures there, such as:
 
   * [Evading Antivirus](https://docs.metasploit.com/docs/using-metasploit/intermediate/evading-anti-virus.html)

--- a/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = GreatRanking # https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking
+  Rank = GreatRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
 
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::System


### PR DESCRIPTION
The PR I put up at #17426 fixed most but not all the references to the old Wiki site on GitHub. This PR fixes 6 other files I missed during that review that may have been updated due to the recent 6.3 merge.

A side note there are also some documentation files for modules that are still referencing the old site however they have formatting that splits the URL across lines so I haven't updated those. If anyone has a good idea how to fix that I'm all ears. Example file for this is `documentation/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.md`.

## Verification
- [ ] Verify that the new links exist and are valid for the context in which they are used.
- [ ] Verify that none of the changes have messed up any links or caused any issues.