### PR TITLE
Add ul_type 12 (UPN and DNS info) to pac bindata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
     bcrypt_pbkdf (1.1.0)
-    bindata (2.4.14)
+    bindata (2.4.15)
     bson (4.15.0)
     builder (3.2.4)
     byebug (11.1.3)

--- a/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
+++ b/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
@@ -253,4 +253,45 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
       end
     end
   end
+
+  describe '#present_upn_and_dns_information' do
+    let(:upn) { 'test@windomain.local' }
+    let(:dns_domain_name) { 'WINDOMAIN.LOCAL' }
+    let(:sam_name) { 'test' }
+    let(:sid) { 'S-1-5-32-544' }
+
+    context 'with no sam name or sid' do
+      let(:flags) { 0b01 }
+      let(:upn_and_dns_info) do
+        Rex::Proto::Kerberos::Pac::Krb5UpnDnsInfo.new(upn: upn, dns_domain_name: dns_domain_name, flags: flags)
+      end
+      it 'returns the correct string' do
+        expect(subject.present_upn_and_dns_information(upn_and_dns_info)).to eq <<~EOF.rstrip
+          UPN and DNS Information:
+            UPN: test@windomain.local
+            DNS Domain Name: WINDOMAIN.LOCAL
+            Flags: 1
+        EOF
+      end
+    end
+
+    context 'with sam name and sid' do
+      let(:flags) { 0b11 }
+      let(:upn_and_dns_info) do
+        Rex::Proto::Kerberos::Pac::Krb5UpnDnsInfo.new(
+          upn: upn, dns_domain_name: dns_domain_name, sam_name: sam_name, sid: sid, flags: flags
+        )
+      end
+      it 'returns the correct string' do
+        expect(subject.present_upn_and_dns_information(upn_and_dns_info)).to eq <<~EOF.rstrip
+          UPN and DNS Information:
+            UPN: test@windomain.local
+            DNS Domain Name: WINDOMAIN.LOCAL
+            Flags: 3
+            SAM Name: test
+            SID: S-1-5-32-544
+        EOF
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds supported for the UPN and DNS info pac structure documented here: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/1c0d6e11-6443-4846-b744-f9f810a504eb

Bumped bindata version to include the fix from here: https://github.com/dmendel/bindata/issues/149#issuecomment-1420069797

I tested around trying to make it so that when you didn't need to manually remember to call `set_offsets!` before writing out the UPN and DNS info element but I couldn't find a nice way of doing that which wouldn't also have the side effect of potentially altering the existing values at the time of reading the ticket, so I've just left it in a similar way to the Pac itself

# Validation
- [ ] CI passes
- [ ] run the inspect ticket module against a ccache/kirbi containing the UPN and DNS info element

