### PR TITLE
Allows integration of creds into modules

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -98,6 +98,62 @@ module Common
     print_line
   end
 
+  def set_creds_from_database(public, private, realm, sorm)
+    if public.empty? && private.empty?
+      print_status("Invalid")
+    end
+    mydatastore = active_module.datastore
+    user_options = ['USERNAME', 'HttpUsername', 'SMBUser', 'DBUSER', 'FTPUSER', 'SMTPUSERNAME', 'NCSUSER', 'IMAPUSER', 'GitUsername', 'IAX_USER', 'POP2USER']
+    pass_options = ['PASSWORD', 'HttpPassword', 'SMBPass', 'DBPASS', 'FTPPASS', 'SMTPPASSWORD', 'NCSPASS', 'IMAPPASS', 'GitPassword', 'IAX_PASS', 'POP2PASS']
+    domain_options = ['DOMAIN', 'SMBDomain', 'DOMAINNAME']
+
+    # options to check if present for active module
+    if sorm == 1
+      if mydatastore.options.include?('USER_FILE') && mydatastore.options.include?('PASS_FILE')
+        user_file = Rex::Quickfile.new("creds-user-file")
+        mydatastore['USER_FILE'] = user_file.path
+        user_file.write(public.join("\n")+"\n")
+        user_file.close
+        pass_file = Rex::Quickfile.new("creds-pass-file")
+        mydatastore['PASS_FILE'] = pass_file.path
+        pass_file.write(public.join("\n")+"\n")
+        pass_file.close
+        if mydatastore.options.include?('USERPASS_FILE')
+          i = 0
+          userpass_file = Rex::Quickfile.new("creds-userpass-file")
+          mydatastore['USERPASS_FILE'] = 'file:'+userpass_file.path
+          while i < public.length do
+            userpass_file.write(public[i]+"\s"+private[i]+"\n")
+            i += 1
+          end
+          userpass_file.close
+        end
+      end
+    else
+      user_options.each do |user_option|
+        if mydatastore.options.include?(user_option)
+          mydatastore[user_option] = public[0]
+          print_line "#{user_option} => #{mydatastore[user_option]}"
+          break
+        end
+      end
+      pass_options.each do |pass_option|
+        if mydatastore.options.include?(pass_option)
+          mydatastore[pass_option] = private[0]
+          print_line "#{pass_option} => #{mydatastore[pass_option]}"
+          break
+        end
+      end
+      domain_options.each do |domain_option|
+        if mydatastore.options.include?(domain_option)
+          mydatastore[domain_option] = realm[0]
+          print_line "#{domain_option} => #{mydatastore[domain_option]}"
+          break
+        end
+      end
+    end
+  end
+
   def show_options(mod) # :nodoc:
     mod_opt = Serializer::ReadableText.dump_options(mod, '   ')
     print("\nModule options (#{mod.fullname}):\n\n#{mod_opt}\n") if (mod_opt and mod_opt.length > 0)

--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -98,9 +98,10 @@ module Common
     print_line
   end
 
-  def set_creds_from_database(public, private, realm, sorm)
-    if public.empty? && private.empty?
-      print_status("Invalid")
+  def set_creds_from_database(publics, privates, realms, multi_creds)
+    if publics.nil? || privates.nil?
+      print_status("Unable to fill: Invalid Credentials. Check for creds index and credential options to be filled")
+      return
     end
     mydatastore = active_module.datastore
     user_options = ['USERNAME', 'HttpUsername', 'SMBUser', 'DBUSER', 'FTPUSER', 'SMTPUSERNAME', 'NCSUSER', 'IMAPUSER', 'GitUsername', 'IAX_USER', 'POP2USER']
@@ -108,22 +109,22 @@ module Common
     domain_options = ['DOMAIN', 'SMBDomain', 'DOMAINNAME']
 
     # options to check if present for active module
-    if sorm == 1
+    if multi_creds == 1
       if mydatastore.options.include?('USER_FILE') && mydatastore.options.include?('PASS_FILE')
         user_file = Rex::Quickfile.new("creds-user-file")
         mydatastore['USER_FILE'] = user_file.path
-        user_file.write(public.join("\n")+"\n")
+        user_file.write(publics.join("\n")+"\n")
         user_file.close
         pass_file = Rex::Quickfile.new("creds-pass-file")
         mydatastore['PASS_FILE'] = pass_file.path
