### PR TITLE
fixing case insensitive issue for show options #17459

### DIFF
--- a/lib/msf/core/module/has_actions.rb
+++ b/lib/msf/core/module/has_actions.rb
@@ -22,7 +22,7 @@ module Msf::Module::HasActions
   def find_action(name)
     return nil if not name
     actions.each do |a|
-      return a if a.name == name
+      return a if a.name.downcase == name.downcase
     end
     return nil
   end


### PR DESCRIPTION
Fixes #17459  where the `show options` fails to show the action if the action is set in different case case.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/ldap_query`
- [x]  `set action run_query_file`
- [x]  `show options`
- [x]  **Verify that the auxiliary action has been properly set**



```
msf6 > use auxiliary/gather/ldap_query
msf6 auxiliary(gather/ldap_query) > set action run_query_file
action => run_query_file
msf6 auxiliary(gather/ldap_query) > show options

Module options (auxiliary/gather/ldap_query):

   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   BASE_DN                         no        LDAP base DN if you already have it
   DOMAIN                          no        The domain to authenticate to
   OUTPUT_FORMAT  table            yes       The output format to use (Accepted: csv, table, json)
   PASSWORD                        no        The password to authenticate with
   RHOSTS                          yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploi
                                             t.html
   RPORT          389              yes       The target port
   SSL            false            no        Enable SSL on the LDAP connection
   USERNAME                        no        The username to authenticate with


   When ACTION is RUN_SINGLE_QUERY:

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   QUERY_ATTRIBUTES                   no        Comma seperated list of attributes to retrieve from the server
   QUERY_FILTER                       no        Filter to send to the target LDAP server to perform the query


   When ACTION is RUN_QUERY_FILE:

   Name             Current Setting  Required  Description
   ----             ---------------  --------  -----------
   QUERY_FILE_PATH                   no        Path to the JSON or YAML file to load and run queries from


Auxiliary action:

   Name            Description
   ----            -----------
   RUN_QUERY_FILE  Execute a custom set of LDAP queries from the JSON or YAML file specified by QUERY_FILE.



View the full module info with the info, or info -d command.

msf6 auxiliary(gather/ldap_query) >
```

Normal Flow

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/ldap_query`
- [x]  `set action RUN_QUERY_FILE`
- [x]  `show options`
- [x]  **Verify that the auxiliary action has been properly set**

```
msf6 > use auxiliary/gather/ldap_query
msf6 auxiliary(gather/ldap_query) > set action RUN_QUERY_FILE
action => RUN_QUERY_FILE
msf6 auxiliary(gather/ldap_query) > show options

Module options (auxiliary/gather/ldap_query):

   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   BASE_DN                         no        LDAP base DN if you already have it
   DOMAIN                          no        The domain to authenticate to
   OUTPUT_FORMAT  table            yes       The output format to use (Accepted: csv, table, json)
   PASSWORD                        no        The password to authenticate with
   RHOSTS                          yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploi
                                             t.html
   RPORT          389              yes       The target port
   SSL            false            no        Enable SSL on the LDAP connection
   USERNAME                        no        The username to authenticate with


   When ACTION is RUN_SINGLE_QUERY:

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   QUERY_ATTRIBUTES                   no        Comma seperated list of attributes to retrieve from the server
   QUERY_FILTER                       no        Filter to send to the target LDAP server to perform the query


   When ACTION is RUN_QUERY_FILE:

   Name             Current Setting  Required  Description
   ----             ---------------  --------  -----------
   QUERY_FILE_PATH                   no        Path to the JSON or YAML file to load and run queries from


Auxiliary action:

   Name            Description
   ----            -----------
   RUN_QUERY_FILE  Execute a custom set of LDAP queries from the JSON or YAML file specified by QUERY_FILE.



View the full module info with the info, or info -d command.

msf6 auxiliary(gather/ldap_query) >
```



