### PR TITLE
Fix #17602 - Update basic_discovery.rc to support commas in RHOSTS values

### DIFF
--- a/scripts/resource/basic_discovery.rc
+++ b/scripts/resource/basic_discovery.rc
@@ -80,6 +80,10 @@ print_line("starting discovery scanners ... stage 1")
 print_line("============================================")
 print_line("")
 
+# Temp variable to store space separated RHOSTS
+nmap_rhosts = framework.datastore['RHOSTS'].gsub(',',' ')
+run_single("set RHOSTS #{nmap_rhosts}")
+
 print_line("")
 print_line("starting portscanners ...")
 print_line("")
@@ -87,15 +91,14 @@ print_line("udp_sweep")
 run_single("use auxiliary/scanner/discovery/udp_sweep")
 run_single("run -j")
 
-# Removed commas before the nmap scan.
 if ( nmap == 1 )
 	print_line("Module: db_nmap")
 	if (verbose == 1)
-		print_line("Using Nmap with the following options: -v -n #{nmapopts} #{framework.datastore['RHOSTS'].gsub(',',' ')}")
-		run_single("db_nmap -v -n #{nmapopts} #{framework.datastore['RHOSTS'].gsub(',',' ')}")
+		print_line("Using Nmap with the following options: -v -n #{nmapopts} #{nmap_rhosts}")
+		run_single("db_nmap -v -n #{nmapopts} #{nmap_rhosts}")
 	else
-		print_line("Using Nmap with the following options: -n #{nmapopts} #{framework.datastore['RHOSTS'].gsub(',',' ')}")
-		run_single("db_nmap -n #{nmapopts} #{framework.datastore['RHOSTS'].gsub(',',' ')}")
+		print_line("Using Nmap with the following options: -n #{nmapopts} #{nmap_rhosts}")
+		run_single("db_nmap -n #{nmapopts} #{nmap_rhosts}")
 	end
 else
 	print_line("Module: portscan/tcp")
@@ -614,7 +617,7 @@ framework.db.workspace.hosts.each do |host|
 			jobwaiting(maxjobs,verbose)
 
 			print_line("Module: titanftp_xcrc_traversal")
-			run_single("use auxiliary/admin/ftp/titanftp_xcrc_traversal")
+			run_single("use auxiliary/scanner/ftp/titanftp_xcrc_traversal")
 			if(verbose == 1)
 				infos(serv,host)
 			end

--- a/scripts/resource/basic_discovery.rc
+++ b/scripts/resource/basic_discovery.rc
@@ -87,14 +87,15 @@ print_line("udp_sweep")
 run_single("use auxiliary/scanner/discovery/udp_sweep")
 run_single("run -j")
 
+# Removed commas before the nmap scan.
 if ( nmap == 1 )
 	print_line("Module: db_nmap")
 	if (verbose == 1)
-		print_line("Using Nmap with the following options: -v -n #{nmapopts} #{framework.datastore['RHOSTS']}")
-		run_single("db_nmap -v -n #{nmapopts} #{framework.datastore['RHOSTS']}")
+		print_line("Using Nmap with the following options: -v -n #{nmapopts} #{framework.datastore['RHOSTS'].gsub(',',' ')}")
+		run_single("db_nmap -v -n #{nmapopts} #{framework.datastore['RHOSTS'].gsub(',',' ')}")
 	else
-		print_line("Using Nmap with the following options: -n #{nmapopts} #{framework.datastore['RHOSTS']}")
-		run_single("db_nmap -n #{nmapopts} #{framework.datastore['RHOSTS']}")
+		print_line("Using Nmap with the following options: -n #{nmapopts} #{framework.datastore['RHOSTS'].gsub(',',' ')}")
+		run_single("db_nmap -n #{nmapopts} #{framework.datastore['RHOSTS'].gsub(',',' ')}")
 	end
 else
 	print_line("Module: portscan/tcp")


### PR DESCRIPTION
Fixed #17602 

This change parses the RHOSTS before passing the arguments to nmap scan in `basic_recovery.rc`. The commas are removed from the RHOSTS (in case they are present).

## Verification

Steps to verify

```
export METASPLOIT_RHOSTS='172.31.2.3/32, 172.31.4.5/32, 172.31.6.7/32'
export METASPLOIT_RESOURCE_DIR=/usr/share/metasploit-framework/scripts/resource
msfconsole --quiet --logger Stdout \
  --execute-command \
  "setg RHOSTS ${METASPLOIT_RHOSTS}; resource ${METASPLOIT_RESOURCE_DIR}/basic_discovery.rc; exit"
```

## Output

```
RHOSTS => 172.31.2.3/32, 172.31.4.5/32, 172.31.6.7/32
[*] Processing /usr/share/metasploit-framework/scripts/resource/basic_discovery.rc for ERB directives.
[*] resource (/usr/share/metasploit-framework/scripts/resource/basic_discovery.rc)> Ruby Code (20400 bytes)
THREADS => 15

============================================
starting discovery scanners ... stage 1
============================================


starting portscanners ...

udp_sweep
[*] Auxiliary module running as background job 0.
Module: db_nmap
Using Nmap with the following options: -n -PN -P0 -O -sSV 172.31.2.3/32 172.31.4.5/32 172.31.6.7/32
```

### Metasploit Version:
`v6.3.0-dev`

(Submitting from the new branch, apologies for the earlier confusion, created the pull request without checking the branch).