-        pass_file.write(public.join("\n")+"\n")
+        pass_file.write(publics.join("\n")+"\n")
         pass_file.close
         if mydatastore.options.include?('USERPASS_FILE')
           i = 0
           userpass_file = Rex::Quickfile.new("creds-userpass-file")
           mydatastore['USERPASS_FILE'] = 'file:'+userpass_file.path
-          while i < public.length do
-            userpass_file.write(public[i]+"\s"+private[i]+"\n")
+          while i < publics.length do
+            userpass_file.write(publics[i]+"\s"+privates[i]+"\n")
             i += 1
           end
           userpass_file.close
@@ -132,21 +133,21 @@ module Common
     else
       user_options.each do |user_option|
         if mydatastore.options.include?(user_option)
-          mydatastore[user_option] = public[0]
+          mydatastore[user_option] = publics[0]
           print_line "#{user_option} => #{mydatastore[user_option]}"
           break
         end
       end
       pass_options.each do |pass_option|
         if mydatastore.options.include?(pass_option)
-          mydatastore[pass_option] = private[0]
+          mydatastore[pass_option] = privates[0]
           print_line "#{pass_option} => #{mydatastore[pass_option]}"
           break
         end
       end
       domain_options.each do |domain_option|
         if mydatastore.options.include?(domain_option)
-          mydatastore[domain_option] = realm[0]
+          mydatastore[domain_option] = realms[0]
           print_line "#{domain_option} => #{mydatastore[domain_option]}"
           break
         end

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -328,7 +328,7 @@ class Creds
     info
   end
 
-  def creds_fill(*args) # sets the creds from database into a module
+  def creds_fill(*args)
     if active_module
       mydatastore = active_module.datastore
     else
@@ -336,64 +336,63 @@ class Creds
       return
     end
     opts = {}
-    usernames = [] #store public values
-    passwords = [] #store private values
-    realms = [] #store realm values
+    usernames = []
+    passwords = []
+    realms = []
     query = framework.db.creds(opts)
     query.each do |core|
       user = core.public ? core.public.username : ''
       usernames << user
       passwd = core.private ? core.private.data : ''
       passwords << passwd
-      realm_val = core.realm ? core.realm.value : '.' # Basic domain is .
+      realm_val = core.realm ? core.realm.value : '.'
       realms << realm_val
     end
     if !args.empty?
-      arguments = args.split(' ')
-      choice = arguments[0][1].split(':') if !arguments[0][1].nil?
-      clength = (choice.nil?) ? 0 : choice.length
-      indices = arguments[0][0].split('-').map! {|i| i.to_i}
+      cred_type = arguments[1].split(':') if !arguments[1].nil?
+      cred_types = (cred_type.nil?) ? 0 : cred_type.length
+      cred_idx = arguments[0].split('-').map {|i| i.to_i}
       multi_creds = 0
     else
       print_error("Invalid Arguments. Usage - creds fill <index>")
       return
     end
-    if (indices.length == 2) && (indices[0] != indices[1])
+    if (cred_idx.length == 2) && (cred_idx[0] != cred_idx[1])
       multi_creds += 1
-      if (indices[0].empty?) || (indices[1] < 0)
+      if (cred_idx[0].to_s.empty?) || (cred_idx[1] < 0)
         print_error("Invalid parameter, #{arguments[0]}. Use correct index")
         return
       end
-      if clength == 0
-        user = usernames[indices[0]..indices[1]]
-        pass = passwords[indices[0]..indices[1]]
-        realm = realms[indices[0]..indices[1]]
+      if cred_types == 0
+        user = usernames[cred_idx[0]..cred_idx[1]]
+        pass = passwords[cred_idx[0]..cred_idx[1]]
+        realm = realms[cred_idx[0]..cred_idx[1]]
         if (user.empty? && pass.empty?)
-          print_status("Invalid Credentials, #{args}. Check for the range of credential indices.")
+          print_status("Invalid Credentials, #{args}. Check for the range of credential index.")
         end
         set_creds_from_database(user, pass, realm, multi_creds)
       else
-        print_error("Invalid Arguments. Unable to fill the creds to #{choice}. ")
+        print_error("Invalid Arguments. Unable to fill the creds to #{cred_type}. ")
         return
       end
-    elsif indices.length == 1
-      if  (indices[0].empty?)
+    elsif cred_idx.length == 1
+      if (cred_idx[0].to_s.empty?)
         print_error("Invalid parameter, #{arguments[0]}. Use correct index")
         return
       end
