### PR TITLE
Fix bootup git warnings on arch

### DIFF
--- a/lib/metasploit/framework/version.rb
+++ b/lib/metasploit/framework/version.rb
@@ -1,5 +1,6 @@
 require 'rbconfig'
 require 'yaml'
+require 'open3'
 
 module Metasploit
   module Framework
@@ -17,13 +18,14 @@ module Metasploit
             version_info = YAML.load_file(version_yml)
             hash = '-' + version_info['build_framework_rev']
           else
-            # determine if git is installed
-            null = RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ ? 'NUL' : '/dev/null'
-            git_installed = system("git --version > #{null} 2>&1")
-
-            # get the hash of the HEAD commit
-            if git_installed && File.exist?(File.join(root, '.git'))
-              hash = '-' + `git rev-parse --short HEAD`
+            # Fallback to using Git version detection if version_yml not present
+            changed_files = %w[git rev-parse --short HEAD]
+            begin
+              # stderr may contain Git warnings that we can ignore
+              output, _stderr, status = ::Open3.capture3(*changed_files, chdir: root)
+              hash = "-#{output}" if status.success?
+            rescue => e
+              elog(e) if defined?(elog)
             end
           end
           hash.strip


### PR DESCRIPTION
closes https://github.com/rapid7/metasploit-framework/issues/17604

## Verification

Run arch:
```
docker run -it archlinux /bin/bash
```

Install metasploit / vim:
```
echo y | pacman -Sy metasploit
echo y | pacman -Sy vim
```

### Before

Bootup warnings:

```
[root@61c1980f91fb /]# msfconsole -qx 'version; exit'
error: unable to normalize alternate object path: /srcdest/metasploit-framework/objects
Framework: 6.2.36-dev-bca8374
Console  : 6.2.36-dev-bca8374
```

### After 

After manually patching the PR changes with `vim /opt/metasploit/lib/metasploit/framework/version.rb`; No warnings:

```
[root@3cf8733a3890 /]# msfconsole -qx 'version; exit'
Framework: 6.2.36-dev-bca8374
Console  : 6.2.36-dev-bca8374
```