### PR TITLE
modules: Check datastore ForceExploit before checking if session is root

### DIFF
--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Local
   #
   def exploit
     # Check if we're already root
-    if is_root? && !datastore['ForceExploit']
+    if !datastore['ForceExploit'] && is_root?
       fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
     end
 

--- a/modules/exploits/freebsd/local/intel_sysret_priv_esc.rb
+++ b/modules/exploits/freebsd/local/intel_sysret_priv_esc.rb
@@ -129,10 +129,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable?(base_dir)

--- a/modules/exploits/freebsd/local/ip6_setpktopt_uaf_priv_esc.rb
+++ b/modules/exploits/freebsd/local/ip6_setpktopt_uaf_priv_esc.rb
@@ -102,6 +102,7 @@ class MetasploitModule < Msf::Exploit::Local
           'WfsDelay' => 10
         },
         'Notes' => {
+          'Reliability' => [REPEATABLE_SESSION],
           'Stability' => [CRASH_OS_RESTARTS],
           'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
         },

--- a/modules/exploits/freebsd/local/ip6_setpktopt_uaf_priv_esc.rb
+++ b/modules/exploits/freebsd/local/ip6_setpktopt_uaf_priv_esc.rb
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
+    if !datastore['ForceExploit'] && is_root?
       fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 

--- a/modules/exploits/freebsd/local/rtld_execl_priv_esc.rb
+++ b/modules/exploits/freebsd/local/rtld_execl_priv_esc.rb
@@ -123,10 +123,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable?(base_dir)

--- a/modules/exploits/linux/local/abrt_sosreport_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_sosreport_priv_esc.rb
@@ -126,10 +126,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -148,10 +148,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -188,10 +188,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -168,8 +168,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
@@ -125,10 +125,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -235,10 +235,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -155,10 +155,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable?(base_dir)

--- a/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
+++ b/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
+    if !datastore['ForceExploit'] && is_root?
       fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 

--- a/modules/exploits/linux/local/cve_2021_3493_overlayfs.rb
+++ b/modules/exploits/linux/local/cve_2021_3493_overlayfs.rb
@@ -114,9 +114,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
-      fail_with(Failure::None, 'Session already has root privileges. Set ForceExploit to override.')
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
+
     base_dir = datastore['WritableDir'].to_s
     unless writable?(base_dir)
       fail_with(Failure::BadConfig, "#{base_dir} is not writable")

--- a/modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb
+++ b/modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb
@@ -186,8 +186,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def run_exploit(check)
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless check

--- a/modules/exploits/linux/local/cve_2022_0995_watch_queue.rb
+++ b/modules/exploits/linux/local/cve_2022_0995_watch_queue.rb
@@ -83,8 +83,8 @@ class MetasploitModule < Msf::Exploit::Local
   def module_check
     # Vulnerable versions are under 5.17:rc8
     # This module only has offsets for Ubuntu 5.13.0-37
-    if is_root? && !datastore['ForceExploit']
-      fail_with(Failure::None, 'Session already has root privileges. Set ForceExploit to override.')
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
     if datastore['DEBUG_SOURCE'] && datastore['COMPILE'] != 'True'
       fail_with(Failure::BadConfig, 'DEBUG_PRINT is only supported when COMPILE is set to True')

--- a/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
@@ -99,8 +99,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    # Check if we're already root
-    if is_root? && !datastore['ForceExploit']
+    if !datastore['ForceExploit'] && is_root?
       fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
     end
 

--- a/modules/exploits/linux/local/diamorphine_rootkit_signal_priv_esc.rb
+++ b/modules/exploits/linux/local/diamorphine_rootkit_signal_priv_esc.rb
@@ -88,10 +88,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -51,10 +51,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
+++ b/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
@@ -225,10 +225,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable?(base_dir)

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -181,10 +181,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/hp_xglance_priv_esc.rb
+++ b/modules/exploits/linux/local/hp_xglance_priv_esc.rb
@@ -109,8 +109,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
@@ -116,8 +116,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
@@ -120,10 +120,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     print_status 'Building package...'

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -167,8 +167,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -200,8 +200,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/network_manager_vpnc_username_priv_esc.rb
+++ b/modules/exploits/linux/local/network_manager_vpnc_username_priv_esc.rb
@@ -96,10 +96,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     @payload_name = ".#{rand_text_alphanumeric rand(10..15)}"

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
+    if !datastore['ForceExploit'] && is_root?
       fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 

