### PR TITLE
Added missing session types to dirty_cow module

### DIFF
--- a/documentation/modules/exploit/osx/local/mac_dirty_cow.md
+++ b/documentation/modules/exploit/osx/local/mac_dirty_cow.md
@@ -43,8 +43,6 @@ msf6 exploit(osx/local/mac_dirty_cow) > set lport 4446
 lport => 4446
 msf6 exploit(osx/local/mac_dirty_cow) > run
 
-[!] SESSION may not be compatible with this module:
-[!]  * incompatible session type: meterpreter
 [*] Started reverse TCP handler on 172.16.199.1:4446
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable.

--- a/modules/exploits/osx/local/mac_dirty_cow.rb
+++ b/modules/exploits/osx/local/mac_dirty_cow.rb
@@ -34,6 +34,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'Platform' => 'osx',
         'Arch' => ARCH_X64,
+        'SessionTypes' => ['shell', 'meterpreter'],
         'DefaultTarget' => 0,
         'DefaultOptions' => { 'PAYLOAD' => 'osx/x64/shell_reverse_tcp' },
         'Targets' => [


### PR DESCRIPTION
I accidentally missed this addition before landing. Sets session types during initialization. 
