### PR TITLE
Removed Commas from RHOSTS #17602

### DIFF
--- a/scripts/resource/basic_discovery.rc
+++ b/scripts/resource/basic_discovery.rc
@@ -19,6 +19,9 @@ if (framework.datastore['RHOSTS'] == nil)
 	return
 end
 
+#Remove any commas present in the RHOSTS
+framework.datastore['RHOSTS'] = framework.datastore['RHOSTS'].gsub(',','')
+
 if (framework.datastore['NMAPOPTS'] != nil)
 	nmapopts = framework.datastore['NMAPOPTS']
 else


### PR DESCRIPTION
Fixed #17602 

This change parses the RHOSTS before passing the arguments to nmap scan in `basic_recovery.rc`. The commas are removed from the RHOSTS (in case they are present).

## Verification

Steps to verify

```
export METASPLOIT_RHOSTS='172.31.2.3/32, 172.31.4.5/32, 172.31.6.7/32'
export METASPLOIT_RESOURCE_DIR=/usr/share/metasploit-framework/scripts/resource
msfconsole --quiet --logger Stdout \
  --execute-command \
  "setg RHOSTS ${METASPLOIT_RHOSTS}; resource ${METASPLOIT_RESOURCE_DIR}/basic_discovery.rc; exit"
```

## Output

```
RHOSTS => 172.31.2.3/32, 172.31.4.5/32, 172.31.6.7/32
[*] Processing /usr/share/metasploit-framework/scripts/resource/basic_discovery.rc for ERB directives.
[*] resource (/usr/share/metasploit-framework/scripts/resource/basic_discovery.rc)> Ruby Code (20400 bytes)
THREADS => 15

============================================
starting discovery scanners ... stage 1
============================================


starting portscanners ...

udp_sweep
[*] Auxiliary module running as background job 0.
Module: db_nmap
Using Nmap with the following options: -n -PN -P0 -O -sSV 172.31.2.3/32 172.31.4.5/32 172.31.6.7/32
```

### Metasploit Version:
`v6.3.0-dev`
