### PR TITLE
Fix metasm_shell by requiring readline

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -149,7 +149,13 @@ module Shell
         if input.eof? || line == nil
           self.stop_count += 1
           next if self.stop_count > 1
-          run_single('quit')
+
+          if block
+            block.call('quit')
+          elsif respond_to?(:run_single)
+            # PseudoShell does not provide run_single
+            run_single('quit')
+          end
 
         # If a block was passed in, pass the line to it.  If it returns true,
         # break out of the shell loop.

--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -31,6 +31,7 @@ require 'msfenv'
 $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
 require 'rex'
+require 'readline'
 require 'metasm'
 
 #PowerPC, seems broken for now in metasm

--- a/tools/exploit/nasm_shell.rb
+++ b/tools/exploit/nasm_shell.rb
@@ -21,6 +21,7 @@ $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
 require 'msfenv'
 require 'rex'
+require 'readline'
 
 # Check to make sure nasm is installed and reachable through the user's PATH.
 begin


### PR DESCRIPTION
Fixes #17590 by adding a missing `require 'readline'` statement. Also fixes an exception due to the PseudoShell not providing `#run_single` that would occur when the shell was exited by the user pressing `Ctrl+D`.

## Verification

- [ ] Start `tools/exploit/metasm_shell.rb`
- [ ] Do not see a stack trace
- [ ] Exit the shell via `Ctrl+D` (EOF)
- [ ] Do not see a stack trace

## Before
```
tools/exploit/metasm_shell.rb       
type "exit" or "quit" to quit
use ";" or "\n" for newline
type "file <file>" to parse a GAS assembler source file

/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell/history_manager.rb:63:in `clear_readline': uninitialized constant #<Class:#<HistoryManager stack size: 0>>::Readline (NameError)
	from /home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell/history_manager.rb:99:in `switch_context'
	from /home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell/history_manager.rb:29:in `push_context'
	from /home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:133:in `run'
	from tools/exploit/metasm_shell.rb:171:in `<main>'
```

## After
```
tools/exploit/metasm_shell.rb
type "exit" or "quit" to quit
use ";" or "\n" for newline
type "file <file>" to parse a GAS assembler source file

metasm > pop eax
"\x58"
metasm > exi
```