### PR TITLE
Add exception handling for finalizer methods

### DIFF
--- a/lib/rbmysql.rb
+++ b/lib/rbmysql.rb
@@ -825,7 +825,11 @@ class RbMysql
     # @private
     def self.finalizer(protocol, statement_id)
       proc do
-        protocol.gc_stmt statement_id
+        begin
+          protocol.gc_stmt statement_id
+        rescue => e
+          elog("finalize method for Stmt failed", error: e)
+        end
       end
     end
 

--- a/lib/rex/post/meterpreter/channel.rb
+++ b/lib/rex/post/meterpreter/channel.rb
@@ -153,7 +153,11 @@ class Channel
   def self.finalize(client, cid)
     proc {
       unless cid.nil?
-        self._close(client, cid)
+        begin
+          self._close(client, cid)
+        rescue => e
+          elog("finalize method for Channel failed", error: e)
+        end
       end
     }
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/event_log.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/event_log.rb
@@ -66,7 +66,13 @@ class EventLog
   end
 
   def self.finalize(client,handle)
-    proc { self.close(client,handle) }
+    proc do
+      begin
+        self.close(client,handle)
+      rescue => e
+        elog("finalize method for EventLog failed", error: e)
+      end
+    end
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -336,7 +336,13 @@ class Process < Rex::Post::Process
   end
 
   def self.finalize(client, handle)
-    proc { self.close(client, handle) }
+    proc do
+      begin
+        self.close(client, handle)
+      rescue => e
+        elog("finalize method for Process failed", error: e)
+      end
+    end
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb
@@ -35,7 +35,13 @@ class RegistryKey
   end
 
   def self.finalize(client,hkey)
-    proc { self.close(client,hkey) }
+    proc do
+      begin
+        self.close(client,hkey)
+      rescue => e
+        elog("finalize method for RegistryKey failed", error: e)
+      end
+    end
   end
 
   ##

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/remote_registry_key.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/remote_registry_key.rb
@@ -34,7 +34,13 @@ class RemoteRegistryKey
   end
 
   def self.finalize(client, hkey)
-    proc { self.close(client, hkey) }
+    proc do
+      begin
+        self.close(client, hkey)
+      rescue => e
+        elog("finalize method for RemoteRegistryKey failed", error: e)
+      end
+    end
   end
 
   ##

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/thread.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/thread.rb
@@ -40,7 +40,13 @@ class Thread < Rex::Post::Thread
   end
 
   def self.finalize(client,handle)
-    proc { self.close(client,handle) }
+    proc do
+      begin
+        self.close(client, handle)
+      rescue => e
+        elog("finalize method for thread failed", error: e)
+      end
+    end
   end
 
   ##


### PR DESCRIPTION
Add exception handling for finalizer methods

Improves https://github.com/rapid7/metasploit-framework/issues/17593

Context: with the following script

```ruby
class Foo
  def initialize(mutex)
    ObjectSpace.define_finalizer self, self.class.finalize(mutex)
  end

  def self.finalize(mutex)
    proc { self.close(mutex) }
  end

  def self.close(mutex)
    raise 'Uncaught error'
  end
end

mutex = ::Mutex.new
puts "creating an instance"
Foo.new(mutex)

puts
puts "before Foo instances:"
ObjectSpace.each_object(Foo) do |instance|
  puts instance
end
GC.start

puts
puts "After foo instances:"
ObjectSpace.each_object(Foo) do |instance|
  puts instance
end
```

Ruby 3.0 silently swallows the exception:

```
ruby crash.rb
creating an instance

before Foo instances:
#<Foo:0x00007f986a822788>

After foo instances:

```

Whilst on Ruby 3.1 the uncaught exception is logged to the console:

```
 ruby crash.rb
creating an instance

before Foo instances:
#<Foo:0x0000000110e0c6d8>
<internal:gc>:34: warning: Exception in finalizer #<Proc:0x0000000110e0c4d0 crash.rb:7>
crash.rb:11:in `close': Uncaught error (RuntimeError)
        from crash.rb:7:in `block in finalize'
        from <internal:gc>:34:in `start'
        from crash.rb:24:in `<main>'

After foo instances:
```

Adding `$VERBOSE = nil` will keep the previous behavior in place; This change is required as https://github.com/ruby/ruby/pull/4670/files checks verbose for `NIL_P` instead of just false. But for now we'll catch and log these exceptions more granularly

```c
static void
warn_exception_in_finalizer(rb_execution_context_t *ec, VALUE final)
{
    if (final != Qundef && !NIL_P(ruby_verbose)) {
	VALUE errinfo = ec->errinfo;
	rb_warn("Exception in finalizer %+"PRIsVALUE, final);
	rb_ec_error_print(ec, errinfo);
    }
}
```

## Verification

- Review the code and ensure it is cromulent
- Test code paths work as expected