Example of a kirbi file in base64 with the extended UPN and DNS info included
```
doIFbTCCBWmgAwIBBaEDAgEWooIEZTCCBGFhggRdMIIEWaADAgEFoREbD1dJTkRPTUFJTi5MT0NBTKIp
MCegAwIBAqEgMB4bBGNpZnMbFmRjMjAxOS53aW5kb21haW4ubG9jYWyjggQSMIIEDqADAgEXoQMCAQOi
ggQABIID/DN1zTi+AIX9ekmkuGT7Rww/9Aikd7WC3SC6qNzGvfYjL20h04Em5iAiy+m1C12a1Z+0yA0h
XmxvDpma65wOEuxj+aunTDnXkYzPXNetp8n4dXtYvw4FVcE+9Y4o4PgshkdgMZJiJb0hzqCAfCTiTgMU
Yd5ZwUAmwP6ikTYJk6FY31a9xM67lXpE5hWmLYDwsnJby6P0uCuwNNrkYr3nLGbPolQoMO/Wr9mHK/ty
zzrWCmcRvbA+rlyV8Hy16YDMvdy4Mk40Hve7AVNbIoOO9j5hffSlEbzCMGMDqXEKZWBmg93aAWsDNZFS
n2KF3N1A9jv37q/jvEM3CBcZ5fYWQjemZ2s69alm/7HuMqL5KELVK2MpgUhzJUdBpQQoGYxN4KUpR7km
ac1eV87i6NJLh1EKdiUntwZs9VcJ0g2w3LsgMw4LHshihwWp1AtojX2J3SXPpvEW4GRKTfJfAqs6fge+
3d6Oc8vISKZhII7vbrW+41Y82QbPXuJk4NpfARF/BAFKp3jy/w8FIEVMYvSkdcUcx1Bft6VtxvotN5iZ
n+ZDV9VLXiRLK0qtUI0aIGV/ojCbuXOV3wCBEUy4rnvAoftmZjzl3p/o3L2d3mHyeOuzRb1l1y7UwXOm
KKIpZPpOSAzbCxzqrsPKNnb74eO3qb5l0eEUaRnB9i8rneDexl0IgHp7HFub4kFJj0WHjvdr4J03Bvt6
ExkE0g1SP8nC5v/2DKCS8DnWt34j98rfhP20xrcU9NQ/9IL6zM84uhI/OVolSqo3LClm5RHD87wFP4mZ
30PRGMyr8GHDLkcioJtc15olVjMPSlo+SkIBvZI7PIs8KVTwYI5PW/7t/TGkMOZuX7n7T/puJwG6Pok/
nS/XLLaMflxp0YQxnDlmn73JZkDjm1CONsBAkY/0FRq40xR2/LhhRG2RlUg+bcu0OThtmRpmi8BNQKyp
Sau3NoFL6nXmskKw9Opf6EOlzUfLXX/K3YlJccVIAhP+QtsjBLOKDtVAyXfVYftgRdIXUaTJg3cm2H9a
04SxL2njZhz0YpN55+MXTRjJsN5jnJrmrLKMW9Wian1IYsqTYAL3fnjOlOUH4PYM4h13ME0Q7s4BIXul
CBtqpAZ7ytwXNWQfPmN4dZHAz+JHt0ROssWenQpDFj9xcHTas+hIxaH4sIZyEwxbl55decdZv386z1HJ
xCmkN/eMKvJxfMsWSrfYr+Dg4iobkPo/IpdfoU7IJ8sWoiLTfIi/R3+XVRM3Gue+3CBOABWAD3Vjzp+s
t0S/DNR4WlUXEPRlEr8NsnfPHlvrcEr8cN3Qjcifre5lvzN1P9gDwCZHdlbmKq41MRFDj0TX9rMCe6r6
KQwDmYmcqqOB8zCB8KADAgEAooHoBIHlfYHiMIHfoIHcMIHZMIHWoBswGaADAgEXoRIEEPNKmCn0rEfa
UUhidlvInL6hERsPV0lORE9NQUlOLkxPQ0FMohEwD6ADAgEBoQgwBhsEdGVzdKMHAwUAQKAAAKQRGA8y
MDIzMDIwMjEzMDYzMVqlERgPMjAyMzAyMDIxMzA2MzFaphEYDzIwMjMwMjAyMjMwNjMxWqcRGA8yMDIz
MDIwOTEzMDYzMVqoERsPV0lORE9NQUlOLkxPQ0FMqSkwJ6ADAgECoSAwHhsEY2lmcxsWZGMyMDE5Lndp
bmRvbWFpbi5sb2NhbA==
```

Alternatively you can generate your own using rubeus with a command like:
`rubeus.exe silver /service:cifs/dc2019.windomain.local /rc4:64FBAE31CC352FC26AF97CBDEF151E03 /creduser:windomain.local\test /credpassword:vagrant /user:test /krbkey:4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326 /krbenctype:aes256 /domain:windomain.local /ptt /sid:S-1-5-21-3541430928-2051711210-1391384369 /extendedupndns`