-      if clength == 0
-        user = usernames[indices[0]..indices[0]]
-        pass = passwords[indices[0]..indices[0]]
-        realm = realms[indices[0]..indices[0]]
+      if cred_types == 0
+        user = usernames[cred_idx[0]..cred_idx[0]]
+        pass = passwords[cred_idx[0]..cred_idx[0]]
+        realm = realms[cred_idx[0]..cred_idx[0]]
         set_creds_from_database(user, pass, realm, multi_creds)
       else
-        if mydatastore.options.include?(choice[0]) && mydatastore.options.include?(choice[1])
-          mydatastore[choice[0]] = usernames[indices[0]]
-          mydatastore[choice[1]] = passwords[indices[0]]
-          print_line "#{choice[0]} => #{mydatastore[choice[0]]}"
-          print_line "#{choice[1]} => #{mydatastore[choice[1]]}"
+        if mydatastore.options.include?(cred_type[0]) && mydatastore.options.include?(cred_type[1])
+          mydatastore[cred_type[0]] = usernames[cred_idx[0]]
+          mydatastore[cred_type[1]] = passwords[cred_idx[0]]
+          print_line "#{cred_type[0]} => #{mydatastore[cred_type[0]]}"
+          print_line "#{cred_type[1]} => #{mydatastore[cred_type[1]]}"
         else
-          print_error("Invalid arguments. #{choice} are not present as options.")
+          print_error("Invalid arguments. #{cred_type} are not present as options.")
           return
         end
       end

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -321,8 +321,7 @@ class Creds
 
   def build_service_info(service)
     if service.name.present?
-      info = "#{service.port}/
-#{service.proto} (#{service.name})"
+      info = "#{service.port}/#{service.proto} (#{service.name})"
     else
       info = "#{service.port}/#{service.proto}"
     end

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -317,7 +317,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Step 8: Trying SQL xp_cmdshell method...")
-    ret = exec_cmd("EXEC master..xp_cmdshell", "cmd /c echo x", "driver={SQL Server};server=(#{datastore['DBHOST']});database=#{datastore['DBNAME']};uid=#{datastore['DBUID']};pwd=#{datastore['DBPASSWORD']}") # based on hdm's sqlrds.pl :)
+    ret = exec_cmd("EXEC master..xp_cmdshell", "cmd /c echo x", "driver={SQL Server};server=(#{datastore['DBHOST']});database=#{datastore['DBNAME']};uid=#{datastore['DBUID']};pwd=#{datastore['DBPASS']}") # based on hdm's sqlrds.pl :)
     return ret if (ret)
 
     return -1

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('DBHOST', [ true, "The SQL Server host", 'local']),
         OptString.new('DBNAME', [ true, "The SQL Server database", 'master']),
         OptString.new('DBUID', [ true, "The SQL Server uid (default is sa)", 'sa']),
-        OptString.new('DBPASSWORD', [ false, "The SQL Server password (default is blank)", '']),
+        OptString.new('DBPASS', [ false, "The SQL Server password (default is blank)", '']),
       ]
     )
 

--- a/modules/post/multi/manage/dbvis_add_db_admin.rb
+++ b/modules/post/multi/manage/dbvis_add_db_admin.rb
@@ -39,8 +39,8 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptString.new('DBALIAS', [true, 'Use dbvis_enum module to find out databases and aliases', 'localhost']),
-        OptString.new('DBUSERNAME', [true, 'The user you want to add to the remote database', 'msf']),
-        OptString.new('DBPASSWORD', [true, 'User password to set', 'msfRocks'])
+        OptString.new('DBUSER', [true, 'The user you want to add to the remote database', 'msf']),
+        OptString.new('DBPASS', [true, 'User password to set', 'msfRocks'])
       ]
     )
   end
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Post
         if errors == true
           print_error("No luck today, access is probably denied for configured user !? Try in verbose mode to know what happened. ")
         else
-          print_good("Privileged user created ! Try now to connect with user : #{datastore['DBUSERNAME']} and password : #{datastore['DBPASSWORD']}")
+          print_good("Privileged user created ! Try now to connect with user : #{datastore['DBUSER']} and password : #{datastore['DBPASS']}")
         end
       end
     end
@@ -239,11 +239,11 @@ class MetasploitModule < Msf::Post
   # Build proper sql
   def get_sql(db_type)
     if db_type =~ /mysql/i
-      sql = "CREATE USER '#{datastore['DBUSERNAME']}'@'localhost' IDENTIFIED BY '#{datastore['DBPASSWORD']}';"
-      sql << "GRANT ALL PRIVILEGES ON *.* TO '#{datastore['DBUSERNAME']}'@'localhost' WITH GRANT OPTION;"
+      sql = "CREATE USER '#{datastore['DBUSER']}'@'localhost' IDENTIFIED BY '#{datastore['DBPASS']}';"
+      sql << "GRANT ALL PRIVILEGES ON *.* TO '#{datastore['DBUSER']}'@'localhost' WITH GRANT OPTION;"
 
