### PR TITLE
Enhances info -d with references to AttackerKB

### DIFF
--- a/data/markdown_doc/default_template.erb
+++ b/data/markdown_doc/default_template.erb
@@ -117,6 +117,13 @@
 
 <%= normalize_pull_requests(items[:mod_pull_requests]) %>
 
+<%- attacker_kb_references = normalize_attackerkb_references(items[:mod_refs]) %>
+<% unless attacker_kb_references.empty? %>
+## AttackerKB references
+
+<%= attacker_kb_references %>
+<% end %>
+
 <% unless items[:mod_refs].empty? %>
 ## References
 

--- a/lib/msf/util/document_generator/document_normalizer.rb
+++ b/lib/msf/util/document_generator/document_normalizer.rb
@@ -185,6 +185,23 @@ module Msf
           targets.collect { |c| "* #{c.name}" } * "\n"
         end
 
+        # Returns the markdown format for module AttackerKB references.
+        #
+        # @param refs [Array] AttackerKB references , with the CVE as the key and the link as the value.
+        # @return [String]
+        def normalize_attackerkb_references(refs)
+          normalized = ''
+
+          # Grabs module CVE's if available and adds each AttackerKB link to the hash
+          refs.each do |ref|
+            next unless ref.ctx_id == 'CVE'
+
+            cve = "#{ref.ctx_id}-#{ref.ctx_val}"
+            link = "https://attackerkb.com/topics/#{ref.ctx_id}-#{ref.ctx_val}?referrer=msfconsole"
+            normalized << "* [#{cve}](#{link})\n"
+          end
+          normalized
+        end
 
         # Returns the markdown format for module references.
         #


### PR DESCRIPTION
This PR enhances the `info -d` commands output to include AttackerKB references as part of its markdown output.

## Example
![image](https://user-images.githubusercontent.com/69522014/216348381-f16ec285-4d20-40c8-bda1-909f60df440f.png)

### Note
Opening this is draft for now until we have an AttackerKB developer confirm that we're happy using the convention of adding `?referrer=msfconsole` to the generated links.

Tests for `spec/lib/msf/util/document_generator/normalizer_spec.rb` also need to be updated.


## Verification

- [ ] Start `msfconsole`
- [ ] `windows/smb/ms17_010_eternalblue`
- [ ] Run `info -d`
- [ ] **Verify** the new `AttackerKB references` section is rendered correctly
- [ ] **Verify** the AttackerKB links redirect correctly