--- a/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
+++ b/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
@@ -131,10 +131,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
+++ b/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
@@ -101,8 +101,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? datastore['WritableDir']

--- a/modules/exploits/linux/local/rds_atomic_free_op_null_pointer_deref_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_atomic_free_op_null_pointer_deref_priv_esc.rb
@@ -125,10 +125,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
@@ -113,10 +113,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/recvmmsg_priv_esc.rb
+++ b/modules/exploits/linux/local/recvmmsg_priv_esc.rb
@@ -142,10 +142,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/reptile_rootkit_reptile_cmd_priv_esc.rb
+++ b/modules/exploits/linux/local/reptile_rootkit_reptile_cmd_priv_esc.rb
@@ -98,10 +98,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
+++ b/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
@@ -126,8 +126,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -134,10 +134,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
+++ b/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
@@ -115,8 +115,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/ubuntu_enlightenment_mount_priv_esc.rb
+++ b/modules/exploits/linux/local/ubuntu_enlightenment_mount_priv_esc.rb
@@ -98,9 +98,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    # Check if we're already root
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     # Make sure we can write our exploit and payload to the local system

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -185,10 +185,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/vcenter_java_wrapper_vmon_priv_esc.rb
+++ b/modules/exploits/linux/local/vcenter_java_wrapper_vmon_priv_esc.rb
@@ -81,9 +81,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    # Check if we're already root
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     # Make sure we can write our exploit and payload to the local system

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -151,10 +151,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-      end
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
+++ b/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
@@ -110,9 +110,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    # Check if we're already root
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     # Make sure we can write our exploit and payload to the local system

--- a/modules/exploits/openbsd/local/dynamic_loader_chpass_privesc.rb
+++ b/modules/exploits/openbsd/local/dynamic_loader_chpass_privesc.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
+    if !datastore['ForceExploit'] && is_root?
       fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
     end
 

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -195,9 +195,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    # Check if we're already root
-    if is_root? && !datastore['ForceExploit']
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+    if !datastore['ForceExploit'] && is_root?
+      fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 
     # Make sure we can write our payload to the remote system

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -51,6 +51,11 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' => {
           'PAYLOAD' => 'osx/x64/meterpreter_reverse_tcp',
           'WfsDelay' => 15
+        },
+        'Notes' => {
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         }
       )
     )

--- a/modules/exploits/qnx/local/ifwatchd_priv_esc.rb
+++ b/modules/exploits/qnx/local/ifwatchd_priv_esc.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root? && !datastore['ForceExploit']
+    if !datastore['ForceExploit'] && is_root?
       fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
     end
 


### PR DESCRIPTION
Currently, many local exploit modules check if the user has root permissions before proceeding, unless the operator has enabled `ForceExploit`.

```ruby
if is_root? && !datastore['ForceExploit']
  fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
end
```

This is good; however, due to the order of conditions, when the operator has selected `ForceExploit` the module will still check first if the user has root permissions.

This is unnecessary. There is no reason to check for root permissions when `ForceExploit` is set. Additionally, as the `is_root?` check requires execution of multiple commands on the remote host, this check is significantly more expensive than a simple Boolean comparison with a local datastore option.

Worse, in instances where the module cannot determine whether the user has root permissions (ie, if `id` is not in `PATH` or returns unexpected output), the module will `raise` on Linux systems. An operator who wished to avoid this failure condition by forcing exploitation would not care if the root check failed - in fact, they may have enabled `ForceExploit` as a workaround specifically because the root check failed.

This PR modifies the conditions in 45 modules to check whether the operator has selected `ForceExploit` before checking permissions, which is slightly more efficient.