-      sql << "CREATE USER '#{datastore['DBUSERNAME']}'@'%' IDENTIFIED BY '#{datastore['DBPASSWORD']}';"
-      sql << "GRANT ALL PRIVILEGES ON *.* TO '#{datastore['DBUSERNAME']}'@'%' WITH GRANT OPTION;"
+      sql << "CREATE USER '#{datastore['DBUSER']}'@'%' IDENTIFIED BY '#{datastore['DBPASS']}';"
+      sql << "GRANT ALL PRIVILEGES ON *.* TO '#{datastore['DBUSER']}'@'%' WITH GRANT OPTION;"
       return sql
     end
     return nil

--- a/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
               'Credentials',
               '===========',
               '',
-              'host  origin  service  public    private   realm  private_type  JtR Format',
-              '----  ------  -------  ------    -------   -----  ------------  ----------',
-              '                       thisuser  thispass         Password      '
+              'id  host  origin  service  public    private   realm  private_type  JtR Format',
+              '--  ----  ------  -------  ------    -------   -----  ------------  ----------',
+              '1                          thisuser  thispass         Password      '
             ])
           end
 
@@ -83,9 +83,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
               'Credentials',
               '===========',
               '',
-              'host  origin  service  public    private   realm  private_type  JtR Format',
-              '----  ------  -------  ------    -------   -----  ------------  ----------',
-              '                       thisuser  thispass         Password      '
+              'id  host  origin  service  public    private   realm  private_type  JtR Format',
+              '--  ----  ------  -------  ------    -------   -----  ------------  ----------',
+              '1                          thisuser  thispass         Password      '
             ])
           end
 
@@ -96,9 +96,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  origin  service  public  private        realm  private_type  JtR Format',
-                '----  ------  -------  ------  -------        -----  ------------  ----------',
-                '                               nonblank_pass         Password      '
+                'id  host  origin  service  public  private        realm  private_type  JtR Format',
+                '--  ----  ------  -------  ------  -------        -----  ------------  ----------',
+                '1                                  nonblank_pass         Password      '
               ])
             end
           end
@@ -109,9 +109,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  origin  service  public         private  realm  private_type  JtR Format',
-                '----  ------  -------  ------         -------  -----  ------------  ----------',
-                '                       nonblank_user                  Password      '
+                'id  host  origin  service  public         private  realm  private_type  JtR Format',
+                '--  ----  ------  -------  ------         -------  -----  ------------  ----------',
+                '1                          nonblank_user                  Password      '
               ])
             end
           end
@@ -125,8 +125,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  origin  service  public  private  realm  private_type  JtR Format',
-                '----  ------  -------  ------  -------  -----  ------------  ----------'
+                'id  host  origin  service  public  private  realm  private_type  JtR Format',
+                '--  ----  ------  -------  ------  -------  -----  ------------  ----------'
               ])
             end
           end
@@ -137,8 +137,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  origin  service  public  private  realm  private_type  JtR Format',
-                '----  ------  -------  ------  -------  -----  ------------  ----------'
+                'id  host  origin  service  public  private  realm  private_type  JtR Format',
+                '--  ----  ------  -------  ------  -------  -----  ------------  ----------'
               ])
             end
           end
@@ -206,9 +206,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  origin  service  public    private   realm  private_type  JtR Format',
-                '----  ------  -------  ------    -------   -----  ------------  ----------',
-                '                       thisuser  thispass         Password      '
+                'id  host  origin  service  public    private   realm  private_type  JtR Format',
+                '--  ----  ------  -------  ------    -------   -----  ------------  ----------',
+                '1                          thisuser  thispass         Password      '
               ])
             end
           end
@@ -223,9 +223,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'host  service  public    private                                                            realm  private_type  JtR Format',
-                '----  -------  ------    -------                                                            -----  ------------  ----------',
-                "               thisuser  #{ntlm_hash}         NTLM hash"
+                'id  host  service  public    private                                                            realm  private_type  JtR Format',
+                '--  ----  -------  ------    -------                                                            -----  ------------  ----------',
+                "1                  thisuser  #{ntlm_hash}         NTLM hash"
               ]
             end
           end

--- a/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
               'Credentials',
               '===========',
               '',
