### PR TITLE
qubes_mirage_firewall_dos: Fix notes for SideEffects and Reliability

### DIFF
--- a/modules/auxiliary/dos/mirageos/qubes_mirage_firewall_dos.rb
+++ b/modules/auxiliary/dos/mirageos/qubes_mirage_firewall_dos.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'Notes' => {
           'Stability' => [CRASH_SERVICE_DOWN],
-          'Reliability' => [IOC_IN_LOGS, PHYSICAL_EFFECTS],
-          'SideEffects' => [UNRELIABLE_SESSION]
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
         },
         'DisclosureDate' => '2022-12-04'
       )


### PR DESCRIPTION
These were switched around for some reason.

`PHYSICAL_EFFECTS` has been removed. I believe this was added in error.

`UNRELIABLE_SESSION` has been removed. Use of `Reliability` for non-exploit modules is not consistent, but usually left blank for if the module does not return a session.

---

We should probably validate these values in `msftidy`. I'll add this one day, but I'm in no hurry. If you're keen to do it first then be my guest.

See also: #16722 #17091 previous merged fixes for similar issue.
