### PR TITLE
Fix Frycos author name in fortra_goanywhere_rce_cve_2023_0669.rb

### DIFF
--- a/modules/exploits/multi/http/fortra_goanywhere_rce_cve_2023_0669.rb
+++ b/modules/exploits/multi/http/fortra_goanywhere_rce_cve_2023_0669.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'Ron Bowes', # Analysis and module
-          'Fryco' # Discovery and analysis
+          'Frycos (Florian Hauser)' # Discovery and analysis
         ],
         'References' => [
           ['CVE', '2023-0669'],


### PR DESCRIPTION
Just a misspelling in my handle. Also added my real name. Thanks for mentioning me. Rob also did an awesome job on this.