### PR TITLE
Link Hadoop YARN exploit to documentation

### DIFF
--- a/modules/exploits/linux/http/hadoop_unauth_exec.rb
+++ b/modules/exploits/linux/http/hadoop_unauth_exec.rb
@@ -14,8 +14,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Hadoop YARN ResourceManager Unauthenticated Command Execution',
       'Description'    => %q{
-          This module uses built-in functionality to execute arbitrary commands on an unsecured Hadoop server which is not configured for strong
-          authentication, via Hadoop's standard ResourceManager REST API.
+          This module uses Hadoop's standard ResourceManager REST API to execute arbitrary commands on an unsecured Hadoop server.
+          Hadoop administrators should enable Kerberos authentication for these endpoints by changing the 'hadoop.security.authentication' setting in 'core-site.xml' from 'simple' (the default) to 'kerberos' before exposing the node to the network.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -26,8 +26,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'http://archive.hack.lu/2016/Wavestone%20-%20Hack.lu%202016%20-%20Hadoop%20safari%20-%20Hunting%20for%20vulnerabilities%20-%20v1.0.pdf'],
-          ['URL', 'https://github.com/vulhub/vulhub/tree/master/hadoop/unauthorized-yarn']
-          # Note, there will never be a CVE for this issue, unless something radical changes in the CVE inclusion rules.
+          ['URL', 'https://github.com/vulhub/vulhub/tree/master/hadoop/unauthorized-yarn'],
+          # Note, there will never be a CVE for this issue, since this is a misconfiguration by the administrator rather than a vulnerability in the software.
+          # Hadoop installations should always configure Kerberos authentication before being exposed to the network,
+          # since the default configuration does not require authentication.
+          ['URL', 'https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SecureMode.html']
         ],
       'Platform'       => 'linux',
       'Arch'           => [ARCH_X86, ARCH_X64],


### PR DESCRIPTION
This exploit scans for misconfigured installations, link to the documentation that describes how to properly secure it.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/hadoop_unauth_exec`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))
