### PR TITLE
Fix finalizer warnings on ruby 3.1

### DIFF
--- a/msfconsole
+++ b/msfconsole
@@ -12,6 +12,8 @@ begin
   if defined?(Warning) && Warning.respond_to?(:[]=)
     Warning[:deprecated] = false
   end
+  # Some of Ruby's internal warnings check if $VERBOSE is nil instead of false
+  $VERBOSE = nil
 
   # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
   require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')


### PR DESCRIPTION
Fixes finalizer warnings on Ruby 3.1

Improves https://github.com/rapid7/metasploit-framework/issues/17593

with the following script

```ruby
class Foo
  def initialize(mutex)
    ObjectSpace.define_finalizer self, self.class.finalize(mutex)
  end

  def self.finalize(mutex)
    proc { self.close(mutex) }
  end

  def self.close(mutex)
    raise 'Uncaught error'
  end
end

mutex = ::Mutex.new
puts "creating an instance"
Foo.new(mutex)

puts
puts "before Foo instances:"
ObjectSpace.each_object(Foo) do |instance|
  puts instance
end
GC.start

puts
puts "After foo instances:"
ObjectSpace.each_object(Foo) do |instance|
  puts instance
end
```

Ruby 3.0 silently swallows the exception:

```
ruby crash.rb
creating an instance

before Foo instances:
#<Foo:0x00007f986a822788>

After foo instances:

```

Whilst on Ruby 3.1 the uncaught exception is logged to the console:

```
 ruby crash.rb
creating an instance

before Foo instances:
#<Foo:0x0000000110e0c6d8>
<internal:gc>:34: warning: Exception in finalizer #<Proc:0x0000000110e0c4d0 crash.rb:7>
crash.rb:11:in `close': Uncaught error (RuntimeError)
        from crash.rb:7:in `block in finalize'
        from <internal:gc>:34:in `start'
        from crash.rb:24:in `<main>'

After foo instances:
```

Adding `$VERBOSE = nil` will keep the previous behavior in place; This change is required as https://github.com/ruby/ruby/pull/4670/files checks verbose for `NIL_P` instead of just false

```c
static void
warn_exception_in_finalizer(rb_execution_context_t *ec, VALUE final)
{
    if (final != Qundef && !NIL_P(ruby_verbose)) {
	VALUE errinfo = ec->errinfo;
	rb_warn("Exception in finalizer %+"PRIsVALUE, final);
	rb_ec_error_print(ec, errinfo);
    }
}
```

## Verification

- Verify the behavior described above