### PR TITLE
Fix bypassuac_injection_winsxs for x64

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_kernel32.rb
@@ -886,7 +886,7 @@ class Def_windows_kernel32
       ["DWORD","dwNotifyFilter","in"],
       ])
 
-    dll.add_function( 'FindFirstFileA', 'DWORD',[
+    dll.add_function( 'FindFirstFileA', 'HANDLE',[
       ["PCHAR","lpFileName","in"],
       ["PBLOB","lpFindFileData","out"],
       ])
@@ -909,7 +909,7 @@ class Def_windows_kernel32
       ["DWORD","dwAdditionalFlags","in"],
       ])
 
-    dll.add_function( 'FindFirstFileW', 'DWORD',[
+    dll.add_function( 'FindFirstFileW', 'HANDLE',[
       ["PWCHAR","lpFileName","in"],
       ["PBLOB","lpFindFileData","out"],
       ])

--- a/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
+++ b/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
@@ -276,8 +276,8 @@ class MetasploitModule < Msf::Exploit::Local
       andOperation = fileAttributes & client.railgun.const("FILE_ATTRIBUTE_DIRECTORY")
       if andOperation
         # Removes the remainder part composed of 'A' of the path and the last null character
-        normalizedData = findFileData[fileNamePadding, fileNamePadding + maxPath].split('AAA')[0]
-        path = "#{payload_filepath}\\#{normalizedData[0, normalizedData.length - 1]}"
+        normalizedData = findFileData[fileNamePadding, fileNamePadding + maxPath].split("\x00", 2).first
+        path = "#{payload_filepath}\\#{normalizedData}"
         directoryNames.push(path)
       end
 

--- a/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
+++ b/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
@@ -285,6 +285,7 @@ class MetasploitModule < Msf::Exploit::Local
       moreFiles = findNextFile['return']
       findFileData = findNextFile['lpFindFileData']
     end
+    client.railgun.kernel32.FindClose(hFile['return'])
 
     if findNextFile['GetLastError'] != client.railgun.const("ERROR_NO_MORE_FILES")
       fail_with(Failure::Unknown, "Cannot get the targeted directories!")


### PR DESCRIPTION
This fixes the `windows/local/bypassuac_injection_winsxs` module for 64-bit Windows. Prior to this, the incorrect railgun definition would cause the session to die because the handle was being truncated from `FindFirstFileA`. Tested on both Windows 8.1 x86 and Windows 8.1 x64.

## Verification

- [x] Start a session as an administrative user that is constrained by UAC on Windows 8.1
- [x] Set the `TARGET` based on the architecture
- [x] Run the module to obtain a new session, see that `getsystem` works (showing UAC was bypassed)