-              'id  host  origin  service  public    private   realm  private_type  JtR Format',
-              '--  ----  ------  -------  ------    -------   -----  ------------  ----------',
-              '1                          thisuser  thispass         Password      '
+              'host  origin  service  public    private   realm  private_type  JtR Format',
+              '----  ------  -------  ------    -------   -----  ------------  ----------',
+              '                       thisuser  thispass         Password      '
             ])
           end
 
@@ -83,9 +83,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
               'Credentials',
               '===========',
               '',
-              'id  host  origin  service  public    private   realm  private_type  JtR Format',
-              '--  ----  ------  -------  ------    -------   -----  ------------  ----------',
-              '1                          thisuser  thispass         Password      '
+              'host  origin  service  public    private   realm  private_type  JtR Format',
+              '----  ------  -------  ------    -------   -----  ------------  ----------',
+              '                       thisuser  thispass         Password      '
             ])
           end
 
@@ -96,9 +96,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'id  host  origin  service  public  private        realm  private_type  JtR Format',
-                '--  ----  ------  -------  ------  -------        -----  ------------  ----------',
-                '1                                  nonblank_pass         Password      '
+                'host  origin  service  public  private        realm  private_type  JtR Format',
+                '----  ------  -------  ------  -------        -----  ------------  ----------',
+                '                               nonblank_pass         Password      '
               ])
             end
           end
@@ -109,9 +109,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'id  host  origin  service  public         private  realm  private_type  JtR Format',
-                '--  ----  ------  -------  ------         -------  -----  ------------  ----------',
-                '1                          nonblank_user                  Password      '
+                'host  origin  service  public         private  realm  private_type  JtR Format',
+                '----  ------  -------  ------         -------  -----  ------------  ----------',
+                '                       nonblank_user                  Password      '
               ])
             end
           end
@@ -125,8 +125,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'id  host  origin  service  public  private  realm  private_type  JtR Format',
-                '--  ----  ------  -------  ------  -------  -----  ------------  ----------'
+                'host  origin  service  public  private  realm  private_type  JtR Format',
+                '----  ------  -------  ------  -------  -----  ------------  ----------'
               ])
             end
           end
@@ -137,8 +137,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'id  host  origin  service  public  private  realm  private_type  JtR Format',
-                '--  ----  ------  -------  ------  -------  -----  ------------  ----------'
+                'host  origin  service  public  private  realm  private_type  JtR Format',
+                '----  ------  -------  ------  -------  -----  ------------  ----------'
               ])
             end
           end
@@ -206,9 +206,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'id  host  origin  service  public    private   realm  private_type  JtR Format',
-                '--  ----  ------  -------  ------    -------   -----  ------------  ----------',
-                '1                          thisuser  thispass         Password      '
+                'host  origin  service  public    private   realm  private_type  JtR Format',
+                '----  ------  -------  ------    -------   -----  ------------  ----------',
+                '                       thisuser  thispass         Password      '
               ])
             end
           end
@@ -223,9 +223,9 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 'Credentials',
                 '===========',
                 '',
-                'id  host  service  public    private                                                            realm  private_type  JtR Format',
-                '--  ----  -------  ------    -------                                                            -----  ------------  ----------',
-                "1                  thisuser  #{ntlm_hash}         NTLM hash"
+                'host  service  public    private                                                            realm  private_type  JtR Format',
+                '----  -------  ------    -------                                                            -----  ------------  ----------',
+                "               thisuser  #{ntlm_hash}         NTLM hash"
               ]
             end
           end


### PR DESCRIPTION
Fix #17367 and improvise #17566 

This change adds the feature to fill creds into modules directly instead of manually adding them to modules.
The credentials stored in database from auxiliary modules which can be seen by `creds` can be filled to modules like
`smb/psexec.rb`, `ssh_login.rb` using `creds fill ` command.
Currently this change allows addition of single credential entry from database to present active module options or Specific options of active module. It also allows addition of multiple credentials in the form of `USER_FILE` and `PASS_FILE` if allowed.

The above changes were successfully observed in Metasploit v6.2.37-dev-1021d2d700

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] use an Auxiliary module to get creds or add them with ` creds add `
- [ ] `creds` will display creds along with their index
- [ ] Load a module like `smb/psexec` 
- [ ] `creds fill 1` would fill the authentication options present `creds fill 1 SMBUser:SMBPass ` would fill the specific authentication.
- [ ] **Verify** with `show options`
- [ ] `creds fill 1-4` would fill multiple credentials as `USER_FILE` and `PASS_FILE` if the options are present.
- [ ] **Verify** with `show options`

This is a preliminary feature implementation. A lot more changes can be done to this feature.