### PR TITLE
Fix soft_check errors for python exploit modules #17657 

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -173,7 +173,7 @@ module ModuleCommandDispatcher
   def report_vuln(instance)
     framework.db.report_vuln(
       workspace: instance.workspace,
-      host: instance.rhost,
+      host: instance.datastore['RHOST'],
       name: instance.name,
       info: "This was flagged as vulnerable by the explicit check of #{instance.fullname}.",
       refs: instance.references


### PR DESCRIPTION
Fixes issue in  #17657  where the "soft_check" function errors when report 'vulnerable' services
Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

- [x] Create a python exploit module
- [x] Implement a soft_check function
- [x] Return 'vulnerable' in the soft_check
- [x] Open the exploit in msfconsole and run 'check'
- [x] **Verify** that an error does not occur

### Example Python Exploit Module
```python
#!/usr/bin/env python3
# modules/exploit/test/anything.py

from metasploit import module

metadata = {
    'name': 'Bug Example',
    'description': 'Always flag a service as vulnerable',
    'authors': [],
    'date': '2023-02-16',
    'references': [],
    'type': 'remote_exploit',
    'targets': [],
    'options': {
        'RHOST': {'type': 'address', 'description': 'Target address', 'required': True, 'default': None}
    }
}

def check(args):
    return 'vulnerable'

if __name__ == '__main__':
    module.run(metadata, None, soft_check=check)
```